### PR TITLE
[202012][MuxOrch] disable pfcwd when switching over

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -24,6 +24,7 @@
 #include "routeorch.h"
 #include "fdborch.h"
 #include "qosorch.h"
+#include "pfcwdorch.h"
 
 /* Global variables */
 extern Directory<Orch*> gDirectory;
@@ -34,6 +35,7 @@ extern AclOrch *gAclOrch;
 extern PortsOrch *gPortsOrch;
 extern FdbOrch *gFdbOrch;
 extern QosOrch *gQosOrch;
+extern PfcWdSwOrch<PfcWdActionHandler,PfcWdActionHandler> *gPfcWdSwOrch;
 
 extern sai_object_id_t gVirtualRouterId;
 extern sai_object_id_t  gUnderlayIfId;
@@ -1531,10 +1533,16 @@ MuxStateOrch::MuxStateOrch(DBConnector *db, const std::string& tableName) :
 
 void MuxStateOrch::updateMuxState(string portName, string muxState)
 {
+    /* Disable Pfc Watchdog for perfomance */
+    gPfcWdSwOrch->stopWdOnAllPorts();
+
     vector<FieldValueTuple> tuples;
     FieldValueTuple tuple("state", muxState);
     tuples.push_back(tuple);
     mux_state_table_.set(portName, tuples);
+
+    /* Enable Pfc Watchdog */
+    gPfcWdSwOrch->startWdOnAllPorts();
 }
 
 bool MuxStateOrch::addOperation(const Request& request)

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -376,7 +376,8 @@ bool OrchDaemon::init()
 
         static const vector<sai_queue_attr_t> queueAttrIds;
 
-        gPfcWdSwOrch = new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
+        gPfcWdSwOrch = (PfcWdSwOrch<PfcWdActionHandler,PfcWdActionHandler> *)
+            new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
                     m_configDb,
                     pfc_wd_tables,
                     portStatIds,
@@ -423,7 +424,8 @@ bool OrchDaemon::init()
         if ((platform == INVM_PLATFORM_SUBSTRING) || (platform == NPS_PLATFORM_SUBSTRING)
 	|| (platform == CLX_PLATFORM_SUBSTRING))
         {
-            gPfcWdSwOrch = new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
+            gPfcWdSwOrch = (PfcWdSwOrch<PfcWdActionHandler,PfcWdActionHandler> *)
+                new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
                         m_configDb,
                         pfc_wd_tables,
                         portStatIds,
@@ -435,7 +437,8 @@ bool OrchDaemon::init()
         }
         else if (platform == BFN_PLATFORM_SUBSTRING)
         {
-            gPfcWdSwOrch = new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
+            gPfcWdSwOrch = (PfcWdSwOrch<PfcWdActionHandler,PfcWdActionHandler> *)
+                new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
                         m_configDb,
                         pfc_wd_tables,
                         portStatIds,
@@ -479,7 +482,8 @@ bool OrchDaemon::init()
             SAI_QUEUE_ATTR_PAUSE_STATUS,
         };
 
-        gPfcWdSwOrch = new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
+        gPfcWdSwOrch = (PfcWdSwOrch<PfcWdActionHandler,PfcWdActionHandler> *)
+            new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
                 m_configDb,
                 pfc_wd_tables,
                 portStatIds,
@@ -502,7 +506,8 @@ bool OrchDaemon::init()
             SAI_QUEUE_ATTR_PAUSE_STATUS,
         };
 
