### PR TITLE
[202205][teamd]: Clean teamd process if LAG creation fails (#2888)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ tests/tests
 tests/mock_tests/tests_response_publisher
 tests/mock_tests/tests_fpmsyncd
 tests/mock_tests/tests_intfmgrd
+tests/mock_tests/tests_teammgrd
 tests/mock_tests/tests_portsyncd
 
 

--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -300,6 +300,8 @@ void TeamMgr::doLagTask(Consumer &consumer)
             {
                 if (addLag(alias, min_links, fallback) == task_need_retry)
                 {
+                    // If LAG creation fails, we need to clean up any potentially orphaned teamd processes
+                    removeLag(alias);
                     it++;
                     continue;
                 }
@@ -615,7 +617,7 @@ task_process_status TeamMgr::addLag(const string &alias, int min_links, bool fal
     SWSS_LOG_INFO("Port channel %s teamd configuration: %s",
             alias.c_str(), conf.str().c_str());
 
-    string warmstart_flag = WarmStart::isWarmStart() ? " -w -o " : " -r ";
+    string warmstart_flag = WarmStart::isWarmStart() ? " -w -o" : " -r";
 
     cmd << TEAMD_CMD
         << warmstart_flag
@@ -642,9 +644,42 @@ bool TeamMgr::removeLag(const string &alias)
 
     stringstream cmd;
     string res;
+    pid_t pid;
 
-    cmd << TEAMD_CMD << " -k -t " << shellquote(alias);
-    EXEC_WITH_ERROR_THROW(cmd.str(), res);
+    try
+    {
+        std::stringstream cmd;
+        cmd << "cat " << shellquote("/var/run/teamd/" + alias + ".pid");
+        EXEC_WITH_ERROR_THROW(cmd.str(), res);
+    }
+    catch (const std::exception &e)
+    {
+        SWSS_LOG_NOTICE("Failed to remove non-existent port channel %s pid...", alias.c_str());
+        return false;
+    }
+
+    try
+    {
+        pid = static_cast<pid_t>(std::stoul(res, nullptr, 10));
+        SWSS_LOG_INFO("Read port channel %s pid %d", alias.c_str(), pid);
+    }
+    catch (const std::exception &e)
+    {
+        SWSS_LOG_ERROR("Failed to read port channel %s pid: %s", alias.c_str(), e.what());
+        return false;
+    }
+
+    try
+    {
+        std::stringstream cmd;
+        cmd << "kill -TERM " << pid;
+        EXEC_WITH_ERROR_THROW(cmd.str(), res);
+    }
+    catch (const std::exception &e)
+    {
+        SWSS_LOG_ERROR("Failed to send SIGTERM to port channel %s pid %d: %s", alias.c_str(), pid, e.what());
+        return false;
+    }
 
     SWSS_LOG_NOTICE("Stop port channel %s", alias.c_str());
 

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -6,9 +6,9 @@ INCLUDES = -I $(FLEX_CTR_DIR) -I $(DEBUG_CTR_DIR) -I $(top_srcdir)/lib -I $(top_
 
 CFLAGS_SAI = -I /usr/include/sai
 
-TESTS = tests tests_intfmgrd
+TESTS = tests tests_intfmgrd tests_teammgrd
 
-noinst_PROGRAMS = tests tests_intfmgrd
+noinst_PROGRAMS = tests tests_intfmgrd tests_teammgrd
 
 LDADD_SAI = -lsaimeta -lsaimetadata -lsaivs -lsairedis
 
@@ -146,3 +146,24 @@ tests_intfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST
 tests_intfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) -I $(top_srcdir)/cfgmgr -I $(top_srcdir)/orchagent/
 tests_intfmgrd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
         -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread
+
+## teammgrd unit tests
+
+tests_teammgrd_SOURCES = teammgrd/teammgr_ut.cpp \
+                         $(top_srcdir)/cfgmgr/teammgr.cpp \
+                         $(top_srcdir)/lib/subintf.cpp \
+                         $(top_srcdir)/orchagent/orch.cpp \
+                         $(top_srcdir)/orchagent/request_parser.cpp \
+                         mock_orchagent_main.cpp \
+                         mock_dbconnector.cpp \
+                         mock_table.cpp \
+                         mock_hiredis.cpp \
+                         fake_response_publisher.cpp \
+                         mock_redisreply.cpp \
+                         common/mock_shell_command.cpp
+
+tests_teammgrd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/cfgmgr -I$(top_srcdir)/lib
+tests_teammgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
+tests_teammgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_teammgrd_INCLUDES)
+tests_teammgrd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
+        -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lgmock_main

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -160,7 +160,7 @@ tests_teammgrd_SOURCES = teammgrd/teammgr_ut.cpp \
                          mock_hiredis.cpp \
                          fake_response_publisher.cpp \
                          mock_redisreply.cpp \
-                         common/mock_shell_command.cpp
+                         mock_shell_command.cpp
 
 tests_teammgrd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/cfgmgr -I$(top_srcdir)/lib
 tests_teammgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)

--- a/tests/mock_tests/mock_shell_command.cpp
+++ b/tests/mock_tests/mock_shell_command.cpp
@@ -1,6 +1,9 @@
 #include <string>
 #include <vector>
 
+/* Override this pointer for custom behavior */
+int (*callback)(const std::string &cmd, std::string &stdout) = nullptr;
+
 int mockCmdReturn = 0;
 std::string mockCmdStdcout = "";
 std::vector<std::string> mockCallArgs;
@@ -8,8 +11,15 @@ std::vector<std::string> mockCallArgs;
 namespace swss {
     int exec(const std::string &cmd, std::string &stdout)
     {
-        mockCallArgs.push_back(cmd);
-        stdout = mockCmdStdcout;
-        return mockCmdReturn;
+        if (callback != nullptr)
+        {
+            return callback(cmd, stdout);
+        }
+        else
+        {
+            mockCallArgs.push_back(cmd);
+            stdout = mockCmdStdcout;
+            return mockCmdReturn;
+        }
     }
 }

--- a/tests/mock_tests/teammgrd/teammgr_ut.cpp
+++ b/tests/mock_tests/teammgrd/teammgr_ut.cpp
@@ -1,0 +1,78 @@
+#include "gtest/gtest.h"
+#include "../mock_table.h"
+#include "teammgr.h"
+
+extern int (*callback)(const std::string &cmd, std::string &stdout);
+extern std::vector<std::string> mockCallArgs;
+
+int cb(const std::string &cmd, std::string &stdout)
+{
+    mockCallArgs.push_back(cmd);
+    if (cmd.find("/usr/bin/teamd -r -t PortChannel1") != std::string::npos)
+    {
+        return 1;
+    }
+    else if (cmd.find("cat \"/var/run/teamd/PortChannel1.pid\"") != std::string::npos)
+    {
+        stdout = "1234";
+        return 0;
+    }
+    return 0;
+}
+
+namespace teammgr_ut
+{
+    struct TeamMgrTest : public ::testing::Test
+    {
+        std::shared_ptr<swss::DBConnector> m_config_db;
+        std::shared_ptr<swss::DBConnector> m_app_db;
+        std::shared_ptr<swss::DBConnector> m_state_db;
+        std::vector<TableConnector> cfg_lag_tables;
+
+        virtual void SetUp() override
+        {
+            testing_db::reset();
+            m_config_db = std::make_shared<swss::DBConnector>("CONFIG_DB", 0);
+            m_app_db = std::make_shared<swss::DBConnector>("APPL_DB", 0);
+            m_state_db = std::make_shared<swss::DBConnector>("STATE_DB", 0);
+
+            swss::Table metadata_table = swss::Table(m_config_db.get(), CFG_DEVICE_METADATA_TABLE_NAME);
+            std::vector<swss::FieldValueTuple> vec;
+            vec.emplace_back("mac", "01:23:45:67:89:ab");
+            metadata_table.set("localhost", vec);
+
+            TableConnector conf_lag_table(m_config_db.get(), CFG_LAG_TABLE_NAME);
+            TableConnector conf_lag_member_table(m_config_db.get(), CFG_LAG_MEMBER_TABLE_NAME);
+            TableConnector state_port_table(m_state_db.get(), STATE_PORT_TABLE_NAME);
+
+            std::vector<TableConnector> tables = {
+                conf_lag_table,
+                conf_lag_member_table,
+                state_port_table
+            };
+
+            cfg_lag_tables = tables;
+            mockCallArgs.clear();
+            callback = cb;
+        }
+    };
+
+    TEST_F(TeamMgrTest, testProcessKilledAfterAddLagFailure)
+    {
+        swss::TeamMgr teammgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_lag_tables);
+        swss::Table cfg_lag_table = swss::Table(m_config_db.get(), CFG_LAG_TABLE_NAME);
+        cfg_lag_table.set("PortChannel1", { { "admin_status", "up" },
+                                            { "mtu", "9100" },
+                                            { "lacp_key", "auto" },
+                                            { "min_links", "2" } });
+        teammgr.addExistingData(&cfg_lag_table);
+        teammgr.doTask();
+        int kill_cmd_called = 0;
+        for (auto cmd : mockCallArgs){
+            if (cmd.find("kill -TERM 1234") != std::string::npos){
+                kill_cmd_called++;
+            }
+        }
+        ASSERT_EQ(kill_cmd_called, 1);
+    }
+}


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
- 202205 cherry-pick for #2888 
- During LAG creation, if the teamd process fails for any reason, cleanup any leftover teamd processes for the LAG alias
- Call `kill` directly in `removeLag` instead of using `teamd -k`

**Why I did it**
- If the teamd process times out for any reason, subsequent attempts to create a LAG may fail if there is an orphaned process left running
- As detailed in https://github.com/sonic-net/sonic-buildimage/issues/8071, `team -k` may block for some time.

**How I verified it**

**Details if related**
