### PR TITLE
[orchagent] Add SAI_ENI_ATTR_VM_UNDERLAY_DIP and SAI_ENI_ATTR_VM_VNI attributes for DASH

### DIFF
--- a/orchagent/dash/dashorch.cpp
+++ b/orchagent/dash/dashorch.cpp
@@ -289,6 +289,12 @@ bool DashOrch::addEniObject(const string& eni, EniEntry& entry)
         return false;
     }
 
+    if (appliance_entries_.empty())
+    {
+        SWSS_LOG_INFO("Retry as no appliance table entry found");
+        return false;
+    }
+
     sai_object_id_t &eni_id = entry.eni_id;
     sai_attribute_t eni_attr;
     vector<sai_attribute_t> eni_attrs;
@@ -315,6 +321,15 @@ bool DashOrch::addEniObject(const string& eni, EniEntry& entry)
 
     eni_attr.id = SAI_ENI_ATTR_ADMIN_STATE;
     eni_attr.value.booldata = entry.admin_state;
+    eni_attrs.push_back(eni_attr);
+
+    eni_attr.id = SAI_ENI_ATTR_VM_UNDERLAY_DIP;
+    copy(eni_attr.value.ipaddr, entry.underlay_ip);
+    eni_attrs.push_back(eni_attr);
+
+    eni_attr.id = SAI_ENI_ATTR_VM_VNI;
+    auto app_entry = appliance_entries_.begin()->second;
+    eni_attr.value.u32 = app_entry.vm_vni;
     eni_attrs.push_back(eni_attr);
 
     sai_status_t status = sai_dash_eni_api->create_eni(&eni_id, gSwitchId,


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
 Added SAI_ENI_ATTR_VM_UNDERLAY_DIP and SAI_ENI_ATTR_VM_VNI attributes to support inbound routing flow
**Why I did it**

**How I verified it**
Loaded DASH configuration referenced in https://github.com/sonic-net/sonic-mgmt/pull/6735 and verified that SAI_ENI_ATTR_VM_UNDERLAY_DIP and SAI_ENI_ATTR_VM_VNI attributes are added

**Details if related**
2022-11-11.18:59:49.362557|c|SAI_OBJECT_TYPE_ENI:oid:0x6d000000000018|SAI_ENI_ATTR_VNET_ID=oid:0x71000000000016|SAI_ENI_ATTR_ADMIN_STATE=false|SAI_ENI_ATTR_VM_UNDERLAY_DIP=ac5c:99c2:30c9:98eb:c617:f88f:7c5c:ea90|SAI_ENI_ATTR_VM_VNI=4321
2022-11-11.18:59:49.364037|c|SAI_OBJECT_TYPE_ENI:oid:0x6d000000000019|SAI_ENI_ATTR_VNET_ID=oid:0x71000000000017|SAI_ENI_ATTR_ADMIN_STATE=false|SAI_ENI_ATTR_VM_UNDERLAY_DIP=50.2.2.2|SAI_ENI_ATTR_VM_VNI=4321
2022-11-11.18:59:49.365416|c|SAI_OBJECT_TYPE_ENI:oid:0x6d00000000001a|SAI_ENI_ATTR_VNET_ID=oid:0x71000000000017|SAI_ENI_ATTR_ADMIN_STATE=false|SAI_ENI_ATTR_VM_UNDERLAY_DIP=d95d:46e5:d5b2:4ce0:2a3:d9d:44a4:f20b|SAI_ENI_ATTR_VM_VNI=4321
2022-11-11.18:59:49.366890|c|SAI_OBJECT_TYPE_ENI:oid:0x6d00000000001b|SAI_ENI_ATTR_VNET_ID=oid:0x71000000000016|SAI_ENI_ATTR_ADMIN_STATE=false|SAI_ENI_ATTR_VM_UNDERLAY_DIP=25.1.1.1|SAI_ENI_ATTR_VM_VNI=4321

Signed-off-by: Prabhat Aravind <paravind@microsoft.com>