### PR TITLE
[Build] Support to collect the test coverage in cobertura format

### DIFF
--- a/.artifactignore
+++ b/.artifactignore
@@ -1,2 +1,5 @@
 **/*
 !*.deb
+!coverage.info
+!coverage.xml
+!build.info

--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -141,12 +141,17 @@ jobs:
 
       find $(Build.ArtifactStagingDirectory)/download/sairedis -name '*.deb' -exec cp "{}" .azure-pipelines/docker-sonic-vs/debs \;
       cp -v $(Build.ArtifactStagingDirectory)/download/*.deb .azure-pipelines/docker-sonic-vs/debs
+      if [ -f $(Build.ArtifactStagingDirectory)/download/coverage.info ]; then
+        cp -v $(Build.ArtifactStagingDirectory)/download/coverage.info $(Build.ArtifactStagingDirectory)/
+        cp -v $(Build.ArtifactStagingDirectory)/download/coverage.xml $(Build.ArtifactStagingDirectory)/
+      fi
 
       pushd .azure-pipelines
 
-      build_args=""
+      build_dir=$(grep BUILD_DIR $(Build.ArtifactStagingDirectory)/download/build.info | cut -d= -f2)
+      build_args="--build-arg build_dir=$build_dir"
       if [ '${{ parameters.asan }}' == True ]; then
-        build_args="--build-arg need_dbg=y"
+        build_args="$build_args --build-arg need_dbg=y"
       fi
 
       docker build $build_args --no-cache -t docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber).asan-${{ parameters.asan }} docker-sonic-vs

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -200,7 +200,6 @@ jobs:
          export ENABLE_ASAN=y
       fi
       ./autogen.sh
-      #export DEB_BUILD_OPTIONS="debug nostrip noopt"
       dpkg-buildpackage -us -uc -b -j$(nproc) && cp ../*.deb .
     displayName: "Compile sonic swss"
   - publish: $(System.DefaultWorkingDirectory)/

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -105,6 +105,7 @@ jobs:
         swig4.0 \
         libdbus-1-dev \
         libteam-dev
+      sudo pip3 install lcov_cobertura
     displayName: "Install dependencies"
   - task: DownloadPipelineArtifact@2
     inputs:
@@ -193,11 +194,13 @@ jobs:
       cp -r pytest.tgz $(Build.ArtifactStagingDirectory)/
       if [ '${{ parameters.archive_gcov }}' == True ]; then
          export ENABLE_GCOV=y
+         echo BUILD_DIR=$(pwd) > build.info
       fi
       if [ '${{ parameters.asan }}' == True ]; then
          export ENABLE_ASAN=y
       fi
       ./autogen.sh
+      #export DEB_BUILD_OPTIONS="debug nostrip noopt"
       dpkg-buildpackage -us -uc -b -j$(nproc) && cp ../*.deb .
     displayName: "Compile sonic swss"
   - publish: $(System.DefaultWorkingDirectory)/

--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -2,6 +2,8 @@ FROM docker-sonic-vs
 
 ARG docker_container_name
 ARG need_dbg
+ARG build_dir
+ENV BUILD_DIR=$build_dir
 
 COPY ["debs", "/debs"]
 
@@ -24,4 +26,12 @@ RUN if [ "$need_dbg" = "y" ] ; then dpkg -i /debs/swss-dbg_1.0.0_amd64.deb ; fi
 
 RUN apt-get update
 
-RUN apt-get -y install lcov
+RUN apt-get -y install software-properties-common libdatetime-perl libcapture-tiny-perl build-essential libcpanel-json-xs-perl git
+
+RUN git clone -b v2.0 --single-branch --depth 1 https://github.com/linux-test-project/lcov && cd lcov && make install
+
+RUN lcov --version
+
+RUN pip3 install lcov_cobertura
+
+RUN if [ -n "$BUILD_DIR" ]; then mkdir -p $BUILD_DIR && tar -xf /tmp/gcov/gcov-source.tar -C $BUILD_DIR; fi

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -44,11 +44,16 @@ jobs:
 - job:
   displayName: vstest
   timeoutInMinutes: ${{ parameters.timeout }}
+  ${{ if parameters.archive_gcov }}:
+    variables:
+      DIFF_COVER_CHECK_THRESHOLD: 80
+      DIFF_COVER_ENABLE: 'true'
 
-  pool: sonic-common
+  pool: sonic-common-test
 
   steps:
   - script: |
+      ip a show dev eth0 || true
       ls -A1 | xargs -I{} sudo rm -rf {}
     displayName: "Clean workspace"
   - checkout: self
@@ -79,6 +84,16 @@ jobs:
     displayName: "Download sonic buildimage ubuntu20.04 deb packages"
 
   - script: |
+        set -ex
+        # Install .NET CORE
+        curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+        sudo apt-add-repository https://packages.microsoft.com/ubuntu/20.04/prod
+        sudo apt-get update
+        sudo apt-get install -y dotnet-sdk-7.0
+        sudo dotnet tool install dotnet-reportgenerator-globaltool  --tool-path /usr/bin
+    displayName: "Install .NET CORE"
+
+  - script: |
       set -ex
       sudo .azure-pipelines/build_and_install_module.sh
 
@@ -92,6 +107,7 @@ jobs:
       sudo apt-get install -y net-tools bridge-utils vlan
       sudo apt-get install -y python3-pip
       sudo pip3 install pytest==4.6.2 attrs==19.1.0 exabgp==4.0.10 distro==1.5.0 docker>=4.4.1 redis==3.3.4 flaky==3.7.0
+      sudo pip3 install lcov_cobertura
     displayName: "Install dependencies"
 
   - script: |
@@ -106,7 +122,9 @@ jobs:
 
       params=""
       if [ '${{ parameters.archive_gcov }}' == True ]; then
-        params=" ${params} --keeptb "
+        cp $(Build.ArtifactStagingDirectory)/download/coverage.info ./
+        cp $(Build.ArtifactStagingDirectory)/download/coverage.xml ./
+        params=" ${params} --enable-coverage --force-recreate-dvs "
       fi
       if [ '${{ parameters.asan }}' == True ]; then
         params=" ${params} --graceful-stop "
@@ -115,43 +133,36 @@ jobs:
         params=" ${params} --num-ports=${{ parameters.num_ports }} "
       fi
 
-      all_tests=$(ls test_*.py)
+      all_tests=$(ls test_*.py | xargs)
       all_tests="${all_tests} p4rt"
 
       if [ -n '${{ parameters.run_tests_pattern }}' ]; then
-        all_tests=" $(ls ${{ parameters.run_tests_pattern }}) "
+        all_tests=" $(ls ${{ parameters.run_tests_pattern }} | xargs) "
       fi
-
-      test_set=()
-      # Run 20 tests as a set.
-      for test in ${all_tests}; do
-        test_set+=("${test}")
-        if [ ${#test_set[@]} -ge 20 ]; then
-          test_name=$(echo "${test_set[0]}" | cut -d "." -f 1)
-          echo "${test_set[*]}" | xargs sudo py.test -v --force-flaky --junitxml="${test_name}_tr.xml" $params --imgname=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber).asan-${{ parameters.asan }}
-          container_count=$(docker ps -q -a | wc -l)
-          if [ '${{ parameters.archive_gcov }}' == True ] && [ ${container_count} -gt 0 ]; then
-            ./gcov_support.sh set_environment $(Build.ArtifactStagingDirectory)
-            docker stop $(docker ps -q -a)
-            docker rm $(docker ps -q -a)
-          fi
-          test_set=()
-        fi
-      done
-      if [ ${#test_set[@]} -gt 0 ]; then
-        test_name=$(echo "${test_set[0]}" | cut -d "." -f 1)
-        echo "${test_set[*]}" | xargs sudo py.test -v $params --force-flaky --junitxml="${test_name}_tr.xml" $params --imgname=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber).asan-${{ parameters.asan }}
-        container_count=$(docker ps -q -a | wc -l)
-        if [ '${{ parameters.archive_gcov }}' == True ] && [ ${container_count} -gt 0 ]; then
-          ./gcov_support.sh set_environment $(Build.ArtifactStagingDirectory)
-          docker stop $(docker ps -q -a)
-          docker rm $(docker ps -q -a)
-        fi
-      fi
+      # Run the tests in parallel and retry
+      retry=3
+      IMAGE_NAME=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber).asan-${{ parameters.asan }}
+      echo $all_tests | xargs -n 1 | xargs -P 8 -I TEST_MODULE sudo ./run-tests.py "$IMAGE_NAME" "$params" "TEST_MODULE" 3
 
       rm -rf $(Build.ArtifactStagingDirectory)/download
     displayName: "Run vs tests"
     continueOnError: ${{ parameters.asan }}
+
+  - script: |
+      set -ex
+      reportgenerator -reporttypes:Cobertura -reports:tests/*coverage.xml -targetdir:.
+      mkdir $(Build.ArtifactStagingDirectory)/gcov
+      cp Cobertura.xml tests/*coverage.xml $(Build.ArtifactStagingDirectory)/gcov/
+      cp tests/*coverage.info $(Build.ArtifactStagingDirectory)/gcov/
+    condition: ${{ parameters.archive_gcov }}
+    displayName: "Generate coverage.xml"
+
+  - task: PublishCodeCoverageResults@1
+    condition: ${{ parameters.archive_gcov }}
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: '$(System.DefaultWorkingDirectory)/Cobertura.xml'
+    displayName: 'Publish test coverage'
 
   - task: PublishTestResults@2
     inputs:
@@ -165,20 +176,8 @@ jobs:
       if [ '${{ parameters.asan }}' == True ]; then
         cp -vr tests/log/*/log/asan $(Build.ArtifactStagingDirectory)/
       fi
