### PR TITLE
[subinterface] Fix admin state handling

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -696,7 +696,7 @@ void IntfsOrch::doTask(Consumer &consumer)
         MacAddress mac;
 
         uint32_t mtu = 0;
-        bool adminUp;
+        bool adminUp = false;
         bool adminStateChanged = false;
         uint32_t nat_zone_id = 0;
         string proxy_arp = "";
@@ -865,10 +865,11 @@ void IntfsOrch::doTask(Consumer &consumer)
             {
                 if (!ip_prefix_in_key && isSubIntf)
                 {
-                    if (adminStateChanged == false)
+                    if (!adminStateChanged)
                     {
                         adminUp = port.m_admin_state_up;
                     }
+
                     if (!gPortsOrch->addSubPort(port, alias, vlan, adminUp, mtu))
                     {
                         it++;
@@ -896,6 +897,12 @@ void IntfsOrch::doTask(Consumer &consumer)
                     it++;
                     continue;
                 }
+
+                if (!adminStateChanged)
+                {
+                    adminUp = port.m_admin_state_up;
+                }
+
                 if (!vnet_orch->setIntf(alias, vnet_name, ip_prefix_in_key ? &ip_prefix : nullptr, adminUp, mtu))
                 {
                     it++;
@@ -909,7 +916,7 @@ void IntfsOrch::doTask(Consumer &consumer)
             }
             else
             {
-                if (adminStateChanged == false)
+                if (!adminStateChanged)
                 {
                     adminUp = port.m_admin_state_up;
                 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
closes https://github.com/sonic-net/sonic-buildimage/issues/15282

The bug is caused by a logic in `intfmgr` which aims to reduce the redundant admin state configuration.
Because of that, `intfsorch` falls back to defaults and treats admin state configuration as disabled.

These changes allow to reset port admin state to it's default value,
when configuration is not received by producer-consumer mechanism.

**What I did**
* Fixed invalid RIF admin state during VNET port subinterface configuration

**Why I did it**
* To resolve the issue with RIF admin state configuration

**How I verified it**
* Run VS tests

**Details if related**
* N/A