### PR TITLE
Remove system neigh DEL operation if SET operation succeeds

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -1420,6 +1420,17 @@ void NeighOrch::doVoqSystemNeighTask(Consumer &consumer)
                     {
                         SWSS_LOG_NOTICE("VOQ encap index updated for neighbor %s", kfvKey(t).c_str());
                         it = consumer.m_toSync.erase(it);
+
+                       /* Remove remaining DEL operation in m_toSync for the same neighbor.
+                        * Since DEL operation is supposed to be executed before SET for the same neighbor
+                        * A remaining DEL after the SET operation means the DEL operation failed previously and should not be executed anymore
+                        */
+                       auto rit = make_reverse_iterator(it);
+                       while (rit != consumer.m_toSync.rend() && rit->first == key && kfvOp(rit->second) == DEL_COMMAND)
+                       {
+                           consumer.m_toSync.erase(next(rit).base());
+                           SWSS_LOG_NOTICE("Removed pending system neighbor DEL operation for %s after SET operation", key.c_str());
+                       }
                     }
                     continue;
                 }
@@ -1481,6 +1492,7 @@ void NeighOrch::doVoqSystemNeighTask(Consumer &consumer)
                 else
                 {
                     it++;
+                    continue;
                 }
             }
             else
@@ -1488,6 +1500,17 @@ void NeighOrch::doVoqSystemNeighTask(Consumer &consumer)
                 /* Duplicate entry */
                 SWSS_LOG_INFO("System neighbor %s already exists", kfvKey(t).c_str());
                 it = consumer.m_toSync.erase(it);
+            }
+
+            /* Remove remaining DEL operation in m_toSync for the same neighbor.
+             * Since DEL operation is supposed to be executed before SET for the same neighbor
+             * A remaining DEL after the SET operation means the DEL operation failed previously and should not be executed anymore
+             */
+            auto rit = make_reverse_iterator(it);
+            while (rit != consumer.m_toSync.rend() && rit->first == key && kfvOp(rit->second) == DEL_COMMAND)
+            {
+                consumer.m_toSync.erase(next(rit).base());
+                SWSS_LOG_NOTICE("Removed pending system neighbor DEL operation for %s after SET operation", key.c_str());
             }
         }
         else if (op == DEL_COMMAND)


### PR DESCRIPTION




<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Remove system neighbor DEL operation in m_toSync if SET operation for the same neighbor succeeds. This is to avoid mistakenly removing the system neighbor.

**Why I did it**
Fix https://github.com/sonic-net/sonic-buildimage/issues/15266

**How I verified it**
https://github.com/sonic-net/sonic-buildimage/issues/15266 was uncovered by https://github.com/sonic-net/sonic-mgmt/blob/master/tests/voq/test_voq_disrupts.py.  The issue was not seen in the test anymore with the fix.

**Details if related**
