### PR TITLE
[LUA_SCRIPT] trap_rates.lua get value error

### DIFF
--- a/orchagent/trap_rates.lua
+++ b/orchagent/trap_rates.lua
@@ -36,7 +36,8 @@ for i = 1, n do
     logit(initialized)
 
     -- Get new COUNTERS values
-    local in_pkts = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_COUNTER_STAT_PACKETS')
+    local in_pkts_str = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_COUNTER_STAT_PACKETS')
+    local in_pkts = tonumber(in_pkts_str) or 0
 
     if initialized == 'DONE' or initialized == 'COUNTERS_LAST' then
         -- Get old COUNTERS values


### PR DESCRIPTION
    Description:
        1. If the SAI_COUNTER_STAT_PACKETS field in the COUNTERS table in the counter db is 0, it will be calculated as a Boolean value by trap_rates.lua, resulting in a script operation error.

        2. Force in_pkts to be converted into a numerical value before operation

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
