### PR TITLE
[DASH] Add retry logic for VNET mapping table

### DIFF
--- a/orchagent/dash/dashvnetorch.cpp
+++ b/orchagent/dash/dashvnetorch.cpp
@@ -331,7 +331,7 @@ bool DashVnetOrch::addVnetMap(const string& key, VnetMapBulkContext& ctxt)
     bool exists = (vnet_map_table_.find(key) != vnet_map_table_.end());
     if (!exists)
     {
-        bool vnet_exists = (gVnetNameToId.find(ctxt.vnet_name) != gVnetNameToId.end())
+        bool vnet_exists = (gVnetNameToId.find(ctxt.vnet_name) != gVnetNameToId.end());
         if (vnet_exists)
         {
             addOutboundCaToPa(key, ctxt);
@@ -339,7 +339,7 @@ bool DashVnetOrch::addVnetMap(const string& key, VnetMapBulkContext& ctxt)
         }
         else
         {
-            SWSS_LOG_INFO("Not creating VNET map for %s since VNET %s doesn't exist", key.c_str(), ctxt.vnet_name.c_str())
+            SWSS_LOG_INFO("Not creating VNET map for %s since VNET %s doesn't exist", key.c_str(), ctxt.vnet_name.c_str());
         }
         return false;
     }

--- a/orchagent/dash/dashvnetorch.cpp
+++ b/orchagent/dash/dashvnetorch.cpp
@@ -271,7 +271,7 @@ void DashVnetOrch::doTaskVnetTable(Consumer& consumer)
     }
 }
 
