### PR TITLE
[mux]: Fix UTs segmentation fault

### DIFF
--- a/tests/mock_tests/mux_rollback_ut.cpp
+++ b/tests/mock_tests/mux_rollback_ut.cpp
@@ -269,6 +269,16 @@ namespace mux_rollback_test
                 CFG_PEER_SWITCH_TABLE_NAME
             };
 
+            vector<string> buffer_tables = {
+                APP_BUFFER_POOL_TABLE_NAME,
+                APP_BUFFER_PROFILE_TABLE_NAME,
+                APP_BUFFER_QUEUE_TABLE_NAME,
+                APP_BUFFER_PG_TABLE_NAME,
+                APP_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME,
+                APP_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME
+            };
+            gBufferOrch = new BufferOrch(m_app_db.get(), m_config_db.get(), m_state_db.get(), buffer_tables);
+
             TableConnector stateDbSwitchTable(m_state_db.get(), STATE_SWITCH_CAPABILITY_TABLE_NAME);
             TableConnector app_switch_table(m_app_db.get(), APP_SWITCH_TABLE_NAME);
             TableConnector conf_asic_sensors(m_config_db.get(), CFG_ASIC_SENSORS_TABLE_NAME);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

Segmentation fault is observed during SWSS compilation:
```
nazariig@3aac6fa57f5a:/sonic/src/sonic-swss/tests/mock_tests$ ./tests --gtest_filter=MuxRollbackTest*
Running main() from /build/googletest-YnT0O3/googletest-1.10.0.20201025/googletest/src/gtest_main.cc
Note: Google Test filter = MuxRollbackTest*
[==========] Running 14 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 14 tests from MuxRollbackTest
[ RUN      ] MuxRollbackTest.StandbyToActiveNeighborAlreadyExists
Segmentation fault (core dumped)
```

**What I did**
* Fixed segmentation fault

**Why I did it**
* To resolve SWSS compilation errors

**How I verified it**
* Compile the SWSS package

