### PR TITLE
[202311] Use shared_ptr for DbConnector objects in PortsOrch and FdbOrch

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -42,8 +42,8 @@ FdbOrch::FdbOrch(DBConnector* applDbConnector, vector<table_name_with_pri_t> app
     Orch::addExecutor(flushNotifier);
 
     /* Add FDB notifications support from ASIC */
-    DBConnector *notificationsDb = new DBConnector("ASIC_DB", 0);
-    m_fdbNotificationConsumer = new swss::NotificationConsumer(notificationsDb, "NOTIFICATIONS");
+    m_notificationsDb = shared_ptr<DBConnector>(new DBConnector("ASIC_DB", 0));
+    m_fdbNotificationConsumer = new swss::NotificationConsumer(m_notificationsDb.get(), "NOTIFICATIONS");
     auto fdbNotifier = new Notifier(m_fdbNotificationConsumer, this, "FDB_NOTIFICATIONS");
     Orch::addExecutor(fdbNotifier);
 }

--- a/orchagent/fdborch.h
+++ b/orchagent/fdborch.h
@@ -113,6 +113,7 @@ private:
     Table m_mclagFdbStateTable;
     NotificationConsumer* m_flushNotificationsConsumer;
     NotificationConsumer* m_fdbNotificationConsumer;
+    shared_ptr<DBConnector> m_notificationsDb;
 
     void doTask(Consumer& consumer);
     void doTask(NotificationConsumer& consumer);

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -628,14 +628,14 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
     }
 
     /* Add port oper status notification support */
-    DBConnector *notificationsDb = new DBConnector("ASIC_DB", 0);
-    m_portStatusNotificationConsumer = new swss::NotificationConsumer(notificationsDb, "NOTIFICATIONS");
+    m_notificationsDb = shared_ptr<DBConnector>(new DBConnector("ASIC_DB", 0));
+    m_portStatusNotificationConsumer = new swss::NotificationConsumer(m_notificationsDb.get(), "NOTIFICATIONS");
     auto portStatusNotificatier = new Notifier(m_portStatusNotificationConsumer, this, "PORT_STATUS_NOTIFICATIONS");
     Orch::addExecutor(portStatusNotificatier);
 
     if (m_cmisModuleAsicSyncSupported)
     {
-        m_portHostTxReadyNotificationConsumer = new swss::NotificationConsumer(notificationsDb, "NOTIFICATIONS");
+        m_portHostTxReadyNotificationConsumer = new swss::NotificationConsumer(m_notificationsDb.get(), "NOTIFICATIONS");
         auto portHostTxReadyNotificatier = new Notifier(m_portHostTxReadyNotificationConsumer, this, "PORT_HOST_TX_NOTIFICATIONS");
         Orch::addExecutor(portHostTxReadyNotificatier);
     }

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -263,6 +263,7 @@ private:
     shared_ptr<DBConnector> m_counter_db;
     shared_ptr<DBConnector> m_flex_db;
     shared_ptr<DBConnector> m_state_db;
+    shared_ptr<DBConnector> m_notificationsDb;
 
     FlexCounterManager port_stat_manager;
     FlexCounterManager port_buffer_drop_stat_manager;


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

In the constructor of PortsOrch and FdbOrch, a pointer to a DbConnector object is created, then used in a notifications consumer. However, because the ownership technically belongs to PortsOrch and FdbOrch, and these are local variables, nothing frees the DbConnector object if instances of these classes get destroyed. This may result in a memory leak.

**Why I did it**

To fix this, wrap these objects in shared_ptr, and then make them instance variables. This makes sure that they get freed when instances of these classes get destroyed.

**How I verified it**

Loaded the master branch build in master branch image on KVM; no apparent errors, and BGP is up.

**Details if related**
