### PR TITLE
Add missing parameter to on_switch_shutdown_request method.

### DIFF
--- a/orchagent/notifications.cpp
+++ b/orchagent/notifications.cpp
@@ -23,7 +23,7 @@ void on_bfd_session_state_change(uint32_t count, sai_bfd_session_state_notificat
     // which causes concurrency access to the DB
 }
 
-void on_switch_shutdown_request()
+void on_switch_shutdown_request(sai_object_id_t switch_id)
 {
     SWSS_LOG_ENTER();
 

--- a/orchagent/notifications.cpp
+++ b/orchagent/notifications.cpp
@@ -30,5 +30,5 @@ void on_switch_shutdown_request()
     /* TODO: Later a better restart story will be told here */
     SWSS_LOG_ERROR("Syncd stopped");
 
-    exit(EXIT_FAILURE);
+    _exit(EXIT_FAILURE);
 }

--- a/orchagent/notifications.cpp
+++ b/orchagent/notifications.cpp
@@ -2,6 +2,7 @@ extern "C" {
 #include "sai.h"
 }
 
+#include <unistd.h>
 #include "logger.h"
 #include "notifications.h"
 

--- a/orchagent/notifications.cpp
+++ b/orchagent/notifications.cpp
@@ -2,7 +2,6 @@ extern "C" {
 #include "sai.h"
 }
 
-#include <unistd.h>
 #include "logger.h"
 #include "notifications.h"
 
@@ -31,5 +30,5 @@ void on_switch_shutdown_request(sai_object_id_t switch_id)
     /* TODO: Later a better restart story will be told here */
     SWSS_LOG_ERROR("Syncd stopped");
 
-    _exit(EXIT_FAILURE);
+    exit(EXIT_FAILURE);
 }

--- a/orchagent/notifications.h
+++ b/orchagent/notifications.h
@@ -7,4 +7,4 @@ extern "C" {
 void on_fdb_event(uint32_t count, sai_fdb_event_notification_data_t *data);
 void on_port_state_change(uint32_t count, sai_port_oper_status_notification_t *data);
 void on_bfd_session_state_change(uint32_t count, sai_bfd_session_state_notification_t *data);
-void on_switch_shutdown_request();
+void on_switch_shutdown_request(sai_object_id_t switch_id);

--- a/orchagent/notifications.h
+++ b/orchagent/notifications.h
@@ -7,4 +7,7 @@ extern "C" {
 void on_fdb_event(uint32_t count, sai_fdb_event_notification_data_t *data);
 void on_port_state_change(uint32_t count, sai_port_oper_status_notification_t *data);
 void on_bfd_session_state_change(uint32_t count, sai_bfd_session_state_notification_t *data);
+
+// The function prototype information can be found here:
+//      https://github.com/sonic-net/sonic-sairedis/blob/master/meta/NotificationSwitchShutdownRequest.cpp#L49
 void on_switch_shutdown_request(sai_object_id_t switch_id);


### PR DESCRIPTION
#### Why I did it
The switch_id parameter missing in on_switch_shutdown_request() method.

#### How I did it
Add missing parameter to on_switch_shutdown_request method.

#### How to verify it
Pass all UT and E2E test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Add ZMQ based ProducerStateTable and CustomerStateTable.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

