### PR TITLE
Updated handling of VRF_VNI mapping and VLAN_VNI mapping for same VNI ID

### DIFF
--- a/orchagent/vrforch.h
+++ b/orchagent/vrforch.h
@@ -155,6 +155,19 @@ public:
             return (-1);
         }
     }
+
+    bool isL3VniVlan(const uint32_t vni) const
+    {
+        if (l3vni_table_.find(vni) != std::end(l3vni_table_))
+        {
+            return l3vni_table_.at(vni).l3_vni;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
     int updateL3VniVlan(uint32_t vni, uint16_t vlan_id);
 private:
     virtual bool addOperation(const Request& request);

--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -2280,10 +2280,10 @@ bool VxlanVrfMapOrch::delOperation(const Request& request)
             const auto tunnel_map_id = tunnel_obj->getDecapMapId(TUNNEL_MAP_T_VLAN);
             SWSS_LOG_NOTICE("Adding tunnel map entry. Tunnel: %s %s",tunnel_name.c_str(),entry.vniVlanMapName.c_str());
 
-            SWSS_LOG_DEBUG("create_tunnel_map_entry tunnel_map_id %lx, vni %d, vlan %d\n", tunnel_map_id, entry.vni_id, entry.vlan_id);
+            SWSS_LOG_DEBUG("create_tunnel_map_entry vni %d, vlan %d\n", entry.vni_id, entry.vlan_id);
             auto tunnel_map_entry_id = create_tunnel_map_entry(MAP_T::VNI_TO_VLAN_ID,
                     tunnel_map_id, entry.vni_id, (uint16_t)entry.vlan_id);
-            SWSS_LOG_DEBUG("updateTnlMapId name %s, map %lx\n", entry.vniVlanMapName.c_str(), tunnel_map_entry_id);
+            SWSS_LOG_DEBUG("updateTnlMapId name %s\n", entry.vniVlanMapName.c_str());
 
             vxlan_tun_map_orch->updateTnlMapId(entry.vniVlanMapName, tunnel_map_entry_id);
         }
@@ -2648,7 +2648,7 @@ bool VxlanTunnelMapOrch::isVniVlanMapExists(uint32_t vni_id, std::string& vniVla
             *tnl_map_entry_id = tunnel_map_entry.map_entry_id;
             *vlan_id = tunnel_map_entry.vlan_id;
             map_entry_exists = true;
-            SWSS_LOG_NOTICE("vniVlanMapName %s, map %lx, vlan %d\n", vniVlanMapName.c_str(), *tnl_map_entry_id, *vlan_id);
+            SWSS_LOG_NOTICE("vniVlanMapName %s, vlan %d\n", vniVlanMapName.c_str(), *vlan_id);
             break;
         }
     }
