### PR TITLE
[202211][EVPN]Fixing race condition when EVPN NVO add arrives late

### DIFF
--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -2353,7 +2353,7 @@ bool EvpnRemoteVnip2pOrch::addOperation(const Request& request)
     {
         SWSS_LOG_WARN("Remote VNI add: Source VTEP not found. remote=%s vid=%d",
                       remote_vtep.c_str(), vlan_id);
-        return true;
+        return false;
     }
 
     VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
@@ -2522,7 +2522,7 @@ bool EvpnRemoteVnip2mpOrch::addOperation(const Request& request)
     {
         SWSS_LOG_WARN("Remote VNI add: Source VTEP not found. remote=%s vid=%d",
                       end_point_ip.c_str(),vlan_id);
-        return true;
+        return false;
     }
 
     if (!gPortsOrch->getVlanByVlanId(vlan_id, vlanPort))
@@ -2602,7 +2602,7 @@ bool EvpnRemoteVnip2mpOrch::delOperation(const Request& request)
     auto vtep_ptr = evpn_orch->getEVPNVtep();
     if (!vtep_ptr)
     {
-        SWSS_LOG_WARN("Remote VNI add: VTEP not found. remote=%s vid=%d",
+        SWSS_LOG_WARN("Remote VNI del: VTEP not found. remote=%s vid=%d",
                       end_point_ip.c_str(), vlan_id);
         return true;
     }

--- a/tests/test_evpn_tunnel_p2mp.py
+++ b/tests/test_evpn_tunnel_p2mp.py
@@ -172,6 +172,49 @@ class TestVxlanOrchP2MP(object):
         vxlan_obj.remove_vlan(dvs, "100")
         vxlan_obj.remove_vlan(dvs, "101")
 
+    def test_delayed_evpn_nvo(self, dvs, testlog):
+        vxlan_obj = self.get_vxlan_obj()
+
+        tunnel_name = 'tunnel_2'
+        map_name = 'map_1000_100'
+        map_name_1 = 'map_1001_101'
+        vlanlist = ['100']
+        vnilist = ['1000']
+
+        vxlan_obj.fetch_exist_entries(dvs)
+        vxlan_obj.create_vlan1(dvs,"Vlan100")
+        vxlan_obj.create_vlan1(dvs,"Vlan101")
+
+        vxlan_obj.create_vxlan_tunnel(dvs, tunnel_name, '6.6.6.6')
+        vxlan_obj.create_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
+        vxlan_obj.create_vxlan_tunnel_map(dvs, tunnel_name, map_name_1, '1001', 'Vlan101')
+        vxlan_obj.create_evpn_remote_vni(dvs, 'Vlan101', '7.7.7.7', '1001')
+
+        vxlan_obj.check_vxlan_sip_tunnel(dvs, tunnel_name, '6.6.6.6', vlanlist, vnilist, ignore_bp=False, tunnel_map_entry_count = 2)
+        vxlan_obj.check_vxlan_tunnel_map_entry(dvs, tunnel_name, vlanlist, vnilist)
+
+
+        vxlan_obj.check_vlan_extension_not_created_p2mp(dvs, '101', '6.6.6.6', '7.7.7.7')
+        vxlan_obj.create_evpn_nvo(dvs, 'nvo1', tunnel_name)
+
+        print("Testing VLAN 101 extension")
+        vxlan_obj.check_vlan_extension_p2mp(dvs, '101', '6.6.6.6', '7.7.7.7')
+
+        print("Testing Vlan Extension removal")
+        vxlan_obj.remove_evpn_remote_vni(dvs, 'Vlan101', '7.7.7.7')
+        vxlan_obj.check_vlan_extension_delete_p2mp(dvs, '101', '6.6.6.6', '7.7.7.7')
+
+        vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
+        vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name_1, '1001', 'Vlan101')
+        vxlan_obj.check_vxlan_tunnel_map_entry_delete(dvs, tunnel_name, vlanlist, vnilist)
+
+        print("Testing SIP Tunnel Deletion")
+        vxlan_obj.remove_evpn_nvo(dvs, 'nvo1')
+        vxlan_obj.remove_vxlan_tunnel(dvs, tunnel_name)
+        vxlan_obj.check_vxlan_sip_tunnel_delete(dvs, tunnel_name, '6.6.6.6', ignore_bp=False)
+        vxlan_obj.remove_vlan(dvs, "100")
+        vxlan_obj.remove_vlan(dvs, "101")
+
     def test_invalid_vlan_extension(self, dvs, testlog):
         vxlan_obj = self.get_vxlan_obj()
 


### PR DESCRIPTION
Manual cherry-pick of https://github.com/sonic-net/sonic-swss/pull/2756
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Sometime during config reload, EVPN NVO table arrives later than remote VNI table entries. In such scenarios, remote vni entries are ignored and this leads to traffic loss. Added fix to retry instead of ignoring.

```
2023-04-30.14:23:40.528130|VXLAN_TUNNEL_MAP_TABLE:vtep1:map_98_Vlan98|SET|vlan:Vlan98|vni:98
2023-04-30.14:23:40.559594|VXLAN_TUNNEL_MAP_TABLE:vtep1:map_99_Vlan99|SET|vlan:Vlan99|vni:99
2023-04-30.14:23:40.572133|VXLAN_REMOTE_VNI_TABLE:Vlan98:1.1.1.1|SET|vni:98
2023-04-30.14:23:40.572180|VXLAN_REMOTE_VNI_TABLE:Vlan98:1.1.1.2|SET|vni:98
2023-04-30.14:23:40.575208|VXLAN_FDB_TABLE:Vlan98:04:3f:72:f7:2d:52|SET|remote_vtep:1.1.1.2|type:dynamic|vni:98
2023-04-30.14:23:40.575240|VXLAN_FDB_TABLE:Vlan98:0c:42:a1:6d:5b:94|SET|remote_vtep:1.1.1.1|type:dynamic|vni:98
2023-04-30.14:23:40.575249|VXLAN_FDB_TABLE:Vlan98:1c:34:da:2c:be:00|SET|remote_vtep:1.1.1.1|type:dynamic|vni:98
2023-04-30.14:23:40.575257|VXLAN_FDB_TABLE:Vlan98:1c:34:da:2c:ca:00|SET|remote_vtep:1.1.1.2|type:dynamic|vni:98
2023-04-30.14:23:40.589995|VXLAN_EVPN_NVO_TABLE:nvo1|SET|source_vtep:vtep1
```
**Why I did it**
To fix race condition as stated in the description

**How I verified it**
Added UT to verify.

**Details if related**
