### PR TITLE
[fpmsyncd] Add support for SRv6

### DIFF
--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -23,6 +23,7 @@ using namespace swss;
 #define MGMT_VRF_PREFIX         "mgmt"
 
 #define NHG_DELIMITER ','
+#define MY_SID_KEY_DELIMITER ':'
 
 #ifndef ETH_ALEN
 #define ETH_ALEN 6
@@ -38,6 +39,7 @@ using namespace swss;
 #define NH_ENCAP_VXLAN      100
 
 #define NH_ENCAP_SRV6_ROUTE         101
+#define NH_ENCAP_SRV6_LOCAL_SID     102
 
 #define IPV4_MAX_BYTE       4
 #define IPV6_MAX_BYTE      16
@@ -45,6 +47,58 @@ using namespace swss;
 #define IPV6_MAX_BITLEN    128
 
 #define ETHER_ADDR_STRLEN (3*ETH_ALEN)
+
+#define DEFAULT_SRV6_LOCALSID_BLOCK_LEN "40"
+#define DEFAULT_SRV6_LOCALSID_NODE_LEN "24"
+#define DEFAULT_SRV6_LOCALSID_FUNC_LEN "16"
+#define DEFAULT_SRV6_LOCALSID_ARG_LEN "0"
+
+enum srv6_localsid_action {
+    SRV6_LOCALSID_ACTION_UNSPEC       = 0,
+    SRV6_LOCALSID_ACTION_END          = 1,
+    SRV6_LOCALSID_ACTION_END_X        = 2,
+    SRV6_LOCALSID_ACTION_END_T        = 3,
+    SRV6_LOCALSID_ACTION_END_DX2      = 4,
+    SRV6_LOCALSID_ACTION_END_DX6      = 5,
+    SRV6_LOCALSID_ACTION_END_DX4      = 6,
+    SRV6_LOCALSID_ACTION_END_DT6      = 7,
+    SRV6_LOCALSID_ACTION_END_DT4      = 8,
+    SRV6_LOCALSID_ACTION_END_B6       = 9,
+    SRV6_LOCALSID_ACTION_END_B6_ENCAP = 10,
+    SRV6_LOCALSID_ACTION_END_BM       = 11,
+    SRV6_LOCALSID_ACTION_END_S        = 12,
+    SRV6_LOCALSID_ACTION_END_AS       = 13,
+    SRV6_LOCALSID_ACTION_END_AM       = 14,
+    SRV6_LOCALSID_ACTION_END_BPF      = 15,
+    SRV6_LOCALSID_ACTION_END_DT46     = 16,
+    SRV6_LOCALSID_ACTION_UDT4         = 100,
+    SRV6_LOCALSID_ACTION_UDT6         = 101,
+    SRV6_LOCALSID_ACTION_UDT46        = 102,
+};
+
+enum {
+    SRV6_LOCALSID_UNSPEC         = 0,
+    SRV6_LOCALSID_ACTION         = 1,
+    SRV6_LOCALSID_SRH            = 2,
+    SRV6_LOCALSID_TABLE          = 3,
+    SRV6_LOCALSID_NH4            = 4,
+    SRV6_LOCALSID_NH6            = 5,
+    SRV6_LOCALSID_IIF            = 6,
+    SRV6_LOCALSID_OIF            = 7,
+    SRV6_LOCALSID_BPF            = 8,
+    SRV6_LOCALSID_VRFTABLE       = 9,
+    SRV6_LOCALSID_COUNTERS       = 10,
+    SRV6_LOCALSID_VRFNAME        = 100,
+    SRV6_LOCALSID_FORMAT         = 101,
+};
+
+enum {
+    SRV6_LOCALSID_FORMAT_UNSPEC         = 0,
+    SRV6_LOCALSID_FORMAT_BLOCK_LEN      = 1,
+    SRV6_LOCALSID_FORMAT_NODE_LEN       = 2,
+    SRV6_LOCALSID_FORMAT_FUNC_LEN       = 3,
+    SRV6_LOCALSID_FORMAT_ARG_LEN        = 4,
+};
 
 enum {
     SRV6_ROUTE_UNSPEC            = 0,
@@ -88,6 +142,7 @@ RouteSync::RouteSync(RedisPipeline *pipeline) :
     m_vnet_routeTable(pipeline, APP_VNET_RT_TABLE_NAME, true),
     m_vnet_tunnelTable(pipeline, APP_VNET_RT_TUNNEL_TABLE_NAME, true),
     m_warmStartHelper(pipeline, &m_routeTable, APP_ROUTE_TABLE_NAME, "bgp", "bgp"),
+    m_srv6LocalSidTable(pipeline, APP_SRV6_MY_SID_TABLE_NAME, true),
     m_nl_sock(NULL), m_link_cache(NULL)
 {
     m_nl_sock = nl_socket_alloc();
@@ -183,6 +238,172 @@ void RouteSync::parseEncapSrv6SteerRoute(struct rtattr *tb, string &vpn_sid,
 
     SWSS_LOG_INFO("Rx vpn_sid:%s src_addr:%s ", vpn_sid.c_str(),
                   src_addr.c_str());
+
+    return;
+}
+
+const char *RouteSync::localSidAction2Str(uint32_t action)
+{
+    switch (action)
+    {
+        case SRV6_LOCALSID_ACTION_UNSPEC:
+            return "unspec";
+        case SRV6_LOCALSID_ACTION_END:
+            return "end";
+        case SRV6_LOCALSID_ACTION_END_X:
+            return "end.x";
+        case SRV6_LOCALSID_ACTION_END_T:
+            return "end.t";
+        case SRV6_LOCALSID_ACTION_END_DX4:
+            return "end.dx4";
+        case SRV6_LOCALSID_ACTION_END_DT6:
+            return "end.dt6";
+        case SRV6_LOCALSID_ACTION_END_DT4:
+            return "end.dt4";
+        case SRV6_LOCALSID_ACTION_END_DT46:
+            return "end.dt46";
+        case SRV6_LOCALSID_ACTION_UDT6:
+            return "udt6";
+        case SRV6_LOCALSID_ACTION_UDT4:
+            return "udt4";
+        case SRV6_LOCALSID_ACTION_UDT46:
+            return "udt46";
+        default:
+            return "unknown";
+    }
+}
+
+/**
+ * @parseEncapSrv6LocalSidFormat() - Parses encapsulated localsid format
+ * @tb:         Pointer to rtattr to look for nested items in.
+ * @block_len:  (output) locator block length
+ * @node_len:   (output) locator node length
+ * @func_len:   (output) function length
+ * @arg_len:    (output) argument length
+ *
+ * Return:      void.
+ */
+void RouteSync::parseEncapSrv6LocalSidFormat(struct rtattr *tb,
+                                             string &block_len,
+                                             string &node_len, string &func_len,
+                                             string &arg_len)
+{
+    struct rtattr *tb_localsid_format[256] = {};
+    uint8_t block_len_buf, node_len_buf, func_len_buf, arg_len_buf;
+
+    parseRtAttrNested(tb_localsid_format, 4, tb);
+
+    if (tb_localsid_format[SRV6_LOCALSID_FORMAT_BLOCK_LEN])
+    {
+        block_len_buf = *(uint8_t *)RTA_DATA(
+            tb_localsid_format[SRV6_LOCALSID_FORMAT_BLOCK_LEN]);
+        block_len += to_string(block_len_buf);
+    }
+    else
+    {
+        block_len += DEFAULT_SRV6_LOCALSID_BLOCK_LEN;
+    }
+
+    if (tb_localsid_format[SRV6_LOCALSID_FORMAT_NODE_LEN])
+    {
+        node_len_buf = *(uint8_t *)RTA_DATA(
+            tb_localsid_format[SRV6_LOCALSID_FORMAT_NODE_LEN]);
+        node_len += to_string(node_len_buf);
+    }
+    else
+    {
+        node_len += DEFAULT_SRV6_LOCALSID_NODE_LEN;
+    }
+
+    if (tb_localsid_format[SRV6_LOCALSID_FORMAT_FUNC_LEN])
+    {
+        func_len_buf = *(uint8_t *)RTA_DATA(
+            tb_localsid_format[SRV6_LOCALSID_FORMAT_FUNC_LEN]);
+        func_len += to_string(func_len_buf);
+    }
+    else
+    {
+        func_len += DEFAULT_SRV6_LOCALSID_FUNC_LEN;
+    }
+
+    if (tb_localsid_format[SRV6_LOCALSID_FORMAT_ARG_LEN])
+    {
+        arg_len_buf = *(uint8_t *)RTA_DATA(
+            tb_localsid_format[SRV6_LOCALSID_FORMAT_ARG_LEN]);
+        arg_len += to_string(arg_len_buf);
+    }
+    else
+    {
+        arg_len += DEFAULT_SRV6_LOCALSID_ARG_LEN;
+    }
+
+    return;
+}
+
+/**
+ * @parseEncapSrv6LocalSid() - Parses encapsulated localsid attributes
+ * @tb:         Pointer to rtattr to look for nested items in.
+ * @block_len:  (output) locator block length
+ * @node_len:   (output) locator node length
+ * @func_len:   (output) function length
+ * @arg_len:    (output) argument length
+ * @action:     (output) behavior defined for the local SID.
+ * @vrf:        (output) VRF name.
+ * @adj:        (output) adjacency.
+ *
+ * Return:      void.
+ */
+void RouteSync::parseEncapSrv6LocalSid(struct rtattr *tb, string &block_len,
+                                       string &node_len, string &func_len,
+                                       string &arg_len, string &action,
+                                       string &vrf, string &adj)
+{
+    struct rtattr *tb_encap[256] = {};
+    uint32_t action_buf = SRV6_LOCALSID_ACTION_UNSPEC;
+    char vrf_buf[IFNAMSIZ + 1] = {0};
+    char adj_buf[MAX_ADDR_SIZE + 1] = {0};
+
+    parseRtAttrNested(tb_encap, 256, tb);
+
+    if (tb_encap[SRV6_LOCALSID_FORMAT])
+        parseEncapSrv6LocalSidFormat(tb_encap[SRV6_LOCALSID_FORMAT], block_len,
+                                     node_len, func_len, arg_len);
+
+    if (tb_encap[SRV6_LOCALSID_ACTION])
+    {
+        action_buf = *(uint32_t *)RTA_DATA(tb_encap[SRV6_LOCALSID_ACTION]);
+    }
+
+    if (tb_encap[SRV6_LOCALSID_NH6])
+    {
+        struct in6_addr *nh6 =
+            (struct in6_addr *)RTA_DATA(tb_encap[SRV6_LOCALSID_NH6]);
+
+        inet_ntop(AF_INET6, nh6, adj_buf, MAX_ADDR_SIZE);
+    }
+
+    if (tb_encap[SRV6_LOCALSID_NH4])
+    {
+        struct in_addr *nh4 =
+            (struct in_addr *)RTA_DATA(tb_encap[SRV6_LOCALSID_NH4]);
+
+        inet_ntop(AF_INET, nh4, adj_buf, MAX_ADDR_SIZE);
+    }
+
+    if (tb_encap[SRV6_LOCALSID_VRFNAME])
+    {
+        memcpy(vrf_buf, (char *)RTA_DATA(tb_encap[SRV6_LOCALSID_VRFNAME]),
+               strlen((char *)RTA_DATA(tb_encap[SRV6_LOCALSID_VRFNAME])));
+    }
+
+    action = localSidAction2Str(action_buf);
+    vrf = vrf_buf;
+    adj = adj_buf;
+
+    SWSS_LOG_INFO("Rx block_len:%s node_len:%s func_len:%s arg_len:%s "
+                  "action:%s vrf:%s adj:%s",
+                  block_len.c_str(), node_len.c_str(), func_len.c_str(),
+                  arg_len.c_str(), action.c_str(), vrf.c_str(), adj.c_str());
 
     return;
 }
@@ -871,6 +1092,269 @@ void RouteSync::onSrv6SteerRouteMsg(struct nlmsghdr *h, int len)
     return;
 }
 
+bool RouteSync::getSrv6LocalSidNextHop(struct nlmsghdr *h, int received_bytes,
+                                       struct rtattr *tb[], string &block_len,
+                                       string &node_len, string &func_len,
+                                       string &arg_len, string &act,
+                                       string &vrf, string &adj)
+{
+    uint16_t encap = 0;
+
+    if (h->nlmsg_type == RTM_NEWROUTE || h->nlmsg_type == RTM_DELROUTE)
+    {
+        if (!tb[RTA_MULTIPATH])
+        {
+            if (tb[RTA_ENCAP_TYPE])
+            {
+                encap = *(uint16_t *)RTA_DATA(tb[RTA_ENCAP_TYPE]);
+            }
+
+            if (tb[RTA_ENCAP] && tb[RTA_ENCAP_TYPE] &&
+                *(uint16_t *)RTA_DATA(tb[RTA_ENCAP_TYPE]) ==
+                    NH_ENCAP_SRV6_LOCAL_SID)
+            {
+                parseEncapSrv6LocalSid(tb[RTA_ENCAP], block_len, node_len,
+                                       func_len, arg_len, act, vrf, adj);
+            }
+            SWSS_LOG_DEBUG("Rx MsgType:%d encap:%d act:%s vrf:%s adj:%s",
+                           h->nlmsg_type, encap, act.c_str(), vrf.c_str(),
+                           adj.c_str());
+        }
+        else
+        {
+            /* This is a multipath route */
+            SWSS_LOG_NOTICE("Multipath localsid routes aren't supported");
+            return false;
+        }
+    }
+    return true;
+}
+
+void RouteSync::onSrv6LocalSidMsg(struct nlmsghdr *h, int len)
+{
+    struct rtmsg *rtm;
+    struct rtattr *tb[RTA_MAX + 1];
+    void *dest = NULL;
+    char dstaddr[IPV6_MAX_BYTE] = {0};
+    int dst_len = 0;
+    char dstaddr_str[MAX_ADDR_SIZE];
+    int nlmsg_type = h->nlmsg_type;
+
+    rtm = (struct rtmsg *)NLMSG_DATA(h);
+
+    /* Parse attributes and extract fields of interest. */
+    memset(tb, 0, sizeof(tb));
+    netlink_parse_rtattr(tb, RTA_MAX, RTM_RTA(rtm), len);
+
+    if (!tb[RTA_DST])
+    {
+        SWSS_LOG_ERROR(
+            "Received an invalid localsid route: missing RTA_DST attribute");
+        return;
+    }
+
+    dest = RTA_DATA(tb[RTA_DST]);
+
+    /*
+     * Only AF_INET6 is allowed for mylocalsid routes
+     */
+    if (rtm->rtm_family == AF_INET)
+    {
+        SWSS_LOG_ERROR(
+            "AF_INET address family is not allowed for localsid routes");
+        return;
+    }
+    else if (rtm->rtm_family == AF_INET6)
+    {
+        if (rtm->rtm_dst_len > IPV6_MAX_BITLEN)
+        {
+            SWSS_LOG_ERROR("Received an invalid localsid route: prefix len %d "
+                           "is out of range",
+                           rtm->rtm_dst_len);
+            return;
+        }
+        memcpy(dstaddr, dest, IPV6_MAX_BYTE);
+        dst_len = rtm->rtm_dst_len;
+    }
+    else
+    {
+        SWSS_LOG_ERROR(
+            "Received an invalid localsid route: invalid address family %d",
+            rtm->rtm_family);
+        return;
+    }
+
+    inet_ntop(rtm->rtm_family, dstaddr, dstaddr_str, MAX_ADDR_SIZE);
+
+    SWSS_LOG_DEBUG("Rx MsgType:%d Family:%d DstAddress:%s/%d", h->nlmsg_type,
+                   rtm->rtm_family, dstaddr_str, dst_len);
+
+    SWSS_LOG_INFO("Receive route message dest ip prefix: %s Op:%s", dstaddr_str,
+                  nlmsg_type == RTM_NEWROUTE ? "add" : "del");
+
+    if (nlmsg_type != RTM_NEWROUTE && nlmsg_type != RTM_DELROUTE)
+    {
+        SWSS_LOG_ERROR("Unknown message-type: %d for %s", nlmsg_type,
+                       dstaddr_str);
+        return;
+    }
+
+    switch (rtm->rtm_type)
+    {
+        case RTN_BLACKHOLE:
+        case RTN_UNREACHABLE:
+        case RTN_PROHIBIT:
+        {
+            SWSS_LOG_ERROR(
+                "RTN_BLACKHOLE route not expected (%s)", dstaddr_str);
+            return;
+        }
+        case RTN_UNICAST:
+            break;
+
+        case RTN_MULTICAST:
+        case RTN_BROADCAST:
+        case RTN_LOCAL:
+            SWSS_LOG_NOTICE(
+                "BUM routes aren't supported yet (%s)", dstaddr_str);
+            return;
+
+        default:
+            return;
+    }
+
+    /* Get nexthop lists */
+    string block_len_str;
+    string node_len_str;
+    string func_len_str;
+    string arg_len_str;
+    string action_str;
+    string vrf_str;
+    string adj_str;
+    string my_sid_table_key;
+    bool ret;
+
+    ret = getSrv6LocalSidNextHop(h, len, tb, block_len_str, node_len_str,
+                                 func_len_str, arg_len_str, action_str, vrf_str,
+                                 adj_str);
+    if (ret == false)
+    {
+        SWSS_LOG_NOTICE("Localsid Route issue with RouteTable msg: %s action: "
+                        "%s vrf: %s adj: %s",
+                        dstaddr_str, action_str.c_str(), vrf_str.c_str(),
+                        adj_str.c_str());
+        return;
+    }
+
+    my_sid_table_key += block_len_str + MY_SID_KEY_DELIMITER;
+    my_sid_table_key += node_len_str + MY_SID_KEY_DELIMITER;
+    my_sid_table_key += func_len_str + MY_SID_KEY_DELIMITER;
+    my_sid_table_key += arg_len_str + MY_SID_KEY_DELIMITER;
+    my_sid_table_key += dstaddr_str;
+
+    if (nlmsg_type == RTM_DELROUTE)
+    {
+        m_srv6LocalSidTable.del(my_sid_table_key);
+        return;
+    }
+
+    if (action_str.empty() || !(action_str.compare("unspec")) ||
+        !(action_str.compare("unknown")))
+    {
+        SWSS_LOG_NOTICE("Localsid IP Prefix: %s act is empty or invalid",
+                        dstaddr_str);
+        return;
+    }
+
+    if (!(action_str.compare("end.dt6")) && vrf_str.empty())
+    {
+        SWSS_LOG_NOTICE("Localsid End.DT6 IP Prefix: %s vrf is empty",
+                        dstaddr_str);
+        return;
+    }
+
+    if (!(action_str.compare("end.dt4")) && vrf_str.empty())
+    {
+        SWSS_LOG_NOTICE("Localsid End.DT4 IP Prefix: %s vrf is empty",
+                        dstaddr_str);
+        return;
+    }
+
+    if (!(action_str.compare("end.dt46")) && vrf_str.empty())
+    {
+        SWSS_LOG_NOTICE("Localsid End.DT46 IP Prefix: %s vrf is empty",
+                        dstaddr_str);
+        return;
+    }
+
+    if (!(action_str.compare("udt6")) && vrf_str.empty())
+    {
+        SWSS_LOG_NOTICE("Localsid uDT6 IP Prefix: %s vrf is empty",
+                        dstaddr_str);
+        return;
+    }
+
+    if (!(action_str.compare("udt4")) && vrf_str.empty())
+    {
+        SWSS_LOG_NOTICE("Localsid uDT4 IP Prefix: %s vrf is empty",
+                        dstaddr_str);
+        return;
+    }
+
+    if (!(action_str.compare("udt46")) && vrf_str.empty())
+    {
+        SWSS_LOG_NOTICE("Localsid uDT46 IP Prefix: %s vrf is empty",
+                        dstaddr_str);
+        return;
+    }
+
+    if (!(action_str.compare("end.t")) && vrf_str.empty())
+    {
+        SWSS_LOG_NOTICE("Localsid End.T IP Prefix: %s vrf is empty",
+                        dstaddr_str);
+        return;
+    }
+
+    if (!(action_str.compare("end.x")) && adj_str.empty())
+    {
+        SWSS_LOG_NOTICE("Localsid End.X IP Prefix: %s adj is empty",
+                        dstaddr_str);
+        return;
+    }
+
+    if (!(action_str.compare("end.dx6")) && adj_str.empty())
+    {
+        SWSS_LOG_NOTICE("Localsid End.DX6 IP Prefix: %s adj is empty",
+                        dstaddr_str);
+        return;
+    }
+
+    if (!(action_str.compare("end.dx4")) && adj_str.empty())
+    {
+        SWSS_LOG_NOTICE("Localsid End.DX4 IP Prefix: %s adj is empty",
+                        dstaddr_str);
+        return;
+    }
+
+    vector<FieldValueTuple> fvVector;
+    FieldValueTuple act("action", action_str);
+    fvVector.push_back(act);
+    if (!vrf_str.empty())
+    {
+        FieldValueTuple vrf("vrf", vrf_str);
+        fvVector.push_back(vrf);
+    }
+    if (!adj_str.empty())
+    {
+        FieldValueTuple adj("adj", adj_str);
+        fvVector.push_back(adj);
+    }
+
+    m_srv6LocalSidTable.set(my_sid_table_key, fvVector);
+
+    return;
+}
+
 uint16_t RouteSync::getEncapType(struct nlmsghdr *h)
 {
     int len;
@@ -965,6 +1449,9 @@ void RouteSync::onMsgRaw(struct nlmsghdr *h)
     {
         case NH_ENCAP_SRV6_ROUTE:
             onSrv6SteerRouteMsg(h, len);
+            break;
+        case NH_ENCAP_SRV6_LOCAL_SID:
+            onSrv6LocalSidMsg(h, len);
             break;
         default:
             /*

--- a/fpmsyncd/routesync.h
+++ b/fpmsyncd/routesync.h
@@ -74,7 +74,9 @@ private:
     /* vnet route table */
     ProducerStateTable  m_vnet_routeTable;
     /* vnet vxlan tunnel table */  
-    ProducerStateTable  m_vnet_tunnelTable; 
+    ProducerStateTable  m_vnet_tunnelTable;
+    /* srv6 local sid table */
+    ProducerStateTable m_srv6LocalSidTable;
     struct nl_cache    *m_link_cache;
     struct nl_sock     *m_nl_sock;
 
@@ -91,6 +93,15 @@ private:
 
     void parseEncapSrv6SteerRoute(struct rtattr *tb, string &vpn_sid, string &src_addr);
 
+    void parseEncapSrv6LocalSid(struct rtattr *tb, string &block_len,
+                                string &node_len, string &func_len,
+                                string &arg_len, string &action, string &vrf,
+                                string &adj);
+
+    void parseEncapSrv6LocalSidFormat(struct rtattr *tb, string &block_len,
+                                      string &node_len, string &func_len,
+                                      string &arg_len);
+
     void parseRtAttrNested(struct rtattr **tb, int max,
                  struct rtattr *rta);
 
@@ -102,6 +113,9 @@ private:
 
     /* Handle routes containing an SRv6 nexthop */
     void onSrv6SteerRouteMsg(struct nlmsghdr *h, int len);
+
+    /* Handle routes containing an SRv6 Local SID nexthop */
+    void onSrv6LocalSidMsg(struct nlmsghdr *h, int len);
 
     /* Handle vnet route */
     void onVnetRouteMsg(int nlmsg_type, struct nl_object *obj, string vnet);
@@ -127,6 +141,12 @@ private:
     bool getSrv6SteerRouteNextHop(struct nlmsghdr *h, int received_bytes,
                         struct rtattr *tb[], string &vpn_sid, string &src_addr);
 
+    bool getSrv6LocalSidNextHop(struct nlmsghdr *h, int received_bytes,
+                                struct rtattr *tb[], string &block_len,
+                                string &node_len, string &func_len,
+                                string &arg_len, string &act, string &vrf,
+                                string &adj);
+
     /* Get next hop list */
     void getNextHopList(struct rtnl_route *route_obj, string& gw_list,
                         string& mpls_list, string& intf_list);
@@ -151,6 +171,8 @@ private:
 
     /* Get encap type */
     uint16_t getEncapType(struct nlmsghdr *h);
+
+    const char *localSidAction2Str(uint32_t action);
 };
 
 }

--- a/fpmsyncd/routesync.h
+++ b/fpmsyncd/routesync.h
@@ -89,6 +89,8 @@ private:
 
     void parseEncap(struct rtattr *tb, uint32_t &encap_value, string &rmac);
 
+    void parseEncapSrv6SteerRoute(struct rtattr *tb, string &vpn_sid, string &src_addr);
+
     void parseRtAttrNested(struct rtattr **tb, int max,
                  struct rtattr *rta);
 
@@ -97,6 +99,9 @@ private:
 
     /* Handle prefix route */
     void onEvpnRouteMsg(struct nlmsghdr *h, int len);
+
+    /* Handle routes containing an SRv6 nexthop */
+    void onSrv6SteerRouteMsg(struct nlmsghdr *h, int len);
 
     /* Handle vnet route */
     void onVnetRouteMsg(int nlmsg_type, struct nl_object *obj, string vnet);
@@ -119,6 +124,9 @@ private:
                         string& nexthops, string& vni_list, string& mac_list,
                         string& intf_list);
 
