### PR TITLE
Revert "[counters] Improve performance by polling only configured ports buffer queue/pg counters"

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -1,6 +1,5 @@
 #include "tokenize.h"
 #include "bufferorch.h"
-#include "directory.h"
 #include "logger.h"
 #include "sai_serialize.h"
 #include "warm_restart.h"
@@ -17,7 +16,6 @@ extern sai_switch_api_t *sai_switch_api;
 extern sai_buffer_api_t *sai_buffer_api;
 
 extern PortsOrch *gPortsOrch;
-extern Directory<Orch*> gDirectory;
 extern sai_object_id_t gSwitchId;
 
 #define BUFFER_POOL_WATERMARK_FLEX_STAT_COUNTER_POLL_MSECS  "60000"
@@ -817,20 +815,6 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
                         return handle_status;
                     }
                 }
-                // create/remove a port queue counter for the queue buffer
-                else
-                {
-                    auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
-                    auto queues = tokens[1];
-                    if (op == SET_COMMAND && flexCounterOrch->getQueueCountersState())
-                    {
-                        gPortsOrch->createPortBufferQueueCounters(port, queues);
-                    }
-                    else if (op == DEL_COMMAND && flexCounterOrch->getQueueCountersState())
-                    {
-                        gPortsOrch->removePortBufferQueueCounters(port, queues);
-                    }
-                }
             }
 
             /* when we apply buffer configuration we need to increase the ref counter of this port
@@ -923,7 +907,7 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
     if (op == SET_COMMAND)
     {
         ref_resolve_status  resolve_result = resolveFieldRefValue(m_buffer_type_maps, buffer_profile_field_name,
-                                             buffer_to_ref_table_map.at(buffer_profile_field_name), tuple,
+                                             buffer_to_ref_table_map.at(buffer_profile_field_name), tuple, 
                                              sai_buffer_profile, buffer_profile_name);
         if (ref_resolve_status::success != resolve_result)
         {
@@ -994,20 +978,6 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
                         if (handle_status != task_process_status::task_success)
                         {
                             return handle_status;
-                        }
-                    }
-                    // create or remove a port PG counter for the PG buffer
-                    else
-                    {
-                        auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
-                        auto pgs = tokens[1];
-                        if (op == SET_COMMAND && flexCounterOrch->getPgWatermarkCountersState())
-                        {
-                            gPortsOrch->createPortBufferPgCounters(port, pgs);
-                        }
-                        else if (op == DEL_COMMAND && flexCounterOrch->getPgWatermarkCountersState())
-                        {
-                            gPortsOrch->removePortBufferPgCounters(port, pgs);
                         }
                     }
                 }

--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -10,7 +10,6 @@
 #include "debugcounterorch.h"
 #include "directory.h"
 #include "copporch.h"
-#include <swss/tokenize.h>
 #include "routeorch.h"
 #include "macsecorch.h"
 #include "flowcounterrouteorch.h"
@@ -63,8 +62,6 @@ unordered_map<string, string> flexCounterGroupMap =
 FlexCounterOrch::FlexCounterOrch(DBConnector *db, vector<string> &tableNames):
     Orch(db, tableNames),
     m_flexCounterConfigTable(db, CFG_FLEX_COUNTER_TABLE_NAME),
-    m_bufferQueueConfigTable(db, CFG_BUFFER_QUEUE_TABLE_NAME),
-    m_bufferPgConfigTable(db, CFG_BUFFER_PG_TABLE_NAME),
     m_flexCounterDb(new DBConnector("FLEX_COUNTER_DB", 0)),
     m_flexCounterGroupTable(new ProducerTable(m_flexCounterDb.get(), FLEX_COUNTER_GROUP_TABLE)),
     m_gbflexCounterDb(new DBConnector("GB_FLEX_COUNTER_DB", 0)),
@@ -160,13 +157,11 @@ void FlexCounterOrch::doTask(Consumer &consumer)
                         }
                         else if(key == QUEUE_KEY)
                         {
-                            gPortsOrch->generateQueueMap(getQueueConfigurations());
-                            m_queue_enabled = true;
+                            gPortsOrch->generateQueueMap();
                         }
                         else if(key == PG_WATERMARK_KEY)
                         {
-                            gPortsOrch->generatePriorityGroupMap(getPgConfigurations());
-                            m_pg_watermark_enabled = true;
+                            gPortsOrch->generatePriorityGroupMap();
                         }
                     }
                     if(gIntfsOrch && (key == RIF_KEY) && (value == "enable"))
@@ -250,16 +245,6 @@ bool FlexCounterOrch::getPortBufferDropCountersState() const
     return m_port_buffer_drop_counter_enabled;
 }
 
-bool FlexCounterOrch::getPgWatermarkCountersState() const
-{
-    return m_pg_watermark_enabled;
-}
-
-bool FlexCounterOrch::getQueueCountersState() const
-{
-    return m_queue_enabled;
-}
-
 bool FlexCounterOrch::bake()
 {
     /*
@@ -300,166 +285,4 @@ bool FlexCounterOrch::bake()
     }
     Consumer* consumer = dynamic_cast<Consumer *>(getExecutor(CFG_FLEX_COUNTER_TABLE_NAME));
     return consumer->addToSync(entries);
-}
-
-map<string, FlexCounterQueueStates> FlexCounterOrch::getQueueConfigurations()
-{
-    SWSS_LOG_ENTER();
-
-    map<string, FlexCounterQueueStates> queuesStateVector;
-    std::vector<std::string> portQueueKeys;
-    m_bufferQueueConfigTable.getKeys(portQueueKeys);
-
-    for (const auto& portQueueKey : portQueueKeys)
-    {
-        auto toks = tokenize(portQueueKey, '|');
-        if (toks.size() != 2)
-        {
-            SWSS_LOG_ERROR("Invalid BUFFER_QUEUE key: [%s]", portQueueKey.c_str());
-            continue;
-        }
-
-        auto configPortNames = tokenize(toks[0], ',');
-        auto configPortQueues = toks[1];
-        toks = tokenize(configPortQueues, '-');
-
-        for (const auto& configPortName : configPortNames)
-        {
-            uint32_t maxQueueNumber = gPortsOrch->getNumberOfPortSupportedQueueCounters(configPortName);
-            uint32_t maxQueueIndex = maxQueueNumber - 1;
-            uint32_t minQueueIndex = 0;
-
-            if (!queuesStateVector.count(configPortName))
-            {
-                FlexCounterQueueStates flexCounterQueueState(maxQueueNumber);
-                queuesStateVector.insert(make_pair(configPortName, flexCounterQueueState));
-            }
-
-            try {
-                auto startIndex = to_uint<uint32_t>(toks[0], minQueueIndex, maxQueueIndex);
-                if (toks.size() > 1)
-                {
-                    auto endIndex = to_uint<uint32_t>(toks[1], minQueueIndex, maxQueueIndex);
-                    queuesStateVector.at(configPortName).enableQueueCounters(startIndex, endIndex);
-                }
-                else
-                {
-                    queuesStateVector.at(configPortName).enableQueueCounter(startIndex);
-                }
-            } catch (std::invalid_argument const& e) {
-                    SWSS_LOG_ERROR("Invalid queue index [%s] for port [%s]", configPortQueues.c_str(), configPortName.c_str());
-                    continue;
-            }
-        }
-    }
-
-    return queuesStateVector;
-}
-
-map<string, FlexCounterPgStates> FlexCounterOrch::getPgConfigurations()
-{
-    SWSS_LOG_ENTER();
-
-    map<string, FlexCounterPgStates> pgsStateVector;
-    std::vector<std::string> portPgKeys;
-    m_bufferPgConfigTable.getKeys(portPgKeys);
-
-    for (const auto& portPgKey : portPgKeys)
-    {
-        auto toks = tokenize(portPgKey, '|');
-        if (toks.size() != 2)
-        {
-            SWSS_LOG_ERROR("Invalid BUFFER_PG key: [%s]", portPgKey.c_str());
-            continue;
-        }
-
-        auto configPortNames = tokenize(toks[0], ',');
-        auto configPortPgs = toks[1];
-        toks = tokenize(configPortPgs, '-');
-
-        for (const auto& configPortName : configPortNames)
-        {
-            uint32_t maxPgNumber = gPortsOrch->getNumberOfPortSupportedPgCounters(configPortName);
-            uint32_t maxPgIndex = maxPgNumber - 1;
-            uint32_t minPgIndex = 0;
-
-            if (!pgsStateVector.count(configPortName))
-            {
-                FlexCounterPgStates flexCounterPgState(maxPgNumber);
-                pgsStateVector.insert(make_pair(configPortName, flexCounterPgState));
-            }
-
-            try {
-                auto startIndex = to_uint<uint32_t>(toks[0], minPgIndex, maxPgIndex);
-                if (toks.size() > 1)
-                {
-                    auto endIndex = to_uint<uint32_t>(toks[1], minPgIndex, maxPgIndex);
-                    pgsStateVector.at(configPortName).enablePgCounters(startIndex, endIndex);
-                }
-                else
-                {
-                    pgsStateVector.at(configPortName).enablePgCounter(startIndex);
-                }
-            } catch (std::invalid_argument const& e) {
-                    SWSS_LOG_ERROR("Invalid pg index [%s] for port [%s]", configPortPgs.c_str(), configPortName.c_str());
-                    continue;
-            }
-        }
-    }
-
-    return pgsStateVector;
-}
-
-FlexCounterQueueStates::FlexCounterQueueStates(uint32_t maxQueueNumber)
-{
-    SWSS_LOG_ENTER();
-    m_queueStates.resize(maxQueueNumber, false);
-}
-
-bool FlexCounterQueueStates::isQueueCounterEnabled(uint32_t index) const
-{
-    SWSS_LOG_ENTER();
-    return m_queueStates[index];
-}
-
-void FlexCounterQueueStates::enableQueueCounters(uint32_t startIndex, uint32_t endIndex)
-{
-    SWSS_LOG_ENTER();
-    for (uint32_t queueIndex = startIndex; queueIndex <= endIndex; queueIndex++)
-    {
-        enableQueueCounter(queueIndex);
-    }
-}
-
-void FlexCounterQueueStates::enableQueueCounter(uint32_t queueIndex)
-{
-    SWSS_LOG_ENTER();
-    m_queueStates[queueIndex] = true;
-}
-
-FlexCounterPgStates::FlexCounterPgStates(uint32_t maxPgNumber)
-{
-    SWSS_LOG_ENTER();
-    m_pgStates.resize(maxPgNumber, false);
-}
-
-bool FlexCounterPgStates::isPgCounterEnabled(uint32_t index) const
-{
-    SWSS_LOG_ENTER();
-    return m_pgStates[index];
-}
-
-void FlexCounterPgStates::enablePgCounters(uint32_t startIndex, uint32_t endIndex)
-{
-    SWSS_LOG_ENTER();
-    for (uint32_t pgIndex = startIndex; pgIndex <= endIndex; pgIndex++)
-    {
-        enablePgCounter(pgIndex);
-    }
-}
-
-void FlexCounterPgStates::enablePgCounter(uint32_t pgIndex)
-{
-    SWSS_LOG_ENTER();
-    m_pgStates[pgIndex] = true;
 }

--- a/orchagent/flexcounterorch.h
+++ b/orchagent/flexcounterorch.h
@@ -10,30 +10,6 @@ extern "C" {
 #include "sai.h"
 }
 
-class FlexCounterQueueStates
-{
-public:
-    FlexCounterQueueStates(uint32_t maxQueueNumber);
-    bool isQueueCounterEnabled(uint32_t index) const;
-    void enableQueueCounters(uint32_t startIndex, uint32_t endIndex);
-    void enableQueueCounter(uint32_t queueIndex);
-
-private:
-    std::vector<bool> m_queueStates{};
-};
-
-class FlexCounterPgStates
-{
-public:
-    FlexCounterPgStates(uint32_t maxPgNumber);
-    bool isPgCounterEnabled(uint32_t index) const;
-    void enablePgCounters(uint32_t startIndex, uint32_t endIndex);
-    void enablePgCounter(uint32_t pgIndex);
-
-private:
-    std::vector<bool> m_pgStates{};
-};
-
 class FlexCounterOrch: public Orch
 {
 public:
@@ -42,10 +18,6 @@ public:
     virtual ~FlexCounterOrch(void);
     bool getPortCountersState() const;
     bool getPortBufferDropCountersState() const;
-    bool getPgWatermarkCountersState() const;
-    bool getQueueCountersState() const;
-    std::map<std::string, FlexCounterQueueStates> getQueueConfigurations();
-    std::map<std::string, FlexCounterPgStates> getPgConfigurations();
     bool getHostIfTrapCounterState() const {return m_hostif_trap_counter_enabled;}
     bool getRouteFlowCountersState() const {return m_route_flow_counter_enabled;}
     bool bake() override;
@@ -57,13 +29,9 @@ private:
     std::shared_ptr<ProducerTable> m_gbflexCounterGroupTable = nullptr;
     bool m_port_counter_enabled = false;
     bool m_port_buffer_drop_counter_enabled = false;
-    bool m_pg_watermark_enabled = false;
-    bool m_queue_enabled = false;
     bool m_hostif_trap_counter_enabled = false;
     bool m_route_flow_counter_enabled = false;
     Table m_flexCounterConfigTable;
-    Table m_bufferQueueConfigTable;
-    Table m_bufferPgConfigTable;
 };
 
 #endif

--- a/orchagent/p4orch/tests/fake_flexcounterorch.cpp
+++ b/orchagent/p4orch/tests/fake_flexcounterorch.cpp
@@ -1,11 +1,8 @@
 #include "copporch.h"
 #include "flexcounterorch.h"
 
-FlexCounterOrch::FlexCounterOrch(swss::DBConnector *db, std::vector<std::string> &tableNames) :
-    Orch(db, tableNames),
-    m_flexCounterConfigTable(db, CFG_FLEX_COUNTER_TABLE_NAME),
-    m_bufferQueueConfigTable(db, CFG_BUFFER_QUEUE_TABLE_NAME),
-    m_bufferPgConfigTable(db, CFG_BUFFER_PG_TABLE_NAME)
+FlexCounterOrch::FlexCounterOrch(swss::DBConnector *db, std::vector<std::string> &tableNames)
+    : Orch(db, tableNames), m_flexCounterConfigTable(db, CFG_FLEX_COUNTER_TABLE_NAME)
 {
 }
 

--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -181,35 +181,11 @@ bool PortsOrch::setPortPfc(sai_object_id_t portId, uint8_t pfc_bitmask)
     return true;
 }
 
-void PortsOrch::generateQueueMap(std::map<string, FlexCounterQueueStates> queuesStateVector)
+void PortsOrch::generateQueueMap()
 {
 }
 
-void PortsOrch::generateQueueMapPerPort(const Port& port, FlexCounterQueueStates& queuesState)
-{
-}
-
-void PortsOrch::createPortBufferQueueCounters(const Port &port, string queues)
-{
-}
-
-void PortsOrch::removePortBufferQueueCounters(const Port &port, string queues)
-{
-}
-
-void PortsOrch::generatePriorityGroupMap(std::map<string, FlexCounterPgStates> pgsStateVector)
-{
-}
-
-void PortsOrch::generatePriorityGroupMapPerPort(const Port& port, FlexCounterPgStates& pgsState)
-{
-}
-
-void PortsOrch::createPortBufferPgCounters(const Port& port, string pgs)
-{
-}
-
-void PortsOrch::removePortBufferPgCounters(const Port& port, string pgs)
+void PortsOrch::generatePriorityGroupMap()
 {
 }
 
@@ -604,6 +580,14 @@ task_process_status PortsOrch::setPortAdvSpeeds(sai_object_id_t port_id, std::ve
 bool PortsOrch::getQueueTypeAndIndex(sai_object_id_t queue_id, string &type, uint8_t &index)
 {
     return true;
+}
+
+void PortsOrch::generateQueueMapPerPort(const Port &port)
+{
+}
+
+void PortsOrch::generatePriorityGroupMapPerPort(const Port &port)
+{
 }
 
 task_process_status PortsOrch::setPortAutoNeg(sai_object_id_t id, int an)

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2788,6 +2788,18 @@ bool PortsOrch::initPort(const string &alias, const string &role, const int inde
                     port_buffer_drop_stat_manager.setCounterIdList(p.m_port_id, CounterType::PORT, port_buffer_drop_stats);
                 }
 
+                /* when a port is added and priority group map counter is enabled --> we need to add pg counter for it */
+                if (m_isPriorityGroupMapGenerated)
+                {
+                    generatePriorityGroupMapPerPort(p);
+                }
+
+                /* when a port is added and queue map counter is enabled --> we need to add queue map counter for it */
+                if (m_isQueueMapGenerated)
+                {
+                    generateQueueMapPerPort(p);
+                }
+
                 PortUpdate update = { p, true };
                 notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
 
