### PR TITLE
[muxorch] Reorder the neighbor disable operations

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -848,18 +848,18 @@ bool MuxNbrHandler::disable(sai_object_id_t tnh)
             return false;
         }
 
-        neigh = NeighborEntry(it->first, alias_);
-        if (!gNeighOrch->disableNeighbor(neigh))
-        {
-            SWSS_LOG_INFO("Disabling neigh failed for %s", neigh.ip_address.to_string().c_str());
-            return false;
-        }
-
         updateTunnelRoute(nh_key, true);
 
         IpPrefix pfx = it->first.to_string();
         if (create_route(pfx, it->second) != SAI_STATUS_SUCCESS)
         {
+            return false;
+        }
+
+        neigh = NeighborEntry(it->first, alias_);
+        if (!gNeighOrch->disableNeighbor(neigh))
+        {
+            SWSS_LOG_INFO("Disabling neigh failed for %s", neigh.ip_address.to_string().c_str());
             return false;
         }
 


### PR DESCRIPTION



<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When mux transits from active to standby, orchagent first disable the
neighbor[1], then program the tunnel route[2].
There is a small period of time between [1] and [2] that the ASIC
is unable to forward the traffic to the neighbor.

So let's reorder those two operations - program the tunnel route first,
then disable the neighbor.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

**Why I did it**
Packet loss observed during `config mux standby`


**How I verified it**
Validate that, with the fix, no more packet loss is observed when `config mux standby`

**Details if related**
