### PR TITLE
[202012][muxorch] handling multiple mux nexthops for route

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -163,6 +163,34 @@ static sai_status_t remove_route(IpPrefix &pfx)
     return status;
 }
 
+/**
+ * @brief sets the given route to point to the given nexthop
+ * @param pfx IpPrefix of the route
+ * @param nexthop NextHopKey of the nexthop
+ * @return SAI_STATUS_SUCCESS on success
+ */
+static sai_status_t set_route(const IpPrefix& pfx, sai_object_id_t next_hop_id)
+{
+    /* set route entry to point to nh */
+    sai_route_entry_t route_entry;
+    sai_attribute_t route_attr;
+
+    route_entry.vr_id = gVirtualRouterId;
+    route_entry.switch_id = gSwitchId;
+    copy(route_entry.destination, pfx);
+
+    route_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    route_attr.value.oid = next_hop_id;
+
+    sai_status_t status = sai_route_api->set_route_entry_attribute(&route_entry, &route_attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to set route entry %s nh %" PRIx64 " rv:%d",
+                pfx.to_string().c_str(), next_hop_id, status);
+    }
+    return status;
+}
+
 static sai_object_id_t create_tunnel(
     const IpAddress* p_dst_ip,
     const IpAddress* p_src_ip,
@@ -523,9 +551,11 @@ bool MuxCable::nbrHandler(bool enable, bool update_rt)
 {
     SWSS_LOG_NOTICE("Processing neighbors for mux %s, enable %d, state %d",
                      mux_name_.c_str(), enable, state_);
+    bool ret;
     if (enable)
     {
-        return nbr_handler_->enable(update_rt);
+        ret = nbr_handler_->enable(update_rt);
+        updateRoutes();
     }
     else
     {
@@ -535,9 +565,10 @@ bool MuxCable::nbrHandler(bool enable, bool update_rt)
             SWSS_LOG_INFO("Null NH object id, retry for %s", peer_ip4_.to_string().c_str());
             return false;
         }
-
-        return nbr_handler_->disable(tnh);
+        updateRoutes();
+        ret = nbr_handler_->disable(tnh);
     }
+    return ret;
 }
 
 void MuxCable::updateNeighbor(NextHopKey nh, bool add)
@@ -553,6 +584,29 @@ void MuxCable::updateNeighbor(NextHopKey nh, bool add)
     else if (mux_name_ == mux_orch_->getNexthopMuxName(nh))
     {
         mux_orch_->removeNexthop(nh);
+        nbr_handler_->removeNeighborRoutes(nh);
+    }
+    updateRoutes();
+}
+
+/**
+ * @brief updates all routes pointing to the cables neighbor list
+ */
+void MuxCable::updateRoutes()
+{
+    MuxNeighbor neighbors = nbr_handler_->getNeighbors();
+    string alias = nbr_handler_->getAlias();
+    for (auto nh = neighbors.begin(); nh != neighbors.end(); nh ++)
+    {
+        std::set<RouteKey> routes;
+        NextHopKey nhkey(nh->first, alias);
+        if (gRouteOrch->getRoutesForNexthop(routes, nhkey))
+        {
+            for (auto rt = routes.begin(); rt != routes.end(); rt++)
+            {
+                mux_orch_->updateRoute(rt->prefix, false);
+            }
+        }
     }
 }
 
@@ -741,6 +795,44 @@ bool MuxNbrHandler::disable(sai_object_id_t tnh)
     }
 
     return true;
+}
+
+/**
+ * @brief removes routes programmed by updateRoute
+ * @param nh NextHopKey that points to neighbor for which to remove routes
+ */
+void MuxNbrHandler::removeNeighborRoutes(NextHopKey nh)
+{
+    std::set<RouteKey> routes;
+    NextHopGroupKey nhg_key;
+    NextHopGroupEntry nhg_entry;
+
+    if (gRouteOrch->getRoutesForNexthop(routes, nh))
+    {
+        for (auto rt = routes.begin(); rt != routes.end(); rt++)
+        {
+            SWSS_LOG_INFO("Removing multi-nexthop route for %s", rt->prefix.to_string().c_str());
+            /* get nexthop group key from syncd */
+            nhg_key = gRouteOrch->getSyncdRouteNhgKey(gVirtualRouterId, rt->prefix);
+
+            /* check for cross-mux neighbors */
+            if (nhg_key.getSize() > 1)
+            {
+                sai_route_entry_t route_entry;
+                route_entry.switch_id = gSwitchId;
+                route_entry.vr_id = gVirtualRouterId;
+                copy(route_entry.destination, rt->prefix);
+                subnet(route_entry.destination, route_entry.destination);
+
+                sai_status_t status = sai_route_api->remove_route_entry(&route_entry);
+                if (status != SAI_STATUS_SUCCESS)
+                {
+                    SWSS_LOG_ERROR("Failed to remove route %s, rv:%d",
+                                    rt->prefix.to_string().c_str(), status);
+                }
+            }
+        }
+    }
 }
 
 sai_object_id_t MuxNbrHandler::getNextHopId(const NextHopKey nhKey)
@@ -944,6 +1036,91 @@ sai_object_id_t MuxOrch::getNextHopTunnelId(std::string tunnelKey, IpAddress& ip
     }
 
     return it->second.nh_id;
