### PR TITLE
[vnetorch] fix keep old VxLAN endpoints after the same endpoints were repeatedly submitted

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1014,7 +1014,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         {
             // In case of updating an existing route, decrease the reference count for the previous nexthop group
             NextHopGroupKey nhg = it_route->second;
-            if(--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
+            if((syncd_nexthop_groups_[vnet][nhg].ref_count - 1) == 0)
             {
                 if (nhg.getSize() > 1)
                 {
@@ -1022,10 +1022,11 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                 }
                 else
                 {
-                    syncd_nexthop_groups_[vnet].erase(nhg);
                     NextHopKey nexthop(nhg.to_string(), true);
                     vrf_obj->removeTunnelNextHop(nexthop);
+                    syncd_nexthop_groups_[vnet].erase(nhg);
                 }
+                --syncd_nexthop_groups_[vnet][nhg].ref_count;
                 delEndpointMonitor(vnet, nhg);
             }
             else

--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -595,10 +595,8 @@ bool VxlanTunnel::removeNextHop(IpAddress& ipAddr, MacAddress macAddress, uint32
                     ipAddr.to_string().c_str(), macAddress.to_string().c_str(), vni,
                     nh_tunnels_[key].ref_count);
 
-    //Decrement ref count if already exists
-    nh_tunnels_[key].ref_count --;
 
-    if (!nh_tunnels_[key].ref_count)
+    if (!(nh_tunnels_[key].ref_count - 1))
     {
         if (sai_next_hop_api->remove_next_hop(nh_tunnels_[key].nh_id) != SAI_STATUS_SUCCESS)
         {
@@ -608,6 +606,8 @@ bool VxlanTunnel::removeNextHop(IpAddress& ipAddr, MacAddress macAddress, uint32
             throw std::runtime_error(err_msg);
         }
 
+        //Decrement ref count if already exists
+        nh_tunnels_[key].ref_count--;
         nh_tunnels_.erase(key);
     }
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add a case of updating an existing route, if the route exists and tries to set the same nexthop
**Why I did it**
orchagent does not call to remove a previous nexthop and try to create exist route if before twice set endpoint for this route and then change endpoint ip and set it again.

**How I verified it**

**Details if related**
