### PR TITLE
[QoS] Fix issue: the WRED profile can not be set if current min > new max or current max < new min

### DIFF
--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -112,6 +112,18 @@ public:
 protected:
     bool convertEcnMode(string str, sai_ecn_mark_mode_t &ecn_val);
     bool convertBool(string str, bool &val);
+private:
+    typedef struct {
+        sai_uint32_t green_max_threshold;
+        sai_uint32_t green_min_threshold;
+        sai_uint32_t yellow_max_threshold;
+        sai_uint32_t yellow_min_threshold;
+        sai_uint32_t red_max_threshold;
+        sai_uint32_t red_min_threshold;
+    } qos_wred_thresholds_t;
+    typedef map<string, qos_wred_thresholds_t> qos_wred_thresholds_store_t;
+
+    static qos_wred_thresholds_store_t m_wredProfiles;
 };
 
 

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -113,6 +113,12 @@ protected:
     bool convertEcnMode(string str, sai_ecn_mark_mode_t &ecn_val);
     bool convertBool(string str, bool &val);
 private:
+    void appendThresholdToAttributeList(sai_attr_id_t type,
+                                        sai_uint32_t threshold,
+                                        bool needDefer,
+                                        vector<sai_attribute_t> &normalQueue,
+                                        vector<sai_attribute_t> &deferredQueue,
+                                        sai_uint32_t &newThreshold);
     typedef struct {
         sai_uint32_t green_max_threshold;
         sai_uint32_t green_min_threshold;

--- a/tests/mock_tests/mock_orchagent_main.h
+++ b/tests/mock_tests/mock_orchagent_main.h
@@ -12,8 +12,8 @@
 #include "mirrororch.h"
 #define private public
 #include "bufferorch.h"
-#undef private
 #include "qosorch.h"
+#undef private
 #include "vrforch.h"
 #include "vnetorch.h"
 #include "vxlanorch.h"


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Fix issue:
Setting a WRED profile can fail in case
 - the current min threshold is greater than the new max threshold
 - or the current max threshold is less than the new min threshold

for any color and at any time.
Eg.
- Current min=1M, max=2M, new min=3M, new max=4M
- The min threshold is set first, so current max (2M) < new min (3M), which violates the condition

This is because there can be only one attribute in each SAI SET operation,
which means the vendor SAI does not understand the whole information of the new attributes and can only perform the sanity check against each SET operation.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**

Fix the issue

**How I verified it**

Manual test and mock test.

**Details if related**
The fix
The thresholds that have been applied to SAI will be stored in orchagent.

The original logic is to handle each attribute to be set and append it to an attribute list.
To resolve the issue, a deferred attribute list is introduced and will be appended to the original attribute list after all the attributes have been handled.

In the new logic, each threshold to be set will be checked against the stored data.
In case it violates the condition, the violating attribute will be deferred, done via putting it into the deferred attributes list.

For any color, there can be only 1 threshold violating the condition.
Otherwise, it means both new min > old max and new max > old min, which means either old max < old min or new max < new min, which means either old or new data is illegal.
This can not happen because illegal data will not be applied and stored.

By doing so, the other threshold will be applied first, which extends the threshold range and breaks the violating condition.
A logic is also introduced to guarantee the min threshold is always less than the max threshold in the new profile to be set.

For the above example,
In the new logic, the min threshold will be deferred so the new max threshold will be applied first and then the new min is applied. In this flow, there is no violation at any time.
- min = 1M, max = 2M
- => min = 1M, max = 4M
- => min = 3M, max = 4M
