### PR TITLE
[202012][orchagent]: Get bridge port ID from FDBOrch cache instead of SAI API #2657

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -522,7 +522,7 @@ bool MuxCable::isIpInSubnet(IpAddress ip)
 bool MuxCable::nbrHandler(bool enable, bool update_rt)
 {
     SWSS_LOG_NOTICE("Processing neighbors for mux %s, enable %d, state %d",
-                     mux_name_.c_str(), enable, state_)
+                     mux_name_.c_str(), enable, state_);
     if (enable)
     {
         return nbr_handler_->enable(update_rt);
@@ -543,7 +543,7 @@ bool MuxCable::nbrHandler(bool enable, bool update_rt)
 void MuxCable::updateNeighbor(NextHopKey nh, bool add)
 {
     SWSS_LOG_NOTICE("Processing update on neighbor %s for mux %s, add %d, state %d",
-                     nh.ip_address.to_string().c_str(), mux_name_.c_str(), add, state_)
+                     nh.ip_address.to_string().c_str(), mux_name_.c_str(), add, state_);
     sai_object_id_t tnh = mux_orch_->getNextHopTunnelId(MUX_TUNNEL, peer_ip4_);
     nbr_handler_->update(nh, tnh, add, state_);
     if (add)

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -521,6 +521,8 @@ bool MuxCable::isIpInSubnet(IpAddress ip)
 
 bool MuxCable::nbrHandler(bool enable, bool update_rt)
 {
+    SWSS_LOG_NOTICE("Processing neighbors for mux %s, enable %d, state %d",
+                     mux_name_.c_str(), enable, state_)
     if (enable)
     {
         return nbr_handler_->enable(update_rt);
@@ -540,6 +542,8 @@ bool MuxCable::nbrHandler(bool enable, bool update_rt)
 
 void MuxCable::updateNeighbor(NextHopKey nh, bool add)
 {
+    SWSS_LOG_NOTICE("Processing update on neighbor %s for mux %s, add %d, state %d",
+                     nh.ip_address.to_string().c_str(), mux_name_.c_str(), add, state_)
     sai_object_id_t tnh = mux_orch_->getNextHopTunnelId(MUX_TUNNEL, peer_ip4_);
     nbr_handler_->update(nh, tnh, add, state_);
     if (add)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
- When looking up bridge port ID from MAC address, use orchagent's internal FDB cache instead of making a SAI API call
- Add some more logs to MuxOrch

**Why I did it**
The SAI API will process FDB events immediately/asynchronously. If orchagent is in the middle of another task and an FDB event occurs, orchagent will not process it until after the current task but the SAI API will. If orchagent's current task requires looking up the bridge port ID a MAC address is learned on, the current SAI API call will return a port that is inconsistent with orchagent's current internal state.

**How I verified it**

**Details if related**
