### PR TITLE
[tests]: Change DVS ENV HWKSU to DPU-2P for DASH vstest

### DIFF
--- a/tests/test_dash_acl.py
+++ b/tests/test_dash_acl.py
@@ -5,7 +5,7 @@ import time
 
 import pytest
 
-DVS_ENV = ["HWSKU=NPU-2P"]
+DVS_ENV = ["HWSKU=DPU-2P"]
 NUM_PORTS = 2
 
 ACL_GROUP_1 = "acl_group_1"

--- a/tests/test_dash_crm.py
+++ b/tests/test_dash_crm.py
@@ -7,7 +7,7 @@ import pytest
 from swsscommon import swsscommon
 
 
-DVS_ENV = ["HWSKU=NPU-2P"]
+DVS_ENV = ["HWSKU=DPU-2P"]
 NUM_PORTS = 2
 
 

--- a/tests/test_dash_vnet.py
+++ b/tests/test_dash_vnet.py
@@ -2,7 +2,7 @@ from swsscommon import swsscommon
 import typing
 import time
 
-DVS_ENV = ["HWSKU=NPU-2P"]
+DVS_ENV = ["HWSKU=DPU-2P"]
 NUM_PORTS = 2
 
 def to_string(value):


### PR DESCRIPTION
 * Change DVS ENV HWSKU to a more appropriate DPU-2P from NPU-2P for DASH vstest

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Change DVS ENV HWSKU to a more appropriate DPU-2P from NPU-2P for DASH vstest
**Why I did it**
DPU-2P is more appropriate for 2-port simulator for DASH vstests 
**How I verified it**
By running DASH vstest manually
**Details if related**
Related sonic-buildimage and sonic-sairedis changes are listed below:
https://github.com/sonic-net/sonic-buildimage/pull/15695
https://github.com/sonic-net/sonic-sairedis/pull/1259