-
-      if [ '${{ parameters.archive_gcov }}' == True ]; then
-        sudo apt-get install -y lcov
-        cd $(Build.ArtifactStagingDirectory)/gcov_tmp/
-        tar -zcvf sonic-gcov.tar.gz sonic-gcov/
-        rm -rf sonic-gcov
-      fi
     displayName: "Collect logs"
     condition: always()
-
-  - publish: $(Build.ArtifactStagingDirectory)/gcov_tmp
-    artifact: ${{ parameters.gcov_artifact_name }}
-    displayName: "Publish gcov output"
-    condition: and(succeeded(), eq('${{ parameters.archive_gcov }}', true))
 
   - publish: $(Build.ArtifactStagingDirectory)/
     artifact: ${{ parameters.log_artifact_name }}@$(System.JobAttempt)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,6 +41,7 @@ stages:
   - template: .azure-pipelines/build-template.yml
     parameters:
       arch: amd64
+      pool: sonicbld
       sonic_slave: sonic-slave-bullseye
       common_lib_artifact_name: common-lib
       swss_common_artifact_name: sonic-swss-common
@@ -55,6 +56,7 @@ stages:
   - template: .azure-pipelines/build-template.yml
     parameters:
       arch: amd64
+      pool: sonicbld
       sonic_slave: sonic-slave-bullseye
       common_lib_artifact_name: common-lib
       swss_common_artifact_name: sonic-swss-common
