### PR TITLE
[202111] [PFC_WD] Avoid applying ZeroBuffer Profiles to ingress PG when a PFC storm is detected

### DIFF
--- a/orchagent/bufferorch.h
+++ b/orchagent/bufferorch.h
@@ -37,14 +37,6 @@ public:
     static type_map m_buffer_type_maps;
     void generateBufferPoolWatermarkCounterIdList(void);
     const object_reference_map &getBufferPoolNameOidMap(void);
-    sai_object_id_t getZeroBufferPool(bool ingress)
-    {
-        return ingress ? m_ingressZeroBufferPool : m_egressZeroBufferPool;
-    }
-
-    void lockZeroBufferPool(bool ingress);
-    void unlockZeroBufferPool(bool ingress);
-    void setZeroBufferPool(bool direction, sai_object_id_t pool);
 
 private:
     typedef task_process_status (BufferOrch::*buffer_table_handler)(KeyOpFieldsValuesTuple &tuple);
@@ -80,10 +72,6 @@ private:
 
     bool m_isBufferPoolWatermarkCounterIdListGenerated = false;
 
-    sai_object_id_t m_ingressZeroBufferPool;
-    sai_object_id_t m_egressZeroBufferPool;
-    int m_ingressZeroPoolRefCount;
-    int m_egressZeroPoolRefCount;
 };
 #endif /* SWSS_BUFFORCH_H */
 

--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -3,7 +3,6 @@
 #include "logger.h"
 #include "sai_serialize.h"
 #include "portsorch.h"
-#include "bufferorch.h"
 #include <vector>
 #include <inttypes.h>
 
@@ -27,7 +26,6 @@
 extern sai_object_id_t gSwitchId;
 extern PortsOrch *gPortsOrch;
 extern AclOrch * gAclOrch;
-extern BufferOrch *gBufferOrch;
 extern sai_port_api_t *sai_port_api;
 extern sai_queue_api_t *sai_queue_api;
 extern sai_buffer_api_t *sai_buffer_api;
@@ -567,7 +565,7 @@ PfcWdZeroBufferHandler::PfcWdZeroBufferHandler(sai_object_id_t port,
         return;
     }
 
-    setPriorityGroupAndQueueLockFlag(portInstance, true);
+    setQueueLockFlag(portInstance, true);
 
     sai_attribute_t attr;
     attr.id = SAI_QUEUE_ATTR_BUFFER_PROFILE_ID;
@@ -583,7 +581,7 @@ PfcWdZeroBufferHandler::PfcWdZeroBufferHandler(sai_object_id_t port,
     sai_object_id_t oldQueueProfileId = attr.value.oid;
 
     attr.id = SAI_QUEUE_ATTR_BUFFER_PROFILE_ID;
-    attr.value.oid = ZeroBufferProfile::getZeroBufferProfile(false);
+    attr.value.oid = ZeroBufferProfile::getZeroBufferProfile();
 
     // Set our zero buffer profile
     status = sai_queue_api->set_queue_attribute(queue, &attr);
@@ -595,35 +593,6 @@ PfcWdZeroBufferHandler::PfcWdZeroBufferHandler(sai_object_id_t port,
 
     // Save original buffer profile
     m_originalQueueBufferProfile = oldQueueProfileId;
-
-    // Get PG
-    sai_object_id_t pg = portInstance.m_priority_group_ids[static_cast <size_t> (queueId)];
-
-    attr.id = SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE;
-
-    // Get PG's buffer profile
-    status = sai_buffer_api->get_ingress_priority_group_attribute(pg, 1, &attr);
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_ERROR("Failed to get buffer profile ID on PG 0x%" PRIx64 ": %d", pg, status);
-        return;
-    }
-
-    // Set zero profile to PG
-    sai_object_id_t oldPgProfileId = attr.value.oid;
-
-    attr.id = SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE;
-    attr.value.oid = ZeroBufferProfile::getZeroBufferProfile(true);
-
-    status = sai_buffer_api->set_ingress_priority_group_attribute(pg, &attr);
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_ERROR("Failed to set buffer profile ID on pg 0x%" PRIx64 ": %d", pg, status);
-        return;
-    }
-
-    // Save original buffer profile
-    m_originalPgBufferProfile = oldPgProfileId;
 }
 
 PfcWdZeroBufferHandler::~PfcWdZeroBufferHandler(void)
@@ -649,41 +618,12 @@ PfcWdZeroBufferHandler::~PfcWdZeroBufferHandler(void)
         return;
     }
 
