### PR TITLE
Dynamic port configuration - add port buffer cfg to the port ref counter

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -42,6 +42,9 @@ map<string, string> buffer_to_ref_table_map = {
     {buffer_profile_list_field_name, APP_BUFFER_PROFILE_TABLE_NAME}
 };
 
+std::map<string, std::map<size_t, string>> pg_port_flags;
+std::map<string, std::map<size_t, string>> queue_port_flags;
+
 BufferOrch::BufferOrch(DBConnector *applDb, DBConnector *confDb, DBConnector *stateDb, vector<string> &tableNames) :
     Orch(applDb, tableNames),
     m_flexCounterDb(new DBConnector("FLEX_COUNTER_DB", 0)),
@@ -949,6 +952,38 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
                     }
                 }
             }
+
+            /* when we apply buffer configuration we need to increase the ref counter of this port
+             * or decrease the ref counter for this port when we remove buffer cfg
+             * so for each priority cfg in each port we will increase/decrease the ref counter
+             * also we need to know when the set command is for creating a buffer cfg or modifying buffer cfg -
+             * we need to increase ref counter only on create flow.
+             * so we added a map that will help us to know what was the last command for this port and priority -
+             * if the last command was set command then it is a modify command and we dont need to increase the buffer counter
+             * all other cases (no last command exist or del command was the last command) it means that we need to increase the ref counter */
+            if (op == SET_COMMAND) 
+            {
+                if (queue_port_flags[port_name][ind] != SET_COMMAND) 
+                {
+                    /* if the last operation was not "set" then it's create and not modify - need to increase ref counter */
+                    gPortsOrch->increasePortRefCount(port_name);
+                }
+            } 
+            else if (op == DEL_COMMAND)
+            {
+                if (queue_port_flags[port_name][ind] == SET_COMMAND) {
+                    /* we need to decrease ref counter only if the last operation was "SET_COMMAND" */
+                    gPortsOrch->decreasePortRefCount(port_name);
+                }
+            } 
+            else 
+            {
+                SWSS_LOG_ERROR("operation value is not SET or DEL (op = %s)", op.c_str());
+                return task_process_status::task_invalid_entry;
+            }
+            /* save the last command (set or delete) */
+            queue_port_flags[port_name][ind] = op;
+
         }
     }
 
@@ -1007,7 +1042,7 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
     if (op == SET_COMMAND)
     {
         ref_resolve_status  resolve_result = resolveFieldRefValue(m_buffer_type_maps, buffer_profile_field_name,
-                                             buffer_to_ref_table_map.at(buffer_profile_field_name), tuple, 
+                                             buffer_to_ref_table_map.at(buffer_profile_field_name), tuple,
                                              sai_buffer_profile, buffer_profile_name);
         if (ref_resolve_status::success != resolve_result)
         {
@@ -1089,6 +1124,39 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
                     }
                 }
             }
