### PR TITLE
Remove counters for Mux ACL

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -809,7 +809,7 @@ MuxAclHandler::MuxAclHandler(sai_object_id_t port, string alias)
         // First time handling of Mux Table, create ACL table, and bind
         createMuxAclTable(port, table_name);
         shared_ptr<AclRulePacket> newRule =
-                make_shared<AclRulePacket>(gAclOrch, rule_name, table_name);
+                make_shared<AclRulePacket>(gAclOrch, rule_name, table_name, false /*no counters*/);
         createMuxAclRule(newRule, table_name);
     }
     else
@@ -820,7 +820,7 @@ MuxAclHandler::MuxAclHandler(sai_object_id_t port, string alias)
         if (rule == nullptr)
         {
             shared_ptr<AclRulePacket> newRule =
-                    make_shared<AclRulePacket>(gAclOrch, rule_name, table_name);
+                    make_shared<AclRulePacket>(gAclOrch, rule_name, table_name, false /*no counters*/);
             createMuxAclRule(newRule, table_name);
         }
         else


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Do not use counters for mux ACL

**Why I did it**
Noticed that with PR https://github.com/sonic-net/sonic-swss/pull/1982 counters are enabled by default. It was not the case earlier.
User won't be able to see it with aclshow and it will waste valuable hardware counter resource.

**How I verified it**

**Details if related**
Master PR: https://github.com/sonic-net/sonic-swss/pull/2643