### PR TITLE
[bfdorch] add default TOS value for BFD session

### DIFF
--- a/orchagent/bfdorch.cpp
+++ b/orchagent/bfdorch.cpp
@@ -14,8 +14,8 @@ using namespace swss;
 #define BFD_SESSION_DEFAULT_TX_INTERVAL 1000
 #define BFD_SESSION_DEFAULT_RX_INTERVAL 1000
 #define BFD_SESSION_DEFAULT_DETECT_MULTIPLIER 10
-// TOS: default 6-bit DSCP value 46, default 2-bit ecn value 0. 46<<2 = 184
-#define BFD_SESSION_DEFAULT_TOS 184
+// TOS: default 6-bit DSCP value 48, default 2-bit ecn value 0. 48<<2 = 192
+#define BFD_SESSION_DEFAULT_TOS 192
 #define BFD_SESSION_MILLISECOND_TO_MICROSECOND 1000
 #define BFD_SRCPORTINIT 49152
 #define BFD_SRCPORTMAX 65536

--- a/orchagent/bfdorch.cpp
+++ b/orchagent/bfdorch.cpp
@@ -14,6 +14,8 @@ using namespace swss;
 #define BFD_SESSION_DEFAULT_TX_INTERVAL 1000
 #define BFD_SESSION_DEFAULT_RX_INTERVAL 1000
 #define BFD_SESSION_DEFAULT_DETECT_MULTIPLIER 10
+// TOS: default 6-bit DSCP value 46, default 2-bit ecn value 0. 46<<2 = 184
+#define BFD_SESSION_DEFAULT_TOS 184
 #define BFD_SESSION_MILLISECOND_TO_MICROSECOND 1000
 #define BFD_SRCPORTINIT 49152
 #define BFD_SRCPORTMAX 65536
@@ -243,7 +245,7 @@ bool BfdOrch::create_bfd_session(const string& key, const vector<FieldValueTuple
     uint32_t tx_interval = BFD_SESSION_DEFAULT_TX_INTERVAL;
     uint32_t rx_interval = BFD_SESSION_DEFAULT_RX_INTERVAL;
     uint8_t multiplier = BFD_SESSION_DEFAULT_DETECT_MULTIPLIER;
-    uint8_t tos = 184;  // default value 46<<2. higher 6-bit tos 46, lower 2-bit ecn 0
+    uint8_t tos = BFD_SESSION_DEFAULT_TOS;
     bool multihop = false;
     MacAddress dst_mac;
     bool dst_mac_provided = false;

--- a/orchagent/bfdorch.cpp
+++ b/orchagent/bfdorch.cpp
@@ -243,6 +243,7 @@ bool BfdOrch::create_bfd_session(const string& key, const vector<FieldValueTuple
     uint32_t tx_interval = BFD_SESSION_DEFAULT_TX_INTERVAL;
     uint32_t rx_interval = BFD_SESSION_DEFAULT_RX_INTERVAL;
     uint8_t multiplier = BFD_SESSION_DEFAULT_DETECT_MULTIPLIER;
+    uint8_t tos = 184;  // default value 46<<2. higher 6-bit tos 46, lower 2-bit ecn 0
     bool multihop = false;
     MacAddress dst_mac;
     bool dst_mac_provided = false;
@@ -290,6 +291,10 @@ bool BfdOrch::create_bfd_session(const string& key, const vector<FieldValueTuple
         {
             dst_mac = MacAddress(value);
             dst_mac_provided = true;
+        }
+        else if (fvField(i) == "tos")
+        {
+            tos = to_uint<uint8_t>(value);
         }
         else
             SWSS_LOG_ERROR("Unsupported BFD attribute %s\n", fvField(i).c_str());
@@ -351,6 +356,10 @@ bool BfdOrch::create_bfd_session(const string& key, const vector<FieldValueTuple
     attr.value.u8 = multiplier;
     attrs.emplace_back(attr);
     fvVector.emplace_back("multiplier", to_string(multiplier));
+
+    attr.id = SAI_BFD_SESSION_ATTR_TOS;
+    attr.value.u8 = tos;
+    attrs.emplace_back(attr);
 
     if (multihop)
     {

--- a/tests/test_bfd.py
+++ b/tests/test_bfd.py
@@ -49,7 +49,7 @@ class TestBfd(object):
         bfdSessions = self.get_exist_bfd_session()
 
         # Create BFD session
-        fieldValues = {"local_addr": "10.0.0.1"}
+        fieldValues = {"local_addr": "10.0.0.1","tos":"64"}
         self.create_bfd_session("default:default:10.0.0.2", fieldValues)
         self.adb.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_BFD_SESSION", len(bfdSessions) + 1)
 
@@ -62,6 +62,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "10.0.0.1",
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "10.0.0.2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
+            "SAI_BFD_SESSION_ATTR_TOS": "64",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4"
         }
         self.check_asic_bfd_session_value(session, expected_adb_values)
@@ -102,6 +103,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "2000::1",
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "2000::2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
+            "SAI_BFD_SESSION_ATTR_TOS": "184",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "6"
         }
         self.check_asic_bfd_session_value(session, expected_adb_values)
@@ -142,6 +144,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "10.0.0.1",
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "10.0.0.2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
+            "SAI_BFD_SESSION_ATTR_TOS": "184",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4",
             "SAI_BFD_SESSION_ATTR_HW_LOOKUP_VALID": "false",
             "SAI_BFD_SESSION_ATTR_DST_MAC_ADDRESS": "00:02:03:04:05:06"
@@ -184,6 +187,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "10.0.0.1",
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "10.0.0.2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
+            "SAI_BFD_SESSION_ATTR_TOS": "184",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4",
             "SAI_BFD_SESSION_ATTR_MIN_TX": "300000",
             "SAI_BFD_SESSION_ATTR_MIN_RX": "500000",
@@ -226,6 +230,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "10.0.0.1",
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "10.0.0.2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
+            "SAI_BFD_SESSION_ATTR_TOS": "184",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4",
             "SAI_BFD_SESSION_ATTR_MULTIPLIER": "5"
         }
@@ -267,6 +272,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "10.0.0.1",
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "10.0.0.2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
+            "SAI_BFD_SESSION_ATTR_TOS": "184",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4",
             "SAI_BFD_SESSION_ATTR_MULTIHOP": "true"
         }
@@ -308,6 +314,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "10.0.0.1",
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "10.0.0.2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_DEMAND_ACTIVE",
+            "SAI_BFD_SESSION_ATTR_TOS": "184",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4"
         }
         self.check_asic_bfd_session_value(session, expected_adb_values)
