### PR TITLE
[Fixbug]: Fix vnet attribute miss if route action is vnet_direct and vnet test cases

### DIFF
--- a/orchagent/dash/dashrouteorch.cpp
+++ b/orchagent/dash/dashrouteorch.cpp
@@ -84,7 +84,11 @@ bool DashRouteOrch::addOutboundRouting(const string& key, OutboundRoutingBulkCon
     outbound_routing_attr.value.u32 = sOutboundAction[ctxt.metadata.action_type()];
     outbound_routing_attrs.push_back(outbound_routing_attr);
 
-    if (ctxt.metadata.action_type() == dash::route_type::RoutingType::ROUTING_TYPE_VNET
+    if (ctxt.metadata.action_type() == dash::route_type::RoutingType::ROUTING_TYPE_DIRECT)
+    {
+        // Intentional empty line, To direct action type, don't need set extra attributes
+    }
+    else if (ctxt.metadata.action_type() == dash::route_type::RoutingType::ROUTING_TYPE_VNET
         && ctxt.metadata.has_vnet()
         && !ctxt.metadata.vnet().empty())
     {   
@@ -110,8 +114,7 @@ bool DashRouteOrch::addOutboundRouting(const string& key, OutboundRoutingBulkCon
     }
     else
     {
-        
-        SWSS_LOG_WARN("Attribute error for outbound routing entry %s", key.c_str());
+        SWSS_LOG_WARN("Attribute action for outbound routing entry %s", key.c_str());
         return false;
     }
 

--- a/orchagent/dash/dashrouteorch.cpp
+++ b/orchagent/dash/dashrouteorch.cpp
@@ -84,23 +84,35 @@ bool DashRouteOrch::addOutboundRouting(const string& key, OutboundRoutingBulkCon
     outbound_routing_attr.value.u32 = sOutboundAction[ctxt.metadata.action_type()];
     outbound_routing_attrs.push_back(outbound_routing_attr);
 
-    if (ctxt.metadata.has_vnet())
-    {
+    if (ctxt.metadata.action_type() == dash::route_type::RoutingType::ROUTING_TYPE_VNET
+        && ctxt.metadata.has_vnet()
+        && !ctxt.metadata.vnet().empty())
+    {   
         outbound_routing_attr.id = SAI_OUTBOUND_ROUTING_ENTRY_ATTR_DST_VNET_ID;
         outbound_routing_attr.value.oid = gVnetNameToId[ctxt.metadata.vnet()];
         outbound_routing_attrs.push_back(outbound_routing_attr);
     }
-
-    if (ctxt.metadata.action_type() == dash::route_type::RoutingType::ROUTING_TYPE_VNET_DIRECT
+    else if (ctxt.metadata.action_type() == dash::route_type::RoutingType::ROUTING_TYPE_VNET_DIRECT
         && ctxt.metadata.has_vnet_direct()
+        && !ctxt.metadata.vnet_direct().vnet().empty()
         && (ctxt.metadata.vnet_direct().overlay_ip().has_ipv4() || ctxt.metadata.vnet_direct().overlay_ip().has_ipv6()))
     {
+        outbound_routing_attr.id = SAI_OUTBOUND_ROUTING_ENTRY_ATTR_DST_VNET_ID;
+        outbound_routing_attr.value.oid = gVnetNameToId[ctxt.metadata.vnet_direct().vnet()];
+        outbound_routing_attrs.push_back(outbound_routing_attr);
+
         outbound_routing_attr.id = SAI_OUTBOUND_ROUTING_ENTRY_ATTR_OVERLAY_IP;
         if (!to_sai(ctxt.metadata.vnet_direct().overlay_ip(), outbound_routing_attr.value.ipaddr))
         {
             return false;
         }
         outbound_routing_attrs.push_back(outbound_routing_attr);
+    }
+    else
+    {
+        
+        SWSS_LOG_WARN("Attribute error for outbound routing entry %s", key.c_str());
+        return false;
     }
 
     object_statuses.emplace_back();


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
1. For outbound routing, I fix a bug that vnet name will lose in vnet_direct case.
2. The fvs from asic db is the dict type in test cases of dash vnet, for a dict will just for its keys.

**Why I did it**
1. The vnet name in vnet and vnet_direct cases are defined in a different field.
https://github.com/sonic-net/sonic-dash-api/blob/3f728d1bbf65d2e8c41bdc023d5c07702a7f848b/proto/route.proto#L30-L32
```
message VnetDirect {
    // destination vnet name if action_type is {vnet, vnet_direct}, a vnet other than eni's vnet means vnet peering
    string vnet = 1;
...
}

message Route {
    route_type.RoutingType action_type = 1;
    oneof Action {
        // destination vnet name if action_type is vnet,, a vnet other than eni's vnet means vnet peering
        string vnet = 2;
        // destination vnet name if action_type is vnet_direct,, a vnet other than eni's vnet means vnet peering
        route_lpm.VnetDirect vnet_direct = 3;
...
    }
  }
```
2. Add the items after fvs to fetch each items of fvs

**How I verified it**
Add a new test case and check tests.
```
$ sudo pytest --dvsname=vs --num-ports=32 test_dash_vnet.py  --pdb
====================================== test session starts ======================================
platform linux -- Python 3.8.10, pytest-7.2.2, pluggy-1.0.0
rootdir: /home/zegan/workspace/sonic-swss/tests
plugins: flaky-3.7.0
collected 8 items

test_dash_vnet.py ........                                                                [100%]

======================================= warnings summary ========================================
```

**Details if related**
