### PR TITLE
Apply default TC for BFD packets

### DIFF
--- a/orchagent/bfdorch.cpp
+++ b/orchagent/bfdorch.cpp
@@ -16,6 +16,8 @@ using namespace swss;
 #define BFD_SESSION_DEFAULT_DETECT_MULTIPLIER 10
 // TOS: default 6-bit DSCP value 48, default 2-bit ecn value 0. 48<<2 = 192
 #define BFD_SESSION_DEFAULT_TOS 192
+// Default TC value for BFD packets.
+#define BFD_SESSION_DEFAULT_TC 7
 #define BFD_SESSION_MILLISECOND_TO_MICROSECOND 1000
 #define BFD_SRCPORTINIT 49152
 #define BFD_SRCPORTMAX 65536
@@ -246,6 +248,7 @@ bool BfdOrch::create_bfd_session(const string& key, const vector<FieldValueTuple
     uint32_t rx_interval = BFD_SESSION_DEFAULT_RX_INTERVAL;
     uint8_t multiplier = BFD_SESSION_DEFAULT_DETECT_MULTIPLIER;
     uint8_t tos = BFD_SESSION_DEFAULT_TOS;
+    uint8_t tc = BFD_SESSION_DEFAULT_TC;
     bool multihop = false;
     MacAddress dst_mac;
     bool dst_mac_provided = false;
@@ -297,6 +300,10 @@ bool BfdOrch::create_bfd_session(const string& key, const vector<FieldValueTuple
         else if (fvField(i) == "tos")
         {
             tos = to_uint<uint8_t>(value);
+        }
+        else if (fvField(i) == "tc")
+        {
+            tc = to_uint<uint8_t>(value);
         }
         else
             SWSS_LOG_ERROR("Unsupported BFD attribute %s\n", fvField(i).c_str());
@@ -361,6 +368,10 @@ bool BfdOrch::create_bfd_session(const string& key, const vector<FieldValueTuple
 
     attr.id = SAI_BFD_SESSION_ATTR_TOS;
     attr.value.u8 = tos;
+    attrs.emplace_back(attr);
+
+    attr.id = SAI_BFD_SESSION_ATTR_TC;
+    attr.value.u8 = tc;
     attrs.emplace_back(attr);
 
     if (multihop)

--- a/tests/test_bfd.py
+++ b/tests/test_bfd.py
@@ -49,7 +49,7 @@ class TestBfd(object):
         bfdSessions = self.get_exist_bfd_session()
 
         # Create BFD session
-        fieldValues = {"local_addr": "10.0.0.1","tos":"64"}
+        fieldValues = {"local_addr": "10.0.0.1","tos":"64","tc":"4"}
         self.create_bfd_session("default:default:10.0.0.2", fieldValues)
         self.adb.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_BFD_SESSION", len(bfdSessions) + 1)
 
@@ -63,7 +63,8 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "10.0.0.2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
             "SAI_BFD_SESSION_ATTR_TOS": "64",
-            "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4"
+            "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4",
+            "SAI_BFD_SESSION_ATTR_TC": "4"
         }
         self.check_asic_bfd_session_value(session, expected_adb_values)
 
@@ -104,7 +105,8 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "2000::2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
             "SAI_BFD_SESSION_ATTR_TOS": "192",
-            "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "6"
+            "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "6",
+            "SAI_BFD_SESSION_ATTR_TC": "7"
         }
         self.check_asic_bfd_session_value(session, expected_adb_values)
 
@@ -147,7 +149,8 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_TOS": "192",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4",
             "SAI_BFD_SESSION_ATTR_HW_LOOKUP_VALID": "false",
-            "SAI_BFD_SESSION_ATTR_DST_MAC_ADDRESS": "00:02:03:04:05:06"
+            "SAI_BFD_SESSION_ATTR_DST_MAC_ADDRESS": "00:02:03:04:05:06",
+            "SAI_BFD_SESSION_ATTR_TC": "7"
         }
         self.check_asic_bfd_session_value(session, expected_adb_values)
 
@@ -191,6 +194,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4",
             "SAI_BFD_SESSION_ATTR_MIN_TX": "300000",
             "SAI_BFD_SESSION_ATTR_MIN_RX": "500000",
+            "SAI_BFD_SESSION_ATTR_TC": "7"
         }
         self.check_asic_bfd_session_value(session, expected_adb_values)
 
@@ -232,7 +236,8 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
             "SAI_BFD_SESSION_ATTR_TOS": "192",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4",
-            "SAI_BFD_SESSION_ATTR_MULTIPLIER": "5"
+            "SAI_BFD_SESSION_ATTR_MULTIPLIER": "5",
+            "SAI_BFD_SESSION_ATTR_TC": "7"
         }
         self.check_asic_bfd_session_value(session, expected_adb_values)
 
@@ -274,7 +279,8 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
             "SAI_BFD_SESSION_ATTR_TOS": "192",
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4",
-            "SAI_BFD_SESSION_ATTR_MULTIHOP": "true"
+            "SAI_BFD_SESSION_ATTR_MULTIHOP": "true",
+            "SAI_BFD_SESSION_ATTR_TC": "7"
         }
         self.check_asic_bfd_session_value(session, expected_adb_values)
 
@@ -315,7 +321,8 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "10.0.0.2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_DEMAND_ACTIVE",
             "SAI_BFD_SESSION_ATTR_TOS": "192",
-            "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4"
+            "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4",
+            "SAI_BFD_SESSION_ATTR_TC": "7"
         }
         self.check_asic_bfd_session_value(session, expected_adb_values)
 
@@ -358,7 +365,8 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "10.0.0.2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
             "SAI_BFD_SESSION_ATTR_TOS": "192",
-            "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4"
+            "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4",
+            "SAI_BFD_SESSION_ATTR_TC": "7"
         }
         self.check_asic_bfd_session_value(session1, expected_adb_values)
 
@@ -388,6 +396,7 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "4",
             "SAI_BFD_SESSION_ATTR_MIN_TX": "300000",
             "SAI_BFD_SESSION_ATTR_MIN_RX": "500000",
+            "SAI_BFD_SESSION_ATTR_TC": "7"
         }
         self.check_asic_bfd_session_value(session2, expected_adb_values)
 
@@ -414,7 +423,8 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "2000::2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_DEMAND_ACTIVE",
             "SAI_BFD_SESSION_ATTR_TOS": "192",
-            "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "6"
+            "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "6",
+            "SAI_BFD_SESSION_ATTR_TC": "7"
         }
         self.check_asic_bfd_session_value(session3, expected_adb_values)
 
@@ -441,7 +451,8 @@ class TestBfd(object):
             "SAI_BFD_SESSION_ATTR_DST_IP_ADDRESS": "3000::2",
             "SAI_BFD_SESSION_ATTR_TYPE": "SAI_BFD_SESSION_TYPE_ASYNC_ACTIVE",
             "SAI_BFD_SESSION_ATTR_TOS": "192",
-            "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "6"
+            "SAI_BFD_SESSION_ATTR_IPHDR_VERSION": "6",
+            "SAI_BFD_SESSION_ATTR_TC": "7"
         }
         self.check_asic_bfd_session_value(session4, expected_adb_values)
 


### PR DESCRIPTION
**What I did**
Apply default TC value for BFD packets when BFD sessions are created. Use SAI attribute SAI_BFD_SESSION_ATTR_TC to set the TC value.

**Why I did it**
To transmit BFD packets using non-default Queue.

**How I verified it**
With default TC value of 7 and QoSmap TC_TO_QUEUE mapping TC(7)-->Queue(7), BFD packets are using Queue 7 on Egress ports.