@@ -350,6 +357,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "10.0.0.1",
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "10.0.0.2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
+            "SAI_BFD_SESSION_ATTR_TOS": "184",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4"
         }
         self.check_asic_bfd_session_value(session1, expected_adb_values)
@@ -376,6 +384,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "10.0.0.1",
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "10.0.1.2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
+            "SAI_BFD_SESSION_ATTR_TOS": "184",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4",
             "SAI_BFD_SESSION_ATTR_MIN_TX": "300000",
             "SAI_BFD_SESSION_ATTR_MIN_RX": "500000",
@@ -404,6 +413,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "2000::1",
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "2000::2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_DEMAND_ACTIVE",
+            "SAI_BFD_SESSION_ATTR_TOS": "184",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "6"
         }
         self.check_asic_bfd_session_value(session3, expected_adb_values)
@@ -430,6 +440,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "3000::1",
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "3000::2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
+            "SAI_BFD_SESSION_ATTR_TOS": "184",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "6"
         }
         self.check_asic_bfd_session_value(session4, expected_adb_values)

--- a/tests/test_bfd.py
+++ b/tests/test_bfd.py
@@ -103,7 +103,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "2000::1",
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "2000::2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
-            "SAI_BFD_SESSION_ATTR_TOS": "184",
+            "SAI_BFD_SESSION_ATTR_TOS": "192",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "6"
         }
         self.check_asic_bfd_session_value(session, expected_adb_values)
@@ -144,7 +144,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "10.0.0.1",
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "10.0.0.2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
-            "SAI_BFD_SESSION_ATTR_TOS": "184",
+            "SAI_BFD_SESSION_ATTR_TOS": "192",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4",
             "SAI_BFD_SESSION_ATTR_HW_LOOKUP_VALID": "false",
             "SAI_BFD_SESSION_ATTR_DST_MAC_ADDRESS": "00:02:03:04:05:06"
@@ -187,7 +187,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "10.0.0.1",
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "10.0.0.2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
-            "SAI_BFD_SESSION_ATTR_TOS": "184",
+            "SAI_BFD_SESSION_ATTR_TOS": "192",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4",
             "SAI_BFD_SESSION_ATTR_MIN_TX": "300000",
             "SAI_BFD_SESSION_ATTR_MIN_RX": "500000",
@@ -230,7 +230,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "10.0.0.1",
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "10.0.0.2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
-            "SAI_BFD_SESSION_ATTR_TOS": "184",
+            "SAI_BFD_SESSION_ATTR_TOS": "192",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4",
             "SAI_BFD_SESSION_ATTR_MULTIPLIER": "5"
         }
