### PR TITLE
[Neighsync] Handle Mac address 'none' during neigh add

### DIFF
--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -143,6 +143,12 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
         nl_addr2str(rtnl_neigh_get_lladdr(neigh), macStr, MAX_ADDR_SIZE);
     }
 
+    if (!delete_key && !strncmp(macStr, "none", MAX_ADDR_SIZE))
+    {
+        SWSS_LOG_NOTICE("Mac address is 'none' for ADD op, ignoring for %s", ipStr);
+        return;
+    }
+
     /* Ignore neighbor entries with Broadcast Mac - Trigger for directed broadcast */
     if (!delete_key && (MacAddress(macStr) == MacAddress("ff:ff:ff:ff:ff:ff")))
     {


### PR DESCRIPTION
**What I did**
In some rare cases, kernel neighbor add notifications are received with Mac string as 'none'. This is from the following libnl code:

https://www.infradead.org/~tgr/libnl/doc/api/lib_2addr_8c_source.html

![image](https://user-images.githubusercontent.com/17460631/210023453-49a9f907-30f8-4096-901b-e290609ffe11.png)

This can cause a neighsyncd crash as below from [here](https://github.com/sonic-net/sonic-swss-common/blob/master/common/macaddress.cpp#L20)


```
Dec 12 07:36:37.149555 ST12-M0 INFO swss#/supervisord: neighsyncd terminate called after throwing an instance of 'std::invalid_argument'
Dec 12 07:36:37.149555 ST12-01M0 INFO swss#/supervisord: neighsyncd   what():  can't parse mac address 'none'
```

**Why I did it**

Prevent crash by checking if MacString is 'none' during neighbor 'add' operation. 

**How I verified it**

**Details if related**
