### PR TITLE
Revert "[202205][Dual-ToR][ACL] bind LAG to ACL table in order to guarantee rule coverage if LAG member will be added to LAG after binding"

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3117,7 +3117,6 @@ void AclOrch::initDefaultTableTypes()
     addAclTableType(
         builder.withName(TABLE_TYPE_DROP)
             .withBindPointType(SAI_ACL_BIND_POINT_TYPE_PORT)
-            .withBindPointType(SAI_ACL_BIND_POINT_TYPE_LAG)
             .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_TC))
             .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_IN_PORTS))
             .build()

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1011,13 +1011,6 @@ void MuxAclHandler::bindAllPorts(AclTable &acl_table)
             acl_table.link(port.m_port_id);
             acl_table.bind(port.m_port_id);
         }
-        else if (port.m_type == Port::LAG && !isIngressAcl())
-        {
-            SWSS_LOG_INFO("Binding LAG %" PRIx64 " to ACL table %s", port.m_lag_id, acl_table.id.c_str());
-
-            acl_table.link(port.m_lag_id);
-            acl_table.bind(port.m_lag_id);
-        }
     }
 }
 


### PR DESCRIPTION
Reverts sonic-net/sonic-swss#2749

Not sure if this is the right approach. Will it cause server to server IO have duplicates?