### PR TITLE
Fixed orchagent crash in VM with the Qos BUFFER_QUEUE|system-port|Queue-id-range config

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -926,6 +926,7 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
         {
             SWSS_LOG_DEBUG("processing queue:%zd", ind);
             sai_object_id_t queue_id;
+            string queues;
 
             if (gMySwitchType == "voq") 
             {
@@ -936,6 +937,7 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
                     return task_process_status::task_invalid_entry;
                 }
                 queue_id = queue_ids[ind];
+                queues = tokens[3];
             } 
             else
             {
@@ -951,11 +953,13 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
                     return task_process_status::task_need_retry;
                 }
                 queue_id = port.m_queue_ids[ind];
+                queues = tokens[1];
             }
 
             if (need_update_sai)
             {
                 SWSS_LOG_DEBUG("Applying buffer profile:0x%" PRIx64 " to queue index:%zd, queue sai_id:0x%" PRIx64, sai_buffer_profile, ind, queue_id);
+
                 sai_status_t sai_status = sai_queue_api->set_queue_attribute(queue_id, &attr);
                 if (sai_status != SAI_STATUS_SUCCESS)
                 {
@@ -970,7 +974,7 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
                 else
                 {
                     auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
-                    auto queues = tokens[1];
+
                     if (op == SET_COMMAND &&
                         (flexCounterOrch->getQueueCountersState() || flexCounterOrch->getQueueWatermarkCountersState()))
                     {

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -970,8 +970,10 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
                         return handle_status;
                     }
                 }
-                // create/remove a port queue counter for the queue buffer
-                else
+                // create/remove a port queue counter for the queue buffer.
+                // For VOQ chassis, flexcounterorch adds the Queue Counters for all egress and VOQ queueis for all front panel and system ports
+                // to  the FLEX_COUNTER_DB irrespective of BUFFER_QUEUE configuration.
+                else if (gMySwitchType != "voq")
                 {
                     auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
 

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -967,8 +967,8 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
                     }
                 }
                 // create/remove a port queue counter for the queue buffer.
-                // For VOQ chassis, flexcounterorch adds the Queue Counters for all egress and VOQ queueis for all front panel and system ports
-                // to  the FLEX_COUNTER_DB irrespective of BUFFER_QUEUE configuration.
+                // For VOQ chassis, flexcounterorch adds the Queue Counters for all egress and VOQ queues of all front panel and system ports
+                // to  the FLEX_COUNTER_DB irrespective of BUFFER_QUEUE configuration. So Port Queue counter needs to be updated only for non VOQ switch.
                 else if (gMySwitchType != "voq")
                 {
                     auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -926,7 +926,6 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
         {
             SWSS_LOG_DEBUG("processing queue:%zd", ind);
             sai_object_id_t queue_id;
-            string queues;
 
             if (gMySwitchType == "voq") 
             {
@@ -937,7 +936,6 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
                     return task_process_status::task_invalid_entry;
                 }
                 queue_id = queue_ids[ind];
-                queues = tokens[3];
             } 
             else
             {
@@ -953,13 +951,11 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
                     return task_process_status::task_need_retry;
                 }
                 queue_id = port.m_queue_ids[ind];
-                queues = tokens[1];
             }
 
             if (need_update_sai)
             {
                 SWSS_LOG_DEBUG("Applying buffer profile:0x%" PRIx64 " to queue index:%zd, queue sai_id:0x%" PRIx64, sai_buffer_profile, ind, queue_id);
-
                 sai_status_t sai_status = sai_queue_api->set_queue_attribute(queue_id, &attr);
                 if (sai_status != SAI_STATUS_SUCCESS)
                 {
@@ -976,7 +972,7 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
                 else if (gMySwitchType != "voq")
                 {
                     auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
-
+                    auto queues = tokens[1];
                     if (op == SET_COMMAND &&
                         (flexCounterOrch->getQueueCountersState() || flexCounterOrch->getQueueWatermarkCountersState()))
                     {


### PR DESCRIPTION


<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Modified BufferOrch::processQueue in orchagent to pass the correct token for queue-id range if the switch_type is voq to  gPortsOrch->createPortBufferQueueCounters.
**Why I did it**
VM crashes with  Qos "BUFFER_QUEUE|system-port|Queue-id-range" config for system ports. The crash was not seen in hardware somehow and queue & voq stats are working with the different code path adding the QUEUE stats counters to FLEX_COUNTER_DB
FlexCounterOrch::doTask -> generateQueueMap -> generateQueueMapPerPort (true) -> addQueueFlexCountersPerPortPerQueueIndex

**How I verified it**
verified that the correct queue id-range is passed to gPortsOrch->createPortBufferQueueCounters. and not crashing.
**Details if related**