+    bool getSrv6SteerRouteNextHop(struct nlmsghdr *h, int received_bytes,
+                        struct rtattr *tb[], string &vpn_sid, string &src_addr);
+
     /* Get next hop list */
     void getNextHopList(struct rtnl_route *route_obj, string& gw_list,
                         string& mpls_list, string& intf_list);
@@ -140,6 +148,9 @@ private:
 
     /* Sends FPM message with RTM_F_OFFLOAD flag set for all routes in the table */
     void sendOffloadReply(swss::DBConnector& db, const std::string& table);
+
+    /* Get encap type */
+    uint16_t getEncapType(struct nlmsghdr *h);
 };
 
 }

--- a/tests/mock_tests/.gitignore
+++ b/tests/mock_tests/.gitignore
@@ -1,1 +1,2 @@
 tests
+tests_fpmsyncd

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -179,17 +179,20 @@ tests_intfmgrd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhired
 
 tests_fpmsyncd_SOURCES = fpmsyncd/test_fpmlink.cpp \
                          fpmsyncd/test_routesync.cpp \
+                         fpmsyncd/receive_srv6_steer_routes_ut.cpp \
+                         fpmsyncd/ut_helpers_fpmsyncd.cpp \
                          fake_netlink.cpp \
                          fake_warmstarthelper.cpp \
