### PR TITLE
[pytest]: Check if appl DB exists before deleting

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -410,9 +410,14 @@ class DockerVirtualSwitch:
         self.flex_db = None
         self.state_db = None
 
-    def destroy(self) -> None:
+    def del_appl_db(self):
+        # APPL DB may not always exist, so use this helper method to check before deleting
         if getattr(self, 'appldb', False):
             del self.appldb
+
+
+    def destroy(self) -> None:
+        self.del_appl_db()
 
         # In case persistent dvs was used removed all the extra server link
         # that were created
@@ -583,8 +588,7 @@ class DockerVirtualSwitch:
         self.ctn.restart()
 
     def restart(self) -> None:
-        if self.appldb:
-            del self.appldb
+        self.del_appl_db()
 
         self.ctn_restart()
         self.check_ready_status_and_init_db()


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add a new helper method for deleting appl DBs, and use it anytime appl DB needs to be deleted

**Why I did it**
If appl DB doesn't exist, statements such as `if self.appldb:` will throw an error

**How I verified it**

**Details if related**
