### PR TITLE
Fix `test_vlan.py`

### DIFF
--- a/tests/dvslib/dvs_vlan.py
+++ b/tests/dvslib/dvs_vlan.py
@@ -72,7 +72,7 @@ class DVSVlan(object):
                                 polling_config=PollingConfig()):
         vlan_entries = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_VLAN",
                                                     expected_num + 1,
-                                                    polling_config)
+                                                    polling_config=polling_config)
 
         return [v for v in vlan_entries if v != self.asic_db.default_vlan_id]
 
@@ -110,6 +110,6 @@ class DVSVlan(object):
     def get_and_verify_vlan_hostif_ids(self, expected_num, polling_config=PollingConfig()):
         hostif_entries = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF",
                                                       expected_num + 1,
-                                                      polling_config)
+                                                      polling_config=polling_config)
         return hostif_entries
 


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
The signature of `wait_for_n_keys` is:
```
def wait_for_n_keys(
    self,
    table_name,
    num_keys,
    wait_at_least_n_keys,
    polling_config = PollingConfig(),
    failure_message = None,
):
```
In the following methods:
`DVSVlan.get_and_verify_vlan_ids`
`DVSVlan.get_and_verify_vlan_hostif_ids`

They pass `polling_config` as the third argument, stored in the parameter `wait_at_least_n_keys` and always evaluated to `True`. This will cause trouble in the vlan or vlan interface removal, `wait_for_n_keys` will always return early as there are always more than expected keys existing in the table. So when next testcase starts, those keys might still exist in the table and fail the next testcase.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

**Why I did it**
Stabilize `test_vlan.py`

**How I verified it**

**Details if related**