+}
+
+/**
+ * @brief updates the given route to point to a single active NH or tunnel
+ * @param pfx IpPrefix of route to update
+ * @param remove bool only true when route is getting removed
+ */
+void MuxOrch::updateRoute(const IpPrefix &pfx, bool remove)
+{
+    NextHopGroupKey nhg_key;
+    NextHopGroupEntry nhg_entry;
+
+    if (remove)
+    {
+        mux_multi_nh_route_tb.erase(pfx);
+        return;
+    }
+
+    /* get nexthop group key from syncd */
+    nhg_key = gRouteOrch->getSyncdRouteNhgKey(gVirtualRouterId, pfx);
+
+    /* check for cross-mux neighbors */
+    if (nhg_key.getSize() > 1)
+    {
+        std::set<NextHopKey> nextHops;
+        sai_object_id_t next_hop_id;
+        sai_status_t status;
+        bool active_found = false;
+
+        /* get nexthops from nexthop group */
+        nextHops = nhg_key.getNextHops();
+
+        auto it = mux_multi_nh_route_tb.find(pfx);
+        if (it != mux_multi_nh_route_tb.end())
+        {
+            MuxCable* cable = findMuxCableInSubnet(it->second.ip_address);
+            if (cable == nullptr || cable->isActive())
+            {
+                SWSS_LOG_NOTICE("Route %s pointing to active neighbor %s",
+                    pfx.to_string().c_str(), it->second.to_string().c_str());
+                return;
+            }
+        }
+
+        SWSS_LOG_NOTICE("Updating route %s pointing to Mux nexthops %s",
+                    pfx.to_string().c_str(), nhg_key.to_string().c_str());
+
+        for (auto it = nextHops.begin(); it != nextHops.end(); it++)
+        {
+            NextHopKey nexthop = *it;
+            MuxCable* cable = findMuxCableInSubnet(nexthop.ip_address);
+            if (cable == nullptr || (cable->isActive() && !active_found))
+            {
+                next_hop_id = gNeighOrch->getLocalNextHopId(nexthop);
+                /* set route entry to point to nh */
+                status = set_route(pfx, next_hop_id);
+                if (status != SAI_STATUS_SUCCESS)
+                {
+                    SWSS_LOG_ERROR("Failed to set route entry %s to nexthop %s",
+                            pfx.to_string().c_str(), nexthop.to_string().c_str());
+                    continue;
+                }
+                SWSS_LOG_INFO("setting route %s with nexthop %s %" PRIx64 "",
+                    pfx.to_string().c_str(), nexthop.to_string().c_str(), next_hop_id);
+                mux_multi_nh_route_tb[pfx] = nexthop;
+                active_found = true;
+                break;
+            }
+        }
+
+        if (!active_found)
+        {
+            next_hop_id = getNextHopTunnelId(MUX_TUNNEL, mux_peer_switch_);
+            /* no active nexthop found, point to first */
+            SWSS_LOG_NOTICE("No Active neighbors found, setting route %s to point to tun",
+                        pfx.getIp().to_string().c_str());
+            status = set_route(pfx, next_hop_id);
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to set route entry %s to tunnel",
+                        pfx.getIp().to_string().c_str());
+            }
+            mux_multi_nh_route_tb.erase(pfx);
+        }
+    }
 }
 
 MuxCable* MuxOrch::findMuxCableInSubnet(IpAddress ip)
@@ -1172,6 +1349,35 @@ void MuxOrch::addNexthop(NextHopKey nh, string muxName)
 void MuxOrch::removeNexthop(NextHopKey nh)
 {
     mux_nexthop_tb_.erase(nh);
+}
+
+/**
+ * @brief checks if mux nexthop tb contains nexthop
+ * @param nexthop NextHopKey
+ * @return true if a mux contains the nexthop
+ */
+bool MuxOrch::containsNextHop(const NextHopKey& nexthop)
+{
+    return mux_nexthop_tb_.find(nexthop) != mux_nexthop_tb_.end();
+}
+
+/**
+ * @brief checks if a given nexthop group belongs to a mux
+ * @param nextHops NextHopGroupKey
+ * @return true if a mux contains any of the nexthops in the group
+ *         false if none of the nexthops belong to a mux
+ */
+bool MuxOrch::isMuxNexthops(const NextHopGroupKey& nextHops)
+{
+    const std::set<NextHopKey> s_nexthops = nextHops.getNextHops();
+    for (auto it = s_nexthops.begin(); it != s_nexthops.end(); it ++)
+    {
+        if (this->containsNextHop(*it))
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 string MuxOrch::getNexthopMuxName(NextHopKey nh)

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -584,7 +584,6 @@ void MuxCable::updateNeighbor(NextHopKey nh, bool add)
     else if (mux_name_ == mux_orch_->getNexthopMuxName(nh))
     {
         mux_orch_->removeNexthop(nh);
-        nbr_handler_->removeNeighborRoutes(nh);
     }
     updateRoutes();
 }
@@ -604,7 +603,7 @@ void MuxCable::updateRoutes()
         {
             for (auto rt = routes.begin(); rt != routes.end(); rt++)
             {
-                mux_orch_->updateRoute(rt->prefix, false);
+                mux_orch_->updateRoute(rt->prefix, true);
             }
         }
     }
@@ -795,44 +794,6 @@ bool MuxNbrHandler::disable(sai_object_id_t tnh)
     }
 
     return true;
-}
-
-/**
- * @brief removes routes programmed by updateRoute
- * @param nh NextHopKey that points to neighbor for which to remove routes
- */
-void MuxNbrHandler::removeNeighborRoutes(NextHopKey nh)
-{
-    std::set<RouteKey> routes;
-    NextHopGroupKey nhg_key;
-    NextHopGroupEntry nhg_entry;
-
-    if (gRouteOrch->getRoutesForNexthop(routes, nh))
-    {
-        for (auto rt = routes.begin(); rt != routes.end(); rt++)
-        {
-            SWSS_LOG_INFO("Removing multi-nexthop route for %s", rt->prefix.to_string().c_str());
-            /* get nexthop group key from syncd */
-            nhg_key = gRouteOrch->getSyncdRouteNhgKey(gVirtualRouterId, rt->prefix);
-
-            /* check for cross-mux neighbors */
-            if (nhg_key.getSize() > 1)
-            {
-                sai_route_entry_t route_entry;
-                route_entry.switch_id = gSwitchId;
-                route_entry.vr_id = gVirtualRouterId;
-                copy(route_entry.destination, rt->prefix);
-                subnet(route_entry.destination, route_entry.destination);
-
-                sai_status_t status = sai_route_api->remove_route_entry(&route_entry);
-                if (status != SAI_STATUS_SUCCESS)
-                {
-                    SWSS_LOG_ERROR("Failed to remove route %s, rv:%d",
-                                    rt->prefix.to_string().c_str(), status);
-                }
-            }
-        }
-    }
 }
 
 sai_object_id_t MuxNbrHandler::getNextHopId(const NextHopKey nhKey)
