### PR TITLE
[macsec]: Set MTU for MACsec

### DIFF
--- a/orchagent/macsecorch.cpp
+++ b/orchagent/macsecorch.cpp
@@ -1275,6 +1275,18 @@ bool MACsecOrch::createMACsecPort(
             phy);
     });
 
+    if (!m_port_orch->getPortMtu(port.m_port_id, macsec_port.m_original_mtu))
+    {
+        SWSS_LOG_WARN("Cannot get Port MTU at the port %s", port_name.c_str());
+        return false;
+    }
+    m_port_orch->setMACsecEnabledState(port.m_port_id, true);
+    if (!m_port_orch->setPortMtu(port.m_port_id, macsec_port.m_original_mtu))
+    {
+        SWSS_LOG_WARN("Cannot set MTU to %u at the MACsec enabled port %s", macsec_port.m_original_mtu, port_name.c_str());
+        return false;
+    }
+
     if (phy)
     {
         if (!setPFCForward(port_id, true))
@@ -1540,6 +1552,13 @@ bool MACsecOrch::deleteMACsecPort(
     {
         SWSS_LOG_WARN("Cannot delete MACsec ingress port at the port %s", port_name.c_str());
         result &= false;
+    }
+
+    m_port_orch->setMACsecEnabledState(port.m_port_id, false);
+    if (!m_port_orch->setPortMtu(port.m_port_id, macsec_port.m_original_mtu))
+    {
+        SWSS_LOG_WARN("Cannot set MTU to %u at the port %s", macsec_port.m_original_mtu, port_name.c_str());
+        return false;
     }
 
     if (phy)

--- a/orchagent/macsecorch.cpp
+++ b/orchagent/macsecorch.cpp
@@ -1275,17 +1275,7 @@ bool MACsecOrch::createMACsecPort(
             phy);
     });
 
-    if (!m_port_orch->getPortMtu(port.m_port_id, macsec_port.m_original_mtu))
-    {
-        SWSS_LOG_WARN("Cannot get Port MTU at the port %s", port_name.c_str());
-        return false;
-    }
-    m_port_orch->setMACsecEnabledState(port.m_port_id, true);
-    if (!m_port_orch->setPortMtu(port.m_port_id, macsec_port.m_original_mtu))
-    {
-        SWSS_LOG_WARN("Cannot set MTU to %u at the MACsec enabled port %s", macsec_port.m_original_mtu, port_name.c_str());
-        return false;
-    }
+    m_port_orch->setMACsecEnabledState(port_id, true);
 
     if (phy)
     {
@@ -1554,12 +1544,7 @@ bool MACsecOrch::deleteMACsecPort(
         result &= false;
     }
 
-    m_port_orch->setMACsecEnabledState(port.m_port_id, false);
-    if (!m_port_orch->setPortMtu(port.m_port_id, macsec_port.m_original_mtu))
-    {
-        SWSS_LOG_WARN("Cannot set MTU to %u at the port %s", macsec_port.m_original_mtu, port_name.c_str());
-        return false;
-    }
+    m_port_orch->setMACsecEnabledState(port_id, false);
 
     if (phy)
     {

--- a/orchagent/macsecorch.h
+++ b/orchagent/macsecorch.h
@@ -109,7 +109,6 @@ private:
         bool                                m_sci_in_sectag;
         bool                                m_enable;
         uint32_t                            m_original_ipg;
-        uint32_t                            m_original_mtu;
     };
     struct MACsecObject
     {

--- a/orchagent/macsecorch.h
+++ b/orchagent/macsecorch.h
@@ -109,6 +109,7 @@ private:
         bool                                m_sci_in_sectag;
         bool                                m_enable;
         uint32_t                            m_original_ipg;
+        uint32_t                            m_original_mtu;
     };
     struct MACsecObject
     {

--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -498,7 +498,7 @@ bool PortsOrch::getPortAdminStatus(sai_object_id_t id, bool &up)
     return true;
 }
 
-bool PortsOrch::setPortMtu(sai_object_id_t id, sai_uint32_t mtu)
+bool PortsOrch::setPortMtu(const Port &port, sai_uint32_t mtu)
 {
     return true;
 }
@@ -562,12 +562,12 @@ bool PortsOrch::getPortSpeed(sai_object_id_t port_id, sai_uint32_t &speed)
     return true;
 }
 
