### PR TITLE
Periodic flush record files instead of flushing them on std::endl.

### DIFF
--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -589,7 +589,7 @@ void Orch::recordTuple(ConsumerBase &consumer, const KeyOpFieldsValuesTuple &tup
 {
     string s = consumer.dumpTuple(tuple);
 
-    gRecordOfs << getTimestamp() << "|" << s << endl;
+    gRecordOfs << getTimestamp() << "|" << s << '\n';
 
     if (gLogRotate)
     {

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -22,6 +22,9 @@ extern sai_switch_api_t*           sai_switch_api;
 extern sai_object_id_t             gSwitchId;
 extern bool                        gSaiRedisLogRotate;
 
+extern ofstream gRecordOfs;
+extern ofstream gResponsePublisherRecordOfs;
+
 extern void syncd_apply_view();
 /*
  * Global orch daemon variables
@@ -686,6 +689,10 @@ void OrchDaemon::flush()
     {
         orch->flushResponses();
     }
+
+    // Flush the record files.
+    gRecordOfs.flush();
+    gResponsePublisherRecordOfs.flush();
 }
 
 /* Release the file handle so the log can be rotated */

--- a/orchagent/response_publisher.cpp
+++ b/orchagent/response_publisher.cpp
@@ -67,7 +67,7 @@ void RecordDBWrite(const std::string &table, const std::string &key, const std::
     }
 
     PerformLogRotate();
-    gResponsePublisherRecordOfs << swss::getTimestamp() << "|" << s << std::endl;
+    gResponsePublisherRecordOfs << swss::getTimestamp() << "|" << s << '\n';
 }
 
 void RecordResponse(const std::string &response_channel, const std::string &key,
@@ -85,7 +85,7 @@ void RecordResponse(const std::string &response_channel, const std::string &key,
     }
 
     PerformLogRotate();
-    gResponsePublisherRecordOfs << swss::getTimestamp() << "|" << s << std::endl;
+    gResponsePublisherRecordOfs << swss::getTimestamp() << "|" << s << '\n';
 }
 
 } // namespace

--- a/tests/mock_tests/mock_orchagent_main.cpp
+++ b/tests/mock_tests/mock_orchagent_main.cpp
@@ -20,6 +20,8 @@ bool gSwssRecord = true;
 bool gLogRotate = false;
 ofstream gRecordOfs;
 string gRecordFile;
+std::ofstream gResponsePublisherRecordOfs;
+std::string gResponsePublisherRecordFile;
 string gMySwitchType = "switch";
 int32_t gVoqMySwitchId = 0;
 string gMyHostName = "Linecard1";

--- a/tests/mock_tests/response_publisher/response_publisher_ut.cpp
+++ b/tests/mock_tests/response_publisher/response_publisher_ut.cpp
@@ -4,8 +4,6 @@
 
 bool gResponsePublisherRecord{false};
 bool gResponsePublisherLogRotate{false};
-std::ofstream gResponsePublisherRecordOfs;
-std::string gResponsePublisherRecordFile;
 
 using namespace swss;
 


### PR DESCRIPTION
**What I did**
Periodic flush record files instead of flushing them on std::endl.

**Why I did it**
For performance purposes. In our testing, this provides 8% end-to-end performance improvement.

**How I verified it**

**Details if related**
