### PR TITLE
[ACL] Write ACL table/rule creation status into STATE_DB

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -4345,6 +4345,7 @@ void AclOrch::doAclTableTask(Consumer &consumer)
                     {
                         SWSS_LOG_NOTICE("Successfully updated existing ACL table %s",
                                         table_id.c_str());
+                        // Mark ACL table as ACTIVE
                         setAclTableStatus(table_id, AclObjectStatus::ACTIVE);
                         it = consumer.m_toSync.erase(it);
                     }
@@ -4352,8 +4353,6 @@ void AclOrch::doAclTableTask(Consumer &consumer)
                     {
                         SWSS_LOG_ERROR("Failed to update existing ACL table %s",
                                         table_id.c_str());
-                        // For now, updateAclTable always return true. So we should never reach here
-                        setAclTableStatus(table_id, AclObjectStatus::INACTIVE);
                         it++;
                     }
                 }
@@ -4361,6 +4360,7 @@ void AclOrch::doAclTableTask(Consumer &consumer)
                 {
                     if (addAclTable(newTable))
                     {
+                        // Mark ACL table as ACTIVE
                         setAclTableStatus(table_id, AclObjectStatus::ACTIVE);
                         it = consumer.m_toSync.erase(it);
                     }
@@ -4384,6 +4384,7 @@ void AclOrch::doAclTableTask(Consumer &consumer)
         {
             if (removeAclTable(table_id))
             {
+                // Remove ACL table status from STATE_DB
                 removeAclTableStatus(table_id);
                 it = consumer.m_toSync.erase(it);
             }

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3014,6 +3014,10 @@ void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, Mirr
 {
     SWSS_LOG_ENTER();
 
+    // Clear ACL_TABLE and ACL_RULE status from STATE_DB
+    removeAllAclTableStatus();
+    removeAllAclRuleStatus();
+
     // TODO: Query SAI to get mirror table capabilities
     // Right now, verified platforms that support mirroring IPv6 packets are
     // Broadcom and Mellanox. Virtual switch is also supported for testing
@@ -4944,3 +4948,27 @@ void AclOrch::removeAclRuleStatus(string table_name, string rule_name)
 {
     m_aclRuleStateTable.del(table_name + string("|") + rule_name);
 }
+
+// Remove all ACL table status from STATE_DB
+void AclOrch::removeAllAclTableStatus()
+{
+    vector<string> keys;
+    m_aclTableStateTable.getKeys(keys);
+
+    for (auto key : keys)
+    {
+        m_aclTableStateTable.del(key);
+    }
+}
+
+// Remove all ACL rule status from STATE_DB
+void AclOrch::removeAllAclRuleStatus()
+{
+    vector<string> keys;
+    m_aclRuleStateTable.getKeys(keys);
+    for (auto key : keys)
+    {
+        m_aclRuleStateTable.del(key);
+    }
+}
+

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -415,6 +415,14 @@ static map<sai_acl_counter_attr_t, sai_acl_counter_attr_t> aclCounterLookup =
     {SAI_ACL_COUNTER_ATTR_ENABLE_PACKET_COUNT, SAI_ACL_COUNTER_ATTR_PACKETS},
 };
 
+static map<AclObjectStatus, string> aclObjectStatusLookup = 
+{
+    {AclObjectStatus::ACTIVE, "Active"},
+    {AclObjectStatus::INACTIVE, "Inactive"},
+    {AclObjectStatus::PENDING_CREATION, "Pending creation"},
+    {AclObjectStatus::PENDING_REMOVAL, "Pending removal"}
+};
+
 static sai_acl_table_attr_t AclEntryFieldToAclTableField(sai_acl_entry_attr_t attr)
 {
     if (!IS_ATTR_ID_IN_RANGE(attr, ACL_ENTRY, FIELD))
@@ -4333,7 +4341,7 @@ void AclOrch::doAclTableTask(Consumer &consumer)
                     {
                         SWSS_LOG_NOTICE("Successfully updated existing ACL table %s",
                                         table_id.c_str());
-                        setAclTableStatus(table_id, true);
+                        setAclTableStatus(table_id, AclObjectStatus::ACTIVE);
                         it = consumer.m_toSync.erase(it);
                     }
                     else
@@ -4341,7 +4349,7 @@ void AclOrch::doAclTableTask(Consumer &consumer)
                         SWSS_LOG_ERROR("Failed to update existing ACL table %s",
                                         table_id.c_str());
                         // For now, updateAclTable always return true. So we should never reach here
-                        setAclTableStatus(table_id, false);
+                        setAclTableStatus(table_id, AclObjectStatus::INACTIVE);
                         it++;
                     }
                 }
@@ -4349,12 +4357,12 @@ void AclOrch::doAclTableTask(Consumer &consumer)
                 {
                     if (addAclTable(newTable))
                     {
-                        setAclTableStatus(table_id, true);
+                        setAclTableStatus(table_id, AclObjectStatus::ACTIVE);
                         it = consumer.m_toSync.erase(it);
                     }
                     else
                     {
-                        setAclTableStatus(table_id, false);
+                        setAclTableStatus(table_id, AclObjectStatus::PENDING_CREATION);
                         it++;
                     }
                 }
@@ -4363,7 +4371,7 @@ void AclOrch::doAclTableTask(Consumer &consumer)
             {
                 it = consumer.m_toSync.erase(it);
                 // Mark the ACL table as inactive if the configuration is invalid
-                setAclTableStatus(table_id, false);
+                setAclTableStatus(table_id, AclObjectStatus::INACTIVE);
                 SWSS_LOG_ERROR("Failed to create ACL table %s, invalid configuration",
                         table_id.c_str());
             }
@@ -4376,7 +4384,11 @@ void AclOrch::doAclTableTask(Consumer &consumer)
                 it = consumer.m_toSync.erase(it);
             }
             else
