### PR TITLE
Update VLAN removal code to work with 5.10 kernel and newer iproute2 versions

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -252,7 +252,7 @@ bool VlanMgr::removeHostVlanMember(int vlan_id, const string &port_alias)
     inner << BRIDGE_CMD " vlan del vid " + std::to_string(vlan_id) + " dev " << shellquote(port_alias) << " && ( "
       "vlanShow=$(" BRIDGE_CMD " vlan show dev " << shellquote(port_alias) << "); "
       "ret=$?; "
-      "if [ $ret -eq 0 ]; then"
+      "if [ $ret -eq 0 ]; then "
       "if (! echo \"$vlanShow\" | " GREP_CMD " -q " << shellquote(port_alias) << ") "
       " || (echo \"$vlanShow\" | " GREP_CMD " -q None$) "
       " || (echo \"$vlanShow\" | " GREP_CMD " -q " << shellquote(port_alias) << "$); then "


### PR DESCRIPTION
There is an issue discovered by Alexander Allen where VLAN member
removal from a VLAN doesn't fully happen on a 5.10 kernel. The reason
for this is that there is a change in the output of the `bridge vlan
show` command between the 4.19 kernel and the 5.10 kernel. To add to
this, the output is different depending on whether iproute2 4.20 or
iproute2 5.10 is installed. These output changes cause only some of the
VLAN member removal code to run; specifically, the interface will not be
the member of a VLAN anymore, but it will still be part of the bridge.

Therefore, update the code that parses the output of `bridge vlan show`
to handle iproute2 4.20 with 4.19 kernel, iproute2 4.20 with 5.10
kernel, and iproute2 5.10 with 5.10 kernel. This should cover all
possible combinations we'll have until all containers are on Bullseye.

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

Tested on virtual switch image with:
* iproute2 4.20 with 4.19 kernel
* iproute2 4.20 with 5.10 kernel
* iproute2 5.10 with 5.10 kernel

**Details if related**
