### PR TITLE
[orchagent] Add SAI_SWITCH_ATTR_SWITCH_ID for fabric switch

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -578,6 +578,10 @@ int main(int argc, char **argv)
         attr.id = SAI_SWITCH_ATTR_TYPE;
         attr.value.u32 = SAI_SWITCH_TYPE_FABRIC;
         attrs.push_back(attr);
+
+        attr.id = SAI_SWITCH_ATTR_SWITCH_ID;
+        attr.value.u32 = gVoqMySwitchId;
+        attrs.push_back(attr);
     }
 
     /* Must be last Attribute */


### PR DESCRIPTION
This will be required since SAI v1.13

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add extra parameter when creating switch when switch type is fabric

**Why I did it**
It will be required attribute since SAI v1.13

**How I verified it**
Build locally

**Details if related**
Build on THIS will fail, since it will require sairedis to updates first, and sairedis will fail because swss don't contain this change, both repos needs to be update before test will start to pass

OA will require to pass "switch_id" param in config for fabric devices, not only for voq, devices, because of that test updates may be required