### PR TITLE
[fpmsyncd] exit with non-zero rc on std::exception

### DIFF
--- a/fpmsyncd/fpmsyncd.cpp
+++ b/fpmsyncd/fpmsyncd.cpp
@@ -196,7 +196,7 @@ int main(int argc, char **argv)
         catch (const exception& e)
         {
             cout << "Exception \"" << e.what() << "\" had been thrown in daemon" << endl;
-            return 0;
+            return EXIT_FAILURE;
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
changed the return code on std::exception to EXIT_FAILURE
**Why I did it**
The original issue consists of two parts:
1. after config reload, fpmsyncd exits silently on exception without being restarted:
'''
root@sonic:/# supervisorctl status                                                                                                                 bgpcfgd                          RUNNING   pid 52, uptime 6:15:04                                                                                  bgpd                             RUNNING   pid 50, uptime 6:15:04                                                                                  bgpmon                           RUNNING   pid 79, uptime 6:15:02                                                                                  dependent-startup                EXITED    Jul 20 05:04 AM                                                                                         fpmsyncd                         EXITED    Jul 20 05:04 AM                                                                                         rsyslogd                         RUNNING   pid 31, uptime 6:15:05                                                                                  staticd                          RUNNING   pid 49, uptime 6:15:04                                                                                  supervisor-proc-exit-listener    RUNNING   pid 28, uptime 6:15:07                                                                                  zebra                            RUNNING   pid 35, uptime 6:15:05                                                                                  zsocket                          EXITED    Jul 20 05:04 AM 

admin@sonic$ docker logs bgpd
2022-07-20 05:04:49,506 INFO exited: fpmsyncd (exit status 0; expected)                                                                            2022-07-20 05:04:49,507 INFO success: bgpmon entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)     
'''
consequently with fpmsyncd dead, configured routes do not appear in the DB.

2. the exception itself:
'''
Exception "Cannot assign requested address" had been thrown in daemon
'''
which could indicate the tcp port fpmsyncd tries to bind to is in TIME_WAIT state after config reload.
Note to see this log I had to print into a drive file instead of stdout/stderr - for some reason it does not get into syslog.
the second issue is still under investigation.

**How I verified it**
fpmsyncd got restarted after the exception

**Details if related**