### PR TITLE
[202012][MuxOrch] disable pfcwd when switching over

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -41,6 +41,7 @@ Directory<Orch*> gDirectory;
 NatOrch *gNatOrch;
 BfdOrch *gBfdOrch;
 QosOrch *gQosOrch;
+PfcWdSwOrch<PfcWdActionHandler,PfcWdActionHandler> *gPfcWdSwOrch;
 
 bool gIsNatSupported = false;
 bool gSaiRedisLogRotate = false;
@@ -376,13 +377,16 @@ bool OrchDaemon::init()
 
         static const vector<sai_queue_attr_t> queueAttrIds;
 
-        m_orchList.push_back(new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
+        gPfcWdSwOrch = (PfcWdSwOrch<PfcWdActionHandler,PfcWdActionHandler> *)
+            new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
                     m_configDb,
                     pfc_wd_tables,
                     portStatIds,
                     queueStatIds,
                     queueAttrIds,
-                    PFC_WD_POLL_MSECS));
+                    PFC_WD_POLL_MSECS);
+
+        m_orchList.push_back(gPfcWdSwOrch);
     }
     else if ((platform == INVM_PLATFORM_SUBSTRING)
              || (platform == CLX_PLATFORM_SUBSTRING)
@@ -421,23 +425,29 @@ bool OrchDaemon::init()
         if ((platform == INVM_PLATFORM_SUBSTRING) || (platform == NPS_PLATFORM_SUBSTRING)
 	|| (platform == CLX_PLATFORM_SUBSTRING))
         {
-            m_orchList.push_back(new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
+            gPfcWdSwOrch = (PfcWdSwOrch<PfcWdActionHandler,PfcWdActionHandler> *)
+                new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
                         m_configDb,
                         pfc_wd_tables,
                         portStatIds,
                         queueStatIds,
                         queueAttrIds,
-                        PFC_WD_POLL_MSECS));
+                        PFC_WD_POLL_MSECS);
+
+            m_orchList.push_back(gPfcWdSwOrch);
         }
         else if (platform == BFN_PLATFORM_SUBSTRING)
         {
-            m_orchList.push_back(new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
+            gPfcWdSwOrch = (PfcWdSwOrch<PfcWdActionHandler,PfcWdActionHandler> *)
+                new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
                         m_configDb,
                         pfc_wd_tables,
                         portStatIds,
                         queueStatIds,
                         queueAttrIds,
-                        PFC_WD_POLL_MSECS));
+                        PFC_WD_POLL_MSECS);
+
+            m_orchList.push_back(gPfcWdSwOrch);
         }
     }
     else if (platform == BRCM_PLATFORM_SUBSTRING)
@@ -473,13 +483,16 @@ bool OrchDaemon::init()
             SAI_QUEUE_ATTR_PAUSE_STATUS,
         };
 
-        m_orchList.push_back(new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
-                    m_configDb,
-                    pfc_wd_tables,
-                    portStatIds,
-                    queueStatIds,
-                    queueAttrIds,
-                    PFC_WD_POLL_MSECS));
+        gPfcWdSwOrch = (PfcWdSwOrch<PfcWdActionHandler,PfcWdActionHandler> *)
+            new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
+                m_configDb,
+                pfc_wd_tables,
+                portStatIds,
+                queueStatIds,
+                queueAttrIds,
+                PFC_WD_POLL_MSECS);
+
+        m_orchList.push_back(gPfcWdSwOrch);
     } else if (platform == CISCO_8000_PLATFORM_SUBSTRING)
     {
         static const vector<sai_port_stat_t> portStatIds;
@@ -494,13 +507,16 @@ bool OrchDaemon::init()
             SAI_QUEUE_ATTR_PAUSE_STATUS,
         };
 
-        m_orchList.push_back(new PfcWdSwOrch<PfcWdSaiDlrInitHandler, PfcWdActionHandler>(
+        gPfcWdSwOrch = (PfcWdSwOrch<PfcWdActionHandler,PfcWdActionHandler> *)
+            new PfcWdSwOrch<PfcWdSaiDlrInitHandler, PfcWdActionHandler>(
                     m_configDb,
                     pfc_wd_tables,
                     portStatIds,
                     queueStatIds,
                     queueAttrIds,
-                    PFC_WD_POLL_MSECS));
+                    PFC_WD_POLL_MSECS);
+
+        m_orchList.push_back(gPfcWdSwOrch);
     }
 
     m_orchList.push_back(&CounterCheckOrch::getInstance(m_configDb));

--- a/orchagent/pfcwdorch.h
+++ b/orchagent/pfcwdorch.h
@@ -77,6 +77,8 @@ public:
     virtual bool startWdOnPort(const Port& port,
             uint32_t detectionTime, uint32_t restorationTime, PfcWdAction action);
     virtual bool stopWdOnPort(const Port& port);
