### PR TITLE
[COPP]If copp group is configured using cfgdb, duplicate trapids will…

### DIFF
--- a/cfgmgr/coppmgr.cpp
+++ b/cfgmgr/coppmgr.cpp
@@ -654,9 +654,6 @@ void CoppMgr::doCoppTrapTask(Consumer &consumer)
                                            m_coppTrapConfMap[key].trap_ids);
             }
 
-            m_coppTrapConfMap[key].trap_group = trap_group;
-            m_coppTrapConfMap[key].trap_ids = trap_ids;
-            m_coppTrapConfMap[key].is_always_enabled = is_always_enabled;
             addTrap(trap_ids, trap_group);
 
             /* When the trap table's trap group is changed, the old trap group


### PR DESCRIPTION
… appear in appdb.

Signed-off-by: qiuyupeng <qiuyupeng@git.asterfusion.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
deleting some code about updating cache in coppmgr
**Why I did it**
It is repetitive and affects subsequent logical judgments
The same code in the next few lines，so i delete it。

1、creating a copp trap group in cfg_db
 hset COPP_GROUP|queue7_group7  trap_action copy trap_priority 7 queue 7 "meter_type" "bytes" "mode" "tr_tcm" "cir" "4096000" "cbs"  "64000" "pir" "8192000"  "pbs" "128000"  "red_action"  "drop"

2、let arp bind the new group
HSET  COPP_TRAP|arp trap_group queue7_group7

3、the old group not del the trap_id(arp) in app db.
127.0.0.1:6379> hgetall "COPP_TABLE:queue7_group7"
 1) "trap_action"
 2) "copy"
 3) "trap_priority"
 4) "7"
 5) "queue"
 6) "7"
 7) "meter_type"
 8) "bytes"
 9) "mode"
10) "tr_tcm"
11) "cir"
12) "4096000"
13) "cbs"
14) "64000"
15) "pir"
16) "8192000"
17) "pbs"
18) "128000"
19) "red_action"
20) "drop"
21) "trap_ids"
22) "arp_req,arp_resp,neigh_discovery"
127.0.0.1:6379> hgetall "COPP_TABLE:queue5_group1"
 1) "cbs"
 2) "64000"
 3) "cir"
 4) "512000"
 5) "meter_type"
 6) "bytes"
 7) "mode"
 8) "tr_tcm"
 9) "pbs"
10) "128000"
11) "pir"
12) "1024000"
13) "queue"
14) "5"
15) "red_action"
16) "drop"
17) "trap_action"
18) "copy"
19) "trap_priority"
20) "5"
21) "trap_ids"
22) "arp_req,arp_resp,neigh_discovery"
127.0.0.1:6379>

**How I verified it**
1、creating a copp trap group in cfg_db
 hset COPP_GROUP|queue7_group7  trap_action copy trap_priority 7 queue 7 "meter_type" "bytes" "mode" "tr_tcm" "cir" "4096000" "cbs"  "64000" "pir" "8192000"  "pbs" "128000"  "red_action"  "drop"

2、let arp bind the new group
HSET  COPP_TRAP|arp trap_group queue7_group7

3、arp only appears in queue7_group7
127.0.0.1:6379> hgetall  "COPP_TABLE:queue5_group1"
 1) "cbs"
 2) "64000"
 3) "cir"
 4) "4096000"
 5) "meter_type"
 6) "bytes"
 7) "mode"
 8) "tr_tcm"
 9) "pbs"
10) "128000"
11) "pir"
12) "8192000"
13) "queue"
14) "5"
15) "red_action"
16) "drop"
17) "trap_action"
18) "copy"
19) "trap_priority"
20) "5"
127.0.0.1:6379> hgetall  "COPP_TABLE:queue7_group7"
 1) "trap_action"
 2) "copy"
 3) "trap_priority"
 4) "7"
 5) "queue"
 6) "7"
 7) "meter_type"
 8) "bytes"
 9) "mode"
10) "tr_tcm"
11) "cir"
12) "1024000"
13) "cbs"
14) "64000"
15) "pir"
16) "2048000"
17) "pbs"
18) "128000"
19) "red_action"
20) "drop"
21) "trap_ids"
22) "arp_req,arp_resp,neigh_discovery"

**Details if related**
