### PR TITLE
tlm_teamd: Filter portchannel subinterface events from STATE_DB LAG_TABLE

### DIFF
--- a/tlm_teamd/Makefile.am
+++ b/tlm_teamd/Makefile.am
@@ -1,4 +1,4 @@
-INCLUDES = -I $(top_srcdir)
+INCLUDES = -I $(top_srcdir) -I$(top_srcdir)/lib
 
 bin_PROGRAMS = tlm_teamd
 

--- a/tlm_teamd/main.cpp
+++ b/tlm_teamd/main.cpp
@@ -9,6 +9,7 @@
 
 #include "teamdctl_mgr.h"
 #include "values_store.h"
+#include "subintf.h"
 
 
 bool g_run = true;
@@ -30,6 +31,11 @@ void update_interfaces(swss::SubscriberStateTable & table, TeamdCtlMgr & mgr)
         const auto & lag_name = kfvKey(entry);
         const auto & op = kfvOp(entry);
 
+        if (lag_name.find(VLAN_SUB_INTERFACE_SEPARATOR) != string::npos)
+        {
+            SWSS_LOG_INFO("Skip subintf %s statedb event", lag_name.c_str());
+            continue;
+        }
         if (op == "SET")
         {
             mgr.add_lag(lag_name);

--- a/tlm_teamd/main.cpp
+++ b/tlm_teamd/main.cpp
@@ -6,6 +6,7 @@
 #include <select.h>
 #include <dbconnector.h>
 #include <subscriberstatetable.h>
+#include <string.h>
 
 #include "teamdctl_mgr.h"
 #include "values_store.h"

--- a/tlm_teamd/main.cpp
+++ b/tlm_teamd/main.cpp
@@ -6,7 +6,6 @@
 #include <select.h>
 #include <dbconnector.h>
 #include <subscriberstatetable.h>
-#include <string.h>
 
 #include "teamdctl_mgr.h"
 #include "values_store.h"
@@ -32,7 +31,7 @@ void update_interfaces(swss::SubscriberStateTable & table, TeamdCtlMgr & mgr)
         const auto & lag_name = kfvKey(entry);
         const auto & op = kfvOp(entry);
 
-        if (lag_name.find(VLAN_SUB_INTERFACE_SEPARATOR) != string::npos)
+        if (lag_name.find(VLAN_SUB_INTERFACE_SEPARATOR) != std::string::npos)
         {
             SWSS_LOG_INFO("Skip subintf %s statedb event", lag_name.c_str());
             continue;


### PR DESCRIPTION
Avoid processing portchannel subinterfaces in teamd

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixes #11218  : https://github.com/Azure/sonic-buildimage/issues/11218

As per Subinterface HLD, portchannel subinterfaces once provisioned by intfmgrd, will be updated to STATE_DB LAG_TABLE.
Teamd subscribes to STATE_DB LAG_TABLE hence it receives portchannel subinterface events though it is not interested in portchannel subinterface events.
Fix is to filter subinterface events prior to adding to teamd event queue.

**Why I did it**
Fix for issue #11218 where teamd syslog errors were observed when portchannel subinterfaces were configured  on the system.

**How I verified it**
Ensured tlm does not add portchannel subinterface STATE_DB LAG_TABLE events to its event queue thus filtering portchannel subinterface events.

**Details if related**