-bool PortsOrch::setGearboxPortsAttr(Port &port, sai_port_attr_t id, void *value)
+bool PortsOrch::setGearboxPortsAttr(const Port &port, sai_port_attr_t id, void *value)
 {
     return true;
 }
 
-bool PortsOrch::setGearboxPortAttr(Port &port, dest_port_type_t port_type, sai_port_attr_t id, void *value)
+bool PortsOrch::setGearboxPortAttr(const Port &port, dest_port_type_t port_type, sai_port_attr_t id, void *value)
 {
     return true;
 }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1135,60 +1135,35 @@ bool PortsOrch::getPortAdminStatus(sai_object_id_t id, bool &up)
     return true;
 }
 
-bool PortsOrch::getPortMtu(sai_object_id_t id, sai_uint32_t &mtu)
-{
-    SWSS_LOG_ENTER();
-
-    sai_attribute_t attr;
-    attr.id = SAI_PORT_ATTR_MTU;
-
-    sai_status_t status = sai_port_api->get_port_attribute(id, 1, &attr);
-
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        task_process_status handle_status = handleSaiGetStatus(SAI_API_PORT, status);
-        if (handle_status != task_success)
-        {
-            return parseHandleSaiStatusFailure(handle_status);
-        }
-    }
-
-    mtu = attr.value.u32 - (uint32_t)(sizeof(struct ether_header) + FCS_LEN + VLAN_TAG_LEN);
-
-    if (isMACsecPort(id))
-    {
-        mtu -= MAX_MACSEC_SECTAG_SIZE;
-    }
-
-    return true;
-}
-
-bool PortsOrch::setPortMtu(sai_object_id_t id, sai_uint32_t mtu)
+bool PortsOrch::setPortMtu(const Port& port, sai_uint32_t mtu)
 {
     SWSS_LOG_ENTER();
 
     sai_attribute_t attr;
     attr.id = SAI_PORT_ATTR_MTU;
     /* mtu + 14 + 4 + 4 = 22 bytes */
-    attr.value.u32 = (uint32_t)(mtu + sizeof(struct ether_header) + FCS_LEN + VLAN_TAG_LEN);
+    mtu += (uint32_t)(sizeof(struct ether_header) + FCS_LEN + VLAN_TAG_LEN);
+    attr.value.u32 = mtu;
 
-    if (isMACsecPort(id))
+    if (isMACsecPort(port.m_port_id))
     {
         attr.value.u32 += MAX_MACSEC_SECTAG_SIZE;
     }
 
-    sai_status_t status = sai_port_api->set_port_attribute(id, &attr);
+    sai_status_t status = sai_port_api->set_port_attribute(port.m_port_id, &attr);
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to set MTU %u to port pid:%" PRIx64 ", rv:%d",
-                attr.value.u32, id, status);
+                attr.value.u32, port.m_port_id, status);
         task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, status);
         if (handle_status != task_success)
         {
             return parseHandleSaiStatusFailure(handle_status);
         }
     }
-    SWSS_LOG_INFO("Set MTU %u to port pid:%" PRIx64, attr.value.u32, id);
+
+    setGearboxPortsAttr(port, SAI_PORT_ATTR_MTU, &mtu);
+    SWSS_LOG_INFO("Set MTU %u to port pid:%" PRIx64, attr.value.u32, port.m_port_id);
     return true;
 }
 
