### PR TITLE
[autoneg]Fixing adv interface types to be set when AN is disabled

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3588,9 +3588,9 @@ void PortsOrch::doPortTask(Consumer &consumer)
                         continue;
                     }
 
-                    if (adv_interface_types != p.m_adv_interface_types && p.m_autoneg == 1)
+                    if (adv_interface_types != p.m_adv_interface_types)
                     {
-                        if (p.m_admin_state_up)
+                        if (p.m_admin_state_up && p.m_autoneg == 1)
                         {
                             /* Bring port down before applying speed */
                             if (!setPortAdminStatus(p, false))


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Allowing advertised interface types to be set even when AN is disabled. The SAI header doesn't restrict this field. In some cases when this field is changed during AN disable, it may not be reflected in SAI leading to errors as seen in the issue below. This will occur when interface type mismatches with advertise interface type and the vendor SAI library has checks.


**Why I did it**
To fix https://github.com/sonic-net/sonic-buildimage/issues/13414

**How I verified it**
Added UT to verify


**Details if related**
