### PR TITLE
[portsorch] process only updated APP_DB fields when port is already   created

### DIFF
--- a/orchagent/port/porthlpr.cpp
+++ b/orchagent/port/porthlpr.cpp
@@ -1001,7 +1001,7 @@ bool PortHelper::parsePortConfig(PortConfig &port) const
         }
     }
 
-    return this->validatePortConfig(port);
+    return true;
 }
 
 bool PortHelper::validatePortConfig(PortConfig &port) const

--- a/orchagent/port/porthlpr.h
+++ b/orchagent/port/porthlpr.h
@@ -28,6 +28,7 @@ public:
     std::string getAdminStatusStr(const PortConfig &port) const;
 
     bool parsePortConfig(PortConfig &port) const;
+    bool validatePortConfig(PortConfig &port) const;
 
 private:
     std::string getFieldValueStr(const PortConfig &port, const std::string &field) const;
@@ -52,6 +53,4 @@ private:
     bool parsePortRole(PortConfig &port, const std::string &field, const std::string &value) const;
     bool parsePortAdminStatus(PortConfig &port, const std::string &field, const std::string &value) const;
     bool parsePortDescription(PortConfig &port, const std::string &field, const std::string &value) const;
-
-    bool validatePortConfig(PortConfig &port) const;
 };

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3572,11 +3572,8 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
         if (op == SET_COMMAND)
         {
-            if (m_portList.find(key) == m_portList.end())
+            auto parsePortFvs = [&](auto& fvMap) -> bool
             {
-                // Aggregate configuration while the port is not created.
-                auto &fvMap = m_portConfigMap[key];
-
                 for (const auto &cit : kfvFieldsValues(keyOpFieldsValues))
                 {
                     auto fieldName = fvField(cit);
@@ -3590,6 +3587,19 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 pCfg.fieldValueMap = fvMap;
 
                 if (!m_portHlpr.parsePortConfig(pCfg))
+                {
+                    return false;
+                }
+
+                return true;
+            };
+
+            if (m_portList.find(key) == m_portList.end())
+            {
+                // Aggregate configuration while the port is not created.
+                auto &fvMap = m_portConfigMap[key];
+
+                if (!parsePortFvs(fvMap))
                 {
                     it = taskMap.erase(it);
                     continue;
@@ -3609,19 +3619,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 // Port is already created, gather updated field-values.
                 std::unordered_map<std::string, std::string> fvMap;
 
-                for (const auto &cit : kfvFieldsValues(keyOpFieldsValues))
-                {
-                    auto fieldName = fvField(cit);
-                    auto fieldValue = fvValue(cit);
-
-                    SWSS_LOG_INFO("FIELD: %s, VALUE: %s", fieldName.c_str(), fieldValue.c_str());
-
-                    fvMap[fieldName] = fieldValue;
-                }
-
-                pCfg.fieldValueMap = fvMap;
-
-                if (!m_portHlpr.parsePortConfig(pCfg))
+                if (!parsePortFvs(fvMap))
                 {
                     it = taskMap.erase(it);
                     continue;

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -952,6 +952,35 @@ namespace portsorch_test
         ASSERT_EQ(_sai_set_admin_state_down_count, ++current_sai_api_call_count);
         ASSERT_EQ(_sai_set_admin_state_up_count, current_sai_api_call_count);
 
+        // Configure non-serdes attribute that does not trigger admin state change
+        std::deque<KeyOpFieldsValuesTuple> kfvMtu = {{
+            "Ethernet0",
+            SET_COMMAND, {
+                { "mtu", "1234" },
+            }
+        }};
+
+        // Refill consumer
+        consumer->addToSync(kfvMtu);
+
+        _hook_sai_port_api();
+        current_sai_api_call_count = _sai_set_admin_state_down_count;
+
+        // Apply configuration
+        static_cast<Orch*>(gPortsOrch)->doTask();
+
+        _unhook_sai_port_api();
+
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", p));
+        ASSERT_TRUE(p.m_admin_state_up);
+
+        // Verify mtu is set
+        ASSERT_EQ(p.m_mtu, 1234);
+
+        // Verify no admin-disable then admin-enable
+        ASSERT_EQ(_sai_set_admin_state_down_count, current_sai_api_call_count);
+        ASSERT_EQ(_sai_set_admin_state_up_count, current_sai_api_call_count);
+
         // Dump pending tasks
         std::vector<std::string> taskList;
         gPortsOrch->dumpPendingTasks(taskList);

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -926,7 +926,6 @@ namespace portsorch_test
         std::deque<KeyOpFieldsValuesTuple> kfvSerdes = {{
             "Ethernet0",
             SET_COMMAND, {
-                { "admin_status", "up"              },
                 { "idriver"     , "0x6,0x6,0x6,0x6" }
             }
         }};


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Fixing an issue when setting some port attribute in APPL_DB triggers serdes parameters to be re-programmed with port toggling. Made portsorch to handle only those attributes that were pushed to APPL_DB, so that serdes programming happens only by xcvrd's request to do so.

**Why I did it**

To fix an issue seen on warm-reboot. After orchagent reconciles, portmgrd sends another update to APPL_DB PORT_TABLE to sync. That trigger port flapping as portsorch does not handle just the fields that got pushed but all fields it has cached in ```m_portConfigMap```.

This also causes unconditionally re-set serdes attributes on any port attribute change, e.g.:

```
config interface mtu Ethernet136 9100
```

```
2024-01-18.09:02:30.712260|s|SAI_OBJECT_TYPE_PORT:oid:0x100000000001e|SAI_PORT_ATTR_ADMIN_STATE=false
2024-01-18.09:02:30.718675|n|port_host_tx_ready|[{"host_tx_ready_status":"SAI_PORT_HOST_TX_READY_STATUS_NOT_READY","port_id":"oid:0x100000000001e","switch_id":"oid:0x21000000000000"}]|
2024-01-18.09:02:30.718724|g|SAI_OBJECT_TYPE_PORT:oid:0x100000000001e|SAI_PORT_ATTR_PORT_SERDES_ID=oid:0x0
2024-01-18.09:02:30.719833|G|SAI_STATUS_SUCCESS|SAI_PORT_ATTR_PORT_SERDES_ID=oid:0x5700000000056c
2024-01-18.09:02:30.719908|r|SAI_OBJECT_TYPE_PORT_SERDES:oid:0x5700000000056c
2024-01-18.09:02:30.721476|c|SAI_OBJECT_TYPE_PORT_SERDES:oid:0x5700000000056d|SAI_PORT_SERDES_ATTR_PORT_ID=oid:0x100000000001e|SAI_PORT_SERDES_ATTR_IDRIVER=8:60,60,60,60,60,60,60,60|SAI_PORT_SERDES_ATTR_TX_FIR_PRE1=8:-2,-2,-2,-2,-2,-2,-2,-2|SAI_PORT_SERDES_ATTR_TX_FIR_PRE2=8:0,0,0,0,0,0,0,0|SAI_PORT_SERDES_ATTR_TX_FIR_MAIN=8:32,32,32,32,32,32,32,32|SAI_PORT_SERDES_ATTR_TX_FIR_POST1=8:6,6,6,6,6,6,6,6|SAI_PORT_SERDES_ATTR_TX_PAM4_RATIO=8:4,4,4,4,4,4,4,4|SAI_PORT_SERDES_ATTR_TX_OUT_COMMON_MODE=8:15,15,15,15,15,15,15,15|SAI_PORT_SERDES_ATTR_TX_PMOS_COMMON_MODE=8:105,105,105,105,105,105,105,105|SAI_PORT_SERDES_ATTR_TX_NMOS_COMMON_MODE=8:95,95,95,95,95,95,95,95|SAI_PORT_SERDES_ATTR_TX_PMOS_VLTG_REG=8:30,30,30,30,30,30,30,30|SAI_PORT_SERDES_ATTR_TX_NMOS_VLTG_REG=8:170,170,170,170,170,170,170,170
2024-01-18.09:02:30.724023|s|SAI_OBJECT_TYPE_PORT:oid:0x100000000001e|SAI_PORT_ATTR_ADMIN_STATE=true
2024-01-18.09:02:30.727609|S|SAI_OBJECT_TYPE_ROUTE_ENTRY||{"dest":"::/0","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000006"}|SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION=SAI_PACKET_ACTION_DROP||{"dest":"::/0","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000006"}|SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID=oid:0x0||{"dest":"0.0.0.0/0","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000006"}|SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION=SAI_PACKET_ACTION_DROP||{"dest":"0.0.0.0/0","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000006"}|SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID=oid:0x0
2024-01-18.09:02:30.731232|s|SAI_OBJECT_TYPE_PORT:oid:0x100000000001e|SAI_PORT_ATTR_MTU=9122
2024-01-18.09:02:30.732856|s|SAI_OBJECT_TYPE_PORT:oid:0x100000000001e|SAI_PORT_ATTR_ADMIN_STATE=false
2024-01-18.09:02:30.736624|g|SAI_OBJECT_TYPE_PORT:oid:0x100000000001e|SAI_PORT_ATTR_PORT_SERDES_ID=oid:0x0
2024-01-18.09:02:30.737289|G|SAI_STATUS_SUCCESS|SAI_PORT_ATTR_PORT_SERDES_ID=oid:0x5700000000056d
2024-01-18.09:02:30.737345|r|SAI_OBJECT_TYPE_PORT_SERDES:oid:0x5700000000056d
2024-01-18.09:02:30.738226|c|SAI_OBJECT_TYPE_PORT_SERDES:oid:0x5700000000056e|SAI_PORT_SERDES_ATTR_PORT_ID=oid:0x100000000001e|SAI_PORT_SERDES_ATTR_IDRIVER=8:60,60,60,60,60,60,60,60|SAI_PORT_SERDES_ATTR_TX_FIR_PRE1=8:-2,-2,-2,-2,-2,-2,-2,-2|SAI_PORT_SERDES_ATTR_TX_FIR_PRE2=8:0,0,0,0,0,0,0,0|SAI_PORT_SERDES_ATTR_TX_FIR_MAIN=8:32,32,32,32,32,32,32,32|SAI_PORT_SERDES_ATTR_TX_FIR_POST1=8:6,6,6,6,6,6,6,6|SAI_PORT_SERDES_ATTR_TX_PAM4_RATIO=8:4,4,4,4,4,4,4,4|SAI_PORT_SERDES_ATTR_TX_OUT_COMMON_MODE=8:15,15,15,15,15,15,15,15|SAI_PORT_SERDES_ATTR_TX_PMOS_COMMON_MODE=8:105,105,105,105,105,105,105,105|SAI_PORT_SERDES_ATTR_TX_NMOS_COMMON_MODE=8:95,95,95,95,95,95,95,95|SAI_PORT_SERDES_ATTR_TX_PMOS_VLTG_REG=8:30,30,30,30,30,30,30,30|SAI_PORT_SERDES_ATTR_TX_NMOS_VLTG_REG=8:170,170,170,170,170,170,170,170
2024-01-18.09:02:30.740160|s|SAI_OBJECT_TYPE_PORT:oid:0x100000000001e|SAI_PORT_ATTR_ADMIN_STATE=true
2024-01-18.09:02:30.805561|n|port_host_tx_ready|[{"host_tx_ready_status":"SAI_PORT_HOST_TX_READY_STATUS_READY","port_id":"oid:0x100000000001e","switch_id":"oid:0x21000000000000"}]|
```

**How I verified it**

By changing mtu of the interface I verified there was not port toggling and running warm-reboot test on T0 topology.

**Details if related**

**Request for 202311**