### PR TITLE
[orchagent]Modifying NPU_SI_SETTINGS_SYNC_STATUS based on NPU SI settings application status

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4066,6 +4066,15 @@ void PortsOrch::doPortTask(Consumer &consumer)
                             SWSS_LOG_NOTICE("Set port %s SI settings is successful", p.m_alias.c_str());
                             p.m_preemphasis = serdes_attr;
                             m_portList[p.m_alias] = p;
+
+                            string value;
+                            bool foundNPUSiSettingsSyncStatus = m_portTable->hget(p.m_alias, "NPU_SI_SETTINGS_SYNC_STATUS", value);
+                            if (foundNPUSiSettingsSyncStatus) {
+                                m_portTable->hset(p.m_alias, "NPU_SI_SETTINGS_SYNC_STATUS", "NPU_SI_SETTINGS_DONE");
+                                SWSS_LOG_NOTICE("NPU_SI_SETTINGS_SYNC_STATUS modified to NPU_SI_SETTINGS_DONE for port %s", p.m_alias.c_str());
+                            } else {
+                                SWSS_LOG_ERROR("Unable to find NPU_SI_SETTINGS_SYNC_STATUS for port %s", p.m_alias.c_str());
+                            }
                         }
                         else
                         {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add change to update NPU_SI_SETTINGS_SYNC_STATUS based on NPU SI settings application status.

**Why I did it**
The change set is part of implementation of the HLD https://github.com/sonic-net/SONiC/pull/1432

**How I verified it**
Please refer to https://github.com/sonic-net/sonic-platform-daemons/pull/403 for the test results.

**Details if related**
