### PR TITLE
Fix memory leak and object copying bugs in orchagent

### DIFF
--- a/orchagent/fabricportsorch.cpp
+++ b/orchagent/fabricportsorch.cpp
@@ -269,8 +269,8 @@ void FabricPortsOrch::updateFabricPortState()
 
         string key = FABRIC_PORT_PREFIX + to_string(lane);
         std::vector<FieldValueTuple> values;
-        uint32_t remote_peer;
-        uint32_t remote_port;
+        uint32_t remote_peer = 0;
+        uint32_t remote_port = 0;
 
         attr.id = SAI_PORT_ATTR_FABRIC_ATTACHED;
         status = sai_port_api->get_port_attribute(port, 1, &attr);

--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -42,8 +42,8 @@ FdbOrch::FdbOrch(DBConnector* applDbConnector, vector<table_name_with_pri_t> app
     Orch::addExecutor(flushNotifier);
 
     /* Add FDB notifications support from ASIC */
-    DBConnector *notificationsDb = new DBConnector("ASIC_DB", 0);
-    m_fdbNotificationConsumer = new swss::NotificationConsumer(notificationsDb, "NOTIFICATIONS");
+    m_notificationsDb = shared_ptr<DBConnector>(new DBConnector("ASIC_DB", 0));
+    m_fdbNotificationConsumer = new swss::NotificationConsumer(m_notificationsDb.get(), "NOTIFICATIONS");
     auto fdbNotifier = new Notifier(m_fdbNotificationConsumer, this, "FDB_NOTIFICATIONS");
     Orch::addExecutor(fdbNotifier);
 }

