### PR TITLE
Remove TODO comments that are no longer relevant

### DIFF
--- a/cfgmgr/intfmgrd.cpp
+++ b/cfgmgr/intfmgrd.cpp
@@ -62,8 +62,6 @@ int main(int argc, char **argv)
         WarmStart::checkWarmStart("intfmgrd", "swss");
 
         IntfMgr intfmgr(&cfgDb, &appDb, &stateDb, cfg_intf_tables);
-
-        // TODO: add tables in stateDB which interface depends on to monitor list
         std::vector<Orch *> cfgOrchList = {&intfmgr};
 
         swss::Select s;

--- a/cfgmgr/portmgrd.cpp
+++ b/cfgmgr/portmgrd.cpp
@@ -53,8 +53,6 @@ int main(int argc, char **argv)
         DBConnector stateDb("STATE_DB", 0);
 
         PortMgr portmgr(&cfgDb, &appDb, &stateDb, cfg_port_tables);
-
-        // TODO: add tables in stateDB which interface depends on to monitor list
         vector<Orch *> cfgOrchList = {&portmgr};
 
         swss::Select s;

--- a/cfgmgr/vrfmgrd.cpp
+++ b/cfgmgr/vrfmgrd.cpp
@@ -64,7 +64,6 @@ int main(int argc, char **argv)
 
         isWarmStart = WarmStart::isWarmStart();
 
-        // TODO: add tables in stateDB which interface depends on to monitor list
         std::vector<Orch *> cfgOrchList = {&vrfmgr};
 
         swss::Select s;

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -1338,11 +1338,6 @@ task_process_status QosOrch::handleSchedulerTable(Consumer& consumer, KeyOpField
                 attr.value.u8 = (uint8_t)stoi(fvValue(*i));
                 sai_attr_list.push_back(attr);
             }
-            else if (fvField(*i) == scheduler_priority_field_name)
-            {
-                // TODO: The meaning is to be able to adjust priority of the given scheduler group.
-                // However currently SAI model does not provide such ability.
-            }
             else if (fvField(*i) == scheduler_meter_type_field_name)
             {
                 sai_meter_type_t meter_value = scheduler_meter_map.at(fvValue(*i));

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -44,7 +44,6 @@ const string scheduler_algo_DWRR                = "DWRR";
 const string scheduler_algo_WRR                 = "WRR";
 const string scheduler_algo_STRICT              = "STRICT";
 const string scheduler_weight_field_name        = "weight";
-const string scheduler_priority_field_name      = "priority";
 const string scheduler_meter_type_field_name    = "meter_type";
 const string scheduler_min_bandwidth_rate_field_name       = "cir";//Committed Information Rate
 const string scheduler_min_bandwidth_burst_rate_field_name = "cbs";//Committed Burst Size


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I removed TODO comments that are no longer relevant.

**Why I did it**
To clean source code, non relevant comments should be cleared from source.

TODOs can be removed from vrfmgrd.cpp, intfmgrd.cpp and portmgrd.cpp as approach was changed and instead of listening to state DB changes, we call function isIntfStateOk() that fetches the information from state DB.

TODO can be removed from qosorch.cpp as there is no plan from SAI to support setting of scheduler group priority.

**How I verified it**
Run compilation.

**Details if related**
