### PR TITLE
[muxorch] Fixing updateRoute logic

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -676,6 +676,7 @@ void MuxCable::updateNeighbor(NextHopKey nh, bool add)
  */
 void MuxCable::updateRoutes()
 {
+    SWSS_LOG_INFO("Updating routes pointing to multiple mux nexthops");
     MuxNeighbor neighbors = nbr_handler_->getNeighbors();
     string alias = nbr_handler_->getAlias();
     for (auto nh = neighbors.begin(); nh != neighbors.end(); nh ++)
@@ -1099,6 +1100,8 @@ void MuxOrch::updateRoute(const IpPrefix &pfx, bool add)
 
     if (!add)
     {
+        SWSS_LOG_INFO("Removing route %s from mux_multi_active_nh_table",
+                pfx.to_string().c_str());
         mux_multi_active_nh_table.erase(pfx);
         return;
     }
@@ -1111,6 +1114,7 @@ void MuxOrch::updateRoute(const IpPrefix &pfx, bool add)
      */
     if (nhg_key.getSize() <= 1)
     {
+        SWSS_LOG_INFO("Route points to single nexthop, ignoring");
         return;
     }
 
@@ -1121,24 +1125,6 @@ void MuxOrch::updateRoute(const IpPrefix &pfx, bool add)
 
     /* get nexthops from nexthop group */
     nextHops = nhg_key.getNextHops();
-
-    auto it = mux_multi_active_nh_table.find(pfx);
-    if (it != mux_multi_active_nh_table.end())
-    {
-        /* This will only work for configured MUX neighbors (most cases)
-         * TODO: add way to find MUX from neighbor
-         */
-        MuxCable* cable = findMuxCableInSubnet(it->second.ip_address);
-        auto standalone = standalone_tunnel_neighbors_.find(it->second.ip_address);
-
-        if ((cable == nullptr && standalone == standalone_tunnel_neighbors_.end()) ||
-             cable->isActive())
-        {
-            SWSS_LOG_INFO("Route %s pointing to active neighbor %s",
-                pfx.to_string().c_str(), it->second.to_string().c_str());
-            return;
-        }
-    }
 
     SWSS_LOG_NOTICE("Updating route %s pointing to Mux nexthops %s",
                 pfx.to_string().c_str(), nhg_key.to_string().c_str());
@@ -1168,7 +1154,7 @@ void MuxOrch::updateRoute(const IpPrefix &pfx, bool add)
                         pfx.to_string().c_str(), nexthop.to_string().c_str());
                 continue;
             }
-            SWSS_LOG_INFO("setting route %s with nexthop %s %" PRIx64 "",
+            SWSS_LOG_NOTICE("setting route %s with nexthop %s %" PRIx64 "",
                 pfx.to_string().c_str(), nexthop.to_string().c_str(), next_hop_id);
             mux_multi_active_nh_table[pfx] = nexthop;
             active_found = true;
@@ -1443,9 +1429,11 @@ bool MuxOrch::isMuxNexthops(const NextHopGroupKey& nextHops)
     {
         if (this->containsNextHop(*it))
         {
+            SWSS_LOG_INFO("Found mux nexthop %s", it->to_string().c_str());
             return true;
         }
     }
+    SWSS_LOG_INFO("No mux nexthop found");
     return false;
 }
 

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -542,7 +542,7 @@ class TestMuxTunnelBase():
                     self.check_route_nexthop(dvs_route, asicdb, route, tunnel_nh_id, True)
 
                 # move neighbor 1 back
-                self.add_neighbor(dvs, neighbors[0], macs[i])
+                self.add_neighbor(dvs, neighbors[0], macs[0])
 
                 print("Testing fdb update in %s, %s for %s" % (start[0], start[1], neighbors[1]))
                 # move neighbor 2
@@ -555,7 +555,7 @@ class TestMuxTunnelBase():
                     self.check_route_nexthop(dvs_route, asicdb, route, tunnel_nh_id, True)
 
                 # move neighbor 2 back
-                self.add_neighbor(dvs, neighbors[0], macs[i])
+                self.add_neighbor(dvs, neighbors[1], macs[1])
 
                 self.del_route(dvs, route)
 
@@ -604,26 +604,38 @@ class TestMuxTunnelBase():
                 self.del_route(dvs, route)
 
             # Check route_updates
+            self.add_neighbor(dvs, self.SERV3_IPV4, macs[2])
             print("Testing route updates")
             self.add_route(dvs, route, neighbors)
             print("setting states to active")
             for port in mux_ports:
                 self.set_mux_state(appdb, port, "active")
