### PR TITLE
[202012][muxorch] set mux state to init upon warm reboot

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -24,6 +24,7 @@
 #include "routeorch.h"
 #include "fdborch.h"
 #include "qosorch.h"
+#include "warm_restart.h"
 
 /* Global variables */
 extern Directory<Orch*> gDirectory;
@@ -401,9 +402,19 @@ MuxCable::MuxCable(string name, IpPrefix& srv_ip4, IpPrefix& srv_ip6, IpAddress 
     state_machine_handlers_.insert(handler_pair(MUX_STATE_INIT_STANDBY, &MuxCable::stateStandby));
     state_machine_handlers_.insert(handler_pair(MUX_STATE_ACTIVE_STANDBY, &MuxCable::stateStandby));
 
-    /* Set initial state to "standby" */
-    stateStandby();
-    state_ = MuxState::MUX_STATE_STANDBY;
+    if (WarmStart::isWarmStart()) {
+        /* Warmboot case, Set initial state to "init" 
+         * State will be updated to previous value upon APP DB sync
+         */
+        SWSS_LOG_INFO("Warm reboot detected, initializing mux state to INIT");
+        state_ = MuxState::MUX_STATE_INIT;
+    }
+    else
+    {
+        /* Set initial state to "standby" */
+        stateStandby();
+        state_ = MuxState::MUX_STATE_STANDBY;
+    }
 }
 
 bool MuxCable::stateInitActive()

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -1478,6 +1478,27 @@ class TestMuxTunnel(TestMuxTunnelBase):
         for ip in test_ips:
             self.check_neighbor_state(dvs, dvs_route, ip, expect_route=False)
 
+    def test_warm_boot_mux_state(
+            self, dvs, appdb, dvs_route, setup_vlan, setup_mux_cable, setup_tunnel,
+            remove_peer_switch, neighbor_cleanup, testlog
+    ):
+        """
+        test mux initialization during warm boot.
+        """
+        self.set_mux_state(appdb, "Ethernet0", "active")
+
+        # Execute the warm reboot
+        dvs.runcmd("config warm_restart enable swss")
+        dvs.stop_swss()
+        dvs.start_swss()
+
+        time.sleep(5)
+
+        fvs = appdb.get_entry(self.APP_MUX_CABLE, "Ethernet0")
+        for key in fvs:
+            if key == "state":
+                assert fvs[key] == "active", "Mux state is not active after warm boot, state: {}".format(fvs[key])
+
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying


### PR DESCRIPTION
What I did:
added condition to set mux state to init upon warm reboot

Why I did it:
bug caused orchagent to crash when mux initialized to standby during warm boot

How I tested:
vstest included