### PR TITLE
sonic-swss: Fix orchagent crash in generateQueueMapPerPort.

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -6123,7 +6123,9 @@ void PortsOrch::generateQueueMapPerPort(const Port& port, FlexCounterQueueStates
         uint8_t queueRealIndex = 0;
         if (getQueueTypeAndIndex(queue_ids[queueIndex], queueType, queueRealIndex))
         {
-            if (!queuesState.isQueueCounterEnabled(queueRealIndex))
+	    /* voq counters are always enabled. There is no mechanism to disable voq
+	     * counters in a voq system. */
+            if (!voq && !queuesState.isQueueCounterEnabled(queueRealIndex))
             {
                 continue;
             }


### PR DESCRIPTION
* generateQueueMap uses m_portList[port].m_queue_ids.size to allocate m_queueStates in FlexCounterQueueStates. But m_portList[port].m_queue_ids.size is zero for system ports which results in isQueueCounterEnabled crash for system ports. Since we do not have support disable voq counters yet, do not check isQueueCounterEnabled for voqs.

**What I did**

Fix orchagent crash in voq systems with the following backtrace.

gdb) bt
#0  0x000055cbe38f7d2d in std::_Bit_reference::operator bool (this=<optimized out>) at /usr/include/c++/10/bits/stl_bvector.h:87               
#1  std::_Bit_const_iterator::operator* (this=<optimized out>) at /usr/include/c++/10/bits/stl_bvector.h:348
#2  std::vector<bool, std::allocator<bool> >::operator[] (__n=0, this=0x55cbe53688f0) at /usr/include/c++/10/bits/stl_bvector.h:918            
#3  FlexCounterQueueStates::isQueueCounterEnabled (this=this@entry=0x55cbe53688f0, index=0) at flexcounterorch.cpp:422
#4  0x000055cbe37692ad in PortsOrch::generateQueueMapPerPort (this=0x55cbe5081360, port=..., queuesState=..., voq=true) at portsorch.cpp:6093
#5  0x000055cbe3769c9a in PortsOrch::generateQueueMap (this=this@entry=0x55cbe5081360, queuesStateVector=std::map with 39 elements = {...}) at portsorch.cpp:6048
#6  0x000055cbe38fb2c8 in FlexCounterOrch::doTask (this=0x55cbe50e9a30, consumer=...) at flexcounterorch.cpp:163                               
#7  0x000055cbe36dd66e in Consumer::drain (this=0x55cbe51bbe40) at orch.cpp:241                                                                
#8  Consumer::drain (this=0x55cbe51bbe40) at orch.cpp:238                                                                                      
#9  Consumer::execute (this=0x55cbe51bbe40) at orch.cpp:235                                                                                    
#10 0x000055cbe36ccc99 in OrchDaemon::start (this=this@entry=0x55cbe505f6b0) at orchdaemon.cpp:757                                             
#11 0x000055cbe3654990 in main (argc=<optimized out>, argv=<optimized out>) at main.cpp:735         

**Why I did it**

Fix orchagent crash in voq system

**How I verified it**

Verified that voq system boots up fine without any crash.
