### PR TITLE
[vlanmgr]: Update "bridge vlan show" to support iproute5.10

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -237,7 +237,7 @@ bool VlanMgr::removeHostVlanMember(int vlan_id, const string &port_alias)
 
     // The command should be generated as:
     // /bin/bash -c '/sbin/bridge vlan del vid {{vlan_id}} dev {{port_alias}} &&
-    //               ( /sbin/bridge vlan show dev {{port_alias}} | /bin/grep -q None;
+    //               ( /sbin/bridge vlan show dev {{port_alias}} | /bin/grep -q -v {{port_alias}};
     //               ret=$?; if [ $ret -eq 0 ]; then
     //               /sbin/ip link set {{port_alias}} nomaster;
     //               elif [ $ret -eq 1 ]; then exit 0;
@@ -247,7 +247,7 @@ bool VlanMgr::removeHostVlanMember(int vlan_id, const string &port_alias)
     ostringstream cmds, inner;
     inner << BRIDGE_CMD " vlan del vid " + std::to_string(vlan_id) + " dev " << shellquote(port_alias) << " && ( "
       BRIDGE_CMD " vlan show dev " << shellquote(port_alias) << " | "
-      GREP_CMD " -q None; ret=$?; if [ $ret -eq 0 ]; then "
+      GREP_CMD " -q -v " << shellquote(port_alias) << "; ret=$?; if [ $ret -eq 0 ]; then "
       IP_CMD " link set " << shellquote(port_alias) << " nomaster; "
       "elif [ $ret -eq 1 ]; then exit 0; "
       "else exit $ret; fi )";


### PR DESCRIPTION
If a device isn't member of any VLAN, it will show
In iproute 4.9 shows
```
port              vlan-id
Ethernet0         None
```

In iproute 5.10 shows
```
port              vlan-id
```

Signed-off-by: Ubuntu <zegan@zegan-test-hk.0y0yh0pwahvetntlrcfftojvof.hx.internal.cloudapp.net>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Update vlanmgr to support iproute5.10

**Why I did it**
The interface `nomaster`  cannot be set when remove host vlan member

**How I verified it**
Check Azp status

**Details if related**
