### PR TITLE
support port isolation group in centec platform

### DIFF
--- a/mclagsyncd/mclaglink.cpp
+++ b/mclagsyncd/mclaglink.cpp
@@ -191,7 +191,8 @@ void MclagLink::setPortIsolate(char *msg)
 {
     static const unordered_set<string> supported {
         BRCM_PLATFORM_SUBSTRING,
-        BFN_PLATFORM_SUBSTRING
+        BFN_PLATFORM_SUBSTRING,
+        CTC_PLATFORM_SUBSTRING
     };
 
     const char *platform = getenv("platform");

--- a/mclagsyncd/mclaglink.h
+++ b/mclagsyncd/mclaglink.h
@@ -53,6 +53,7 @@
 
 #define BRCM_PLATFORM_SUBSTRING "broadcom"
 #define BFN_PLATFORM_SUBSTRING  "barefoot"
+#define CTC_PLATFORM_SUBSTRING  "centec"
 
 using namespace std;
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add centec platform to supported platform list for port isolation group

**Why I did it**
Centec platform support port isolation group, but it was not in the supported platforms list.

**How I verified it**
Build centec image, run regression

**Details if related**