@@ -137,8 +139,8 @@ stages:
       asan: true
 
 - stage: Gcov
+  condition: false
   dependsOn: Test
-  condition: in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues')
   jobs:
   - template: .azure-pipelines/gcov.yml
     parameters:

--- a/cfgmgr/Makefile.am
+++ b/cfgmgr/Makefile.am
@@ -102,20 +102,20 @@ macsecmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(
 macsecmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 if GCOV_ENABLED
-vlanmgrd_LDADD += -lgcovpreload
-teammgrd_LDADD += -lgcovpreload
-portmgrd_LDADD += -lgcovpreload
-intfmgrd_LDADD+= -lgcovpreload
-buffermgrd_LDADD += -lgcovpreload
-vrfmgrd_LDADD += -lgcovpreload
-nbrmgrd_LDADD += -lgcovpreload
-vxlanmgrd_LDADD += -lgcovpreload
-sflowmgrd_LDADD += -lgcovpreload
-natmgrd_LDADD += -lgcovpreload
-coppmgrd_LDADD += -lgcovpreload
-tunnelmgrd_LDADD += -lgcovpreload
-macsecmgrd_LDADD += -lgcovpreload
-fabricmgrd_LDADD += -lgcovpreload
+vlanmgrd_SOURCES += ../gcovpreload/gcovpreload.cpp
+teammgrd_SOURCES += ../gcovpreload/gcovpreload.cpp
+portmgrd_SOURCES += ../gcovpreload/gcovpreload.cpp
+fabricmgrd_SOURCES += ../gcovpreload/gcovpreload.cpp
+intfmgrd_SOURCES += ../gcovpreload/gcovpreload.cpp
+buffermgrd_SOURCES += ../gcovpreload/gcovpreload.cpp
+vrfmgrd_SOURCES += ../gcovpreload/gcovpreload.cpp
+nbrmgrd_SOURCES += ../gcovpreload/gcovpreload.cpp
+vxlanmgrd_SOURCES +=  ../gcovpreload/gcovpreload.cpp
+sflowmgrd_SOURCES +=  ../gcovpreload/gcovpreload.cpp
+natmgrd_SOURCES += ../gcovpreload/gcovpreload.cpp
+coppmgrd_SOURCES += ../gcovpreload/gcovpreload.cpp
+tunnelmgrd_SOURCES += ../gcovpreload/gcovpreload.cpp
+macsecmgrd_SOURCES += ../gcovpreload/gcovpreload.cpp
 endif
 
 if ASAN_ENABLED

--- a/debian/rules
+++ b/debian/rules
@@ -33,7 +33,7 @@ ifeq ($(ENABLE_ASAN), y)
 endif
 
 ifeq ($(ENABLE_GCOV), y)
-	configure_opts += --enable-gcov CFLAGS="-g -O0" CXXFLAGS="-g -O0"
+	configure_opts += --enable-gcov --enable-code-coverage CFLAGS="-g -O0" CXXFLAGS="-g -O0"
 endif
 
 override_dh_auto_configure:
@@ -43,9 +43,10 @@ override_dh_auto_install:
 	dh_auto_install --destdir=debian/swss
 ifeq ($(ENABLE_GCOV), y)
 	mkdir -p debian/swss/tmp/gcov
-	sh ./tests/gcov_support.sh collect swss
+	lcov -c --directory . --no-external --exclude "$(shell pwd)/tests/*" --exclude "$(shell pwd)/**/tests/*" --output-file coverage.info
+	lcov_cobertura coverage.info -o coverage.xml
+	find ./ -type f -regex '.*\.\(h\|cpp\|gcno\|info\)' | tar -cf debian/swss/tmp/gcov/gcov-source.tar -T -
 endif
 
 override_dh_strip:
 	dh_strip --dbg-package=swss-dbg
-

--- a/fdbsyncd/Makefile.am
+++ b/fdbsyncd/Makefile.am
@@ -15,7 +15,7 @@ fdbsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(COV_CFLAGS) $(CF
 fdbsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon $(COV_LDFLAGS)
 
 if GCOV_ENABLED
-fdbsyncd_LDADD += -lgcovpreload
+fdbsyncd_SOURCES += ../gcovpreload/gcovpreload.cpp
 endif
 
 if ASAN_ENABLED

--- a/fpmsyncd/Makefile.am
+++ b/fpmsyncd/Makefile.am
@@ -15,7 +15,7 @@ fpmsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
 fpmsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon
 
 if GCOV_ENABLED
-fpmsyncd_LDADD += -lgcovpreload
+fpmsyncd_SOURCES += ../gcovpreload/gcovpreload.cpp
 endif
 
 if ASAN_ENABLED

--- a/gcovpreload/Makefile
+++ b/gcovpreload/Makefile
@@ -6,7 +6,7 @@ CXX:=$(shell sh -c 'type $${CXX%% *} >/dev/null 2>/dev/null && echo $(CXX) || ec
 
 DYLIBSUFFIX=so
 DYLIBNAME=$(LIBNAME).$(DYLIBSUFFIX)
-DYLIB_MAKE_CMD=$(CC) -shared -fpic gcovpreload.c -o ${DYLIBNAME}
+DYLIB_MAKE_CMD=$(CC) -shared -fpic gcovpreload.cpp -o ${DYLIBNAME}
 
 all:
 	$(DYLIB_MAKE_CMD)

--- a/gcovpreload/gcovpreload.cpp
+++ b/gcovpreload/gcovpreload.cpp
@@ -2,15 +2,15 @@
 #include <stdlib.h>
 #include <signal.h>
 #include <signal.h>
-#define SIMPLE_WAY
+
+extern "C" void __gcov_dump();
 
 void sighandler(int signo)
 {
 #ifdef SIMPLE_WAY
     exit(signo);
 #else
-    extern void __gcov_flush();
-    __gcov_flush(); /* flush out gcov stats data */
+    __gcov_dump();
     raise(signo); /* raise the signal again to crash process */
 #endif
 }
@@ -33,9 +33,9 @@ void ctor()
     struct sigaction sa;
     sa.sa_handler = sighandler;
     sigemptyset(&sa.sa_mask);
-    sa.sa_flags = SA_RESETHAND;
+    sa.sa_flags = (int)SA_RESETHAND;
 
-    for(i = 0; i < sizeof(sigs)/sizeof(sigs[0]); ++i) {
+    for(i = 0; i < (int)(sizeof(sigs)/sizeof(sigs[0])); ++i) {
         if (sigaction(sigs[i], &sa, NULL) == -1) {
             perror("Could not set signal handler");
         }

--- a/mclagsyncd/Makefile.am
+++ b/mclagsyncd/Makefile.am
@@ -15,7 +15,7 @@ mclagsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
 mclagsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon
 
 if GCOV_ENABLED
-mclagsyncd_LDADD += -lgcovpreload
+mclagsyncd_SOURCES += ../gcovpreload/gcovpreload.cpp
 endif
 
 if ASAN_ENABLED

--- a/natsyncd/Makefile.am
+++ b/natsyncd/Makefile.am
@@ -15,7 +15,7 @@ natsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
 natsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lnl-nf-3 -lswsscommon
 
 if GCOV_ENABLED
-natsyncd_LDADD += -lgcovpreload
+natsyncd_SOURCES += ../gcovpreload/gcovpreload.cpp
 endif
 
 if ASAN_ENABLED

--- a/neighsyncd/Makefile.am
+++ b/neighsyncd/Makefile.am
@@ -15,7 +15,7 @@ neighsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
 neighsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon
 
 if GCOV_ENABLED
-neighsyncd_LDADD += -lgcovpreload
+neighsyncd_SOURCES += ../gcovpreload/gcovpreload.cpp
 endif
 
 if ASAN_ENABLED

--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -148,9 +148,9 @@ orchagent_restart_check_CPPFLAGS = $(DBGFLAGS) $(AM_CPPFLAGS) $(CFLAGS_COMMON) $
 orchagent_restart_check_LDADD = $(LDFLAGS_ASAN) -lhiredis -lswsscommon -lpthread
 
 if GCOV_ENABLED
-orchagent_LDADD += -lgcovpreload
-routeresync_LDADD += -lgcovpreload
-orchagent_restart_check_LDADD += -lgcovpreload
+orchagent_SOURCES += ../gcovpreload/gcovpreload.cpp
+routeresync_SOURCES += ../gcovpreload/gcovpreload.cpp
+orchagent_restart_check_SOURCES += ../gcovpreload/gcovpreload.cpp
 endif
 
 if ASAN_ENABLED

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -226,7 +226,7 @@ bool NeighOrch::addNextHop(const NextHopKey &nh)
         nexthop.alias = inbp.m_alias;
     }
 
-    assert(!hasNextHop(nexthop));
+    // assert(!hasNextHop(nexthop));
     sai_object_id_t rif_id = m_intfsOrch->getRouterIntfsId(nh.alias);
 
     vector<sai_attribute_t> next_hop_attrs;
@@ -654,7 +654,7 @@ int NeighOrch::getNextHopRefCount(const NextHopKey &nexthop)
 
 void NeighOrch::increaseNextHopRefCount(const NextHopKey &nexthop, uint32_t count)
 {
-    assert(hasNextHop(nexthop));
+    // assert(hasNextHop(nexthop));
     if (m_syncdNextHops.find(nexthop) != m_syncdNextHops.end())
     {
         m_syncdNextHops[nexthop].ref_count += count;

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -226,7 +226,7 @@ bool NeighOrch::addNextHop(const NextHopKey &nh)
         nexthop.alias = inbp.m_alias;
     }
 
-    // assert(!hasNextHop(nexthop));
+    assert(!hasNextHop(nexthop));
     sai_object_id_t rif_id = m_intfsOrch->getRouterIntfsId(nh.alias);
 
     vector<sai_attribute_t> next_hop_attrs;
@@ -654,7 +654,7 @@ int NeighOrch::getNextHopRefCount(const NextHopKey &nexthop)
 
 void NeighOrch::increaseNextHopRefCount(const NextHopKey &nexthop, uint32_t count)
 {
-    // assert(hasNextHop(nexthop));
+    assert(hasNextHop(nexthop));
     if (m_syncdNextHops.find(nexthop) != m_syncdNextHops.end())
     {
         m_syncdNextHops[nexthop].ref_count += count;

--- a/portsyncd/Makefile.am
+++ b/portsyncd/Makefile.am
@@ -15,7 +15,7 @@ portsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
 portsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon
 
 if GCOV_ENABLED
-portsyncd_LDADD += -lgcovpreload
+portsyncd_SOURCES += ../gcovpreload/gcovpreload.cpp
 endif
 
 if ASAN_ENABLED

--- a/swssconfig/Makefile.am
+++ b/swssconfig/Makefile.am
@@ -21,8 +21,8 @@ swssplayer_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
 swssplayer_LDADD = $(LDFLAGS_ASAN) -lswsscommon
 
 if GCOV_ENABLED
-swssconfig_LDADD += -lgcovpreload
-swssplayer_LDADD += -lgcovpreload
+swssconfig_SOURCES += ../gcovpreload/gcovpreload.cpp
+swssplayer_SOURCES += ../gcovpreload/gcovpreload.cpp
 endif
 
 if ASAN_ENABLED

--- a/teamsyncd/Makefile.am
+++ b/teamsyncd/Makefile.am
@@ -15,7 +15,7 @@ teamsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
 teamsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lhiredis -lswsscommon -lteam
 
 if GCOV_ENABLED
-teamsyncd_LDADD += -lgcovpreload
+teamsyncd_SOURCES += ../gcovpreload/gcovpreload.cpp
 endif
 
 if ASAN_ENABLED

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import tarfile
 import io
+import traceback
 
 from typing import Dict, Tuple
 from datetime import datetime
@@ -101,6 +102,11 @@ def pytest_addoption(parser):
                      default=NUM_PORTS,
                      type=int,
                      help="number of ports")
+
+    parser.addoption("--enable-coverage",
+                     action="store_true",
+                     default=False,
+                     help="Collect the test coverage information")
 
 
 def random_string(size=4, chars=string.ascii_uppercase + string.digits):
@@ -283,6 +289,7 @@ class DockerVirtualSwitch:
         newctnname: str = None,
         ctnmounts: Dict[str, str] = None,
         buffer_model: str = None,
+        enable_coverage: bool = False
     ):
         self.basicd = ["redis-server", "rsyslogd"]
         self.swssd = [
@@ -304,6 +311,7 @@ class DockerVirtualSwitch:
         self.dvsname = name
         self.vct = vct
         self.ctn = None
+        self.enable_coverage = enable_coverage
 
         self.cleanup = not keeptb
 
@@ -440,9 +448,36 @@ class DockerVirtualSwitch:
         if getattr(self, 'appldb', False):
             del self.appldb
 
+    def collect_coverage(self):
+        if not self.enable_coverage:
+            return
+        try:
+            # Generate the gcda files
+            self.runcmd('killall5 -15')
+            time.sleep(1)
+
+            # Stop the services to reduce the CPU comsuption
+            if self.cleanup:
+                self.runcmd('supervisorctl stop all')
+
+            # Generate the converage info by lcov and copy to the host
+            cmd = f"docker exec {self.ctn.short_id} sh -c 'cd $BUILD_DIR; rm -rf **/.libs ./lib/libSaiRedis*; lcov -c --directory . --no-external --exclude tests --ignore-errors gcov,unused --output-file /tmp/coverage.info; sed -i \"s#SF:$BUILD_DIR/#SF:#\" /tmp/coverage.info; lcov_cobertura /tmp/coverage.info -o /tmp/coverage.xml'"
+            subprocess.getstatusoutput(cmd)
+            cmd = f"docker exec {self.ctn.short_id} sh -c 'cd $BUILD_DIR; find . -name *.gcda -type f   -exec tar -rf /tmp/gcda.tar {{}} \\;'"
+            subprocess.getstatusoutput(cmd)
+            cmd = f"docker cp {self.ctn.short_id}:/tmp/gcda.tar {self.ctn.short_id}.gcda.tar"
+            subprocess.getstatusoutput(cmd)
+            cmd = f"docker cp {self.ctn.short_id}:/tmp/coverage.info {self.ctn.short_id}.coverage.info"
+            subprocess.getstatusoutput(cmd)
+            cmd = f"docker cp {self.ctn.short_id}:/tmp/coverage.xml {self.ctn.short_id}.coverage.xml"
+            subprocess.getstatusoutput(cmd)
+        except:
+            traceback.print_exc()
 
     def destroy(self) -> None:
         self.del_appl_db()
+
+        self.collect_coverage()
 
         # In case persistent dvs was used removed all the extra server link
         # that were created
@@ -451,10 +486,13 @@ class DockerVirtualSwitch:
 
         # persistent and clean-up flag are mutually exclusive
         elif self.cleanup:
-            self.ctn.remove(force=True)
-            self.ctn_sw.remove(force=True)
-            os.system(f"rm -rf {self.mount}")
-            self.destroy_servers()
+            try:
+                self.ctn.remove(force=True)
+                self.ctn_sw.remove(force=True)
+                os.system(f"rm -rf {self.mount}")
+                self.destroy_servers()
+            except docker.errors.NotFound:
+                print("Skipped the container not found error, the container has already removed.")
 
     def destroy_servers(self):
         for s in self.servers:
@@ -1400,7 +1438,8 @@ class DockerVirtualChassisTopology:
         log_path=None,
         max_cpu=2,
         forcedvs=None,
-        topoFile=None
+        topoFile=None,
+        enable_coverage=False,
     ):
         self.ns = namespace
         self.chassbr = "br4chs"
@@ -1414,6 +1453,7 @@ class DockerVirtualChassisTopology:
         self.log_path = log_path
         self.max_cpu = max_cpu
         self.forcedvs = forcedvs
+        self.enable_coverage = enable_coverage
 
         if self.ns is None:
             self.ns = random_string()
@@ -1466,7 +1506,7 @@ class DockerVirtualChassisTopology:
                 self.dvss[ctn.name] = DockerVirtualSwitch(ctn.name, self.imgname, self.keeptb,
                                                           self.env, log_path=ctn.name,
                                                           max_cpu=self.max_cpu, forcedvs=self.forcedvs,
-                                                          vct=self)
+                                                          vct=self, enable_coverage=self.enable_coverage)
         if self.chassbr is None and len(self.dvss) > 0:
             ret, res = self.ctn_runcmd(self.dvss.values()[0].ctn,
                                        "sonic-cfggen --print-data -j /usr/share/sonic/virtual_chassis/vct_connections.json")
@@ -1537,6 +1577,8 @@ class DockerVirtualChassisTopology:
 
     def destroy(self):
         self.verify_vct()
+        for dv in self.dvss.values():
+            dv.collect_coverage()
         if self.keeptb:
             return
         self.oper = "delete"
@@ -1587,7 +1629,8 @@ class DockerVirtualChassisTopology:
                                                          max_cpu=self.max_cpu,
                                                          forcedvs=self.forcedvs,
                                                          vct=self,newctnname=ctnname,
-                                                         ctnmounts=vol)
+                                                         ctnmounts=vol,
+                                                         enable_coverage=self.enable_coverage)
             self.set_ctninfo(ctndir, ctnname, self.dvss[ctnname].pid)
         return
 
@@ -1759,6 +1802,7 @@ def manage_dvs(request) -> str:
     buffer_model = request.config.getoption("--buffer_model")
     force_recreate = request.config.getoption("--force-recreate-dvs")
     graceful_stop = request.config.getoption("--graceful-stop")
+    enable_coverage = request.config.getoption("--enable-coverage")
 
     dvs = None
     curr_dvs_env = [] # lgtm[py/unused-local-variable]
@@ -1790,7 +1834,7 @@ def manage_dvs(request) -> str:
                 dvs.get_logs()
                 dvs.destroy()
 
-            dvs = DockerVirtualSwitch(name, imgname, keeptb, new_dvs_env, log_path, max_cpu, forcedvs, buffer_model = buffer_model)
+            dvs = DockerVirtualSwitch(name, imgname, keeptb, new_dvs_env, log_path, max_cpu, forcedvs, buffer_model = buffer_model, enable_coverage=enable_coverage)
 
             curr_dvs_env = new_dvs_env
 
@@ -1811,6 +1855,7 @@ def manage_dvs(request) -> str:
     if graceful_stop:
         dvs.stop_swss()
         dvs.stop_syncd()
+
     dvs.get_logs()
     dvs.destroy()
 
@@ -1839,13 +1884,14 @@ def vst(request):
     keeptb = request.config.getoption("--keeptb")
     imgname = request.config.getoption("--imgname")
     max_cpu = request.config.getoption("--max_cpu")
+    enable_coverage = request.config.getoption("--enable-coverage")
     log_path = vctns if vctns else request.module.__name__
     dvs_env = getattr(request.module, "DVS_ENV", [])
     if not topo:
         # use ecmp topology as default
         topo = "virtual_chassis/chassis_supervisor.json"
     vct = DockerVirtualChassisTopology(vctns, imgname, keeptb, dvs_env, log_path, max_cpu,
-                                       forcedvs, topo)
+                                       forcedvs, topo, enable_coverage)
     yield vct
     vct.get_logs(request.module.__name__)
     vct.destroy()
@@ -1858,13 +1904,14 @@ def vct(request):
     keeptb = request.config.getoption("--keeptb")
     imgname = request.config.getoption("--imgname")
     max_cpu = request.config.getoption("--max_cpu")
+    enable_coverage = request.config.getoption("--enable-coverage")
     log_path = vctns if vctns else request.module.__name__
     dvs_env = getattr(request.module, "DVS_ENV", [])
     if not topo:
         # use ecmp topology as default
         topo = "virtual_chassis/chassis_with_ecmp_neighbors.json"
     vct = DockerVirtualChassisTopology(vctns, imgname, keeptb, dvs_env, log_path, max_cpu,
-                                       forcedvs, topo)
+                                       forcedvs, topo, enable_coverage)
     yield vct
     vct.get_logs(request.module.__name__)
     vct.destroy()

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+IMAGE_NAME=$1
+PY_TEST_PARAMS="$2"
+TESTS="$3"
+RETRY=$4
+[ -z "RETRY" ] && RETRY=1
+JUNITXML=$(echo "$TESTS" | cut -d "." -f1)_tr.xml
+
+set -x
+for ((i=1; i<=$RETRY; i++)); do
+    echo "Running the py test for tests: $TESTS, $i/$RETRY..."
+    py.test -v --force-flaky --junitxml="$JUNITXML" $PY_TEST_PARAMS --imgname="$IMAGE_NAME" $TESTS && break
+done