-            print("triggering another route update")
-            self.add_route(dvs, route, neighbors)
-            self.check_route_nexthop(dvs_route, asicdb, route, neighbors[0])
+            self.set_mux_state(appdb, "Ethernet4", "active")
 
+            print("triggering another route update")
+            # add new neighbor to route to force route update
+            self.add_route(dvs, route, [neighbors[0], self.SERV3_IPV4])
+            self.check_route_nexthop(dvs_route, asicdb, route, neighbors[0])
+            self.del_route(dvs,route)
+
+            time.sleep(2)
+
+            self.add_route(dvs, route, neighbors)
             print("setting states to standby")
             for port in mux_ports:
                 self.set_mux_state(appdb, port, "standby")
+            self.set_mux_state(appdb, "Ethernet4", "standby")
+
             print("triggering another route update")
+            # add new neighbor to route to force route update
+            self.add_route(dvs, route, [neighbors[0], self.SERV3_IPV4])
             self.add_route(dvs, route, neighbors)
             self.check_route_nexthop(dvs_route, asicdb, route, tunnel_nh_id, True)
-
             self.del_route(dvs,route)
 
             for neighbor in neighbors:
                 self.del_neighbor(dvs, neighbor)
+            self.del_neighbor(dvs, self.SERV3_IPV4)
 
             print("Testing add/remove of neighbors")
             for start in starting_states:
@@ -1493,7 +1505,7 @@ class TestMuxTunnel(TestMuxTunnelBase):
     def test_multi_nexthop(self, dvs, dvs_route, intf_fdb_map, neighbor_cleanup, testlog):
         appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
         asicdb = dvs.get_asic_db()
-        macs = [intf_fdb_map["Ethernet0"], intf_fdb_map["Ethernet4"]]
+        macs = [intf_fdb_map["Ethernet0"], intf_fdb_map["Ethernet4"], intf_fdb_map["Ethernet8"]]
 
         self.create_and_test_multi_nexthop_routes(dvs, dvs_route, appdb, macs, asicdb)
 

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -584,14 +584,14 @@ class TestMuxTunnelBase():
                         print("setting %s to %s" % (mux_ports[toggle_index], ACTIVE))
                         self.set_mux_state(appdb, mux_ports[toggle_index], ACTIVE)
                         if start[keep_index] == ACTIVE:
-                            self.check_route_nexthop(dvs_route, asicdb, route, neighbors[keep_index])
+                            self.check_route_nexthop(dvs_route, asicdb, route, neighbors[0])
                         else:
                             self.check_route_nexthop(dvs_route, asicdb, route, neighbors[toggle_index])
                     else:
                         print("setting %s to %s" % (mux_ports[toggle_index], ACTIVE))
                         self.set_mux_state(appdb, mux_ports[toggle_index], ACTIVE)
                         if start[keep_index] == ACTIVE:
-                            self.check_route_nexthop(dvs_route, asicdb, route, neighbors[keep_index])
+                            self.check_route_nexthop(dvs_route, asicdb, route, neighbors[0])
                         else:
                             self.check_route_nexthop(dvs_route, asicdb, route, neighbors[toggle_index])
 
@@ -602,6 +602,25 @@ class TestMuxTunnelBase():
                         else:
                             self.check_route_nexthop(dvs_route, asicdb, route, tunnel_nh_id, True)
                 self.del_route(dvs, route)
+
+            # Check route_updates
+            print("Testing route updates")
+            self.add_route(dvs, route, neighbors)
+            print("setting states to active")
+            for port in mux_ports:
+                self.set_mux_state(appdb, port, "active")
+            print("triggering another route update")
+            self.add_route(dvs, route, neighbors)
+            self.check_route_nexthop(dvs_route, asicdb, route, neighbors[0])
+
+            print("setting states to standby")
+            for port in mux_ports:
+                self.set_mux_state(appdb, port, "standby")
+            print("triggering another route update")
+            self.add_route(dvs, route, neighbors)
+            self.check_route_nexthop(dvs_route, asicdb, route, tunnel_nh_id, True)
+
+            self.del_route(dvs,route)
 
             for neighbor in neighbors:
                 self.del_neighbor(dvs, neighbor)


### PR DESCRIPTION
What I did:
- Removed logic that prevented routes from updating if an active nexthop was already found in updateRoute cache.
- added test to check for scenario where ecmp route update triggers after updateRoute programs route to point to single nh
- Added logs to some key paths in updateRoute logic to add visibility

Why I did it:
Bug in logic was causing routes getting updated multiple times to skip updateRoute logic

How I did it:
removing logic that checked cache for active nexthop

https://github.com/sonic-net/sonic-swss/pull/2952 