### PR TITLE
[azp]: Remove sonic-eventd when building DVS image

### DIFF
--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -8,7 +8,6 @@ ADD ["debs", "/debs"]
 RUN dpkg --purge python-swsscommon python3-swsscommon swss libsairedis sonic-db-cli libswsscommon libsaimetadata libsaivs syncd-vs sonic-eventd
 
 RUN dpkg -i /debs/libswsscommon_1.0.0_amd64.deb
-RUN dpkg -i /debs/python-swsscommon_1.0.0_amd64.deb
 RUN dpkg -i /debs/python3-swsscommon_1.0.0_amd64.deb
 RUN dpkg -i /debs/sonic-db-cli_1.0.0_amd64.deb
 

--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -5,7 +5,7 @@ ARG need_dbg
 
 ADD ["debs", "/debs"]
 
-RUN dpkg --purge python-swsscommon python3-swsscommon swss libsairedis sonic-db-cli libswsscommon libsaimetadata libsaivs syncd-vs
+RUN dpkg --purge python-swsscommon python3-swsscommon swss libsairedis sonic-db-cli libswsscommon libsaimetadata libsaivs syncd-vs sonic-eventd
 
 RUN dpkg -i /debs/libswsscommon_1.0.0_amd64.deb
 RUN dpkg -i /debs/python-swsscommon_1.0.0_amd64.deb


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When building the DVS image for testing, remove sonic-eventd when also removing swsscommon and other libraries

**Why I did it**
The DVS image recently moved from buster to bullseye, which introduced sonic-eventd. Sonic-eventd is dependent on libswsscommon and so when the DVS build tried to remove libswsscommon, it would fail since sonic-eventd was not being removed.

**How I verified it**

**Details if related**
