### PR TITLE
Change log level for NH down during ECMP create

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1267,7 +1267,7 @@ bool RouteOrch::addNextHopGroup(const NextHopGroupKey &nexthops)
         // skip next hop group member create for neighbor from down port
         if (m_neighOrch->isNextHopFlagSet(it, NHFLAGS_IFDOWN))
         {
-            SWSS_LOG_INFO("Interface down for NH %s, skip this NH", it.to_string().c_str());
+            SWSS_LOG_NOTICE("Interface down for NH %s, skip this NH", it.to_string().c_str());
             continue;
         }
 


### PR DESCRIPTION
**What I did**
Change the log level for NH down event during ECMP create.

**Why I did it**
During ECMP create, down NHs are skipped and these events are not captured in syslog. Change the log level to NOTICE to capture these events in syslog for debugging.
