### PR TITLE
[fdborch] Only call flushFDBEntries() when there is a bridge port OID in port state update

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -1170,7 +1170,10 @@ void FdbOrch::updatePortOperState(const PortOperStateUpdate& update)
     if (update.operStatus == SAI_PORT_OPER_STATUS_DOWN)
     {
         swss::Port p = update.port;
-        flushFDBEntries(p.m_bridge_port_id, SAI_NULL_OBJECT_ID);
+        if (p.m_bridge_port_id != SAI_NULL_OBJECT_ID)
+        {
+            flushFDBEntries(p.m_bridge_port_id, SAI_NULL_OBJECT_ID);
+        }
 
         // Get BVID of each VLAN that this port is a member of
         // and call notifyObserversFDBFlush


### PR DESCRIPTION
**What I did**
Only call flushFDBEntries() when there is a bridge port OID in port state update for fdborch.

**Why I did it**
The flushFDBEntries() has the check at the beginning. But it is wrong to call the function to begin with.
This will get rid of the false warning log message in flushFDBEntries().

**How I verified it**

**Details if related**
