### PR TITLE
[orchagent] Fix issue: ip prefix shall be inited even if VRF/VNET is not ready

### DIFF
--- a/orchagent/flex_counter/flowcounterrouteorch.cpp
+++ b/orchagent/flex_counter/flowcounterrouteorch.cpp
@@ -636,7 +636,7 @@ void FlowCounterRouteOrch::createRouteFlowCounterByPattern(const RoutePattern &r
             {
                 return;
             }
-            
+
             if (route_pattern.is_match(route_pattern.vrf_id, entry.first))
             {
                 if (isRouteAlreadyBound(route_pattern, entry.first))
@@ -885,7 +885,7 @@ void FlowCounterRouteOrch::handleRouteRemove(sai_object_id_t vrf_id, const IpPre
     {
         return;
     }
-    
+
     for (const auto &route_pattern : mRoutePatternSet)
     {
         if (route_pattern.is_match(vrf_id, ip_prefix))
@@ -953,6 +953,7 @@ bool FlowCounterRouteOrch::parseRouteKeyForRoutePattern(const std::string &key, 
     else
     {
         vrf_name = key.substr(0, found);
+        ip_prefix = IpPrefix(key.substr(found+1));
         auto *vrf_orch = gDirectory.get<VRFOrch*>();
         if (!key.compare(0, strlen(VRF_PREFIX), VRF_PREFIX) && vrf_orch->isVRFexists(vrf_name))
         {
@@ -966,8 +967,6 @@ bool FlowCounterRouteOrch::parseRouteKeyForRoutePattern(const std::string &key, 
                 return false;
             }
         }
-
-        ip_prefix = IpPrefix(key.substr(found+1));
     }
 
     return true;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Fix issue: ip prefix of a route flow pattern shall be initialized even if VRF/VNET is not ready

**Why I did it**

The issue cause a crash:

```
Sep 15 13:44:39.986661 sonic INFO swss#supervisord: orchagent terminate called after throwing an instance of 'std::logic_error'
Sep 15 13:44:39.986661 sonic INFO swss#supervisord: orchagent   what():  basic_string::_M_construct null not valid
```

**How I verified it**

Manual test and added new unit test.

**Details if related**

The flow in which IpPrefix had an uninitialized member, consists of:

1. FlowCounterRouteOrch::addRoutePattern() with 'Vnet1|100.1.1.1/32'

2. Vnet1 does not exist yet, but the logic of addRoutePattern ignores that, assuming default vrf was meant and due to the way parseRouteKeyForRoutePattern works IpPrefix is left unitialized

3. Vnet1 is created

4. Flow counters are enabled, generateRouteFlowStats() -> createRouteFlowCounterByPattern() -> createRouteFlowCounterFromVnetRoutes() is called

5. Because we inserted a route pattern with defalt vrf id and unititliazed IpPrefix it leads to a crash

