### PR TITLE
Add refillToSync() into ConsumerBase to support warmboot.

### DIFF
--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -163,6 +163,9 @@ public:
 
     // Returns: the number of entries added to m_toSync
     size_t addToSync(const std::deque<swss::KeyOpFieldsValuesTuple> &entries);
+
+    size_t refillToSync();
+    size_t refillToSync(swss::Table* table);
 };
 
 class Consumer : public ConsumerBase {
@@ -194,8 +197,6 @@ public:
         return getDbConnector()->getDbName();
     }
 
-    size_t refillToSync();
-    size_t refillToSync(swss::Table* table);
     void execute() override;
     void drain() override;
 };


### PR DESCRIPTION
**What I did**
Add refillToSync() into ConsumerBase to support warmboot.

**Why I did it**
Add warmboot support for zmq consumer.

**How I verified it**
This will be useful when we migrate other orchs to use zmq.

**Details if related**
UT
