### PR TITLE
Add application and orchdameon warm start default status

### DIFF
--- a/neighsyncd/neighsyncd.cpp
+++ b/neighsyncd/neighsyncd.cpp
@@ -61,6 +61,10 @@ int main(int argc, char **argv)
                 }
                 sync.getRestartAssist()->startReconcileTimer(s);
             }
+            else
+            {
+                sync.getRestartAssist()->warmStartDisabled();
+            }
 
             netlink.registerGroup(RTNLGRP_NEIGH);
             cout << "Listens to neigh messages..." << endl;

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -660,6 +660,10 @@ bool OrchDaemon::init()
             return false;
         }
     }
+    else
+    {
+        WarmStart::setWarmStartState("orchagent", WarmStart::WSDISABLED);
+    }
 
     return true;
 }

--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -41,6 +41,10 @@ TeamSync::TeamSync(DBConnector *db, DBConnector *stateDb, Select *select) :
         WarmStart::setWarmStartState(TEAMSYNCD_APP_NAME, WarmStart::INITIALIZED);
         SWSS_LOG_NOTICE("Starting in warmstart mode");
     }
+    else
+    {
+        WarmStart::setWarmStartState(TEAMSYNCD_APP_NAME, WarmStart::WSDISABLED);
+    }
 }
 
 void TeamSync::periodic()


### PR DESCRIPTION
    Description:
        1. When executing warm-reboot continuously, the orchagent cannot finish pre-warm task within 10 secs.
        2. And then, the orchagent will be frozen by "second" warm restart.
        3. In order to prevent the orchagent is frozen, add warm start default status.
        4. If executing warm-reboot, will check wart start status.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
