### PR TITLE
[dash] add USE_DST_VNET_VNI attribute to CA-to-PA entry

### DIFF
--- a/orchagent/dash/dashvnetorch.cpp
+++ b/orchagent/dash/dashvnetorch.cpp
@@ -291,6 +291,10 @@ bool DashVnetOrch::addOutboundCaToPa(const string& key, VnetMapBulkContext& ctxt
     memcpy(outbound_ca_to_pa_attr.value.mac, ctxt.mac_address.getMac(), sizeof(sai_mac_t));
     outbound_ca_to_pa_attrs.push_back(outbound_ca_to_pa_attr);
 
+    outbound_ca_to_pa_attr.id = SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_USE_DST_VNET_VNI;
+    outbound_ca_to_pa_attr.value.booldata = ctxt.use_dst_vni;
+    outbound_ca_to_pa_attrs.push_back(outbound_ca_to_pa_attr);
+
     object_statuses.emplace_back();
     outbound_ca_to_pa_bulker_.create_entry(&object_statuses.back(), &outbound_ca_to_pa_entry,
             (uint32_t)outbound_ca_to_pa_attrs.size(), outbound_ca_to_pa_attrs.data());

--- a/orchagent/dash/dashvnetorch.h
+++ b/orchagent/dash/dashvnetorch.h
@@ -59,7 +59,7 @@ struct VnetMapBulkContext
     swss::IpAddress underlay_ip;
     swss::MacAddress mac_address;
     uint32_t metering_bucket;
-    bool use_dst_vni;
+    bool use_dst_vni = false;
     std::deque<sai_status_t> outbound_ca_to_pa_object_statuses;
     std::deque<sai_status_t> pa_validation_object_statuses;
     VnetMapBulkContext() {}


### PR DESCRIPTION
**What I did**
Added SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_USE_DST_VNET_VNI value handling to addOutboundCaToPa()
**Why I did it**
To support DASH_VNET_MAPPING_TABLE:use_dst_vni configuration
**How I verified it**
Created DASH_VNET_MAPPING_TABLE entry with 'use_dst_vni' configuration
**Details if related**
