### PR TITLE
[build] add missing package libyang-dev in lgtm.yml

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -16,6 +16,7 @@ extraction:
       - libnl-genl-3-dev
       - libnl-route-3-dev
       - libnl-nf-3-dev
+      - libyang-dev
       - libzmq3-dev
       - libzmq5
       - swig3.0


### PR DESCRIPTION
**What I did**

**Why I did it**
lgtm build process broken. This PR will fix it.
```
[2022-09-30 18:21:33] [build-stderr] In file included from defaultvalueprovider.cpp:10:
[2022-09-30 18:21:33] [build-stderr] defaultvalueprovider.h:8:10: fatal error: libyang/libyang.h: No such file or directory
[2022-09-30 18:21:33] [build-stderr]     8 | #include <libyang/libyang.h>
[2022-09-30 18:21:33] [build-stderr]       |          ^~~~~~~~~~~~~~~~~~~
[2022-09-30 18:21:33] [build-stderr] compilation terminated.
```

**How I verified it**
The lgtm.yml change does not take effect in this PR's checker. I manually test it https://lgtm.com/logs/19f4015aec3863d7d4e7d5667cbbc251efd1d0f4/lang:cpp

**Details if related**
