### PR TITLE
[202205][FlexCounters] Fixed orchagent crash issue#2395

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -6088,7 +6088,7 @@ void PortsOrch::generateQueueMap(map<string, FlexCounterQueueStates> queuesState
             {
                 auto maxQueueNumber = getNumberOfPortSupportedQueueCounters(it.second.m_alias);
                 FlexCounterQueueStates flexCounterQueueState(maxQueueNumber);
-                if (isCreateAllQueues)
+                if (isCreateAllQueues && maxQueueNumber)
                 {
                     flexCounterQueueState.enableQueueCounters(0, maxQueueNumber - 1);
                 }
@@ -6226,7 +6226,7 @@ void PortsOrch::addQueueFlexCounters(map<string, FlexCounterQueueStates> queuesS
             {
                 auto maxQueueNumber = getNumberOfPortSupportedQueueCounters(it.second.m_alias);
                 FlexCounterQueueStates flexCounterQueueState(maxQueueNumber);
-                if (isCreateAllQueues)
+                if (isCreateAllQueues && maxQueueNumber)
                 {
                     flexCounterQueueState.enableQueueCounters(0, maxQueueNumber - 1);
                 }
@@ -6303,7 +6303,7 @@ void PortsOrch::addQueueWatermarkFlexCounters(map<string, FlexCounterQueueStates
             {
                 auto maxQueueNumber = getNumberOfPortSupportedQueueCounters(it.second.m_alias);
                 FlexCounterQueueStates flexCounterQueueState(maxQueueNumber);
-                if (isCreateAllQueues)
+                if (isCreateAllQueues && maxQueueNumber)
                 {
                     flexCounterQueueState.enableQueueCounters(0, maxQueueNumber - 1);
                 }
@@ -6486,7 +6486,7 @@ void PortsOrch::generatePriorityGroupMap(map<string, FlexCounterPgStates> pgsSta
             {
                 auto maxPgNumber = getNumberOfPortSupportedPgCounters(it.second.m_alias);
                 FlexCounterPgStates flexCounterPgState(maxPgNumber);
-                if (isCreateAllPgs)
+                if (isCreateAllPgs && maxPgNumber)
                 {
                     flexCounterPgState.enablePgCounters(0, maxPgNumber - 1);
                 }
@@ -6602,7 +6602,7 @@ void PortsOrch::addPriorityGroupFlexCounters(map<string, FlexCounterPgStates> pg
             {
                 auto maxPgNumber = getNumberOfPortSupportedPgCounters(it.second.m_alias);
                 FlexCounterPgStates flexCounterPgState(maxPgNumber);
-                if (isCreateAllPgs)
+                if (isCreateAllPgs && maxPgNumber)
                 {
                     flexCounterPgState.enablePgCounters(0, maxPgNumber - 1);
                 }
@@ -6671,7 +6671,7 @@ void PortsOrch::addPriorityGroupWatermarkFlexCounters(map<string, FlexCounterPgS
             {
                 auto maxPgNumber = getNumberOfPortSupportedPgCounters(it.second.m_alias);
                 FlexCounterPgStates flexCounterPgState(maxPgNumber);
-                if (isCreateAllPgs)
+                if (isCreateAllPgs && maxPgNumber)
                 {
                     flexCounterPgState.enablePgCounters(0, maxPgNumber - 1);
                 }


### PR DESCRIPTION
Issue seen on platforms that are not supporting queue-watermark and pg counters.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Cherry-pick fix for orchagent crash reported in https://github.com/sonic-net/sonic-swss/issues/2935
**Why I did it**
Added checks to skip if max values for PG and queue are 0
**How I verified it**
Reloaded swss debian with fix and enable flex counters watermark and pg-drop
**Details if related**
