### PR TITLE
In the MCLAG scenario, if the ICCP peer link bridge port is being del…

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4984,6 +4984,10 @@ bool PortsOrch::removeBridgePort(Port &port)
     gFdbOrch->flushFDBEntries(port.m_bridge_port_id, SAI_NULL_OBJECT_ID);
     SWSS_LOG_INFO("Flush FDB entries for port %s", port.m_alias.c_str());
 
+    /* Notify bridge port deletion */
+    PortUpdate update = { port, false };
+    notify(SUBJECT_TYPE_BRIDGE_PORT_CHANGE, static_cast<void *>(&update));
+
     /* Remove bridge port */
     status = sai_bridge_api->remove_bridge_port(port.m_bridge_port_id);
     if (status != SAI_STATUS_SUCCESS)
@@ -4999,9 +5003,6 @@ bool PortsOrch::removeBridgePort(Port &port)
     saiOidToAlias.erase(port.m_bridge_port_id);
     port.m_bridge_port_id = SAI_NULL_OBJECT_ID;
 
-    /* Remove bridge port */
-    PortUpdate update = { port, false };
-    notify(SUBJECT_TYPE_BRIDGE_PORT_CHANGE, static_cast<void *>(&update));
 
     SWSS_LOG_NOTICE("Remove bridge port %s from default 1Q bridge", port.m_alias.c_str());
 


### PR DESCRIPTION

**What I did**
while processing the bridge port removal,  altered the invocation order 
from,
1. Remove bridge port in SAI (sai_bridge_api->remove_bridge_port())
2. Notify about the bridge port deletion to Isolation group module (orchagent)

to,
1. Notify about the bridge port deletion to Isolation group module (orchagent)
2. Remove bridge port in SAI (sai_bridge_api->remove_bridge_port())


**Why I did it**
When Bridge removal is triggered before clearing the isolation group reference, then SAI returns error stating the bridge port reference count is still non-zero.  reversing the invocation order will solve the issue and avoid the SAI errors for Bridgeport deletion.

**How I verified it**
1. Deletion of ICCP Bridge port , followed by MCLAG interface Bridgeport - PASS
2. Deletion of MCLAG interface Bridge port , followed by ICCP Bridgeport - PASS
3. Recreating the MCLAG interface bridge port followed by ICCP interface bridge port - PASS
4. Recreating the ICCP interface bridge port followed by MCLAG interface bridge port - PASS

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
-->
Fix for ICCP Bridgeport removal failure when MCLAG interface bridgeport exist