+            {
+                // Set the status of ACL_TABLE to pending removal if removeAclTable returns error
+                setAclTableStatus(table_id, AclObjectStatus::PENDING_REMOVAL);
                 it++;
+            }
         }
         else
         {
@@ -4517,12 +4529,12 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
             {
                 if (addAclRule(newRule, table_id))
                 {
-                    setAclRuleStatus(table_id, rule_id, true);
+                    setAclRuleStatus(table_id, rule_id, AclObjectStatus::ACTIVE);
                     it = consumer.m_toSync.erase(it);
                 }
                 else
                 {
-                    setAclRuleStatus(table_id, rule_id, false);
+                    setAclRuleStatus(table_id, rule_id, AclObjectStatus::PENDING_CREATION);
                     it++;
                 }
             }
@@ -4530,7 +4542,7 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
             {
                 it = consumer.m_toSync.erase(it);
                 // Mark the rule inactive if the configuration is invalid
-                setAclRuleStatus(table_id, rule_id, false);
+                setAclRuleStatus(table_id, rule_id, AclObjectStatus::INACTIVE);
                 SWSS_LOG_ERROR("Failed to create ACL rule. Rule configuration is invalid");
             }
         }
@@ -4542,7 +4554,11 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
                 it = consumer.m_toSync.erase(it);
             }
             else
+            {
+                // Mark pending removal status if removeAclRule returns error
+                setAclRuleStatus(table_id, rule_id, AclObjectStatus::PENDING_REMOVAL);
                 it++;
+            }
         }
         else
         {
@@ -4902,17 +4918,10 @@ bool AclOrch::getAclBindPortId(Port &port, sai_object_id_t &port_id)
 }
 
 // Set the status of ACL table in STATE_DB
-void AclOrch::setAclTableStatus(string table_name, bool active)
+void AclOrch::setAclTableStatus(string table_name, AclObjectStatus status)
 {
     vector<FieldValueTuple> fvVector;
-    if (active)
-    {
-        fvVector.emplace_back("status", "Active");
-    }
-    else
-    {
-        fvVector.emplace_back("status", "Inactive");
-    }
+    fvVector.emplace_back("status", aclObjectStatusLookup[status]);
     m_aclTableStateTable.set(table_name, fvVector);
 }
 
