### PR TITLE
[Dual-ToR] handle 'mux_tunnel_egress_acl' attrib in order to change ACL configuration (drop on ingress/egress) on standby ToR

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3156,6 +3156,7 @@ void AclOrch::initDefaultTableTypes()
         builder.withName(TABLE_TYPE_DROP)
             .withBindPointType(SAI_ACL_BIND_POINT_TYPE_PORT)
             .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_TC))
+            .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_IN_PORTS))
             .build()
     );
 

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -93,6 +93,7 @@
 
 #define MLNX_MAX_RANGES_COUNT   16
 #define INGRESS_TABLE_DROP      "IngressTableDrop"
+#define EGRESS_TABLE_DROP       "EgressTableDrop"
 #define RULE_OPER_ADD           0
 #define RULE_OPER_DELETE        1
 

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -787,8 +787,14 @@ MuxAclHandler::MuxAclHandler(sai_object_id_t port, string alias)
 {
     SWSS_LOG_ENTER();
 
+    string value;
+    shared_ptr<DBConnector> m_config_db = shared_ptr<DBConnector>(new DBConnector("CONFIG_DB", 0));
+    unique_ptr<Table> m_systemDefaultsTable = unique_ptr<Table>(new Table(m_config_db.get(), "SYSTEM_DEFAULTS"));
+    m_systemDefaultsTable->hget("mux_tunnel_egress_acl", "status", value);
+    is_ingress_acl_ = value != "enabled";
+
     // There is one handler instance per MUX port
-    string table_name = MUX_ACL_TABLE_NAME;
+    string table_name = is_ingress_acl_ ? MUX_ACL_TABLE_NAME : EGRESS_TABLE_DROP;
     string rule_name = MUX_ACL_RULE_NAME;
 
     port_ = port;
@@ -826,7 +832,7 @@ MuxAclHandler::MuxAclHandler(sai_object_id_t port, string alias)
 MuxAclHandler::~MuxAclHandler(void)
 {
     SWSS_LOG_ENTER();
-    string table_name = MUX_ACL_TABLE_NAME;
+    string table_name = is_ingress_acl_ ? MUX_ACL_TABLE_NAME : EGRESS_TABLE_DROP;
     string rule_name = MUX_ACL_RULE_NAME;
 
     SWSS_LOG_NOTICE("Un-Binding port %" PRIx64 "", port_);
@@ -872,7 +878,7 @@ void MuxAclHandler::createMuxAclTable(sai_object_id_t port, string strTable)
     auto dropType = gAclOrch->getAclTableType(TABLE_TYPE_DROP);
     assert(dropType);
     acl_table.validateAddType(*dropType);
-    acl_table.stage = ACL_STAGE_INGRESS;
+    acl_table.stage = is_ingress_acl_ ? ACL_STAGE_INGRESS : ACL_STAGE_EGRESS;
     gAclOrch->addAclTable(acl_table);
     bindAllPorts(acl_table);
 }

--- a/orchagent/muxorch.h
+++ b/orchagent/muxorch.h
@@ -55,6 +55,7 @@ private:
     // class shared dict: ACL table name -> ACL table
     static std::map<std::string, AclTable> acl_table_;
     sai_object_id_t port_ = SAI_NULL_OBJECT_ID;
+    bool is_ingress_acl_ = true;
     string alias_;
 };
 


### PR DESCRIPTION
Signed-off-by: Andriy Yurkiv <ayurkiv@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Use "mux_tunnel_ingress_acl" to set ACL rules on ingress/egress side depending on attribute value ("disabled/enabled").

**Why I did it**
We need to drop data-plane traffic and handle Control-plane traffic in the Dual-ToR scenario.
But we can't do it on Mellanox platform and process traffic on ingress.
To workaround it we can set ACL rules on egress ports, so will process control plane on ingress and drop Data-plane traffic that came from standby port on egress

**How I verified it**
check "show mux status" on standby ToR - Mux status should be healthy.
check "show what-just-happened" on standby ToR - no ICMP drop expected on standby ports.

**Details if related**