+    virtual bool startWdOnAllPorts();
+    virtual bool stopWdOnAllPorts();
 
     task_process_status createEntry(const string& key, const vector<FieldValueTuple>& data) override;
     virtual void doTask(SelectableTimer &timer);
@@ -118,8 +120,14 @@ private:
     void enableBigRedSwitchMode();
     void setBigRedSwitchMode(string value);
 
+    bool isStormingOnPort(Port port);
+    bool continueWdOnPort(const Port& port);
+    bool pauseWdOnPort(const Port& port);
+
     map<sai_object_id_t, PfcWdQueueEntry> m_entryMap;
     map<sai_object_id_t, PfcWdQueueEntry> m_brsEntryMap;
+    // Track configs during disable
+    map<sai_object_id_t, vector<FieldValueTuple>> m_pfcwdconfigs;
 
     const vector<sai_port_stat_t> c_portStatIds;
     const vector<sai_queue_stat_t> c_queueStatIds;

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -56,6 +56,8 @@ class TestMuxTunnelBase():
 
     PING_CMD                    = "timeout 0.5 ping -c1 -W1 -i0 -n -q {ip}"
 
+    PFC_WD_QUEUE_MAX               = 8
+
     SAI_ROUTER_INTERFACE_ATTR_TYPE = "SAI_ROUTER_INTERFACE_ATTR_TYPE"
     SAI_ROUTER_INTERFACE_TYPE_VLAN = "SAI_ROUTER_INTERFACE_TYPE_VLAN"
 
@@ -226,6 +228,10 @@ class TestMuxTunnelBase():
                 count += 1
 
         assert num_tnl_nh == count
+
+    def check_syslog(self, dvs, marker, err_log, expected_cnt):
+        (exitcode, num) = dvs.runcmd(['sh', '-c', "awk \'/%s/,ENDFILE {print;}\' /var/log/syslog | grep \"%s\" | wc -l" % (marker, err_log)])
+        assert int(num.strip()) >= int(expected_cnt)
 
     def add_neighbor(self, dvs, ip, mac):
         if ip_address(ip).version == 6:
@@ -598,6 +604,40 @@ class TestMuxTunnelBase():
             assert start
             assert end
 
+    def create_and_test_pfcwd(self, dvs, appdb, counters_db, config_db):
+        test_port = "Ethernet0"
+        counter_queue = 3
+
+        marker = dvs.add_log_marker()
+
+        # Enabling some extra logging to catch info message
+        dvs.runcmd("swssloglevel -l INFO -c orchagent")
+
+        # Do a switchover
+        self.set_mux_state(appdb, test_port, "active")
+        time.sleep(1)
+
+        # # Check that pfc_wd was stopped
+        self.check_syslog(dvs, marker, "Stopped PFC Watchdog on port " + test_port, 1)
+        # Check that pfc_wd was started
+        self.check_syslog(dvs, marker, "Started PFC Watchdog on port " + test_port, 1)
+
+        # Set a storm on port
+        self.set_storm_state_on_port_queue(counters_db, test_port, counter_queue, state="enabled")
+        # Wait for storm state to set
+        time.sleep(1)
+
+        marker = dvs.add_log_marker()
+
+        # Do a switchover
+        self.set_mux_state(appdb, test_port, "standby")
+
+        # Check that pfcwd wasn't disabled on port
+        self.check_syslog(dvs, marker, "Storm active on port " + test_port, 1)
+
+        # Disable extra logging
+        dvs.runcmd("swssloglevel -l NOTICE -c orchagent")
+
     def check_interface_exists_in_asicdb(self, asicdb, sai_oid):
         asicdb.wait_for_entry(self.ASIC_RIF_TABLE, sai_oid)
         return True
@@ -854,6 +894,78 @@ class TestMuxTunnelBase():
         else:
             pytest.fail('Invalid test action {}'.format(action))
 
