### PR TITLE
[vstest] Fix DB connection for mclag test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1144,10 +1144,10 @@ class DockerVirtualSwitch:
     # deps: acl, fdb_update, fdb, intf_mac, mirror_port_erspan, mirror_port_span,
     # policer, port_dpb_vlan, vlan
     def setup_db(self):
-        self.pdb = swsscommon.DBConnector(0, self.redis_sock, 0)
-        self.adb = swsscommon.DBConnector(1, self.redis_sock, 0)
-        self.cdb = swsscommon.DBConnector(4, self.redis_sock, 0)
-        self.sdb = swsscommon.DBConnector(6, self.redis_sock, 0)
+        self.pdb = swsscommon.DBConnector(swsscommon.APPL_DB, self.redis_sock, 0)
+        self.adb = swsscommon.DBConnector(swsscommon.ASIC_DB, self.redis_sock, 0)
+        self.cdb = swsscommon.DBConnector(swsscommon.CONFIG_DB, self.redis_sock, 0)
+        self.sdb = swsscommon.DBConnector(swsscommon.STATE_DB, self.redis_sock, 0)
 
     def getSwitchOid(self):
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_SWITCH")

--- a/tests/test_mclag_cfg.py
+++ b/tests/test_mclag_cfg.py
@@ -39,7 +39,7 @@ def create_mclag_domain(dvs, domain_id, source_ip, peer_ip, peer_link):
     tbl = swsscommon.Table(dvs.cdb, "MCLAG_DOMAIN")
     fvs = swsscommon.FieldValuePairs([("source_ip", source_ip),
                                   ("peer_ip", peer_ip),
-				("peer_link", peer_link)])
+                                  ("peer_link", peer_link)])
     tbl.set(domain_id, fvs)
     time.sleep(1)
 
@@ -96,22 +96,22 @@ class TestMclagConfig(object):
     # Testcase 1 Verify Configuration of MCLAG Domain with src, peer ip and peer link config gets updated in CONFIG_DB
     @pytest.mark.dev_sanity
     def test_mclag_cfg_domain_add(self, dvs, testlog):
-        self.cfg_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
+        dvs.setup_db()
 
         #cleanup existing entries
-        delete_table_keys(self.cfg_db, self.CFG_MCLAG_DOMAIN_TABLE) 
-        delete_table_keys(self.cfg_db, self.CFG_MCLAG_INTERFACE_TABLE) 
+        delete_table_keys(dvs.cdb, self.CFG_MCLAG_DOMAIN_TABLE)
+        delete_table_keys(dvs.cdb, self.CFG_MCLAG_INTERFACE_TABLE)
 
         create_mclag_domain(dvs, self.MCLAG_DOMAIN_ID, self.MCLAG_SRC_IP, self.MCLAG_PEER_IP, self.MCLAG_PEER_LINK)
         time.sleep(2)
-        
+
         #check whether domain cfg table contents are same as configured values
