### PR TITLE
[dash] Add refillToSync() into ConsumerBase to support warmboot.

### DIFF
--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -159,6 +159,9 @@ public:
 
     // Returns: the number of entries added to m_toSync
     size_t addToSync(const std::deque<swss::KeyOpFieldsValuesTuple> &entries);
+
+    size_t refillToSync();
+    size_t refillToSync(swss::Table* table);
 };
 
 class Consumer : public ConsumerBase {
@@ -190,8 +193,6 @@ public:
         return getDbConnector()->getDbName();
     }
 
-    size_t refillToSync();
-    size_t refillToSync(swss::Table* table);
     void execute() override;
     void drain() override;
 };


### PR DESCRIPTION
Add refillToSync() into ConsumerBase to support warmboot.

**What I did**
Add warmboot support for zmq consumer.

**Why I did it**
This will be useful when we migrate other orchs to use zmq.

**How I verified it**
UT

**Details if related**
