### PR TITLE
[dash] Fix the issue with bulk creation of CA to PA and PA validation entries.

### DIFF
--- a/orchagent/dash/dashvnetorch.cpp
+++ b/orchagent/dash/dashvnetorch.cpp
@@ -333,12 +333,13 @@ bool DashVnetOrch::addVnetMap(const string& key, VnetMapBulkContext& ctxt)
         {
             addOutboundCaToPa(key, ctxt);
             addPaValidation(key, ctxt);
+            return true;
         }
         else
         {
             SWSS_LOG_INFO("Not creating VNET map for %s since VNET %s doesn't exist", key.c_str(), ctxt.vnet_name.c_str());
+            return false;
         }
-        return false;
     }
     // If the VNET map is already added, don't add it to the bulker and
     // return true so it's removed from the consumer 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix the issue with the bulk creation of CA to PA and PA validation entries.

**Why I did it**
Before the fix, DashVnetOrch::addVnetMap always returned false after the creation of CA to PA and PA validation entries.
Which was considered by the calling DashVnetOrch::doTaskVnetMapTable method as an indication that the entry wasn't created. As a result, DashVnetOrch::doTaskVnetMapTable didn't remove the entry from the sync map (consumer.m_toSync) and tried to add the same entry again. Which caused an error and orchagent crash in an attempt to create the same CA to PA and PA validation entries in ASIC DB again.

**How I verified it**
Load the following configuration with `swssconfig` utility:
```
[
    {
      "DASH_APPLIANCE_TABLE:appliance-1": {
        "sip": "221.0.0.1",
        "vm_vni": "1"
      },
      "OP": "SET"
    },
    {
        "DASH_VNET_TABLE:vnet-1": {
          "vni": 1
        },
        "OP": "SET"
    },
    {
        "DASH_VNET_MAPPING_TABLE:vnet-1:1.4.0.1": {
            "routing_type": "vnet_encap",
            "underlay_ip": "221.2.0.1",
            "mac_address": "00:1B:6E:00:00:01",
            "use_dst_vni": "true"
        },
    "OP": "SET"
    },
    {
        "DASH_VNET_MAPPING_TABLE:vnet-1:1.4.0.2": {
            "routing_type": "vnet_encap",
            "underlay_ip": "221.2.0.1",
            "mac_address": "00:1B:6E:00:00:02",
            "use_dst_vni": "true"
        },
    "OP": "SET"
    },
    {
        "DASH_VNET_MAPPING_TABLE:vnet-1:1.4.0.3": {
            "routing_type": "vnet_encap",
            "underlay_ip": "221.2.0.1",
            "mac_address": "00:1B:6E:00:00:03",
            "use_dst_vni": "true"
        },
    "OP": "SET"
    },
    {
        "DASH_VNET_MAPPING_TABLE:vnet-1:1.4.0.4": {
            "routing_type": "vnet_encap",
            "underlay_ip": "221.2.0.1",
            "mac_address": "00:1B:6E:00:00:04",
            "use_dst_vni": "true"
        },
    "OP": "SET"
    }
]
```

**Details if related**