@@ -1043,83 +1004,103 @@ sai_object_id_t MuxOrch::getNextHopTunnelId(std::string tunnelKey, IpAddress& ip
  * @param pfx IpPrefix of route to update
  * @param remove bool only true when route is getting removed
  */
-void MuxOrch::updateRoute(const IpPrefix &pfx, bool remove)
+void MuxOrch::updateRoute(const IpPrefix &pfx, bool add)
 {
     NextHopGroupKey nhg_key;
     NextHopGroupEntry nhg_entry;
 
-    if (remove)
+    if (!add)
     {
-        mux_multi_nh_route_tb.erase(pfx);
+        mux_multi_active_nh_table.erase(pfx);
         return;
     }
 
     /* get nexthop group key from syncd */
     nhg_key = gRouteOrch->getSyncdRouteNhgKey(gVirtualRouterId, pfx);
 
-    /* check for cross-mux neighbors */
-    if (nhg_key.getSize() > 1)
+    /* check for multi-nh neighbors.
+     * if none are present, ignore
+     */
+    if (nhg_key.getSize() <= 1)
     {
-        std::set<NextHopKey> nextHops;
-        sai_object_id_t next_hop_id;
-        sai_status_t status;
-        bool active_found = false;
+        return;
+    }
 
-        /* get nexthops from nexthop group */
-        nextHops = nhg_key.getNextHops();
+    std::set<NextHopKey> nextHops;
+    sai_object_id_t next_hop_id;
+    sai_status_t status;
+    bool active_found = false;
 
-        auto it = mux_multi_nh_route_tb.find(pfx);
-        if (it != mux_multi_nh_route_tb.end())
+    /* get nexthops from nexthop group */
+    nextHops = nhg_key.getNextHops();
+
+    auto it = mux_multi_active_nh_table.find(pfx);
+    if (it != mux_multi_active_nh_table.end())
+    {
+        /* This will only work for configured MUX neighbors (most cases)
+         * TODO: add way to find MUX from neighbor
+         */
+        MuxCable* cable = findMuxCableInSubnet(it->second.ip_address);
+        auto standalone = standalone_tunnel_neighbors_.find(it->second.ip_address);
+
+        if ((cable == nullptr && standalone == standalone_tunnel_neighbors_.end()) ||
+             cable->isActive())
         {
-            MuxCable* cable = findMuxCableInSubnet(it->second.ip_address);
-            if (cable == nullptr || cable->isActive())
-            {
-                SWSS_LOG_NOTICE("Route %s pointing to active neighbor %s",
-                    pfx.to_string().c_str(), it->second.to_string().c_str());
-                return;
-            }
+            SWSS_LOG_INFO("Route %s pointing to active neighbor %s",
+                pfx.to_string().c_str(), it->second.to_string().c_str());
+            return;
         }
+    }
 
-        SWSS_LOG_NOTICE("Updating route %s pointing to Mux nexthops %s",
-                    pfx.to_string().c_str(), nhg_key.to_string().c_str());
+    SWSS_LOG_NOTICE("Updating route %s pointing to Mux nexthops %s",
+                pfx.to_string().c_str(), nhg_key.to_string().c_str());
 
-        for (auto it = nextHops.begin(); it != nextHops.end(); it++)
+    for (auto it = nextHops.begin(); it != nextHops.end(); it++)
+    {
+        NextHopKey nexthop = *it;
+        /* This will only work for configured MUX neighbors (most cases)
+         * TODO: add way to find MUX from neighbor
+         */
+        MuxCable* cable = findMuxCableInSubnet(nexthop.ip_address);
+        auto standalone = standalone_tunnel_neighbors_.find(nexthop.ip_address);
+
+        if ((cable == nullptr && standalone == standalone_tunnel_neighbors_.end()) ||
+             cable->isActive())
         {
-            NextHopKey nexthop = *it;
-            MuxCable* cable = findMuxCableInSubnet(nexthop.ip_address);
-            if (cable == nullptr || (cable->isActive() && !active_found))
-            {
-                next_hop_id = gNeighOrch->getLocalNextHopId(nexthop);
-                /* set route entry to point to nh */
-                status = set_route(pfx, next_hop_id);
-                if (status != SAI_STATUS_SUCCESS)
-                {
-                    SWSS_LOG_ERROR("Failed to set route entry %s to nexthop %s",
-                            pfx.to_string().c_str(), nexthop.to_string().c_str());
-                    continue;
-                }
-                SWSS_LOG_INFO("setting route %s with nexthop %s %" PRIx64 "",
-                    pfx.to_string().c_str(), nexthop.to_string().c_str(), next_hop_id);
-                mux_multi_nh_route_tb[pfx] = nexthop;
-                active_found = true;
-                break;
-            }
-        }
-
-        if (!active_found)
-        {
-            next_hop_id = getNextHopTunnelId(MUX_TUNNEL, mux_peer_switch_);
-            /* no active nexthop found, point to first */
-            SWSS_LOG_NOTICE("No Active neighbors found, setting route %s to point to tun",
-                        pfx.getIp().to_string().c_str());
+            /* Here we pull from local nexthop ID because neighbor update occurs during state change
+             * before nexthopID is updated in neighorch. This ensures that if a neighbor is Active
+             * only that neighbor's nexthop ID is added, and not the tunnel nexthop
+             */
+            next_hop_id = gNeighOrch->getLocalNextHopId(nexthop);
+            /* set route entry to point to nh */
             status = set_route(pfx, next_hop_id);
             if (status != SAI_STATUS_SUCCESS)
             {
-                SWSS_LOG_ERROR("Failed to set route entry %s to tunnel",
-                        pfx.getIp().to_string().c_str());
+                SWSS_LOG_ERROR("Failed to set route entry %s to nexthop %s",
+                        pfx.to_string().c_str(), nexthop.to_string().c_str());
+                continue;
             }
-            mux_multi_nh_route_tb.erase(pfx);
+            SWSS_LOG_INFO("setting route %s with nexthop %s %" PRIx64 "",
+                pfx.to_string().c_str(), nexthop.to_string().c_str(), next_hop_id);
+            mux_multi_active_nh_table[pfx] = nexthop;
+            active_found = true;
+            break;
         }
+    }
+
+    if (!active_found)
+    {
+        next_hop_id = getNextHopTunnelId(MUX_TUNNEL, mux_peer_switch_);
+        /* no active nexthop found, point to first */
+        SWSS_LOG_INFO("No Active neighbors found, setting route %s to point to tun",
+                    pfx.getIp().to_string().c_str());
+        status = set_route(pfx, next_hop_id);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to set route entry %s to tunnel",
+                    pfx.getIp().to_string().c_str());
+        }
+        mux_multi_active_nh_table.erase(pfx);
     }
 }
 

--- a/orchagent/muxorch.h
+++ b/orchagent/muxorch.h
@@ -65,8 +65,6 @@ public:
     bool disable(sai_object_id_t);
     void update(NextHopKey nh, sai_object_id_t, bool = true, MuxState = MuxState::MUX_STATE_INIT);
 
-    void removeNeighborRoutes(NextHopKey nh);
-
     sai_object_id_t getNextHopId(const NextHopKey);
     MuxNeighbor getNeighbors() const { return neighbors_; };
     string getAlias() const { return alias_; };
