### PR TITLE
202205:Fix Egress queue counters on voq systems.

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -6126,6 +6126,16 @@ void PortsOrch::generateQueueMapPerPort(const Port& port, FlexCounterQueueStates
         }
         else
         {
+            // In voq systems, always install a flex counter for this egress queue
+            // to track stats. In voq systems, the buffer profiles are defined on
+            // sysports. So the phy ports do not have buffer queue config. Hence
+            // queuesStateVector built by getQueueConfigurations in flexcounterorch
+            // never has phy ports in voq systems. So always enabled egress queue
+            // counter on voq systems.
+            if (gMySwitchType == "voq")
+            {
+               addQueueFlexCountersPerPortPerQueueIndex(port, queueIndex, false);
+            }
             queuePortVector.emplace_back(id, sai_serialize_object_id(port.m_port_id));
         }
     }


### PR DESCRIPTION
**What I did**
In voq systems, the buffer profiles are defined on sysports.  So the
phy ports do not have buffer queue config and queuesStateVector
built by getQueueConfigurations in flexcounterorch never has phy
ports in voq systems. So in voq systems, always enable egress queue
counters.

**Why I did it**

Fix https://github.com/sonic-net/sonic-buildimage/issues/14061

**How I verified it**

Verified egress queue counters and voq counters on both 7800r3ak_36dm2_lc and 7800r3_48cqm2_lc

**Details if related**
