### PR TITLE
[Vlan]: Added SWSS support to handle new vlan cli OPTIONAL command 

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -266,6 +266,7 @@ void VlanMgr::doVlanTask(Consumer &consumer)
             string mtu = DEFAULT_MTU_STR;
             vector<FieldValueTuple> fvVector;
             string members;
+            string vlan_type = "";
 
             /*
              * If state is already set for this vlan, but it doesn't exist in m_vlans set,
@@ -310,6 +311,12 @@ void VlanMgr::doVlanTask(Consumer &consumer)
                      */
                     SWSS_LOG_DEBUG("%s mtu %s: Host VLAN mtu setting to be supported.", key.c_str(), mtu.c_str());
                 }
+                /* Vlan_type (management/control)*/
+                else if (fvField(i) == "vlan_type")
+                {
+                    vlan_type = fvValue(i);
+                    SWSS_LOG_DEBUG("%s type %s to be supported.", key.c_str(), vlan_type.c_str());
+                }
                 else if (fvField(i) == "members@") {
                     members = fvValue(i);
                 }
@@ -323,6 +330,13 @@ void VlanMgr::doVlanTask(Consumer &consumer)
 
             FieldValueTuple m("mtu", mtu);
             fvVector.push_back(m);
+
+            if(vlan_type != "")
+            {
+                FieldValueTuple vm("vlan_type", vlan_type);
+                fvVector.push_back(vm);
+            }
+
 
             m_appVlanTableProducer.set(key, fvVector);
             m_vlans.insert(key);

--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -331,7 +331,7 @@ void VlanMgr::doVlanTask(Consumer &consumer)
             FieldValueTuple m("mtu", mtu);
             fvVector.push_back(m);
 
-            if(vlan_type != "")
+            if (!vlan_type.empty())
             {
                 FieldValueTuple vm("vlan_type", vlan_type);
                 fvVector.push_back(vm);

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2354,11 +2354,16 @@ void PortsOrch::doVlanTask(Consumer &consumer)
         {
             // Retrieve attributes
             uint32_t mtu = 0;
+            string vlan_type = "";
             for (auto i : kfvFieldsValues(t))
             {
                 if (fvField(i) == "mtu")
                 {
                     mtu = (uint32_t)stoul(fvValue(i));
+                }
+                else if (fvField(i) == "vlan_type")
+                {
+                    vlan_type = fvValue(i);
                 }
             }
 
@@ -2369,7 +2374,7 @@ void PortsOrch::doVlanTask(Consumer &consumer)
              */
             if (m_portList.find(vlan_alias) == m_portList.end())
             {
-                if (!addVlan(vlan_alias))
+                if (!addVlan(vlan_alias, vlan_type))
                 {
                     it++;
                     continue;
@@ -3219,17 +3224,47 @@ bool PortsOrch::setBridgePortLearnMode(Port &port, string learn_mode)
     return true;
 }
 
-bool PortsOrch::addVlan(string vlan_alias)
+bool PortsOrch::addVlan(string vlan_alias, string vlan_type)
 {
     SWSS_LOG_ENTER();
 
     sai_object_id_t vlan_oid;
+    vector<sai_attribute_t> attrs;
 
     sai_vlan_id_t vlan_id = (uint16_t)stoi(vlan_alias.substr(4));
     sai_attribute_t attr;
     attr.id = SAI_VLAN_ATTR_VLAN_ID;
     attr.value.u16 = vlan_id;
-    sai_status_t status = sai_vlan_api->create_vlan(&vlan_oid, gSwitchId, 1, &attr);
+    attrs.push_back(attr);
+
+    /* SAI support is yet to be added for vlan_type attribute.
+     * For now, we can use SAI_VLAN_ATTR_META_DATA attr_id with
+     * hard-coded values. New enums yet to be introduced in SAI
+     * for values
+     *  0 = data (default)
+     *  1 = management
+     *  2 = control
+     *  Change this code once attribute and enums introduced in saivlan.h
+     *  */
+    if(vlan_type != "")
+    {
+        attr.id = SAI_VLAN_ATTR_META_DATA;
+        if(vlan_type == "management")
+        {
+            attr.value.u32 = 1;
+        }
+        else if(vlan_type == "control")
+        {
+            attr.value.u32 = 2;
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Invalid Vlan mode %s vid:%hu", vlan_type.c_str(), vlan_id);
+            return false;
+        }
+        attrs.push_back(attr);
+    }
+    sai_status_t status = sai_vlan_api->create_vlan(&vlan_oid, gSwitchId, (uint32_t)attrs.size(), attrs.data());
 
     if (status != SAI_STATUS_SUCCESS)
     {

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3246,14 +3246,14 @@ bool PortsOrch::addVlan(string vlan_alias, string vlan_type)
      *  2 = control
      *  Change this code once attribute and enums introduced in saivlan.h
      *  */
-    if(vlan_type != "")
+    if (!vlan_type.empty())
     {
         attr.id = SAI_VLAN_ATTR_META_DATA;
-        if(vlan_type == "management")
+        if (vlan_type == "management")
         {
             attr.value.u32 = 1;
         }
-        else if(vlan_type == "control")
+        else if (vlan_type == "control")
         {
             attr.value.u32 = 2;
         }

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -195,7 +195,7 @@ private:
     bool removeBridgePort(Port &port);
     bool setBridgePortLearnMode(Port &port, string learn_mode);
 
-    bool addVlan(string vlan);
+    bool addVlan(string vlan, string vlan_type);
     bool removeVlan(Port vlan);
     bool addVlanMember(Port &vlan, Port &port, string& tagging_mode);
     bool removeVlanMember(Port &vlan, Port &port);


### PR DESCRIPTION
vlan type - data/mananagement/control

PR : https://github.com/Azure/sonic-utilities/pull/956
Purpose is to identify the vlan type. This is optional configuration.
If not set, it will be treated as regular ("data") vlan (current behavior).
Note: SAI PR is separately raised and not merged.
Meanwhile, we have hard-coded the values. This can be fixed once SAI PR is merged.

Signed-off-by: Rajkumar Pennadam Ramamoorthy <rpennadamram@marvell.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added SWSS support for new vlan enhancement. type - management/control
**Why I did it**
We have a use-case to differentiate managament and control traffic from regular data-traffic in data path.
**How I verified it**
configure the command from cli. Check CONFIG_DB,APP_DB and ASIC_DB for "vlan_type" value.
**Details if related**
Details of CLI command can be found in PR, https://github.com/Azure/sonic-utilities/pull/956