@@ -2021,7 +1996,7 @@ void PortsOrch::initPortSupportedSpeeds(const std::string& alias, sai_object_id_
 /*
  * If Gearbox is enabled and this is a Gearbox port then set the attributes accordingly.
  */
-bool PortsOrch::setGearboxPortsAttr(Port &port, sai_port_attr_t id, void *value)
+bool PortsOrch::setGearboxPortsAttr(const Port &port, sai_port_attr_t id, void *value)
 {
     bool status = false;
 
@@ -2039,7 +2014,7 @@ bool PortsOrch::setGearboxPortsAttr(Port &port, sai_port_attr_t id, void *value)
  * If Gearbox is enabled and this is a Gearbox port then set the specific lane attribute.
  * Note: the appl_db is also updated (Gearbox config_db tables are TBA).
  */
-bool PortsOrch::setGearboxPortAttr(Port &port, dest_port_type_t port_type, sai_port_attr_t id, void *value)
+bool PortsOrch::setGearboxPortAttr(const Port &port, dest_port_type_t port_type, sai_port_attr_t id, void *value)
 {
     sai_status_t status = SAI_STATUS_SUCCESS;
     sai_object_id_t dest_port_id;
@@ -2092,6 +2067,15 @@ bool PortsOrch::setGearboxPortAttr(Port &port, dest_port_type_t port_type, sai_p
                         attr.value.u32 = speed;
                     }
                     SWSS_LOG_NOTICE("BOX: Set %s lane %s %d", port.m_alias.c_str(), speed_attr.c_str(), speed);
+                    break;
+                case SAI_PORT_ATTR_MTU:
+                    attr.id = id;
+                    attr.value.u32 = *static_cast<sai_uint32_t*>(value);
+                    if (LINE_PORT_TYPE == port_type && isMACsecPort(dest_port_id))
+                    {
+                        attr.value.u32 += MAX_MACSEC_SECTAG_SIZE;
+                    }
+                    SWSS_LOG_NOTICE("BOX: Set %s MTU %d", port.m_alias.c_str(), attr.value.u32);
                     break;
                 default:
                     return false;
@@ -3302,7 +3286,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
                 if (mtu != 0 && mtu != p.m_mtu)
                 {
-                    if (setPortMtu(p.m_port_id, mtu))
+                    if (setPortMtu(p, mtu))
                     {
                         p.m_mtu = mtu;
                         m_portList[alias] = p;
@@ -6686,6 +6670,8 @@ bool PortsOrch::initGearboxPort(Port &port)
             SWSS_LOG_NOTICE("BOX: Connected Gearbox ports; system-side:0x%" PRIx64 " to line-side:0x%" PRIx64, systemPort, linePort);
             m_gearboxPortListLaneMap[port.m_port_id] = make_tuple(systemPort, linePort);
             port.m_line_side_id = linePort;
+            saiOidToAlias[systemPort] = port.m_alias;
+            saiOidToAlias[linePort] = port.m_alias;
 
             /* Add gearbox system/line port name map to counter table */
             FieldValueTuple tuple(port.m_alias + "_system", sai_serialize_object_id(systemPort));
@@ -7192,6 +7178,13 @@ void PortsOrch::setMACsecEnabledState(sai_object_id_t port_id, bool enabled)
 {
     SWSS_LOG_ENTER();
 
+    Port p;
+    if (!getPort(port_id, p))
+    {
+        SWSS_LOG_ERROR("Failed to get port object for port id 0x%" PRIx64, port_id);
+        return;
+    }
+
     if (enabled)
     {
         m_macsecEnabledPorts.insert(port_id);
@@ -7200,6 +7193,8 @@ void PortsOrch::setMACsecEnabledState(sai_object_id_t port_id, bool enabled)
     {
         m_macsecEnabledPorts.erase(port_id);
     }
+
+    setPortMtu(p, p.m_mtu);
 }
 
 bool PortsOrch::isMACsecPort(sai_object_id_t port_id) const

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -311,6 +311,7 @@ private:
 
     bool setPortAdminStatus(Port &port, bool up);
     bool getPortAdminStatus(sai_object_id_t id, bool& up);
+    bool getPortMtu(const Port& port, sai_uint32_t &mtu);
     bool setPortMtu(const Port& port, sai_uint32_t mtu);
     bool setPortTpid(sai_object_id_t id, sai_uint16_t tpid);
     bool setPortPvid (Port &port, sai_uint32_t pvid);

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -18,6 +18,7 @@
 
 #define FCS_LEN 4
 #define VLAN_TAG_LEN 4
+#define MAX_MACSEC_SECTAG_SIZE                           (32)
 #define PORT_STAT_COUNTER_FLEX_COUNTER_GROUP "PORT_STAT_COUNTER"
 #define PORT_RATE_COUNTER_FLEX_COUNTER_GROUP "PORT_RATE_COUNTER"
 #define PORT_BUFFER_DROP_STAT_FLEX_COUNTER_GROUP "PORT_BUFFER_DROP_STAT"
@@ -174,6 +175,11 @@ public:
 
     bool decrFdbCount(const string& alias, int count);
 
+    void setMACsecEnabledState(sai_object_id_t port_id, bool enabled);
+    bool isMACsecPort(sai_object_id_t port_id) const;
+    bool getPortMtu(sai_object_id_t id, sai_uint32_t &mtu);
+    bool setPortMtu(sai_object_id_t id, sai_uint32_t mtu);
+
 private:
     unique_ptr<Table> m_counterTable;
     unique_ptr<Table> m_counterLagTable;
@@ -301,7 +307,6 @@ private:
 
     bool setPortAdminStatus(Port &port, bool up);
     bool getPortAdminStatus(sai_object_id_t id, bool& up);
-    bool setPortMtu(sai_object_id_t id, sai_uint32_t mtu);
     bool setPortTpid(sai_object_id_t id, sai_uint16_t tpid);
     bool setPortPvid (Port &port, sai_uint32_t pvid);
     bool getPortPvid(Port &port, sai_uint32_t &pvid);
@@ -374,8 +379,8 @@ private:
     void voqSyncAddLagMember(Port &lag, Port &port);
     void voqSyncDelLagMember(Port &lag, Port &port);
     unique_ptr<LagIdAllocator> m_lagIdAllocator;
+    set<sai_object_id_t> m_macsecEnabledPorts;
 
     std::unordered_set<std::string> generateCounterStats(const string& type, bool gearbox = false);
-
 };
 #endif /* SWSS_PORTSORCH_H */

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -18,7 +18,7 @@
 
 #define FCS_LEN 4
 #define VLAN_TAG_LEN 4
-#define MAX_MACSEC_SECTAG_SIZE                           (32)
+#define MAX_MACSEC_SECTAG_SIZE 32
 #define PORT_STAT_COUNTER_FLEX_COUNTER_GROUP "PORT_STAT_COUNTER"
 #define PORT_RATE_COUNTER_FLEX_COUNTER_GROUP "PORT_RATE_COUNTER"
 #define PORT_BUFFER_DROP_STAT_FLEX_COUNTER_GROUP "PORT_BUFFER_DROP_STAT"
@@ -177,8 +177,6 @@ public:
 
     void setMACsecEnabledState(sai_object_id_t port_id, bool enabled);
     bool isMACsecPort(sai_object_id_t port_id) const;
-    bool getPortMtu(sai_object_id_t id, sai_uint32_t &mtu);
-    bool setPortMtu(sai_object_id_t id, sai_uint32_t mtu);
 
 private:
     unique_ptr<Table> m_counterTable;
@@ -307,6 +305,7 @@ private:
 
     bool setPortAdminStatus(Port &port, bool up);
     bool getPortAdminStatus(sai_object_id_t id, bool& up);
+    bool setPortMtu(const Port& port, sai_uint32_t mtu);
     bool setPortTpid(sai_object_id_t id, sai_uint16_t tpid);
     bool setPortPvid (Port &port, sai_uint32_t pvid);
     bool getPortPvid(Port &port, sai_uint32_t &pvid);
@@ -321,8 +320,8 @@ private:
     void initPortSupportedSpeeds(const std::string& alias, sai_object_id_t port_id);
     task_process_status setPortSpeed(Port &port, sai_uint32_t speed);
     bool getPortSpeed(sai_object_id_t id, sai_uint32_t &speed);
-    bool setGearboxPortsAttr(Port &port, sai_port_attr_t id, void *value);
-    bool setGearboxPortAttr(Port &port, dest_port_type_t port_type, sai_port_attr_t id, void *value);
+    bool setGearboxPortsAttr(const Port &port, sai_port_attr_t id, void *value);
+    bool setGearboxPortAttr(const Port &port, dest_port_type_t port_type, sai_port_attr_t id, void *value);
 
     task_process_status setPortAdvSpeeds(sai_object_id_t port_id, std::vector<sai_uint32_t>& speed_list);
 


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Set extra MTU for MACsec enabled port.

**Why I did it**
MACsec frame will expend the packet with MACsec SecTAG, Otherwise if a packet length equals the MTU which will be dropped by SAI port.

**How I verified it**
Assume 9100 is the MTU, Check by the command `ping -s 9100 10.0.0.57`

**Details if related**
