### PR TITLE
[Chassis]Remove redundant updateFabricPortState

### DIFF
--- a/orchagent/fabricportsorch.cpp
+++ b/orchagent/fabricportsorch.cpp
@@ -141,8 +141,6 @@ int FabricPortsOrch::getFabricPortList()
 
     m_getFabricPortListDone = true;
 
-    updateFabricPortState();
-
     return FABRIC_PORT_SUCCESS;
 }
 


### PR DESCRIPTION
**What I did**
Call to `updateFabricPortState` in `FabricPortsOrch::getFabricPortList()` is redundant as `FabricPortsOrch::doTask()` already calls it.

This change helps mitigate the MHz spikes during boot up of the supe as described in https://github.com/sonic-net/sonic-buildimage/issues/15321.

**Why I did it**
To help address https://github.com/sonic-net/sonic-buildimage/issues/15321.

**How I verified it**
Boot up supe on Voq chassis and query fabric counters.

**Details if related**
