### PR TITLE
Check resource release or not before removing local vtep.

### DIFF
--- a/orchagent/vxlanorch.h
+++ b/orchagent/vxlanorch.h
@@ -271,6 +271,11 @@ public:
         return vxlan_tunnel_table_.at(tunnelName).get();
     }
 
+    auto getVxlanTunnelSize()
+    {
+        return vxlan_tunnel_table_.size();
+    }
+
     bool addTunnel(const std::string tunnel_name,VxlanTunnel* tnlptr)
     {
        vxlan_tunnel_table_[tunnel_name] = (VxlanTunnel_T)tnlptr;
@@ -340,6 +345,11 @@ public:
         {
             return 0;
         }
+    }
+
+    auto getVniVlanMapTableSize()
+    {
+        return vxlan_vni_vlan_map_table_.size();
     }
 
     void addVlanMappedToVni(uint32_t vni, uint16_t vlan_id)
@@ -529,6 +539,11 @@ public:
     VxlanTunnel* getEVPNVtep() 
     { 
         return source_vtep_ptr;
+    }
+
+    void delEVPNVtep()
+    {
+        source_vtep_ptr = NULL;
     }
 
 private:


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
we have added check to avoid the user tunnel
be removed earlier than local vtep, and this patch is to add to check the
vlan vni map which is also be removed earlier than local vtep.
**Why I did it**
testing on delete L2 vni ,  in test it will delete vni via restconf at same time.
if not check all evpn config deleted before delete vetp affect some resource can't released.
~~~
Mar 10 09:11:32.084398 accton-mlag-demo-001-leaf1 NOTICE swss#orchagent: :- delTunnelUser: diprefcnt for remote 10.0.0.29 = -1
Mar 10 09:11:32.084538 accton-mlag-demo-001-leaf1 ERR swss#orchagent: :- removeVlan: Failed to remove non-empty VLAN Vlan10
Mar 10 09:11:32.084688 accton-mlag-demo-001-leaf1 NOTICE swss#orchagent: :- delOperation: Vxlan tunnel 'vtep1' was removed
Mar 10 09:11:32.084688 accton-mlag-demo-001-leaf1 WARNING swss#orchagent: :- delOperation: NVO Delete failed as VTEP Ptr is NULL
Mar 10 09:11:32.085225 accton-mlag-demo-001-leaf1 NOTICE swss#orchagent: :- removeFdbEntry: FdbOrch RemoveFDBEntry: mac=04:f8:f8:6a:f9:91 bv_id=0x260000000005e2 origin 4
Mar 10 09:11:32.085246 accton-mlag-demo-001-leaf1 NOTICE swss#orchagent: :- deleteFdbEntryFromSavedFDB: FDB entry found in saved fdb. deleting...mac=04:f8:f8:6a:f9:91 vlan_id=0x3e8 origin:4 port:Port_EVPN_10.0.0.29
~~~
**How I verified it**
testing on delete L2 vni 10 times via restconf, the issue without happen by checking syslog.
**Details if related**
