### PR TITLE
Combine v4 and v6 L3 ACL rules on optimized platforms #1267

### DIFF
--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -502,12 +502,14 @@ public:
     bool isAclMirrorV6Supported() const;
     bool isAclMirrorV4Supported() const;
     bool isAclMirrorTableSupported(string type) const;
+    bool isAclL3V4V6TableSupported(acl_stage_type_t stage) const;
     bool isAclActionListMandatoryOnTableCreation(acl_stage_type_t stage) const;
     bool isAclActionSupported(acl_stage_type_t stage, sai_acl_action_type_t action) const;
     bool isAclActionEnumValueSupported(sai_acl_action_type_t action, sai_acl_action_parameter_t param) const;
 
     bool m_isCombinedMirrorV6Table = true;
     map<string, bool> m_mirrorTableCapabilities;
+    map<acl_stage_type_t, bool> m_L3V4V6Capability;
 
     void registerFlexCounter(const AclRule& rule);
     void deregisterFlexCounter(const AclRule& rule);

--- a/orchagent/acltable.h
+++ b/orchagent/acltable.h
@@ -25,6 +25,7 @@ extern "C" {
 
 #define TABLE_TYPE_L3                   "L3"
 #define TABLE_TYPE_L3V6                 "L3V6"
+#define TABLE_TYPE_L3V4V6               "L3V4V6"
 #define TABLE_TYPE_MIRROR               "MIRROR"
 #define TABLE_TYPE_MIRRORV6             "MIRRORV6"
 #define TABLE_TYPE_MIRROR_DSCP          "MIRROR_DSCP"

--- a/tests/test_acl_l3v4v6.py
+++ b/tests/test_acl_l3v4v6.py
@@ -1,0 +1,62 @@
+import pytest
+from requests import request
+
+L3V4V6_TABLE_TYPE = "L3V4V6"
+L3V4V6_TABLE_NAME = "L3_V4V6_TEST"
+L3V4V6_BIND_PORTS = ["Ethernet0", "Ethernet4", "Ethernet8"]
+L3V4V6_RULE_NAME = "L3V4V6_TEST_RULE"
+
+class TestAcl:
+    @pytest.fixture
+    def l3v4v6_acl_table(self, dvs_acl):
+        try:
+            dvs_acl.create_acl_table(L3V4V6_TABLE_NAME,
+                                     L3V4V6_TABLE_TYPE,
+                                     L3V4V6_BIND_PORTS)
+            yield dvs_acl.get_acl_table_ids(1)[0]
+        finally:
+            dvs_acl.remove_acl_table(L3V4V6_TABLE_NAME)
+            dvs_acl.verify_acl_table_count(0)
+
+    @pytest.fixture
+    def setup_teardown_neighbor(self, dvs):
+        try:
+            # NOTE: set_interface_status has a dependency on cdb within dvs,
+            # so we still need to setup the db. This should be refactored.
+            dvs.setup_db()
+
+            # Bring up an IP interface with a neighbor
+            dvs.set_interface_status("Ethernet4", "up")
+            dvs.add_ip_address("Ethernet4", "10.0.0.1/24")
+            dvs.add_neighbor("Ethernet4", "10.0.0.2", "00:01:02:03:04:05")
+
+            yield dvs.get_asic_db().wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP", 1)[0]
+        finally:
+            # Clean up the IP interface and neighbor
+            dvs.remove_neighbor("Ethernet4", "10.0.0.2")
+            dvs.remove_ip_address("Ethernet4", "10.0.0.1/24")
+            dvs.set_interface_status("Ethernet4", "down")
+
+    def test_L3V4V6AclTableCreationDeletion(self, dvs_acl):
+        try:
+            # Create an L3V4V6 ACL table with default ACL actions
+            dvs_acl.create_acl_table(L3V4V6_TABLE_NAME, L3V4V6_TABLE_TYPE, L3V4V6_BIND_PORTS)
+
+            acl_table_id = dvs_acl.get_acl_table_ids(1)[0]
+            acl_table_group_ids = dvs_acl.get_acl_table_group_ids(len(L3V4V6_BIND_PORTS))
+
+            dvs_acl.verify_acl_table_group_members(acl_table_id, acl_table_group_ids, 1)
+            dvs_acl.verify_acl_table_port_binding(acl_table_id, L3V4V6_BIND_PORTS, 1)
+            # Verify status is written into STATE_DB
+            dvs_acl.verify_acl_table_status(L3V4V6_TABLE_NAME, "Active")
+        finally:
+            dvs_acl.remove_acl_table(L3V4V6_TABLE_NAME)
+            dvs_acl.verify_acl_table_count(0)
+            # Verify the STATE_DB entry is removed
+            dvs_acl.verify_acl_table_status(L3V4V6_TABLE_NAME, None)
+
+
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_acl_l3v4v6.py
+++ b/tests/test_acl_l3v4v6.py
@@ -39,7 +39,6 @@ class TestAcl:
 
     def test_L3V4V6AclTableCreationDeletion(self, dvs_acl):
         try:
-            # Create an L3V4V6 ACL table with default ACL actions
             dvs_acl.create_acl_table(L3V4V6_TABLE_NAME, L3V4V6_TABLE_TYPE, L3V4V6_BIND_PORTS)
 
             acl_table_id = dvs_acl.get_acl_table_ids(1)[0]
@@ -55,6 +54,44 @@ class TestAcl:
             # Verify the STATE_DB entry is removed
             dvs_acl.verify_acl_table_status(L3V4V6_TABLE_NAME, None)
 
+    def test_ValidAclRuleCreation_sip_dip(self, dvs_acl, l3v4v6_acl_table):
+        config_qualifiers = {"DST_IP": "20.0.0.1/32",
+                             "SRC_IP": "10.0.0.0/32"};
+
+        dvs_acl.create_acl_rule(L3V4V6_TABLE_NAME, "VALID_RULE", config_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3V4V6_TABLE_NAME, "VALID_RULE", "Active")
+
+        dvs_acl.remove_acl_rule(L3V4V6_TABLE_NAME, "VALID_RULE")
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3V4V6_TABLE_NAME, "VALID_RULE", None)
+        dvs_acl.verify_no_acl_rules()
+
+    def test_InvalidAclRuleCreation_sip_sipv6(self, dvs_acl, l3v4v6_acl_table):
+        config_qualifiers = {"SRC_IPV6": "2777::0/64",
+                             "SRC_IP": "10.0.0.0/32"};
+
+        dvs_acl.create_acl_rule(L3V4V6_TABLE_NAME, "INVALID_RULE", config_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3V4V6_TABLE_NAME, "INVALID_RULE", "Inactive")
+
+        dvs_acl.remove_acl_rule(L3V4V6_TABLE_NAME, "INVALID_RULE")
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3V4V6_TABLE_NAME, "INVALID_RULE", None)
+        dvs_acl.verify_no_acl_rules()
+
+    def test_InvalidAclRuleCreation_dip_sipv6(self, dvs_acl, l3v4v6_acl_table):
+        config_qualifiers = {"SRC_IPV6": "2777::0/64",
+                             "DST_IP": "10.0.0.0/32"};
+
+        dvs_acl.create_acl_rule(L3V4V6_TABLE_NAME, "INVALID_RULE", config_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3V4V6_TABLE_NAME, "INVALID_RULE", "Inactive")
+
+        dvs_acl.remove_acl_rule(L3V4V6_TABLE_NAME, "INVALID_RULE")
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3V4V6_TABLE_NAME, "INVALID_RULE", None)
+        dvs_acl.verify_no_acl_rules()
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Support a new ACL table type called L3V4V6.
This table supports both v4 and v6 Match types.
Add unit tests for this new ACL table type.
HLD: https://github.com/sonic-net/SONiC/pull/1267

Signed-off-by: Ravi(Marvell) rck@innovium.com


**Why I did it**
To optimise ACL TCAM usage in capable platforms.

**How I verified it**
Add unit tests for this new ACL table type.


```
sudo pytest -s test_acl_l3v4v6.py
collected 2 items

test_acl_l3v4v6.py ..

======================= 2 passed, 1 warning in 60.88s (0:01:00) 

```