### PR TITLE
[orchagent] Do not set internal port count to the PortConfigDone DB value.

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3294,14 +3294,6 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
             setPortConfigState(PORT_CONFIG_RECEIVED);
 
-            for (const auto &cit : kfvFieldsValues(keyOpFieldsValues))
-            {
-                if (fvField(cit) == "count")
-                {
-                    m_portCount = to_uint<uint32_t>(fvValue(cit));
-                }
-            }
-
             SWSS_LOG_INFO("Got PortConfigDone notification from portsyncd");
 
             it = taskMap.begin();


### PR DESCRIPTION
**What I did**
Do not set internal port count to the PortConfigDone DB value.

**Why I did it**
Fix https://github.com/sonic-net/sonic-swss/issues/2904


