### PR TITLE
[202111] cherrypick ACL fixes (#2298) and (#2351)

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -153,6 +153,176 @@ static const acl_capabilities_t defaultAclActionsSupported =
     }
 };
 
+static acl_table_action_list_lookup_t defaultAclActionList = 
+{
+    {
+        // L3
+        TABLE_TYPE_L3,
+        {
+            {
+                ACL_STAGE_INGRESS,
+                {
+                    SAI_ACL_ACTION_TYPE_PACKET_ACTION,
+                    SAI_ACL_ACTION_TYPE_REDIRECT
+                }
+            },
+            {
+                ACL_STAGE_EGRESS,
+                {
+                    SAI_ACL_ACTION_TYPE_PACKET_ACTION,
+                    SAI_ACL_ACTION_TYPE_REDIRECT
+                }
+            }
+        }
+    },
+    {
+        // L3V6
+        TABLE_TYPE_L3V6,
+        {
+            {
+                ACL_STAGE_INGRESS,
+                {
+                    SAI_ACL_ACTION_TYPE_PACKET_ACTION,
+                    SAI_ACL_ACTION_TYPE_REDIRECT
+                }
+            },
+            {
+                ACL_STAGE_EGRESS,
+                {
+                    SAI_ACL_ACTION_TYPE_PACKET_ACTION,
+                    SAI_ACL_ACTION_TYPE_REDIRECT
+                }
+            }
+        }
+    },
+    {
+        // MIRROR
+        TABLE_TYPE_MIRROR,
+        {
+            {
+                ACL_STAGE_INGRESS,
+                {
+                    SAI_ACL_ACTION_TYPE_MIRROR_INGRESS
+                }
+            },
+            {
+                ACL_STAGE_EGRESS,
+                {
+                    SAI_ACL_ACTION_TYPE_MIRROR_EGRESS
+                }
+            }
+        }
+    },
+    {
+        // MIRRORV6
+        TABLE_TYPE_MIRRORV6,
+        {
+            {
+                ACL_STAGE_INGRESS,
+                {
+                    SAI_ACL_ACTION_TYPE_MIRROR_INGRESS
+                }
+            },
+            {
+                ACL_STAGE_EGRESS,
+                {
+                    SAI_ACL_ACTION_TYPE_MIRROR_EGRESS
+                }
+            }
+        }
+    },
+    {
+        // MIRROR_DSCP
+        TABLE_TYPE_MIRROR_DSCP,
+        {
+            {
+                ACL_STAGE_INGRESS,
+                {
+                    SAI_ACL_ACTION_TYPE_MIRROR_INGRESS
+                }
+            },
+            {
+                ACL_STAGE_EGRESS,
+                {
+                    SAI_ACL_ACTION_TYPE_MIRROR_EGRESS
+                }
+            }
+        }
+    },
+    {
+        // TABLE_TYPE_PFCWD
+        TABLE_TYPE_PFCWD,
+        {
+            {
+                ACL_STAGE_INGRESS,
+                {
+                    SAI_ACL_ACTION_TYPE_PACKET_ACTION
+                }
+            },
+            {
+                ACL_STAGE_EGRESS,
+                {
+                    SAI_ACL_ACTION_TYPE_PACKET_ACTION
+                }
+            }
+        }
+    },
+    {
+        // MCLAG
+        TABLE_TYPE_MCLAG,
+        {
+            {
+                ACL_STAGE_INGRESS,
+                {
+                    SAI_ACL_ACTION_TYPE_PACKET_ACTION
+                }
+            },
+            {
+                ACL_STAGE_EGRESS,
+                {
+                    SAI_ACL_ACTION_TYPE_PACKET_ACTION
+                }
+            }
+        }
+    },
+    {
+        // MUX
+        TABLE_TYPE_MUX,
+        {
+            {
+                ACL_STAGE_INGRESS,
+                {
+                    SAI_ACL_ACTION_TYPE_PACKET_ACTION
+                }
+            },
+            {
+                ACL_STAGE_EGRESS,
+                {
+                    SAI_ACL_ACTION_TYPE_PACKET_ACTION
+                }
+            }
+        }
+    },
+    {
+        // DROP
+        TABLE_TYPE_DROP,
+        {
+            {
+                ACL_STAGE_INGRESS,
+                {
+                    SAI_ACL_ACTION_TYPE_PACKET_ACTION
+                }
+            },
+            {
+                ACL_STAGE_EGRESS,
+                {
+                    SAI_ACL_ACTION_TYPE_PACKET_ACTION
+                }
+            }
+        }
+    }
+};
+
 static acl_ip_type_lookup_t aclIpTypeLookup =
 {
     { IP_TYPE_ANY,         SAI_ACL_IP_TYPE_ANY },
@@ -299,6 +469,12 @@ const map<sai_acl_table_attr_t, shared_ptr<AclTableMatchInterface>>& AclTableTyp
 const set<sai_acl_action_type_t>& AclTableType::getActions() const
 {
     return m_aclAcitons;
+}
+
+bool AclTableType::addAction(sai_acl_action_type_t action)
+{
+    m_aclAcitons.insert(action);
+    return true;
 }
 
 AclTableTypeBuilder& AclTableTypeBuilder::withName(string name)
@@ -1806,6 +1982,51 @@ AclTable::AclTable(AclOrch *pAclOrch, string id) noexcept : m_pAclOrch(pAclOrch)
 AclTable::AclTable(AclOrch *pAclOrch) noexcept : m_pAclOrch(pAclOrch)
 {
 
+}
+
+bool AclTable::addMandatoryActions()
+{
+    SWSS_LOG_ENTER();
+
+    if (stage == ACL_STAGE_UNKNOWN)
+    {
+        return false;
+    }
+
+    if (!m_pAclOrch->isAclActionListMandatoryOnTableCreation(stage))
+    {
+        // No op if action list is not mandatory on table creation.
+        return true;
+    }
+    if (!type.getActions().empty())
+    {
+        // No change if action_list is provided
+        return true;
+    }
+
+    sai_acl_action_type_t acl_action = SAI_ACL_ACTION_TYPE_COUNTER;
+    if (m_pAclOrch->isAclActionSupported(stage, acl_action))
+    {
+        SWSS_LOG_INFO("Add counter acl action");
+        type.addAction(acl_action);
+    }
+
+    if (defaultAclActionList.count(type.getName()) != 0)
+    {
+        // Add the default action list
+        for (auto action : defaultAclActionList[type.getName()][stage])
+        {
+            if (m_pAclOrch->isAclActionSupported(stage, acl_action))
+            {
+                SWSS_LOG_INFO("Added default action for table type %s stage %s",
+                                    type.getName().c_str(),
+                                    ((stage == ACL_STAGE_INGRESS)? "INGRESS":"EGRESS"));
+                type.addAction(action);
+            }
+        }
+    }
+
+    return true;
 }
 
 bool AclTable::validateAddType(const AclTableType &tableType)
@@ -3943,6 +4164,8 @@ void AclOrch::doAclTableTask(Consumer &consumer)
             }
 
             newTable.validateAddType(*tableType);
