### PR TITLE
[bfdorch] add local discriminator to state DB

### DIFF
--- a/orchagent/bfdorch.cpp
+++ b/orchagent/bfdorch.cpp
@@ -306,9 +306,11 @@ bool BfdOrch::create_bfd_session(const string& key, const vector<FieldValueTuple
     attrs.emplace_back(attr);
     fvVector.emplace_back("type", session_type_lookup.at(bfd_session_type));
 
+    uint32_t local_discriminator = bfd_gen_id();
     attr.id = SAI_BFD_SESSION_ATTR_LOCAL_DISCRIMINATOR;
-    attr.value.u32 = bfd_gen_id();
+    attr.value.u32 = local_discriminator;
     attrs.emplace_back(attr);
+    fvVector.emplace_back("local_discriminator", to_string(local_discriminator));
 
     attr.id = SAI_BFD_SESSION_ATTR_UDP_SRC_PORT;
     attr.value.u32 = bfd_src_port();

--- a/tests/test_bfd.py
+++ b/tests/test_bfd.py
@@ -68,7 +68,7 @@ class TestBfd(object):
 
         # Check STATE_DB entry related to the BFD session
         expected_sdb_values = {"state": "Down", "type": "async_active", "local_addr" : "10.0.0.1", "tx_interval" :"1000",
-                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false"}
+                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false", "local_discriminator" : "1"}
         self.check_state_bfd_session_value("default|default|10.0.0.2", expected_sdb_values)
 
         # Send BFD session state notification to update BFD session state
@@ -108,7 +108,7 @@ class TestBfd(object):
 
         # Check STATE_DB entry related to the BFD session
         expected_sdb_values = {"state": "Down", "type": "async_active", "local_addr" : "2000::1", "tx_interval" :"1000",
-                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false"}
+                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false", "local_discriminator" : "2"}
         self.check_state_bfd_session_value("default|default|2000::2", expected_sdb_values)
 
         # Send BFD session state notification to update BFD session state
@@ -150,7 +150,7 @@ class TestBfd(object):
 
         # Check STATE_DB entry related to the BFD session
         expected_sdb_values = {"state": "Down", "type": "async_active", "local_addr" : "10.0.0.1", "tx_interval" :"1000",
-                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false"}
+                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false", "local_discriminator" : "3"}
         self.check_state_bfd_session_value("default|Ethernet0|10.0.0.2", expected_sdb_values)
 
         # Send BFD session state notification to update BFD session state
@@ -192,7 +192,7 @@ class TestBfd(object):
 
         # Check STATE_DB entry related to the BFD session
         expected_sdb_values = {"state": "Down", "type": "async_active", "local_addr" : "10.0.0.1", "tx_interval" :"300",
-                                        "rx_interval" : "500", "multiplier" : "10", "multihop": "false"}
+                                        "rx_interval" : "500", "multiplier" : "10", "multihop": "false", "local_discriminator" : "3"}
         self.check_state_bfd_session_value("default|default|10.0.0.2", expected_sdb_values)
 
         # Send BFD session state notification to update BFD session state
@@ -233,7 +233,7 @@ class TestBfd(object):
 
         # Check STATE_DB entry related to the BFD session
         expected_sdb_values = {"state": "Down", "type": "async_active", "local_addr" : "10.0.0.1", "tx_interval" :"1000",
-                                        "rx_interval" : "1000", "multiplier" : "5", "multihop": "false"}
+                                        "rx_interval" : "1000", "multiplier" : "5", "multihop": "false", "local_discriminator" : "4"}
         self.check_state_bfd_session_value("default|default|10.0.0.2", expected_sdb_values)
 
         # Send BFD session state notification to update BFD session state
@@ -274,7 +274,7 @@ class TestBfd(object):
 
         # Check STATE_DB entry related to the BFD session
         expected_sdb_values = {"state": "Down", "type": "async_active", "local_addr" : "10.0.0.1", "tx_interval" :"1000",
-                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "true"}
+                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "true", "local_discriminator" : "5"}
         self.check_state_bfd_session_value("default|default|10.0.0.2", expected_sdb_values)
 
         # Send BFD session state notification to update BFD session state
@@ -314,7 +314,7 @@ class TestBfd(object):
 
         # Check STATE_DB entry related to the BFD session
         expected_sdb_values = {"state": "Down", "type": "demand_active", "local_addr" : "10.0.0.1", "tx_interval" :"1000",
-                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false"}
+                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false", "local_discriminator" : "6"}
         self.check_state_bfd_session_value("default|default|10.0.0.2", expected_sdb_values)
 
         # Send BFD session state notification to update BFD session state
@@ -357,7 +357,7 @@ class TestBfd(object):
         # Check STATE_DB entry related to the BFD session 1
         key_state_db1 = "default|default|10.0.0.2"
         expected_sdb_values1 = {"state": "Down", "type": "async_active", "local_addr" : "10.0.0.1", "tx_interval" :"1000",
-                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false"}
+                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false", "local_discriminator" : "7"}
         self.check_state_bfd_session_value(key_state_db1, expected_sdb_values1)
 
         # Create BFD session 2
@@ -385,7 +385,7 @@ class TestBfd(object):
         # Check STATE_DB entry related to the BFD session 2
         key_state_db2 = "default|default|10.0.1.2"
         expected_sdb_values2 = {"state": "Down", "type": "async_active", "local_addr" : "10.0.0.1", "tx_interval" :"300",
-                                        "rx_interval" : "500", "multiplier" : "10", "multihop": "false"}
+                                        "rx_interval" : "500", "multiplier" : "10", "multihop": "false", "local_discriminator" : "8"}
         self.check_state_bfd_session_value(key_state_db2, expected_sdb_values2)
 
         # Create BFD session 3
@@ -411,7 +411,7 @@ class TestBfd(object):
         # Check STATE_DB entry related to the BFD session 3
         key_state_db3 = "default|default|2000::2"
         expected_sdb_values3 = {"state": "Down", "type": "demand_active", "local_addr" : "2000::1", "tx_interval" :"1000",
-                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false"}
+                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false", "local_discriminator" : "9"}
         self.check_state_bfd_session_value(key_state_db3, expected_sdb_values3)
 
         # Create BFD session 4
@@ -437,7 +437,7 @@ class TestBfd(object):
         # Check STATE_DB entry related to the BFD session 4
         key_state_db4 = "default|default|3000::2"
         expected_sdb_values4 = {"state": "Down", "type": "async_active", "local_addr" : "3000::1", "tx_interval" :"1000",
-                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false"}
+                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false", "local_discriminator" : "10"}
         self.check_state_bfd_session_value(key_state_db4, expected_sdb_values4)
 
         # Update BFD session states

--- a/tests/test_bfd.py
+++ b/tests/test_bfd.py
@@ -192,7 +192,7 @@ class TestBfd(object):
 
         # Check STATE_DB entry related to the BFD session
         expected_sdb_values = {"state": "Down", "type": "async_active", "local_addr" : "10.0.0.1", "tx_interval" :"300",
-                                        "rx_interval" : "500", "multiplier" : "10", "multihop": "false", "local_discriminator" : "3"}
+                                        "rx_interval" : "500", "multiplier" : "10", "multihop": "false", "local_discriminator" : "4"}
         self.check_state_bfd_session_value("default|default|10.0.0.2", expected_sdb_values)
 
         # Send BFD session state notification to update BFD session state
@@ -233,7 +233,7 @@ class TestBfd(object):
 
         # Check STATE_DB entry related to the BFD session
         expected_sdb_values = {"state": "Down", "type": "async_active", "local_addr" : "10.0.0.1", "tx_interval" :"1000",
-                                        "rx_interval" : "1000", "multiplier" : "5", "multihop": "false", "local_discriminator" : "4"}
+                                        "rx_interval" : "1000", "multiplier" : "5", "multihop": "false", "local_discriminator" : "5"}
         self.check_state_bfd_session_value("default|default|10.0.0.2", expected_sdb_values)
 
         # Send BFD session state notification to update BFD session state
@@ -274,7 +274,7 @@ class TestBfd(object):
 
         # Check STATE_DB entry related to the BFD session
         expected_sdb_values = {"state": "Down", "type": "async_active", "local_addr" : "10.0.0.1", "tx_interval" :"1000",
-                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "true", "local_discriminator" : "5"}
+                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "true", "local_discriminator" : "6"}
         self.check_state_bfd_session_value("default|default|10.0.0.2", expected_sdb_values)
 
         # Send BFD session state notification to update BFD session state
@@ -314,7 +314,7 @@ class TestBfd(object):
 
         # Check STATE_DB entry related to the BFD session
         expected_sdb_values = {"state": "Down", "type": "demand_active", "local_addr" : "10.0.0.1", "tx_interval" :"1000",
-                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false", "local_discriminator" : "6"}
+                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false", "local_discriminator" : "7"}
         self.check_state_bfd_session_value("default|default|10.0.0.2", expected_sdb_values)
 
         # Send BFD session state notification to update BFD session state
@@ -357,7 +357,7 @@ class TestBfd(object):
         # Check STATE_DB entry related to the BFD session 1
         key_state_db1 = "default|default|10.0.0.2"
         expected_sdb_values1 = {"state": "Down", "type": "async_active", "local_addr" : "10.0.0.1", "tx_interval" :"1000",
-                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false", "local_discriminator" : "7"}
+                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false", "local_discriminator" : "8"}
         self.check_state_bfd_session_value(key_state_db1, expected_sdb_values1)
 
         # Create BFD session 2
@@ -385,7 +385,7 @@ class TestBfd(object):
         # Check STATE_DB entry related to the BFD session 2
         key_state_db2 = "default|default|10.0.1.2"
         expected_sdb_values2 = {"state": "Down", "type": "async_active", "local_addr" : "10.0.0.1", "tx_interval" :"300",
-                                        "rx_interval" : "500", "multiplier" : "10", "multihop": "false", "local_discriminator" : "8"}
+                                        "rx_interval" : "500", "multiplier" : "10", "multihop": "false", "local_discriminator" : "9"}
         self.check_state_bfd_session_value(key_state_db2, expected_sdb_values2)
 
         # Create BFD session 3
@@ -411,7 +411,7 @@ class TestBfd(object):
         # Check STATE_DB entry related to the BFD session 3
         key_state_db3 = "default|default|2000::2"
         expected_sdb_values3 = {"state": "Down", "type": "demand_active", "local_addr" : "2000::1", "tx_interval" :"1000",
-                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false", "local_discriminator" : "9"}
+                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false", "local_discriminator" : "10"}
         self.check_state_bfd_session_value(key_state_db3, expected_sdb_values3)
 
         # Create BFD session 4
@@ -437,7 +437,7 @@ class TestBfd(object):
         # Check STATE_DB entry related to the BFD session 4
         key_state_db4 = "default|default|3000::2"
         expected_sdb_values4 = {"state": "Down", "type": "async_active", "local_addr" : "3000::1", "tx_interval" :"1000",
-                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false", "local_discriminator" : "10"}
+                                        "rx_interval" : "1000", "multiplier" : "10", "multihop": "false", "local_discriminator" : "11"}
         self.check_state_bfd_session_value(key_state_db4, expected_sdb_values4)
 
         # Update BFD session states


### PR DESCRIPTION
Double commit for same design changes in 202012, PR https://github.com/sonic-net/sonic-swss/pull/2587

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
add local discriminator to state DB for "show bfd summary/peer" to show it.

**Why I did it**
For upcoming BFD debugging related CLI, user need to use local_discriminator to specify which BFD session they want to debug. current show bfd CLI does not have this information (the local_discriminator is not in state DB).
Also, this is local_discriminator printed into syslog, user may want to correlate this local_discriminator to BFD session.

**How I verified it**
with modified code, and modified show bfd python script, the local discriminator can be shown in 'show bfd' cmd:
(show "NA" if there is no local_discriminator in state DB.)
modification for "show bfd" script will be committed separately in another PR.
```
cisco@sonic:/var/tmp$ show bfd sum
Total number of BFD sessions: 1
Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop    Local Discriminator
-----------  -----------  -------  -------  ------------  ------------  -------------  -------------  ------------  ----------  ---------------------
192.85.2.24  default      default  Down     async_active  192.85.2.29            1000           1000             3  true        NA
cisco@sonic:/var/tmp$ show bfd peer 192.85.2.24
Total number of BFD sessions for peer IP 192.85.2.24: 1
Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop    Local Discriminator
-----------  -----------  -------  -------  ------------  ------------  -------------  -------------  ------------  ----------  ---------------------
192.85.2.24  default      default  Down     async_active  192.85.2.29            1000           1000             3  true        NA
cisco@sonic:/var/tmp$ docker exec -i swss swssconfig /dev/stdin < bfd.cfg
cisco@sonic:/var/tmp$ show bfd peer 192.85.2.24
Total number of BFD sessions for peer IP 192.85.2.24: 1
Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop      Local Discriminator
-----------  -----------  -------  -------  ------------  ------------  -------------  -------------  ------------  ----------  ---------------------
192.85.2.24  default      default  Down     async_active  192.85.2.29            1000           1000             3  true                            1
cisco@sonic:/var/tmp$ show bfd sum
Total number of BFD sessions: 1
Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop      Local Discriminator
-----------  -----------  -------  -------  ------------  ------------  -------------  -------------  ------------  ----------  ---------------------
192.85.2.24  default      default  Down     async_active  192.85.2.29            1000           1000             3  true                            1
```

**Details if related**
