### PR TITLE
Fix vs test issue: failed to remove vlan due to referenced by vlan interface

### DIFF
--- a/tests/dvslib/dvs_vlan.py
+++ b/tests/dvslib/dvs_vlan.py
@@ -46,6 +46,10 @@ class DVSVlan(object):
         member = "Vlan{}|{}".format(vlanID, interface)
         self.config_db.delete_entry("VLAN_MEMBER", member)
 
+    def remove_vlan_interface(self, vlanID):
+        vlan = "Vlan{}".format(vlanID)
+        self.config_db.delete_entry("VLAN_INTERFACE", vlan)
+
     def check_app_db_vlan_fields(self, fvs, admin_status="up", mtu="9100"):
         assert fvs.get("admin_status") == admin_status
         assert fvs.get("mtu") == mtu

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -459,6 +459,7 @@ class TestVlan(object):
 
         wait_for_result(arp_accept_disabled, PollingConfig(), "IPv4 arp_accept not disabled")
 
+        self.dvs_vlan.remove_vlan_interface(vlan)
         self.dvs_vlan.remove_vlan(vlan)
         self.dvs_vlan.get_and_verify_vlan_ids(0)
 
@@ -487,6 +488,7 @@ class TestVlan(object):
 
         wait_for_result(proxy_arp_disabled, PollingConfig(), 'IPv4 proxy_arp or proxy_arp_pvlan not disabled')
 
+        self.dvs_vlan.remove_vlan_interface(vlan)
         self.dvs_vlan.remove_vlan(vlan)
         self.dvs_vlan.get_and_verify_vlan_ids(0)
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Fix: remove the VLAN interface before removing the VLAN itself

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**

There is a logic in VLAN vs test cases `test_VlanGratArp` and `test_VlanProxyArp` to create a VLAN, a VLAN interface and then remove the VLAN and then check whether the VLAN is removed from SAI.
However, the step to remove the VLAN interface is missed, which causes the VLAN to be referenced and prevents it from being deleted.

**How I verified it**

Run vs test.

**Details if related**