--- a/tlm_teamd/Makefile.am
+++ b/tlm_teamd/Makefile.am
@@ -15,7 +15,7 @@ tlm_teamd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(JANSSON_CFLAGS)
 tlm_teamd_LDADD = $(LDFLAGS_ASAN) -lhiredis -lswsscommon -lteamdctl $(JANSSON_LIBS)
 
 if GCOV_ENABLED
-tlm_teamd_LDADD += -lgcovpreload
+tlm_teamd_SOURCES += ../gcovpreload/gcovpreload.cpp
 endif
 
 if ASAN_ENABLED


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
1. Support to dump the gcda files in the each of docker-sonic-vs containers when running the tests of sonic-swss.
2. Support to collect the coverage in the cobertura format directly from the sonic-swss build and the docker-sonic-vs containers during the component tests.
3. Simply the logic to collect the coverage. Use the dotnet tool reportgenerator to merge all the coverage files in cobertura  format.
4. Reduce build time using the sonicbld agent pool (36 minutes -> 20 minutes), reduce test time by running the tests in parallel (8 pytest processes) and using more powerful agent pool sonic-common-test (4hours -> 1 hours).
5. Improve the test stability, retry 3 times if failed.

**Why I did it**
Fix the coverage issue, some of the files are not covered in the coverage report.
Reduce the build/test time.

**How I verified it**
see the full coverage page in the build result.


**Details if related**
1. __gcov_flush removed in GCC11, changed to use gcov_dump, see https://gcc.gnu.org/onlinedocs/gcc/Gcov-and-Optimization.html. The gcov shared library does not work as expected, changed to link the gcov ctor in the programs directly.
2. Add the --enable-coverage option in the conftest.py to collect the coverage.
3. Add a test utility tests/run-tests.py to run the test module with retry.
4. Change gcovpreload.c to gcovpreload.cpp, some of the gcc options are not supported if using the suffix xxxx.c, such as -std=c++14, -Wno-reorder.