-                         fake_producerstatetable.cpp \
                          mock_dbconnector.cpp \
                          mock_table.cpp \
                          mock_hiredis.cpp \
+                         mock_redisreply.cpp \
                          $(top_srcdir)/warmrestart/ \
                          $(top_srcdir)/fpmsyncd/fpmlink.cpp \
                          $(top_srcdir)/fpmsyncd/routesync.cpp
 
-tests_fpmsyncd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/tests_fpmsyncd -I$(top_srcdir)/lib -I$(top_srcdir)/warmrestart
+tests_fpmsyncd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/tests_fpmsyncd -I$(top_srcdir)/lib -I$(top_srcdir)/warmrestart -I$(top_srcdir)/fpmsyncd
+tests_fpmsyncd_CXXFLAGS = -Wl,-wrap,rtnl_link_i2name
 tests_fpmsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
 tests_fpmsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_fpmsyncd_INCLUDES)
 tests_fpmsyncd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -180,6 +180,7 @@ tests_intfmgrd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhired
 tests_fpmsyncd_SOURCES = fpmsyncd/test_fpmlink.cpp \
                          fpmsyncd/test_routesync.cpp \
                          fpmsyncd/receive_srv6_steer_routes_ut.cpp \
+                         fpmsyncd/receive_srv6_localsids_ut.cpp \
                          fpmsyncd/ut_helpers_fpmsyncd.cpp \
                          fake_netlink.cpp \
                          fake_warmstarthelper.cpp \

