### PR TITLE
Explicitly initialize two local variables to 0

### DIFF
--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -697,7 +697,7 @@ set<string> Orch::generateIdListFromMap(unsigned long idsMap, sai_uint32_t maxId
 {
     unsigned long currentIdMask = 1;
     bool started = false, needGenerateMap = false;
-    sai_uint32_t lower, upper;
+    sai_uint32_t lower = 0, upper = 0;
     set<string> idStringList;
     for (sai_uint32_t id = 0; id <= maxId; id ++)
     {


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

GCC 12 (in Debian Bookworm) claims that on armhf targets, the `lower` local variable in `Orch::generateIdListFromMap` could potentially be used uninitialized a few lines later when it's being converted to a string. I don't see how that could be the case here, since if the string is being printed, the only code path where this is possible requires `lower` to have been set to something. It also only complains about this for armhf and i386 (i.e. 32-bit platforms); amd64 and arm64 (64-bit platforms) are fine. (i386 was manually tested by installing the 32-bit crosscompiler and development headers in a slave container and running the g++ command to compile orch.cpp.)

**Why I did it**

To silence the warning, set both `lower` and `upper` to 0 explicitly.

**How I verified it**

**Details if related**
