### PR TITLE
[202012]: Reduce log level when FDB cache lookup fails

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -512,7 +512,9 @@ bool FdbOrch::getPort(const MacAddress& mac, uint16_t vlan, Port& port)
     auto it = m_entries.find(entry);
     if (it == m_entries.end())
     {
-        SWSS_LOG_ERROR("Failed to get cached bridge port ID for FDB entry %s",
+        // This message is now expected in many cases since orchagent will process events such as
+        // learning new neighbor entries prior to updating the m_entries FDB cache.
+        SWSS_LOG_INFO("Failed to get cached bridge port ID for FDB entry %s",
             mac.to_string().c_str());
         return false;
     }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

This PR contains part of the changes from #2657 to the master branch. The rest of the changes from #2657 are in #2658 to the 202012 branch.

**What I did**
When looking up a bridge port OID in the FDB cache, misses are logged at level INFO.

**Why I did it**
Orchagent does not always process FDB updates first, which means the FDB cache may be incomplete at times. For example, if orchagent learns a new neighbor on a new MAC address, the neighbor update may be processed first, then the FDB update for the new MAC. During neighbor update processing, orchagent may access the FDB cache which has not yet been updated to include the new MAC address.

**How I verified it**

**Details if related**
