### PR TITLE
Added support for front panel port prefix regex

### DIFF
--- a/portsyncd/linksync.cpp
+++ b/portsyncd/linksync.cpp
@@ -10,6 +10,7 @@
 #include "producerstatetable.h"
 #include "tokenize.h"
 #include "exec.h"
+#include "schema.h"
 
 #include "linkcache.h"
 #include "portsyncd/linksync.h"
@@ -20,6 +21,7 @@
 #include <set>
 #include <sstream>
 #include <iomanip>
+#include <regex>
 
 using namespace std;
 using namespace swss;
@@ -28,7 +30,6 @@ using namespace swss;
 #define TEAM_DRV_NAME   "team"
 
 const string MGMT_PREFIX = "eth";
-const string INTFS_PREFIX = "Ethernet";
 const string LAG_PREFIX = "PortChannel";
 
 extern set<string> g_portSet;
@@ -128,7 +129,7 @@ LinkSync::LinkSync(DBConnector *appl_db, DBConnector *state_db) :
             string key = idx_p->if_name;
 
             /* Skip all non-frontpanel ports */
-            if (key.compare(0, INTFS_PREFIX.length(), INTFS_PREFIX))
+            if (!regex_match(key, regex(FRONT_PANEL_PORT_PREFIX_REGEX)))
             {
                 continue;
             }
@@ -165,7 +166,7 @@ void LinkSync::onMsg(int nlmsg_type, struct nl_object *obj)
     struct rtnl_link *link = (struct rtnl_link *)obj;
     string key = rtnl_link_get_name(link);
 
-    if (key.compare(0, INTFS_PREFIX.length(), INTFS_PREFIX) &&
+    if (!regex_search(key, regex(FRONT_PANEL_PORT_PREFIX_REGEX)) &&
         key.compare(0, LAG_PREFIX.length(), LAG_PREFIX) &&
         key.compare(0, MGMT_PREFIX.length(), MGMT_PREFIX))
     {


### PR DESCRIPTION
What I did
Removed the dependency on the "Ethernet" string in the SONiC code base and added support
for extending the front panel port name pattern.

How I did it

Introduced FRONT_PANEL_PORT_PREFIX_REGEX that extends the old FRONT_PANEL_PORT_PREFIX ("Ethernet")
Updated all the relevant usage of the "Ethernet" throughout the code base to use the new regex pattern
How to verify it
Pass all UT and CI testing.

Why I did it
In order to support distinguishing between different types of front panel ports in a maintainable fashion.
Specifically, we are planning to bring up a system with 'service' ports (in addition to the regular ethernet data ports) - these
are lower speed ports that used for connection to accelerators, internal loopbacks and more.

**- Related Commits and Merge Strategy**
_This is part of a group of related commits and should be merged **after https://github.com/Azure/sonic-swss-common/pull/598 and https://github.com/Azure/sonic-buildimage/pull/10471 and https://github.com/Azure/sonic-py-swsssdk/pull/121**._

The full merge order is:

1. swss-common - https://github.com/Azure/sonic-swss-common/pull/598
2. sonic-buildimage - https://github.com/Azure/sonic-buildimage/pull/10471
3. swsssdk - https://github.com/Azure/sonic-py-swsssdk/pull/121
4. all the rest
     [ https://github.com/Azure/sonic-utilities/pull/2127](https://github.com/Azure/sonic-utilities/pull/2127)
     [ https://github.com/Azure/sonic-snmpagent/pull/251](https://github.com/Azure/sonic-snmpagent/pull/251)
     [ https://github.com/Azure/sonic-swss/pull/2223](https://github.com/Azure/sonic-swss/pull/2223)
     [ https://github.com/Azure/sonic-platform-daemons/pull/252](https://github.com/Azure/sonic-platform-daemons/pull/252)
     [ https://github.com/Azure/sonic-platform-common/pull/274](https://github.com/Azure/sonic-platform-common/pull/274)
