### PR TITLE
[orchagent]: Get bridge port ID from orchagent cache instead of SAI API

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -636,29 +636,21 @@ bool FdbOrch::getPort(const MacAddress& mac, uint16_t vlan, Port& port)
         return false;
     }
 
-    sai_fdb_entry_t entry;
-    entry.switch_id = gSwitchId;
-    memcpy(entry.mac_address, mac.getMac(), sizeof(sai_mac_t));
+    FdbEntry entry;
+    entry.mac = mac;
     entry.bv_id = port.m_vlan_info.vlan_oid;
 
-    sai_attribute_t attr;
-    attr.id = SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID;
-
-    sai_status_t status = sai_fdb_api->get_fdb_entry_attribute(&entry, 1, &attr);
-    if (status != SAI_STATUS_SUCCESS)
+    auto it = m_entries.find(entry);
+    if (it == m_entries.end())
     {
-        SWSS_LOG_ERROR("Failed to get bridge port ID for FDB entry %s, rv:%d",
-            mac.to_string().c_str(), status);
-        task_process_status handle_status = handleSaiGetStatus(SAI_API_FDB, status);
-        if (handle_status != task_process_status::task_success)
-        {
-            return false;
-        }
+        SWSS_LOG_ERROR("Failed to get cached bridge port ID for FDB entry %s",
+            mac.to_string().c_str());
+        return false;
     }
 
-    if (!m_portsOrch->getPortByBridgePortId(attr.value.oid, port))
+    if (!m_portsOrch->getPortByBridgePortId(it->second.bridge_port_id, port))
     {
-        SWSS_LOG_ERROR("Failed to get port by bridge port ID 0x%" PRIx64, attr.value.oid);
+        SWSS_LOG_ERROR("Failed to get port by bridge port ID 0x%" PRIx64, it->second.bridge_port_id);
         return false;
     }
 

--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -643,7 +643,9 @@ bool FdbOrch::getPort(const MacAddress& mac, uint16_t vlan, Port& port)
     auto it = m_entries.find(entry);
     if (it == m_entries.end())
     {
-        SWSS_LOG_ERROR("Failed to get cached bridge port ID for FDB entry %s",
+        // This message is now expected in many cases since orchagent will process events such as
+        // learning new neighbor entries prior to updating the m_entries FDB cache.
+        SWSS_LOG_INFO("Failed to get cached bridge port ID for FDB entry %s",
             mac.to_string().c_str());
         return false;
     }

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -534,6 +534,8 @@ bool MuxCable::isIpInSubnet(IpAddress ip)
 
 bool MuxCable::nbrHandler(bool enable, bool update_rt)
 {
+    SWSS_LOG_NOTICE("Processing neighbors for mux %s, enable %d, state %d",
+                     mux_name_.c_str(), enable, state_)
     if (enable)
     {
         return nbr_handler_->enable(update_rt);
@@ -553,6 +555,8 @@ bool MuxCable::nbrHandler(bool enable, bool update_rt)
 
 void MuxCable::updateNeighbor(NextHopKey nh, bool add)
 {
+    SWSS_LOG_NOTICE("Processing update on neighbor %s for mux %s, add %d, state %d",
+                     nh.ip_address.to_string().c_str(), mux_name_.c_str(), add, state_)
     sai_object_id_t tnh = mux_orch_->getNextHopTunnelId(MUX_TUNNEL, peer_ip4_);
     nbr_handler_->update(nh, tnh, add, state_);
     if (add)

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -535,7 +535,7 @@ bool MuxCable::isIpInSubnet(IpAddress ip)
 bool MuxCable::nbrHandler(bool enable, bool update_rt)
 {
     SWSS_LOG_NOTICE("Processing neighbors for mux %s, enable %d, state %d",
-                     mux_name_.c_str(), enable, state_)
+                     mux_name_.c_str(), enable, state_);
     if (enable)
     {
         return nbr_handler_->enable(update_rt);
@@ -556,7 +556,7 @@ bool MuxCable::nbrHandler(bool enable, bool update_rt)
 void MuxCable::updateNeighbor(NextHopKey nh, bool add)
 {
     SWSS_LOG_NOTICE("Processing update on neighbor %s for mux %s, add %d, state %d",
-                     nh.ip_address.to_string().c_str(), mux_name_.c_str(), add, state_)
+                     nh.ip_address.to_string().c_str(), mux_name_.c_str(), add, state_);
     sai_object_id_t tnh = mux_orch_->getNextHopTunnelId(MUX_TUNNEL, peer_ip4_);
     nbr_handler_->update(nh, tnh, add, state_);
     if (add)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
- When looking up bridge port ID from MAC address, use orchagent's internal FDB cache instead of making a SAI API call
- Add some more logs to MuxOrch

**Why I did it**
The SAI API will process FDB events immediately/asynchronously. If orchagent is in the middle of another task and an FDB event occurs, orchagent will not process it until after the current task but the SAI API will. If orchagent's current task requires looking up the bridge port ID a MAC address is learned on, the current SAI API call will return a port that is inconsistent with orchagent's current internal state.

**How I verified it**

**Details if related**
