### PR TITLE
[202205][CodeQL]: Use dependencies with relevant versions in azp template

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -75,7 +75,7 @@ jobs:
       name: Build sonic-swss-common
       run: |
         cd ..
-        git clone https://github.com/sonic-net/sonic-swss-common
+        git clone -b ${{ github.ref_name }} https://github.com/sonic-net/sonic-swss-common
         pushd sonic-swss-common
         ./autogen.sh
         dpkg-buildpackage -rfakeroot -us -uc -b -j$(nproc)
@@ -89,14 +89,13 @@ jobs:
       name: Build sonic-sairedis
       run: |
         cd ..
-        git clone --recursive https://github.com/sonic-net/sonic-sairedis
+        git clone -b ${{ github.ref_name }} --recursive https://github.com/sonic-net/sonic-sairedis
         pushd sonic-sairedis
         ./autogen.sh
         DEB_BUILD_OPTIONS=nocheck \
         SWSS_COMMON_INC="$(dirname $GITHUB_WORKSPACE)/usr/include" \
         SWSS_COMMON_LIB="$(dirname $GITHUB_WORKSPACE)/usr/lib/x86_64-linux-gnu" \
-        DEB_CFLAGS_SET="-Wno-error" DEB_CXXFLAGS_SET="-Wno-error" \
-        dpkg-buildpackage -rfakeroot -us -uc -b -Psyncd,vs,nopython2 -j$(nproc)
+        fakeroot debian/rules -j$(nproc) CFLAGS="-Wno-error" CXXFLAGS="-Wno-error" binary-syncd-vs
         popd
         dpkg-deb -x libsairedis_${SAIREDIS_VER}_amd64.deb $(dirname $GITHUB_WORKSPACE)
         dpkg-deb -x libsairedis-dev_${SAIREDIS_VER}_amd64.deb $(dirname $GITHUB_WORKSPACE)
@@ -112,7 +111,7 @@ jobs:
       name: Build libnl
       run: |
         cd ..
-        git clone https://github.com/sonic-net/sonic-buildimage
+        git clone -b ${{ github.ref_name }} https://github.com/sonic-net/sonic-buildimage
         pushd sonic-buildimage/src/libnl3
         git clone https://github.com/thom311/libnl libnl3-${LIBNL3_VER}
         pushd libnl3-${LIBNL3_VER}


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
* Increase robustness of `CodeQL`: use only dependencies with the relevant versions

**Why I did it**
* To fix `CodeQL` compilation failures

**How I verified it**
1. Make a PR
2. Do a push

**Details if related**
* Backport from `master`: https://github.com/sonic-net/sonic-swss/pull/2845
* Takes effect only after PR is merged