### PR TITLE
[202211] CodeQL: Use 202211 branch of swss-common and sairedis instead of master

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -92,6 +92,7 @@ jobs:
         cd ..
         git clone https://github.com/sonic-net/sonic-swss-common
         pushd sonic-swss-common
+        git checkout 202211
         ./autogen.sh
         fakeroot dpkg-buildpackage -us -uc -b
         popd
@@ -104,6 +105,7 @@ jobs:
         cd ..
         git clone --recursive https://github.com/sonic-net/sonic-sairedis
         pushd sonic-sairedis
+        git checkout 202211
         ./autogen.sh
         DEB_BUILD_OPTIONS=nocheck SWSS_COMMON_INC="$(dirname $GITHUB_WORKSPACE)/usr/include" SWSS_COMMON_LIB="$(dirname $GITHUB_WORKSPACE)/usr/lib/x86_64-linux-gnu" fakeroot debian/rules CFLAGS="-Wno-error" CXXFLAGS="-Wno-error" binary-syncd-vs
         popd


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

For CodeQL analysis, make sure the 202211 branch of swss-common and sairedis are used when analyzing 202211 branch of swss.

**Why I did it**

**How I verified it**

**Details if related**
