### PR TITLE
[tests]: Supply src_ip attribute for tunnels

### DIFF
--- a/tests/mock_tests/mux_rollback_ut.cpp
+++ b/tests/mock_tests/mux_rollback_ut.cpp
@@ -98,6 +98,7 @@ namespace mux_rollback_test
 
             tunnel_table.set(MUX_TUNNEL, { { "dscp_mode", "uniform" },
                                            { "dst_ip", "2.2.2.2" },
+                                           { "src_ip", "3.3.3.3" },
                                            { "ecn_mode", "copy_from_outer" },
                                            { "encap_ecn_mode", "standard" },
                                            { "ttl_mode", "pipe" },

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -66,6 +66,7 @@ class TestMuxTunnelBase():
     DEFAULT_TUNNEL_PARAMS = {
         "tunnel_type": "IPINIP",
         "dst_ip": SELF_IPV4,
+        "src_ip": PEER_IPV4,
         "dscp_mode": "pipe",
         "ecn_mode": "standard",
         "ttl_mode": "pipe",

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -2393,6 +2393,7 @@ class TestWarmReboot(object):
         tunnel_params = {
             "tunnel_type": "IPINIP",
             "dst_ip": "10.1.0.32",
+            "src_ip": "10.1.0.33",
             "dscp_mode": "uniform",
             "ecn_mode": "standard",
             "ttl_mode": "pipe"


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
For any tests involving IPinIP tunnels, provide a value for the "src_ip" SAI attribute

**Why I did it**
SAI v1.13 makes "src_ip" a required attribute when creating IPinIP tunnels

**How I verified it**

**Details if related**
