### PR TITLE
[bugfix] vnet ping missing with secondary endpoints empty in priority routes.

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1061,8 +1061,8 @@ bool VNetRouteOrch::selectNextHopGroup(const string& vnet,
     else if (!hasNextHopGroup(vnet, nexthops_primary))
     {
         SWSS_LOG_INFO("Creating next hop group  %s", nexthops_primary.to_string().c_str());
-        setEndpointMonitor(vnet, monitors, nexthops_primary, "", ipPrefix);
-        if (!createNextHopGroup(vnet, nexthops_primary, vrf_obj, ""))
+        setEndpointMonitor(vnet, monitors, nexthops_primary, monitoring, ipPrefix);
+        if (!createNextHopGroup(vnet, nexthops_primary, vrf_obj, monitoring))
         {
             delEndpointMonitor(vnet, nexthops_primary, ipPrefix);
             return false;

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -3171,6 +3171,30 @@ class TestVnetOrch(object):
         check_remove_state_db_routes(dvs, 'Vnet12', "100.100.1.67/32")
         #adv should be gone.
         check_remove_routes_advertisement(dvs, "100.100.1.0/24")
+
+		#Add priority route with no secondary enpoints
+        create_vnet_routes(dvs, "100.100.1.71/32", vnet_name, '19.0.0.1,19.0.0.2', ep_monitor='19.1.0.1,19.1.0.2', profile = "test_prf", primary ='19.0.0.1,19.0.0.2',monitoring='custom', adv_prefix='100.100.1.0/24')
+        update_monitor_session_state(dvs, '100.100.1.71/32', '19.1.0.1', 'up')
+        update_monitor_session_state(dvs, '100.100.1.71/32', '19.1.0.2', 'up')
+
+        time.sleep(2)
+        check_state_db_routes(dvs, vnet_name, "100.100.1.71/32", ['19.0.0.1,19.0.0.2'])
+        # The default Vnet setting does not advertise prefix
+        check_routes_advertisement(dvs, "100.100.1.0/24", "test_prf")
+
+        update_monitor_session_state(dvs, '100.100.1.71/32', '19.1.0.1', 'down')
+        check_state_db_routes(dvs, vnet_name, "100.100.1.71/32", ['19.0.0.2'])
+        # The default Vnet setting does not advertise prefix
+        check_routes_advertisement(dvs, "100.100.1.0/24", "test_prf")
+
+        update_monitor_session_state(dvs, '100.100.1.71/32', '19.1.0.2', 'down')
+        check_remove_state_db_routes(dvs, 'Vnet12', "100.100.1.71/32")
+
+        #remove first route
+        delete_vnet_routes(dvs, "100.100.1.71/32", vnet_name)
+        vnet_obj.check_del_vnet_routes(dvs, 'Vnet12', ["100.100.1.71/32"])
+        check_remove_state_db_routes(dvs, 'Vnet12', "100.100.1.71/32")
+
         delete_vnet_entry(dvs,vnet_name)
         vnet_obj.check_del_vnet_entry(dvs, vnet_name)
         delete_vxlan_tunnel(dvs, tunnel_name)

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -3172,22 +3172,25 @@ class TestVnetOrch(object):
         #adv should be gone.
         check_remove_routes_advertisement(dvs, "100.100.1.0/24")
 
-		#Add priority route with no secondary enpoints
-        create_vnet_routes(dvs, "100.100.1.71/32", vnet_name, '19.0.0.1,19.0.0.2', ep_monitor='19.1.0.1,19.1.0.2', profile = "test_prf", primary ='19.0.0.1,19.0.0.2',monitoring='custom', adv_prefix='100.100.1.0/24')
-        update_monitor_session_state(dvs, '100.100.1.71/32', '19.1.0.1', 'up')
-        update_monitor_session_state(dvs, '100.100.1.71/32', '19.1.0.2', 'up')
+        #Add priority route with no secondary enpoints
+        create_vnet_routes(dvs, "100.100.1.71/32", vnet_name, '19.0.0.1,19.0.0.2', ep_monitor='19.0.0.1,19.0.0.2', profile = "test_prf", primary ='19.0.0.1,19.0.0.2',monitoring='custom', adv_prefix='100.100.1.0/24')
+        update_monitor_session_state(dvs, '100.100.1.71/32', '19.0.0.1', 'up')
+        update_monitor_session_state(dvs, '100.100.1.71/32', '19.0.0.2', 'up')
 
+        #verify that no BFD sessions are created.
+        check_del_bfd_session(dvs, ['19.0.0.1'])
+        check_del_bfd_session(dvs, ['19.0.0.2'])
         time.sleep(2)
         check_state_db_routes(dvs, vnet_name, "100.100.1.71/32", ['19.0.0.1,19.0.0.2'])
         # The default Vnet setting does not advertise prefix
         check_routes_advertisement(dvs, "100.100.1.0/24", "test_prf")
 
-        update_monitor_session_state(dvs, '100.100.1.71/32', '19.1.0.1', 'down')
+        update_monitor_session_state(dvs, '100.100.1.71/32', '19.0.0.1', 'down')
         check_state_db_routes(dvs, vnet_name, "100.100.1.71/32", ['19.0.0.2'])
         # The default Vnet setting does not advertise prefix
         check_routes_advertisement(dvs, "100.100.1.0/24", "test_prf")
 
-        update_monitor_session_state(dvs, '100.100.1.71/32', '19.1.0.2', 'down')
+        update_monitor_session_state(dvs, '100.100.1.71/32', '19.0.0.2', 'down')
         check_remove_state_db_routes(dvs, 'Vnet12', "100.100.1.71/32")
 
         #remove first route


### PR DESCRIPTION
When a configuration is added with custom monitoring such that there are no secondary endpoints in the configuration, this does not result in vnet ping session creation. This change fixes that and adds a test.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
added a fix.
**Why I did it**

**How I verified it**
added a test which emulates this scenario.
**Details if related**
