### PR TITLE
[tests]: Set HWSKU to NPU for dash vstests

### DIFF
--- a/tests/test_dash_acl.py
+++ b/tests/test_dash_acl.py
@@ -5,7 +5,8 @@ import time
 
 import pytest
 
-DVS_ENV = ["HWSKU=Nvidia-MBF2H536C"]
+DVS_ENV = ["HWSKU=NPU"]
+NUM_PORTS = 2
 
 ACL_GROUP_1 = "acl_group_1"
 ACL_GROUP_2 = "acl_group_2"

--- a/tests/test_dash_acl.py
+++ b/tests/test_dash_acl.py
@@ -5,7 +5,7 @@ import time
 
 import pytest
 
-DVS_ENV = ["HWSKU=NPU"]
+DVS_ENV = ["HWSKU=NPU-2P"]
 NUM_PORTS = 2
 
 ACL_GROUP_1 = "acl_group_1"

--- a/tests/test_dash_crm.py
+++ b/tests/test_dash_crm.py
@@ -7,7 +7,7 @@ import pytest
 from swsscommon import swsscommon
 
 
-DVS_ENV = ["HWSKU=Nvidia-MBF2H536C"]
+DVS_ENV = ["HWSKU=NPU"]
 NUM_PORTS = 2
 
 

--- a/tests/test_dash_crm.py
+++ b/tests/test_dash_crm.py
@@ -7,7 +7,7 @@ import pytest
 from swsscommon import swsscommon
 
 
-DVS_ENV = ["HWSKU=NPU"]
+DVS_ENV = ["HWSKU=NPU-2P"]
 NUM_PORTS = 2
 
 

--- a/tests/test_dash_vnet.py
+++ b/tests/test_dash_vnet.py
@@ -2,7 +2,7 @@ from swsscommon import swsscommon
 import typing
 import time
 
-DVS_ENV = ["HWSKU=NPU"]
+DVS_ENV = ["HWSKU=NPU-2P"]
 NUM_PORTS = 2
 
 def to_string(value):

--- a/tests/test_dash_vnet.py
+++ b/tests/test_dash_vnet.py
@@ -2,6 +2,9 @@ from swsscommon import swsscommon
 import typing
 import time
 
+DVS_ENV = ["HWSKU=NPU"]
+NUM_PORTS = 2
+
 def to_string(value):
     if isinstance(value, bool):
         return "true" if value else "false"


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Define a generic NPU SKU for docker-sonic-vs
**Why I did it**
Bluefield3 hwsku(Nvidia-MBF2H536C) is not planned to be made available upstream in the near future. Therefore , inorder to pass DASH vstests on azure pipeline runs, this change is being made.
**How I verified it**
By making sure that DASH vstests are able to run and pass on azure pipeline.
**Details if related**