-        ok,error_info = dvs.all_table_entry_has(self.cfg_db, self.CFG_MCLAG_DOMAIN_TABLE, self.MCLAG_DOMAIN_ID,
-                    [ 
+        ok,error_info = dvs.all_table_entry_has(dvs.cdb, self.CFG_MCLAG_DOMAIN_TABLE, self.MCLAG_DOMAIN_ID,
+                    [
                         ("source_ip",self.MCLAG_SRC_IP),
                         ("peer_ip",self.MCLAG_PEER_IP),
                         ("peer_link",self.MCLAG_PEER_LINK)
-                    ]                    
+                    ]
                 )
         assert ok,error_info
 
@@ -119,25 +119,27 @@ class TestMclagConfig(object):
     # Testcase 3 Verify Configuration of MCLAG Interface to existing domain
     @pytest.mark.dev_sanity
     def test_mclag_cfg_intf_add(self, dvs, testlog):
-        self.cfg_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
+        dvs.setup_db()
+
         create_mclag_interface(dvs, self.MCLAG_DOMAIN_ID, self.MCLAG_INTERFACE1)
         time.sleep(2)
-        
+
         #check whether mclag interface config is reflected
         key_string = self.MCLAG_DOMAIN_ID + "|" + self.MCLAG_INTERFACE1
-        ok,error_info = check_table_exists(self.cfg_db, self.CFG_MCLAG_INTERFACE_TABLE, key_string)
+        ok,error_info = check_table_exists(dvs.cdb, self.CFG_MCLAG_INTERFACE_TABLE, key_string)
         assert ok,error_info
 
     # Testcase 4 Verify remove and add mclag interface
     @pytest.mark.dev_sanity
     def test_mclag_cfg_intf_remove_and_add(self, dvs, testlog):
-        self.cfg_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
+        dvs.setup_db()
+
         remove_mclag_interface(dvs, self.MCLAG_DOMAIN_ID, self.MCLAG_INTERFACE1)
         time.sleep(2)
-        
+
         #check whether mclag interface is removed
         key_string = self.MCLAG_DOMAIN_ID + "|" + self.MCLAG_INTERFACE1
-        ok,error_info = check_table_doesnt_exists(self.cfg_db, self.CFG_MCLAG_INTERFACE_TABLE, key_string)
+        ok,error_info = check_table_doesnt_exists(dvs.cdb, self.CFG_MCLAG_INTERFACE_TABLE, key_string)
         assert ok,error_info
 
         #add different mclag interface
@@ -146,46 +148,46 @@ class TestMclagConfig(object):
 
         #check whether new mclag interface is added
         key_string = self.MCLAG_DOMAIN_ID + "|" + self.MCLAG_INTERFACE2
-        ok,error_info = check_table_exists(self.cfg_db, self.CFG_MCLAG_INTERFACE_TABLE, key_string)
+        ok,error_info = check_table_exists(dvs.cdb, self.CFG_MCLAG_INTERFACE_TABLE, key_string)
         assert ok,error_info
 
     # Testcase 5 Verify Configuration of valid values for session timeout
     @pytest.mark.dev_sanity
     def test_mclag_cfg_session_timeout_valid_values(self, dvs, testlog):
-        self.cfg_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
+        dvs.setup_db()
 
         for value in self.MCLAG_SESS_TMOUT_VALID_LIST:
             add_mclag_domain_field(dvs, self.MCLAG_DOMAIN_ID, "session_timeout", value)
-            
+
             time.sleep(2)
-            
+
             #check whether domain cfg table contents are same as configured values
-            ok,error_info = dvs.all_table_entry_has(self.cfg_db, self.CFG_MCLAG_DOMAIN_TABLE, self.MCLAG_DOMAIN_ID,
-                        [ 
+            ok,error_info = dvs.all_table_entry_has(dvs.cdb, self.CFG_MCLAG_DOMAIN_TABLE, self.MCLAG_DOMAIN_ID,
+                        [
                             ("source_ip",self.MCLAG_SRC_IP),
                             ("peer_ip",self.MCLAG_PEER_IP),
                             ("peer_link",self.MCLAG_PEER_LINK),
                             ("session_timeout",value)
-                        ]                    
+                        ]
                     )
             assert ok,error_info
 
     # Testcase 6 Verify Configuration of valid values for KA timer
     @pytest.mark.dev_sanity
     def test_mclag_cfg_ka_valid_values(self, dvs, testlog):
-        self.cfg_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
+        dvs.setup_db()
 
         for value in self.MCLAG_KA_VALID_LIST:
             add_mclag_domain_field(dvs, self.MCLAG_DOMAIN_ID, "keepalive_interval", value)
             time.sleep(2)
             #check whether domain cfg table contents are same as configured values
-            ok,error_info = dvs.all_table_entry_has(self.cfg_db, self.CFG_MCLAG_DOMAIN_TABLE, self.MCLAG_DOMAIN_ID,
-                        [ 
+            ok,error_info = dvs.all_table_entry_has(dvs.cdb, self.CFG_MCLAG_DOMAIN_TABLE, self.MCLAG_DOMAIN_ID,
+                        [
                             ("source_ip",self.MCLAG_SRC_IP),
                             ("peer_ip",self.MCLAG_PEER_IP),
                             ("peer_link",self.MCLAG_PEER_LINK),
                             ("keepalive_interval",value)
-                        ]                    
+                        ]
                     )
             assert ok,error_info
 
@@ -193,17 +195,16 @@ class TestMclagConfig(object):
     # Testcase 7 Verify Deletion of MCLAG Domain
     @pytest.mark.dev_sanity
     def test_mclag_cfg_domain_del(self, dvs, testlog):
-        self.cfg_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
+        dvs.setup_db()
 
         remove_mclag_domain(dvs, self.MCLAG_DOMAIN_ID)
         time.sleep(2)
-        
+
         #check whether domain cfg table contents are same as configured values
-        ok, error_info = check_table_doesnt_exists(self.cfg_db, self.CFG_MCLAG_DOMAIN_TABLE, self.MCLAG_DOMAIN_ID)
+        ok, error_info = check_table_doesnt_exists(dvs.cdb, self.CFG_MCLAG_DOMAIN_TABLE, self.MCLAG_DOMAIN_ID)
         assert ok,error_info
 
         #make sure mclag interface tables entries are also deleted when mclag domain is deleted
-        key_string = self.MCLAG_DOMAIN_ID 
-        ok,error_info = check_table_doesnt_exists(self.cfg_db, self.CFG_MCLAG_INTERFACE_TABLE, key_string)
+        key_string = self.MCLAG_DOMAIN_ID
+        ok,error_info = check_table_doesnt_exists(dvs.cdb, self.CFG_MCLAG_INTERFACE_TABLE, key_string)
         assert ok,error_info
-


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
* Fixed DB connection errors in mclag test

**Why I did it**
* To fix VS test standalone run

**How I verified it**
1. Run `test_mclag_cfg.py`

**Details if related**
Test script:
```
root@r-sonic-vs: ~# cat run_single.sh
#!/bin/bash

IMAGE="docker-sonic-vs:latest"
TEST="${1}"

cd sonic-swss/tests
py.test --force-flaky --log-cli-level=info --imgname=${IMAGE} ${TEST} -vvv
```

Test log:
```
root@r-sonic-vs: ~# ./run_single.sh test_mclag_cfg.py
========================================================================= test session starts =========================================================================
platform linux -- Python 3.8.10, pytest-7.1.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/work/development/ppi/sonic-swss/tests
plugins: flaky-3.7.0
collected 6 items

test_mclag_cfg.py::TestMclagConfig::test_mclag_cfg_domain_add FAILED                                                                                            [ 16%]
test_mclag_cfg.py::TestMclagConfig::test_mclag_cfg_intf_add FAILED                                                                                              [ 33%]
test_mclag_cfg.py::TestMclagConfig::test_mclag_cfg_intf_remove_and_add FAILED                                                                                   [ 50%]
test_mclag_cfg.py::TestMclagConfig::test_mclag_cfg_session_timeout_valid_values FAILED                                                                          [ 66%]
test_mclag_cfg.py::TestMclagConfig::test_mclag_cfg_ka_valid_values FAILED                                                                                       [ 83%]
test_mclag_cfg.py::TestMclagConfig::test_mclag_cfg_domain_del FAILED                                                                                            [100%]

============================================================================== FAILURES ===============================================================================
______________________________________________________________ TestMclagConfig.test_mclag_cfg_domain_add ______________________________________________________________

self = <test_mclag_cfg.TestMclagConfig object at 0x7f4e0efffa30>, dvs = <conftest.DockerVirtualSwitch object at 0x7f4e0f0116d0>, testlog = None

    @pytest.mark.dev_sanity
    def test_mclag_cfg_domain_add(self, dvs, testlog):
        self.cfg_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)

        #cleanup existing entries
        delete_table_keys(self.cfg_db, self.CFG_MCLAG_DOMAIN_TABLE)
        delete_table_keys(self.cfg_db, self.CFG_MCLAG_INTERFACE_TABLE)

>       create_mclag_domain(dvs, self.MCLAG_DOMAIN_ID, self.MCLAG_SRC_IP, self.MCLAG_PEER_IP, self.MCLAG_PEER_LINK)

test_mclag_cfg.py:105:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

dvs = <conftest.DockerVirtualSwitch object at 0x7f4e0f0116d0>, domain_id = '4095', source_ip = '10.5.1.1', peer_ip = '10.5.1.2', peer_link = 'PortChannel11'

    def create_mclag_domain(dvs, domain_id, source_ip, peer_ip, peer_link):
>       tbl = swsscommon.Table(dvs.cdb, "MCLAG_DOMAIN")
E       AttributeError: 'DockerVirtualSwitch' object has no attribute 'cdb'

test_mclag_cfg.py:39: AttributeError
_______________________________________________________________ TestMclagConfig.test_mclag_cfg_intf_add _______________________________________________________________

self = <test_mclag_cfg.TestMclagConfig object at 0x7f4e0efffaf0>, dvs = <conftest.DockerVirtualSwitch object at 0x7f4e0f0116d0>, testlog = None

    @pytest.mark.dev_sanity
    def test_mclag_cfg_intf_add(self, dvs, testlog):
        self.cfg_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
>       create_mclag_interface(dvs, self.MCLAG_DOMAIN_ID, self.MCLAG_INTERFACE1)

test_mclag_cfg.py:123:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

dvs = <conftest.DockerVirtualSwitch object at 0x7f4e0f0116d0>, domain_id = '4095', mclag_interface = 'PortChannel50'

    def create_mclag_interface(dvs, domain_id, mclag_interface):
>       tbl = swsscommon.Table(dvs.cdb, "MCLAG_INTERFACE")
E       AttributeError: 'DockerVirtualSwitch' object has no attribute 'cdb'

test_mclag_cfg.py:58: AttributeError
_________________________________________________________ TestMclagConfig.test_mclag_cfg_intf_remove_and_add __________________________________________________________

self = <test_mclag_cfg.TestMclagConfig object at 0x7f4e0efffc70>, dvs = <conftest.DockerVirtualSwitch object at 0x7f4e0f0116d0>, testlog = None

    @pytest.mark.dev_sanity
    def test_mclag_cfg_intf_remove_and_add(self, dvs, testlog):
        self.cfg_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
>       remove_mclag_interface(dvs, self.MCLAG_DOMAIN_ID, self.MCLAG_INTERFACE1)

test_mclag_cfg.py:135:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

dvs = <conftest.DockerVirtualSwitch object at 0x7f4e0f0116d0>, domain_id = '4095', mclag_interface = 'PortChannel50'

    def remove_mclag_interface(dvs, domain_id, mclag_interface):
>       tbl = swsscommon.Table(dvs.cdb, "MCLAG_INTERFACE")
E       AttributeError: 'DockerVirtualSwitch' object has no attribute 'cdb'

test_mclag_cfg.py:65: AttributeError
_____________________________________________________ TestMclagConfig.test_mclag_cfg_session_timeout_valid_values _____________________________________________________

self = <test_mclag_cfg.TestMclagConfig object at 0x7f4e0efffdf0>, dvs = <conftest.DockerVirtualSwitch object at 0x7f4e0f0116d0>, testlog = None

    @pytest.mark.dev_sanity
    def test_mclag_cfg_session_timeout_valid_values(self, dvs, testlog):
        self.cfg_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)

        for value in self.MCLAG_SESS_TMOUT_VALID_LIST:
>           add_mclag_domain_field(dvs, self.MCLAG_DOMAIN_ID, "session_timeout", value)

test_mclag_cfg.py:158:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

dvs = <conftest.DockerVirtualSwitch object at 0x7f4e0f0116d0>, domain_id = '4095', field = 'session_timeout', value = '3'

    def add_mclag_domain_field(dvs, domain_id, field, value):
>       tbl = swsscommon.Table(dvs.cdb, "MCLAG_DOMAIN")
E       AttributeError: 'DockerVirtualSwitch' object has no attribute 'cdb'

test_mclag_cfg.py:52: AttributeError
___________________________________________________________ TestMclagConfig.test_mclag_cfg_ka_valid_values ____________________________________________________________

self = <test_mclag_cfg.TestMclagConfig object at 0x7f4e0effff70>, dvs = <conftest.DockerVirtualSwitch object at 0x7f4e0f0116d0>, testlog = None

    @pytest.mark.dev_sanity
    def test_mclag_cfg_ka_valid_values(self, dvs, testlog):
        self.cfg_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)

        for value in self.MCLAG_KA_VALID_LIST:
>           add_mclag_domain_field(dvs, self.MCLAG_DOMAIN_ID, "keepalive_interval", value)

test_mclag_cfg.py:179:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

dvs = <conftest.DockerVirtualSwitch object at 0x7f4e0f0116d0>, domain_id = '4095', field = 'keepalive_interval', value = '1'

    def add_mclag_domain_field(dvs, domain_id, field, value):
>       tbl = swsscommon.Table(dvs.cdb, "MCLAG_DOMAIN")
E       AttributeError: 'DockerVirtualSwitch' object has no attribute 'cdb'

test_mclag_cfg.py:52: AttributeError
______________________________________________________________ TestMclagConfig.test_mclag_cfg_domain_del ______________________________________________________________

self = <test_mclag_cfg.TestMclagConfig object at 0x7f4e0f011130>, dvs = <conftest.DockerVirtualSwitch object at 0x7f4e0f2d2100>, testlog = None

    @pytest.mark.dev_sanity
    def test_mclag_cfg_domain_del(self, dvs, testlog):
        self.cfg_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)

>       remove_mclag_domain(dvs, self.MCLAG_DOMAIN_ID)

test_mclag_cfg.py:198:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

dvs = <conftest.DockerVirtualSwitch object at 0x7f4e0f2d2100>, domain_id = '4095'

    def remove_mclag_domain(dvs, domain_id):
>       tbl = swsscommon.Table(dvs.cdb, "MCLAG_DOMAIN")
E       AttributeError: 'DockerVirtualSwitch' object has no attribute 'cdb'

test_mclag_cfg.py:47: AttributeError
========================================================================== warnings summary ===========================================================================
conftest.py:1819
  /root/work/development/ppi/sonic-swss/tests/conftest.py:1819: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
  Use @pytest.fixture instead; they are the same.
    @pytest.yield_fixture(scope="module")

test_mclag_cfg.py:97
  /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:97: PytestUnknownMarkWarning: Unknown pytest.mark.dev_sanity - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.dev_sanity

test_mclag_cfg.py:120
  /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:120: PytestUnknownMarkWarning: Unknown pytest.mark.dev_sanity - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.dev_sanity

test_mclag_cfg.py:132
  /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:132: PytestUnknownMarkWarning: Unknown pytest.mark.dev_sanity - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.dev_sanity

test_mclag_cfg.py:153
  /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:153: PytestUnknownMarkWarning: Unknown pytest.mark.dev_sanity - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.dev_sanity

test_mclag_cfg.py:174
  /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:174: PytestUnknownMarkWarning: Unknown pytest.mark.dev_sanity - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.dev_sanity

test_mclag_cfg.py:194
  /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:194: PytestUnknownMarkWarning: Unknown pytest.mark.dev_sanity - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.dev_sanity

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===Flaky Test Report===

test_mclag_cfg_domain_add failed (1 runs remaining out of 2).
        <class 'AttributeError'>
        'DockerVirtualSwitch' object has no attribute 'cdb'
        [<TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:105>, <TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:39>]
test_mclag_cfg_domain_add failed; it passed 0 out of the required 1 times.
        <class 'AttributeError'>
        'DockerVirtualSwitch' object has no attribute 'cdb'
        [<TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:105>, <TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:39>]
test_mclag_cfg_intf_add failed (1 runs remaining out of 2).
        <class 'AttributeError'>
        'DockerVirtualSwitch' object has no attribute 'cdb'
        [<TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:123>, <TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:58>]
test_mclag_cfg_intf_add failed; it passed 0 out of the required 1 times.
        <class 'AttributeError'>
        'DockerVirtualSwitch' object has no attribute 'cdb'
        [<TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:123>, <TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:58>]
test_mclag_cfg_intf_remove_and_add failed (1 runs remaining out of 2).
        <class 'AttributeError'>
        'DockerVirtualSwitch' object has no attribute 'cdb'
        [<TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:135>, <TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:65>]
test_mclag_cfg_intf_remove_and_add failed; it passed 0 out of the required 1 times.
        <class 'AttributeError'>
        'DockerVirtualSwitch' object has no attribute 'cdb'
        [<TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:135>, <TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:65>]
test_mclag_cfg_session_timeout_valid_values failed (1 runs remaining out of 2).
        <class 'AttributeError'>
        'DockerVirtualSwitch' object has no attribute 'cdb'
        [<TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:158>, <TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:52>]
test_mclag_cfg_session_timeout_valid_values failed; it passed 0 out of the required 1 times.
        <class 'AttributeError'>
        'DockerVirtualSwitch' object has no attribute 'cdb'
        [<TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:158>, <TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:52>]
test_mclag_cfg_ka_valid_values failed (1 runs remaining out of 2).
        <class 'AttributeError'>
        'DockerVirtualSwitch' object has no attribute 'cdb'
        [<TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:179>, <TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:52>]
test_mclag_cfg_ka_valid_values failed; it passed 0 out of the required 1 times.
        <class 'AttributeError'>
        'DockerVirtualSwitch' object has no attribute 'cdb'
        [<TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:179>, <TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:52>]
test_mclag_cfg_domain_del failed (1 runs remaining out of 2).
        <class 'AttributeError'>
        'DockerVirtualSwitch' object has no attribute 'cdb'
        [<TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:198>, <TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:47>]
test_mclag_cfg_domain_del failed; it passed 0 out of the required 1 times.
        <class 'AttributeError'>
        'DockerVirtualSwitch' object has no attribute 'cdb'
        [<TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:198>, <TracebackEntry /root/work/development/ppi/sonic-swss/tests/test_mclag_cfg.py:47>]

===End Flaky Test Report===
======================================================================= short test summary info =======================================================================
FAILED test_mclag_cfg.py::TestMclagConfig::test_mclag_cfg_domain_add - AttributeError: 'DockerVirtualSwitch' object has no attribute 'cdb'
FAILED test_mclag_cfg.py::TestMclagConfig::test_mclag_cfg_intf_add - AttributeError: 'DockerVirtualSwitch' object has no attribute 'cdb'
FAILED test_mclag_cfg.py::TestMclagConfig::test_mclag_cfg_intf_remove_and_add - AttributeError: 'DockerVirtualSwitch' object has no attribute 'cdb'
FAILED test_mclag_cfg.py::TestMclagConfig::test_mclag_cfg_session_timeout_valid_values - AttributeError: 'DockerVirtualSwitch' object has no attribute 'cdb'
FAILED test_mclag_cfg.py::TestMclagConfig::test_mclag_cfg_ka_valid_values - AttributeError: 'DockerVirtualSwitch' object has no attribute 'cdb'
FAILED test_mclag_cfg.py::TestMclagConfig::test_mclag_cfg_domain_del - AttributeError: 'DockerVirtualSwitch' object has no attribute 'cdb'
============================================================== 6 failed, 7 warnings in 128.67s (0:02:08) ==============================================================
```