### PR TITLE
Add orchagent heart beat message for watchdog.

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -771,7 +771,7 @@ void OrchDaemon::start()
         {
             heart_beat = tend;
             // output heart beat message to supervisord with 'PROCESS_COMMUNICATION' event: http://supervisord.org/events.html
-            cout << "<!--XSUPERVISOR:BEGIN-->" << "process:orchagent\norchagent heart beat message." << "<!--XSUPERVISOR:END-->" << endl;
+            cout << "<!--XSUPERVISOR:BEGIN-->\norchagent heart beat message.\n<!--XSUPERVISOR:END-->" << endl;
         }
 
         auto *c = (Executor *)s;

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -76,6 +76,7 @@ OrchDaemon::OrchDaemon(DBConnector *applDb, DBConnector *configDb, DBConnector *
 {
     SWSS_LOG_ENTER();
     m_select = new Select();
+    m_lastHeartBeat = std::chrono::high_resolution_clock::now();
 }
 
 OrchDaemon::~OrchDaemon()

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -770,8 +770,8 @@ void OrchDaemon::start()
         if (diff.count() >= HEART_BEAT_INTERVAL_MSECS)
         {
             heart_beat = tend;
-            // output heart beat message to supervisord with 'PROCESS_COMMUNICATION' event: http://supervisord.org/events.html
-            cout << "<!--XSUPERVISOR:BEGIN-->\norchagent heart beat message.\n<!--XSUPERVISOR:END-->" << endl;
+            // output heart beat message to supervisord with 'PROCESS_COMMUNICATION_STDOUT' event: http://supervisord.org/events.html
+            cout << "<!--XSUPERVISOR:BEGIN-->heartbeat<!--XSUPERVISOR:END-->" << endl;
         }
 
         auto *c = (Executor *)s;

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -6,6 +6,7 @@
 #include "logger.h"
 #include <sairedis.h>
 #include "warm_restart.h"
+#include <iostream>
 
 #define SAI_SWITCH_ATTR_CUSTOM_RANGE_BASE SAI_SWITCH_ATTR_CUSTOM_RANGE_START
 #include "sairedis.h"
@@ -769,7 +770,8 @@ void OrchDaemon::start()
         if (diff.count() >= HEART_BEAT_INTERVAL_MSECS)
         {
             heart_beat = tend;
-            SWSS_LOG_INFO("Orchagent heart beat message.");
+            // output heart beat message to supervisord with 'PROCESS_COMMUNICATION' event: http://supervisord.org/events.html
+            cout << "<!--XSUPERVISOR:BEGIN-->" << "Orchagent heart beat." << "<!--XSUPERVISOR:END-->" << endl;
         }
 
         auto *c = (Executor *)s;

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -20,7 +20,7 @@ using namespace swss;
 #define PFC_WD_POLL_MSECS 100
 
 /* orchagent heart beat message interval */
-#define HEART_BEAT_INTERVAL_MSECS 60 * 1000
+#define HEART_BEAT_INTERVAL_MSECS 10 * 1000
 
 extern sai_switch_api_t*           sai_switch_api;
 extern sai_object_id_t             gSwitchId;
@@ -771,7 +771,7 @@ void OrchDaemon::start()
         {
             heart_beat = tend;
             // output heart beat message to supervisord with 'PROCESS_COMMUNICATION' event: http://supervisord.org/events.html
-            cout << "<!--XSUPERVISOR:BEGIN-->" << "Orchagent heart beat." << "<!--XSUPERVISOR:END-->" << endl;
+            cout << "<!--XSUPERVISOR:BEGIN-->" << "process:orchagent\norchagent heart beat message." << "<!--XSUPERVISOR:END-->" << endl;
         }
 
         auto *c = (Executor *)s;

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -965,13 +965,11 @@ void OrchDaemon::addOrchList(Orch *o)
 
 void OrchDaemon::heartBeat(std::chrono::time_point<std::chrono::high_resolution_clock> tcurrent)
 {
-    static auto tlast = std::chrono::high_resolution_clock::now();
-
     // output heart beat message to SYSLOG
-    auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(tcurrent - tlast);
+    auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(tcurrent - m_lastHeartBeat);
     if (diff.count() >= HEART_BEAT_INTERVAL_MSECS)
     {
-        tlast = tcurrent;
+        m_lastHeartBeat = tcurrent;
         // output heart beat message to supervisord with 'PROCESS_COMMUNICATION_STDOUT' event: http://supervisord.org/events.html
         cout << "<!--XSUPERVISOR:BEGIN-->heartbeat<!--XSUPERVISOR:END-->" << endl;
     }

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -91,7 +91,7 @@ private:
     std::vector<Orch *> m_orchList;
     Select *m_select;
     
-    static std::chrono::time_point<std::chrono::high_resolution_clock> m_lastHeartBeat = std::chrono::high_resolution_clock::now();
+    std::chrono::time_point<std::chrono::high_resolution_clock> m_lastHeartBeat;
 
     void flush();
 

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -90,6 +90,8 @@ private:
 
     std::vector<Orch *> m_orchList;
     Select *m_select;
+    
+    static std::chrono::time_point<std::chrono::high_resolution_clock> m_lastHeartBeat = std::chrono::high_resolution_clock::now();
 
     void flush();
 

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -92,6 +92,8 @@ private:
     Select *m_select;
 
     void flush();
+
+    void heartBeat(std::chrono::time_point<std::chrono::high_resolution_clock> tcurrent);
 };
 
 class FabricOrchDaemon : public OrchDaemon


### PR DESCRIPTION
**What I did**
Improve orch agent: output heartbeat message to systemd.

**Why I did it**
Currently SONiC monit system only monit orchagent process exist or not. If orchagent process stuck and stop processing, current monit can't find and report it.

**How I verified it**
Pass all UT.
Manually validate the heartbeat message works correctly.

**Details if related**
Another inprogress PR will add watchdog for this heartbeat message:
https://github.com/sonic-net/sonic-buildimage/pull/14686

sonic-mgmt UT PR: https://github.com/sonic-net/sonic-mgmt/pull/8306