### PR TITLE
Revert "Revert "[voq][chassis]Add show fabric counters port/queue com…

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -724,9 +724,8 @@ int main(int argc, char **argv)
         if (gMySwitchType == "voq")
         {
             orchDaemon->setFabricEnabled(true);
-            // SAI doesn't fully support counters for non fabric asics
-            orchDaemon->setFabricPortStatEnabled(false);
-            orchDaemon->setFabricQueueStatEnabled(false);
+            orchDaemon->setFabricPortStatEnabled(true);
+            orchDaemon->setFabricQueueStatEnabled(true);
         }
     }
     else


### PR DESCRIPTION
…mands (#2522)" (#2611)"

This reverts commit b6bbc3e6a8ec79bd5542436e2b99ab6f0c81521b.
Reverts https://github.com/sonic-net/sonic-swss/pull/](https://github.com/sonic-net/sonic-swss/pull/2611)

Before merging this revert, the Broadcom SAI needs to be updated to support fabric counters.
