### PR TITLE
[QoS] Enhance QosOrch::doTask by handling QUEUE table after all the rest tables handled to avoid retry

### DIFF
--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -2137,12 +2137,13 @@ void QosOrch::doTask()
     SWSS_LOG_ENTER();
 
     auto *port_qos_map_cfg_exec = getExecutor(CFG_PORT_QOS_MAP_TABLE_NAME);
+    auto *queue_exec = getExecutor(CFG_QUEUE_TABLE_NAME);
 
     for (const auto &it : m_consumerMap)
     {
         auto *exec = it.second.get();
 
-        if (exec == port_qos_map_cfg_exec)
+        if (exec == port_qos_map_cfg_exec || exec == queue_exec)
         {
             continue;
         }
@@ -2151,6 +2152,7 @@ void QosOrch::doTask()
     }
 
     port_qos_map_cfg_exec->drain();
+    queue_exec->drain();
 }
 
 void QosOrch::doTask(Consumer &consumer)

--- a/tests/mock_tests/qosorch_ut.cpp
+++ b/tests/mock_tests/qosorch_ut.cpp
@@ -1086,6 +1086,8 @@ namespace qosorch_test
         entries.clear();
         // Drain QUEUE table
         static_cast<Orch *>(gQosOrch)->doTask();
+        // Drain SCHEDULER table
+        static_cast<Orch *>(gQosOrch)->doTask();
         // The dependency should be removed
         CheckDependency(CFG_QUEUE_TABLE_NAME, "Ethernet0|0", "scheduler", CFG_SCHEDULER_TABLE_NAME);
         static_cast<Orch *>(gQosOrch)->dumpPendingTasks(ts);


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Enhance `QosOrch::doTask` by handling QUEUE table after all the rest tables handled to avoid retry

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**

**How I verified it**

**Details if related**

During system initialization, QoS table items are received before `gPortsOrch->allPortsReady()` becomes true and will be handled all together after it becomes true.
In most cases, it will be handled in the for loop in the following snippet of code in `OrchDaemon::start()`
```
        auto *c = (Executor *)s;
        c->execute();

        /* After each iteration, periodically check all m_toSync map to
         * execute all the remaining tasks that need to be retried. */

        /* TODO: Abstract Orch class to have a specific todo list */
        for (Orch *o : m_orchList)
            o->doTask();
```
The `QUEUE` table items reference `WRED_PROFILE` and `SCHEDULER_PROFILE` table items. In case the latter tables are handled after the `QUEUE` table, the `QUEUE` table needs to be retried in the next for loop, which is not necessary.
So, we adjust the order in which the tables are handled to guarantee that all QoS table items to be handled in a single call to `QosOrch::doTask`.
