### PR TITLE
[RouteOrch] Publish route state for route to Loopback interface

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -751,6 +751,9 @@ void RouteOrch::doTask(Consumer& consumer)
                             it = consumer.m_toSync.erase(it);
                         else
                             it++;
+
+                        /* Publish route state to advertise routes to Loopback interface */
+                        publishRouteState(ctx);
                         continue;
                     }
 
@@ -2548,7 +2551,7 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
 
     SWSS_LOG_INFO("Remove route %s with next hop(s) %s",
             ipPrefix.to_string().c_str(), it_route->second.nhg_key.to_string().c_str());
-    
+
     /* Publish removal status, removes route entry from APPL STATE DB */
     publishRouteState(ctx);
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Publish exception route state to APPL_STATE_DB.

**Why I did it**

Fixes https://github.com/sonic-net/sonic-buildimage/issues/17638

Route to loopback interface is not advertised to peers when FIB suppression is enabled.


The proper way would be to program route to HW and then publish the route state, however to keep the existing behaviour this W/A is proposed until a final solution.


**How I verified it**


Route is queued:
```
admin@sonic:~$ show ipv6 route |grep q
       > - selected route, * - FIB route, q - queued route, r - rejected route
S>qfc00:1::/64 [1/0] is directly connected, Loopback0, 00:02:00
```

With this change:
```
admin@sonic:~$ show ipv6 route | grep q
       > - selected route, * - FIB route, q - queued route, r - rejected route
```

**Details if related**
