### PR TITLE
[202205][FDB]Fixing FDB consolidated flush for Remote MACs

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -109,6 +109,7 @@ bool FdbOrch::storeFdbEntryState(const FdbUpdate& update)
 
         fdbdata.bridge_port_id = update.port.m_bridge_port_id;
         fdbdata.type = update.type;
+        fdbdata.sai_fdb_type = update.sai_fdb_type;
         fdbdata.origin = FDB_ORIGIN_LEARN;
         fdbdata.remote_ip = "";
         fdbdata.esi = "";
@@ -206,20 +207,19 @@ Handles the SAI_FDB_EVENT_FLUSHED notification recieved from syncd
 */
 void FdbOrch::handleSyncdFlushNotif(const sai_object_id_t& bv_id,
                                     const sai_object_id_t& bridge_port_id,
-                                    const MacAddress& mac)
+                                    const MacAddress& mac,
+                                    const sai_fdb_entry_type_t& sai_fdb_type)
 {
     // Consolidated flush will have a zero mac
     MacAddress flush_mac("00:00:00:00:00:00");
 
-    /* TODO: Read the SAI_FDB_FLUSH_ATTR_ENTRY_TYPE attr from the flush notif
-    and clear the entries accordingly, currently only non-static entries are flushed
-    */
     if (bridge_port_id == SAI_NULL_OBJECT_ID && bv_id == SAI_NULL_OBJECT_ID)
     {
         for (auto itr = m_entries.begin(); itr != m_entries.end();)
         {
             auto curr = itr++;
-            if (curr->second.type != "static" && (curr->first.mac == mac || mac == flush_mac))
+            if (curr->second.sai_fdb_type == sai_fdb_type &&
+                (curr->first.mac == mac || mac == flush_mac))
             {
                 clearFdbEntry(curr->first);
             }
@@ -233,7 +233,8 @@ void FdbOrch::handleSyncdFlushNotif(const sai_object_id_t& bv_id,
             auto curr = itr++;
             if (curr->second.bridge_port_id == bridge_port_id)
             {
-                if (curr->second.type != "static" && (curr->first.mac == mac || mac == flush_mac))
+                if (curr->second.sai_fdb_type == sai_fdb_type &&
+                    (curr->first.mac == mac || mac == flush_mac))
                 {
                     clearFdbEntry(curr->first);
                 }
@@ -248,7 +249,8 @@ void FdbOrch::handleSyncdFlushNotif(const sai_object_id_t& bv_id,
             auto curr = itr++;
             if (curr->first.bv_id == bv_id)
             {
-                if (curr->second.type != "static" && (curr->first.mac == mac || mac == flush_mac))
+                if (curr->second.sai_fdb_type == sai_fdb_type &&
+                    (curr->first.mac == mac || mac == flush_mac))
                 {
                     clearFdbEntry(curr->first);
                 }
@@ -263,7 +265,8 @@ void FdbOrch::handleSyncdFlushNotif(const sai_object_id_t& bv_id,
             auto curr = itr++;
             if (curr->first.bv_id == bv_id && curr->second.bridge_port_id == bridge_port_id)
             {
-                if (curr->second.type != "static" && (curr->first.mac == mac || mac == flush_mac))
+                if (curr->second.sai_fdb_type == sai_fdb_type &&
+                    (curr->first.mac == mac || mac == flush_mac))
                 {
                     clearFdbEntry(curr->first);
                 }
@@ -274,7 +277,8 @@ void FdbOrch::handleSyncdFlushNotif(const sai_object_id_t& bv_id,
 
 void FdbOrch::update(sai_fdb_event_t        type,
                      const sai_fdb_entry_t* entry,
-                     sai_object_id_t        bridge_port_id)
+                     sai_object_id_t        bridge_port_id,
+                     const sai_fdb_entry_type_t   &sai_fdb_type)
 {
     SWSS_LOG_ENTER();
 
@@ -365,6 +369,7 @@ void FdbOrch::update(sai_fdb_event_t        type,
 
                     attr.id = SAI_FDB_ENTRY_ATTR_TYPE;
                     attr.value.s32 = SAI_FDB_ENTRY_TYPE_DYNAMIC;
+                    update.sai_fdb_type = SAI_FDB_ENTRY_TYPE_DYNAMIC;
                     attrs.push_back(attr);
 
                     attr.id = SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID;
@@ -399,6 +404,7 @@ void FdbOrch::update(sai_fdb_event_t        type,
 
         update.add = true;
         update.entry.port_name = update.port.m_alias;
+        update.sai_fdb_type = SAI_FDB_ENTRY_TYPE_DYNAMIC;
         update.type = "dynamic";
         update.port.m_fdb_count++;
         m_portsOrch->setPort(update.port.m_alias, update.port);
@@ -569,6 +575,7 @@ void FdbOrch::update(sai_fdb_event_t        type,
         }
         update.port.m_fdb_count++;
         m_portsOrch->setPort(update.port.m_alias, update.port);
+        update.sai_fdb_type = SAI_FDB_ENTRY_TYPE_DYNAMIC;
         storeFdbEntryState(update);
 
         notify(SUBJECT_TYPE_FDB_CHANGE, &update);
@@ -592,7 +599,7 @@ void FdbOrch::update(sai_fdb_event_t        type,
         SWSS_LOG_INFO("FDB Flush: [ %s , %s ] = { port: %s }", update.entry.mac.to_string().c_str(),
                       vlanName.c_str(), update.port.m_alias.c_str());
 
-        handleSyncdFlushNotif(entry->bv_id, bridge_port_id, update.entry.mac);
+        handleSyncdFlushNotif(entry->bv_id, bridge_port_id, update.entry.mac, sai_fdb_type);
 
         break;
     }
@@ -987,6 +994,7 @@ void FdbOrch::doTask(NotificationConsumer& consumer)
     {
         uint32_t count;
         sai_fdb_event_notification_data_t *fdbevent = nullptr;
+        sai_fdb_entry_type_t sai_fdb_type = SAI_FDB_ENTRY_TYPE_DYNAMIC;
 
         sai_deserialize_fdb_event_ntf(data, count, &fdbevent);
 
@@ -999,11 +1007,14 @@ void FdbOrch::doTask(NotificationConsumer& consumer)
                 if (fdbevent[i].attr[j].id == SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID)
                 {
                     oid = fdbevent[i].attr[j].value.oid;
-                    break;
+                }
+                else if (fdbevent[i].attr[j].id == SAI_FDB_ENTRY_ATTR_TYPE)
+                {
+                    sai_fdb_type = (sai_fdb_entry_type_t)fdbevent[i].attr[j].value.s32;
                 }
             }
 
-            this->update(fdbevent[i].event_type, &fdbevent[i].fdb_entry, oid);
+            this->update(fdbevent[i].event_type, &fdbevent[i].fdb_entry, oid, sai_fdb_type);
         }
 
         sai_deserialize_free_fdb_event_ntf(count, fdbevent);
@@ -1317,6 +1328,7 @@ bool FdbOrch::addFdbEntry(const FdbEntry& entry, const string& port_name,
     {
         attr.value.s32 = (fdbData.type == "dynamic") ? SAI_FDB_ENTRY_TYPE_DYNAMIC : SAI_FDB_ENTRY_TYPE_STATIC;
     }
+    fdbData.sai_fdb_type = (sai_fdb_entry_type_t)attr.value.s32;
 
     attrs.push_back(attr);
 

--- a/orchagent/fdborch.h
+++ b/orchagent/fdborch.h
@@ -36,6 +36,7 @@ struct FdbUpdate
     Port port;
     string type;
     bool add;
+    sai_fdb_entry_type_t sai_fdb_type;
 };
 
 struct FdbFlushUpdate
@@ -62,6 +63,7 @@ struct FdbData
     string remote_ip;
     string    esi;
     unsigned int vni;
+    sai_fdb_entry_type_t sai_fdb_type;
 };
 
 struct SavedFdbEntry
@@ -90,7 +92,7 @@ public:
     }
 
     bool bake() override;
-    void update(sai_fdb_event_t, const sai_fdb_entry_t *, sai_object_id_t);
+    void update(sai_fdb_event_t, const sai_fdb_entry_t *, sai_object_id_t, const sai_fdb_entry_type_t &);
     void update(SubjectType type, void *cntx);
     bool getPort(const MacAddress&, uint16_t, Port&);
 
@@ -124,7 +126,8 @@ private:
     void notifyTunnelOrch(Port& port);
 
     void clearFdbEntry(const FdbEntry&);
-    void handleSyncdFlushNotif(const sai_object_id_t&, const sai_object_id_t&, const MacAddress& );
+    void handleSyncdFlushNotif(const sai_object_id_t&, const sai_object_id_t&, const MacAddress&,
+                               const sai_fdb_entry_type_t&);
 };
 
 #endif /* SWSS_FDBORCH_H */

--- a/tests/mock_tests/mock_orchagent_main.h
+++ b/tests/mock_tests/mock_orchagent_main.h
@@ -81,3 +81,4 @@ extern sai_queue_api_t *sai_queue_api;
 extern sai_udf_api_t* sai_udf_api;
 extern sai_mpls_api_t* sai_mpls_api;
 extern sai_counter_api_t* sai_counter_api;
+extern sai_fdb_api_t* sai_fdb_api;

--- a/tests/mock_tests/ut_saihelper.cpp
+++ b/tests/mock_tests/ut_saihelper.cpp
@@ -85,6 +85,7 @@ namespace ut_helper
         sai_api_query(SAI_API_QUEUE, (void **)&sai_queue_api);
         sai_api_query(SAI_API_MPLS, (void**)&sai_mpls_api);
         sai_api_query(SAI_API_COUNTER, (void**)&sai_counter_api);
+        sai_api_query(SAI_API_FDB, (void**)&sai_fdb_api);
 
         return SAI_STATUS_SUCCESS;
     }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Cherrypick of https://github.com/sonic-net/sonic-swss/pull/2673 to 202205
Fixed FDB flush for remote MACS in EVPN scenario. Even though FDB MAC is received as dynamic, it would be installed as static in SAI and thus during flush it would not be removed. However SONiC's db when processing the FLUSH event removes all the dynamic macs and thus clearing VXLAN remote mac from cache.

Hence during flush modified logic to check by sai_fdb_type rather than SONiC's type


**Why I did it**
To avoid Remote VxLAN FDB getting cleared wrongly in flush.


**How I verified it**
Added UT to verify


**Details if related**
