### PR TITLE
[vstest] Only collect stdout of orchagent_restart_check in vstest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -601,7 +601,7 @@ class DockerVirtualSwitch:
         self.check_ready_status_and_init_db()
 
     def runcmd(self, cmd: str, include_stderr=True) -> Tuple[int, str]:
-        res = self.ctn.exec_run(cmd)
+        res = self.ctn.exec_run(cmd, stdout=True, stderr=include_stderr)
         exitcode = res.exit_code
         out = res.output.decode("utf-8")
 

--- a/tests/test_storm_control.py
+++ b/tests/test_storm_control.py
@@ -211,7 +211,7 @@ class TestStormControl(object):
         dvs.warm_restart_swss("true")
 
         # freeze orchagent for warm restart
-        (exitcode, result) = dvs.runcmd("/usr/bin/orchagent_restart_check")
+        (exitcode, result) = dvs.runcmd("/usr/bin/orchagent_restart_check", include_stderr=False)
         assert result == "RESTARTCHECK succeeded\n"
         time.sleep(2)
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
This PR is to fix the flaky test cases in vstest.
We frequently saw test failures in PR testing like below
```
def test_warm_restart_all_interfaces(self,dvs,testlog):
        self.setup_db(dvs)
    
        tbl = swsscommon.Table(self.cdb,"PORT")
        for key in tbl.getKeys():
            self.add_storm_control_on_interface(dvs,key,"broadcast",1000000)
            self.add_storm_control_on_interface(dvs,key,"unknown-unicast",2000000)
            self.add_storm_control_on_interface(dvs,key,"unknown-multicast",3000000)
        #dvs.runcmd("config save -y")
        # enable warm restart
        dvs.warm_restart_swss("true")
    
        # freeze orchagent for warm restart
        (exitcode, result) = dvs.runcmd("/usr/bin/orchagent_restart_check")
>       assert result == "RESTARTCHECK succeeded\n"
E       AssertionError: assert 'RESTARTCHECK...unction 503\n' == 'RESTARTCHECK succeeded\n'
E         + RESTARTCHECK succeeded
E         - RESTARTCHECK failed
E         - profiling:/__w/1/s/common/.libs/libswsscommon_la-countertable.gcda:Merge mismatch for function 503

```
The output is produced by gcov. However, it's collected into the output of `orchagent_restart_check` and leads to test failure because the output is not as expected.
```
- profiling:/__w/1/s/common/.libs/libswsscommon_la-countertable.gcda:Merge mismatch for function 503
```
This PR fixes the issue by adding an argument `include_stderr` to `runcmd`. When `include_stderr` is set to `False`, only stdout is collected.

**Why I did it**
This PR is to fix the flaky test cases in vstest.

**How I verified it**
Verified by running vstest locally.

**Details if related**
