### PR TITLE
[202012][intfmgr]: Enable `accept_untracked_na` kernel param

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -317,7 +317,7 @@ void IntfMgr::removeSubIntfState(const string &alias)
 bool IntfMgr::setIntfGratArp(const string &alias, const string &grat_arp)
 {
     /*
-     * Enable gratuitous ARP by accepting unsolicited ARP replies
+     * Enable gratuitous ARP by accepting unsolicited ARP replies and untracked neighbor advertisements
      */
     stringstream cmd;
     string res;
@@ -339,8 +339,15 @@ bool IntfMgr::setIntfGratArp(const string &alias, const string &grat_arp)
 
     cmd << ECHO_CMD << " " << garp_enabled << " > /proc/sys/net/ipv4/conf/" << alias << "/arp_accept";
     EXEC_WITH_ERROR_THROW(cmd.str(), res);
-
     SWSS_LOG_INFO("ARP accept set to \"%s\" on interface \"%s\"",  grat_arp.c_str(), alias.c_str());
+
+    cmd.clear();
+    cmd.str(std::string());
+
+    cmd << ECHO_CMD << " " << garp_enabled << " > /proc/sys/net/ipv6/conf/" << alias << "/accept_untracked_na";
+    EXEC_WITH_ERROR_THROW(cmd.str(), res);
+    SWSS_LOG_INFO("`accept_untracked_na` set to \"%s\" on interface \"%s\"",  grat_arp.c_str(), alias.c_str());
+
     return true;
 }
 


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When enabling gratuitous ARP, also enable acceptance of untracked neighbor advertisements

**Why I did it**
For dual ToR devices, this helps keep the neighbor caches of both ToRs in sync since the standby ToR's neighbor solicitation messages are always dropped. By enabling this kernel parameter, we allow the standby to learn neighbor entries using NA messages generated by the active ToR's NS messages.

**How I verified it**

**Details if related**
Do not merge until https://github.com/sonic-net/sonic-buildimage/pull/11929 is merged