@@ -4923,17 +4932,10 @@ void AclOrch::removeAclTableStatus(string table_name)
 }
 
 // Set the status of ACL rule in STATE_DB
-void AclOrch::setAclRuleStatus(string table_name, string rule_name, bool active)
+void AclOrch::setAclRuleStatus(string table_name, string rule_name, AclObjectStatus status)
 {
     vector<FieldValueTuple> fvVector;
-    if (active)
-    {
-        fvVector.emplace_back("status", "Active");
-    }
-    else
-    {
-        fvVector.emplace_back("status", "Inactive");
-    }
+    fvVector.emplace_back("status", aclObjectStatusLookup[status]);
     m_aclRuleStateTable.set(table_name + string("|") + rule_name, fvVector);
 }
 

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -4517,12 +4517,12 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
             {
                 if (addAclRule(newRule, table_id))
                 {
-                    setAclRuleStatus(rule_id, true);
+                    setAclRuleStatus(table_id, rule_id, true);
                     it = consumer.m_toSync.erase(it);
                 }
                 else
                 {
-                    setAclRuleStatus(rule_id, false);
+                    setAclRuleStatus(table_id, rule_id, false);
                     it++;
                 }
             }
@@ -4530,7 +4530,7 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
             {
                 it = consumer.m_toSync.erase(it);
                 // Mark the rule inactive if the configuration is invalid
-                setAclRuleStatus(rule_id, false);
+                setAclRuleStatus(table_id, rule_id, false);
                 SWSS_LOG_ERROR("Failed to create ACL rule. Rule configuration is invalid");
             }
         }
@@ -4538,7 +4538,7 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
         {
             if (removeAclRule(table_id, rule_id))
             {
-                removeAclRuleStatus(rule_id);
+                removeAclRuleStatus(table_id, rule_id);
                 it = consumer.m_toSync.erase(it);
             }
             else
@@ -4907,11 +4907,11 @@ void AclOrch::setAclTableStatus(string table_name, bool active)
     vector<FieldValueTuple> fvVector;
     if (active)
     {
-        fvVector.emplace_back("Status", "Active");
+        fvVector.emplace_back("status", "Active");
     }
     else
     {
-        fvVector.emplace_back("Status", "Inactive");
+        fvVector.emplace_back("status", "Inactive");
     }
     m_aclTableStateTable.set(table_name, fvVector);
 }
@@ -4923,22 +4923,22 @@ void AclOrch::removeAclTableStatus(string table_name)
 }
 
 // Set the status of ACL rule in STATE_DB
-void AclOrch::setAclRuleStatus(string rule_name, bool active)
+void AclOrch::setAclRuleStatus(string table_name, string rule_name, bool active)
 {
     vector<FieldValueTuple> fvVector;
     if (active)
     {
-        fvVector.emplace_back("Status", "Active");
+        fvVector.emplace_back("status", "Active");
     }
     else
     {
-        fvVector.emplace_back("Status", "Inactive");
+        fvVector.emplace_back("status", "Inactive");
     }
-    m_aclRuleStateTable.set(rule_name, fvVector);
+    m_aclRuleStateTable.set(table_name + string("|") + rule_name, fvVector);
 }
 
 // Remove the status record of given ACL rule from STATE_DB
