### PR TITLE
[intfmgr]: Enable `accept_untracked_na` kernel param

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -535,7 +535,7 @@ void IntfMgr::removeSubIntfState(const string &alias)
 bool IntfMgr::setIntfGratArp(const string &alias, const string &grat_arp)
 {
     /*
-     * Enable gratuitous ARP by accepting unsolicited ARP replies
+     * Enable gratuitous ARP by accepting unsolicited ARP replies and untracked neighbor advertisements
      */
     stringstream cmd;
     string res;
@@ -557,8 +557,15 @@ bool IntfMgr::setIntfGratArp(const string &alias, const string &grat_arp)
 
     cmd << ECHO_CMD << " " << garp_enabled << " > /proc/sys/net/ipv4/conf/" << alias << "/arp_accept";
     EXEC_WITH_ERROR_THROW(cmd.str(), res);
-
     SWSS_LOG_INFO("ARP accept set to \"%s\" on interface \"%s\"",  grat_arp.c_str(), alias.c_str());
+
+    cmd.clear();
+    cmd.str(std::string());
+
+    cmd << ECHO_CMD << " " << garp_enabled << " > /proc/sys/net/ipv6/conf/" << alias << "/accept_untracked_na";
+    EXEC_WITH_ERROR_THROW(cmd.str(), res);
+    SWSS_LOG_INFO("`accept_untracked_na` set to \"%s\" on interface \"%s\"",  grat_arp.c_str(), alias.c_str());
+
     return true;
 }
 

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -30,6 +30,7 @@ extraction:
       - graphviz
       - autoconf-archive
       - uuid-dev
+      - libyang
     after_prepare:
       - git clone https://github.com/Azure/sonic-buildimage; pushd sonic-buildimage/src/libnl3
       - git clone https://github.com/thom311/libnl libnl3-3.5.0; pushd libnl3-3.5.0; git checkout tags/libnl3_5_0

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -30,7 +30,6 @@ extraction:
       - graphviz
       - autoconf-archive
       - uuid-dev
-      - libyang
     after_prepare:
       - git clone https://github.com/Azure/sonic-buildimage; pushd sonic-buildimage/src/libnl3
       - git clone https://github.com/thom311/libnl libnl3-3.5.0; pushd libnl3-3.5.0; git checkout tags/libnl3_5_0

--- a/tests/dvslib/dvs_vlan.py
+++ b/tests/dvslib/dvs_vlan.py
@@ -13,6 +13,17 @@ class DVSVlan(object):
         vlan_entry = {"vlanid": vlanID}
         self.config_db.create_entry("VLAN", vlan, vlan_entry)
 
+    def create_vlan_interface(self,  vlanID):
+        vlan = "Vlan{}".format(vlanID)
+        vlan_intf_entry = {}
+        self.config_db.create_entry("VLAN_INTERFACE", vlan, vlan_intf_entry)
+
+    def set_vlan_intf_property(self, vlanID, property, value):
+        vlan_key = "Vlan{}".format(vlanID)
+        vlan_entry = self.config_db.get_entry("VLAN_INTERFACE", vlan_key)
+        vlan_entry[property] = value
+        self.config_db.update_entry("VLAN_INTERFACE", vlan_key, vlan_entry)
+
     def create_vlan_hostif(self, vlan, hostif_name):
         vlan = "Vlan{}".format(vlan)
         vlan_entry = {"vlanid": vlan,  "host_ifname": hostif_name}

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -1,6 +1,5 @@
 import distro
 import pytest
-import time
 
 from distutils.version import StrictVersion
 from dvslib.dvs_common import PollingConfig, wait_for_result

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -1,5 +1,6 @@
 import distro
 import pytest
+import time
 
 from distutils.version import StrictVersion
 from dvslib.dvs_common import PollingConfig
@@ -435,6 +436,57 @@ class TestVlan(object):
         self.dvs_vlan.remove_vlan(vlan)
         self.dvs_vlan.get_and_verify_vlan_ids(0)
         self.dvs_vlan.get_and_verify_vlan_hostif_ids(len(dvs.asic_db.hostif_name_map) - 1)
