### PR TITLE
Fix race condition in sub-interface handling

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -40,8 +40,7 @@ IntfMgr::IntfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
         m_stateVrfTable(stateDb, STATE_VRF_TABLE_NAME),
         m_stateIntfTable(stateDb, STATE_INTERFACE_TABLE_NAME),
         m_appIntfTableProducer(appDb, APP_INTF_TABLE_NAME),
-        m_neighTable(appDb, APP_NEIGH_TABLE_NAME),
-        m_appLagTable(appDb, APP_LAG_TABLE_NAME)
+        m_neighTable(appDb, APP_NEIGH_TABLE_NAME)
 {
     auto subscriberStateTable = new swss::SubscriberStateTable(stateDb,
             STATE_PORT_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE, 100);
@@ -382,7 +381,7 @@ std::string IntfMgr::getIntfMtu(const string &alias)
     }
     else if (!alias.compare(0, strlen("Po"), "Po"))
     {
-        portTable = &m_appLagTable;
+        portTable = &m_stateLagTable;
     }
     else
     {

--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -350,7 +350,7 @@ std::string IntfMgr::getIntfAdminStatus(const string &alias)
     }
     else if (!alias.compare(0, strlen("Po"), "Po"))
     {
-        portTable = &m_appLagTable;
+        portTable = &m_stateLagTable;
     }
     else
     {

--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -30,7 +30,7 @@ public:
 private:
     ProducerStateTable m_appIntfTableProducer;
     Table m_cfgIntfTable, m_cfgVlanIntfTable, m_cfgLagIntfTable, m_cfgLoopbackIntfTable;
-    Table m_statePortTable, m_stateLagTable, m_stateVlanTable, m_stateVrfTable, m_stateIntfTable, m_appLagTable;
+    Table m_statePortTable, m_stateLagTable, m_stateVlanTable, m_stateVrfTable, m_stateIntfTable;
     Table m_neighTable;
 
     SubIntfMap m_subIntfList;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Fix race condition in sub-interface handling

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**

A sub-interface's becomes admin up in the following scenarios:
1. A port becomes admin up in STATE_DB.LAG_TABLE when there are sub-interfaces created based on it
2. A sub-interfaces is created when the parent port's admin_status is up in APPL_DB.LAG_TABLE

However, it's possible that
- the sub-interfaces have not been created while STATE_DB.LAG_TABLE is updated
- the LAGs, as the parent ports, are still admin-down in APPL_DB.LAG_TABLE when sub-interfaces are created. In this scenario, sub-interfaces will keep admin-down forever.

Fix:
In (2), check LAG's admin status in STATE_DB instead of APPL_DB
The same logic is applied to the MTU setting

**How I verified it**

Manual and unit test

**Details if related**

```
STATE_DB.LAG_TABLE update path: CONFIG_DB -> teammgrd -> teamd userspace -> teamd driver -> netlink socket -> teamsyncd -> STATE_DB
APPL_DB.LAG_TABLE update path: CONFIG_DB -> teammgrd -> APPL_DB.LAG_TABLE_KEY_SET (ProducerStateTable) -> orchagent APPL_DB.LAG_TABLE (SubscriberStateTable) 
```
The orchagent handles the key set using SubscriberStateTable when all the current pending items in m_toSync have been drained. In case there are a large number of items to be drained, it is possible for orchagent to take a long time to handle items in key set. In this case, APPL_DB is updated long after STATE_DB and the above issue occurs.