### PR TITLE
[vstest] Only collect stdout of orchagent_restart_check in vstest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -600,7 +600,7 @@ class DockerVirtualSwitch:
         self.ctn_restart()
         self.check_ready_status_and_init_db()
 
-    def runcmd(self, cmd: str) -> Tuple[int, str]:
+    def runcmd(self, cmd: str, include_stderr=True) -> Tuple[int, str]:
         res = self.ctn.exec_run(cmd)
         exitcode = res.exit_code
         out = res.output.decode("utf-8")

--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -229,7 +229,7 @@ class TestFdb(object):
         dvs.warm_restart_swss("true")
 
         # freeze orchagent for warm restart
-        (exitcode, result) = dvs.runcmd("/usr/bin/orchagent_restart_check")
+        (exitcode, result) = dvs.runcmd("/usr/bin/orchagent_restart_check", include_stderr=False)
         assert result == "RESTARTCHECK succeeded\n"
         time.sleep(2)
 

--- a/tests/test_port_an.py
+++ b/tests/test_port_an.py
@@ -258,7 +258,7 @@ class TestPortAutoNeg(object):
         dvs.warm_restart_swss("true")
 
         # freeze orchagent for warm restart
-        (exitcode, result) = dvs.runcmd("/usr/bin/orchagent_restart_check")
+        (exitcode, result) = dvs.runcmd("/usr/bin/orchagent_restart_check", include_stderr=False)
         assert result == "RESTARTCHECK succeeded\n"
         time.sleep(2)
 

--- a/tests/test_port_lt.py
+++ b/tests/test_port_lt.py
@@ -103,7 +103,7 @@ class TestPortLinkTraining(object):
         assert exitcode == 0
 
         # freeze orchagent for warm restart
-        (exitcode, result) = dvs.runcmd("/usr/bin/orchagent_restart_check")
+        (exitcode, result) = dvs.runcmd("/usr/bin/orchagent_restart_check", include_stderr=False)
         assert result == "RESTARTCHECK succeeded\n"
         time.sleep(2)
 

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -891,23 +891,23 @@ class TestWarmReboot(object):
 
         time.sleep(1)
         # Should fail, since neighbor for next 20.0.0.1 has not been not resolved yet
-        (exitcode, result) =  dvs.runcmd("/usr/bin/orchagent_restart_check")
+        (exitcode, result) =  dvs.runcmd("/usr/bin/orchagent_restart_check", include_stderr=False)
         assert result == "RESTARTCHECK failed\n"
 
         # Should succeed, the option for skipPendingTaskCheck -s and noFreeze -n have been provided.
         # Wait up to 500 milliseconds for response from orchagent. Default wait time is 1000 milliseconds.
-        (exitcode, result) =  dvs.runcmd("/usr/bin/orchagent_restart_check -n -s -w 500")
+        (exitcode, result) =  dvs.runcmd("/usr/bin/orchagent_restart_check -n -s -w 500", include_stderr=False)
         assert result == "RESTARTCHECK succeeded\n"
 
         # Remove unfinished routes
         ps._del("3.3.3.0/24")
 
         time.sleep(1)
-        (exitcode, result) =  dvs.runcmd("/usr/bin/orchagent_restart_check")
+        (exitcode, result) =  dvs.runcmd("/usr/bin/orchagent_restart_check", include_stderr=False)
         assert result == "RESTARTCHECK succeeded\n"
 
         # Should fail since orchagent has been frozen at last step.
-        (exitcode, result) =  dvs.runcmd("/usr/bin/orchagent_restart_check -n -s -w 500")
+        (exitcode, result) =  dvs.runcmd("/usr/bin/orchagent_restart_check -n -s -w 500", include_stderr=False)
         assert result == "RESTARTCHECK failed\n"
 
         # Cleaning previously pushed route-entry to ease life of subsequent testcases.


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
This PR is to fix the flaky test cases in vstest.
We frequently saw test failures in PR testing like below
```
test_PortAutoNegWarm failed (1 runs remaining out of 2).
	<class 'AssertionError'>
	assert 'RESTARTCHECK...unction 267\n' == 'RESTARTCHECK succeeded\n'
    RESTARTCHECK succeeded
  - profiling:/__w/1/s/common/.libs/libswsscommon_la-consumerstatetable.gcda:Merge mismatch for function 267
	[<TracebackEntry /agent/_work/1/s/tests/test_port_an.py:262>]
```
The output is produced by gcov. However, it's collected into the output of `orchagent_restart_check` and leads to test failure because the output is not as expected.
```
- profiling:/__w/1/s/common/.libs/libswsscommon_la-consumerstatetable.gcda:Merge mismatch for function 267
	[<TracebackEntry /agent/_work/1/s/tests/test_port_an.py:262>]
```
This PR fixes the issue by adding an argument `include_stderr` to `runcmd`. When `include_stderr` is set to `False`, only stdout is collected.

**Why I did it**
This PR is to fix the flaky test cases in vstest.

**How I verified it**
Verified by running vstest locally.

**Details if related**