+    def setup_pfcwd(self, dvs, config_db):
+        pfc_test_ports = ["Ethernet0"]
+        pfc_test_queue = 3
+        # set cable lengths
+        for port in pfc_test_ports:
+            fvs = {port: "5m"}
+            config_db.update_entry("CABLE_LENGTH", "AZURE", fvs)
+            dvs.port_admin_set(port, "up")
+
+        # enable pfcwd
+        self.set_flex_counter_status("PFCWD", "enable", config_db)
+        self.set_flex_counter_status("QUEUE", "enable", config_db)
+
+        for port in pfc_test_ports:
+            self.set_ports_pfc(port, pfc_test_queue, config_db, "enable")
+
+        self.start_pfcwd_on_ports(pfc_test_ports, config_db)
+
+    def teardown_pfcwd(self, dvs, config_db):
+        pfc_test_ports = ["Ethernet0"]
+
+        # disable pfcwd
+        self.set_flex_counter_status("PFCWD", "disable", config_db)
+        # disable queue
+        self.set_flex_counter_status("QUEUE", "disable", config_db)
+
+        for port in pfc_test_ports:
+            # shutdown port
+            dvs.port_admin_set(port, "down")
+
+    def set_flex_counter_status(self, key, state, config_db):
+        fvs = {'FLEX_COUNTER_STATUS': state}
+        config_db.update_entry("FLEX_COUNTER_TABLE", key, fvs)
+        time.sleep(1)
+
+    def set_ports_pfc(self, port, queue, config_db, status='enable'):
+        keyname = 'pfcwd_sw_enable'
+        if 'enable' in status:
+            fvs = {keyname: str(queue), 'pfc_enable': str(queue)}
+            config_db.create_entry("PORT_QOS_MAP", port, fvs)
+        else:
+            config_db.delete_entry("PORT_QOS_MAP", port)
+
+    def start_pfcwd_on_ports(self, test_ports, config_db, poll_interval="200", detection_time="200", restoration_time="200", action="drop"):
+        pfcwd_info = {"POLL_INTERVAL": poll_interval}
+        config_db.update_entry("PFC_WD", "GLOBAL", pfcwd_info)
+
+        pfcwd_info = {"action": action,
+                      "detection_time" : detection_time,
+                      "restoration_time": restoration_time
+                     }
+
+        for port in test_ports:
+            config_db.update_entry("PFC_WD", port, pfcwd_info)
+
+    def stop_pfcwd_on_ports(self, dvs, port):
+        config_db = dvs.get_config_db()
+        config_db.delete_entry("PFC_WD", port)
+
+    def verify_pfcwd_state_on_port(self, counters_db, port, state="stormed"):
+        fvs = {"PFC_WD_STATUS": state}
+        queue_oids = counters_db.get_entry("COUNTERS_QUEUE_NAME_MAP", "")
+        for queue in range(0,self.PFC_WD_QUEUE_MAX):
+            queue_name = port + ":" + str(queue)
+            counters_db.wait_for_field_match("COUNTERS", queue_oids[queue_name], fvs)
+
+    def set_storm_state_on_port_queue(self, counters_db, port, queue, state="enabled"):
+        fvs = {"DEBUG_STORM": state}
+        queue_oids = counters_db.get_entry("COUNTERS_QUEUE_NAME_MAP", "")
+        queue_name = port + ":" + str(queue)
+        counters_db.update_entry("COUNTERS", queue_oids[queue_name], fvs)
+
     @pytest.fixture(scope='module')
     def setup_vlan(self, dvs):
         self.create_vlan_interface(dvs)
@@ -987,6 +1099,13 @@ class TestMuxTunnelBase():
 
         return fdb_map
 
+    @pytest.fixture
+    def setup_teardown_pfcwd(self, dvs):
+        config_db = dvs.get_config_db()
+        self.setup_pfcwd(dvs, config_db)
+        yield
+        self.teardown_pfcwd(dvs, config_db)
+
 
 class TestMuxTunnel(TestMuxTunnelBase):
     """ Tests for Mux tunnel creation and removal """
@@ -1097,6 +1216,20 @@ class TestMuxTunnel(TestMuxTunnelBase):
 
         for ip in test_ips:
             self.check_neighbor_state(dvs, dvs_route, ip, expect_route=False)
+
+    def test_mux_pfcwd_switching(
+            self, dvs, neighbor_cleanup, setup_vlan,
+            setup_mux_cable, setup_tunnel, setup_peer_switch,
+            setup_qos_map, setup_teardown_pfcwd, testlog
+    ):
+        """ test pfcwd gets disabled, then enabled """
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        counters_db = dvs.get_counters_db()
+        config_db = dvs.get_config_db()
+
+        self.create_and_test_pfcwd(dvs, appdb, counters_db, config_db)
+
+
 
 
 # Add Dummy always-pass test at end as workaroud


### PR DESCRIPTION
Why I did it:
to improve switchover performance

How I did it:
Added stopPFCWdOnAllPorts and startPFCWdOnAllPorts function in PFCWdSwOrch. On each switchover, PFC Wd is stopped unless there is a storm currently on the port. Then when switchover is completed, PFC Wd is enabled again

How to test:
$ pytest test_mux.py::TestMuxTunnel::test_mux_pfcwd_switching

Signed-off-by: Nikola Dancejic <ndancejic@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
