### PR TITLE
Orchagent not to exit upon shutdown message from syncd

### DIFF
--- a/orchagent/notifications.cpp
+++ b/orchagent/notifications.cpp
@@ -5,7 +5,7 @@ extern "C" {
 #include "logger.h"
 #include "notifications.h"
 
-extern bool gIsSwitchShutdown
+extern bool gIsSwitchShutdown;
 
 void on_fdb_event(uint32_t count, sai_fdb_event_notification_data_t *data)
 {
@@ -23,7 +23,6 @@ void on_switch_shutdown_request()
 {
     SWSS_LOG_ENTER();
 
-    /* TODO: Later a better restart story will be told here */
     SWSS_LOG_ERROR("Syncd stopped");
 
     gIsSwitchShutdown = true;

--- a/orchagent/notifications.cpp
+++ b/orchagent/notifications.cpp
@@ -5,6 +5,8 @@ extern "C" {
 #include "logger.h"
 #include "notifications.h"
 
+extern bool gIsSwitchShutdown
+
 void on_fdb_event(uint32_t count, sai_fdb_event_notification_data_t *data)
 {
     // don't use this event handler, because it runs by libsairedis in a separate thread
@@ -24,5 +26,5 @@ void on_switch_shutdown_request()
     /* TODO: Later a better restart story will be told here */
     SWSS_LOG_ERROR("Syncd stopped");
 
-    exit(EXIT_FAILURE);
+    gIsSwitchShutdown = true;
 }

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -16,6 +16,7 @@ using namespace swss;
 /* select() function timeout retry time */
 #define SELECT_TIMEOUT 1000
 #define PFC_WD_POLL_MSECS 100
+#define SWITCH_SHUTDOWN_LOG_INTERVAL_IN_SECS 60
 
 extern sai_switch_api_t*           sai_switch_api;
 extern sai_object_id_t             gSwitchId;
@@ -38,8 +39,6 @@ Directory<Orch*> gDirectory;
 NatOrch *gNatOrch;
 
 bool gIsNatSupported = false;
-
-#define SWITCH_SHUTDOWN_LOG_INTERVAL_IN_SECS 60
 bool gIsSwitchShutdown = false;
 
 
@@ -521,8 +520,6 @@ void OrchDaemon::start()
             static time_t last_log = 0;
 
             if ((time(NULL) - last_log) > SWITCH_SHUTDOWN_LOG_INTERVAL_IN_SECS) {
-                SWSS_LOG_ENTER();
-
                 SWSS_LOG_ERROR("Syncd stopped");
 
                 last_log = time(NULL)

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -39,6 +39,10 @@ NatOrch *gNatOrch;
 
 bool gIsNatSupported = false;
 
+#define SWITCH_SHUTDOWN_LOG_INTERVAL_IN_SECS 60
+bool gIsSwitchShutdown = false;
+
+
 OrchDaemon::OrchDaemon(DBConnector *applDb, DBConnector *configDb, DBConnector *stateDb) :
         m_applDb(applDb),
         m_configDb(configDb),
@@ -513,6 +517,19 @@ void OrchDaemon::start()
                 }
             }
         }
+        if (gIsSwitchShutdown) {
+            static time_t last_log = 0;
+
+            if ((time(NULL) - last_log) > SWITCH_SHUTDOWN_LOG_INTERVAL_IN_SECS) {
+                SWSS_LOG_ENTER();
+
+                SWSS_LOG_ERROR("Syncd stopped");
+
+                last_log = time(NULL)
+            }
+
+        }
+
     }
 }
 

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -522,7 +522,7 @@ void OrchDaemon::start()
             if ((time(NULL) - last_log) > SWITCH_SHUTDOWN_LOG_INTERVAL_IN_SECS) {
                 SWSS_LOG_ERROR("Syncd stopped");
 
-                last_log = time(NULL)
+                last_log = time(NULL);
             }
 
         }

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -672,8 +672,10 @@ OrchDaemon::checkAndExit()
     swss::Table tbl(m_configDb, "CONTAINER_FEATURE");
     string val;
 
-    if (tbl.hget("swss", "orchagent_exit_on_switch_shutdown", val)) {
-        if (val == "enable") {
+    if (tbl.hget("swss", "orchagent_exit_on_switch_shutdown", val))
+    {
+        if (val == "enable")
+        {
             SWSS_LOG_ERROR("Exiting....");
             exit(EXIT_FAILURE);
         }
@@ -685,7 +687,8 @@ OrchDaemon::handleSwitchShutdown()
 {
     SWSS_LOG_ENTER();
 
-    while(true) {
+    while(true)
+    {
         checkAndExit();
         SWSS_LOG_ERROR("Syncd stopped");
         sleep(SWITCH_SHUTDOWN_LOG_INTERVAL_IN_SECS);

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -57,8 +57,8 @@ private:
 
     void flush();
 
-    void handle_switch_shutdown();
-    void check_and_exit();
+    void handleSwitchShutdown();
+    void checkAndExit();
 };
 
 #endif /* SWSS_ORCHDAEMON_H */

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -56,6 +56,9 @@ private:
     Select *m_select;
 
     void flush();
+
+    void handle_switch_shutdown();
+    void check_and_exit();
 };
 
 #endif /* SWSS_ORCHDAEMON_H */


### PR DESCRIPTION
When orchagent receives shutdown message from syncd, it exits, which triggers
some chain of events that result in swss restart. Change this default behavior as
not to exit, but repeatedly log "switcch down" error message, which can raise an
alert for a manual repair.

**Justification:**
When orchagent exits, the chain reaction triggers the entire restart of swss.
But depending on the root-cause of syncd's reason to exit, the swss-restart
may not solve the problem, but put the system in repeated cycle of restart.

Instead if we leave orchagent running with error log, someone can manually
root cause the reason for syncd exit, fix the root cause,  and then restart
swss,  which has higher probability to come up fine. Moreover, until the manual
intervention, the data traffic  would be moving unaffected. The manual fix would
also involve, safety checks and isolate the device, before making any fixes.
Hence the issue can be fixed clean with least disruption.

On the other hand, until manual fix, no new rules can be applied to data-traffic.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
