### PR TITLE
[202205] Revert "[voq][chassis]Add show fabric counters port/queue commands (#…

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -708,8 +708,9 @@ int main(int argc, char **argv)
         if (gMySwitchType == "voq")
         {
             orchDaemon->setFabricEnabled(true);
-            orchDaemon->setFabricPortStatEnabled(true);
-            orchDaemon->setFabricQueueStatEnabled(true);
+            // SAI doesn't fully support counters for non fabric asics
+            orchDaemon->setFabricPortStatEnabled(false);
+            orchDaemon->setFabricQueueStatEnabled(false);
         }
     }
     else


### PR DESCRIPTION
…2522)"

This reverts commit 1e37d0e4e8a34e54274bdb210c14c0ff365fd178.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Revert #2522  in 202205 branch

**Why I did it**
Fixes sonic-net/sonic-buildimage#13324
**How I verified it**

**Details if related**
