### PR TITLE
Inband ports not being initialized correctly #14520

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -7908,14 +7908,13 @@ bool PortsOrch::addSystemPorts()
                 }
 
                 //System port for local port. Update the system port info in the existing physical port
-                Port local_port;
-                if(!getPort(attr.value.oid, local_port))
+                if(!getPort(attr.value.oid, port))
                 {
                     //This is system port for non-front panel local port (CPU or OLP or RCY (Inband)). Not an error
                     SWSS_LOG_NOTICE("Add port for non-front panel local system port 0x%" PRIx64 "; core: %d, core port: %d",
                             system_port_oid, core_index, core_port_index);
                 }
-                local_port.m_system_port_info.local_port_oid = attr.value.oid;
+                port.m_system_port_info.local_port_oid = attr.value.oid;
             }
 
             port.m_system_port_oid = system_port_oid;


### PR DESCRIPTION
This fixes an issue with the system initialization of the inband ports.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

I removed the variable local_port. Data was being read into it but it was not being used.

**Why I did it**

This was causing incorrect data to be written to CHASSIS_APP_DB for some ports. Here is an example of what the relevant records look like in the database before this issue was fixed:

admin@cmp218-3:~$ sonic-db-cli CHASSIS_APP_DB keys \*
SYSTEM_LAG_ID_END
SYSTEM_NEIGH||fc00:3000::1
SYSTEM_LAG_ID_START
SYSTEM_NEIGH||1.1.1.3
SYSTEM_NEIGH||1.1.1.1
SYSTEM_NEIGH||fc00:3000::3
SYSTEM_INTERFACE

Some of the keys are malformed.

With the fix this is the result:

admin@cmp218-3:~$ sonic-db-cli CHASSIS_APP_DB keys \* | grep -i IB0
SYSTEM_INTERFACE|cmp218-3|asic0|Ethernet-IB0
SYSTEM_NEIGH|cmp218-3|asic0|Ethernet-IB0|1.1.1.1
SYSTEM_NEIGH|cmp218-3|asic0|Ethernet-IB0|fc00:3000::1
admin@cmp218-3:~$ sonic-db-cli CHASSIS_APP_DB keys \* | grep -i IB1
SYSTEM_NEIGH|cmp218-3|asic1|Ethernet-IB1|fc00:3000::3
SYSTEM_NEIGH|cmp218-3|asic1|Ethernet-IB1|1.1.1.3
SYSTEM_INTERFACE|cmp218-3|asic1|Ethernet-IB1

In this case the keys are correct.

Without this fix routing between linecards in a modular chassis fails and routing between asics on a multi-asic line card would also fail. Ping would fail and the associated iBGP sessions would not come up.

It's worth noting that this issue was found in the master branch but is not present in the 202205 branch

**How I verified it**

This was testing by verifying that the CHASSIS_APP_DB entries were correct. And by making sure that the iBGP sessions would come up.

**Details if related**
