### PR TITLE
[portsorch] remove port OID from saiOidToAlias map on port deletion

### DIFF
--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -82,16 +82,16 @@ namespace portsorch_test
     {
         sai_port_api = pold_sai_port_api;
     }
-    
+
     sai_queue_api_t ut_sai_queue_api;
     sai_queue_api_t *pold_sai_queue_api;
     int _sai_set_queue_attr_count = 0;
-    
+
     sai_status_t _ut_stub_sai_set_queue_attribute(sai_object_id_t queue_id, const sai_attribute_t *attr)
     {
         if(attr->id == SAI_QUEUE_ATTR_PFC_DLR_INIT)
         {
-            if(attr->value.booldata == true) 
+            if(attr->value.booldata == true)
             {
                 _sai_set_queue_attr_count++;
             }
@@ -268,6 +268,46 @@ namespace portsorch_test
         }
 
     };
+
+    /**
+     * Test that verifies PortsOrch::getPort() on a port that has been deleted
+     */
+    TEST_F(PortsOrchTest, GetPortTest)
+    {
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        std::deque<KeyOpFieldsValuesTuple> entries;
+
+        // Get SAI default ports to populate DB
+        auto ports = ut_helper::getInitialSaiPorts();
+
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+
+        // Set PortConfigDone
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+
+        // refill consumer
+        gPortsOrch->addExistingData(&portTable);
+
+        // Apply configuration :
+        //  create ports
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+        ASSERT_NE(port.m_port_id, SAI_NULL_OBJECT_ID);
+
+        // Delete port
+        entries.push_back({"Ethernet0", "DEL", {}});
+        auto consumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_PORT_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+        entries.clear();
+
+        ASSERT_FALSE(gPortsOrch->getPort(port.m_port_id, port));
+    }
 
     TEST_F(PortsOrchTest, PortSupportedFecModes)
     {
@@ -892,7 +932,7 @@ namespace portsorch_test
     * updated to DB.
     */
     TEST_F(PortsOrchTest, PortOperStatusIsUpAndOperSpeedIsZero)
-    {   
+    {
         Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
 
         // Get SAI default ports to populate DB
@@ -917,7 +957,7 @@ namespace portsorch_test
         Port port;
         gPortsOrch->getPort("Ethernet0", port);
         ASSERT_TRUE(port.m_oper_status != SAI_PORT_OPER_STATUS_UP);
-        
+
         // save original api since we will spy
         auto orig_port_api = sai_port_api;
         sai_port_api = new sai_port_api_t();
@@ -935,14 +975,14 @@ namespace portsorch_test
                     // Return 0 for port operational speed
                     attrs[0].value.u32 = 0;
                 }
-                
+
                 return (sai_status_t)SAI_STATUS_SUCCESS;
             }
         );
 
         auto exec = static_cast<Notifier *>(gPortsOrch->getExecutor("PORT_STATUS_NOTIFICATIONS"));
         auto consumer = exec->getNotificationConsumer();
-        
+
         // mock a redis reply for notification, it notifies that Ehernet0 is going to up
         mockReply = (redisReply *)calloc(sizeof(redisReply), 1);
         mockReply->type = REDIS_REPLY_ARRAY;
@@ -964,7 +1004,7 @@ namespace portsorch_test
         // trigger the notification
         consumer->readData();
         gPortsOrch->doTask(*consumer);
-        mockReply = nullptr; 
+        mockReply = nullptr;
 
         gPortsOrch->getPort("Ethernet0", port);
         ASSERT_TRUE(port.m_oper_status == SAI_PORT_OPER_STATUS_UP);


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

I fixed an issue that on port deletion (port breakout scenario), the port OID is not removed from ```saiOidToAlias``` map, resulting in ```getPort``` returns ```true``` when querying non-existing port OID but the ```Port``` structure is not filled with correct values. Also lowered the log level on receiving non-existing port operational status update

**Why I did it**

To fix errors in the log during breakout:

```
Oct  4 13:15:45.654396 r-bulldog-04 NOTICE swss#orchagent: :- updatePortOperStatus: Port  oper state set from unknown to down
Oct  4 13:15:45.654773 r-bulldog-04 ERR swss#orchagent: :- set: switch id oid:0x0 doesn't exist
Oct  4 13:15:45.654773 r-bulldog-04 WARNING swss#orchagent: :- setHostIntfsOperStatus: Failed to set operation status DOWN to host interface
Oct  4 13:15:45.654773 r-bulldog-04 ERR swss#orchagent: :- updatePortOperStatus: Failed to set host interface  operational status down
Oct  4 13:15:45.654773 r-bulldog-04 WARNING swss#orchagent: :- flushFDBEntries: Couldn't flush FDB. Bridge port OID: 0x0 bvid:0,
```

**How I verified it**

Run UT, run manual port breakout tests.

**Details if related**