-        gPfcWdSwOrch = new PfcWdSwOrch<PfcWdSaiDlrInitHandler, PfcWdActionHandler>(
+        gPfcWdSwOrch = (PfcWdSwOrch<PfcWdActionHandler,PfcWdActionHandler> *)
+            new PfcWdSwOrch<PfcWdSaiDlrInitHandler, PfcWdActionHandler>(
                     m_configDb,
                     pfc_wd_tables,
                     portStatIds,

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -376,8 +376,7 @@ bool OrchDaemon::init()
 
         static const vector<sai_queue_attr_t> queueAttrIds;
 
-        PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>* pfcwd_sw_orch =
-            new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
+        gPfcWdSwOrch = new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
                     m_configDb,
                     pfc_wd_tables,
                     portStatIds,
@@ -385,8 +384,7 @@ bool OrchDaemon::init()
                     queueAttrIds,
                     PFC_WD_POLL_MSECS);
 
-        gDirectory.set(pfcwd_sw_orch);
-        m_orchList.push_back(pfcwd_sw_orch);
+        m_orchList.push_back(gPfcWdSwOrch);
     }
     else if ((platform == INVM_PLATFORM_SUBSTRING)
              || (platform == CLX_PLATFORM_SUBSTRING)
@@ -425,8 +423,7 @@ bool OrchDaemon::init()
         if ((platform == INVM_PLATFORM_SUBSTRING) || (platform == NPS_PLATFORM_SUBSTRING)
 	|| (platform == CLX_PLATFORM_SUBSTRING))
         {
-            PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>* pfcwd_sw_orch =
-                new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
+            gPfcWdSwOrch = new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
                         m_configDb,
                         pfc_wd_tables,
                         portStatIds,
@@ -434,13 +431,11 @@ bool OrchDaemon::init()
                         queueAttrIds,
                         PFC_WD_POLL_MSECS);
 
-            gDirectory.set(pfcwd_sw_orch);
-            m_orchList.push_back(pfcwd_sw_orch);
+            m_orchList.push_back(gPfcWdSwOrch);
         }
         else if (platform == BFN_PLATFORM_SUBSTRING)
         {
-            PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>* pfcwd_sw_orch =
-                new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
+            gPfcWdSwOrch = new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
                         m_configDb,
                         pfc_wd_tables,
                         portStatIds,
@@ -448,8 +443,7 @@ bool OrchDaemon::init()
                         queueAttrIds,
                         PFC_WD_POLL_MSECS);
 
-            gDirectory.set(pfcwd_sw_orch);
-            m_orchList.push_back(pfcwd_sw_orch);
+            m_orchList.push_back(gPfcWdSwOrch);
         }
     }
     else if (platform == BRCM_PLATFORM_SUBSTRING)
@@ -485,8 +479,7 @@ bool OrchDaemon::init()
             SAI_QUEUE_ATTR_PAUSE_STATUS,
         };
 
-        PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>* pfcwd_sw_orch =
-            new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
+        gPfcWdSwOrch = new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
                 m_configDb,
                 pfc_wd_tables,
                 portStatIds,
@@ -494,8 +487,7 @@ bool OrchDaemon::init()
                 queueAttrIds,
                 PFC_WD_POLL_MSECS);
 
-        gDirectory.set(pfcwd_sw_orch);
-        m_orchList.push_back(pfcwd_sw_orch);
+        m_orchList.push_back(gPfcWdSwOrch);
     } else if (platform == CISCO_8000_PLATFORM_SUBSTRING)
     {
         static const vector<sai_port_stat_t> portStatIds;
@@ -510,8 +502,7 @@ bool OrchDaemon::init()
             SAI_QUEUE_ATTR_PAUSE_STATUS,
         };
 
-        PfcWdSwOrch<PfcWdSaiDlrInitHandler, PfcWdActionHandler>* pfcwd_sw_orch =
-            new PfcWdSwOrch<PfcWdSaiDlrInitHandler, PfcWdActionHandler>(
+        gPfcWdSwOrch = new PfcWdSwOrch<PfcWdSaiDlrInitHandler, PfcWdActionHandler>(
                     m_configDb,
                     pfc_wd_tables,
                     portStatIds,
@@ -519,8 +510,7 @@ bool OrchDaemon::init()
                     queueAttrIds,
                     PFC_WD_POLL_MSECS);
 
-        gDirectory.set(pfcwd_sw_orch);
-        m_orchList.push_back(pfcwd_sw_orch);
+        m_orchList.push_back(gPfcWdSwOrch);
     }
 
     m_orchList.push_back(&CounterCheckOrch::getInstance(m_configDb));

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -41,6 +41,7 @@ Directory<Orch*> gDirectory;
 NatOrch *gNatOrch;
 BfdOrch *gBfdOrch;
 QosOrch *gQosOrch;
