### PR TITLE
Use json.hpp from nlohmann-json-dev instead of from swss-common (#2900)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -68,6 +68,7 @@ jobs:
             autoconf-archive \
             uuid-dev \
             libjansson-dev \
+            nlohmann-json3-dev \
             python \
             stgit
 

--- a/cfgmgr/buffermgrd.cpp
+++ b/cfgmgr/buffermgrd.cpp
@@ -11,7 +11,7 @@
 #include <fstream>
 #include <iostream>
 #include "json.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "warm_restart.h"
 
 using namespace std;

--- a/cfgmgr/coppmgr.cpp
+++ b/cfgmgr/coppmgr.cpp
@@ -8,7 +8,7 @@
 #include "exec.h"
 #include "shellcmd.h"
 #include "warm_restart.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include <unordered_map>
 #include <unordered_set>
 

--- a/gearsyncd/gearparserbase.h
+++ b/gearsyncd/gearparserbase.h
@@ -25,7 +25,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
-#include "swss/json.hpp"
+#include <nlohmann/json.hpp>
 #pragma GCC diagnostic pop
 
 using json = nlohmann::json;

--- a/orchagent/p4orch/acl_rule_manager.cpp
+++ b/orchagent/p4orch/acl_rule_manager.cpp
@@ -9,7 +9,7 @@
 #include "crmorch.h"
 #include "dbconnector.h"
 #include "intfsorch.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "orch.h"
 #include "p4orch.h"

--- a/orchagent/p4orch/acl_table_manager.cpp
+++ b/orchagent/p4orch/acl_table_manager.cpp
@@ -7,7 +7,7 @@
 #include "SaiAttributeList.h"
 #include "crmorch.h"
 #include "dbconnector.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "orch.h"
 #include "p4orch.h"

--- a/orchagent/p4orch/acl_util.cpp
+++ b/orchagent/p4orch/acl_util.cpp
@@ -1,7 +1,7 @@
 #include "p4orch/acl_util.h"
 
 #include "converter.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "sai_serialize.h"
 #include "table.h"

--- a/orchagent/p4orch/acl_util.h
+++ b/orchagent/p4orch/acl_util.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "p4orch/p4orch_util.h"
 #include "return_code.h"
 extern "C"

--- a/orchagent/p4orch/ext_tables_manager.cpp
+++ b/orchagent/p4orch/ext_tables_manager.cpp
@@ -8,7 +8,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include "directory.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "tokenize.h"
 #include "orch.h"

--- a/orchagent/p4orch/ext_tables_manager.h
+++ b/orchagent/p4orch/ext_tables_manager.h
@@ -6,7 +6,7 @@
 #include <vector>
 
 #include "macaddress.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "orch.h"
 #include "p4orch/object_manager_interface.h"
 #include "p4orch/p4oidmapper.h"

--- a/orchagent/p4orch/gre_tunnel_manager.cpp
+++ b/orchagent/p4orch/gre_tunnel_manager.cpp
@@ -9,7 +9,7 @@
 #include "crmorch.h"
 #include "dbconnector.h"
 #include "ipaddress.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "p4orch/p4orch_util.h"
 #include "sai_serialize.h"

--- a/orchagent/p4orch/l3_admit_manager.cpp
+++ b/orchagent/p4orch/l3_admit_manager.cpp
@@ -7,7 +7,7 @@
 
 #include "SaiAttributeList.h"
 #include "dbconnector.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "p4orch/p4orch_util.h"
 #include "portsorch.h"

--- a/orchagent/p4orch/mirror_session_manager.cpp
+++ b/orchagent/p4orch/mirror_session_manager.cpp
@@ -4,7 +4,7 @@
 
 #include "SaiAttributeList.h"
 #include "dbconnector.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "p4orch/p4orch_util.h"
 #include "portsorch.h"
 #include "sai_serialize.h"

--- a/orchagent/p4orch/neighbor_manager.cpp
+++ b/orchagent/p4orch/neighbor_manager.cpp
@@ -7,7 +7,7 @@
 #include "SaiAttributeList.h"
 #include "crmorch.h"
 #include "dbconnector.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "orch.h"
 #include "p4orch/p4orch_util.h"

--- a/orchagent/p4orch/next_hop_manager.cpp
+++ b/orchagent/p4orch/next_hop_manager.cpp
@@ -8,7 +8,7 @@
 #include "crmorch.h"
 #include "dbconnector.h"
 #include "ipaddress.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "p4orch/p4orch.h"
 #include "p4orch/p4orch_util.h"

--- a/orchagent/p4orch/route_manager.cpp
+++ b/orchagent/p4orch/route_manager.cpp
@@ -11,7 +11,7 @@
 #include "converter.h"
 #include "crmorch.h"
 #include "dbconnector.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "p4orch/p4orch_util.h"
 #include "sai_serialize.h"

--- a/orchagent/p4orch/router_interface_manager.cpp
+++ b/orchagent/p4orch/router_interface_manager.cpp
@@ -10,7 +10,7 @@
 #include "SaiAttributeList.h"
 #include "dbconnector.h"
 #include "directory.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "orch.h"
 #include "p4orch/p4orch_util.h"

--- a/orchagent/p4orch/tables_definition_manager.cpp
+++ b/orchagent/p4orch/tables_definition_manager.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 #include "directory.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "tokenize.h"
 #include "orch.h"

--- a/orchagent/p4orch/tables_definition_manager.h
+++ b/orchagent/p4orch/tables_definition_manager.h
@@ -6,7 +6,7 @@
 #include <vector>
 
 #include "macaddress.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "orch.h"
 #include "p4orch/object_manager_interface.h"
 #include "p4orch/p4oidmapper.h"

--- a/orchagent/p4orch/tests/acl_manager_test.cpp
+++ b/orchagent/p4orch/tests/acl_manager_test.cpp
@@ -9,7 +9,7 @@
 #include "acl_table_manager.h"
 #include "acl_util.h"
 #include "acltable.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "mock_sai_acl.h"
 #include "mock_sai_hostif.h"
 #include "mock_sai_policer.h"

--- a/orchagent/p4orch/tests/gre_tunnel_manager_test.cpp
+++ b/orchagent/p4orch/tests/gre_tunnel_manager_test.cpp
@@ -8,7 +8,7 @@
 #include <unordered_map>
 
 #include "ipaddress.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "mock_response_publisher.h"
 #include "mock_sai_router_interface.h"
 #include "mock_sai_serialize.h"

--- a/orchagent/p4orch/tests/l3_admit_manager_test.cpp
+++ b/orchagent/p4orch/tests/l3_admit_manager_test.cpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <unordered_map>
 
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "mock_response_publisher.h"
 #include "mock_sai_my_mac.h"
 #include "p4oidmapper.h"

--- a/orchagent/p4orch/tests/mirror_session_manager_test.cpp
+++ b/orchagent/p4orch/tests/mirror_session_manager_test.cpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "mock_response_publisher.h"
 #include "mock_sai_mirror.h"
 #include "p4oidmapper.h"

--- a/orchagent/p4orch/tests/neighbor_manager_test.cpp
+++ b/orchagent/p4orch/tests/neighbor_manager_test.cpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <unordered_set>
 
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "mock_response_publisher.h"
 #include "mock_sai_neighbor.h"
 #include "p4orch.h"

--- a/orchagent/p4orch/tests/next_hop_manager_test.cpp
+++ b/orchagent/p4orch/tests/next_hop_manager_test.cpp
@@ -8,7 +8,7 @@
 #include <unordered_map>
 
 #include "ipaddress.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "mock_response_publisher.h"
 #include "mock_sai_hostif.h"
 #include "mock_sai_next_hop.h"

--- a/orchagent/p4orch/tests/route_manager_test.cpp
+++ b/orchagent/p4orch/tests/route_manager_test.cpp
@@ -9,7 +9,7 @@
 #include <vector>
 
 #include "ipprefix.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "mock_response_publisher.h"
 #include "mock_sai_route.h"
 #include "p4orch.h"

--- a/orchagent/p4orch/tests/wcmp_manager_test.cpp
+++ b/orchagent/p4orch/tests/wcmp_manager_test.cpp
@@ -5,7 +5,7 @@
 
 #include <string>
 
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "mock_response_publisher.h"
 #include "mock_sai_acl.h"
 #include "mock_sai_hostif.h"

--- a/orchagent/p4orch/wcmp_manager.cpp
+++ b/orchagent/p4orch/wcmp_manager.cpp
@@ -7,7 +7,7 @@
 #include "SaiAttributeList.h"
 #include "crmorch.h"
 #include "dbconnector.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "p4orch/p4orch_util.h"
 #include "portsorch.h"

--- a/swssconfig/swssconfig.cpp
+++ b/swssconfig/swssconfig.cpp
@@ -9,7 +9,7 @@
 #include "logger.h"
 #include "dbconnector.h"
 #include "producerstatetable.h"
-#include "json.hpp"
+#include <nlohmann/json.hpp>
 
 using namespace std;
 using namespace swss;


### PR DESCRIPTION
* Use json.hpp from nlohmann-json-dev instead of from swss-common

This header file comes from an external package, and a very old version of the header file has been checked into swss-common. This will cause problems for the upcoming Bookworm upgrade.

Change references to the header file to use the Debian package nlohmann-json-dev, instead of from swss-common.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
