### PR TITLE
Fix for 2053, Fix IPv6 BGP multipath-relax peer-type.

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -51,6 +51,13 @@ IntfMgr::IntfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
             setWarmReplayDoneState();
         }
     }
+
+    string swtype;
+    Table cfgDeviceMetaDataTable(cfgDb, CFG_DEVICE_METADATA_TABLE_NAME);
+    if(cfgDeviceMetaDataTable.hget("localhost", "switch_type", swtype))
+    {
+       mySwitchType = swtype;
+    }
 }
 
 void IntfMgr::setIntfIp(const string &alias, const string &opCmd,
@@ -70,9 +77,23 @@ void IntfMgr::setIntfIp(const string &alias, const string &opCmd,
     }
     else
     {
+        string metric = "";
+        // Kernel adds connected route with default metric of 256. But the metric is not
+        // communicated to frr unless the ip address is added with explicit metric
+        // In voq system, We need the static route to the remote neighbor and connected
+        // route to have the same metric to enable BGP to choose paths from routes learned
+        // via eBGP and iBGP over the internal inband port be part of same ecmp group.
+        // For v4 both the metrics (connected and static) are default 0 so we do not need
+        // to set the metric explicitly.
+        if(mySwitchType == "voq")
+        {
+           metric = " metric 256";
+        }
+
         (prefixLen < 127) ?
-        (cmd << IP_CMD << " -6 address " << shellquote(opCmd) << " " << shellquote(ipPrefixStr) << " broadcast " << shellquote(broadcastIpStr) << " dev " << shellquote(alias)) :
-        (cmd << IP_CMD << " -6 address " << shellquote(opCmd) << " " << shellquote(ipPrefixStr) << " dev " << shellquote(alias));
+        (cmd << IP_CMD << " -6 address " << shellquote(opCmd) << " " << shellquote(ipPrefixStr) << " broadcast " << shellquote(broadcastIpStr) <<
+         " dev " << shellquote(alias) << metric) :
+        (cmd << IP_CMD << " -6 address " << shellquote(opCmd) << " " << shellquote(ipPrefixStr) << " dev " << shellquote(alias) << metric);
     }
 
     int ret = swss::exec(cmd.str(), res);

--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -25,6 +25,7 @@ private:
     std::set<std::string> m_subIntfList;
     std::set<std::string> m_loopbackIntfList;
     std::set<std::string> m_pendingReplayIntfList;
+    std::string mySwitchType;
 
     void setIntfIp(const std::string &alias, const std::string &opCmd, const IpPrefix &ipPrefix);
     void setIntfVrf(const std::string &alias, const std::string &vrfName);

--- a/cfgmgr/nbrmgr.cpp
+++ b/cfgmgr/nbrmgr.cpp
@@ -509,7 +509,12 @@ bool NbrMgr::addKernelRoute(string odev, IpAddress ip_addr)
     }
     else
     {
-        cmd = string("") + IP_CMD + " -6 route add " + ip_str + "/128 dev " + odev;
+        // In voq system, We need the static route to the remote neighbor and connected
+        // route to have the same metric to enable BGP to choose paths from routes learned
+        // via eBGP and iBGP over the internal inband port be part of same ecmp group.
+        // For v4 both the metrics (connected and static) are default 0 so we do not need
+        // to set the metric explicitly.
+        cmd = string("") + IP_CMD + " -6 route add " + ip_str + "/128 dev " + odev + " metric 256";
         SWSS_LOG_NOTICE("IPv6 Route Add cmd: %s",cmd.c_str());
     }
 


### PR DESCRIPTION
By default the metric for ipv6 static route is 1024. This makes it the
routes learned via the internal bgp sessions inferior to the Ebgp
routes. So make the metric 256 which make the static route metric same
as connected route metric.

**What I did**
By default the metric for ipv6 static route is 1024. This makes it the
routes learned via the internal bgp sessions inferior to the Ebgp
routes. So make the metric 256 which make the static route metric same
as connected route metric.

**Why I did it**
To fix IPv6 BGP multipath-relax peer-type.

**How I verified it**
Verified voq chassis can learn a route which ecmps routes advertised by internal ibgp neighbor and ebgp neighbor.
