### PR TITLE
Enable/disable Dash ZmqConsumer and switch back to Redis based consumer by parameter.

### DIFF
--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -894,12 +894,20 @@ void ZmqOrch::addConsumer(DBConnector *db, string tableName, int pri, ZmqServer 
 {
     if (db->getDbId() == APPL_DB)
     {
-        SWSS_LOG_DEBUG("[ZMQ] ZmqConsumer initialize for: %s", tableName.c_str());
-        addExecutor(new ZmqConsumer(new ZmqConsumerStateTable(db, tableName, *zmqServer, gBatchSize, pri), this, tableName));
+        if (zmqServer != nullptr)
+        {
+            SWSS_LOG_DEBUG("ZmqConsumer initialize for: %s", tableName.c_str());
+            addExecutor(new ZmqConsumer(new ZmqConsumerStateTable(db, tableName, *zmqServer, gBatchSize, pri), this, tableName));
+        }
+        else
+        {
+            SWSS_LOG_DEBUG("Consumer initialize for: %s", tableName.c_str());
+            addExecutor(new Consumer(new ConsumerStateTable(db, tableName, gBatchSize, pri), this, tableName));
+        }
     }
     else
     {
-        SWSS_LOG_WARN("ZmqConsumer not enabled for consumer db: %d, table: %s", db->getDbId(), tableName.c_str());
+        SWSS_LOG_WARN("ZmqOrch does not support create consumer for db: %d, table: %s", db->getDbId(), tableName.c_str());
     }
 }
 


### PR DESCRIPTION
Enable/disable Dash ZmqConsumer by parameter.

**What I did**
Change code to allow disable ZMQ and switch back to Redis Consumer.

**Why I did it**
Dash orch UT still need Redis based Consumer, so improve to disable ZMQ and switch back to Redis Consumer.

**How I verified it**
Pass all UT.

**Details if related**