### PR TITLE
Reducing the severity of oper fec attribute get failure

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -7385,7 +7385,7 @@ bool PortsOrch::getPortOperFec(const Port& port, sai_port_fec_mode_t &fec_mode) 
     sai_status_t ret = sai_port_api->get_port_attribute(port.m_port_id, 1, &attr);
     if (ret != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR("Failed to get oper fec for %s", port.m_alias.c_str());
+        SWSS_LOG_NOTICE("Failed to get oper fec for %s", port.m_alias.c_str());
         return false;
     }
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Reduced the severity of log when get attribute of oper fec failed.

**Why I did it**
The oper fec is not a mandatory attribute and may not be implemented by vendor SAI, in which case throwing an error is wrong. Reduced the severity of the log message to notice. This will also fix the checker issues in https://github.com/sonic-net/sonic-buildimage/pull/16785

**How I verified it**


**Details if related**
