### PR TITLE
swss: Fix Invalid port oid messages generated because of voq counters.

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -6150,16 +6150,12 @@ void PortsOrch::generateQueueMapPerPort(const Port& port, FlexCounterQueueStates
     else
     {
         m_queueTable->set("", queueVector);
+        CounterCheckOrch::getInstance().addPort(port);
     }
 
     m_queuePortTable->set("", queuePortVector);
     m_queueIndexTable->set("", queueIndexVector);
     m_queueTypeTable->set("", queueTypeVector);
-
-    if (!voq)
-    {
-       CounterCheckOrch::getInstance().addPort(port);
-    }
 }
 
 void PortsOrch::createPortBufferQueueCounters(const Port &port, string queues)

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -6156,7 +6156,10 @@ void PortsOrch::generateQueueMapPerPort(const Port& port, FlexCounterQueueStates
     m_queueIndexTable->set("", queueIndexVector);
     m_queueTypeTable->set("", queueTypeVector);
 
-    CounterCheckOrch::getInstance().addPort(port);
+    if (!voq)
+    {
+       CounterCheckOrch::getInstance().addPort(port);
+    }
 }
 
 void PortsOrch::createPortBufferQueueCounters(const Port &port, string queues)


### PR DESCRIPTION
**What I did**

* Do not add Voq oids to CounterCheckOrch since CounterCheckOrch is not relevant for voqs.

**Why I did it**

To fix the invalid oids messages generated by CounterCheckOrch for voq.

**How I verified it**

Verified that the messages are no longer generated and voq counters are still gathered.

