### PR TITLE
[copp] add dhcpv6 copp rules

### DIFF
--- a/debian/swss.install
+++ b/debian/swss.install
@@ -1,3 +1,4 @@
 swssconfig/sample/netbouncer.json etc/swss/config.d
 swssconfig/sample/00-copp.config.json etc/swss/config.d
+swssconfig/sample/01-copp-dhcpv6.config.json etc/swss/config.d
 neighsyncd/restore_neighbors.py usr/bin

--- a/swssconfig/sample/01-copp-dhcpv6.config.json
+++ b/swssconfig/sample/01-copp-dhcpv6.config.json
@@ -1,0 +1,11 @@
+[
+    {
+        "COPP_TABLE:trap.group.dhcpv6": {
+            "trap_ids": "dhcpv6",
+            "trap_action":"trap",
+            "trap_priority":"4",
+            "queue": "4"
+        },
+        "OP": "SET"
+    }
+]


### PR DESCRIPTION
**What I did**
Add secondary COPP config file to enable DHCP V6

**Why I did it**
Need to enable DHCP V6

**How I verified it**
Warm reboot from a version without it to a version with it.
Warm reboot from a version with it to same version.
Cold reboot.

In all 3 cases, dhcp v6 rules are correctly installed.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
