### PR TITLE
Revert "[aclorch] Fixed issue #2204.Support IN_PORTS qualifer in MIRRORV6 table."

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3217,7 +3217,7 @@ void AclOrch::initDefaultTableTypes()
      * | -----------------------------------------------------------------|
      * | MATCH_ETHERTYPE   |      √       |      √       |                |
      * |------------------------------------------------------------------|
-     * | MATCH_IN_PORTS    |      √       |      √       |       √        |
+     * | MATCH_IN_PORTS    |      √       |      √       |                |
      * |------------------------------------------------------------------|
      */
 
@@ -3278,7 +3278,6 @@ void AclOrch::initDefaultTableTypes()
                 .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_L4_SRC_PORT))
                 .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_L4_DST_PORT))
                 .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_TCP_FLAGS))
-                .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_IN_PORTS))
                 .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_DSCP))
                 .withMatch(make_shared<AclTableRangeMatch>(set<sai_acl_range_type_t>{
                     {SAI_ACL_RANGE_TYPE_L4_SRC_PORT_RANGE, SAI_ACL_RANGE_TYPE_L4_DST_PORT_RANGE}}))

--- a/tests/test_mirror_ipv6_separate.py
+++ b/tests/test_mirror_ipv6_separate.py
@@ -237,7 +237,6 @@ class TestMirror(object):
             "SAI_ACL_TABLE_ATTR_FIELD_L4_DST_PORT",
             "SAI_ACL_TABLE_ATTR_FIELD_TCP_FLAGS",
             "SAI_ACL_TABLE_ATTR_FIELD_DSCP",
-            "SAI_ACL_TABLE_ATTR_FIELD_IN_PORTS",
             "SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID"
         ]
 


### PR DESCRIPTION
Reverts sonic-net/sonic-swss#2668

which cause ACL creation failure on Mellanox platform with below err msg. 
2023-03-02T11:25:00.2743784Z E               Mar  2 11:22:51.042274 str2-msn2700-spy-2 ERR syncd#SDK: [ACL.ERR] Failed calculating key blocks - too many keys selected.
2023-03-02T11:25:00.2744673Z E               
2023-03-02T11:25:00.2745732Z E               Mar  2 11:22:51.043026 str2-msn2700-spy-2 ERR swss#orchagent: :- create: create status: SAI_STATUS_FAILURE
2023-03-02T11:25:00.2746583Z E               
2023-03-02T11:25:00.2747724Z E               Mar  2 11:22:51.043196 str2-msn2700-spy-2 ERR swss#orchagent: :- addAclTable: Failed to create ACL table EVERFLOWV6
2023-03-02T11:25:00.2748625Z E               
2023-03-02T11:25:00.2749932Z E               Mar  2 11:22:51.043384 str2-msn2700-spy-2 ERR syncd#SDK: [SAI_ACL.ERR] mlnx_sai_acl.c[13937]- mlnx_create_acl_table:  Failed to create flex key - Internal Error. 