### PR TITLE
[pfcwd] Enhance DLR_INIT based recovery and DLR_PACKET_ACTION for broadcom platforms

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -609,7 +609,7 @@ bool OrchDaemon::init()
 
         if(gSwitchOrch->checkPfcDlrInitEnable())
         {
-            m_orchList.push_back(new PfcWdSwOrch<PfcWdDlrHandler, PfcWdLossyHandler>(
+            m_orchList.push_back(new PfcWdSwOrch<PfcWdDlrHandler, PfcWdDlrHandler>(
                         m_configDb,
                         pfc_wd_tables,
                         portStatIds,

--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -25,6 +25,7 @@
 
 extern sai_object_id_t gSwitchId;
 extern PortsOrch *gPortsOrch;
+extern SwitchOrch *gSwitchOrch;
 extern AclOrch * gAclOrch;
 extern sai_port_api_t *sai_port_api;
 extern sai_queue_api_t *sai_queue_api;
@@ -483,7 +484,7 @@ PfcWdLossyHandler::PfcWdLossyHandler(sai_object_id_t port, sai_object_id_t queue
     SWSS_LOG_ENTER();
 
     string platform = getenv("platform") ? getenv("platform") : "";
-    if (platform == CISCO_8000_PLATFORM_SUBSTRING)
+    if (platform == CISCO_8000_PLATFORM_SUBSTRING || ((platform == BRCM_PLATFORM_SUBSTRING) && (gSwitchOrch->checkPfcDlrInitEnable())))
     {
         SWSS_LOG_DEBUG("Skipping in constructor PfcWdLossyHandler for platform %s on port 0x%" PRIx64,
                        platform.c_str(), port);
@@ -510,7 +511,7 @@ PfcWdLossyHandler::~PfcWdLossyHandler(void)
     SWSS_LOG_ENTER();
 
     string platform = getenv("platform") ? getenv("platform") : "";
-    if (platform == CISCO_8000_PLATFORM_SUBSTRING)
+    if (platform == CISCO_8000_PLATFORM_SUBSTRING || ((platform == BRCM_PLATFORM_SUBSTRING) && (gSwitchOrch->checkPfcDlrInitEnable())))
     {
         SWSS_LOG_DEBUG("Skipping in destructor PfcWdLossyHandler for platform %s on port 0x%" PRIx64,
                        platform.c_str(), getPort());

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -238,11 +238,11 @@ task_process_status PfcWdOrch<DropHandler, ForwardHandler>::createEntry(const st
                 {
                     if(gSwitchOrch->checkPfcDlrInitEnable())
                     {
-                        if(getPfcDlrPacketAction() == PfcWdAction::PFC_WD_ACTION_UNKNOWN)
+                        if((getPfcDlrPacketAction() == PfcWdAction::PFC_WD_ACTION_UNKNOWN) || m_pfcwd_ports.empty())
                         {
                             sai_attribute_t attr;
                             attr.id = SAI_SWITCH_ATTR_PFC_DLR_PACKET_ACTION;
-                            attr.value.u32 = (sai_uint32_t)action;
+                            attr.value.u32 = packet_action_map.at(value);
 
                             sai_status_t status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);
                             if(status != SAI_STATUS_SUCCESS)
@@ -307,6 +307,7 @@ task_process_status PfcWdOrch<DropHandler, ForwardHandler>::createEntry(const st
     }
 
     SWSS_LOG_NOTICE("Started PFC Watchdog on port %s", port.m_alias.c_str());
+    m_pfcwd_ports.insert(port.m_alias);
     return task_process_status::task_success;
 }
 
@@ -325,6 +326,7 @@ task_process_status PfcWdOrch<DropHandler, ForwardHandler>::deleteEntry(const st
     }
 
     SWSS_LOG_NOTICE("Stopped PFC Watchdog on port %s", name.c_str());
+    m_pfcwd_ports.erase(port.m_alias);
     return task_process_status::task_success;
 }
 
@@ -1104,5 +1106,5 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::bake()
 // Trick to keep member functions in a separate file
 template class PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>;
 template class PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>;
-template class PfcWdSwOrch<PfcWdDlrHandler, PfcWdLossyHandler>;
+template class PfcWdSwOrch<PfcWdDlrHandler, PfcWdDlrHandler>;
 template class PfcWdSwOrch<PfcWdSaiDlrInitHandler, PfcWdActionHandler>;

--- a/orchagent/pfcwdorch.h
+++ b/orchagent/pfcwdorch.h
@@ -23,6 +23,12 @@ enum class PfcWdAction
     PFC_WD_ACTION_ALERT,
 };
 
+static const map<string, sai_packet_action_t> packet_action_map = {
+    {"drop", SAI_PACKET_ACTION_DROP},
+    {"forward", SAI_PACKET_ACTION_FORWARD},
+    {"alert", SAI_PACKET_ACTION_FORWARD}
+};
+
 template <typename DropHandler, typename ForwardHandler>
 class PfcWdOrch: public Orch
 {
@@ -61,6 +67,7 @@ private:
     shared_ptr<DBConnector> m_countersDb = nullptr;
     shared_ptr<Table> m_countersTable = nullptr;
     PfcWdAction PfcDlrPacketAction = PfcWdAction::PFC_WD_ACTION_UNKNOWN;
+    std::set<std::string> m_pfcwd_ports;
 };
 
 template <typename DropHandler, typename ForwardHandler>

--- a/tests/mock_tests/mock_orchagent_main.h
+++ b/tests/mock_tests/mock_orchagent_main.h
@@ -13,6 +13,9 @@
 #define private public
 #include "bufferorch.h"
 #include "qosorch.h"
+#define protected public
+#include "pfcwdorch.h"
+#undef protected
 #undef private
 #include "vrforch.h"
 #include "vnetorch.h"
@@ -52,6 +55,7 @@ extern FdbOrch *gFdbOrch;
 extern MirrorOrch *gMirrorOrch;
 extern BufferOrch *gBufferOrch;
 extern QosOrch *gQosOrch;
+template <typename DropHandler, typename ForwardHandler> PfcWdSwOrch<DropHandler, ForwardHandler> *gPfcwdOrch;
 extern VRFOrch *gVrfOrch;
 extern NhgOrch *gNhgOrch;
 extern Srv6Orch  *gSrv6Orch;

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -10,6 +10,7 @@
 #include "mock_sai_bridge.h"
 #define private public
 #include "pfcactionhandler.h"
+#include "switchorch.h"
 #include <sys/mman.h>
 #undef private
 
@@ -63,6 +64,7 @@ namespace portsorch_test
 
     uint32_t _sai_set_port_fec_count;
     int32_t _sai_port_fec_mode;
+    uint32_t _sai_set_pfc_mode_count;
     sai_status_t _ut_stub_sai_set_port_attribute(
         _In_ sai_object_id_t port_id,
         _In_ const sai_attribute_t *attr)
@@ -77,11 +79,17 @@ namespace portsorch_test
             /* Simulating failure case */
             return SAI_STATUS_FAILURE;
         }
+	else if (attr[0].id == SAI_PORT_PRIORITY_FLOW_CONTROL_MODE_COMBINED)
+	{
+	    _sai_set_pfc_mode_count++;
+        }
         return pold_sai_port_api->set_port_attribute(port_id, attr);
     }
 
     uint32_t *_sai_syncd_notifications_count;
     int32_t *_sai_syncd_notification_event;
+    uint32_t _sai_switch_dlr_packet_action_count;
+    uint32_t _sai_switch_dlr_packet_action;
     sai_status_t _ut_stub_sai_set_switch_attribute(
         _In_ sai_object_id_t switch_id,
         _In_ const sai_attribute_t *attr)
@@ -91,6 +99,11 @@ namespace portsorch_test
             *_sai_syncd_notifications_count =+ 1;
             *_sai_syncd_notification_event = attr[0].value.s32;
         }
+	else if (attr[0].id == SAI_SWITCH_ATTR_PFC_DLR_PACKET_ACTION)
+        {
+	    _sai_switch_dlr_packet_action_count++;
+	    _sai_switch_dlr_packet_action = attr[0].value.s32;
+	}
         return pold_sai_switch_api->set_switch_attribute(switch_id, attr);
     }
 
@@ -233,6 +246,17 @@ namespace portsorch_test
             ::testing_db::reset();
 
             // Create dependencies ...
+            TableConnector stateDbSwitchTable(m_state_db.get(), "SWITCH_CAPABILITY");
+            TableConnector app_switch_table(m_app_db.get(), APP_SWITCH_TABLE_NAME);
+            TableConnector conf_asic_sensors(m_config_db.get(), CFG_ASIC_SENSORS_TABLE_NAME);
+
+            vector<TableConnector> switch_tables = {
+                conf_asic_sensors,
+                app_switch_table
+            };
+
+            ASSERT_EQ(gSwitchOrch, nullptr);
+            gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
 
             const int portsorch_base_pri = 40;
 
@@ -282,6 +306,62 @@ namespace portsorch_test
 
             ASSERT_EQ(gNeighOrch, nullptr);
             gNeighOrch = new NeighOrch(m_app_db.get(), APP_NEIGH_TABLE_NAME, gIntfsOrch, gFdbOrch, gPortsOrch, m_chassis_app_db.get());
+
+            vector<string> qos_tables = {
+                CFG_TC_TO_QUEUE_MAP_TABLE_NAME,
+                CFG_SCHEDULER_TABLE_NAME,
+                CFG_DSCP_TO_TC_MAP_TABLE_NAME,
+                CFG_MPLS_TC_TO_TC_MAP_TABLE_NAME,
+                CFG_DOT1P_TO_TC_MAP_TABLE_NAME,
+                CFG_QUEUE_TABLE_NAME,
+                CFG_PORT_QOS_MAP_TABLE_NAME,
+                CFG_WRED_PROFILE_TABLE_NAME,
+                CFG_TC_TO_PRIORITY_GROUP_MAP_TABLE_NAME,
+                CFG_PFC_PRIORITY_TO_PRIORITY_GROUP_MAP_TABLE_NAME,
+                CFG_PFC_PRIORITY_TO_QUEUE_MAP_TABLE_NAME,
+                CFG_DSCP_TO_FC_MAP_TABLE_NAME,
+                CFG_EXP_TO_FC_MAP_TABLE_NAME,
+                CFG_TC_TO_DSCP_MAP_TABLE_NAME
+            };
+            gQosOrch = new QosOrch(m_config_db.get(), qos_tables);
+
+            vector<string> pfc_wd_tables = {
+                CFG_PFC_WD_TABLE_NAME
+            };
+
+            static const vector<sai_port_stat_t> portStatIds =
+            {
+                SAI_PORT_STAT_PFC_0_RX_PKTS,
+                SAI_PORT_STAT_PFC_1_RX_PKTS,
+                SAI_PORT_STAT_PFC_2_RX_PKTS,
+                SAI_PORT_STAT_PFC_3_RX_PKTS,
+                SAI_PORT_STAT_PFC_4_RX_PKTS,
+                SAI_PORT_STAT_PFC_5_RX_PKTS,
+                SAI_PORT_STAT_PFC_6_RX_PKTS,
+                SAI_PORT_STAT_PFC_7_RX_PKTS,
+                SAI_PORT_STAT_PFC_0_ON2OFF_RX_PKTS,
+                SAI_PORT_STAT_PFC_1_ON2OFF_RX_PKTS,
+                SAI_PORT_STAT_PFC_2_ON2OFF_RX_PKTS,
+                SAI_PORT_STAT_PFC_3_ON2OFF_RX_PKTS,
+                SAI_PORT_STAT_PFC_4_ON2OFF_RX_PKTS,
+                SAI_PORT_STAT_PFC_5_ON2OFF_RX_PKTS,
+                SAI_PORT_STAT_PFC_6_ON2OFF_RX_PKTS,
+                SAI_PORT_STAT_PFC_7_ON2OFF_RX_PKTS,
+            };
+
+            static const vector<sai_queue_stat_t> queueStatIds =
+            {
+                SAI_QUEUE_STAT_PACKETS,
+                SAI_QUEUE_STAT_CURR_OCCUPANCY_BYTES,
+            };
+
+            static const vector<sai_queue_attr_t> queueAttrIds =
+            {
+                SAI_QUEUE_ATTR_PAUSE_STATUS,
+            };
+            ASSERT_EQ((gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler>), nullptr);
+            gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler> = new PfcWdSwOrch<PfcWdDlrHandler, PfcWdDlrHandler>(m_config_db.get(), pfc_wd_tables, portStatIds, queueStatIds, queueAttrIds, 100);
+
         }
 
         virtual void TearDown() override
@@ -304,6 +384,12 @@ namespace portsorch_test
             gPortsOrch = nullptr;
             delete gBufferOrch;
             gBufferOrch = nullptr;
+            delete gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler>;
+            gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler> = nullptr;
+            delete gQosOrch;
+            gQosOrch = nullptr;
+            delete gSwitchOrch;
+            gSwitchOrch = nullptr;
 
             // clear orchs saved in directory
             gDirectory.m_values.clear();
@@ -855,6 +941,7 @@ namespace portsorch_test
 
     TEST_F(PortsOrchTest, PfcDlrHandlerCallingDlrInitAttribute)
     {
+        _hook_sai_port_api();
         _hook_sai_queue_api();
         Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
         Table pgTable = Table(m_app_db.get(), APP_BUFFER_PG_TABLE_NAME);
@@ -898,14 +985,161 @@ namespace portsorch_test
         // Simulate storm drop handler started on Ethernet0 TC 3
         Port port;
         gPortsOrch->getPort("Ethernet0", port);
+	auto current_pfc_mode_count = _sai_set_pfc_mode_count;
         auto countersTable = make_shared<Table>(m_counters_db.get(), COUNTERS_TABLE);
         auto dropHandler = make_unique<PfcWdDlrHandler>(port.m_port_id, port.m_queue_ids[3], 3, countersTable);
+	ASSERT_EQ(current_pfc_mode_count, _sai_set_pfc_mode_count);
         ASSERT_TRUE(_sai_set_queue_attr_count == 1);
 
         dropHandler.reset();
+	ASSERT_EQ(current_pfc_mode_count, _sai_set_pfc_mode_count);
         ASSERT_FALSE(_sai_set_queue_attr_count == 1);
 
         _unhook_sai_queue_api();
+	_unhook_sai_port_api();
+    }
+
+    TEST_F(PortsOrchTest, PfcDlrPacketAction)
+    {
+	_hook_sai_switch_api();
+	std::deque<KeyOpFieldsValuesTuple> entries;
+	sai_packet_action_t dlr_packet_action;
+	gSwitchOrch->m_PfcDlrInitEnable = true;
+        gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler>->m_platform = BRCM_PLATFORM_SUBSTRING;
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+	Table cfgPfcwdTable = Table(m_config_db.get(), CFG_PFC_WD_TABLE_NAME);
+	Table cfgPortQosMapTable = Table(m_config_db.get(), CFG_PORT_QOS_MAP_TABLE_NAME);
+
+        // Get SAI default ports to populate DB
+        auto ports = ut_helper::getInitialSaiPorts();
+
+        // Populate port table with SAI ports
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+
+        // Set PortConfigDone, PortInitDone
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+        portTable.set("PortInitDone", { { "lanes", "0" } });
+
+        // refill consumer
+        gPortsOrch->addExistingData(&portTable);
+
+        // Apply configuration :
+        //  create ports
+
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        // Apply configuration
+        //          ports
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        ASSERT_TRUE(gPortsOrch->allPortsReady());
+
+        // No more tasks
+        vector<string> ts;
+        gPortsOrch->dumpPendingTasks(ts);
+        ASSERT_TRUE(ts.empty());
+        ts.clear();
+
+        entries.clear();
+	entries.push_back({"Ethernet0", "SET",
+			    {
+			      {"pfc_enable", "3,4"},
+			      {"pfcwd_sw_enable", "3,4"}
+			  }});
+	entries.push_back({"Ethernet8", "SET",
+			    {
+			      {"pfc_enable", "3,4"},
+			      {"pfcwd_sw_enable", "3,4"}
+			  }});
+        auto portQosMapConsumer = dynamic_cast<Consumer *>(gQosOrch->getExecutor(CFG_PORT_QOS_MAP_TABLE_NAME));
+        portQosMapConsumer->addToSync(entries);
+        entries.clear();
+	static_cast<Orch *>(gQosOrch)->doTask();
+
+        // create pfcwd entry for first port with drop action
+	dlr_packet_action = SAI_PACKET_ACTION_DROP;
+	entries.push_back({"GLOBAL", "SET",
+			  {
+			    {"POLL_INTERVAL", "200"},
+			  }});
+	entries.push_back({"Ethernet0", "SET",
+			  {
+			    {"action", "drop"},
+			    {"detection_time", "200"},
+			    {"restoration_time", "200"}
+			  }});
+
+        auto PfcwdConsumer = dynamic_cast<Consumer *>(gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler>->getExecutor(CFG_PFC_WD_TABLE_NAME));
+	PfcwdConsumer->addToSync(entries);
+        entries.clear();
+
+        auto current_switch_dlr_packet_action_count = _sai_switch_dlr_packet_action_count;
+        static_cast<Orch *>(gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler>)->doTask();
+	ASSERT_EQ(++current_switch_dlr_packet_action_count, _sai_switch_dlr_packet_action_count);
+        ASSERT_EQ(_sai_switch_dlr_packet_action, dlr_packet_action);
+        ASSERT_EQ((gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler>->m_pfcwd_ports.size()), 1);
+
+	// create pfcwd entry for second port with drop action
+	entries.push_back({"Ethernet8", "SET",
+			  {
+			    {"action", "drop"},
+			    {"detection_time", "200"},
+			    {"restoration_time", "200"}
+			  }});
+	PfcwdConsumer->addToSync(entries);
+        entries.clear();
+        current_switch_dlr_packet_action_count = _sai_switch_dlr_packet_action_count;
+        static_cast<Orch *>(gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler>)->doTask();
+	// verify no change in count
+	ASSERT_EQ(current_switch_dlr_packet_action_count, _sai_switch_dlr_packet_action_count);
+
+        // remove both the entries
+        entries.push_back({"Ethernet0", "DEL",
+                           {{}}
+                          });
+	PfcwdConsumer->addToSync(entries);
+        entries.clear();
+        static_cast<Orch *>(gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler>)->doTask();
+        ASSERT_EQ((gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler>->m_pfcwd_ports.size()), 1);
+
+        entries.push_back({"Ethernet8", "DEL",
+                           {{}}
+                          });
+	PfcwdConsumer->addToSync(entries);
+        entries.clear();
+        static_cast<Orch *>(gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler>)->doTask();
+
+        // create pfcwd entry for first port with forward action
+	dlr_packet_action = SAI_PACKET_ACTION_FORWARD;
+	entries.push_back({"Ethernet0", "SET",
+			  {
+			    {"action", "forward"},
+			    {"detection_time", "200"},
+			    {"restoration_time", "200"}
+			  }});
+
+	PfcwdConsumer->addToSync(entries);
+        entries.clear();
+
+        current_switch_dlr_packet_action_count = _sai_switch_dlr_packet_action_count;
+        static_cast<Orch *>(gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler>)->doTask();
+	ASSERT_EQ(++current_switch_dlr_packet_action_count, _sai_switch_dlr_packet_action_count);
+        ASSERT_EQ(_sai_switch_dlr_packet_action, dlr_packet_action);
+        ASSERT_EQ((gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler>->m_pfcwd_ports.size()), 1);
+
+        // remove the entry
+        entries.push_back({"Ethernet0", "DEL",
+                           {{}}
+                          });
+	PfcwdConsumer->addToSync(entries);
+        entries.clear();
+        static_cast<Orch *>(gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler>)->doTask();
+        ASSERT_EQ((gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler>->m_pfcwd_ports.size()), 0);
+
+	_unhook_sai_switch_api();
     }
 
     TEST_F(PortsOrchTest, PfcZeroBufferHandler)


### PR DESCRIPTION
What I did
This PR contains the following changes
- for brcm platforms that support DLR_INIT based recovery, use that method for both drop and forward action
- While using DLR_INIT based recovery, do not update the pfc bitmask for that port
- Update the logic to handle allowing drop/forward action on all ports without requiring a restart of swss
- Mock tests for DLR_INIT and DLR_PACKET action

Why I did it
To provide support for DLR_INIT based pfcwd recovery on broadcom platforms in certain roles

How I verified it
Mock tests
Tested on various brcm platforms (TD3 dual tor, Th2 T1, TD3 single tor) with a custom swss deb along with updated bcm config and verified that the pfcwd recovery mechanism is as expected on 202205