### PR TITLE
[202211]Revert "[EVPN]Fixing race condition when EVPN NVO add comes late (#27…

### DIFF
--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -2353,7 +2353,7 @@ bool EvpnRemoteVnip2pOrch::addOperation(const Request& request)
     {
         SWSS_LOG_WARN("Remote VNI add: Source VTEP not found. remote=%s vid=%d",
                       remote_vtep.c_str(), vlan_id);
-        return false;
+        return true;
     }
 
     VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
@@ -2522,7 +2522,7 @@ bool EvpnRemoteVnip2mpOrch::addOperation(const Request& request)
     {
         SWSS_LOG_WARN("Remote VNI add: Source VTEP not found. remote=%s vid=%d",
                       end_point_ip.c_str(),vlan_id);
-        return false;
+        return true;
     }
 
     if (!gPortsOrch->getVlanByVlanId(vlan_id, vlanPort))
@@ -2602,7 +2602,7 @@ bool EvpnRemoteVnip2mpOrch::delOperation(const Request& request)
     auto vtep_ptr = evpn_orch->getEVPNVtep();
     if (!vtep_ptr)
     {
-        SWSS_LOG_WARN("Remote VNI del: VTEP not found. remote=%s vid=%d",
+        SWSS_LOG_WARN("Remote VNI add: VTEP not found. remote=%s vid=%d",
                       end_point_ip.c_str(), vlan_id);
         return true;
     }

--- a/tests/test_evpn_tunnel.py
+++ b/tests/test_evpn_tunnel.py
@@ -213,51 +213,6 @@ class TestVxlanOrch(object):
         vxlan_obj.remove_vlan(dvs, "100")
         vxlan_obj.remove_vlan(dvs, "101")
 
-    def test_delayed_evpn_nvo(self, dvs, testlog):
-        vxlan_obj = self.get_vxlan_obj()
-
-        tunnel_name = 'tunnel_2'
-        map_name = 'map_1000_100'
-        map_name_1 = 'map_1001_101'
-        vlanlist = ['100']
-        vnilist = ['1000']
-
-        vxlan_obj.fetch_exist_entries(dvs)
-        vxlan_obj.create_vlan1(dvs,"Vlan100")
-        vxlan_obj.create_vlan1(dvs,"Vlan101")
-
-        vxlan_obj.create_vxlan_tunnel(dvs, tunnel_name, '6.6.6.6')
-        vxlan_obj.create_vxlan_tunnel_map(dvs, tunnel_name, map_name_1, '1001', 'Vlan101')
-        vxlan_obj.create_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
-
-        vxlan_obj.check_vxlan_sip_tunnel(dvs, tunnel_name, '6.6.6.6', vlanlist, vnilist, tunnel_map_entry_count = 2)
-        vxlan_obj.check_vxlan_tunnel_map_entry(dvs, tunnel_name, vlanlist, vnilist)
-
-
-        vxlan_obj.create_evpn_remote_vni(dvs, 'Vlan101', '7.7.7.7', '1001')
-        vxlan_obj.check_vxlan_dip_tunnel_not_created(dvs, tunnel_name, '6.6.6.6', '7.7.7.7')
-        vxlan_obj.create_evpn_nvo(dvs, 'nvo1', tunnel_name)
-
-        print("Testing VLAN 101 extension")
-        vxlan_obj.check_vxlan_dip_tunnel(dvs, tunnel_name, '6.6.6.6', '7.7.7.7')
-        vxlan_obj.check_vlan_extension(dvs, '101', '7.7.7.7')
-
-        print("Testing Vlan Extension removal")
-        vxlan_obj.remove_evpn_remote_vni(dvs, 'Vlan101', '7.7.7.7')
-        vxlan_obj.check_vlan_extension_delete(dvs, '101', '7.7.7.7')
-        vxlan_obj.check_vxlan_dip_tunnel_delete(dvs, '7.7.7.7')
-
-        vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
-        vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name_1, '1001', 'Vlan101')
-        vxlan_obj.check_vxlan_tunnel_map_entry_delete(dvs, tunnel_name, vlanlist, vnilist)
-
-        print("Testing SIP Tunnel Deletion")
-        vxlan_obj.remove_evpn_nvo(dvs, 'nvo1')
-        vxlan_obj.remove_vxlan_tunnel(dvs, tunnel_name)
-        vxlan_obj.check_vxlan_sip_tunnel_delete(dvs, tunnel_name, '6.6.6.6')
-        vxlan_obj.remove_vlan(dvs, "100")
-        vxlan_obj.remove_vlan(dvs, "101")
-
     def test_invalid_vlan_extension(self, dvs, testlog):
         vxlan_obj = self.get_vxlan_obj()
 

