### PR TITLE
[routesync] Stale neighbor fix (PR #2553) review comment fix

### DIFF
--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -782,7 +782,7 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
             // In this case since we do not want the route with next hop on eth0/docker0, we return. 
             // But still we need to clear the route from the APPL_DB. Otherwise the APPL_DB and data 
             // path will be left with stale route entry
-            if(alsv.size() == 1)
+            if((nlmsg_type == RTM_DELROUTE) && (alsv.size() == 1))
             {
                 if (!warmRestartInProgress)
                 {


### PR DESCRIPTION

**What I did**

Fixed a review comment for the commits made in PR #2553 

**Why I did it**

The original fix in PR #2553 deleted stale neighbor from APPL_DB and ASIC_DB even for new route (if the route has only one next hop on interface eth0 or docker0). This is incorrect. The stale neighbor should be cleared only for the route delete command. There was review comment identifying this requirement. To address the review comment, changes are done to stale neighbor fix PR #2553. Changes include adding check to delete the stale neighbor from ASIC_DB and APPL_DB only if the kernel command is RTM_DELROUTE

**How I verified it**

vs test

**Details if related**

PR #2553 