### PR TITLE
Add Identity attribute for LAG

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3391,8 +3391,15 @@ bool PortsOrch::addLag(string lag_alias)
     SWSS_LOG_ENTER();
 
     sai_object_id_t lag_id;
-    sai_status_t status = sai_lag_api->create_lag(&lag_id, gSwitchId, 0, NULL);
+    sai_attribute_t attr;
+    vector<sai_attribute_t> attrs;
+    sai_status_t status;
 
+    attr.id = SAI_LAG_ATTR_NAME;
+    strncpy((char *)&attr.value.chardata, lag_alias.c_str(), sizeof(attr.value.chardata));
+    attrs.push_back(attr);
+
+    status = sai_lag_api->create_lag(&lag_id, gSwitchId, (uint32_t)attrs.size(), attrs.data());
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to create LAG %s lid:%" PRIx64, lag_alias.c_str(), lag_id);


### PR DESCRIPTION
- What I did
  Use the Identify attribute to fix the issue that view comparison for LAG [Azure/SONiC#354](https://github.com/Azure/sonic-sairedis/issues/354)

- How I did it
  Add SAI_LAG_ATTR_NAME to identify the LAG.
  It needs to set SAI_LAG_ATTR_NAME when create LAG.
  For view comparison, it uses this attribute to find the matched LAG.

Signed-off-by: chiourung_huang <chiourung_huang@edge-core.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->