### PR TITLE
Fixed set admin_status for deleted subintf due to late notification

### DIFF
--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -153,7 +153,7 @@ tests_portsyncd_LDADD = $(LDADD_GTEST) -lnl-genl-3 -lhiredis -lhiredis \
 
 ## intfmgrd unit tests
 
-tests_intfmgrd_SOURCES = intfmgrd/add_ipv6_prefix_ut.cpp \
+tests_intfmgrd_SOURCES = intfmgrd/intfmgr_ut.cpp \
                          $(top_srcdir)/cfgmgr/intfmgr.cpp \
                          $(top_srcdir)/lib/subintf.cpp \
                          $(top_srcdir)/orchagent/orch.cpp \

--- a/tests/mock_tests/intfmgrd/add_ipv6_prefix_ut.cpp
+++ b/tests/mock_tests/intfmgrd/add_ipv6_prefix_ut.cpp
@@ -26,6 +26,15 @@ int cb(const std::string &cmd, std::string &stdout){
     return 0;
 }
 
+
+int cb2(const std::string &cmd, std::string &stdout){
+    if (cmd == "/sbin/ip link set \"Ethernet64.10\" \"up\""){
+        return 1;
+    }
+    return 0;
+}
+
+
 // Test Fixture
 namespace add_ipv6_prefix_ut
 {
@@ -105,5 +114,21 @@ namespace add_ipv6_prefix_ut
             }
         }
         ASSERT_EQ(ip_cmd_called, 1);
+    }
+
+    TEST_F(IntfMgrTest, testEden){
+        callback = cb2;
+        swss::IntfMgr intfmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_intf_tables);
+        intfmgr.setHostSubIntfAdminStatus("Ethernet64.10", "up", "up");
+    }
+
+    TEST_F(IntfMgrTest, testEden2){
+        callback = cb2;
+        swss::IntfMgr intfmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_intf_tables);
+        /* Set portStateTable */
+        std::vector<swss::FieldValueTuple> values;
+        values.emplace_back("state", "ok");
+        intfmgr.m_statePortTable.set("Ethernet64.10", values, "SET", "");
+        EXPECT_THROW(intfmgr.setHostSubIntfAdminStatus("Ethernet64.10", "up", "up"), std::runtime_error);
     }
 }

--- a/tests/mock_tests/intfmgrd/intfmgr_ut.cpp
+++ b/tests/mock_tests/intfmgrd/intfmgr_ut.cpp
@@ -1,6 +1,6 @@
 #include "gtest/gtest.h"
 #include <iostream>
-#include <fstream>  
+#include <fstream>
 #include <unistd.h>
 #include <sys/stat.h>
 #include "../mock_table.h"
@@ -20,23 +20,17 @@ int cb(const std::string &cmd, std::string &stdout){
     else if (cmd.find("/sbin/ip -6 address \"add\"") == 0) {
         return Ethernet0IPv6Set ? 0 : 2;
     }
+    else if (cmd == "/sbin/ip link set \"Ethernet64.10\" \"up\""){
+        return 1;
+    }
     else {
         return 0;
     }
     return 0;
 }
 
-
-int cb2(const std::string &cmd, std::string &stdout){
-    if (cmd == "/sbin/ip link set \"Ethernet64.10\" \"up\""){
-        return 1;
-    }
-    return 0;
-}
-
-
 // Test Fixture
-namespace add_ipv6_prefix_ut
+namespace intfmgr_ut
 {
     struct IntfMgrTest : public ::testing::Test
     {
@@ -44,14 +38,14 @@ namespace add_ipv6_prefix_ut
         std::shared_ptr<swss::DBConnector> m_app_db;
         std::shared_ptr<swss::DBConnector> m_state_db;
         std::vector<std::string> cfg_intf_tables;
-        
+
         virtual void SetUp() override
-        {   
+        {
             testing_db::reset();
             m_config_db = std::make_shared<swss::DBConnector>("CONFIG_DB", 0);
             m_app_db = std::make_shared<swss::DBConnector>("APPL_DB", 0);
             m_state_db = std::make_shared<swss::DBConnector>("STATE_DB", 0);
-            
+
             swss::WarmStart::initialize("intfmgrd", "swss");
 
             std::vector<std::string> tables = {
@@ -116,14 +110,16 @@ namespace add_ipv6_prefix_ut
         ASSERT_EQ(ip_cmd_called, 1);
     }
 
-    TEST_F(IntfMgrTest, testEden){
-        callback = cb2;
+    //This test except no runtime error when the set admin status command failed
+    //and the subinterface has not ok status (for example not existing subinterface)
+    TEST_F(IntfMgrTest, testSetAdminStatusFailToNotOkSubInt){
         swss::IntfMgr intfmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_intf_tables);
         intfmgr.setHostSubIntfAdminStatus("Ethernet64.10", "up", "up");
     }
 
-    TEST_F(IntfMgrTest, testEden2){
-        callback = cb2;
+    //This test except runtime error when the set admin status command failed
+    //and the subinterface has ok status
+    TEST_F(IntfMgrTest, testSetAdminStatusFailToOkSubInt){
         swss::IntfMgr intfmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_intf_tables);
         /* Set portStateTable */
         std::vector<swss::FieldValueTuple> values;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Handled a race condition in intfmgrd which tries to immediately apply an admin_status SET notif after a DEL causing it to crash

**Why I did it**
Ignores errors on the set admin_status command for subinterface when the subinterface state is not OK.


**How I verified it**

**Details if related**
This PR reference to older PR that fix the same issue in portmgr: https://github.com/sonic-net/sonic-swss/pull/2431