### PR TITLE
Change the log messages in addKernelNeigh/Route from ERROR to INFO.

### DIFF
--- a/cfgmgr/nbrmgr.cpp
+++ b/cfgmgr/nbrmgr.cpp
@@ -397,7 +397,7 @@ void NbrMgr::doStateSystemNeighTask(Consumer &consumer)
 
             if (!addKernelNeigh(nbr_odev, ip_address, mac_address))
             {
-                SWSS_LOG_ERROR("Neigh entry add on dev %s failed for '%s'", nbr_odev.c_str(), kfvKey(t).c_str());
+                SWSS_LOG_INFO("Neigh entry add on dev %s failed for '%s'", nbr_odev.c_str(), kfvKey(t).c_str());
                 // Delete neigh to take care of deletion of exiting nbr for mac change. This makes sure that
                 // re-try will be successful and route addtion (below) will be attempted and be successful
                 delKernelNeigh(nbr_odev, ip_address);
@@ -411,7 +411,7 @@ void NbrMgr::doStateSystemNeighTask(Consumer &consumer)
 
             if (!addKernelRoute(nbr_odev, ip_address))
             {
-                SWSS_LOG_ERROR("Route entry add on dev %s failed for '%s'", nbr_odev.c_str(), kfvKey(t).c_str());
+                SWSS_LOG_INFO("Route entry add on dev %s failed for '%s'", nbr_odev.c_str(), kfvKey(t).c_str());
                 delKernelNeigh(nbr_odev, ip_address);
                 // Delete route to take care of deletion of exiting route of nbr for mac change.
                 delKernelRoute(ip_address);
@@ -522,8 +522,8 @@ bool NbrMgr::addKernelRoute(string odev, IpAddress ip_addr)
 
     if(ret)
     {
-        /* Just log error and return */
-        SWSS_LOG_ERROR("Failed to add route for %s, error: %d", ip_str.c_str(), ret);
+        /* This failure the caller expects is due to mac move */
+        SWSS_LOG_INFO("Failed to add route for %s, error: %d", ip_str.c_str(), ret);
         return false;
     }
 
@@ -586,8 +586,8 @@ bool NbrMgr::addKernelNeigh(string odev, IpAddress ip_addr, MacAddress mac_addr)
 
     if(ret)
     {
-        /* Just log error and return */
-        SWSS_LOG_ERROR("Failed to add Nbr for %s, error: %d", ip_str.c_str(), ret);
+        /* This failure the caller expects is due to mac move */
+        SWSS_LOG_INFO("Failed to add Nbr for %s, error: %d", ip_str.c_str(), ret);
         return false;
     }
 

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -239,6 +239,8 @@ class TestVirtualChassis(object):
         # Test neighbor on Ethernet4 since Ethernet0 is used as Inband port
         test_neigh_dev = "Ethernet4"
         test_neigh_ip = "10.8.104.3"
+        # Use this as the initial mac address of interface, later change to  test_neigh_mac
+        test_neigh_orig_mac = "00:01:02:03:04:77"
         test_neigh_mac = "00:01:02:03:04:05"
 
         dvss = vct.dvss
@@ -259,7 +261,8 @@ class TestVirtualChassis(object):
 
                     # Add a static neighbor
                     _, res = dvs.runcmd(['sh', "-c", "ip neigh show"])
-                    _, res = dvs.runcmd(['sh', "-c", f"ip neigh add {test_neigh_ip} lladdr {test_neigh_mac} dev {test_neigh_dev}"])
+                    _, res = dvs.runcmd(['sh', "-c", f"ip neigh add {test_neigh_ip} lladdr {test_neigh_orig_mac} dev {test_neigh_dev}"])
+                    _, res = dvs.runcmd(['sh', "-c", f"ip neigh change {test_neigh_ip} lladdr {test_neigh_mac} dev {test_neigh_dev}"])
                     assert res == "", "Error configuring static neigh"
 
                     asic_db = dvs.get_asic_db()

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -1,5 +1,6 @@
 from swsscommon import swsscommon
 from dvslib.dvs_database import DVSDatabase
+from dvslib.dvs_common import wait_for_result
 import ast
 
 class TestVirtualChassis(object):
@@ -391,7 +392,7 @@ class TestVirtualChassis(object):
                     
                         break
 
-            return test_neigh_asic_db_key, test_sysneigh_chassis_app_db_key, test_remote_neigh_asic_db_key
+            return (True, test_neigh_asic_db_key, test_sysneigh_chassis_app_db_key, test_remote_neigh_asic_db_key)
 
         # Original mac_address of neighbor, and the new mac_address for mac change test
         test_neigh_orig_mac = "00:01:02:03:04:77"
@@ -402,7 +403,7 @@ class TestVirtualChassis(object):
         wait_for_result(chassis_system_neigh_create(self, vct, test_neigh_orig_mac, "add"))
 
         # Second step to update the mac address and check local/chassis_db/remote entry creation
-        test_neigh_asic_db_key, test_sysneigh_chassis_app_db_key, test_remote_neigh_asic_db_key = wait_for_result(chassis_system_neigh_create(self, vct, test_neigh_mac, "change"))
+        _, test_neigh_asic_db_key, test_sysneigh_chassis_app_db_key, test_remote_neigh_asic_db_key = wait_for_result(chassis_system_neigh_create(self, vct, test_neigh_mac, "change"))
 
         # Verify system neighbor delete and clearing
         dvss = vct.dvss

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -236,6 +236,9 @@ class TestVirtualChassis(object):
         # Configure port type inband interface
         self.config_inbandif_port(vct, inband_port)
 
+        # Grouping together the checks done during neighbor entry create into a function chassis_system_neigh_create()
+        # if action is "add" it creates a new neighbor entry in local asic
+        # if action is "change" it updates an existing neighbor entry with the mac_address
         def chassis_system_neigh_create(self, vct, mac_address, action):
             # Test neighbor on Ethernet4 since Ethernet0 is used as Inband port
             test_neigh_dev = "Ethernet4"
@@ -388,13 +391,18 @@ class TestVirtualChassis(object):
                     
                         break
 
-        # Test mac change for a neighbor.
-        # Use this as the initial mac address of interface, later change to  test_neigh_mac
+            return test_neigh_asic_db_key, test_sysneigh_chassis_app_db_key, test_remote_neigh_asic_db_key
+
+        # Original mac_address of neighbor, and the new mac_address for mac change test
         test_neigh_orig_mac = "00:01:02:03:04:77"
         test_neigh_mac = "00:01:02:03:04:05"
 
-        chassis_system_neigh_create(self, vct, test_neigh_orig_mac, "add")
-        chassis_system_neigh_create(self, vct, test_neigh_mac, "change")
+        # Test mac change for a neighbor.
+        # First step is to add a new neighbor and check local/chassis_db/remote entry creation
+        test_neigh_asic_db_key, test_sysneigh_chassis_app_db_key, test_remote_neigh_asic_db_key = chassis_system_neigh_create(self, vct, test_neigh_orig_mac, "add")
+
+        # Second step to update the mac address and check local/chassis_db/remote entry creation
+        test_neigh_asic_db_key, test_sysneigh_chassis_app_db_key, test_remote_neigh_asic_db_key = chassis_system_neigh_create(self, vct, test_neigh_mac, "change")
 
         # Verify system neighbor delete and clearing
         dvss = vct.dvss

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -392,7 +392,7 @@ class TestVirtualChassis(object):
                     
                         break
 
-            return (True, test_neigh_asic_db_key, test_sysneigh_chassis_app_db_key, test_remote_neigh_asic_db_key)
+            return True, (test_neigh_asic_db_key, test_sysneigh_chassis_app_db_key, test_remote_neigh_asic_db_key)
 
         # Original mac_address of neighbor, and the new mac_address for mac change test
         test_neigh_orig_mac = "00:01:02:03:04:77"
@@ -403,7 +403,7 @@ class TestVirtualChassis(object):
         wait_for_result(chassis_system_neigh_create(self, vct, test_neigh_orig_mac, "add"))
 
         # Second step to update the mac address and check local/chassis_db/remote entry creation
-        _, test_neigh_asic_db_key, test_sysneigh_chassis_app_db_key, test_remote_neigh_asic_db_key = wait_for_result(chassis_system_neigh_create(self, vct, test_neigh_mac, "change"))
+        _, (test_neigh_asic_db_key, test_sysneigh_chassis_app_db_key, test_remote_neigh_asic_db_key) = wait_for_result(chassis_system_neigh_create(self, vct, test_neigh_mac, "change"))
 
         # Verify system neighbor delete and clearing
         dvss = vct.dvss

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -399,10 +399,10 @@ class TestVirtualChassis(object):
 
         # Test mac change for a neighbor.
         # First step is to add a new neighbor and check local/chassis_db/remote entry creation
-        test_neigh_asic_db_key, test_sysneigh_chassis_app_db_key, test_remote_neigh_asic_db_key = chassis_system_neigh_create(self, vct, test_neigh_orig_mac, "add")
+        wait_for_result(chassis_system_neigh_create(self, vct, test_neigh_orig_mac, "add"))
 
         # Second step to update the mac address and check local/chassis_db/remote entry creation
-        test_neigh_asic_db_key, test_sysneigh_chassis_app_db_key, test_remote_neigh_asic_db_key = chassis_system_neigh_create(self, vct, test_neigh_mac, "change")
+        test_neigh_asic_db_key, test_sysneigh_chassis_app_db_key, test_remote_neigh_asic_db_key = wait_for_result(chassis_system_neigh_create(self, vct, test_neigh_mac, "change"))
 
         # Verify system neighbor delete and clearing
         dvss = vct.dvss

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -236,162 +236,168 @@ class TestVirtualChassis(object):
         # Configure port type inband interface
         self.config_inbandif_port(vct, inband_port)
 
-        # Test neighbor on Ethernet4 since Ethernet0 is used as Inband port
-        test_neigh_dev = "Ethernet4"
-        test_neigh_ip = "10.8.104.3"
+        def chassis_system_neigh_create(self, vct, mac_address, action):
+            # Test neighbor on Ethernet4 since Ethernet0 is used as Inband port
+            test_neigh_dev = "Ethernet4"
+            test_neigh_ip = "10.8.104.3"
+
+            dvss = vct.dvss
+            print("name {}".format(dvss.keys()))
+            for name in dvss.keys():
+                dvs = dvss[name]
+
+                config_db = dvs.get_config_db()
+                metatbl = config_db.get_entry("DEVICE_METADATA", "localhost")
+
+                cfg_switch_type = metatbl.get("switch_type")
+
+                # Neighbor record verifiation done in line card
+                if cfg_switch_type == "voq":
+                    lc_switch_id = metatbl.get("switch_id")
+                    assert lc_switch_id != "", "Got error in getting switch_id from CONFIG_DB DEVICE_METADATA"
+                    if lc_switch_id == "0":
+
+                        # Add a static neighbor
+                        _, res = dvs.runcmd(['sh', "-c", "ip neigh show"])
+                        _, res = dvs.runcmd(['sh', "-c", f"ip neigh {action} {test_neigh_ip} lladdr {mac_address} dev {test_neigh_dev}"])
+                        assert res == "", "Error configuring static neigh"
+
+                        asic_db = dvs.get_asic_db()
+                        asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY", 1)
+                        neighkeys = asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY")
+                        assert len(neighkeys), "No neigh entries in ASIC_DB"
+
+                        # Check for presence of the neighbor in ASIC_DB
+                        test_neigh = ""
+                        for nkey in neighkeys:
+                            ne = ast.literal_eval(nkey)
+                            if ne['ip'] == test_neigh_ip:
+                                test_neigh = nkey
+                                break
+
+                        assert test_neigh != "", "Neigh not found in ASIC_DB"
+
+                        # Preserve test neigh asic db key for delete verification later
+                        test_neigh_asic_db_key = test_neigh
+
+                        # Check for presence of encap index, retrieve and store it for sync verification
+                        test_neigh_entry = asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY", test_neigh)
+                        test_neigh_entry_attrs = asic_db.wait_for_fields("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY", test_neigh, ["SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX"])
+                        print(test_neigh)
+                        print(test_neigh_entry)
+                        print(test_neigh_entry_attrs)
+                        encap_index = test_neigh_entry_attrs["SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX"]
+                        assert encap_index != "" and encap_index != None, "VOQ encap index is not programmed in ASIC_DB"
+
+                        break
+
+            # Verify neighbor record syncing with encap index
+            for name in dvss.keys():
+                if name.startswith("supervisor"):
+                    dvs = dvss[name]
+                    chassis_app_db = DVSDatabase(swsscommon.CHASSIS_APP_DB, dvs.redis_chassis_sock)
+                    chassis_app_db.wait_for_n_keys("SYSTEM_NEIGH", 1)
+                    sysneighkeys = chassis_app_db.get_keys("SYSTEM_NEIGH")
+
+                    print(sysneighkeys)
+                    test_sysneigh = ""
+                    for sysnk in sysneighkeys:
+                        sysnk_tok = sysnk.split("|")
+                        assert len(sysnk_tok) == 3, "Invalid system neigh key in chassis app db"
+                        if sysnk_tok[2] == test_neigh_ip:
+                            test_sysneigh = sysnk
+                            break
+
+                    assert test_sysneigh != "", "Neigh is not sync-ed to chassis app db"
+
+                    # Preserve test sys neigh chassis app db key for delete verification later
+                    test_sysneigh_chassis_app_db_key = test_sysneigh
+
+                    test_sysneigh_entry = chassis_app_db.get_entry("SYSTEM_NEIGH", test_sysneigh)
+                    sys_neigh_encap_index = test_sysneigh_entry.get("encap_index")
+                    assert sys_neigh_encap_index != "", "System neigh in chassis app db does not have encap index"
+
+                    assert encap_index == sys_neigh_encap_index, "Encap index not sync-ed correctly"
+
+                    break
+
+            # Verify programming of remote neighbor in asic db and programming of static route and static
+            # neigh in the kernel for the remote neighbor. The neighbor created in linecard 1  will be a
+            # remote neighbor in other linecards. Verity existence of the test neighbor in  linecards other
+            # than linecard 1
+            for name in dvss.keys():
+                dvs = dvss[name]
+
+                config_db = dvs.get_config_db()
+                metatbl = config_db.get_entry("DEVICE_METADATA", "localhost")
+
+                cfg_switch_type = metatbl.get("switch_type")
+
+                # Neighbor record verifiation done in line card
+                if cfg_switch_type == "voq":
+                    lc_switch_id = metatbl.get("switch_id")
+                    assert lc_switch_id != "", "Got error in getting switch_id from CONFIG_DB DEVICE_METADATA"
+                    if lc_switch_id != "0":
+                        # Linecard other than linecard 1
+                        asic_db = dvs.get_asic_db()
+                        asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY", 1)
+                        neighkeys = asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY")
+                        assert len(neighkeys), "No neigh entries in ASIC_DB"
+
+                        # Check for presence of the remote neighbor in ASIC_DB
+                        remote_neigh = ""
+                        for nkey in neighkeys:
+                            ne = ast.literal_eval(nkey)
+                            if ne['ip'] == test_neigh_ip:
+                                remote_neigh = nkey
+                                break
+                        
+                        assert remote_neigh != "", "Remote neigh not found in ASIC_DB"
+
+                        # Preserve remote neigh asic db neigh key for delete verification later
+                        test_remote_neigh_asic_db_key = remote_neigh
+                    
+                        # Check for kernel entries
+
+                        _, output = dvs.runcmd("ip neigh show")
+                        assert f"{test_neigh_ip} dev {inband_port}" in output, "Kernel neigh not found for remote neighbor"
+
+                        _, output = dvs.runcmd("ip route show")
+                        assert f"{test_neigh_ip} dev {inband_port} scope link" in output, "Kernel route not found for remote neighbor"
+                   
+                        # Check for ASIC_DB entries.
+
+                        # Check for presence of encap index, retrieve and store it for sync verification
+                        remote_neigh_entry = asic_db.get_entry("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY", remote_neigh)
+                    
+                        # Validate encap index
+                        remote_encap_index = remote_neigh_entry.get("SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX")
+                        assert remote_encap_index != "", "VOQ encap index is not programmed for remote neigh in ASIC_DB"
+                        assert remote_encap_index == encap_index, "Encap index of remote neigh mismatch with allocated encap index"
+                    
+                        # Validate MAC
+                        mac = remote_neigh_entry.get("SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS")
+                        assert mac != "", "MAC address is not programmed for remote neigh in ASIC_DB"
+                        assert mac == mac_address, "Encap index of remote neigh mismatch with allocated encap index"
+                    
+                        # Check for other mandatory attributes
+                        # For remote neighbors, is_local must be "false"
+                        is_local = remote_neigh_entry.get("SAI_NEIGHBOR_ENTRY_ATTR_IS_LOCAL")
+                        assert is_local != "", "is_local attribute is not programmed for remote neigh in ASIC_DB"
+                        assert is_local == "false", "is_local attribute is true for remote neigh"
+                    
+                        break
+
+        # Test mac change for a neighbor.
         # Use this as the initial mac address of interface, later change to  test_neigh_mac
         test_neigh_orig_mac = "00:01:02:03:04:77"
         test_neigh_mac = "00:01:02:03:04:05"
 
-        dvss = vct.dvss
-        print("name {}".format(dvss.keys()))
-        for name in dvss.keys():
-            dvs = dvss[name]
-
-            config_db = dvs.get_config_db()
-            metatbl = config_db.get_entry("DEVICE_METADATA", "localhost")
-
-            cfg_switch_type = metatbl.get("switch_type")
-
-            # Neighbor record verifiation done in line card
-            if cfg_switch_type == "voq":
-                lc_switch_id = metatbl.get("switch_id")
-                assert lc_switch_id != "", "Got error in getting switch_id from CONFIG_DB DEVICE_METADATA"
-                if lc_switch_id == "0":
-
-                    # Add a static neighbor
-                    _, res = dvs.runcmd(['sh', "-c", "ip neigh show"])
-                    _, res = dvs.runcmd(['sh', "-c", f"ip neigh add {test_neigh_ip} lladdr {test_neigh_orig_mac} dev {test_neigh_dev}"])
-                    _, res = dvs.runcmd(['sh', "-c", f"ip neigh change {test_neigh_ip} lladdr {test_neigh_mac} dev {test_neigh_dev}"])
-                    assert res == "", "Error configuring static neigh"
-
-                    asic_db = dvs.get_asic_db()
-                    asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY", 1)
-                    neighkeys = asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY")
-                    assert len(neighkeys), "No neigh entries in ASIC_DB"
-
-                    # Check for presence of the neighbor in ASIC_DB
-                    test_neigh = ""
-                    for nkey in neighkeys:
-                        ne = ast.literal_eval(nkey)
-                        if ne['ip'] == test_neigh_ip:
-                            test_neigh = nkey
-                            break
-
-                    assert test_neigh != "", "Neigh not found in ASIC_DB"
-
-                    # Preserve test neigh asic db key for delete verification later
-                    test_neigh_asic_db_key = test_neigh
-
-                    # Check for presence of encap index, retrieve and store it for sync verification
-                    test_neigh_entry = asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY", test_neigh)
-                    test_neigh_entry_attrs = asic_db.wait_for_fields("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY", test_neigh, ["SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX"])
-                    print(test_neigh)
-                    print(test_neigh_entry)
-                    print(test_neigh_entry_attrs)
-                    encap_index = test_neigh_entry_attrs["SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX"]
-                    assert encap_index != "" and encap_index != None, "VOQ encap index is not programmed in ASIC_DB"
-
-                    break
-
-        # Verify neighbor record syncing with encap index
-        for name in dvss.keys():
-            if name.startswith("supervisor"):
-                dvs = dvss[name]
-                chassis_app_db = DVSDatabase(swsscommon.CHASSIS_APP_DB, dvs.redis_chassis_sock)
-                chassis_app_db.wait_for_n_keys("SYSTEM_NEIGH", 1)
-                sysneighkeys = chassis_app_db.get_keys("SYSTEM_NEIGH")
-
-                print(sysneighkeys)
-                test_sysneigh = ""
-                for sysnk in sysneighkeys:
-                    sysnk_tok = sysnk.split("|")
-                    assert len(sysnk_tok) == 3, "Invalid system neigh key in chassis app db"
-                    if sysnk_tok[2] == test_neigh_ip:
-                        test_sysneigh = sysnk
-                        break
-
-                assert test_sysneigh != "", "Neigh is not sync-ed to chassis app db"
-
-                # Preserve test sys neigh chassis app db key for delete verification later
-                test_sysneigh_chassis_app_db_key = test_sysneigh
-
-                test_sysneigh_entry = chassis_app_db.get_entry("SYSTEM_NEIGH", test_sysneigh)
-                sys_neigh_encap_index = test_sysneigh_entry.get("encap_index")
-                assert sys_neigh_encap_index != "", "System neigh in chassis app db does not have encap index"
-
-                assert encap_index == sys_neigh_encap_index, "Encap index not sync-ed correctly"
-
-                break
-
-        # Verify programming of remote neighbor in asic db and programming of static route and static
-        # neigh in the kernel for the remote neighbor. The neighbor created in linecard 1  will be a 
-        # remote neighbor in other linecards. Verity existence of the test neighbor in  linecards other 
-        # than linecard 1
-        for name in dvss.keys():
-            dvs = dvss[name]
-
-            config_db = dvs.get_config_db()
-            metatbl = config_db.get_entry("DEVICE_METADATA", "localhost")
-
-            cfg_switch_type = metatbl.get("switch_type")
-
-            # Neighbor record verifiation done in line card
-            if cfg_switch_type == "voq":    
-                lc_switch_id = metatbl.get("switch_id")
-                assert lc_switch_id != "", "Got error in getting switch_id from CONFIG_DB DEVICE_METADATA"
-                if lc_switch_id != "0":
-                    # Linecard other than linecard 1
-                    asic_db = dvs.get_asic_db()
-                    asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY", 1)
-                    neighkeys = asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY")
-                    assert len(neighkeys), "No neigh entries in ASIC_DB"
-                    
-                    # Check for presence of the remote neighbor in ASIC_DB
-                    remote_neigh = ""
-                    for nkey in neighkeys:
-                        ne = ast.literal_eval(nkey)
-                        if ne['ip'] == test_neigh_ip:
-                            remote_neigh = nkey
-                            break
-                        
-                    assert remote_neigh != "", "Remote neigh not found in ASIC_DB"
-
-                    # Preserve remote neigh asic db neigh key for delete verification later
-                    test_remote_neigh_asic_db_key = remote_neigh
-                    
-                    # Check for kernel entries
-
-                    _, output = dvs.runcmd("ip neigh show")
-                    assert f"{test_neigh_ip} dev {inband_port}" in output, "Kernel neigh not found for remote neighbor"
-
-                    _, output = dvs.runcmd("ip route show")
-                    assert f"{test_neigh_ip} dev {inband_port} scope link" in output, "Kernel route not found for remote neighbor"
-                   
-                    # Check for ASIC_DB entries. 
-
-                    # Check for presence of encap index, retrieve and store it for sync verification
-                    remote_neigh_entry = asic_db.get_entry("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY", remote_neigh)
-                    
-                    # Validate encap index
-                    remote_encap_index = remote_neigh_entry.get("SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX")
-                    assert remote_encap_index != "", "VOQ encap index is not programmed for remote neigh in ASIC_DB"
-                    assert remote_encap_index == encap_index, "Encap index of remote neigh mismatch with allocated encap index"
-                    
-                    # Validate MAC
-                    mac = remote_neigh_entry.get("SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS")
-                    assert mac != "", "MAC address is not programmed for remote neigh in ASIC_DB"
-                    assert mac == test_neigh_mac, "Encap index of remote neigh mismatch with allocated encap index"
-                    
-                    # Check for other mandatory attributes
-                    # For remote neighbors, is_local must be "false" 
-                    is_local = remote_neigh_entry.get("SAI_NEIGHBOR_ENTRY_ATTR_IS_LOCAL")
-                    assert is_local != "", "is_local attribute is not programmed for remote neigh in ASIC_DB"
-                    assert is_local == "false", "is_local attribute is true for remote neigh"
-                    
-                    break
+        chassis_system_neigh_create(self, vct, test_neigh_orig_mac, "add")
+        chassis_system_neigh_create(self, vct, test_neigh_mac, "change")
 
         # Verify system neighbor delete and clearing
+        dvss = vct.dvss
         for name in dvss.keys():
             dvs = dvss[name]
 


### PR DESCRIPTION
**What I did**
Change the Error reporting for API's addKernelRoute, addKernelNeigh from ERR to INFO as the code logic already deletes and retries the creation of Neigh/Route 

For the test **tests/test_virtual_chassis.py::test_chassis_system_neigh** the following change was made 

1. Grouped the neighbor creation,  validation of the DB entry present in local and remote LC into a new function chassis_system_neigh_create()
2. Call this function first with mac_address = "00:01:02:03:04:77", action as "add" to create a new neighbor entry.
3. Call this function again with mac_address = "00:01:02:03:04:05", action as "change" to update the mac_addres of that neighbor entry already created before.

**Why I did it**
There was sonic-mgmt test failures in multi-asic devices where the Neighbor and routes learnt in in one ASIC is synced with the nearby ASIC, and in case of mac move there is possibility for an existing entry to be updated with a new mac address ( using the command /sbin/ip neigh add <ip> lladdr <mac-address> dev <device>) . This causes error as ip neigh/route add command will fail (error : nbrmgrd RTNETLINK answers: File exists)  

```
E               Failed: Processes "['analyze_logs--<MultiAsicSonicHost str2--lc1-1>']" failed with exit code "1"
E               Exception:
E               expected_match: 0
E               expected_missing_match: 0
E               match: 1
E               
E               Match Messages:
E               Aug 16 16:39:19.939498 str2--lc1-1 ERR swss1#nbrmgrd: :- doStateSystemNeighTask: Route entry add on dev Ethernet-IB1 failed for 'str2--lc1-1|asic0|PortChannel102|29.0.0.2'
E               
E               Traceback:
E               Traceback (most recent call last):
E                 File "/home/jujoseph/CHASSIS/CHASSIS/sonic-mgmt-int/tests/common/helpers/parallel.py", line 31, in run
E                   Process.run(self)
E                 File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
E                   self._target(*self._args, **self._kwargs)
E                 File "/home/jujoseph/CHASSIS/CHASSIS/sonic-mgmt-int/tests/common/helpers/parallel.py", line 226, in wrapper
E                   target(*args, **kwargs)
E                 File "/home/jujoseph/CHASSIS/CHASSIS/sonic-mgmt-int/tests/common/plugins/loganalyzer/__init__.py", line 39, in analyze_logs
E                   dut_analyzer.analyze(markers[node.hostname])
E                 File "/home/jujoseph/CHASSIS/CHASSIS/sonic-mgmt-int/tests/common/plugins/loganalyzer/loganalyzer.py", line 369, in analyze
E                   self._verify_log(analyzer_summary)
E                 File "/home/jujoseph/CHASSIS/CHASSIS/sonic-mgmt-int/tests/common/plugins/loganalyzer/loganalyzer.py", line 133, in _verify_log
E                   raise LogAnalyzerError(result_str)
E               LogAnalyzerError: expected_match: 0
E               expected_missing_match: 0
E               match: 1
E               
E               Match Messages:
E               Aug 16 16:39:19.939498 str2--lc1-1 ERR swss1#nbrmgrd: :- doStateSystemNeighTask: Route entry add on dev Ethernet-IB1 failed for 'str2--lc1-1|asic0|PortChannel102|29.0.0.2'

---------------------------------------------------- generated xml file: /home/jujoseph/CHASSIS/CHASSIS/sonic-mgmt-int/tests/logs/tr.xml ------------------------------------------------------
=================================================================================== short test summary info ====================================================================================
ERROR arp/test_neighbor_mac_noptf.py::TestNeighborMacNoPtf::testNeighborMacNoPtf[4-str2--lc1-1-0] - Failed: Processes "['analyze_logs--<MultiAsicSonicHost str2--lc1-1>']" failed wit...
============================================================================= 1 passed, 1 error in 316.96 seconds ==============================================================================
```

**How I verified it**
With this fix the tests passed

```
jujoseph@c3e1277334f8:~/CHASSIS/CHASSIS/sonic-mgmt-int/tests$ ./run_tests.sh -c arp/test_neighbor_mac_noptf.py::TestNeighborMacNoPtf::testNeighborMacNoPtf[4-str2--lc1-1-0]  -n vms29-t2--1 -d str2--lc1-1 -i "../ansible/str2,../ansible/veos" -t "t2,any" -S "dualtor_io" -e "--skip_sanity" -u
=== Running tests in groups ===
/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py:44: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.exceptions import InvalidSignature
===================================================================================== test session starts ======================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.5, py-1.11.0, pluggy-0.13.1
ansible: 2.8.12
rootdir: /home/jujoseph/CHASSIS/CHASSIS/sonic-mgmt-int/tests, inifile: pytest.ini
plugins: forked-1.3.0, metadata-1.11.0, xdist-1.28.0, html-1.22.1, allure-pytest-2.8.22, repeat-0.9.1, ansible-2.2.2
collected 1 item                                                                                                                                                                               

arp/test_neighbor_mac_noptf.py::TestNeighborMacNoPtf::testNeighborMacNoPtf[4-str2--lc1-1-0] PASSED                                                                                   [100%]

----------------------------------------------------- generated xml file: /home/jujoseph/CHASSIS/CHASSIS/sonic-mgmt-int/tests/logs/tr.xml ------------------------------------------------------
================================================================================== 1 passed in 317.49 seconds ==================================================================================
INFO:root:Can not get Allure report URL. Please check logs
jujoseph@c3e1277334f8:~/CHASSIS/CHASSIS/sonic-mgmt-int/tests$

```

**Details if related**
