### PR TITLE
resource monitoring support for generic SAI extension tables

### DIFF
--- a/orchagent/crmorch.h
+++ b/orchagent/crmorch.h
@@ -34,6 +34,7 @@ enum class CrmResourceType
     CRM_SRV6_MY_SID_ENTRY,
     CRM_SRV6_NEXTHOP,
     CRM_NEXTHOP_GROUP_MAP,
+    CRM_EXT_TABLE,
 };
 
 enum class CrmThresholdType
@@ -63,6 +64,10 @@ public:
     void incCrmAclTableUsedCounter(CrmResourceType resource, sai_object_id_t tableId);
     // Decrement "used" counter for the per ACL table CRM resources (ACL entry/counter)
     void decCrmAclTableUsedCounter(CrmResourceType resource, sai_object_id_t tableId);
+    // Increment "used" counter for the EXT table CRM resources
+    void incCrmExtTableUsedCounter(CrmResourceType resource, std::string table_name);
+    // Decrement "used" counter for the EXT table CRM resources
+    void decCrmExtTableUsedCounter(CrmResourceType resource, std::string table_name);
 
 private:
     std::shared_ptr<swss::DBConnector> m_countersDb = nullptr;
@@ -105,4 +110,5 @@ private:
     void checkCrmThresholds();
     std::string getCrmAclKey(sai_acl_stage_t stage, sai_acl_bind_point_type_t bindPoint);
     std::string getCrmAclTableKey(sai_object_id_t id);
+    std::string getCrmP4rtTableKey(std::string table_name);
 };

--- a/orchagent/p4orch/ext_tables_manager.cpp
+++ b/orchagent/p4orch/ext_tables_manager.cpp
@@ -12,6 +12,7 @@
 #include "logger.h"
 #include "tokenize.h"
 #include "orch.h"
+#include "crmorch.h"
 #include "p4orch/p4orch.h"
 #include "p4orch/p4orch_util.h"
 
@@ -21,6 +22,7 @@ extern sai_generic_programmable_api_t *sai_generic_programmable_api;
 extern Directory<Orch *> gDirectory;
 extern sai_object_id_t gSwitchId;
 extern P4Orch *gP4Orch;
+extern CrmOrch *gCrmOrch;
 
 P4ExtTableEntry *ExtTablesManager::getP4ExtTableEntry(const std::string &table_name, const std::string &key)
 {
@@ -467,6 +469,9 @@ ReturnCode ExtTablesManager::createP4ExtTableEntry(const P4ExtTableAppDbEntry &a
                            << app_db_entry.table_name.c_str()
                            << " , entry " << app_db_entry.table_key.c_str();
     }
+    std::string crm_table_name = "EXT_" + app_db_entry.table_name;
+    boost::algorithm::to_upper(crm_table_name);
+    gCrmOrch->incCrmExtTableUsedCounter(CrmResourceType::CRM_EXT_TABLE, crm_table_name);
 
 
     ext_table_entry.sai_entry_oid = sai_generic_programmable_oid;
@@ -598,6 +603,9 @@ ReturnCode ExtTablesManager::removeP4ExtTableEntry(const std::string &table_name
                            << "remove sai api call failed for extension entry table "
                            << table_name.c_str() << " , entry " << table_key.c_str();
     }
+    std::string crm_table_name = "EXT_" + table_name;
+    boost::algorithm::to_upper(crm_table_name);
+    gCrmOrch->decCrmExtTableUsedCounter(CrmResourceType::CRM_EXT_TABLE, crm_table_name);
 
 
     auto ext_table_key = KeyGenerator::generateExtTableKey(table_name, table_key);


### PR DESCRIPTION
High Level Design: https://github.com/sonic-net/SONiC/pull/1243

The change incudes,
- new resource type to reprsent all extension tables
- countermap for each extension table under this new resource type
- extension table mgr to call APIs to track usage counter of entries in each extension table
- pytest automation

Signed-off-by: svshah-intel shitanshu.shah@intel.com
