### PR TITLE
[dualtor] Fix neighbor miss when mux is not ready

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1104,7 +1104,7 @@ void MuxOrch::updateNeighbor(const NeighborUpdate& update)
         return;
     }
 
-    auto standalone_tunnel_neigh_it = standalone_tunnel_neighbors_.find(update.entry.ip_address);
+    bool is_tunnel_route_installed = isStandaloneTunnelRouteInstalled(update.entry.ip_address);
     // Handling zero MAC neighbor updates
     if (!update.mac)
     {
@@ -1115,7 +1115,7 @@ void MuxOrch::updateNeighbor(const NeighborUpdate& update)
 
         if (update.add)
         {
-            if (standalone_tunnel_neigh_it == standalone_tunnel_neighbors_.end())
+            if (!is_tunnel_route_installed)
             {
                 createStandaloneTunnelRoute(update.entry.ip_address);
             }
@@ -1130,7 +1130,7 @@ void MuxOrch::updateNeighbor(const NeighborUpdate& update)
      * make sure to remove any existing tunnel routes to prevent conflicts.
      * This block also covers the case of neighbor deletion.
      */
-    if (standalone_tunnel_neigh_it != standalone_tunnel_neighbors_.end())
+    if (is_tunnel_route_installed)
     {
         removeStandaloneTunnelRoute(update.entry.ip_address);
     }
@@ -1472,6 +1472,11 @@ void MuxOrch::removeStandaloneTunnelRoute(IpAddress neighborIp)
     IpPrefix pfx = neighborIp.to_string();
     remove_route(pfx);
     standalone_tunnel_neighbors_.erase(neighborIp);
+}
+
+bool MuxOrch::isStandaloneTunnelRouteInstalled(const IpAddress& neighborIp)
+{
+    return standalone_tunnel_neighbors_.find(neighborIp) != standalone_tunnel_neighbors_.end();
 }
 
 MuxCableOrch::MuxCableOrch(DBConnector *db, DBConnector *sdb, const std::string& tableName):

--- a/orchagent/muxorch.h
+++ b/orchagent/muxorch.h
@@ -202,6 +202,8 @@ public:
     bool removeNextHopTunnel(std::string tunnelKey, IpAddress& ipAddr);
     sai_object_id_t getNextHopTunnelId(std::string tunnelKey, IpAddress& ipAddr);
 
+    bool isStandaloneTunnelRouteInstalled(const IpAddress& neighborIp);
+
 private:
     virtual bool addOperation(const Request& request);
     virtual bool delOperation(const Request& request);

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -739,20 +739,32 @@ void NeighOrch::doTask(Consumer &consumer)
                     mac_address = MacAddress(fvValue(*i));
             }
 
-            if (m_syncdNeighbors.find(neighbor_entry) == m_syncdNeighbors.end()
-                    || m_syncdNeighbors[neighbor_entry].mac != mac_address)
+            bool nbr_not_found = (m_syncdNeighbors.find(neighbor_entry) == m_syncdNeighbors.end());
+            if (nbr_not_found || m_syncdNeighbors[neighbor_entry].mac != mac_address)
             {
-                // only for unresolvable neighbors that are new
                 if (!mac_address)
                 {
-                    if (addZeroMacTunnelRoute(neighbor_entry, mac_address))
+                    if (nbr_not_found)
                     {
-                        it = consumer.m_toSync.erase(it);
+                        // only for unresolvable neighbors that are new
+                        if (addZeroMacTunnelRoute(neighbor_entry, mac_address))
+                        {
+                            it = consumer.m_toSync.erase(it);
+                        }
+                        else
+                        {
+                            it++;
+                            continue;
+                        }
                     }
                     else
                     {
-                        it++;
-                        continue;
+                        /*
+                         * For neighbors that were previously resolvable but are now unresolvable,
+                         * we expect such neighbor entries to be deleted prior to a zero MAC update
+                         * arriving for that same neighbor.
+                         */
+                        it = consumer.m_toSync.erase(it);
                     }
                 }
                 else if (addNeighbor(neighbor_entry, mac_address))

--- a/orchagent/neighorch.h
+++ b/orchagent/neighorch.h
@@ -116,7 +116,7 @@ private:
     bool resolveNeighborEntry(const NeighborEntry &, const MacAddress &);
     void clearResolvedNeighborEntry(const NeighborEntry &);
 
-    void addZeroMacTunnelRoute(const NeighborEntry &, const MacAddress &);
+    bool addZeroMacTunnelRoute(const NeighborEntry &, const MacAddress &);
 };
 
 #endif /* SWSS_NEIGHORCH_H */

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -1226,6 +1226,35 @@ class TestMuxTunnel(TestMuxTunnelBase):
                 expected_mac=mac if exp_result[REAL_MAC] else '00:00:00:00:00:00'
             )
 
