### PR TITLE
[neighsyncd] Enabling ipv4 link local entries for non-dualtor

### DIFF
--- a/tests/test_neighbor.py
+++ b/tests/test_neighbor.py
@@ -431,12 +431,12 @@ class TestNeighbor(object):
         # check application database
         tbl = swsscommon.Table(self.pdb, "NEIGH_TABLE:Ethernet8")
         intf_entries = tbl.getKeys()
-        assert len(intf_entries) == 0
+        assert len(intf_entries) == 1
 
         # check ASIC neighbor database
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY")
         intf_entries = tbl.getKeys()
-        assert len(intf_entries) == 0
+        assert len(intf_entries) == 1
 
         # remove neighbor
         self.remove_neighbor("Ethernet8", "169.254.0.0")

--- a/tests/test_neighbor.py
+++ b/tests/test_neighbor.py
@@ -6,6 +6,13 @@ from swsscommon import swsscommon
 
 
 class TestNeighbor(object):
+    CONFIG_PEER_SWITCH          = "PEER_SWITCH"
+    PEER_SWITCH_HOST            = "peer_switch_hostname"
+
+    DEFAULT_PEER_SWITCH_PARAMS = {
+        "address_ipv4": PEER_IPV4
+    }
+
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)
         self.adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
@@ -460,6 +467,61 @@ class TestNeighbor(object):
         intf_entries = tbl.getKeys()
         assert len(intf_entries) == 0
 
+    def test_Ipv4LinkLocalNeighborWithDualToR(self, dvs, testlog, setup_peer_switch):
+        self.setup_db(dvs)
+
+        # bring up interface
+        self.set_admin_status("Ethernet8", "up")
+
+        # create interface
+        self.create_l3_intf("Ethernet8", "")
+
+        # assign IP to interface
+        self.add_ip_address("Ethernet8", "10.0.0.1/24")
+
+        # add neighbor
+        self.add_neighbor("Ethernet8", "169.254.0.0", "00:01:02:03:04:05")
+
+        # check application database
+        tbl = swsscommon.Table(self.pdb, "NEIGH_TABLE:Ethernet8")
+        intf_entries = tbl.getKeys()
+        assert len(intf_entries) == 0
+
+        # check ASIC neighbor database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY")
+        intf_entries = tbl.getKeys()
+        assert len(intf_entries) == 0
+
+        # remove neighbor
+        self.remove_neighbor("Ethernet8", "169.254.0.0")
+
+        # remove IP from interface
+        self.remove_ip_address("Ethernet8", "10.0.0.1/24")
+
+        # remove interface
+        self.remove_l3_intf("Ethernet8")
+
+        # bring down interface
+        self.set_admin_status("Ethernet8", "down")
+
+        # check application database
+        tbl = swsscommon.Table(self.pdb, "NEIGH_TABLE:Ethernet8")
+        intf_entries = tbl.getKeys()
+        assert len(intf_entries) == 0
+
+        # check ASIC neighbor database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY")
+        intf_entries = tbl.getKeys()
+        assert len(intf_entries) == 0
+
+    @pytest.fixture
+    def setup_peer_switch(self, dvs):
+        config_db = dvs.get_config_db()
+        config_db.create_entry(
+            self.CONFIG_PEER_SWITCH,
+            self.PEER_SWITCH_HOST,
+            self.DEFAULT_PEER_SWITCH_PARAMS
+        )
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying

--- a/tests/test_neighbor.py
+++ b/tests/test_neighbor.py
@@ -8,6 +8,7 @@ from swsscommon import swsscommon
 class TestNeighbor(object):
     CONFIG_PEER_SWITCH          = "PEER_SWITCH"
     PEER_SWITCH_HOST            = "peer_switch_hostname"
+    PEER_IPV4                   = "10.1.0.33"
 
     DEFAULT_PEER_SWITCH_PARAMS = {
         "address_ipv4": PEER_IPV4


### PR DESCRIPTION
Allow ipv4 link local entries to be programmed to the hardware unless on
a dual-tor setup.

fixing sonic-net/sonic-buildimage#11830

Signed-off-by: Nikola Dancejic <ndancejic@microsoft.com>