### PR TITLE
[portsorch]: Enhancing SWSS OA logs to capture host_tx_ready change events

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1102,8 +1102,8 @@ void PortsOrch::initHostTxReadyState(Port &port)
     if (hostTxReady.empty())
     {
         m_portStateTable.hset(port.m_alias, "host_tx_ready", "false");
-        SWSS_LOG_INFO("initalize hostTxReady %s with status %s",
-                port.m_alias.c_str(), hostTxReady.c_str());
+        SWSS_LOG_NOTICE("initialize host_tx_ready as false for port %s",
+                        port.m_alias.c_str());
     }
 }
 
@@ -1119,15 +1119,16 @@ bool PortsOrch::setPortAdminStatus(Port &port, bool state)
     if (!state)
     {
         m_portStateTable.hset(port.m_alias, "host_tx_ready", "false");
-        SWSS_LOG_INFO("Set admin status DOWN host_tx_ready to false to port pid:%" PRIx64,
-                port.m_port_id);
+        SWSS_LOG_NOTICE("Set admin status DOWN host_tx_ready to false for port %s",
+                port.m_alias.c_str());
     }
 
     sai_status_t status = sai_port_api->set_port_attribute(port.m_port_id, &attr);
     if (status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR("Failed to set admin status %s to port pid:%" PRIx64,
-                       state ? "UP" : "DOWN", port.m_port_id);
+        SWSS_LOG_ERROR("Failed to set admin status %s for port %s."
+                       " Setting host_tx_ready as false",
+                       state ? "UP" : "DOWN", port.m_alias.c_str());
         m_portStateTable.hset(port.m_alias, "host_tx_ready", "false");
         task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, status);
         if (handle_status != task_success)
@@ -1140,14 +1141,16 @@ bool PortsOrch::setPortAdminStatus(Port &port, bool state)
     if (gbstatus != true)
     {
         m_portStateTable.hset(port.m_alias, "host_tx_ready", "false");
+        SWSS_LOG_NOTICE("Set host_tx_ready to false as gbstatus is false "
+                        "for port %s", port.m_alias.c_str());
     }
 
     /* Update the state table for host_tx_ready*/
     if (state && (gbstatus == true) && (status == SAI_STATUS_SUCCESS) )
     {
         m_portStateTable.hset(port.m_alias, "host_tx_ready", "true");
-        SWSS_LOG_INFO("Set admin status UP host_tx_ready to true to port pid:%" PRIx64,
-                port.m_port_id);
+        SWSS_LOG_NOTICE("Set admin status UP host_tx_ready to true for port %s",
+                port.m_alias.c_str());
     }
 
     return true;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
It seems that currently, we don't print the value of host_tx_ready in some places while setting it. We need to ensure to log the value of host_tx_ready in such cases.
Example:
https://github.com/sonic-net/sonic-swss/blob/872b80b699d25e84a352a8511cb8882792a2443c/orchagent/portsorch.cpp#L1105-L1106

Also, we should display port number instead of port_id to keep logging consistent.
https://github.com/sonic-net/sonic-swss/blob/872b80b699d25e84a352a8511cb8882792a2443c/orchagent/portsorch.cpp#LL1149C28-L1149C44

May 25 22:28:47.759325 sonic NOTICE swss#orchagent: :- doPortTask: Set port Ethernet136 admin status to up
May 25 22:28:47.759566 sonic INFO swss#orchagent: :- initHostTxReadyState: initalize hostTxReady Ethernet144 with status
May 25 22:28:47.760391 sonic INFO swss#orchagent: :- setPortAdminStatus: Set admin status UP host_tx_ready to true to port pid:**1000000000015**

**Why I did it**
This was done to improve debuggability

**How I verified it**
Please find the logs below captured after restarting swss, shut and no shut for a port
Jun 14 23:15:36.159567 sonic NOTICE swss#orchagent: :- setPortAdminStatus: Set admin status UP host_tx_ready to true for port Ethernet88
Jun 14 23:15:36.159754 sonic NOTICE swss#orchagent: :- initHostTxReadyState: initialize host_tx_ready as false for port Ethernet96
Jun 14 23:15:36.160567 sonic NOTICE swss#orchagent: :- setPortAdminStatus: Set admin status UP host_tx_ready to true for port Ethernet96
Jun 14 23:18:41.299182 sonic NOTICE swss#orchagent: :- setPortAdminStatus: Set admin status DOWN host_tx_ready to false for port Ethernet144
Jun 14 23:19:02.074076 sonic NOTICE swss#orchagent: :- setPortAdminStatus: Set admin status UP host_tx_ready to true for port Ethernet144

**Details if related**
