### PR TITLE
On teammgrd/teamsyncd exits, return EXIT_FAILURE

### DIFF
--- a/cfgmgr/teammgrd.cpp
+++ b/cfgmgr/teammgrd.cpp
@@ -98,5 +98,5 @@ int main(int argc, char **argv)
         return EXIT_FAILURE;
     }
 
-    return EXIT_SUCCESS;
+    return EXIT_FAILURE;
 }

--- a/teamsyncd/teamsyncd.cpp
+++ b/teamsyncd/teamsyncd.cpp
@@ -52,8 +52,8 @@ int main(int argc, char **argv)
     catch (const std::exception& e)
     {
         cout << "Exception \"" << e.what() << "\" had been thrown in daemon" << endl;
-        return 0;
+        return EXIT_FAILURE;
     }
 
-    return 0;
+    return EXIT_FAILURE;
 }


### PR DESCRIPTION
**What I did**
    When teammgrd/teamsyncd exits -- return FAILURE so that supervisord catch it and teamd docker is restarted.
    
**Why I did it**
   Fixes https://github.com/Azure/sonic-buildimage/issues/10534

  I have seen this in builds from 201911 to master.

**How I verified it**
Checked by sending SIGTERM to teamsyncd/teammgrd processes 
```

Apr 15 21:57:38.156111 str-a7280cr3-2 INFO teamd#supervisord 2022-04-15 21:57:38,155 INFO exited: teamsyncd (exit status 0; expected)

Apr 15 22:20:09.530223 str-a7280cr3-2 INFO teamd#supervisord 2022-04-15 22:20:09,529 INFO exited: teammgrd (exit status 0; expected)

-- with fix

Apr 15 22:24:39.752008 str-a7280cr3-2 INFO teamd#supervisord 2022-04-15 22:24:39,751 INFO exited: teamsyncd (exit status 1; not expected)
AND teamd docker restarts


```


**Details if related**
