### PR TITLE
[Chassis][202205][orchagent] : Support WRED profiles on system ports

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -797,7 +797,7 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
             return task_process_status::task_invalid_entry;
         }
 
-        if(tokens[0] == gMyHostName)
+        if((tokens[0] == gMyHostName) && (tokens[1] == gMyAsicName))
         {
            local_port = true;
            local_port_name = tokens[2];

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -20,6 +20,8 @@ extern PortsOrch *gPortsOrch;
 extern Directory<Orch*> gDirectory;
 extern sai_object_id_t gSwitchId;
 extern string gMySwitchType;
+extern string gMyHostName;
+extern string gMyAsicName;
 
 #define BUFFER_POOL_WATERMARK_FLEX_STAT_COUNTER_POLL_MSECS  "60000"
 
@@ -774,6 +776,8 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
     vector<string> tokens;
     sai_uint32_t range_low, range_high;
     bool need_update_sai = true;
+    bool local_port = false;
+    string local_port_name;
 
     SWSS_LOG_DEBUG("Processing:%s", key.c_str());
     tokens = tokenize(key, delimiter);
@@ -791,6 +795,13 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
         if (!parseIndexRange(tokens[3], range_low, range_high))
         {
             return task_process_status::task_invalid_entry;
+        }
+
+        if(tokens[0] == gMyHostName)
+        {
+           local_port = true;
+           local_port_name = tokens[2];
+           SWSS_LOG_INFO("System port %s is local port %d local port name %s", port_names[0].c_str(), local_port, local_port_name.c_str());
         }
     }
     else 
