### PR TITLE
[copp] Add ISIS, LDP and micro-BFD trap types to CoPP manager

### DIFF
--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -58,6 +58,7 @@ static map<string, sai_hostif_trap_type_t> trap_id_map = {
     {"bgp", SAI_HOSTIF_TRAP_TYPE_BGP},
     {"dhcpv6", SAI_HOSTIF_TRAP_TYPE_DHCPV6},
     {"ospfv6", SAI_HOSTIF_TRAP_TYPE_OSPFV6},
+    {"isis", SAI_HOSTIF_TRAP_TYPE_ISIS},
     {"vrrpv6", SAI_HOSTIF_TRAP_TYPE_VRRPV6},
     {"bgpv6", SAI_HOSTIF_TRAP_TYPE_BGPV6},
     {"neigh_discovery", SAI_HOSTIF_TRAP_TYPE_IPV6_NEIGHBOR_DISCOVERY},
@@ -75,7 +76,10 @@ static map<string, sai_hostif_trap_type_t> trap_id_map = {
     {"bfd", SAI_HOSTIF_TRAP_TYPE_BFD},
     {"bfdv6", SAI_HOSTIF_TRAP_TYPE_BFDV6},
     {"src_nat_miss", SAI_HOSTIF_TRAP_TYPE_SNAT_MISS},
-    {"dest_nat_miss", SAI_HOSTIF_TRAP_TYPE_DNAT_MISS}
+    {"dest_nat_miss", SAI_HOSTIF_TRAP_TYPE_DNAT_MISS},
+    {"ldp", SAI_HOSTIF_TRAP_TYPE_LDP},
+    {"bfd_micro", SAI_HOSTIF_TRAP_TYPE_BFD_MICRO},
+    {"bfdv6_micro", SAI_HOSTIF_TRAP_TYPE_BFDV6_MICRO}
 };
 
 static map<string, sai_packet_action_t> packet_action_map = {
@@ -519,7 +523,7 @@ task_process_status CoppOrch::processCoppRule(Consumer& consumer)
                                     policer_attribs, genetlink_attribs))
         {
             return task_process_status::task_invalid_entry;
-        } 
+        }
 
         /* Set host interface trap group */
         if (m_trap_group_map.find(trap_group_name) != m_trap_group_map.end())