-void AclOrch::removeAclRuleStatus(string rule_name)
+void AclOrch::removeAclRuleStatus(string table_name, string rule_name)
 {
-    m_aclRuleStateTable.del(rule_name);
+    m_aclRuleStateTable.del(table_name + string("|") + rule_name);
 }

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3509,7 +3509,7 @@ AclOrch::AclOrch(vector<TableConnector>& connectors, DBConnector* stateDb, Switc
         Orch(connectors),
         m_aclStageCapabilityTable(stateDb, STATE_ACL_STAGE_CAPABILITY_TABLE_NAME),
         m_aclTableStateTable(stateDb, STATE_ACL_TABLE_TABLE_NAME),
-        m_aclRuleStateTable(stateDB, STATE_ACL_RULE_TABLE_NAME),
+        m_aclRuleStateTable(stateDb, STATE_ACL_RULE_TABLE_NAME),
         m_switchOrch(switchOrch),
         m_mirrorOrch(mirrorOrch),
         m_neighOrch(neighOrch),
@@ -4362,6 +4362,8 @@ void AclOrch::doAclTableTask(Consumer &consumer)
             else
             {
                 it = consumer.m_toSync.erase(it);
+                // Mark the ACL table as inactive if the configuration is invalid
+                setAclTableStatus(table_id, false);
                 SWSS_LOG_ERROR("Failed to create ACL table %s, invalid configuration",
                         table_id.c_str());
             }
@@ -4527,6 +4529,8 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
             else
             {
                 it = consumer.m_toSync.erase(it);
+                // Mark the rule inactive if the configuration is invalid
+                setAclRuleStatus(rule_id, false);
                 SWSS_LOG_ERROR("Failed to create ACL rule. Rule configuration is invalid");
             }
         }
@@ -4919,7 +4923,7 @@ void AclOrch::removeAclTableStatus(string table_name)
 }
 
 // Set the status of ACL rule in STATE_DB
