### PR TITLE
[vstest][virtual chassis] Removed dvs.runcmd using click commands

### DIFF
--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -39,7 +39,7 @@ class TestVirtualChassis(object):
 
             # Configure only for line cards
             if cfg_switch_type == "voq":
-                dvs.runcmd(f"config interface startup {ibport}")
+                dvs.port_admin_set(f"{ibport}", "up")
                 config_db.create_entry("VOQ_INBAND_INTERFACE", f"{ibport}", {"inband_type": "port"})
                 
     def del_inbandif_port(self, vct, ibport):


### PR DESCRIPTION
**What I did**

The click commands usage is avoided in test_virtual_chassis.py

**Why I did it**

To fix issue https://github.com/Azure/sonic-buildimage/issues/10246

**How I verified it**

- Executed vstest for test_virtual_chassis.py with docker-sonic-vs.gz and observed that the VOQ inband port is brought up correctly and tests related to VOQ inband interface pass.

**Details if related**