--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -42,7 +42,7 @@ FdbOrch::FdbOrch(DBConnector* applDbConnector, vector<table_name_with_pri_t> app
     Orch::addExecutor(flushNotifier);
 
     /* Add FDB notifications support from ASIC */
-    m_notificationsDb = shared_ptr<DBConnector>(new DBConnector("ASIC_DB", 0));
+    m_notificationsDb = make_shared<DBConnector>("ASIC_DB", 0);
     m_fdbNotificationConsumer = new swss::NotificationConsumer(m_notificationsDb.get(), "NOTIFICATIONS");
     auto fdbNotifier = new Notifier(m_fdbNotificationConsumer, this, "FDB_NOTIFICATIONS");
     Orch::addExecutor(fdbNotifier);

--- a/orchagent/fdborch.h
+++ b/orchagent/fdborch.h
@@ -113,6 +113,7 @@ private:
     Table m_mclagFdbStateTable;
     NotificationConsumer* m_flushNotificationsConsumer;
     NotificationConsumer* m_fdbNotificationConsumer;
+    shared_ptr<DBConnector> m_notificationsDb;
 
     void doTask(Consumer& consumer);
     void doTask(NotificationConsumer& consumer);

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -329,7 +329,7 @@ bool MirrorOrch::validateSrcPortList(const string& srcPortList)
                 vector<Port> portv;
                 int portCount = 0;
                 m_portsOrch->getLagMember(port, portv);
-                for (const auto p : portv)
+                for (const auto &p : portv)
                 {
                     if (checkPortExistsInSrcPortList(p.m_alias, srcPortList))
                     {
@@ -828,7 +828,7 @@ bool MirrorOrch::setUnsetPortMirror(Port port,
     {
         vector<Port> portv;
         m_portsOrch->getLagMember(port, portv);
-        for (const auto p : portv)
+        for (const auto &p : portv)
         {
             if (p.m_type != Port::PHY)
             {

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -628,7 +628,7 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
     }
 
     /* Add port oper status notification support */
-    m_notificationsDb = shared_ptr<DBConnector>(new DBConnector("ASIC_DB", 0));
+    m_notificationsDb = make_shared<DBConnector>("ASIC_DB", 0);
     m_portStatusNotificationConsumer = new swss::NotificationConsumer(m_notificationsDb.get(), "NOTIFICATIONS");
     auto portStatusNotificatier = new Notifier(m_portStatusNotificationConsumer, this, "PORT_STATUS_NOTIFICATIONS");
     Orch::addExecutor(portStatusNotificatier);

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -628,14 +628,14 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
     }
 
     /* Add port oper status notification support */
-    DBConnector *notificationsDb = new DBConnector("ASIC_DB", 0);
-    m_portStatusNotificationConsumer = new swss::NotificationConsumer(notificationsDb, "NOTIFICATIONS");
+    m_notificationsDb = shared_ptr<DBConnector>(new DBConnector("ASIC_DB", 0));
+    m_portStatusNotificationConsumer = new swss::NotificationConsumer(m_notificationsDb.get(), "NOTIFICATIONS");
     auto portStatusNotificatier = new Notifier(m_portStatusNotificationConsumer, this, "PORT_STATUS_NOTIFICATIONS");
     Orch::addExecutor(portStatusNotificatier);
 
     if (m_cmisModuleAsicSyncSupported)
     {
-        m_portHostTxReadyNotificationConsumer = new swss::NotificationConsumer(notificationsDb, "NOTIFICATIONS");
+        m_portHostTxReadyNotificationConsumer = new swss::NotificationConsumer(m_notificationsDb.get(), "NOTIFICATIONS");
         auto portHostTxReadyNotificatier = new Notifier(m_portHostTxReadyNotificationConsumer, this, "PORT_HOST_TX_NOTIFICATIONS");
         Orch::addExecutor(portHostTxReadyNotificatier);
     }
@@ -2335,7 +2335,7 @@ bool PortsOrch::setHostIntfsStripTag(Port &port, sai_hostif_vlan_tag_t strip)
         return false;
     }
 
-    for (const auto p: portv)
+    for (const auto &p: portv)
     {
         sai_attribute_t attr;
         attr.id = SAI_HOSTIF_ATTR_VLAN_TAG;

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -263,6 +263,7 @@ private:
     shared_ptr<DBConnector> m_counter_db;
     shared_ptr<DBConnector> m_flex_db;
     shared_ptr<DBConnector> m_state_db;
+    shared_ptr<DBConnector> m_notificationsDb;
 
     FlexCounterManager port_stat_manager;
     FlexCounterManager port_buffer_drop_stat_manager;

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -459,6 +459,8 @@ namespace aclorch_test
             gMirrorOrch = nullptr;
             delete gRouteOrch;
             gRouteOrch = nullptr;
+            delete gFlowCounterRouteOrch;
+            gFlowCounterRouteOrch = nullptr;
             delete gSrv6Orch;
             gSrv6Orch = nullptr;
             delete gNeighOrch;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

When compiled with GCC 12, there are two types of compiler errors that get revealed. The first is GCC saying that in a for-loop, if the variable used for the objects is const, then a reference to the original object in the list can be used, instead of making a copy. The second is that two variables could potentially be used uninitialized. This appears to be a false positive to me, but I assigned it to 0 regardless.

There are, however, issues seen when running the tests. In a Bookworm-based container, the CoppMgrTest.CoppTest test case failed when run as part of the full test suite. However, when run individually, it passes. The error message is the following:

```
[ RUN      ] CoppMgrTest.CoppTest
mkdir: cannot create directory '/etc/sonic/': File exists
copp_ut.cpp:16: Failure
Expected equality of these values:
  status
    Which is: 256
  0
sudo: pam_open_session: Too many open files
sudo: policy plugin failed session initialization
copp_ut.cpp:28: Failure
Expected equality of these values:
  status
    Which is: 256
  0
[  FAILED  ] CoppMgrTest.CoppTest (15 ms)
```

Looking further, by the end of the test, there are a bunch of unconnected unix sockets opened, more than 1000 sockets. I suspect sudo (specifically, the `pam_open_session` module) is complaining that there are too many open files.

Looking into the test cases and the code, `FdbOrch` is creating a new `DBConnector` object, but it doesn't look like anything cleans this up if `FdbOrch` is destroyed.

Additionally, in the `AclOrch` test suite, nothing is deleting the `gFlowCounterRouteOrch` object. I've added a delete call for this.

There are still a bunch of file descriptors being created, suggesting there's still a leak somewhere, but now at least the full tests (when run in this order) are passing.

**Why I did it**

This is needed to create the docker-swss-layer-bookworm layer in sonic-buildimage, to allow for containers to upgrade to Bookworm.

This also fixes the potential for a runtime memory leak.

**How I verified it**

**Details if related**
