### PR TITLE
[202012] Fix for "orchagent crashed when trying to delete fdb static entry with swssconfig #11046"

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -701,7 +701,12 @@ void FdbOrch::doTask(NotificationConsumer& consumer)
              * so far only support flush all the FDB entries
              * flush per port and flush per vlan will be added later.
              */
-            status = sai_fdb_api->flush_fdb_entries(gSwitchId, 0, NULL);
+            vector<sai_attribute_t>    attrs;
+            sai_attribute_t            attr;
+            attr.id = SAI_FDB_FLUSH_ATTR_ENTRY_TYPE;
+            attr.value.s32 = SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC;
+            attrs.push_back(attr);
+            status = sai_fdb_api->flush_fdb_entries(gSwitchId, (uint32_t)attrs.size(), attrs.data());
             if (status != SAI_STATUS_SUCCESS)
             {
                 SWSS_LOG_ERROR("Flush fdb failed, return code %x", status);
@@ -797,6 +802,11 @@ void FdbOrch::flushFDBEntries(sai_object_id_t bridge_port_oid,
         attrs.push_back(attr);
     }
 
+    /* do not flush static mac */
+    attr.id = SAI_FDB_FLUSH_ATTR_ENTRY_TYPE;
+    attr.value.s32 = SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC;
+    attrs.push_back(attr);
+    
     SWSS_LOG_INFO("Flushing FDB bridge_port_oid: 0x%" PRIx64 ", and bvid_oid:0x%" PRIx64 ".", bridge_port_oid, vlan_oid);
 
     rv = sai_fdb_api->flush_fdb_entries(gSwitchId, (uint32_t)attrs.size(), attrs.data());


### PR DESCRIPTION
Root cause:
When fdb flush was issued after adding a static mac, the mac was deleted due to the flush. Then when we try to remove the static mac, it thrown error and crashed due to the mac not found.

Fix:
Updated fdb flush to flush only dynamic mac.