@@ -2659,7 +2659,7 @@ bool VxlanTunnelMapOrch::isVniVlanMapExists(uint32_t vni_id, std::string& vniVla
 void VxlanTunnelMapOrch::updateTnlMapId(std::string vniVlanMapName, sai_object_id_t tunnel_map_id)
 {
     SWSS_LOG_ENTER();
-    SWSS_LOG_NOTICE("name %s, map %lx\n", vniVlanMapName.c_str(), tunnel_map_id);
+    SWSS_LOG_NOTICE("name %s\n", vniVlanMapName.c_str());
     vxlan_tunnel_map_table_[vniVlanMapName].map_entry_id = tunnel_map_id;
 }
 

--- a/orchagent/vxlanorch.h
+++ b/orchagent/vxlanorch.h
@@ -410,6 +410,10 @@ public:
     {
         return vxlan_tunnel_map_table_.find(name) != std::end(vxlan_tunnel_map_table_);
     }
+
+    bool isVniVlanMapExists(uint32_t vni_id, std::string& vniVlanMapName, sai_object_id_t *tnl_map_entry_id, uint32_t *vlan_id);
+
+    void updateTnlMapId(std::string vniVlanMapName, sai_object_id_t tunnel_map_id);
 private:
     virtual bool addOperation(const Request& request);
     virtual bool delOperation(const Request& request);
@@ -436,6 +440,10 @@ public:
 struct vrf_map_entry_t {
     sai_object_id_t encap_id;
     sai_object_id_t decap_id;
+    bool isL2Vni;
+    std::string vniVlanMapName;
+    uint32_t vlan_id;
+    uint32_t vni_id;
 };
 
 typedef std::map<string, vrf_map_entry_t> VxlanVrfTable;

--- a/tests/evpn_tunnel.py
+++ b/tests/evpn_tunnel.py
@@ -485,6 +485,24 @@ class VxlanTunnel(object):
             (exitcode, out) = dvs.runcmd(iplinkcmd)
             assert exitcode == 0, "Kernel device not created"
 
+    def check_vxlan_tunnel_map_entry_removed(self, dvs, tunnel_name, vidlist, vnidlist):
+        asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
+
+        tbl = swsscommon.Table(asic_db, self.ASIC_TUNNEL_MAP_ENTRY)
+
+        expected_attributes_1 = {
+        'SAI_TUNNEL_MAP_ENTRY_ATTR_TUNNEL_MAP_TYPE': 'SAI_TUNNEL_MAP_TYPE_VNI_TO_VLAN_ID',
+        'SAI_TUNNEL_MAP_ENTRY_ATTR_TUNNEL_MAP': self.tunnel_map_map[tunnel_name][0],
+        'SAI_TUNNEL_MAP_ENTRY_ATTR_VLAN_ID_VALUE': vidlist[0],
+        'SAI_TUNNEL_MAP_ENTRY_ATTR_VNI_ID_KEY': vnidlist[0],
+        }
+
+        for x in range(len(vidlist)):
+            expected_attributes_1['SAI_TUNNEL_MAP_ENTRY_ATTR_VLAN_ID_VALUE'] = vidlist[x]
+            expected_attributes_1['SAI_TUNNEL_MAP_ENTRY_ATTR_VNI_ID_KEY'] = vnidlist[x]
+            ret = self.helper.get_key_with_attr(asic_db, self.ASIC_TUNNEL_MAP_ENTRY, expected_attributes_1)
+            assert len(ret) == 0, "SIP TunnelMap entry not removed"
+
     def check_vxlan_sip_tunnel_delete(self, dvs, tunnel_name, sip, ignore_bp = True):
         asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
         app_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
@@ -517,7 +535,8 @@ class VxlanTunnel(object):
             assert status == False, "Tunnel bridgeport entry not deleted"
 
     def check_vxlan_sip_tunnel(self, dvs, tunnel_name, src_ip, vidlist, vnidlist, 
-                               dst_ip = '0.0.0.0', skip_dst_ip = 'True', ignore_bp = True):
+                               dst_ip = '0.0.0.0', skip_dst_ip = 'True', ignore_bp = True,
+                               tunnel_map_entry_count = 3):
         asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
         app_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
 
@@ -527,7 +546,7 @@ class VxlanTunnel(object):
 
         # check that the vxlan tunnel termination are there
         assert self.helper.how_many_entries_exist(asic_db, self.ASIC_TUNNEL_MAP) == (len(self.tunnel_map_ids) + 4), "The TUNNEL_MAP wasn't created"
-        assert self.helper.how_many_entries_exist(asic_db, self.ASIC_TUNNEL_MAP_ENTRY) == (len(self.tunnel_map_entry_ids) + 3), "The TUNNEL_MAP_ENTRY is created"
+        assert self.helper.how_many_entries_exist(asic_db, self.ASIC_TUNNEL_MAP_ENTRY) == (len(self.tunnel_map_entry_ids) + tunnel_map_entry_count), "The TUNNEL_MAP_ENTRY is created"
         assert self.helper.how_many_entries_exist(asic_db, self.ASIC_TUNNEL_TABLE) == (len(self.tunnel_ids) + 1), "The TUNNEL wasn't created"
         assert self.helper.how_many_entries_exist(asic_db, self.ASIC_TUNNEL_TERM_ENTRY) == (len(self.tunnel_term_ids) + 1), "The TUNNEL_TERM_TABLE_ENTRY wasm't created"
 
