### PR TITLE
Add show fabric counters port/queue commands

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -708,9 +708,8 @@ int main(int argc, char **argv)
         if (gMySwitchType == "voq")
         {
             orchDaemon->setFabricEnabled(true);
-            // SAI doesn't fully support counters for non fabric asics
-            orchDaemon->setFabricPortStatEnabled(false);
-            orchDaemon->setFabricQueueStatEnabled(false);
+            orchDaemon->setFabricPortStatEnabled(true);
+            orchDaemon->setFabricQueueStatEnabled(true);
         }
     }
     else


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Enable show fabric counters port command:

show fabric counters port
```# show fabric counters port
  ASIC    PORT    STATE    IN_CELL    IN_OCTET    OUT_CELL    OUT_OCTET    CRC    FEC_CORRECTABLE    FEC_UNCORRECTABLE    SYMBOL_ERR
------  ------  -------  ---------  ----------  ----------  -----------  -----  -----------------  -------------------  ------------
     0       0       up          0           0           4          740      0                  3               305128             3
     0       1       up          0           0           4          740      0                314               232123           245
     0       2       up          0           0           4          740      0                  0               265156             0
.......
```
Enable show fabric counters queue command :
```# show fabric counters queue
  ASIC    PORT    STATE    QUEUE_ID    CURRENT_BYTE    CURRENT_LEVEL    WATERMARK_LEVEL
------  ------  -------  ----------  --------------  ---------------  -----------------
     0       0       up           0             N/A              N/A                N/A
     0       1       up           0             N/A              N/A                N/A
 ......
```
**Why I did it**

**How I verified it**

**Details if related**
This PR is dependent on -
https://github.com/sonic-net/sonic-utilities/pull/2499
