### PR TITLE
[nbrmgr] Interface cache for Neighbor refresh

### DIFF
--- a/cfgmgr/nbrmgr.h
+++ b/cfgmgr/nbrmgr.h
@@ -14,10 +14,26 @@ using namespace std;
 
 namespace swss {
 
+struct IntfsEntry
+{
+    bool ipv6_enable_config = false;
+    bool is_sag = false;
+    bool is_ip_unnm = false;
+    MacAddress source_mac;
+    std::set<IpPrefix>  ip_addresses;
+    string donar_intf;
+    string vrf_name;
+    int v4_addr_cnt;
+    int v6_addr_cnt;
+};
+
+typedef map<string, IntfsEntry> IntfsTable;
+
+
 class NbrMgr : public Orch
 {
 public:
-    NbrMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const std::vector<std::string> &tableNames);
+    NbrMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const vector<TableConnector> &tableNames);
     using Orch::doTask;
 
     bool isNeighRestoreDone();
@@ -40,8 +56,22 @@ private:
     bool isIntfOperUp(const std::string &alias);
     unique_ptr<Table> m_cfgVoqInbandInterfaceTable;
 
+    void doIpInterfaceTask(Consumer &consumer);
+    void doSystemMacTask(Consumer &consumer);
+    MacAddress getSystemMac(void);
+    MacAddress getIntfsMac(const string& ifname);
+    string getSubnetInterfaceName(const string &alias, const IpAddress &ip);
+    IpAddress getIntfIpAddress(string ifname, IpAddress dst_ip);
+    bool isPrefixSubnet(const IpAddress &ip, const string &alias);
+    bool hasIntfIpAddress(string ifname, bool isV4);
+    string readLineFromFile(const string file, bool *exists);
+
     Table m_statePortTable, m_stateLagTable, m_stateVlanTable, m_stateIntfTable, m_stateNeighRestoreTable;
     struct nl_sock *m_nl_sock;
+
+    IntfsTable m_IntfsTable;
+    MacAddress m_system_mac;
+
 };
 
 }

--- a/cfgmgr/nbrmgrd.cpp
+++ b/cfgmgr/nbrmgrd.cpp
@@ -49,15 +49,21 @@ int main(int argc, char **argv)
 
     try
     {
-        vector<string> cfg_nbr_tables = {
-            CFG_NEIGH_TABLE_NAME,
-        };
-
         DBConnector cfgDb("CONFIG_DB", 0);
         DBConnector appDb("APPL_DB", 0);
         DBConnector stateDb("STATE_DB", 0);
 
-        NbrMgr nbrmgr(&cfgDb, &appDb, &stateDb, cfg_nbr_tables);
+        TableConnector cfg_nbr_table(&cfgDb, CFG_NEIGH_TABLE_NAME);
+        TableConnector cfg_intf_table(&cfgDb, CFG_INTF_TABLE_NAME);
+        TableConnector cfg_device_metadat_table(&cfgDb, CFG_DEVICE_METADATA_TABLE_NAME);
+
+        vector<TableConnector> nbrTables = {
+                          cfg_nbr_table,
+                          cfg_intf_table,
+                          cfg_device_metadat_table,
+        };
+
+        NbrMgr nbrmgr(&cfgDb, &appDb, &stateDb, nbrTables);
 
         WarmStart::initialize("nbrmgrd", "swss");
         WarmStart::checkWarmStart("nbrmgrd", "swss");


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Added Interface cache in nbrmgrd to handle neighbor refresh 

Nbrmgrd subscribes to Interface Table events and adss/deletes interface cache ==> Interface to IPAddr list info, whenever ip address is added or removed from an L3 physical interface.

**Why I did it**

Please refer https://github.com/sonic-net/SONiC/pull/1043

**How I verified it**

There are no new processing in OA based on this change, hence no update to Syncd/SAI, only the cache information is updated in nbrmgrd.

**Details if related**

This is one part of the change to support neighbor refresh functionality. For the complete list of related Code PRs, please refer to https://github.com/sonic-net/SONiC/pull/1043.

