### PR TITLE
Support and handle default vlan creation and deletion

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -603,6 +603,20 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
     m_default1QBridge = attrs[0].value.oid;
     m_defaultVlan = attrs[1].value.oid;
 
+    attr.id = SAI_VLAN_ATTR_VLAN_ID;
+
+    status = sai_vlan_api->get_vlan_attribute(m_defaultVlan, 1, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+     {
+        SWSS_LOG_ERROR("Failed to Get Default VLAN ID , status = %d", status);
+        task_process_status handle_status = handleSaiGetStatus(SAI_API_VLAN, status);
+        if (handle_status != task_process_status::task_success)
+        {
+            throw runtime_error("PortsOrch initialization failure");
+        }
+    }
+    m_defaultVlanId = attr.value.u16;
+
     /* Get System ports */
     getSystemPorts();
 
@@ -5052,21 +5066,26 @@ bool PortsOrch::addVlan(string vlan_alias)
     SWSS_LOG_ENTER();
 
     sai_object_id_t vlan_oid;
-
     sai_vlan_id_t vlan_id = (uint16_t)stoi(vlan_alias.substr(4));
     sai_attribute_t attr;
-    attr.id = SAI_VLAN_ATTR_VLAN_ID;
-    attr.value.u16 = vlan_id;
 
-    sai_status_t status = sai_vlan_api->create_vlan(&vlan_oid, gSwitchId, 1, &attr);
-
-    if (status != SAI_STATUS_SUCCESS)
+    if (vlan_id == m_defaultVlanId)
     {
-        SWSS_LOG_ERROR("Failed to create VLAN %s vid:%hu", vlan_alias.c_str(), vlan_id);
-        task_process_status handle_status = handleSaiCreateStatus(SAI_API_VLAN, status);
-        if (handle_status != task_success)
+        vlan_oid = m_defaultVlan;
+    }
+    else
+    {
+        attr.id = SAI_VLAN_ATTR_VLAN_ID;
+        attr.value.u16 = vlan_id;
+        sai_status_t status = sai_vlan_api->create_vlan(&vlan_oid, gSwitchId, 1, &attr);
+        if (status != SAI_STATUS_SUCCESS)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            SWSS_LOG_ERROR("Failed to create VLAN %s vid:%hu", vlan_alias.c_str(), vlan_id);
+            task_process_status handle_status = handleSaiCreateStatus(SAI_API_VLAN, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
     }
 
@@ -5127,15 +5146,18 @@ bool PortsOrch::removeVlan(Port vlan)
         return false;
     }
 
-    sai_status_t status = sai_vlan_api->remove_vlan(vlan.m_vlan_info.vlan_oid);
-    if (status != SAI_STATUS_SUCCESS)
+    if (vlan.m_vlan_info.vlan_id != m_defaultVlanId)
     {
-        SWSS_LOG_ERROR("Failed to remove VLAN %s vid:%hu",
-                vlan.m_alias.c_str(), vlan.m_vlan_info.vlan_id);
-        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_VLAN, status);
-        if (handle_status != task_success)
+        sai_status_t status = sai_vlan_api->remove_vlan(vlan.m_vlan_info.vlan_oid);
+        if (status != SAI_STATUS_SUCCESS)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            SWSS_LOG_ERROR("Failed to remove VLAN %s vid:%hu",
+                    vlan.m_alias.c_str(), vlan.m_vlan_info.vlan_id);
+            task_process_status handle_status = handleSaiRemoveStatus(SAI_API_VLAN, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
     }
 

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -233,6 +233,7 @@ private:
     // TODO: Add Bridge/Vlan class
     sai_object_id_t m_default1QBridge;
     sai_object_id_t m_defaultVlan;
+    unsigned int m_defaultVlanId;
 
     typedef enum
     {


### PR DESCRIPTION
**What I did**
When the operator is creating/deleting the default vlan, skip invoking SAI apis. instead 
use the pre-determined SAI vlan oid, determined during portsorch initialization.


**Why I did it**
For the issue described in https://github.com/sonic-net/sonic-buildimage/issues/9946, this issue is fixed by blocking the default vlan creation at click level.
This may result in non-usability of the default vlan. Instead, as a part of this fix, Orchagent avoids invoking SAI API when default vlan is configured. Instead the default vlan id and default vlan SAI OID are determined during portsorch initialization and used upon operator configuration request.

**How I verified it**
configure vlan 1
un configure vlan 1
configure non default vlan , say vlan 100
un configure non-default vlan , say vlan 100
learning and forwarding on vlan 1
FDB flush on vlan 1
show vlan brief
show mac
save and restore and check vlan 1 configuration remains.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
-->
Handle default vlan creation/deletion at orchagent without crash.