### PR TITLE
[macsecmgr]: Add rekey period in macsec mgr

### DIFF
--- a/cfgmgr/macsecmgr.cpp
+++ b/cfgmgr/macsecmgr.cpp
@@ -718,7 +718,7 @@ bool MACsecMgr::configureMACsec(
                 session.sock,
                 port_name,
                 network_id,
-                "macsec_rekey_period",
+                "mka_rekey_period",
                 profile.rekey_period);
         }
 


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Expose mka rekey option to config db

**Why I did it**
This feature is needed

**How I verified it**
Run 
```
redis-cli -n 4 hmset "MACSEC_PROFILE|test_profile" "priority" "64" "cipher_suite" "GCM-AES-128" "primary_cak" "0123456789ABCDEF0123456789ABCDEF" "primary_ckn" "6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435" "fallback_cak" "" "fallback_ckn" "" "policy" "security" "enable_replay_protect" "0" "replay_window" "0" "send_sci" "1" "rekey_period" "10"

redis-cli -n 4 hmset "PORT|Ethernet0" "macsec" "test_profile"
```
The SAK should be proactively refresh about 10 seconds

**Details if related**
