### PR TITLE
[SFLOW] Failed to breakout due to configure Sflow

### DIFF
--- a/orchagent/sfloworch.cpp
+++ b/orchagent/sfloworch.cpp
@@ -379,7 +379,17 @@ void SflowOrch::doTask(Consumer &consumer)
         string op = kfvOp(tuple);
         string alias = kfvKey(tuple);
 
-        gPortsOrch->getPort(alias, port);
+        /* There are chances the the port has not been created in SAI and
+         * handling on the new created port for sflow goes the SAI port creation when dynamic port
+         * breakout command is executed. Needs to call getPort() here to ensure the port
+         * has been created by SAI.
+         */
+        if (!gPortsOrch->getPort(alias, port))
+        {
+            it++;
+            continue;
+        }
+
         if (op == SET_COMMAND)
         {
             bool      admin_state = m_sflowStatus;


### PR DESCRIPTION
There are chances that the port has not been created and handling on the new created port for sflow when dynamic port breakout command is executed. It needs to wait port ready before setting sflow on the port.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
Sometimes swss would dead when enable sflow and do port breakout, 
```
May 24 02:04:34.033589 sonic INFO ConfigMgmt: Write in DB: {'INTERFACE': {'Ethernet48': None, ('Ethernet48', '10.0.0.96/31'): None}, 'PORT': {'Ethernet48': None}, 'SFLOW_SESSION': {'Ethernet48': None}}
May 24 02:04:36.046650 sonic INFO ConfigMgmt: Write in DB: {'PORT': {'Ethernet48': {'alias': 'Eth49/1(Port49)', 'lanes': '37', 'speed': '25000', 'index': '49','parent_port': 'Ethernet48'}, 'Ethernet49': {'alias': 'Eth49/2(Port49)', 'lanes': '38', 'speed': '25000', 'index': '49','parent_port': 'Ethernet48'}, 'Ethernet50': {'alias': 'Eth49/3(Port49)', 'lanes': '39', 'speed': '25000', 'index': '49', 'parent_port': 'Ethernet48'},'Ethernet51': {'alias': 'Eth49/4(Port49)', 'lanes': '40', 'speed': '25000', 'index': '49', 'parent_port': 'Ethernet48'}}}
May 24 02:04:36.054081 sonic ERR swss#orchagent: :- set: switch id oid:0x0 doesn't exist
May 24 02:04:36.054540 sonic ERR swss#orchagent: :- sflowAddPort: Failed to set session f000000000a06 on port 0
May 24 02:04:36.054540 sonic ERR swss#orchagent: :- handleSaiSetStatus: Encountered failure in set operation, exiting orchagent, SAI API: SAI_API_PORT, status: SAI_STATUS_INVALID_PARAMETER
```

**What I did**
Wait until port is created successfully when sflow is set for port.

**Why I did it**
It should get correct port ID when set sflow for port.

**How I verified it**
1. enable sflow
2. breakout port
3. make sure swss work well

```
root@sonic:/# config sflow enable
root@sonic:/# config sflow collector add test 188.188.87.120
root@sonic:/# config sflow interface enable Ethernet480
root@sonic:/# config interface breakout Ethernet480 1x400G -f -y

Running Breakout Mode : 1x100G[40G](4)
Target Breakout Mode : 1x400G

Ports to be deleted :
 {
    "Ethernet480": "100000"
}
Ports to be added :
 {
    "Ethernet480": "400000"
}

After running Logic to limit the impact

Final list of ports to be deleted :
 {
    "Ethernet480": "100000"
}
Final list of ports to be added :
 {
    "Ethernet480": "400000"
}
sonic_yang(6):Note: Below table(s) have no YANG models: CONSOLE_SWITCH, DEVICE_NEIGHBOR_METADATA, DHCP_SERVER, RESTAPI, SNMP, SNMP_COMMUNITY, XCVRD_LOG
Breakout process got successfully completed.
Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.
root@sonic:/# docker ps
CONTAINER ID   IMAGE                                COMMAND                  CREATED       STATUS       PORTS     NAMES
0a067666242d   docker-snmp:latest                   "/usr/local/bin/supe…"   6 hours ago   Up 5 hours             snmp
7c5fdf312b7e   docker-sonic-telemetry:latest        "/usr/local/bin/supe…"   6 hours ago   Up 5 hours             telemetry
511a035536c2   docker-sonic-mgmt-framework:latest   "/usr/local/bin/supe…"   6 hours ago   Up 5 hours             mgmt-framework
a10d1f0f41f6   656d607218cd                         "/usr/bin/docker_ini…"   6 hours ago   Up 5 hours             dhcp_relay
336087158a63   docker-router-advertiser:latest      "/usr/bin/docker-ini…"   6 hours ago   Up 5 hours             radv
53582ba9a454   docker-stp:latest                    "/usr/local/bin/supe…"   6 hours ago   Up 5 hours             stp
bf0c1ccaf978   docker-lldp:latest                   "/usr/bin/docker-lld…"   6 hours ago   Up 5 hours             lldp
68b9607dbb6d   docker-sflow:latest                  "/usr/local/bin/supe…"   6 hours ago   Up 5 hours             sflow
8a40a1815a9a   docker-nat:latest                    "/usr/local/bin/supe…"   6 hours ago   Up 5 hours             nat
bbe128d46ac9   docker-syncd-brcm:latest             "/usr/local/bin/supe…"   6 hours ago   Up 5 hours             syncd
64655f48c833   docker-teamd:latest                  "/usr/local/bin/supe…"   6 hours ago   Up 5 hours             teamd
5eeb5a6d7f91   docker-sonic-p4rt:latest             "/usr/local/bin/supe…"   6 hours ago   Up 5 hours             p4rt
9823b8fc5fbf   docker-iccpd:latest                  "/usr/local/bin/supe…"   6 hours ago   Up 5 hours             iccpd
4f8359ee47a6   docker-orchagent:latest              "/usr/bin/docker-ini…"   6 hours ago   Up 5 hours             swss
208f5cb495ad   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   6 hours ago   Up 5 hours             bgp
f6ac8af3b17f   docker-platform-monitor:latest       "/usr/bin/docker_ini…"   6 hours ago   Up 5 hours             pmon
a0e6dbce950e   docker-database:latest               "/usr/local/bin/dock…"   6 hours ago   Up 5 hours             database
root@sonic:/#
root@sonic:/# show interfaces status Ethernet480
  Interface                            Lanes    Speed    MTU    Oper FEC          Alias    Vlan    Oper    Admin    ProtoDown    Eff Admin    Type    Asym PFC    Oper Speed
-----------  -------------------------------  -------  -----  ----------  -------------  ------  ------  -------  -----------  -----------  ------  ----------  ------------
Ethernet480  386,387,388,389,390,391,392,393     400G   9100          rs  Eth61(Port61)  routed    down     down        False          N/A     N/A         N/A          400G
root@sonic:/#
```

**Details if related**
