### PR TITLE
[portinit] Do not call GET on SAI_PORT_ATTR_SPEED when AUTONEG is enabled

### DIFF
--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -606,6 +606,11 @@ bool PortsOrch::getQueueTypeAndIndex(sai_object_id_t queue_id, string &type, uin
     return true;
 }
 
+bool PortsOrch::isAutoNegEnabled(sai_object_id_t id)
+{
+    return true;
+}
+
 task_process_status PortsOrch::setPortAutoNeg(sai_object_id_t id, int an)
 {
     return task_success;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4681,9 +4681,15 @@ bool PortsOrch::initializePort(Port &port)
         return false;
     }
 
-    /* initialize port admin speed */
-    if (!getPortSpeed(port.m_port_id, port.m_speed))
+    if (port.m_autoneg == 1 && !getPortAdvSpeeds(port, true, port.m_adv_speeds))
     {
+        /* initialize port advertised speed */
+        SWSS_LOG_ERROR("Failed to get initial port advertised speed %d", port.m_adv_speeds);
+        return false;
+    }
+    else if (!getPortSpeed(port.m_port_id, port.m_speed))
+    {
+        /* initialize port admin speed */
         SWSS_LOG_ERROR("Failed to get initial port admin speed %d", port.m_speed);
         return false;
     }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2495,11 +2495,7 @@ bool PortsOrch::isAutoNegEnabled(sai_object_id_t id)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to get port AutoNeg status for port pid:%" PRIx64, id);
-        task_process_status handle_status = handleSaiGetStatus(SAI_API_PORT, status);
-        if (handle_status != task_process_status::task_success)
-        {
-            return false;
-        }
+        return false;
     }
 
     return attr.value.booldata;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4681,15 +4681,14 @@ bool PortsOrch::initializePort(Port &port)
         return false;
     }
 
+    /* initialize port advertised speed */
     if (port.m_autoneg == 1 && !getPortAdvSpeeds(port, true, port.m_adv_speeds))
     {
-        /* initialize port advertised speed */
-        SWSS_LOG_ERROR("Failed to get initial port advertised speed %d", port.m_adv_speeds);
+        SWSS_LOG_ERROR("Failed to get initial port advertised speed");
         return false;
     }
-    else if (!getPortSpeed(port.m_port_id, port.m_speed))
+    else if (!getPortSpeed(port.m_port_id, port.m_speed)) /* initialize port admin speed */
     {
-        /* initialize port admin speed */
         SWSS_LOG_ERROR("Failed to get initial port admin speed %d", port.m_speed);
         return false;
     }

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -359,6 +359,7 @@ private:
     bool m_isPortCounterMapGenerated = false;
     bool m_isPortBufferDropCounterMapGenerated = false;
 
+    bool isAutoNegEnabled(sai_object_id_t id);
     task_process_status setPortAutoNeg(sai_object_id_t id, int an);
     bool setPortFecMode(sai_object_id_t id, int fec);
     task_process_status setPortInterfaceType(sai_object_id_t id, sai_port_interface_type_t interface_type);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
During port init if AutoNeg is enabled do not do GET oper on `SAI_PORT_ATTR_SPEED` (do not call `getPortSpeed`)

**Why I did it**
This PR fixes an issue where in some platforms syncd crashes when AutoNeg is enabled and port is oper down.
The crash happens in the warmboot recovery path:
1. In the target image as part of portinit, GET operation on `SAI_PORT_ATTR_SPEED` returns a random value.
4. This random value does not match the speed in the base image.
5. Diff in speed causes syncd comparison logic to attempt to set newly detected speed.
6. Comparison logic crashes in APPLY_VIEW when doing a SET speed operation on port with the new speed.

Why SAI returns random value in GET oper on `SAI_PORT_ATTR_SPEED`:
SAI returns random value as when autoneg is enabled attribute `SAI_PORT_ATTR_SPEED` is not set in the first place.
When autoneg is enabled a list of speeds is set using attribute `SAI_PORT_ATTR_ADVERTISED_SPEED` (instead of `SAI_PORT_ATTR_SPEED` when autoneg is not enabled.

In autoneg enabled case, get oper on `SAI_PORT_ATTR_SPEED` is not allowed as the speed on the port is not certain, and instead depends on advertised/negotiated speed.

The autoneg speed handling is done separately after portinit logic.
https://github.com/sonic-net/sonic-swss/blob/e04bb436eabe135eca2482852dc492599432d44b/orchagent/portsorch.cpp#L3294

https://github.com/sonic-net/sonic-swss/blob/e04bb436eabe135eca2482852dc492599432d44b/orchagent/portsorch.cpp#L3508

**How I verified it**

Built and installed a new swss image on a physical device.

Without this change:
```
2022-12-02.21:39:53.553522|g|SAI_OBJECT_TYPE_PORT:oid:0x100000000005b|SAI_PORT_ATTR_ADMIN_STATE=false
2022-12-02.21:39:53.554071|G|SAI_STATUS_SUCCESS|SAI_PORT_ATTR_ADMIN_STATE=true
2022-12-02.21:39:53.554090|g|SAI_OBJECT_TYPE_PORT:oid:0x100000000005b|SAI_PORT_ATTR_SPEED=0
2022-12-02.21:39:53.556303|G|SAI_STATUS_SUCCESS|SAI_PORT_ATTR_SPEED=25000
```

With this change, a GET call on AUTO_NEG_MODE is done, if FALSE, GET on PORT_ATTR_SPEED is done:
```
2022-12-02.22:13:07.852038|g|SAI_OBJECT_TYPE_PORT:oid:0x100000000005b|SAI_PORT_ATTR_ADMIN_STATE=true
2022-12-02.22:13:07.852562|G|SAI_STATUS_SUCCESS|SAI_PORT_ATTR_ADMIN_STATE=true
2022-12-02.22:13:07.852581|g|SAI_OBJECT_TYPE_PORT:oid:0x100000000005b|SAI_PORT_ATTR_AUTO_NEG_MODE=true
2022-12-02.22:13:07.852942|G|SAI_STATUS_SUCCESS|SAI_PORT_ATTR_AUTO_NEG_MODE=false
2022-12-02.22:13:07.852961|g|SAI_OBJECT_TYPE_PORT:oid:0x100000000005b|SAI_PORT_ATTR_SPEED=0
2022-12-02.22:13:07.855123|G|SAI_STATUS_SUCCESS|SAI_PORT_ATTR_SPEED=25000
```

**Details if related**