@@ -177,6 +175,11 @@ public:
         return mux_cable_tb_.at(portName).get();
     }
 
+    bool isMultiNexthopRoute(const IpPrefix& pfx)
+    {
+        return (mux_multi_active_nh_table.find(pfx) != mux_multi_active_nh_table.end());
+    }
+
     MuxCable* findMuxCableInSubnet(IpAddress);
     bool isNeighborActive(const IpAddress&, const MacAddress&, string&);
     void update(SubjectType, void *);
@@ -192,7 +195,7 @@ public:
     bool removeNextHopTunnel(std::string tunnelKey, IpAddress& ipAddr);
     sai_object_id_t getNextHopTunnelId(std::string tunnelKey, IpAddress& ipAddr);
 
-    void updateRoute(const IpPrefix &pfx, bool remove);
+    void updateRoute(const IpPrefix &pfx, bool add);
 
 private:
     virtual bool addOperation(const Request& request);
@@ -221,7 +224,7 @@ private:
     NextHopTb mux_nexthop_tb_;
 
     /* contains reference of programmed routes by updateRoute */
-    MuxRouteTb mux_multi_nh_route_tb;
+    MuxRouteTb mux_multi_active_nh_table;
 
     handler_map handler_map_;
 

--- a/orchagent/muxorch.h
+++ b/orchagent/muxorch.h
@@ -65,7 +65,11 @@ public:
     bool disable(sai_object_id_t);
     void update(NextHopKey nh, sai_object_id_t, bool = true, MuxState = MuxState::MUX_STATE_INIT);
 
+    void removeNeighborRoutes(NextHopKey nh);
+
     sai_object_id_t getNextHopId(const NextHopKey);
+    MuxNeighbor getNeighbors() const { return neighbors_; };
+    string getAlias() const { return alias_; };
 
 private:
     MuxNeighbor neighbors_;
@@ -93,6 +97,7 @@ public:
 
     bool isIpInSubnet(IpAddress ip);
     void updateNeighbor(NextHopKey nh, bool add);
+    void updateRoutes();
     sai_object_id_t getNextHopId(const NextHopKey nh)
     {
         return nbr_handler_->getNextHopId(nh);
@@ -145,6 +150,7 @@ typedef std::unique_ptr<MuxCable> MuxCable_T;
 typedef std::map<std::string, MuxCable_T> MuxCableTb;
 typedef std::map<IpAddress, NHTunnel> MuxTunnelNHs;
 typedef std::map<NextHopKey, std::string> NextHopTb;
+typedef std::map<IpPrefix, NextHopKey> MuxRouteTb;
 
 class MuxCfgRequest : public Request
 {
@@ -177,12 +183,16 @@ public:
 
     void addNexthop(NextHopKey, string = "");
     void removeNexthop(NextHopKey);
+    bool containsNextHop(const NextHopKey&);
+    bool isMuxNexthops(const NextHopGroupKey&);
     string getNexthopMuxName(NextHopKey);
     sai_object_id_t getNextHopId(const NextHopKey&);
 
     sai_object_id_t createNextHopTunnel(std::string tunnelKey, IpAddress& ipAddr);
     bool removeNextHopTunnel(std::string tunnelKey, IpAddress& ipAddr);
     sai_object_id_t getNextHopTunnelId(std::string tunnelKey, IpAddress& ipAddr);
+
+    void updateRoute(const IpPrefix &pfx, bool remove);
 
 private:
     virtual bool addOperation(const Request& request);
@@ -209,6 +219,9 @@ private:
     MuxCableTb mux_cable_tb_;
     MuxTunnelNHs mux_tunnel_nh_;
     NextHopTb mux_nexthop_tb_;
+
+    /* contains reference of programmed routes by updateRoute */
+    MuxRouteTb mux_multi_nh_route_tb;
 
     handler_map handler_map_;
 

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include "routeorch.h"
 #include "logger.h"
+#include "muxorch.h"
 #include "swssnet.h"
 #include "crmorch.h"
 #include "directory.h"
@@ -223,6 +224,24 @@ void RouteOrch::updateDefRouteState(string ip, bool add)
 bool RouteOrch::hasNextHopGroup(const NextHopGroupKey& nexthops) const
 {
     return m_syncdNextHopGroups.find(nexthops) != m_syncdNextHopGroups.end();
+}
+
+/**
+ * @brief checks if given nexthop is in a nexthop group
+ * @param nexthop NextHopKey
+ * @returns true if nexthop is in a nexthop group
+ */
+bool RouteOrch::inNextHopGroup(const NextHopKey& nexthop, NextHopGroupKey& nhgKey)
+{
+    for (auto it = m_syncdNextHopGroups.begin(); it != m_syncdNextHopGroups.end(); it++)
+    {
+        if (it->second.nhopgroup_members.find(nexthop) != it->second.nhopgroup_members.end())
+        {
+            nhgKey = it->first;
+            return true;
+        }
+    }
+    return false;
 }
 
 sai_object_id_t RouteOrch::getNextHopGroupId(const NextHopGroupKey& nexthops)
@@ -1335,6 +1354,19 @@ bool RouteOrch::updateNextHopRoutes(const NextHopKey& nextHop, uint32_t& numRout
         return true;
     }
 
+    /* Check if nexthop is mux nexthop */
+    MuxOrch* mux_orch = gDirectory.get<MuxOrch*>();
+    NextHopGroupKey nhg_key;
+    if (inNextHopGroup(nextHop, nhg_key) && mux_orch->isMuxNexthops(nhg_key))
+    {
+        /* multiple mux nexthop case:
+         * skip for now, muxOrch::updateRoute() will handle route
+         */
+        SWSS_LOG_INFO("NH %s is in mux nexthop group, skipping.",
+                      nextHop.ip_address.to_string().c_str());
+        return true;
+    }
+
     sai_route_entry_t route_entry;
     sai_attribute_t route_attr;
     sai_object_id_t next_hop_id;
@@ -1368,6 +1400,24 @@ bool RouteOrch::updateNextHopRoutes(const NextHopKey& nextHop, uint32_t& numRout
     }
 
     return true;
+}
+
+/**
+ * @brief returns a route prefix associated with nexthopkey
+ * @param routeKeys empty set of routekeys to populate
+ * @param nexthopKey nexthop key to lookup
+ * @return true if found, false if not found.
+ */
+bool RouteOrch::getRoutesForNexthop(std::set<RouteKey>& routeKeys, const NextHopKey& nexthopKey)
+{
+    auto it = m_nextHops.find(nexthopKey);
+
+    if (it != m_nextHops.end())
+    {
+        routeKeys = it->second;
+    }
+
+    return it != m_nextHops.end();
 }
 
 void RouteOrch::addTempRoute(RouteBulkContext& ctx, const NextHopGroupKey &nextHops)
@@ -1903,6 +1953,9 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
                 ipPrefix.to_string().c_str(), nextHops.to_string().c_str());
     }
 
