### PR TITLE
[MuxOrch] Set internal class state to reflect the actual state

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -367,6 +367,7 @@ MuxCable::MuxCable(string name, IpPrefix& srv_ip4, IpPrefix& srv_ip6, IpAddress 
 
     /* Set initial state to "standby" */
     stateStandby();
+    state_ = MuxState::MUX_STATE_STANDBY;
 }
 
 bool MuxCable::stateInitActive()


### PR DESCRIPTION
**What I did**
Set internal class variable to set to STANDBY.
Default value was set to INIT and not modified after setting to standby. 

**Why I did it**
Fix for https://github.com/sonic-net/sonic-buildimage/issues/11654

**How I verified it**

**Details if related**
