### PR TITLE
[orchagent, SRv6]: create seglist support to set sid list type

### DIFF
--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -233,6 +233,7 @@ and reflects the LAG ports into the redis under: `LAG_TABLE:<team0>:port`
     key           = ROUTE_TABLE:segment ; SRV6 segment name
     ; field       = value
     path          = STRING              ; Comma-separated list of IPV6 prefixes for a SRV6 segment
+    type          = STRING              ; SRV6 segment list type like "insert", "encaps.red"; If not provided, default type will be "encaps.red"
 
 ---------------------------------------------
 ### SRV6_MY_SID_TABLE

--- a/orchagent/srv6orch.h
+++ b/orchagent/srv6orch.h
@@ -76,7 +76,7 @@ class Srv6Orch : public Orch
         void doTask(Consumer &consumer);
         void doTaskSidTable(const KeyOpFieldsValuesTuple &tuple);
         void doTaskMySidTable(const KeyOpFieldsValuesTuple &tuple);
-        bool createUpdateSidList(const string seg_name, const string ips);
+        bool createUpdateSidList(const string seg_name, const string ips, const string sidlist_type);
         bool deleteSidList(const string seg_name);
         bool createSrv6Tunnel(const string srv6_source);
         bool createSrv6Nexthop(const NextHopKey &nh);

--- a/tests/test_srv6.py
+++ b/tests/test_srv6.py
@@ -121,11 +121,14 @@ class TestSrv6(object):
         self.adb = dvs.get_asic_db()
         self.cdb = dvs.get_config_db()
 
-    def create_sidlist(self, segname, ips):
+    def create_sidlist(self, segname, ips, type=None):
         table = "ASIC_STATE:SAI_OBJECT_TYPE_SRV6_SIDLIST"
         existed_entries = get_exist_entries(self.adb.db_connection, table)
 
-        fvs=swsscommon.FieldValuePairs([('path', ips)])
+        if type is None:
+            fvs=swsscommon.FieldValuePairs([('path', ips)])
+        else:
+            fvs=swsscommon.FieldValuePairs([('path', ips), ('type', type)])
         segtbl = swsscommon.ProducerStateTable(self.pdb.db_connection, "SRV6_SID_LIST_TABLE")
         segtbl.set(segname, fvs)
 
@@ -239,9 +242,30 @@ class TestSrv6(object):
 
 
         # create 2nd seg lists
-        self.create_sidlist('seg2', 'baba:2002:10::,baba:2002:20::')
-        # create 3rd seg lists
-        self.create_sidlist('seg3', 'baba:2003:10::,baba:2003:20::')
+        sidlist_id = self.create_sidlist('seg2', 'baba:2002:10::,baba:2002:20::', 'insert.red')
+
+        # check ASIC SAI_OBJECT_TYPE_SRV6_SIDLIST database
+        tbl = swsscommon.Table(self.adb.db_connection, "ASIC_STATE:SAI_OBJECT_TYPE_SRV6_SIDLIST")
+        (status, fvs) = tbl.get(sidlist_id)
+        assert status == True
+        for fv in fvs:
+            if fv[0] == "SAI_SRV6_SIDLIST_ATTR_SEGMENT_LIST":
+                assert fv[1] == "2:baba:2002:10::,baba:2002:20::"
+            elif fv[0] == "SAI_SRV6_SIDLIST_ATTR_TYPE":
+                assert fv[1] == "SAI_SRV6_SIDLIST_TYPE_INSERT_RED"
+
+        # create 3rd seg lists with unsupported or wrong naming of sid list type, for this case, it will use default type: ENCAPS_RED
+        sidlist_id = self.create_sidlist('seg3', 'baba:2003:10::,baba:2003:20::', 'reduced')
+
+        # check ASIC SAI_OBJECT_TYPE_SRV6_SIDLIST database
+        tbl = swsscommon.Table(self.adb.db_connection, "ASIC_STATE:SAI_OBJECT_TYPE_SRV6_SIDLIST")
+        (status, fvs) = tbl.get(sidlist_id)
+        assert status == True
+        for fv in fvs:
+            if fv[0] == "SAI_SRV6_SIDLIST_ATTR_SEGMENT_LIST":
+                assert fv[1] == "2:baba:2003:10::,baba:2003:20::"
+            elif fv[0] == "SAI_SRV6_SIDLIST_ATTR_TYPE":
+                assert fv[1] == "SAI_SRV6_SIDLIST_TYPE_ENCAPS_RED"
 
         # create 2nd v4 route with single sidlists
         self.create_srv6_route('20.20.20.21/32','seg2','1001:2000::1')


### PR DESCRIPTION
If user doesn't set the sid list type, type will be ENCAPS_RED

What I did
create seglist support to set sid list type

Why I did it
could not set different sidlist type under local testing

How I verified it
set different sidlist type of seg list and confirm it works under local testing

Signed-off-by: link_chiang <link_chiang@edge-core.com>
