### PR TITLE
Disable `arp_evict_nocarrier` for vlan host intf 

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -134,6 +134,11 @@ bool VlanMgr::addHostVlan(int vlan_id)
     std::string res;
     EXEC_WITH_ERROR_THROW(cmds, res);
 
+    res.clear();
+    const std::string echo_cmd = std::string("")
+      + ECHO_CMD + " 0 > /proc/sys/net/ipv4/conf/" + VLAN_PREFIX + std::to_string(vlan_id) + "/arp_evict_nocarrier";
+    swss::exec(echo_cmd, res);
+
     return true;
 }
 

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -488,6 +488,48 @@ class TestVlan(object):
 
         self.dvs_vlan.remove_vlan(vlan)
 
+    def test_VlanMemberLinkDown(self, dvs):
+
+        # TODO: add_ip_address has a dependency on cdb within dvs,
+        # so we still need to setup the db. This should be refactored.
+        dvs.setup_db()
+
+        vlan = "1000"
+        vlan_ip = "192.168.0.1/21"
+        interface = "Ethernet0"
+        vlan_interface = "Vlan%s" % vlan
+        server_ip = "192.168.0.100"
+        vlan_intf_sysctl_param_path = "/proc/sys/net/ipv4/conf/%s/arp_evict_nocarrier" % vlan_interface
+
+        self.dvs_vlan.create_vlan(vlan)
+        vlan_oid = self.dvs_vlan.get_and_verify_vlan_ids(1)[0]
+        self.dvs_vlan.verify_vlan(vlan_oid, vlan)
+        self.dvs_vlan.create_vlan_member(vlan, interface)
+        self.dvs_vlan.verify_vlan_member(vlan_oid, interface)
+        dvs.set_interface_status(interface, "up")
+        dvs.add_ip_address(vlan_interface, vlan_ip)
+        dvs.runcmd("ip neigh replace %s lladdr 11:22:33:44:55:66 dev %s nud stale" % (server_ip, vlan_interface))
+
+        neigh_oid = self.dvs_vlan.app_db.wait_for_n_keys("NEIGH_TABLE", 1)[0]
+        assert vlan_interface in neigh_oid and server_ip in neigh_oid
+
+        # NOTE: arp_evict_nocarrier is available for kernel >= v5.16 and current
+        # docker-sonic-vs is based on kernel v5.4.0, so test only if this sysctl
+        # param is present
+        rc, res = dvs.runcmd("cat %s" % vlan_intf_sysctl_param_path)
+        if rc == 0:
+            assert res.strip() == "0"
+            dvs.set_interface_status(interface, "down")
+            neigh_oid = self.dvs_vlan.app_db.wait_for_n_keys("NEIGH_TABLE", 1)[0]
+            assert vlan_interface in neigh_oid and server_ip in neigh_oid
+
+        dvs.runcmd("ip neigh flush all")
+        dvs.remove_ip_address(vlan_interface, vlan_ip)
+        self.dvs_vlan.remove_vlan_member(vlan, interface)
+        self.dvs_vlan.get_and_verify_vlan_member_ids(0)
+        self.dvs_vlan.remove_vlan(vlan)
+        self.dvs_vlan.get_and_verify_vlan_ids(0)
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Cherry-pick back https://github.com/sonic-net/sonic-swss/pull/2469 into 202205.

**Why I did it**
It is reverted in 202205: https://github.com/sonic-net/sonic-swss/pull/2518 because of the flakiness of `test_vlan.py`

**How I verified it**
This depends on the following PRs:
https://github.com/sonic-net/sonic-swss/pull/2504
https://github.com/sonic-net/sonic-swss/pull/2541


**Details if related**
