### PR TITLE
Make sure new binaries replace existing binaries in docker-sonic-vs

### DIFF
--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -5,6 +5,11 @@ ARG need_dbg
 
 COPY ["debs", "/debs"]
 
+# Remove existing packages first before installing the new/current packages. This is to overcome limitations with
+# Docker's diff detection mechanism, where only the file size and the modification timestamp (which will remain the
+# same, even though contents have changed) are checked between the previous and current layer.
+RUN dpkg --purge libswsscommon python3-swsscommon sonic-db-cli libsaimetadata libsairedis libsaivs syncd-vs swss sonic-eventd
+
 RUN dpkg -i /debs/libswsscommon_1.0.0_amd64.deb \
             /debs/python3-swsscommon_1.0.0_amd64.deb \
             /debs/sonic-db-cli_1.0.0_amd64.deb \


### PR DESCRIPTION


<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

PR #2717 removed a step where existing deb packages were removed before installing the new deb packages. The problem is that due to Docker's change detection code, where it only checks the file size and the modification timestamp, even if the file gets modified when installing a newer debian package, the file size may remain the same, and the modification timestamp will remain the same (since this is based on the debian/changelog timestamp). This caused changed binaries to not actually replace the existing binaries.

Fix this by re-adding the line that removed existing packages first.

**Why I did it**

**How I verified it**

**Details if related**
