### PR TITLE
sonic-swss: Sync and program remote lag member status.

### DIFF
--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -473,7 +473,7 @@ bool PortsOrch::setLagTpid(sai_object_id_t id, sai_uint16_t tpid)
     return true;
 }
 
-bool PortsOrch::addLagMember(Port &lag, Port &port, bool enableForwarding)
+bool PortsOrch::addLagMember(Port &lag, Port &port, string member_status)
 {
     return true;
 }
@@ -699,7 +699,7 @@ void PortsOrch::voqSyncDelLag(Port &lag)
 {
 }
 
-void PortsOrch::voqSyncAddLagMember(Port &lag, Port &port)
+void PortsOrch::voqSyncAddLagMember(Port &lag, Port &port, string status)
 {
 }
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4388,11 +4388,17 @@ void PortsOrch::doLagMemberTask(Consumer &consumer)
                     continue;
                 }
 
-                if (!addLagMember(lag, port, (status == "enabled")))
+                if (!addLagMember(lag, port, status))
                 {
                     it++;
                     continue;
                 }
+            }
+
+            if ((gMySwitchType == "voq") && (port.m_type != Port::SYSTEM))
+            {
+               //Sync to SYSTEM_LAG_MEMBER_TABLE of CHASSIS_APP_DB
+               voqSyncAddLagMember(lag, port, status);
             }
 
             /* Sync an enabled member */
@@ -5819,9 +5825,10 @@ void PortsOrch::getLagMember(Port &lag, vector<Port> &portv)
     }
 }
 
-bool PortsOrch::addLagMember(Port &lag, Port &port, bool enableForwarding)
+bool PortsOrch::addLagMember(Port &lag, Port &port, string member_status)
 {
     SWSS_LOG_ENTER();
+    bool enableForwarding = (member_status == "enabled");
 
     sai_uint32_t pvid;
     if (getPortPvid(lag, pvid))
@@ -5893,7 +5900,7 @@ bool PortsOrch::addLagMember(Port &lag, Port &port, bool enableForwarding)
     if (gMySwitchType == "voq")
     {
         //Sync to SYSTEM_LAG_MEMBER_TABLE of CHASSIS_APP_DB
-        voqSyncAddLagMember(lag, port);
+        voqSyncAddLagMember(lag, port, member_status);
     }
 
     return true;
@@ -5981,12 +5988,6 @@ bool PortsOrch::setCollectionOnLagMember(Port &lagMember, bool enableCollection)
     /* Port must be LAG member */
     assert(lagMember.m_lag_member_id);
 
-    // Collection is not applicable for system port lag members (i.e, members of remote LAGs)
-    if (lagMember.m_type == Port::SYSTEM)
-    {
-        return true;
-    }
-
     sai_status_t status = SAI_STATUS_FAILURE;
     sai_attribute_t attr {};
 
@@ -6017,12 +6018,6 @@ bool PortsOrch::setDistributionOnLagMember(Port &lagMember, bool enableDistribut
 {
     /* Port must be LAG member */
     assert(lagMember.m_lag_member_id);
-
-    // Distribution is not applicable for system port lag members (i.e, members of remote LAGs)
-    if (lagMember.m_type == Port::SYSTEM)
-    {
-        return true;
-    }
 
     sai_status_t status = SAI_STATUS_FAILURE;
     sai_attribute_t attr {};
@@ -8038,7 +8033,7 @@ void PortsOrch::voqSyncDelLag(Port &lag)
     m_tableVoqSystemLagTable->del(key);
 }
 
-void PortsOrch::voqSyncAddLagMember(Port &lag, Port &port)
+void PortsOrch::voqSyncAddLagMember(Port &lag, Port &port, string status)
 {
     // Sync only local lag's member add to CHASSIS_APP_DB
     if (lag.m_system_lag_info.switch_id != gVoqMySwitchId)
@@ -8047,8 +8042,8 @@ void PortsOrch::voqSyncAddLagMember(Port &lag, Port &port)
     }
 
     vector<FieldValueTuple> attrs;
-    FieldValueTuple nullFv ("NULL", "NULL");
-    attrs.push_back(nullFv);
+    FieldValueTuple statusFv ("status", status);
+    attrs.push_back(statusFv);
 
     string key = lag.m_system_lag_info.alias + ":" + port.m_system_port_info.alias;
     m_tableVoqSystemLagMemberTable->set(key, attrs);

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -340,7 +340,7 @@ private:
     bool addLag(string lag, uint32_t spa_id, int32_t switch_id);
     bool removeLag(Port lag);
     bool setLagTpid(sai_object_id_t id, sai_uint16_t tpid);
-    bool addLagMember(Port &lag, Port &port, bool enableForwarding);
+    bool addLagMember(Port &lag, Port &port, string status);
     bool removeLagMember(Port &lag, Port &port);
     bool setCollectionOnLagMember(Port &lagMember, bool enableCollection);
     bool setDistributionOnLagMember(Port &lagMember, bool enableDistribution);
@@ -459,7 +459,7 @@ private:
     unique_ptr<Table> m_tableVoqSystemLagMemberTable;
     void voqSyncAddLag(Port &lag);
     void voqSyncDelLag(Port &lag);
-    void voqSyncAddLagMember(Port &lag, Port &port);
+    void voqSyncAddLagMember(Port &lag, Port &port, string status);
     void voqSyncDelLagMember(Port &lag, Port &port);
     unique_ptr<LagIdAllocator> m_lagIdAllocator;
     set<sai_object_id_t> m_macsecEnabledPorts;


### PR DESCRIPTION
   * SYSTEM_LAG_MEMBER_TABLE is updated to carry the member status.
   * Pass lag member status to addLagMember so that it can be updated in SYSTEM_LAG_MEMBER_TABLE.
   * In doLagMemberTask add code to update lag member status in SYSTEM_LAG_MEMBER_TABLE so that remote linecards can handle the member status.
   * Remove the code that ignore collecting/distributing update for members of remote lags.
   * Update voqSyncAddLagMember to update the lag member status.

**What I did**

Sync and program remote lag member status.

**Why I did it**

To fix the issue where remote lag memberships were not updated when the local lag memberships changes.

**How I verified it**

Verified that the traffic from remote linecards is redistributed to active members when a link goes down.

**Details if related**
