### PR TITLE
[202012][MuxOrch] disable pfcwd when switching over

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -41,6 +41,7 @@ Directory<Orch*> gDirectory;
 NatOrch *gNatOrch;
 BfdOrch *gBfdOrch;
 QosOrch *gQosOrch;
+PfcWdSwOrch<PfcWdActionHandler,PfcWdActionHandler> *gPfcWdSwOrch;
 
 bool gIsNatSupported = false;
 
@@ -375,13 +376,16 @@ bool OrchDaemon::init()
 
         static const vector<sai_queue_attr_t> queueAttrIds;
 
-        m_orchList.push_back(new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
+        gPfcWdSwOrch = (PfcWdSwOrch<PfcWdActionHandler,PfcWdActionHandler> *)
+            new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
                     m_configDb,
                     pfc_wd_tables,
                     portStatIds,
                     queueStatIds,
                     queueAttrIds,
-                    PFC_WD_POLL_MSECS));
+                    PFC_WD_POLL_MSECS);
+
+        m_orchList.push_back(gPfcWdSwOrch);
     }
     else if ((platform == INVM_PLATFORM_SUBSTRING)
              || (platform == CLX_PLATFORM_SUBSTRING)
@@ -420,23 +424,29 @@ bool OrchDaemon::init()
         if ((platform == INVM_PLATFORM_SUBSTRING) || (platform == NPS_PLATFORM_SUBSTRING)
 	|| (platform == CLX_PLATFORM_SUBSTRING))
         {
-            m_orchList.push_back(new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
+            gPfcWdSwOrch = (PfcWdSwOrch<PfcWdActionHandler,PfcWdActionHandler> *)
+                new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
                         m_configDb,
                         pfc_wd_tables,
                         portStatIds,
                         queueStatIds,
                         queueAttrIds,
-                        PFC_WD_POLL_MSECS));
+                        PFC_WD_POLL_MSECS);
+
+            m_orchList.push_back(gPfcWdSwOrch);
         }
         else if (platform == BFN_PLATFORM_SUBSTRING)
         {
-            m_orchList.push_back(new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
+            gPfcWdSwOrch = (PfcWdSwOrch<PfcWdActionHandler,PfcWdActionHandler> *)
+                new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
                         m_configDb,
                         pfc_wd_tables,
                         portStatIds,
                         queueStatIds,
                         queueAttrIds,
-                        PFC_WD_POLL_MSECS));
+                        PFC_WD_POLL_MSECS);
+
+            m_orchList.push_back(gPfcWdSwOrch);
         }
     }
     else if (platform == BRCM_PLATFORM_SUBSTRING)
@@ -472,13 +482,16 @@ bool OrchDaemon::init()
             SAI_QUEUE_ATTR_PAUSE_STATUS,
         };
 
-        m_orchList.push_back(new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
-                    m_configDb,
-                    pfc_wd_tables,
-                    portStatIds,
-                    queueStatIds,
-                    queueAttrIds,
-                    PFC_WD_POLL_MSECS));
+        gPfcWdSwOrch = (PfcWdSwOrch<PfcWdActionHandler,PfcWdActionHandler> *)
+            new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
+                m_configDb,
+                pfc_wd_tables,
+                portStatIds,
+                queueStatIds,
+                queueAttrIds,
+                PFC_WD_POLL_MSECS);
+
+        m_orchList.push_back(gPfcWdSwOrch);
     } else if (platform == CISCO_8000_PLATFORM_SUBSTRING)
     {
         static const vector<sai_port_stat_t> portStatIds;
@@ -493,13 +506,16 @@ bool OrchDaemon::init()
             SAI_QUEUE_ATTR_PAUSE_STATUS,
         };
 
-        m_orchList.push_back(new PfcWdSwOrch<PfcWdSaiDlrInitHandler, PfcWdActionHandler>(
+        gPfcWdSwOrch = (PfcWdSwOrch<PfcWdActionHandler,PfcWdActionHandler> *)
+            new PfcWdSwOrch<PfcWdSaiDlrInitHandler, PfcWdActionHandler>(
                     m_configDb,
                     pfc_wd_tables,
                     portStatIds,
                     queueStatIds,
                     queueAttrIds,
-                    PFC_WD_POLL_MSECS));
+                    PFC_WD_POLL_MSECS);
+
+        m_orchList.push_back(gPfcWdSwOrch);
     }
 
     m_orchList.push_back(&CounterCheckOrch::getInstance(m_configDb));

--- a/orchagent/pfcwdorch.h
+++ b/orchagent/pfcwdorch.h
@@ -77,6 +77,8 @@ public:
     virtual bool startWdOnPort(const Port& port,
             uint32_t detectionTime, uint32_t restorationTime, PfcWdAction action);
     virtual bool stopWdOnPort(const Port& port);
+    virtual bool startWdOnAllPorts();
+    virtual bool stopWdOnAllPorts();
 
     task_process_status createEntry(const string& key, const vector<FieldValueTuple>& data) override;
     virtual void doTask(SelectableTimer &timer);
@@ -118,8 +120,14 @@ private:
     void enableBigRedSwitchMode();
     void setBigRedSwitchMode(string value);
 
+    bool isStormingOnPort(Port port);
+    bool continueWdOnPort(const Port& port);
+    bool pauseWdOnPort(const Port& port);
+
     map<sai_object_id_t, PfcWdQueueEntry> m_entryMap;
     map<sai_object_id_t, PfcWdQueueEntry> m_brsEntryMap;
+    // Track configs during disable
+    map<sai_object_id_t, vector<FieldValueTuple>> m_pfcwdconfigs;
 
     const vector<sai_port_stat_t> c_portStatIds;
     const vector<sai_queue_stat_t> c_queueStatIds;

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -914,7 +914,7 @@ class TestMuxTunnelBase():
 
     def teardown_pfcwd(self, dvs, config_db):
         pfc_test_ports = ["Ethernet0"]
-        pfc_test_queue = 3
+
         # disable pfcwd
         self.set_flex_counter_status("PFCWD", "disable", config_db)
         # disable queue


### PR DESCRIPTION
Why I did it:
to improve switchover performance

How I did it:
Added stopPFCWdOnAllPorts and startPFCWdOnAllPorts function in PFCWdSwOrch. On each switchover, PFC Wd is stopped unless there is a storm currently on the port. Then when switchover is completed, PFC Wd is enabled again

How to test:
$ pytest test_mux.py::TestMuxTunnel::test_mux_pfcwd_switching

Signed-off-by: Nikola Dancejic <ndancejic@microsoft.com>