@@ -854,6 +865,12 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
     {
         Port port;
         SWSS_LOG_DEBUG("processing port:%s", port_name.c_str());
+
+        if(local_port == true)
+        {
+            port_name = local_port_name;
+        }
+
         if (!gPortsOrch->getPort(port_name, port))
         {
             SWSS_LOG_ERROR("Port with alias:%s not found", port_name.c_str());
@@ -970,8 +987,17 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
         // set order is detected.
         for (const auto &port_name : port_names)
         {
-            if (gPortsOrch->isPortAdminUp(port_name)) {
-                SWSS_LOG_WARN("Queue profile '%s' applied after port %s is up", key.c_str(), port_name.c_str());
+            if(local_port == true)
+            {
+                if (gPortsOrch->isPortAdminUp(local_port_name)) {
+                    SWSS_LOG_WARN("Queue profile '%s' applied after port %s is up", key.c_str(), port_name.c_str());
+                }
+            }
+            else
+            {
+                if (gPortsOrch->isPortAdminUp(port_name)) {
+                    SWSS_LOG_WARN("Queue profile '%s' applied after port %s is up", key.c_str(), port_name.c_str());
+                }
             }
         }
     }

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -28,6 +28,9 @@ extern PortsOrch *gPortsOrch;
 extern QosOrch *gQosOrch;
 extern sai_object_id_t gSwitchId;
 extern CrmOrch *gCrmOrch;
+extern string gMySwitchType;
+extern string gMyHostName;
+extern string gMyAsicName;
 
 map<string, sai_ecn_mark_mode_t> ecn_map = {
     {"ecn_none", SAI_ECN_MARK_MODE_NONE},
@@ -1631,22 +1634,58 @@ sai_object_id_t QosOrch::getSchedulerGroup(const Port &port, const sai_object_id
 bool QosOrch::applySchedulerToQueueSchedulerGroup(Port &port, size_t queue_ind, sai_object_id_t scheduler_profile_id)
 {
     SWSS_LOG_ENTER();
+    sai_object_id_t queue_id;
+    Port input_port = port;
+    sai_object_id_t group_id = 0;
 
-    if (port.m_queue_ids.size() <= queue_ind)
+    if (gMySwitchType == "voq") 
     {
-        SWSS_LOG_ERROR("Invalid queue index specified:%zd", queue_ind);
-        return false;
+        if(port.m_system_port_info.type == SAI_SYSTEM_PORT_TYPE_REMOTE)
+        {
+            return true;
+        }
+       
+        // Get local port from system port. port is pointing to local port now
+        if (!gPortsOrch->getPort(port.m_system_port_info.local_port_oid, port))
+        {
+            SWSS_LOG_ERROR("Port with alias:%s not found", port.m_alias.c_str());
+            return task_process_status::task_invalid_entry;
+        }
+
+        if (port.m_queue_ids.size() <= queue_ind)
+        {
+            SWSS_LOG_ERROR("Invalid queue index specified:%zd", queue_ind);
+            return false;
+        }
+        queue_id = port.m_queue_ids[queue_ind];
+        
+        group_id = getSchedulerGroup(port, queue_id);
+        if(group_id == SAI_NULL_OBJECT_ID)
+        {
+            SWSS_LOG_ERROR("Failed to find a scheduler group for port: %s queue: %zu", port.m_alias.c_str(), queue_ind);
+            return false;
+        }
+
+        // port is set back to system port
+        port = input_port;
     }
-
-    const sai_object_id_t queue_id = port.m_queue_ids[queue_ind];
-
-    const sai_object_id_t group_id = getSchedulerGroup(port, queue_id);
-    if(group_id == SAI_NULL_OBJECT_ID)
+    else
     {
-        SWSS_LOG_ERROR("Failed to find a scheduler group for port: %s queue: %zu", port.m_alias.c_str(), queue_ind);
-        return false;
+        if (port.m_queue_ids.size() <= queue_ind)
+        {
+            SWSS_LOG_ERROR("Invalid queue index specified:%zd", queue_ind);
+            return false;
+        }
+        queue_id = port.m_queue_ids[queue_ind];
+        
+        group_id = getSchedulerGroup(port, queue_id);
+        if(group_id == SAI_NULL_OBJECT_ID)
+        {
+            SWSS_LOG_ERROR("Failed to find a scheduler group for port: %s queue: %zu", port.m_alias.c_str(), queue_ind);
+            return false;
+        }
     }
-
+    
     /* Apply scheduler profile to all port groups  */
     sai_attribute_t attr;
     sai_status_t    sai_status;
@@ -1677,12 +1716,25 @@ bool QosOrch::applyWredProfileToQueue(Port &port, size_t queue_ind, sai_object_i
     sai_status_t    sai_status;
     sai_object_id_t queue_id;
 
-    if (port.m_queue_ids.size() <= queue_ind)
+    if (gMySwitchType == "voq") 
     {
-        SWSS_LOG_ERROR("Invalid queue index specified:%zd", queue_ind);
-        return false;
+        std :: vector<sai_object_id_t> queue_ids = gPortsOrch->getPortVoQIds(port);
+        if (queue_ids.size() <= queue_ind)
+        {
+            SWSS_LOG_ERROR("Invalid voq index specified:%zd", queue_ind);
+            return task_process_status::task_invalid_entry;
+        }
+        queue_id = queue_ids[queue_ind];
+    } 
+    else
+    {
+        if (port.m_queue_ids.size() <= queue_ind)
+        {
+            SWSS_LOG_ERROR("Invalid queue index specified:%zd", queue_ind);
+            return false;
+        }
+        queue_id = port.m_queue_ids[queue_ind];
     }
-    queue_id = port.m_queue_ids[queue_ind];
 
     attr.id = SAI_QUEUE_ATTR_WRED_PROFILE_ID;
     attr.value.oid = sai_wred_profile;
@@ -1708,23 +1760,54 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer, KeyOpFieldsVal
     string op = kfvOp(tuple);
     size_t queue_ind = 0;
     vector<string> tokens;
+    bool local_port = false;
+    string local_port_name;
 
     sai_uint32_t range_low, range_high;
     vector<string> port_names;
 
     ref_resolve_status  resolve_result;
-    // sample "QUEUE: {Ethernet4|0-1}"
+    /*
+        Input sample "QUEUE : {Ethernet4|0-1}" or
+                     "QUEUE : {STG01-0101-0400-01T2-LC6|ASIC0|Ethernet4|0-1}"
+    */
     tokens = tokenize(key, config_db_key_delimiter);
-    if (tokens.size() != 2)
+
+    if (gMySwitchType == "voq") 
     {
-        SWSS_LOG_ERROR("malformed key:%s. Must contain 2 tokens", key.c_str());
-        return task_process_status::task_invalid_entry;
+        if (tokens.size() != 4)
+        {
+            SWSS_LOG_ERROR("malformed key:%s. Must contain 4 tokens", key.c_str());
+            return task_process_status::task_invalid_entry;
+        }
+
+        port_names = tokenize(tokens[0] + config_db_key_delimiter + tokens[1] + config_db_key_delimiter + tokens[2], list_item_delimiter);
+        if (!parseIndexRange(tokens[3], range_low, range_high))
+        {
+            SWSS_LOG_ERROR("Failed to parse range:%s", tokens[3].c_str());
+            return task_process_status::task_invalid_entry;
+        }
+
+        if(tokens[0] == gMyHostName)
+        {
+           local_port = true;
+           local_port_name = tokens[2];
+           SWSS_LOG_INFO("System port %s is local port %d local port name %s", port_names[0].c_str(), local_port, local_port_name.c_str());
+        }
     }
-    port_names = tokenize(tokens[0], list_item_delimiter);
-    if (!parseIndexRange(tokens[1], range_low, range_high))
+    else
     {
-        SWSS_LOG_ERROR("Failed to parse range:%s", tokens[1].c_str());
-        return task_process_status::task_invalid_entry;
+        if (tokens.size() != 2)
+        {
+            SWSS_LOG_ERROR("malformed key:%s. Must contain 2 tokens", key.c_str());
+            return task_process_status::task_invalid_entry;
+        }
+        port_names = tokenize(tokens[0], list_item_delimiter);
+        if (!parseIndexRange(tokens[1], range_low, range_high))
+        {
+            SWSS_LOG_ERROR("Failed to parse range:%s", tokens[1].c_str());
+            return task_process_status::task_invalid_entry;
+        }
     }
 
     bool donotChangeScheduler = false;
@@ -1818,6 +1901,12 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer, KeyOpFieldsVal
     {
         Port port;
         SWSS_LOG_DEBUG("processing port:%s", port_name.c_str());
+
+        if(local_port == true)
+        {
+            port_name = local_port_name;
+        }
+
         if (!gPortsOrch->getPort(port_name, port))
         {
             SWSS_LOG_ERROR("Port with alias:%s not found", port_name.c_str());

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -1788,7 +1788,7 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer, KeyOpFieldsVal
             return task_process_status::task_invalid_entry;
         }
 
-        if(tokens[0] == gMyHostName)
+        if((tokens[0] == gMyHostName) && (tokens[1] == gMyAsicName))
         {
            local_port = true;
            local_port_name = tokens[2];

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -886,9 +886,7 @@ class TestVirtualChassis(object):
                 app_db.wait_for_deleted_entry('PORT_TABLE', port)
                 num = asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT",
                                               num_ports-1)
-                assert len(num) == num_ports-1
-
-                marker = dvs.add_log_marker()
+                assert len(num) == num_ports
 
                 # Create port
                 config_db.update_entry("PORT", port, port_info)
@@ -900,7 +898,7 @@ class TestVirtualChassis(object):
                 # Check that we see the logs for removing default vlan
                 matching_log = "removeDefaultVlanMembers: Remove 0 VLAN members from default VLAN"
                 _, logSeen = dvs.runcmd( [ "sh", "-c",
-                     "awk '/{}/,ENDFILE {{print;}}' /var/log/syslog | grep '{}' | wc -l".format( marker, matching_log ) ] )
+                  "awk STARTFILE/ENDFILE /var/log/syslog | grep 'removeDefaultVlanMembers: Remove 32 VLAN members from default VLAN' | wc -l"] )
                 assert logSeen.strip() == "1"
 
             buffer_model.disable_dynamic_buffer(dvs.get_config_db(), dvs.runcmd)
@@ -937,6 +935,13 @@ class TestVirtualChassis(object):
                         print("WRED profile not applied on queue4 on system port %s", key)
                         assert wred_profile == 'AZURE_LOSSLESS'
 
+                # Check that we see the logs for applying WRED_PROFILE on all system ports
+                matching_log = "SAI_QUEUE_ATTR_WRED_PROFILE_ID"
+                _, logSeen = dvs.runcmd([ "sh", "-c",
+                     "awk STARTFILE/ENDFILE /var/log/swss/sairedis.rec | grep SAI_QUEUE_ATTR_WRED_PROFILE_ID | wc -l"])
+
+                # Total number of logs = (No of system ports * No of lossless priorities) - No of lossless priorities for CPU ports
+                assert logSeen.strip() == str(len(system_ports)*2 - 2)
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -905,6 +905,39 @@ class TestVirtualChassis(object):
 
             buffer_model.disable_dynamic_buffer(dvs.get_config_db(), dvs.runcmd)
 
+    def test_chassis_wred_profile_on_system_ports(self, vct):
+        """Test whether wred profile is applied on system ports in VoQ chassis.
+        """
+        dvss = vct.dvss
+        for name in dvss.keys():
+            dvs = dvss[name]
+
+            config_db = dvs.get_config_db()
+            app_db = dvs.get_app_db()
+            asic_db = dvs.get_asic_db()
+            metatbl = config_db.get_entry("DEVICE_METADATA", "localhost")
+            cfg_switch_type = metatbl.get("switch_type")
+
+            if cfg_switch_type == "voq":
+                # Get all the keys from SYTEM_PORT table and check whether wred_profile is applied properly
+                system_ports = config_db.get_keys('SYSTEM_PORT')
+
+                for key in system_ports:
+                    queue3 = key + '|' + '3'
+                    queue_entry = config_db.get_entry('QUEUE', queue3)
+                    wred_profile = queue_entry['wred_profile']
+                    if wred_profile != 'AZURE_LOSSLESS':
+                        print("WRED profile not applied on queue3 on system port %s", key)
+                        assert wred_profile == 'AZURE_LOSSLESS'
+
+                    queue4 = key + '|' + '4'
+                    queue_entry = config_db.get_entry('QUEUE', queue4)
+                    wred_profile = queue_entry['wred_profile']
+                    if wred_profile != 'AZURE_LOSSLESS':
+                        print("WRED profile not applied on queue4 on system port %s", key)
+                        assert wred_profile == 'AZURE_LOSSLESS'
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/virtual_chassis/1/default_config.json
+++ b/tests/virtual_chassis/1/default_config.json
@@ -27,672 +27,672 @@
         }
     },
     "SYSTEM_PORT": {
-        "Linecard1|Ethernet0": {
+        "lc1|Ethernet0": {
             "speed": "40000",
             "system_port_id": "1",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "1"
         },
-        "Linecard1|Asic0|Ethernet4": {
+        "lc1|Asic0|Ethernet4": {
             "speed": "40000",
             "system_port_id": "2",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "2"
         },
-        "Linecard1|Asic0|Ethernet8": {
+        "lc1|Asic0|Ethernet8": {
             "speed": "40000",
             "system_port_id": "3",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "3"
         },
-        "Linecard1|Asic0|Ethernet12": {
+        "lc1|Asic0|Ethernet12": {
             "speed": "40000",
             "system_port_id": "4",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "4"
         },
-        "Linecard1|Asic0|Ethernet16": {
+        "lc1|Asic0|Ethernet16": {
             "speed": "40000",
             "system_port_id": "5",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "5"
         },
-        "Linecard1|Asic0|Ethernet20": {
+        "lc1|Asic0|Ethernet20": {
             "speed": "40000",
             "system_port_id": "6",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "6"
         },
-        "Linecard1|Asic0|Ethernet24": {
+        "lc1|Asic0|Ethernet24": {
             "speed": "40000",
             "system_port_id": "7",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "7"
         },
-        "Linecard1|Asic0|Ethernet28": {
+        "lc1|Asic0|Ethernet28": {
             "speed": "40000",
             "system_port_id": "8",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "8"
         },
-        "Linecard1|Asic0|Ethernet32": {
+        "lc1|Asic0|Ethernet32": {
             "speed": "40000",
             "system_port_id": "9",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "9"
         },
-        "Linecard1|Asic0|Ethernet36": {
+        "lc1|Asic0|Ethernet36": {
             "speed": "40000",
             "system_port_id": "10",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "10"
         },
-        "Linecard1|Asic0|Ethernet40": {
+        "lc1|Asic0|Ethernet40": {
             "speed": "40000",
             "system_port_id": "11",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "11"
         },
-        "Linecard1|Asic0|Ethernet44": {
+        "lc1|Asic0|Ethernet44": {
             "speed": "40000",
             "system_port_id": "12",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "12"
         },
-        "Linecard1|Asic0|Ethernet48": {
+        "lc1|Asic0|Ethernet48": {
             "speed": "40000",
             "system_port_id": "13",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "13"
         },
-        "Linecard1|Asic0|Ethernet52": {
+        "lc1|Asic0|Ethernet52": {
             "speed": "40000",
             "system_port_id": "14",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "14"
         },
-        "Linecard1|Asic0|Ethernet56": {
+        "lc1|Asic0|Ethernet56": {
             "speed": "40000",
             "system_port_id": "15",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "15"
         },
-        "Linecard1|Asic0|Ethernet60": {
+        "lc1|Asic0|Ethernet60": {
             "speed": "40000",
             "system_port_id": "16",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "16"
         },
-        "Linecard1|Asic0|Ethernet64": {
+        "lc1|Asic0|Ethernet64": {
             "speed": "40000",
             "system_port_id": "17",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "1"
         },
-        "Linecard1|Asic0|Ethernet68": {
+        "lc1|Asic0|Ethernet68": {
             "speed": "40000",
             "system_port_id": "18",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "2"
         },
-        "Linecard1|Asic0|Ethernet72": {
+        "lc1|Asic0|Ethernet72": {
             "speed": "40000",
             "system_port_id": "19",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "3"
         },
-        "Linecard1|Asic0|Ethernet76": {
+        "lc1|Asic0|Ethernet76": {
             "speed": "40000",
             "system_port_id": "20",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "4"
         },
-        "Linecard1|Asic0|Ethernet80": {
+        "lc1|Asic0|Ethernet80": {
             "speed": "40000",
             "system_port_id": "21",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "5"
         },
-        "Linecard1|Asic0|Ethernet84": {
+        "lc1|Asic0|Ethernet84": {
             "speed": "40000",
             "system_port_id": "22",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "6"
         },
-        "Linecard1|Asic0|Ethernet88": {
+        "lc1|Asic0|Ethernet88": {
             "speed": "40000",
             "system_port_id": "23",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "7"
         },
-        "Linecard1|Asic0|Ethernet92": {
+        "lc1|Asic0|Ethernet92": {
             "speed": "40000",
             "system_port_id": "24",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "8"
         },
-        "Linecard1|Asic0|Ethernet96": {
+        "lc1|Asic0|Ethernet96": {
             "speed": "40000",
             "system_port_id": "25",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "9"
         },
-        "Linecard1|Asic0|Ethernet100": {
+        "lc1|Asic0|Ethernet100": {
             "speed": "40000",
             "system_port_id": "26",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "10"
         },
-        "Linecard1|Asic0|Ethernet104": {
+        "lc1|Asic0|Ethernet104": {
             "speed": "40000",
             "system_port_id": "27",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "11"
         },
-        "Linecard1|Asic0|Ethernet108": {
+        "lc1|Asic0|Ethernet108": {
             "speed": "40000",
             "system_port_id": "28",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "12"
         },
-        "Linecard1|Asic0|Ethernet112": {
+        "lc1|Asic0|Ethernet112": {
             "speed": "40000",
             "system_port_id": "29",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "13"
         },
-        "Linecard1|Asic0|Ethernet116": {
+        "lc1|Asic0|Ethernet116": {
             "speed": "40000",
             "system_port_id": "30",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "14"
         },
-        "Linecard1|Asic0|Ethernet120": {
+        "lc1|Asic0|Ethernet120": {
             "speed": "40000",
             "system_port_id": "31",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "15"
         },
-        "Linecard1|Asic0|Ethernet124": {
+        "lc1|Asic0|Ethernet124": {
             "speed": "40000",
             "system_port_id": "32",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "16"
         },
-        "Linecard2|Asic0|Ethernet0": {
+        "lc2|Asic0|Ethernet0": {
             "speed": "40000",
             "system_port_id": "33",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "1"
         },
-        "Linecard2|Asic0|Ethernet4": {
+        "lc2|Asic0|Ethernet4": {
             "speed": "40000",
             "system_port_id": "34",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "2"
         },
-        "Linecard2|Asic0|Ethernet8": {
+        "lc2|Asic0|Ethernet8": {
             "speed": "40000",
             "system_port_id": "35",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "3"
         },
-        "Linecard2|Asic0|Ethernet12": {
+        "lc2|Asic0|Ethernet12": {
             "speed": "40000",
             "system_port_id": "36",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "4"
         },
-        "Linecard2|Asic0|Ethernet16": {
+        "lc2|Asic0|Ethernet16": {
             "speed": "40000",
             "system_port_id": "37",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "5"
         },
-        "Linecard2|Asic0|Ethernet20": {
+        "lc2|Asic0|Ethernet20": {
             "speed": "40000",
             "system_port_id": "38",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "6"
         },
-        "Linecard2|Asic0|Ethernet24": {
+        "lc2|Asic0|Ethernet24": {
             "speed": "40000",
             "system_port_id": "39",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "7"
         },
-        "Linecard2|Asic0|Ethernet28": {
+        "lc2|Asic0|Ethernet28": {
             "speed": "40000",
             "system_port_id": "40",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "8"
         },
-        "Linecard2|Asic0|Ethernet32": {
+        "lc2|Asic0|Ethernet32": {
             "speed": "40000",
             "system_port_id": "41",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "9"
         },
-        "Linecard2|Asic0|Ethernet36": {
+        "lc2|Asic0|Ethernet36": {
             "speed": "40000",
             "system_port_id": "42",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "10"
         },
-        "Linecard2|Asic0|Ethernet40": {
+        "lc2|Asic0|Ethernet40": {
             "speed": "40000",
             "system_port_id": "43",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "11"
         },
-        "Linecard2|Asic0|Ethernet44": {
+        "lc2|Asic0|Ethernet44": {
             "speed": "40000",
             "system_port_id": "44",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "12"
         },
-        "Linecard2|Asic0|Ethernet48": {
+        "lc2|Asic0|Ethernet48": {
             "speed": "40000",
             "system_port_id": "45",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "13"
         },
-        "Linecard2|Asic0|Ethernet52": {
+        "lc2|Asic0|Ethernet52": {
             "speed": "40000",
             "system_port_id": "46",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "14"
         },
-        "Linecard2|Asic0|Ethernet56": {
+        "lc2|Asic0|Ethernet56": {
             "speed": "40000",
             "system_port_id": "47",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "15"
         },
-        "Linecard2|Asic0|Ethernet60": {
+        "lc2|Asic0|Ethernet60": {
             "speed": "40000",
             "system_port_id": "48",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "16"
         },
-        "Linecard2|Asic0|Ethernet64": {
+        "lc2|Asic0|Ethernet64": {
             "speed": "40000",
             "system_port_id": "49",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "1"
         },
-        "Linecard2|Asic0|Ethernet68": {
+        "lc2|Asic0|Ethernet68": {
             "speed": "40000",
             "system_port_id": "50",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "2"
         },
-        "Linecard2|Asic0|Ethernet72": {
+        "lc2|Asic0|Ethernet72": {
             "speed": "40000",
             "system_port_id": "51",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "3"
         },
-        "Linecard2|Asic0|Ethernet76": {
+        "lc2|Asic0|Ethernet76": {
             "speed": "40000",
             "system_port_id": "52",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "4"
         },
-        "Linecard2|Asic0|Ethernet80": {
+        "lc2|Asic0|Ethernet80": {
             "speed": "40000",
             "system_port_id": "53",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "5"
         },
-        "Linecard2|Asic0|Ethernet84": {
+        "lc2|Asic0|Ethernet84": {
             "speed": "40000",
             "system_port_id": "54",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "6"
         },
-        "Linecard2|Asic0|Ethernet88": {
+        "lc2|Asic0|Ethernet88": {
             "speed": "40000",
             "system_port_id": "55",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "7"
         },
-        "Linecard2|Asic0|Ethernet92": {
+        "lc2|Asic0|Ethernet92": {
             "speed": "40000",
             "system_port_id": "56",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "8"
         },
-        "Linecard2|Asic0|Ethernet96": {
+        "lc2|Asic0|Ethernet96": {
             "speed": "40000",
             "system_port_id": "57",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "9"
         },
-        "Linecard2|Asic0|Ethernet100": {
+        "lc2|Asic0|Ethernet100": {
             "speed": "40000",
             "system_port_id": "58",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "10"
         },
-        "Linecard2|Asic0|Ethernet104": {
+        "lc2|Asic0|Ethernet104": {
             "speed": "40000",
             "system_port_id": "59",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "11"
         },
-        "Linecard2|Asic0|Ethernet108": {
+        "lc2|Asic0|Ethernet108": {
             "speed": "40000",
             "system_port_id": "60",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "12"
         },
-        "Linecard2|Asic0|Ethernet112": {
+        "lc2|Asic0|Ethernet112": {
             "speed": "40000",
             "system_port_id": "61",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "13"
         },
-        "Linecard2|Asic0|Ethernet116": {
+        "lc2|Asic0|Ethernet116": {
             "speed": "40000",
             "system_port_id": "62",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "14"
         },
-        "Linecard2|Asic0|Ethernet120": {
+        "lc2|Asic0|Ethernet120": {
             "speed": "40000",
             "system_port_id": "63",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "15"
         },
-        "Linecard2|Asic0|Ethernet124": {
+        "lc2|Asic0|Ethernet124": {
             "speed": "40000",
             "system_port_id": "64",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "16"
         },
-        "Linecard3|Asic0|Ethernet0": {
+        "lc3|Asic0|Ethernet0": {
             "speed": "40000",
             "system_port_id": "65",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "1"
         },
-        "Linecard3|Asic0|Ethernet4": {
+        "lc3|Asic0|Ethernet4": {
             "speed": "40000",
             "system_port_id": "66",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "2"
         },
-        "Linecard3|Asic0|Ethernet8": {
+        "lc3|Asic0|Ethernet8": {
             "speed": "40000",
             "system_port_id": "67",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "3"
         },
-        "Linecard3|Asic0|Ethernet12": {
+        "lc3|Asic0|Ethernet12": {
             "speed": "40000",
             "system_port_id": "68",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "4"
         },
-        "Linecard3|Asic0|Ethernet16": {
+        "lc3|Asic0|Ethernet16": {
             "speed": "40000",
             "system_port_id": "69",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "5"
         },
-        "Linecard3|Asic0|Ethernet20": {
+        "lc3|Asic0|Ethernet20": {
             "speed": "40000",
             "system_port_id": "70",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "6"
         },
-        "Linecard3|Asic0|Ethernet24": {
+        "lc3|Asic0|Ethernet24": {
             "speed": "40000",
             "system_port_id": "71",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "7"
         },
-        "Linecard3|Asic0|Ethernet28": {
+        "lc3|Asic0|Ethernet28": {
             "speed": "40000",
             "system_port_id": "72",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "8"
         },
-        "Linecard3|Asic0|Ethernet32": {
+        "lc3|Asic0|Ethernet32": {
             "speed": "40000",
             "system_port_id": "73",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "9"
         },
-        "Linecard3|Asic0|Ethernet36": {
+        "lc3|Asic0|Ethernet36": {
             "speed": "40000",
             "system_port_id": "74",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "10"
         },
-        "Linecard3|Asic0|Ethernet40": {
+        "lc3|Asic0|Ethernet40": {
             "speed": "40000",
             "system_port_id": "75",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "11"
         },
-        "Linecard3|Asic0|Ethernet44": {
+        "lc3|Asic0|Ethernet44": {
             "speed": "40000",
             "system_port_id": "76",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "12"
         },
-        "Linecard3|Asic0|Ethernet48": {
+        "lc3|Asic0|Ethernet48": {
             "speed": "40000",
             "system_port_id": "77",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "13"
         },
-        "Linecard3|Asic0|Ethernet52": {
+        "lc3|Asic0|Ethernet52": {
             "speed": "40000",
             "system_port_id": "78",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "14"
         },
-        "Linecard3|Asic0|Ethernet56": {
+        "lc3|Asic0|Ethernet56": {
             "speed": "40000",
             "system_port_id": "79",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "15"
         },
-        "Linecard3|Asic0|Ethernet60": {
+        "lc3|Asic0|Ethernet60": {
             "speed": "40000",
             "system_port_id": "80",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "16"
         },
-        "Linecard3|Asic0|Ethernet64": {
+        "lc3|Asic0|Ethernet64": {
             "speed": "40000",
             "system_port_id": "81",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "1"
         },
-        "Linecard3|Asic0|Ethernet68": {
+        "lc3|Asic0|Ethernet68": {
             "speed": "40000",
             "system_port_id": "82",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "2"
         },
-        "Linecard3|Asic0|Ethernet72": {
+        "lc3|Asic0|Ethernet72": {
             "speed": "40000",
             "system_port_id": "83",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "3"
         },
-        "Linecard3|Asic0|Ethernet76": {
+        "lc3|Asic0|Ethernet76": {
             "speed": "40000",
             "system_port_id": "84",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "4"
         },
-        "Linecard3|Asic0|Ethernet80": {
+        "lc3|Asic0|Ethernet80": {
             "speed": "40000",
             "system_port_id": "85",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "5"
         },
-        "Linecard3|Asic0|Ethernet84": {
+        "lc3|Asic0|Ethernet84": {
             "speed": "40000",
             "system_port_id": "86",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "6"
         },
-        "Linecard3|Asic0|Ethernet88": {
+        "lc3|Asic0|Ethernet88": {
             "speed": "40000",
             "system_port_id": "87",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "7"
         },
-        "Linecard3|Asic0|Ethernet92": {
+        "lc3|Asic0|Ethernet92": {
             "speed": "40000",
             "system_port_id": "88",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "8"
         },
-        "Linecard3|Asic0|Ethernet96": {
+        "lc3|Asic0|Ethernet96": {
             "speed": "40000",
             "system_port_id": "89",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "9"
         },
-        "Linecard3|Asic0|Ethernet100": {
+        "lc3|Asic0|Ethernet100": {
             "speed": "40000",
             "system_port_id": "90",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "10"
         },
-        "Linecard3|Asic0|Ethernet104": {
+        "lc3|Asic0|Ethernet104": {
             "speed": "40000",
             "system_port_id": "91",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "11"
         },
-        "Linecard3|Asic0|Ethernet108": {
+        "lc3|Asic0|Ethernet108": {
             "speed": "40000",
             "system_port_id": "92",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "12"
         },
-        "Linecard3|Asic0|Ethernet112": {
+        "lc3|Asic0|Ethernet112": {
             "speed": "40000",
             "system_port_id": "93",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "13"
         },
-        "Linecard3|Asic0|Ethernet116": {
+        "lc3|Asic0|Ethernet116": {
             "speed": "40000",
             "system_port_id": "94",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "14"
         },
-        "Linecard3|Asic0|Ethernet120": {
+        "lc3|Asic0|Ethernet120": {
             "speed": "40000",
             "system_port_id": "95",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "15"
         },
-        "Linecard3|Asic0|Ethernet124": {
+        "lc3|Asic0|Ethernet124": {
             "speed": "40000",
             "system_port_id": "96",
             "switch_id": "4",

--- a/tests/virtual_chassis/1/default_config.json
+++ b/tests/virtual_chassis/1/default_config.json
@@ -34,665 +34,665 @@
             "core_index": "0",
             "core_port_index": "1"
         },
-        "Linecard1|Ethernet4": {
+        "Linecard1|Asic0|Ethernet4": {
             "speed": "40000",
             "system_port_id": "2",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "2"
         },
-        "Linecard1|Ethernet8": {
+        "Linecard1|Asic0|Ethernet8": {
             "speed": "40000",
             "system_port_id": "3",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "3"
         },
-        "Linecard1|Ethernet12": {
+        "Linecard1|Asic0|Ethernet12": {
             "speed": "40000",
             "system_port_id": "4",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "4"
         },
-        "Linecard1|Ethernet16": {
+        "Linecard1|Asic0|Ethernet16": {
             "speed": "40000",
             "system_port_id": "5",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "5"
         },
-        "Linecard1|Ethernet20": {
+        "Linecard1|Asic0|Ethernet20": {
             "speed": "40000",
             "system_port_id": "6",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "6"
         },
-        "Linecard1|Ethernet24": {
+        "Linecard1|Asic0|Ethernet24": {
             "speed": "40000",
             "system_port_id": "7",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "7"
         },
-        "Linecard1|Ethernet28": {
+        "Linecard1|Asic0|Ethernet28": {
             "speed": "40000",
             "system_port_id": "8",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "8"
         },
-        "Linecard1|Ethernet32": {
+        "Linecard1|Asic0|Ethernet32": {
             "speed": "40000",
             "system_port_id": "9",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "9"
         },
-        "Linecard1|Ethernet36": {
+        "Linecard1|Asic0|Ethernet36": {
             "speed": "40000",
             "system_port_id": "10",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "10"
         },
-        "Linecard1|Ethernet40": {
+        "Linecard1|Asic0|Ethernet40": {
             "speed": "40000",
             "system_port_id": "11",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "11"
         },
-        "Linecard1|Ethernet44": {
+        "Linecard1|Asic0|Ethernet44": {
             "speed": "40000",
             "system_port_id": "12",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "12"
         },
-        "Linecard1|Ethernet48": {
+        "Linecard1|Asic0|Ethernet48": {
             "speed": "40000",
             "system_port_id": "13",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "13"
         },
-        "Linecard1|Ethernet52": {
+        "Linecard1|Asic0|Ethernet52": {
             "speed": "40000",
             "system_port_id": "14",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "14"
         },
-        "Linecard1|Ethernet56": {
+        "Linecard1|Asic0|Ethernet56": {
             "speed": "40000",
             "system_port_id": "15",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "15"
         },
-        "Linecard1|Ethernet60": {
+        "Linecard1|Asic0|Ethernet60": {
             "speed": "40000",
             "system_port_id": "16",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "16"
         },
-        "Linecard1|Ethernet64": {
+        "Linecard1|Asic0|Ethernet64": {
             "speed": "40000",
             "system_port_id": "17",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "1"
         },
-        "Linecard1|Ethernet68": {
+        "Linecard1|Asic0|Ethernet68": {
             "speed": "40000",
             "system_port_id": "18",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "2"
         },
-        "Linecard1|Ethernet72": {
+        "Linecard1|Asic0|Ethernet72": {
             "speed": "40000",
             "system_port_id": "19",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "3"
         },
-        "Linecard1|Ethernet76": {
+        "Linecard1|Asic0|Ethernet76": {
             "speed": "40000",
             "system_port_id": "20",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "4"
         },
-        "Linecard1|Ethernet80": {
+        "Linecard1|Asic0|Ethernet80": {
             "speed": "40000",
             "system_port_id": "21",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "5"
         },
-        "Linecard1|Ethernet84": {
+        "Linecard1|Asic0|Ethernet84": {
             "speed": "40000",
             "system_port_id": "22",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "6"
         },
-        "Linecard1|Ethernet88": {
+        "Linecard1|Asic0|Ethernet88": {
             "speed": "40000",
             "system_port_id": "23",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "7"
         },
-        "Linecard1|Ethernet92": {
+        "Linecard1|Asic0|Ethernet92": {
             "speed": "40000",
             "system_port_id": "24",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "8"
         },
-        "Linecard1|Ethernet96": {
+        "Linecard1|Asic0|Ethernet96": {
             "speed": "40000",
             "system_port_id": "25",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "9"
         },
-        "Linecard1|Ethernet100": {
+        "Linecard1|Asic0|Ethernet100": {
             "speed": "40000",
             "system_port_id": "26",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "10"
         },
-        "Linecard1|Ethernet104": {
+        "Linecard1|Asic0|Ethernet104": {
             "speed": "40000",
             "system_port_id": "27",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "11"
         },
-        "Linecard1|Ethernet108": {
+        "Linecard1|Asic0|Ethernet108": {
             "speed": "40000",
             "system_port_id": "28",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "12"
         },
-        "Linecard1|Ethernet112": {
+        "Linecard1|Asic0|Ethernet112": {
             "speed": "40000",
             "system_port_id": "29",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "13"
         },
-        "Linecard1|Ethernet116": {
+        "Linecard1|Asic0|Ethernet116": {
             "speed": "40000",
             "system_port_id": "30",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "14"
         },
-        "Linecard1|Ethernet120": {
+        "Linecard1|Asic0|Ethernet120": {
             "speed": "40000",
             "system_port_id": "31",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "15"
         },
-        "Linecard1|Ethernet124": {
+        "Linecard1|Asic0|Ethernet124": {
             "speed": "40000",
             "system_port_id": "32",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "16"
         },
-        "Linecard2|Ethernet0": {
+        "Linecard2|Asic0|Ethernet0": {
             "speed": "40000",
             "system_port_id": "33",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "1"
         },
-        "Linecard2|Ethernet4": {
+        "Linecard2|Asic0|Ethernet4": {
             "speed": "40000",
             "system_port_id": "34",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "2"
         },
-        "Linecard2|Ethernet8": {
+        "Linecard2|Asic0|Ethernet8": {
             "speed": "40000",
             "system_port_id": "35",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "3"
         },
-        "Linecard2|Ethernet12": {
+        "Linecard2|Asic0|Ethernet12": {
             "speed": "40000",
             "system_port_id": "36",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "4"
         },
-        "Linecard2|Ethernet16": {
+        "Linecard2|Asic0|Ethernet16": {
             "speed": "40000",
             "system_port_id": "37",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "5"
         },
-        "Linecard2|Ethernet20": {
+        "Linecard2|Asic0|Ethernet20": {
             "speed": "40000",
             "system_port_id": "38",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "6"
         },
-        "Linecard2|Ethernet24": {
+        "Linecard2|Asic0|Ethernet24": {
             "speed": "40000",
             "system_port_id": "39",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "7"
         },
-        "Linecard2|Ethernet28": {
+        "Linecard2|Asic0|Ethernet28": {
             "speed": "40000",
             "system_port_id": "40",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "8"
         },
-        "Linecard2|Ethernet32": {
+        "Linecard2|Asic0|Ethernet32": {
             "speed": "40000",
             "system_port_id": "41",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "9"
         },
-        "Linecard2|Ethernet36": {
+        "Linecard2|Asic0|Ethernet36": {
             "speed": "40000",
             "system_port_id": "42",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "10"
         },
-        "Linecard2|Ethernet40": {
+        "Linecard2|Asic0|Ethernet40": {
             "speed": "40000",
             "system_port_id": "43",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "11"
         },
-        "Linecard2|Ethernet44": {
+        "Linecard2|Asic0|Ethernet44": {
             "speed": "40000",
             "system_port_id": "44",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "12"
         },
-        "Linecard2|Ethernet48": {
+        "Linecard2|Asic0|Ethernet48": {
             "speed": "40000",
             "system_port_id": "45",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "13"
         },
-        "Linecard2|Ethernet52": {
+        "Linecard2|Asic0|Ethernet52": {
             "speed": "40000",
             "system_port_id": "46",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "14"
         },
-        "Linecard2|Ethernet56": {
+        "Linecard2|Asic0|Ethernet56": {
             "speed": "40000",
             "system_port_id": "47",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "15"
         },
-        "Linecard2|Ethernet60": {
+        "Linecard2|Asic0|Ethernet60": {
             "speed": "40000",
             "system_port_id": "48",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "16"
         },
-        "Linecard2|Ethernet64": {
+        "Linecard2|Asic0|Ethernet64": {
             "speed": "40000",
             "system_port_id": "49",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "1"
         },
-        "Linecard2|Ethernet68": {
+        "Linecard2|Asic0|Ethernet68": {
             "speed": "40000",
             "system_port_id": "50",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "2"
         },
-        "Linecard2|Ethernet72": {
+        "Linecard2|Asic0|Ethernet72": {
             "speed": "40000",
             "system_port_id": "51",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "3"
         },
-        "Linecard2|Ethernet76": {
+        "Linecard2|Asic0|Ethernet76": {
             "speed": "40000",
             "system_port_id": "52",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "4"
         },
-        "Linecard2|Ethernet80": {
+        "Linecard2|Asic0|Ethernet80": {
             "speed": "40000",
             "system_port_id": "53",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "5"
         },
-        "Linecard2|Ethernet84": {
+        "Linecard2|Asic0|Ethernet84": {
             "speed": "40000",
             "system_port_id": "54",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "6"
         },
-        "Linecard2|Ethernet88": {
+        "Linecard2|Asic0|Ethernet88": {
             "speed": "40000",
             "system_port_id": "55",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "7"
         },
-        "Linecard2|Ethernet92": {
+        "Linecard2|Asic0|Ethernet92": {
             "speed": "40000",
             "system_port_id": "56",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "8"
         },
-        "Linecard2|Ethernet96": {
+        "Linecard2|Asic0|Ethernet96": {
             "speed": "40000",
             "system_port_id": "57",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "9"
         },
-        "Linecard2|Ethernet100": {
+        "Linecard2|Asic0|Ethernet100": {
             "speed": "40000",
             "system_port_id": "58",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "10"
         },
-        "Linecard2|Ethernet104": {
+        "Linecard2|Asic0|Ethernet104": {
             "speed": "40000",
             "system_port_id": "59",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "11"
         },
-        "Linecard2|Ethernet108": {
+        "Linecard2|Asic0|Ethernet108": {
             "speed": "40000",
             "system_port_id": "60",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "12"
         },
-        "Linecard2|Ethernet112": {
+        "Linecard2|Asic0|Ethernet112": {
             "speed": "40000",
             "system_port_id": "61",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "13"
         },
-        "Linecard2|Ethernet116": {
+        "Linecard2|Asic0|Ethernet116": {
             "speed": "40000",
             "system_port_id": "62",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "14"
         },
-        "Linecard2|Ethernet120": {
+        "Linecard2|Asic0|Ethernet120": {
             "speed": "40000",
             "system_port_id": "63",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "15"
         },
-        "Linecard2|Ethernet124": {
+        "Linecard2|Asic0|Ethernet124": {
             "speed": "40000",
             "system_port_id": "64",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "16"
         },
-        "Linecard3|Ethernet0": {
+        "Linecard3|Asic0|Ethernet0": {
             "speed": "40000",
             "system_port_id": "65",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "1"
         },
-        "Linecard3|Ethernet4": {
+        "Linecard3|Asic0|Ethernet4": {
             "speed": "40000",
             "system_port_id": "66",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "2"
         },
-        "Linecard3|Ethernet8": {
+        "Linecard3|Asic0|Ethernet8": {
             "speed": "40000",
             "system_port_id": "67",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "3"
         },
-        "Linecard3|Ethernet12": {
+        "Linecard3|Asic0|Ethernet12": {
             "speed": "40000",
             "system_port_id": "68",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "4"
         },
-        "Linecard3|Ethernet16": {
+        "Linecard3|Asic0|Ethernet16": {
             "speed": "40000",
             "system_port_id": "69",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "5"
         },
-        "Linecard3|Ethernet20": {
+        "Linecard3|Asic0|Ethernet20": {
             "speed": "40000",
             "system_port_id": "70",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "6"
         },
-        "Linecard3|Ethernet24": {
+        "Linecard3|Asic0|Ethernet24": {
             "speed": "40000",
             "system_port_id": "71",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "7"
         },
-        "Linecard3|Ethernet28": {
+        "Linecard3|Asic0|Ethernet28": {
             "speed": "40000",
             "system_port_id": "72",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "8"
         },
-        "Linecard3|Ethernet32": {
+        "Linecard3|Asic0|Ethernet32": {
             "speed": "40000",
             "system_port_id": "73",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "9"
         },
-        "Linecard3|Ethernet36": {
+        "Linecard3|Asic0|Ethernet36": {
             "speed": "40000",
             "system_port_id": "74",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "10"
         },
-        "Linecard3|Ethernet40": {
+        "Linecard3|Asic0|Ethernet40": {
             "speed": "40000",
             "system_port_id": "75",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "11"
         },
-        "Linecard3|Ethernet44": {
+        "Linecard3|Asic0|Ethernet44": {
             "speed": "40000",
             "system_port_id": "76",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "12"
         },
-        "Linecard3|Ethernet48": {
+        "Linecard3|Asic0|Ethernet48": {
             "speed": "40000",
             "system_port_id": "77",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "13"
         },
-        "Linecard3|Ethernet52": {
+        "Linecard3|Asic0|Ethernet52": {
             "speed": "40000",
             "system_port_id": "78",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "14"
         },
-        "Linecard3|Ethernet56": {
+        "Linecard3|Asic0|Ethernet56": {
             "speed": "40000",
             "system_port_id": "79",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "15"
         },
-        "Linecard3|Ethernet60": {
+        "Linecard3|Asic0|Ethernet60": {
             "speed": "40000",
             "system_port_id": "80",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "16"
         },
-        "Linecard3|Ethernet64": {
+        "Linecard3|Asic0|Ethernet64": {
             "speed": "40000",
             "system_port_id": "81",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "1"
         },
-        "Linecard3|Ethernet68": {
+        "Linecard3|Asic0|Ethernet68": {
             "speed": "40000",
             "system_port_id": "82",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "2"
         },
-        "Linecard3|Ethernet72": {
+        "Linecard3|Asic0|Ethernet72": {
             "speed": "40000",
             "system_port_id": "83",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "3"
         },
-        "Linecard3|Ethernet76": {
+        "Linecard3|Asic0|Ethernet76": {
             "speed": "40000",
             "system_port_id": "84",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "4"
         },
-        "Linecard3|Ethernet80": {
+        "Linecard3|Asic0|Ethernet80": {
             "speed": "40000",
             "system_port_id": "85",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "5"
         },
-        "Linecard3|Ethernet84": {
+        "Linecard3|Asic0|Ethernet84": {
             "speed": "40000",
             "system_port_id": "86",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "6"
         },
-        "Linecard3|Ethernet88": {
+        "Linecard3|Asic0|Ethernet88": {
             "speed": "40000",
             "system_port_id": "87",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "7"
         },
-        "Linecard3|Ethernet92": {
+        "Linecard3|Asic0|Ethernet92": {
             "speed": "40000",
             "system_port_id": "88",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "8"
         },
-        "Linecard3|Ethernet96": {
+        "Linecard3|Asic0|Ethernet96": {
             "speed": "40000",
             "system_port_id": "89",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "9"
         },
-        "Linecard3|Ethernet100": {
+        "Linecard3|Asic0|Ethernet100": {
             "speed": "40000",
             "system_port_id": "90",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "10"
         },
-        "Linecard3|Ethernet104": {
+        "Linecard3|Asic0|Ethernet104": {
             "speed": "40000",
             "system_port_id": "91",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "11"
         },
-        "Linecard3|Ethernet108": {
+        "Linecard3|Asic0|Ethernet108": {
             "speed": "40000",
             "system_port_id": "92",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "12"
         },
-        "Linecard3|Ethernet112": {
+        "Linecard3|Asic0|Ethernet112": {
             "speed": "40000",
             "system_port_id": "93",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "13"
         },
-        "Linecard3|Ethernet116": {
+        "Linecard3|Asic0|Ethernet116": {
             "speed": "40000",
             "system_port_id": "94",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "14"
         },
-        "Linecard3|Ethernet120": {
+        "Linecard3|Asic0|Ethernet120": {
             "speed": "40000",
             "system_port_id": "95",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "15"
         },
-        "Linecard3|Ethernet124": {
+        "Linecard3|Asic0|Ethernet124": {
             "speed": "40000",
             "system_port_id": "96",
             "switch_id": "4",

--- a/tests/virtual_chassis/2/default_config.json
+++ b/tests/virtual_chassis/2/default_config.json
@@ -29,665 +29,665 @@
             "core_index": "0",
             "core_port_index": "1"
         },
-        "Linecard1|Ethernet4": {
+        "Linecard1|Asic0|Ethernet4": {
             "speed": "40000",
             "system_port_id": "2",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "2"
         },
-        "Linecard1|Ethernet8": {
+        "Linecard1|Asic0|Ethernet8": {
             "speed": "40000",
             "system_port_id": "3",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "3"
         },
-        "Linecard1|Ethernet12": {
+        "Linecard1|Asic0|Ethernet12": {
             "speed": "40000",
             "system_port_id": "4",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "4"
         },
-        "Linecard1|Ethernet16": {
+        "Linecard1|Asic0|Ethernet16": {
             "speed": "40000",
             "system_port_id": "5",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "5"
         },
-        "Linecard1|Ethernet20": {
+        "Linecard1|Asic0|Ethernet20": {
             "speed": "40000",
             "system_port_id": "6",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "6"
         },
-        "Linecard1|Ethernet24": {
+        "Linecard1|Asic0|Ethernet24": {
             "speed": "40000",
             "system_port_id": "7",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "7"
         },
-        "Linecard1|Ethernet28": {
+        "Linecard1|Asic0|Ethernet28": {
             "speed": "40000",
             "system_port_id": "8",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "8"
         },
-        "Linecard1|Ethernet32": {
+        "Linecard1|Asic0|Ethernet32": {
             "speed": "40000",
             "system_port_id": "9",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "9"
         },
-        "Linecard1|Ethernet36": {
+        "Linecard1|Asic0|Ethernet36": {
             "speed": "40000",
             "system_port_id": "10",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "10"
         },
-        "Linecard1|Ethernet40": {
+        "Linecard1|Asic0|Ethernet40": {
             "speed": "40000",
             "system_port_id": "11",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "11"
         },
-        "Linecard1|Ethernet44": {
+        "Linecard1|Asic0|Ethernet44": {
             "speed": "40000",
             "system_port_id": "12",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "12"
         },
-        "Linecard1|Ethernet48": {
+        "Linecard1|Asic0|Ethernet48": {
             "speed": "40000",
             "system_port_id": "13",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "13"
         },
-        "Linecard1|Ethernet52": {
+        "Linecard1|Asic0|Ethernet52": {
             "speed": "40000",
             "system_port_id": "14",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "14"
         },
-        "Linecard1|Ethernet56": {
+        "Linecard1|Asic0|Ethernet56": {
             "speed": "40000",
             "system_port_id": "15",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "15"
         },
-        "Linecard1|Ethernet60": {
+        "Linecard1|Asic0|Ethernet60": {
             "speed": "40000",
             "system_port_id": "16",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "16"
         },
-        "Linecard1|Ethernet64": {
+        "Linecard1|Asic0|Ethernet64": {
             "speed": "40000",
             "system_port_id": "17",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "1"
         },
-        "Linecard1|Ethernet68": {
+        "Linecard1|Asic0|Ethernet68": {
             "speed": "40000",
             "system_port_id": "18",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "2"
         },
-        "Linecard1|Ethernet72": {
+        "Linecard1|Asic0|Ethernet72": {
             "speed": "40000",
             "system_port_id": "19",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "3"
         },
-        "Linecard1|Ethernet76": {
+        "Linecard1|Asic0|Ethernet76": {
             "speed": "40000",
             "system_port_id": "20",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "4"
         },
-        "Linecard1|Ethernet80": {
+        "Linecard1|Asic0|Ethernet80": {
             "speed": "40000",
             "system_port_id": "21",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "5"
         },
-        "Linecard1|Ethernet84": {
+        "Linecard1|Asic0|Ethernet84": {
             "speed": "40000",
             "system_port_id": "22",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "6"
         },
-        "Linecard1|Ethernet88": {
+        "Linecard1|Asic0|Ethernet88": {
             "speed": "40000",
             "system_port_id": "23",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "7"
         },
-        "Linecard1|Ethernet92": {
+        "Linecard1|Asic0|Ethernet92": {
             "speed": "40000",
             "system_port_id": "24",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "8"
         },
-        "Linecard1|Ethernet96": {
+        "Linecard1|Asic0|Ethernet96": {
             "speed": "40000",
             "system_port_id": "25",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "9"
         },
-        "Linecard1|Ethernet100": {
+        "Linecard1|Asic0|Ethernet100": {
             "speed": "40000",
             "system_port_id": "26",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "10"
         },
-        "Linecard1|Ethernet104": {
+        "Linecard1|Asic0|Ethernet104": {
             "speed": "40000",
             "system_port_id": "27",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "11"
         },
-        "Linecard1|Ethernet108": {
+        "Linecard1|Asic0|Ethernet108": {
             "speed": "40000",
             "system_port_id": "28",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "12"
         },
-        "Linecard1|Ethernet112": {
+        "Linecard1|Asic0|Ethernet112": {
             "speed": "40000",
             "system_port_id": "29",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "13"
         },
-        "Linecard1|Ethernet116": {
+        "Linecard1|Asic0|Ethernet116": {
             "speed": "40000",
             "system_port_id": "30",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "14"
         },
-        "Linecard1|Ethernet120": {
+        "Linecard1|Asic0|Ethernet120": {
             "speed": "40000",
             "system_port_id": "31",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "15"
         },
-        "Linecard1|Ethernet124": {
+        "Linecard1|Asic0|Ethernet124": {
             "speed": "40000",
             "system_port_id": "32",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "16"
         },
-        "Linecard2|Ethernet0": {
+        "Linecard2|Asic0|Ethernet0": {
             "speed": "40000",
             "system_port_id": "33",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "1"
         },
-        "Linecard2|Ethernet4": {
+        "Linecard2|Asic0|Ethernet4": {
             "speed": "40000",
             "system_port_id": "34",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "2"
         },
-        "Linecard2|Ethernet8": {
+        "Linecard2|Asic0|Ethernet8": {
             "speed": "40000",
             "system_port_id": "35",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "3"
         },
-        "Linecard2|Ethernet12": {
+        "Linecard2|Asic0|Ethernet12": {
             "speed": "40000",
             "system_port_id": "36",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "4"
         },
-        "Linecard2|Ethernet16": {
+        "Linecard2|Asic0|Ethernet16": {
             "speed": "40000",
             "system_port_id": "37",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "5"
         },
-        "Linecard2|Ethernet20": {
+        "Linecard2|Asic0|Ethernet20": {
             "speed": "40000",
             "system_port_id": "38",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "6"
         },
-        "Linecard2|Ethernet24": {
+        "Linecard2|Asic0|Ethernet24": {
             "speed": "40000",
             "system_port_id": "39",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "7"
         },
-        "Linecard2|Ethernet28": {
+        "Linecard2|Asic0|Ethernet28": {
             "speed": "40000",
             "system_port_id": "40",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "8"
         },
-        "Linecard2|Ethernet32": {
+        "Linecard2|Asic0|Ethernet32": {
             "speed": "40000",
             "system_port_id": "41",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "9"
         },
-        "Linecard2|Ethernet36": {
+        "Linecard2|Asic0|Ethernet36": {
             "speed": "40000",
             "system_port_id": "42",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "10"
         },
-        "Linecard2|Ethernet40": {
+        "Linecard2|Asic0|Ethernet40": {
             "speed": "40000",
             "system_port_id": "43",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "11"
         },
-        "Linecard2|Ethernet44": {
+        "Linecard2|Asic0|Ethernet44": {
             "speed": "40000",
             "system_port_id": "44",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "12"
         },
-        "Linecard2|Ethernet48": {
+        "Linecard2|Asic0|Ethernet48": {
             "speed": "40000",
             "system_port_id": "45",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "13"
         },
-        "Linecard2|Ethernet52": {
+        "Linecard2|Asic0|Ethernet52": {
             "speed": "40000",
             "system_port_id": "46",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "14"
         },
-        "Linecard2|Ethernet56": {
+        "Linecard2|Asic0|Ethernet56": {
             "speed": "40000",
             "system_port_id": "47",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "15"
         },
-        "Linecard2|Ethernet60": {
+        "Linecard2|Asic0|Ethernet60": {
             "speed": "40000",
             "system_port_id": "48",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "16"
         },
-        "Linecard2|Ethernet64": {
+        "Linecard2|Asic0|Ethernet64": {
             "speed": "40000",
             "system_port_id": "49",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "1"
         },
-        "Linecard2|Ethernet68": {
+        "Linecard2|Asic0|Ethernet68": {
             "speed": "40000",
             "system_port_id": "50",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "2"
         },
-        "Linecard2|Ethernet72": {
+        "Linecard2|Asic0|Ethernet72": {
             "speed": "40000",
             "system_port_id": "51",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "3"
         },
-        "Linecard2|Ethernet76": {
+        "Linecard2|Asic0|Ethernet76": {
             "speed": "40000",
             "system_port_id": "52",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "4"
         },
-        "Linecard2|Ethernet80": {
+        "Linecard2|Asic0|Ethernet80": {
             "speed": "40000",
             "system_port_id": "53",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "5"
         },
-        "Linecard2|Ethernet84": {
+        "Linecard2|Asic0|Ethernet84": {
             "speed": "40000",
             "system_port_id": "54",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "6"
         },
-        "Linecard2|Ethernet88": {
+        "Linecard2|Asic0|Ethernet88": {
             "speed": "40000",
             "system_port_id": "55",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "7"
         },
-        "Linecard2|Ethernet92": {
+        "Linecard2|Asic0|Ethernet92": {
             "speed": "40000",
             "system_port_id": "56",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "8"
         },
-        "Linecard2|Ethernet96": {
+        "Linecard2|Asic0|Ethernet96": {
             "speed": "40000",
             "system_port_id": "57",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "9"
         },
-        "Linecard2|Ethernet100": {
+        "Linecard2|Asic0|Ethernet100": {
             "speed": "40000",
             "system_port_id": "58",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "10"
         },
-        "Linecard2|Ethernet104": {
+        "Linecard2|Asic0|Ethernet104": {
             "speed": "40000",
             "system_port_id": "59",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "11"
         },
-        "Linecard2|Ethernet108": {
+        "Linecard2|Asic0|Ethernet108": {
             "speed": "40000",
             "system_port_id": "60",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "12"
         },
-        "Linecard2|Ethernet112": {
+        "Linecard2|Asic0|Ethernet112": {
             "speed": "40000",
             "system_port_id": "61",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "13"
         },
-        "Linecard2|Ethernet116": {
+        "Linecard2|Asic0|Ethernet116": {
             "speed": "40000",
             "system_port_id": "62",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "14"
         },
-        "Linecard2|Ethernet120": {
+        "Linecard2|Asic0|Ethernet120": {
             "speed": "40000",
             "system_port_id": "63",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "15"
         },
-        "Linecard2|Ethernet124": {
+        "Linecard2|Asic0|Ethernet124": {
             "speed": "40000",
             "system_port_id": "64",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "16"
         },
-        "Linecard3|Ethernet0": {
+        "Linecard3|Asic0|Ethernet0": {
             "speed": "40000",
             "system_port_id": "65",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "1"
         },
-        "Linecard3|Ethernet4": {
+        "Linecard3|Asic0|Ethernet4": {
             "speed": "40000",
             "system_port_id": "66",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "2"
         },
-        "Linecard3|Ethernet8": {
+        "Linecard3|Asic0|Ethernet8": {
             "speed": "40000",
             "system_port_id": "67",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "3"
         },
-        "Linecard3|Ethernet12": {
+        "Linecard3|Asic0|Ethernet12": {
             "speed": "40000",
             "system_port_id": "68",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "4"
         },
-        "Linecard3|Ethernet16": {
+        "Linecard3|Asic0|Ethernet16": {
             "speed": "40000",
             "system_port_id": "69",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "5"
         },
-        "Linecard3|Ethernet20": {
+        "Linecard3|Asic0|Ethernet20": {
             "speed": "40000",
             "system_port_id": "70",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "6"
         },
-        "Linecard3|Ethernet24": {
+        "Linecard3|Asic0|Ethernet24": {
             "speed": "40000",
             "system_port_id": "71",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "7"
         },
-        "Linecard3|Ethernet28": {
+        "Linecard3|Asic0|Ethernet28": {
             "speed": "40000",
             "system_port_id": "72",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "8"
         },
-        "Linecard3|Ethernet32": {
+        "Linecard3|Asic0|Ethernet32": {
             "speed": "40000",
             "system_port_id": "73",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "9"
         },
-        "Linecard3|Ethernet36": {
+        "Linecard3|Asic0|Ethernet36": {
             "speed": "40000",
             "system_port_id": "74",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "10"
         },
-        "Linecard3|Ethernet40": {
+        "Linecard3|Asic0|Ethernet40": {
             "speed": "40000",
             "system_port_id": "75",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "11"
         },
-        "Linecard3|Ethernet44": {
+        "Linecard3|Asic0|Ethernet44": {
             "speed": "40000",
             "system_port_id": "76",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "12"
         },
-        "Linecard3|Ethernet48": {
+        "Linecard3|Asic0|Ethernet48": {
             "speed": "40000",
             "system_port_id": "77",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "13"
         },
-        "Linecard3|Ethernet52": {
+        "Linecard3|Asic0|Ethernet52": {
             "speed": "40000",
             "system_port_id": "78",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "14"
         },
-        "Linecard3|Ethernet56": {
+        "Linecard3|Asic0|Ethernet56": {
             "speed": "40000",
             "system_port_id": "79",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "15"
         },
-        "Linecard3|Ethernet60": {
+        "Linecard3|Asic0|Ethernet60": {
             "speed": "40000",
             "system_port_id": "80",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "16"
         },
-        "Linecard3|Ethernet64": {
+        "Linecard3|Asic0|Ethernet64": {
             "speed": "40000",
             "system_port_id": "81",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "1"
         },
-        "Linecard3|Ethernet68": {
+        "Linecard3|Asic0|Ethernet68": {
             "speed": "40000",
             "system_port_id": "82",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "2"
         },
-        "Linecard3|Ethernet72": {
+        "Linecard3|Asic0|Ethernet72": {
             "speed": "40000",
             "system_port_id": "83",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "3"
         },
-        "Linecard3|Ethernet76": {
+        "Linecard3|Asic0|Ethernet76": {
             "speed": "40000",
             "system_port_id": "84",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "4"
         },
-        "Linecard3|Ethernet80": {
+        "Linecard3|Asic0|Ethernet80": {
             "speed": "40000",
             "system_port_id": "85",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "5"
         },
-        "Linecard3|Ethernet84": {
+        "Linecard3|Asic0|Ethernet84": {
             "speed": "40000",
             "system_port_id": "86",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "6"
         },
-        "Linecard3|Ethernet88": {
+        "Linecard3|Asic0|Ethernet88": {
             "speed": "40000",
             "system_port_id": "87",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "7"
         },
-        "Linecard3|Ethernet92": {
+        "Linecard3|Asic0|Ethernet92": {
             "speed": "40000",
             "system_port_id": "88",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "8"
         },
-        "Linecard3|Ethernet96": {
+        "Linecard3|Asic0|Ethernet96": {
             "speed": "40000",
             "system_port_id": "89",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "9"
         },
-        "Linecard3|Ethernet100": {
+        "Linecard3|Asic0|Ethernet100": {
             "speed": "40000",
             "system_port_id": "90",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "10"
         },
-        "Linecard3|Ethernet104": {
+        "Linecard3|Asic0|Ethernet104": {
             "speed": "40000",
             "system_port_id": "91",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "11"
         },
-        "Linecard3|Ethernet108": {
+        "Linecard3|Asic0|Ethernet108": {
             "speed": "40000",
             "system_port_id": "92",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "12"
         },
-        "Linecard3|Ethernet112": {
+        "Linecard3|Asic0|Ethernet112": {
             "speed": "40000",
             "system_port_id": "93",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "13"
         },
-        "Linecard3|Ethernet116": {
+        "Linecard3|Asic0|Ethernet116": {
             "speed": "40000",
             "system_port_id": "94",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "14"
         },
-        "Linecard3|Ethernet120": {
+        "Linecard3|Asic0|Ethernet120": {
             "speed": "40000",
             "system_port_id": "95",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "15"
         },
-        "Linecard3|Ethernet124": {
+        "Linecard3|Asic0|Ethernet124": {
             "speed": "40000",
             "system_port_id": "96",
             "switch_id": "4",

--- a/tests/virtual_chassis/2/default_config.json
+++ b/tests/virtual_chassis/2/default_config.json
@@ -22,672 +22,672 @@
         }
     },
     "SYSTEM_PORT": {
-        "Linecard1|Ethernet0": {
+        "lc1|Ethernet0": {
             "speed": "40000",
             "system_port_id": "1",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "1"
         },
-        "Linecard1|Asic0|Ethernet4": {
+        "lc1|Asic0|Ethernet4": {
             "speed": "40000",
             "system_port_id": "2",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "2"
         },
-        "Linecard1|Asic0|Ethernet8": {
+        "lc1|Asic0|Ethernet8": {
             "speed": "40000",
             "system_port_id": "3",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "3"
         },
-        "Linecard1|Asic0|Ethernet12": {
+        "lc1|Asic0|Ethernet12": {
             "speed": "40000",
             "system_port_id": "4",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "4"
         },
-        "Linecard1|Asic0|Ethernet16": {
+        "lc1|Asic0|Ethernet16": {
             "speed": "40000",
             "system_port_id": "5",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "5"
         },
-        "Linecard1|Asic0|Ethernet20": {
+        "lc1|Asic0|Ethernet20": {
             "speed": "40000",
             "system_port_id": "6",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "6"
         },
-        "Linecard1|Asic0|Ethernet24": {
+        "lc1|Asic0|Ethernet24": {
             "speed": "40000",
             "system_port_id": "7",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "7"
         },
-        "Linecard1|Asic0|Ethernet28": {
+        "lc1|Asic0|Ethernet28": {
             "speed": "40000",
             "system_port_id": "8",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "8"
         },
-        "Linecard1|Asic0|Ethernet32": {
+        "lc1|Asic0|Ethernet32": {
             "speed": "40000",
             "system_port_id": "9",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "9"
         },
-        "Linecard1|Asic0|Ethernet36": {
+        "lc1|Asic0|Ethernet36": {
             "speed": "40000",
             "system_port_id": "10",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "10"
         },
-        "Linecard1|Asic0|Ethernet40": {
+        "lc1|Asic0|Ethernet40": {
             "speed": "40000",
             "system_port_id": "11",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "11"
         },
-        "Linecard1|Asic0|Ethernet44": {
+        "lc1|Asic0|Ethernet44": {
             "speed": "40000",
             "system_port_id": "12",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "12"
         },
-        "Linecard1|Asic0|Ethernet48": {
+        "lc1|Asic0|Ethernet48": {
             "speed": "40000",
             "system_port_id": "13",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "13"
         },
-        "Linecard1|Asic0|Ethernet52": {
+        "lc1|Asic0|Ethernet52": {
             "speed": "40000",
             "system_port_id": "14",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "14"
         },
-        "Linecard1|Asic0|Ethernet56": {
+        "lc1|Asic0|Ethernet56": {
             "speed": "40000",
             "system_port_id": "15",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "15"
         },
-        "Linecard1|Asic0|Ethernet60": {
+        "lc1|Asic0|Ethernet60": {
             "speed": "40000",
             "system_port_id": "16",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "16"
         },
-        "Linecard1|Asic0|Ethernet64": {
+        "lc1|Asic0|Ethernet64": {
             "speed": "40000",
             "system_port_id": "17",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "1"
         },
-        "Linecard1|Asic0|Ethernet68": {
+        "lc1|Asic0|Ethernet68": {
             "speed": "40000",
             "system_port_id": "18",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "2"
         },
-        "Linecard1|Asic0|Ethernet72": {
+        "lc1|Asic0|Ethernet72": {
             "speed": "40000",
             "system_port_id": "19",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "3"
         },
-        "Linecard1|Asic0|Ethernet76": {
+        "lc1|Asic0|Ethernet76": {
             "speed": "40000",
             "system_port_id": "20",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "4"
         },
-        "Linecard1|Asic0|Ethernet80": {
+        "lc1|Asic0|Ethernet80": {
             "speed": "40000",
             "system_port_id": "21",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "5"
         },
-        "Linecard1|Asic0|Ethernet84": {
+        "lc1|Asic0|Ethernet84": {
             "speed": "40000",
             "system_port_id": "22",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "6"
         },
-        "Linecard1|Asic0|Ethernet88": {
+        "lc1|Asic0|Ethernet88": {
             "speed": "40000",
             "system_port_id": "23",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "7"
         },
-        "Linecard1|Asic0|Ethernet92": {
+        "lc1|Asic0|Ethernet92": {
             "speed": "40000",
             "system_port_id": "24",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "8"
         },
-        "Linecard1|Asic0|Ethernet96": {
+        "lc1|Asic0|Ethernet96": {
             "speed": "40000",
             "system_port_id": "25",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "9"
         },
-        "Linecard1|Asic0|Ethernet100": {
+        "lc1|Asic0|Ethernet100": {
             "speed": "40000",
             "system_port_id": "26",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "10"
         },
-        "Linecard1|Asic0|Ethernet104": {
+        "lc1|Asic0|Ethernet104": {
             "speed": "40000",
             "system_port_id": "27",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "11"
         },
-        "Linecard1|Asic0|Ethernet108": {
+        "lc1|Asic0|Ethernet108": {
             "speed": "40000",
             "system_port_id": "28",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "12"
         },
-        "Linecard1|Asic0|Ethernet112": {
+        "lc1|Asic0|Ethernet112": {
             "speed": "40000",
             "system_port_id": "29",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "13"
         },
-        "Linecard1|Asic0|Ethernet116": {
+        "lc1|Asic0|Ethernet116": {
             "speed": "40000",
             "system_port_id": "30",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "14"
         },
-        "Linecard1|Asic0|Ethernet120": {
+        "lc1|Asic0|Ethernet120": {
             "speed": "40000",
             "system_port_id": "31",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "15"
         },
-        "Linecard1|Asic0|Ethernet124": {
+        "lc1|Asic0|Ethernet124": {
             "speed": "40000",
             "system_port_id": "32",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "16"
         },
-        "Linecard2|Asic0|Ethernet0": {
+        "lc2|Asic0|Ethernet0": {
             "speed": "40000",
             "system_port_id": "33",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "1"
         },
-        "Linecard2|Asic0|Ethernet4": {
+        "lc2|Asic0|Ethernet4": {
             "speed": "40000",
             "system_port_id": "34",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "2"
         },
-        "Linecard2|Asic0|Ethernet8": {
+        "lc2|Asic0|Ethernet8": {
             "speed": "40000",
             "system_port_id": "35",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "3"
         },
-        "Linecard2|Asic0|Ethernet12": {
+        "lc2|Asic0|Ethernet12": {
             "speed": "40000",
             "system_port_id": "36",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "4"
         },
-        "Linecard2|Asic0|Ethernet16": {
+        "lc2|Asic0|Ethernet16": {
             "speed": "40000",
             "system_port_id": "37",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "5"
         },
-        "Linecard2|Asic0|Ethernet20": {
+        "lc2|Asic0|Ethernet20": {
             "speed": "40000",
             "system_port_id": "38",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "6"
         },
-        "Linecard2|Asic0|Ethernet24": {
+        "lc2|Asic0|Ethernet24": {
             "speed": "40000",
             "system_port_id": "39",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "7"
         },
-        "Linecard2|Asic0|Ethernet28": {
+        "lc2|Asic0|Ethernet28": {
             "speed": "40000",
             "system_port_id": "40",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "8"
         },
-        "Linecard2|Asic0|Ethernet32": {
+        "lc2|Asic0|Ethernet32": {
             "speed": "40000",
             "system_port_id": "41",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "9"
         },
-        "Linecard2|Asic0|Ethernet36": {
+        "lc2|Asic0|Ethernet36": {
             "speed": "40000",
             "system_port_id": "42",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "10"
         },
-        "Linecard2|Asic0|Ethernet40": {
+        "lc2|Asic0|Ethernet40": {
             "speed": "40000",
             "system_port_id": "43",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "11"
         },
-        "Linecard2|Asic0|Ethernet44": {
+        "lc2|Asic0|Ethernet44": {
             "speed": "40000",
             "system_port_id": "44",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "12"
         },
-        "Linecard2|Asic0|Ethernet48": {
+        "lc2|Asic0|Ethernet48": {
             "speed": "40000",
             "system_port_id": "45",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "13"
         },
-        "Linecard2|Asic0|Ethernet52": {
+        "lc2|Asic0|Ethernet52": {
             "speed": "40000",
             "system_port_id": "46",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "14"
         },
-        "Linecard2|Asic0|Ethernet56": {
+        "lc2|Asic0|Ethernet56": {
             "speed": "40000",
             "system_port_id": "47",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "15"
         },
-        "Linecard2|Asic0|Ethernet60": {
+        "lc2|Asic0|Ethernet60": {
             "speed": "40000",
             "system_port_id": "48",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "16"
         },
-        "Linecard2|Asic0|Ethernet64": {
+        "lc2|Asic0|Ethernet64": {
             "speed": "40000",
             "system_port_id": "49",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "1"
         },
-        "Linecard2|Asic0|Ethernet68": {
+        "lc2|Asic0|Ethernet68": {
             "speed": "40000",
             "system_port_id": "50",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "2"
         },
-        "Linecard2|Asic0|Ethernet72": {
+        "lc2|Asic0|Ethernet72": {
             "speed": "40000",
             "system_port_id": "51",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "3"
         },
-        "Linecard2|Asic0|Ethernet76": {
+        "lc2|Asic0|Ethernet76": {
             "speed": "40000",
             "system_port_id": "52",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "4"
         },
-        "Linecard2|Asic0|Ethernet80": {
+        "lc2|Asic0|Ethernet80": {
             "speed": "40000",
             "system_port_id": "53",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "5"
         },
-        "Linecard2|Asic0|Ethernet84": {
+        "lc2|Asic0|Ethernet84": {
             "speed": "40000",
             "system_port_id": "54",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "6"
         },
-        "Linecard2|Asic0|Ethernet88": {
+        "lc2|Asic0|Ethernet88": {
             "speed": "40000",
             "system_port_id": "55",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "7"
         },
-        "Linecard2|Asic0|Ethernet92": {
+        "lc2|Asic0|Ethernet92": {
             "speed": "40000",
             "system_port_id": "56",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "8"
         },
-        "Linecard2|Asic0|Ethernet96": {
+        "lc2|Asic0|Ethernet96": {
             "speed": "40000",
             "system_port_id": "57",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "9"
         },
-        "Linecard2|Asic0|Ethernet100": {
+        "lc2|Asic0|Ethernet100": {
             "speed": "40000",
             "system_port_id": "58",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "10"
         },
-        "Linecard2|Asic0|Ethernet104": {
+        "lc2|Asic0|Ethernet104": {
             "speed": "40000",
             "system_port_id": "59",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "11"
         },
-        "Linecard2|Asic0|Ethernet108": {
+        "lc2|Asic0|Ethernet108": {
             "speed": "40000",
             "system_port_id": "60",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "12"
         },
-        "Linecard2|Asic0|Ethernet112": {
+        "lc2|Asic0|Ethernet112": {
             "speed": "40000",
             "system_port_id": "61",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "13"
         },
-        "Linecard2|Asic0|Ethernet116": {
+        "lc2|Asic0|Ethernet116": {
             "speed": "40000",
             "system_port_id": "62",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "14"
         },
-        "Linecard2|Asic0|Ethernet120": {
+        "lc2|Asic0|Ethernet120": {
             "speed": "40000",
             "system_port_id": "63",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "15"
         },
-        "Linecard2|Asic0|Ethernet124": {
+        "lc2|Asic0|Ethernet124": {
             "speed": "40000",
             "system_port_id": "64",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "16"
         },
-        "Linecard3|Asic0|Ethernet0": {
+        "lc3|Asic0|Ethernet0": {
             "speed": "40000",
             "system_port_id": "65",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "1"
         },
-        "Linecard3|Asic0|Ethernet4": {
+        "lc3|Asic0|Ethernet4": {
             "speed": "40000",
             "system_port_id": "66",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "2"
         },
-        "Linecard3|Asic0|Ethernet8": {
+        "lc3|Asic0|Ethernet8": {
             "speed": "40000",
             "system_port_id": "67",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "3"
         },
-        "Linecard3|Asic0|Ethernet12": {
+        "lc3|Asic0|Ethernet12": {
             "speed": "40000",
             "system_port_id": "68",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "4"
         },
-        "Linecard3|Asic0|Ethernet16": {
+        "lc3|Asic0|Ethernet16": {
             "speed": "40000",
             "system_port_id": "69",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "5"
         },
-        "Linecard3|Asic0|Ethernet20": {
+        "lc3|Asic0|Ethernet20": {
             "speed": "40000",
             "system_port_id": "70",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "6"
         },
-        "Linecard3|Asic0|Ethernet24": {
+        "lc3|Asic0|Ethernet24": {
             "speed": "40000",
             "system_port_id": "71",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "7"
         },
-        "Linecard3|Asic0|Ethernet28": {
+        "lc3|Asic0|Ethernet28": {
             "speed": "40000",
             "system_port_id": "72",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "8"
         },
-        "Linecard3|Asic0|Ethernet32": {
+        "lc3|Asic0|Ethernet32": {
             "speed": "40000",
             "system_port_id": "73",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "9"
         },
-        "Linecard3|Asic0|Ethernet36": {
+        "lc3|Asic0|Ethernet36": {
             "speed": "40000",
             "system_port_id": "74",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "10"
         },
-        "Linecard3|Asic0|Ethernet40": {
+        "lc3|Asic0|Ethernet40": {
             "speed": "40000",
             "system_port_id": "75",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "11"
         },
-        "Linecard3|Asic0|Ethernet44": {
+        "lc3|Asic0|Ethernet44": {
             "speed": "40000",
             "system_port_id": "76",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "12"
         },
-        "Linecard3|Asic0|Ethernet48": {
+        "lc3|Asic0|Ethernet48": {
             "speed": "40000",
             "system_port_id": "77",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "13"
         },
-        "Linecard3|Asic0|Ethernet52": {
+        "lc3|Asic0|Ethernet52": {
             "speed": "40000",
             "system_port_id": "78",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "14"
         },
-        "Linecard3|Asic0|Ethernet56": {
+        "lc3|Asic0|Ethernet56": {
             "speed": "40000",
             "system_port_id": "79",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "15"
         },
-        "Linecard3|Asic0|Ethernet60": {
+        "lc3|Asic0|Ethernet60": {
             "speed": "40000",
             "system_port_id": "80",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "16"
         },
-        "Linecard3|Asic0|Ethernet64": {
+        "lc3|Asic0|Ethernet64": {
             "speed": "40000",
             "system_port_id": "81",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "1"
         },
-        "Linecard3|Asic0|Ethernet68": {
+        "lc3|Asic0|Ethernet68": {
             "speed": "40000",
             "system_port_id": "82",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "2"
         },
-        "Linecard3|Asic0|Ethernet72": {
+        "lc3|Asic0|Ethernet72": {
             "speed": "40000",
             "system_port_id": "83",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "3"
         },
-        "Linecard3|Asic0|Ethernet76": {
+        "lc3|Asic0|Ethernet76": {
             "speed": "40000",
             "system_port_id": "84",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "4"
         },
-        "Linecard3|Asic0|Ethernet80": {
+        "lc3|Asic0|Ethernet80": {
             "speed": "40000",
             "system_port_id": "85",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "5"
         },
-        "Linecard3|Asic0|Ethernet84": {
+        "lc3|Asic0|Ethernet84": {
             "speed": "40000",
             "system_port_id": "86",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "6"
         },
-        "Linecard3|Asic0|Ethernet88": {
+        "lc3|Asic0|Ethernet88": {
             "speed": "40000",
             "system_port_id": "87",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "7"
         },
-        "Linecard3|Asic0|Ethernet92": {
+        "lc3|Asic0|Ethernet92": {
             "speed": "40000",
             "system_port_id": "88",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "8"
         },
-        "Linecard3|Asic0|Ethernet96": {
+        "lc3|Asic0|Ethernet96": {
             "speed": "40000",
             "system_port_id": "89",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "9"
         },
-        "Linecard3|Asic0|Ethernet100": {
+        "lc3|Asic0|Ethernet100": {
             "speed": "40000",
             "system_port_id": "90",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "10"
         },
-        "Linecard3|Asic0|Ethernet104": {
+        "lc3|Asic0|Ethernet104": {
             "speed": "40000",
             "system_port_id": "91",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "11"
         },
-        "Linecard3|Asic0|Ethernet108": {
+        "lc3|Asic0|Ethernet108": {
             "speed": "40000",
             "system_port_id": "92",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "12"
         },
-        "Linecard3|Asic0|Ethernet112": {
+        "lc3|Asic0|Ethernet112": {
             "speed": "40000",
             "system_port_id": "93",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "13"
         },
-        "Linecard3|Asic0|Ethernet116": {
+        "lc3|Asic0|Ethernet116": {
             "speed": "40000",
             "system_port_id": "94",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "14"
         },
-        "Linecard3|Asic0|Ethernet120": {
+        "lc3|Asic0|Ethernet120": {
             "speed": "40000",
             "system_port_id": "95",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "15"
         },
-        "Linecard3|Asic0|Ethernet124": {
+        "lc3|Asic0|Ethernet124": {
             "speed": "40000",
             "system_port_id": "96",
             "switch_id": "4",

--- a/tests/virtual_chassis/3/default_config.json
+++ b/tests/virtual_chassis/3/default_config.json
@@ -29,665 +29,665 @@
             "core_index": "0",
             "core_port_index": "1"
         },
-        "Linecard1|Ethernet4": {
+        "Linecard1|Asic0|Ethernet4": {
             "speed": "40000",
             "system_port_id": "2",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "2"
         },
-        "Linecard1|Ethernet8": {
+        "Linecard1|Asic0|Ethernet8": {
             "speed": "40000",
             "system_port_id": "3",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "3"
         },
-        "Linecard1|Ethernet12": {
+        "Linecard1|Asic0|Ethernet12": {
             "speed": "40000",
             "system_port_id": "4",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "4"
         },
-        "Linecard1|Ethernet16": {
+        "Linecard1|Asic0|Ethernet16": {
             "speed": "40000",
             "system_port_id": "5",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "5"
         },
-        "Linecard1|Ethernet20": {
+        "Linecard1|Asic0|Ethernet20": {
             "speed": "40000",
             "system_port_id": "6",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "6"
         },
-        "Linecard1|Ethernet24": {
+        "Linecard1|Asic0|Ethernet24": {
             "speed": "40000",
             "system_port_id": "7",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "7"
         },
-        "Linecard1|Ethernet28": {
+        "Linecard1|Asic0|Ethernet28": {
             "speed": "40000",
             "system_port_id": "8",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "8"
         },
-        "Linecard1|Ethernet32": {
+        "Linecard1|Asic0|Ethernet32": {
             "speed": "40000",
             "system_port_id": "9",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "9"
         },
-        "Linecard1|Ethernet36": {
+        "Linecard1|Asic0|Ethernet36": {
             "speed": "40000",
             "system_port_id": "10",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "10"
         },
-        "Linecard1|Ethernet40": {
+        "Linecard1|Asic0|Ethernet40": {
             "speed": "40000",
             "system_port_id": "11",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "11"
         },
-        "Linecard1|Ethernet44": {
+        "Linecard1|Asic0|Ethernet44": {
             "speed": "40000",
             "system_port_id": "12",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "12"
         },
-        "Linecard1|Ethernet48": {
+        "Linecard1|Asic0|Ethernet48": {
             "speed": "40000",
             "system_port_id": "13",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "13"
         },
-        "Linecard1|Ethernet52": {
+        "Linecard1|Asic0|Ethernet52": {
             "speed": "40000",
             "system_port_id": "14",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "14"
         },
-        "Linecard1|Ethernet56": {
+        "Linecard1|Asic0|Ethernet56": {
             "speed": "40000",
             "system_port_id": "15",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "15"
         },
-        "Linecard1|Ethernet60": {
+        "Linecard1|Asic0|Ethernet60": {
             "speed": "40000",
             "system_port_id": "16",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "16"
         },
-        "Linecard1|Ethernet64": {
+        "Linecard1|Asic0|Ethernet64": {
             "speed": "40000",
             "system_port_id": "17",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "1"
         },
-        "Linecard1|Ethernet68": {
+        "Linecard1|Asic0|Ethernet68": {
             "speed": "40000",
             "system_port_id": "18",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "2"
         },
-        "Linecard1|Ethernet72": {
+        "Linecard1|Asic0|Ethernet72": {
             "speed": "40000",
             "system_port_id": "19",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "3"
         },
-        "Linecard1|Ethernet76": {
+        "Linecard1|Asic0|Ethernet76": {
             "speed": "40000",
             "system_port_id": "20",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "4"
         },
-        "Linecard1|Ethernet80": {
+        "Linecard1|Asic0|Ethernet80": {
             "speed": "40000",
             "system_port_id": "21",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "5"
         },
-        "Linecard1|Ethernet84": {
+        "Linecard1|Asic0|Ethernet84": {
             "speed": "40000",
             "system_port_id": "22",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "6"
         },
-        "Linecard1|Ethernet88": {
+        "Linecard1|Asic0|Ethernet88": {
             "speed": "40000",
             "system_port_id": "23",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "7"
         },
-        "Linecard1|Ethernet92": {
+        "Linecard1|Asic0|Ethernet92": {
             "speed": "40000",
             "system_port_id": "24",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "8"
         },
-        "Linecard1|Ethernet96": {
+        "Linecard1|Asic0|Ethernet96": {
             "speed": "40000",
             "system_port_id": "25",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "9"
         },
-        "Linecard1|Ethernet100": {
+        "Linecard1|Asic0|Ethernet100": {
             "speed": "40000",
             "system_port_id": "26",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "10"
         },
-        "Linecard1|Ethernet104": {
+        "Linecard1|Asic0|Ethernet104": {
             "speed": "40000",
             "system_port_id": "27",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "11"
         },
-        "Linecard1|Ethernet108": {
+        "Linecard1|Asic0|Ethernet108": {
             "speed": "40000",
             "system_port_id": "28",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "12"
         },
-        "Linecard1|Ethernet112": {
+        "Linecard1|Asic0|Ethernet112": {
             "speed": "40000",
             "system_port_id": "29",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "13"
         },
-        "Linecard1|Ethernet116": {
+        "Linecard1|Asic0|Ethernet116": {
             "speed": "40000",
             "system_port_id": "30",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "14"
         },
-        "Linecard1|Ethernet120": {
+        "Linecard1|Asic0|Ethernet120": {
             "speed": "40000",
             "system_port_id": "31",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "15"
         },
-        "Linecard1|Ethernet124": {
+        "Linecard1|Asic0|Ethernet124": {
             "speed": "40000",
             "system_port_id": "32",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "16"
         },
-        "Linecard2|Ethernet0": {
+        "Linecard2|Asic0|Ethernet0": {
             "speed": "40000",
             "system_port_id": "33",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "1"
         },
-        "Linecard2|Ethernet4": {
+        "Linecard2|Asic0|Ethernet4": {
             "speed": "40000",
             "system_port_id": "34",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "2"
         },
-        "Linecard2|Ethernet8": {
+        "Linecard2|Asic0|Ethernet8": {
             "speed": "40000",
             "system_port_id": "35",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "3"
         },
-        "Linecard2|Ethernet12": {
+        "Linecard2|Asic0|Ethernet12": {
             "speed": "40000",
             "system_port_id": "36",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "4"
         },
-        "Linecard2|Ethernet16": {
+        "Linecard2|Asic0|Ethernet16": {
             "speed": "40000",
             "system_port_id": "37",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "5"
         },
-        "Linecard2|Ethernet20": {
+        "Linecard2|Asic0|Ethernet20": {
             "speed": "40000",
             "system_port_id": "38",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "6"
         },
-        "Linecard2|Ethernet24": {
+        "Linecard2|Asic0|Ethernet24": {
             "speed": "40000",
             "system_port_id": "39",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "7"
         },
-        "Linecard2|Ethernet28": {
+        "Linecard2|Asic0|Ethernet28": {
             "speed": "40000",
             "system_port_id": "40",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "8"
         },
-        "Linecard2|Ethernet32": {
+        "Linecard2|Asic0|Ethernet32": {
             "speed": "40000",
             "system_port_id": "41",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "9"
         },
-        "Linecard2|Ethernet36": {
+        "Linecard2|Asic0|Ethernet36": {
             "speed": "40000",
             "system_port_id": "42",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "10"
         },
-        "Linecard2|Ethernet40": {
+        "Linecard2|Asic0|Ethernet40": {
             "speed": "40000",
             "system_port_id": "43",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "11"
         },
-        "Linecard2|Ethernet44": {
+        "Linecard2|Asic0|Ethernet44": {
             "speed": "40000",
             "system_port_id": "44",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "12"
         },
-        "Linecard2|Ethernet48": {
+        "Linecard2|Asic0|Ethernet48": {
             "speed": "40000",
             "system_port_id": "45",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "13"
         },
-        "Linecard2|Ethernet52": {
+        "Linecard2|Asic0|Ethernet52": {
             "speed": "40000",
             "system_port_id": "46",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "14"
         },
-        "Linecard2|Ethernet56": {
+        "Linecard2|Asic0|Ethernet56": {
             "speed": "40000",
             "system_port_id": "47",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "15"
         },
-        "Linecard2|Ethernet60": {
+        "Linecard2|Asic0|Ethernet60": {
             "speed": "40000",
             "system_port_id": "48",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "16"
         },
-        "Linecard2|Ethernet64": {
+        "Linecard2|Asic0|Ethernet64": {
             "speed": "40000",
             "system_port_id": "49",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "1"
         },
-        "Linecard2|Ethernet68": {
+        "Linecard2|Asic0|Ethernet68": {
             "speed": "40000",
             "system_port_id": "50",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "2"
         },
-        "Linecard2|Ethernet72": {
+        "Linecard2|Asic0|Ethernet72": {
             "speed": "40000",
             "system_port_id": "51",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "3"
         },
-        "Linecard2|Ethernet76": {
+        "Linecard2|Asic0|Ethernet76": {
             "speed": "40000",
             "system_port_id": "52",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "4"
         },
-        "Linecard2|Ethernet80": {
+        "Linecard2|Asic0|Ethernet80": {
             "speed": "40000",
             "system_port_id": "53",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "5"
         },
-        "Linecard2|Ethernet84": {
+        "Linecard2|Asic0|Ethernet84": {
             "speed": "40000",
             "system_port_id": "54",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "6"
         },
-        "Linecard2|Ethernet88": {
+        "Linecard2|Asic0|Ethernet88": {
             "speed": "40000",
             "system_port_id": "55",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "7"
         },
-        "Linecard2|Ethernet92": {
+        "Linecard2|Asic0|Ethernet92": {
             "speed": "40000",
             "system_port_id": "56",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "8"
         },
-        "Linecard2|Ethernet96": {
+        "Linecard2|Asic0|Ethernet96": {
             "speed": "40000",
             "system_port_id": "57",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "9"
         },
-        "Linecard2|Ethernet100": {
+        "Linecard2|Asic0|Ethernet100": {
             "speed": "40000",
             "system_port_id": "58",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "10"
         },
-        "Linecard2|Ethernet104": {
+        "Linecard2|Asic0|Ethernet104": {
             "speed": "40000",
             "system_port_id": "59",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "11"
         },
-        "Linecard2|Ethernet108": {
+        "Linecard2|Asic0|Ethernet108": {
             "speed": "40000",
             "system_port_id": "60",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "12"
         },
-        "Linecard2|Ethernet112": {
+        "Linecard2|Asic0|Ethernet112": {
             "speed": "40000",
             "system_port_id": "61",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "13"
         },
-        "Linecard2|Ethernet116": {
+        "Linecard2|Asic0|Ethernet116": {
             "speed": "40000",
             "system_port_id": "62",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "14"
         },
-        "Linecard2|Ethernet120": {
+        "Linecard2|Asic0|Ethernet120": {
             "speed": "40000",
             "system_port_id": "63",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "15"
         },
-        "Linecard2|Ethernet124": {
+        "Linecard2|Asic0|Ethernet124": {
             "speed": "40000",
             "system_port_id": "64",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "16"
         },
-        "Linecard3|Ethernet0": {
+        "Linecard3|Asic0|Ethernet0": {
             "speed": "40000",
             "system_port_id": "65",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "1"
         },
-        "Linecard3|Ethernet4": {
+        "Linecard3|Asic0|Ethernet4": {
             "speed": "40000",
             "system_port_id": "66",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "2"
         },
-        "Linecard3|Ethernet8": {
+        "Linecard3|Asic0|Ethernet8": {
             "speed": "40000",
             "system_port_id": "67",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "3"
         },
-        "Linecard3|Ethernet12": {
+        "Linecard3|Asic0|Ethernet12": {
             "speed": "40000",
             "system_port_id": "68",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "4"
         },
-        "Linecard3|Ethernet16": {
+        "Linecard3|Asic0|Ethernet16": {
             "speed": "40000",
             "system_port_id": "69",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "5"
         },
-        "Linecard3|Ethernet20": {
+        "Linecard3|Asic0|Ethernet20": {
             "speed": "40000",
             "system_port_id": "70",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "6"
         },
-        "Linecard3|Ethernet24": {
+        "Linecard3|Asic0|Ethernet24": {
             "speed": "40000",
             "system_port_id": "71",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "7"
         },
-        "Linecard3|Ethernet28": {
+        "Linecard3|Asic0|Ethernet28": {
             "speed": "40000",
             "system_port_id": "72",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "8"
         },
-        "Linecard3|Ethernet32": {
+        "Linecard3|Asic0|Ethernet32": {
             "speed": "40000",
             "system_port_id": "73",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "9"
         },
-        "Linecard3|Ethernet36": {
+        "Linecard3|Asic0|Ethernet36": {
             "speed": "40000",
             "system_port_id": "74",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "10"
         },
-        "Linecard3|Ethernet40": {
+        "Linecard3|Asic0|Ethernet40": {
             "speed": "40000",
             "system_port_id": "75",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "11"
         },
-        "Linecard3|Ethernet44": {
+        "Linecard3|Asic0|Ethernet44": {
             "speed": "40000",
             "system_port_id": "76",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "12"
         },
-        "Linecard3|Ethernet48": {
+        "Linecard3|Asic0|Ethernet48": {
             "speed": "40000",
             "system_port_id": "77",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "13"
         },
-        "Linecard3|Ethernet52": {
+        "Linecard3|Asic0|Ethernet52": {
             "speed": "40000",
             "system_port_id": "78",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "14"
         },
-        "Linecard3|Ethernet56": {
+        "Linecard3|Asic0|Ethernet56": {
             "speed": "40000",
             "system_port_id": "79",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "15"
         },
-        "Linecard3|Ethernet60": {
+        "Linecard3|Asic0|Ethernet60": {
             "speed": "40000",
             "system_port_id": "80",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "16"
         },
-        "Linecard3|Ethernet64": {
+        "Linecard3|Asic0|Ethernet64": {
             "speed": "40000",
             "system_port_id": "81",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "1"
         },
-        "Linecard3|Ethernet68": {
+        "Linecard3|Asic0|Ethernet68": {
             "speed": "40000",
             "system_port_id": "82",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "2"
         },
-        "Linecard3|Ethernet72": {
+        "Linecard3|Asic0|Ethernet72": {
             "speed": "40000",
             "system_port_id": "83",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "3"
         },
-        "Linecard3|Ethernet76": {
+        "Linecard3|Asic0|Ethernet76": {
             "speed": "40000",
             "system_port_id": "84",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "4"
         },
-        "Linecard3|Ethernet80": {
+        "Linecard3|Asic0|Ethernet80": {
             "speed": "40000",
             "system_port_id": "85",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "5"
         },
-        "Linecard3|Ethernet84": {
+        "Linecard3|Asic0|Ethernet84": {
             "speed": "40000",
             "system_port_id": "86",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "6"
         },
-        "Linecard3|Ethernet88": {
+        "Linecard3|Asic0|Ethernet88": {
             "speed": "40000",
             "system_port_id": "87",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "7"
         },
-        "Linecard3|Ethernet92": {
+        "Linecard3|Asic0|Ethernet92": {
             "speed": "40000",
             "system_port_id": "88",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "8"
         },
-        "Linecard3|Ethernet96": {
+        "Linecard3|Asic0|Ethernet96": {
             "speed": "40000",
             "system_port_id": "89",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "9"
         },
-        "Linecard3|Ethernet100": {
+        "Linecard3|Asic0|Ethernet100": {
             "speed": "40000",
             "system_port_id": "90",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "10"
         },
-        "Linecard3|Ethernet104": {
+        "Linecard3|Asic0|Ethernet104": {
             "speed": "40000",
             "system_port_id": "91",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "11"
         },
-        "Linecard3|Ethernet108": {
+        "Linecard3|Asic0|Ethernet108": {
             "speed": "40000",
             "system_port_id": "92",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "12"
         },
-        "Linecard3|Ethernet112": {
+        "Linecard3|Asic0|Ethernet112": {
             "speed": "40000",
             "system_port_id": "93",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "13"
         },
-        "Linecard3|Ethernet116": {
+        "Linecard3|Asic0|Ethernet116": {
             "speed": "40000",
             "system_port_id": "94",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "14"
         },
-        "Linecard3|Ethernet120": {
+        "Linecard3|Asic0|Ethernet120": {
             "speed": "40000",
             "system_port_id": "95",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "15"
         },
-        "Linecard3|Ethernet124": {
+        "Linecard3|Asic0|Ethernet124": {
             "speed": "40000",
             "system_port_id": "96",
             "switch_id": "4",

--- a/tests/virtual_chassis/3/default_config.json
+++ b/tests/virtual_chassis/3/default_config.json
@@ -22,672 +22,672 @@
         }
     },
     "SYSTEM_PORT": {
-        "Linecard1|Ethernet0": {
+        "lc1|Ethernet0": {
             "speed": "40000",
             "system_port_id": "1",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "1"
         },
-        "Linecard1|Asic0|Ethernet4": {
+        "lc1|Asic0|Ethernet4": {
             "speed": "40000",
             "system_port_id": "2",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "2"
         },
-        "Linecard1|Asic0|Ethernet8": {
+        "lc1|Asic0|Ethernet8": {
             "speed": "40000",
             "system_port_id": "3",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "3"
         },
-        "Linecard1|Asic0|Ethernet12": {
+        "lc1|Asic0|Ethernet12": {
             "speed": "40000",
             "system_port_id": "4",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "4"
         },
-        "Linecard1|Asic0|Ethernet16": {
+        "lc1|Asic0|Ethernet16": {
             "speed": "40000",
             "system_port_id": "5",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "5"
         },
-        "Linecard1|Asic0|Ethernet20": {
+        "lc1|Asic0|Ethernet20": {
             "speed": "40000",
             "system_port_id": "6",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "6"
         },
-        "Linecard1|Asic0|Ethernet24": {
+        "lc1|Asic0|Ethernet24": {
             "speed": "40000",
             "system_port_id": "7",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "7"
         },
-        "Linecard1|Asic0|Ethernet28": {
+        "lc1|Asic0|Ethernet28": {
             "speed": "40000",
             "system_port_id": "8",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "8"
         },
-        "Linecard1|Asic0|Ethernet32": {
+        "lc1|Asic0|Ethernet32": {
             "speed": "40000",
             "system_port_id": "9",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "9"
         },
-        "Linecard1|Asic0|Ethernet36": {
+        "lc1|Asic0|Ethernet36": {
             "speed": "40000",
             "system_port_id": "10",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "10"
         },
-        "Linecard1|Asic0|Ethernet40": {
+        "lc1|Asic0|Ethernet40": {
             "speed": "40000",
             "system_port_id": "11",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "11"
         },
-        "Linecard1|Asic0|Ethernet44": {
+        "lc1|Asic0|Ethernet44": {
             "speed": "40000",
             "system_port_id": "12",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "12"
         },
-        "Linecard1|Asic0|Ethernet48": {
+        "lc1|Asic0|Ethernet48": {
             "speed": "40000",
             "system_port_id": "13",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "13"
         },
-        "Linecard1|Asic0|Ethernet52": {
+        "lc1|Asic0|Ethernet52": {
             "speed": "40000",
             "system_port_id": "14",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "14"
         },
-        "Linecard1|Asic0|Ethernet56": {
+        "lc1|Asic0|Ethernet56": {
             "speed": "40000",
             "system_port_id": "15",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "15"
         },
-        "Linecard1|Asic0|Ethernet60": {
+        "lc1|Asic0|Ethernet60": {
             "speed": "40000",
             "system_port_id": "16",
             "switch_id": "0",
             "core_index": "0",
             "core_port_index": "16"
         },
-        "Linecard1|Asic0|Ethernet64": {
+        "lc1|Asic0|Ethernet64": {
             "speed": "40000",
             "system_port_id": "17",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "1"
         },
-        "Linecard1|Asic0|Ethernet68": {
+        "lc1|Asic0|Ethernet68": {
             "speed": "40000",
             "system_port_id": "18",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "2"
         },
-        "Linecard1|Asic0|Ethernet72": {
+        "lc1|Asic0|Ethernet72": {
             "speed": "40000",
             "system_port_id": "19",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "3"
         },
-        "Linecard1|Asic0|Ethernet76": {
+        "lc1|Asic0|Ethernet76": {
             "speed": "40000",
             "system_port_id": "20",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "4"
         },
-        "Linecard1|Asic0|Ethernet80": {
+        "lc1|Asic0|Ethernet80": {
             "speed": "40000",
             "system_port_id": "21",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "5"
         },
-        "Linecard1|Asic0|Ethernet84": {
+        "lc1|Asic0|Ethernet84": {
             "speed": "40000",
             "system_port_id": "22",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "6"
         },
-        "Linecard1|Asic0|Ethernet88": {
+        "lc1|Asic0|Ethernet88": {
             "speed": "40000",
             "system_port_id": "23",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "7"
         },
-        "Linecard1|Asic0|Ethernet92": {
+        "lc1|Asic0|Ethernet92": {
             "speed": "40000",
             "system_port_id": "24",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "8"
         },
-        "Linecard1|Asic0|Ethernet96": {
+        "lc1|Asic0|Ethernet96": {
             "speed": "40000",
             "system_port_id": "25",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "9"
         },
-        "Linecard1|Asic0|Ethernet100": {
+        "lc1|Asic0|Ethernet100": {
             "speed": "40000",
             "system_port_id": "26",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "10"
         },
-        "Linecard1|Asic0|Ethernet104": {
+        "lc1|Asic0|Ethernet104": {
             "speed": "40000",
             "system_port_id": "27",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "11"
         },
-        "Linecard1|Asic0|Ethernet108": {
+        "lc1|Asic0|Ethernet108": {
             "speed": "40000",
             "system_port_id": "28",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "12"
         },
-        "Linecard1|Asic0|Ethernet112": {
+        "lc1|Asic0|Ethernet112": {
             "speed": "40000",
             "system_port_id": "29",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "13"
         },
-        "Linecard1|Asic0|Ethernet116": {
+        "lc1|Asic0|Ethernet116": {
             "speed": "40000",
             "system_port_id": "30",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "14"
         },
-        "Linecard1|Asic0|Ethernet120": {
+        "lc1|Asic0|Ethernet120": {
             "speed": "40000",
             "system_port_id": "31",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "15"
         },
-        "Linecard1|Asic0|Ethernet124": {
+        "lc1|Asic0|Ethernet124": {
             "speed": "40000",
             "system_port_id": "32",
             "switch_id": "0",
             "core_index": "1",
             "core_port_index": "16"
         },
-        "Linecard2|Asic0|Ethernet0": {
+        "lc2|Asic0|Ethernet0": {
             "speed": "40000",
             "system_port_id": "33",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "1"
         },
-        "Linecard2|Asic0|Ethernet4": {
+        "lc2|Asic0|Ethernet4": {
             "speed": "40000",
             "system_port_id": "34",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "2"
         },
-        "Linecard2|Asic0|Ethernet8": {
+        "lc2|Asic0|Ethernet8": {
             "speed": "40000",
             "system_port_id": "35",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "3"
         },
-        "Linecard2|Asic0|Ethernet12": {
+        "lc2|Asic0|Ethernet12": {
             "speed": "40000",
             "system_port_id": "36",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "4"
         },
-        "Linecard2|Asic0|Ethernet16": {
+        "lc2|Asic0|Ethernet16": {
             "speed": "40000",
             "system_port_id": "37",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "5"
         },
-        "Linecard2|Asic0|Ethernet20": {
+        "lc2|Asic0|Ethernet20": {
             "speed": "40000",
             "system_port_id": "38",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "6"
         },
-        "Linecard2|Asic0|Ethernet24": {
+        "lc2|Asic0|Ethernet24": {
             "speed": "40000",
             "system_port_id": "39",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "7"
         },
-        "Linecard2|Asic0|Ethernet28": {
+        "lc2|Asic0|Ethernet28": {
             "speed": "40000",
             "system_port_id": "40",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "8"
         },
-        "Linecard2|Asic0|Ethernet32": {
+        "lc2|Asic0|Ethernet32": {
             "speed": "40000",
             "system_port_id": "41",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "9"
         },
-        "Linecard2|Asic0|Ethernet36": {
+        "lc2|Asic0|Ethernet36": {
             "speed": "40000",
             "system_port_id": "42",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "10"
         },
-        "Linecard2|Asic0|Ethernet40": {
+        "lc2|Asic0|Ethernet40": {
             "speed": "40000",
             "system_port_id": "43",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "11"
         },
-        "Linecard2|Asic0|Ethernet44": {
+        "lc2|Asic0|Ethernet44": {
             "speed": "40000",
             "system_port_id": "44",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "12"
         },
-        "Linecard2|Asic0|Ethernet48": {
+        "lc2|Asic0|Ethernet48": {
             "speed": "40000",
             "system_port_id": "45",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "13"
         },
-        "Linecard2|Asic0|Ethernet52": {
+        "lc2|Asic0|Ethernet52": {
             "speed": "40000",
             "system_port_id": "46",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "14"
         },
-        "Linecard2|Asic0|Ethernet56": {
+        "lc2|Asic0|Ethernet56": {
             "speed": "40000",
             "system_port_id": "47",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "15"
         },
-        "Linecard2|Asic0|Ethernet60": {
+        "lc2|Asic0|Ethernet60": {
             "speed": "40000",
             "system_port_id": "48",
             "switch_id": "2",
             "core_index": "0",
             "core_port_index": "16"
         },
-        "Linecard2|Asic0|Ethernet64": {
+        "lc2|Asic0|Ethernet64": {
             "speed": "40000",
             "system_port_id": "49",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "1"
         },
-        "Linecard2|Asic0|Ethernet68": {
+        "lc2|Asic0|Ethernet68": {
             "speed": "40000",
             "system_port_id": "50",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "2"
         },
-        "Linecard2|Asic0|Ethernet72": {
+        "lc2|Asic0|Ethernet72": {
             "speed": "40000",
             "system_port_id": "51",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "3"
         },
-        "Linecard2|Asic0|Ethernet76": {
+        "lc2|Asic0|Ethernet76": {
             "speed": "40000",
             "system_port_id": "52",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "4"
         },
-        "Linecard2|Asic0|Ethernet80": {
+        "lc2|Asic0|Ethernet80": {
             "speed": "40000",
             "system_port_id": "53",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "5"
         },
-        "Linecard2|Asic0|Ethernet84": {
+        "lc2|Asic0|Ethernet84": {
             "speed": "40000",
             "system_port_id": "54",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "6"
         },
-        "Linecard2|Asic0|Ethernet88": {
+        "lc2|Asic0|Ethernet88": {
             "speed": "40000",
             "system_port_id": "55",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "7"
         },
-        "Linecard2|Asic0|Ethernet92": {
+        "lc2|Asic0|Ethernet92": {
             "speed": "40000",
             "system_port_id": "56",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "8"
         },
-        "Linecard2|Asic0|Ethernet96": {
+        "lc2|Asic0|Ethernet96": {
             "speed": "40000",
             "system_port_id": "57",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "9"
         },
-        "Linecard2|Asic0|Ethernet100": {
+        "lc2|Asic0|Ethernet100": {
             "speed": "40000",
             "system_port_id": "58",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "10"
         },
-        "Linecard2|Asic0|Ethernet104": {
+        "lc2|Asic0|Ethernet104": {
             "speed": "40000",
             "system_port_id": "59",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "11"
         },
-        "Linecard2|Asic0|Ethernet108": {
+        "lc2|Asic0|Ethernet108": {
             "speed": "40000",
             "system_port_id": "60",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "12"
         },
-        "Linecard2|Asic0|Ethernet112": {
+        "lc2|Asic0|Ethernet112": {
             "speed": "40000",
             "system_port_id": "61",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "13"
         },
-        "Linecard2|Asic0|Ethernet116": {
+        "lc2|Asic0|Ethernet116": {
             "speed": "40000",
             "system_port_id": "62",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "14"
         },
-        "Linecard2|Asic0|Ethernet120": {
+        "lc2|Asic0|Ethernet120": {
             "speed": "40000",
             "system_port_id": "63",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "15"
         },
-        "Linecard2|Asic0|Ethernet124": {
+        "lc2|Asic0|Ethernet124": {
             "speed": "40000",
             "system_port_id": "64",
             "switch_id": "2",
             "core_index": "1",
             "core_port_index": "16"
         },
-        "Linecard3|Asic0|Ethernet0": {
+        "lc3|Asic0|Ethernet0": {
             "speed": "40000",
             "system_port_id": "65",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "1"
         },
-        "Linecard3|Asic0|Ethernet4": {
+        "lc3|Asic0|Ethernet4": {
             "speed": "40000",
             "system_port_id": "66",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "2"
         },
-        "Linecard3|Asic0|Ethernet8": {
+        "lc3|Asic0|Ethernet8": {
             "speed": "40000",
             "system_port_id": "67",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "3"
         },
-        "Linecard3|Asic0|Ethernet12": {
+        "lc3|Asic0|Ethernet12": {
             "speed": "40000",
             "system_port_id": "68",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "4"
         },
-        "Linecard3|Asic0|Ethernet16": {
+        "lc3|Asic0|Ethernet16": {
             "speed": "40000",
             "system_port_id": "69",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "5"
         },
-        "Linecard3|Asic0|Ethernet20": {
+        "lc3|Asic0|Ethernet20": {
             "speed": "40000",
             "system_port_id": "70",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "6"
         },
-        "Linecard3|Asic0|Ethernet24": {
+        "lc3|Asic0|Ethernet24": {
             "speed": "40000",
             "system_port_id": "71",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "7"
         },
-        "Linecard3|Asic0|Ethernet28": {
+        "lc3|Asic0|Ethernet28": {
             "speed": "40000",
             "system_port_id": "72",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "8"
         },
-        "Linecard3|Asic0|Ethernet32": {
+        "lc3|Asic0|Ethernet32": {
             "speed": "40000",
             "system_port_id": "73",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "9"
         },
-        "Linecard3|Asic0|Ethernet36": {
+        "lc3|Asic0|Ethernet36": {
             "speed": "40000",
             "system_port_id": "74",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "10"
         },
-        "Linecard3|Asic0|Ethernet40": {
+        "lc3|Asic0|Ethernet40": {
             "speed": "40000",
             "system_port_id": "75",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "11"
         },
-        "Linecard3|Asic0|Ethernet44": {
+        "lc3|Asic0|Ethernet44": {
             "speed": "40000",
             "system_port_id": "76",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "12"
         },
-        "Linecard3|Asic0|Ethernet48": {
+        "lc3|Asic0|Ethernet48": {
             "speed": "40000",
             "system_port_id": "77",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "13"
         },
-        "Linecard3|Asic0|Ethernet52": {
+        "lc3|Asic0|Ethernet52": {
             "speed": "40000",
             "system_port_id": "78",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "14"
         },
-        "Linecard3|Asic0|Ethernet56": {
+        "lc3|Asic0|Ethernet56": {
             "speed": "40000",
             "system_port_id": "79",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "15"
         },
-        "Linecard3|Asic0|Ethernet60": {
+        "lc3|Asic0|Ethernet60": {
             "speed": "40000",
             "system_port_id": "80",
             "switch_id": "4",
             "core_index": "0",
             "core_port_index": "16"
         },
-        "Linecard3|Asic0|Ethernet64": {
+        "lc3|Asic0|Ethernet64": {
             "speed": "40000",
             "system_port_id": "81",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "1"
         },
-        "Linecard3|Asic0|Ethernet68": {
+        "lc3|Asic0|Ethernet68": {
             "speed": "40000",
             "system_port_id": "82",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "2"
         },
-        "Linecard3|Asic0|Ethernet72": {
+        "lc3|Asic0|Ethernet72": {
             "speed": "40000",
             "system_port_id": "83",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "3"
         },
-        "Linecard3|Asic0|Ethernet76": {
+        "lc3|Asic0|Ethernet76": {
             "speed": "40000",
             "system_port_id": "84",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "4"
         },
-        "Linecard3|Asic0|Ethernet80": {
+        "lc3|Asic0|Ethernet80": {
             "speed": "40000",
             "system_port_id": "85",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "5"
         },
-        "Linecard3|Asic0|Ethernet84": {
+        "lc3|Asic0|Ethernet84": {
             "speed": "40000",
             "system_port_id": "86",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "6"
         },
-        "Linecard3|Asic0|Ethernet88": {
+        "lc3|Asic0|Ethernet88": {
             "speed": "40000",
             "system_port_id": "87",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "7"
         },
-        "Linecard3|Asic0|Ethernet92": {
+        "lc3|Asic0|Ethernet92": {
             "speed": "40000",
             "system_port_id": "88",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "8"
         },
-        "Linecard3|Asic0|Ethernet96": {
+        "lc3|Asic0|Ethernet96": {
             "speed": "40000",
             "system_port_id": "89",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "9"
         },
-        "Linecard3|Asic0|Ethernet100": {
+        "lc3|Asic0|Ethernet100": {
             "speed": "40000",
             "system_port_id": "90",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "10"
         },
-        "Linecard3|Asic0|Ethernet104": {
+        "lc3|Asic0|Ethernet104": {
             "speed": "40000",
             "system_port_id": "91",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "11"
         },
-        "Linecard3|Asic0|Ethernet108": {
+        "lc3|Asic0|Ethernet108": {
             "speed": "40000",
             "system_port_id": "92",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "12"
         },
-        "Linecard3|Asic0|Ethernet112": {
+        "lc3|Asic0|Ethernet112": {
             "speed": "40000",
             "system_port_id": "93",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "13"
         },
-        "Linecard3|Asic0|Ethernet116": {
+        "lc3|Asic0|Ethernet116": {
             "speed": "40000",
             "system_port_id": "94",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "14"
         },
-        "Linecard3|Asic0|Ethernet120": {
+        "lc3|Asic0|Ethernet120": {
             "speed": "40000",
             "system_port_id": "95",
             "switch_id": "4",
             "core_index": "1",
             "core_port_index": "15"
         },
-        "Linecard3|Asic0|Ethernet124": {
+        "lc3|Asic0|Ethernet124": {
             "speed": "40000",
             "system_port_id": "96",
             "switch_id": "4",


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

MSFT ADO: 24595422

What I did
Added support to apply wred profile on system ports

Why I did it
remote system ports were missing wred profile

How I verified it
Tested on sonic chassis

Details if related