+    m_syncdRoutes[vrf_id][ipPrefix] = nextHops;
+
+    MuxOrch* mux_orch = gDirectory.get<MuxOrch*>();
     if (nextHops.getSize() == 1 && !nextHops.is_overlay_nexthop())
     {
         RouteKey r_key = { vrf_id, ipPrefix };
@@ -1912,13 +1965,25 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
             addNextHopRoute(nexthop, r_key);
         }
     }
+    else if (mux_orch->isMuxNexthops(nextHops))
+    {
+        RouteKey routekey = { vrf_id, ipPrefix };
+        auto nexthop_list = nextHops.getNextHops();
+        for (auto nh = nexthop_list.begin(); nh != nexthop_list.end(); nh++)
+        {
+            if (!nh->ip_address.isZero())
+            {
+                addNextHopRoute(*nh, routekey);
+            }
+        }
+        // update routes to reflect mux state
+        mux_orch->updateRoute(ipPrefix, false);
+    }
 
     if (ipPrefix.isDefaultRoute())
     {
         updateDefRouteState(ipPrefix.to_string(), true);
     }
-
-    m_syncdRoutes[vrf_id][ipPrefix] = nextHops;
 
     notifyNextHopChangeObservers(vrf_id, ipPrefix, nextHops, true);
     return true;
@@ -2054,6 +2119,7 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
         }
     }
 