+    def test_neighbor_miss_no_mux(
+            self, dvs, dvs_route, setup_vlan, setup_tunnel,
+            setup_peer_switch, neighbor_cleanup, testlog
+    ):
+        config_db = dvs.get_config_db()
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+
+        test_ip = self.SERV1_SOC_IPV4
+        self.ping_ip(dvs, test_ip)
+
+        # no mux present, no standalone tunnel route installed
+        self.check_neighbor_state(dvs, dvs_route, test_ip, expect_route=False)
+
+        # setup the mux
+        config_db = dvs.get_config_db()
+        self.create_mux_cable(config_db)
+
+        # set port state as standby
+        self.set_mux_state(appdb, "Ethernet0", "standby")
+        self.check_neighbor_state(dvs, dvs_route, test_ip, expect_route=True)
+
+        # set port state as active
+        self.set_mux_state(appdb, "Ethernet0", "active")
+        self.check_neighbor_state(dvs, dvs_route, test_ip, expect_route=False)
+
+        # clear the FAILED neighbor
+        self.clear_neighbors(dvs)
+        self.check_neighbor_state(dvs, dvs_route, test_ip, expect_route=False)
+
     def test_neighbor_miss_no_peer(
             self, dvs, dvs_route, setup_vlan, setup_mux_cable, setup_tunnel,
             remove_peer_switch, neighbor_cleanup, testlog

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -1246,6 +1246,8 @@ class TestMuxTunnel(TestMuxTunnelBase):
         # setup the mux
         config_db = dvs.get_config_db()
         self.create_mux_cable(config_db)
+        # tunnel route should be installed immediately after mux setup
+        self.check_neighbor_state(dvs, dvs_route, test_ip, expect_route=True)
 
         # set port state as standby
         self.set_mux_state(appdb, "Ethernet0", "standby")

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -1173,11 +1173,15 @@ class TestMuxTunnel(TestMuxTunnelBase):
 
         self.create_and_test_route(appdb, asicdb, dvs, dvs_route)
 
-    def test_NH(self, dvs, dvs_route, intf_fdb_map, setup_peer_switch, setup_tunnel, testlog):
+    def test_NH(self, dvs, dvs_route, intf_fdb_map, setup, setup_mux_cable,
+                setup_peer_switch, setup_tunnel, testlog):
         """ test NH routes and mux state change """
         appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
         asicdb = dvs.get_asic_db()
         mac = intf_fdb_map["Ethernet0"]
+
+        # get tunnel nexthop
+        self.check_tnl_nexthop_in_asic_db(asicdb)
 
         self.create_and_test_NH_routes(appdb, asicdb, dvs, dvs_route, mac)
 

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -1227,7 +1227,7 @@ class TestMuxTunnel(TestMuxTunnelBase):
             )
 
     def test_neighbor_miss_no_mux(
-            self, dvs, dvs_route, setup_vlan, setup_tunnel,
+            self, dvs, dvs_route, setup_vlan, setup_tunnel, setup,
             setup_peer_switch, neighbor_cleanup, testlog
     ):
         config_db = dvs.get_config_db()
@@ -1249,7 +1249,7 @@ class TestMuxTunnel(TestMuxTunnelBase):
 
         # set port state as active
         self.set_mux_state(appdb, "Ethernet0", "active")
-        self.check_neighbor_state(dvs, dvs_route, test_ip, expect_route=False)
+        self.check_neighbor_state(dvs, dvs_route, test_ip, expect_route=True)
 
         # clear the FAILED neighbor
         self.clear_neighbors(dvs)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
The issue is that `MuxOrch::m_syncdNeighbors` assumes all cached zero-mac neighbors have tunnel routes installed. The check before adding tunnel routes ignores the following zero-mac neighbor events.
Let's ensure that, if a zero-mac neighbor is present in `MuxOrch::m_syncdNeighbors`, it has a tunnel route installed.
So let's check the tunnel route install success before adding a neighbor to `MuxOrch::m_syncdNeighbors`.

**Why I did it**
To fix #2675
If `MuxOrch` is not fully initialized, and there is a `FAILED` neighbor added to kernel, the tunnel route creation will fail. But the subsequent `FAILED` neighbor events cannot trigger tunnel route creation because `MuxOrch::m_syncdNeighbors` caches the first event and regard the tunnel as already installed.

**How I verified it**
UT and verify on testbed.

**Details if related**
