### PR TITLE
[gearbox] Support setting tx taps on gearbox ports

### DIFF
--- a/gearsyncd/gearboxparser.cpp
+++ b/gearsyncd/gearboxparser.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "gearboxparser.h"
+#include "gearboxutils.h"
 #include "phyparser.h"
 #include <vector>
 
@@ -42,7 +43,7 @@ bool GearboxParser::parse()
         return false;
     }
 
-    json phys, phy, interfaces, interface, val, lanes;
+    json phys, phy, interfaces, interface, val, lanes, txFir;
 
     std::vector<swss::FieldValueTuple> attrs;
 
@@ -285,6 +286,27 @@ bool GearboxParser::parse()
                     SWSS_LOG_ERROR("missing 'line_lanes' field in 'interfaces' item %d in gearbox configuration", iter);
                     return false;
                 }
+
+                for (std::string txFirKey: swss::tx_fir_strings)
+                {
+                    if (interface.find(txFirKey) != interface.end())
+                    {
+                        txFir = interface[txFirKey]; // vec
+                        std::string txFirValuesStr("");
+                        for (uint32_t iter2 = 0; iter2 < txFir.size(); iter2++)
+                        {
+                            val = txFir[iter2];
+                            if (txFirValuesStr.length() > 0)
+                            {
+                                 txFirValuesStr += ",";
+                            }
+                            txFirValuesStr += std::to_string(val.get<int>());
+                        }
+                        attr = std::make_pair(txFirKey, txFirValuesStr);
+                        attrs.push_back(attr);
+                    }
+                }
+
                 std::string key;
                 key = "interface:" + std::to_string(index);
                 if (getWriteToDb() == true) 

--- a/lib/gearboxutils.cpp
+++ b/lib/gearboxutils.cpp
@@ -266,6 +266,11 @@ std::map<int, gearbox_interface_t> GearboxUtils::loadInterfaceMap(Table *gearbox
                         }
                     }
                 }
+                else if (tx_fir_strings.find(val.first) != tx_fir_strings.end())
+                {
+                    SWSS_LOG_DEBUG("Parsed key:%s, val:%s", val.first.c_str(), val.second.c_str());
+                    interface.tx_firs[val.first] = val.second;
+                }
             }
             gearboxInterfaceMap[interface.index] = interface;
         }

--- a/lib/gearboxutils.h
+++ b/lib/gearboxutils.h
@@ -30,6 +30,24 @@
 
 namespace swss {
 
+static const std::set<std::string> tx_fir_strings =
+{
+    "system_tx_fir_pre1",
+    "system_tx_fir_pre2",
+    "system_tx_fir_pre3",
+    "system_tx_fir_post1",
+    "system_tx_fir_post2",
+    "system_tx_fir_post3",
+    "system_tx_fir_main",
+    "line_tx_fir_pre1",
+    "line_tx_fir_pre2",
+    "line_tx_fir_pre3",
+    "line_tx_fir_post1",
+    "line_tx_fir_post2",
+    "line_tx_fir_post3",
+    "line_tx_fir_main"
+};
+
 typedef struct
 {
     int phy_id;
@@ -54,6 +72,7 @@ typedef struct
     int phy_id;
     std::set<int> line_lanes;
     std::set<int> system_lanes;
+    std::map<std::string, std::string> tx_firs;
 } gearbox_interface_t;
 
 typedef struct

--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -623,7 +623,7 @@ void PortsOrch::updateDbPortOperSpeed(Port &port, sai_uint32_t speed)
 {
 }
 
-void PortsOrch::getPortSerdesVal(const std::string &s, std::vector<uint32_t> &lane_values)
+void PortsOrch::getPortSerdesVal(const std::string &s, std::vector<uint32_t> &lane_values, int base)
 {
 }
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -6789,7 +6789,8 @@ void PortsOrch::removePortSerdesAttribute(sai_object_id_t port_id)
 }
 
 void PortsOrch::getPortSerdesVal(const std::string& val_str,
-                                 std::vector<uint32_t> &lane_values)
+                                 std::vector<uint32_t> &lane_values,
+                                 int base)
 {
     SWSS_LOG_ENTER();
 
@@ -6799,23 +6800,7 @@ void PortsOrch::getPortSerdesVal(const std::string& val_str,
 
     while (std::getline(iss, lane_str, ','))
     {
-        lane_val = (uint32_t)std::stoul(lane_str, NULL, 16);
-        lane_values.push_back(lane_val);
-    }
-}
-
-void PortsOrch::getPortSerdesValBase10(const std::string& val_str,
-                                       std::vector<uint32_t> &lane_values)
-{
-    SWSS_LOG_ENTER();
-
-    uint32_t lane_val;
-    std::string lane_str;
-    std::istringstream iss(val_str);
-
-    while (std::getline(iss, lane_str, ','))
-    {
-        lane_val = (uint32_t)std::stoul(lane_str, NULL, 10);
+        lane_val = (uint32_t)std::stoul(lane_str, NULL, base);
         lane_values.push_back(lane_val);
     }
 }
@@ -7199,7 +7184,7 @@ bool PortsOrch::initGearboxPort(Port &port)
             for (auto pair: tx_fir_strings_system_side) {
                 if (m_gearboxInterfaceMap[port.m_index].tx_firs.find(pair.first) != m_gearboxInterfaceMap[port.m_index].tx_firs.end() ) {
                     attr_val.clear();
-                    getPortSerdesValBase10(m_gearboxInterfaceMap[port.m_index].tx_firs[pair.first], attr_val);
+                    getPortSerdesVal(m_gearboxInterfaceMap[port.m_index].tx_firs[pair.first], attr_val, 10);
                     serdes_attr.insert(serdes_attr_pair(pair.second, attr_val));
                 }
             }
@@ -7219,7 +7204,7 @@ bool PortsOrch::initGearboxPort(Port &port)
             for (auto pair: tx_fir_strings_line_side) {
                 if (m_gearboxInterfaceMap[port.m_index].tx_firs.find(pair.first) != m_gearboxInterfaceMap[port.m_index].tx_firs.end() ) {
                     attr_val.clear();
-                    getPortSerdesValBase10(m_gearboxInterfaceMap[port.m_index].tx_firs[pair.first], attr_val);
+                    getPortSerdesVal(m_gearboxInterfaceMap[port.m_index].tx_firs[pair.first], attr_val, 10);
                     serdes_attr.insert(serdes_attr_pair(pair.second, attr_val));
                 }
             }

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -49,6 +49,28 @@ static const unordered_map<string, sai_port_oper_status_t> string_oper_status =
     { "not present", SAI_PORT_OPER_STATUS_NOT_PRESENT }
 };
 
