### PR TITLE
[vstest]: Extend the list of required external dependencies

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -35,7 +35,7 @@ SWSS, Redis, and all the other required components run inside a virtual switch D
 
     ```
     sudo modprobe team
-    sudo apt install python3-pip net-tools ethtool vlan libnl-nf-3-200 libnl-cli-3-200
+    sudo apt install python3-pip net-tools bridge-utils ethtool vlan libnl-nf-3-200 libnl-cli-3-200
     sudo pip3 install docker pytest flaky redis distro dataclasses fstring
     ```
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
* Extend the list of required external dependencies with `bridge-utils`

**Why I did it**
* To fix the issue of missing `brctl` command

**How I verified it**
* Run `test_fabric.py` test

**Details if related**
Test log:
```
======================================================================= test session starts ========================================================================
platform linux -- Python 3.8.10, pytest-7.1.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/work/development/ppi/sonic-swss/tests
plugins: flaky-3.7.0
collected 2 items                                                                                                                                                  

test_fabric.py::TestVirtualChassis::test_voq_switch ERROR                                                                                                    [ 50%]
test_fabric.py::test_nonflaky_dummy PASSED                                                                                                                   [100%]

============================================================================== ERRORS ==============================================================================
_______________________________________________________ ERROR at setup of TestVirtualChassis.test_voq_switch _______________________________________________________

request = <SubRequest 'vst' for <Function test_voq_switch>>

    @pytest.yield_fixture(scope="module")
    def vst(request):
        vctns = request.config.getoption("--vctns")
        topo = request.config.getoption("--topo")
        forcedvs = request.config.getoption("--forcedvs")
        keeptb = request.config.getoption("--keeptb")
        imgname = request.config.getoption("--imgname")
        max_cpu = request.config.getoption("--max_cpu")
        log_path = vctns if vctns else request.module.__name__
        dvs_env = getattr(request.module, "DVS_ENV", [])
        if not topo:
            # use ecmp topology as default
            topo = "virtual_chassis/chassis_supervisor.json"
>       vct = DockerVirtualChassisTopology(vctns, imgname, keeptb, dvs_env, log_path, max_cpu,
                                           forcedvs, topo)

conftest.py:1832: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
conftest.py:1418: in __init__
    self.handle_request()
conftest.py:1513: in handle_request
    self.create_vct_ctn(ctndir)
conftest.py:1573: in create_vct_ctn
    self.dvss[ctnname] = DockerVirtualSwitch(name=None, imgname=self.imgname,
conftest.py:409: in __init__
    self.check_ready_status_and_init_db()
conftest.py:463: in check_ready_status_and_init_db
    self.check_services_ready()
conftest.py:501: in check_services_ready
    wait_for_result(_polling_function, service_polling_config)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

polling_function = <function DockerVirtualSwitch.check_services_ready.<locals>._polling_function at 0x7f44728ffaf0>
polling_config = PollingConfig(polling_interval=1, timeout=60, strict=True), failure_message = None

    def wait_for_result(
        polling_function: Callable[[], Tuple[bool, Any]],
        polling_config: PollingConfig = PollingConfig(),
        failure_message: str = None,
    ) -> Tuple[bool, Any]:
        """Run `polling_function` periodically using the specified `polling_config`.
    
        Args:
            polling_function: The function being polled. The function cannot take any arguments and
                must return a status which indicates if the function was succesful or not, as well as
                some return value.
            polling_config: The parameters to use to poll the polling function.
            failure_message: The message to print if the call times out. This will only take effect
                if the PollingConfig is set to strict.
    
        Returns:
            If the polling function succeeds, then this method will return True and the output of the
            polling function.
    
            If it does not succeed within the provided timeout, it will return False and whatever the
            output of the polling function was on the final attempt.
        """
        for _ in range(polling_config.iterations()):
            status, result = polling_function()
    
            if status:
                return (True, result)
    
            time.sleep(polling_config.polling_interval)
    
        if polling_config.strict:
            message = failure_message or f"Operation timed out after {polling_config.timeout} seconds with result {result}"
>           assert False, message
E           AssertionError: Operation timed out after 60 seconds with result {'arp_update': 'STOPPED', 'bgpd': 'STOPPED', 'buffermgrd': 'STOPPED', 'containercfgd': 'STOPPED', 'coppmgrd': 'STOPPED', 'fdbsyncd': 'STOPPED', 'fpmsyncd': 'STOPPED', 'gbsyncd': 'STOPPED', 'gearsyncd': 'STOPPED', 'intfmgrd': 'STOPPED', 'natmgrd': 'STOPPED', 'natsyncd': 'STOPPED', 'nbrmgrd': 'STOPPED', 'neighsyncd': 'STOPPED', 'orchagent': 'STOPPED', 'portmgrd': 'STOPPED', 'portsyncd': 'STOPPED', 'redis-chassis': 'STOPPED', 'redis-server': 'RUNNING', 'restore_neighbors': 'STOPPED', 'rsyslogd': 'RUNNING', 'sflowmgrd': 'STOPPED', 'start.sh': 'RUNNING', 'staticd': 'STOPPED', 'syncd': 'STOPPED', 'teammgrd': 'STOPPED', 'teamsyncd': 'STOPPED', 'tunnelmgrd': 'STOPPED', 'vlanmgrd': 'STOPPED', 'vrfmgrd': 'STOPPED', 'vxlanmgrd': 'STOPPED', 'zebra': 'STOPPED'}

dvslib/dvs_common.py:60: AssertionError
---------------------------------------------------------------------- Captured stdout setup -----------------------------------------------------------------------
VCT ns: 4PEB
------rc=1 for cmd: sudo ip netns exec 4PEB brctl addbr br4chs------
b'exec of "brctl" failed: No such file or directory'
------
------rc=1 for cmd: sudo ip netns exec 4PEB ip link set dev br4chs up------
b'Cannot find device "br4chs"'
------
------rc=1 for cmd: sudo ip netns exec 4PEB ip link del 4PEBveth8------
b'Cannot find device "4PEBveth8"'
------
------rc=1 for cmd: sudo ip netns exec 4PEB brctl addif br4chs 4PEBveth8------
b'exec of "brctl" failed: No such file or directory'
------
------rc=1 for cmd: sudo ip netns exec 4PEB ip link del 4PEBveth1------
b'Cannot find device "4PEBveth1"'
------
------rc=1 for cmd: sudo ip netns exec 4PEB brctl addif br4chs 4PEBveth1------
b'exec of "brctl" failed: No such file or directory'
------
========================================================================= warnings summary =========================================================================
conftest.py:1819
  /root/work/development/ppi/sonic-swss/tests/conftest.py:1819: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
  Use @pytest.fixture instead; they are the same.
    @pytest.yield_fixture(scope="module")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================== short test summary info ======================================================================
ERROR test_fabric.py::TestVirtualChassis::test_voq_switch - AssertionError: Operation timed out after 60 seconds with result {'arp_update': 'STOPPED', 'bgpd': 'S...
======================================================== 1 passed, 1 warning, 1 error in 162.99s (0:02:42) =========================================================
```