### PR TITLE
orchagent would crash, when portsorch failed to remove bridge port

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4065,13 +4065,31 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
                 {
                     if (m_portVlanMember[port.m_alias].empty())
                     {
-                        removeBridgePort(port);
+                        if (!removeBridgePort(port))
+                        {
+                            SWSS_LOG_NOTICE("Failed to removeBridgePort %s",port.m_alias.c_str());
+                            it++;
+                            continue;
+                        }
                     }
                     it = consumer.m_toSync.erase(it);
                 }
                 else
                 {
                     it++;
+                }
+            }
+            else if (m_portVlanMember[port.m_alias].empty() && port.m_bridge_port_id != SAI_NULL_OBJECT_ID)
+            {
+                SWSS_LOG_WARN("Port %s was removed from vlan, but it is still as bridge port OID %" PRIx64 ", try to remove bridge port again", port.m_alias.c_str(), port.m_bridge_port_id);
+                if (!removeBridgePort(port))
+                {
+                    it++;
+                    continue;
+                }
+                else
+                {
+                    it = consumer.m_toSync.erase(it);
                 }
             }
             else
@@ -4990,11 +5008,15 @@ bool PortsOrch::removeBridgePort(Port &port)
     {
         SWSS_LOG_ERROR("Failed to remove bridge port %s from default 1Q bridge, rv:%d",
             port.m_alias.c_str(), status);
+#if 0
         task_process_status handle_status = handleSaiRemoveStatus(SAI_API_BRIDGE, status);
         if (handle_status != task_success)
         {
             return parseHandleSaiStatusFailure(handle_status);
         }
+#else
+        return false;
+#endif
     }
     saiOidToAlias.erase(port.m_bridge_port_id);
     port.m_bridge_port_id = SAI_NULL_OBJECT_ID;


### PR DESCRIPTION
    Root cause:
        Failed to remove bridge port becasue reference count is not 0

    Solution:
        1. put DEL task into m_toSync, when portsorch failed to remove bridge port
        2. if port was removed from vlan but m_bridge_port_id is not SAI_NULL_OBJECT_ID,
           portsorch will try to remove bridgeport again until reference count is 0

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
