### PR TITLE
Fix the Fec Mode Setting of gbsyncd

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1290,7 +1290,7 @@ bool PortsOrch::setPortFec(Port &port, string &mode)
 
     SWSS_LOG_NOTICE("Set port %s FEC mode %s", port.m_alias.c_str(), mode.c_str());
 
-    setGearboxPortsAttr(port, SAI_PORT_ATTR_FEC_MODE, &mode);
+    setGearboxPortsAttr(port, SAI_PORT_ATTR_FEC_MODE, &port.m_fec_mode);
 
     return true;
 }


### PR DESCRIPTION
Why I did:

PR: https://github.com/sonic-net/sonic-swss/pull/2400 made change to pass `<string>` as argument to API `setPortFecMode` but did not updated the corresponding gbsyncd API call which is making gbsyncd to fail with below errors

```
Aug 25 19:21:54.446591 str2-xxxx-lc1-3 ERR swss1#orchagent: :- meta_generic_validation_set: SAI_PORT_ATTR_FEC_MODE:SAI_ATTR_VALUE_TYPE_INT32 is enum, but value 1989570112 not found on allowed values list
Aug 25 19:21:54.446591 str2-xxxx-lc1-3 ERR swss1#orchagent: :- setGearboxPortAttr: BOX: Failed to set Ethernet13 port attribute 51
Aug 25 19:21:54.446605 str2-xxxx-lc1-3 ERR swss1#orchagent: :- handleSaiSetStatus: Encountered failure in set operation, exiting orchagent, SAI API: SAI_API_PORT, status: SAI_STATUS_INVALID_PARAMETER
```

How I fixed:
Passed the expected value in pointer to integer format.

