### PR TITLE
Align watermark flow with port configuration

### DIFF
--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -28,7 +28,9 @@ extern FlowCounterRouteOrch *gFlowCounterRouteOrch;
 #define PORT_KEY                    "PORT"
 #define PORT_BUFFER_DROP_KEY        "PORT_BUFFER_DROP"
 #define QUEUE_KEY                   "QUEUE"
+#define QUEUE_WATERMARK             "QUEUE_WATERMARK"
 #define PG_WATERMARK_KEY            "PG_WATERMARK"
+#define PG_DROP_KEY                 "PG_DROP"
 #define RIF_KEY                     "RIF"
 #define ACL_KEY                     "ACL"
 #define TUNNEL_KEY                  "TUNNEL"
@@ -158,10 +160,22 @@ void FlexCounterOrch::doTask(Consumer &consumer)
                         else if(key == QUEUE_KEY)
                         {
                             gPortsOrch->generateQueueMap();
+                            gPortsOrch->addQueueFlexCounters();
+                        }
+                        else if(key == QUEUE_WATERMARK)
+                        {
+                            gPortsOrch->generateQueueMap();
+                            gPortsOrch->addQueueWatermarkFlexCounters();
+                        }
+                        else if(key == PG_DROP_KEY)
+                        {
+                            gPortsOrch->generatePriorityGroupMap();
+                            gPortsOrch->addPriorityGroupFlexCounters();
                         }
                         else if(key == PG_WATERMARK_KEY)
                         {
                             gPortsOrch->generatePriorityGroupMap();
+                            gPortsOrch->addPriorityGroupWatermarkFlexCounters();
                         }
                     }
                     if(gIntfsOrch && (key == RIF_KEY) && (value == "enable"))

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -131,7 +131,11 @@ public:
     bool getPortPfcWatchdogStatus(sai_object_id_t portId, uint8_t *pfc_bitmask);
 
     void generateQueueMap();
+    void addQueueFlexCounters();
+    void addQueueWatermarkFlexCounters();
     void generatePriorityGroupMap();
+    void addPriorityGroupFlexCounters();
+    void addPriorityGroupWatermarkFlexCounters();
     void generatePortCounterMap();
     void generatePortBufferDropCounterMap();
 
@@ -340,10 +344,20 @@ private:
     bool m_isQueueMapGenerated = false;
     void generateQueueMapPerPort(const Port& port);
     void removeQueueMapPerPort(const Port& port);
+    bool m_isQueueFlexCountersAdded = false;
+    void addQueueFlexCountersPerPort(const Port& port);
+
+    bool m_isQueueWatermarkFlexCountersAdded = false;
+    void addQueueWatermarkFlexCountersPerPort(const Port& port);
 
     bool m_isPriorityGroupMapGenerated = false;
     void generatePriorityGroupMapPerPort(const Port& port);
     void removePriorityGroupMapPerPort(const Port& port);
+    bool m_isPriorityGroupFlexCountersAdded = false;
+    void addPriorityGroupFlexCountersPerPort(const Port& port);
+
+    bool m_isPriorityGroupWatermarkFlexCountersAdded = false;
+    void addPriorityGroupWatermarkFlexCountersPerPort(const Port& port);
 
     bool m_isPortCounterMapGenerated = false;
     bool m_isPortBufferDropCounterMapGenerated = false;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Align watermark flow with port configuration
correct the queue, watermark and pg-drop counterpoll functionality according to cli commands

**Why I did it**
the flow before this commit was wrong, when watermark counterpoll was enabled, stats wasn't created in FLEX_COUNTERS_DB 
and COUNTERS_DB unless enabling queue counterpoll as well.
in the same way when pg-drop counterpoll was enabled stats weren't added until watermark was enabled.
This is due to the wrong flow where queue and pg maps were generated only when queue or watermark (pg-watermark)
key was detected in flexcountersorch.cpp

**How I verified it**
manual testing
VS test (updated to reflect current flow) - before this commit only queue was tested

**Details if related**
