### PR TITLE
Install libyang in azure pipeline for swss-common.

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -121,6 +121,7 @@ jobs:
         target/debs/buster/libnl-route-3-dev_*.deb
         target/debs/buster/libnl-nf-3-200_*.deb
         target/debs/buster/libnl-nf-3-dev_*.deb
+        target/debs/buster/libyang_*.deb
     displayName: "Download common libs"
   - script: |
       set -ex

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -48,7 +48,7 @@ jobs:
       set -ex
       sudo .azure-pipelines/build_and_install_module.sh
 
-      sudo apt-get install -y libhiredis0.14
+      sudo apt-get install -y libhiredis0.14 libyang0.16
       sudo dpkg -i --force-confask,confnew $(Build.ArtifactStagingDirectory)/download/libswsscommon_1.0.0_amd64.deb || apt-get install -f
       sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/python3-swsscommon_1.0.0_amd64.deb
 


### PR DESCRIPTION
#### Why I did it
sonic-swss-common lib will add depency to libyang, so need install libyang lib to prevent build and UT break.

#### How I did it
Modify azure pipeline to install libyang in azure pipeline steps.

#### How to verify it
Pass all UT.

#### Which release branch to backport (provide reason below if selected)

#### Description for the changelog
Modify azure pipeline to install libyang in azure pipeline steps.

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