+PfcWdSwOrch<PfcWdActionHandler,PfcWdActionHandler> *gPfcWdSwOrch;
 
 bool gIsNatSupported = false;
 
@@ -375,13 +376,17 @@ bool OrchDaemon::init()
 
         static const vector<sai_queue_attr_t> queueAttrIds;
 
-        m_orchList.push_back(new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
+        PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>* pfcwd_sw_orch =
+            new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
                     m_configDb,
                     pfc_wd_tables,
                     portStatIds,
                     queueStatIds,
                     queueAttrIds,
-                    PFC_WD_POLL_MSECS));
+                    PFC_WD_POLL_MSECS);
+
+        gDirectory.set(pfcwd_sw_orch);
+        m_orchList.push_back(pfcwd_sw_orch);
     }
     else if ((platform == INVM_PLATFORM_SUBSTRING)
              || (platform == CLX_PLATFORM_SUBSTRING)
@@ -420,23 +425,31 @@ bool OrchDaemon::init()
         if ((platform == INVM_PLATFORM_SUBSTRING) || (platform == NPS_PLATFORM_SUBSTRING)
 	|| (platform == CLX_PLATFORM_SUBSTRING))
         {
-            m_orchList.push_back(new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
+            PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>* pfcwd_sw_orch =
+                new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
                         m_configDb,
                         pfc_wd_tables,
                         portStatIds,
                         queueStatIds,
                         queueAttrIds,
-                        PFC_WD_POLL_MSECS));
+                        PFC_WD_POLL_MSECS);
+
+            gDirectory.set(pfcwd_sw_orch);
+            m_orchList.push_back(pfcwd_sw_orch);
         }
         else if (platform == BFN_PLATFORM_SUBSTRING)
         {
-            m_orchList.push_back(new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
+            PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>* pfcwd_sw_orch =
+                new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
                         m_configDb,
                         pfc_wd_tables,
                         portStatIds,
                         queueStatIds,
                         queueAttrIds,
-                        PFC_WD_POLL_MSECS));
+                        PFC_WD_POLL_MSECS);
+
+            gDirectory.set(pfcwd_sw_orch);
+            m_orchList.push_back(pfcwd_sw_orch);
         }
     }
     else if (platform == BRCM_PLATFORM_SUBSTRING)
@@ -472,13 +485,17 @@ bool OrchDaemon::init()
             SAI_QUEUE_ATTR_PAUSE_STATUS,
         };
 
-        m_orchList.push_back(new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
-                    m_configDb,
-                    pfc_wd_tables,
-                    portStatIds,
-                    queueStatIds,
-                    queueAttrIds,
-                    PFC_WD_POLL_MSECS));
+        PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>* pfcwd_sw_orch =
+            new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
+                m_configDb,
+                pfc_wd_tables,
+                portStatIds,
+                queueStatIds,
+                queueAttrIds,
+                PFC_WD_POLL_MSECS);
+
+        gDirectory.set(pfcwd_sw_orch);
+        m_orchList.push_back(pfcwd_sw_orch);
     } else if (platform == CISCO_8000_PLATFORM_SUBSTRING)
     {
         static const vector<sai_port_stat_t> portStatIds;
@@ -493,13 +510,17 @@ bool OrchDaemon::init()
             SAI_QUEUE_ATTR_PAUSE_STATUS,
         };
 
-        m_orchList.push_back(new PfcWdSwOrch<PfcWdSaiDlrInitHandler, PfcWdActionHandler>(
+        PfcWdSwOrch<PfcWdSaiDlrInitHandler, PfcWdActionHandler>* pfcwd_sw_orch =
+            new PfcWdSwOrch<PfcWdSaiDlrInitHandler, PfcWdActionHandler>(
                     m_configDb,
                     pfc_wd_tables,
                     portStatIds,
                     queueStatIds,
                     queueAttrIds,
-                    PFC_WD_POLL_MSECS));
+                    PFC_WD_POLL_MSECS);
+
+        gDirectory.set(pfcwd_sw_orch);
+        m_orchList.push_back(pfcwd_sw_orch);
     }
 
     m_orchList.push_back(&CounterCheckOrch::getInstance(m_configDb));

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -775,19 +775,24 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::startWdOnAllPorts()
         m_pfcwdconfigs.erase(pos);
     }
 