**Details if related**
```
Starting program: /sonic/src/sonic-swss/tests/mock_tests/tests --gtest_filter=MuxRollbackTest\*
[Thread debugging using libthread_db enabled]
Using host libthread_db library "[32m/lib/x86_64-linux-gnu/libthread_db.so.1[m".Running main() from /build/googletest-YnT0O3/googletest-1.10.0.20201025/googletest/src/
gtest_main.cc
[0;33mNote: Google Test filter = MuxRollbackTest*
[m[0;32m[==========] [mRunning 14 tests from 1 test suite.
[0;32m[----------] [mGlobal test environment set-up.
[0;32m[----------] [m14 tests from MuxRollbackTest
[0;32m[ RUN      ] [mMuxRollbackTest.StandbyToActiveNeighborAlreadyExists

[New Thread 0x7ffff6861700 (LWP 16189)]
[New Thread 0x7ffff6060700 (LWP 16190)]
[New Thread 0x7ffff585f700 (LWP 16191)]

Thread 1 "tests" received signal SIGSEGV, Segmentation fault.
[34m0x0000555555b15612[m in [33mstd::_Hashtable<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<c
har, std::char_traits<char>, std::allocator<char> > const, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<
std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>
, std::allocator<char> > const, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<
char, std::char_traits<char>, std::allocator<char> > > > > >, std::__detail::_Select1st, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::al

char, std::char_traits<char>, std::allocator<char> > > > > >, std::__detail::_Select1st, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::al
locator<char> > >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::__detail::_Mod_range_hashing, std::__detail::_Defa
ult_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::_M_bucket_index[m ([36mthis[m=0xc0, [36m__k[m="Ethernet4",
 [36m__c[m=8856329075299762650) at [32m/usr/include/c++/10/bits/hashtable.h[m:682
[?2004h[?2004l[?2004h(gdb) bt
#0  [34m0x0000555555b15612[m in [33mstd::_Hashtable<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_stri
ng<char, std::char_traits<char>, std::allocator<char> > const, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::alloca
tor<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<c
har>, std::allocator<char> > const, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_str
ing<char, std::char_traits<char>, std::allocator<char> > > > > >, std::__detail::_Select1st, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std
::allocator<char> > >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::__detail::_Mod_range_hashing, std::__detail::_
Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::_M_bucket_index[m ([36mthis[m=0xc0, [36m__k[m="Etherne
t4", [36m__c[m=8856329075299762650) at [32m/usr/include/c++/10/bits/hashtable.h[m:682
#1  [34m0x0000555555b13dd1[m in [33mstd::_Hashtable<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_stri
ng<char, std::char_traits<char>, std::allocator<char> > const, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::alloca
tor<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<c
har>, std::allocator<char> > const, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_str
ing<char, std::char_traits<char>, std::allocator<char> > > > > >, std::__detail::_Select1st, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std
::allocator<char> > >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::__detail::_Mod_range_hashing, std::__detail::_
Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::find[m ([36mthis[m=0xc0, [36m__k[m="Ethernet4") at [32
m/usr/include/c++/10/bits/hashtable.h[m:1469
#2  [34m0x0000555555b12a43[m in [33mstd::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::__cxx11::basic
_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, std::

_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, std::
hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::all
ocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::vector<std::__cxx11::basic_strin
g<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >::find[
m ([36mthis[m=0xc0, [36m__x[m="Ethernet4") at [32m/usr/include/c++/10/bits/unordered_map.h[m:924
#3  [34m0x0000555555b082a4[m in [33mBufferOrch::isPortReady[m ([36mthis[m=0x0, [36mport_name[m="Ethernet4") at [32m../../orchagent/bufferorch.cpp[m:248
#4  [34m0x0000555555a54891[m in [33mPortsOrch::doPortTask[m ([36mthis[m=0x5555566b7770, [36mconsumer[m=...) at [32m../../orchagent/portsorch.cpp[m:3446
#5  [34m0x0000555555a5b12f[m in [33mPortsOrch::doTask[m ([36mthis[m=0x5555566b7770, [36mconsumer[m=...) at [32m../../orchagent/portsorch.cpp[m:4736
#6  [34m0x000055555594bfeb[m in [33mConsumer::drain[m ([36mthis[m=0x5555566b7240) at [32m../../orchagent/orch.cpp[m:241
#7  [34m0x0000555555a5af39[m in [33mPortsOrch::doTask[m ([36mthis[m=0x5555566b7770) at [32m../../orchagent/portsorch.cpp[m:4713
#8  [34m0x00005555558ee809[m in [33mmux_rollback_test::MuxRollbackTest::ApplyDualTorConfigs[m ([36mthis[m=0x55555650bef0) at [32mmux_rollback_ut.cpp[m:115
#9  [34m0x00005555558f1dff[m in [33mmux_rollback_test::MuxRollbackTest::SetUp[m ([36mthis[m=0x55555650bef0) at [32mmux_rollback_ut.cpp[m:372
#10 [34m0x0000555555fa5e17[m in [33mvoid testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char co
nst*)[m ()
#11 [34m0x0000555555f9c079[m in [33mtesting::Test::Run()[m ()
#12 [34m0x0000555555f9c245[m in [33mtesting::TestInfo::Run()[m ()
#13 [34m0x0000555555f9c6d9[m in [33mtesting::TestSuite::Run()[m ()
#14 [34m0x0000555555f9cd22[m in [33mtesting::internal::UnitTestImpl::RunAllTests()[m ()
#15 [34m0x0000555555fa6387[m in [33mbool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*
, bool (testing::internal::UnitTestImpl::*)(), char const*)[m ()
#16 [34m0x0000555555f9c308[m in [33mtesting::UnitTest::Run()[m ()
#17 [34m0x0000555555688430[m in [33mmain[m ()
```