+static const std::map<std::string, sai_port_serdes_attr_t> tx_fir_strings_system_side =
+{
+    {"system_tx_fir_pre1", SAI_PORT_SERDES_ATTR_TX_FIR_PRE1},
+    {"system_tx_fir_pre2", SAI_PORT_SERDES_ATTR_TX_FIR_PRE2},
+    {"system_tx_fir_pre3", SAI_PORT_SERDES_ATTR_TX_FIR_PRE3},
+    {"system_tx_fir_post1", SAI_PORT_SERDES_ATTR_TX_FIR_POST1},
+    {"system_tx_fir_post2", SAI_PORT_SERDES_ATTR_TX_FIR_POST2},
+    {"system_tx_fir_post3", SAI_PORT_SERDES_ATTR_TX_FIR_POST3},
+    {"system_tx_fir_main", SAI_PORT_SERDES_ATTR_TX_FIR_MAIN}
+};
+
+static const std::map<std::string, sai_port_serdes_attr_t> tx_fir_strings_line_side =
+{
+    {"line_tx_fir_pre1", SAI_PORT_SERDES_ATTR_TX_FIR_PRE1},
+    {"line_tx_fir_pre2", SAI_PORT_SERDES_ATTR_TX_FIR_PRE2},
+    {"line_tx_fir_pre3", SAI_PORT_SERDES_ATTR_TX_FIR_PRE3},
+    {"line_tx_fir_post1", SAI_PORT_SERDES_ATTR_TX_FIR_POST1},
+    {"line_tx_fir_post2", SAI_PORT_SERDES_ATTR_TX_FIR_POST2},
+    {"line_tx_fir_post3", SAI_PORT_SERDES_ATTR_TX_FIR_POST3},
+    {"line_tx_fir_main", SAI_PORT_SERDES_ATTR_TX_FIR_MAIN}
+};
+
 struct PortUpdate
 {
     Port port;
@@ -385,11 +407,12 @@ private:
     void refreshPortStateLinkTraining(const Port &port);
 
     void getPortSerdesVal(const std::string& s, std::vector<uint32_t> &lane_values);
+    void getPortSerdesValBase10(const std::string& s, std::vector<uint32_t> &lane_values);
     bool getPortAdvSpeedsVal(const std::string &s, std::vector<uint32_t> &speed_values);
     bool getPortInterfaceTypeVal(const std::string &s, sai_port_interface_type_t &interface_type);
     bool getPortAdvInterfaceTypesVal(const std::string &s, std::vector<uint32_t> &type_values);
 
-    bool setPortSerdesAttribute(sai_object_id_t port_id,
+    bool setPortSerdesAttribute(sai_object_id_t port_id, sai_object_id_t switch_id,
                                 std::map<sai_port_serdes_attr_t, std::vector<uint32_t>> &serdes_attr);
 
 

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -406,8 +406,7 @@ private:
     void refreshPortStateAutoNeg(const Port &port);
     void refreshPortStateLinkTraining(const Port &port);
 
-    void getPortSerdesVal(const std::string& s, std::vector<uint32_t> &lane_values);
-    void getPortSerdesValBase10(const std::string& s, std::vector<uint32_t> &lane_values);
+    void getPortSerdesVal(const std::string& s, std::vector<uint32_t> &lane_values, int base = 16);
     bool getPortAdvSpeedsVal(const std::string &s, std::vector<uint32_t> &speed_values);
     bool getPortInterfaceTypeVal(const std::string &s, sai_port_interface_type_t &interface_type);
     bool getPortAdvInterfaceTypesVal(const std::string &s, std::vector<uint32_t> &type_values);

--- a/tests/test_gearbox.py
+++ b/tests/test_gearbox.py
@@ -104,8 +104,10 @@ class GBAsic(DVSDatabase):
                 ("SAI_PORT_SERDES_ATTR_TX_FIR_MAIN", "tx_fir_main"),
                 ("SAI_PORT_SERDES_ATTR_TX_FIR_PRE1", "tx_fir_pre1"),
                 ("SAI_PORT_SERDES_ATTR_TX_FIR_PRE2", "tx_fir_pre2"),
+                ("SAI_PORT_SERDES_ATTR_TX_FIR_PRE3", "tx_fir_pre3"),
                 ("SAI_PORT_SERDES_ATTR_TX_FIR_POST1", "tx_fir_post1"),
                 ("SAI_PORT_SERDES_ATTR_TX_FIR_POST2", "tx_fir_post2"),
+                ("SAI_PORT_SERDES_ATTR_TX_FIR_POST3", "tx_fir_post3"),
             ]:
                 if asic_db_key not in fvs:
                    continue

--- a/tests/test_gearbox.py
+++ b/tests/test_gearbox.py
@@ -70,6 +70,7 @@ class GBAsic(DVSDatabase):
         DVSDatabase.__init__(self, db_id, connector)
         self.gearbox = gearbox
         self.ports = {}
+        self.port_oid_to_intf_idx = {}
         self._wait_for_gb_asic_db_to_initialize()
 
         for connector in self.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT_CONNECTOR"):
@@ -88,8 +89,28 @@ class GBAsic(DVSDatabase):
                 if intf["system_lanes"] == system_lanes:
                     assert intf["line_lanes"] == line_lanes
                     self.ports[intf["index"]] = (system_port_oid, line_port_oid)
+                    self.port_oid_to_intf_idx[system_port_oid] = (i, True)
+                    self.port_oid_to_intf_idx[line_port_oid] = (i, False)
 
         assert len(self.ports) == len(self.gearbox.interfaces)
+
+        for serdes in self.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT_SERDES"):
+            fvs = self.get_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT_SERDES", serdes)
+            port_oid = fvs.get("SAI_PORT_SERDES_ATTR_PORT_ID")
+            intf_idx, is_system = self.port_oid_to_intf_idx[port_oid]
+            intf = self.gearbox.interfaces[ intf_idx ]
+            appl_db_key_prefix = 'system_' if is_system else 'line_'
+            for asic_db_key, appl_db_key_suffix in [
+                ("SAI_PORT_SERDES_ATTR_TX_FIR_MAIN", "tx_fir_main"),
+                ("SAI_PORT_SERDES_ATTR_TX_FIR_PRE1", "tx_fir_pre1"),
+                ("SAI_PORT_SERDES_ATTR_TX_FIR_PRE2", "tx_fir_pre2"),
+                ("SAI_PORT_SERDES_ATTR_TX_FIR_POST1", "tx_fir_post1"),
+                ("SAI_PORT_SERDES_ATTR_TX_FIR_POST2", "tx_fir_post2"),
+            ]:
+                if asic_db_key not in fvs:
+                   continue
+                asic_db_value = fvs.get(asic_db_key).split(":")[-1]
+                assert intf[appl_db_key_prefix + appl_db_key_suffix] == asic_db_value
 
     def _wait_for_gb_asic_db_to_initialize(self) -> None:
         """Wait up to 30 seconds for the default fields to appear in ASIC DB."""


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
This change adds support for setting tx tap or tuning values on gearbox ports. It uses the SAI attributes such as SAI_PORT_SERDES_ATTR_TX_FIR_PRE1 to communicate with SAI-based gearbox drivers. For the values, they are provided in the format like "system_tx_fir_pre2": [1,1] for an interface from gearbox_config.json. 

**Why I did it**

**How I verified it**
We verified that values provided in https://github.com/Azure/sonic-buildimage/pull/10084 are set to the chip with this change.

Added test to tests/test_gearbox.py. The added test will not pass until the following two changes (which should be merged first) are merged:
Support SAI_PORT_ATTR_PORT_SERDES_ID on vs gearbox: https://github.com/Azure/sonic-sairedis/pull/1082
Add gearbox taps to vs gearbox_config.json: https://github.com/Azure/sonic-buildimage/pull/11480

**Details if related**
