### PR TITLE
Update FDB state table when , MAC entries are modified as dynamic_local.

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -1462,6 +1462,11 @@ bool FdbOrch::addFdbEntry(const FdbEntry& entry, const string& port_name,
     {
         //If the MAC is dynamic_local change the origin accordingly
         //MAC is added/updated as dynamic to allow aging.
+        SWSS_LOG_INFO("MAC-Update Modify to dynamic FDB %s in %s on from-%s:to-%s from-%s:to-%s origin-%d-to-%d",
+                entry.mac.to_string().c_str(), vlan.m_alias.c_str(), oldPort.m_alias.c_str(),
+                port_name.c_str(), oldType.c_str(), fdbData.type.c_str(),
+                oldOrigin, fdbData.origin);
+
         storeFdbData.origin = FDB_ORIGIN_LEARN;
         storeFdbData.type = "dynamic";
     }
@@ -1470,8 +1475,10 @@ bool FdbOrch::addFdbEntry(const FdbEntry& entry, const string& port_name,
 
     string key = "Vlan" + to_string(vlan.m_vlan_info.vlan_id) + ":" + entry.mac.to_string();
 
-    if ((fdbData.origin != FDB_ORIGIN_MCLAG_ADVERTIZED) &&
-            (fdbData.origin != FDB_ORIGIN_VXLAN_ADVERTIZED))
+    if (((fdbData.origin != FDB_ORIGIN_MCLAG_ADVERTIZED) &&
+         (fdbData.origin != FDB_ORIGIN_VXLAN_ADVERTIZED)) ||
+        ((fdbData.origin == FDB_ORIGIN_MCLAG_ADVERTIZED) &&
+          (fdbData.type == "dynamic_local")))
     {
         /* State-DB is updated only for Local Mac addresses */
         // Write to StateDb

--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -1464,7 +1464,7 @@ bool FdbOrch::addFdbEntry(const FdbEntry& entry, const string& port_name,
         //MAC is added/updated as dynamic to allow aging.
         SWSS_LOG_INFO("MAC-Update Modify to dynamic FDB %s in %s on from-%s:to-%s from-%s:to-%s origin-%d-to-%d",
                 entry.mac.to_string().c_str(), vlan.m_alias.c_str(), oldPort.m_alias.c_str(),
-                port_name.c_str(), oldType.c_str(), fdbData.type.c_str(),
+                port_name.c_str(), oldType.c_str(), fdbData.type.c_str(), 
                 oldOrigin, fdbData.origin);
 
         storeFdbData.origin = FDB_ORIGIN_LEARN;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

#### What I did 
When the FDB entry is updated as dynamic_local, then the FDB entry is updated in the FDB state table.

#### Why I did it
When the MCLAG synced FDB entries are modified as dynamic_local, then such entries are NOT updated in the FDB state table.
due to this, when these FDB entries are aged out, then the MCLAG module is not initimated about the MAC ageing, hence
there is no way the peer MCLAG node could flush these. it will remain as stale entries in the peer node.



#### How to verify it
Let both the MCLAG peers(A & B) both have locally learnt as well as synced in FDB entries.
when the MCLAG interface at node A is going down, then the synced in FDB entries in node B will be modified as dynamic_local.
when these entries are aged out at node B, then its flushed in node A as well.

without the fix, the FDB entries will remain stale at node A.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [X] 202205
