### PR TITLE
Buffermgr adjusted according to the new fast reboot implementation

### DIFF
--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -175,6 +175,8 @@ private:
     bool m_bufferPoolReady;
     bool m_bufferObjectsPending;
     bool m_bufferCompletelyInitialized;
+    bool m_isFastReboot;
+    bool m_isWarmReboot;
 
     std::string m_configuredSharedHeadroomPoolSize;
 

--- a/tests/mock_tests/mock_dbconnector.cpp
+++ b/tests/mock_tests/mock_dbconnector.cpp
@@ -8,9 +8,12 @@
 #include <map>
 
 #include "dbconnector.h"
+#include "mock_table.h"
 
 namespace swss
 {
+    using namespace testing_db;
+
     DBConnector::DBConnector(int dbId, const std::string &hostname, int port, unsigned int timeout) :
         m_dbId(dbId)
     {
@@ -60,5 +63,10 @@ namespace swss
     int DBConnector::getDbId() const
     {
         return m_dbId;
+    }
+
+    std::shared_ptr<std::string> DBConnector::get(const std::string &key)
+    {
+        return __DBConnector_get(*this, key);
     }
 }

--- a/tests/mock_tests/mock_table.h
+++ b/tests/mock_tests/mock_table.h
@@ -5,4 +5,5 @@
 namespace testing_db
 {
     void reset();
+    std::shared_ptr<std::string> __DBConnector_get(swss::DBConnector &db, const std::string &tableKey);
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
1. Adjust fast reboot logic because WarmStart::isWarmStart() will be true for both warm/fast start in the new infra
2. Support mock functions used by warm relevant classes: DBConnector::get and Table::hset operations. 

Depends on sonic-net/sonic-swss-common#691
Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**
There is an optimization for fast reboot in dynamic buffer manager but now we are not able to distinguish between fast and warm reboot.
So we need to adjust it accordingly.

**How I verified it**

Manual test and mock test.

**Details if related**
