### PR TITLE
Run test orchagent coredump

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3956,10 +3956,17 @@ void PortsOrch::doVlanTask(Consumer &consumer)
             Port vlan;
             getPort(vlan_alias, vlan);
 
+            if (!getPort(vlan_alias, vlan))
+            {
+                SWSS_LOG_NOTICE("Failed to locate VLAN %s", vlan_alias.c_str());
+                it = consumer.m_toSync.erase(it);
+                continue;
+            }
+
             if (removeVlan(vlan))
                 it = consumer.m_toSync.erase(it);
             else
-                it++;
+                it = consumer.m_toSync.upper_bound(it->first);
         }
         else
         {


### PR DESCRIPTION
Cause:
    No check before removeVlan and No use upper_bound.
Solution:
    Check vlan existsing before removeVlan and use upper_bound.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
