### PR TITLE
fix map::at error if vrf_id not in m_syncdRoutes

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -2046,6 +2046,12 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
         }
     }
 
+    if (m_syncdRoutes.find(vrf_id) == m_syncdRoutes.end())
+    {
+        m_syncdRoutes.emplace(vrf_id, RouteTable());
+        m_vrfOrch->increaseVrfRefCount(vrf_id);
+    }
+
     auto it_status = object_statuses.begin();
     auto it_route = m_syncdRoutes.at(vrf_id).find(ipPrefix);
     if (isFineGrained)
@@ -2454,7 +2460,7 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
 
     SWSS_LOG_INFO("Remove route %s with next hop(s) %s",
             ipPrefix.to_string().c_str(), it_route->second.nhg_key.to_string().c_str());
-    
+
     /* Publish removal status, removes route entry from APPL STATE DB */
     publishRouteState(ctx);
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
fix map::at error if vrf_id not in m_syncdRoutes

**Why I did it**
Assuming that there is one vrf Vrf1, starts with only one route prefixA
Then comes the RouterBulker operations,  prefixA was deleted and a prefixB was added.

During status handlement of prefixA, in removeRoutePost, Vrf1 will be erased from m_syncdRoutes
Then During status handlement of prefixB, m_syncdRoutes does not have Vrf1, but addRoutePost will directly calls m_syncdRoutes.at(vrf_id), this will throw an exception.

**How I verified it**

**Details if related**
