### PR TITLE
Fix orchagent missing request when logrotate happens.

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -754,7 +754,6 @@ void OrchDaemon::start()
             gSaiRedisLogRotate = false;
 
             logRotate();
-            continue;
         }
 
         auto *c = (Executor *)s;


### PR DESCRIPTION
**What I did**
Fix orchagent request missing when logrotate happens.

**Why I did it**
The sairedis logrotate has been moved into the daemon main select loop. After it finishes, it should not continue, because that will drop the event that has been selected.

**How I verified it**

**Details if related**
