### PR TITLE
[crm] Fix issue with continues EXCEEDED and CLEAR logs for ACL group/…

### DIFF
--- a/orchagent/crmorch.cpp
+++ b/orchagent/crmorch.cpp
@@ -340,13 +340,18 @@ void CrmOrch::handleSetCommand(const string& key, const vector<FieldValueTuple>&
             }
             else if (crmThreshTypeResMap.find(field) != crmThreshTypeResMap.end())
             {
-                auto resourceType = crmThreshTypeResMap.at(field);
                 auto thresholdType = crmThreshTypeMap.at(value);
+                auto resourceType = crmThreshTypeResMap.at(field);
+                auto &resource = m_resourcesMap.at(resourceType);
 
-                if (m_resourcesMap.at(resourceType).thresholdType != thresholdType)
+                if (resource.thresholdType != thresholdType)
                 {
-                    m_resourcesMap.at(resourceType).thresholdType = thresholdType;
-                    m_resourcesMap.at(resourceType).exceededLogCounter = 0;
+                    resource.thresholdType = thresholdType;
+
+                    for (auto &cnt : resource.countersMap)
+                    {
+                        cnt.second.exceededLogCounter = 0;
+                    }
                 }
             }
             else if (crmThreshLowResMap.find(field) != crmThreshLowResMap.end())
@@ -723,7 +728,7 @@ void CrmOrch::checkCrmThresholds()
     {
         auto &res = i.second;
 
-        for (const auto &j : i.second.countersMap)
+        for (auto &j : i.second.countersMap)
         {
             auto &cnt = j.second;
             uint64_t utilization = 0;
@@ -762,7 +767,7 @@ void CrmOrch::checkCrmThresholds()
                     throw runtime_error("Unknown threshold type for CRM resource");
             }
 
-            if ((utilization >= res.highThreshold) && (res.exceededLogCounter < CRM_EXCEEDED_MSG_MAX))
+            if ((utilization >= res.highThreshold) && (cnt.exceededLogCounter < CRM_EXCEEDED_MSG_MAX))
             {
                 event_params_t params = {
                     { "percent", to_string(percentageUtil) },
@@ -773,14 +778,14 @@ void CrmOrch::checkCrmThresholds()
                               res.name.c_str(), threshType.c_str(), percentageUtil, cnt.usedCounter, cnt.availableCounter);
 
                 event_publish(g_events_handle, "chk_crm_threshold", &params);
-                res.exceededLogCounter++;
+                cnt.exceededLogCounter++;
             }
-            else if ((utilization <= res.lowThreshold) && (res.exceededLogCounter > 0) && (res.highThreshold != res.lowThreshold))
+            else if ((utilization <= res.lowThreshold) && (cnt.exceededLogCounter > 0) && (res.highThreshold != res.lowThreshold))
             {
                 SWSS_LOG_WARN("%s THRESHOLD_CLEAR for %s %u%% Used count %u free count %u",
                               res.name.c_str(), threshType.c_str(), percentageUtil, cnt.usedCounter, cnt.availableCounter);
 
-                res.exceededLogCounter = 0;
+                cnt.exceededLogCounter = 0;
             }
         } // end of counters loop
     } // end of resources loop

--- a/orchagent/crmorch.h
+++ b/orchagent/crmorch.h
@@ -74,6 +74,7 @@ private:
         sai_object_id_t id = 0;
         uint32_t availableCounter = 0;
         uint32_t usedCounter = 0;
+        uint32_t exceededLogCounter = 0;
     };
 
     struct CrmResourceEntry
@@ -88,7 +89,6 @@ private:
 
         std::map<std::string, CrmResourceCounter> countersMap;
 
-        uint32_t exceededLogCounter = 0;
         CrmResourceStatus resStatus = CrmResourceStatus::CRM_RES_SUPPORTED;
     };
 

--- a/tests/test_crm.py
+++ b/tests/test_crm.py
@@ -697,12 +697,22 @@ class TestCrm(object):
         entry_used_counter = getCrmCounterValue(dvs, 'ACL_STATS:INGRESS:PORT', 'crm_stats_acl_group_used')
         assert entry_used_counter == 3
 