--- a/tests/mock_tests/fpmsyncd/receive_srv6_localsids_ut.cpp
+++ b/tests/mock_tests/fpmsyncd/receive_srv6_localsids_ut.cpp
@@ -1,0 +1,261 @@
+#include "ut_helpers_fpmsyncd.h"
+#include "gtest/gtest.h"
+#include <gmock/gmock.h>
+#include "mock_table.h"
+#include <net/if.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include "ipaddress.h"
+
+#define private public // Need to modify internal cache
+#include "fpmlink.h"
+#include "routesync.h"
+#undef private
+
+using namespace swss;
+using namespace testing;
+
+/*
+Test Fixture
+*/
+namespace ut_fpmsyncd
+{
+    struct FpmSyncdSRv6LocalSIDsTest : public ::testing::Test
+    {
+        std::shared_ptr<swss::DBConnector> m_app_db;
+        std::shared_ptr<swss::RedisPipeline> pipeline;
+        std::shared_ptr<RouteSync> m_routeSync;
+        std::shared_ptr<FpmLink> m_fpmLink;
+        std::shared_ptr<swss::Table> m_srv6LocalSidTable;
+
+        virtual void SetUp() override
+        {
+            testing_db::reset();
+
+            m_app_db = std::make_shared<swss::DBConnector>("APPL_DB", 0);
+
+            /* Construct dependencies */
+
+            /*  1) RouteSync */
+            pipeline = std::make_shared<swss::RedisPipeline>(m_app_db.get());
+            m_routeSync = std::make_shared<RouteSync>(pipeline.get());
+
+            /* 2) FpmLink */
+            m_fpmLink = std::make_shared<FpmLink>(m_routeSync.get());
+
+            /* 3) SRV6_MY_SID_TABLE in APP_DB */
+            m_srv6LocalSidTable = std::make_shared<swss::Table>(m_app_db.get(), APP_SRV6_MY_SID_TABLE_NAME);
+        }
+
+        virtual void TearDown() override
+        {
+        }
+    };
+}
+
+namespace ut_fpmsyncd
+{
+    /* Test Receiving a route containing an SRv6 Local SID nexthop bound to the End.DT4 behavior */
+    TEST_F(FpmSyncdSRv6LocalSIDsTest, RecevingRouteWithSRv6LocalSIDEndDT4)
+    {
+        ASSERT_NE(m_routeSync, nullptr);
+
+        /* Create a Netlink object containing an SRv6 Local SID */
+        IpAddress _localsid = IpAddress("fc00:0:1:1::");
+        uint8_t _block_len = 32;
+        uint8_t _node_len = 16;
+        uint8_t _func_len = 16;
+        uint8_t _arg_len = 0;
+        uint32_t _action = SRV6_LOCALSID_ACTION_END_DT4;
+        char *_vrf = "Vrf10";
+
+        struct nlmsg *nl_obj = create_srv6_localsid_nlmsg(RTM_NEWROUTE, &_localsid, _block_len, _node_len, _func_len, _arg_len, _action, _vrf);
+        if (!nl_obj)
+            printf("Error\n\n");
+
+        /* Send the Netlink object to the FpmLink */
+        m_fpmLink->processRawMsg(&nl_obj->n);
+
+        /* Check that fpmsyncd created the correct entries in APP_DB */
+        std::string action;
+        ASSERT_EQ(m_srv6LocalSidTable->hget("32:16:16:0:fc00:0:1:1::", "action", action), true);
+        ASSERT_EQ(action, "end.dt4");
+
+        std::string vrf;
+        ASSERT_EQ(m_srv6LocalSidTable->hget("32:16:16:0:fc00:0:1:1::", "vrf", vrf), true);
+        ASSERT_EQ(vrf, "Vrf10");
+
+        /* Destroy the Netlink object and free the memory */
+        free_nlobj(nl_obj);
+    }
+
+    /* Test Receiving a route containing an SRv6 Local SID nexthop bound to the End.DT6 behavior */
+    TEST_F(FpmSyncdSRv6LocalSIDsTest, RecevingRouteWithSRv6LocalSIDEndDT6)
+    {
+        ASSERT_NE(m_routeSync, nullptr);
+
+        /* Create a Netlink object containing an SRv6 Local SID */
+        IpAddress _localsid = IpAddress("fc00:0:1:1::");
+        uint8_t _block_len = 32;
+        uint8_t _node_len = 16;
+        uint8_t _func_len = 16;
+        uint8_t _arg_len = 0;
+        uint32_t _action = SRV6_LOCALSID_ACTION_END_DT6;
+        char *_vrf = "Vrf10";
+
+        struct nlmsg *nl_obj = create_srv6_localsid_nlmsg(RTM_NEWROUTE, &_localsid, _block_len, _node_len, _func_len, _arg_len, _action, _vrf);
+        if (!nl_obj)
+            printf("Error\n\n");
+
+        /* Send the Netlink object to the FpmLink */
+        m_fpmLink->processRawMsg(&nl_obj->n);
+
+        /* Check that fpmsyncd created the correct entries in APP_DB */
+        std::string action;
+        ASSERT_EQ(m_srv6LocalSidTable->hget("32:16:16:0:fc00:0:1:1::", "action", action), true);
+        ASSERT_EQ(action, "end.dt6");
+
+        std::string vrf;
+        ASSERT_EQ(m_srv6LocalSidTable->hget("32:16:16:0:fc00:0:1:1::", "vrf", vrf), true);
+        ASSERT_EQ(vrf, "Vrf10");
+
+        /* Destroy the Netlink object and free the memory */
+        free_nlobj(nl_obj);
+    }
+
+    /* Test Receiving a route containing an SRv6 Local SID nexthop bound to the End.DT46 behavior */
+    TEST_F(FpmSyncdSRv6LocalSIDsTest, RecevingRouteWithSRv6LocalSIDEndDT46)
+    {
+        ASSERT_NE(m_routeSync, nullptr);
+
+        /* Create a Netlink object containing an SRv6 Local SID */
+        IpAddress _localsid = IpAddress("fc00:0:1:1::");
+        uint8_t _block_len = 32;
+        uint8_t _node_len = 16;
+        uint8_t _func_len = 16;
+        uint8_t _arg_len = 0;
+        uint32_t _action = SRV6_LOCALSID_ACTION_END_DT46;
+        char *_vrf = "Vrf10";
+
+        struct nlmsg *nl_obj = create_srv6_localsid_nlmsg(RTM_NEWROUTE, &_localsid, _block_len, _node_len, _func_len, _arg_len, _action, _vrf);
+        if (!nl_obj)
+            printf("Error\n\n");
+
+        /* Send the Netlink object to the FpmLink */
+        m_fpmLink->processRawMsg(&nl_obj->n);
+
+        /* Check that fpmsyncd created the correct entries in APP_DB */
+        std::string action;
+        ASSERT_EQ(m_srv6LocalSidTable->hget("32:16:16:0:fc00:0:1:1::", "action", action), true);
+        ASSERT_EQ(action, "end.dt46");
+
+        std::string vrf;
+        ASSERT_EQ(m_srv6LocalSidTable->hget("32:16:16:0:fc00:0:1:1::", "vrf", vrf), true);
+        ASSERT_EQ(vrf, "Vrf10");
+
+        /* Destroy the Netlink object and free the memory */
+        free_nlobj(nl_obj);
+    }
+
+    /* Test Receiving a route containing an SRv6 Local SID nexthop bound to the uDT4 behavior */
+    TEST_F(FpmSyncdSRv6LocalSIDsTest, RecevingRouteWithSRv6LocalSIDUDT4)
+    {
+        ASSERT_NE(m_routeSync, nullptr);
+
+        /* Create a Netlink object containing an SRv6 Local SID */
+        IpAddress _localsid = IpAddress("fc00:0:1:1::");
+        uint8_t _block_len = 32;
+        uint8_t _node_len = 16;
+        uint8_t _func_len = 16;
+        uint8_t _arg_len = 0;
+        uint32_t _action = SRV6_LOCALSID_ACTION_UDT4;
+        char *_vrf = "Vrf10";
+
+        struct nlmsg *nl_obj = create_srv6_localsid_nlmsg(RTM_NEWROUTE, &_localsid, _block_len, _node_len, _func_len, _arg_len, _action, _vrf);
+        if (!nl_obj)
+            printf("Error\n\n");
+
+        /* Send the Netlink object to the FpmLink */
+        m_fpmLink->processRawMsg(&nl_obj->n);
+
+        /* Check that fpmsyncd created the correct entries in APP_DB */
+        std::string action;
+        ASSERT_EQ(m_srv6LocalSidTable->hget("32:16:16:0:fc00:0:1:1::", "action", action), true);
+        ASSERT_EQ(action, "udt4");
+
+        std::string vrf;
+        ASSERT_EQ(m_srv6LocalSidTable->hget("32:16:16:0:fc00:0:1:1::", "vrf", vrf), true);
+        ASSERT_EQ(vrf, "Vrf10");
+
+        /* Destroy the Netlink object and free the memory */
+        free_nlobj(nl_obj);
+    }
+
+    /* Test Receiving a route containing an SRv6 Local SID nexthop bound to the uDT6 behavior */
+    TEST_F(FpmSyncdSRv6LocalSIDsTest, RecevingRouteWithSRv6LocalSIDUDT6)
+    {
+        ASSERT_NE(m_routeSync, nullptr);
+
+        /* Create a Netlink object containing an SRv6 Local SID */
+        IpAddress _localsid = IpAddress("fc00:0:1:1::");
+        uint8_t _block_len = 32;
+        uint8_t _node_len = 16;
+        uint8_t _func_len = 16;
+        uint8_t _arg_len = 0;
+        uint32_t _action = SRV6_LOCALSID_ACTION_UDT6;
+        char *_vrf = "Vrf10";
+
+        struct nlmsg *nl_obj = create_srv6_localsid_nlmsg(RTM_NEWROUTE, &_localsid, _block_len, _node_len, _func_len, _arg_len, _action, _vrf);
+        if (!nl_obj)
+            printf("Error\n\n");
+
+        /* Send the Netlink object to the FpmLink */
+        m_fpmLink->processRawMsg(&nl_obj->n);
+
+        /* Check that fpmsyncd created the correct entries in APP_DB */
+        std::string action;
+        ASSERT_EQ(m_srv6LocalSidTable->hget("32:16:16:0:fc00:0:1:1::", "action", action), true);
+        ASSERT_EQ(action, "udt6");
+
+        std::string vrf;
+        ASSERT_EQ(m_srv6LocalSidTable->hget("32:16:16:0:fc00:0:1:1::", "vrf", vrf), true);
+        ASSERT_EQ(vrf, "Vrf10");
+
+        /* Destroy the Netlink object and free the memory */
+        free_nlobj(nl_obj);
+    }
+
+    /* Test Receiving a route containing an SRv6 Local SID nexthop bound to the uDT46 behavior */
+    TEST_F(FpmSyncdSRv6LocalSIDsTest, RecevingRouteWithSRv6LocalSIDUDT46)
+    {
+        ASSERT_NE(m_routeSync, nullptr);
+
+        /* Create a Netlink object containing an SRv6 Local SID */
+        IpAddress _localsid = IpAddress("fc00:0:1:1::");
+        uint8_t _block_len = 32;
+        uint8_t _node_len = 16;
+        uint8_t _func_len = 16;
+        uint8_t _arg_len = 0;
+        uint32_t _action = SRV6_LOCALSID_ACTION_UDT46;
+        char *_vrf = "Vrf10";
+
+        struct nlmsg *nl_obj = create_srv6_localsid_nlmsg(RTM_NEWROUTE, &_localsid, _block_len, _node_len, _func_len, _arg_len, _action, _vrf);
+        if (!nl_obj)
+            printf("Error\n\n");
+
+        /* Send the Netlink object to the FpmLink */
+        m_fpmLink->processRawMsg(&nl_obj->n);
+
+        /* Check that fpmsyncd created the correct entries in APP_DB */
+        std::string action;
+        ASSERT_EQ(m_srv6LocalSidTable->hget("32:16:16:0:fc00:0:1:1::", "action", action), true);
+        ASSERT_EQ(action, "udt46");
+
+        std::string vrf;
+        ASSERT_EQ(m_srv6LocalSidTable->hget("32:16:16:0:fc00:0:1:1::", "vrf", vrf), true);
+        ASSERT_EQ(vrf, "Vrf10");
+
+        /* Destroy the Netlink object and free the memory */
+        free_nlobj(nl_obj);
+    }
+}

