### PR TITLE
Avoid printing to syslog in case port status is not changed

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -6618,13 +6618,13 @@ void PortsOrch::doTask(NotificationConsumer &consumer)
 
 void PortsOrch::updatePortOperStatus(Port &port, sai_port_oper_status_t status)
 {
-    SWSS_LOG_NOTICE("Port %s oper state set from %s to %s",
-            port.m_alias.c_str(), oper_status_strings.at(port.m_oper_status).c_str(),
-            oper_status_strings.at(status).c_str());
     if (status == port.m_oper_status)
     {
         return;
     }
+    SWSS_LOG_NOTICE("Port %s oper state set from %s to %s",
+            port.m_alias.c_str(), oper_status_strings.at(port.m_oper_status).c_str(),
+            oper_status_strings.at(status).c_str());
 
     if (port.m_type == Port::PHY)
     {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Print port status change to syslog only after checking that new status differs from current status.

**Why I did it**
Printing of messages of port being changed from up to up (while actually port status is not being changed) cause log analyzer to fail on fast-reboot test.
According to sonic-mgmt tests/platform_tests/reboot_timing_constants.py

**How I verified it**
Fast-reboot community test.

**Details if related**
