### PR TITLE
[muxorch] Adding case for maintaining current state

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -443,13 +443,19 @@ void MuxCable::setState(string new_state)
     new_state = muxStateValToString.at(ns);
 
     auto it = muxStateTransition.find(make_pair(state_, ns));
-
     if (it ==  muxStateTransition.end())
     {
         // Update HW Mux cable state anyways
         mux_cb_orch_->updateMuxState(mux_name_, new_state);
-        SWSS_LOG_ERROR("State transition from %s to %s is not-handled ",
-                        muxStateValToString.at(state_).c_str(), new_state.c_str());
+        if (strcmp(new_state.c_str(), muxStateValToString.at(state_).c_str()) == 0)
+        {
+            SWSS_LOG_NOTICE("[%s] Maintaining current MUX state", mux_name_.c_str());
+        }
+        else
+        {
+            SWSS_LOG_ERROR("State transition from %s to %s is not-handled ",
+                            muxStateValToString.at(state_).c_str(), new_state.c_str());
+        }
         return;
     }
 

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -1119,7 +1119,6 @@ class TestMuxTunnel(TestMuxTunnelBase):
             self.check_neighbor_state(dvs, dvs_route, ip, expect_route=False)
 
 
-
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -313,6 +313,15 @@ class TestMuxTunnelBase():
         self.check_neigh_in_asic_db(asicdb, self.SERV2_IPV4)
         self.check_neigh_in_asic_db(asicdb, self.SERV2_IPV6)
 
+        marker = dvs.add_log_marker()
+
+        self.set_mux_state(appdb, "Ethernet0", "active")
+        self.set_mux_state(appdb, "Ethernet0", "active")
+        self.check_syslog(dvs, marker, "Maintaining current MUX state", 1)
+
+        self.set_mux_state(appdb, "Ethernet0", "init")
+        self.check_syslog(dvs, marker, "State transition from active to init is not-handled", 1)
+
     def create_and_test_fdb(self, appdb, asicdb, dvs, dvs_route):
 
         self.set_mux_state(appdb, "Ethernet0", "active")
@@ -1109,21 +1118,6 @@ class TestMuxTunnel(TestMuxTunnelBase):
         for ip in test_ips:
             self.check_neighbor_state(dvs, dvs_route, ip, expect_route=False)
 
-    def test_mux_states(
-        self, dvs, neighbor_cleanup, setup_vlan,
-        setup_mux_cable, setup_tunnel, setup_peer_switch,
-        setup_qos_map, testlog
-    ):
-        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
-
-        marker = dvs.add_log_marker()
-
-        self.set_mux_state(appdb, "Ethernet0", "active")
-        self.set_mux_state(appdb, "Ethernet0", "active")
-        self.check_syslog(dvs, marker, "Maintaining current MUX state", 1)
-
-        self.set_mux_state(appdb, "Ethernet0", "init")
-        self.check_syslog(dvs, marker, "State transition from active to init is not-handled", 1)
 
 
 # Add Dummy always-pass test at end as workaroud


### PR DESCRIPTION
What I did:
Added a case where if current and previous Mux states
are the same, post a log entry that acknowleges this
change and returns without doing anything.

Why I did it:
Valid state changes such as active-active and
standby-standby were causing error logs

How I tested it:
added a case to check active-active state change
and standby-standby state change.

Signed-off-by: Nikola Dancejic <ndancejic@microsoft.com>