### PR TITLE
[202205][buffers] Add handler for the 'create_only_config_db_buffers' configuration knob

### DIFF
--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -68,6 +68,7 @@ FlexCounterOrch::FlexCounterOrch(DBConnector *db, vector<string> &tableNames):
     m_flexCounterConfigTable(db, CFG_FLEX_COUNTER_TABLE_NAME),
     m_bufferQueueConfigTable(db, CFG_BUFFER_QUEUE_TABLE_NAME),
     m_bufferPgConfigTable(db, CFG_BUFFER_PG_TABLE_NAME),
+    m_deviceMetadataConfigTable(db, CFG_DEVICE_METADATA_TABLE_NAME),
     m_flexCounterDb(new DBConnector("FLEX_COUNTER_DB", 0)),
     m_flexCounterGroupTable(new ProducerTable(m_flexCounterDb.get(), FLEX_COUNTER_GROUP_TABLE)),
     m_gbflexCounterDb(new DBConnector("GB_FLEX_COUNTER_DB", 0)),
@@ -329,11 +330,41 @@ bool FlexCounterOrch::bake()
     return consumer->addToSync(entries);
 }
 
+static bool isCreateOnlyConfigDbBuffers(Table& deviceMetadataConfigTable)
+{
+    std::string createOnlyConfigDbBuffersValue;
+
+    try
+    {
+        if (deviceMetadataConfigTable.hget("localhost", "create_only_config_db_buffers", createOnlyConfigDbBuffersValue))
+        {
+            if (createOnlyConfigDbBuffersValue == "true")
+            {
+                return true;
+            }
+        }
+    }
+    catch(const std::system_error& e)
+    {
+        SWSS_LOG_ERROR("System error: %s", e.what());
+    }
+
+    return false;
+}
+
 map<string, FlexCounterQueueStates> FlexCounterOrch::getQueueConfigurations()
 {
     SWSS_LOG_ENTER();
 
     map<string, FlexCounterQueueStates> queuesStateVector;
+
+    if (!isCreateOnlyConfigDbBuffers(m_deviceMetadataConfigTable))
+    {
+        FlexCounterQueueStates flexCounterQueueState(0);
+        queuesStateVector.insert(make_pair(createAllAvailableBuffersStr, flexCounterQueueState));
+        return queuesStateVector;
+    }
+
     std::vector<std::string> portQueueKeys;
     m_bufferQueueConfigTable.getKeys(portQueueKeys);
 
@@ -393,6 +424,14 @@ map<string, FlexCounterPgStates> FlexCounterOrch::getPgConfigurations()
     SWSS_LOG_ENTER();
 
     map<string, FlexCounterPgStates> pgsStateVector;
+
+    if (!isCreateOnlyConfigDbBuffers(m_deviceMetadataConfigTable))
+    {
+        FlexCounterPgStates flexCounterPgState(0);
+        pgsStateVector.insert(make_pair(createAllAvailableBuffersStr, flexCounterPgState));
+        return pgsStateVector;
+    }
+
     std::vector<std::string> portPgKeys;
     m_bufferPgConfigTable.getKeys(portPgKeys);
 

--- a/orchagent/flexcounterorch.h
+++ b/orchagent/flexcounterorch.h
@@ -10,6 +10,8 @@ extern "C" {
 #include "sai.h"
 }
 
+const std::string createAllAvailableBuffersStr = "create_all_available_buffers";
+
 class FlexCounterQueueStates
 {
 public:
@@ -68,6 +70,7 @@ private:
     Table m_flexCounterConfigTable;
     Table m_bufferQueueConfigTable;
     Table m_bufferPgConfigTable;
+    Table m_deviceMetadataConfigTable;
 };
 
 #endif

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -6072,6 +6072,14 @@ void PortsOrch::generateQueueMap(map<string, FlexCounterQueueStates> queuesState
         return;
     }
 
+    bool isCreateAllQueues = false;
+
+    if (queuesStateVector.count(createAllAvailableBuffersStr))
+    {
+        isCreateAllQueues = true;
+        queuesStateVector.clear();
+    }
+
     for (const auto& it: m_portList)
     {
         if (it.second.m_type == Port::PHY)
@@ -6080,6 +6088,10 @@ void PortsOrch::generateQueueMap(map<string, FlexCounterQueueStates> queuesState
             {
                 auto maxQueueNumber = getNumberOfPortSupportedQueueCounters(it.second.m_alias);
                 FlexCounterQueueStates flexCounterQueueState(maxQueueNumber);
+                if (isCreateAllQueues)
+                {
+                    flexCounterQueueState.enableQueueCounters(0, maxQueueNumber - 1);
+                }
                 queuesStateVector.insert(make_pair(it.second.m_alias, flexCounterQueueState));
             }
             generateQueueMapPerPort(it.second, queuesStateVector.at(it.second.m_alias), false);
@@ -6094,6 +6106,10 @@ void PortsOrch::generateQueueMap(map<string, FlexCounterQueueStates> queuesState
             {
                 auto maxQueueNumber = getNumberOfPortSupportedQueueCounters(it.second.m_alias);
                 FlexCounterQueueStates flexCounterQueueState(maxQueueNumber);
+                if (isCreateAllQueues)
+                {
+                    flexCounterQueueState.enableQueueCounters(0, maxQueueNumber - 1);
+                }
                 queuesStateVector.insert(make_pair(it.second.m_alias, flexCounterQueueState));
             }
 
@@ -6198,6 +6214,14 @@ void PortsOrch::addQueueFlexCounters(map<string, FlexCounterQueueStates> queuesS
         return;
     }
 
+    bool isCreateAllQueues = false;
+
+    if (queuesStateVector.count(createAllAvailableBuffersStr))
+    {
+        isCreateAllQueues = true;
+        queuesStateVector.clear();
+    }
+
     for (const auto& it: m_portList)
     {
         if (it.second.m_type == Port::PHY)
@@ -6206,6 +6230,10 @@ void PortsOrch::addQueueFlexCounters(map<string, FlexCounterQueueStates> queuesS
             {
                 auto maxQueueNumber = getNumberOfPortSupportedQueueCounters(it.second.m_alias);
                 FlexCounterQueueStates flexCounterQueueState(maxQueueNumber);
+                if (isCreateAllQueues)
+                {
+                    flexCounterQueueState.enableQueueCounters(0, maxQueueNumber - 1);
+                }
                 queuesStateVector.insert(make_pair(it.second.m_alias, flexCounterQueueState));
             }
             addQueueFlexCountersPerPort(it.second, queuesStateVector.at(it.second.m_alias));
@@ -6263,6 +6291,14 @@ void PortsOrch::addQueueWatermarkFlexCounters(map<string, FlexCounterQueueStates
         return;
     }
 
+    bool isCreateAllQueues = false;
+
+    if (queuesStateVector.count(createAllAvailableBuffersStr))
+    {
+        isCreateAllQueues = true;
+        queuesStateVector.clear();
+    }
+
     for (const auto& it: m_portList)
     {
         if (it.second.m_type == Port::PHY)
@@ -6271,6 +6307,10 @@ void PortsOrch::addQueueWatermarkFlexCounters(map<string, FlexCounterQueueStates
             {
                 auto maxQueueNumber = getNumberOfPortSupportedQueueCounters(it.second.m_alias);
                 FlexCounterQueueStates flexCounterQueueState(maxQueueNumber);
+                if (isCreateAllQueues)
+                {
+                    flexCounterQueueState.enableQueueCounters(0, maxQueueNumber - 1);
+                }
                 queuesStateVector.insert(make_pair(it.second.m_alias, flexCounterQueueState));
             }
             addQueueWatermarkFlexCountersPerPort(it.second, queuesStateVector.at(it.second.m_alias));
@@ -6434,6 +6474,14 @@ void PortsOrch::generatePriorityGroupMap(map<string, FlexCounterPgStates> pgsSta
         return;
     }
 
+    bool isCreateAllPgs = false;
+
+    if (pgsStateVector.count(createAllAvailableBuffersStr))
+    {
+        isCreateAllPgs = true;
+        pgsStateVector.clear();
+    }
+
     for (const auto& it: m_portList)
     {
         if (it.second.m_type == Port::PHY)
@@ -6442,6 +6490,10 @@ void PortsOrch::generatePriorityGroupMap(map<string, FlexCounterPgStates> pgsSta
             {
                 auto maxPgNumber = getNumberOfPortSupportedPgCounters(it.second.m_alias);
                 FlexCounterPgStates flexCounterPgState(maxPgNumber);
+                if (isCreateAllPgs)
+                {
+                    flexCounterPgState.enablePgCounters(0, maxPgNumber - 1);
+                }
                 pgsStateVector.insert(make_pair(it.second.m_alias, flexCounterPgState));
             }
             generatePriorityGroupMapPerPort(it.second, pgsStateVector.at(it.second.m_alias));
@@ -6538,6 +6590,14 @@ void PortsOrch::addPriorityGroupFlexCounters(map<string, FlexCounterPgStates> pg
         return;
     }
 
+    bool isCreateAllPgs = false;
+
+    if (pgsStateVector.count(createAllAvailableBuffersStr))
+    {
+        isCreateAllPgs = true;
+        pgsStateVector.clear();
+    }
+
     for (const auto& it: m_portList)
     {
         if (it.second.m_type == Port::PHY)
@@ -6546,6 +6606,10 @@ void PortsOrch::addPriorityGroupFlexCounters(map<string, FlexCounterPgStates> pg
             {
                 auto maxPgNumber = getNumberOfPortSupportedPgCounters(it.second.m_alias);
                 FlexCounterPgStates flexCounterPgState(maxPgNumber);
+                if (isCreateAllPgs)
+                {
+                    flexCounterPgState.enablePgCounters(0, maxPgNumber - 1);
+                }
                 pgsStateVector.insert(make_pair(it.second.m_alias, flexCounterPgState));
             }
             addPriorityGroupFlexCountersPerPort(it.second, pgsStateVector.at(it.second.m_alias));
@@ -6595,6 +6659,14 @@ void PortsOrch::addPriorityGroupWatermarkFlexCounters(map<string, FlexCounterPgS
         return;
     }
 
+    bool isCreateAllPgs = false;
+
+    if (pgsStateVector.count(createAllAvailableBuffersStr))
+    {
+        isCreateAllPgs = true;
+        pgsStateVector.clear();
+    }
+
     for (const auto& it: m_portList)
     {
         if (it.second.m_type == Port::PHY)
@@ -6603,6 +6675,10 @@ void PortsOrch::addPriorityGroupWatermarkFlexCounters(map<string, FlexCounterPgS
             {
                 auto maxPgNumber = getNumberOfPortSupportedPgCounters(it.second.m_alias);
                 FlexCounterPgStates flexCounterPgState(maxPgNumber);
+                if (isCreateAllPgs)
+                {
+                    flexCounterPgState.enablePgCounters(0, maxPgNumber - 1);
+                }
                 pgsStateVector.insert(make_pair(it.second.m_alias, flexCounterPgState));
             }
             addPriorityGroupWatermarkFlexCountersPerPort(it.second, pgsStateVector.at(it.second.m_alias));

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -6106,10 +6106,6 @@ void PortsOrch::generateQueueMap(map<string, FlexCounterQueueStates> queuesState
             {
                 auto maxQueueNumber = getNumberOfPortSupportedQueueCounters(it.second.m_alias);
                 FlexCounterQueueStates flexCounterQueueState(maxQueueNumber);
-                if (isCreateAllQueues)
-                {
-                    flexCounterQueueState.enableQueueCounters(0, maxQueueNumber - 1);
-                }
                 queuesStateVector.insert(make_pair(it.second.m_alias, flexCounterQueueState));
             }
 

--- a/tests/test_flex_counters.py
+++ b/tests/test_flex_counters.py
@@ -200,6 +200,10 @@ class TestFlexCounters(object):
         self.config_db.create_entry("FLEX_COUNTER_TABLE", key, group_stats_entry)
         self.wait_for_interval_set(group, interval)
 
+    def set_only_config_db_buffers_field(self, value):
+        fvs = {'create_only_config_db_buffers' : value}
+        self.config_db.update_entry("DEVICE_METADATA", "localhost", fvs)
+
     @pytest.mark.parametrize("counter_type", counter_group_meta.keys())
     def test_flex_counters(self, dvs, counter_type):
         """
@@ -712,19 +716,43 @@ class TestFlexCounters(object):
     def set_admin_status(self, interface, status):
         self.config_db.update_entry("PORT", interface, {"admin_status": status})
 
+    @pytest.mark.parametrize('counter_type', [('queue_counter'), ('pg_drop_counter')])
+    def test_create_only_config_db_buffers_false(self, dvs, counter_type):
+        """
+        Test steps:
+            1. By default the configuration knob 'create_only_config_db_value' is missing.
+            2. Get the counter OID for the interface 'Ethernet0:7' from the counters database.
+            3. Perform assertions based on the 'create_only_config_db_value':
+                - If 'create_only_config_db_value' is 'false' or does not exist, assert that the counter OID has a valid OID value.
+
+        Args:
+            dvs (object): virtual switch object
+            counter_type (str): The type of counter being tested
+        """
+        self.setup_dbs(dvs)
+        meta_data = counter_group_meta[counter_type]
+        self.set_flex_counter_group_status(meta_data['key'], meta_data['name_map'])
+
+        counter_oid = self.counters_db.db_connection.hget(meta_data['name_map'], 'Ethernet0:7')
+        assert counter_oid is not None, "Counter OID should have a valid OID value when create_only_config_db_value is 'false' or does not exist"
+
     def test_create_remove_buffer_pg_watermark_counter(self, dvs):
         """
         Test steps:
-            1. Enable PG flex counters.
-            2. Configure new buffer prioriy group for a port
-            3. Verify counter is automatically created
-            4. Remove the new buffer prioriy group for the port
-            5. Verify counter is automatically removed
+            1. Reset config_db
+            2. Set 'create_only_config_db_buffers' to 'true'
+            3. Enable PG flex counters.
+            4. Configure new buffer prioriy group for a port
+            5. Verify counter is automatically created
+            6. Remove the new buffer prioriy group for the port
+            7. Verify counter is automatically removed
 
         Args:
             dvs (object): virtual switch object
         """
+        dvs.restart()
         self.setup_dbs(dvs)
+        self.set_only_config_db_buffers_field('true')
         meta_data = counter_group_meta['pg_watermark_counter']
 
         self.set_flex_counter_group_status(meta_data['key'], meta_data['name_map'])
@@ -736,6 +764,26 @@ class TestFlexCounters(object):
         self.config_db.delete_entry('BUFFER_PG', 'Ethernet0|1')
         self.wait_for_buffer_pg_queue_counter(meta_data['name_map'], 'Ethernet0', '1', False)
         self.wait_for_id_list_remove(meta_data['group_name'], "Ethernet0", counter_oid)
+
+    @pytest.mark.parametrize('counter_type', [('queue_counter'), ('pg_drop_counter')])
+    def test_create_only_config_db_buffers_true(self, dvs, counter_type):
+        """
+        Test steps:
+            1. The 'create_only_config_db_buffers' was set to 'true' by previous test.
+            2. Get the counter OID for the interface 'Ethernet0:7' from the counters database.
+            3. Perform assertions based on the 'create_only_config_db_value':
+                - If 'create_only_config_db_value' is 'true', assert that the counter OID is None.
+
+        Args:
+            dvs (object): virtual switch object
+            counter_type (str): The type of counter being tested
+        """
+        self.setup_dbs(dvs)
+        meta_data = counter_group_meta[counter_type]
+        self.set_flex_counter_group_status(meta_data['key'], meta_data['name_map'])
+
+        counter_oid = self.counters_db.db_connection.hget(meta_data['name_map'], 'Ethernet0:7')
+        assert counter_oid is None, "Counter OID should be None when create_only_config_db_value is 'true'"
 
     def test_create_remove_buffer_queue_counter(self, dvs):
         """


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add support in the orchagent for the configuration knob:

```
{
    "DEVICE_METADATA": {
        "localhost": {
            "create_only_config_db_buffers": "true"
            ...
        }
    }
}
```

**Why I did it**
If the `"create_only_config_db_buffers"` is equal to `"true"` - buffers will be created according to the config_db configuration (for example `BUFFER_QUEUE|*` table).
If the `"create_only_config_db_buffers"` is equal to `"false"` or does not exist - the maximum available buffers (which are read from SAI) will be created, regardless of `the config_db` buffer config.

**How I verified it**
Add UT.

Manual verification:
1. Install the image with this PR included on the not `MSFT SKU` switch
2. Check the `show queue counters` output and verify that only configured in `CONFIG_DB` buffers are created
```
root@sonic:/home/admin# show queue counters
     Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
---------  -----  --------------  ---------------  -----------  ------------
Ethernet0    UC0               0                0            0           N/A
Ethernet0    UC1               0                0            0           N/A
Ethernet0    UC2               0                0            0           N/A
Ethernet0    UC3               0                0            0           N/A
Ethernet0    UC4               0                0            0           N/A
Ethernet0    UC5               0                0            0           N/A
Ethernet0    UC6               0                0            0           N/A
```
3. Open the `/usr/share/sonic/device/$DEVICE/$SKU/create_only_config_db_buffers.json` and change it to:
```
"create_only_config_db_buffers": "false"
```
4. Do `config reload`
5. Check the `show queue counters` output and verify that all available buffers are created
```
root@sonic:/home/admin# show queue counters
     Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes
---------  -----  --------------  ---------------  -----------  ------------
Ethernet0    UC0               0                0            0           N/A
Ethernet0    UC1               0                0            0           N/A
Ethernet0    UC2               0                0            0           N/A
Ethernet0    UC3               0                0            0           N/A
Ethernet0    UC4               0                0            0           N/A
Ethernet0    UC5               0                0            0           N/A
Ethernet0    UC6               0                0            0           N/A
Ethernet0    UC7              60            15346            0           N/A
Ethernet0    MC8             N/A              N/A          N/A           N/A
Ethernet0    MC9             N/A              N/A          N/A           N/A
Ethernet0   MC10             N/A              N/A          N/A           N/A
Ethernet0   MC11             N/A              N/A          N/A           N/A
Ethernet0   MC12             N/A              N/A          N/A           N/A
Ethernet0   MC13             N/A              N/A          N/A           N/A
Ethernet0   MC14             N/A              N/A          N/A           N/A
Ethernet0   MC15             N/A              N/A          N/A           N/A
```

**Details if related**
