### PR TITLE
McLAG Stale Static mac is present in hardware even after the port-channel is removed from VLAN

### DIFF
--- a/mclagsyncd/mclaglink.cpp
+++ b/mclagsyncd/mclaglink.cpp
@@ -192,7 +192,8 @@ void MclagLink::setPortIsolate(char *msg)
     static const unordered_set<string> supported {
         BRCM_PLATFORM_SUBSTRING,
         BFN_PLATFORM_SUBSTRING,
-        CTC_PLATFORM_SUBSTRING
+        CTC_PLATFORM_SUBSTRING,
+	INVM_PLATFORM_SUBSTRING
     };
 
     const char *platform = getenv("platform");

--- a/mclagsyncd/mclaglink.h
+++ b/mclagsyncd/mclaglink.h
@@ -54,6 +54,7 @@
 #define BRCM_PLATFORM_SUBSTRING "broadcom"
 #define BFN_PLATFORM_SUBSTRING  "barefoot"
 #define CTC_PLATFORM_SUBSTRING  "centec"
+#define INVM_PLATFORM_SUBSTRING "innovium"
 
 using namespace std;
 

--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -1149,6 +1149,48 @@ void FdbOrch::updatePortOperState(const PortOperStateUpdate& update)
     return;
 }
 
+void FdbOrch::flushMclagRemoteFDBEntries(sai_object_id_t bridge_port_oid,
+                              Port &vlan)
+{
+    SWSS_LOG_DEBUG("Mclag remote mac flush:Input port = 0x%" PRIx64", bv_id=0x%" PRIx64,
+                               bridge_port_oid, vlan.m_vlan_info.vlan_oid);
+    Port port;
+    for (auto itr = m_entries.begin(); itr != m_entries.end();)
+    {
+        FdbData fdbData = itr->second;
+        FdbEntry entry;
+	entry.mac = itr->first.mac;
+	entry.bv_id = itr->first.bv_id;
+
+
+        SWSS_LOG_DEBUG("FDB DB:origin = %d, port = 0x%" PRIx64", mac=%s, bv_id=0x%" PRIx64,
+                     itr->second.origin, fdbData.bridge_port_id,
+                     itr->first.mac.to_string().c_str(), itr->first.bv_id);
+
+	++itr;
+        if ((fdbData.bridge_port_id == bridge_port_oid) &&
+            (entry.bv_id == vlan.m_vlan_info.vlan_oid) &&
+            (fdbData.origin == FDB_ORIGIN_MCLAG_ADVERTIZED))
+        {
+	    
+            if (!removeFdbEntry(entry, fdbData.origin))
+            {
+                SWSS_LOG_ERROR("remove FDB entry fail mac=%s, bv_id=0x%" PRIx64,
+                               entry.mac.to_string().c_str(), entry.bv_id);
+
+            } else {
+                SWSS_LOG_NOTICE("removed FDB entry. mac=%s, bv_id=0x%" PRIx64,
+                               entry.mac.to_string().c_str(), entry.bv_id);
+            }
+	    if (m_portsOrch->getPortByBridgePortId(fdbData.bridge_port_id, port))
+            {
+                saved_fdb_entries[port.m_alias].push_back(
+                        {entry.mac, vlan.m_vlan_info.vlan_id, fdbData});
+	    }
+        }
+    }
+}
+
 void FdbOrch::updateVlanMember(const VlanMemberUpdate& update)
 {
     SWSS_LOG_ENTER();
@@ -1157,6 +1199,7 @@ void FdbOrch::updateVlanMember(const VlanMemberUpdate& update)
     {
         swss::Port vlan = update.vlan;
         swss::Port port = update.member;
+        flushMclagRemoteFDBEntries(port.m_bridge_port_id,vlan);
         flushFDBEntries(port.m_bridge_port_id, vlan.m_vlan_info.vlan_oid);
         notifyObserversFDBFlush(port, vlan.m_vlan_info.vlan_oid);
         return;
@@ -1221,13 +1264,25 @@ bool FdbOrch::addFdbEntry(const FdbEntry& entry, const string& port_name,
     {
         end_point_ip = fdbData.remote_ip;
     }
+
+    auto it = m_entries.find(entry);
     /* Retry until port is member of vlan*/
     if (!m_portsOrch->isVlanMember(vlan, port, end_point_ip))
     {
         SWSS_LOG_INFO("Saving a fdb entry until port %s becomes vlan %s member", port_name.c_str(), vlan.m_alias.c_str());
+	/*
+	 * Mclag Synced mac scenario
+	 *     -> mac moved from ICL to Nonmember VLT (after shut/no shut on VLT portchannel)
+	 *        delete the existing entry and save the fdb entries and wait VLT becomes member of VLAN
+	 */
+	if (it != m_entries.end()) {
+            removeFdbEntry(entry, it->second.origin);
+	}
         saved_fdb_entries[port_name].push_back({entry.mac,
                 vlan.m_vlan_info.vlan_id, fdbData});
         return true;
+    } else {
+	deleteFdbEntryFromSavedFDB (entry.mac, vlan.m_vlan_info.vlan_id, fdbData.origin);
     }
 
     sai_status_t status;
@@ -1242,7 +1297,6 @@ bool FdbOrch::addFdbEntry(const FdbEntry& entry, const string& port_name,
     FdbOrigin oldOrigin = FDB_ORIGIN_INVALID ;
     bool macUpdate = false;
 
-    auto it = m_entries.find(entry);
     if (it != m_entries.end())
     {
         /* get existing port and type */

--- a/orchagent/fdborch.h
+++ b/orchagent/fdborch.h
@@ -101,6 +101,8 @@ public:
     void flushFDBEntries(sai_object_id_t bridge_port_oid,
                          sai_object_id_t vlan_oid);
     void notifyObserversFDBFlush(Port &p, sai_object_id_t&);
+    void flushMclagRemoteFDBEntries(sai_object_id_t bridge_port_oid,
+		                    Port &vlan);
 
 private:
     PortsOrch *m_portsOrch;

--- a/tests/test_mclag_fdb.py
+++ b/tests/test_mclag_fdb.py
@@ -483,7 +483,157 @@ def test_mclagFdb_static_mac_dynamic_move_reject(dvs, testlog):
         "MCLAG_FDB_TABLE", "Vlan200:3C:85:99:5E:00:01",
     )
 
-# Test-12 Verify cleanup of the basic config.
+# Test-12 Remote Static MAC Add Vlan member remove and add
+
+@pytest.mark.dev_sanity
+def test_mclagFdb_remote_static_mac_add_member_remove_add(dvs, testlog):
+    dvs.setup_db()
+
+    create_entry_pst(
+        dvs.pdb,
+        "MCLAG_FDB_TABLE", "Vlan200:3C:85:99:5E:00:01",
+        [
+            ("port", "PortChannel0005"),
+            ("type", "static"),
+        ]
+    )
+
+    # check that the FDB entry was inserted into ASIC DB
+    assert how_many_entries_exist(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY") == 1, "The MCLAG static fdb entry not inserted to ASIC"
+
+    ok, extra = dvs.is_fdb_entry_exists(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY",
+            [("mac", "3C:85:99:5E:00:01"), ("bvid", str(dvs.getVlanOid("200")))],
+                    [("SAI_FDB_ENTRY_ATTR_TYPE", "SAI_FDB_ENTRY_TYPE_STATIC")]
+    )
+
+    assert ok, str(extra)
+
+    dvs.remove_vlan_member("200", "PortChannel0005")
+    # check that the FDB entry was inserted into ASIC DB
+    assert how_many_entries_exist(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY") == 0, "The MCLAG static should not be present in ASIC"
+
+    ok, extra = dvs.is_fdb_entry_exists(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY",
+            [("mac", "3C:85:99:5E:00:01"), ("bvid", str(dvs.getVlanOid("200")))],
+                    [("SAI_FDB_ENTRY_ATTR_TYPE", "SAI_FDB_ENTRY_TYPE_STATIC")]
+    )
+
+    assert ok == False, str(extra)
+
+    dvs.create_vlan_member("200", "PortChannel0005")
+    # check that the FDB entry was inserted into ASIC DB
+    assert how_many_entries_exist(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY") == 1, "The MCLAG static fdb entry not inserted to ASIC"
+
+    ok, extra = dvs.is_fdb_entry_exists(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY",
+            [("mac", "3C:85:99:5E:00:01"), ("bvid", str(dvs.getVlanOid("200")))],
+                    [("SAI_FDB_ENTRY_ATTR_TYPE", "SAI_FDB_ENTRY_TYPE_STATIC")]
+    )
+    assert ok, str(extra)
+
+    delete_entry_pst(
+        dvs.pdb,
+        "MCLAG_FDB_TABLE", "Vlan200:3C:85:99:5E:00:01",
+    )
+
+
+# Test-13 Remote Static MAC Add
+# add static mac on vlan 200, portchannel5
+# remove portchannel5 from vlan 200
+# move mac from portchannel5 to portchannel6
+# delete mac from portchannel6
+# add portchannel5 to vlan 200
+# verify whether static mac is configured on portchannel5
+
+@pytest.mark.dev_sanity
+def test_mclagFdb_remote_static_mac_use_cases(dvs, testlog):
+    dvs.setup_db()
+
+    create_entry_pst(
+        dvs.pdb,
+        "MCLAG_FDB_TABLE", "Vlan200:3C:85:99:5E:00:01",
+        [
+            ("port", "PortChannel0005"),
+            ("type", "static"),
+        ]
+    )
+
+    # check that the FDB entry was inserted into ASIC DB
+    assert how_many_entries_exist(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY") == 1, "The MCLAG static fdb entry not inserted to ASIC"
+
+    ok, extra = dvs.is_fdb_entry_exists(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY",
+            [("mac", "3C:85:99:5E:00:01"), ("bvid", str(dvs.getVlanOid("200")))],
+                    [("SAI_FDB_ENTRY_ATTR_TYPE", "SAI_FDB_ENTRY_TYPE_STATIC")]
+    )
+
+    assert ok, str(extra)
+
+    dvs.remove_vlan_member("200", "PortChannel0005")
+    # check that the FDB entry was inserted into ASIC DB
+    assert how_many_entries_exist(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY") == 0, "The MCLAG static should not be present in ASIC"
+
+    ok, extra = dvs.is_fdb_entry_exists(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY",
+            [("mac", "3C:85:99:5E:00:01"), ("bvid", str(dvs.getVlanOid("200")))],
+                    [("SAI_FDB_ENTRY_ATTR_TYPE", "SAI_FDB_ENTRY_TYPE_STATIC")]
+    )
+
+    assert ok == False, str(extra)
+
+    #Move MAC to PortChannel0008 on Local PortChannel0006
+    create_entry_pst(
+        dvs.pdb,
+        "MCLAG_FDB_TABLE", "Vlan200:3C:85:99:5E:00:01",
+        [
+            ("port", "PortChannel0006"),
+            ("type", "static"),
+        ]
+    )
+    # check that the FDB entry was inserted into ASIC DB
+    assert how_many_entries_exist(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY") == 1, "The fdb entry  inserted to ASIC"
+
+    ok, extra = dvs.is_fdb_entry_exists(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY",
+            [("mac", "3C:85:99:5E:00:01"), ("bvid", str(dvs.getVlanOid("200")))],
+                    [("SAI_FDB_ENTRY_ATTR_TYPE", "SAI_FDB_ENTRY_TYPE_STATIC")]
+    )
+
+    assert ok == True, str(extra)
+
+    delete_entry_pst(
+        dvs.pdb,
+        "MCLAG_FDB_TABLE", "Vlan200:3C:85:99:5E:00:01",
+    )
+
+    time.sleep(2)
+
+    # check that the FDB entry was inserted into ASIC DB
+    assert how_many_entries_exist(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY") == 0, "The fdb entry flushed"
+
+    ok, extra = dvs.is_fdb_entry_exists(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY",
+            [("mac", "3C:85:99:5E:00:01"), ("bvid", str(dvs.getVlanOid("200")))],
+                    [("SAI_FDB_ENTRY_ATTR_TYPE", "SAI_FDB_ENTRY_TYPE_DYNAMIC")]
+    )
+
+    assert ok == False, str(extra)
+
+    dvs.create_vlan_member("200", "PortChannel0005")
+    # check that the FDB entry was inserted into ASIC DB
+    assert how_many_entries_exist(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY") == 0, "The MCLAG static should not be present in ASIC"
+
+    ok, extra = dvs.is_fdb_entry_exists(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY",
+            [("mac", "3C:85:99:5E:00:01"), ("bvid", str(dvs.getVlanOid("200")))],
+                    [("SAI_FDB_ENTRY_ATTR_TYPE", "SAI_FDB_ENTRY_TYPE_STATIC")]
+    )
+
+    assert ok == False, str(extra)
+
+    time.sleep(2)
+    # check that the FDB entry was deleted from ASIC DB
+    assert how_many_entries_exist(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY") == 0, "The MCLAG static fdb entry not deleted"
+    delete_entry_pst(
+        dvs.pdb,
+        "MCLAG_FDB_TABLE", "Vlan200:3C:85:99:5E:00:01",
+    )
+
+
+# Test-14 Verify cleanup of the basic config.
 
 @pytest.mark.dev_sanity
 def test_mclagFdb_basic_config_del(dvs, testlog):


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

    1. VLT VLAN Member removal - As part of Vlan member remove flush the static entries from hardware and update the saved_fdb_entries for restoration
    2. Mac move to ICL (due to VLT shut) - This is like mac move to ICL in this cases previously saved FDB entries in saved_fdb_entries has to be removed.
       So when VLT is added as vlan member mac entry will not be restored back to Hardware.

**Why I did it**
    Create Mclag intance.
    Create vlan 101 (make member for VLT ports as members)
    Send traffic on Vlan 101 so node-1 learns the mac address as dynamic and synced to node-2 as static entry.
    now remove node-2 vlan 101 membership for VLT port channel and check the h/w, ASIC_DB stale entry will be present.


**How I verified it**

    Test cases Tried on device :-
    1. Node - 2 VLT synced mac address configured as static - PASS
    2. Remove VLT from VLAN 101  verify hardware mac entry is not present - PASS
    3. Shut the VLT port verify mac entry moved to ICL - PASS
    4. Flush the entry in Node-1 verify mac address in node-2 pointing to ICL is removed - PASS
    5. no shut the VLT port and add VLT as member of VLAN 101 verify mac address is not present in H/W - PASS

 
**Details if related**

   Test cases tried in docker vs :-
    +# Test-13 Remote Static MAC Add
    +# add static mac on vlan 200, portchannel5
    +# remove portchannel5 from vlan 200
    +# move mac from portchannel5 to portchannel6
    +# delete mac from portchannel6
    +# add portchannel5 to vlan 200
    +# verify whether static mac is configured on portchannel5