+
+            /* when we apply buffer configuration we need to increase the ref counter of this port
+             * or decrease the ref counter for this port when we remove buffer cfg
+             * so for each priority cfg in each port we will increase/decrease the ref counter
+             * also we need to know when the set command is for creating a buffer cfg or modifying buffer cfg -
+             * we need to increase ref counter only on create flow.
+             * so we added a map that will help us to know what was the last command for this port and priority -
+             * if the last command was set command then it is a modify command and we dont need to increase the buffer counter
+             * all other cases (no last command exist or del command was the last command) it means that we need to increase the ref counter */
+            if (op == SET_COMMAND) 
+            {
+                if (pg_port_flags[port_name][ind] != SET_COMMAND) 
+                {
+                    /* if the last operation was not "set" then it's create and not modify - need to increase ref counter */
+                    gPortsOrch->increasePortRefCount(port_name);
+                }
+            } 
+            else if (op == DEL_COMMAND)
+            {
+                if (pg_port_flags[port_name][ind] == SET_COMMAND) 
+                {
+                    /* we need to decrease ref counter only if the last operation was "SET_COMMAND" */
+                    gPortsOrch->decreasePortRefCount(port_name);
+                }
+            } 
+            else 
+            {
+                SWSS_LOG_ERROR("operation value is not SET or DEL (op = %s)", op.c_str());
+                return task_process_status::task_invalid_entry;
+            }
+            /* save the last command (set or delete) */
+            pg_port_flags[port_name][ind] = op;
+
         }
         if (portUpdated)
         {

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -971,7 +971,8 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
             } 
             else if (op == DEL_COMMAND)
             {
-                if (queue_port_flags[port_name][ind] == SET_COMMAND) {
+                if (queue_port_flags[port_name][ind] == SET_COMMAND) 
+		{
                     /* we need to decrease ref counter only if the last operation was "SET_COMMAND" */
                     gPortsOrch->decreasePortRefCount(port_name);
                 }

--- a/tests/test_port_add_remove.py
+++ b/tests/test_port_add_remove.py
@@ -1,5 +1,6 @@
 import pytest
 import time
+import buffer_model
 from dvslib.dvs_common import PollingConfig
 
 # the port to be removed and add
@@ -8,15 +9,35 @@ PORT_B = "Ethernet68"
 
 """
 DELETE_CREATE_ITERATIONS defines the number of iteration of delete and create to  ports,
-we add different timeouts between delete/create to catch potential race condition that can lead to system crush.
+we add different timeouts between delete/create to catch potential race condition that can lead to system crush
+
+Add \ Remove of Buffers can be done only when the model is dynamic.
 """
 DELETE_CREATE_ITERATIONS = 10
 
+@pytest.yield_fixture
+def dynamic_buffer(dvs):
+    buffer_model.enable_dynamic_buffer(dvs.get_config_db(), dvs.runcmd)
+    yield
+    buffer_model.disable_dynamic_buffer(dvs.get_config_db(), dvs.runcmd)
+
+@pytest.mark.usefixtures('dvs_port_manager')
+@pytest.mark.usefixtures("dynamic_buffer")    
 class TestPortAddRemove(object):
 
     def test_remove_add_remove_port_with_buffer_cfg(self, dvs, testlog):
         config_db = dvs.get_config_db()
         asic_db = dvs.get_asic_db()
+        state_db = dvs.get_state_db()
+        app_db = dvs.get_app_db()
+
+        # set mmu size
+        fvs = {"mmu_size": "12766208"}
+        state_db.create_entry("BUFFER_MAX_PARAM_TABLE", "global", fvs)
+        bufferMaxParameter = state_db.wait_for_entry("BUFFER_MAX_PARAM_TABLE", PORT_A)
+
+        # Startup interface
+        dvs.port_admin_set(PORT_A, 'up')
 
         # get port info
         port_info = config_db.get_entry("PORT", PORT_A)
@@ -24,14 +45,14 @@ class TestPortAddRemove(object):
         # get the number of ports before removal
         num_of_ports = len(asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT"))
 
-        # remove buffer pg cfg for the port
-        # record the buffer pgs before removing them
+        # remove buffer pg cfg for the port (record the buffer pgs before removing them)
         pgs = config_db.get_keys('BUFFER_PG')
         buffer_pgs = {}
         for key in pgs:
             if PORT_A in key:
                 buffer_pgs[key] = config_db.get_entry('BUFFER_PG', key)
                 config_db.delete_entry('BUFFER_PG', key)
+                app_db.wait_for_deleted_entry("BUFFER_PG_TABLE", key)
 
         # modify buffer queue entry to egress_lossless_profile instead of egress_lossy_profile
         config_db.update_entry("BUFFER_QUEUE", "%s|0-2"%PORT_A, {"profile": "egress_lossless_profile"})
@@ -43,7 +64,11 @@ class TestPortAddRemove(object):
             if PORT_A in key:
                 buffer_queues[key] = config_db.get_entry('BUFFER_QUEUE', key)
                 config_db.delete_entry('BUFFER_QUEUE', key)
+                app_db.wait_for_deleted_entry('BUFFER_QUEUE_TABLE', key)
 
+        # Shutdown interface
+        dvs.port_admin_set(PORT_A, 'down')
+                
         # try to remove this port
         config_db.delete_entry('PORT', PORT_A)
         num = asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT",
@@ -53,7 +78,9 @@ class TestPortAddRemove(object):
         # verify that the port was removed properly since all buffer configuration was removed also
         assert len(num) == num_of_ports - 1
 
-        config_db.create_entry("PORT", PORT_A, port_info)
+        # set back the port 
+        config_db.update_entry("PORT", PORT_A, port_info)
+
         # verify that the port has been readded
         num = asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT",
                               num_of_ports,
@@ -68,6 +95,8 @@ class TestPortAddRemove(object):
         for key, queue in buffer_queues.items():
             config_db.update_entry("BUFFER_QUEUE", key, queue)
 
+        time.sleep(5)
+
         # Remove the port with buffer configuration
         config_db.delete_entry('PORT', PORT_A)
         num = asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT",
@@ -80,6 +109,7 @@ class TestPortAddRemove(object):
         # Remove buffer pgs
         for key in buffer_pgs.keys():
             config_db.delete_entry('BUFFER_PG', key)
+            app_db.wait_for_deleted_entry("BUFFER_PG_TABLE", key)
 
         num = asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT",
                                       num_of_ports-1,
@@ -91,6 +121,7 @@ class TestPortAddRemove(object):
         # Remove buffer queue
         for key in buffer_queues.keys():
             config_db.delete_entry('BUFFER_QUEUE', key)
+            app_db.wait_for_deleted_entry('BUFFER_QUEUE_TABLE', key)
 
         num = asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT",
                                       num_of_ports-1,
@@ -99,13 +130,18 @@ class TestPortAddRemove(object):
         # verify that the port wasn't removed since we still have buffer cfg
         assert len(num) == num_of_ports - 1
 
+        # set back the port as it is required for next test 
+        config_db.update_entry("PORT", PORT_A, port_info)
+       
+
 
     @pytest.mark.parametrize("scenario", ["one_port", "all_ports"])
     def test_add_remove_all_the_ports(self, dvs, testlog, scenario):
         config_db = dvs.get_config_db()
         state_db = dvs.get_state_db()
         asic_db = dvs.get_asic_db()
-   
+        app_db = dvs.get_app_db()
+
         # get the number of ports before removal
         num_of_ports = len(asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT"))
         
@@ -117,20 +153,38 @@ class TestPortAddRemove(object):
         else:
             assert False
 
+        # delete all PGs and QUEUEs from the relevant ports 
+        pgs = config_db.get_keys('BUFFER_PG')
+        queues = config_db.get_keys('BUFFER_QUEUE')
+
+        for port in ports:
+            for key in pgs:
+                if port in key:
+                    config_db.delete_entry('BUFFER_PG', key)
+                    app_db.wait_for_deleted_entry('BUFFER_PG_TABLE', key)
+
+            for key in queues:
+                if port in key:
+                    config_db.delete_entry('BUFFER_QUEUE', key)
+                    app_db.wait_for_deleted_entry('BUFFER_QUEUE_TABLE', key)
+
         ports_info = {}
-        
+
+        for key in ports:
+            # read port info and save it
+            ports_info[key] = config_db.get_entry("PORT", key)
+
+
         for i in range(DELETE_CREATE_ITERATIONS):
             # remove ports
             for key in ports:
-                # read port info and save it
-                ports_info[key] = config_db.get_entry("PORT", key)
-                
-                # remove a port
-                self.dvs_port.remove_port(key)
+                config_db.delete_entry('PORT',key)
+                app_db.wait_for_deleted_entry("PORT_TABLE", key)
     
             # verify remove port
             num = asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT",
                                           num_of_ports-len(ports))
+
             assert len(num) == num_of_ports-len(ports)
             
             # add port
@@ -140,17 +194,20 @@ class TestPortAddRemove(object):
             """
             time.sleep(i%3)
             for key in ports:
-                config_db.create_entry("PORT", key, ports_info[key])
+                config_db.update_entry("PORT", key, ports_info[key])
+                app_db.wait_for_entry('PORT_TABLE',key)
 
             # verify add port            
             num = asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT",
                                   num_of_ports)
+
             assert len(num) == num_of_ports
                 
             time.sleep((i%2)+1)           
             
         # run ping
         dvs.setup_db()
+
         dvs.create_vlan("6")
         dvs.create_vlan_member("6", PORT_A)
         dvs.create_vlan_member("6", PORT_B)

--- a/tests/test_port_add_remove.py
+++ b/tests/test_port_add_remove.py
@@ -1,0 +1,56 @@
+import pytest
+import time
+from dvslib.dvs_common import PollingConfig
+
+# the port to be removed and add
+PORT = "Ethernet0"
+
+class TestPortAddRemove(object):
+
+    def test_remove_port_with_buffer_cfg(self, dvs, testlog):
+        config_db = dvs.get_config_db()
+        asic_db = dvs.get_asic_db()
+
+        # get port info
+        port_info = config_db.get_entry("PORT", PORT)
+
+        # get the number of ports before removal
+        num_of_ports = len(asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT"))
+
+        # try to remove this port
+        config_db.delete_entry('PORT', PORT)
+        num = asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT",
+                                      num_of_ports-1,
+                                      polling_config = PollingConfig(polling_interval = 1, timeout = 5.00, strict = False))
+
+        # verify that the port wasn't removed since we still have buffer cfg
+        assert len(num) == num_of_ports
+
+        # remove buffer pg cfg for the port
+        pgs = config_db.get_keys('BUFFER_PG')
+        for key in pgs:
+            if PORT in key:
+                config_db.delete_entry('BUFFER_PG', key)
+
+        num = asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT",
+                              num_of_ports-1,
+                              polling_config = PollingConfig(polling_interval = 1, timeout = 5.00, strict = False))
+
+        # verify that the port wasn't removed since we still have buffer cfg
+        assert len(num) == num_of_ports
+
+        # modify buffer queue entry to egress_lossless_profile instead of egress_lossy_profile
+        config_db.update_entry("BUFFER_QUEUE", "%s|0-2"%PORT, {"profile": "egress_lossless_profile"})
+
+        # remove buffer queue cfg for the port
+        pgs = config_db.get_keys('BUFFER_QUEUE')
+        for key in pgs:
+            if PORT in key:
+                config_db.delete_entry('BUFFER_QUEUE', key)
+
+        num = asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT",
+                              num_of_ports-1,
+                              polling_config = PollingConfig(polling_interval = 1, timeout = 5.00, strict = True))
+
+        # verify that the port was removed properly since all buffer configuration was removed also
+        assert len(num) == num_of_ports - 1

--- a/tests/test_port_add_remove.py
+++ b/tests/test_port_add_remove.py
@@ -21,9 +21,17 @@ def dynamic_buffer(dvs):
     yield
     buffer_model.disable_dynamic_buffer(dvs.get_config_db(), dvs.runcmd)
 
+
 @pytest.mark.usefixtures('dvs_port_manager')
 @pytest.mark.usefixtures("dynamic_buffer")    
 class TestPortAddRemove(object):
+
+    def set_mmu(self,dvs):
+        state_db = dvs.get_state_db()
+        # set mmu size
+        fvs = {"mmu_size": "12766208"}
+        state_db.create_entry("BUFFER_MAX_PARAM_TABLE", "global", fvs)
+
 
     def test_remove_add_remove_port_with_buffer_cfg(self, dvs, testlog):
         config_db = dvs.get_config_db()
@@ -32,9 +40,7 @@ class TestPortAddRemove(object):
         app_db = dvs.get_app_db()
 
         # set mmu size
-        fvs = {"mmu_size": "12766208"}
-        state_db.create_entry("BUFFER_MAX_PARAM_TABLE", "global", fvs)
-        bufferMaxParameter = state_db.wait_for_entry("BUFFER_MAX_PARAM_TABLE", PORT_A)
+        self.set_mmu(dvs)
 
         # Startup interface
         dvs.port_admin_set(PORT_A, 'up')
@@ -141,6 +147,9 @@ class TestPortAddRemove(object):
         state_db = dvs.get_state_db()
         asic_db = dvs.get_asic_db()
         app_db = dvs.get_app_db()
+
+        # set mmu size
+        self.set_mmu(dvs)
 
         # get the number of ports before removal
         num_of_ports = len(asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT"))


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

This PR replace PR [#2022](https://github.com/Azure/sonic-swss/pull/2022)

Added increasing/decreasing to the port ref counter each time a port buffer configuration is added or removed
Implemented according to the - https://github.com/Azure/SONiC/pull/900


**Why I did it**
In order to avoid cases where a port is removed before the buffer configuration on this port were removed also

**How I verified it**
VS Test was added in order to test it. 
we remove a port with buffer configuration and the port is not removed. only after all buffer configurations on this port were 
removed - this port will be removed.

**Details if related**
