### PR TITLE
[202205] enable fabric counters support

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -708,9 +708,8 @@ int main(int argc, char **argv)
         if (gMySwitchType == "voq")
         {
             orchDaemon->setFabricEnabled(true);
-            // SAI doesn't fully support counters for non fabric asics
-            orchDaemon->setFabricPortStatEnabled(false);
-            orchDaemon->setFabricQueueStatEnabled(false);
+            orchDaemon->setFabricPortStatEnabled(true);
+            orchDaemon->setFabricQueueStatEnabled(true);
         }
     }
     else


### PR DESCRIPTION
…mands (#2522)" (#2612)"

This reverts commit 34995f149a34125f9108473d092c95ed67482af0.

**What I did**
Reverted https://github.com/sonic-net/sonic-swss/commit/34995f149a34125f9108473d092c95ed67482af0 to re-enable fabric counters support. Broadcom SAI 7.1.32 has been integrated into 202205 which fixes the crash problem.

**Why I did it**
To re-enable fabric counters support.

**How I verified it**
Loaded image to confirm that syncd no longer crashes.

**Other details**
The corresponding revert against `master` is this PR: https://github.com/sonic-net/sonic-swss/pull/2652. However, the PR against `master` cannot merge until the corresponding Broadcom SAI has the appropriate fix.