@@ -798,10 +817,10 @@ class VxlanTunnel(object):
     def check_vxlan_tunnel_vrf_map_entry(self, dvs, tunnel_name, vrf_name, vni_id):
         asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
 
-        tunnel_map_entry_id = self.helper.get_created_entries(asic_db, self.ASIC_TUNNEL_MAP_ENTRY, self.tunnel_map_entry_ids, 3)
+        tunnel_map_entry_id = self.helper.get_created_entries(asic_db, self.ASIC_TUNNEL_MAP_ENTRY, self.tunnel_map_entry_ids, 2)
 
         # check that the vxlan tunnel termination are there
-        assert self.helper.how_many_entries_exist(asic_db, self.ASIC_TUNNEL_MAP_ENTRY) == (len(self.tunnel_map_entry_ids) + 3), "The TUNNEL_MAP_ENTRY is created too early"
+        assert self.helper.how_many_entries_exist(asic_db, self.ASIC_TUNNEL_MAP_ENTRY) == (len(self.tunnel_map_entry_ids) + 2), "The TUNNEL_MAP_ENTRY is created too early"
 
         ret = self.helper.get_key_with_attr(asic_db, self.ASIC_TUNNEL_MAP_ENTRY,
             {

--- a/tests/evpn_tunnel.py
+++ b/tests/evpn_tunnel.py
@@ -488,8 +488,6 @@ class VxlanTunnel(object):
     def check_vxlan_tunnel_map_entry_removed(self, dvs, tunnel_name, vidlist, vnidlist):
         asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
 
-        tbl = swsscommon.Table(asic_db, self.ASIC_TUNNEL_MAP_ENTRY)
-
         expected_attributes_1 = {
         'SAI_TUNNEL_MAP_ENTRY_ATTR_TUNNEL_MAP_TYPE': 'SAI_TUNNEL_MAP_TYPE_VNI_TO_VLAN_ID',
         'SAI_TUNNEL_MAP_ENTRY_ATTR_TUNNEL_MAP': self.tunnel_map_map[tunnel_name][0],

--- a/tests/test_evpn_l3_vxlan.py
+++ b/tests/test_evpn_l3_vxlan.py
@@ -68,10 +68,10 @@ class TestL3Vxlan(object):
         helper.check_object(self.pdb, "VXLAN_VRF_TABLE", "%s:%s" % (tunnel_name, vrf_map_name), exp_attr1)
 
         print ("\tTesting SIP Tunnel Creation")
-        vxlan_obj.check_vxlan_sip_tunnel(dvs, tunnel_name, '6.6.6.6', vlanlist, vnilist)
+        vxlan_obj.check_vxlan_sip_tunnel(dvs, tunnel_name, '6.6.6.6', vlanlist, vnilist, tunnel_map_entry_count = 2)
 
         print ("\tTesting Tunnel Vlan VNI Map Entry")
-        vxlan_obj.check_vxlan_tunnel_map_entry(dvs, tunnel_name, vlanlist, vnilist)
+        vxlan_obj.check_vxlan_tunnel_map_entry_removed(dvs, tunnel_name, vlanlist, vnilist)
 
         print ("\tTesting Tunnel VRF VNI Map Entry")
         vxlan_obj.check_vxlan_tunnel_vrf_map_entry(dvs, tunnel_name, 'Vrf-RED', '1000')
@@ -82,6 +82,7 @@ class TestL3Vxlan(object):
         vxlan_obj.check_vxlan_tunnel_vrf_map_entry_remove(dvs, tunnel_name, 'Vrf-RED', '1000')
 
         print ("\tTesting Tunnel Vlan VNI Map entry removal")
+        vxlan_obj.check_vxlan_tunnel_map_entry(dvs, tunnel_name, vlanlist, vnilist)
         vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
         vxlan_obj.check_vxlan_tunnel_map_entry_delete(dvs, tunnel_name, vlanlist, vnilist)
 
@@ -143,10 +144,10 @@ class TestL3Vxlan(object):
         helper.check_object(self.pdb, "VXLAN_VRF_TABLE", "%s:%s" % (tunnel_name, vrf_map_name), exp_attr1)
 
         print ("\tTesting SIP Tunnel Creation")
-        vxlan_obj.check_vxlan_sip_tunnel(dvs, tunnel_name, '6.6.6.6', vlanlist, vnilist)
+        vxlan_obj.check_vxlan_sip_tunnel(dvs, tunnel_name, '6.6.6.6', vlanlist, vnilist, tunnel_map_entry_count = 2)
 
         print ("\tTesting Tunnel Vlan Map Entry")
-        vxlan_obj.check_vxlan_tunnel_map_entry(dvs, tunnel_name, vlanlist, vnilist)
+        vxlan_obj.check_vxlan_tunnel_map_entry_removed(dvs, tunnel_name, vlanlist, vnilist)
 
         print ("\tTesting Tunnel Vrf Map Entry")
         vxlan_obj.check_vxlan_tunnel_vrf_map_entry(dvs, tunnel_name, 'Vrf-RED', '1000')
@@ -180,6 +181,7 @@ class TestL3Vxlan(object):
         vxlan_obj.check_del_router_interface(dvs, "Vlan100")
 
         print ("\tTesting Tunnel Map entry removal")
+        vxlan_obj.check_vxlan_tunnel_map_entry(dvs, tunnel_name, vlanlist, vnilist)
         vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
         vxlan_obj.check_vxlan_tunnel_map_entry_delete(dvs, tunnel_name, vlanlist, vnilist)
 
@@ -242,10 +244,10 @@ class TestL3Vxlan(object):
         helper.check_object(self.pdb, "VXLAN_VRF_TABLE", "%s:%s" % (tunnel_name, vrf_map_name), exp_attr1)
 
         print ("\tTesting SIP Tunnel Creation")
-        vxlan_obj.check_vxlan_sip_tunnel(dvs, tunnel_name, '6.6.6.6', vlanlist, vnilist)
+        vxlan_obj.check_vxlan_sip_tunnel(dvs, tunnel_name, '6.6.6.6', vlanlist, vnilist, tunnel_map_entry_count = 2)
 
         print ("\tTesting Tunnel Vlan Map Entry")
-        vxlan_obj.check_vxlan_tunnel_map_entry(dvs, tunnel_name, vlanlist, vnilist)
+        vxlan_obj.check_vxlan_tunnel_map_entry_removed(dvs, tunnel_name, vlanlist, vnilist)
 
         print ("\tTesting Tunnel Vrf Map Entry")
         vxlan_obj.check_vxlan_tunnel_vrf_map_entry(dvs, tunnel_name, 'Vrf-RED', '1000')
@@ -386,6 +388,7 @@ class TestL3Vxlan(object):
         vxlan_obj.check_del_router_interface(dvs, "Vlan100")
 
         print ("\tTesting Tunnel Map entry removal")
+        vxlan_obj.check_vxlan_tunnel_map_entry(dvs, tunnel_name, vlanlist, vnilist)
         vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
         vxlan_obj.check_vxlan_tunnel_map_entry_delete(dvs, tunnel_name, vlanlist, vnilist)
 
@@ -449,10 +452,10 @@ class TestL3Vxlan(object):
         helper.check_object(self.pdb, "VXLAN_VRF_TABLE", "%s:%s" % (tunnel_name, vrf_map_name), exp_attr1)
 
         print ("\tTesting SIP Tunnel Creation")
-        vxlan_obj.check_vxlan_sip_tunnel(dvs, tunnel_name, '6.6.6.6', vlanlist, vnilist)
+        vxlan_obj.check_vxlan_sip_tunnel(dvs, tunnel_name, '6.6.6.6', vlanlist, vnilist, tunnel_map_entry_count = 2)
 
         print ("\tTesting Tunnel Vlan Map Entry")
-        vxlan_obj.check_vxlan_tunnel_map_entry(dvs, tunnel_name, vlanlist, vnilist)
+        vxlan_obj.check_vxlan_tunnel_map_entry_removed(dvs, tunnel_name, vlanlist, vnilist)
 
         print ("\tTesting Tunnel Vrf Map Entry")
         vxlan_obj.check_vxlan_tunnel_vrf_map_entry(dvs, tunnel_name, 'Vrf-RED', '1000')
@@ -594,6 +597,7 @@ class TestL3Vxlan(object):
         vxlan_obj.check_del_router_interface(dvs, "Vlan100")
 
         print ("\tTesting Tunnel Map entry removal")
+        vxlan_obj.check_vxlan_tunnel_map_entry(dvs, tunnel_name, vlanlist, vnilist)
         vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
         vxlan_obj.check_vxlan_tunnel_map_entry_delete(dvs, tunnel_name, vlanlist, vnilist)
 

--- a/tests/test_evpn_l3_vxlan_p2mp.py
+++ b/tests/test_evpn_l3_vxlan_p2mp.py
@@ -67,10 +67,10 @@ class TestL3VxlanP2MP(object):
         helper.check_object(self.pdb, "VXLAN_VRF_TABLE", "%s:%s" % (tunnel_name, vrf_map_name), exp_attr1)
 
         print ("\tTesting SIP Tunnel Creation")
-        vxlan_obj.check_vxlan_sip_tunnel(dvs, tunnel_name, '6.6.6.6', vlanlist, vnilist, ignore_bp=False)
+        vxlan_obj.check_vxlan_sip_tunnel(dvs, tunnel_name, '6.6.6.6', vlanlist, vnilist, ignore_bp=False, tunnel_map_entry_count=2)
 
         print ("\tTesting Tunnel Vlan VNI Map Entry")
-        vxlan_obj.check_vxlan_tunnel_map_entry(dvs, tunnel_name, vlanlist, vnilist)
+        vxlan_obj.check_vxlan_tunnel_map_entry_removed(dvs, tunnel_name, vlanlist, vnilist)
 
         print ("\tTesting Tunnel VRF VNI Map Entry")
         vxlan_obj.check_vxlan_tunnel_vrf_map_entry(dvs, tunnel_name, 'Vrf-RED', '1000')
@@ -81,6 +81,7 @@ class TestL3VxlanP2MP(object):
         vxlan_obj.check_vxlan_tunnel_vrf_map_entry_remove(dvs, tunnel_name, 'Vrf-RED', '1000')
 
         print ("\tTesting Tunnel Vlan VNI Map entry removal")
+        vxlan_obj.check_vxlan_tunnel_map_entry(dvs, tunnel_name, vlanlist, vnilist)
         vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
         vxlan_obj.check_vxlan_tunnel_map_entry_delete(dvs, tunnel_name, vlanlist, vnilist)
 
@@ -141,10 +142,10 @@ class TestL3VxlanP2MP(object):
         helper.check_object(self.pdb, "VXLAN_VRF_TABLE", "%s:%s" % (tunnel_name, vrf_map_name), exp_attr1)
 
         print ("\tTesting SIP Tunnel Creation")
-        vxlan_obj.check_vxlan_sip_tunnel(dvs, tunnel_name, '6.6.6.6', vlanlist, vnilist, ignore_bp=False)
+        vxlan_obj.check_vxlan_sip_tunnel(dvs, tunnel_name, '6.6.6.6', vlanlist, vnilist, ignore_bp=False, tunnel_map_entry_count=2)
 
         print ("\tTesting Tunnel Vlan Map Entry")
-        vxlan_obj.check_vxlan_tunnel_map_entry(dvs, tunnel_name, vlanlist, vnilist)
+        vxlan_obj.check_vxlan_tunnel_map_entry_removed(dvs, tunnel_name, vlanlist, vnilist)
 
         print ("\tTesting Tunnel Vrf Map Entry")
         vxlan_obj.check_vxlan_tunnel_vrf_map_entry(dvs, tunnel_name, 'Vrf-RED', '1000')
@@ -172,6 +173,7 @@ class TestL3VxlanP2MP(object):
         vxlan_obj.check_del_router_interface(dvs, "Vlan100")
 
         print ("\tTesting Tunnel Map entry removal")
+        vxlan_obj.check_vxlan_tunnel_map_entry(dvs, tunnel_name, vlanlist, vnilist)
         vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
         vxlan_obj.check_vxlan_tunnel_map_entry_delete(dvs, tunnel_name, vlanlist, vnilist)
 
@@ -233,10 +235,10 @@ class TestL3VxlanP2MP(object):
         helper.check_object(self.pdb, "VXLAN_VRF_TABLE", "%s:%s" % (tunnel_name, vrf_map_name), exp_attr1)
 
         print ("\tTesting SIP Tunnel Creation")
-        vxlan_obj.check_vxlan_sip_tunnel(dvs, tunnel_name, '6.6.6.6', vlanlist, vnilist, ignore_bp=False)
+        vxlan_obj.check_vxlan_sip_tunnel(dvs, tunnel_name, '6.6.6.6', vlanlist, vnilist, ignore_bp=False, tunnel_map_entry_count=2)
 
         print ("\tTesting Tunnel Vlan Map Entry")
-        vxlan_obj.check_vxlan_tunnel_map_entry(dvs, tunnel_name, vlanlist, vnilist)
+        vxlan_obj.check_vxlan_tunnel_map_entry_removed(dvs, tunnel_name, vlanlist, vnilist)
 
         print ("\tTesting Tunnel Vrf Map Entry")
         vxlan_obj.check_vxlan_tunnel_vrf_map_entry(dvs, tunnel_name, 'Vrf-RED', '1000')
@@ -373,6 +375,7 @@ class TestL3VxlanP2MP(object):
         vxlan_obj.check_del_router_interface(dvs, "Vlan100")
 
         print ("\tTesting Tunnel Map entry removal")
+        vxlan_obj.check_vxlan_tunnel_map_entry(dvs, tunnel_name, vlanlist, vnilist)
         vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
         vxlan_obj.check_vxlan_tunnel_map_entry_delete(dvs, tunnel_name, vlanlist, vnilist)
 
@@ -436,10 +439,10 @@ class TestL3VxlanP2MP(object):
         helper.check_object(self.pdb, "VXLAN_VRF_TABLE", "%s:%s" % (tunnel_name, vrf_map_name), exp_attr1)
 
         print ("\tTesting SIP Tunnel Creation")
-        vxlan_obj.check_vxlan_sip_tunnel(dvs, tunnel_name, '6.6.6.6', vlanlist, vnilist, ignore_bp=False)
+        vxlan_obj.check_vxlan_sip_tunnel(dvs, tunnel_name, '6.6.6.6', vlanlist, vnilist, ignore_bp=False, tunnel_map_entry_count=2)
 
         print ("\tTesting Tunnel Vlan Map Entry")
-        vxlan_obj.check_vxlan_tunnel_map_entry(dvs, tunnel_name, vlanlist, vnilist)
+        vxlan_obj.check_vxlan_tunnel_map_entry_removed(dvs, tunnel_name, vlanlist, vnilist)
 
         print ("\tTesting Tunnel Vrf Map Entry")
         vxlan_obj.check_vxlan_tunnel_vrf_map_entry(dvs, tunnel_name, 'Vrf-RED', '1000')
@@ -577,6 +580,7 @@ class TestL3VxlanP2MP(object):
         vxlan_obj.check_del_router_interface(dvs, "Vlan100")
 
         print ("\tTesting Tunnel Map entry removal")
+        vxlan_obj.check_vxlan_tunnel_map_entry(dvs, tunnel_name, vlanlist, vnilist)
         vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
         vxlan_obj.check_vxlan_tunnel_map_entry_delete(dvs, tunnel_name, vlanlist, vnilist)
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Updated handling of VRF_VNI mapping and VLAN_VNI mapping for same VNI ID

**Why I did it**
When a VNI (L3 VNI) is mapped to VRF,  corresponding VNI (L2 VNI) to Vlan mapping is not required.
Updated VxLAN Orchagent code to remove Vlan-VNI mapping entry when VRF is mapped to same VNI.
Also Re-add Vlan-VNI mapping entry when VRF-VNI mapping for same VNI is removed.

**How I verified it**

**Details if related**
