### PR TITLE
[pfc] pfc no-drop remains enabled even after no-drop prio are removed from qos_port_map.

### DIFF
--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -1445,15 +1445,12 @@ task_process_status QosOrch::handlePortQosMapTable(Consumer& consumer)
             SWSS_LOG_INFO("Applied %s to port %s", it->second.first.c_str(), port_name.c_str());
         }
 
-        if (pfc_enable)
+        if (!gPortsOrch->setPortPfc(port.m_port_id, pfc_enable))
         {
-            if (!gPortsOrch->setPortPfc(port.m_port_id, pfc_enable))
-            {
-                SWSS_LOG_ERROR("Failed to apply PFC bits 0x%x to port %s", pfc_enable, port_name.c_str());
-            }
-
-            SWSS_LOG_INFO("Applied PFC bits 0x%x to port %s", pfc_enable, port_name.c_str());
+            SWSS_LOG_ERROR("Failed to apply PFC bits 0x%x to port %s", pfc_enable, port_name.c_str());
         }
+
+        SWSS_LOG_INFO("Applied PFC bits 0x%x to port %s", pfc_enable, port_name.c_str());
     }
 
     SWSS_LOG_NOTICE("Applied QoS maps to ports");


### PR DESCRIPTION
… from the port

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Apply the config even for empty nodrop priorities as well(pfc_enable)so that the no-drop priorities don't get served by pfc when user disables them.

**Why I did it**
While applying qos map, pfc no-drop priorities were getting applied only when there is at least one no-drop priorities. If the no-drop priorities list is empty, then these setting were not pushed downwards. Hence no drop priorities were still getting served which is not correct.

**How I verified it**
Create a VLAN and add port P1,P2,P3 in this VLAN
Perform config qos reload to apply the pfc & qos configuration  and to configure priorities 3-4 as no-drop.
Send line rate learnt traffic from P1 & P2 with dot1p 3 to P3 to create congestion at P3. 
Pause frames on P1 & P2 will be observed.
Stop the traffic from P1 & P2.
Replace "pfc_enable" :"3,4" with "pfc_enable"      : ""   in PORT_QOS_MAP table of file  /tmp/qos.json file and perform "config load /tmp/qos.json -y".
Start the traffic on P1 & P2 again
Without the fix, Pause frames were getting generated. 
With the fix ,Pause frames on P1 & P2 are not observed for priority 3. 

**Details if related**
