### PR TITLE
[test_mux] add sleep in test_NH

### DIFF
--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -551,7 +551,8 @@ class TestMuxTunnelBase():
         self.set_mux_state(appdb, "Ethernet0", "active")
         self.add_neighbor(dvs, neigh_ip, mac)
         self.add_neighbor(dvs, neigh_ipv6, mac)
-        time.sleep(1)
+        asicdb.wait_for_entry(self.ASIC_NEIGH_TABLE, neigh_ip)
+        asicdb.wait_for_entry(self.ASIC_NEIGH_TABLE, neigh_ipv6)
         dvs.runcmd(
             "vtysh -c \"configure terminal\" -c \"ip route " + nh_route +
             " " + neigh_ip + "\""
@@ -561,6 +562,7 @@ class TestMuxTunnelBase():
             " " + neigh_ipv6 + "\""
         )
         apdb.wait_for_entry("ROUTE_TABLE", nh_route)
+
         rtkeys = dvs_route.check_asicdb_route_entries([nh_route])
         rtkeys_ipv6 = dvs_route.check_asicdb_route_entries([nh_route_ipv6])
         self.check_nexthop_in_asic_db(asicdb, rtkeys[0])
@@ -573,7 +575,9 @@ class TestMuxTunnelBase():
 
         self.del_neighbor(dvs, neigh_ip)
         self.del_neighbor(dvs, neigh_ipv6)
-        time.sleep(1)
+        asicdb.wait_for_deleted_entry(self.ASIC_NEIGH_TABLE, neigh_ip)
+        asicdb.wait_for_deleted_entry(self.ASIC_NEIGH_TABLE, neigh_ipv6)
+
         self.check_nexthop_in_asic_db(asicdb, rtkeys[0], True)
         self.check_nexthop_in_asic_db(asicdb, rtkeys_ipv6[0], True)
 
@@ -584,7 +588,9 @@ class TestMuxTunnelBase():
 
         self.add_neighbor(dvs, neigh_ip, mac)
         self.add_neighbor(dvs, neigh_ipv6, mac)
-        time.sleep(1)
+        asicdb.wait_for_entry(self.ASIC_NEIGH_TABLE, neigh_ip)
+        asicdb.wait_for_entry(self.ASIC_NEIGH_TABLE, neigh_ipv6)
+
         self.check_nexthop_in_asic_db(asicdb, rtkeys[0])
         self.check_nexthop_in_asic_db(asicdb, rtkeys_ipv6[0])
         dvs.runcmd(

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -551,8 +551,6 @@ class TestMuxTunnelBase():
         self.set_mux_state(appdb, "Ethernet0", "active")
         self.add_neighbor(dvs, neigh_ip, mac)
         self.add_neighbor(dvs, neigh_ipv6, mac)
-        asicdb.wait_for_entry(self.ASIC_NEIGH_TABLE, neigh_ip)
-        asicdb.wait_for_entry(self.ASIC_NEIGH_TABLE, neigh_ipv6)
         dvs.runcmd(
             "vtysh -c \"configure terminal\" -c \"ip route " + nh_route +
             " " + neigh_ip + "\""
@@ -562,6 +560,7 @@ class TestMuxTunnelBase():
             " " + neigh_ipv6 + "\""
         )
         apdb.wait_for_entry("ROUTE_TABLE", nh_route)
+        apdb.wait_for_entry("ROUTE_TABLE", nh_route_ipv6)
 
         rtkeys = dvs_route.check_asicdb_route_entries([nh_route])
         rtkeys_ipv6 = dvs_route.check_asicdb_route_entries([nh_route_ipv6])
@@ -575,8 +574,8 @@ class TestMuxTunnelBase():
 
         self.del_neighbor(dvs, neigh_ip)
         self.del_neighbor(dvs, neigh_ipv6)
-        asicdb.wait_for_deleted_entry(self.ASIC_NEIGH_TABLE, neigh_ip)
-        asicdb.wait_for_deleted_entry(self.ASIC_NEIGH_TABLE, neigh_ipv6)
+        apdb.wait_for_deleted_entry(self.APP_NEIGH_TABLE, neigh_ip)
+        apdb.wait_for_deleted_entry(self.APP_NEIGH_TABLE, neigh_ipv6)
 
         self.check_nexthop_in_asic_db(asicdb, rtkeys[0], True)
         self.check_nexthop_in_asic_db(asicdb, rtkeys_ipv6[0], True)
@@ -588,8 +587,8 @@ class TestMuxTunnelBase():
 
         self.add_neighbor(dvs, neigh_ip, mac)
         self.add_neighbor(dvs, neigh_ipv6, mac)
-        asicdb.wait_for_entry(self.ASIC_NEIGH_TABLE, neigh_ip)
-        asicdb.wait_for_entry(self.ASIC_NEIGH_TABLE, neigh_ipv6)
+        apdb.wait_for_entry(self.APP_NEIGH_TABLE, neigh_ip)
+        apdb.wait_for_entry(self.APP_NEIGH_TABLE, neigh_ipv6)
 
         self.check_nexthop_in_asic_db(asicdb, rtkeys[0])
         self.check_nexthop_in_asic_db(asicdb, rtkeys_ipv6[0])
@@ -609,8 +608,12 @@ class TestMuxTunnelBase():
             "vtysh -c \"configure terminal\" -c \"no ipv6 route " + nh_route_ipv6 +
             " " + neigh_ipv6 + "\""
         )
