### PR TITLE
Fixed set mtu for deleted subintf due to late notification

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -447,9 +447,19 @@ std::string IntfMgr::setHostSubIntfMtu(const string &alias, const string &mtu, c
     }
     SWSS_LOG_INFO("subintf %s active mtu: %s", alias.c_str(), subifMtu.c_str());
     cmd << IP_CMD " link set " << shellquote(alias) << " mtu " << shellquote(subifMtu);
-    EXEC_WITH_ERROR_THROW(cmd.str(), res);
+    std::string cmd_str = cmd.str();
+    int ret = swss::exec(cmd_str, res);
 
-    return subifMtu;
+    if (ret && !isIntfStateOk(alias))
+    {
+        // Can happen when a DEL notification is sent by portmgrd immediately followed by a new SET notif
+        SWSS_LOG_WARN("Setting mtu to alias:%s netdev failed with cmd:%s, rc:%d, error:%s", alias.c_str(), cmd_str.c_str(), ret, res.c_str());
+    }
+    else if(ret)
+    {
+        throw runtime_error(cmd_str + " : " + res);
+    }
+        return subifMtu;
 }
 
 void IntfMgr::updateSubIntfAdminStatus(const string &alias, const string &admin)
@@ -468,7 +478,7 @@ void IntfMgr::updateSubIntfAdminStatus(const string &alias, const string &admin)
                 continue;
             }
             std::vector<FieldValueTuple> fvVector;
-            string subintf_admin = setHostSubIntfAdminStatus(intf, m_subIntfList[intf].adminStatus, admin); 
+            string subintf_admin = setHostSubIntfAdminStatus(intf, m_subIntfList[intf].adminStatus, admin);
             m_subIntfList[intf].currAdminStatus = subintf_admin;
             FieldValueTuple fvTuple("admin_status", subintf_admin);
             fvVector.push_back(fvTuple);

--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -456,11 +456,11 @@ std::string IntfMgr::setHostSubIntfMtu(const string &alias, const string &mtu, c
         // followed by a new DEL notification that send by portmgrd
         SWSS_LOG_WARN("Setting mtu to %s netdev failed with cmd:%s, rc:%d, error:%s", alias.c_str(), cmd_str.c_str(), ret, res.c_str());
     }
-    else if(ret)
+    else if (ret)
     {
         throw runtime_error(cmd_str + " : " + res);
     }
-        return subifMtu;
+    return subifMtu;
 }
 
 void IntfMgr::updateSubIntfAdminStatus(const string &alias, const string &admin)

--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -452,8 +452,9 @@ std::string IntfMgr::setHostSubIntfMtu(const string &alias, const string &mtu, c
 
     if (ret && !isIntfStateOk(alias))
     {
-        // Can happen when a DEL notification is sent by portmgrd immediately followed by a new SET notif
-        SWSS_LOG_WARN("Setting mtu to alias:%s netdev failed with cmd:%s, rc:%d, error:%s", alias.c_str(), cmd_str.c_str(), ret, res.c_str());
+        // Can happen when a SET notification on the PORT_TABLE in the State DB
+        // followed by a new DEL notification that send by portmgrd
+        SWSS_LOG_WARN("Setting mtu to %s netdev failed with cmd:%s, rc:%d, error:%s", alias.c_str(), cmd_str.c_str(), ret, res.c_str());
     }
     else if(ret)
     {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Ignores errors on the set MTU command for subinterface when the subinterface state is not OK.

**Why I did it**

A race condition between the portmgrd and the intfmgrd sometimes causes running a set MTU command on a deleted subinterface.
The logs and the error:
```
INFO swss#supervisord: intfmgrd Cannot find device "Ethernet32.58"
ERR swss#intfmgrd: :- main: Runtime error: /sbin/ip link set "Ethernet32.58" mtu "9100" :
INFO swss#supervisord 2022-11-08 05:53:33,057 INFO exited: intfmgrd (exit status 255; not expected)
```

**How I verified it**

Run the test_loopback_action_reload test and saw no errors in the logs.

**Details if related**