--- a/tests/mock_tests/fpmsyncd/receive_srv6_steer_routes_ut.cpp
+++ b/tests/mock_tests/fpmsyncd/receive_srv6_steer_routes_ut.cpp
@@ -1,0 +1,118 @@
+#include "ut_helpers_fpmsyncd.h"
+#include "gtest/gtest.h"
+#include <gmock/gmock.h>
+#include "mock_table.h"
+#include <net/if.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include "ipaddress.h"
+#include "ipprefix.h"
+
+#define private public // Need to modify internal cache
+#include "fpmlink.h"
+#include "routesync.h"
+#undef private
+
+using namespace swss;
+using namespace testing;
+
+/*
+Test Fixture
+*/
+namespace ut_fpmsyncd
+{
+    struct FpmSyncdSRv6RoutesTest : public ::testing::Test
+    {
+        std::shared_ptr<swss::DBConnector> m_app_db;
+        std::shared_ptr<swss::RedisPipeline> pipeline;
+        std::shared_ptr<RouteSync> m_routeSync;
+        std::shared_ptr<FpmLink> m_fpmLink;
+        std::shared_ptr<swss::Table> m_routeTable;
+
+        virtual void SetUp() override
+        {
+            testing_db::reset();
+
+            m_app_db = std::make_shared<swss::DBConnector>("APPL_DB", 0);
+
+            /* Construct dependencies */
+
+            /* 1) RouteSync */
+            pipeline = std::make_shared<swss::RedisPipeline>(m_app_db.get());
+            m_routeSync = std::make_shared<RouteSync>(pipeline.get());
+
+            /* 2) FpmLink */
+            m_fpmLink = std::make_shared<FpmLink>(m_routeSync.get());
+
+            /* 3) ROUTE_TABLE in APP_DB */
+            m_routeTable = std::make_shared<swss::Table>(m_app_db.get(), APP_ROUTE_TABLE_NAME);
+        }
+
+        virtual void TearDown() override
+        {
+        }
+    };
+}
+
+namespace ut_fpmsyncd
+{
+    /* Test Receiving an SRv6 Steer Route (with an IPv4 prefix) */
+    TEST_F(FpmSyncdSRv6RoutesTest, RecevingSRv6SteerRoutesWithIPv4Prefix)
+    {
+        ASSERT_NE(m_routeSync, nullptr);
+
+        /* Create a Netlink object containing an SRv6 Steer Route */
+        IpPrefix _dst = IpPrefix("192.168.6.0/24");
+        IpAddress _vpn_sid = IpAddress("fc00:0:2:1::");
+        IpAddress _encap_src_addr = IpAddress("fc00:0:1:1::1");
+
+        struct nlmsg *nl_obj = create_srv6_steer_route_nlmsg(RTM_NEWROUTE, &_dst, &_encap_src_addr, &_vpn_sid);
+        if (!nl_obj)
+            throw std::runtime_error("SRv6 Steer Route creation failed");
+
+        /* Send the Netlink object to the FpmLink */
+        m_fpmLink->processRawMsg(&nl_obj->n);
+
+        /* Check that fpmsyncd created the correct entries in APP_DB */
+        std::string vpn_sid;
+        ASSERT_EQ(m_routeTable->hget("Vrf10:192.168.6.0/24", "vpn_sid", vpn_sid), true);
+        ASSERT_EQ(vpn_sid, "fc00:0:2:1::");
+
+        std::string seg_src;
+        ASSERT_EQ(m_routeTable->hget("Vrf10:192.168.6.0/24", "seg_src", seg_src), true);
+        ASSERT_EQ(seg_src, "fc00:0:1:1::1");
+
+        /* Destroy the Netlink object and free the memory */
+        free_nlobj(nl_obj);
+    }
+
+    /* Test Receiving an SRv6 Steer Route (with an IPv6 prefix) */
+    TEST_F(FpmSyncdSRv6RoutesTest, RecevingSRv6SteerRoutesWithIPv6Prefix)
+    {
+        ASSERT_NE(m_routeSync, nullptr);
+
+        /* Create a Netlink object containing an SRv6 Steer Route */
+        IpPrefix _dst = IpPrefix("fd00:0:21::/64");
+        IpAddress _vpn_sid = IpAddress("fc00:0:2:1::");
+        IpAddress _encap_src_addr = IpAddress("fc00:0:1:1::1");
+
+        struct nlmsg *nl_obj = create_srv6_steer_route_nlmsg(RTM_NEWROUTE, &_dst, &_encap_src_addr, &_vpn_sid);
+        if (!nl_obj)
+            throw std::runtime_error("SRv6 Steer Route creation failed");
+
+        /* Send the Netlink object to the FpmLink */
+        m_fpmLink->processRawMsg(&nl_obj->n);
+
+        /* Check that fpmsyncd created the correct entries in APP_DB */
+        std::string vpn_sid;
+        ASSERT_EQ(m_routeTable->hget("Vrf10:fd00:0:21::/64", "vpn_sid", vpn_sid), true);
+        ASSERT_EQ(vpn_sid, "fc00:0:2:1::");
+
+        std::string seg_src;
+        ASSERT_EQ(m_routeTable->hget("Vrf10:fd00:0:21::/64", "seg_src", seg_src), true);
+        ASSERT_EQ(seg_src, "fc00:0:1:1::1");
+
+        /* Destroy the Netlink object and free the memory */
+        free_nlobj(nl_obj);
+    }
+}

