### PR TITLE
overlay_dmac change in Vnet configuration.

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -509,9 +509,14 @@ bool VNetOrch::addOperation(const Request& request)
             else
             {
                 SWSS_LOG_NOTICE("VNET '%s' already exists ", vnet_name.c_str());
+                if (overlay_dmac != it->second->getOverlayDMac())
+                {
+                    it->second->setOverlayDMac(overlay_dmac);
+                    VNetRouteOrch* vnet_route_orch = gDirectory.get<VNetRouteOrch*>();
+                    vnet_route_orch->updateAllMonitoringSession(vnet_name);
+                }
             }
         }
-
         if (create)
         {
             vnet_table_[vnet_name] = std::move(obj);
@@ -1842,6 +1847,36 @@ void VNetRouteOrch::removeBfdSession(const string& vnet, const NextHopKey& endpo
     bfd_session_producer_.del(key);
 
     bfd_sessions_.erase(monitor_addr);
+}
+
+void VNetRouteOrch::updateAllMonitoringSession(const string& vnet)
+{
+    SWSS_LOG_ENTER();
+    vector<FieldValueTuple>  data;
+    auto *vnet_obj = vnet_orch_->getTypePtr<VNetVrfObject>(vnet);
+    auto overlay_dmac = vnet_obj->getOverlayDMac();
+    SWSS_LOG_INFO ("updating overlay dmac value to %s", overlay_dmac.to_string().c_str());
+
+    if (monitor_info_.find(vnet) != monitor_info_.end())
+    {
+        for (auto prefix : monitor_info_[vnet])
+        {
+            for (auto monitor_addr : monitor_info_[vnet][prefix.first])
+            {
+
+                string key = monitor_addr.first.to_string() + ":" + prefix.first.to_string();
+                SWSS_LOG_INFO ("updating the overlay dmac of %s", key.c_str());
+
+                FieldValueTuple fvTuple1("packet_type", "vxlan");
+                data.push_back(fvTuple1);
+
+                FieldValueTuple fvTuple3("overlay_dmac", overlay_dmac.to_string());
+                data.push_back(fvTuple3);
+
+                monitor_session_producer_->set(key, data);
+            }
+        }
+    }
 }
 
 void VNetRouteOrch::createMonitoringSession(const string& vnet, const NextHopKey& endpoint, const IpAddress& monitor_addr, IpPrefix& ipPrefix)

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -425,7 +425,7 @@ bool VNetOrch::addOperation(const Request& request)
     sai_attribute_t attr;
     vector<sai_attribute_t> attrs;
     set<string> peer_list = {};
-    bool peer = false, create = false, advertise_prefix = false, od_mac = false;
+    bool peer = false, create = false, advertise_prefix = false;
     uint32_t vni=0;
     string tunnel;
     string scope;
@@ -464,7 +464,6 @@ bool VNetOrch::addOperation(const Request& request)
         else if (name == "overlay_dmac")
         {
             overlay_dmac = request.getAttrMacAddress("overlay_dmac");
-            od_mac = true;
         }
         else
         {
@@ -510,7 +509,7 @@ bool VNetOrch::addOperation(const Request& request)
             else
             {
                 SWSS_LOG_NOTICE("VNET '%s' already exists ", vnet_name.c_str());
-                if (od_mac && overlay_dmac != it->second->getOverlayDMac())
+                if (!!overlay_dmac && overlay_dmac != it->second->getOverlayDMac())
                 {
                     it->second->setOverlayDMac(overlay_dmac);
                     VNetRouteOrch* vnet_route_orch = gDirectory.get<VNetRouteOrch*>();

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -425,7 +425,7 @@ bool VNetOrch::addOperation(const Request& request)
     sai_attribute_t attr;
     vector<sai_attribute_t> attrs;
     set<string> peer_list = {};
-    bool peer = false, create = false, advertise_prefix = false;
+    bool peer = false, create = false, advertise_prefix = false, od_mac = false;
     uint32_t vni=0;
     string tunnel;
     string scope;
@@ -464,6 +464,7 @@ bool VNetOrch::addOperation(const Request& request)
         else if (name == "overlay_dmac")
         {
             overlay_dmac = request.getAttrMacAddress("overlay_dmac");
+            od_mac = true;
         }
         else
         {
@@ -509,7 +510,7 @@ bool VNetOrch::addOperation(const Request& request)
             else
             {
                 SWSS_LOG_NOTICE("VNET '%s' already exists ", vnet_name.c_str());
-                if (overlay_dmac != it->second->getOverlayDMac())
+                if (od_mac && overlay_dmac != it->second->getOverlayDMac())
                 {
                     it->second->setOverlayDMac(overlay_dmac);
                     VNetRouteOrch* vnet_route_orch = gDirectory.get<VNetRouteOrch*>();

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -138,6 +138,11 @@ public:
         return overlay_dmac_;
     }
 
+    void setOverlayDMac(swss::MacAddress mac_addr)
+    {
+        overlay_dmac_ = mac_addr;
+    }
+
     virtual ~VNetObject() noexcept(false) {};
 
 private:
@@ -418,6 +423,7 @@ public:
 
     void update(SubjectType, void *);
     void updateMonitorState(string& op, const IpPrefix& prefix , const IpAddress& endpoint, string state);
+    void updateAllMonitoringSession(const string& vnet);
 
 private:
     virtual bool addOperation(const Request& request);

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -3226,6 +3226,13 @@ class TestVnetOrch(object):
         vnet_obj.check_custom_monitor_app_db(dvs, "100.100.1.11/32", "19.1.0.2", "vxlan", "22:33:33:44:44:88")
         vnet_obj.check_custom_monitor_app_db(dvs, "100.100.1.11/32", "19.1.0.3", "vxlan", "22:33:33:44:44:88")
 
+        #update the Dmac to empty. This should have no impact.
+        create_vnet_entry(dvs, vnet_name, tunnel_name, '10022', "", advertise_prefix=True, overlay_dmac="")
+
+        #verify the appdb entries.
+        vnet_obj.check_custom_monitor_app_db(dvs, "100.100.1.11/32", "19.1.0.1", "vxlan", "22:33:33:44:44:88")
+        vnet_obj.check_custom_monitor_app_db(dvs, "100.100.1.11/32", "19.1.0.2", "vxlan", "22:33:33:44:44:88")
+        vnet_obj.check_custom_monitor_app_db(dvs, "100.100.1.11/32", "19.1.0.3", "vxlan", "22:33:33:44:44:88")
 
         #remove first route
         delete_vnet_routes(dvs, "100.100.1.11/32", vnet_name)

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -1060,7 +1060,7 @@ class VnetVxlanVrfTunnel(object):
 
     def check_custom_monitor_app_db(self, dvs, prefix, endpoint, packet_type, overlay_dmac):
         app_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
-        key = prefix + ':' + endpoint
+        key = endpoint + ':' + prefix
         check_object(app_db, self.APP_VNET_MONITOR, key,
             {
                 "packet_type": packet_type,
@@ -3171,6 +3171,104 @@ class TestVnetOrch(object):
         check_remove_state_db_routes(dvs, 'Vnet12', "100.100.1.67/32")
         #adv should be gone.
         check_remove_routes_advertisement(dvs, "100.100.1.0/24")
+        delete_vnet_entry(dvs,vnet_name)
+        vnet_obj.check_del_vnet_entry(dvs, vnet_name)
+        delete_vxlan_tunnel(dvs, tunnel_name)
+
+    '''
+    Test 23 - Test for vxlan custom monitoring. CHanging the overlay_dmac of the Vnet on the fly.
+    '''
+    def test_vnet_orch_23(self, dvs, testlog):
+        vnet_obj = self.get_vnet_obj()
+
+        tunnel_name = 'tunnel_22'
+        vnet_name = "Vnet22"
+        vnet_obj.fetch_exist_entries(dvs)
+
+        create_vxlan_tunnel(dvs, tunnel_name, '9.9.9.3')
+        create_vnet_entry(dvs, vnet_name, tunnel_name, '10022', "", advertise_prefix=True, overlay_dmac="22:33:33:44:44:66")
+        delete_vnet_entry(dvs,vnet_name)
+
+        create_vnet_entry(dvs, vnet_name, tunnel_name, '10022', "", advertise_prefix=True, overlay_dmac="22:33:33:44:44:66")
+        create_vnet_entry(dvs, vnet_name, tunnel_name, '10022', "", advertise_prefix=True, overlay_dmac="22:33:33:44:44:77")
+        delete_vnet_entry(dvs,vnet_name)
+
+        #update the Dmac of the vnet before adding any routes.
+        create_vnet_entry(dvs, vnet_name, tunnel_name, '10022', "", advertise_prefix=True, overlay_dmac="22:33:33:44:44:66")
+        create_vnet_entry(dvs, vnet_name, tunnel_name, '10022', "", advertise_prefix=True, overlay_dmac="22:33:33:44:44:77")
+
+        vnet_obj.check_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, vnet_name, '10022')
+
+        vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, '9.9.9.3')
+
+        vnet_obj.fetch_exist_entries(dvs)
+        #Add first Route
+        create_vnet_routes(dvs, "100.100.1.11/32", vnet_name, '19.0.0.1,19.0.0.2,19.0.0.3', ep_monitor='19.1.0.1,19.1.0.2,19.1.0.3', profile = "test_prf", primary ='19.0.0.1',monitoring='custom', adv_prefix='100.100.1.0/24')
+        #verify the appdb entries.
+        vnet_obj.check_custom_monitor_app_db(dvs, "100.100.1.11/32", "19.1.0.1", "vxlan", "22:33:33:44:44:77")
+        vnet_obj.check_custom_monitor_app_db(dvs, "100.100.1.11/32", "19.1.0.2", "vxlan", "22:33:33:44:44:77")
+        vnet_obj.check_custom_monitor_app_db(dvs, "100.100.1.11/32", "19.1.0.3", "vxlan", "22:33:33:44:44:77")
+
+        #update the Dmac after a route is added.
+        create_vnet_entry(dvs, vnet_name, tunnel_name, '10022', "", advertise_prefix=True, overlay_dmac="22:33:33:44:44:88")
+
+        #verify the appdb entries.
+        vnet_obj.check_custom_monitor_app_db(dvs, "100.100.1.11/32", "19.1.0.1", "vxlan", "22:33:33:44:44:88")
+        vnet_obj.check_custom_monitor_app_db(dvs, "100.100.1.11/32", "19.1.0.2", "vxlan", "22:33:33:44:44:88")
+        vnet_obj.check_custom_monitor_app_db(dvs, "100.100.1.11/32", "19.1.0.3", "vxlan", "22:33:33:44:44:88")
+
+        #bring up an enpoint.
+        update_monitor_session_state(dvs, '100.100.1.11/32', '19.1.0.1', 'up')
+
+        #verify the appdb entries.
+        vnet_obj.check_custom_monitor_app_db(dvs, "100.100.1.11/32", "19.1.0.1", "vxlan", "22:33:33:44:44:88")
+        vnet_obj.check_custom_monitor_app_db(dvs, "100.100.1.11/32", "19.1.0.2", "vxlan", "22:33:33:44:44:88")
+        vnet_obj.check_custom_monitor_app_db(dvs, "100.100.1.11/32", "19.1.0.3", "vxlan", "22:33:33:44:44:88")
+
+
+        #remove first route
+        delete_vnet_routes(dvs, "100.100.1.11/32", vnet_name)
+        vnet_obj.check_del_vnet_routes(dvs, 'Vnet12', ["100.100.1.11/32"])
+        check_remove_state_db_routes(dvs, 'Vnet12', "100.100.1.11/32")
+
+        #make sure that the app db entries are removed.
+        vnet_obj.check_custom_monitor_deleted(dvs, "100.100.1.11/32", "19.1.0.1")
+        vnet_obj.check_custom_monitor_deleted(dvs, "100.100.1.11/32", "19.1.0.2")
+        vnet_obj.check_custom_monitor_deleted(dvs, "100.100.1.11/32", "19.1.0.3")
+        vnet_obj.check_custom_monitor_deleted(dvs, "100.100.1.11/32", "19.1.0.4")
+        time.sleep(2)
+
+        #bring down an enpoint.
+        update_monitor_session_state(dvs, '100.100.1.11/32', '19.1.0.1', 'down')
+
+        create_vnet_entry(dvs, vnet_name, tunnel_name, '10022', "", advertise_prefix=True, overlay_dmac="22:33:33:44:44:66")
+
+        #Add first Route again
+        create_vnet_routes(dvs, "100.100.1.11/32", vnet_name, '19.0.0.1,19.0.0.2,19.0.0.3', ep_monitor='19.1.0.1,19.1.0.2,19.1.0.3', profile = "test_prf", primary ='19.0.0.1',monitoring='custom', adv_prefix='100.100.1.0/24')
+
+        #bring up the endpoint.
+        update_monitor_session_state(dvs, '100.100.1.11/32', '19.1.0.1', 'up')
+
+        # The default Vnet setting advertises the prefix.
+        check_routes_advertisement(dvs, "100.100.1.0/24", "test_prf")
+
+        #verify the appdb entries.
+        vnet_obj.check_custom_monitor_app_db(dvs, "100.100.1.11/32", "19.1.0.1", "vxlan", "22:33:33:44:44:66")
+        vnet_obj.check_custom_monitor_app_db(dvs, "100.100.1.11/32", "19.1.0.2", "vxlan", "22:33:33:44:44:66")
+        vnet_obj.check_custom_monitor_app_db(dvs, "100.100.1.11/32", "19.1.0.3", "vxlan", "22:33:33:44:44:66")
+
+        #remove first route
+        delete_vnet_routes(dvs, "100.100.1.11/32", vnet_name)
+        vnet_obj.check_del_vnet_routes(dvs, 'Vnet12', ["100.100.1.11/32"])
+        check_remove_state_db_routes(dvs, 'Vnet12', "100.100.1.11/32")
+
+        #make sure that the app db entries are removed.
+        vnet_obj.check_custom_monitor_deleted(dvs, "100.100.1.11/32", "19.1.0.1")
+        vnet_obj.check_custom_monitor_deleted(dvs, "100.100.1.11/32", "19.1.0.2")
+        vnet_obj.check_custom_monitor_deleted(dvs, "100.100.1.11/32", "19.1.0.3")
+        vnet_obj.check_custom_monitor_deleted(dvs, "100.100.1.11/32", "19.1.0.4")
+        time.sleep(2)
         delete_vnet_entry(dvs,vnet_name)
         vnet_obj.check_del_vnet_entry(dvs, vnet_name)
         delete_vxlan_tunnel(dvs, tunnel_name)


### PR DESCRIPTION
Added support to handle changing overlay_dmac in Vnet configurations.
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added support to handle Vnet configuration changes such as Overlay_dmac.

**Why I did it**
In a running system, if the overlay_dmac of a Vnet is changed, this needs to be reflected in the VNET monitor configuration.
**How I verified it**
Added a unit test.
**Details if related**
