### PR TITLE
[Dynamic Buffer Calc] Enhance the logic to check maximum headroom exceeding to cover corner scenarios

### DIFF
--- a/cfgmgr/buffer_check_headroom_mellanox.lua
+++ b/cfgmgr/buffer_check_headroom_mellanox.lua
@@ -118,7 +118,6 @@ for pg_key, profile in pairs(all_pgs) do
         current_profile_size = tonumber(referenced_profile_size)
     else
         current_profile_size = input_profile_size
-        profile = input_profile_name
     end
     if current_profile_size == 0 then
         current_profile_size = lossy_pg_size

--- a/cfgmgr/buffer_check_headroom_mellanox.lua
+++ b/cfgmgr/buffer_check_headroom_mellanox.lua
@@ -101,7 +101,7 @@ for i = 1, #pending_pg_keys do
 end
 
 if new_pg ~= nil and get_number_of_pgs(new_pg) ~= 0 then
-    all_pgs['BUFFER_PG_TABLE:' .. new_pg_pg] = input_profile_name
+    all_pgs['BUFFER_PG_TABLE:' .. new_pg] = input_profile_name
 end
 
 -- Handle all the PGs, accumulate the sizes

--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -1497,7 +1497,7 @@ task_process_status BufferMgrDynamic::refreshPgsForPort(const string &port, cons
 
         // Calculate whether accumulative headroom size exceeds the maximum value
         // Abort if it does
-        if (!isHeadroomResourceValid(port, m_bufferProfileLookup[newProfile], exactly_matched_key))
+        if (!isHeadroomResourceValid(port, m_bufferProfileLookup[newProfile], key))
         {
             SWSS_LOG_ERROR("Update speed (%s) and cable length (%s) for port %s failed, accumulative headroom size exceeds the limit",
                            speed.c_str(), cable_length.c_str(), port.c_str());

--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -1051,10 +1051,10 @@ bool BufferMgrDynamic::isHeadroomResourceValid(const string &port, const buffer_
     // profile: the profile referenced by the new_pg (if provided) or all PGs
     // new_pg: which pg is newly added?
 
-    if (!profile.lossless)
+    if (!profile.lossless && new_pg.empty())
     {
-        SWSS_LOG_INFO("No need to check headroom for lossy PG port %s profile %s size %s pg %s",
-                  port.c_str(), profile.name.c_str(), profile.size.c_str(), new_pg.c_str());
+        SWSS_LOG_INFO("No need to check headroom for lossy PG port %s profile %s size %s without a PG specified",
+                  port.c_str(), profile.name.c_str(), profile.size.c_str());
         return true;
     }
 
@@ -3005,6 +3005,11 @@ task_process_status BufferMgrDynamic::handleSingleBufferPgEntry(const string &ke
                     bufferPg.dynamic_calculated = profileRef.dynamic_calculated;
                     bufferPg.configured_profile_name = profileName;
                     bufferPg.lossless = profileRef.lossless;
+                    if (!profileRef.lossless && !isHeadroomResourceValid(port, profileRef, key))
+                    {
+                        SWSS_LOG_ERROR("Unable to configure lossy PG %s, accumulative headroom size exceeds the limit", key.c_str());
+                        return task_process_status::task_failed;
+                    }
                 }
                 bufferPg.static_configured = true;
                 bufferPg.configured_profile_name = profileName;

--- a/tests/test_buffer_dynamic.py
+++ b/tests/test_buffer_dynamic.py
@@ -812,6 +812,10 @@ class TestBufferMgrDyn(object):
 
             dvs.runcmd(f"logger -t pytest === configuring Ethernet0|3-4 ===")
             self.config_db.update_entry('BUFFER_PG', 'Ethernet0|3-4', {'profile': 'test'})
+
+            # Make sure the entry has been handled by buffermgrd and is pending on orchagent's queue
+            self.app_db.wait_for_field_match("_BUFFER_PG_TABLE", "Ethernet0:3-4", {"profile": "test"})
+
             # Should not be added due to the maximum headroom exceeded
             dvs.runcmd(f"logger -t pytest === configuring Ethernet0|1 fail ===")
             self.config_db.update_entry('BUFFER_PG', 'Ethernet0|1', {'profile': 'ingress_lossy_profile'})

--- a/tests/test_buffer_dynamic.py
+++ b/tests/test_buffer_dynamic.py
@@ -811,7 +811,7 @@ class TestBufferMgrDyn(object):
             dvs.runcmd("kill -s SIGCONT {}".format(oa_pid))
 
             # Check whether BUFFER_PG_TABLE is updated as expected 
-            self.app_db.wait_for_field_match("_BUFFER_PG_TABLE", "Ethernet0:3-4", {"profile": "test"})
+            self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:3-4", {"profile": "test"})
 
             keys = self.app_db.get_keys('BUFFER_PG_TABLE')
 

--- a/tests/test_buffer_dynamic.py
+++ b/tests/test_buffer_dynamic.py
@@ -803,12 +803,12 @@ class TestBufferMgrDyn(object):
             dvs.runcmd("kill -s SIGSTOP {}".format(oa_pid))
 
             # Create a lossless profile
-            self.config_db.update_entry('BUFFER_PROFILE', 'test',
-                                        {'xon': '19456',
-                                         'xoff': '10240',
-                                         'size': '29696',
-                                         'dynamic_th': '0',
-                                         'pool': 'ingress_lossless_pool'})
+            profile_fvs = {'xon': '19456',
+                          'xoff': '10240',
+                          'size': '29696',
+                          'dynamic_th': '0',
+                          'pool': 'ingress_lossless_pool'}
+            self.config_db.update_entry('BUFFER_PROFILE', 'test', profile_fvs)
 
             dvs.runcmd(f"logger -t pytest === configuring Ethernet0|3-4 ===")
             self.config_db.update_entry('BUFFER_PG', 'Ethernet0|3-4', {'profile': 'test'})
@@ -835,6 +835,12 @@ class TestBufferMgrDyn(object):
 
             assert 'Ethernet0:1' not in keys
             assert 'Ethernet0:6' not in keys
+
+            # Update the profile
+            profile_fvs['size'] = '28672'
+            profile_fvs['xoff'] = '9216'
+            self.config_db.update_entry('BUFFER_PROFILE', 'test', profile_fvs)
+            self.app_db.wait_for_field_match('BUFFER_PROFILE_TABLE', 'test', profile_fvs)
         finally:
             dvs.runcmd("kill -s SIGCONT {}".format(oa_pid))
 

--- a/tests/test_buffer_dynamic.py
+++ b/tests/test_buffer_dynamic.py
@@ -807,14 +807,14 @@ class TestBufferMgrDyn(object):
             # Should not be added due to the maximum headroom exceeded
             self.config_db.update_entry('BUFFER_PG', 'Ethernet0|6', {'profile': 'test'})
 
+            # Resume orchagent
             dvs.runcmd("kill -s SIGCONT {}".format(oa_pid))
-            time.sleep(1)
 
             # Check whether BUFFER_PG_TABLE is updated as expected 
+            self.app_db.wait_for_field_match("_BUFFER_PG_TABLE", "Ethernet0:3-4", {"profile": "test"})
+
             keys = self.app_db.get_keys('BUFFER_PG_TABLE')
 
-            assert 'Ethernet0:3-4' in keys
-            assert 'Ethernet0:0' in keys
             assert 'Ethernet0:1' not in keys
             assert 'Ethernet0:6' not in keys
         finally:

--- a/tests/test_buffer_dynamic.py
+++ b/tests/test_buffer_dynamic.py
@@ -775,6 +775,12 @@ class TestBufferMgrDyn(object):
     def test_bufferPortMaxParameter(self, dvs, testlog):
         self.setup_db(dvs)
 
+        # Update log level so that we can analyze the log in case the test failed
+        logfvs = self.config_db.wait_for_entry("LOGGER", "buffermgrd")
+        old_log_level = logfvs.get("LOGLEVEL")
+        logfvs["LOGLEVEL"] = "INFO"
+        self.config_db.update_entry("LOGGER", "buffermgrd", logfvs)
+
         # Check whether port's maximum parameter has been exposed to STATE_DB
         fvs = self.state_db.wait_for_entry("BUFFER_MAX_PARAM_TABLE", "Ethernet0")
         assert int(fvs["max_queues"]) and int(fvs["max_priority_groups"])
@@ -828,6 +834,10 @@ class TestBufferMgrDyn(object):
             fvs.pop("max_headroom_size")
             self.state_db.delete_entry("BUFFER_MAX_PARAM_TABLE", "Ethernet0")
             self.state_db.update_entry("BUFFER_MAX_PARAM_TABLE", "Ethernet0", fvs)
+
+            if old_log_level:
+                logfvs["LOGLEVEL"] = old_log_level
+                self.config_db.update_entry("LOGGER", "buffermgrd", logfvs)
 
             dvs.port_admin_set('Ethernet0', 'down')
 

--- a/tests/test_buffer_dynamic.py
+++ b/tests/test_buffer_dynamic.py
@@ -788,18 +788,15 @@ class TestBufferMgrDyn(object):
         _, oa_pid = dvs.runcmd("pgrep orchagent")
 
         try:
-            dvs.runcmd(f"logger -t pytest === setting max_headroom_size ===")
             fvs["max_headroom_size"] = "122880"
             self.state_db.update_entry("BUFFER_MAX_PARAM_TABLE", "Ethernet0", fvs)
 
             # Startup interface
-            dvs.runcmd(f"logger -t pytest === starting up interface ===")
             dvs.port_admin_set('Ethernet0', 'up')
             # Wait for the lossy profile to be handled
             self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:0", {"profile": "ingress_lossy_profile"})
 
             # Stop orchagent to simulate the scenario that the system is during initialization
-            dvs.runcmd(f"logger -t pytest === stopping orchagent ===")
             dvs.runcmd("kill -s SIGSTOP {}".format(oa_pid))
 
             # Create a lossless profile
@@ -810,27 +807,22 @@ class TestBufferMgrDyn(object):
                           'pool': 'ingress_lossless_pool'}
             self.config_db.update_entry('BUFFER_PROFILE', 'test', profile_fvs)
 
-            dvs.runcmd(f"logger -t pytest === configuring Ethernet0|3-4 ===")
             self.config_db.update_entry('BUFFER_PG', 'Ethernet0|3-4', {'profile': 'test'})
 
             # Make sure the entry has been handled by buffermgrd and is pending on orchagent's queue
             self.app_db.wait_for_field_match("_BUFFER_PG_TABLE", "Ethernet0:3-4", {"profile": "test"})
 
             # Should not be added due to the maximum headroom exceeded
-            dvs.runcmd(f"logger -t pytest === configuring Ethernet0|1 fail ===")
             self.config_db.update_entry('BUFFER_PG', 'Ethernet0|1', {'profile': 'ingress_lossy_profile'})
             # Should not be added due to the maximum headroom exceeded
-            dvs.runcmd(f"logger -t pytest === configuring Ethernet0|6 fail ===")
             self.config_db.update_entry('BUFFER_PG', 'Ethernet0|6', {'profile': 'test'})
 
             # Resume orchagent
-            dvs.runcmd(f"logger -t pytest === resuming orchagent ===")
             dvs.runcmd("kill -s SIGCONT {}".format(oa_pid))
 
             # Check whether BUFFER_PG_TABLE is updated as expected 
-            dvs.runcmd(f"logger -t pytest === checking Ethernet0:3-4 ===")
             self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:3-4", {"profile": "test"})
-            dvs.runcmd(f"logger -t pytest === checking failing keys ===")
+
             keys = self.app_db.get_keys('BUFFER_PG_TABLE')
 
             assert 'Ethernet0:1' not in keys


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Enhance the logic to check maximum headroom exceeding to cover corner scenarios

Currently, the logic to check the maximum headroom exceeding works well when a user changes any buffer configuration in the dynamic buffer model, preventing all problematic configurations from being applied to the ASIC.
However, it can fail when a problematic configuration is `config_db.json` and `config reload` is executed. To cover this scenario, the following actions need to be done:

1. Take the pending PG keys and buffer profiles into account when calculating the maximum headroom
    - Existing buffer PGs and buffer profiles can be in the pending queue since there are a large number of notifications needed to be handled during system initialization, which takes time.
2. Take the lossy PG into account when calculating the maximum headroom.
    - Non-default lossy PG can be added by the user in `config_db.json`
3. Pass the PG to the Lua plugin when refreshing PGs for a port

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**

Cover corner scenarios.

**How I verified it**

Manual test, vs test, regression test (dynamic buffer)

**Details if related**
