### PR TITLE
[Everflow/ERSPAN] Set correct destination port and mac address when the nexthop is updated for ERSPAN mirror destination

### DIFF
--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -263,6 +263,7 @@ public:
     sai_object_id_t getCounterOid() const;
     bool hasCounter() const;
     vector<sai_object_id_t> getInPorts() const;
+    bool getCreateCounter() const;
 
     const vector<AclRangeConfig>& getRangeConfig() const;
     static shared_ptr<AclRule> makeShared(AclOrch *acl, MirrorOrch *mirror, DTelOrch *dtel, const string& rule, const string& table, const KeyOpFieldsValuesTuple&);

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -50,7 +50,6 @@ extern sai_port_api_t *sai_port_api;
 extern sai_object_id_t  gSwitchId;
 extern PortsOrch*       gPortsOrch;
 extern string           gMySwitchType;
-extern IntfsOrch        *gIntfsOrch;
 
 using namespace std::rel_ops;
 
@@ -584,12 +583,11 @@ void MirrorOrch::setSessionState(const string& name, const MirrorEntry& session,
     if (attr.empty() || attr == MIRROR_SESSION_MONITOR_PORT)
     {
         Port port;
-        if ((gMySwitchType == "voq") && (session.type == MIRROR_SESSION_ERSPAN) &&
-            (gIntfsOrch->isRemoteSystemPortIntf(session.neighborInfo.neighbor.alias)))
+        if ((gMySwitchType == "voq") && (session.type == MIRROR_SESSION_ERSPAN))
         {
              if (!m_portsOrch->getRecircPort(port, "Rec"))
              {
-                 SWSS_LOG_ERROR("Failed to get recirc prot mirror session %s", name.c_str());
+                 SWSS_LOG_ERROR("Failed to get recirc port for mirror session %s", name.c_str());
                  return;
              }
 	}
@@ -947,7 +945,7 @@ bool MirrorOrch::activateSession(const string& name, MirrorEntry& session)
             Port recirc_port;
             if (!m_portsOrch->getRecircPort(recirc_port, "Rec"))
             {
-                SWSS_LOG_ERROR("Failed to get recirc prot");
+                SWSS_LOG_ERROR("Failed to get recirc port");
                 return false;
             }
             attr.value.oid = recirc_port.m_port_id;
@@ -1178,7 +1176,7 @@ bool MirrorOrch::updateSessionDstPort(const string& name, MirrorEntry& session)
     {
          if (!m_portsOrch->getRecircPort(port, "Rec"))
          {
-             SWSS_LOG_ERROR("Failed to get recirc prot mirror session %s", name.c_str());
+             SWSS_LOG_ERROR("Failed to get recirc port for mirror session %s", name.c_str());
              return false;
          }
          attr.value.oid = port.m_port_id;

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -50,6 +50,7 @@ extern sai_port_api_t *sai_port_api;
 extern sai_object_id_t  gSwitchId;
 extern PortsOrch*       gPortsOrch;
 extern string           gMySwitchType;
+extern IntfsOrch        *gIntfsOrch;
 
 using namespace std::rel_ops;
 
@@ -583,13 +584,31 @@ void MirrorOrch::setSessionState(const string& name, const MirrorEntry& session,
     if (attr.empty() || attr == MIRROR_SESSION_MONITOR_PORT)
     {
         Port port;
-        m_portsOrch->getPort(session.neighborInfo.portId, port);
+        if ((gMySwitchType == "voq") && (session.type == MIRROR_SESSION_ERSPAN) &&
+            (gIntfsOrch->isRemoteSystemPortIntf(session.neighborInfo.neighbor.alias)))
+        {
+             if (!m_portsOrch->getRecircPort(port, "Rec"))
+             {
+                 SWSS_LOG_ERROR("Failed to get recirc prot mirror session %s", name.c_str());
+                 return;
+             }
+	}
+	else
+	{
+           m_portsOrch->getPort(session.neighborInfo.portId, port);
+	}
         fvVector.emplace_back(MIRROR_SESSION_MONITOR_PORT, port.m_alias);
     }
 
     if (attr.empty() || attr == MIRROR_SESSION_DST_MAC_ADDRESS)
     {
-        value = session.neighborInfo.mac.to_string();
+        if ((gMySwitchType == "voq") && (session.type == MIRROR_SESSION_ERSPAN))
+        {
+             value = gMacAddress.to_string();
+        } else
+        {
+             value = session.neighborInfo.mac.to_string();
+        }
         fvVector.emplace_back(MIRROR_SESSION_DST_MAC_ADDRESS, value);
     }
 
@@ -999,9 +1018,9 @@ bool MirrorOrch::activateSession(const string& name, MirrorEntry& session)
 
         attr.id = SAI_MIRROR_SESSION_ATTR_DST_MAC_ADDRESS;
         // Use router mac as mirror dst mac in voq switch.
-        if (gMySwitchType == "voq")
+        if ((gMySwitchType == "voq") && (session.type == MIRROR_SESSION_ERSPAN))
         {
-            memcpy(attr.value.mac, gMacAddress.getMac(), sizeof(sai_mac_t));
+             memcpy(attr.value.mac, gMacAddress.getMac(), sizeof(sai_mac_t));
         }
         else
         {
@@ -1115,19 +1134,19 @@ bool MirrorOrch::updateSessionDstMac(const string& name, MirrorEntry& session)
 
     sai_attribute_t attr;
     attr.id = SAI_MIRROR_SESSION_ATTR_DST_MAC_ADDRESS;
-    if (gMySwitchType == "voq")
+    if ((gMySwitchType == "voq") && (session.type == MIRROR_SESSION_ERSPAN))
     {
-        memcpy(attr.value.mac, gMacAddress.getMac(), sizeof(sai_mac_t));
+         memcpy(attr.value.mac, gMacAddress.getMac(), sizeof(sai_mac_t));
     } else
     {
-        memcpy(attr.value.mac, session.neighborInfo.mac.getMac(), sizeof(sai_mac_t));
+         memcpy(attr.value.mac, session.neighborInfo.mac.getMac(), sizeof(sai_mac_t));
     }
 
     sai_status_t status = sai_mirror_api->set_mirror_session_attribute(session.sessionId, &attr);
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to update mirror session %s destination MAC to %s, rv:%d",
-                name.c_str(), session.neighborInfo.mac.to_string().c_str(), status);
+                name.c_str(), sai_serialize_mac(attr.value.mac).c_str(), status);
         task_process_status handle_status =  handleSaiSetStatus(SAI_API_MIRROR, status);
         if (handle_status != task_success)
         {
@@ -1136,7 +1155,7 @@ bool MirrorOrch::updateSessionDstMac(const string& name, MirrorEntry& session)
     }
 
     SWSS_LOG_NOTICE("Update mirror session %s destination MAC to %s",
-            name.c_str(), session.neighborInfo.mac.to_string().c_str());
+            name.c_str(), sai_serialize_mac(attr.value.mac).c_str());
 
     setSessionState(name, session, MIRROR_SESSION_DST_MAC_ADDRESS);
 
@@ -1154,27 +1173,19 @@ bool MirrorOrch::updateSessionDstPort(const string& name, MirrorEntry& session)
 
     sai_attribute_t attr;
     attr.id = SAI_MIRROR_SESSION_ATTR_MONITOR_PORT;
-    if (session.type == MIRROR_SESSION_SPAN)
+    // Set monitor port to recirc port in voq switch.
+    if ((gMySwitchType == "voq") && (session.type == MIRROR_SESSION_ERSPAN))
     {
-      attr.value.oid = session.neighborInfo.portId;
+         if (!m_portsOrch->getRecircPort(port, "Rec"))
+         {
+             SWSS_LOG_ERROR("Failed to get recirc prot mirror session %s", name.c_str());
+             return false;
+         }
+         attr.value.oid = port.m_port_id;
     }
     else
     {
-        // Set monitor port to recirc port in voq switch.
-        if (gMySwitchType == "voq")
-        {
-            Port recirc_port;
-            if (!m_portsOrch->getRecircPort(recirc_port, "Rec"))
-            {
-                SWSS_LOG_ERROR("Failed to get recirc prot");
-                return false;
-            }
-            attr.value.oid = recirc_port.m_port_id;
-        }
-        else
-        {
-          attr.value.oid = session.neighborInfo.portId;
-	}
+         attr.value.oid = session.neighborInfo.portId;
     }
 
     sai_status_t status = sai_mirror_api->


### PR DESCRIPTION

Signed-off-by: Sakthivadivu Saravanaraj <sakthivadivu.saravanaraj@nokia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixed the issues reported in https://github.com/Azure/sonic-buildimage/issues/11457
**Why I did it**
getNeighborEntry:  This function compares Neighbor alias with nexthop alias. Since the alias for nexthop was modified from systemport name to Inband port name in addNextHop, the alias comparison was failing and  mirror session was deactivated. Modified the getNeighborEntry to  compare the correct alias.
updateSessionDstMac: Modified the code to set the dest mac of the mirror to gMacAddress if it is voq switch
updateSessionDstPort: Set the dest port of the mirror to Rec port if the mirror is ERSPAN mirror
removeRanges: Delete the acl range only if it was created . If the acl entry with mirror action is created when the mirror is not activated, only counter is created. Acl range and acl rule are not created. So removeRanges returns false and hence "Failed to remove acl rule" errors printed many times in syslog.
AclRuleMirror::activate :  If Acl rule with mirror action was created before the mirror was activated and deleted, the counter was deleted. So activating the mirror calls AclRule:::createRule without creating counter and orchagent calls sairedis with counter Object as NULL and sai_meta layer returns error, so orchagent crashes. Added code to create counter if not valid before creating the rule.
**How I verified it**
Verified ingress and egress mirror oc tests passes
**Details if related**
