### PR TITLE
[flowcounterrouter] Fix the route remove flow for non-yet bound prefixes

### DIFF
--- a/orchagent/flex_counter/flowcounterrouteorch.cpp
+++ b/orchagent/flex_counter/flowcounterrouteorch.cpp
@@ -602,18 +602,25 @@ bool FlowCounterRouteOrch::isRouteAlreadyBound(const RoutePattern &route_pattern
 {
     SWSS_LOG_ENTER();
 
-    auto iter = mBoundRouteCounters.find(route_pattern);
-    if (iter == mBoundRouteCounters.end())
+    auto iter_bound = mBoundRouteCounters.find(route_pattern);
+    if (iter_bound != mBoundRouteCounters.end())
     {
-        auto pending_iter = mPendingAddToFlexCntr.find(route_pattern);
-        if (pending_iter != mPendingAddToFlexCntr.end())
+        if (iter_bound->second.find(ip_prefix) != iter_bound->second.end())
         {
-            return pending_iter->second.find(ip_prefix) != pending_iter->second.end();
+            return true;
         }
-        return false;
     }
 
-    return iter->second.find(ip_prefix) != iter->second.end();
+    auto iter_pending = mPendingAddToFlexCntr.find(route_pattern);
+    if (iter_pending != mPendingAddToFlexCntr.end())
+    {
+        if (iter_pending->second.find(ip_prefix) != iter_pending->second.end())
+        {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 void FlowCounterRouteOrch::createRouteFlowCounterByPattern(const RoutePattern &route_pattern, size_t current_bound_count)

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -2448,7 +2448,6 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
     }
     else
     {
-        gFlowCounterRouteOrch->handleRouteRemove(vrf_id, ipPrefix);
         it_route_table->second.erase(ipPrefix);
 
         /* Notify about the route next hop removal */
@@ -2459,6 +2458,8 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
             m_syncdRoutes.erase(vrf_id);
             m_vrfOrch->decreaseVrfRefCount(vrf_id);
         }
+
+        gFlowCounterRouteOrch->handleRouteRemove(vrf_id, ipPrefix);
     }
 
     return true;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Update the isRouteAlreadyBound to consider both the maps for verifying whether the prefix is deleted or not.

**Why I did it**

- When a route is deleted and the flow counter for that route is not yet bound i.e. still in mPendingAddToFlexCntr (in rare cases), the orchagent will not delete the flow counters and they will remain even after the corresponding route is deleted

- Happens because isRouteAlreadyBound method presumes all the route counters for a route pattern would either be in mPendingAddToFlexCntr or mBoundRouteCounters. But in some cases they might exist in both the maps

**How I verified it**

**Details if related**