@@ -583,7 +587,7 @@ task_process_status CoppOrch::processCoppRule(Consumer& consumer)
                     if (sai_status != SAI_STATUS_SUCCESS)
                     {
                         SWSS_LOG_ERROR("Failed to set attribute %d on trap %" PRIx64 ""
-                                " on group %s", i.id, m_syncdTrapIds[trap_id].trap_obj, 
+                                " on group %s", i.id, m_syncdTrapIds[trap_id].trap_obj,
                                 trap_group_name.c_str());
                         task_process_status handle_status = handleSaiSetStatus(SAI_API_HOSTIF, sai_status);
                         if (handle_status != task_process_status::task_success)
@@ -601,10 +605,10 @@ task_process_status CoppOrch::processCoppRule(Consumer& consumer)
         }
         if (!genetlink_attribs.empty())
         {
-            if (m_trap_group_hostif_map.find(m_trap_group_map[trap_group_name]) != 
+            if (m_trap_group_hostif_map.find(m_trap_group_map[trap_group_name]) !=
                     m_trap_group_hostif_map.end())
             {
-                SWSS_LOG_ERROR("Genetlink hostif exists for the trap group %s", 
+                SWSS_LOG_ERROR("Genetlink hostif exists for the trap group %s",
                                trap_group_name.c_str());
                 return task_process_status::task_failed;
             }
@@ -800,7 +804,7 @@ bool CoppOrch::trapGroupProcessTrapIdChange (string trap_group_name,
             SWSS_LOG_ERROR("Failed to set traps to trap group %s", trap_group_name.c_str());
             return false;
         }
-        if (m_trap_group_hostif_map.find(m_trap_group_map[trap_group_name]) != 
+        if (m_trap_group_hostif_map.find(m_trap_group_map[trap_group_name]) !=
                                          m_trap_group_hostif_map.end())
         {
             if (!createGenetlinkHostIfTable(add_trap_ids))
@@ -819,7 +823,7 @@ bool CoppOrch::trapGroupProcessTrapIdChange (string trap_group_name,
                  * A trap ID will be present in rem_trap_id in two scenarios
                  * 1) When trap group for a trap ID is changed
                  * 2) When trap ID is completely removed
-                 * In case 1 the first call would be to add the trap ids to a different 
+                 * In case 1 the first call would be to add the trap ids to a different
                  * group. This would result in changing the mapping of trap id to trap group
                  * In case 2 the mapping will remain the same. In this case the trap
                  * object needs to be deleted
@@ -830,7 +834,7 @@ bool CoppOrch::trapGroupProcessTrapIdChange (string trap_group_name,
                                                                     m_syncdTrapIds[i].trap_obj);
                     if (sai_status != SAI_STATUS_SUCCESS)
                     {
-                        SWSS_LOG_ERROR("Failed to remove trap object %" PRId64 "", 
+                        SWSS_LOG_ERROR("Failed to remove trap object %" PRId64 "",
                                        m_syncdTrapIds[i].trap_obj);
                         task_process_status handle_status = handleSaiRemoveStatus(SAI_API_HOSTIF, sai_status);
                         if (handle_status != task_success)
@@ -1092,4 +1096,3 @@ bool CoppOrch::trapGroupUpdatePolicer (string trap_group_name,
     }
     return true;
 }
-

--- a/tests/test_copp.py
+++ b/tests/test_copp.py
@@ -50,6 +50,7 @@ traps_to_trap_type = {
         "bgp": "SAI_HOSTIF_TRAP_TYPE_BGP",
         "dhcpv6": "SAI_HOSTIF_TRAP_TYPE_DHCPV6",
         "ospfv6": "SAI_HOSTIF_TRAP_TYPE_OSPFV6",
+        "isis": "SAI_HOSTIF_TRAP_TYPE_ISIS",
         "vrrpv6": "SAI_HOSTIF_TRAP_TYPE_VRRPV6",
         "bgpv6": "SAI_HOSTIF_TRAP_TYPE_BGPV6",
         "neigh_discovery": "SAI_HOSTIF_TRAP_TYPE_IPV6_NEIGHBOR_DISCOVERY",
@@ -67,7 +68,10 @@ traps_to_trap_type = {
         "bfd": "SAI_HOSTIF_TRAP_TYPE_BFD",
         "bfdv6": "SAI_HOSTIF_TRAP_TYPE_BFDV6",
         "src_nat_miss": "SAI_HOSTIF_TRAP_TYPE_SNAT_MISS",
-        "dest_nat_miss": "SAI_HOSTIF_TRAP_TYPE_DNAT_MISS"
+        "dest_nat_miss": "SAI_HOSTIF_TRAP_TYPE_DNAT_MISS",
+        "ldp": "SAI_HOSTIF_TRAP_TYPE_LDP",
+        "bfd_micro": "SAI_HOSTIF_TRAP_TYPE_BFD_MICRO",
+        "bfdv6_micro": "SAI_HOSTIF_TRAP_TYPE_BFDV6_MICRO"
         }
 
 copp_group_default = {
@@ -201,12 +205,12 @@ class TestCopp(object):
         self.feature_tbl.set("sflow", fvs)
         time.sleep(2)
 
-   
+
     def validate_policer(self, policer_oid, field, value):
         (status, fvs) = self.policer_atbl.get(policer_oid)
         assert status == True
         attr = field_to_sai_attr[field]
-        
+
         attr_value = value
         if field == "mode":
             attr_value = policer_mode_map[value]
@@ -218,7 +222,7 @@ class TestCopp(object):
         for fv in fvs:
             if (fv[0] == attr):
                 assert attr_value == fv[1]
-                
+
     def validate_trap_group(self, trap_oid, trap_group):
         (status, trap_fvs) = self.trap_atbl.get(trap_oid)
         assert status == True
@@ -244,11 +248,11 @@ class TestCopp(object):
                     policer_oid = fv[1]
                 elif fv[0] == "SAI_HOSTIF_TRAP_GROUP_ATTR_QUEUE":
                     queue = fv[1]
-                
+
         for keys in trap_group:
             obj_type = field_to_sai_obj_type[keys]
             if obj_type == "SAI_OBJECT_TYPE_POLICER":
-                assert policer_oid != "" 
+                assert policer_oid != ""
                 assert policer_oid != "oid:0x0"
                 self.validate_policer(policer_oid, keys, trap_group[keys])
 
@@ -267,7 +271,7 @@ class TestCopp(object):
                     assert trap_priority == trap_group[keys]
 
             elif obj_type == "SAI_OBJECT_TYPE_HOSTIF":
-                host_tbl_keys = self.hostiftbl_atbl.getKeys();
+                host_tbl_keys = self.hostiftbl_atbl.getKeys()
                 host_tbl_key = None
                 for host_tbl_entry in host_tbl_keys:
                     (status, fvs) = self.hostiftbl_atbl.get(host_tbl_entry)
@@ -334,7 +338,7 @@ class TestCopp(object):
             if "sample_packet" not in trap_ids:
                 continue
             trap_group = copp_trap[traps]
-            trap_found = False 
+            trap_found = False
             trap_type = traps_to_trap_type["sample_packet"]
             for key in trap_keys:
                 (status, fvs) = self.trap_atbl.get(key)
@@ -498,8 +502,8 @@ class TestCopp(object):
     def test_new_trap_add(self, dvs, testlog):
         self.setup_copp(dvs)
         global copp_trap
-        traps = "eapol"
-        fvs = swsscommon.FieldValuePairs([("trap_group", "queue1_group2"),("trap_ids", "eapol")])
+        traps = "eapol,isis,bfd_micro,bfdv6_micro,ldp"
+        fvs = swsscommon.FieldValuePairs([("trap_group", "queue1_group2"),("trap_ids", traps)])
         self.trap_ctbl.set(traps, fvs)
         copp_trap[traps] = copp_group_queue1_group2
         time.sleep(2)
@@ -527,8 +531,8 @@ class TestCopp(object):
     def test_new_trap_del(self, dvs, testlog):
         self.setup_copp(dvs)
         global copp_trap
-        traps = "eapol"
-        fvs = swsscommon.FieldValuePairs([("trap_group", "queue1_group2"),("trap_ids", "eapol")])
+        traps = "eapol,isis,bfd_micro,bfdv6_micro,ldp"
+        fvs = swsscommon.FieldValuePairs([("trap_group", "queue1_group2"),("trap_ids", traps)])
         self.trap_ctbl.set(traps, fvs)
         copp_trap[traps] = copp_group_queue1_group2
         time.sleep(2)


### PR DESCRIPTION
* Add ISIS, LDP and micro-BFD traps to copp

* Removed unnecessary pytest markup which was skipping the copp UTs

* Add UTs for the new traps

Signed-off-by: Alexandru Banu <v-albanu@microsoft.com>

**What I did**
I've added ISIS, LDP and micro-BFD trap types to copp and enabled the copp UTs.

**Why I did it**
To enable ISIS, LDP and micro-BFD traps. The latter two have been added to SAI in https://github.com/opencomputeproject/SAI/commit/516406550d2069be943c8d7fc19bf672b5ced763.

**How I verified it**
Updated the existing `test_copp.py` to include the new traps.

**Details if related**