-bool DashVnetOrch::addOutboundCaToPa(const string& key, VnetMapBulkContext& ctxt)
+void DashVnetOrch::addOutboundCaToPa(const string& key, VnetMapBulkContext& ctxt)
 {
     SWSS_LOG_ENTER();
 
@@ -298,11 +298,9 @@ bool DashVnetOrch::addOutboundCaToPa(const string& key, VnetMapBulkContext& ctxt
     object_statuses.emplace_back();
     outbound_ca_to_pa_bulker_.create_entry(&object_statuses.back(), &outbound_ca_to_pa_entry,
             (uint32_t)outbound_ca_to_pa_attrs.size(), outbound_ca_to_pa_attrs.data());
-
-    return false;
 }
 
-bool DashVnetOrch::addPaValidation(const string& key, VnetMapBulkContext& ctxt)
+void DashVnetOrch::addPaValidation(const string& key, VnetMapBulkContext& ctxt)
 {
     SWSS_LOG_ENTER();
 
@@ -320,8 +318,6 @@ bool DashVnetOrch::addPaValidation(const string& key, VnetMapBulkContext& ctxt)
     object_statuses.emplace_back();
     pa_validation_bulker_.create_entry(&object_statuses.back(), &pa_validation_entry,
             attr_count, &pa_validation_attr);
-
-    return false;
 }
 
 bool DashVnetOrch::addVnetMap(const string& key, VnetMapBulkContext& ctxt)
@@ -432,7 +428,7 @@ bool DashVnetOrch::addVnetMapPost(const string& key, const VnetMapBulkContext& c
     return true;
 }
 
-bool DashVnetOrch::removeOutboundCaToPa(const string& key, VnetMapBulkContext& ctxt)
+void DashVnetOrch::removeOutboundCaToPa(const string& key, VnetMapBulkContext& ctxt)
 {
     SWSS_LOG_ENTER();
 
@@ -444,11 +440,9 @@ bool DashVnetOrch::removeOutboundCaToPa(const string& key, VnetMapBulkContext& c
 
     object_statuses.emplace_back();
     outbound_ca_to_pa_bulker_.remove_entry(&object_statuses.back(), &outbound_ca_to_pa_entry);
-
-    return false;
 }
 
-bool DashVnetOrch::removePaValidation(const string& key, VnetMapBulkContext& ctxt)
+void DashVnetOrch::removePaValidation(const string& key, VnetMapBulkContext& ctxt)
 {
     SWSS_LOG_ENTER();
 
@@ -460,8 +454,6 @@ bool DashVnetOrch::removePaValidation(const string& key, VnetMapBulkContext& ctx
 
     object_statuses.emplace_back();
     pa_validation_bulker_.remove_entry(&object_statuses.back(), &pa_validation_entry);
-
-    return false;
 }
 
 bool DashVnetOrch::removeVnetMap(const string& key, VnetMapBulkContext& ctxt)

--- a/orchagent/dash/dashvnetorch.cpp
+++ b/orchagent/dash/dashvnetorch.cpp
@@ -331,11 +331,21 @@ bool DashVnetOrch::addVnetMap(const string& key, VnetMapBulkContext& ctxt)
     bool exists = (vnet_map_table_.find(key) != vnet_map_table_.end());
     if (!exists)
     {
-        addOutboundCaToPa(key, ctxt);
-        addPaValidation(key, ctxt);
+        bool vnet_exists = (gVnetNameToId.find(ctxt.vnet_name) != gVnetNameToId.end())
+        if (vnet_exists)
+        {
+            addOutboundCaToPa(key, ctxt);
+            addPaValidation(key, ctxt);
+        }
+        else
+        {
+            SWSS_LOG_INFO("Not creating VNET map for %s since VNET %s doesn't exist", key.c_str(), ctxt.vnet_name.c_str())
+        }
+        return false;
     }
-
-    return false;
+    // If the VNET map is already added, don't add it to the bulker and
+    // return true so it's removed from the consumer 
+    return true;
 }
 
 bool DashVnetOrch::addOutboundCaToPaPost(const string& key, const VnetMapBulkContext& ctxt)

--- a/orchagent/dash/dashvnetorch.h
+++ b/orchagent/dash/dashvnetorch.h
@@ -93,13 +93,13 @@ private:
     bool addVnetPost(const std::string& key, const DashVnetBulkContext& ctxt);
     bool removeVnet(const std::string& key, DashVnetBulkContext& ctxt);
     bool removeVnetPost(const std::string& key, const DashVnetBulkContext& ctxt);
-    bool addOutboundCaToPa(const std::string& key, VnetMapBulkContext& ctxt);
+    void addOutboundCaToPa(const std::string& key, VnetMapBulkContext& ctxt);
     bool addOutboundCaToPaPost(const std::string& key, const VnetMapBulkContext& ctxt);
-    bool removeOutboundCaToPa(const std::string& key, VnetMapBulkContext& ctxt);
+    void removeOutboundCaToPa(const std::string& key, VnetMapBulkContext& ctxt);
     bool removeOutboundCaToPaPost(const std::string& key, const VnetMapBulkContext& ctxt);
-    bool addPaValidation(const std::string& key, VnetMapBulkContext& ctxt);
+    void addPaValidation(const std::string& key, VnetMapBulkContext& ctxt);
     bool addPaValidationPost(const std::string& key, const VnetMapBulkContext& ctxt);
-    bool removePaValidation(const std::string& key, VnetMapBulkContext& ctxt);
+    void removePaValidation(const std::string& key, VnetMapBulkContext& ctxt);
     bool removePaValidationPost(const std::string& key, const VnetMapBulkContext& ctxt);
     bool addVnetMap(const std::string& key, VnetMapBulkContext& ctxt);
     bool addVnetMapPost(const std::string& key, const VnetMapBulkContext& ctxt);


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When adding a VNET map entry, if the VNET doesn't yet exist, defer the operation and retry it later.

**Why I did it**
Currently, adding a VNET map before the corresponding VNET causes an orchagent crash.

**How I verified it**
1. Copy the SWSS package with these changes and install to a testbed
2. Set orchagent log level to INFO
3. Use `swssconfig` to apply a DASH config with only a VNET mapping table
4. Check that orchagent doesn't crash, and the following logs are seen in the syslog:
```
INFO swss#orchagent: :- addVnetMap: Not creating VNET map for Vnet2:20.2.2.2 since VNET Vnet2 doesn't exist
```
5. Use `swssconfig to apply a DASH config with a VNET table matching the original VNET mapping table
6. Check that orchagent doesn't crash, and the following log is seen:
```
NOTICE swss#orchagent: :- addVnetMapPost: Vnet map added for Vnet2:20.2.2.2
```
7. Confirm that testbed is able to forward traffic normally

**Details if related**
