### PR TITLE
[fabricportsorch] Collect counters for fabric links

### DIFF
--- a/orchagent/fabricportsorch.h
+++ b/orchagent/fabricportsorch.h
@@ -12,18 +12,22 @@
 class FabricPortsOrch : public Orch, public Subject
 {
 public:
-    FabricPortsOrch(DBConnector *appl_db, vector<table_name_with_pri_t> &tableNames);
+    FabricPortsOrch(DBConnector *appl_db, vector<table_name_with_pri_t> &tableNames,
+                    bool fabricPortStatEnabled=true, bool fabricQueueStatEnabled=true);
     bool allPortsReady();
     void generateQueueStats();
 
 private:
+    bool m_fabricPortStatEnabled;
+    bool m_fabricQueueStatEnabled;
+
     shared_ptr<DBConnector> m_state_db;
     shared_ptr<DBConnector> m_counter_db;
     shared_ptr<DBConnector> m_flex_db;
 
     unique_ptr<Table> m_stateTable;
-    unique_ptr<Table> m_laneQueueCounterTable;
-    unique_ptr<Table> m_lanePortCounterTable;
+    unique_ptr<Table> m_portNameQueueCounterTable;
+    unique_ptr<Table> m_portNamePortCounterTable;
     unique_ptr<ProducerTable> m_flexCounterTable;
 
     swss::SelectableTimer *m_timer = nullptr;

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -708,6 +708,9 @@ int main(int argc, char **argv)
         if (gMySwitchType == "voq")
         {
             orchDaemon->setFabricEnabled(true);
+            // SAI doesn't fully support counters for non fabric asics
+            orchDaemon->setFabricPortStatEnabled(false);
+            orchDaemon->setFabricQueueStatEnabled(false);
         }
     }
     else

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -459,7 +459,7 @@ bool OrchDaemon::init()
         vector<table_name_with_pri_t> fabric_port_tables = {
            // empty for now
         };
-        gFabricPortsOrch = new FabricPortsOrch(m_applDb, fabric_port_tables);
+        gFabricPortsOrch = new FabricPortsOrch(m_applDb, fabric_port_tables, m_fabricPortStatEnabled, m_fabricQueueStatEnabled);
         m_orchList.push_back(gFabricPortsOrch);
     }
 

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -69,6 +69,14 @@ public:
     {
         m_fabricEnabled = enabled;
     }
+    void setFabricPortStatEnabled(bool enabled)
+    {
+        m_fabricPortStatEnabled = enabled;
+    }
+    void setFabricQueueStatEnabled(bool enabled)
+    {
+        m_fabricQueueStatEnabled = enabled;
+    }
     void logRotate();
 private:
     DBConnector *m_applDb;
@@ -77,6 +85,8 @@ private:
     DBConnector *m_chassisAppDb;
 
     bool m_fabricEnabled = false;
+    bool m_fabricPortStatEnabled = true;
+    bool m_fabricQueueStatEnabled = true;
 
     std::vector<Orch *> m_orchList;
     Select *m_select;

