### PR TITLE
[202305] Send hearbeat during warm reboot freese (#2923)

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -824,7 +824,7 @@ void OrchDaemon::start()
                     flush();
 
                     SWSS_LOG_WARN("Orchagent is frozen for warm restart!");
-                    sleep(UINT_MAX);
+                    freezeAndHeartBeat(UINT_MAX);
                 }
             }
         }
@@ -990,6 +990,19 @@ void OrchDaemon::heartBeat(std::chrono::time_point<std::chrono::high_resolution_
         m_lastHeartBeat = tcurrent;
         // output heart beat message to supervisord with 'PROCESS_COMMUNICATION_STDOUT' event: http://supervisord.org/events.html
         cout << "<!--XSUPERVISOR:BEGIN-->heartbeat<!--XSUPERVISOR:END-->" << endl;
+    }
+}
+
+void OrchDaemon::freezeAndHeartBeat(unsigned int duration)
+{
+    while (duration > 0)
+    {
+        // Send heartbeat message to prevent Orchagent stuck alert.
+        auto tend = std::chrono::high_resolution_clock::now();
+        heartBeat(tend);
+
+        duration--;
+        sleep(1);
     }
 }
 

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -96,6 +96,8 @@ private:
     void flush();
 
     void heartBeat(std::chrono::time_point<std::chrono::high_resolution_clock> tcurrent);
+
+    void freezeAndHeartBeat(unsigned int duration);
 };
 
 class FabricOrchDaemon : public OrchDaemon


### PR DESCRIPTION
Orchangent send heartbeat during warm-reboot to prevent Orchagent stuck alert.

#### Why I did it
Orchangent will freese during warm-reboot, then supervisor-proc-exit-listener will generate false alert during warm reboot:
https://github.com/sonic-net/sonic-buildimage/issues/16686

##### Work item tracking
- Microsoft ADO: 25295846

#### How I did it
Send heartbeat during warm-reboot freeze.

#### How to verify it
Pass all UT.
Manually verify issue fixed by check syslog.


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x]  SONiC.master-17060.400216-0d0a0dba4
- [x] SONiC.202305-17081.401641-ec2aed854

#### Description for the changelog
Orchangent send heartbeat during warm-reboot to prevent Orchagent stuck alert.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

