### PR TITLE
Dual-ToR][ACL] bind LAG to ACL table in order to guarantee rule coverage if lag menber will be added to LAG after binding

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3199,6 +3199,7 @@ void AclOrch::initDefaultTableTypes()
     addAclTableType(
         builder.withName(TABLE_TYPE_DROP)
             .withBindPointType(SAI_ACL_BIND_POINT_TYPE_PORT)
+            .withBindPointType(SAI_ACL_BIND_POINT_TYPE_LAG)
             .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_TC))
             .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_IN_PORTS))
             .build()

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -977,6 +977,13 @@ void MuxAclHandler::bindAllPorts(AclTable &acl_table)
             acl_table.link(port.m_port_id);
             acl_table.bind(port.m_port_id);
         }
+        else if (port.m_type == Port::LAG && !is_ingress_acl_)
+        {
+            SWSS_LOG_INFO("Binding LAG %" PRIx64 " to ACL table %s", port.m_lag_id, acl_table.id.c_str());
+
+            acl_table.link(port.m_lag_id);
+            acl_table.bind(port.m_lag_id);
+        }
     }
 }
 


### PR DESCRIPTION
…

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Bind LAG to ACL table in order to guarantee ACL rule coverage if LAG member will be added to LAG after ACL binding

**Why I did it**
After config reload or reboot due to timing, we often see race condition when port are not yet added to LAG, but egress ACL table group already created and port is bound to this group.
It causes that ACL rules are not working on LAG's members that were added after binding.

**How I verified it**
Run test:
`py.test dualtor_io/test_normal_op.py::test_normal_op_upstream[active-standby`]

**Details if related**
