### PR TITLE
Swss Changes to Support Static Lag

### DIFF
--- a/cfgmgr/teammgr.h
+++ b/cfgmgr/teammgr.h
@@ -41,7 +41,7 @@ private:
     void doLagMemberTask(Consumer &consumer);
     void doPortUpdateTask(Consumer &consumer);
 
-    task_process_status addLag(const std::string &alias, int min_links, bool fall_back, bool fast_rate);
+    task_process_status addLag(const std::string &alias, int min_links, bool fall_back, bool fast_rate, bool static_lag);
     bool removeLag(const std::string &alias);
     task_process_status addLagMember(const std::string &lag, const std::string &member);
     bool removeLagMember(const std::string &lag, const std::string &member);

--- a/tlm_teamd/values_store.h
+++ b/tlm_teamd/values_store.h
@@ -41,11 +41,13 @@ private:
     std::vector<std::string> update_storage(const HashOfRecords & storage);
     void update_db(const HashOfRecords & storage, const std::vector<std::string> & keys_to_refresh);
     void extract_values(const std::string & lag_name, json_t * root, HashOfRecords & storage);
+    void extract_values_static(const std::string & lag_name, json_t * root, HashOfRecords & storage);
 
     HashOfRecords m_storage;  // our main storage
     const swss::DBConnector * m_db;
 
     const std::vector<std::pair<std::string, ValuesStore::json_type>> m_lag_paths = {
+        { "setup.runner_name",           ValuesStore::json_type::string  },
         { "setup.kernel_team_mode_name", ValuesStore::json_type::string  },
         { "setup.pid",                   ValuesStore::json_type::integer },
         { "runner.active",               ValuesStore::json_type::boolean },
@@ -70,4 +72,19 @@ private:
         { "runner.selected",                   ValuesStore::json_type::boolean },
         { "runner.state",                      ValuesStore::json_type::string  },
     };
+
+    const std::vector<std::pair<std::string, ValuesStore::json_type>> m_lag_static_paths = {
+        { "setup.runner_name",           ValuesStore::json_type::string  },
+        { "setup.kernel_team_mode_name", ValuesStore::json_type::string  },
+        { "setup.pid",                   ValuesStore::json_type::integer },
+        { "team_device.ifinfo.dev_addr", ValuesStore::json_type::string  },
+        { "team_device.ifinfo.ifindex",  ValuesStore::json_type::integer },
+    };
+    const std::vector<std::pair<std::string, ValuesStore::json_type>> m_member_static_paths = {
+        { "ifinfo.dev_addr",                   ValuesStore::json_type::string  },
+        { "ifinfo.ifindex",                    ValuesStore::json_type::integer },
+        { "link.up",                           ValuesStore::json_type::boolean },
+        { "link_watches.list.link_watch_0.up", ValuesStore::json_type::boolean },
+    };
+
 };


### PR DESCRIPTION


<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Static lag support changes in SWSS module
https://github.com/sonic-net/SONiC/pull/1039

**Why I did it**
1. swss handles --static flag and corresponding invokes teamd instance with loadbalance as the option.
2. updating the LAG table to support static flag so "show inter portchannel" works fine.

**How I verified it**
	Test cases	
1	Create static port channel with static flag 	pass
2	verify static has option flag true or false	pass
3	Add static member see the portchannel is up	pass
4	verify teamd is created with loadbalance option by default	pass
5	Remove last portchannel member check port channel down	pass
6	Remove portchannel member check port channel still up	pass
7	verify teamdctl config dump	pass
8	verify teamdctl state dump	pass
9	shutdown the portchannel check the kernel state	pass
10	no shutdown the portchannel check the kernel state	pass
11	"Check the show output matches the review comment 
root@sonic:~# show inter port
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
       S - selected, D - deselected, * - not synced
  No.  Team Dev      Protocol     Ports
-----  ------------  -----------  ------------
    1  PortChannel1  NONE(A)(Up)  Ethernet0(S)
    2  PortChannel2  NONE(A)(Up)  Ethernet8(S)
    4  PortChannel4  NONE(A)(Dw)
"	pass
12	teamnl is set to loadbalance	pass
13	save and reload and verify portchannel is up	pass
14	"docker restart teamd 
teamd stopped
swss stopped
syncd stopped

swss started
syncd started
teamd started"	pass
16	verify teamd settles doesnt hog cpu with 100% cpu usage	pass


**Details if related**
Libteam change pull request - https://github.com/sonic-net/sonic-buildimage/pull/12360