--- a/tests/mock_tests/fpmsyncd/ut_helpers_fpmsyncd.cpp
+++ b/tests/mock_tests/fpmsyncd/ut_helpers_fpmsyncd.cpp
@@ -1,0 +1,371 @@
+#include "ut_helpers_fpmsyncd.h"
+#include "ipaddress.h"
+#include "ipprefix.h"
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+
+#define IPV6_MAX_BYTE      16
+#define IPV6_MAX_BITLEN    128
+
+/*
+ * Mock rtnl_link_i2name() call
+ * We simulate the existence of a VRF called Vrf10 with ifindex 10.
+ * Calling rtnl_link_i2name(_, 10, _, _) will return the name of the VRF (i.e., "Vrf10" string)
+ */
+extern "C" {
+char *__wrap_rtnl_link_i2name(struct nl_cache *cache, int ifindex, char *dst, size_t len)
+{
+    switch (ifindex)
+    {
+        case 10:
+            strncpy(dst, "Vrf10", 6);
+            return dst;
+        default:
+            return NULL;
+    }
+}
+}
+
+namespace ut_fpmsyncd
+{
+    /* Add a unspecific attribute to netlink message */
+    bool nl_attr_put(struct nlmsghdr *n, unsigned int maxlen, int type,
+                     const void *data, unsigned int alen)
+    {
+        int len;
+        struct rtattr *rta;
+
+        len = (int)RTA_LENGTH(alen);
+
+        if (NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len) > maxlen)
+            return false;
+
+        rta = reinterpret_cast<struct rtattr *>(static_cast<void *>(((char *)n) + NLMSG_ALIGN(n->nlmsg_len)));
+        rta->rta_type = (uint16_t)type;
+        rta->rta_len = (uint16_t)len;
+
+        if (data)
+            memcpy(RTA_DATA(rta), data, alen);
+        else
+            assert(alen == 0);
+
+        n->nlmsg_len = NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len);
+
+        return true;
+    }
+
+    /* Add 8 bit integer attribute to netlink message */
+    bool nl_attr_put8(struct nlmsghdr *n, unsigned int maxlen, int type,
+                      uint16_t data)
+    {
+        return nl_attr_put(n, maxlen, type, &data, sizeof(uint8_t));
+    }
+
+    /* Add 16 bit integer attribute to netlink message */
+    bool nl_attr_put16(struct nlmsghdr *n, unsigned int maxlen, int type,
+                       uint16_t data)
+    {
+        return nl_attr_put(n, maxlen, type, &data, sizeof(uint16_t));
+    }
+
+    /* Add 32 bit integer attribute to netlink message */
+    bool nl_attr_put32(struct nlmsghdr *n, unsigned int maxlen, int type,
+                       uint32_t data)
+    {
+        return nl_attr_put(n, maxlen, type, &data, sizeof(uint32_t));
+    }
+
+    /* Start a new level of nested attributes */
+    struct rtattr *nl_attr_nest(struct nlmsghdr *n, unsigned int maxlen, int type)
+    {
+        struct rtattr *nest = NLMSG_TAIL(n);
+
+        if (!nl_attr_put(n, maxlen, type, NULL, 0))
+            return NULL;
+
+        nest->rta_type |= NLA_F_NESTED;
+        return nest;
+    }
+
+    /* Finalize nesting of attributes */
+    int nl_attr_nest_end(struct nlmsghdr *n, struct rtattr *nest)
+    {
+        nest->rta_len = (uint16_t)((uint8_t *)NLMSG_TAIL(n) - (uint8_t *)nest);
+        return n->nlmsg_len;
+    }
+
+    /* Build a Netlink object containing an SRv6 Steering Route */
+    struct nlmsg *create_srv6_steer_route_nlmsg(
+        uint16_t cmd,
+        IpPrefix *dst,
+        IpAddress *encap_src_addr,
+        IpAddress *vpn_sid,
+        uint16_t table_id)
+    {
+        struct rtattr *nest;
+
+        /* Allocate memory for the Netlink objct */
+        struct nlmsg *nl_obj = (struct nlmsg *)calloc(1, sizeof(struct nlmsg));
+        if (!nl_obj)
+            throw std::runtime_error("netlink: nlmsg object allocation failed");
+
+        nl_obj->n.nlmsg_len = NLMSG_LENGTH(sizeof(struct rtmsg));
+        nl_obj->n.nlmsg_flags = NLM_F_CREATE | NLM_F_REQUEST;
+
+        if (cmd == RTM_NEWROUTE &&
+            dst->isV4())
+            nl_obj->n.nlmsg_flags |= NLM_F_REPLACE;
+
+        nl_obj->n.nlmsg_type = cmd;
+
+        nl_obj->n.nlmsg_pid = 100;
+
+        nl_obj->r.rtm_family = dst->getIp().getIp().family;
+        nl_obj->r.rtm_dst_len = (unsigned char)(dst->getMaskLength());
+        nl_obj->r.rtm_scope = RT_SCOPE_UNIVERSE;
+
+        nl_obj->r.rtm_protocol = 11; // ZEBRA protocol
+
+        if (cmd != RTM_DELROUTE)
+            nl_obj->r.rtm_type = RTN_UNICAST;
+
+        /* Add the destination address */
+        if (dst->isV4())
+        {
+            if (!nl_attr_put32(&nl_obj->n, sizeof(*nl_obj),
+                               RTA_DST, dst->getIp().getV4Addr()))
+                return NULL;
+        }
+        else
+        {
+            if (!nl_attr_put(&nl_obj->n, sizeof(*nl_obj),
+                             RTA_DST, dst->getIp().getV6Addr(), IPV6_MAX_BYTE))
+                return NULL;
+        }
+
+        /* Add the table ID */
+        if (table_id < 256)
+            nl_obj->r.rtm_table = (unsigned char)table_id;
+        else
+        {
+            nl_obj->r.rtm_table = RT_TABLE_UNSPEC;
+            if (!nl_attr_put32(&nl_obj->n, sizeof(*nl_obj), RTA_TABLE, table_id))
+                return NULL;
+        }
+
+        /* If the Netlink message is a Delete Route message, we have done */
+        if (cmd == RTM_DELROUTE)
+        {
+            NLMSG_ALIGN(nl_obj->n.nlmsg_len);
+            return nl_obj;
+        }
+
+        /* Add encapsulation type NH_ENCAP_SRV6_ROUTE (SRv6 Route) */
+        if (!nl_attr_put16(&nl_obj->n, sizeof(*nl_obj), RTA_ENCAP_TYPE,
+                           NH_ENCAP_SRV6_ROUTE))
+            return NULL;
+
+        /* Add encapsulation information */
+        nest = nl_attr_nest(&nl_obj->n, sizeof(*nl_obj), RTA_ENCAP);
+        if (!nest)
+            return NULL;
+
+        /* Add source address for SRv6 encapsulation */
+        if (!nl_attr_put(
+                &nl_obj->n, sizeof(*nl_obj), SRV6_ROUTE_ENCAP_SRC_ADDR,
+                encap_src_addr->getV6Addr(), 16))
+            return NULL;
+
+        /* Add the VPN SID */
+        if (!nl_attr_put(&nl_obj->n, sizeof(*nl_obj), SRV6_ROUTE_VPN_SID,
+                         vpn_sid->getV6Addr(), 16))
+            return NULL;
+
+        nl_attr_nest_end(&nl_obj->n, nest);
+
+        return nl_obj;
+    }
+
+    /* Build a Netlink object containing an SRv6 Local SID */
+    struct nlmsg *create_srv6_localsid_nlmsg(
+        uint16_t cmd,
+        IpAddress *localsid,
+        uint8_t block_len,
+        uint8_t node_len,
+        uint8_t func_len,
+        uint8_t arg_len,
+        uint32_t action,
+        char *vrf,
+        uint16_t table_id)
+    {
+        struct rtattr *nest, *inner_nest;
+
+        /* Allocate memory for the Netlink object */
+        struct nlmsg *nl_obj = (struct nlmsg *)malloc(sizeof(struct nlmsg));
+        if (!nl_obj)
+            throw std::runtime_error("netlink: nlmsg object allocation failed");
+
+        memset(nl_obj, 0, sizeof(*nl_obj));
+
+        nl_obj->n.nlmsg_len = NLMSG_LENGTH(sizeof(struct rtmsg));
+        nl_obj->n.nlmsg_flags = NLM_F_CREATE | NLM_F_REQUEST;
+
+        nl_obj->n.nlmsg_type = cmd;
+
+        nl_obj->n.nlmsg_pid = 100;
+
+        nl_obj->r.rtm_family = AF_INET6;
+        nl_obj->r.rtm_dst_len = IPV6_MAX_BITLEN;
+        nl_obj->r.rtm_scope = RT_SCOPE_UNIVERSE;
+
+        nl_obj->r.rtm_protocol = 11; // Protocol ZEBRA
+
+        if (cmd != RTM_DELROUTE)
+            nl_obj->r.rtm_type = RTN_UNICAST;
+
+        /* Add local SID address */
+        if (localsid->isV4())
+        {
+            throw std::runtime_error("SRv6 local SID cannot be an IPv4 address");
+        }
+        else
+        {
+            if (!nl_attr_put(&nl_obj->n, sizeof(*nl_obj),
+                             RTA_DST, localsid->getV6Addr(), 16))
+                return NULL;
+        }
+
+        /* Add table ID */
+        if (table_id < 256)
+            nl_obj->r.rtm_table = (unsigned char)table_id;
+        else
+        {
+            nl_obj->r.rtm_table = RT_TABLE_UNSPEC;
+            if (!nl_attr_put32(&nl_obj->n, sizeof(*nl_obj), RTA_TABLE, table_id))
+                return NULL;
+        }
+
+        /* If the Netlink message is a Delete Route message, we have done */
+        if (cmd == RTM_DELROUTE)
+        {
+            NLMSG_ALIGN(nl_obj->n.nlmsg_len);
+            return nl_obj;
+        }
+
+        /* Add encapsulation type NH_ENCAP_SRV6_LOCAL_SID (SRv6 Local SID) */
+        if (!nl_attr_put16(&nl_obj->n, sizeof(*nl_obj), RTA_ENCAP_TYPE,
+                           NH_ENCAP_SRV6_LOCAL_SID))
+            return NULL;
+
+        /* Add encapsulation information */
+        nest = nl_attr_nest(&nl_obj->n, sizeof(*nl_obj), RTA_ENCAP);
+        if (!nest)
+            return NULL;
+
+        /* Add SID format information */
+        inner_nest =
+            nl_attr_nest(&nl_obj->n, sizeof(*nl_obj),
+                         SRV6_LOCALSID_FORMAT);
+
+        /* Add block bits length */
+        if (!nl_attr_put8(
+                &nl_obj->n, sizeof(*nl_obj),
+                SRV6_LOCALSID_FORMAT_BLOCK_LEN,
+                block_len))
+            return NULL;
+
+        /* Add node bits length */
+        if (!nl_attr_put8(
+                &nl_obj->n, sizeof(*nl_obj),
+                SRV6_LOCALSID_FORMAT_NODE_LEN,
+                node_len))
+            return NULL;
+
+        /* Add function bits length */
+        if (!nl_attr_put8(
+                &nl_obj->n, sizeof(*nl_obj),
+                SRV6_LOCALSID_FORMAT_FUNC_LEN,
+                func_len))
+            return NULL;
+
+        /* Add argument bits length */
+        if (!nl_attr_put8(
+                &nl_obj->n, sizeof(*nl_obj),
+                SRV6_LOCALSID_FORMAT_ARG_LEN,
+                arg_len))
+            return NULL;
+
+        nl_attr_nest_end(&nl_obj->n, inner_nest);
+
+        /* Add local SID behavior (action and parameters) */
+        switch (action)
+        {
+            case SRV6_LOCALSID_ACTION_END_DT4:
+                if (!nl_attr_put32(&nl_obj->n, sizeof(*nl_obj),
+                                   SRV6_LOCALSID_ACTION,
+                                   SRV6_LOCALSID_ACTION_END_DT4))
+                    return NULL;
+                if (!nl_attr_put(&nl_obj->n, sizeof(*nl_obj),
+                                 SRV6_LOCALSID_VRFNAME,
+                                 vrf, (uint32_t)strlen(vrf)))
+                    return NULL;
+                break;
+            case SRV6_LOCALSID_ACTION_END_DT6:
+                if (!nl_attr_put32(&nl_obj->n, sizeof(*nl_obj),
+                                   SRV6_LOCALSID_ACTION,
+                                   SRV6_LOCALSID_ACTION_END_DT6))
+                    return NULL;
+                if (!nl_attr_put(&nl_obj->n, sizeof(*nl_obj),
+                                 SRV6_LOCALSID_VRFNAME,
+                                 vrf, (uint32_t)strlen(vrf)))
+                    return NULL;
+                break;
+            case SRV6_LOCALSID_ACTION_END_DT46:
+                if (!nl_attr_put32(&nl_obj->n, sizeof(*nl_obj),
+                                   SRV6_LOCALSID_ACTION,
+                                   SRV6_LOCALSID_ACTION_END_DT46))
+                    return NULL;
+                if (!nl_attr_put(&nl_obj->n, sizeof(*nl_obj),
+                                 SRV6_LOCALSID_VRFNAME,
+                                 vrf, (uint32_t)strlen(vrf)))
+                    return NULL;
+                break;
+            case SRV6_LOCALSID_ACTION_UDT4:
+                if (!nl_attr_put32(&nl_obj->n, sizeof(*nl_obj),
+                                   SRV6_LOCALSID_ACTION,
+                                   SRV6_LOCALSID_ACTION_UDT4))
+                    return NULL;
+                if (!nl_attr_put(&nl_obj->n, sizeof(*nl_obj),
+                                 SRV6_LOCALSID_VRFNAME,
+                                 vrf, (uint32_t)strlen(vrf)))
+                    return NULL;
+                break;
+            case SRV6_LOCALSID_ACTION_UDT6:
+                if (!nl_attr_put32(&nl_obj->n, sizeof(*nl_obj),
+                                   SRV6_LOCALSID_ACTION,
+                                   SRV6_LOCALSID_ACTION_UDT6))
+                    return NULL;
+                if (!nl_attr_put(&nl_obj->n, sizeof(*nl_obj),
+                                 SRV6_LOCALSID_VRFNAME,
+                                 vrf, (uint32_t)strlen(vrf)))
+                    return NULL;
+                break;
+            case SRV6_LOCALSID_ACTION_UDT46:
+                if (!nl_attr_put32(&nl_obj->n, sizeof(*nl_obj),
+                                   SRV6_LOCALSID_ACTION,
+                                   SRV6_LOCALSID_ACTION_UDT46))
+                    return NULL;
+                if (!nl_attr_put(&nl_obj->n, sizeof(*nl_obj),
+                                 SRV6_LOCALSID_VRFNAME,
+                                 vrf, (uint32_t)strlen(vrf)))
+                    return NULL;
+                break;
+            default:
+                throw std::runtime_error("Unsupported localsid action\n");
+        }
+
+        nl_attr_nest_end(&nl_obj->n, nest);
+
+        return nl_obj;
+    }
+}

