### PR TITLE
[muxorch] return true if the nbr IP is in the skip_neighbors list

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -962,6 +962,10 @@ bool MuxOrch::isNeighborActive(const IpAddress& nbr, const MacAddress& mac, stri
 
     if (ptr)
     {
+        if (ptr->getSkipNeighborsSet().find(nbr) != ptr->getSkipNeighborsSet().end())
+        {
+            return true;
+        }
         return ptr->isActive();
     }
 

--- a/orchagent/muxorch.h
+++ b/orchagent/muxorch.h
@@ -97,6 +97,10 @@ public:
     {
         return nbr_handler_->getNextHopId(nh);
     }
+    std::set<IpAddress> getSkipNeighborsSet()
+    {
+        return skip_neighbors_;
+    }
 
 private:
     bool stateActive();


### PR DESCRIPTION
Orchagent was not programming neighbor IP to h/w L3 host table during
initialization because they were set as Standby. When the links became
active, SoC IPs were added to the skip_neighbors_ list and never
programmed. fix:

- Added public method MuxCable::getSkipNeighborsSet()
- check if nbr is in skip_neighbors_ when checking if cable is Active

Signed-off-by: Nikola Dancejic <ndancejic@microsoft.com>

related to: https://github.com/sonic-net/sonic-swss/pull/2369
