### PR TITLE
[DPU] Simplify SWSS initialization to meet DPU requirements.

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -28,6 +28,7 @@ extern sai_switch_api_t* sai_switch_api;
 extern sai_object_id_t   gSwitchId;
 extern PortsOrch*        gPortsOrch;
 extern CrmOrch *gCrmOrch;
+extern string gMySwitchType;
 
 #define MIN_VLAN_ID 1    // 0 is a reserved VLAN ID
 #define MAX_VLAN_ID 4095 // 4096 is a reserved VLAN ID
@@ -2944,27 +2945,30 @@ void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, Mirr
     }
     m_switchOrch->set_switch_capability(fvVector);
 
-    sai_attribute_t attrs[2];
-    attrs[0].id = SAI_SWITCH_ATTR_ACL_ENTRY_MINIMUM_PRIORITY;
-    attrs[1].id = SAI_SWITCH_ATTR_ACL_ENTRY_MAXIMUM_PRIORITY;
+    if (gMySwitchType != "dpu")
+    {
+        sai_attribute_t attrs[2];
+        attrs[0].id = SAI_SWITCH_ATTR_ACL_ENTRY_MINIMUM_PRIORITY;
+        attrs[1].id = SAI_SWITCH_ATTR_ACL_ENTRY_MAXIMUM_PRIORITY;
 
-    sai_status_t status = sai_switch_api->get_switch_attribute(gSwitchId, 2, attrs);
-    if (status == SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_NOTICE("Get ACL entry priority values, min: %u, max: %u", attrs[0].value.u32, attrs[1].value.u32);
-        AclRule::setRulePriorities(attrs[0].value.u32, attrs[1].value.u32);
-    }
-    else
-    {
-        SWSS_LOG_ERROR("Failed to get ACL entry priority min/max values, rv:%d", status);
-        task_process_status handle_status = handleSaiGetStatus(SAI_API_SWITCH, status);
-        if (handle_status != task_process_status::task_success)
+        sai_status_t status = sai_switch_api->get_switch_attribute(gSwitchId, 2, attrs);
+        if (status == SAI_STATUS_SUCCESS)
         {
-            throw "AclOrch initialization failure";
+            SWSS_LOG_NOTICE("Get ACL entry priority values, min: %u, max: %u", attrs[0].value.u32, attrs[1].value.u32);
+            AclRule::setRulePriorities(attrs[0].value.u32, attrs[1].value.u32);
         }
-    }
+        else
+        {
+            SWSS_LOG_ERROR("Failed to get ACL entry priority min/max values, rv:%d", status);
+            task_process_status handle_status = handleSaiGetStatus(SAI_API_SWITCH, status);
+            if (handle_status != task_process_status::task_success)
+            {
+                throw "AclOrch initialization failure";
+            }
+        }
 
-    queryAclActionCapability();
+        queryAclActionCapability();
+    }
 
     for (auto stage: {ACL_STAGE_INGRESS, ACL_STAGE_EGRESS})
     {

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -17,6 +17,7 @@ extern sai_buffer_api_t *sai_buffer_api;
 
 extern PortsOrch *gPortsOrch;
 extern sai_object_id_t gSwitchId;
+extern string gMySwitchType;
 
 #define BUFFER_POOL_WATERMARK_FLEX_STAT_COUNTER_POLL_MSECS  "60000"
 
@@ -54,7 +55,11 @@ BufferOrch::BufferOrch(DBConnector *applDb, DBConnector *confDb, DBConnector *st
     initTableHandlers();
     initBufferReadyLists(applDb, confDb);
     initFlexCounterGroupTable();
-    initBufferConstants();
+
+    if (gMySwitchType != "dpu")
+    {
+        initBufferConstants();
+    }
 };
 
 void BufferOrch::initTableHandlers()

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -177,7 +177,7 @@ void getCfgSwitchType(DBConnector *cfgDb, string &switch_type)
         switch_type = "switch";
     }
 
