### PR TITLE
[202211]Custom monitoring based priority tunnels

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -55,6 +55,7 @@ BfdOrch *gBfdOrch;
 Srv6Orch *gSrv6Orch;
 FlowCounterRouteOrch *gFlowCounterRouteOrch;
 DebugCounterOrch *gDebugCounterOrch;
+MonitorOrch *gMonitorOrch;
 
 bool gIsNatSupported = false;
 bool gSaiRedisLogRotate = false;
@@ -165,6 +166,8 @@ bool OrchDaemon::init()
     gDirectory.set(vnet_rt_orch);
     VRFOrch *vrf_orch = new VRFOrch(m_applDb, APP_VRF_TABLE_NAME, m_stateDb, STATE_VRF_OBJECT_TABLE_NAME);
     gDirectory.set(vrf_orch);
+    gMonitorOrch = new MonitorOrch(m_stateDb, STATE_VNET_MONITOR_TABLE_NAME); 
+    gDirectory.set(gMonitorOrch);
 
     const vector<string> chassis_frontend_tables = {
         CFG_PASS_THROUGH_ROUTE_TABLE_NAME,
@@ -353,7 +356,7 @@ bool OrchDaemon::init()
      * when iterating ConsumerMap. This is ensured implicitly by the order of keys in ordered map.
      * For cases when Orch has to process tables in specific order, like PortsOrch during warm start, it has to override Orch::doTask()
      */
-    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, gFlowCounterRouteOrch, gIntfsOrch, gNeighOrch, gNhgMapOrch, gNhgOrch, gCbfNhgOrch, gRouteOrch, gCoppOrch, gQosOrch, wm_orch, gPolicerOrch, tunnel_decap_orch, sflow_orch, gDebugCounterOrch, gMacsecOrch, gBfdOrch, gSrv6Orch, mux_orch, mux_cb_orch};
+    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, gFlowCounterRouteOrch, gIntfsOrch, gNeighOrch, gNhgMapOrch, gNhgOrch, gCbfNhgOrch, gRouteOrch, gCoppOrch, gQosOrch, wm_orch, gPolicerOrch, tunnel_decap_orch, sflow_orch, gDebugCounterOrch, gMacsecOrch, gBfdOrch, gSrv6Orch, mux_orch, mux_cb_orch, gMonitorOrch};
 
     bool initialize_dtel = false;
     if (platform == BFN_PLATFORM_SUBSTRING || platform == VS_PLATFORM_SUBSTRING)

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -732,7 +732,7 @@ sai_object_id_t VNetRouteOrch::getNextHopGroupId(const string& vnet, const NextH
     return syncd_nexthop_groups_[vnet][nexthops].next_hop_group_id;
 }
 