--- a/tests/test_evpn_tunnel_p2mp.py
+++ b/tests/test_evpn_tunnel_p2mp.py
@@ -172,49 +172,6 @@ class TestVxlanOrchP2MP(object):
         vxlan_obj.remove_vlan(dvs, "100")
         vxlan_obj.remove_vlan(dvs, "101")
 
-    def test_delayed_evpn_nvo(self, dvs, testlog):
-        vxlan_obj = self.get_vxlan_obj()
-
-        tunnel_name = 'tunnel_2'
-        map_name = 'map_1000_100'
-        map_name_1 = 'map_1001_101'
-        vlanlist = ['100']
-        vnilist = ['1000']
-
-        vxlan_obj.fetch_exist_entries(dvs)
-        vxlan_obj.create_vlan1(dvs,"Vlan100")
-        vxlan_obj.create_vlan1(dvs,"Vlan101")
-
-        vxlan_obj.create_vxlan_tunnel(dvs, tunnel_name, '6.6.6.6')
-        vxlan_obj.create_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
-        vxlan_obj.create_vxlan_tunnel_map(dvs, tunnel_name, map_name_1, '1001', 'Vlan101')
-        vxlan_obj.create_evpn_remote_vni(dvs, 'Vlan101', '7.7.7.7', '1001')
-
-        vxlan_obj.check_vxlan_sip_tunnel(dvs, tunnel_name, '6.6.6.6', vlanlist, vnilist, ignore_bp=False, tunnel_map_entry_count = 2)
-        vxlan_obj.check_vxlan_tunnel_map_entry(dvs, tunnel_name, vlanlist, vnilist)
-
-
-        vxlan_obj.check_vlan_extension_not_created_p2mp(dvs, '101', '6.6.6.6', '7.7.7.7')
-        vxlan_obj.create_evpn_nvo(dvs, 'nvo1', tunnel_name)
-
-        print("Testing VLAN 101 extension")
-        vxlan_obj.check_vlan_extension_p2mp(dvs, '101', '6.6.6.6', '7.7.7.7')
-
-        print("Testing Vlan Extension removal")
-        vxlan_obj.remove_evpn_remote_vni(dvs, 'Vlan101', '7.7.7.7')
-        vxlan_obj.check_vlan_extension_delete_p2mp(dvs, '101', '6.6.6.6', '7.7.7.7')
-
-        vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
-        vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name_1, '1001', 'Vlan101')
-        vxlan_obj.check_vxlan_tunnel_map_entry_delete(dvs, tunnel_name, vlanlist, vnilist)
-
-        print("Testing SIP Tunnel Deletion")
-        vxlan_obj.remove_evpn_nvo(dvs, 'nvo1')
-        vxlan_obj.remove_vxlan_tunnel(dvs, tunnel_name)
-        vxlan_obj.check_vxlan_sip_tunnel_delete(dvs, tunnel_name, '6.6.6.6', ignore_bp=False)
-        vxlan_obj.remove_vlan(dvs, "100")
-        vxlan_obj.remove_vlan(dvs, "101")
-
     def test_invalid_vlan_extension(self, dvs, testlog):
         vxlan_obj = self.get_vxlan_obj()
 


### PR DESCRIPTION


This reverts commit a484ab8684c45d56340bbb3a704ae6ca039e9282.
Reverts the PR https://github.com/sonic-net/sonic-swss/pull/2757

The fix added breaks the previously added workaround https://github.com/sonic-net/sonic-swss/pull/2626. Hence requesting to revert the fix.
Once we find a proper solution for https://github.com/sonic-net/sonic-buildimage/issues/12361 we need to reintegrate this PR
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