--- a/tests/mock_tests/fpmsyncd/ut_helpers_fpmsyncd.h
+++ b/tests/mock_tests/fpmsyncd/ut_helpers_fpmsyncd.h
@@ -1,0 +1,105 @@
+#include "ipaddress.h"
+#include "ipprefix.h"
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+
+using namespace swss;
+
+#define NLMSG_TAIL(nmsg) \
+    (reinterpret_cast<struct rtattr *>(static_cast<void *>((((uint8_t *)nmsg)) + NLMSG_ALIGN((nmsg)->nlmsg_len))))
+
+/* Values copied from fpmsyncd/routesync.cpp */
+#define NH_ENCAP_SRV6_ROUTE         101
+#define NH_ENCAP_SRV6_LOCAL_SID     102
+
+enum {  /* Values copied from fpmsyncd/routesync.cpp */
+    SRV6_ROUTE_UNSPEC            = 0,
+    SRV6_ROUTE_VPN_SID           = 1,
+    SRV6_ROUTE_ENCAP_SRC_ADDR    = 2,
+};
+
+enum srv6_localsid_action {  /* Values copied from fpmsyncd/routesync.cpp */
+    SRV6_LOCALSID_ACTION_UNSPEC       = 0,
+    SRV6_LOCALSID_ACTION_END          = 1,
+    SRV6_LOCALSID_ACTION_END_X        = 2,
+    SRV6_LOCALSID_ACTION_END_T        = 3,
+    SRV6_LOCALSID_ACTION_END_DX2      = 4,
+    SRV6_LOCALSID_ACTION_END_DX6      = 5,
+    SRV6_LOCALSID_ACTION_END_DX4      = 6,
+    SRV6_LOCALSID_ACTION_END_DT6      = 7,
+    SRV6_LOCALSID_ACTION_END_DT4      = 8,
+    SRV6_LOCALSID_ACTION_END_B6       = 9,
+    SRV6_LOCALSID_ACTION_END_B6_ENCAP = 10,
+    SRV6_LOCALSID_ACTION_END_BM       = 11,
+    SRV6_LOCALSID_ACTION_END_S        = 12,
+    SRV6_LOCALSID_ACTION_END_AS       = 13,
+    SRV6_LOCALSID_ACTION_END_AM       = 14,
+    SRV6_LOCALSID_ACTION_END_BPF      = 15,
+    SRV6_LOCALSID_ACTION_END_DT46     = 16,
+    SRV6_LOCALSID_ACTION_UDT4         = 100,
+    SRV6_LOCALSID_ACTION_UDT6         = 101,
+    SRV6_LOCALSID_ACTION_UDT46        = 102,
+};
+
+enum {  /* Values copied from fpmsyncd/routesync.cpp */
+    SRV6_LOCALSID_UNSPEC         = 0,
+    SRV6_LOCALSID_ACTION         = 1,
+    SRV6_LOCALSID_SRH            = 2,
+    SRV6_LOCALSID_TABLE          = 3,
+    SRV6_LOCALSID_NH4            = 4,
+    SRV6_LOCALSID_NH6            = 5,
+    SRV6_LOCALSID_IIF            = 6,
+    SRV6_LOCALSID_OIF            = 7,
+    SRV6_LOCALSID_BPF            = 8,
+    SRV6_LOCALSID_VRFTABLE       = 9,
+    SRV6_LOCALSID_COUNTERS       = 10,
+    SRV6_LOCALSID_VRFNAME        = 100,
+    SRV6_LOCALSID_FORMAT         = 101,
+};
+
+enum {  /* Values copied from fpmsyncd/routesync.cpp */
+    SRV6_LOCALSID_FORMAT_UNSPEC         = 0,
+    SRV6_LOCALSID_FORMAT_BLOCK_LEN      = 1,
+    SRV6_LOCALSID_FORMAT_NODE_LEN       = 2,
+    SRV6_LOCALSID_FORMAT_FUNC_LEN       = 3,
+    SRV6_LOCALSID_FORMAT_ARG_LEN        = 4,
+};
+
+namespace ut_fpmsyncd
+{
+    struct nlmsg
+    {
+        struct nlmsghdr n;
+        struct rtmsg r;
+        char buf[512];
+    };
+
+    /* Add a unspecific attribute to netlink message */
+    bool nl_attr_put(struct nlmsghdr *n, unsigned int maxlen, int type,
+                     const void *data, unsigned int alen);
+    /* Add 8 bit integer attribute to netlink message */
+    bool nl_attr_put8(struct nlmsghdr *n, unsigned int maxlen, int type,
+                      uint16_t data);
+    /* Add 16 bit integer attribute to netlink message */
+    bool nl_attr_put16(struct nlmsghdr *n, unsigned int maxlen, int type,
+                       uint16_t data);
+    /* Add 32 bit integer attribute to netlink message */
+    bool nl_attr_put32(struct nlmsghdr *n, unsigned int maxlen, int type,
+                       uint32_t data);
+    /* Start a new level of nested attributes */
+    struct rtattr *nl_attr_nest(struct nlmsghdr *n, unsigned int maxlen, int type);
+    /* Finalize nesting of attributes */
+    int nl_attr_nest_end(struct nlmsghdr *n, struct rtattr *nest);
+    /* Build a Netlink object containing an SRv6 Steering Route */
+    struct nlmsg *create_srv6_steer_route_nlmsg(uint16_t cmd, IpPrefix *dst, IpAddress *encap_src_addr,
+                                                IpAddress *vpn_sid, uint16_t table_id = 10);
+    /* Build a Netlink object containing an SRv6 Local SID */
+    struct nlmsg *create_srv6_localsid_nlmsg(uint16_t cmd, IpAddress *localsid, uint8_t block_len,
+                                             uint8_t node_len, uint8_t func_len, uint8_t arg_len,
+                                             uint32_t action, char *vrf, uint16_t table_id = 10);
+    /* Free the memory allocated for a Netlink object */
+    inline void free_nlobj(struct nlmsg *msg)
+    {
+        free(msg);
+    }
+}


