### PR TITLE
[Nbrmgrd] [Neighsyncd] Neighbor Cache for neighbor refresh feature

### DIFF
--- a/cfgmgr/nbrmgr.h
+++ b/cfgmgr/nbrmgr.h
@@ -4,15 +4,54 @@
 #include <string>
 #include <map>
 #include <set>
+#include <time.h>
 
 #include "dbconnector.h"
 #include "producerstatetable.h"
 #include "orch.h"
 #include "netmsg.h"
+#include "timestamp.h"
+
+
+#define TIMEOUT_MIN_PERCENT         30
+#define TIMEOUT_MAX_PERCENT         70
 
 using namespace std;
 
 namespace swss {
+
+
+struct NeighCacheEntry
+{
+    MacAddress          mac_address;
+    int                 state;
+    unsigned long long  start_time;
+    unsigned long long  refresh_timeout;
+    int                 num_refresh_sent;
+};
+
+struct NeighCacheKey
+{
+    IpAddress       ip_address;     // neighbor IP address
+    string          alias;          // Interface name
+
+    bool operator<(const NeighCacheKey &o) const
+    {
+        return tie(ip_address, alias) < tie(o.ip_address, o.alias);
+    }
+
+    bool operator==(const NeighCacheKey &o) const
+    {
+        return ((ip_address == o.ip_address) && (alias == o.alias));
+    }
+
+    bool operator!=(const NeighCacheKey &o) const
+    {
+        return !(*this == o);
+    }
+};
+
+typedef map<NeighCacheKey, NeighCacheEntry> NeighCacheTable;
 
 class NbrMgr : public Orch
 {
@@ -40,8 +79,21 @@ private:
     bool isIntfOperUp(const std::string &alias);
     unique_ptr<Table> m_cfgVoqInbandInterfaceTable;
 
+    bool addNeighToCache(IpAddress ipAddress, string alias, string mac, int state);
+    bool delNeighFrmCache(IpAddress ipAddress, string alias);
+    bool updateNeighCache(string op, int type, IpAddress ip, string ifname, string mac, int state, int flags);
+    bool isRefreshRequired(int type, IpAddress ip, string ifname, string mac, int state, int flags);
+    void doNeighCacheTask(Consumer &consumer);
+    unsigned long long get_currtime_ms(void);
+    unsigned long long get_refresh_timeout(bool isV4);
+
     Table m_statePortTable, m_stateLagTable, m_stateVlanTable, m_stateIntfTable, m_stateNeighRestoreTable;
     struct nl_sock *m_nl_sock;
+
+    NeighCacheTable m_neighCache;
+    unsigned long long m_ref_timeout_v4;
+    unsigned long long m_ref_timeout_v6;
+
 };
 
 }

--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -20,6 +20,7 @@ using namespace swss;
 
 NeighSync::NeighSync(RedisPipeline *pipelineAppDB, DBConnector *stateDb, DBConnector *cfgDb) :
     m_neighTable(pipelineAppDB, APP_NEIGH_TABLE_NAME),
+    m_neighRefreshTable(pipelineAppDB, APP_NEIGH_REFRESH_TABLE_NAME),
     m_stateNeighRestoreTable(stateDb, STATE_NEIGH_RESTORE_TABLE_NAME),
     m_cfgInterfaceTable(cfgDb, CFG_INTF_TABLE_NAME),
     m_cfgLagInterfaceTable(cfgDb, CFG_LAG_INTF_TABLE_NAME),
@@ -112,6 +113,11 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
         return;
     }
 
+    // Add only physical interface neighbors to refresh table
+    bool addToRefresh = false;
+    if (!intfName.compare(0, strlen("Ethernet"), "Ethernet"))
+        addToRefresh = true;
+
     bool delete_key = false;
     bool use_zero_mac = false;
     if (is_dualtor && (state == NUD_INCOMPLETE || state == NUD_FAILED))
@@ -166,10 +172,31 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
         if (delete_key == true)
         {
             m_neighTable.del(key);
-            return;
         }
-        m_neighTable.set(key, fvVector);
+        else
+        {
+            m_neighTable.set(key, fvVector);
+        }
     }
+
+    if(addToRefresh)
+    {
+        SWSS_LOG_INFO("Neigh Refresh Table %s, Key - %s", 
+                        ((nlmsg_type == RTM_DELNEIGH) ? "Del" : "Add"), key.c_str());
+
+        if (nlmsg_type == RTM_DELNEIGH)
+        {
+            m_neighRefreshTable.del(key);
+        }
+        else
+        {
+            FieldValueTuple st("state", to_string(state));
+            fvVector.push_back(st);
+
+            m_neighRefreshTable.set(key, fvVector);
+        }
+    }
+
 }
 
 /* To check the ipv6 link local is enabled on a given port */

--- a/neighsyncd/neighsync.h
+++ b/neighsyncd/neighsync.h
@@ -38,6 +38,7 @@ public:
 private:
     Table m_stateNeighRestoreTable, m_cfgPeerSwitchTable;
     ProducerStateTable m_neighTable;
+    ProducerStateTable m_neighRefreshTable;
     AppRestartAssist  *m_AppRestartAssist;
     Table m_cfgVlanInterfaceTable, m_cfgLagInterfaceTable, m_cfgInterfaceTable;
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Added neighbor cache in nbrmgrd to handle neighbor refresh 

Neighsyncd receives neighbor table events from kernel and adds the neighbor in NEIGH_REFRESH_TABLE. 

Nbrmgrd subscribes NEIGH_REFRESH_TABLE events and adds/deletes neighbor entries in neighbor cache.

While adding/updating neighbor entries, current time and the refresh timeout is also stored, which are then used for timeout handling.

**Why I did it**

Below PR has the details.
https://github.com/sonic-net/SONiC/pull/1043

**How I verified it**

There are no new processing in OA based on this change, hence no update to Syncd/SAI.

Verified with syslogs that the neighbors are added/deleted in Nbrmgrd neighbor cache.

**Details if related**

This is one part of the change to support neighbor refresh functionality. For the complete list of related Code PRs, please refer to https://github.com/sonic-net/SONiC/pull/1043.