-void AclOrch::setAclRuleStatus(string rule_name, book active)
+void AclOrch::setAclRuleStatus(string rule_name, bool active)
 {
     vector<FieldValueTuple> fvVector;
     if (active)

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -100,6 +100,14 @@
 
 #define ACL_COUNTER_FLEX_COUNTER_GROUP "ACL_STAT_COUNTER"
 
+enum AclObjectStatus
+{
+    ACTIVE = 0,
+    INACTIVE,
+    PENDING_CREATION,
+    PENDING_REMOVAL
+};
+
 struct AclActionCapabilities
 {
     set<sai_acl_action_type_t> actionList;
@@ -553,8 +561,8 @@ private:
 
     string generateAclRuleIdentifierInCountersDb(const AclRule& rule) const;
 
-    void setAclTableStatus(string table_name, bool active);
-    void setAclRuleStatus(string table_name, string rule_name, bool active);
+    void setAclTableStatus(string table_name, AclObjectStatus status);
+    void setAclRuleStatus(string table_name, string rule_name, AclObjectStatus status);
 
     void removeAclTableStatus(string table_name);
     void removeAclRuleStatus(string table_name, string rule_name);

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -554,10 +554,10 @@ private:
     string generateAclRuleIdentifierInCountersDb(const AclRule& rule) const;
 
     void setAclTableStatus(string table_name, bool active);
-    void setAclRuleStatus(string rule_name, bool active);
+    void setAclRuleStatus(string table_name, string rule_name, bool active);
 
     void removeAclTableStatus(string table_name);
-    void removeAclRuleStatus(string rule_name);
+    void removeAclRuleStatus(string table_name, string rule_name);
 
     map<sai_object_id_t, AclTable> m_AclTables;
     // TODO: Move all ACL tables into one map: name -> instance

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -567,6 +567,9 @@ private:
     void removeAclTableStatus(string table_name);
     void removeAclRuleStatus(string table_name, string rule_name);
 
+    void removeAllAclTableStatus();
+    void removeAllAclRuleStatus();
+
     map<sai_object_id_t, AclTable> m_AclTables;
     // TODO: Move all ACL tables into one map: name -> instance
     map<string, AclTable> m_ctrlAclTables;

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -553,6 +553,12 @@ private:
 
     string generateAclRuleIdentifierInCountersDb(const AclRule& rule) const;
 
+    void setAclTableStatus(string table_name, bool active);
+    void setAclRuleStatus(string rule_name, bool active);
+
+    void removeAclTableStatus(string table_name);
+    void removeAclRuleStatus(string rule_name);
+
     map<sai_object_id_t, AclTable> m_AclTables;
     // TODO: Move all ACL tables into one map: name -> instance
     map<string, AclTable> m_ctrlAclTables;
@@ -562,6 +568,9 @@ private:
     static Table m_countersTable;
 
     Table m_aclStageCapabilityTable;
+
+    Table m_aclTableStateTable;
+    Table m_aclRuleStateTable;
 
     map<acl_stage_type_t, string> m_mirrorTableId;
     map<acl_stage_type_t, string> m_mirrorV6TableId;

--- a/tests/dvslib/dvs_acl.py
+++ b/tests/dvslib/dvs_acl.py
@@ -1,6 +1,6 @@
 """Utilities for interacting with ACLs when writing VS tests."""
 from typing import Callable, Dict, List
-
+from swsscommon import swsscommon
 
 class DVSAcl:
     """Manage ACL tables and rules on the virtual switch."""
@@ -17,6 +17,9 @@ class DVSAcl:
     ADB_ACL_GROUP_TABLE_NAME = "ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP"
     ADB_ACL_GROUP_MEMBER_TABLE_NAME = "ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP_MEMBER"
     ADB_ACL_COUNTER_TABLE_NAME = "ASIC_STATE:SAI_OBJECT_TYPE_ACL_COUNTER"
+
+    STATE_DB_ACL_TABLE_TABLE_NAME = "ACL_TABLE_TABLE"
+    STATE_DB_ACL_RULE_TABLE_NAME = "ACL_RULE_TABLE"
 
     ADB_ACL_STAGE_LOOKUP = {
         "ingress": "SAI_ACL_STAGE_INGRESS",
@@ -740,3 +743,43 @@ class DVSAcl:
         rule_to_counter_map = self.counters_db.get_entry("ACL_COUNTER_RULE_MAP", "")
         counter_to_rule_map = {v: k for k, v in rule_to_counter_map.items()}
         assert counter_oid in counter_to_rule_map
+
+    def verify_acl_table_status(
+            self,
+            acl_table_name,
+            expected_status
+    ) -> None:
+        """Verify that the STATE_DB status of ACL table is as expected.
+
+        Args:
+            acl_table_name: The name of ACL table to check
+            expected_status: The expected status in STATE_DB
+        """
+        if expected_status:
+            fvs = self.state_db.wait_for_entry(self.STATE_DB_ACL_TABLE_TABLE_NAME, acl_table_name)
+            assert len(fvs) > 0
+            assert (fvs['status'] == expected_status) 
+        else:
+            self.state_db.wait_for_deleted_entry(self.STATE_DB_ACL_TABLE_TABLE_NAME, acl_table_name)
+
+    def verify_acl_rule_status(
+            self,
+            acl_table_name,
+            acl_rule_name,
+            expected_status
+    ) -> None:
+        """Verify that the STATE_DB status of ACL rule is as expected.
+
+        Args:
+            acl_table_name: The name of ACL table to check
+            acl_rule_name: The name of ACL rule to check
+            expected_status: The expected status in STATE_DB
+        """
+        key = acl_table_name + "|" + acl_rule_name
+        if expected_status:
+            fvs = self.state_db.wait_for_entry(self.STATE_DB_ACL_RULE_TABLE_NAME, key)
+            assert len(fvs) > 0
+            assert (fvs['status'] == expected_status) 
+        else:
+            self.state_db.wait_for_deleted_entry(self.STATE_DB_ACL_TABLE_TABLE_NAME, key)
+

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -108,6 +108,29 @@ class TestAcl:
             # Verify the STATE_DB entry is removed
             dvs_acl.verify_acl_table_status(L3_TABLE_NAME, None)
 
+    def test_InvalidAclTableCreationDeletion(self, dvs_acl):
+        try:
+            dvs_acl.create_acl_table("INVALID_ACL_TABLE", L3_TABLE_TYPE, "dummy_port", "invalid_stage")
+            # Verify status is written into STATE_DB
+            dvs_acl.verify_acl_table_status("INVALID_ACL_TABLE", "Inactive")
+        finally:
+            dvs_acl.remove_acl_table("INVALID_ACL_TABLE")
+            dvs_acl.verify_acl_table_count(0)
+            # Verify the STATE_DB entry is removed
+            dvs_acl.verify_acl_table_status("INVALID_ACL_TABLE", None)
+
+    def test_InvalidAclRuleCreation(self, dvs_acl, l3_acl_table):
+        config_qualifiers = {"INVALID_QUALIFIER": "TEST"}
+
+        dvs_acl.create_acl_rule(L3_TABLE_NAME, "INVALID_RULE", config_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, "INVALID_RULE", "Inactive")
+
+        dvs_acl.remove_acl_rule(L3_TABLE_NAME, "INVALID_RULE")
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, "INVALID_RULE", None)
+        dvs_acl.verify_no_acl_rules()
+
     def test_AclRuleL4SrcPort(self, dvs_acl, l3_acl_table):
         config_qualifiers = {"L4_SRC_PORT": "65000"}
         expected_sai_qualifiers = {

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -100,9 +100,13 @@ class TestAcl:
 
             dvs_acl.verify_acl_table_group_members(acl_table_id, acl_table_group_ids, 1)
             dvs_acl.verify_acl_table_port_binding(acl_table_id, L3_BIND_PORTS, 1)
+            # Verify status is written into STATE_DB
+            dvs_acl.verify_acl_table_status(L3_TABLE_NAME, "Active")
         finally:
             dvs_acl.remove_acl_table(L3_TABLE_NAME)
             dvs_acl.verify_acl_table_count(0)
+            # Verify the STATE_DB entry is removed
+            dvs_acl.verify_acl_table_status(L3_TABLE_NAME, None)
 
     def test_AclRuleL4SrcPort(self, dvs_acl, l3_acl_table):
         config_qualifiers = {"L4_SRC_PORT": "65000"}
@@ -112,8 +116,12 @@ class TestAcl:
 
         dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, "Active")
 
         dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     def test_AclRuleIpProtocol(self, dvs_acl, l3_acl_table):
@@ -124,8 +132,12 @@ class TestAcl:
 
         dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, "Active")
 
         dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     def test_AclRuleTCPProtocolAppendedForTCPFlags(self, dvs_acl, l3_acl_table):
@@ -141,8 +153,12 @@ class TestAcl:
         }
         dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, "Active")
 
         dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     def test_AclRuleNextHeader(self, dvs_acl, l3_acl_table):