-    auto idx = size_t(getQueueId());
-    sai_object_id_t pg = portInstance.m_priority_group_ids[idx];
-    sai_object_id_t pending_profile_id = portInstance.m_priority_group_pending_profile[idx];
-
-    attr.id = SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE;
-
-    if (pending_profile_id != SAI_NULL_OBJECT_ID)
-    {
-        attr.value.oid = pending_profile_id;
-        SWSS_LOG_NOTICE("Priority group %zd on port %s has been restored to pending profile 0x%" PRIx64,
-                        idx, portInstance.m_alias.c_str(), pending_profile_id);
-        portInstance.m_priority_group_pending_profile[idx] = SAI_NULL_OBJECT_ID;
-    }
-    else
-    {
-        attr.value.oid = m_originalPgBufferProfile;
-        SWSS_LOG_NOTICE("Priority group %zd on port %s has been restored to original profile 0x%" PRIx64,
-                        idx, portInstance.m_alias.c_str(), m_originalPgBufferProfile);
-    }
-
-    // Set our zero buffer profile
-    status = sai_buffer_api->set_ingress_priority_group_attribute(pg, &attr);
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_ERROR("Failed to set buffer profile ID on queue 0x%" PRIx64 ": %d", getQueue(), status);
-        return;
-    }
-
-    setPriorityGroupAndQueueLockFlag(portInstance, false);
+    setQueueLockFlag(portInstance, false);
 }
 