+    m_pfcwdconfigs.clear();
+
     return true;
 }
 
 template <typename DropHandler, typename ForwardHandler>
 bool PfcWdSwOrch<DropHandler, ForwardHandler>::PfcWdInStormOnPort(Port port) {
-    PfcWdActionHandler::PfcWdQueueStats status;
+    string status;
     sai_object_id_t queueId = SAI_NULL_OBJECT_ID;
     for (uint8_t i = 0; i < PFC_WD_TC_MAX; i++)
     {
-        sai_object_id_t queueId = port.m_queue_ids[i];
-        PfcWdActionHandler::getQueueStats(
-                this->getCountersTable(),
-                sai_serialize_object_id(queueId));
+        queueId = port.m_queue_ids[i];
+        string countersKey = this->getCountersTable()->getTableName()
+                + this->getCountersTable()->getTableNameSeparator()
+                + sai_serialize_object_id(queueId);
+
+        status = *this->getCountersDb()->hget(countersKey, "PFC_WD_STATUS");
+
         if (status == PFC_WD_IN_STORM)
         {
             SWSS_LOG_ERROR("Storm detected on port %s.", port.m_alias.c_str());

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -772,6 +772,7 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::startWdOnAllPorts()
         }
 
         createEntry(port.m_alias, pos->second);
+        m_pfcwdconfigs.erase(pos);
     }
 
     return true;
@@ -809,7 +810,7 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::stopWdOnAllPorts()
         configs.push_back(FieldValueTuple("PFC_WD_RESTORATION_TIME", restoration));
         configs.push_back(FieldValueTuple("PFC_WD_ACTION", action));
 
-        m_pfcwdconfigs.emplace(port.m_alias, configs);
+        m_pfcwdconfigs.insert(port.m_alias, configs);
 
         PfcWdOrch<DropHandler, ForwardHandler>::deleteEntry(port.m_alias);
     }

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -802,8 +802,8 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::stopWdOnAllPorts()
         }
 
         string detection = *this->getCountersDb()->hget(countersKey, "PFC_WD_DETECTION_TIME");
-        string restoration = *this->getCountersDb()->hget(countersKey, "PFC_WD_DETECTION_TIME");
-        string action = *this->getCountersDb()->hget(countersKey, "PFC_WD_DETECTION_TIME");
+        string restoration = *this->getCountersDb()->hget(countersKey, "PFC_WD_RESTORATION_TIME");
+        string action = *this->getCountersDb()->hget(countersKey, "PFC_WD_ACTION");
 
         configs.push_back(FieldValueTuple("PFC_WD_DETECTION_TIME", detection));
         configs.push_back(FieldValueTuple("PFC_WD_RESTORATION_TIME", restoration));

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -810,7 +810,7 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::stopWdOnAllPorts()
         configs.push_back(FieldValueTuple("PFC_WD_RESTORATION_TIME", restoration));
         configs.push_back(FieldValueTuple("PFC_WD_ACTION", action));
 
-        m_pfcwdconfigs.insert(port.m_alias, configs);
+        m_pfcwdconfigs.emplace(port.m_alias, configs);
 
         PfcWdOrch<DropHandler, ForwardHandler>::deleteEntry(port.m_alias);
     }

--- a/orchagent/pfcwdorch.h
+++ b/orchagent/pfcwdorch.h
@@ -120,6 +120,8 @@ private:
     void enableBigRedSwitchMode();
     void setBigRedSwitchMode(string value);
 