@@ -150,9 +166,13 @@ class TestAcl:
 
         # Shouldn't allow NEXT_HEADER on vanilla L3 tables.
         dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, "Inactive")
         dvs_acl.verify_no_acl_rules()
 
         dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleNextHeaderAppendedForTCPFlags(self, dvs_acl, l3v6_acl_table):
@@ -169,8 +189,12 @@ class TestAcl:
 
         dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, "Active")
 
         dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     def test_AclRuleInPorts(self, dvs_acl, mirror_acl_table):
@@ -187,9 +211,13 @@ class TestAcl:
         }
 
         dvs_acl.create_acl_rule(MIRROR_TABLE_NAME, MIRROR_RULE_NAME, config_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(MIRROR_TABLE_NAME, MIRROR_RULE_NAME, "Active")
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
         dvs_acl.remove_acl_rule(MIRROR_TABLE_NAME, MIRROR_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(MIRROR_TABLE_NAME, MIRROR_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     def test_AclRuleOutPorts(self, dvs_acl, mclag_acl_table):
@@ -207,8 +235,12 @@ class TestAcl:
 
         dvs_acl.create_acl_rule(MCLAG_TABLE_NAME, MCLAG_RULE_NAME, config_qualifiers)
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(MCLAG_TABLE_NAME, MCLAG_RULE_NAME, "Active")
 
         dvs_acl.remove_acl_rule(MCLAG_TABLE_NAME, MCLAG_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(MCLAG_TABLE_NAME, MCLAG_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     def test_AclRuleInPortsNonExistingInterface(self, dvs_acl, mirror_acl_table):
@@ -220,9 +252,12 @@ class TestAcl:
         }
 
         dvs_acl.create_acl_rule(MIRROR_TABLE_NAME, MIRROR_RULE_NAME, config_qualifiers)
-
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(MIRROR_TABLE_NAME, MIRROR_RULE_NAME, "Inactive")
         dvs_acl.verify_no_acl_rules()
         dvs_acl.remove_acl_rule(MIRROR_TABLE_NAME, MIRROR_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(MIRROR_TABLE_NAME, MIRROR_RULE_NAME, None)
 
     def test_AclRuleOutPortsNonExistingInterface(self, dvs_acl, mclag_acl_table):
         """
@@ -233,9 +268,12 @@ class TestAcl:
         }
 
         dvs_acl.create_acl_rule(MCLAG_TABLE_NAME, MCLAG_RULE_NAME, config_qualifiers)
-
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(MCLAG_TABLE_NAME, MCLAG_RULE_NAME, "Inactive")
         dvs_acl.verify_no_acl_rules()
         dvs_acl.remove_acl_rule(MCLAG_TABLE_NAME, MCLAG_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(MCLAG_TABLE_NAME, MCLAG_RULE_NAME, None)
 
     def test_AclRuleVlanId(self, dvs_acl, l3_acl_table):
         config_qualifiers = {"VLAN_ID": "100"}
@@ -244,9 +282,13 @@ class TestAcl:
         }
 
         dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, "Active")
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
         dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     def test_V6AclTableCreationDeletion(self, dvs_acl):
@@ -259,8 +301,12 @@ class TestAcl:
             acl_table_group_ids = dvs_acl.get_acl_table_group_ids(len(L3V6_BIND_PORTS))
             dvs_acl.verify_acl_table_group_members(acl_table_id, acl_table_group_ids, 1)
             dvs_acl.verify_acl_table_port_binding(acl_table_id, L3V6_BIND_PORTS, 1)
+            # Verify status is written into STATE_DB
+            dvs_acl.verify_acl_table_status(L3V6_TABLE_NAME, "Active")
         finally:
             dvs_acl.remove_acl_table(L3V6_TABLE_NAME)
+            # Verify the STATE_DB entry is cleared
+            dvs_acl.verify_acl_table_status(L3V6_TABLE_NAME, None)
             dvs_acl.verify_acl_table_count(0)
 
     def test_V6AclRuleIPv6Any(self, dvs_acl, l3v6_acl_table):
@@ -270,9 +316,13 @@ class TestAcl:
         }
 
         dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, "Active")
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
         dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleIPv6AnyDrop(self, dvs_acl, l3v6_acl_table):
@@ -286,8 +336,12 @@ class TestAcl:
                                 config_qualifiers,
                                 action="DROP")
         dvs_acl.verify_acl_rule(expected_sai_qualifiers, action="DROP")
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, "Active")
 
         dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     # This test validates that backwards compatibility works as expected, it should
@@ -300,8 +354,12 @@ class TestAcl:
 
         dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, "Active")
 
         dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleNextHeader(self, dvs_acl, l3v6_acl_table):
@@ -312,8 +370,12 @@ class TestAcl:
 
         dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, "Active")
 
         dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleSrcIPv6(self, dvs_acl, l3v6_acl_table):
@@ -325,8 +387,12 @@ class TestAcl:
 
         dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, "Active")
 
         dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleDstIPv6(self, dvs_acl, l3v6_acl_table):
@@ -337,8 +403,12 @@ class TestAcl:
 
         dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, "Active")
 
         dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleL4SrcPort(self, dvs_acl, l3v6_acl_table):
@@ -349,8 +419,12 @@ class TestAcl:
 
         dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, "Active")
 
         dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleL4DstPort(self, dvs_acl, l3v6_acl_table):
@@ -361,8 +435,12 @@ class TestAcl:
 
         dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, "Active")
 
         dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleL4SrcPortRange(self, dvs_acl, l3v6_acl_table):
@@ -373,8 +451,12 @@ class TestAcl:
 
         dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, "Active")
 
         dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleL4DstPortRange(self, dvs_acl, l3v6_acl_table):
@@ -385,8 +467,12 @@ class TestAcl:
 
         dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, "Active")
 
         dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleVlanId(self, dvs_acl, l3v6_acl_table):
@@ -397,8 +483,12 @@ class TestAcl:
 
         dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, "Active")
 
         dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     def test_InsertAclRuleBetweenPriorities(self, dvs_acl, l3_acl_table):
@@ -430,6 +520,8 @@ class TestAcl:
                                     f"PRIORITY_TEST_RULE_{rule}",
                                     config_qualifiers[rule], action=config_actions[rule],
                                     priority=rule)
+            # Verify status is written into STATE_DB
+            dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"PRIORITY_TEST_RULE_{rule}", "Active")
 
         dvs_acl.verify_acl_rule_set(rule_priorities, config_actions, expected_sai_qualifiers)
 
@@ -447,9 +539,12 @@ class TestAcl:
                                 action="DROP",
                                 priority=odd_priority)
         dvs_acl.verify_acl_rule_set(rule_priorities, config_actions, expected_sai_qualifiers)
-
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"PRIORITY_TEST_RULE_{odd_priority}", "Active")
         for rule in rule_priorities:
             dvs_acl.remove_acl_rule(L3_TABLE_NAME, f"PRIORITY_TEST_RULE_{rule}")
+            # Verify the STATE_DB entry is removed
+            dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"PRIORITY_TEST_RULE_{rule}", None)
         dvs_acl.verify_no_acl_rules()
 
     def test_RulesWithDiffMaskLengths(self, dvs_acl, l3_acl_table):
@@ -488,10 +583,14 @@ class TestAcl:
                                     config_qualifiers[rule],
                                     action=config_actions[rule],
                                     priority=rule)
+            # Verify status is written into STATE_DB
+            dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"MASK_TEST_RULE_{rule}", "Active")
         dvs_acl.verify_acl_rule_set(rule_priorities, config_actions, expected_sai_qualifiers)
 
         for rule in rule_priorities:
             dvs_acl.remove_acl_rule(L3_TABLE_NAME, f"MASK_TEST_RULE_{rule}")
+            # Verify the STATE_DB entry is removed
+            dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"MASK_TEST_RULE_{rule}", None)
         dvs_acl.verify_no_acl_rules()
 
     def test_AclRuleIcmp(self, dvs_acl, l3_acl_table):
@@ -507,8 +606,12 @@ class TestAcl:
 
         dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, "Active")
 
         dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
         dvs_acl.remove_acl_table(L3_TABLE_NAME)
@@ -527,8 +630,12 @@ class TestAcl:
 
         dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, "Active")
 
         dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     def test_AclRuleRedirect(self, dvs, dvs_acl, l3_acl_table, setup_teardown_neighbor):
@@ -546,8 +653,11 @@ class TestAcl:
 
         next_hop_id = setup_teardown_neighbor
         dvs_acl.verify_redirect_acl_rule(expected_sai_qualifiers, next_hop_id, priority="20")
-
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, "Active")
         dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
         dvs_acl.create_redirect_acl_rule(L3_TABLE_NAME,
@@ -558,8 +668,11 @@ class TestAcl:
 
         intf_id = dvs.asic_db.port_name_map["Ethernet4"]
         dvs_acl.verify_redirect_acl_rule(expected_sai_qualifiers, intf_id, priority="20")
-
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, "Active")
         dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
     
     def test_AclTableMandatoryMatchFields(self, dvs, pfcwd_acl_table):


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generated with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
HLD https://github.com/sonic-net/SONiC/pull/1261
This PR is to update `orchagent` to write ACL table/rule creation status into `STATE_DB`.
Currently, `show acl table` and `show acl rule` commands read ACL table/rule configuration from `CONFIG_DB` directly. We don't know whether the ACL table or rule is created successfully.
We improved `orchagent` to write the status of ACL table/rule into a `STATE_DB` table. 

**Why I did it**
Add the status of ACL table and ACL rule into `STATE_DB` so that user can tell whether the table or rule is created successfully.

**How I verified it**
Verified by copying the updated `orchagent` to a testbed and run.

**Details if related**
HLD https://github.com/sonic-net/SONiC/pull/1261