+
+            newTable.addMandatoryActions();
 
             // validate and create/update ACL Table
             if (bAllAttributesOk && newTable.validate())

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -153,7 +153,7 @@ static const acl_capabilities_t defaultAclActionsSupported =
     }
 };
 
-static acl_table_action_list_lookup_t defaultAclActionList = 
+static acl_table_action_list_lookup_t defaultAclActionList =
 {
     {
         // L3
@@ -2016,7 +2016,7 @@ bool AclTable::addMandatoryActions()
         // Add the default action list
         for (auto action : defaultAclActionList[type.getName()][stage])
         {
-            if (m_pAclOrch->isAclActionSupported(stage, acl_action))
+            if (m_pAclOrch->isAclActionSupported(stage, action))
             {
                 SWSS_LOG_INFO("Added default action for table type %s stage %s",
                                     type.getName().c_str(),

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -113,6 +113,9 @@ typedef tuple<sai_acl_range_type_t, int, int> acl_range_properties_t;
 typedef map<acl_stage_type_t, AclActionCapabilities> acl_capabilities_t;
 typedef map<sai_acl_action_type_t, set<int32_t>> acl_action_enum_values_capabilities_t;
 
+typedef map<acl_stage_type_t, set<sai_acl_action_type_t> > acl_stage_action_list_t;
+typedef map<string, acl_stage_action_list_t> acl_table_action_list_lookup_t;
+
 class AclRule;
 
 class AclTableMatchInterface
@@ -155,6 +158,8 @@ public:
     const map<sai_acl_table_attr_t, shared_ptr<AclTableMatchInterface>>& getMatches() const;
     const set<sai_acl_range_type_t>& getRangeTypes() const;
     const set<sai_acl_action_type_t>& getActions() const;
+
+    bool addAction(sai_acl_action_type_t action);
 
 private:
     friend class AclTableTypeBuilder;
@@ -386,6 +391,9 @@ public:
     bool validateAddPorts(const unordered_set<string> &value);
     bool validate();
     bool create();
+
+    // Add actions to ACL table if mandatory action list is required on table creation.
+    bool addMandatoryActions();
 
     // validate AclRule match attribute against rule and table configuration
     bool validateAclRuleMatch(sai_acl_entry_attr_t matchId, const AclRule& rule) const;

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -1743,4 +1743,96 @@ namespace aclorch_test
         // try to delete non existing acl rule
         ASSERT_TRUE(orch->m_aclOrch->removeAclRule(tableId, ruleId));
     }
+
+    sai_switch_api_t *old_sai_switch_api;
+
+    // The following function is used to override SAI API get_switch_attribute to request passing
+    // mandatory ACL actions to SAI when creating mirror ACL table.
+    sai_status_t getSwitchAttribute(_In_ sai_object_id_t switch_id,_In_ uint32_t attr_count,
+                                    _Inout_ sai_attribute_t *attr_list)
+    {
+        if (attr_count == 1)
+        {
+            switch(attr_list[0].id)
+            {
+            case SAI_SWITCH_ATTR_MAX_ACL_ACTION_COUNT:
+                attr_list[0].value.u32 = 2;
+                return SAI_STATUS_SUCCESS;
+            case SAI_SWITCH_ATTR_ACL_STAGE_INGRESS:
+            case SAI_SWITCH_ATTR_ACL_STAGE_EGRESS:
+                attr_list[0].value.aclcapability.action_list.count = 2;
+                attr_list[0].value.aclcapability.action_list.list[0]= SAI_ACL_ACTION_TYPE_COUNTER;
+                attr_list[0].value.aclcapability.action_list.list[1]=
+                    attr_list[0].id == SAI_SWITCH_ATTR_ACL_STAGE_INGRESS ?
+                        SAI_ACL_ACTION_TYPE_MIRROR_INGRESS : SAI_ACL_ACTION_TYPE_MIRROR_EGRESS;
+                attr_list[0].value.aclcapability.is_action_list_mandatory = true;
+                return SAI_STATUS_SUCCESS;
+            }
+        }
+        return old_sai_switch_api->get_switch_attribute(switch_id, attr_count, attr_list);
+    }
+
+    TEST_F(AclOrchTest, AclTableCreationWithMandatoryActions)
+    {
+        // Override SAI API get_switch_attribute to request passing mandatory ACL actions to SAI
+        // when creating mirror ACL table.
+        old_sai_switch_api = sai_switch_api;
+        sai_switch_api_t new_sai_switch_api = *sai_switch_api;
+        sai_switch_api = &new_sai_switch_api;
+        sai_switch_api->get_switch_attribute = getSwitchAttribute;
+
+        // Set platform env to enable support of MIRRORV6 ACL table.
+        bool unset_platform_env = false;
+        if (!getenv("platform"))
+        {
+            setenv("platform", VS_PLATFORM_SUBSTRING, 0);
+            unset_platform_env = true;
+        }
+
+        auto orch = createAclOrch();
+
+        for (const auto &acl_table_type : { TABLE_TYPE_MIRROR, TABLE_TYPE_MIRRORV6, TABLE_TYPE_MIRROR_DSCP })
+        {
+            for (const auto &acl_table_stage : { STAGE_INGRESS, STAGE_EGRESS })
+            {
+                // Create ACL table.
+                string acl_table_id = "mirror_acl_table";
+                auto kvfAclTable = deque<KeyOpFieldsValuesTuple>(
+                    { { acl_table_id,
+                        SET_COMMAND,
+                        { { ACL_TABLE_DESCRIPTION, acl_table_type },
+                          { ACL_TABLE_TYPE, acl_table_type },
+                          { ACL_TABLE_STAGE, acl_table_stage },
+                          { ACL_TABLE_PORTS, "1,2" } } } });
+                orch->doAclTableTask(kvfAclTable);
+                auto acl_table = orch->getAclTable(acl_table_id);
+                ASSERT_NE(acl_table, nullptr);
+
+                // Verify mandaotry ACL actions has been added.
+                auto acl_actions = acl_table->type.getActions();
+                ASSERT_NE(acl_actions.find(SAI_ACL_ACTION_TYPE_COUNTER), acl_actions.end());
+                sai_acl_action_type_t action = strcmp(acl_table_stage, STAGE_INGRESS) == 0 ?
+                    SAI_ACL_ACTION_TYPE_MIRROR_INGRESS : SAI_ACL_ACTION_TYPE_MIRROR_EGRESS;
+                ASSERT_NE(acl_actions.find(action), acl_actions.end());
+
+                // Delete ACL table.
+                kvfAclTable = deque<KeyOpFieldsValuesTuple>(
+                    { { acl_table_id,
+                        DEL_COMMAND,
+                        {} } });
+                orch->doAclTableTask(kvfAclTable);
+                acl_table = orch->getAclTable(acl_table_id);
+                ASSERT_EQ(acl_table, nullptr);
+            }
+        }
+
+        // Unset platform env.
+        if (unset_platform_env)
+        {
+            unsetenv("platform");
+        }
+
+        // Restore sai_switch_api.
+        sai_switch_api = old_sai_switch_api;
+    }
 } // namespace nsAclOrchTest


### PR DESCRIPTION
**What I did**
Cherry-pick the following commits 

commit 910bfd4d17782a059daf2d81deb87673ae6ca58e
Author: bingwang-ms <66248323+bingwang-ms@users.noreply.github.com>
Date:   Sat May 28 03:04:14 2022 +0800
 
    [ACL] Add default action_list for default ACL table type (#2298)
commit 1b8bd94ef7e44f6089fc12efd456a3caa7aafd3f
Author: Ravindranath C K <rck@innovium.com>
Date:   Fri Jun 24 20:20:52 2022 +0530

    Create ACL table fails due to incorrect check for supported ACL actions #11235 (#2351)

    Signed-off-by: rck-innovium <rck@innovium.com>

**Why I did it**

**How I verified it**

**Details if related**
