### PR TITLE
[vlanmgr] Disable `arp_evict_nocarrier` for vlan host intf

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -134,6 +134,11 @@ bool VlanMgr::addHostVlan(int vlan_id)
     std::string res;
     EXEC_WITH_ERROR_THROW(cmds, res);
 
+    res.clear();
+    const std::string echo_cmd = std::string("")
+      + ECHO_CMD + " 0 > /proc/sys/net/ipv4/conf/" + VLAN_PREFIX + std::to_string(vlan_id) + "/arp_evict_nocarrier";
+    swss::exec(echo_cmd, res);
+
     return true;
 }
 

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -488,6 +488,48 @@ class TestVlan(object):
 
         self.dvs_vlan.remove_vlan(vlan)
 
+    def test_VlanMemberLinkDown(self, dvs):
+
+        # TODO: add_ip_address has a dependency on cdb within dvs,
+        # so we still need to setup the db. This should be refactored.
+        dvs.setup_db()
+
+        vlan = "1000"
+        vlan_ip = "192.168.0.1/21"
+        interface = "Ethernet0"
+        vlan_interface = "Vlan%s" % vlan
+        server_ip = "192.168.0.100"
+        vlan_intf_sysctl_param_path = "/proc/sys/net/ipv4/conf/%s/arp_evict_nocarrier" % vlan_interface
+
+        self.dvs_vlan.create_vlan(vlan)
+        vlan_oid = self.dvs_vlan.get_and_verify_vlan_ids(1)[0]
+        self.dvs_vlan.verify_vlan(vlan_oid, vlan)
+        self.dvs_vlan.create_vlan_member(vlan, interface)
+        self.dvs_vlan.verify_vlan_member(vlan_oid, interface)
+        dvs.set_interface_status(interface, "up")
+        dvs.add_ip_address(vlan_interface, vlan_ip)
+        dvs.runcmd("ip neigh replace %s lladdr 11:22:33:44:55:66 dev %s nud stale" % (server_ip, vlan_interface))
+
+        neigh_oid = self.dvs_vlan.app_db.wait_for_n_keys("NEIGH_TABLE", 1)[0]
+        assert vlan_interface in neigh_oid and server_ip in neigh_oid
+
+        # NOTE: arp_evict_nocarrier is available for kernel >= v5.16 and current
+        # docker-sonic-vs is based on kernel v5.4.0, so test only if this sysctl
+        # param is present
+        rc, res = dvs.runcmd("cat %s" % vlan_intf_sysctl_param_path)
+        if rc == 0:
+            assert res.strip() == "0"
+            dvs.set_interface_status(interface, "down")
+            neigh_oid = self.dvs_vlan.app_db.wait_for_n_keys("NEIGH_TABLE", 1)[0]
+            assert vlan_interface in neigh_oid and server_ip in neigh_oid
+
+        dvs.runcmd("ip neigh flush all")
+        dvs.remove_ip_address(vlan_interface, vlan_ip)
+        self.dvs_vlan.remove_vlan_member(vlan, interface)
+        self.dvs_vlan.get_and_verify_vlan_member_ids(0)
+        self.dvs_vlan.remove_vlan(vlan)
+        self.dvs_vlan.get_and_verify_vlan_ids(0)
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():


### PR DESCRIPTION


<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
To fix: https://github.com/sonic-net/sonic-buildimage/issues/11924

This PR depends on: https://github.com/sonic-net/sonic-linux-kernel/pull/293

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

**Why I did it**
Disable the sysctl parameter `arp_evict_nocarrier` for the host vlan interfaces.
So if its member ports are all down and host vlan interfaces become `NO-CARRIER`, the neighbor learned will not be flushed.

