### PR TITLE
[muxorch] Returning true if nbr in skip_neighbor_ in isNeighborActive()

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -963,7 +963,7 @@ bool MuxOrch::isNeighborActive(const IpAddress& nbr, const MacAddress& mac, stri
 
     if (ptr)
     {
-        return ptr->isActive() || ptr->isSkipNeighbor(nbr);
+        return (ptr->isActive() || ptr->isSkipNeighbor(nbr));
     }
 
     string port;
@@ -977,7 +977,7 @@ bool MuxOrch::isNeighborActive(const IpAddress& nbr, const MacAddress& mac, stri
     if (!port.empty() && isMuxExists(port))
     {
         MuxCable* ptr = getMuxCable(port);
-        return ptr->isActive() || ptr->isSkipNeighbor(nbr);
+        return (ptr->isActive() || ptr->isSkipNeighbor(nbr));
     }
 
     NextHopKey nh_key = NextHopKey(nbr, alias);
@@ -985,7 +985,7 @@ bool MuxOrch::isNeighborActive(const IpAddress& nbr, const MacAddress& mac, stri
     if (port.empty() && !curr_port.empty() && isMuxExists(curr_port))
     {
         MuxCable* ptr = getMuxCable(curr_port);
-        return ptr->isActive() || ptr->isSkipNeighbor(nbr);
+        return (ptr->isActive() || ptr->isSkipNeighbor(nbr));
     }
 
     return true;

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -963,7 +963,7 @@ bool MuxOrch::isNeighborActive(const IpAddress& nbr, const MacAddress& mac, stri
 
     if (ptr)
     {
-        return ptr->isActive() | ptr->isSkipNeighbor(nbr);
+        return ptr->isActive() || ptr->isSkipNeighbor(nbr);
     }
 
     string port;
@@ -977,7 +977,7 @@ bool MuxOrch::isNeighborActive(const IpAddress& nbr, const MacAddress& mac, stri
     if (!port.empty() && isMuxExists(port))
     {
         MuxCable* ptr = getMuxCable(port);
-        return ptr->isActive() | ptr->isSkipNeighbor(nbr);
+        return ptr->isActive() || ptr->isSkipNeighbor(nbr);
     }
 
     NextHopKey nh_key = NextHopKey(nbr, alias);
@@ -985,7 +985,7 @@ bool MuxOrch::isNeighborActive(const IpAddress& nbr, const MacAddress& mac, stri
     if (port.empty() && !curr_port.empty() && isMuxExists(curr_port))
     {
         MuxCable* ptr = getMuxCable(curr_port);
-        return ptr->isActive() | ptr->isSkipNeighbor(nbr);
+        return ptr->isActive() || ptr->isSkipNeighbor(nbr);
     }
 
     return true;

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -963,11 +963,7 @@ bool MuxOrch::isNeighborActive(const IpAddress& nbr, const MacAddress& mac, stri
 
     if (ptr)
     {
-        if (ptr->getSkipNeighborsSet().find(nbr) != ptr->getSkipNeighborsSet().end())
-        {
-            return true;
-        }
-        return ptr->isActive();
+        return ptr->isActive() | ptr->isSkipNeighbor(nbr);
     }
 
     string port;
@@ -981,7 +977,7 @@ bool MuxOrch::isNeighborActive(const IpAddress& nbr, const MacAddress& mac, stri
     if (!port.empty() && isMuxExists(port))
     {
         MuxCable* ptr = getMuxCable(port);
-        return ptr->isActive();
+        return ptr->isActive() | ptr->isSkipNeighbor(nbr);
     }
 
     NextHopKey nh_key = NextHopKey(nbr, alias);
@@ -989,7 +985,7 @@ bool MuxOrch::isNeighborActive(const IpAddress& nbr, const MacAddress& mac, stri
     if (port.empty() && !curr_port.empty() && isMuxExists(curr_port))
     {
         MuxCable* ptr = getMuxCable(curr_port);
-        return ptr->isActive();
+        return ptr->isActive() | ptr->isSkipNeighbor(nbr);
     }
 
     return true;

--- a/orchagent/muxorch.h
+++ b/orchagent/muxorch.h
@@ -97,9 +97,9 @@ public:
     {
         return nbr_handler_->getNextHopId(nh);
     }
-    std::set<IpAddress> getSkipNeighborsSet()
+    bool isSkipNeighbor(const IpAddress& nbr)
     {
-        return skip_neighbors_;
+        return (skip_neighbors_.find(nbr) != skip_neighbors_.end());
     }
 
 private:


### PR DESCRIPTION
PR #2407 added a check which returned true in isNeighborActive if it is
in the skip_neighbors_ list, but only checked for Mux in Subnet. This
extends that check to Mux Ports and Nexthop Muxes.

Signed-off-by: Nikola Dancejic <ndancejic@microsoft.com>