### PR DESCRIPTION
The `dplane_fpm_nl` module in FRR allows SONiC to learn the forwarding information computed by FRR. FRR already supports many SRv6 functionalities. There is an open PR (FRRouting/frr/pull/12301) to extend the `dplane_fpm_nl` module of FRR to export the required SRv6 information to SONiC.

OrchAgent (specifically, RouteOrch and SRv6Orch) in SONiC SWSS can already extract the SRv6 information from the APP_DB and push it towards the ASIC_DB ([sonic-net/sonic-swss/pull/1964](https://github.com/sonic-net/sonic-swss/pull/1964)).

However, the `fpmsyncd` in SONiC SWSS does not process the SRv6 information received from FRR. This PR extends `fpmsyncd` to parse the SRv6 information received from FRR and push it toward the APP_DB.

**What I did**

I added support for SRv6 to `fpmsyncd`:
* I added a handler `onSrv6RouteMsg()` which is able to parse Netlink messages containing an SRv6 Steering Route and create an entry in the `ROUTE_TABLE` of `APP_DB`.
* I added a handler `onSrv6LocalSidMsg()` which is able to parse Netlink messages containing an SRv6 Local SID and create an entry in the `SRV6_MY_SID_TABLE` of `APP_DB`.
* I changed `onMsgRaw()` to pass the Netlink messages to the appropriate handler depending on the encapsulation type.
* I added the unit tests to verify that `fpmsyncd` processes the Netlink messages and updates the `APP_DB` correctly.


**Why I did it**

FRR supports many SRv6 functionalities. There is an open PR ([FRRouting/frr/pull/12301](https://github.com/FRRouting/frr/pull/12301)) to extend the `dplane_fpm_nl` module of FRR to export the required SRv6 information to SONiC.

However, the `fpmsyncd` in SONiC SWSS did not process the SRv6 information received from FRR.


**How I verified it**

I added new unit tests in `tests/mock_tests/fpmsyncd/receive_srv6_localsids_ut.cpp` and `tests/mock_tests/fpmsyncd/receive_srv6_steer_routes_ut.cpp`.


**Details if related**
SRv6 HLD: https://github.com/sonic-net/SONiC/blob/master/doc/srv6/srv6_hld.md
SRv6 uSID HLD: https://github.com/sonic-net/SONiC/blob/master/doc/srv6/SRv6_uSID.md