### PR TITLE
[portsorch]: Set default hostif TX queue

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -30,6 +30,7 @@
 #include "countercheckorch.h"
 #include "notifier.h"
 #include "fdborch.h"
+#include "switchorch.h"
 #include "stringutility.h"
 #include "subscriberstatetable.h"
 
@@ -49,6 +50,7 @@ extern NeighOrch *gNeighOrch;
 extern CrmOrch *gCrmOrch;
 extern BufferOrch *gBufferOrch;
 extern FdbOrch *gFdbOrch;
+extern SwitchOrch *gSwitchOrch;
 extern Directory<Orch*> gDirectory;
 extern sai_system_port_api_t *sai_system_port_api;
 extern string gMySwitchType;
@@ -2582,7 +2584,6 @@ bool PortsOrch::createVlanHostIntf(Port& vl, string hostif_name)
 
     vector<sai_attribute_t> attrs;
     sai_attribute_t attr;
-    sai_attr_capability_t capability;
 
     attr.id = SAI_HOSTIF_ATTR_TYPE;
     attr.value.s32 = SAI_HOSTIF_TYPE_NETDEV;
@@ -2602,23 +2603,13 @@ bool PortsOrch::createVlanHostIntf(Port& vl, string hostif_name)
     attrs.push_back(attr);
 
     bool set_hostif_tx_queue = false;
-    if (sai_query_attribute_capability(gSwitchId, SAI_OBJECT_TYPE_HOSTIF,
-                                            SAI_HOSTIF_ATTR_QUEUE,
-                                            &capability)
-                                            == SAI_STATUS_SUCCESS)
+    if (gSwitchOrch->querySwitchCapability(SAI_OBJECT_TYPE_HOSTIF, SAI_HOSTIF_ATTR_QUEUE))
     {
-        if (capability.create_implemented)
-        {
-            set_hostif_tx_queue = true;
-        }
-        else
-        {
-            SWSS_LOG_WARN("Hostif queue attribute not supported");
-        }
+        set_hostif_tx_queue = true;
     }
     else
     {
-        SWSS_LOG_WARN("Unable to query the hostif queue capability");
+        SWSS_LOG_WARN("Hostif queue attribute not supported");
     }
 
     if (set_hostif_tx_queue)
@@ -4853,7 +4844,6 @@ bool PortsOrch::addHostIntfs(Port &port, string alias, sai_object_id_t &host_int
 
     sai_attribute_t attr;
     vector<sai_attribute_t> attrs;
-    sai_attr_capability_t capability;
 
     attr.id = SAI_HOSTIF_ATTR_TYPE;
     attr.value.s32 = SAI_HOSTIF_TYPE_NETDEV;
@@ -4873,24 +4863,13 @@ bool PortsOrch::addHostIntfs(Port &port, string alias, sai_object_id_t &host_int
     attrs.push_back(attr);
 
     bool set_hostif_tx_queue = false;
-    if (sai_query_attribute_capability(gSwitchId, SAI_OBJECT_TYPE_HOSTIF,
-                                            SAI_HOSTIF_ATTR_QUEUE,
-                                            &capability)
-                                            == SAI_STATUS_SUCCESS)
-
+    if (gSwitchOrch->querySwitchCapability(SAI_OBJECT_TYPE_HOSTIF, SAI_HOSTIF_ATTR_QUEUE))
     {
-        if (capability.create_implemented)
-        {
-            set_hostif_tx_queue = true;
-        }
-        else
-        {
-            SWSS_LOG_WARN("Hostif queue attribute not supported");
-        }
+        set_hostif_tx_queue = true;
     }
     else
     {
-        SWSS_LOG_WARN("Unable to query the hostif queue capability");
+        SWSS_LOG_WARN("Hostif queue attribute not supported");
     }
 
     if (set_hostif_tx_queue)

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -61,6 +61,7 @@ extern event_handle_t g_events_handle;
 #define VLAN_PREFIX         "Vlan"
 #define DEFAULT_VLAN_ID     1
 #define MAX_VALID_VLAN_ID   4094
+#define DEFAULT_HOSTIF_TX_QUEUE 7
 
 #define PORT_SPEED_LIST_DEFAULT_SIZE                     16
 #define PORT_STATE_POLLING_SEC                            5
@@ -2599,6 +2600,10 @@ bool PortsOrch::createVlanHostIntf(Port& vl, string hostif_name)
     attr.value.chardata[SAI_HOSTIF_NAME_SIZE - 1] = '\0';
     attrs.push_back(attr);
 
+    attr.id = SAI_HOSTIF_ATTR_QUEUE;
+    attr.value.u32 = DEFAULT_HOSTIF_TX_QUEUE;
+    attrs.push_back(attr);
+
     sai_status_t status = sai_hostif_api->create_hostif(&vl.m_vlan_info.host_intf_id, gSwitchId, (uint32_t)attrs.size(), attrs.data());
     if (status != SAI_STATUS_SUCCESS)
     {
@@ -4834,6 +4839,10 @@ bool PortsOrch::addHostIntfs(Port &port, string alias, sai_object_id_t &host_int
         SWSS_LOG_WARN("Host interface name %s is too long and will be truncated to %d bytes", alias.c_str(), SAI_HOSTIF_NAME_SIZE - 1);
     }
     attr.value.chardata[SAI_HOSTIF_NAME_SIZE - 1] = '\0';
+    attrs.push_back(attr);
+
+    attr.id = SAI_HOSTIF_ATTR_QUEUE;
+    attr.value.u32 = DEFAULT_HOSTIF_TX_QUEUE;
     attrs.push_back(attr);
 
     sai_status_t status = sai_hostif_api->create_hostif(&host_intfs_id, gSwitchId, (uint32_t)attrs.size(), attrs.data());

--- a/tests/dvslib/dvs_vlan.py
+++ b/tests/dvslib/dvs_vlan.py
@@ -106,6 +106,7 @@ class DVSVlan(object):
         assert hostif.get("SAI_HOSTIF_ATTR_TYPE") == "SAI_HOSTIF_TYPE_NETDEV"
         assert hostif.get("SAI_HOSTIF_ATTR_OBJ_ID") == vlan_oid
         assert hostif.get("SAI_HOSTIF_ATTR_NAME") == hostif_name
+        assert hostif.get("SAI_HOSTIF_ATTR_QUEUE") == "7"
 
     def get_and_verify_vlan_hostif_ids(self, expected_num, polling_config=PollingConfig()):
         hostif_entries = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF",

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -277,6 +277,17 @@ class TestPort(object):
             if fv[0] == "SAI_PORT_ATTR_SERDES_IPREDRIVER":
                 assert fv[1] == ipre_val_asic
 
+    def test_PortHostif(self, dvs):
+        adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
+        atbl = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF")
+        host_intfs = atbl.getKeys()
+        for intf in host_intfs:
+            status, fvs = atbl.get(intf)
+            assert status, "Error getting value for key"
+            attributes = dict(fvs)
+            hostif_queue = attributes.get("SAI_HOSTIF_ATTR_QUEUE")
+            assert hostif_queue == "7"
+
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying


### PR DESCRIPTION
* To avoid data and control packets sharing the same TX queue and possibly leading to control packet losses, pin control traffic to queue 7 by default.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Set default queue for control packets to 7.
**Why I did it**
To avoid control packets like BGP keepalives from being lost when link utilization becomes 100%
**How I verified it**
Tested on multiple platorms with ICMP packets to make sure they use TX queue 0
**Details if related**
