### PR TITLE
[202205] Fixed set admin_status for deleted subintf due to late notification

### DIFF
--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -128,7 +128,7 @@ tests_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis -lpthr
 
 ## intfmgrd unit tests
 
-tests_intfmgrd_SOURCES = intfmgrd/add_ipv6_prefix_ut.cpp \
+tests_intfmgrd_SOURCES = intfmgrd/intfmgr_ut.cpp \
                         $(top_srcdir)/cfgmgr/intfmgr.cpp \
                         $(top_srcdir)/orchagent/orch.cpp \
                         $(top_srcdir)/orchagent/request_parser.cpp \

--- a/tests/mock_tests/intfmgrd/intfmgr_ut.cpp
+++ b/tests/mock_tests/intfmgrd/intfmgr_ut.cpp
@@ -1,6 +1,6 @@
 #include "gtest/gtest.h"
 #include <iostream>
-#include <fstream>  
+#include <fstream>
 #include <unistd.h>
 #include <sys/stat.h>
 #include "../mock_table.h"
@@ -28,6 +28,9 @@ int cb(const std::string &cmd, std::string &stdout){
     else if (cmd.find("/sbin/ip -6 address \"add\"") == 0) {
         return Ethernet0IPv6Set ? 0 : 2;
     }
+    else if (cmd == "/sbin/ip link set \"Ethernet64.10\" \"up\""){
+        return 1;
+    }
     else {
         return 0;
     }
@@ -35,7 +38,7 @@ int cb(const std::string &cmd, std::string &stdout){
 }
 
 // Test Fixture
-namespace add_ipv6_prefix_ut
+namespace intfmgr_ut
 {
     struct IntfMgrTest : public ::testing::Test
     {
@@ -43,14 +46,14 @@ namespace add_ipv6_prefix_ut
         std::shared_ptr<swss::DBConnector> m_app_db;
         std::shared_ptr<swss::DBConnector> m_state_db;
         std::vector<std::string> cfg_intf_tables;
-        
+
         virtual void SetUp() override
-        {   
+        {
             testing_db::reset();
             m_config_db = std::make_shared<swss::DBConnector>("CONFIG_DB", 0);
             m_app_db = std::make_shared<swss::DBConnector>("APPL_DB", 0);
             m_state_db = std::make_shared<swss::DBConnector>("STATE_DB", 0);
-            
+
             swss::WarmStart::initialize("intfmgrd", "swss");
 
             std::vector<std::string> tables = {
@@ -113,5 +116,23 @@ namespace add_ipv6_prefix_ut
             }
         }
         ASSERT_EQ(ip_cmd_called, 1);
+    }
+
+    //This test except no runtime error when the set admin status command failed
+    //and the subinterface has not ok status (for example not existing subinterface)
+    TEST_F(IntfMgrTest, testSetAdminStatusFailToNotOkSubInt){
+        swss::IntfMgr intfmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_intf_tables);
+        intfmgr.setHostSubIntfAdminStatus("Ethernet64.10", "up", "up");
+    }
+
+    //This test except runtime error when the set admin status command failed
+    //and the subinterface has ok status
+    TEST_F(IntfMgrTest, testSetAdminStatusFailToOkSubInt){
+        swss::IntfMgr intfmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_intf_tables);
+        /* Set portStateTable */
+        std::vector<swss::FieldValueTuple> values;
+        values.emplace_back("state", "ok");
+        intfmgr.m_statePortTable.set("Ethernet64.10", values, "SET", "");
+        EXPECT_THROW(intfmgr.setHostSubIntfAdminStatus("Ethernet64.10", "up", "up"), std::runtime_error);
     }
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Handled a race condition in intfmgrd which tries to immediately apply an admin_status SET notif after a DEL causing it to crash
**Why I did it**
Ignores errors on the set admin_status command for subinterface when the subinterface state is not OK.
**How I verified it**
Unit tests
**Details if related**
This PR reference to older PR that fix the same issue in portmgr: https://github.com/sonic-net/sonic-swss/pull/2431