**How I verified it**
Build image together with the kernel change:
1. verify the sysctl param `arp_evict_no_carrier` for `Vlan1000`
```
# cat /proc/sys/net/ipv4/conf/Vlan1000/arp_evict_nocarrier
0
```
2. check the neighbor learned from `Vlan1000`
```
# ip neighbor | grep Vlan1000
192.168.0.13 dev Vlan1000 lladdr 82:7b:a1:ac:3d:0c STALE
192.168.0.15 dev Vlan1000 lladdr ea:5e:4b:f2:84:0e STALE
192.168.0.9 dev Vlan1000 lladdr 72:ce:37:c0:39:08 STALE
192.168.0.24 dev Vlan1000 lladdr ea:47:b9:01:4c:17 STALE
192.168.0.4 dev Vlan1000 lladdr 02:e1:1a:90:eb:03 STALE
192.168.0.11 dev Vlan1000 lladdr 56:a0:28:b5:b7:0a STALE
192.168.0.6 dev Vlan1000 lladdr 52:52:cb:52:7b:05 STALE
192.168.0.21 dev Vlan1000 lladdr 8e:a7:11:a3:1c:14 STALE
192.168.0.23 dev Vlan1000 lladdr 8e:83:cc:23:3b:16 STALE
192.168.0.2 dev Vlan1000 lladdr e2:48:09:46:76:01 STALE
192.168.0.17 dev Vlan1000 lladdr 16:0a:b6:0e:4d:10 STALE
192.168.0.12 dev Vlan1000 lladdr be:26:ff:0f:7e:0b STALE
192.168.0.19 dev Vlan1000 lladdr da:1b:c4:ca:10:12 STALE
192.168.0.14 dev Vlan1000 lladdr 66:e0:b9:f1:09:0d STALE
192.168.0.8 dev Vlan1000 lladdr c2:4d:53:03:bc:07 STALE
192.168.0.10 dev Vlan1000 lladdr 42:55:42:18:c7:09 STALE
192.168.0.25 dev Vlan1000 lladdr e6:75:31:cc:2e:18 STALE
192.168.0.5 dev Vlan1000 lladdr be:b2:73:06:4d:04 STALE
192.168.0.20 dev Vlan1000 lladdr 2e:d9:c9:5f:00:13 STALE
192.168.0.7 dev Vlan1000 lladdr ce:87:30:f2:d7:06 STALE
192.168.0.22 dev Vlan1000 lladdr ce:9e:72:38:21:15 STALE
192.168.0.16 dev Vlan1000 lladdr 76:0c:c4:6e:09:0f STALE
192.168.0.3 dev Vlan1000 lladdr 42:97:97:7d:c9:02 STALE
192.168.0.18 dev Vlan1000 lladdr 62:7d:fb:3e:87:11 STALE
```
3. shutdown all the member ports of `Vlan1000`
4. verify `Vlan1000` device becomes `NO-CARRIER` and neighbors are kept
```
# ip -j -p link show Vlan1000
[ {
        "ifindex": 59,
        "link": "Bridge",
        "ifname": "Vlan1000",
        "flags": [ "NO-CARRIER","BROADCAST","MULTICAST","ALLMULTI","UP" ],
        "mtu": 9100,
        "qdisc": "noqueue",
        "operstate": "LOWERLAYERDOWN",
        "linkmode": "DEFAULT",
        "group": "default",
        "txqlen": 1000,
        "link_type": "ether",
        "address": "00:aa:bb:cc:dd:ee",
        "broadcast": "ff:ff:ff:ff:ff:ff"
    } ]
# ip neighbor | grep Vlan1000
192.168.0.13 dev Vlan1000  FAILED
192.168.0.15 dev Vlan1000  FAILED
192.168.0.9 dev Vlan1000  FAILED
192.168.0.24 dev Vlan1000  FAILED
192.168.0.4 dev Vlan1000  FAILED
192.168.0.11 dev Vlan1000  FAILED
192.168.0.6 dev Vlan1000  FAILED
192.168.0.21 dev Vlan1000  FAILED
192.168.0.23 dev Vlan1000  FAILED
192.168.0.2 dev Vlan1000  FAILED
192.168.0.17 dev Vlan1000  FAILED
192.168.0.12 dev Vlan1000  FAILED
192.168.0.19 dev Vlan1000  FAILED
192.168.0.14 dev Vlan1000  FAILED
192.168.0.8 dev Vlan1000  FAILED
192.168.0.10 dev Vlan1000  FAILED
192.168.0.25 dev Vlan1000  FAILED
192.168.0.5 dev Vlan1000  FAILED
192.168.0.20 dev Vlan1000  FAILED
192.168.0.7 dev Vlan1000  FAILED
192.168.0.22 dev Vlan1000  FAILED
192.168.0.16 dev Vlan1000  FAILED
192.168.0.3 dev Vlan1000  FAILED
192.168.0.18 dev Vlan1000  FAILED
```


**Details if related**
