### PR TITLE
[AclOrch] Dereg ACL Counters during ACL_TABLE Del Op

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -2525,6 +2525,12 @@ bool AclTable::clear()
     for (auto& rulepair: rules)
     {
         auto& rule = *rulepair.second;
+
+        if (rule.hasCounter())
+        {
+            m_pAclOrch->deregisterFlexCounter(rule);
+        }
+
         bool suc = rule.remove();
         if (!suc)
         {


### PR DESCRIPTION
Signed-off-by: Vivek Reddy Karri <vkarri@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Deleting ACL Tables deletes all the associated Rules but it doesn't delete the associated counters.

**Why I did it**

```
{
    "ACL_TABLE_TYPE": {
        "CUSTOM_L3": {
            "MATCHES": [
                "IN_PORTS",
                "OUT_PORTS",
                "SRC_IP"
            ],
            "ACTIONS": [
                "PACKET_ACTION",
                "MIRROR_INGRESS_ACTION",
                "COUNTER"
            ],
            "BIND_POINTS": [
                "PORT"
            ]
        }
    },
    "ACL_RULE": {
        "DATAACL|RULE0": {
            "PRIORITY": "999",
            "PACKET_ACTION": "DROP",
            "SRC_IP": "1.1.1.1/32"
        }
    }
}
```
config acl add table DATAACL CUSTOM_L3 --description="DATAACL table" --stage=ingress

**Delete the ACL Table:** sudo config acl remove table DATAACL

Flex Counter Object is not removed
```
Dec 16 02:21:04.343646 r-leopard-32 ERR syncd#SDK: [SAI_ACL.ERR] mlnx_sai_acl.c[14363]- mlnx_acl_counter_get:  Failure to get counter in SDK - Entry Not Found
Dec 16 02:21:04.343646 r-leopard-32 ERR syncd#SDK: [SAI_UTILS.ERR] mlnx_sai_utils.c[1937]- get_dispatch_attribs_handler: Failed getting attrib SAI_ACL_COUNTER_ATTR_BYTES
Dec 16 02:21:04.343706 r-leopard-32 ERR syncd#SDK: [SAI_UTILS.ERR] mlnx_sai_utils.c[2074]- sai_get_attributes: Failed attribs dispatch
Dec 16 02:21:04.343706 r-leopard-32 WARNING syncd#SDK: :- collectAclCounterAttrs: Failed to get attr of ACL counter oid:0x90000000007ab: SAI_STATUS_ITEM_NOT_FOUND
```
```
root@r-leopard-32:/home/admin# redis-cli -n 2 hgetall "ACL_COUNTER_RULE_MAP"
1) "DATAACL:RULE0"
2) "oid:0x90000000007ab"
```

**How I verified it**

Applied the same config and verified if the Counter objects are deleted from the APPL_DB.

**Details if related**