+
+    def test_VlanGratArp(self, dvs):
+        vlan = "2"
+        self.dvs_vlan.create_vlan(vlan)
+        self.dvs_vlan.create_vlan_interface(vlan)
+        self.dvs_vlan.set_vlan_intf_property(vlan, "grat_arp", "enabled")
+
+        time.sleep(1)
+
+        rc, res = dvs.runcmd("cat /proc/sys/net/ipv4/conf/Vlan{}/arp_accept".format(vlan))
+        assert res.strip("\n") == "1", "IPv4 arp_accept not enabled"
+
+        # Not currently possible to test `accept_untracked_na` as it doesn't exist in the kernel for
+        # our test VMs (only present in kernels 5.19 and above)
+        # rc, res = dvs.runcmd("cat /proc/sys/net/ipv6/conf/Vlan{}/accept_untracked_na".format(vlan))
+        # assert res.strip("\n") == "1", "IPv6 accept_untracked_na not enabled"
+
+        self.dvs_vlan.set_vlan_intf_property(vlan, "grat_arp", "disabled")
+
+        time.sleep(1)
+
+        rc, res = dvs.runcmd("cat /proc/sys/net/ipv4/conf/Vlan{}/arp_accept".format(vlan))
+        assert res.strip("\n") == "0", "IPv4 arp_accept not disabled"
+
+        # rc, res = dvs.runcmd("cat /proc/sys/net/ipv6/conf/Vlan{}/accept_untracked_na".format(vlan))
+        # assert res.strip("\n") == "0", "IPv6 accept_untracked_na not disabled"
+        self.dvs_vlan.remove_vlan(vlan)
+
+    def test_VlanProxyArp(self, dvs): 
+        vlan = "2"
+        self.dvs_vlan.create_vlan(vlan)
+        self.dvs_vlan.create_vlan_interface(vlan)
+        self.dvs_vlan.set_vlan_intf_property(vlan, "proxy_arp", "enabled")
+        time.sleep(1)
+
+        rc, res = dvs.runcmd("cat /proc/sys/net/ipv4/conf/Vlan{}/proxy_arp_pvlan".format(vlan))
+        assert res.strip("\n") == "1", "IPv4 proxy_arp_pvlan not enabled"
+
+        rc, res = dvs.runcmd("cat /proc/sys/net/ipv4/conf/Vlan{}/proxy_arp".format(vlan))
+        assert res.strip("\n") == "1", "IPv4 proxy_arp not enabled"
+
+        self.dvs_vlan.set_vlan_intf_property(vlan, "proxy_arp", "disabled")
+        time.sleep(1)
+
+        rc, res = dvs.runcmd("cat /proc/sys/net/ipv4/conf/Vlan{}/proxy_arp_pvlan".format(vlan))
+        assert res.strip("\n") == "0", "IPv4 proxy_arp_pvlan not disabled"
+
+        rc, res = dvs.runcmd("cat /proc/sys/net/ipv4/conf/Vlan{}/proxy_arp".format(vlan))
+        assert res.strip("\n") == "0", "IPv4 proxy_arp not disabled"
+
+        self.dvs_vlan.remove_vlan(vlan)
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -3,7 +3,7 @@ import pytest
 import time
 
 from distutils.version import StrictVersion
-from dvslib.dvs_common import PollingConfig
+from dvslib.dvs_common import PollingConfig, wait_for_result
 
 @pytest.mark.usefixtures("testlog")
 @pytest.mark.usefixtures('dvs_vlan_manager')
@@ -438,53 +438,54 @@ class TestVlan(object):
         self.dvs_vlan.get_and_verify_vlan_hostif_ids(len(dvs.asic_db.hostif_name_map) - 1)
 
     def test_VlanGratArp(self, dvs):
+        def arp_accept_enabled():
+            rc, res = dvs.runcmd("cat /proc/sys/net/ipv4/conf/Vlan{}/arp_accept".format(vlan))
+            return (res.strip("\n") == "1", res)
+
+        def arp_accept_disabled():
+            rc, res = dvs.runcmd("cat /proc/sys/net/ipv4/conf/Vlan{}/arp_accept".format(vlan))
+            return (res.strip("\n") == "0", res)
+
         vlan = "2"
         self.dvs_vlan.create_vlan(vlan)
         self.dvs_vlan.create_vlan_interface(vlan)
         self.dvs_vlan.set_vlan_intf_property(vlan, "grat_arp", "enabled")
 
-        time.sleep(1)
-
-        rc, res = dvs.runcmd("cat /proc/sys/net/ipv4/conf/Vlan{}/arp_accept".format(vlan))
-        assert res.strip("\n") == "1", "IPv4 arp_accept not enabled"
+        wait_for_result(arp_accept_enabled, PollingConfig(), "IPv4 arp_accept not enabled")
 
         # Not currently possible to test `accept_untracked_na` as it doesn't exist in the kernel for
         # our test VMs (only present in kernels 5.19 and above)
