### PR TITLE
Add Isolation Support for Innovium based platforms

### DIFF
--- a/mclagsyncd/mclaglink.cpp
+++ b/mclagsyncd/mclaglink.cpp
@@ -192,7 +192,8 @@ void MclagLink::setPortIsolate(char *msg)
     static const unordered_set<string> supported {
         BRCM_PLATFORM_SUBSTRING,
         BFN_PLATFORM_SUBSTRING,
-        CTC_PLATFORM_SUBSTRING
+        CTC_PLATFORM_SUBSTRING,
+	INVM_PLATFORM_SUBSTRING
     };
 
     const char *platform = getenv("platform");

--- a/mclagsyncd/mclaglink.h
+++ b/mclagsyncd/mclaglink.h
@@ -54,6 +54,7 @@
 #define BRCM_PLATFORM_SUBSTRING "broadcom"
 #define BFN_PLATFORM_SUBSTRING  "barefoot"
 #define CTC_PLATFORM_SUBSTRING  "centec"
+#define INVM_PLATFORM_SUBSTRING "innovium"
 
 using namespace std;
 


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added Isolation Support for Innovium based platforms

**Why I did it**
Innovium SAI doesnt support ACL based Isolation group, it supports only Isolation group SAI method to achieve egress block mask.

**How I verified it**
1. configure mclag 
2. verify the hardware programming for ICL port
    ifcs show sysport <vlt-port> "ig_type is set to IG2"
    ifcs show sysport <icl-port> "ig_type is set to IG1"
3. Verified bridgeport removal "IG2 is resetted to IG0" 
4. Verified bridgeport addition "IG0 is set to IG1 or IG2 depending on the VLT or ICL port"

**Details if related**
None