+    bool PfcWdInStormOnPort(Port port);
+
     map<sai_object_id_t, PfcWdQueueEntry> m_entryMap;
     map<sai_object_id_t, PfcWdQueueEntry> m_brsEntryMap;
     // Track configs during disable

--- a/orchagent/pfcwdorch.h
+++ b/orchagent/pfcwdorch.h
@@ -77,6 +77,8 @@ public:
     virtual bool startWdOnPort(const Port& port,
             uint32_t detectionTime, uint32_t restorationTime, PfcWdAction action);
     virtual bool stopWdOnPort(const Port& port);
+    virtual bool startWdOnAllPorts();
+    virtual bool stopWdOnAllPorts();
 
     task_process_status createEntry(const string& key, const vector<FieldValueTuple>& data) override;
     virtual void doTask(SelectableTimer &timer);
@@ -120,6 +122,8 @@ private:
 
     map<sai_object_id_t, PfcWdQueueEntry> m_entryMap;
     map<sai_object_id_t, PfcWdQueueEntry> m_brsEntryMap;
+    // Track configs during disable
+    map<string, vector<FieldValueTuple>> m_pfcwdconfigs;
 
     const vector<sai_port_stat_t> c_portStatIds;
     const vector<sai_queue_stat_t> c_queueStatIds;

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -859,6 +859,7 @@ class TestMuxTunnelBase():
 
     def check_pfc_wd_state(self, dvs, state):
         pfc_wd_state = dvs.runcmd('show runningconfiguration all | grep default_pfcwd | grep ' + state)
+        assert (pfc_wd_state == state);
 
     @pytest.fixture(scope='module')
     def setup_vlan(self, dvs):

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -858,7 +858,7 @@ class TestMuxTunnelBase():
             pytest.fail('Invalid test action {}'.format(action))
 
     def check_pfc_wd_state(self, dvs, state):
-        pfc_wd_state = dvs.runcmd('show runningconfiguration all | grep default_pfcwd | grep ' + state)
+        pfc_wd_state = dvs.runcmd("show runningconfiguration all | grep default_pfcwd | grep " + state)
         assert (pfc_wd_state == state);
 
     @pytest.fixture(scope='module')

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -303,6 +303,9 @@ class TestMuxTunnelBase():
         self.check_neigh_in_asic_db(asicdb, self.SERV2_IPV4)
         self.check_neigh_in_asic_db(asicdb, self.SERV2_IPV6)
 
+        # Check that pfc_wd is enabled after switchovers
+        self.check_pfc_wd_state(dvs, "enable")
+
     def create_and_test_fdb(self, appdb, asicdb, dvs, dvs_route):
 
         self.set_mux_state(appdb, "Ethernet0", "active")
@@ -853,6 +856,9 @@ class TestMuxTunnelBase():
             self.del_neighbor(dvs, test_info[IP])
         else:
             pytest.fail('Invalid test action {}'.format(action))
+
+    def check_pfc_wd_state(self, dvs, state):
+        pfc_wd_state = dvs.runcmd('show runningconfiguration all | grep default_pfcwd | grep ' + state)
 
     @pytest.fixture(scope='module')
     def setup_vlan(self, dvs):

--- a/tests/test_pfcwd.py
+++ b/tests/test_pfcwd.py
@@ -207,7 +207,7 @@ class TestPfcwdFunc(object):
                 queue_name = port + ":" + str(queue)
                 self.counters_db.update_entry("COUNTERS", self.queue_oids[queue_name], fvs)
 
-    def set_storm_state(self, queues, state="enabled"):
+    def set_storm_state(self, queues, state="'enabled'"):
         fvs = {"DEBUG_STORM": state}
         for port in self.test_ports:
             for queue in queues:


### PR DESCRIPTION
Why I did it:
to improve switchover performance

How I did it:
Added stopPFCWdOnAllPorts and startPFCWdOnAllPorts function in PFCWdSwOrch. On each switchover, PFC Wd is stopped unless there is a storm currently on the port. Then when switchover is completed, PFC Wd is enabled again

Signed-off-by: Nikola Dancejic <ndancejic@microsoft.com>