### PR TITLE
[dash] Change dash orchagent from Redis consumer state table to ZMQ consumer state table.

### DIFF
--- a/orchagent/dash/dashaclorch.cpp
+++ b/orchagent/dash/dashaclorch.cpp
@@ -285,8 +285,8 @@ sai_attr_id_t getSaiStage(DashAclDirection d, sai_ip_addr_family_t f, DashAclSta
     return stage->second;
 }
 
-DashAclOrch::DashAclOrch(DBConnector *db, const vector<string> &tables, DashOrch *dash_orch) :
-    Orch(db, tables),
+DashAclOrch::DashAclOrch(DBConnector *db, const vector<string> &tables, DashOrch *dash_orch, ZmqServer *zmqServer) :
+    Orch(db, tables, zmqServer),
     m_dash_orch(dash_orch)
 {
     SWSS_LOG_ENTER();
@@ -294,7 +294,7 @@ DashAclOrch::DashAclOrch(DBConnector *db, const vector<string> &tables, DashOrch
     assert(m_dash_orch);
 }
 
-void DashAclOrch::doTask(Consumer &consumer)
+void DashAclOrch::doTask(ZmqConsumer &consumer)
 {
     SWSS_LOG_ENTER();
 

--- a/orchagent/dash/dashaclorch.cpp
+++ b/orchagent/dash/dashaclorch.cpp
@@ -286,7 +286,7 @@ sai_attr_id_t getSaiStage(DashAclDirection d, sai_ip_addr_family_t f, DashAclSta
 }
 
 DashAclOrch::DashAclOrch(DBConnector *db, const vector<string> &tables, DashOrch *dash_orch, ZmqServer *zmqServer) :
-    Orch(db, tables, zmqServer),
+    ZmqOrch(db, tables, zmqServer),
     m_dash_orch(dash_orch)
 {
     SWSS_LOG_ENTER();

--- a/orchagent/dash/dashaclorch.h
+++ b/orchagent/dash/dashaclorch.h
@@ -65,7 +65,7 @@ using DashAclTable = std::unordered_map<std::string, DashAclEntry>;
 using DashAclGroupTable = std::unordered_map<std::string, DashAclGroupEntry>;
 using DashAclRuleTable = std::unordered_map<std::string, DashAclRuleEntry>;
 
-class DashAclOrch : public Orch
+class DashAclOrch : public ZmqOrch
 {
 public:
     using TaskArgs = std::vector<swss::FieldValueTuple>;

--- a/orchagent/dash/dashaclorch.h
+++ b/orchagent/dash/dashaclorch.h
@@ -13,6 +13,7 @@
 #include <dbconnector.h>
 #include <bulker.h>
 #include <orch.h>
+#include "zmqserver.h"
 
 #include "dashorch.h"
 
@@ -69,10 +70,10 @@ class DashAclOrch : public Orch
 public:
     using TaskArgs = std::vector<swss::FieldValueTuple>;
 
-    DashAclOrch(swss::DBConnector *db, const std::vector<std::string> &tables, DashOrch *dash_orch);
+    DashAclOrch(swss::DBConnector *db, const std::vector<std::string> &tables, DashOrch *dash_orch, swss::ZmqServer *zmqServer);
 
 private:
-    void doTask(Consumer &consumer);
+    void doTask(ZmqConsumer &consumer);
 
     task_process_status taskUpdateDashAclIn(
         const std::string &key,

--- a/orchagent/dash/dashorch.cpp
+++ b/orchagent/dash/dashorch.cpp
@@ -29,7 +29,7 @@ extern sai_object_id_t gSwitchId;
 extern size_t gMaxBulkSize;
 extern CrmOrch *gCrmOrch;
 
-DashOrch::DashOrch(DBConnector *db, vector<string> &tableName, ZmqServer *zmqServer) : Orch(db, tableName, zmqServer)
+DashOrch::DashOrch(DBConnector *db, vector<string> &tableName, ZmqServer *zmqServer) : ZmqOrch(db, tableName, zmqServer)
 {
     SWSS_LOG_ENTER();
 }

--- a/orchagent/dash/dashorch.cpp
+++ b/orchagent/dash/dashorch.cpp
@@ -29,7 +29,7 @@ extern sai_object_id_t gSwitchId;
 extern size_t gMaxBulkSize;
 extern CrmOrch *gCrmOrch;
 
-DashOrch::DashOrch(DBConnector *db, vector<string> &tableName) : Orch(db, tableName)
+DashOrch::DashOrch(DBConnector *db, vector<string> &tableName, ZmqServer *zmqServer) : Orch(db, tableName, zmqServer)
 {
     SWSS_LOG_ENTER();
 }
@@ -132,7 +132,7 @@ bool DashOrch::removeApplianceEntry(const string& appliance_id)
     return true;
 }
 
-void DashOrch::doTaskApplianceTable(Consumer& consumer)
+void DashOrch::doTaskApplianceTable(ZmqConsumer& consumer)
 {
     SWSS_LOG_ENTER();
 
@@ -218,7 +218,7 @@ bool DashOrch::removeRoutingTypeEntry(const string& routing_type)
     return true;
 }
 
-void DashOrch::doTaskRoutingTypeTable(Consumer& consumer)
+void DashOrch::doTaskRoutingTypeTable(ZmqConsumer& consumer)
 {
     SWSS_LOG_ENTER();
 
@@ -529,7 +529,7 @@ bool DashOrch::removeEni(const string& eni)
     return true;
 }
 
-void DashOrch::doTaskEniTable(Consumer& consumer)
+void DashOrch::doTaskEniTable(ZmqConsumer& consumer)
 {
     SWSS_LOG_ENTER();
 
@@ -624,7 +624,7 @@ bool DashOrch::removeQosEntry(const string& qos_name)
     return true;
 }
 
-void DashOrch::doTaskQosTable(Consumer& consumer)
+void DashOrch::doTaskQosTable(ZmqConsumer& consumer)
 {
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
@@ -684,7 +684,7 @@ void DashOrch::doTaskQosTable(Consumer& consumer)
     }
 }
 
-void DashOrch::doTask(Consumer& consumer)
+void DashOrch::doTask(ZmqConsumer& consumer)
 {
     SWSS_LOG_ENTER();
 

--- a/orchagent/dash/dashorch.h
+++ b/orchagent/dash/dashorch.h
@@ -53,7 +53,7 @@ typedef std::map<std::string, RoutingTypeEntry> RoutingTypeTable;
 typedef std::map<std::string, EniEntry> EniTable;
 typedef std::map<std::string, QosEntry> QosTable;
 
-class DashOrch : public Orch
+class DashOrch : public ZmqOrch
 {
 public:
     DashOrch(swss::DBConnector *db, std::vector<std::string> &tables, swss::ZmqServer *zmqServer);

--- a/orchagent/dash/dashorch.h
+++ b/orchagent/dash/dashorch.h
@@ -14,7 +14,7 @@
 #include "macaddress.h"
 #include "timer.h"
 #include "dashorch.h"
-#include "saihelper.h"
+#include "zmqserver.h"
 
 struct ApplianceEntry
 {
@@ -56,7 +56,7 @@ typedef std::map<std::string, QosEntry> QosTable;
 class DashOrch : public Orch
 {
 public:
-    DashOrch(swss::DBConnector *db, std::vector<std::string> &tables);
+    DashOrch(swss::DBConnector *db, std::vector<std::string> &tables, swss::ZmqServer *zmqServer);
     const EniEntry *getEni(const std::string &eni) const;
 
 private:
@@ -64,11 +64,11 @@ private:
     RoutingTypeTable routing_type_entries_;
     EniTable eni_entries_;
     QosTable qos_entries_;
-    void doTask(Consumer &consumer);
-    void doTaskApplianceTable(Consumer &consumer);
-    void doTaskRoutingTypeTable(Consumer &consumer);
-    void doTaskEniTable(Consumer &consumer);
-    void doTaskQosTable(Consumer &consumer);
+    void doTask(ZmqConsumer &consumer);
+    void doTaskApplianceTable(ZmqConsumer &consumer);
+    void doTaskRoutingTypeTable(ZmqConsumer &consumer);
+    void doTaskEniTable(ZmqConsumer &consumer);
+    void doTaskQosTable(ZmqConsumer &consumer);
     bool addApplianceEntry(const std::string& appliance_id, const ApplianceEntry &entry);
     bool removeApplianceEntry(const std::string& appliance_id);
     bool addRoutingTypeEntry(const std::string& routing_type, const RoutingTypeEntry &entry);

--- a/orchagent/dash/dashrouteorch.cpp
+++ b/orchagent/dash/dashrouteorch.cpp
@@ -41,7 +41,7 @@ static std::unordered_map<std::string, sai_outbound_routing_entry_action_t> sOut
 DashRouteOrch::DashRouteOrch(DBConnector *db, vector<string> &tableName, DashOrch *dash_orch, ZmqServer *zmqServer) :
     outbound_routing_bulker_(sai_dash_outbound_routing_api, gMaxBulkSize),
     inbound_routing_bulker_(sai_dash_inbound_routing_api, gMaxBulkSize),
-    Orch(db, tableName, zmqServer),
+    ZmqOrch(db, tableName, zmqServer),
     dash_orch_(dash_orch)
 {
     SWSS_LOG_ENTER();

--- a/orchagent/dash/dashrouteorch.cpp
+++ b/orchagent/dash/dashrouteorch.cpp
@@ -38,10 +38,10 @@ static std::unordered_map<std::string, sai_outbound_routing_entry_action_t> sOut
     { "drop", SAI_OUTBOUND_ROUTING_ENTRY_ACTION_DROP }
 };
 
-DashRouteOrch::DashRouteOrch(DBConnector *db, vector<string> &tableName, DashOrch *dash_orch) :
+DashRouteOrch::DashRouteOrch(DBConnector *db, vector<string> &tableName, DashOrch *dash_orch, ZmqServer *zmqServer) :
     outbound_routing_bulker_(sai_dash_outbound_routing_api, gMaxBulkSize),
     inbound_routing_bulker_(sai_dash_inbound_routing_api, gMaxBulkSize),
-    Orch(db, tableName),
+    Orch(db, tableName, zmqServer),
     dash_orch_(dash_orch)
 {
     SWSS_LOG_ENTER();
@@ -197,7 +197,7 @@ bool DashRouteOrch::removeOutboundRoutingPost(const string& key, const OutboundR
     return true;
 }
 
-void DashRouteOrch::doTaskRouteTable(Consumer& consumer)
+void DashRouteOrch::doTaskRouteTable(ZmqConsumer& consumer)
 {
     SWSS_LOG_ENTER();
 
@@ -481,7 +481,7 @@ bool DashRouteOrch::removeInboundRoutingPost(const string& key, const InboundRou
     return true;
 }
 
-void DashRouteOrch::doTaskRouteRuleTable(Consumer& consumer)
+void DashRouteOrch::doTaskRouteRuleTable(ZmqConsumer& consumer)
 {
     SWSS_LOG_ENTER();
 
@@ -626,7 +626,7 @@ void DashRouteOrch::doTaskRouteRuleTable(Consumer& consumer)
     }
 }
 
-void DashRouteOrch::doTask(Consumer& consumer)
+void DashRouteOrch::doTask(ZmqConsumer& consumer)
 {
     SWSS_LOG_ENTER();
 

--- a/orchagent/dash/dashrouteorch.h
+++ b/orchagent/dash/dashrouteorch.h
@@ -78,7 +78,7 @@ struct InboundRoutingBulkContext
     }
 };
 
-class DashRouteOrch : public Orch
+class DashRouteOrch : public ZmqOrch
 {
 public:
     DashRouteOrch(swss::DBConnector *db, std::vector<std::string> &tables, DashOrch *dash_orch, swss::ZmqServer *zmqServer);

--- a/orchagent/dash/dashrouteorch.h
+++ b/orchagent/dash/dashrouteorch.h
@@ -13,6 +13,7 @@
 #include "macaddress.h"
 #include "timer.h"
 #include "dashorch.h"
+#include "zmqserver.h"
 
 struct OutboundRoutingEntry
 {
@@ -80,7 +81,7 @@ struct InboundRoutingBulkContext
 class DashRouteOrch : public Orch
 {
 public:
-    DashRouteOrch(swss::DBConnector *db, std::vector<std::string> &tables, DashOrch *dash_orch);
+    DashRouteOrch(swss::DBConnector *db, std::vector<std::string> &tables, DashOrch *dash_orch, swss::ZmqServer *zmqServer);
 
 private:
     RoutingTable routing_entries_;
@@ -89,9 +90,9 @@ private:
     EntityBulker<sai_dash_inbound_routing_api_t> inbound_routing_bulker_;
     DashOrch *dash_orch_;
 
-    void doTask(Consumer &consumer);
-    void doTaskRouteTable(Consumer &consumer);
-    void doTaskRouteRuleTable(Consumer &consumer);
+    void doTask(ZmqConsumer &consumer);
+    void doTaskRouteTable(ZmqConsumer &consumer);
+    void doTaskRouteRuleTable(ZmqConsumer &consumer);
     bool addOutboundRouting(const std::string& key, OutboundRoutingBulkContext& ctxt);
     bool addOutboundRoutingPost(const std::string& key, const OutboundRoutingBulkContext& ctxt);
     bool removeOutboundRouting(const std::string& key, OutboundRoutingBulkContext& ctxt);

--- a/orchagent/dash/dashvnetorch.cpp
+++ b/orchagent/dash/dashvnetorch.cpp
@@ -32,11 +32,11 @@ extern sai_object_id_t gSwitchId;
 extern size_t gMaxBulkSize;
 extern CrmOrch *gCrmOrch;
 
-DashVnetOrch::DashVnetOrch(DBConnector *db, vector<string> &tables) :
+DashVnetOrch::DashVnetOrch(DBConnector *db, vector<string> &tables, ZmqServer *zmqServer) :
     vnet_bulker_(sai_dash_vnet_api, gSwitchId, gMaxBulkSize),
     outbound_ca_to_pa_bulker_(sai_dash_outbound_ca_to_pa_api, gMaxBulkSize),
     pa_validation_bulker_(sai_dash_pa_validation_api, gMaxBulkSize),
-    Orch(db, tables)
+    Orch(db, tables, zmqServer)
 {
     SWSS_LOG_ENTER();
 }
@@ -150,7 +150,7 @@ bool DashVnetOrch::removeVnetPost(const string& vnet_name, const DashVnetBulkCon
     return true;
 }
 
-void DashVnetOrch::doTaskVnetTable(Consumer& consumer)
+void DashVnetOrch::doTaskVnetTable(ZmqConsumer& consumer)
 {
     SWSS_LOG_ENTER();
 
@@ -628,7 +628,7 @@ bool DashVnetOrch::removeVnetMapPost(const string& key, const VnetMapBulkContext
     return true;
 }
 
-void DashVnetOrch::doTaskVnetMapTable(Consumer& consumer)
+void DashVnetOrch::doTaskVnetMapTable(ZmqConsumer& consumer)
 {
     SWSS_LOG_ENTER();
 
@@ -776,7 +776,7 @@ void DashVnetOrch::doTaskVnetMapTable(Consumer& consumer)
     }
 }
 
-void DashVnetOrch::doTask(Consumer &consumer)
+void DashVnetOrch::doTask(ZmqConsumer &consumer)
 {
     SWSS_LOG_ENTER();
 

--- a/orchagent/dash/dashvnetorch.cpp
+++ b/orchagent/dash/dashvnetorch.cpp
@@ -36,7 +36,7 @@ DashVnetOrch::DashVnetOrch(DBConnector *db, vector<string> &tables, ZmqServer *z
     vnet_bulker_(sai_dash_vnet_api, gSwitchId, gMaxBulkSize),
     outbound_ca_to_pa_bulker_(sai_dash_outbound_ca_to_pa_api, gMaxBulkSize),
     pa_validation_bulker_(sai_dash_pa_validation_api, gMaxBulkSize),
-    Orch(db, tables, zmqServer)
+    ZmqOrch(db, tables, zmqServer)
 {
     SWSS_LOG_ENTER();
 }

--- a/orchagent/dash/dashvnetorch.h
+++ b/orchagent/dash/dashvnetorch.h
@@ -11,6 +11,7 @@
 #include "ipaddresses.h"
 #include "macaddress.h"
 #include "timer.h"
+#include "zmqserver.h"
 
 struct VnetEntry
 {
@@ -78,7 +79,7 @@ struct VnetMapBulkContext
 class DashVnetOrch : public Orch
 {
 public:
-    DashVnetOrch(swss::DBConnector *db, std::vector<std::string> &tables);
+    DashVnetOrch(swss::DBConnector *db, std::vector<std::string> &tables, swss::ZmqServer *zmqServer);
 
 private:
     DashVnetTable vnet_table_;
@@ -88,9 +89,9 @@ private:
     EntityBulker<sai_dash_outbound_ca_to_pa_api_t> outbound_ca_to_pa_bulker_;
     EntityBulker<sai_dash_pa_validation_api_t> pa_validation_bulker_;
 
-    void doTask(Consumer &consumer);
-    void doTaskVnetTable(Consumer &consumer);
-    void doTaskVnetMapTable(Consumer &consumer);
+    void doTask(ZmqConsumer &consumer);
+    void doTaskVnetTable(ZmqConsumer &consumer);
+    void doTaskVnetMapTable(ZmqConsumer &consumer);
     bool addVnet(const std::string& key, DashVnetBulkContext& ctxt);
     bool addVnetPost(const std::string& key, const DashVnetBulkContext& ctxt);
     bool removeVnet(const std::string& key, DashVnetBulkContext& ctxt);

--- a/orchagent/dash/dashvnetorch.h
+++ b/orchagent/dash/dashvnetorch.h
@@ -76,7 +76,7 @@ struct VnetMapBulkContext
     }
 };
 
-class DashVnetOrch : public Orch
+class DashVnetOrch : public ZmqOrch
 {
 public:
     DashVnetOrch(swss::DBConnector *db, std::vector<std::string> &tables, swss::ZmqServer *zmqServer);

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -83,7 +83,7 @@ string gMyAsicName = "";
 
 void usage()
 {
-    cout << "usage: orchagent [-h] [-r record_type] [-d record_location] [-f swss_rec_filename] [-j sairedis_rec_filename] [-b batch_size] [-m MAC] [-i INST_ID] [-s] [-z mode] [-k bulk_size]" << endl;
+    cout << "usage: orchagent [-h] [-r record_type] [-d record_location] [-f swss_rec_filename] [-j sairedis_rec_filename] [-b batch_size] [-m MAC] [-i INST_ID] [-s] [-z mode] [-k bulk_size] [-q zmq_server_address]" << endl;
     cout << "    -h: display this message" << endl;
     cout << "    -r record_type: record orchagent logs with type (default 3)" << endl;
     cout << "                    Bit 0: sairedis.rec, Bit 1: swss.rec, Bit 2: responsepublisher.rec. For example:" << endl;
@@ -101,6 +101,7 @@ void usage()
     cout << "    -f swss_rec_filename: swss record log filename(default 'swss.rec')" << endl;
     cout << "    -j sairedis_rec_filename: sairedis record log filename(default sairedis.rec)" << endl;
     cout << "    -k max bulk size in bulk mode (default 1000)" << endl;
+    cout << "    -q zmq_server_address: ZMQ server address (default tcp://*:1234)" << endl;
 }
 
 void sighup_handler(int signo)
@@ -349,6 +350,7 @@ int main(int argc, char **argv)
     string record_location = ".";
     string swss_rec_filename = "swss.rec";
     string sairedis_rec_filename = "sairedis.rec";
+    string zmq_server_address = "tcp://*:1234";
     string responsepublisher_rec_filename = "responsepublisher.rec";
     int record_type = 3; // Only swss and sairedis recordings enabled by default.
 
@@ -430,6 +432,12 @@ int main(int argc, char **argv)
                 }
             }
             break;
+        case 'q':
+            if (optarg)
+            {
+                zmq_server_address = optarg;
+            }
+            break;
         default: /* '?' */
             exit(EXIT_FAILURE);
         }
@@ -444,6 +452,10 @@ int main(int argc, char **argv)
     DBConnector appl_db("APPL_DB", 0);
     DBConnector config_db("CONFIG_DB", 0);
     DBConnector state_db("STATE_DB", 0);
+
+    // Instantiate ZMQ server 
+    SWSS_LOG_NOTICE("[ZMQ] Instantiate ZMQ server : %s", zmq_server_address.c_str());
+    ZmqServer zmq_server(zmq_server_address.c_str());
 
     // Get switch_type
     getCfgSwitchType(&config_db, gMySwitchType);
@@ -724,7 +736,7 @@ int main(int argc, char **argv)
     shared_ptr<OrchDaemon> orchDaemon;
     if (gMySwitchType != "fabric")
     {
-        orchDaemon = make_shared<OrchDaemon>(&appl_db, &config_db, &state_db, chassis_app_db.get());
+        orchDaemon = make_shared<OrchDaemon>(&appl_db, &config_db, &state_db, chassis_app_db.get(), &zmq_server);
         if (gMySwitchType == "voq")
         {
             orchDaemon->setFabricEnabled(true);
@@ -735,7 +747,7 @@ int main(int argc, char **argv)
     }
     else
     {
-        orchDaemon = make_shared<FabricOrchDaemon>(&appl_db, &config_db, &state_db, chassis_app_db.get());
+        orchDaemon = make_shared<FabricOrchDaemon>(&appl_db, &config_db, &state_db, chassis_app_db.get(), &zmq_server);
     }
 
     if (!orchDaemon->init())

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -350,7 +350,7 @@ int main(int argc, char **argv)
     string record_location = ".";
     string swss_rec_filename = "swss.rec";
     string sairedis_rec_filename = "sairedis.rec";
-    string zmq_server_address = "tcp://*:1234";
+    string zmq_server_address = "tcp://*:" + to_string(DASH_ORCH_ZMQ_PORT);
     string responsepublisher_rec_filename = "responsepublisher.rec";
     int record_type = 3; // Only swss and sairedis recordings enabled by default.
 

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -31,7 +31,6 @@ extern "C" {
 #include <signal.h>
 #include "warm_restart.h"
 #include "gearboxutils.h"
-#include "schema.h"
 
 using namespace std;
 using namespace swss;

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -101,7 +101,7 @@ void usage()
     cout << "    -f swss_rec_filename: swss record log filename(default 'swss.rec')" << endl;
     cout << "    -j sairedis_rec_filename: sairedis record log filename(default sairedis.rec)" << endl;
     cout << "    -k max bulk size in bulk mode (default 1000)" << endl;
-    cout << "    -q zmq_server_address: ZMQ server address (default tcp://*:1234)" << endl;
+    cout << "    -q zmq_server_address: ZMQ server address (default tcp://*:8020)" << endl;
 }
 
 void sighup_handler(int signo)
@@ -350,7 +350,7 @@ int main(int argc, char **argv)
     string record_location = ".";
     string swss_rec_filename = "swss.rec";
     string sairedis_rec_filename = "sairedis.rec";
-    string zmq_server_address = "tcp://*:" + to_string(DASH_ORCH_ZMQ_PORT);
+    string zmq_server_address = "tcp://*:" + to_string(ORCH_ZMQ_PORT);
     string responsepublisher_rec_filename = "responsepublisher.rec";
     int record_type = 3; // Only swss and sairedis recordings enabled by default.
 

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -101,7 +101,7 @@ void usage()
     cout << "    -f swss_rec_filename: swss record log filename(default 'swss.rec')" << endl;
     cout << "    -j sairedis_rec_filename: sairedis record log filename(default sairedis.rec)" << endl;
     cout << "    -k max bulk size in bulk mode (default 1000)" << endl;
-    cout << "    -q zmq_server_address: ZMQ server address (default tcp://*:8020)" << endl;
+    cout << "    -q zmq_server_address: ZMQ server address (default tcp://127.0.0.1:8020)" << endl;
 }
 
 void sighup_handler(int signo)
@@ -350,7 +350,7 @@ int main(int argc, char **argv)
     string record_location = ".";
     string swss_rec_filename = "swss.rec";
     string sairedis_rec_filename = "sairedis.rec";
-    string zmq_server_address = "tcp://*:" + to_string(ORCH_ZMQ_PORT);
+    string zmq_server_address = "tcp://127.0.0.1:" + to_string(ORCH_ZMQ_PORT);
     string responsepublisher_rec_filename = "responsepublisher.rec";
     int record_type = 3; // Only swss and sairedis recordings enabled by default.
 

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -31,6 +31,7 @@ extern "C" {
 #include <signal.h>
 #include "warm_restart.h"
 #include "gearboxutils.h"
+#include "schema.h"
 
 using namespace std;
 using namespace swss;
@@ -454,7 +455,7 @@ int main(int argc, char **argv)
     DBConnector state_db("STATE_DB", 0);
 
     // Instantiate ZMQ server 
-    SWSS_LOG_NOTICE("[ZMQ] Instantiate ZMQ server : %s", zmq_server_address.c_str());
+    SWSS_LOG_NOTICE("Instantiate ZMQ server : %s", zmq_server_address.c_str());
     ZmqServer zmq_server(zmq_server_address.c_str());
 
     // Get switch_type

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -299,7 +299,19 @@ void ConsumerBase::drain_impl()
 
 void Consumer::execute()
 {
-    ConsumerBase::execute_impl<swss::ConsumerTableBase>();
+    // ConsumerBase::execute_impl<swss::ConsumerTableBase>();
+    SWSS_LOG_ENTER();
+
+    size_t update_size = 0;
+    auto table = static_cast<swss::ConsumerTableBase *>(getSelectable());
+    do
+    {
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        table->pops(entries);
+        update_size = addToSync(entries);
+    } while (update_size != 0);
+
+    drain();
 }
 
 void Consumer::drain()

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -272,14 +272,6 @@ void ConsumerBase::dumpPendingTasks(vector<string> &ts)
     }
 }
 
-template<class ORCH_T, class CONSUMER_T>
-void ConsumerBase::drain_impl()
-{
-    if (!m_toSync.empty())
-        ((ORCH_T *)m_orch)->doTask((CONSUMER_T&)*this);
-}
-
-
 void Consumer::execute()
 {
     // ConsumerBase::execute_impl<swss::ConsumerTableBase>();
@@ -299,7 +291,8 @@ void Consumer::execute()
 
 void Consumer::drain()
 {
-    ConsumerBase::drain_impl<Orch, Consumer>();
+    if (!m_toSync.empty())
+        ((Orch *)m_orch)->doTask((Consumer&)*this);
 }
 
 void ZmqConsumer::execute()
@@ -321,7 +314,8 @@ void ZmqConsumer::execute()
 
 void ZmqConsumer::drain()
 {
-    ConsumerBase::drain_impl<ZmqOrch, ZmqConsumer>();
+    if (!m_toSync.empty())
+        ((ZmqOrch *)m_orch)->doTask((ZmqConsumer&)*this);
 }
 
 size_t Orch::addExistingData(const string& tableName)

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -25,24 +25,24 @@ extern ofstream gRecordOfs;
 extern bool gLogRotate;
 extern string gRecordFile;
 
-Orch::Orch(DBConnector *db, const string tableName, int pri, ZmqServer *zmqServer)
+Orch::Orch(DBConnector *db, const string tableName, int pri)
 {
-    addConsumer(db, tableName, pri, zmqServer);
+    addConsumer(db, tableName, pri);
 }
 
-Orch::Orch(DBConnector *db, const vector<string> &tableNames, ZmqServer *zmqServer)
+Orch::Orch(DBConnector *db, const vector<string> &tableNames)
 {
     for (auto it : tableNames)
     {
-        addConsumer(db, it, default_orch_pri, zmqServer);
+        addConsumer(db, it, default_orch_pri);
     }
 }
 
-Orch::Orch(DBConnector *db, const vector<table_name_with_pri_t> &tableNames_with_pri, ZmqServer *zmqServer)
+Orch::Orch(DBConnector *db, const vector<table_name_with_pri_t> &tableNames_with_pri)
 {
     for (const auto& it : tableNames_with_pri)
     {
-        addConsumer(db, it.first, it.second, zmqServer);
+        addConsumer(db, it.first, it.second);
     }
 }
 
@@ -54,11 +54,39 @@ Orch::Orch(const vector<TableConnector>& tables)
     }
 }
 
+Orch::Orch()
+{
+}
+
 Orch::~Orch()
 {
     if (gRecordOfs.is_open())
     {
         gRecordOfs.close();
+    }
+}
+
+ZmqOrch::ZmqOrch(DBConnector *db, const string tableName, int pri, ZmqServer *zmqServer)
+: Orch()
+{
+    addConsumer(db, tableName, pri, zmqServer);
+}
+
+ZmqOrch::ZmqOrch(DBConnector *db, const vector<string> &tableNames, ZmqServer *zmqServer)
+: Orch()
+{
+    for (auto it : tableNames)
+    {
+        addConsumer(db, it, default_orch_pri, zmqServer);
+    }
+}
+
+ZmqOrch::ZmqOrch(DBConnector *db, const vector<table_name_with_pri_t> &tableNames_with_pri, ZmqServer *zmqServer)
+: Orch()
+{
+    for (const auto& it : tableNames_with_pri)
+    {
+        addConsumer(db, it.first, it.second, zmqServer);
     }
 }
 
@@ -244,12 +272,13 @@ void ConsumerBase::dumpPendingTasks(vector<string> &ts)
     }
 }
 
-void Consumer::execute()
+template<class SELECTABLE_T>
+void ConsumerBase::execute_impl()
 {
     SWSS_LOG_ENTER();
 
     size_t update_size = 0;
-    auto table = static_cast<swss::ConsumerTableBase *>(getSelectable());
+    auto table = static_cast<SELECTABLE_T *>(getSelectable());
     do
     {
         std::deque<KeyOpFieldsValuesTuple> entries;
@@ -258,34 +287,34 @@ void Consumer::execute()
     } while (update_size != 0);
 
     drain();
+}
+
+template<class CONSUMER_T>
+void ConsumerBase::drain_impl()
+{
+    if (!m_toSync.empty())
+        m_orch->doTask((CONSUMER_T&)*this);
+}
+
+
+void Consumer::execute()
+{
+    ConsumerBase::execute_impl<swss::ConsumerTableBase>();
 }
 
 void Consumer::drain()
 {
-    if (!m_toSync.empty())
-        m_orch->doTask(*this);
+    ConsumerBase::drain_impl<Consumer>();
 }
 
 void ZmqConsumer::execute()
 {
-    SWSS_LOG_ENTER();
-
-    size_t update_size = 0;
-    auto table = static_cast<swss::ZmqConsumerStateTable *>(getSelectable());
-    do
-    {
-        std::deque<KeyOpFieldsValuesTuple> entries;
-        table->pops(entries);
-        update_size = addToSync(entries);
-    } while (update_size != 0);
-
-    drain();
+    ConsumerBase::execute_impl<swss::ZmqConsumerStateTable>();
 }
 
 void ZmqConsumer::drain()
 {
-    if (!m_toSync.empty())
-        m_orch->doTask(*this);
+    ConsumerBase::drain_impl<ZmqConsumer>();
 }
 
 size_t Orch::addExistingData(const string& tableName)
@@ -848,27 +877,28 @@ bool Orch::isItemIdsMapContinuous(unsigned long idsMap, sai_uint32_t maxId)
     return true;
 }
 
-void Orch::addConsumer(DBConnector *db, string tableName, int pri, ZmqServer *zmqServer)
+void Orch::addConsumer(DBConnector *db, string tableName, int pri)
 {
-    if (zmqServer != nullptr)
-    {
-        if (db->getDbId() == APPL_DB)
-        {
-            SWSS_LOG_DEBUG("[ZMQ] ZmqConsumer initialize for: %s", tableName.c_str());
-            addExecutor(new ZmqConsumer(new ZmqConsumerStateTable(db, tableName, *zmqServer, gBatchSize, pri), this, tableName));
-        }
-        else
-        {
-            SWSS_LOG_WARN("ZmqConsumer not enabled for consumer db: %d, table: %s", db->getDbId(), tableName.c_str());
-        }
-    }
-    else if (db->getDbId() == CONFIG_DB || db->getDbId() == STATE_DB || db->getDbId() == CHASSIS_APP_DB)
+    if (db->getDbId() == CONFIG_DB || db->getDbId() == STATE_DB || db->getDbId() == CHASSIS_APP_DB)
     {
         addExecutor(new Consumer(new SubscriberStateTable(db, tableName, TableConsumable::DEFAULT_POP_BATCH_SIZE, pri), this, tableName));
     }
     else
     {
         addExecutor(new Consumer(new ConsumerStateTable(db, tableName, gBatchSize, pri), this, tableName));
+    }
+}
+
+void ZmqOrch::addConsumer(DBConnector *db, string tableName, int pri, ZmqServer *zmqServer)
+{
+    if (db->getDbId() == APPL_DB)
+    {
+        SWSS_LOG_DEBUG("[ZMQ] ZmqConsumer initialize for: %s", tableName.c_str());
+        addExecutor(new ZmqConsumer(new ZmqConsumerStateTable(db, tableName, *zmqServer, gBatchSize, pri), this, tableName));
+    }
+    else
+    {
+        SWSS_LOG_WARN("ZmqConsumer not enabled for consumer db: %d, table: %s", db->getDbId(), tableName.c_str());
     }
 }
 

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -289,11 +289,11 @@ void ConsumerBase::execute_impl()
     drain();
 }
 
-template<class CONSUMER_T>
+template<class ORCH_T, class CONSUMER_T>
 void ConsumerBase::drain_impl()
 {
     if (!m_toSync.empty())
-        m_orch->doTask((CONSUMER_T&)*this);
+        ((ORCH_T *)m_orch)->doTask((CONSUMER_T&)*this);
 }
 
 
@@ -304,7 +304,7 @@ void Consumer::execute()
 
 void Consumer::drain()
 {
-    ConsumerBase::drain_impl<Consumer>();
+    ConsumerBase::drain_impl<Orch, Consumer>();
 }
 
 void ZmqConsumer::execute()
@@ -314,7 +314,7 @@ void ZmqConsumer::execute()
 
 void ZmqConsumer::drain()
 {
-    ConsumerBase::drain_impl<ZmqConsumer>();
+    ConsumerBase::drain_impl<ZmqOrch, ZmqConsumer>();
 }
 
 size_t Orch::addExistingData(const string& tableName)

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -272,23 +272,6 @@ void ConsumerBase::dumpPendingTasks(vector<string> &ts)
     }
 }
 
-template<class SELECTABLE_T>
-void ConsumerBase::execute_impl()
-{
-    SWSS_LOG_ENTER();
-
-    size_t update_size = 0;
-    auto table = static_cast<SELECTABLE_T *>(getSelectable());
-    do
-    {
-        std::deque<KeyOpFieldsValuesTuple> entries;
-        table->pops(entries);
-        update_size = addToSync(entries);
-    } while (update_size != 0);
-
-    drain();
-}
-
 template<class ORCH_T, class CONSUMER_T>
 void ConsumerBase::drain_impl()
 {
@@ -321,7 +304,19 @@ void Consumer::drain()
 
 void ZmqConsumer::execute()
 {
-    ConsumerBase::execute_impl<swss::ZmqConsumerStateTable>();
+    // ConsumerBase::execute_impl<swss::ConsumerTableBase>();
+    SWSS_LOG_ENTER();
+
+    size_t update_size = 0;
+    auto table = static_cast<swss::ZmqConsumerStateTable *>(getSelectable());
+    do
+    {
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        table->pops(entries);
+        update_size = addToSync(entries);
+    } while (update_size != 0);
+
+    drain();
 }
 
 void ZmqConsumer::drain()

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -159,9 +159,6 @@ public:
 
     // Returns: the number of entries added to m_toSync
     size_t addToSync(const std::deque<swss::KeyOpFieldsValuesTuple> &entries);
-
-    template<class ORCH_T, class CONSUMER_T>
-    void drain_impl();
 };
 
 class Consumer : public ConsumerBase {

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -160,9 +160,6 @@ public:
     // Returns: the number of entries added to m_toSync
     size_t addToSync(const std::deque<swss::KeyOpFieldsValuesTuple> &entries);
 
-    template<class SELECTABLE_T>
-    void execute_impl();
-
     template<class ORCH_T, class CONSUMER_T>
     void drain_impl();
 };

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -163,7 +163,7 @@ public:
     template<class SELECTABLE_T>
     void execute_impl();
 
-    template<class CONSUMER_T>
+    template<class ORCH_T, class CONSUMER_T>
     void drain_impl();
 };
 
@@ -259,7 +259,6 @@ public:
 
     /* Run doTask against a specific executor */
     virtual void doTask(Consumer &consumer) { };
-    virtual void doTask(ZmqConsumer &consumer) { };
     virtual void doTask(swss::NotificationConsumer &consumer) { }
     virtual void doTask(swss::SelectableTimer &timer) { }
 
@@ -306,6 +305,8 @@ public:
     ZmqOrch(swss::DBConnector *db, const std::string tableName, int pri, swss::ZmqServer *zmqServer);
     ZmqOrch(swss::DBConnector *db, const std::vector<std::string> &tableNames, swss::ZmqServer *zmqServer);
     ZmqOrch(swss::DBConnector *db, const std::vector<table_name_with_pri_t> &tableNameWithPri, swss::ZmqServer *zmqServer);
+
+    virtual void doTask(ZmqConsumer &consumer) { };
 
 private:
     void addConsumer(swss::DBConnector *db, std::string tableName, int pri, swss::ZmqServer *zmqServer);

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -159,6 +159,12 @@ public:
 
     // Returns: the number of entries added to m_toSync
     size_t addToSync(const std::deque<swss::KeyOpFieldsValuesTuple> &entries);
+
+    template<class SELECTABLE_T>
+    void execute_impl();
+
+    template<class CONSUMER_T>
+    void drain_impl();
 };
 
 class Consumer : public ConsumerBase {
@@ -231,10 +237,11 @@ typedef std::pair<swss::DBConnector *, std::vector<std::string>> TablesConnector
 class Orch
 {
 public:
-    Orch(swss::DBConnector *db, const std::string tableName, int pri = default_orch_pri, swss::ZmqServer *zmqServer = nullptr);
-    Orch(swss::DBConnector *db, const std::vector<std::string> &tableNames, swss::ZmqServer *zmqServer = nullptr);
-    Orch(swss::DBConnector *db, const std::vector<table_name_with_pri_t> &tableNameWithPri, swss::ZmqServer *zmqServer = nullptr);
+    Orch(swss::DBConnector *db, const std::string tableName, int pri = default_orch_pri);
+    Orch(swss::DBConnector *db, const std::vector<std::string> &tableNames);
+    Orch(swss::DBConnector *db, const std::vector<table_name_with_pri_t> &tableNameWithPri);
     Orch(const std::vector<TableConnector>& tables);
+    Orch();
     virtual ~Orch();
 
     std::vector<swss::Selectable*> getSelectables();
@@ -290,7 +297,18 @@ protected:
 
     ResponsePublisher m_publisher;
 private:
-    void addConsumer(swss::DBConnector *db, std::string tableName, int pri = default_orch_pri, swss::ZmqServer *zmqServer = nullptr);
+    void addConsumer(swss::DBConnector *db, std::string tableName, int pri = default_orch_pri);
+};
+
+class ZmqOrch : public Orch
+{
+public:
+    ZmqOrch(swss::DBConnector *db, const std::string tableName, int pri, swss::ZmqServer *zmqServer);
+    ZmqOrch(swss::DBConnector *db, const std::vector<std::string> &tableNames, swss::ZmqServer *zmqServer);
+    ZmqOrch(swss::DBConnector *db, const std::vector<table_name_with_pri_t> &tableNameWithPri, swss::ZmqServer *zmqServer);
+
+private:
+    void addConsumer(swss::DBConnector *db, std::string tableName, int pri, swss::ZmqServer *zmqServer);
 };
 
 #include "request_parser.h"

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -235,7 +235,6 @@ public:
     Orch(swss::DBConnector *db, const std::vector<std::string> &tableNames);
     Orch(swss::DBConnector *db, const std::vector<table_name_with_pri_t> &tableNameWithPri);
     Orch(const std::vector<TableConnector>& tables);
-    Orch();
     virtual ~Orch();
 
     std::vector<swss::Selectable*> getSelectables();
@@ -268,6 +267,7 @@ public:
 protected:
     ConsumerMap m_consumerMap;
 
+    Orch();
     static void logfileReopen();
     std::string dumpTuple(Consumer &consumer, const swss::KeyOpFieldsValuesTuple &tuple);
     ref_resolve_status resolveFieldRefValue(type_map&, const std::string&, const std::string&, swss::KeyOpFieldsValuesTuple&, sai_object_id_t&, std::string&);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -64,11 +64,12 @@ event_handle_t g_events_handle;
 #define DEFAULT_MAX_BULK_SIZE 1000
 size_t gMaxBulkSize = DEFAULT_MAX_BULK_SIZE;
 
-OrchDaemon::OrchDaemon(DBConnector *applDb, DBConnector *configDb, DBConnector *stateDb, DBConnector *chassisAppDb) :
+OrchDaemon::OrchDaemon(DBConnector *applDb, DBConnector *configDb, DBConnector *stateDb, DBConnector *chassisAppDb, ZmqServer *zmqServer) :
         m_applDb(applDb),
         m_configDb(configDb),
         m_stateDb(stateDb),
-        m_chassisAppDb(chassisAppDb)
+        m_chassisAppDb(chassisAppDb),
+        m_zmqServer(zmqServer)
 {
     SWSS_LOG_ENTER();
     m_select = new Select();
@@ -226,7 +227,7 @@ bool OrchDaemon::init()
         APP_DASH_VNET_TABLE_NAME,
         APP_DASH_VNET_MAPPING_TABLE_NAME
     };
-    DashVnetOrch *dash_vnet_orch = new DashVnetOrch(m_applDb, dash_vnet_tables);
+    DashVnetOrch *dash_vnet_orch = new DashVnetOrch(m_applDb, dash_vnet_tables, m_zmqServer);
     gDirectory.set(dash_vnet_orch);
 
     vector<string> dash_tables = {
@@ -236,7 +237,7 @@ bool OrchDaemon::init()
         APP_DASH_QOS_TABLE_NAME
     };
 
-    DashOrch *dash_orch = new DashOrch(m_applDb, dash_tables);
+    DashOrch *dash_orch = new DashOrch(m_applDb, dash_tables, m_zmqServer);
     gDirectory.set(dash_orch);
 
     vector<string> dash_route_tables = {
@@ -244,7 +245,7 @@ bool OrchDaemon::init()
         APP_DASH_ROUTE_RULE_TABLE_NAME
     };
 
-    DashRouteOrch *dash_route_orch = new DashRouteOrch(m_applDb, dash_route_tables, dash_orch);
+    DashRouteOrch *dash_route_orch = new DashRouteOrch(m_applDb, dash_route_tables, dash_orch, m_zmqServer);
     gDirectory.set(dash_route_orch);
 
     vector<string> dash_acl_tables = {
@@ -253,7 +254,7 @@ bool OrchDaemon::init()
         APP_DASH_ACL_GROUP_TABLE_NAME,
         APP_DASH_ACL_RULE_TABLE_NAME
     };
-    DashAclOrch *dash_acl_orch = new DashAclOrch(m_applDb, dash_acl_tables, dash_orch);
+    DashAclOrch *dash_acl_orch = new DashAclOrch(m_applDb, dash_acl_tables, dash_orch, m_zmqServer);
     gDirectory.set(dash_acl_orch);
 
     vector<string> qos_tables = {
@@ -993,8 +994,8 @@ void OrchDaemon::addOrchList(Orch *o)
     m_orchList.push_back(o);
 }
 
-FabricOrchDaemon::FabricOrchDaemon(DBConnector *applDb, DBConnector *configDb, DBConnector *stateDb, DBConnector *chassisAppDb) :
-    OrchDaemon(applDb, configDb, stateDb, chassisAppDb),
+FabricOrchDaemon::FabricOrchDaemon(DBConnector *applDb, DBConnector *configDb, DBConnector *stateDb, DBConnector *chassisAppDb, ZmqServer *zmqServer) :
+    OrchDaemon(applDb, configDb, stateDb, chassisAppDb, zmqServer),
     m_applDb(applDb),
     m_configDb(configDb)
 {

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -4,6 +4,7 @@
 #include "dbconnector.h"
 #include "producerstatetable.h"
 #include "consumertable.h"
+#include "zmqserver.h"
 #include "select.h"
 
 #include "portsorch.h"
@@ -57,7 +58,7 @@ extern bool gSaiRedisLogRotate;
 class OrchDaemon
 {
 public:
-    OrchDaemon(DBConnector *, DBConnector *, DBConnector *, DBConnector *);
+    OrchDaemon(DBConnector *, DBConnector *, DBConnector *, DBConnector *, ZmqServer *);
     ~OrchDaemon();
 
     virtual bool init();
@@ -87,6 +88,7 @@ private:
     DBConnector *m_configDb;
     DBConnector *m_stateDb;
     DBConnector *m_chassisAppDb;
+    ZmqServer *m_zmqServer;
 
     bool m_fabricEnabled = false;
     bool m_fabricPortStatEnabled = true;
@@ -101,7 +103,7 @@ private:
 class FabricOrchDaemon : public OrchDaemon
 {
 public:
-    FabricOrchDaemon(DBConnector *, DBConnector *, DBConnector *, DBConnector *);
+    FabricOrchDaemon(DBConnector *, DBConnector *, DBConnector *, DBConnector *, ZmqServer *);
     bool init() override;
 private:
     DBConnector *m_applDb;

--- a/tests/mock_tests/orchdaemon_ut.cpp
+++ b/tests/mock_tests/orchdaemon_ut.cpp
@@ -33,7 +33,7 @@ namespace orchdaemon_test
                 sai_switch_api->get_switch_attribute = &mock_get_switch_attribute;
                 sai_switch_api->set_switch_attribute = &mock_set_switch_attribute;
 
-                orchd = new OrchDaemon(&appl_db, &config_db, &state_db, &counters_db);
+                orchd = new OrchDaemon(&appl_db, &config_db, &state_db, &counters_db, nullptr);
 
             };
 


### PR DESCRIPTION
Change dash orchagent from Redis consumer state table to ZMQ consumer state table.

**What I did**
Change dash orchagent from Redis consumer state table to ZMQ consumer state table.

**Why I did it**
To improve dash entry create performance, change dash orchagent from Redis consumer state table to ZMQ consumer state table.

**How I verified it**
Pass all UT.

**Details if related**