### PR TITLE
Allow NOT_IMPLEMENTED sai return status for availability monitoring API

### DIFF
--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -361,7 +361,10 @@ bool MirrorOrch::isHwResourcesAvailable()
     );
     if (status != SAI_STATUS_SUCCESS)
     {
-        if (status == SAI_STATUS_NOT_SUPPORTED)
+        if ((status == SAI_STATUS_NOT_SUPPORTED) ||
+            (status == SAI_STATUS_NOT_IMPLEMENTED) ||
+            SAI_STATUS_IS_ATTR_NOT_SUPPORTED(status) ||
+            SAI_STATUS_IS_ATTR_NOT_IMPLEMENTED(status))
         {
             SWSS_LOG_WARN("Mirror session resource availability monitoring is not supported. Skipping ...");
             return true;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added SAI_STATUS_NOT_IMPLEMENTED to SAI return status check while fetching resource availability.

**Why I did it**
If resource availability lookup API is not supported for a specific object, the API returns SAI_STATUS_NOT_IMPLEMENTED or SAI_STATUS_NOT_SUPPORTED. These return values do not indicate unavailability of the resource itself and need to be ignored.

**How I verified it**
Everflow tests on 202205 with SAI which returns SAI_STATUS_NOT_IMPLEMENTED

**Details if related**