-        # remove ACL table
-        #tbl._del("test-aclv6")
-        #time.sleep(2)
-        #atbl = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP")
-        #table_used_counter = getCrmCounterValue(dvs, 'ACL_STATS:INGRESS:PORT', 'crm_stats_acl_group_used')
-        #assert table_used_counter == 0
+        marker = dvs.add_log_marker()
+        crm_update(dvs, "polling_interval", "1")
+        crm_update(dvs, "acl_group_threshold_type", "used")
+        crm_update(dvs, "acl_group_low_threshold", str(0))
+        crm_update(dvs, "acl_group_high_threshold", str(2))
+
+        time.sleep(2)
+        check_syslog(dvs, marker, "ACL_GROUP THRESHOLD_EXCEEDED for TH_USED", 1)
+        check_syslog(dvs, marker, "ACL_GROUP THRESHOLD_CLEAR for TH_USED", 0)
+
+        tbl._del("test-aclv6")
+        time.sleep(2)
+        check_syslog(dvs, marker, "ACL_GROUP THRESHOLD_CLEAR for TH_USED", 1)
+
+        table_used_counter = getCrmCounterValue(dvs, 'ACL_STATS:INGRESS:PORT', 'crm_stats_acl_group_used')
+        assert table_used_counter == 0
 
     def test_CrmSnatEntry(self, dvs, testlog):
 


### PR DESCRIPTION
…table counters

Signed-off-by: Volodymyr Samotiy <volodymyrs@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Moved ```exceededLogCounter``` from ```CrmResourceEntry``` to ```CrmResourceCounter```.

Some resources (ACL group/table) have few different counters but CRM logic counts number of printed EXCEEDED messages only per resource (per group of counters but not per each counter separately). Sharing the same message counter for few different resource counters causes the problem: when we, for example, configure resources for one counter from the group and all other counters from the same resource group are 0, in such case CRM prints EXCEEDED message for 1st counter, then 2nd counter clears it and prints CLEAR message. As a result CRM will continuously print EXCEED and CLEAR messages.
```
WARNING swss#orchagent: :- checkCrmThresholds: ACL_TABLE THRESHOLD_EXCEEDED for TH_PERCENTAGE 2% Used count 5 free count 189
WARNING swss#orchagent: :- checkCrmThresholds: ACL_TABLE THRESHOLD_EXCEEDED for TH_PERCENTAGE 2% Used count 5 free count 189
WARNING swss#orchagent: :- checkCrmThresholds: ACL_TABLE THRESHOLD_CLEAR for TH_PERCENTAGE 0% Used count 0 free count 189
WARNING swss#orchagent: :- checkCrmThresholds: ACL_TABLE THRESHOLD_EXCEEDED for TH_PERCENTAGE 2% Used count 4 free count 189
WARNING swss#orchagent: :- checkCrmThresholds: ACL_TABLE THRESHOLD_EXCEEDED for TH_PERCENTAGE 2% Used count 4 free count 189
WARNING swss#orchagent: :- checkCrmThresholds: ACL_TABLE THRESHOLD_CLEAR for TH_PERCENTAGE 0% Used count 0 free count 189
WARNING swss#orchagent: :- checkCrmThresholds: ACL_TABLE THRESHOLD_EXCEEDED for TH_PERCENTAGE 2% Used count 5 free count 189
WARNING swss#orchagent: :- checkCrmThresholds: ACL_TABLE THRESHOLD_EXCEEDED for TH_PERCENTAGE 2% Used count 5 free count 189
WARNING swss#orchagent: :- checkCrmThresholds: ACL_TABLE THRESHOLD_CLEAR for TH_PERCENTAGE 0% Used count 0 free count 189
``` 

In order to fix it need to count printed EXCEEDED messages per each counter but not per group of counters, even if these counters are related to the same resource type.

**Why I did it**
To fix the issue with continues EXCEEDED and CLEAR log messages for ACL group/table CRM resources.

**How I verified it**
* Manually
* By running VS test (updated with additional logic to cover this use case)
* By running CRM test from sonic-mgmt

**Details if related**
N/A