### PR TITLE
[DPU] Fix unit tests compilation after merge from master branch.

### DIFF
--- a/tests/mock_tests/portsyncd/portsyncd_ut.cpp
+++ b/tests/mock_tests/portsyncd/portsyncd_ut.cpp
@@ -28,6 +28,7 @@ extern std::string mockCmdStdcout;
 extern std::vector<std::string> mockCallArgs;
 std::set<std::string> g_portSet;
 bool g_init = false;
+std::string g_switchType;
 
 void writeToApplDB(swss::ProducerStateTable &p, swss::DBConnector &cfgDb)
 {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix unit tests compilation issue after merge from the master branch:
```
/bin/bash ../../libtool  --tag=CXX   --mode=link g++ -Wl,-wrap,if_nameindex -Wl,-wrap,if_freenameindex -g -O2 -ffile-prefix-map=/sonic/src/sonic-swss=. -fstack-protector-strong -Wformat -Werror=format-security  -Wl,-z,relro -o tests_portsyncd tests_portsyncd-portsyncd_ut.o tests_portsyncd-linksync.o tests_portsyncd-mock_dbconnector.o tests_portsyncd-mock_shell_command.o tests_portsyncd-mock_table.o tests_portsyncd-mock_hiredis.o tests_portsyncd-mock_redisreply.o -L/usr/src/gtest -lnl-genl-3 -lhiredis -lhiredis -lswsscommon -lswsscommon -lgtest -lgtest_main -lnl-3 -lnl-route-3 -lpthread -lnl-nf-3 -lnl-route-3 -lnl-genl-3 -lnl-3 -lhiredis
libtool: link: g++ -Wl,-wrap -Wl,if_nameindex -Wl,-wrap -Wl,if_freenameindex -g -O2 -ffile-prefix-map=/sonic/src/sonic-swss=. -fstack-protector-strong -Wformat -Werror=format-security -Wl,-z -Wl,relro -o tests_portsyncd tests_portsyncd-portsyncd_ut.o tests_portsyncd-linksync.o tests_portsyncd-mock_dbconnector.o tests_portsyncd-mock_shell_command.o tests_portsyncd-mock_table.o tests_portsyncd-mock_hiredis.o tests_portsyncd-mock_redisreply.o  -L/usr/src/gtest -lswsscommon -lgtest -lgtest_main -lpthread -lnl-nf-3 -lnl-route-3 -lnl-genl-3 -lnl-3 -lhiredis
/usr/bin/ld: tests_portsyncd-linksync.o: in function `bool std::operator==<char, std::char_traits<char>, std::allocator<char> >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const*)':
/usr/include/c++/10/bits/basic_string.h:6187: undefined reference to `g_switchType[abi:cxx11]'
/usr/bin/ld: /usr/include/c++/10/bits/basic_string.h:6187: undefined reference to `g_switchType[abi:cxx11]'
collect2: error: ld returned 1 exit status

```

**Why I did it**
To fix compilation of SWSS deb package.

**How I verified it**
Compile SWSS deb package.

**Details if related**
