### PR TITLE
[orchagent]:add local_discriminator  for BFD session to state_db

### DIFF
--- a/orchagent/bfdorch.cpp
+++ b/orchagent/bfdorch.cpp
@@ -306,9 +306,11 @@ bool BfdOrch::create_bfd_session(const string& key, const vector<FieldValueTuple
     attrs.emplace_back(attr);
     fvVector.emplace_back("type", session_type_lookup.at(bfd_session_type));
 
+    uint32_t local_discriminator = bfd_gen_id();
     attr.id = SAI_BFD_SESSION_ATTR_LOCAL_DISCRIMINATOR;
-    attr.value.u32 = bfd_gen_id();
+    attr.value.u32 = local_discriminator;
     attrs.emplace_back(attr);
+    fvVector.emplace_back("local_discriminator", to_string(local_discriminator));
 
     attr.id = SAI_BFD_SESSION_ATTR_UDP_SRC_PORT;
     attr.value.u32 = bfd_src_port();


### PR DESCRIPTION


<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add local_discriminator to state DB when bfdorch create_bfd_session. 

**Why I did it**
For upcoming BFD debugging related CLI, user need to use local_discriminator to specify which BFD session they want to debug. current show bfd CLI does not have this information (the local_discriminator is not in state DB).
Also, this is local_discriminator printed into syslog, user may want to correlate this local_discriminator to BFD session.

**How I verified it**
with modified code, and modified show bfd python script, the local discriminator can be shown in 'show bfd' cmd:
(show "NA" if there is no local_discriminator in state DB.)
modification for "show bfd" script will be committed separately in another PR.

```
cisco@sonic:/var/tmp$ show bfd sum
Total number of BFD sessions: 1
Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop    Local Discriminator
-----------  -----------  -------  -------  ------------  ------------  -------------  -------------  ------------  ----------  ---------------------
192.85.2.24  default      default  Down     async_active  192.85.2.29            1000           1000             3  true        NA
cisco@sonic:/var/tmp$ show bfd peer 192.85.2.24
Total number of BFD sessions for peer IP 192.85.2.24: 1
Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop    Local Discriminator
-----------  -----------  -------  -------  ------------  ------------  -------------  -------------  ------------  ----------  ---------------------
192.85.2.24  default      default  Down     async_active  192.85.2.29            1000           1000             3  true        NA
cisco@sonic:/var/tmp$ docker exec -i swss swssconfig /dev/stdin < bfd.cfg
cisco@sonic:/var/tmp$ show bfd peer 192.85.2.24
Total number of BFD sessions for peer IP 192.85.2.24: 1
Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop      Local Discriminator
-----------  -----------  -------  -------  ------------  ------------  -------------  -------------  ------------  ----------  ---------------------
192.85.2.24  default      default  Down     async_active  192.85.2.29            1000           1000             3  true                            1
cisco@sonic:/var/tmp$ show bfd sum
Total number of BFD sessions: 1
Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop      Local Discriminator
-----------  -----------  -------  -------  ------------  ------------  -------------  -------------  ------------  ----------  ---------------------
192.85.2.24  default      default  Down     async_active  192.85.2.29            1000           1000             3  true                            1
```

**Details if related**
  Example of BFD session entry in state DB with local_discriminator:
```
"BFD_SESSION_TABLE|default|default|192.85.2.24": {
    "expireat": 1667599670.656455, 
    "ttl": -0.001, 
    "type": "hash", 
    "value": {
      "local_addr": "192.85.2.29", 
      "local_discriminator": "1", 
      "multihop": "true", 
      "multiplier": "3", 
      "rx_interval": "1000", 
      "state": "Down", 
      "tx_interval": "1000", 
      "type": "async_active"
    }
  },