+        apdb.wait_for_deleted_entry("ROUTE_TABLE", nh_route)
+        apdb.wait_for_deleted_entry("ROUTE_TABLE", nh_route_ipv6)
         self.del_neighbor(dvs, neigh_ip)
         self.del_neighbor(dvs, neigh_ipv6)
+        apdb.wait_for_deleted_entry(self.APP_NEIGH_TABLE, neigh_ip)
+        apdb.wait_for_deleted_entry(self.APP_NEIGH_TABLE, neigh_ipv6)
 
     def get_expected_sai_qualifiers(self, portlist, dvs_acl):
         expected_sai_qualifiers = {

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -576,19 +576,19 @@ class TestMuxTunnelBase():
         self.del_neighbor(dvs, neigh_ipv6)
         apdb.wait_for_deleted_entry(self.APP_NEIGH_TABLE, neigh_ip)
         apdb.wait_for_deleted_entry(self.APP_NEIGH_TABLE, neigh_ipv6)
+        asicdb.wait_for_deleted_entry(self.ASIC_NEIGH_TABLE, neigh_ip)
+        asicdb.wait_for_deleted_entry(self.ASIC_NEIGH_TABLE, neigh_ip)
 
         self.check_nexthop_in_asic_db(asicdb, rtkeys[0], True)
         self.check_nexthop_in_asic_db(asicdb, rtkeys_ipv6[0], True)
 
         # Set state to active, learn neighbor again
         self.set_mux_state(appdb, "Ethernet0", "active")
-        self.check_nexthop_in_asic_db(asicdb, rtkeys[0], True)
-        self.check_nexthop_in_asic_db(asicdb, rtkeys_ipv6[0], True)
 
         self.add_neighbor(dvs, neigh_ip, mac)
         self.add_neighbor(dvs, neigh_ipv6, mac)
-        apdb.wait_for_entry(self.APP_NEIGH_TABLE, neigh_ip)
-        apdb.wait_for_entry(self.APP_NEIGH_TABLE, neigh_ipv6)
+        self.check_neigh_in_asic_db(asicdb, neigh_ip)
+        self.check_neigh_in_asic_db(asicdb, neigh_ipv6)
 
         self.check_nexthop_in_asic_db(asicdb, rtkeys[0])
         self.check_nexthop_in_asic_db(asicdb, rtkeys_ipv6[0])
@@ -608,12 +608,8 @@ class TestMuxTunnelBase():
             "vtysh -c \"configure terminal\" -c \"no ipv6 route " + nh_route_ipv6 +
             " " + neigh_ipv6 + "\""
         )
-        apdb.wait_for_deleted_entry("ROUTE_TABLE", nh_route)
-        apdb.wait_for_deleted_entry("ROUTE_TABLE", nh_route_ipv6)
         self.del_neighbor(dvs, neigh_ip)
         self.del_neighbor(dvs, neigh_ipv6)
-        apdb.wait_for_deleted_entry(self.APP_NEIGH_TABLE, neigh_ip)
-        apdb.wait_for_deleted_entry(self.APP_NEIGH_TABLE, neigh_ipv6)
 
     def get_expected_sai_qualifiers(self, portlist, dvs_acl):
         expected_sai_qualifiers = {

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -551,6 +551,7 @@ class TestMuxTunnelBase():
         self.set_mux_state(appdb, "Ethernet0", "active")
         self.add_neighbor(dvs, neigh_ip, mac)
         self.add_neighbor(dvs, neigh_ipv6, mac)
+        time.sleep(1)
         dvs.runcmd(
             "vtysh -c \"configure terminal\" -c \"ip route " + nh_route +
             " " + neigh_ip + "\""
@@ -572,6 +573,7 @@ class TestMuxTunnelBase():
 
         self.del_neighbor(dvs, neigh_ip)
         self.del_neighbor(dvs, neigh_ipv6)
+        time.sleep(1)
         self.check_nexthop_in_asic_db(asicdb, rtkeys[0], True)
         self.check_nexthop_in_asic_db(asicdb, rtkeys_ipv6[0], True)
 
@@ -582,6 +584,7 @@ class TestMuxTunnelBase():
 
         self.add_neighbor(dvs, neigh_ip, mac)
         self.add_neighbor(dvs, neigh_ipv6, mac)
+        time.sleep(1)
         self.check_nexthop_in_asic_db(asicdb, rtkeys[0])
         self.check_nexthop_in_asic_db(asicdb, rtkeys_ipv6[0])
         dvs.runcmd(


### PR DESCRIPTION
What I did: added sleep after adding/removing neighbors in test_NH

Why I did it: resolve PR failures due to timing issues between adding/deleting neighbors and them being present in the asic_db

Signed-off-by: Nikola Dancejic <ndancejic@microsoft.com>