@@ -272,7 +272,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "10.0.0.1",
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "10.0.0.2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
-            "SAI_BFD_SESSION_ATTR_TOS": "184",
+            "SAI_BFD_SESSION_ATTR_TOS": "192",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4",
             "SAI_BFD_SESSION_ATTR_MULTIHOP": "true"
         }
@@ -314,7 +314,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "10.0.0.1",
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "10.0.0.2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_DEMAND_ACTIVE",
-            "SAI_BFD_SESSION_ATTR_TOS": "184",
+            "SAI_BFD_SESSION_ATTR_TOS": "192",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4"
         }
         self.check_asic_bfd_session_value(session, expected_adb_values)
@@ -357,7 +357,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "10.0.0.1",
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "10.0.0.2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
-            "SAI_BFD_SESSION_ATTR_TOS": "184",
+            "SAI_BFD_SESSION_ATTR_TOS": "192",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4"
         }
         self.check_asic_bfd_session_value(session1, expected_adb_values)
@@ -384,7 +384,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "10.0.0.1",
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "10.0.1.2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
-            "SAI_BFD_SESSION_ATTR_TOS": "184",
+            "SAI_BFD_SESSION_ATTR_TOS": "192",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4",
             "SAI_BFD_SESSION_ATTR_MIN_TX": "300000",
             "SAI_BFD_SESSION_ATTR_MIN_RX": "500000",
@@ -413,7 +413,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "2000::1",
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "2000::2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_DEMAND_ACTIVE",
-            "SAI_BFD_SESSION_ATTR_TOS": "184",
+            "SAI_BFD_SESSION_ATTR_TOS": "192",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "6"
         }
         self.check_asic_bfd_session_value(session3, expected_adb_values)
@@ -440,7 +440,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "3000::1",
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "3000::2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
-            "SAI_BFD_SESSION_ATTR_TOS": "184",
+            "SAI_BFD_SESSION_ATTR_TOS": "192",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "6"
         }
         self.check_asic_bfd_session_value(session4, expected_adb_values)


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add default TOS value when create BFD session, default DSCP value is 46, default ECN is 0. The BFD session configuration will override this default value.

**Why I did it**
Higher DSCP value is preferred for BFD packet.

**How I verified it**
Set different TOS value in BFD session configuration, and create BFD session in DUT.
Load the test image with the design change, connect a traffic generator (with BFD protocol support), capture the packet sent out by DUT, check the DSCP and ECN field in the captured packet.

```
cisco@sonic:/var/tmp$ cat bfd.cfg
[
  {
      "BFD_SESSION_TABLE:default:default:192.168.88.2": {
      "tos": "186",
      "multihop": "true",
      "rx_interval": "1000",
      "tx_interval": "1000",
      "local_addr": "192.168.88.1"
  },
  "OP": "SET"
}
]
```
<img width="757" alt="image" src="https://user-images.githubusercontent.com/96146196/222870178-35a4a356-fcc2-4cc8-8efe-a25216243a69.png">

APP_DB dump:
```
 cisco@sonic:/var/tmp$ head -n 50 redis0.log 
{
  "BFD_SESSION_TABLE:default:default:192.168.88.2": {
    "expireat": 1677887525.8233933,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "local_addr": "192.168.88.1",
      "multihop": "true",
      "rx_interval": "1000",
      "tos": "186",
      "tx_interval": "1000"
    }
  },
  ```
  ASIC DB dump:
  ```
    "ASIC_STATE:SAI_OBJECT_TYPE_BFD_SESSION:oid:0x45000000000989": {
    "expireat": 1677887399.4435563,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "SAI_BFD_SESSION_ATTR_BFD_ENCAPSULATION_TYPE": "SAI_BFD_ENCAPSULATION_TYPE_NONE",
      "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "192.168.88.2",
      "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4",
      "SAI_BFD_SESSION_ATTR_LOCAL_DISCRIMINATOR": "6",
      "SAI_BFD_SESSION_ATTR_MIN_RX": "1000000",
      "SAI_BFD_SESSION_ATTR_MIN_TX": "1000000",
      "SAI_BFD_SESSION_ATTR_MULTIHOP": "true",
      "SAI_BFD_SESSION_ATTR_MULTIPLIER": "10",
      "SAI_BFD_SESSION_ATTR_REMOTE_DISCRIMINATOR": "0",
      "SAI_BFD_SESSION_ATTR_SRC_IP_ADDRESS": "192.168.88.1",
      "SAI_BFD_SESSION_ATTR_TOS": "186",
      "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
      "SAI_BFD_SESSION_ATTR_UDP_SRC_PORT": "49157",
      "SAI_BFD_SESSION_ATTR_VIRTUAL_ROUTER": "oid:0x3000000000042"
    }
  },
  ```
  
**Details if related**
