### PR TITLE
When Bridge port is deleted treat L2 call back event AGED as FLUSH

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -283,6 +283,7 @@ void FdbOrch::update(sai_fdb_event_t        type,
     update.entry.bv_id = entry->bv_id;
     update.type = "dynamic";
     Port vlan;
+    char *platform = getenv("platform");
 
     SWSS_LOG_INFO("FDB event:%d, MAC: %s , BVID: 0x%" PRIx64 " , \
                    bridge port ID: 0x%" PRIx64 ".",
@@ -301,6 +302,16 @@ void FdbOrch::update(sai_fdb_event_t        type,
             */
             SWSS_LOG_INFO("Flush event: Failed to get port by bridge port ID 0x%" PRIx64 ".",
                         bridge_port_id);
+        }
+        else if (((NULL != platform) && (strstr(platform, BRCM_PLATFORM_SUBSTRING))) &&
+                   (type == SAI_FDB_EVENT_AGED)) 
+        {
+            /* Some Platforms like Broadcom, sends the BCM L2 delete call back as Aged event.
+             * if the bridge port is already deleted, to clean up the stale entries,
+             * consider it as FLUSH event */
+            SWSS_LOG_INFO("Flush event: Bridge port ID 0x%" PRIx64 " not available, considering age event as flush.",
+                           bridge_port_id);
+            type = SAI_FDB_EVENT_FLUSHED;
         } else {
             SWSS_LOG_ERROR("Failed to get port by bridge port ID 0x%" PRIx64 ".",
                         bridge_port_id);


### PR DESCRIPTION
**What I did**
When a L2 aged call back 'SAI_FDB_EVENT_AGED'  is received after the underlying Bridgeport is deleted, then treat it as 'SAI_FDB_EVENT_FLUSHED' 


**Why I did it**
For the scenario explained in the issue https://github.com/sonic-net/sonic-swss/pull/2254 , the fix made does not handle it for the broadcom based platforms.
Broadcom based platforms, does not support "SAI_FDB_EVENT_FLUSHED" event and only "SAI_FDB_EVENT_AGED" is posted instead. Hence when a L2 call back routine is received as AGED event after the underlying bridge port is deleted, then to clean-up the internal cache . its treated as SAI_FDB_EVENT_FLUSHED.

**How I verified it**
In broadcom based platforms) create vlan say 100b) associate interface say Ethernet0 with vlan 100c) Learn about 100 dynamic macs on Ethernet0,vlan100d) remove Ethernet0, vlan100 membership) remove vlan 100
Without fix, step 'e' will fail , as the internal cache would not be deleted. With Fix, it will be deleted successfully from the Application DB. 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
-->
Treat AGED event as FLUSH when bridge port is deleted for broadcom based platforms.