### PR TITLE
Support type7 encoded CAK key for macsec in config_db

### DIFF
--- a/cfgmgr/macsecmgr.cpp
+++ b/cfgmgr/macsecmgr.cpp
@@ -143,7 +143,6 @@ static std::string decodeKey(const std::string &cipher_str, const MACsecMgr::MAC
         decodedPassword += (char)(hex_int ^ salts[saltIdx++ % (sizeof(salts)/sizeof(salts[0]))]);
     }
 
-    SWSS_LOG_ERROR("\n INPUT (%s) OUTPUT (%s)", cipher_str.c_str(), decodedPassword.c_str());
     return decodedPassword;
 }
 

--- a/cfgmgr/macsecmgr.cpp
+++ b/cfgmgr/macsecmgr.cpp
@@ -115,7 +115,6 @@ static std::string decodeKey(const std::string &cipher_str)
         decodedPassword += (char)(hex_int ^ salts[saltIdx++ % (sizeof(salts)/sizeof(salts[0]))]);
     }
 
-    SWSS_LOG_ERROR("\n INPUT (%s) OUTPUT (%s)", cipher_str.c_str(), decodedPassword.c_str());
     return decodedPassword;
 }
 

--- a/cfgmgr/macsecmgr.cpp
+++ b/cfgmgr/macsecmgr.cpp
@@ -34,6 +34,20 @@ constexpr std::uint64_t RETRY_TIME = 30;
 /* retry interval, in millisecond */
 constexpr std::uint64_t RETRY_INTERVAL = 100;
 
+/*
+ * The input cipher_str is the encoded string which can be either of length 66 bytes or 130 bytes.
+ *
+ * 66 bytes of length, for 128-byte cipher suite
+ *   - first 2 bytes of the string will be the index from the magic salt string.
+ *   - remaining 64 bytes will be encoded string from the 32-byte plain text CAK input string.
+ *
+ * 130 bytes of length, for 256-byte cipher suite
+ *   - first 2 bytes of the string will be the index from the magic salt string.
+ *   - remaining 128 bytes will be encoded string from the 32 byte plain text CAK input string.
+*/
+constexpr std::size_t AES_LEN_128_BYTE = 66;
+constexpr std::size_t AES_LEN_256_BYTE = 130;
+
 static void lexical_convert(const std::string &policy_str, MACsecMgr::MACsecProfile::Policy & policy)
 {
     SWSS_LOG_ENTER();
@@ -79,14 +93,15 @@ static void lexical_convert(const std::string &cipher_str, MACsecMgr::MACsecProf
 }
 
 
+
 /* Decodes a Type 7 encoded input.
  *
- * The Type 7 encoded string consists of two decimal digits, followed by a series of hexadecimal characters
+ * The Type 7 encoding consists of two decimal digits(encoding the salt), followed a series of hexadecimal characters,
+ * two for every byte in the encoded password. An example encoding(of "password") is 044B0A151C36435C0D.
+ * This has a salt/offset of 4 (04 in the example), and encodes password via 4B0A151C36435C0D.
  *
- * An example: encoding of string "password" is 044B0A151C36435C0D.
- * This has a salt/offset of 4 (04 in the example), and the encoded string for "password" is 4B0A151C36435C0D.
- *
- * The algorithm is a straightforward XOR Cipher that relies on an ascii-encoded 53-byte magic salt string
+ * The algorithm is a straightforward XOR Cipher that relies on the following ascii-encoded 53-byte constant:
+ *    "dsfd;kfoA,.iyewrkldJKDHSUBsgvca69834ncxv9873254k;fg87"
  *
  * Decode()
  *    Get the salt index from the first 2 chars
@@ -95,13 +110,26 @@ static void lexical_convert(const std::string &cipher_str, MACsecMgr::MACsecProf
  *        XOR the i'th byte of the password with the j'th byte of the magic constant.
  *        append to the decoded string.
  */
-static std::string decodeKey(const std::string &cipher_str)
+static std::string decodeKey(const std::string &cipher_str, const MACsecMgr::MACsecProfile::CipherSuite & cipher_suite)
 {
     int salts[] = { 0x64, 0x73, 0x66, 0x64, 0x3B, 0x6B, 0x66, 0x6F, 0x41, 0x2C, 0x2E, 0x69, 0x79, 0x65, 0x77, 0x72, 0x6B, 0x6C, 0x64, 0x4A, 0x4B, 0x44, 0x48, 0x53, 0x55, 0x42, 0x73, 0x67, 0x76, 0x63, 0x61, 0x36, 0x39, 0x38, 0x33, 0x34, 0x6E, 0x63, 0x78, 0x76, 0x39, 0x38, 0x37, 0x33, 0x32, 0x35, 0x34, 0x6B, 0x3B, 0x66, 0x67, 0x38, 0x37 };
 
     std::string decodedPassword = std::string("");
     std::string cipher_hex_str = std::string("");
     unsigned int hex_int, saltIdx;
+
+    if ((cipher_suite == MACsecMgr::MACsecProfile::CipherSuite::GCM_AES_128) ||
+        (cipher_suite == MACsecMgr::MACsecProfile::CipherSuite::GCM_AES_XPN_128))
+    {
+        if (cipher_str.length() != AES_LEN_128_BYTE)
+            throw std::invalid_argument("Invalid length for cipher_string : " + cipher_str);
+    }
+    else if ((cipher_suite == MACsecMgr::MACsecProfile::CipherSuite::GCM_AES_256) ||
+             (cipher_suite == MACsecMgr::MACsecProfile::CipherSuite::GCM_AES_XPN_256))
+    {
+        if (cipher_str.length() != AES_LEN_256_BYTE)
+            throw std::invalid_argument("Invalid length for cipher_string : " + cipher_str);
+    }
 
     // Get the salt index from the cipher_str
     saltIdx = (unsigned int) stoi(cipher_str.substr(0,2));
@@ -115,6 +143,7 @@ static std::string decodeKey(const std::string &cipher_str)
         decodedPassword += (char)(hex_int ^ salts[saltIdx++ % (sizeof(salts)/sizeof(salts[0]))]);
     }
 
+    SWSS_LOG_ERROR("\n INPUT (%s) OUTPUT (%s)", cipher_str.c_str(), decodedPassword.c_str());
     return decodedPassword;
 }
 
