### PR TITLE
Make routing type field names consistent

### DIFF
--- a/orchagent/dash/dashrouteorch.cpp
+++ b/orchagent/dash/dashrouteorch.cpp
@@ -81,14 +81,14 @@ bool DashRouteOrch::addOutboundRouting(const string& key, OutboundRoutingBulkCon
     auto& object_statuses = ctxt.object_statuses;
 
     outbound_routing_attr.id = SAI_OUTBOUND_ROUTING_ENTRY_ATTR_ACTION;
-    outbound_routing_attr.value.u32 = sOutboundAction[ctxt.metadata.action_type()];
+    outbound_routing_attr.value.u32 = sOutboundAction[ctxt.metadata.routing_type()];
     outbound_routing_attrs.push_back(outbound_routing_attr);
 
-    if (ctxt.metadata.action_type() == dash::route_type::RoutingType::ROUTING_TYPE_DIRECT)
+    if (ctxt.metadata.routing_type() == dash::route_type::RoutingType::ROUTING_TYPE_DIRECT)
     {
         // Intentional empty line, To direct action type, don't need set extra attributes
     }
-    else if (ctxt.metadata.action_type() == dash::route_type::RoutingType::ROUTING_TYPE_VNET
+    else if (ctxt.metadata.routing_type() == dash::route_type::RoutingType::ROUTING_TYPE_VNET
         && ctxt.metadata.has_vnet()
         && !ctxt.metadata.vnet().empty())
     {   
@@ -96,7 +96,7 @@ bool DashRouteOrch::addOutboundRouting(const string& key, OutboundRoutingBulkCon
         outbound_routing_attr.value.oid = gVnetNameToId[ctxt.metadata.vnet()];
         outbound_routing_attrs.push_back(outbound_routing_attr);
     }
-    else if (ctxt.metadata.action_type() == dash::route_type::RoutingType::ROUTING_TYPE_VNET_DIRECT
+    else if (ctxt.metadata.routing_type() == dash::route_type::RoutingType::ROUTING_TYPE_VNET_DIRECT
         && ctxt.metadata.has_vnet_direct()
         && !ctxt.metadata.vnet_direct().vnet().empty()
         && (ctxt.metadata.vnet_direct().overlay_ip().has_ipv4() || ctxt.metadata.vnet_direct().overlay_ip().has_ipv6()))

--- a/tests/_test_dash_crm.py
+++ b/tests/_test_dash_crm.py
@@ -272,7 +272,7 @@ class OutboundRouting(Resource):
             prefix = f"20.2.{i}.0/24"
             if self.addr_family == 'ipv6':
                 prefix = f'2002::{i}:1011/126'
-            self.route_table.add(f"eni1:{prefix}", {"action_type":"vnet", "vnet":"vnet1"})
+            self.route_table.add(f"eni1:{prefix}", {"routing_type":"vnet", "vnet":"vnet1"})
 
     def clear(self):
         self.route_table.remove_all()

--- a/tests/test_dash_vnet.py
+++ b/tests/test_dash_vnet.py
@@ -235,7 +235,7 @@ class TestDash(object):
         self.underlay_ip = "101.1.2.3"
         pb = VnetMapping()
         pb.mac_address = bytes.fromhex(self.mac_address.replace(":", ""))
-        pb.action_type = RoutingType.ROUTING_TYPE_VNET_ENCAP
+        pb.routing_type = RoutingType.ROUTING_TYPE_VNET_ENCAP
         pb.underlay_ip.ipv4 = socket.htonl(int(ipaddress.ip_address(self.underlay_ip)))
 
         dashobj.create_vnet_map(self.vnet, self.ip1, {"pb": pb.SerializeToString()})
@@ -264,10 +264,10 @@ class TestDash(object):
         self.vnet = "Vnet1"
         self.mac_string = "F4939FEFC47E"
         self.ip = "10.1.0.0/24"
-        self.action_type = "vnet_direct"
+        self.routing_type = "vnet_direct"
         self.overlay_ip= "10.0.0.6"
         pb = Route()
-        pb.action_type = RoutingType.ROUTING_TYPE_VNET_DIRECT
+        pb.routing_type = RoutingType.ROUTING_TYPE_VNET_DIRECT
         pb.vnet_direct.vnet = self.vnet
         pb.vnet_direct.overlay_ip.ipv4 = socket.htonl(int(ipaddress.ip_address(self.overlay_ip)))
         dashobj.create_outbound_routing(self.mac_string, self.ip, {"pb": pb.SerializeToString()})
@@ -295,7 +295,6 @@ class TestDash(object):
         self.priority = "1"
         self.protocol = "0"
         pb = RouteRule()
-# pb.action_type = RoutingType.ROUTING_TYPE_DECAP
         pb.pa_validation = True
         pb.priority = int(self.priority)
         pb.protocol = int(self.protocol)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Some DB fields are named 'action_type' when they contain routing_type information instead. Rename these fields to 'routing_type' to avoid confusion with 'action_type' fields

**Why I did it**

**How I verified it**

**Details if related**
