### PR TITLE
[Mellanox] Fix error in peer response time when headroom is calculated for 800G

### DIFF
--- a/cfgmgr/buffer_headroom_mellanox.lua
+++ b/cfgmgr/buffer_headroom_mellanox.lua
@@ -39,6 +39,7 @@ local ret = {}
 -- the key of table pause_quanta_per_speed is operating speed at Mb/s
 -- the value of table pause_quanta_per_speed is the number of pause_quanta
 local pause_quanta_per_speed = {}
+pause_quanta_per_speed[800000] = 905
 pause_quanta_per_speed[400000] = 905
 pause_quanta_per_speed[200000] = 453
 pause_quanta_per_speed[100000] = 394


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Fix an error in peer response time when headroom is calculated for 800G

**Why I did it**

Bug fix.

**How I verified it**

Manually test

**Details if related**