-void PfcWdZeroBufferHandler::setPriorityGroupAndQueueLockFlag(Port& port, bool isLocked) const
+void PfcWdZeroBufferHandler::setQueueLockFlag(Port& port, bool isLocked) const
 {
-    // set lock bits on PG and queue
-    port.m_priority_group_lock[static_cast<size_t>(getQueueId())] = isLocked;
+    // set lock bits on queue
     for (size_t i = 0; i < port.m_queue_ids.size(); ++i)
     {
         if (port.m_queue_ids[i] == getQueue())
@@ -703,9 +643,8 @@ PfcWdZeroBufferHandler::ZeroBufferProfile::~ZeroBufferProfile(void)
 {
     SWSS_LOG_ENTER();
 
-    // Destroy ingress and egress profiles and pools
-    destroyZeroBufferProfile(true);
-    destroyZeroBufferProfile(false);
+    // Destroy egress profiles and pools
+    destroyZeroBufferProfile();
 }
 
 PfcWdZeroBufferHandler::ZeroBufferProfile &PfcWdZeroBufferHandler::ZeroBufferProfile::getInstance(void)
@@ -717,38 +656,19 @@ PfcWdZeroBufferHandler::ZeroBufferProfile &PfcWdZeroBufferHandler::ZeroBufferPro
     return instance;
 }
 
-sai_object_id_t& PfcWdZeroBufferHandler::ZeroBufferProfile::getPool(bool ingress)
-{
-    // If there is a cached zero buffer pool, just use it
-    // else fetch zero buffer pool from buffer orch
-    // If there is one, use it and increase the reference number.
-    // otherwise, just return NULL OID
-    // PfcWdZeroBufferHandler will create it later and notify buffer orch later
-    auto &poolId = ingress ? m_zeroIngressBufferPool : m_zeroEgressBufferPool;
-    if (poolId == SAI_NULL_OBJECT_ID)
-    {
-        poolId = gBufferOrch->getZeroBufferPool(ingress);
-        if (poolId != SAI_NULL_OBJECT_ID)
-        {
-            gBufferOrch->lockZeroBufferPool(ingress);
-        }
-    }
-    return poolId;
-}
-
-sai_object_id_t PfcWdZeroBufferHandler::ZeroBufferProfile::getZeroBufferProfile(bool ingress)
+sai_object_id_t PfcWdZeroBufferHandler::ZeroBufferProfile::getZeroBufferProfile()
 {
     SWSS_LOG_ENTER();
 
-    if (getInstance().getProfile(ingress) == SAI_NULL_OBJECT_ID)
+    if (getInstance().getProfile() == SAI_NULL_OBJECT_ID)
     {
-        getInstance().createZeroBufferProfile(ingress);
+        getInstance().createZeroBufferProfile();
     }
 
-    return getInstance().getProfile(ingress);
+    return getInstance().getProfile();
 }
 
-void PfcWdZeroBufferHandler::ZeroBufferProfile::createZeroBufferProfile(bool ingress)
+void PfcWdZeroBufferHandler::ZeroBufferProfile::createZeroBufferProfile()
 {
     SWSS_LOG_ENTER();
 
@@ -756,60 +676,51 @@ void PfcWdZeroBufferHandler::ZeroBufferProfile::createZeroBufferProfile(bool ing
     vector<sai_attribute_t> attribs;
     sai_status_t status;
 
-    auto &poolId = getPool(ingress);
+    // Create zero pool
+    attr.id = SAI_BUFFER_POOL_ATTR_SIZE;
+    attr.value.u64 = 0;
+    attribs.push_back(attr);
 
-    if (SAI_NULL_OBJECT_ID == poolId)
+    attr.id = SAI_BUFFER_POOL_ATTR_TYPE;
+    attr.value.u32 = SAI_BUFFER_POOL_TYPE_EGRESS;
+    attribs.push_back(attr);
+
+    attr.id = SAI_BUFFER_POOL_ATTR_THRESHOLD_MODE;
+    attr.value.u32 = SAI_BUFFER_POOL_THRESHOLD_MODE_DYNAMIC;
+    attribs.push_back(attr);
+
+    status = sai_buffer_api->create_buffer_pool(
+        &getPool(),
+        gSwitchId,
+        static_cast<uint32_t>(attribs.size()),
+        attribs.data());
+    if (status != SAI_STATUS_SUCCESS)
     {
-        // Create zero pool
-        attr.id = SAI_BUFFER_POOL_ATTR_SIZE;
-        attr.value.u64 = 0;
-        attribs.push_back(attr);
-
-        attr.id = SAI_BUFFER_POOL_ATTR_TYPE;
-        attr.value.u32 = ingress ? SAI_BUFFER_POOL_TYPE_INGRESS : SAI_BUFFER_POOL_TYPE_EGRESS;
-        attribs.push_back(attr);
-
-        attr.id = SAI_BUFFER_POOL_ATTR_THRESHOLD_MODE;
-        attr.value.u32 = SAI_BUFFER_POOL_THRESHOLD_MODE_STATIC;
-        attribs.push_back(attr);
-
-        status = sai_buffer_api->create_buffer_pool(
-            &poolId,
-            gSwitchId,
-            static_cast<uint32_t>(attribs.size()),
-            attribs.data());
-        if (status != SAI_STATUS_SUCCESS)
-        {
-            SWSS_LOG_ERROR("Failed to create dynamic zero buffer pool for PFC WD: %d", status);
-            return;
-        }
-
-        // Pass the ownership to BufferOrch
-        gBufferOrch->setZeroBufferPool(ingress, poolId);
-        gBufferOrch->lockZeroBufferPool(ingress);
+        SWSS_LOG_ERROR("Failed to create dynamic zero buffer pool for PFC WD: %d", status);
+        return;
     }
 
     // Create zero profile
     attribs.clear();
 
     attr.id = SAI_BUFFER_PROFILE_ATTR_POOL_ID;
-    attr.value.oid = getPool(ingress);
+    attr.value.oid = getPool();
     attribs.push_back(attr);
 
     attr.id = SAI_BUFFER_PROFILE_ATTR_THRESHOLD_MODE;
-    attr.value.u32 = SAI_BUFFER_PROFILE_THRESHOLD_MODE_STATIC;
+    attr.value.u32 = SAI_BUFFER_PROFILE_THRESHOLD_MODE_DYNAMIC;
     attribs.push_back(attr);
 
     attr.id = SAI_BUFFER_PROFILE_ATTR_BUFFER_SIZE;
     attr.value.u64 = 0;
     attribs.push_back(attr);
 
-    attr.id = SAI_BUFFER_PROFILE_ATTR_SHARED_STATIC_TH;
-    attr.value.s8 = 0;
+    attr.id = SAI_BUFFER_PROFILE_ATTR_SHARED_DYNAMIC_TH;
+    attr.value.s8 = -8;
     attribs.push_back(attr);
 
     status = sai_buffer_api->create_buffer_profile(
-            &getProfile(ingress),
+            &getProfile(),
             gSwitchId,
             static_cast<uint32_t>(attribs.size()),
             attribs.data());
@@ -820,23 +731,20 @@ void PfcWdZeroBufferHandler::ZeroBufferProfile::createZeroBufferProfile(bool ing
     }
 }
 
-void PfcWdZeroBufferHandler::ZeroBufferProfile::destroyZeroBufferProfile(bool ingress)
+void PfcWdZeroBufferHandler::ZeroBufferProfile::destroyZeroBufferProfile()
 {
     SWSS_LOG_ENTER();
 
-    if (getProfile(ingress) != SAI_NULL_OBJECT_ID)
+    sai_status_t status = sai_buffer_api->remove_buffer_profile(getProfile());
+    if (status != SAI_STATUS_SUCCESS)
     {
-        sai_status_t status = sai_buffer_api->remove_buffer_profile(getProfile(ingress));
-        if (status != SAI_STATUS_SUCCESS)
-        {
-            SWSS_LOG_ERROR("Failed to remove static zero buffer profile for PFC WD: %d", status);
-            return;
-        }
+        SWSS_LOG_ERROR("Failed to remove static zero buffer profile for PFC WD: %d", status);
+        return;
     }
 
-    auto &pool = ingress ? m_zeroIngressBufferPool : m_zeroEgressBufferPool;
-    if (pool != SAI_NULL_OBJECT_ID)
+    status = sai_buffer_api->remove_buffer_pool(getPool());
+    if (status != SAI_STATUS_SUCCESS)
     {
-        gBufferOrch->unlockZeroBufferPool(ingress);
+        SWSS_LOG_ERROR("Failed to remove static zero buffer pool for PFC WD: %d", status);
     }
 }

--- a/orchagent/pfcactionhandler.h
+++ b/orchagent/pfcactionhandler.h
@@ -125,39 +125,39 @@ class PfcWdZeroBufferHandler: public PfcWdLossyHandler
 
     private:
         /*
-         * Sets lock bits on port's priority group and queue
-         * to protect them from being changed by other Orch's
-         */
-        void setPriorityGroupAndQueueLockFlag(Port& port, bool isLocked) const;
+         * Sets lock bits on port's queue
+         * to protect it from being changed by other Orch's
+        */
+        void setQueueLockFlag(Port& port, bool isLocked) const;
 
         // Singletone class for keeping shared data - zero buffer profiles
         class ZeroBufferProfile
         {
             public:
                 ~ZeroBufferProfile(void);
-                static sai_object_id_t getZeroBufferProfile(bool ingress);
+                static sai_object_id_t getZeroBufferProfile();
 
             private:
                 ZeroBufferProfile(void);
                 static ZeroBufferProfile &getInstance(void);
-                void createZeroBufferProfile(bool ingress);
-                void destroyZeroBufferProfile(bool ingress);
+                void createZeroBufferProfile();
+                void destroyZeroBufferProfile();
 
-                sai_object_id_t& getProfile(bool ingress)
+                sai_object_id_t& getProfile()
                 {
-                    return ingress ? m_zeroIngressBufferProfile : m_zeroEgressBufferProfile;
+                    return m_zeroEgressBufferProfile;
                 }
 
-                sai_object_id_t& getPool(bool ingress);
+                sai_object_id_t& getPool()
+                {
+                    return m_zeroEgressBufferPool;
+                }
 
-                sai_object_id_t m_zeroIngressBufferPool = SAI_NULL_OBJECT_ID;
                 sai_object_id_t m_zeroEgressBufferPool = SAI_NULL_OBJECT_ID;
-                sai_object_id_t m_zeroIngressBufferProfile = SAI_NULL_OBJECT_ID;
                 sai_object_id_t m_zeroEgressBufferProfile = SAI_NULL_OBJECT_ID;
         };
 
         sai_object_id_t m_originalQueueBufferProfile = SAI_NULL_OBJECT_ID;
-        sai_object_id_t m_originalPgBufferProfile = SAI_NULL_OBJECT_ID;
 };
 
 // PFC queue that implements drop action by draining queue via SAI

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -152,15 +152,13 @@ public:
     bool      m_mpls = false;
 
     /*
-     * Following two bit vectors are used to lock
-     * the PG/queue from being changed in BufferOrch.
+     * Following bit vector is used to lock
+     * the queue from being changed in BufferOrch.
      * The use case scenario is when PfcWdZeroBufferHandler
-     * sets zero buffer profile it should protect PG/queue
+     * sets zero buffer profile it should protect queue
      * from being overwritten in BufferOrch.
      */
     std::vector<bool> m_queue_lock;
-    std::vector<bool> m_priority_group_lock;
-    std::vector<sai_object_id_t> m_priority_group_pending_profile;
 
     std::unordered_set<sai_object_id_t> m_ingress_acl_tables_uset;
     std::unordered_set<sai_object_id_t> m_egress_acl_tables_uset;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4063,8 +4063,6 @@ void PortsOrch::initializePriorityGroups(Port &port)
     SWSS_LOG_INFO("Get %d priority groups for port %s", attr.value.u32, port.m_alias.c_str());
 
     port.m_priority_group_ids.resize(attr.value.u32);
-    port.m_priority_group_lock.resize(attr.value.u32);
-    port.m_priority_group_pending_profile.resize(attr.value.u32);
 
     if (attr.value.u32 == 0)
     {


### PR DESCRIPTION

What I did
Avoid dropping traffic that is ingressing the port/pg that is in storm. The code changes in this PR avoid creating the ingress zero pool and profile and does not attach any zero profile to the ingress pg when pfcwd is triggered

Revert changes related to #1480 where the retry mechanism was added to BufferOrch which caches the task retries and while the PG is locked by PfcWdZeroBufferHandler.

Revert changes related to #2164 in PfcWdZeroBufferHandler & ZeroBufferProfile & BufferOrch.

Updated UT's accordingly

Signed-off-by: Vivek Reddy Karri <vkarri@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
