### PR TITLE
Fix neighbor doesn't update all attribute

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -912,15 +912,18 @@ bool NeighOrch::addNeighbor(const NeighborEntry &neighborEntry, const MacAddress
     }
     else if (isHwConfigured(neighborEntry))
     {
-        status = sai_neighbor_api->set_neighbor_entry_attribute(&neighbor_entry, &neighbor_attr);
-        if (status != SAI_STATUS_SUCCESS)
+        for(auto itr : neighbor_attrs)
         {
-            SWSS_LOG_ERROR("Failed to update neighbor %s on %s, rv:%d",
-                           macAddress.to_string().c_str(), alias.c_str(), status);
-            task_process_status handle_status = handleSaiSetStatus(SAI_API_NEIGHBOR, status);
-            if (handle_status != task_success)
+            status = sai_neighbor_api->set_neighbor_entry_attribute(&neighbor_entry, &itr);
+            if (status != SAI_STATUS_SUCCESS)
             {
-                return parseHandleSaiStatusFailure(handle_status);
+                SWSS_LOG_ERROR("Failed to update neighbor %s on %s, rv:%d",
+                               macAddress.to_string().c_str(), alias.c_str(), status);
+                task_process_status handle_status = handleSaiSetStatus(SAI_API_NEIGHBOR, status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
         }
         SWSS_LOG_NOTICE("Updated neighbor %s on %s", macAddress.to_string().c_str(), alias.c_str());


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix neighbor doesn't update all attribute
**Why I did it**
 ipv4 link local neighbor doesn't trigger update mac when kernel change mac
 command
 ~~~
root@as9726-32d-1:/home/admin# ip neigh add 169.254.0.222 dev PortChannel102 lladdr 52:54:00:3d:4b:22
root@as9726-32d-1:/home/admin# ip neigh replace 169.254.0.222 dev PortChannel102 lladdr 52:54:00:3d:4b:88
~~~
sairedis log
~~~
2022-12-19.16:10:46.302551|r|SAI_OBJECT_TYPE_NEIGHBOR_ENTRY:{"ip":"20.20.20.20","rif":"oid:0x600000000058d","switch_id":"oid:0x21000000000000"}
2022-12-19.16:16:40.083417|c|SAI_OBJECT_TYPE_NEIGHBOR_ENTRY:{"ip":"169.254.0.222","rif":"oid:0x600000000058d","switch_id":"oid:0x21000000000000"}|SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS=52:54:00:3D:4B:22|SAI_NEIGHBOR_ENTRY_ATTR_NO_HOST_ROUTE=true
2022-12-19.16:16:40.086088|c|SAI_OBJECT_TYPE_NEXT_HOP:oid:0x4000000000620|SAI_NEXT_HOP_ATTR_TYPE=SAI_NEXT_HOP_TYPE_IP|SAI_NEXT_HOP_ATTR_IP=169.254.0.222|SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID=oid:0x600000000058d
2022-12-19.16:17:05.746970|s|SAI_OBJECT_TYPE_NEIGHBOR_ENTRY:{"ip":"169.254.0.222","rif":"oid:0x600000000058d","switch_id":"oid:0x21000000000000"}|SAI_NEIGHBOR_ENTRY_ATTR_NO_HOST_ROUTE=true
~~~
**How I verified it**
create a ipv4 link local neighbor and change the neighbor mac
check sairedis did set mac
~~~
root@as9726-32d-1:/home/admin# ip neigh add 169.254.0.222 dev PortChannel102 lladdr 52:54:00:3d:4b:22
root@as9726-32d-1:/home/admin# ip neigh replace 169.254.0.222 dev PortChannel102 lladdr 52:54:00:3d:4b:88
~~~
sairedis log
~~~
2022-12-19.16:22:32.009143|c|SAI_OBJECT_TYPE_NEIGHBOR_ENTRY:{"ip":"169.254.0.222","rif":"oid:0x6000000000589","switch_id":"oid:0x21000000000000"}|SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS=52:54:00:3D:4B:22|SAI_NEIGHBOR_ENTRY_ATTR_NO_HOST_ROUTE=true
2022-12-19.16:22:32.011333|c|SAI_OBJECT_TYPE_NEXT_HOP:oid:0x4000000000626|SAI_NEXT_HOP_ATTR_TYPE=SAI_NEXT_HOP_TYPE_IP|SAI_NEXT_HOP_ATTR_IP=169.254.0.222|SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID=oid:0x6000000000589
2022-12-19.16:22:45.413179|s|SAI_OBJECT_TYPE_NEIGHBOR_ENTRY:{"ip":"169.254.0.222","rif":"oid:0x6000000000589","switch_id":"oid:0x21000000000000"}|SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS=52:54:00:3D:4B:88
2022-12-19.16:22:45.415482|s|SAI_OBJECT_TYPE_NEIGHBOR_ENTRY:{"ip":"169.254.0.222","rif":"oid:0x6000000000589","switch_id":"oid:0x21000000000000"}|SAI_NEIGHBOR_ENTRY_ATTR_NO_HOST_ROUTE=true
~~~
**Details if related**
