### PR TITLE
Set tunnel id to saiOidToAlias for support update tunnel status.

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -65,7 +65,6 @@ bool FdbOrch::bake()
     return true;
 }
 
-
 bool FdbOrch::storeFdbEntryState(const FdbUpdate& update)
 {
     const FdbEntry& entry = update.entry;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -5347,7 +5347,10 @@ bool PortsOrch::addTunnel(string tunnel_alias, sai_object_id_t tunnel_id, bool h
     {
         tunnel.m_learn_mode = "disable";
     }
+
+    tunnel.m_oper_status = SAI_PORT_OPER_STATUS_DOWN;
     m_portList[tunnel_alias] = tunnel;
+    saiOidToAlias[tunnel_id] = tunnel_alias;
 
     SWSS_LOG_INFO("addTunnel:: %" PRIx64, tunnel_id);
 
@@ -5358,6 +5361,7 @@ bool PortsOrch::removeTunnel(Port tunnel)
 {
     SWSS_LOG_ENTER();
 
+    saiOidToAlias.erase(tunnel.m_tunnel_id);
     m_portList.erase(tunnel.m_alias);
 
     return true;
@@ -5631,7 +5635,7 @@ void PortsOrch::updatePortOperStatus(Port &port, sai_port_oper_status_t status)
         return;
     }
 
-    if (port.m_type == Port::PHY)
+    if (port.m_type == Port::PHY || port.m_type == Port::TUNNEL)
     {
         updateDbPortOperStatus(port, status);
     }

--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -299,7 +299,7 @@ create_tunnel(
           num_map++;
       }
     }
-      
+
     attr.id = SAI_TUNNEL_ATTR_DECAP_MAPPERS;
     attr.value.objlist.count = num_map;
     attr.value.objlist.list = map_list;
@@ -1536,7 +1536,7 @@ bool VxlanTunnelOrch::removeVxlanTunnelMap(string tunnelName, uint32_t vni)
         return false;
     }
 
-    // Update the map count and if this is the last mapping entry 
+    // Update the map count and if this is the last mapping entry
     // make SAI calls to delete the tunnel and tunnel termination objects.
 
     tunnel_obj->vlan_vrf_vni_count--;
@@ -1730,6 +1730,7 @@ bool  VxlanTunnelOrch::delTunnelUser(const std::string remote_vtep, uint32_t vni
 
     port_tunnel_name = getTunnelPortName(remote_vtep);
     gPortsOrch->getPort(port_tunnel_name,tunnelPort);
+
     if ((vtep_ptr->getRemoteEndPointRefCnt(remote_vtep) == 1) &&
        tunnelPort.m_fdb_count == 0)
     {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
1.Set tunnel id to saiOidToAlias for support update tunnel status.
2. if create tunnel port successfully notify change tunnel port status from down to up 
**Why I did it**
update tunnel status 
admin@as7726-32x-2:~$ show vxlan remotevtep
+-----------+-----------+-------------------+--------------+
| SIP             | DIP           | Creation Source   | OperStatus   |
+===========+===========+===================+==============+
| 10.1.0.32    | 10.0.0.65  | EVPN                    | oper_up      |
+-----------+-----------+-------------------+--------------+
Total count : 1

**How I verified it**
1.create l2 vni environment
2.check tunnel status "show vxlan remotevtep"
3.check syslog
~~~
/var/log/syslog.1:Dec 14 10:25:43.929560 as7726-32x-2 NOTICE swss#orchagent: :- createDynamicDIPTunnel: Created P2P Tunnel remote IP 10.0.0.65
/var/log/syslog.1:Dec 14 10:25:43.929560 as7726-32x-2 NOTICE swss#orchagent: :- addTunnelUser: diprefcnt for remote 10.0.0.65 = 1
/var/log/syslog.1:Dec 14 10:25:43.930397 as7726-32x-2 INFO syncd#syncd: [none] brcm_sai_create_bridge_port:227 bridge_port_id: 0x  2a043a00000004 tunnel_id 4
/var/log/syslog.1:Dec 14 10:25:43.930895 as7726-32x-2 NOTICE swss#orchagent: :- addBridgePort: Add bridge port Port_EVPN_10.0.0.65 to default 1Q bridge
/var/log/syslog.1:Dec 14 10:25:43.931588 as7726-32x-2 INFO syncd#syncd: [none] _brcm_sai_bridge_port_valid:1297 idx 4
/var/log/syslog.1:Dec 14 10:25:43.932158 as7726-32x-2 NOTICE swss#orchagent: :- addVlanMember: Add member Port_EVPN_10.0.0.65 to VLAN Vlan1000 vid:1000 pid0
/var/log/syslog.1:Dec 14 10:25:43.932536 as7726-32x-2 NOTICE swss#orchagent: :- doTask: Get port state change notification id:2a00000000069f status:1
/var/log/syslog.1:Dec 14 10:25:43.932536 as7726-32x-2 NOTICE swss#orchagent: :- updatePortOperStatus: Port Port_EVPN_10.0.0.65 oper state set from down to up
~~~
**Details if related**
