### PR TITLE
Fixes QoS scheduler config on chips that do not support hierarchical scheduler

### DIFF
--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -1590,9 +1590,19 @@ bool QosOrch::applySchedulerToQueueSchedulerGroup(Port &port, size_t queue_ind, 
     attr.value.oid = scheduler_profile_id;
 
     sai_status = sai_scheduler_group_api->set_scheduler_group_attribute(group_id, &attr);
+    if (SAI_STATUS_NOT_SUPPORTED != sai_status)
+    {
+        /* On some chips, hierarchical scheduler configuration may not be supported.
+         * Let's try configuring at the queue level */
+        attr.id = SAI_QUEUE_ATTR_SCHEDULER_PROFILE_ID;
+        sai_status = sai_queue_api->set_queue_attribute(queue_id, &attr);
+    }
+    
     if (SAI_STATUS_SUCCESS != sai_status)
     {
-        SWSS_LOG_ERROR("Failed applying scheduler profile:0x%" PRIx64 " to scheduler group:0x%" PRIx64 ", port:%s", scheduler_profile_id, group_id, port.m_alias.c_str());
+        SWSS_LOG_ERROR("Failed applying scheduler profile:0x%" PRIx64 
+            " to scheduler group:0x%" PRIx64 " and queue:0x%" PRIx64 
+            ", port:%s", scheduler_profile_id, group_id, queue_id, port.m_alias.c_str());
         task_process_status handle_status = handleSaiSetStatus(SAI_API_SCHEDULER_GROUP, sai_status);
         if (handle_status != task_success)
         {


### PR DESCRIPTION
**What I did**
This PR fixes QoS scheduler configuration failure on chips that do not support hierarchical scheduling

**Why I did it**
Scheduler configuration using scheduler_group SAI API fails on chips such as BCM56275 which does not support hierarchical scheduling. On these chips, scheduler_group SAI API returns error (SAI_STATUS_NOT_SUPPORTED) because it does not support L2 level scheduler configuration. On these chips, we need to use QUEUE SAI API instead to configure scheduling at the queue level. 

**How I verified it**

1. Verified scheduler configuration (config.txt) on switch based on BCM56275 
1. Verified deletion of scheduler configuration (config qos clear) on switch which has BCM56275 
1. Verified scheduler configuration (config.txt) on switch based on BCM56960
1. Verified deletion of scheduler configuration (config qos clear) on switch which has BCM56960

Refer to UT-sairedis-log.txt

**Details if related**
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211

[config.txt](https://github.com/sonic-net/sonic-swss/files/10796184/config.txt)
[UT-sairedis-log.txt](https://github.com/sonic-net/sonic-swss/files/10796193/UT-sairedis-log.txt)


