### PR TITLE
[vlan] Revise sleep time for pytest case "test_addMaxVlan".

### DIFF
--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -262,7 +262,7 @@ class TestVlan(object):
         while vlan <= max_vid:
             self.create_vlan(str(vlan), 0)
             vlan += 1
-        time.sleep(480)
+        time.sleep(360)
 
         # check asic database
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_VLAN")
@@ -274,7 +274,7 @@ class TestVlan(object):
         while vlan <= max_vid:
             self.remove_vlan(str(vlan), 0)
             vlan += 1
-        time.sleep(480)
+        time.sleep(360)
 
         # check asic database
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_VLAN")

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -262,7 +262,7 @@ class TestVlan(object):
         while vlan <= max_vid:
             self.create_vlan(str(vlan), 0)
             vlan += 1
-        time.sleep(240)
+        time.sleep(600)
 
         # check asic database
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_VLAN")
@@ -274,7 +274,7 @@ class TestVlan(object):
         while vlan <= max_vid:
             self.remove_vlan(str(vlan), 0)
             vlan += 1
-        time.sleep(300)
+        time.sleep(600)
 
         # check asic database
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_VLAN")

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -274,7 +274,7 @@ class TestVlan(object):
         while vlan <= max_vid:
             self.remove_vlan(str(vlan), 0)
             vlan += 1
-        time.sleep(360)
+        time.sleep(420)
 
         # check asic database
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_VLAN")

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -262,7 +262,7 @@ class TestVlan(object):
         while vlan <= max_vid:
             self.create_vlan(str(vlan), 0)
             vlan += 1
-        time.sleep(600)
+        time.sleep(480)
 
         # check asic database
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_VLAN")
@@ -274,7 +274,7 @@ class TestVlan(object):
         while vlan <= max_vid:
             self.remove_vlan(str(vlan), 0)
             vlan += 1
-        time.sleep(600)
+        time.sleep(480)
 
         # check asic database
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_VLAN")

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -13,16 +13,16 @@ class TestVlan(object):
         self.adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
         self.cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
 
-    def create_vlan(self, vlan):
+    def create_vlan(self, vlan, sleep=1):
         tbl = swsscommon.Table(self.cdb, "VLAN")
         fvs = swsscommon.FieldValuePairs([("vlanid", vlan)])
         tbl.set("Vlan" + vlan, fvs)
-        time.sleep(1)
+        time.sleep(sleep)
 
-    def remove_vlan(self, vlan):
+    def remove_vlan(self, vlan, sleep=1):
         tbl = swsscommon.Table(self.cdb, "VLAN")
         tbl._del("Vlan" + vlan)
-        time.sleep(1)
+        time.sleep(sleep)
 
     def create_vlan_member(self, vlan, interface):
         tbl = swsscommon.Table(self.cdb, "VLAN_MEMBER")
@@ -251,7 +251,6 @@ class TestVlan(object):
             #remove vlan
             self.remove_vlan(vlan)
 
-    @pytest.mark.skip(reason="AddMaxVlan take too long to execute")
     def test_AddMaxVlan(self, dvs, testlog):
         self.setup_db(dvs)
 
@@ -261,8 +260,9 @@ class TestVlan(object):
         # create max vlan
         vlan = min_vid
         while vlan <= max_vid:
-            self.create_vlan(str(vlan))
+            self.create_vlan(str(vlan), 0)
             vlan += 1
+        time.sleep(240)
 
         # check asic database
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_VLAN")
@@ -272,8 +272,9 @@ class TestVlan(object):
         # remove all vlan
         vlan = min_vid
         while vlan <= max_vid:
-            self.remove_vlan(str(vlan))
+            self.remove_vlan(str(vlan), 0)
             vlan += 1
+        time.sleep(300)
 
         # check asic database
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_VLAN")


### PR DESCRIPTION
Signed-off-by: Emma Lin <emma_lin@edge-core.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Revise sleep time for pytest case "test_AddMaxVlan".

**Why I did it**
Because the pytest case "test_AddMaxVlan" is taking too long time to finish.

**How I verified it**


**Details if related**
=================================== test session starts ===================================
platform linux2 -- Python 2.7.15rc1, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/ubuntu/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 11 items

test_vlan.py::TestVlan::test_VlanAddRemove PASSED                                   [  9%]
test_vlan.py::TestVlan::test_MultipleVlan PASSED                                    [ 18%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectKeyPrefix[test_input0-0] PASSED    [ 27%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectKeyPrefix[test_input1-0] PASSED    [ 36%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectKeyPrefix[test_input2-0] PASSED    [ 45%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectKeyPrefix[test_input3-1] PASSED    [ 54%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectValueType[test_input0-0] PASSED    [ 63%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectValueType[test_input1-0] PASSED    [ 72%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectValueType[test_input2-0] PASSED    [ 81%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectValueType[test_input3-1] PASSED    [ 90%]
test_vlan.py::TestVlan::test_AddMaxVlan PASSED                                      [100%]

=============================== 11 passed in 599.15 seconds ===============================