-    if (switch_type != "voq" && switch_type != "fabric" && switch_type != "chassis-packet" && switch_type != "switch")
+    if (switch_type != "voq" && switch_type != "fabric" && switch_type != "chassis-packet" && switch_type != "switch" && switch_type != "dpu")
     {
         SWSS_LOG_ERROR("Invalid switch type %s configured", switch_type.c_str());
     	//If configured switch type is none of the supported, assume regular switch
@@ -425,15 +425,27 @@ int main(int argc, char **argv)
     initSaiApi();
     initSaiRedis(record_location, sairedis_rec_filename);
 
+    // Instantiate database connectors
+    DBConnector appl_db("APPL_DB", 0);
+    DBConnector config_db("CONFIG_DB", 0);
+    DBConnector state_db("STATE_DB", 0);
+
+    // Get switch_type
+    getCfgSwitchType(&config_db, gMySwitchType);
+
     sai_attribute_t attr;
     vector<sai_attribute_t> attrs;
 
     attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
     attr.value.booldata = true;
     attrs.push_back(attr);
-    attr.id = SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY;
-    attr.value.ptr = (void *)on_fdb_event;
-    attrs.push_back(attr);
+
+    if (gMySwitchType != "dpu")
+    {
+        attr.id = SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY;
+        attr.value.ptr = (void *)on_fdb_event;
+        attrs.push_back(attr);
+    }
 
     // Initialize recording parameters.
     gSairedisRecord =
@@ -481,14 +493,6 @@ int main(int argc, char **argv)
     attr.id = SAI_SWITCH_ATTR_SHUTDOWN_REQUEST_NOTIFY;
     attr.value.ptr = (void *)on_switch_shutdown_request;
     attrs.push_back(attr);
-
-    // Instantiate database connectors
-    DBConnector appl_db("APPL_DB", 0);
-    DBConnector config_db("CONFIG_DB", 0);
-    DBConnector state_db("STATE_DB", 0);
-
-    // Get switch_type
-    getCfgSwitchType(&config_db, gMySwitchType);
 
     if (gMySwitchType != "fabric" && gMacAddress)
     {
@@ -570,7 +574,7 @@ int main(int argc, char **argv)
     attr.value.u64 = gSwitchId;
     attrs.push_back(attr);
 
-    if (gMySwitchType == "voq" || gMySwitchType == "fabric" || gMySwitchType == "chassis-packet")
+    if (gMySwitchType == "voq" || gMySwitchType == "fabric" || gMySwitchType == "chassis-packet" || gMySwitchType == "dpu")
     {
         /* We set this long timeout in order for orchagent to wait enough time for
          * response from syncd. It is needed since switch create takes more time
@@ -578,7 +582,7 @@ int main(int argc, char **argv)
          * and systems ports to initialize
          */
 
-        if (gMySwitchType == "voq" || gMySwitchType == "chassis-packet")
+        if (gMySwitchType == "voq" || gMySwitchType == "chassis-packet" || gMySwitchType == "dpu")
         {
             attr.value.u64 = (5 * SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT);
         }
@@ -608,7 +612,7 @@ int main(int argc, char **argv)
     }
     SWSS_LOG_NOTICE("Create a switch, id:%" PRIu64, gSwitchId);
 
-    if (gMySwitchType == "voq" || gMySwitchType == "fabric" || gMySwitchType == "chassis-packet")
+    if (gMySwitchType == "voq" || gMySwitchType == "fabric" || gMySwitchType == "chassis-packet" || gMySwitchType == "dpu")
     {
         /* Set syncd response timeout back to the default value */
         attr.id = SAI_REDIS_SWITCH_ATTR_SYNC_OPERATION_RESPONSE_TIMEOUT;

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -21,6 +21,7 @@ using namespace swss;
 extern sai_switch_api_t*           sai_switch_api;
 extern sai_object_id_t             gSwitchId;
 extern bool                        gSaiRedisLogRotate;
+extern string                      gMySwitchType;
 
 extern void syncd_apply_view();
 /*
@@ -629,9 +630,12 @@ bool OrchDaemon::init()
 
     m_orchList.push_back(&CounterCheckOrch::getInstance(m_configDb));
 
-    vector<string> p4rt_tables = {APP_P4RT_TABLE_NAME};
-    gP4Orch = new P4Orch(m_applDb, p4rt_tables, vrf_orch, gCoppOrch);
-    m_orchList.push_back(gP4Orch);
+    if (gMySwitchType != "dpu")
+    {
+        vector<string> p4rt_tables = {APP_P4RT_TABLE_NAME};
+        gP4Orch = new P4Orch(m_applDb, p4rt_tables, vrf_orch, gCoppOrch);
+        m_orchList.push_back(gP4Orch);
+    }
 
     if (WarmStart::isWarmStart())
     {

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -630,12 +630,9 @@ bool OrchDaemon::init()
 
     m_orchList.push_back(&CounterCheckOrch::getInstance(m_configDb));
 
-    if (gMySwitchType != "dpu")
-    {
-        vector<string> p4rt_tables = {APP_P4RT_TABLE_NAME};
-        gP4Orch = new P4Orch(m_applDb, p4rt_tables, vrf_orch, gCoppOrch);
-        m_orchList.push_back(gP4Orch);
-    }
+    vector<string> p4rt_tables = {APP_P4RT_TABLE_NAME};
+    gP4Orch = new P4Orch(m_applDb, p4rt_tables, vrf_orch, gCoppOrch);
+    m_orchList.push_back(gP4Orch);
 
     if (WarmStart::isWarmStart())
     {

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -55,6 +55,7 @@ extern string gMySwitchType;
 extern int32_t gVoqMySwitchId;
 extern string gMyHostName;
 extern string gMyAsicName;
+extern string gMySwitchType;
 
 #define DEFAULT_SYSTEM_PORT_MTU 9100
 #define VLAN_PREFIX         "Vlan"
@@ -548,32 +549,38 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
         }
     }
 
-    /* Get default 1Q bridge and default VLAN */
-    vector<sai_attribute_t> attrs;
-    attr.id = SAI_SWITCH_ATTR_DEFAULT_1Q_BRIDGE_ID;
-    attrs.push_back(attr);
-    attr.id = SAI_SWITCH_ATTR_DEFAULT_VLAN_ID;
-    attrs.push_back(attr);
-
-    status = sai_switch_api->get_switch_attribute(gSwitchId, (uint32_t)attrs.size(), attrs.data());
-    if (status != SAI_STATUS_SUCCESS)
+    if (gMySwitchType != "dpu")
     {
-        SWSS_LOG_ERROR("Failed to get default 1Q bridge and/or default VLAN, rv:%d", status);
-        task_process_status handle_status = handleSaiGetStatus(SAI_API_SWITCH, status);
-        if (handle_status != task_process_status::task_success)
-        {
-            throw runtime_error("PortsOrch initialization failure");
-        }
-    }
+        /* Get default 1Q bridge and default VLAN */
+        vector<sai_attribute_t> attrs;
+        attr.id = SAI_SWITCH_ATTR_DEFAULT_1Q_BRIDGE_ID;
+        attrs.push_back(attr);
+        attr.id = SAI_SWITCH_ATTR_DEFAULT_VLAN_ID;
+        attrs.push_back(attr);
 
-    m_default1QBridge = attrs[0].value.oid;
-    m_defaultVlan = attrs[1].value.oid;
+        status = sai_switch_api->get_switch_attribute(gSwitchId, (uint32_t)attrs.size(), attrs.data());
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to get default 1Q bridge and/or default VLAN, rv:%d", status);
+            task_process_status handle_status = handleSaiGetStatus(SAI_API_SWITCH, status);
+            if (handle_status != task_process_status::task_success)
+            {
+                throw runtime_error("PortsOrch initialization failure");
+            }
+        }
+
+        m_default1QBridge = attrs[0].value.oid;
+        m_defaultVlan = attrs[1].value.oid;
+    }
 
     /* Get System ports */
     getSystemPorts();
 
-    removeDefaultVlanMembers();
-    removeDefaultBridgePorts();
+    if (gMySwitchType != "dpu")
+    {
+        removeDefaultVlanMembers();
+        removeDefaultBridgePorts();
+    }
 
     /* Add port oper status notification support */
     DBConnector *notificationsDb = new DBConnector("ASIC_DB", 0);
@@ -4273,9 +4280,12 @@ bool PortsOrch::initializePort(Port &port)
 
     SWSS_LOG_NOTICE("Initializing port alias:%s pid:%" PRIx64, port.m_alias.c_str(), port.m_port_id);
 
-    initializePriorityGroups(port);
-    initializeQueues(port);
-    initializePortBufferMaximumParameters(port);
+    if (gMySwitchType != "dpu")
+    {
+        initializePriorityGroups(port);
+        initializeQueues(port);
+        initializePortBufferMaximumParameters(port);
+    }
 
     /* Create host interface */
     if (!addHostIntfs(port, port.m_alias, port.m_hif_id))

--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -34,6 +34,7 @@ using namespace swss;
  */
 set<string> g_portSet;
 bool g_init = false;
+string g_switchType;
 
 void usage()
 {
@@ -69,6 +70,13 @@ int main(int argc, char **argv)
     DBConnector appl_db("APPL_DB", 0);
     DBConnector state_db("STATE_DB", 0);
     ProducerStateTable p(&appl_db, APP_PORT_TABLE_NAME);
+
+    Table cfgDeviceMetaDataTable(&cfgDb, CFG_DEVICE_METADATA_TABLE_NAME);
+    if (!cfgDeviceMetaDataTable.hget("localhost", "switch_type", g_switchType))
+    {
+        //Switch type is not configured. Consider it default = "switch" (regular switch)
+        g_switchType = "switch";
+    }
 
     WarmStart::initialize("portsyncd", "swss");
     WarmStart::checkWarmStart("portsyncd", "swss");


### PR DESCRIPTION
Signed-off-by: Oleksandr Ivantsiv <oivantsiv@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
DPU supports features subset from Switch SONiC. To allow SWSS to run on DPU the initialization flow was simplified. During the start of the SWSS applications unsupported attributes are not configured. The list of SAI attributes supported by DPU is documented in DASH HLD.
- The precondition is to have the switch type as 'dpu'
- SAI Redis timeouts were extended such as for other switch types
- Only SAI calls are masked, the rest is the same using defaults. It is assumed that the user should not invoke flows/CLI commands which DPU does not support. No extra validation has been added.

**Why I did it**
To allow the SWSS application to run on DPU.

**How I verified it**
Run SWSS on DPU platform. Verify that unsupported attributes are not called.
Run SONiC as VS set as switch type DPU

**Details if related**