-bool VNetRouteOrch::addNextHopGroup(const string& vnet, const NextHopGroupKey &nexthops, VNetVrfObject *vrf_obj)
+bool VNetRouteOrch::addNextHopGroup(const string& vnet, const NextHopGroupKey &nexthops, VNetVrfObject *vrf_obj, const string& monitoring)
 {
     SWSS_LOG_ENTER();
 
@@ -753,7 +753,7 @@ bool VNetRouteOrch::addNextHopGroup(const string& vnet, const NextHopGroupKey &n
     for (auto it : next_hop_set)
     {
         nh_seq_id_in_nhgrp[it] = ++seq_id;
-        if (nexthop_info_[vnet].find(it.ip_address) != nexthop_info_[vnet].end() && nexthop_info_[vnet][it.ip_address].bfd_state != SAI_BFD_SESSION_STATE_UP)
+        if (monitoring != "custom" && nexthop_info_[vnet].find(it.ip_address) != nexthop_info_[vnet].end() && nexthop_info_[vnet][it.ip_address].bfd_state != SAI_BFD_SESSION_STATE_UP)
         {
             continue;
         }
@@ -892,9 +892,178 @@ bool VNetRouteOrch::removeNextHopGroup(const string& vnet, const NextHopGroupKey
     return true;
 }
 
+bool VNetRouteOrch::createNextHopGroup(const string& vnet,
+                                       NextHopGroupKey& nexthops,
+                                       VNetVrfObject *vrf_obj,
+                                       const string& monitoring)
+{
+
+    if (nexthops.getSize() == 0)
+    {
+        return true;
+    }
+    else if (nexthops.getSize() == 1)
+    {
+        NextHopKey nexthop(nexthops.to_string(), true);
+        NextHopGroupInfo next_hop_group_entry;
+        next_hop_group_entry.next_hop_group_id = vrf_obj->getTunnelNextHop(nexthop);
+        next_hop_group_entry.ref_count = 0;
+        if (monitoring == "custom" || nexthop_info_[vnet].find(nexthop.ip_address) == nexthop_info_[vnet].end() || nexthop_info_[vnet][nexthop.ip_address].bfd_state == SAI_BFD_SESSION_STATE_UP)
+        {
+            next_hop_group_entry.active_members[nexthop] = SAI_NULL_OBJECT_ID;
+        }
+        syncd_nexthop_groups_[vnet][nexthops] = next_hop_group_entry;
+    }
+    else
+    {
+        if (!addNextHopGroup(vnet, nexthops, vrf_obj, monitoring))
+        {
+            SWSS_LOG_ERROR("Failed to create next hop group %s", nexthops.to_string().c_str());
+            return false;
+        }
+    }
+    return true;
+}
+
+NextHopGroupKey VNetRouteOrch::getActiveNHSet(const string& vnet,
+                                       NextHopGroupKey& nexthops,
+                                       const IpPrefix& ipPrefix)
+{
+    // This  function takes  a nexthop group key and iterates over the nexthops in that group
+    // to identify the ones which are active based on their monitor session state.
+    // These next hops are collected into another next hop group key called nhg_custom and returned.
+    NextHopGroupKey nhg_custom("", true);
+    set<NextHopKey> next_hop_set = nexthops.getNextHops();
+    for (auto it : next_hop_set)
+    {
+        if(monitor_info_.find(vnet) != monitor_info_.end() &&
+            monitor_info_[vnet].find(ipPrefix) != monitor_info_[vnet].end())
+        {
+            for (auto monitor : monitor_info_[vnet][ipPrefix])
+            {
+                if (monitor.second.endpoint == it)
+                {
+                    if (monitor.second.state == MONITOR_SESSION_STATE_UP)
+                    {
+                        // monitor session exists and is up
+                        nhg_custom.add(it);
+
+                    }
+                    continue;
+                }
+            }
+        }
+    }
+    return nhg_custom;
+}
+
+bool VNetRouteOrch::selectNextHopGroup(const string& vnet,
+                                       NextHopGroupKey& nexthops_primary,
+                                       NextHopGroupKey& nexthops_secondary,
+                                       const string& monitoring,
+                                       IpPrefix& ipPrefix,
+                                       VNetVrfObject *vrf_obj,
+                                       NextHopGroupKey& nexthops_selected,
+                                       const map<NextHopKey, IpAddress>& monitors)
+{
+    // This function returns the next hop group which is to be used to in the hardware.
+    // for non priority tunnel routes, this would return nexthops_primary or its subset if
+    // BFD sessions for the endpoits in the NHG are up.
+    // For priority tunnel scenario, it sets up endpoint monitors for both primary and secondary.
+    // This is followed by an attempt to create a NHG which can be subset of nexthops_primary
+    // depending on the endpoint monitor state. If no NHG from primary is created, we attempt
+    // the same for secondary.
+    if(nexthops_secondary.getSize() != 0 && monitoring == "custom")
+    {
+        auto it_route =  syncd_tunnel_routes_[vnet].find(ipPrefix);
+        if (it_route == syncd_tunnel_routes_[vnet].end())
+        {
+            setEndpointMonitor(vnet, monitors, nexthops_primary, monitoring, ipPrefix);
+            setEndpointMonitor(vnet, monitors, nexthops_secondary, monitoring, ipPrefix);
+        }
+        else
+        {
+            if (it_route->second.primary != nexthops_primary)
+            {
+                setEndpointMonitor(vnet, monitors, nexthops_primary, monitoring, ipPrefix);
+            }
+            if (it_route->second.secondary != nexthops_secondary)
+            {
+                setEndpointMonitor(vnet, monitors, nexthops_secondary, monitoring, ipPrefix);
+            }
+            nexthops_selected = it_route->second.nhg_key;
+            return true;
+        }
+
+        NextHopGroupKey nhg_custom = getActiveNHSet( vnet, nexthops_primary, ipPrefix);
+        if (!hasNextHopGroup(vnet, nhg_custom))
+        {
+            if (!createNextHopGroup(vnet, nhg_custom, vrf_obj, monitoring))
+            {
+                SWSS_LOG_WARN("Failed to create Primary based custom next hop group. Cannot proceed.");
+                delEndpointMonitor(vnet, nexthops_primary, ipPrefix);
+                delEndpointMonitor(vnet, nexthops_secondary, ipPrefix);
+                monitor_info_[vnet].erase(ipPrefix);
+
+                return false;
+            }
+        }
+        if (nhg_custom.getSize() > 0 )
+        {
+            SWSS_LOG_INFO(" Created Primary based custom next hop group.%s", nhg_custom.to_string().c_str() );
+            nexthops_selected = nhg_custom;
+            return true;
+        }
+        NextHopGroupKey nhg_custom_sec = getActiveNHSet( vnet, nexthops_secondary, ipPrefix);
+
+        if (!hasNextHopGroup(vnet, nhg_custom_sec))
+        {
+            if (!createNextHopGroup(vnet, nhg_custom_sec, vrf_obj, monitoring))
+            {
+                SWSS_LOG_WARN("Failed to create secondary based custom next hop group. Cannot proceed.");
+                delEndpointMonitor(vnet, nexthops_primary, ipPrefix);
+                delEndpointMonitor(vnet, nexthops_secondary, ipPrefix);
+                monitor_info_[vnet].erase(ipPrefix);
+
+                return false;
+            }
+        }
+        if (nhg_custom_sec.getSize() > 0 )
+        {
+            SWSS_LOG_INFO(" Created Secondary based custom next hop group.(%s).", nhg_custom_sec.to_string().c_str() );
+            nexthops_selected = nhg_custom_sec;
+            return true;
+        }
+        // nhg_custom is empty. we shall create a dummy enpty NHG for book keeping.
+        if (!hasNextHopGroup(vnet, nhg_custom) && !hasNextHopGroup(vnet, nhg_custom_sec) )
+        {
+            NextHopGroupInfo next_hop_group_entry;
+            next_hop_group_entry.next_hop_group_id = SAI_NULL_OBJECT_ID;
+            next_hop_group_entry.ref_count = 0;
+            syncd_nexthop_groups_[vnet][nhg_custom] = next_hop_group_entry;
+        }
+        nexthops_selected = nhg_custom;
+        return true;
+    }
+    else if (!hasNextHopGroup(vnet, nexthops_primary))
+    {
+        SWSS_LOG_INFO("Creating next hop group  %s", nexthops_primary.to_string().c_str());
+        setEndpointMonitor(vnet, monitors, nexthops_primary, "", ipPrefix);
+        if (!createNextHopGroup(vnet, nexthops_primary, vrf_obj, ""))
+        {
+            delEndpointMonitor(vnet, nexthops_primary, ipPrefix);
+            return false;
+        }
+    }
+    nexthops_selected = nexthops_primary;
+    return true;
+}
+
 template<>
 bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipPrefix,
                                                NextHopGroupKey& nexthops, string& op, string& profile,
+                                               const string& monitoring, NextHopGroupKey& nexthops_secondary,
+                                               const IpPrefix& adv_prefix,
                                                const map<NextHopKey, IpAddress>& monitors)
 {
     SWSS_LOG_ENTER();
@@ -932,33 +1101,15 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
 
     if (op == SET_COMMAND)
     {
-        sai_object_id_t nh_id;
-        if (!hasNextHopGroup(vnet, nexthops))
+        sai_object_id_t nh_id = SAI_NULL_OBJECT_ID;
+        NextHopGroupKey active_nhg("", true);
+        if (!selectNextHopGroup(vnet, nexthops, nexthops_secondary, monitoring, ipPrefix, vrf_obj, active_nhg, monitors))
         {
-            setEndpointMonitor(vnet, monitors, nexthops);
-            if (nexthops.getSize() == 1)
-            {
-                NextHopKey nexthop(nexthops.to_string(), true);
-                NextHopGroupInfo next_hop_group_entry;
-                next_hop_group_entry.next_hop_group_id = vrf_obj->getTunnelNextHop(nexthop);
-                next_hop_group_entry.ref_count = 0;
-                if (nexthop_info_[vnet].find(nexthop.ip_address) == nexthop_info_[vnet].end() || nexthop_info_[vnet][nexthop.ip_address].bfd_state == SAI_BFD_SESSION_STATE_UP)
-                {
-                    next_hop_group_entry.active_members[nexthop] = SAI_NULL_OBJECT_ID;
-                }
-                syncd_nexthop_groups_[vnet][nexthops] = next_hop_group_entry;
-            }
-            else
-            {
-                if (!addNextHopGroup(vnet, nexthops, vrf_obj))
-                {
-                    delEndpointMonitor(vnet, nexthops);
-                    SWSS_LOG_ERROR("Failed to create next hop group %s", nexthops.to_string().c_str());
-                    return false;
-                }
-            }
+            return true;
         }
-        nh_id = syncd_nexthop_groups_[vnet][nexthops].next_hop_group_id;
+
+        // note: nh_id can be SAI_NULL_OBJECT_ID when active_nhg is empty.
+        nh_id = syncd_nexthop_groups_[vnet][active_nhg].next_hop_group_id;
 
         auto it_route = syncd_tunnel_routes_[vnet].find(ipPrefix);
         for (auto vr_id : vr_set)
@@ -966,11 +1117,11 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
             bool route_status = true;
 
             // Remove route if the nexthop group has no active endpoint
-            if (syncd_nexthop_groups_[vnet][nexthops].active_members.empty())
+            if (syncd_nexthop_groups_[vnet][active_nhg].active_members.empty())
             {
                 if (it_route != syncd_tunnel_routes_[vnet].end())
                 {
-                    NextHopGroupKey nhg = it_route->second;
+                    NextHopGroupKey nhg = it_route->second.nhg_key;
                     // Remove route when updating from a nhg with active member to another nhg without
                     if (!syncd_nexthop_groups_[vnet][nhg].active_members.empty())
                     {
@@ -986,7 +1137,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                 }
                 else
                 {
-                    NextHopGroupKey nhg = it_route->second;
+                    NextHopGroupKey nhg = it_route->second.nhg_key;
                     if (syncd_nexthop_groups_[vnet][nhg].active_members.empty())
                     {
                         route_status = add_route(vr_id, pfx, nh_id);
@@ -1002,52 +1153,110 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
             {
                 SWSS_LOG_ERROR("Route add/update failed for %s, vr_id '0x%" PRIx64, ipPrefix.to_string().c_str(), vr_id);
                 /* Clean up the newly created next hop group entry */
-                if (nexthops.getSize() > 1)
+                if (active_nhg.getSize() > 1)
                 {
-                    removeNextHopGroup(vnet, nexthops, vrf_obj);
+                    removeNextHopGroup(vnet, active_nhg, vrf_obj);
                 }
                 return false;
             }
         }
-
-        if (it_route != syncd_tunnel_routes_[vnet].end())
+        bool route_updated = false;
+        bool priority_route_updated = false;
+        if (it_route != syncd_tunnel_routes_[vnet].end() &&
+            ((monitoring == "" && it_route->second.nhg_key != nexthops) ||
+            (monitoring == "custom" && (it_route->second.primary != nexthops || it_route->second.secondary != nexthops_secondary))))
         {
-            // In case of updating an existing route, decrease the reference count for the previous nexthop group
-            NextHopGroupKey nhg = it_route->second;
-            if(--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
+            route_updated = true;
+            NextHopGroupKey nhg = it_route->second.nhg_key;
+            if (monitoring == "custom")
             {
-                if (nhg.getSize() > 1)
+                // if the previously active NHG is same as the newly created active NHG.case of primary secondary swap or
+                //when primary is active and secondary is changed or vice versa. In these cases we dont remove the NHG
+                // but only remove the monitors for the set which has changed.
+                if (it_route->second.primary != nexthops)
                 {
-                    removeNextHopGroup(vnet, nhg, vrf_obj);
+                    delEndpointMonitor(vnet, it_route->second.primary, ipPrefix);
                 }
-                else
+                if (it_route->second.secondary != nexthops_secondary)
                 {
-                    syncd_nexthop_groups_[vnet].erase(nhg);
-                    NextHopKey nexthop(nhg.to_string(), true);
-                    vrf_obj->removeTunnelNextHop(nexthop);
+                    delEndpointMonitor(vnet, it_route->second.secondary, ipPrefix);
                 }
-                delEndpointMonitor(vnet, nhg);
+                if (monitor_info_[vnet][ipPrefix].empty())
+                {
+                    monitor_info_[vnet].erase(ipPrefix);
+                }
+                priority_route_updated = true;
             }
             else
             {
-                syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
+                // In case of updating an existing route, decrease the reference count for the previous nexthop group
+                if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
+                {
+                    if (nhg.getSize() > 1)
+                    {
+                        removeNextHopGroup(vnet, nhg, vrf_obj);
+                    }
+                    else
+                    {
+                        syncd_nexthop_groups_[vnet].erase(nhg);
+                        if(nhg.getSize() == 1)
+                        {
+                            NextHopKey nexthop(nhg.to_string(), true);
+                            vrf_obj->removeTunnelNextHop(nexthop);
+                        }
+                    }
+                    if (monitoring != "custom")
+                    {
+                        delEndpointMonitor(vnet, nhg, ipPrefix);
+                    }
+                }
+                else
+                {
+                    syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
+                }
+                vrf_obj->removeRoute(ipPrefix);
+                vrf_obj->removeProfile(ipPrefix);
             }
-            vrf_obj->removeRoute(ipPrefix);
-            vrf_obj->removeProfile(ipPrefix);
         }
-
-        syncd_nexthop_groups_[vnet][nexthops].tunnel_routes.insert(ipPrefix);
-
-        syncd_tunnel_routes_[vnet][ipPrefix] = nexthops;
-        syncd_nexthop_groups_[vnet][nexthops].ref_count++;
-        vrf_obj->addRoute(ipPrefix, nexthops);
-
         if (!profile.empty())
         {
             vrf_obj->addProfile(ipPrefix, profile);
         }
+        if (it_route == syncd_tunnel_routes_[vnet].end() || route_updated)
+        {
+            syncd_nexthop_groups_[vnet][active_nhg].tunnel_routes.insert(ipPrefix);
+            VNetTunnelRouteEntry tunnel_route_entry;
+            tunnel_route_entry.nhg_key = active_nhg;
+            tunnel_route_entry.primary = nexthops;
+            tunnel_route_entry.secondary = nexthops_secondary;
+            syncd_tunnel_routes_[vnet][ipPrefix] = tunnel_route_entry;
+            syncd_nexthop_groups_[vnet][active_nhg].ref_count++;
 
-        postRouteState(vnet, ipPrefix, nexthops, profile);
+            if (priority_route_updated)
+            {
+                MonitorUpdate update;
+                update.prefix = ipPrefix;
+                update.state = MONITOR_SESSION_STATE_UNKNOWN;
+                update.vnet = vnet;
+                updateVnetTunnelCustomMonitor(update);
+                return true;
+            }
+
+            if (adv_prefix.to_string() != ipPrefix.to_string() && prefix_to_adv_prefix_.find(ipPrefix) == prefix_to_adv_prefix_.end())
+            {
+                prefix_to_adv_prefix_[ipPrefix] = adv_prefix;
+                if (adv_prefix_refcount_.find(adv_prefix) == adv_prefix_refcount_.end())
+                {
+                    adv_prefix_refcount_[adv_prefix] = 0;
+                }
+                if(active_nhg.getSize() > 0)
+                {
+                    adv_prefix_refcount_[adv_prefix] += 1;
+                }
+            }
+            vrf_obj->addRoute(ipPrefix, active_nhg);
+        }
+        postRouteState(vnet, ipPrefix, active_nhg, profile);
     }
     else if (op == DEL_COMMAND)
     {
@@ -1058,8 +1267,8 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                 ipPrefix.to_string().c_str());
             return true;
         }
-        NextHopGroupKey nhg = it_route->second;
-
+        NextHopGroupKey nhg = it_route->second.nhg_key;
+        auto last_nhg_size = nhg.getSize();
         for (auto vr_id : vr_set)
         {
             // If an nhg has no active member, the route should already be removed
@@ -1082,14 +1291,28 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
             else
             {
                 syncd_nexthop_groups_[vnet].erase(nhg);
-                NextHopKey nexthop(nhg.to_string(), true);
-                vrf_obj->removeTunnelNextHop(nexthop);
+                // We need to check specifically if there is only one next hop active.
+                // In case of Priority routes we can end up in a situation where the active NHG has 0 nexthops.
+                if(nhg.getSize() == 1)
+                {
+                    NextHopKey nexthop(nhg.to_string(), true);
+                    vrf_obj->removeTunnelNextHop(nexthop);
+                }
             }
-            delEndpointMonitor(vnet, nhg);
+            if (monitor_info_[vnet].find(ipPrefix) == monitor_info_[vnet].end())
+            {
+                delEndpointMonitor(vnet, nhg, ipPrefix);
+            }
         }
         else
         {
             syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
+        }
+        if (monitor_info_[vnet].find(ipPrefix) != monitor_info_[vnet].end())
+        {
+            delEndpointMonitor(vnet, it_route->second.primary, ipPrefix);
+            delEndpointMonitor(vnet, it_route->second.secondary, ipPrefix);
+            monitor_info_[vnet].erase(ipPrefix);
         }
 
         syncd_tunnel_routes_[vnet].erase(ipPrefix);
@@ -1102,8 +1325,21 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         vrf_obj->removeProfile(ipPrefix);
 
         removeRouteState(vnet, ipPrefix);
-    }
+        if (prefix_to_adv_prefix_.find(ipPrefix) != prefix_to_adv_prefix_.end())
+        {
+            auto adv_pfx = prefix_to_adv_prefix_[ipPrefix];
+            prefix_to_adv_prefix_.erase(ipPrefix);
 
+            if (last_nhg_size > 0)
+            {
+                adv_prefix_refcount_[adv_pfx] -= 1;
+                if (adv_prefix_refcount_[adv_pfx] == 0)
+                {
+                    adv_prefix_refcount_.erase(adv_pfx);
+                }
+            }
+        }
+    }
     return true;
 }
 
@@ -1168,7 +1404,7 @@ bool VNetRouteOrch::updateTunnelRoute(const string& vnet, IpPrefix& ipPrefix,
                 ipPrefix.to_string().c_str());
             return true;
         }
-        NextHopGroupKey nhg = it_route->second;
+        NextHopGroupKey nhg = it_route->second.nhg_key;
 
         for (auto vr_id : vr_set)
         {
@@ -1567,11 +1803,8 @@ void VNetRouteOrch::createBfdSession(const string& vnet, const NextHopKey& endpo
 
         FieldValueTuple fvTuple("local_addr", src_ip.to_string());
         data.push_back(fvTuple);
-
-	data.emplace_back("multihop", "true");
-
+        data.emplace_back("multihop", "true");
         bfd_session_producer_.set(key, data);
-
         bfd_sessions_[monitor_addr].bfd_state = SAI_BFD_SESSION_STATE_DOWN;
     }
 
@@ -1603,7 +1836,48 @@ void VNetRouteOrch::removeBfdSession(const string& vnet, const NextHopKey& endpo
     bfd_sessions_.erase(monitor_addr);
 }
 
-void VNetRouteOrch::setEndpointMonitor(const string& vnet, const map<NextHopKey, IpAddress>& monitors, NextHopGroupKey& nexthops)
+void VNetRouteOrch::createMonitoringSession(const string& vnet, const NextHopKey& endpoint, const IpAddress& monitor_addr, IpPrefix& ipPrefix)
+{
+    SWSS_LOG_ENTER();
+
+    vector<FieldValueTuple>  data;
+    auto *vnet_obj = vnet_orch_->getTypePtr<VNetVrfObject>(vnet);
+
+    auto overlay_dmac = vnet_obj->getOverlayDMac();
+    string key = monitor_addr.to_string() + ":" + ipPrefix.to_string();
+    FieldValueTuple fvTuple1("packet_type", "vxlan");
+    data.push_back(fvTuple1);
+
+    FieldValueTuple fvTuple3("overlay_dmac", overlay_dmac.to_string());
+    data.push_back(fvTuple3);
+
+    monitor_session_producer_->set(key, data);
+
+    MonitorSessionInfo info = monitor_info_[vnet][ipPrefix][monitor_addr];
+    info.endpoint = endpoint;
+    info.ref_count = 1;
+    info.state = MONITOR_SESSION_STATE_DOWN;
+    monitor_info_[vnet][ipPrefix][monitor_addr] = info;
+
+}
+
+void VNetRouteOrch::removeMonitoringSession(const string& vnet, const NextHopKey& endpoint, const IpAddress& monitor_addr, IpPrefix& ipPrefix)
+{
+    SWSS_LOG_ENTER();
+
+    if (monitor_info_[vnet].find(ipPrefix) == monitor_info_[vnet].end() ||
+        monitor_info_[vnet][ipPrefix].find(monitor_addr) == monitor_info_[vnet][ipPrefix].end())
+    {
+        SWSS_LOG_NOTICE("Monitor session for prefix %s endpoint %s does not exist", ipPrefix.to_string().c_str(), endpoint.to_string().c_str());
+    }
+
+    string key = monitor_addr.to_string() + ":" + ipPrefix.to_string();
+
+    monitor_session_producer_->del(key);
+    monitor_info_[vnet][ipPrefix].erase(monitor_addr);
+}
+
+void VNetRouteOrch::setEndpointMonitor(const string& vnet, const map<NextHopKey, IpAddress>& monitors, NextHopGroupKey& nexthops, const string& monitoring, IpPrefix& ipPrefix)
 {
     SWSS_LOG_ENTER();
 
@@ -1611,9 +1885,31 @@ void VNetRouteOrch::setEndpointMonitor(const string& vnet, const map<NextHopKey,
     {
         NextHopKey nh = monitor.first;
         IpAddress monitor_ip = monitor.second;
-        if (nexthop_info_[vnet].find(nh.ip_address) == nexthop_info_[vnet].end())
+        set<NextHopKey> next_hop_set = nexthops.getNextHops();
+        if (next_hop_set.find(nh) != next_hop_set.end())
         {
-            createBfdSession(vnet, nh, monitor_ip);
+            if (monitoring == "custom")
+            {
+                if (monitor_info_[vnet].find(ipPrefix) == monitor_info_[vnet].end() ||
+                    monitor_info_[vnet][ipPrefix].find(monitor_ip) == monitor_info_[vnet][ipPrefix].end())
+                {
+                    createMonitoringSession(vnet, nh, monitor_ip, ipPrefix);
+                }
+                else
+                {
+                    SWSS_LOG_INFO("Monitoring session for prefix %s endpoint %s, monitor %s already exists", ipPrefix.to_string().c_str(),
+                        nh.to_string().c_str(), monitor_ip.to_string().c_str());
+                    monitor_info_[vnet][ipPrefix][monitor_ip].ref_count += 1;
+                }
+            }
+            else
+            {
+                if (nexthop_info_[vnet].find(nh.ip_address) == nexthop_info_[vnet].end())
+                {
+                    createBfdSession(vnet, nh, monitor_ip);
+                }
+                nexthop_info_[vnet][nh.ip_address].ref_count++;
+            }
         }
 
         nexthop_info_[vnet][nh.ip_address].ref_count++;
@@ -1628,11 +1924,72 @@ void VNetRouteOrch::delEndpointMonitor(const string& vnet, NextHopGroupKey& next
     for (auto nhk: nhks)
     {
         IpAddress ip = nhk.ip_address;
-        if (nexthop_info_[vnet].find(ip) != nexthop_info_[vnet].end()) {
-            if (--nexthop_info_[vnet][ip].ref_count == 0)
+        if (is_custom_monitoring)
+        {
+            for ( auto monitor : monitor_info_[vnet][ipPrefix])
             {
-                IpAddress monitor_addr = nexthop_info_[vnet][ip].monitor_addr;
-                removeBfdSession(vnet, nhk, monitor_addr);
+                if (monitor.second.endpoint == nhk)
+                {
+                    if (--monitor_info_[vnet][ipPrefix][monitor.first].ref_count == 0)
+                    {
+                        removeMonitoringSession(vnet, nhk, monitor.first, ipPrefix);
+                        break;
+                    }
+                }
+            }
+        }
+        else
+        {
+            if (nexthop_info_[vnet].find(ip) != nexthop_info_[vnet].end()) {
+                if (--nexthop_info_[vnet][ip].ref_count == 0)
+                {
+                    IpAddress monitor_addr = nexthop_info_[vnet][ip].monitor_addr;
+                    removeBfdSession(vnet, nhk, monitor_addr);
+                }
+            }
+        }
+    }
+}
+
+void VNetRouteOrch::updateMonitorState(string& op, const IpPrefix& prefix, const IpAddress& monitor, string state)
+{
+    SWSS_LOG_ENTER();
+    if( op == SET_COMMAND)
+    {
+        for (auto iter :  monitor_info_)
+        {
+            std::string vnet = iter.first;
+            if (monitor_info_[vnet].find(prefix) != monitor_info_[vnet].end() &&
+                monitor_info_[vnet][prefix].find(monitor) != monitor_info_[vnet][prefix].end())
+            {
+                if (state =="up")
+                {
+                    if (monitor_info_[vnet][prefix][monitor].state != MONITOR_SESSION_STATE_UP)
+                    {
+                        SWSS_LOG_NOTICE("Monitor session state for %s|%s (%s) changed from down to up", prefix.to_string().c_str(),
+                            monitor.to_string().c_str(), monitor_info_[vnet][prefix][monitor].endpoint.ip_address.to_string().c_str());
+                        struct MonitorUpdate status_update;
+                        status_update.state = MONITOR_SESSION_STATE_UP;
+                        status_update.prefix = prefix;
+                        status_update.monitor = monitor;
+                        status_update.vnet = vnet;
+                        updateVnetTunnelCustomMonitor(status_update);
+                    }
+                }
+                else if (state =="down")
+                {
+                    if (monitor_info_[vnet][prefix][monitor].state != MONITOR_SESSION_STATE_DOWN)
+                    {
+                        SWSS_LOG_NOTICE("Monitor session state for %s|%s (%s) changed from up to down", prefix.to_string().c_str(),
+                            monitor.to_string().c_str(), monitor_info_[vnet][prefix][monitor].endpoint.ip_address.to_string().c_str());
+                        struct MonitorUpdate status_update;
+                        status_update.state = MONITOR_SESSION_STATE_DOWN;
+                        status_update.prefix = prefix;
+                        status_update.monitor = monitor;
+                        status_update.vnet = vnet;
+                        updateVnetTunnelCustomMonitor(status_update);
+                    }
+                }
             }
         }
     }
@@ -1642,11 +1999,11 @@ void VNetRouteOrch::postRouteState(const string& vnet, IpPrefix& ipPrefix, NextH
 {
     const string state_db_key = vnet + state_db_key_delimiter + ipPrefix.to_string();
     vector<FieldValueTuple> fvVector;
-
     NextHopGroupInfo& nhg_info = syncd_nexthop_groups_[vnet][nexthops];
     string route_state = nhg_info.active_members.empty() ? "inactive" : "active";
     string ep_str = "";
     int idx_ep = 0;
+
     for (auto nh_pair : nhg_info.active_members)
     {
         NextHopKey nh = nh_pair.first;
@@ -1659,15 +2016,26 @@ void VNetRouteOrch::postRouteState(const string& vnet, IpPrefix& ipPrefix, NextH
 
     state_vnet_rt_tunnel_table_->set(state_db_key, fvVector);
 
+    auto prefix_to_use = ipPrefix;
+    if (prefix_to_adv_prefix_.find(ipPrefix) != prefix_to_adv_prefix_.end())
+    {
+        route_state = "";
+        auto adv_pfx = prefix_to_adv_prefix_[ipPrefix];
+        if (adv_prefix_refcount_[adv_pfx] == 1)
+        {
+            route_state = "active";
+            prefix_to_use = adv_pfx;
+        }
+     }
     if (vnet_orch_->getAdvertisePrefix(vnet))
     {
         if (route_state == "active")
         {
-            addRouteAdvertisement(ipPrefix, profile);
+            addRouteAdvertisement(prefix_to_use, profile);
         }
-        else
+        else if (route_state == "inactive")
         {
-            removeRouteAdvertisement(ipPrefix);
+            removeRouteAdvertisement(prefix_to_use);
         }
     }
 }
@@ -1676,7 +2044,19 @@ void VNetRouteOrch::removeRouteState(const string& vnet, IpPrefix& ipPrefix)
 {
     const string state_db_key = vnet + state_db_key_delimiter + ipPrefix.to_string();
     state_vnet_rt_tunnel_table_->del(state_db_key);
-    removeRouteAdvertisement(ipPrefix);
+
+    if(prefix_to_adv_prefix_.find(ipPrefix) !=prefix_to_adv_prefix_.end())
+    {
+        auto adv_pfx = prefix_to_adv_prefix_[ipPrefix];
+        if(adv_prefix_refcount_[adv_pfx] == 1)
+        {
+            removeRouteAdvertisement(adv_pfx);
+        }
+    }
+    else
+    {
+        removeRouteAdvertisement(ipPrefix);
+    }
 }
 
 void VNetRouteOrch::addRouteAdvertisement(IpPrefix& ipPrefix, string& profile)
@@ -1907,6 +2287,229 @@ void VNetRouteOrch::updateVnetTunnel(const BfdUpdate& update)
     }
 }
 
+void VNetRouteOrch::updateVnetTunnelCustomMonitor(const MonitorUpdate& update)
+{
+    SWSS_LOG_ENTER();
+// This function recieves updates from the MonitorOrch for the endpoints state.
+// Based on the state of the endpoints for a particular route, this function attempts
+// to construct the primary next hop group. if it fails to do so,it attempts to create
+// the secondary next hop group. After that it applies the next hop group and deletes
+// the old next hop group.
+// This function is also called in the case when the route configuration is updated to
+// apply the new next hop group. In this case, the caller sets the state to
+// MONITOR_SESSION_STATE_UNKNOWN and config_update and updateRoute are set to true.
+// This function should never recieve MONITOR_SESSION_STATE_UNKNOWN from MonitorOrch.
+
+    auto prefix = update.prefix;
+    auto state = update.state;
+    auto monitor = update.monitor;
+    auto vnet = update.vnet;
+    bool updateRoute = false;
+    bool config_update = false;
+    if (state != MONITOR_SESSION_STATE_UNKNOWN)
+    {
+        monitor_info_[vnet][prefix][monitor].state = state;
+    }
+    else
+    {
+        // we are coming here as a result of route config update. We need to repost the route if applicable.
+        updateRoute = true;
+        config_update = true;
+    }
+
+    auto route = syncd_tunnel_routes_[vnet].find(prefix);
+    if (route == syncd_tunnel_routes_[vnet].end())
+    {
+        SWSS_LOG_ERROR("Unexpected! Monitor Update for absent route.");
+        return;
+
+    }
+    auto *vrf_obj = vnet_orch_->getTypePtr<VNetVrfObject>(vnet);
+    set<sai_object_id_t> vr_set;
+
+    auto l_fn = [&] (const string& vnet) {
+        auto *vnet_obj = vnet_orch_->getTypePtr<VNetVrfObject>(vnet);
+        sai_object_id_t vr_id = vnet_obj->getVRidIngress();
+        vr_set.insert(vr_id);
+    };
+
+    l_fn(vnet);
+
+    auto primary = route->second.primary;
+    auto secondary = route->second.secondary;
+    auto active_nhg = route->second.nhg_key;
+    NextHopGroupKey nhg_custom("", true);
+    sai_ip_prefix_t pfx;
+    copy(pfx, prefix);
+    NextHopGroupKey nhg_custom_primary = getActiveNHSet( vnet, primary, prefix);
+    NextHopGroupKey nhg_custom_secondary = getActiveNHSet( vnet, secondary, prefix);
+    if (nhg_custom_primary.getSize() > 0)
+    {
+        if (nhg_custom_primary != active_nhg )
+        {
+            if (!hasNextHopGroup(vnet, nhg_custom_primary))
+            {
+                if (!createNextHopGroup(vnet, nhg_custom_primary, vrf_obj, "custom"))
+                {
+                    SWSS_LOG_WARN("Failed to create primary based custom next hop group. Cannot proceed.");
+                    return;
+                }
+            }
+            updateRoute = true;
+        }
+        if (updateRoute)
+        {
+            nhg_custom = nhg_custom_primary;
+        }
+    }
+    else if (nhg_custom_secondary.getSize() > 0)
+    {
+        if (nhg_custom_secondary != active_nhg )
+        {
+            if (!hasNextHopGroup(vnet, nhg_custom_secondary))
+            {
+                if (!createNextHopGroup(vnet, nhg_custom_secondary, vrf_obj, "custom"))
+                {
+                    SWSS_LOG_WARN("Failed to create primary based custom next hop group. Cannot proceed.");
+                    return;
+                }
+            }
+            updateRoute = true;
+        }
+        if (updateRoute)
+        {
+            nhg_custom = nhg_custom_secondary;
+        }
+    }
+    else
+    {
+        //both HHG's are inactive, need to remove the route.
+        updateRoute = true;
+    }
+
+    if (nhg_custom.getSize() == 0)
+    {
+        // nhg_custom is empty. we shall create a dummy empty NHG for book keeping.
+        SWSS_LOG_INFO(" Neither Primary or Secondary endpoints are up.");
+        if (!hasNextHopGroup(vnet, nhg_custom))
+        {
+            NextHopGroupInfo next_hop_group_entry;
+            next_hop_group_entry.next_hop_group_id = SAI_NULL_OBJECT_ID;
+            next_hop_group_entry.ref_count = 0;
+            syncd_nexthop_groups_[vnet][nhg_custom] = next_hop_group_entry;
+        }
+    }
+    auto active_nhg_size = active_nhg.getSize();
+    if (updateRoute)
+    {
+        for (auto vr_id : vr_set)
+        {
+            if (nhg_custom.getSize() == 0)
+            {
+                if (active_nhg_size > 0)
+                {
+                    // we need to remove the route
+                    del_route(vr_id, pfx);
+                }
+            }
+            else
+            {
+                bool route_status = true;
+                // note: nh_id can be SAI_NULL_OBJECT_ID when active_nhg is empty.
+                auto nh_id = syncd_nexthop_groups_[vnet][nhg_custom].next_hop_group_id;
+                if (active_nhg_size > 0)
+                {
+                    // we need to replace the nhg in the route
+                    route_status = update_route(vr_id, pfx, nh_id);
+                }
+                else
+                {
+                    // we need to readd the route.
+                    route_status = add_route(vr_id, pfx, nh_id);
+                }
+                if (!route_status)
+                {
+                    SWSS_LOG_ERROR("Route add/update failed for %s, vr_id '0x%" PRIx64, prefix.to_string().c_str(), vr_id);
+                    /* Clean up the newly created next hop group entry */
+                    if (nhg_custom.getSize() > 1)
+                    {
+                        removeNextHopGroup(vnet, nhg_custom, vrf_obj);
+                    }
+                    return;
+                }
+                vrf_obj->addRoute(prefix, nhg_custom);
+            }
+        }
+        if (config_update && nhg_custom != active_nhg)
+        {
+            // This convoluted logic has very good reason behind it.
+            // when a route configuration gets updated, if the new endpoints are same but primaries
+            // are changed, we must increase the ref count of active group to save it from premature
+            // deletion at this place. So, we increment the refcount of existing active_nhg in doRotueTask right
+            // before we call this function. Once here we need to undo this increment of refCount for the active_nhg
+            // which is no longer relevant.
+            syncd_nexthop_groups_[vnet][active_nhg].ref_count--;
+        }
+
+        if(--syncd_nexthop_groups_[vnet][active_nhg].ref_count == 0)
+        {
+            if (active_nhg_size > 1)
+            {
+                removeNextHopGroup(vnet, active_nhg, vrf_obj);
+            }
+            else
+            {
+                syncd_nexthop_groups_[vnet].erase(active_nhg);
+                if(active_nhg_size == 1)
+                {
+                    NextHopKey nexthop(active_nhg.to_string(), true);
+                    vrf_obj->removeTunnelNextHop(nexthop);
+                }
+            }
+        }
+        else
+        {
+            syncd_nexthop_groups_[vnet][active_nhg].tunnel_routes.erase(prefix);
+        }
+        syncd_nexthop_groups_[vnet][nhg_custom].tunnel_routes.insert(prefix);
+        syncd_tunnel_routes_[vnet][prefix].nhg_key = nhg_custom;
+        if (nhg_custom != active_nhg)
+        {
+            syncd_nexthop_groups_[vnet][nhg_custom].ref_count++;
+        }
+        if (nhg_custom.getSize() == 0 && active_nhg_size > 0)
+        {
+            vrf_obj->removeRoute(prefix);
+            removeRouteState(vnet, prefix);
+            if (prefix_to_adv_prefix_.find(prefix) != prefix_to_adv_prefix_.end())
+            {
+                auto adv_pfx = prefix_to_adv_prefix_[prefix];
+                adv_prefix_refcount_[adv_pfx] -=1;
+                if (adv_prefix_refcount_[adv_pfx] == 0)
+                {
+                    adv_prefix_refcount_.erase(adv_pfx);
+                }
+            }
+        }
+        else if (nhg_custom.getSize() > 0 && active_nhg_size == 0)
+        {
+            auto adv_prefix = prefix_to_adv_prefix_[prefix];
+            if (adv_prefix_refcount_.find(adv_prefix) == adv_prefix_refcount_.end())
+            {
+                adv_prefix_refcount_[adv_prefix] = 0;
+            }
+            adv_prefix_refcount_[adv_prefix] += 1;
+            string profile = vrf_obj->getProfile(prefix);
+            postRouteState(vnet, prefix, nhg_custom, profile);
+        }
+        else
+        {
+            string profile = vrf_obj->getProfile(prefix);
+            postRouteState(vnet, prefix, nhg_custom, profile);
+        }
+    }
+}
+
 bool VNetRouteOrch::handleTunnel(const Request& request)
 {
     SWSS_LOG_ENTER();
@@ -1916,7 +2519,11 @@ bool VNetRouteOrch::handleTunnel(const Request& request)
     vector<string> vni_list;
     vector<IpAddress> monitor_list;
     string profile = "";
-
+    vector<IpAddress> primary_list;
+    string monitoring;
+    swss::IpPrefix adv_prefix;
+    bool has_priority_ep = false;
+    bool has_adv_pfx = false;
     for (const auto& name: request.getAttrFieldNames())
     {
         if (name == "endpoint")
@@ -1940,6 +2547,19 @@ bool VNetRouteOrch::handleTunnel(const Request& request)
         else if (name == "profile")
         {
             profile = request.getAttrString(name);
+        }
+        else if (name == "primary")
+        {
+            primary_list = request.getAttrIPList(name);
+        }
+        else if (name == "monitoring")
+        {
+            monitoring = request.getAttrString(name);
+        }
+        else if (name == "adv_prefix")
+        {
+            adv_prefix = request.getAttrIpPrefix(name);
+            has_adv_pfx = true;
         }
         else
         {
@@ -1965,6 +2585,11 @@ bool VNetRouteOrch::handleTunnel(const Request& request)
         SWSS_LOG_ERROR("Peer monitor size of %zu does not match endpoint size of %zu", monitor_list.size(), ip_list.size());
         return false;
     }
+    if (!primary_list.empty() && monitor_list.empty())
+    {
+        SWSS_LOG_ERROR("Primary/backup behaviour cannot function without endpoint monitoring.");
+        return true;
+    }
 
     const std::string& vnet_name = request.getKeyString(0);
     auto ip_pfx = request.getKeyIpPrefix(1);
@@ -1973,6 +2598,14 @@ bool VNetRouteOrch::handleTunnel(const Request& request)
     SWSS_LOG_INFO("VNET-RT '%s' op '%s' for pfx %s", vnet_name.c_str(),
                    op.c_str(), ip_pfx.to_string().c_str());
 
+    if (!primary_list.empty())
+    {
+        has_priority_ep = true;
+        SWSS_LOG_INFO("Handling Priority Tunnel with prefix %s", ip_pfx.to_string().c_str());
+    }
+
+    NextHopGroupKey nhg_primary("", true);
+    NextHopGroupKey nhg_secondary("", true);
     NextHopGroupKey nhg("", true);
     map<NextHopKey, IpAddress> monitors;
     for (size_t idx_ip = 0; idx_ip < ip_list.size(); idx_ip++)
@@ -1995,16 +2628,31 @@ bool VNetRouteOrch::handleTunnel(const Request& request)
         }
 
         NextHopKey nh(ip, mac, vni, true);
-        nhg.add(nh);
         if (!monitor_list.empty())
         {
             monitors[nh] = monitor_list[idx_ip];
         }
+        if (has_priority_ep)
+        {
+            if (std::find(primary_list.begin(), primary_list.end(), ip) != primary_list.end())
+            {
+                // only add the primary endpoint ips.
+                nhg_primary.add(nh);
+            }
+            else
+            {
+                nhg_secondary.add(nh);
+            }
+        }
+        nhg.add(nh);
     }
-
+    if (!has_adv_pfx)
+    {
+        adv_prefix = ip_pfx;
+    }
     if (vnet_orch_->isVnetExecVrf())
     {
-        return doRouteTask<VNetVrfObject>(vnet_name, ip_pfx, nhg, op, profile, monitors);
+        return doRouteTask<VNetVrfObject>(vnet_name, ip_pfx, (has_priority_ep == true) ? nhg_primary : nhg, op, profile, monitoring, nhg_secondary, adv_prefix, monitors);
     }
 
     return true;
@@ -2147,6 +2795,47 @@ bool VNetCfgRouteOrch::doVnetRouteTask(const KeyOpFieldsValuesTuple & t, const s
         SWSS_LOG_ERROR("Unknown command : %s", op.c_str());
         return false;
     }
+
+    return true;
+}
+
+MonitorOrch::MonitorOrch(DBConnector *db, string tableName):
+    Orch2(db, tableName, request_)
+{
+    SWSS_LOG_ENTER();
+}
+
+MonitorOrch::~MonitorOrch(void)
+{
+    SWSS_LOG_ENTER();
+}
+
+bool MonitorOrch::addOperation(const Request& request)
+{
+    SWSS_LOG_ENTER();
+    auto monitor = request.getKeyIpAddress(0);
+    auto ip_Prefix = request.getKeyIpPrefix(1);
+
+    auto session_state = request.getAttrString("state");
+    SWSS_LOG_INFO("Added state table entry for monitor %s|%s", ip_Prefix.to_string().c_str(),monitor.to_string().c_str());
+
+    string op = SET_COMMAND;
+    VNetRouteOrch* vnet_route_orch = gDirectory.get<VNetRouteOrch*>();
+    vnet_route_orch->updateMonitorState(op ,ip_Prefix, monitor, session_state );
+
+    return true;
+}
+
+bool MonitorOrch::delOperation(const Request& request)
+{
+    SWSS_LOG_ENTER();
+    auto monitor = request.getKeyIpAddress(0);
+    auto ip_Prefix = request.getKeyIpPrefix(1);
+
+    SWSS_LOG_INFO("Deleting state table entry for monitor %s|%s", ip_Prefix.to_string().c_str(),monitor.to_string().c_str());
+    VNetRouteOrch* vnet_route_orch = gDirectory.get<VNetRouteOrch*>();
+    string op = DEL_COMMAND;
+    vnet_route_orch->updateMonitorState(op, ip_Prefix, monitor, "" );
 
     return true;
 }

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -64,7 +64,7 @@ def get_created_entry(db, table, existed_entries):
 def get_all_created_entries(db, table, existed_entries):
     tbl =  swsscommon.Table(db, table)
     entries = set(tbl.getKeys())
-    new_entries = list(entries - existed_entries)
+    new_entries = list(entries - set(existed_entries))
     assert len(new_entries) >= 0, "Get all could be no new created entries."
     new_entries.sort()
     return new_entries
@@ -444,6 +444,15 @@ def update_bfd_session_state(dvs, addr, state):
     ntf_data = "[{\"bfd_session_id\":\""+bfd_id+"\",\"session_state\":\""+bfd_sai_state[state]+"\"}]"
     ntf.send("bfd_session_state_change", ntf_data, fvp)
 
+def update_monitor_session_state(dvs, addr, monitor, state):
+    state_db = swsscommon.DBConnector(swsscommon.STATE_DB, dvs.redis_sock, 0)
+    create_entry_tbl(
+        state_db,
+        "VNET_MONITOR_TABLE", '|', "%s|%s" % (monitor,addr),
+        [
+            ("state", state),
+        ]
+    )
 
 def get_bfd_session_id(dvs, addr):
     asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
@@ -872,6 +881,26 @@ class VnetVxlanVrfTunnel(object):
 
         assert self.serialize_endpoint_group(endpoints) == expected_endpoint_str
 
+    def get_nexthop_groups(self, dvs, nhg):
+        asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
+        tbl_nhgm =  swsscommon.Table(asic_db, self.ASIC_NEXT_HOP_GROUP_MEMBER)
+        tbl_nh =  swsscommon.Table(asic_db, self.ASIC_NEXT_HOP)
+        nhg_data = {}
+        nhg_data['id'] = nhg
+        entries = set(tbl_nhgm.getKeys())
+        nhg_data['endpoints'] = []
+        for entry in entries:
+            status, fvs = tbl_nhgm.get(entry)
+            fvs = dict(fvs)
+            assert status, "Got an error when get a key"
+            if fvs["SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID"] == nhg:
+                nh_key = fvs["SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID"]
+                status, nh_fvs = tbl_nh.get(nh_key)
+                nh_fvs = dict(nh_fvs)
+                assert status, "Got an error when get a key"
+                endpoint = nh_fvs["SAI_NEXT_HOP_ATTR_IP"]
+                nhg_data['endpoints'].append(endpoint)
+        return nhg_data
     def check_vnet_ecmp_routes(self, dvs, name, endpoints, tunnel, mac=[], vni=[], route_ids=[], nhg="", ordered_ecmp="false", nh_seq_id=None):
         asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
         endpoint_str = name + "|" + self.serialize_endpoint_group(endpoints)
@@ -935,6 +964,74 @@ class VnetVxlanVrfTunnel(object):
 
         return new_route, new_nhg
 
+    def check_priority_vnet_ecmp_routes(self, dvs, name, endpoints_primary, tunnel, mac=[], vni=[], route_ids=[], count =1, prefix =""):
+        asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
+        endpoint_str_primary = name + "|" + self.serialize_endpoint_group(endpoints_primary)
+        new_nhgs = []
+        expected_attrs_primary = {}
+        for idx, endpoint in enumerate(endpoints_primary):
+            expected_attr = {
+                        "SAI_NEXT_HOP_ATTR_TYPE": "SAI_NEXT_HOP_TYPE_TUNNEL_ENCAP",
+                        "SAI_NEXT_HOP_ATTR_IP": endpoint,
+                        "SAI_NEXT_HOP_ATTR_TUNNEL_ID": self.tunnel[tunnel],
+                    }
+            if vni and vni[idx]:
+                expected_attr.update({'SAI_NEXT_HOP_ATTR_TUNNEL_VNI': vni[idx]})
+            if mac and mac[idx]:
+                expected_attr.update({'SAI_NEXT_HOP_ATTR_TUNNEL_MAC': mac[idx]})
+            expected_attrs_primary[endpoint] = expected_attr
+
+        if len(endpoints_primary) == 1:
+            if route_ids:
+                new_route = route_ids
+            else:
+                new_route = get_created_entries(asic_db, self.ASIC_ROUTE_ENTRY, self.routes, count)
+            return new_route
+        else :
+            new_nhgs = get_all_created_entries(asic_db, self.ASIC_NEXT_HOP_GROUP, self.nhgs)
+            found_match = False
+
+            for nhg in new_nhgs:
+                nhg_data = self.get_nexthop_groups(dvs, nhg)
+                eplist = self.serialize_endpoint_group(nhg_data['endpoints'])
+                if eplist == self.serialize_endpoint_group(endpoints_primary):
+                    self.nhg_ids[endpoint_str_primary] = nhg
+                    found_match = True
+
+            assert found_match, "the expected Nexthop group was not found."
+
+            # Check routes in ingress VRF
+            expected_nhg_attr = {
+                            "SAI_NEXT_HOP_GROUP_ATTR_TYPE": "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP",
+                        }
+            for nhg in new_nhgs:
+                check_object(asic_db, self.ASIC_NEXT_HOP_GROUP, nhg, expected_nhg_attr)
+
+            # Check nexthop group member
+            self.check_next_hop_group_member(dvs, self.nhg_ids[endpoint_str_primary], "false", endpoints_primary, expected_attrs_primary)
+
+            if route_ids:
+                new_route = route_ids
+            else:
+                new_route = get_created_entries(asic_db, self.ASIC_ROUTE_ENTRY, self.routes, count)
+
+            #Check if the route is in expected VRF
+            active_nhg = self.nhg_ids[endpoint_str_primary]
+            for idx in range(count):
+                if prefix != "" and prefix not in new_route[idx] :
+                    continue
+                check_object(asic_db, self.ASIC_ROUTE_ENTRY, new_route[idx],
+                            {
+                                "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID": active_nhg,
+                            }
+                        )
+                rt_key = json.loads(new_route[idx])
+
+
+            self.routes.update(new_route)
+            del self.nhg_ids[endpoint_str_primary]
+            return new_route
+
     def check_del_vnet_routes(self, dvs, name, prefixes=[]):
         # TODO: Implement for VRF VNET
 
@@ -948,6 +1045,21 @@ class VnetVxlanVrfTunnel(object):
 
         return True
 
+    def check_custom_monitor_app_db(self, dvs, prefix, endpoint, packet_type, overlay_dmac):
+        app_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        key = prefix + ':' + endpoint
+        check_object(app_db, self.APP_VNET_MONITOR, key,
+            {
+                "packet_type": packet_type,
+                "overlay_dmac" : overlay_dmac
+            }
+        )
+        return True
+
+    def check_custom_monitor_deleted(self, dvs, prefix, endpoint):
+        app_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        key = endpoint + ':' + prefix
+        check_deleted_object(app_db, self.APP_VNET_MONITOR, key)
 
 class TestVnetOrch(object):
 
@@ -1470,6 +1582,10 @@ class TestVnetOrch(object):
 
         create_vxlan_tunnel_map(dvs, tunnel_name, 'map_1', 'Vlan1000', '1000')
 
+        delete_vnet_entry(dvs, 'Vnet1')
+        vnet_obj.check_del_vnet_entry(dvs, 'Vnet1')
+        delete_vxlan_tunnel(dvs, tunnel_name)
+
     '''
     Test 7 - Test for vnet tunnel routes with ECMP nexthop group
     '''
@@ -1538,6 +1654,7 @@ class TestVnetOrch(object):
 
         delete_vnet_entry(dvs, vnet_name)
         vnet_obj.check_del_vnet_entry(dvs, vnet_name)
+        delete_vxlan_tunnel(dvs, tunnel_name)
 
     '''
     Test 8 - Test for ipv6 vnet tunnel routes with ECMP nexthop group
@@ -1624,6 +1741,7 @@ class TestVnetOrch(object):
 
         delete_vnet_entry(dvs, vnet_name)
         vnet_obj.check_del_vnet_entry(dvs, vnet_name)
+        delete_vxlan_tunnel(dvs, tunnel_name)
     
 
         '''
@@ -1755,6 +1873,7 @@ class TestVnetOrch(object):
 
         delete_vnet_entry(dvs, vnet_name)
         vnet_obj.check_del_vnet_entry(dvs, vnet_name)
+        delete_vxlan_tunnel(dvs, tunnel_name)
 
 
     '''
@@ -1891,7 +2010,7 @@ class TestVnetOrch(object):
 
         delete_vnet_entry(dvs, vnet_name)
         vnet_obj.check_del_vnet_entry(dvs, vnet_name)
-
+        delete_vxlan_tunnel(dvs, tunnel_name)
 
     '''
     Test 11 - Test for vnet tunnel routes with both single endpoint and ECMP group with endpoint health monitor
@@ -1999,6 +2118,7 @@ class TestVnetOrch(object):
 
         delete_vnet_entry(dvs, vnet_name)
         vnet_obj.check_del_vnet_entry(dvs, vnet_name)
+        delete_vxlan_tunnel(dvs, tunnel_name)
 
 
     '''
@@ -2128,7 +2248,914 @@ class TestVnetOrch(object):
 
         delete_vnet_entry(dvs, 'Vnet12')
         vnet_obj.check_del_vnet_entry(dvs, 'Vnet12')
+        delete_vxlan_tunnel(dvs, tunnel_name)
 
+
+        tunnel_name = 'tunnel_13'
+        vnet_obj.fetch_exist_entries(dvs)
+
+        create_vxlan_tunnel(dvs, tunnel_name, 'fd:8::32')
+        create_vnet_entry(dvs, 'Vnet13', tunnel_name, '10008', "")
+
+        vnet_obj.check_vnet_entry(dvs, 'Vnet13')
+        vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, 'Vnet13', '10008')
+
+        vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, 'fd:8::32')
+
+        # Create an ECMP tunnel route
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vnet_routes(dvs, "fd:8:10::32/128", 'Vnet13', 'fd:8:1::1,fd:8:1::2,fd:8:1::3')
+        route1, nhg1_1 = vnet_obj.check_vnet_ecmp_routes(dvs, 'Vnet13', ['fd:8:1::1', 'fd:8:1::2', 'fd:8:1::3'], tunnel_name)
+        check_state_db_routes(dvs, 'Vnet13', "fd:8:10::32/128", ['fd:8:1::1', 'fd:8:1::2', 'fd:8:1::3'])
+        # The default Vnet setting does not advertise prefix
+        check_remove_routes_advertisement(dvs, "fd:8:10::32/128")
+
+        # readd same tunnel again
+        set_vnet_routes(dvs, "fd:8:10::32/128", 'Vnet13', 'fd:8:1::1,fd:8:1::2,fd:8:1::3')
+        route1, nhg1_2 = vnet_obj.check_vnet_ecmp_routes(dvs, 'Vnet13', ['fd:8:1::1', 'fd:8:1::2', 'fd:8:1::3'], tunnel_name, route_ids=route1)
+        check_state_db_routes(dvs, 'Vnet13', "fd:8:10::32/128", ['fd:8:1::1', 'fd:8:1::2', 'fd:8:1::3'])
+        # The default Vnet setting does not advertise prefix
+        check_remove_routes_advertisement(dvs, "fd:8:10::32/128")
+        # Check only one group is present
+        vnet_obj.fetch_exist_entries(dvs)
+        assert nhg1_1 in vnet_obj.nhgs
+        assert len(vnet_obj.nhgs) == 1
+        assert nhg1_1 == nhg1_2
+
+        # Remove one of the tunnel routes
+        delete_vnet_routes(dvs, "fd:8:10::32/128", 'Vnet13')
+        vnet_obj.check_del_vnet_routes(dvs, 'Vnet13', ["fd:8:10::32/128"])
+        check_remove_state_db_routes(dvs, 'Vnet13', "fd:8:10::32/128")
+        check_remove_routes_advertisement(dvs, "fd:8:10::32/128")
+
+        # Check the nexthop group still exists
+        vnet_obj.fetch_exist_entries(dvs)
+        assert nhg1_2 not in  vnet_obj.nhgs
+        assert len(vnet_obj.nhgs) == 0
+        delete_vnet_entry(dvs, 'Vnet13')
+        vnet_obj.check_del_vnet_entry(dvs, 'Vnet13')
+
+    '''
+    Test 14 - Test for configuration idempotent behaviour 2
+    '''
+    def test_vnet_orch_14(self, dvs, testlog):
+        vnet_obj = self.get_vnet_obj()
+
+        tunnel_name = 'tunnel_14'
+        vnet_obj.fetch_exist_entries(dvs)
+
+        create_vxlan_tunnel(dvs, tunnel_name, 'fd:8::32')
+        create_vnet_entry(dvs, 'Vnet14', tunnel_name, '10008', "")
+
+        vnet_obj.check_vnet_entry(dvs, 'Vnet14')
+        vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, 'Vnet14', '10008')
+
+        vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, 'fd:8::32')
+
+        # Create an ECMP tunnel route
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vnet_routes(dvs, "fd:8:10::32/128", 'Vnet14', 'fd:8:1::1,fd:8:1::2,fd:8:1::3')
+        route1, nhg1_1 = vnet_obj.check_vnet_ecmp_routes(dvs, 'Vnet14', ['fd:8:1::1', 'fd:8:1::2', 'fd:8:1::3'], tunnel_name)
+        check_state_db_routes(dvs, 'Vnet14', "fd:8:10::32/128", ['fd:8:1::1', 'fd:8:1::2', 'fd:8:1::3'])
+        # The default Vnet setting does not advertise prefix
+        check_remove_routes_advertisement(dvs, "fd:8:10::32/128")
+
+        # readd same tunnel again
+        set_vnet_routes(dvs, "fd:8:10::32/128", 'Vnet14', 'fd:8:1::1,fd:8:1::2,fd:8:1::3')
+        route1, nhg1_2 = vnet_obj.check_vnet_ecmp_routes(dvs, 'Vnet14', ['fd:8:1::1', 'fd:8:1::2', 'fd:8:1::3'], tunnel_name, route_ids=route1)
+        check_state_db_routes(dvs, 'Vnet14', "fd:8:10::32/128", ['fd:8:1::1', 'fd:8:1::2', 'fd:8:1::3'])
+        # The default Vnet setting does not advertise prefix
+        check_remove_routes_advertisement(dvs, "fd:8:10::32/128")
+
+        #update nexthops for the same tunnel.
+        set_vnet_routes(dvs, "fd:8:10::32/128", 'Vnet14', 'fd:8:1::1,fd:8:1::2,fd:8:1::3,fd:8:1::4')
+        route1, nhg1_2 = vnet_obj.check_vnet_ecmp_routes(dvs, 'Vnet14', ['fd:8:1::1', 'fd:8:1::2', 'fd:8:1::3', 'fd:8:1::4'], tunnel_name, route_ids=route1)
+        check_state_db_routes(dvs, 'Vnet14', "fd:8:10::32/128", ['fd:8:1::1', 'fd:8:1::2', 'fd:8:1::3', 'fd:8:1::4'])
+        # The default Vnet setting does not advertise prefix
+        check_remove_routes_advertisement(dvs, "fd:8:10::32/128")
+
+        # Check the previous nexthop group is removed
+        vnet_obj.fetch_exist_entries(dvs)
+        assert nhg1_1 not in vnet_obj.nhgs
+        assert nhg1_2 in vnet_obj.nhgs
+
+        # Remove the tunnel route
+        delete_vnet_routes(dvs, "fd:8:10::32/128", 'Vnet14')
+        vnet_obj.check_del_vnet_routes(dvs, 'Vnet14', ["fd:8:10::32/128"])
+        check_remove_state_db_routes(dvs, 'Vnet14', "fd:8:10::32/128")
+        check_remove_routes_advertisement(dvs, "fd:8:10::32/128")
+        # Remove the tunnel route
+        delete_vnet_routes(dvs, "fd:8:10::32/128", 'Vnet14')
+        vnet_obj.check_del_vnet_routes(dvs, 'Vnet14', ["fd:8:10::32/128"])
+        check_remove_state_db_routes(dvs, 'Vnet14', "fd:8:10::32/128")
+        check_remove_routes_advertisement(dvs, "fd:8:10::32/128")
+
+        # Check the nexthop group still exists
+        vnet_obj.fetch_exist_entries(dvs)
+        assert nhg1_2 not in  vnet_obj.nhgs
+        assert nhg1_1 not in  vnet_obj.nhgs
+
+        delete_vnet_entry(dvs, 'Vnet14')
+        vnet_obj.check_del_vnet_entry(dvs, 'Vnet14')
+        delete_vxlan_tunnel(dvs, tunnel_name)
+
+    '''
+    Test 15 - Test for configuration idempotent behaviour single endpoint
+    '''
+    def test_vnet_orch_15(self, dvs, testlog):
+        vnet_obj = self.get_vnet_obj()
+
+        tunnel_name = 'tunnel_15'
+        vnet_obj.fetch_exist_entries(dvs)
+
+        create_vxlan_tunnel(dvs, tunnel_name, 'fd:8::32')
+        create_vnet_entry(dvs, 'Vnet15', tunnel_name, '10008', "")
+
+        vnet_obj.check_vnet_entry(dvs, 'Vnet15')
+        vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, 'Vnet15', '10008')
+
+        vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, 'fd:8::32')
+
+        # Create an tunnel route
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vnet_routes(dvs, "fd:8:10::32/128", 'Vnet15', 'fd:8:1::1')
+        route1 = vnet_obj.check_vnet_routes(dvs, 'Vnet15', 'fd:8:1::1', tunnel_name)
+        check_state_db_routes(dvs, 'Vnet15', "fd:8:10::32/128", ['fd:8:1::1'])
+        # The default Vnet setting does not advertise prefix
+        check_remove_routes_advertisement(dvs, "fd:8:10::32/128")
+
+        # readd same tunnel again
+        set_vnet_routes(dvs, "fd:8:10::32/128", 'Vnet15', 'fd:8:1::1')
+        route1 = vnet_obj.check_vnet_routes(dvs, 'Vnet15', 'fd:8:1::1', tunnel_name, route_ids=route1)
+        check_state_db_routes(dvs, 'Vnet15', "fd:8:10::32/128", ['fd:8:1::1'])
+        # The default Vnet setting does not advertise prefix
+        check_remove_routes_advertisement(dvs, "fd:8:10::32/128")
+        # Check only one group is present
+        vnet_obj.fetch_exist_entries(dvs)
+        assert len(vnet_obj.nhops) == 1
+
+        # Remove one of the tunnel routes
+        delete_vnet_routes(dvs, "fd:8:10::32/128", 'Vnet15')
+        vnet_obj.check_del_vnet_routes(dvs, 'Vnet15', ["fd:8:10::32/128"])
+        check_remove_state_db_routes(dvs, 'Vnet15', "fd:8:10::32/128")
+        check_remove_routes_advertisement(dvs, "fd:8:10::32/128")
+
+        # Check the nexthop group still exists
+        vnet_obj.fetch_exist_entries(dvs)
+        assert len(vnet_obj.nhops) == 0
+        delete_vnet_entry(dvs, 'Vnet15')
+        vnet_obj.check_del_vnet_entry(dvs, 'Vnet15')
+        delete_vxlan_tunnel(dvs, tunnel_name)
+
+    '''
+    Test 16 - Test for configuration idempotent behaviour single endpoint with BFD
+    '''
+    def test_vnet_orch_16(self, dvs, testlog):
+        vnet_obj = self.get_vnet_obj()
+
+        tunnel_name = 'tunnel_16'
+        vnet_obj.fetch_exist_entries(dvs)
+
+        create_vxlan_tunnel(dvs, tunnel_name, 'fd:8::33')
+        create_vnet_entry(dvs, 'Vnet16', tunnel_name, '10008', "")
+
+        vnet_obj.check_vnet_entry(dvs, 'Vnet16')
+        vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, 'Vnet16', '10008')
+
+        vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, 'fd:8::33')
+
+        # Create a tunnel route
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vnet_routes(dvs, "fd:8:11::32/128", 'Vnet16', 'fd:8:2::1', ep_monitor='fd:8:2::1')
+        update_bfd_session_state(dvs, 'fd:8:2::1', 'Up')
+        time.sleep(2)
+
+        route1 = vnet_obj.check_vnet_routes(dvs, 'Vnet16', 'fd:8:2::1', tunnel_name)
+        check_state_db_routes(dvs, 'Vnet16', "fd:8:11::32/128", ['fd:8:2::1'])
+        # The default Vnet setting does not advertise prefix
+        check_remove_routes_advertisement(dvs, "fd:8:11::32/128")
+
+        # readd same tunnel again
+        set_vnet_routes(dvs, "fd:8:11::32/128", 'Vnet16', 'fd:8:2::1', ep_monitor='fd:8:2::1')
+        route1 = vnet_obj.check_vnet_routes(dvs, 'Vnet16', 'fd:8:2::1', tunnel_name, route_ids=route1)
+        check_state_db_routes(dvs, 'Vnet16', "fd:8:11::32/128", ['fd:8:2::1'])
+        # The default Vnet setting does not advertise prefix
+        check_remove_routes_advertisement(dvs, "fd:8:11::32/128")
+        # Check only one group is present
+        vnet_obj.fetch_exist_entries(dvs)
+        assert len(vnet_obj.nhops) == 1
+
+        update_bfd_session_state(dvs, 'fd:8:2::1', 'Down')
+        time.sleep(2)
+        # readd same tunnel again
+        set_vnet_routes(dvs, "fd:8:11::32/128", 'Vnet16', 'fd:8:2::1', ep_monitor='fd:8:2::1')
+
+        update_bfd_session_state(dvs, 'fd:8:2::1', 'Up')
+        time.sleep(2)
+
+        route1 = vnet_obj.check_vnet_routes(dvs, 'Vnet16', 'fd:8:2::1', tunnel_name,route_ids=route1)
+        check_state_db_routes(dvs, 'Vnet16', "fd:8:11::32/128", ['fd:8:2::1'])
+        # The default Vnet setting does not advertise prefix
+        check_remove_routes_advertisement(dvs, "fd:8:11::32/128")
+
+
+        # Remove one of the tunnel routes
+        delete_vnet_routes(dvs, "fd:8:11::32/128", 'Vnet16')
+        vnet_obj.check_del_vnet_routes(dvs, 'Vnet16', ["fd:8:11::32/128"])
+        check_remove_state_db_routes(dvs, 'Vnet16', "fd:8:11::32/128")
+        check_remove_routes_advertisement(dvs, "fd:8:11::32/128")
+
+        # Check the nexthop group still exists
+        vnet_obj.fetch_exist_entries(dvs)
+        assert len(vnet_obj.nhops) == 0
+        delete_vnet_entry(dvs, 'Vnet16')
+        vnet_obj.check_del_vnet_entry(dvs, 'Vnet16')
+        delete_vxlan_tunnel(dvs, tunnel_name)
+
+    '''
+    Test 17 - Test for configuration idempotent behaviour multiple endpoint with BFD
+    '''
+    def test_vnet_orch_17(self, dvs, testlog):
+        vnet_obj = self.get_vnet_obj()
+
+        tunnel_name = 'tunnel_17'
+
+        vnet_obj.fetch_exist_entries(dvs)
+
+        create_vxlan_tunnel(dvs, tunnel_name, '9.9.9.9')
+        create_vnet_entry(dvs, 'Vnet17', tunnel_name, '10017', "")
+
+        vnet_obj.check_vnet_entry(dvs, 'Vnet17')
+        vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, 'Vnet17', '10017')
+
+        vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, '9.9.9.9')
+
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vnet_routes(dvs, "100.100.1.1/32", 'Vnet17', '9.0.0.1,9.0.0.2,9.0.0.3', ep_monitor='9.1.0.1,9.1.0.2,9.1.0.3')
+
+        # default bfd status is down, route should not be programmed in this status
+        vnet_obj.check_del_vnet_routes(dvs, 'Vnet17', ["100.100.1.1/32"])
+        check_state_db_routes(dvs, 'Vnet17', "100.100.1.1/32", [])
+        check_remove_routes_advertisement(dvs, "100.100.1.1/32")
+
+        #readd the route
+        set_vnet_routes(dvs, "100.100.1.1/32", 'Vnet17', '9.0.0.1,9.0.0.2,9.0.0.3',ep_monitor='9.1.0.1,9.1.0.2,9.1.0.3')
+        vnet_obj.check_del_vnet_routes(dvs, 'Vnet17', ["100.100.1.1/32"])
+        check_state_db_routes(dvs, 'Vnet17', "100.100.1.1/32", [])
+        check_remove_routes_advertisement(dvs, "100.100.1.1/32")
+
+        # Route should be properly configured when all bfd session states go up
+        update_bfd_session_state(dvs, '9.1.0.1', 'Up')
+        update_bfd_session_state(dvs, '9.1.0.2', 'Up')
+        update_bfd_session_state(dvs, '9.1.0.3', 'Up')
+        time.sleep(2)
+
+        route1, nhg1_1 = vnet_obj.check_vnet_ecmp_routes(dvs, 'Vnet17', ['9.0.0.1', '9.0.0.2', '9.0.0.3'], tunnel_name)
+        check_state_db_routes(dvs, 'Vnet17', "100.100.1.1/32", ['9.0.0.1', '9.0.0.2', '9.0.0.3'])
+        # The default Vnet setting does not advertise prefix
+        check_remove_routes_advertisement(dvs, "100.100.1.1/32")
+
+        #readd the active route
+        set_vnet_routes(dvs, "100.100.1.1/32", 'Vnet17', '9.0.0.1,9.0.0.2,9.0.0.3',ep_monitor='9.1.0.1,9.1.0.2,9.1.0.3')
+        route2, nhg1_2 = vnet_obj.check_vnet_ecmp_routes(dvs, 'Vnet17', ['9.0.0.1', '9.0.0.2', '9.0.0.3'], tunnel_name, route_ids=route1, nhg=nhg1_1)
+        check_state_db_routes(dvs, 'Vnet17', "100.100.1.1/32", ['9.0.0.1', '9.0.0.2', '9.0.0.3'])
+        # The default Vnet setting does not advertise prefix
+        check_remove_routes_advertisement(dvs, "100.100.1.1/32")
+        assert nhg1_1 == nhg1_2
+        assert len(vnet_obj.nhgs) == 1
+
+        # Remove tunnel route
+        delete_vnet_routes(dvs, "100.100.1.1/32", 'Vnet17')
+        vnet_obj.check_del_vnet_routes(dvs, 'Vnet17', ["100.100.1.1/32"])
+        check_remove_state_db_routes(dvs, 'Vnet17', "100.100.1.1/32")
+        check_remove_routes_advertisement(dvs, "100.100.1.1/32")
+
+        # Check the corresponding nexthop group is removed
+        vnet_obj.fetch_exist_entries(dvs)
+        assert nhg1_1 not in vnet_obj.nhgs
+        # Check the BFD session specific to the endpoint group is removed while others exist
+        check_del_bfd_session(dvs, ['9.1.0.1', '9.1.0.2', '9.1.0.3'])
+
+        delete_vnet_entry(dvs, 'Vnet17')
+        vnet_obj.check_del_vnet_entry(dvs, 'Vnet17')
+        delete_vxlan_tunnel(dvs, tunnel_name)
+
+    '''
+    Test 18 - Test for priority vnet tunnel routes with ECMP nexthop group. test primary secondary switchover.
+    '''
+    def test_vnet_orch_18(self, dvs, testlog):
+        vnet_obj = self.get_vnet_obj()
+        tunnel_name = 'tunnel_18'
+        vnet_name = 'vnet18'
+        asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
+
+        vnet_obj.fetch_exist_entries(dvs)
+
+        create_vxlan_tunnel(dvs, tunnel_name, '9.9.9.9')
+        create_vnet_entry(dvs, vnet_name, tunnel_name, '10018', "", advertise_prefix=True, overlay_dmac="22:33:33:44:44:66")
+
+        vnet_obj.check_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, vnet_name, '10018')
+
+        vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, '9.9.9.9')
+
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vnet_routes(dvs, "100.100.1.1/32", vnet_name, '9.1.0.1,9.1.0.2,9.1.0.3,9.1.0.4', ep_monitor='9.1.0.1,9.1.0.2,9.1.0.3,9.1.0.4', primary ='9.1.0.1,9.1.0.2', monitoring='custom', adv_prefix='100.100.1.0/24')
+
+        # default monitor status is down, route should not be programmed in this status
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name, ["100.100.1.1/32"])
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", [])
+        check_remove_routes_advertisement(dvs, "100.100.1.0/24")
+
+        # Route should be properly configured when all monitor session states go up. Only primary Endpoints should be in use.
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.1', 'up')
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.2', 'up')
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.3', 'up')
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.4', 'up')
+
+        time.sleep(2)
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.1','9.1.0.2'], tunnel_name)
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", ['9.1.0.1','9.1.0.2'])
+        # The default Vnet setting does not advertise prefix
+        check_routes_advertisement(dvs, "100.100.1.0/24")
+
+        # Remove first primary endpoint from group.
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.2', 'down')
+        time.sleep(2)
+        route1= vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.1'], tunnel_name, route_ids=route1)
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", ['9.1.0.1'])
+        # The default Vnet setting does not advertise prefix
+        check_routes_advertisement(dvs, "100.100.1.0/24")
+
+        # Switch to secondary if both primary down
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.1', 'down')
+        time.sleep(2)
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.3','9.1.0.4'], tunnel_name, route_ids=route1)
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", ['9.1.0.3','9.1.0.4'])
+        # The default Vnet setting does not advertise prefix
+        check_routes_advertisement(dvs, "100.100.1.0/24")
+
+        # removing first endpoint of secondary. route should remain on secondary NHG
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.3', 'down')
+        time.sleep(2)
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.4'], tunnel_name, route_ids=route1)
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", ['9.1.0.4'])
+        # The default Vnet setting does not advertise prefix
+        check_routes_advertisement(dvs, "100.100.1.0/24")
+
+        # removing last endpoint of secondary. route should be removed
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.4', 'down')
+        time.sleep(2)
+
+        new_nhgs = get_all_created_entries(asic_db, vnet_obj.ASIC_NEXT_HOP_GROUP, [])
+        assert len(new_nhgs) == 0
+        check_remove_routes_advertisement(dvs, "100.100.1.0/24")
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name, ["100.100.1.1/32"])
+        check_remove_state_db_routes(dvs, vnet_name, "100.100.1.1/32")
+
+        #Route should come up with secondary endpoints.
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.3', 'up')
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.4', 'up')
+
+        time.sleep(2)
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.3','9.1.0.4'], tunnel_name, route_ids=route1)
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", ['9.1.0.3','9.1.0.4'])
+        # The default Vnet setting does not advertise prefix
+        check_routes_advertisement(dvs, "100.100.1.0/24")
+
+        #Route should be switched to the primary endpoint.
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.1', 'up')
+        time.sleep(2)
+        route1= vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.1'], tunnel_name, route_ids=route1)
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", ['9.1.0.1'])
+        # The default Vnet setting does not advertise prefix
+        check_routes_advertisement(dvs, "100.100.1.0/24")
+
+        #Route should be updated with the second primary endpoint.
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.2', 'up')
+        time.sleep(2)
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.1','9.1.0.2'], tunnel_name, route_ids=route1)
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", ['9.1.0.1','9.1.0.2'])
+        # The default Vnet setting does not advertise prefix
+        check_routes_advertisement(dvs, "100.100.1.0/24")
+
+        #Route should not be impacted by seconday endpoints going down.
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.3', 'down')
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.4', 'down')
+        time.sleep(2)
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.1','9.1.0.2'], tunnel_name, route_ids=route1)
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", ['9.1.0.1','9.1.0.2'])
+        # The default Vnet setting does not advertise prefix
+        check_routes_advertisement(dvs, "100.100.1.0/24")
+
+        #Route should not be impacted by seconday endpoints coming back up.
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.3', 'up')
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.4', 'up')
+        time.sleep(2)
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.1','9.1.0.2'], tunnel_name, route_ids=route1)
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", ['9.1.0.1','9.1.0.2'])
+        # The default Vnet setting does not advertise prefix
+        check_routes_advertisement(dvs, "100.100.1.0/24")
+
+        # Remove tunnel route 1
+        delete_vnet_routes(dvs, "100.100.1.1/32", vnet_name)
+        time.sleep(2)
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name, ["100.100.1.1/32"])
+        check_remove_state_db_routes(dvs, vnet_name, "100.100.1.1/32")
+        check_remove_routes_advertisement(dvs, "100.100.1.0/24")
+
+        # Confirm the monitor sessions are removed
+        vnet_obj.check_custom_monitor_deleted(dvs, "100.100.1.1/32", "9.1.0.1")
+        vnet_obj.check_custom_monitor_deleted(dvs, "100.100.1.1/32", "9.1.0.2")
+        vnet_obj.check_custom_monitor_deleted(dvs, "100.100.1.1/32", "9.1.0.3")
+        vnet_obj.check_custom_monitor_deleted(dvs, "100.100.1.1/32", "9.1.0.4")
+
+        delete_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_del_vnet_entry(dvs, vnet_name)
+        delete_vxlan_tunnel(dvs, tunnel_name)
+
+    '''
+   Test 19 - Test for 2 priority vnet tunnel routes with overlapping primary secondary ECMP nexthop group.
+    '''
+    def test_vnet_orch_19(self, dvs, testlog):
+        vnet_obj = self.get_vnet_obj()
+        tunnel_name = 'tunnel_19'
+        vnet_name = 'Vnet19'
+        asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
+
+        vnet_obj.fetch_exist_entries(dvs)
+
+        create_vxlan_tunnel(dvs, tunnel_name, '9.9.9.19')
+        create_vnet_entry(dvs, vnet_name, tunnel_name, '10019', "", advertise_prefix=True, overlay_dmac="22:33:33:44:44:66")
+
+        vnet_obj.check_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, vnet_name, '10019')
+
+        vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, '9.9.9.19')
+
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vnet_routes(dvs, "100.100.1.1/32", vnet_name, '9.1.0.1,9.1.0.2,9.1.0.3,9.1.0.4', ep_monitor='9.1.0.1,9.1.0.2,9.1.0.3,9.1.0.4', profile="Test_profile", primary ='9.1.0.1,9.1.0.2', monitoring='custom', adv_prefix='100.100.1.0/24')
+        create_vnet_routes(dvs, "200.100.1.1/32", vnet_name, '9.1.0.1,9.1.0.2,9.1.0.3,9.1.0.4', ep_monitor='9.1.0.1,9.1.0.2,9.1.0.3,9.1.0.4', primary ='9.1.0.3,9.1.0.4', monitoring='custom', adv_prefix='200.100.1.0/24')
+
+        # default monitor session status is down, route should not be programmed in this status
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name, ["100.100.1.1/32"])
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", [])
+        check_remove_routes_advertisement(dvs, "100.100.1.0/24")
+
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name, ["200.100.1.1/32"])
+        check_state_db_routes(dvs, vnet_name, "200.100.1.1/32", [])
+        check_remove_routes_advertisement(dvs, "200.100.1.0/24")
+
+        # Route should be properly configured when all monitor session states go up. Only primary Endpoints should be in use.
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.1', 'up')
+        time.sleep(2)
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.1'], tunnel_name, prefix="100.100.1.1/32")
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", ['9.1.0.1'])
+        check_routes_advertisement(dvs, "100.100.1.0/24", "Test_profile")
+
+        update_monitor_session_state(dvs, '200.100.1.1/32', '9.1.0.1', 'up')
+        time.sleep(2)
+        route2 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.1'], tunnel_name, route_ids=route1, prefix="200.100.1.1/32")
+        check_state_db_routes(dvs, vnet_name, "200.100.1.1/32", ['9.1.0.1'])
+        check_routes_advertisement(dvs, "200.100.1.0/24", "")
+
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.2', 'up')
+        time.sleep(2)
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.1','9.1.0.2'], tunnel_name, route_ids=route1, prefix="100.100.1.1/32")
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", ['9.1.0.1','9.1.0.2'])
+        check_routes_advertisement(dvs, "100.100.1.0/24", "Test_profile")
+
+        update_monitor_session_state(dvs, '200.100.1.1/32', '9.1.0.2', 'up')
+        time.sleep(2)
+        route2 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.1','9.1.0.2'], tunnel_name, route_ids=route1, prefix="200.100.1.1/32")
+        check_state_db_routes(dvs, vnet_name, "200.100.1.1/32", ['9.1.0.1','9.1.0.2'])
+        check_routes_advertisement(dvs, "200.100.1.0/24", "")
+
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.3', 'up')
+        update_monitor_session_state(dvs, '200.100.1.1/32', '9.1.0.3', 'up')
+        time.sleep(2)
+
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.1','9.1.0.2'], tunnel_name, route_ids=route1, prefix="100.100.1.1/32")
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", ['9.1.0.1','9.1.0.2'])
+        check_routes_advertisement(dvs, "100.100.1.0/24", "Test_profile")
+
+        route2 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.3'], tunnel_name, route_ids=route1, prefix="200.100.1.1/32")
+        check_state_db_routes(dvs, vnet_name, "200.100.1.1/32", ['9.1.0.3'])
+        check_routes_advertisement(dvs, "200.100.1.0/24", "")
+
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.4', 'up')
+        update_monitor_session_state(dvs, '200.100.1.1/32', '9.1.0.4', 'up')
+        time.sleep(2)
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.1','9.1.0.2'], tunnel_name, route_ids=route1, prefix="100.100.1.1/32")
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", ['9.1.0.1','9.1.0.2'])
+        check_routes_advertisement(dvs, "100.100.1.0/24", "Test_profile")
+
+        route2 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.3','9.1.0.4'], tunnel_name, route_ids=route1, prefix="200.100.1.1/32")
+        check_state_db_routes(dvs, vnet_name, "200.100.1.1/32", ['9.1.0.3','9.1.0.4'])
+        check_routes_advertisement(dvs, "200.100.1.0/24", "")
+
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.1', 'down')
+        update_monitor_session_state(dvs, '200.100.1.1/32', '9.1.0.1', 'down')
+        time.sleep(2)
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.2'], tunnel_name, route_ids=route1, prefix="100.100.1.1/32")
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", ['9.1.0.2'])
+        check_routes_advertisement(dvs, "100.100.1.0/24", "Test_profile")
+
+        route2 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.3','9.1.0.4'], tunnel_name, route_ids=route1, prefix="200.100.1.1/32")
+        check_state_db_routes(dvs, vnet_name, "200.100.1.1/32", ['9.1.0.3','9.1.0.4'])
+        check_routes_advertisement(dvs, "200.100.1.0/24", "")
+
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.2', 'down')
+        update_monitor_session_state(dvs, '200.100.1.1/32', '9.1.0.2', 'down')
+        time.sleep(2)
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.3','9.1.0.4'], tunnel_name, route_ids=route1, prefix="100.100.1.1/32")
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", ['9.1.0.3','9.1.0.4'])
+        check_routes_advertisement(dvs, "100.100.1.0/24", "Test_profile")
+
+        route2 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.3','9.1.0.4'], tunnel_name, route_ids=route1, prefix="200.100.1.1/32")
+        check_state_db_routes(dvs, vnet_name, "200.100.1.1/32", ['9.1.0.3','9.1.0.4'])
+        check_routes_advertisement(dvs, "200.100.1.0/24", "")
+
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.3', 'down')
+        update_monitor_session_state(dvs, '200.100.1.1/32', '9.1.0.3', 'down')
+        time.sleep(2)
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.4'], tunnel_name, route_ids=route1, prefix="100.100.1.1/32")
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", ['9.1.0.4'])
+        check_routes_advertisement(dvs, "100.100.1.0/24", "Test_profile")
+
+        route2 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['9.1.0.4'], tunnel_name, route_ids=route1, prefix="200.100.1.1/32")
+        check_state_db_routes(dvs, vnet_name, "200.100.1.1/32", ['9.1.0.4'])
+        check_routes_advertisement(dvs, "200.100.1.0/24", "")
+
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.4', 'down')
+        update_monitor_session_state(dvs, '200.100.1.1/32', '9.1.0.4', 'down')
+        time.sleep(2)
+
+        #we should still have two NHGs but no active route
+        new_nhgs = get_all_created_entries(asic_db, vnet_obj.ASIC_NEXT_HOP_GROUP, vnet_obj.nhgs)
+        assert len(new_nhgs) == 0
+        check_remove_routes_advertisement(dvs, "100.100.1.1/32")
+        check_remove_routes_advertisement(dvs, "200.100.1.1/32")
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name, ["100.100.1.1/32"])
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name, ["200.100.1.1/32"])
+        check_remove_state_db_routes(dvs, vnet_name, "100.100.1.1/32")
+        check_remove_state_db_routes(dvs, vnet_name, "200.100.1.1/32")
+        check_remove_routes_advertisement(dvs, "100.100.1.0/24")
+        check_remove_routes_advertisement(dvs, "200.100.1.0/24")
+
+        # Remove tunnel route 1
+        delete_vnet_routes(dvs, "100.100.1.1/32", vnet_name)
+        delete_vnet_routes(dvs, "200.100.1.1/32", vnet_name)
+
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name, ["100.100.1.1/32"])
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name, ["200.100.1.1/32"])
+
+        check_remove_state_db_routes(dvs, vnet_name, "100.100.1.1/32")
+        check_remove_state_db_routes(dvs, vnet_name, "200.100.1.1/32")
+
+        check_remove_routes_advertisement(dvs, "100.100.1.0/24")
+        check_remove_routes_advertisement(dvs, "200.100.1.0/24")
+
+
+        # Confirm the monitor sessions are removed
+        vnet_obj.check_custom_monitor_deleted(dvs, "100.100.1.1/32", "9.1.0.1")
+        vnet_obj.check_custom_monitor_deleted(dvs, "100.100.1.1/32", "9.1.0.2")
+        vnet_obj.check_custom_monitor_deleted(dvs, "100.100.1.1/32", "9.1.0.3")
+        vnet_obj.check_custom_monitor_deleted(dvs, "100.100.1.1/32", "9.1.0.4")
+
+        vnet_obj.check_custom_monitor_deleted(dvs, "200.100.1.1/32", "9.1.0.1")
+        vnet_obj.check_custom_monitor_deleted(dvs, "200.100.1.1/32", "9.1.0.2")
+        vnet_obj.check_custom_monitor_deleted(dvs, "200.100.1.1/32", "9.1.0.3")
+        vnet_obj.check_custom_monitor_deleted(dvs, "200.100.1.1/32", "9.1.0.4")
+
+        delete_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_del_vnet_entry(dvs, vnet_name)
+        delete_vxlan_tunnel(dvs, tunnel_name)
+
+    '''
+   Test 20 - Test for Single enpoint priority vnet tunnel routes. Test primary secondary switchover.
+    '''
+    def test_vnet_orch_20(self, dvs, testlog):
+        vnet_obj = self.get_vnet_obj()
+        tunnel_name = 'tunnel_20'
+        vnet_name = 'Vnet20'
+        asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
+
+        vnet_obj.fetch_exist_entries(dvs)
+
+        create_vxlan_tunnel(dvs, tunnel_name, '9.9.9.9')
+        create_vnet_entry(dvs, vnet_name, tunnel_name, '10020', "", advertise_prefix=True, overlay_dmac="22:33:33:44:44:66")
+
+        vnet_obj.check_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, vnet_name, '10020')
+
+        vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, '9.9.9.9')
+
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vnet_routes(dvs, "100.100.1.1/32", vnet_name, '9.1.0.1,9.1.0.2', ep_monitor='9.1.0.1,9.1.0.2', primary ='9.1.0.1', profile="Test_profile", monitoring='custom', adv_prefix='100.100.1.0/24')
+
+        # default monitor session status is down, route should not be programmed in this status
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name, ["100.100.1.1/32"])
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", [])
+        check_remove_routes_advertisement(dvs, "100.100.1.0/24")
+
+        # Route should be properly configured when all monitor session states go up. Only primary Endpoints should be in use.
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.1', 'up')
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.2', 'up')
+        time.sleep(2)
+        nhids = get_all_created_entries(asic_db, vnet_obj.ASIC_NEXT_HOP,set())
+        tbl_nh =  swsscommon.Table(asic_db, vnet_obj.ASIC_NEXT_HOP)
+        nexthops = dict()
+        for nhid in nhids:
+            status, nh_fvs = tbl_nh.get(nhid)
+            nh_fvs = dict(nh_fvs)
+            for key in nh_fvs.keys():
+                if key == 'SAI_NEXT_HOP_ATTR_IP':
+                    nexthops[nh_fvs[key]] = nhid
+        assert len(nexthops.keys()) == 1
+
+        route = get_created_entries(asic_db, vnet_obj.ASIC_ROUTE_ENTRY, vnet_obj.routes, 1)
+        check_object(asic_db, vnet_obj.ASIC_ROUTE_ENTRY, route[0],
+                        {
+                            "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID": nexthops['9.1.0.1'],
+                        }
+                    )
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", ['9.1.0.1'])
+        check_routes_advertisement(dvs, "100.100.1.0/24", "Test_profile")
+
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.2', 'down')
+        time.sleep(2)
+
+        route = get_created_entries(asic_db, vnet_obj.ASIC_ROUTE_ENTRY, vnet_obj.routes, 1)
+        check_object(asic_db, vnet_obj.ASIC_ROUTE_ENTRY, route[0],
+                        {
+                            "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID": nexthops['9.1.0.1'],
+                        }
+                    )
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", ['9.1.0.1'])
+        check_routes_advertisement(dvs, "100.100.1.0/24", "Test_profile")
+
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.1', 'down')
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.2', 'up')
+
+        time.sleep(2)
+
+        nhids = get_all_created_entries(asic_db, vnet_obj.ASIC_NEXT_HOP,set())
+        tbl_nh =  swsscommon.Table(asic_db, vnet_obj.ASIC_NEXT_HOP)
+        nexthops = dict()
+        for nhid in nhids:
+            status, nh_fvs = tbl_nh.get(nhid)
+            nh_fvs = dict(nh_fvs)
+            for key in nh_fvs.keys():
+                if key == 'SAI_NEXT_HOP_ATTR_IP':
+                    nexthops[nh_fvs[key]] = nhid
+        assert len(nexthops.keys()) == 1
+
+        route = get_created_entries(asic_db, vnet_obj.ASIC_ROUTE_ENTRY, vnet_obj.routes, 1)
+        check_object(asic_db, vnet_obj.ASIC_ROUTE_ENTRY, route[0],
+                        {
+                            "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID": nexthops['9.1.0.2'],
+                        }
+                    )
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", ['9.1.0.2'])
+        check_routes_advertisement(dvs, "100.100.1.0/24", "Test_profile")
+
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.1', 'up')
+        time.sleep(2)
+
+        nhids = get_all_created_entries(asic_db, vnet_obj.ASIC_NEXT_HOP,set())
+        tbl_nh =  swsscommon.Table(asic_db, vnet_obj.ASIC_NEXT_HOP)
+        nexthops = dict()
+        for nhid in nhids:
+            status, nh_fvs = tbl_nh.get(nhid)
+            nh_fvs = dict(nh_fvs)
+            for key in nh_fvs.keys():
+                if key == 'SAI_NEXT_HOP_ATTR_IP':
+                    nexthops[nh_fvs[key]] = nhid
+        assert len(nexthops.keys()) == 1
+
+        route = get_created_entries(asic_db, vnet_obj.ASIC_ROUTE_ENTRY, vnet_obj.routes, 1)
+        check_object(asic_db, vnet_obj.ASIC_ROUTE_ENTRY, route[0],
+                        {
+                            "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID": nexthops['9.1.0.1'],
+                        }
+                    )
+        check_state_db_routes(dvs, vnet_name, "100.100.1.1/32", ['9.1.0.1'])
+        check_routes_advertisement(dvs, "100.100.1.0/24", "Test_profile")
+
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.1', 'down')
+        update_monitor_session_state(dvs, '100.100.1.1/32', '9.1.0.2', 'down')
+
+        time.sleep(2)
+
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name, ["100.100.1.1/32"])
+        check_remove_state_db_routes(dvs, vnet_name, "100.100.1.1/32")
+        check_remove_routes_advertisement(dvs, "200.100.1.0/24")
+
+
+        # Remove tunnel route 1
+        delete_vnet_routes(dvs, "100.100.1.1/32", vnet_name)
+
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name, ["100.100.1.1/32"])
+        check_remove_state_db_routes(dvs, vnet_name, "100.100.1.1/32")
+        check_remove_routes_advertisement(dvs, "100.100.1.0/24")
+
+        vnet_obj.check_custom_monitor_deleted(dvs, "100.100.1.1/32", "9.1.0.1")
+        vnet_obj.check_custom_monitor_deleted(dvs, "100.100.1.1/32", "9.1.0.2")
+
+        delete_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_del_vnet_entry(dvs, vnet_name)
+        delete_vxlan_tunnel(dvs, tunnel_name)
+
+    '''
+    Test 21 - Test for priority vxlan tunnel with adv_prefix, adv profile. test route re-addition, route update, primary seocndary swap.
+    '''
+    def test_vnet_orch_21(self, dvs, testlog):
+        vnet_obj = self.get_vnet_obj()
+
+        tunnel_name = 'tunnel_21'
+        vnet_name = "Vnet21"
+        vnet_obj.fetch_exist_entries(dvs)
+
+        create_vxlan_tunnel(dvs, tunnel_name, 'fd:10::32')
+        create_vnet_entry(dvs, vnet_name, tunnel_name, '10021', "", advertise_prefix=True, overlay_dmac="22:33:33:44:44:66")
+
+        vnet_obj.check_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, vnet_name, '10021')
+
+        vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, 'fd:10::32')
+        vnet_obj.fetch_exist_entries(dvs)
+
+        #Add first Route
+        create_vnet_routes(dvs, "fd:10:10::1/128", vnet_name, 'fd:10:1::1,fd:10:1::2,fd:10:1::3,fd:10:1::4', ep_monitor='fd:10:2::1,fd:10:2::2,fd:10:2::3,fd:10:2::4', profile = "test_prf", primary ='fd:10:1::3,fd:10:1::4',monitoring='custom', adv_prefix="fd:10:10::/64")
+        update_monitor_session_state(dvs, 'fd:10:10::1/128', 'fd:10:2::1', 'up')
+        update_monitor_session_state(dvs, 'fd:10:10::1/128', 'fd:10:2::2', 'up')
+
+        time.sleep(2)
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['fd:10:1::1','fd:10:1::2'], tunnel_name, prefix="fd:10:10::1/128")
+        check_state_db_routes(dvs, vnet_name, "fd:10:10::1/128", ['fd:10:1::1,fd:10:1::2'])
+        check_routes_advertisement(dvs, "fd:10:10::/64", "test_prf")
+
+        #add 2nd route
+        create_vnet_routes(dvs, "fd:10:10::21/128", vnet_name, 'fd:11:1::1,fd:11:1::2,fd:11:1::3,fd:11:1::4', ep_monitor='fd:11:2::1,fd:11:2::2,fd:11:2::3,fd:11:2::4', profile = "test_prf", primary ='fd:11:1::1,fd:11:1::2',monitoring='custom', adv_prefix='fd:10:10::/64')
+        update_monitor_session_state(dvs, 'fd:10:10::21/128', 'fd:11:2::1', 'up')
+        update_monitor_session_state(dvs, 'fd:10:10::21/128', 'fd:11:2::2', 'up')
+        update_monitor_session_state(dvs, 'fd:10:10::21/128', 'fd:11:2::3', 'up')
+        update_monitor_session_state(dvs, 'fd:10:10::21/128', 'fd:11:2::4', 'up')
+        
+        time.sleep(2)
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['fd:11:1::1','fd:11:1::2'], tunnel_name, route_ids=route1, prefix="fd:10:10::21/128")
+        check_state_db_routes(dvs, vnet_name, "fd:10:10::21/128", ['fd:11:1::1,fd:11:1::2'])
+        check_routes_advertisement(dvs, "fd:10:10::/64", "test_prf")
+
+        #remove first route
+        delete_vnet_routes(dvs, "fd:10:10::1/128", vnet_name)
+        vnet_obj.check_del_vnet_routes(dvs, 'Vnet12', ["fd:10:10::1/128"])
+        check_remove_state_db_routes(dvs, 'Vnet12', "fd:10:10::1/128")
+
+        #adv should still be up.
+        check_routes_advertisement(dvs, "fd:10:10::/64")
+
+        #add 3rd route
+        create_vnet_routes(dvs, "fd:10:10::31/128", vnet_name, 'fd:11:1::1,fd:11:1::2,fd:11:1::3,fd:11:1::4', ep_monitor='fd:11:2::1,fd:11:2::2,fd:11:2::3,fd:11:2::4', profile = "test_prf", primary ='fd:11:1::1,fd:11:1::2',monitoring='custom', adv_prefix='fd:10:10::/64')
+        update_monitor_session_state(dvs, 'fd:10:10::31/128', 'fd:11:2::1', 'up')
+        update_monitor_session_state(dvs, 'fd:10:10::31/128', 'fd:11:2::2', 'up')
+        time.sleep(2)
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['fd:11:1::1','fd:11:1::2'], tunnel_name, route_ids=route1, prefix="fd:10:10::31/128")
+        check_state_db_routes(dvs, vnet_name, "fd:10:10::31/128", ['fd:11:1::1,fd:11:1::2'])
+        check_routes_advertisement(dvs, "fd:10:10::/64", "test_prf")
+
+        #delete 2nd route
+        delete_vnet_routes(dvs, "fd:10:10::21/128", vnet_name)
+        vnet_obj.check_del_vnet_routes(dvs, 'Vnet12', ["fd:10:10::21/128"])
+        check_remove_state_db_routes(dvs, 'Vnet12', "fd:10:10::21/128")
+
+        #adv should still be up.
+        check_routes_advertisement(dvs, "fd:10:10::/64")
+
+        #remove 3rd route
+        delete_vnet_routes(dvs, "fd:10:10::31/128", vnet_name)
+        vnet_obj.check_del_vnet_routes(dvs, 'Vnet12', ["fd:10:10::31/128"])
+        check_remove_state_db_routes(dvs, 'Vnet12', "fd:10:10::31/128")
+
+        #adv should be gone.
+        check_remove_routes_advertisement(dvs, "fd:10:10::/64")
+        delete_vnet_entry(dvs,vnet_name)
+        vnet_obj.check_del_vnet_entry(dvs, vnet_name)
+        delete_vxlan_tunnel(dvs, tunnel_name)
+
+    '''
+    Test 22 - Test for vxlan custom monitoring with adv_prefix. Add route twice and change nexthops case
+    '''
+    def test_vnet_orch_22(self, dvs, testlog):
+        vnet_obj = self.get_vnet_obj()
+
+        tunnel_name = 'tunnel_22'
+        vnet_name = "Vnet22"
+        vnet_obj.fetch_exist_entries(dvs)
+
+        create_vxlan_tunnel(dvs, tunnel_name, '9.9.9.3')
+        create_vnet_entry(dvs, vnet_name, tunnel_name, '10022', "", advertise_prefix=True, overlay_dmac="22:33:33:44:44:66")
+
+        vnet_obj.check_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, vnet_name, '10022')
+
+        vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, '9.9.9.3')
+
+        vnet_obj.fetch_exist_entries(dvs)
+        #Add first Route
+        create_vnet_routes(dvs, "100.100.1.11/32", vnet_name, '19.0.0.1,19.0.0.2,19.0.0.3', ep_monitor='19.1.0.1,19.1.0.2,19.1.0.3', profile = "test_prf", primary ='19.0.0.1',monitoring='custom', adv_prefix='100.100.1.0/24')
+        update_monitor_session_state(dvs, '100.100.1.11/32', '19.1.0.1', 'up')
+        time.sleep(2)
+        vnet_obj.check_vnet_routes(dvs, vnet_name, '19.0.0.1', tunnel_name)
+        check_state_db_routes(dvs, vnet_name, "100.100.1.11/32", ['19.0.0.1'])
+        # The default Vnet setting does not advertise prefix
+        check_routes_advertisement(dvs, "100.100.1.0/24", "test_prf")
+
+        #Add first Route again
+        create_vnet_routes(dvs, "100.100.1.11/32", vnet_name, '19.0.0.1,19.0.0.2,19.0.0.3', ep_monitor='19.1.0.1,19.1.0.2,19.1.0.3', profile = "test_prf", primary ='19.0.0.1',monitoring='custom', adv_prefix='100.100.1.0/24')
+        check_state_db_routes(dvs, vnet_name, "100.100.1.11/32", ['19.0.0.1'])
+        # The default Vnet setting does not advertise prefix
+        check_routes_advertisement(dvs, "100.100.1.0/24", "test_prf")
+
+        #remove first route
+        delete_vnet_routes(dvs, "100.100.1.11/32", vnet_name)
+        vnet_obj.check_del_vnet_routes(dvs, 'Vnet12', ["100.100.1.11/32"])
+        check_remove_state_db_routes(dvs, 'Vnet12', "100.100.1.11/32")
+
+        #adv should be gone.
+        check_remove_routes_advertisement(dvs, "100.100.1.0/24")
+
+        #add 2nd route
+        create_vnet_routes(dvs, "100.100.1.57/32", vnet_name, '5.0.0.1,5.0.0.2,5.0.0.3,5.0.0.4', ep_monitor='5.1.0.1,5.1.0.2,5.1.0.3,5.1.0.4', profile = "test_prf", primary ='5.0.0.1,5.0.0.2',monitoring='custom', adv_prefix='100.100.1.0/24')
+        update_monitor_session_state(dvs, '100.100.1.57/32', '5.1.0.1', 'up')
+        update_monitor_session_state(dvs, '100.100.1.57/32', '5.1.0.2', 'up')
+        time.sleep(2)
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['5.0.0.1','5.0.0.2'], tunnel_name, prefix="100.100.1.57/32")
+        check_state_db_routes(dvs, vnet_name, "100.100.1.57/32", ['5.0.0.1,5.0.0.2'])
+        # The default Vnet setting does not advertise prefix
+        check_routes_advertisement(dvs, "100.100.1.0/24", "test_prf")
+
+        #modify  2nd route switch primary with secondary
+        create_vnet_routes(dvs, "100.100.1.57/32", vnet_name, '5.0.0.1,5.0.0.2,5.0.0.3,5.0.0.4', ep_monitor='5.1.0.1,5.1.0.2,5.1.0.3,5.1.0.4', profile = "test_prf", primary ='5.0.0.3,5.0.0.4',monitoring='custom', adv_prefix='100.100.1.0/24')
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['5.0.0.1','5.0.0.2'], tunnel_name, route_ids=route1, prefix="100.100.1.57/32")
+        check_state_db_routes(dvs, vnet_name, "100.100.1.57/32", ['5.0.0.1','5.0.0.2'])
+        # The default Vnet setting does not advertise prefix
+        check_routes_advertisement(dvs, "100.100.1.0/24", "test_prf")
+
+        #delete 2nd route
+        delete_vnet_routes(dvs, "100.100.1.57/32", vnet_name)
+        vnet_obj.check_del_vnet_routes(dvs, 'Vnet12', ["100.100.1.57/32"])
+        check_remove_state_db_routes(dvs, 'Vnet12', "100.100.1.57/32")
+        #adv should be gone.
+        check_remove_routes_advertisement(dvs, "100.100.1.0/24")
+
+        #add 3rd route
+        create_vnet_routes(dvs, "100.100.1.67/32", vnet_name, '5.0.0.1,5.0.0.2,5.0.0.3,5.0.0.4', ep_monitor='5.1.0.1,5.1.0.2,5.1.0.3,5.1.0.4', profile = "test_prf", primary ='5.0.0.1,5.0.0.2',monitoring='custom', adv_prefix='100.100.1.0/24')
+        update_monitor_session_state(dvs, '100.100.1.67/32', '5.1.0.1', 'up')
+        update_monitor_session_state(dvs, '100.100.1.67/32', '5.1.0.2', 'up')
+        time.sleep(2)
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['5.0.0.1','5.0.0.2'], tunnel_name, prefix="100.100.1.67/32")
+        check_state_db_routes(dvs, vnet_name, "100.100.1.67/32", ['5.0.0.1,5.0.0.2'])
+        # The default Vnet setting does not advertise prefix
+        check_routes_advertisement(dvs, "100.100.1.0/24", "test_prf")
+
+        #modify  3rd route next hops to secondary
+        create_vnet_routes(dvs, "100.100.1.67/32", vnet_name, '5.0.0.1,5.0.0.2,5.0.0.3,5.0.0.4', ep_monitor='5.1.0.1,5.1.0.2,5.1.0.3,5.1.0.4', profile = "test_prf", primary ='5.0.0.3,5.0.0.4',monitoring='custom', adv_prefix='100.100.1.0/24')
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['5.0.0.1','5.0.0.2'], tunnel_name, route_ids=route1, prefix="100.100.1.67/32")
+        check_state_db_routes(dvs, vnet_name, "100.100.1.67/32", ['5.0.0.1','5.0.0.2'])
+        # The default Vnet setting does not advertise prefix
+        check_routes_advertisement(dvs, "100.100.1.0/24", "test_prf")
+
+         #modify  3rd route next hops to a new set.
+        create_vnet_routes(dvs, "100.100.1.67/32", vnet_name, '5.0.0.5,5.0.0.6,5.0.0.7,5.0.0.8', ep_monitor='5.1.0.5,5.1.0.6,5.1.0.7,5.1.0.8', profile = "test_prf", primary ='5.0.0.5,5.0.0.6',monitoring='custom', adv_prefix='100.100.1.0/24')
+        update_monitor_session_state(dvs, '100.100.1.67/32', '5.1.0.5', 'up')
+        update_monitor_session_state(dvs, '100.100.1.67/32', '5.1.0.6', 'up')
+        time.sleep(2)
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['5.0.0.5','5.0.0.6'], tunnel_name, route_ids=route1, prefix="100.100.1.67/32")
+        check_state_db_routes(dvs, vnet_name, "100.100.1.67/32", ['5.0.0.5,5.0.0.6'])
+        # The default Vnet setting does not advertise prefix
+        check_routes_advertisement(dvs, "100.100.1.0/24", "test_prf")
+
+        update_monitor_session_state(dvs, '100.100.1.67/32', '5.1.0.7', 'up')
+        update_monitor_session_state(dvs, '100.100.1.67/32', '5.1.0.8', 'up')
+
+        create_vnet_routes(dvs, "100.100.1.67/32", vnet_name, '5.0.0.5,5.0.0.6,5.0.0.7,5.0.0.8', ep_monitor='5.1.0.5,5.1.0.6,5.1.0.7,5.1.0.8', profile = "test_prf", primary ='5.0.0.7,5.0.0.8',monitoring='custom', adv_prefix='100.100.1.0/24')
+        time.sleep(2)
+        route1 = vnet_obj.check_priority_vnet_ecmp_routes(dvs, vnet_name, ['5.0.0.7','5.0.0.8'], tunnel_name, route_ids=route1, prefix="100.100.1.67/32")
+        check_state_db_routes(dvs, vnet_name, "100.100.1.67/32", ['5.0.0.7,5.0.0.8'])
+        # The default Vnet setting does not advertise prefix
+        check_routes_advertisement(dvs, "100.100.1.0/24", "test_prf")
+
+        #delete 3rd route
+        delete_vnet_routes(dvs, "100.100.1.67/32", vnet_name)
+        vnet_obj.check_del_vnet_routes(dvs, 'Vnet12', ["100.100.1.67/32"])
+        check_remove_state_db_routes(dvs, 'Vnet12', "100.100.1.67/32")
+        #adv should be gone.
+        check_remove_routes_advertisement(dvs, "100.100.1.0/24")
+        delete_vnet_entry(dvs,vnet_name)
+        vnet_obj.check_del_vnet_entry(dvs, vnet_name)
+        delete_vxlan_tunnel(dvs, tunnel_name)
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying


### PR DESCRIPTION
This PR implements the Vxlan ECMP priority tunnels where route next hop groups are switched based on the state of the next hop monitor session and their priority. This implementation allows primary and secondary next-hop groups which are switched based on the monitor state of the next hops. Please see the included tests to see what this code would do for detail.

cherry-pick  https://github.com/sonic-net/sonic-swss/pull/2719

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