--- a/tests/test_fabric.py
+++ b/tests/test_fabric.py
@@ -1,0 +1,83 @@
+from swsscommon import swsscommon
+from dvslib.dvs_database import DVSDatabase
+import ast
+import json
+
+# Fabric counters
+NUMBER_OF_RETRIES = 10
+
+counter_group_meta = {
+    'fabric_port_counter': {
+        'key': 'FABRIC_PORT',
+        'group_name': 'FABRIC_PORT_STAT_COUNTER',
+        'name_map': 'COUNTERS_FABRIC_PORT_NAME_MAP',
+        'post_test':  'post_port_counter_test',
+    },
+    'fabric_queue_counter': {
+        'key': 'FABRIC_QUEUE',
+        'group_name': 'FABRIC_QUEUE_STAT_COUNTER',
+        'name_map': 'COUNTERS_FABRIC_QUEUE_NAME_MAP',
+    },
+}
+
+class TestVirtualChassis(object):
+
+    def wait_for_id_list(self, flex_db, stat, name, oid):
+        for retry in range(NUMBER_OF_RETRIES):
+            id_list = flex_db.db_connection.hgetall("FLEX_COUNTER_TABLE:" + stat + ":" + oid).items()
+            if len(id_list) > 0:
+                return
+            else:
+                time.sleep(1)
+
+        assert False, "No ID list for counter " + str(name)
+
+    def verify_flex_counters_populated(self, flex_db, counters_db, map, stat):
+        counters_keys = counters_db.db_connection.hgetall(map)
+        for counter_entry in counters_keys.items():
+            name = counter_entry[0]
+            oid = counter_entry[1]
+            self.wait_for_id_list(flex_db, stat, name, oid)
+
+    def test_voq_switch(self, vst):
+        """Test VOQ switch objects configuration.
+
+        This test validates configuration of switch creation objects required for
+        VOQ switches. The switch_type, max_cores and switch_id attributes configuration
+        are verified. For the System port config list, it is verified that all the
+        configured system ports are avaiable in the asic db by checking the count.
+        """
+
+        if vst is None:
+            return
+
+        dvss = vst.dvss
+        for name in dvss.keys():
+            dvs = dvss[name]
+            # Get the config info
+            config_db = dvs.get_config_db()
+            metatbl = config_db.get_entry("DEVICE_METADATA", "localhost")
+
+            cfg_switch_type = metatbl.get("switch_type")
+            if cfg_switch_type == "fabric":
+               flex_db = dvs.get_flex_db()
+               counters_db = dvs.get_counters_db()
+               for ct in counter_group_meta.keys():
+                  meta_data = counter_group_meta[ct]
+                  counter_key = meta_data['key']
+                  counter_stat = meta_data['group_name']
+                  counter_map = meta_data['name_map']
+                  self.verify_flex_counters_populated(flex_db, counters_db, counter_map, counter_stat)
+
+                  port_counters_keys = counters_db.db_connection.hgetall(meta_data['name_map'])
+                  port_counters_stat_keys = flex_db.get_keys("FLEX_COUNTER_TABLE:" + meta_data['group_name'])
+                  for port_stat in port_counters_stat_keys:
+                     assert port_stat in dict(port_counters_keys.items()).values(), "Non port created on PORT_STAT_COUNTER group: {}".format(port_stat)
+            else:
+               print( "We do not check switch type:", cfg_switch_type )
+
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass
+

--- a/tests/virtual_chassis/8/default_config.json
+++ b/tests/virtual_chassis/8/default_config.json
@@ -1,0 +1,13 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "hostname": "supervisor",
+            "chassis_db_address" : "10.8.1.200",
+            "inband_address" : "10.8.1.200/24",
+            "switch_type": "fabric",
+            "sub_role" : "BackEnd",
+            "start_chassis_db" : "1",
+            "comment" : "default_config for a vs that runs chassis_db"
+        }
+    }
+}

--- a/tests/virtual_chassis/chassis_supervisor.json
+++ b/tests/virtual_chassis/chassis_supervisor.json
@@ -1,0 +1,5 @@
+{
+    "VIRTUAL_TOPOLOGY": {
+        "chassis_instances" : [ "8", "1", "2", "3" ]
+    }
+}


### PR DESCRIPTION
This change is enabling collections of fabric link counters as port and queue stats.

Currently only fabric asics can be collected, so collection is disabled for switch asics.
The reasons are that BCM SAI supports up to 256 logical ports, which is not enough
for ports + fabric lanes, and fabric queue counters are not supported by SAI at
this moment.

The following sonic-swss-common PR is required: [PR #551](https://github.com/Azure/sonic-swss-common/pull/551)
sonic-utilities [PR #1860](https://github.com/Azure/sonic-utilities/pull/1860) adds the
corresponding `show fabric counters` CLI command.
