### PR TITLE
[routeorch] Fixing bug with multiple routes pointing to nhg

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -2497,20 +2497,21 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
             {
                 SWSS_LOG_NOTICE("Remove Nexthop Group %s", ol_nextHops.to_string().c_str());
                 m_bulkNhgReducedRefCnt.emplace(it_route->second.nhg_key, 0);
-                if (mux_orch->isMuxNexthops(ol_nextHops))
+            }
+            if (mux_orch->isMuxNexthops(ol_nextHops))
+            {
+                SWSS_LOG_NOTICE("Remove mux Nexthop %s", ol_nextHops.to_string().c_str());
+                RouteKey routekey = { vrf_id, ipPrefix };
+                auto nexthop_list = ol_nextHops.getNextHops();
+                for (auto nh = nexthop_list.begin(); nh != nexthop_list.end(); nh++)
                 {
-                    SWSS_LOG_NOTICE("Remove mux Nexthop %s", ol_nextHops.to_string().c_str());
-                    RouteKey routekey = { vrf_id, ipPrefix };
-                    auto nexthop_list = ol_nextHops.getNextHops();
-                    for (auto nh = nexthop_list.begin(); nh != nexthop_list.end(); nh++)
+                    if (!nh->ip_address.isZero())
                     {
-                        if (!nh->ip_address.isZero())
-                        {
-                            removeNextHopRoute(*nh, routekey);
-                        }
+                        SWSS_LOG_NOTICE("removeNextHopRoute");
+                        removeNextHopRoute(*nh, routekey);
                     }
-                    mux_orch->updateRoute(ipPrefix, false);
                 }
+                mux_orch->updateRoute(ipPrefix, false);
             }
         }
         else if (ol_nextHops.is_overlay_nexthop())


### PR DESCRIPTION
**What I did**

- Fixed a bug where multiple routes pointing to the same nhg would not remove the route from m_nextHops cache in routeorch

- Refactored multi_mux_nexthops tests and added new test cases

**Why I did it**

Caught the bug while refactoring, this will cause issues with switchover if one of the routes is removed

**How I verified it**

Ran refactored tests on local vstest setup, and all test cases passed

