### PR TITLE
orchagent/portsorch: Allow to set advertised-types when autoneg is disabled

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3567,9 +3567,9 @@ void PortsOrch::doPortTask(Consumer &consumer)
                         continue;
                     }
 
-                    if (adv_interface_types != p.m_adv_interface_types && p.m_autoneg == 1)
+                    if (adv_interface_types != p.m_adv_interface_types)
                     {
-                        if (p.m_admin_state_up)
+                        if (p.m_admin_state_up && p.m_autoneg == 1)
                         {
                             /* Bring port down before applying speed */
                             if (!setPortAdminStatus(p, false))


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix function to allow to set advertised-types when autoneg is disabled.

**Why I did it**
In the original code, advertised-types cannot be set when autoneg is disabled, which it would cause upper layer and the chip have different configuration.