-        # rc, res = dvs.runcmd("cat /proc/sys/net/ipv6/conf/Vlan{}/accept_untracked_na".format(vlan))
-        # assert res.strip("\n") == "1", "IPv6 accept_untracked_na not enabled"
 
         self.dvs_vlan.set_vlan_intf_property(vlan, "grat_arp", "disabled")
 
-        time.sleep(1)
+        wait_for_result(arp_accept_disabled, PollingConfig(), "IPv4 arp_accept not disabled")
 
-        rc, res = dvs.runcmd("cat /proc/sys/net/ipv4/conf/Vlan{}/arp_accept".format(vlan))
-        assert res.strip("\n") == "0", "IPv4 arp_accept not disabled"
-
-        # rc, res = dvs.runcmd("cat /proc/sys/net/ipv6/conf/Vlan{}/accept_untracked_na".format(vlan))
-        # assert res.strip("\n") == "0", "IPv6 accept_untracked_na not disabled"
         self.dvs_vlan.remove_vlan(vlan)
 
     def test_VlanProxyArp(self, dvs): 
+
+        def proxy_arp_enabled():
+            rc, proxy_arp_res = dvs.runcmd("cat /proc/sys/net/ipv4/conf/Vlan{}/proxy_arp".format(vlan))
+            rc, pvlan_res = dvs.runcmd("cat /proc/sys/net/ipv4/conf/Vlan{}/proxy_arp_pvlan".format(vlan))
+
+            return (proxy_arp_res.strip("\n") == "1" and pvlan_res.strip("\n") == "1", (proxy_arp_res, pvlan_res))
+
+        def proxy_arp_disabled():
+            rc, proxy_arp_res = dvs.runcmd("cat /proc/sys/net/ipv4/conf/Vlan{}/proxy_arp".format(vlan))
+            rc, pvlan_res = dvs.runcmd("cat /proc/sys/net/ipv4/conf/Vlan{}/proxy_arp_pvlan".format(vlan))
+
+            return (proxy_arp_res.strip("\n") == "0" and pvlan_res.strip("\n") == "0", (proxy_arp_res, pvlan_res))
+            
         vlan = "2"
         self.dvs_vlan.create_vlan(vlan)
         self.dvs_vlan.create_vlan_interface(vlan)
         self.dvs_vlan.set_vlan_intf_property(vlan, "proxy_arp", "enabled")
-        time.sleep(1)
 
-        rc, res = dvs.runcmd("cat /proc/sys/net/ipv4/conf/Vlan{}/proxy_arp_pvlan".format(vlan))
-        assert res.strip("\n") == "1", "IPv4 proxy_arp_pvlan not enabled"
-
-        rc, res = dvs.runcmd("cat /proc/sys/net/ipv4/conf/Vlan{}/proxy_arp".format(vlan))
-        assert res.strip("\n") == "1", "IPv4 proxy_arp not enabled"
+        wait_for_result(proxy_arp_enabled, PollingConfig(), 'IPv4 proxy_arp or proxy_arp_pvlan not enabled')
 
         self.dvs_vlan.set_vlan_intf_property(vlan, "proxy_arp", "disabled")
-        time.sleep(1)
 
-        rc, res = dvs.runcmd("cat /proc/sys/net/ipv4/conf/Vlan{}/proxy_arp_pvlan".format(vlan))
-        assert res.strip("\n") == "0", "IPv4 proxy_arp_pvlan not disabled"
-
-        rc, res = dvs.runcmd("cat /proc/sys/net/ipv4/conf/Vlan{}/proxy_arp".format(vlan))
-        assert res.strip("\n") == "0", "IPv4 proxy_arp not disabled"
+        wait_for_result(proxy_arp_disabled, PollingConfig(), 'IPv4 proxy_arp or proxy_arp_pvlan not disabled')
 
         self.dvs_vlan.remove_vlan(vlan)
 


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When enabling gratuitous ARP, also enable acceptance of untracked neighbor advertisements

**Why I did it**
For dual ToR devices, this helps keep the neighbor caches of both ToRs in sync since the standby ToR's neighbor solicitation messages are always dropped. By enabling this kernel parameter, we allow the standby to learn neighbor entries using NA messages generated by the active ToR's NS messages.

Depends on following PRs for their respective branches:

- https://github.com/sonic-net/sonic-linux-kernel/pull/292
- https://github.com/sonic-net/sonic-linux-kernel/pull/291

**How I verified it**

**Details if related**
Do not merge until https://github.com/sonic-net/sonic-buildimage/pull/11947 is merged