+    MuxOrch* mux_orch = gDirectory.get<MuxOrch*>();
     if (m_fgNhgOrch->syncdContainsFgNhg(vrf_id, ipPrefix))
     {
         /* Delete Fine Grained nhg if the revmoved route pointed to it */
@@ -2072,6 +2138,20 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
             && m_syncdNextHopGroups[it_route->second].ref_count == 0)
         {
             m_bulkNhgReducedRefCnt.emplace(it_route->second);
+            if (mux_orch->isMuxNexthops(ol_nextHops))
+            {
+                SWSS_LOG_NOTICE("Remove mux Nexthop %s", ol_nextHops.to_string().c_str());
+                RouteKey routekey = { vrf_id, ipPrefix };
+                auto nexthop_list = ol_nextHops.getNextHops();
+                for (auto nh = nexthop_list.begin(); nh != nexthop_list.end(); nh++)
+                {
+                    if (!nh->ip_address.isZero())
+                    {
+                        removeNextHopRoute(*nh, routekey);
+                    }
+                }
+                mux_orch->updateRoute(ipPrefix, true);
+            }
         }
         else if (ol_nextHops.is_overlay_nexthop())
         {

--- a/orchagent/routeorch.h
+++ b/orchagent/routeorch.h
@@ -109,9 +109,7 @@ public:
     RouteOrch(DBConnector *db, string tableName, SwitchOrch *switchOrch, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch, FgNhgOrch *fgNhgOrch);
 
     bool hasNextHopGroup(const NextHopGroupKey&) const;
-    bool inNextHopGroup(const NextHopKey&, NextHopGroupKey& nhgKey);
     sai_object_id_t getNextHopGroupId(const NextHopGroupKey&);
-    NextHopGroupEntry getNextHopGroupEntry(const NextHopGroupKey&);
 
     void attach(Observer *, const IpAddress&, sai_object_id_t vrf_id = gVirtualRouterId);
     void detach(Observer *, const IpAddress&, sai_object_id_t vrf_id = gVirtualRouterId);

--- a/orchagent/routeorch.h
+++ b/orchagent/routeorch.h
@@ -109,7 +109,9 @@ public:
     RouteOrch(DBConnector *db, string tableName, SwitchOrch *switchOrch, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch, FgNhgOrch *fgNhgOrch);
 
     bool hasNextHopGroup(const NextHopGroupKey&) const;
+    bool inNextHopGroup(const NextHopKey&, NextHopGroupKey& nhgKey);
     sai_object_id_t getNextHopGroupId(const NextHopGroupKey&);
+    NextHopGroupEntry getNextHopGroupEntry(const NextHopGroupKey&);
 
     void attach(Observer *, const IpAddress&, sai_object_id_t vrf_id = gVirtualRouterId);
     void detach(Observer *, const IpAddress&, sai_object_id_t vrf_id = gVirtualRouterId);
@@ -124,6 +126,7 @@ public:
     void addNextHopRoute(const NextHopKey&, const RouteKey&);
     void removeNextHopRoute(const NextHopKey&, const RouteKey&);
     bool updateNextHopRoutes(const NextHopKey&, uint32_t&);
+    bool getRoutesForNexthop(std::set<RouteKey>&, const NextHopKey&);
 
     bool validnexthopinNextHopGroup(const NextHopKey&, uint32_t&);
     bool invalidnexthopinNextHopGroup(const NextHopKey&, uint32_t&);

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -15,6 +15,7 @@ tunnel_nh_id = 0
 class TestMuxTunnelBase():
     APP_MUX_CABLE               = "MUX_CABLE_TABLE"
     APP_NEIGH_TABLE             = "NEIGH_TABLE"
+    APP_ROUTE_TABLE             = "ROUTE_TABLE"
     APP_TUNNEL_DECAP_TABLE_NAME = "TUNNEL_DECAP_TABLE"
     ASIC_TUNNEL_TABLE           = "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL"
     ASIC_TUNNEL_TERM_ENTRIES    = "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL_TERM_TABLE_ENTRY"
@@ -22,6 +23,7 @@ class TestMuxTunnelBase():
     ASIC_VRF_TABLE              = "ASIC_STATE:SAI_OBJECT_TYPE_VIRTUAL_ROUTER"
     ASIC_NEIGH_TABLE            = "ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY"
     ASIC_NEXTHOP_TABLE          = "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP"
+    ASIC_NHG_MEMBER_TABLE       = "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER"
     ASIC_ROUTE_TABLE            = "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY"
     ASIC_FDB_TABLE              = "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY"
     ASIC_SWITCH_TABLE           = "ASIC_STATE:SAI_OBJECT_TYPE_SWITCH"
@@ -160,6 +162,26 @@ class TestMuxTunnelBase():
                 break
 
         return vlan_oid
+    
+    def get_nexthop_oid(self, asicdb, nexthop):
+        # gets nexthop oid
+        nexthop_keys = asicdb.get_keys(self.ASIC_NEXTHOP_TABLE)
+
+        nexthop_oid = ''
+        for nexthop_key in nexthop_keys:
+            entry = asicdb.get_entry(self.ASIC_NEXTHOP_TABLE, nexthop_key)
+            if entry["SAI_NEXT_HOP_ATTR_IP"] == nexthop:
+                nexthop_oid = nexthop_key
+                break
+
+        return nexthop_oid
+    
+    def get_route_nexthop_oid(self, route_key, asicdb):
+        # gets nexthop oid
+        entry = asicdb.get_entry(self.ASIC_ROUTE_TABLE, route_key)
+        assert 'SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID' in entry
+
+        return entry['SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID']
 
     def check_neigh_in_asic_db(self, asicdb, ip, expected=True):
         rif_oid = self.get_vlan_rif_oid(asicdb)
@@ -231,6 +253,18 @@ class TestMuxTunnelBase():
 
         assert num_tnl_nh == count
 
+    def check_route_nexthop(self, dvs_route, asicdb, route, nexthop, tunnel=False):
+        route_key = dvs_route.check_asicdb_route_entries([route])
+        route_nexthop_oid = self.get_route_nexthop_oid(route_key[0], asicdb)
+        
+        if tunnel:
+            assert route_nexthop_oid == nexthop
+            return
+
+        nexthop_oid = self.get_nexthop_oid(asicdb, nexthop)
+
+        assert route_nexthop_oid == nexthop_oid
+
     def add_neighbor(self, dvs, ip, mac):
         if ip_address(ip).version == 6:
             dvs.runcmd("ip -6 neigh replace " + ip + " lladdr " + mac + " dev Vlan1000")
@@ -258,6 +292,26 @@ class TestMuxTunnelBase():
         ps._del("Vlan1000:"+mac)
 
         time.sleep(1)
+
+    def add_route(self, dvs, route, nexthops, ifaces=[]):
+        apdb = dvs.get_app_db()
+        nexthop_str = ",".join(nexthops)
+        if len(ifaces) == 0:
+            ifaces = [self.VLAN_1000 for k in range(len(nexthops))]
+        iface_str = ",".join(ifaces)
+        ps = swsscommon.ProducerStateTable(apdb.db_connection, self.APP_ROUTE_TABLE)
+        fvs = swsscommon.FieldValuePairs(
+                [
+                    ("nexthop", nexthop_str),
+                    ("ifname", iface_str)
+                ]
+              )
+        ps.set(route, fvs)
+
+    def del_route(self, dvs, route):
+        apdb = dvs.get_app_db()
+        ps = swsscommon.ProducerStateTable(apdb.db_connection, self.APP_ROUTE_TABLE)
+        ps._del(route)
 
     def create_and_test_neighbor(self, confdb, appdb, asicdb, dvs, dvs_route):
 
@@ -420,92 +474,214 @@ class TestMuxTunnelBase():
         self.set_mux_state(appdb, "Ethernet4", "active")
         dvs_route.check_asicdb_deleted_route_entries([rtprefix])
 
-        # Test ECMP routes
+    def multi_nexthop_test(self, dvs, dvs_route, asicdb, appdb, route, neighbors, macs):
+        mux_ports = ["Ethernet0", "Ethernet4"]
 
-        self.set_mux_state(appdb, "Ethernet0", "active")
-        self.set_mux_state(appdb, "Ethernet4", "active")
+        # Set state to active for initial state
+        for port in mux_ports:
+            self.set_mux_state(appdb, port, "active")
 
-        rtprefix = "5.6.7.0/24"
+        # add neighbors for initial state
+        for i,neighbor in enumerate(neighbors):
+            self.add_neighbor(dvs, neighbor, macs[i])
+        
+        try:
+            # toggle between states and add route in various combos of state
+            print("Testing add/remove/update of route")
+            starting_states = [(ACTIVE, ACTIVE), (ACTIVE, STANDBY), (STANDBY, ACTIVE), (STANDBY, STANDBY)]
+            for start in starting_states:
+                print("Adding route with %s: %s and %s: %s" % (mux_ports[0], start[0], mux_ports[1], start[1]))
+                self.set_mux_state(appdb, mux_ports[0], start[0])
+                self.set_mux_state(appdb, mux_ports[1], start[1])
+                self.add_route(dvs, route, neighbors)
+                if start[0] == "active":
+                    self.check_route_nexthop(dvs_route, asicdb, route, neighbors[0])
+                elif start[1] == "active":
+                    self.check_route_nexthop(dvs_route, asicdb, route, neighbors[1])
+                else:
+                    self.check_route_nexthop(dvs_route, asicdb, route, tunnel_nh_id, True)
 
-        dvs_route.check_asicdb_deleted_route_entries([rtprefix])
+                print("Testing fdb update in %s, %s for %s" % (start[0], start[1], neighbors[0]))
+                # move neighbor 1
+                self.add_neighbor(dvs, neighbors[0], "00:aa:bb:cc:dd:ee")
+                if start[0] == "active":
+                    self.check_route_nexthop(dvs_route, asicdb, route, neighbors[0])
+                elif start[1] == "active":
+                    self.check_route_nexthop(dvs_route, asicdb, route, neighbors[1])
+                else:
+                    self.check_route_nexthop(dvs_route, asicdb, route, tunnel_nh_id, True)
 
-        ps = swsscommon.ProducerStateTable(pdb.db_connection, "ROUTE_TABLE")
+                # move neighbor 1 back
+                self.add_neighbor(dvs, neighbors[0], macs[i])
 
-        fvs = swsscommon.FieldValuePairs(
-                [
-                    ("nexthop", self.SERV1_IPV4 + "," + self.SERV2_IPV4),
-                    ("ifname", "Vlan1000,Vlan1000")
-                ]
-              )
+                print("Testing fdb update in %s, %s for %s" % (start[0], start[1], neighbors[1]))
+                # move neighbor 2
+                self.add_neighbor(dvs, neighbors[0], "00:aa:bb:cc:dd:ee")
+                if start[0] == "active":
+                    self.check_route_nexthop(dvs_route, asicdb, route, neighbors[0])
+                elif start[1] == "active":
+                    self.check_route_nexthop(dvs_route, asicdb, route, neighbors[1])
+                else:
+                    self.check_route_nexthop(dvs_route, asicdb, route, tunnel_nh_id, True)
 
-        ps.set(rtprefix, fvs)
+                # move neighbor 2 back
+                self.add_neighbor(dvs, neighbors[0], macs[i])
 
-        # Check if route was propagated to ASIC DB
-        rtkeys = dvs_route.check_asicdb_route_entries([rtprefix])
+                self.del_route(dvs, route)
 
-        # Check for nexthop group and validate nexthop group member in asic db
-        self.check_nexthop_group_in_asic_db(asicdb, rtkeys[0])
 
-        # Step: 1 - Change one NH to standby and verify ecmp route
-        self.set_mux_state(appdb, "Ethernet0", "standby")
-        self.check_nexthop_group_in_asic_db(asicdb, rtkeys[0], 1)
+            # toggle mux states to check setState actions
+            print("Testing toggling state")
+            starting_states = [(ACTIVE, ACTIVE), (ACTIVE, STANDBY), (STANDBY, ACTIVE), (STANDBY, STANDBY)]
+            for start in starting_states:
+                self.set_mux_state(appdb, mux_ports[0], start[0])
+                self.set_mux_state(appdb, mux_ports[1], start[1])
+                self.add_route(dvs, route, neighbors)
 
-        # Step: 2 - Change the other NH to standby and verify ecmp route
-        self.set_mux_state(appdb, "Ethernet4", "standby")
-        self.check_nexthop_group_in_asic_db(asicdb, rtkeys[0], 2)
+                for toggle_index,port in enumerate(mux_ports):
+                    keep_index = (toggle_index + 1) % 2
 
-        # Step: 3 - Change one NH to back to Active and verify ecmp route
-        self.set_mux_state(appdb, "Ethernet0", "active")
-        self.check_nexthop_group_in_asic_db(asicdb, rtkeys[0], 1)
+                    print("keeping %s as %s while toggling %s from %s" % \
+                          (mux_ports[keep_index], start[keep_index], mux_ports[toggle_index], start[toggle_index]))
 
-        # Step: 4 - Change the other NH to Active and verify ecmp route
-        self.set_mux_state(appdb, "Ethernet4", "active")
-        self.check_nexthop_group_in_asic_db(asicdb, rtkeys[0])
+                    if start[toggle_index] == ACTIVE:
+                        print("setting %s to %s" % (mux_ports[toggle_index], STANDBY))
+                        self.set_mux_state(appdb, mux_ports[toggle_index], STANDBY)
+                        if start[keep_index] == ACTIVE:
+                            self.check_route_nexthop(dvs_route, asicdb, route, neighbors[keep_index])
+                        else:
+                            self.check_route_nexthop(dvs_route, asicdb, route, tunnel_nh_id, True)
 
-        ps._del(rtprefix)
+                        print("setting %s to %s" % (mux_ports[toggle_index], ACTIVE))
+                        self.set_mux_state(appdb, mux_ports[toggle_index], ACTIVE)
+                        if start[keep_index] == ACTIVE:
+                            self.check_route_nexthop(dvs_route, asicdb, route, neighbors[keep_index])
+                        else:
+                            self.check_route_nexthop(dvs_route, asicdb, route, neighbors[toggle_index])
+                    else:
+                        print("setting %s to %s" % (mux_ports[toggle_index], ACTIVE))
+                        self.set_mux_state(appdb, mux_ports[toggle_index], ACTIVE)
+                        if start[keep_index] == ACTIVE:
+                            self.check_route_nexthop(dvs_route, asicdb, route, neighbors[keep_index])
+                        else:
+                            self.check_route_nexthop(dvs_route, asicdb, route, neighbors[toggle_index])
 
-        # Test IPv6 ECMP routes and start with standby config
-        self.set_mux_state(appdb, "Ethernet0", "standby")
-        self.set_mux_state(appdb, "Ethernet4", "standby")
+                        print("setting %s to %s" % (mux_ports[toggle_index], STANDBY))
+                        self.set_mux_state(appdb, mux_ports[toggle_index], STANDBY)
+                        if start[keep_index] == ACTIVE:
+                            self.check_route_nexthop(dvs_route, asicdb, route, neighbors[keep_index])
+                        else:
+                            self.check_route_nexthop(dvs_route, asicdb, route, tunnel_nh_id, True)
+                self.del_route(dvs, route)
 
-        rtprefix = "2020::/64"
+            for neighbor in neighbors:
+                self.del_neighbor(dvs, neighbor)
 
-        dvs_route.check_asicdb_deleted_route_entries([rtprefix])
+            print("Testing add/remove of neighbors in mux nexthop group")
+            starting_states = [(ACTIVE, ACTIVE), (ACTIVE, STANDBY), (STANDBY, ACTIVE), (STANDBY, STANDBY)]
+            for start in starting_states:
+                print("Testing add/remove of neighbors in %s, %s" % start)
+                self.set_mux_state(appdb, mux_ports[0], start[0])
+                self.set_mux_state(appdb, mux_ports[1], start[1])
+                self.add_route(dvs, route, neighbors)
 
-        ps = swsscommon.ProducerStateTable(pdb.db_connection, "ROUTE_TABLE")
+                # add first neighbor
+                self.add_neighbor(dvs, neighbors[0], macs[0])
+                if start[0] == ACTIVE:
+                    self.check_route_nexthop(dvs_route, asicdb, route, neighbors[0])
 
-        fvs = swsscommon.FieldValuePairs(
-                [
-                    ("nexthop", self.SERV1_IPV6 + "," + self.SERV2_IPV6),
-                    ("ifname", "tun0,tun0")
-                ]
-              )
+                # add second neighbor
+                self.add_neighbor(dvs, neighbors[1], macs[1])
+                time.sleep(1)
+                if start[0] == ACTIVE:
+                    self.check_route_nexthop(dvs_route, asicdb, route, neighbors[0])
+                elif start[1] == ACTIVE:
+                    self.check_route_nexthop(dvs_route, asicdb, route, neighbors[1])
+                else:
+                    self.check_route_nexthop(dvs_route, asicdb, route, tunnel_nh_id, True)
 
-        ps.set(rtprefix, fvs)
+                # remove first neighbor
+                self.del_route(dvs,route)
+                for neighbor in neighbors:
+                    self.del_neighbor(dvs, neighbor)
 
-        # Check if route was propagated to ASIC DB
-        rtkeys = dvs_route.check_asicdb_route_entries([rtprefix])
+        finally:
+            # Cleanup
+            for port in mux_ports:
+                self.set_mux_state(appdb, port, "active")
+            self.del_route(dvs,route)
+            for neighbor in neighbors:
+                self.del_neighbor(dvs, neighbor)
 
-        # Check for nexthop group and validate nexthop group member in asic db
-        self.check_nexthop_group_in_asic_db(asicdb, rtkeys[0], 2)
+    def create_and_test_multi_nexthop_routes(self, dvs, dvs_route, appdb, macs, asicdb):
+        '''
+        Tests case where there are multiple nexthops tied to a route
+        If the nexthops are tied to a mux, then only the first active neighbor will be programmed
+        If not, the route should point to a regular ECMP group
+        '''
 
-        # Step: 1 - Change one NH to active and verify ecmp route
-        self.set_mux_state(appdb, "Ethernet0", "active")
-        self.check_nexthop_group_in_asic_db(asicdb, rtkeys[0], 1)
+        route_ipv4 = "2.3.4.0/24"
+        route_ipv6 = "2023::/64"
+        ipv4_neighbors = [self.SERV1_IPV4, self.SERV2_IPV4]
+        ipv6_neighbors = [self.SERV1_IPV6, self.SERV2_IPV6]
 
-        # Step: 2 - Change the other NH to active and verify ecmp route
-        self.set_mux_state(appdb, "Ethernet4", "active")
-        self.check_nexthop_group_in_asic_db(asicdb, rtkeys[0])
+        self.multi_nexthop_test(dvs, dvs_route, asicdb, appdb, route_ipv4, ipv4_neighbors, macs)
+        self.multi_nexthop_test(dvs, dvs_route, asicdb, appdb, route_ipv6, ipv6_neighbors, macs)
 
-        # Step: 3 - Change one NH to back to standby and verify ecmp route
-        self.set_mux_state(appdb, "Ethernet0", "standby")
-        self.check_nexthop_group_in_asic_db(asicdb, rtkeys[0], 1)
+        try:
+            # neighbor not tied to mux cable case
+            non_mux_ipv4 = ["11.11.11.11", "12.12.12.12"]
+            non_mux_ipv6 = ["2222::100", "2222::101"]
+            non_mux_macs = ["00:aa:bb:cc:dd:ee", "00:aa:bb:cc:dd:ff"]
+            print("Testing neighbors that are not tied to a mux cable")
 
-        # Step: 4 - Change the other NH to standby and verify ecmp route
-        self.set_mux_state(appdb, "Ethernet4", "standby")
-        self.check_nexthop_group_in_asic_db(asicdb, rtkeys[0], 2)
+            for i in range(2):
+                self.add_neighbor(dvs, non_mux_ipv4[i], non_mux_macs[i])
+                self.add_neighbor(dvs, non_mux_ipv6[i], non_mux_macs[i])
 
-        ps._del(rtprefix)
+            self.add_route(dvs, route_ipv4, non_mux_ipv4)
+            self.add_route(dvs, route_ipv6, non_mux_ipv6)
+
+            # Check for route pointing to first neighbor
+            self.check_route_nexthop(dvs_route, asicdb, route_ipv4, non_mux_ipv4[0])
+            self.check_route_nexthop(dvs_route, asicdb, route_ipv6, non_mux_ipv6[0])
+
+            # Cleanup
+            self.del_route(dvs, route_ipv4)
+            self.del_route(dvs, route_ipv6)
+            for i in range(2):
+                self.del_neighbor(dvs, non_mux_ipv4[i])
+                self.del_neighbor(dvs, non_mux_ipv6[i])
+
+            # neighbor not in mux cable case
+            non_mux_ipv4 = ["11.11.11.11", "12.12.12.12"]
+            non_mux_ipv6 = ["2222::100", "2222::101"]
+            non_mux_macs = ["00:aa:bb:cc:dd:ee", "00:aa:bb:cc:dd:ff"]
+            print("Testing neighbors that are not tied to a mux cable")
+            for i in range(2):
+                self.add_neighbor(dvs, non_mux_ipv4[i], non_mux_macs[i])
+                self.add_neighbor(dvs, non_mux_ipv6[i], non_mux_macs[i])
+
+            self.add_route(dvs, route_ipv4, non_mux_ipv4)
+            self.add_route(dvs, route_ipv6, non_mux_ipv6)
+
+            # Check for route pointing to first neighbor
+            self.check_route_nexthop(dvs_route, asicdb, route_ipv4, non_mux_ipv4[0])
+            self.check_route_nexthop(dvs_route, asicdb, route_ipv6, non_mux_ipv6[0])
+
+            # Cleanup
+            self.del_route(dvs, route_ipv4)
+            self.del_route(dvs, route_ipv6)
+            for i in range(2):
+                self.del_neighbor(dvs, non_mux_ipv4[i])
+                self.del_neighbor(dvs, non_mux_ipv6[i])
+        finally:
+            # Cleanup
+            self.del_route(dvs, route_ipv4)
+            self.del_route(dvs, route_ipv6)
+            for i in range(2):
+                self.del_neighbor(dvs, non_mux_ipv4[i])
+                self.del_neighbor(dvs, non_mux_ipv6[i])
 
     def create_and_test_NH_routes(self, appdb, asicdb, dvs, dvs_route, mac):
         '''
@@ -1128,7 +1304,14 @@ class TestMuxTunnel(TestMuxTunnelBase):
         asicdb = dvs.get_asic_db()
         mac = intf_fdb_map["Ethernet0"]
 
-        self.create_and_test_NH_routes(appdb, asicdb, dvs, dvs_route, mac)
+        self.create_and_test_NH_routes(appdb, asicdb, dvs, dvs_route, mac, 5)
+
+    def test_multi_nexthop(self, dvs, dvs_route, intf_fdb_map, neighbor_cleanup, testlog):
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+        macs = [intf_fdb_map["Ethernet0"], intf_fdb_map["Ethernet4"]]
+
+        self.create_and_test_multi_nexthop_routes(dvs, dvs_route, appdb, macs, asicdb)
 
     def test_acl(self, dvs, dvs_acl, testlog):
         """ test acl and mux state change """


### PR DESCRIPTION
What I did: added logic to handle when a route points to a nexthop group with mux neighbors. In this case, only one active neighbor, or the tunnel nexthop will be programmed to the ASIC.

Why I did it: having a route with multiple mux neighbors caused a data loop which lead to packet loss when different neighbors were in different states.

How I did it: added logic to update routes when a route is changed, a mux neighbor is changed, or there is a mux state change.

HLD: https://github.com/sonic-net/SONiC/pull/1256

cherry-pick of https://github.com/sonic-net/sonic-swss/pull/2656