### PR TITLE
[pytest]: Check for duplicate intfs when creating servers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,6 +183,12 @@ class VirtualServer:
                 f"ip netns exec {self.nsname} ip link add {self.nsname[0:12]}"
                 f" type veth peer name {self.pifname}"
             )
+
+            # ensure self.pifname is not already an interface in the DVS net namespace
+            rc, _ = subprocess.getstatusoutput(f"nsenter -t {pid} -n ip link show | grep '{self.pifname}@'")
+            if not rc:
+                ensure_system(f"nsenter -t {pid} -n ip link delete {self.pifname}")
+
             ensure_system(f"ip netns exec {self.nsname} ip link set {self.pifname} netns {pid}")
 
             # bring up link in the virtual server


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When creating virtual servers, before a network interface into the DVS network namespace, check if that interface name is already used in the DVS namespace. If it is, delete it before moving the new interface.

**Why I did it**
When deleting virtual servers during test teardown, sometimes the tunnel interface in the DVS associated with a server is not deleted (happens if the connected host interface was used/brought up during the test). Thus, when creating new virtual servers for the next test module, the leftover interface will conflict with a new interface.

**How I verified it**

**Details if related**