@@ -2838,6 +2850,18 @@ void PortsOrch::deInitPort(string alias, sai_object_id_t port_id)
     if (flex_counters_orch->getPortBufferDropCountersState())
     {
         port_buffer_drop_stat_manager.clearCounterIdList(p.m_port_id);
+    }
+
+    /* remove pg port counters */
+    if (m_isPriorityGroupMapGenerated)
+    {
+        removePriorityGroupMapPerPort(p);
+    }
+
+    /* remove queue port counters */
+    if (m_isQueueMapGenerated)
+    {
+        removeQueueMapPerPort(p);
     }
 
     /* remove port name map from counter table */
@@ -5946,7 +5970,7 @@ bool PortsOrch::removeTunnel(Port tunnel)
     return true;
 }
 
-void PortsOrch::generateQueueMap(map<string, FlexCounterQueueStates> queuesStateVector)
+void PortsOrch::generateQueueMap()
 {
     if (m_isQueueMapGenerated)
     {
@@ -5957,20 +5981,52 @@ void PortsOrch::generateQueueMap(map<string, FlexCounterQueueStates> queuesState
     {
         if (it.second.m_type == Port::PHY)
         {
-            if (!queuesStateVector.count(it.second.m_alias))
-            {
-                auto maxQueueNumber = getNumberOfPortSupportedQueueCounters(it.second.m_alias);
-                FlexCounterQueueStates flexCounterQueueState(maxQueueNumber);
-                queuesStateVector.insert(make_pair(it.second.m_alias, flexCounterQueueState));
-            }
-            generateQueueMapPerPort(it.second, queuesStateVector.at(it.second.m_alias));
+            generateQueueMapPerPort(it.second);
         }
     }
 
     m_isQueueMapGenerated = true;
 }
 
-void PortsOrch::generateQueueMapPerPort(const Port& port, FlexCounterQueueStates& queuesState)
+void PortsOrch::removeQueueMapPerPort(const Port& port)
+{
+    /* Remove the Queue map in the Counter DB */
+
+    for (size_t queueIndex = 0; queueIndex < port.m_queue_ids.size(); ++queueIndex)
+    {
+        std::ostringstream name;
+        name << port.m_alias << ":" << queueIndex;
+        std::unordered_set<string> counter_stats;
+
+        const auto id = sai_serialize_object_id(port.m_queue_ids[queueIndex]);
+
+        m_queueTable->hdel("",name.str());
+        m_queuePortTable->hdel("",id);
+
+        string queueType;
+        uint8_t queueRealIndex = 0;
+        if (getQueueTypeAndIndex(port.m_queue_ids[queueIndex], queueType, queueRealIndex))
+        {
+            m_queueTypeTable->hdel("",id);
+            m_queueIndexTable->hdel("",id);
+        }
+
+        for (const auto& it: queue_stat_ids)
+        {
+            counter_stats.emplace(sai_serialize_queue_stat(it));
+        }
+        queue_stat_manager.clearCounterIdList(port.m_queue_ids[queueIndex]);
+
+        /* remove watermark queue counters */
+        string key = getQueueWatermarkFlexCounterTableKey(id);
+
+        m_flexCounterTable->del(key);
+    }
+
+    CounterCheckOrch::getInstance().removePort(port);
+}
+
+void PortsOrch::generateQueueMapPerPort(const Port& port)
 {
     /* Create the Queue map in the Counter DB */
     /* Add stat counters to flex_counter */
@@ -5986,20 +6042,16 @@ void PortsOrch::generateQueueMapPerPort(const Port& port, FlexCounterQueueStates
 
         const auto id = sai_serialize_object_id(port.m_queue_ids[queueIndex]);
 
+        queueVector.emplace_back(name.str(), id);
+        queuePortVector.emplace_back(id, sai_serialize_object_id(port.m_port_id));
+
         string queueType;
         uint8_t queueRealIndex = 0;
         if (getQueueTypeAndIndex(port.m_queue_ids[queueIndex], queueType, queueRealIndex))
         {
-            if (!queuesState.isQueueCounterEnabled(queueRealIndex))
-            {
-                continue;
-            }
             queueTypeVector.emplace_back(id, queueType);
             queueIndexVector.emplace_back(id, to_string(queueRealIndex));
         }
-
-        queueVector.emplace_back(name.str(), id);
-        queuePortVector.emplace_back(id, sai_serialize_object_id(port.m_port_id));
 
         // Install a flex counter for this queue to track stats
         std::unordered_set<string> counter_stats;
@@ -6034,120 +6086,7 @@ void PortsOrch::generateQueueMapPerPort(const Port& port, FlexCounterQueueStates
     CounterCheckOrch::getInstance().addPort(port);
 }
 
-void PortsOrch::createPortBufferQueueCounters(const Port &port, string queues)
-{
-    SWSS_LOG_ENTER();
-
-    /* Create the Queue map in the Counter DB */
-    /* Add stat counters to flex_counter */
-    vector<FieldValueTuple> queueVector;
-    vector<FieldValueTuple> queuePortVector;
-    vector<FieldValueTuple> queueIndexVector;
-    vector<FieldValueTuple> queueTypeVector;
-
-    auto toks = tokenize(queues, '-');
-    auto startIndex = to_uint<uint32_t>(toks[0]);
-    auto endIndex = startIndex;
-    if (toks.size() > 1)
-    {
-        endIndex = to_uint<uint32_t>(toks[1]);
-    }
-
-    for (auto queueIndex = startIndex; queueIndex <= endIndex; queueIndex++)
-    {
-        std::ostringstream name;
-        name << port.m_alias << ":" << queueIndex;
-
-        const auto id = sai_serialize_object_id(port.m_queue_ids[queueIndex]);
-
-        string queueType;
-        uint8_t queueRealIndex = 0;
-        if (getQueueTypeAndIndex(port.m_queue_ids[queueIndex], queueType, queueRealIndex))
-        {
-            queueTypeVector.emplace_back(id, queueType);
-            queueIndexVector.emplace_back(id, to_string(queueRealIndex));
-        }
-
-        queueVector.emplace_back(name.str(), id);
-        queuePortVector.emplace_back(id, sai_serialize_object_id(port.m_port_id));
-
-        // Install a flex counter for this queue to track stats
-        std::unordered_set<string> counter_stats;
-        for (const auto& it: queue_stat_ids)
-        {
-            counter_stats.emplace(sai_serialize_queue_stat(it));
-        }
-        queue_stat_manager.setCounterIdList(port.m_queue_ids[queueIndex], CounterType::QUEUE, counter_stats);
-
-        /* add watermark queue counters */
-        string key = getQueueWatermarkFlexCounterTableKey(id);
-
-        string delimiter("");
-        std::ostringstream counters_stream;
-        for (const auto& it: queueWatermarkStatIds)
-        {
-            counters_stream << delimiter << sai_serialize_queue_stat(it);
-            delimiter = comma;
-        }
-
-        vector<FieldValueTuple> fieldValues;
-        fieldValues.emplace_back(QUEUE_COUNTER_ID_LIST, counters_stream.str());
-
-        m_flexCounterTable->set(key, fieldValues);
-    }
-
-    m_queueTable->set("", queueVector);
-    m_queuePortTable->set("", queuePortVector);
-    m_queueIndexTable->set("", queueIndexVector);
-    m_queueTypeTable->set("", queueTypeVector);
-
-    CounterCheckOrch::getInstance().addPort(port);
-}
-
-void PortsOrch::removePortBufferQueueCounters(const Port &port, string queues)
-{
-    SWSS_LOG_ENTER();
-
-    /* Remove the Queues maps in the Counter DB */
-    /* Remove stat counters from flex_counter DB */
-    auto toks = tokenize(queues, '-');
-    auto startIndex = to_uint<uint32_t>(toks[0]);
-    auto endIndex = startIndex;
-    if (toks.size() > 1)
-    {
-        endIndex = to_uint<uint32_t>(toks[1]);
-    }
-
-    for (auto queueIndex = startIndex; queueIndex <= endIndex; queueIndex++)
-    {
-        std::ostringstream name;
-        name << port.m_alias << ":" << queueIndex;
-        const auto id = sai_serialize_object_id(port.m_queue_ids[queueIndex]);
-
-        // Remove the queue counter from counters DB maps
-        m_queueTable->hdel("", name.str());
-        m_queuePortTable->hdel("", id);
-
-        string queueType;
-        uint8_t queueRealIndex = 0;
-        if (getQueueTypeAndIndex(port.m_queue_ids[queueIndex], queueType, queueRealIndex))
-        {
-            m_queueTypeTable->hdel("", id);
-            m_queueIndexTable->hdel("", id);
-        }
-
-        // Remove the flex counter for this queue
-        queue_stat_manager.clearCounterIdList(port.m_queue_ids[queueIndex]);
-
-        // Remove watermark queue counters
-        string key = getQueueWatermarkFlexCounterTableKey(id);
-        m_flexCounterTable->del(key);
-    }
-
-    CounterCheckOrch::getInstance().removePort(port);
-}
-
-void PortsOrch::generatePriorityGroupMap(map<string, FlexCounterPgStates> pgsStateVector)
+void PortsOrch::generatePriorityGroupMap()
 {
     if (m_isPriorityGroupMapGenerated)
     {
@@ -6158,20 +6097,40 @@ void PortsOrch::generatePriorityGroupMap(map<string, FlexCounterPgStates> pgsSta
     {
         if (it.second.m_type == Port::PHY)
         {
-            if (!pgsStateVector.count(it.second.m_alias))
-            {
-                auto maxPgNumber = getNumberOfPortSupportedPgCounters(it.second.m_alias);
-                FlexCounterPgStates flexCounterPgState(maxPgNumber);
-                pgsStateVector.insert(make_pair(it.second.m_alias, flexCounterPgState));
-            }
-            generatePriorityGroupMapPerPort(it.second, pgsStateVector.at(it.second.m_alias));
+            generatePriorityGroupMapPerPort(it.second);
         }
     }
 
     m_isPriorityGroupMapGenerated = true;
 }
 
-void PortsOrch::generatePriorityGroupMapPerPort(const Port& port, FlexCounterPgStates& pgsState)
+void PortsOrch::removePriorityGroupMapPerPort(const Port& port)
+{
+    /* Remove the PG map in the Counter DB */
+
+    for (size_t pgIndex = 0; pgIndex < port.m_priority_group_ids.size(); ++pgIndex)
+    {
+        std::ostringstream name;
+        name << port.m_alias << ":" << pgIndex;
+
+        const auto id = sai_serialize_object_id(port.m_priority_group_ids[pgIndex]);
+        string key = getPriorityGroupWatermarkFlexCounterTableKey(id);
+
+        m_pgTable->hdel("",name.str());
+        m_pgPortTable->hdel("",id);
+        m_pgIndexTable->hdel("",id);
+
+        m_flexCounterTable->del(key);
+
+        key = getPriorityGroupDropPacketsFlexCounterTableKey(id);
+        /* remove dropped packets counters to flex_counter */
+        m_flexCounterTable->del(key);
+    }
+
+    CounterCheckOrch::getInstance().removePort(port);
+}
+
+void PortsOrch::generatePriorityGroupMapPerPort(const Port& port)
 {
     /* Create the PG map in the Counter DB */
     /* Add stat counters to flex_counter */
@@ -6181,10 +6140,6 @@ void PortsOrch::generatePriorityGroupMapPerPort(const Port& port, FlexCounterPgS
 
     for (size_t pgIndex = 0; pgIndex < port.m_priority_group_ids.size(); ++pgIndex)
     {
-        if (!pgsState.isPgCounterEnabled(static_cast<uint32_t>(pgIndex)))
-        {
-            continue;
-        }
         std::ostringstream name;
         name << port.m_alias << ":" << pgIndex;
 
@@ -6231,111 +6186,6 @@ void PortsOrch::generatePriorityGroupMapPerPort(const Port& port, FlexCounterPgS
     m_pgIndexTable->set("", pgIndexVector);
 
     CounterCheckOrch::getInstance().addPort(port);
-}
-
-void PortsOrch::createPortBufferPgCounters(const Port& port, string pgs)
-{
-    SWSS_LOG_ENTER();
-
-    /* Create the PG map in the Counter DB */
-    /* Add stat counters to flex_counter */
-    vector<FieldValueTuple> pgVector;
-    vector<FieldValueTuple> pgPortVector;
-    vector<FieldValueTuple> pgIndexVector;
-
-    auto toks = tokenize(pgs, '-');
-    auto startIndex = to_uint<uint32_t>(toks[0]);
-    auto endIndex = startIndex;
-    if (toks.size() > 1)
-    {
-        endIndex = to_uint<uint32_t>(toks[1]);
-    }
-
-    for (auto pgIndex = startIndex; pgIndex <= endIndex; pgIndex++)
-    {
-        std::ostringstream name;
-        name << port.m_alias << ":" << pgIndex;
-
-        const auto id = sai_serialize_object_id(port.m_priority_group_ids[pgIndex]);
-
-        pgVector.emplace_back(name.str(), id);
-        pgPortVector.emplace_back(id, sai_serialize_object_id(port.m_port_id));
-        pgIndexVector.emplace_back(id, to_string(pgIndex));
-
-        string key = getPriorityGroupWatermarkFlexCounterTableKey(id);
-
-        std::string delimiter = "";
-        std::ostringstream counters_stream;
-        /* Add watermark counters to flex_counter */
-        for (const auto& it: ingressPriorityGroupWatermarkStatIds)
-        {
-            counters_stream << delimiter << sai_serialize_ingress_priority_group_stat(it);
-            delimiter = comma;
-        }
-
-        vector<FieldValueTuple> fieldValues;
-        fieldValues.emplace_back(PG_COUNTER_ID_LIST, counters_stream.str());
-        m_flexCounterTable->set(key, fieldValues);
-
-        delimiter = "";
-        std::ostringstream ingress_pg_drop_packets_counters_stream;
-        key = getPriorityGroupDropPacketsFlexCounterTableKey(id);
-        /* Add dropped packets counters to flex_counter */
-        for (const auto& it: ingressPriorityGroupDropStatIds)
-        {
-            ingress_pg_drop_packets_counters_stream << delimiter << sai_serialize_ingress_priority_group_stat(it);
-            if (delimiter.empty())
-            {
-                delimiter = comma;
-            }
-        }
-        fieldValues.clear();
-        fieldValues.emplace_back(PG_COUNTER_ID_LIST, ingress_pg_drop_packets_counters_stream.str());
-        m_flexCounterTable->set(key, fieldValues);
-    }
-
-    m_pgTable->set("", pgVector);
-    m_pgPortTable->set("", pgPortVector);
-    m_pgIndexTable->set("", pgIndexVector);
-
-    CounterCheckOrch::getInstance().addPort(port);
-}
-
-void PortsOrch::removePortBufferPgCounters(const Port& port, string pgs)
-{
-    SWSS_LOG_ENTER();
-
-    /* Remove the Pgs maps in the Counter DB */
-    /* Remove stat counters from flex_counter DB */
-    auto toks = tokenize(pgs, '-');
-    auto startIndex = to_uint<uint32_t>(toks[0]);
-    auto endIndex = startIndex;
-    if (toks.size() > 1)
-    {
-        endIndex = to_uint<uint32_t>(toks[1]);
-    }
-
-    for (auto pgIndex = startIndex; pgIndex <= endIndex; pgIndex++)
-    {
-        std::ostringstream name;
-        name << port.m_alias << ":" << pgIndex;
-        const auto id = sai_serialize_object_id(port.m_priority_group_ids[pgIndex]);
-
-        // Remove the pg counter from counters DB maps
-        m_pgTable->hdel("", name.str());
-        m_pgPortTable->hdel("", id);
-        m_pgIndexTable->hdel("", id);
-
-        // Remove dropped packets counters from flex_counter
-        string key = getPriorityGroupDropPacketsFlexCounterTableKey(id);
-        m_flexCounterTable->del(key);
-
-        // Remove watermark counters from flex_counter
-        key = getPriorityGroupWatermarkFlexCounterTableKey(id);
-        m_flexCounterTable->del(key);
-    }
-
-    CounterCheckOrch::getInstance().removePort(port);
 }
 
 void PortsOrch::generatePortCounterMap()
@@ -6386,16 +6236,6 @@ void PortsOrch::generatePortBufferDropCounterMap()
     }
 
     m_isPortBufferDropCounterMapGenerated = true;
-}
-
-uint32_t PortsOrch::getNumberOfPortSupportedPgCounters(string port)
-{
-    return static_cast<uint32_t>(m_portList[port].m_priority_group_ids.size());
-}
-
-uint32_t PortsOrch::getNumberOfPortSupportedQueueCounters(string port)
-{
-    return static_cast<uint32_t>(m_portList[port].m_queue_ids.size());
 }
 
 void PortsOrch::doTask(NotificationConsumer &consumer)

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -131,17 +131,9 @@ public:
 
     bool setPortPfcWatchdogStatus(sai_object_id_t portId, uint8_t pfc_bitmask);
     bool getPortPfcWatchdogStatus(sai_object_id_t portId, uint8_t *pfc_bitmask);
-    
-    void generateQueueMap(map<string, FlexCounterQueueStates> queuesStateVector);
-    uint32_t getNumberOfPortSupportedQueueCounters(string port);
-    void createPortBufferQueueCounters(const Port &port, string queues);
-    void removePortBufferQueueCounters(const Port &port, string queues);
 
-    void generatePriorityGroupMap(map<string, FlexCounterPgStates> pgsStateVector);
-    uint32_t getNumberOfPortSupportedPgCounters(string port);
-    void createPortBufferPgCounters(const Port &port, string pgs);
-    void removePortBufferPgCounters(const Port& port, string pgs);
-
+    void generateQueueMap();
+    void generatePriorityGroupMap();
     void generatePortCounterMap();
     void generatePortBufferDropCounterMap();
 
@@ -352,9 +344,13 @@ private:
     bool getQueueTypeAndIndex(sai_object_id_t queue_id, string &type, uint8_t &index);
 
     bool m_isQueueMapGenerated = false;
-    void generateQueueMapPerPort(const Port& port, FlexCounterQueueStates& queuesState);
+    void generateQueueMapPerPort(const Port& port);
+    void removeQueueMapPerPort(const Port& port);
+
     bool m_isPriorityGroupMapGenerated = false;
-    void generatePriorityGroupMapPerPort(const Port& port, FlexCounterPgStates& pgsState);
+    void generatePriorityGroupMapPerPort(const Port& port);
+    void removePriorityGroupMapPerPort(const Port& port);
+
     bool m_isPortCounterMapGenerated = false;
     bool m_isPortBufferDropCounterMapGenerated = false;
 

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -160,14 +160,13 @@ namespace portsorch_test
 
             ASSERT_EQ(gPortsOrch, nullptr);
 
-            gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
-
             vector<string> flex_counter_tables = {
                 CFG_FLEX_COUNTER_TABLE_NAME
             };
             auto* flexCounterOrch = new FlexCounterOrch(m_config_db.get(), flex_counter_tables);
             gDirectory.set(flexCounterOrch);
 
+            gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
             vector<string> buffer_tables = { APP_BUFFER_POOL_TABLE_NAME,
                                              APP_BUFFER_PROFILE_TABLE_NAME,
                                              APP_BUFFER_QUEUE_TABLE_NAME,
@@ -893,7 +892,7 @@ namespace portsorch_test
     * updated to DB.
     */
     TEST_F(PortsOrchTest, PortOperStatusIsUpAndOperSpeedIsZero)
-    {
+    {   
         Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
 
         // Get SAI default ports to populate DB
@@ -918,7 +917,7 @@ namespace portsorch_test
         Port port;
         gPortsOrch->getPort("Ethernet0", port);
         ASSERT_TRUE(port.m_oper_status != SAI_PORT_OPER_STATUS_UP);
-
+        
         // save original api since we will spy
         auto orig_port_api = sai_port_api;
         sai_port_api = new sai_port_api_t();
@@ -936,14 +935,14 @@ namespace portsorch_test
                     // Return 0 for port operational speed
                     attrs[0].value.u32 = 0;
                 }
-
+                
                 return (sai_status_t)SAI_STATUS_SUCCESS;
             }
         );
 
         auto exec = static_cast<Notifier *>(gPortsOrch->getExecutor("PORT_STATUS_NOTIFICATIONS"));
         auto consumer = exec->getNotificationConsumer();
-
+        
         // mock a redis reply for notification, it notifies that Ehernet0 is going to up
         mockReply = (redisReply *)calloc(sizeof(redisReply), 1);
         mockReply->type = REDIS_REPLY_ARRAY;
@@ -965,7 +964,7 @@ namespace portsorch_test
         // trigger the notification
         consumer->readData();
         gPortsOrch->doTask(*consumer);
-        mockReply = nullptr;
+        mockReply = nullptr; 
 
         gPortsOrch->getPort("Ethernet0", port);
         ASSERT_TRUE(port.m_oper_status == SAI_PORT_OPER_STATUS_UP);

--- a/tests/mock_tests/routeorch_ut.cpp
+++ b/tests/mock_tests/routeorch_ut.cpp
@@ -176,14 +176,14 @@ namespace routeorch_test
                 { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
             };
 
-            ASSERT_EQ(gPortsOrch, nullptr);
-            gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
-
             vector<string> flex_counter_tables = {
                 CFG_FLEX_COUNTER_TABLE_NAME
             };
             auto* flexCounterOrch = new FlexCounterOrch(m_config_db.get(), flex_counter_tables);
             gDirectory.set(flexCounterOrch);
+
+            ASSERT_EQ(gPortsOrch, nullptr);
+            gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
 
             static const  vector<string> route_pattern_tables = {
                 CFG_FLOW_COUNTER_ROUTE_PATTERN_TABLE_NAME,

--- a/tests/test_buffer_traditional.py
+++ b/tests/test_buffer_traditional.py
@@ -77,14 +77,12 @@ class TestBuffer(object):
 
     @pytest.fixture
     def setup_teardown_test(self, dvs):
-        self.setup_db(dvs)
-        self.set_port_qos_table(self.INTF, '3,4')
-        self.lossless_pg_combinations = ['3-4']
-        time.sleep(2)
-
-        yield
-
-        self.teardown()
+        try:
+            self.setup_db(dvs)
+            self.set_port_qos_table(self.INTF, '3,4')
+            self.lossless_pg_combinations = ['3-4']
+        finally:
+            self.teardown()
 
     def test_zero_cable_len_profile_update(self, dvs, setup_teardown_test):
         orig_cable_len = None

--- a/tests/test_pg_drop_counter.py
+++ b/tests/test_pg_drop_counter.py
@@ -2,12 +2,16 @@ import os
 import re
 import time
 import json
+import pytest
 import redis
 
 from swsscommon import swsscommon
 
 pg_drop_attr = "SAI_INGRESS_PRIORITY_GROUP_STAT_DROPPED_PACKETS"
 
+PORT = "Ethernet0"
+
+@pytest.mark.usefixtures('dvs_port_manager')
 class TestPGDropCounter(object):
     DEFAULT_POLL_INTERVAL = 10
     pgs = {}
@@ -57,11 +61,14 @@ class TestPGDropCounter(object):
             assert found, "entry name %s not found" % (entry_name)
 
     def set_up_flex_counter(self):
+        pg_stats_entry = {"PG_COUNTER_ID_LIST": "{}".format(pg_drop_attr)}
+        for pg in self.pgs:
+            self.flex_db.create_entry("FLEX_COUNTER_TABLE", "PG_DROP_STAT_COUNTER:{}".format(pg), pg_stats_entry)
+
         fc_status_enable = {"FLEX_COUNTER_STATUS": "enable"}
+
         self.config_db.create_entry("FLEX_COUNTER_TABLE", "PG_DROP", fc_status_enable)
         self.config_db.create_entry("FLEX_COUNTER_TABLE", "PG_WATERMARK", fc_status_enable)
-        # Wait for DB's to populate by orchagent
-        time.sleep(2)
 
     def clear_flex_counter(self):
         for pg in self.pgs:
@@ -72,12 +79,10 @@ class TestPGDropCounter(object):
         
     def test_pg_drop_counters(self, dvs):
         self.setup_dbs(dvs)
-        self.set_up_flex_counter()
-        # Get all configured counters OID's
-        self.pgs = self.counters_db.db_connection.hgetall("COUNTERS_PG_NAME_MAP").values()
-        assert self.pgs is not None and len(self.pgs) > 0
-
+        self.pgs = self.asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP")
         try:
+            self.set_up_flex_counter()
+
             self.populate_asic(dvs, "0")
             time.sleep(self.DEFAULT_POLL_INTERVAL)
             self.verify_value(dvs, self.pgs, pg_drop_attr, "0")
@@ -92,3 +97,48 @@ class TestPGDropCounter(object):
         finally:
             self.clear_flex_counter()
 
+    def test_pg_drop_counter_port_add_remove(self, dvs):
+        self.setup_dbs(dvs)
+
+        try:
+            # configure pg drop flex counter
+            self.set_up_flex_counter()
+
+            # receive port info
+            fvs = self.config_db.get_entry("PORT", PORT)
+            assert len(fvs) > 0
+        
+            # save all the oids of the pg drop counters            
+            oid_list = []
+            for priority in range(0,7):
+                oid_list.append(dvs.get_counters_db().get_entry("COUNTERS_PG_NAME_MAP", "")["%s:%d"%(PORT, priority)])
+                # verify that counters exists on flex counter
+                fields = self.flex_db.get_entry("FLEX_COUNTER_TABLE", "PG_WATERMARK_STAT_COUNTER:%s"%oid_list[-1])
+                assert len(fields) == 1
+
+            # remove port
+            port_oid = self.counters_db.get_entry("COUNTERS_PORT_NAME_MAP", "")[PORT]
+            self.dvs_port.remove_port(PORT)
+            dvs.get_asic_db().wait_for_deleted_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid)
+        
+            # verify counters were removed from flex counter table
+            for oid in oid_list:
+                fields = self.flex_db.get_entry("FLEX_COUNTER_TABLE", "PG_WATERMARK_STAT_COUNTER:%s"%oid)
+                assert len(fields) == 0
+              
+            # add port and wait until the port is added on asic db
+            num_of_keys_without_port = len(dvs.get_asic_db().get_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT"))
+            self.config_db.create_entry("PORT", PORT, fvs)
+            dvs.get_asic_db().wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT", num_of_keys_without_port + 1)
+            dvs.get_counters_db().wait_for_fields("COUNTERS_PG_NAME_MAP", "", ["%s:0"%(PORT)])
+            
+            # verify counter was added
+            for priority in range(0,7):
+                oid = dvs.get_counters_db().get_entry("COUNTERS_PG_NAME_MAP", "")["%s:%d"%(PORT, priority)]
+      
+                # verify that counters exists on flex counter
+                fields = self.flex_db.get_entry("FLEX_COUNTER_TABLE", "PG_WATERMARK_STAT_COUNTER:%s"%oid)
+                assert len(fields) == 1
+            
+        finally:
+            self.clear_flex_counter()


### PR DESCRIPTION
Reverts sonic-net/sonic-swss#2360

Causing submodule pointer update failure. Revert this once sonic-mgmt tests are available