### PR TITLE
[MuxOrch] Enabling neighbor when adding in active state

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -567,6 +567,8 @@ void MuxCable::updateNeighbor(NextHopKey nh, bool add)
 
 void MuxNbrHandler::update(NextHopKey nh, sai_object_id_t tunnelId, bool add, MuxState state)
 {
+    uint32_t num_routes = 0;
+
     SWSS_LOG_INFO("Neigh %s on %s, add %d, state %d",
                    nh.ip_address.to_string().c_str(), nh.alias.c_str(), add, state);
 
@@ -592,6 +594,7 @@ void MuxNbrHandler::update(NextHopKey nh, sai_object_id_t tunnelId, bool add, Mu
         case MuxState::MUX_STATE_ACTIVE:
             neighbors_[nh.ip_address] = gNeighOrch->getLocalNextHopId(nh);
             gNeighOrch->enableNeighbor(nh);
+            gRouteOrch->updateNextHopRoutes(nh, num_routes);
             break;
         case MuxState::MUX_STATE_STANDBY:
             neighbors_[nh.ip_address] = tunnelId;

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -591,6 +591,12 @@ void NeighOrch::decreaseNextHopRefCount(const NextHopKey &nexthop, uint32_t coun
     assert(hasNextHop(nexthop));
     if (m_syncdNextHops.find(nexthop) != m_syncdNextHops.end())
     {
+        if ((m_syncdNextHops[nexthop].ref_count - (int)count) < 0)
+        {
+            SWSS_LOG_ERROR("Ref count cannot be negative for next_hop_id: 0x%" PRIx64 " with ip: %s and alias: %s",
+                   m_syncdNextHops[nexthop].next_hop_id, nexthop.ip_address.to_string().c_str(), nexthop.alias.c_str());
+            return;
+        }
         m_syncdNextHops[nexthop].ref_count -= count;
     }
 }

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -595,6 +595,8 @@ void NeighOrch::decreaseNextHopRefCount(const NextHopKey &nexthop, uint32_t coun
         {
             SWSS_LOG_ERROR("Ref count cannot be negative for next_hop_id: 0x%" PRIx64 " with ip: %s and alias: %s",
                    m_syncdNextHops[nexthop].next_hop_id, nexthop.ip_address.to_string().c_str(), nexthop.alias.c_str());
+            // Reset refcount to 0 to match expected value
+            m_syncdNextHops[nexthop].ref_count = 0;
             return;
         }
         m_syncdNextHops[nexthop].ref_count -= count;

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -537,6 +537,66 @@ class TestMuxTunnelBase():
 
         ps._del(rtprefix)
 
+    def create_and_test_NH_routes(self, appdb, asicdb, dvs, dvs_route, mac):
+        '''
+        Tests case where neighbor is removed in standby and added in active with route
+        '''
+        nh_route = "2.2.2.0/24"
+        nh_route_ipv6 = "2023::/64"
+        neigh_ip = self.SERV1_IPV4
+        neigh_ipv6 = self.SERV1_IPV6
+        apdb = dvs.get_app_db()
+
+        # Setup
+        self.set_mux_state(appdb, "Ethernet0", "active")
+        self.add_neighbor(dvs, neigh_ip, mac)
+        self.add_neighbor(dvs, neigh_ipv6, mac)
+        dvs.runcmd(
+            "vtysh -c \"configure terminal\" -c \"ip route " + nh_route +
+            " " + neigh_ip + "\""
+        )
+        dvs.runcmd(
+            "vtysh -c \"configure terminal\" -c \"ipv6 route " + nh_route_ipv6 +
+            " " + neigh_ipv6 + "\""
+        )
+        apdb.wait_for_entry("ROUTE_TABLE", nh_route)
+        rtkeys = dvs_route.check_asicdb_route_entries([nh_route])
+        rtkeys_ipv6 = dvs_route.check_asicdb_route_entries([nh_route_ipv6])
+        self.check_nexthop_in_asic_db(asicdb, rtkeys[0])
+        self.check_nexthop_in_asic_db(asicdb, rtkeys_ipv6[0])
+
+        # Set state to standby and delete neighbor
+        self.set_mux_state(appdb, "Ethernet0", "standby")
+        self.check_nexthop_in_asic_db(asicdb, rtkeys[0], True)
+        self.check_nexthop_in_asic_db(asicdb, rtkeys_ipv6[0], True)
+
+        self.del_neighbor(dvs, neigh_ip)
+        self.del_neighbor(dvs, neigh_ipv6)
+        self.check_nexthop_in_asic_db(asicdb, rtkeys[0], True)
+        self.check_nexthop_in_asic_db(asicdb, rtkeys_ipv6[0], True)
+
+        # Set state to active, learn neighbor again
+        self.set_mux_state(appdb, "Ethernet0", "active")
+        self.check_nexthop_in_asic_db(asicdb, rtkeys[0], True)
+        self.check_nexthop_in_asic_db(asicdb, rtkeys_ipv6[0], True)
+
+        self.add_neighbor(dvs, neigh_ip, mac)
+        self.add_neighbor(dvs, neigh_ipv6, mac)
+        self.check_nexthop_in_asic_db(asicdb, rtkeys[0])
+        self.check_nexthop_in_asic_db(asicdb, rtkeys_ipv6[0])
+
+        # Cleanup
+        dvs.runcmd(
+            "vtysh -c \"configure terminal\" -c \"no ip route " + nh_route +
+            " " + neigh_ip + "\""
+        )
+        dvs.runcmd(
+            "vtysh -c \"configure terminal\" -c \"no ipv6 route " + nh_route_ipv6 +
+            " " + neigh_ipv6 + "\""
+        )
+        self.del_neighbor(dvs, neigh_ip)
+        self.del_neighbor(dvs, neigh_ipv6)
+
     def get_expected_sai_qualifiers(self, portlist, dvs_acl):
         expected_sai_qualifiers = {
             "SAI_ACL_ENTRY_ATTR_PRIORITY": self.ACL_PRIORITY,
@@ -1098,6 +1158,14 @@ class TestMuxTunnel(TestMuxTunnelBase):
         asicdb = dvs.get_asic_db()
 
         self.create_and_test_route(appdb, asicdb, dvs, dvs_route)
+
+    def test_NH(self, dvs, dvs_route, intf_fdb_map, setup_peer_switch, setup_tunnel, testlog):
+        """ test NH routes and mux state change """
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+        mac = intf_fdb_map["Ethernet0"]
+
+        self.create_and_test_NH_routes(appdb, asicdb, dvs, dvs_route, mac)
 
     def test_acl(self, dvs, dvs_acl, testlog):
         """ test acl and mux state change """

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -584,6 +584,12 @@ class TestMuxTunnelBase():
         self.add_neighbor(dvs, neigh_ipv6, mac)
         self.check_nexthop_in_asic_db(asicdb, rtkeys[0])
         self.check_nexthop_in_asic_db(asicdb, rtkeys_ipv6[0])
+        dvs.runcmd(
+            "ip neigh flush " + neigh_ip
+        )
+        dvs.runcmd(
+            "ip neigh flush " + neigh_ipv6
+        )
 
         # Cleanup
         dvs.runcmd(


### PR DESCRIPTION
What I did: called enable when adding a neighbor in active state

Why I did it: NH routes weren't being updated if they existed in standby state before neighbor is added

Signed-off-by: Nikola Dancejic <ndancejic@microsoft.com>