@@ -739,7 +768,7 @@ bool MACsecMgr::configureMACsec(
             port_name,
             network_id,
             "mka_cak",
-            decodeKey(profile.primary_cak));
+            decodeKey(profile.primary_cak, profile.cipher_suite));
 
         wpa_cli_exec_and_check(
             session.sock,


### PR DESCRIPTION
**What I did**
Support type7 encoded CAK key for macsec in config_db

MSFT ADO : 25046448

**Why I did it**
The external store has the macsec CAK keys stored in type7 format. Hence the automation tools retrieve these keys and stores in config_db in type7 format. 

This need to be decoded to text format for wpa_supplicant to consume.

**How I verified it**
Verified with type7 encoded CAK keys, macsec sessions should come up 

MACSEC_PROFILE **(earlier format where CAK is in text)**
```
    },
    "MACSEC_PROFILE": {
        "macsec-profile": {
            "cipher_suite": "GCM-AES-XPN-256",
            "primary_cak": "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
            "primary_ckn": "6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435",
            "priority": "4",
            "rekey_period": "1800"
        },
        "macsec-profile2": {
            "cipher_suite": "GCM-AES-XPN-256",
            "primary_cak": "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789",
            "primary_ckn": "707172737475767778797A3031323334356162636465666768696A6B6C6D6E6F",
            "priority": "4",
            "rekey_period": "1800"
        }
    },
```

MACSEC_PROFILE **(NEW format: where CAK is in type 7 encoded)**
```
    "MACSEC_PROFILE": {
        "macsec-profile": {
            "cipher_suite": "GCM-AES-XPN-256",
            "primary_cak": "3848470b0b030604020c527a24247c7222435756085f5359761417283b2633372d5c557878707d65627a4a26342025737f0802065d574d400e000e727076702e7d",
            "primary_ckn": "6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435",
            "priority": "4",
            "rekey_period": "1800"
        },
        "macsec-profile-two": {
            "cipher_suite": "GCM-AES-XPN-256"
            "primary_cak": "543224277f2e205f701e1d5d4c53404a522d26090f010e63647040534355560e007971772a263e46080a0407070303530227257b73213556550958525a771b1650",
            "primary_ckn": "707172737475767778797A3031323334356162636465666768696A6B6C6D6E6F",
            "priority": "4",
            "rekey_period": "1800"
        }
    },
```

Even with CLI, we need to enter the CAK in type 7 encoded format 

```
    sudo config macsec -n asic0 profile add macsec_profile --cipher_suite GCM-AES-XPN-256 --primary_cak **<type_7_encoded_string>**  --primary_ckn "6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435"  --priority 0
```

Testing with CLI 

```
sudo config macsec -n asic0 profile add macsec_profile --cipher_suite GCM-AES-XPN-256 --primary_cak "207b757a60617745504e5a20747a7c76725e524a450d0d01040a0c75297822227e07554155500e5d5157786d6c2a3d2031425a5e577e7e727f6b6c033124322627" --primary_ckn "6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435"  --priority 0
sudo config macsec -n asic1 profile add macsec_profile --cipher_suite GCM-AES-XPN-256 --primary_cak "207b757a60617745504e5a20747a7c76725e524a450d0d01040a0c75297822227e07554155500e5d5157786d6c2a3d2031425a5e577e7e727f6b6c033124322627" --primary_ckn "6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435"  --priority 0

sudo config macsec -n asic0 port add Ethernet32 macsec_profile
sudo config macsec -n asic0 port add Ethernet40 macsec_profile
sudo config macsec -n asic0 port add Ethernet128 macsec_profile
sudo config save -y

In the config DB we have 

    "MACSEC_PROFILE": {
        "macsec_profile": {
            "cipher_suite": "GCM-AES-XPN-256",
            "policy": "security",
            "primary_cak": "207b757a60617745504e5a20747a7c76725e524a450d0d01040a0c75297822227e07554155500e5d5157786d6c2a3d2031425a5e577e7e727f6b6c033124322627",
            "primary_ckn": "6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435",
            "priority": "0",
            "send_sci": "true"
        }
    },


admin@str2-xxxx-lc1-1:~$ show macsec 
MACsec port(Ethernet32)
---------------------  ---------------
cipher_suite           GCM-AES-XPN-256
enable                 true
enable_encrypt         true
enable_protect         true
enable_replay_protect  false
profile                macsec_profile
replay_window          0
send_sci               true
---------------------  ---------------
        MACsec Egress SC (407c7dbb260b0001)
        -----------  -
        encoding_an  0
        -----------  -
                MACsec Egress SA (0)
                -------------------------------------  ----------------------------------------------------------------
                auth_key                               2CDCB20F72BDE084B6AD14CA4A03D59C
                next_pn                                1
                sak                                    742B4A43E26DD61B1706D8EC0D2C054B7C0913F9F3A187DB091CBD3D5AEBD60B
                salt                                   2856BA84178D0E3DA1C5A82C
                ssci                                   2
                SAI_MACSEC_SA_ATTR_CURRENT_XPN         35
                SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED    4798
                SAI_MACSEC_SA_STAT_OCTETS_PROTECTED    0
                SAI_MACSEC_SA_STAT_OUT_PKTS_ENCRYPTED  34
                SAI_MACSEC_SA_STAT_OUT_PKTS_PROTECTED  0
                -------------------------------------  ----------------------------------------------------------------
        MACsec Ingress SC (de40441302b10001)
                MACsec Ingress SA (0)
                ---------------------------------------  ----------------------------------------------------------------
                active                                   true
                auth_key                                 2CDCB20F72BDE084B6AD14CA4A03D59C
                lowest_acceptable_pn                     1
                sak                                      742B4A43E26DD61B1706D8EC0D2C054B7C0913F9F3A187DB091CBD3D5AEBD60B
                salt                                     2856BA84178D0E3DA1C5A82C
                ssci                                     1
                SAI_MACSEC_SA_ATTR_CURRENT_XPN           499
                SAI_MACSEC_SA_STAT_IN_PKTS_DELAYED       0
                SAI_MACSEC_SA_STAT_IN_PKTS_INVALID       0
                SAI_MACSEC_SA_STAT_IN_PKTS_LATE          0
                SAI_MACSEC_SA_STAT_IN_PKTS_NOT_USING_SA  0
                SAI_MACSEC_SA_STAT_IN_PKTS_NOT_VALID     0
                SAI_MACSEC_SA_STAT_IN_PKTS_OK            23
                SAI_MACSEC_SA_STAT_IN_PKTS_UNCHECKED     0
                SAI_MACSEC_SA_STAT_IN_PKTS_UNUSED_SA     0
                SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED      2312
                SAI_MACSEC_SA_STAT_OCTETS_PROTECTED      0
                ---------------------------------------  ----------------------------------------------------------------
MACsec port(Ethernet40)
---------------------  ---------------
cipher_suite           GCM-AES-XPN-256
enable                 true
enable_encrypt         true
enable_protect         true
enable_replay_protect  false
profile                macsec_profile
replay_window          0
send_sci               true
---------------------  ---------------
        MACsec Egress SC (407c7dbb260b0001)
        -----------  -
        encoding_an  0
        -----------  -
                MACsec Egress SA (0)
                -------------------------------------  ----------------------------------------------------------------
                auth_key                               2400F83757B0C270283F183CDD9AF14D
                next_pn                                1
                sak                                    7737F1D322F7DCBE54677519B1E34FC71EAF069250D27E913854CD0D57075478
                salt                                   9133F41248073FCD7156BB28
                ssci                                   2
                SAI_MACSEC_SA_ATTR_CURRENT_XPN         146
                SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED    34627
                SAI_MACSEC_SA_STAT_OCTETS_PROTECTED    0
                SAI_MACSEC_SA_STAT_OUT_PKTS_ENCRYPTED  145
                SAI_MACSEC_SA_STAT_OUT_PKTS_PROTECTED  0
                -------------------------------------  ----------------------------------------------------------------
        MACsec Ingress SC (be6d4c83f3190002)
                MACsec Ingress SA (0)
                ---------------------------------------  ----------------------------------------------------------------
                active                                   true
                auth_key                                 2400F83757B0C270283F183CDD9AF14D
                lowest_acceptable_pn                     1
                sak                                      7737F1D322F7DCBE54677519B1E34FC71EAF069250D27E913854CD0D57075478
                salt                                     9133F41248073FCD7156BB28
                ssci                                     1
                SAI_MACSEC_SA_ATTR_CURRENT_XPN           6508
                SAI_MACSEC_SA_STAT_IN_PKTS_DELAYED       0
                SAI_MACSEC_SA_STAT_IN_PKTS_INVALID       0
                SAI_MACSEC_SA_STAT_IN_PKTS_LATE          0
                SAI_MACSEC_SA_STAT_IN_PKTS_NOT_USING_SA  0
                SAI_MACSEC_SA_STAT_IN_PKTS_NOT_VALID     0
                SAI_MACSEC_SA_STAT_IN_PKTS_OK            147
                SAI_MACSEC_SA_STAT_IN_PKTS_UNCHECKED     0
                SAI_MACSEC_SA_STAT_IN_PKTS_UNUSED_SA     0
                SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED      286640
                SAI_MACSEC_SA_STAT_OCTETS_PROTECTED      0
                ---------------------------------------  ----------------------------------------------------------------
MACsec port(Ethernet128)
---------------------  ---------------
cipher_suite           GCM-AES-XPN-256
enable                 true
enable_encrypt         true
enable_protect         true
enable_replay_protect  false
profile                macsec_profile
replay_window          0
send_sci               true
---------------------  ---------------
        MACsec Egress SC (407c7dbb260b0001)
        -----------  -
        encoding_an  0
        -----------  -
                MACsec Egress SA (0)
                -------------------------------------  ----------------------------------------------------------------
                auth_key                               D176D49FED2CCF26F1A04DC89E93672B
                next_pn                                1
                sak                                    01AFA5483DDEA4EF669129C7FC869B36CF349AA4B1D310F522DB2AEA79545EFE
                salt                                   9FCB0225DEF5A3F39F8A6808
                ssci                                   2
                SAI_MACSEC_SA_ATTR_CURRENT_XPN         53
                SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED    15661
                SAI_MACSEC_SA_STAT_OCTETS_PROTECTED    0
                SAI_MACSEC_SA_STAT_OUT_PKTS_ENCRYPTED  52
                SAI_MACSEC_SA_STAT_OUT_PKTS_PROTECTED  0
                -------------------------------------  ----------------------------------------------------------------
        MACsec Ingress SC (f669c302dc3f0001)
                MACsec Ingress SA (0)
                ---------------------------------------  ----------------------------------------------------------------
                active                                   true
                auth_key                                 D176D49FED2CCF26F1A04DC89E93672B
                lowest_acceptable_pn                     1
                sak                                      01AFA5483DDEA4EF669129C7FC869B36CF349AA4B1D310F522DB2AEA79545EFE
                salt                                     9FCB0225DEF5A3F39F8A6808
                ssci                                     1
                SAI_MACSEC_SA_ATTR_CURRENT_XPN           98
                SAI_MACSEC_SA_STAT_IN_PKTS_DELAYED       0
                SAI_MACSEC_SA_STAT_IN_PKTS_INVALID       0
                SAI_MACSEC_SA_STAT_IN_PKTS_LATE          0
                SAI_MACSEC_SA_STAT_IN_PKTS_NOT_USING_SA  0
                SAI_MACSEC_SA_STAT_IN_PKTS_NOT_VALID     0
                SAI_MACSEC_SA_STAT_IN_PKTS_OK            68
                SAI_MACSEC_SA_STAT_IN_PKTS_UNCHECKED     0
                SAI_MACSEC_SA_STAT_IN_PKTS_UNUSED_SA     0
                SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED      65929
                SAI_MACSEC_SA_STAT_OCTETS_PROTECTED      0
                ---------------------------------------  ----------------------------------------------------------------




```