### PR TITLE
[dash] Remove pending DEL ops after a SET

### DIFF
--- a/orchagent/dash/dashaclorch.cpp
+++ b/orchagent/dash/dashaclorch.cpp
@@ -358,6 +358,13 @@ void DashAclOrch::doTask(Consumer &consumer)
             }
 
             itr = consumer.m_toSync.erase(itr);
+
+            auto rit = make_reverse_iterator(it);
+            while (rit != consumer.m_toSync.rend() && rit->first == key && kfvOp(rit->second) == DEL_COMMAND)
+            {
+                consumer.m_toSync.erase(next(rit).base());
+                SWSS_LOG_NOTICE("Removed pending DASH ACL DEL operation for %s after SET operation", key.c_str());
+            }
         }
     }
 }

--- a/orchagent/dash/dashaclorch.cpp
+++ b/orchagent/dash/dashaclorch.cpp
@@ -359,7 +359,7 @@ void DashAclOrch::doTask(Consumer &consumer)
 
             itr = consumer.m_toSync.erase(itr);
 
-            auto rit = make_reverse_iterator(it);
+            auto rit = make_reverse_iterator(itr);
             while (rit != consumer.m_toSync.rend() && rit->first == key && kfvOp(rit->second) == DEL_COMMAND)
             {
                 consumer.m_toSync.erase(next(rit).base());


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
If there is a pending DEL op (not able to go through because some pre-req is not met, e.g. cannot remove an ACL group because it is still bound to an ENI), if we get a subsequent SET for the same key, remove the old DEL operation.

**Why I did it**
If the DEL op never goes through, it will remain in the task queue forever.

**How I verified it**

**Details if related**
