### PR TITLE
Vxlan ecmp tunnel with priority Endpoints.[202012]

### DIFF
--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -324,10 +324,19 @@ struct BfdSessionInfo
 
 struct VNetTunnelRouteEntry 
 {
-    NextHopGroupKey ngh_key; 
+    NextHopGroupKey nhg_key; 
     NextHopGroupKey primary;
     NextHopGroupKey secondary;
 };
+
+typedef enum
+{
+    TUNNEL_ROUTE_ACTION_NONE         = 0,
+    TUNNEL_ROUTE_ACTION_ADD_ROUTE    = 1,
+    TUNNEL_ROUTE_ACTION_DELETE_ROUTE = 2,
+    TUNNEL_ROUTE_ACTION_REPLACE_NHG  = 3,
+    TUNNEL_ROUTE_ACTION_COUNT
+} tunnel_route_action_t;
 
 typedef std::map<NextHopGroupKey, NextHopGroupInfo> VNetNextHopGroupInfoTable;
 typedef std::map<IpPrefix, VNetTunnelRouteEntry> VNetTunnelRouteTable;
@@ -367,6 +376,7 @@ private:
     bool selectNextHopGroup(const string&, NextHopGroupKey&, NextHopGroupKey&,
                             VNetVrfObject *vrf_obj, NextHopGroupKey&,
                             const std::map<NextHopKey,IpAddress>& monitors=std::map<NextHopKey, IpAddress>());
+    tunnel_route_action_t switchNextHopGroup(const string&, NextHopGroupKey&,  IpPrefix&, NextHopGroupKey&);
 
     void createBfdSession(const string& vnet, const NextHopKey& endpoint, const IpAddress& ipAddr);
     void removeBfdSession(const string& vnet, const NextHopKey& endpoint, const IpAddress& ipAddr);
@@ -379,6 +389,7 @@ private:
 
     void updateVnetTunnel(const BfdUpdate&);
     bool updateTunnelRoute(const string& vnet, IpPrefix& ipPrefix, NextHopGroupKey& nexthops, string& op);
+    bool updateTunnelRouteNextHopGroup(const string& vnet, IpPrefix& ipPrefix, NextHopGroupKey& nexthops);
 
     template<typename T>
     bool doRouteTask(const string& vnet, IpPrefix& ipPrefix, NextHopGroupKey& nexthops, string& op, string& profile,


### PR DESCRIPTION
Added support for Priority endpoints in Vxlan ECMP tunnel.
<!--
Please make sure you have read and understood the contribution guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generated with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, assignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
This commit does not amend the existing behavior of the system. This change adds support for creating two NHG's (primary and secondary) so they can be switched when primary endpoints go down.
When a secondary endpoint comes back up, the next hop group with secondary endpoints is replaced with the primary one for the route.
If the primary endpoints list is provided,  it must be the same as the **"endpoint"** list.
**Why I did it**
To add support for Primary /Backup endpoint routing behavior.
**How I verified it**
Added 3  test cases to verify the functionality and existing tests are passing.
**Details if related**
