### PR TITLE
Revert "[vlanmgr] Disable `arp_evict_nocarrier` for vlan host intf"

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -134,11 +134,6 @@ bool VlanMgr::addHostVlan(int vlan_id)
     std::string res;
     EXEC_WITH_ERROR_THROW(cmds, res);
 
-    res.clear();
-    const std::string echo_cmd = std::string("")
-      + ECHO_CMD + " 0 > /proc/sys/net/ipv4/conf/" + VLAN_PREFIX + std::to_string(vlan_id) + "/arp_evict_nocarrier";
-    swss::exec(echo_cmd, res);
-
     return true;
 }
 

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -492,48 +492,6 @@ class TestVlan(object):
         self.dvs_vlan.remove_vlan(vlan)
         self.dvs_vlan.get_and_verify_vlan_ids(0)
 
-    def test_VlanMemberLinkDown(self, dvs):
-
-        # TODO: add_ip_address has a dependency on cdb within dvs,
-        # so we still need to setup the db. This should be refactored.
-        dvs.setup_db()
-
-        vlan = "1000"
-        vlan_ip = "192.168.0.1/21"
-        interface = "Ethernet0"
-        vlan_interface = "Vlan%s" % vlan
-        server_ip = "192.168.0.100"
-        vlan_intf_sysctl_param_path = "/proc/sys/net/ipv4/conf/%s/arp_evict_nocarrier" % vlan_interface
-
-        self.dvs_vlan.create_vlan(vlan)
-        vlan_oid = self.dvs_vlan.get_and_verify_vlan_ids(1)[0]
-        self.dvs_vlan.verify_vlan(vlan_oid, vlan)
-        self.dvs_vlan.create_vlan_member(vlan, interface)
-        self.dvs_vlan.verify_vlan_member(vlan_oid, interface)
-        dvs.set_interface_status(interface, "up")
-        dvs.add_ip_address(vlan_interface, vlan_ip)
-        dvs.runcmd("ip neigh replace %s lladdr 11:22:33:44:55:66 dev %s nud stale" % (server_ip, vlan_interface))
-
-        neigh_oid = self.dvs_vlan.app_db.wait_for_n_keys("NEIGH_TABLE", 1)[0]
-        assert vlan_interface in neigh_oid and server_ip in neigh_oid
-
-        # NOTE: arp_evict_nocarrier is available for kernel >= v5.16 and current
-        # docker-sonic-vs is based on kernel v5.4.0, so test only if this sysctl
-        # param is present
-        rc, res = dvs.runcmd("cat %s" % vlan_intf_sysctl_param_path)
-        if rc == 0:
-            assert res.strip() == "0"
-            dvs.set_interface_status(interface, "down")
-            neigh_oid = self.dvs_vlan.app_db.wait_for_n_keys("NEIGH_TABLE", 1)[0]
-            assert vlan_interface in neigh_oid and server_ip in neigh_oid
-
-        dvs.runcmd("ip neigh flush all")
-        dvs.remove_ip_address(vlan_interface, vlan_ip)
-        self.dvs_vlan.remove_vlan_member(vlan, interface)
-        self.dvs_vlan.get_and_verify_vlan_member_ids(0)
-        self.dvs_vlan.remove_vlan(vlan)
-        self.dvs_vlan.get_and_verify_vlan_ids(0)
-
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():


### PR DESCRIPTION
Need revert PR #2469 because new UT 'test_VlanMemberLinkDown' does not work on 202205 or older version.
And currently some 202205 branch P0 PR https://github.com/sonic-net/sonic-swss-common/pull/706 been block by this UT.