### PR TITLE
T2-VOQ-VS: Fix iBGP bringup issue 

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -1467,7 +1467,8 @@ void NeighOrch::doVoqSystemNeighTask(Consumer &consumer)
                     {
                         string platform = getenv("ASIC_VENDOR") ? getenv("ASIC_VENDOR") : "";
                         // For VS platform, dont overwrite the MAC address
-                        if (platform != VS_PLATFORM_SUBSTRING) {
+                        if (platform != VS_PLATFORM_SUBSTRING) 
+                        {
                             mac_address = gMacAddress;
                         }
                     }

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -1444,42 +1444,10 @@ void NeighOrch::doVoqSystemNeighTask(Consumer &consumer)
                     //kernel programming.
                     if(ibif.m_type != Port::VLAN)
                     {
-                        mac_address = gMacAddress;
-
-                        // For VS platforms, the mac of the static neigh should not be same as asic's own mac.
-                        // This is because host originated packets will have same mac for both src and dst which
-                        // will result in host NOT sending packet out. To address this problem which is specific
-                        // to port type inband interfaces, set the mac to the neighbor's owner asic's mac. Since
-                        // the owner asic's mac is not readily avaiable here, the owner asic mac is derived from
-                        // the switch id and lower 5 bytes of asic mac which is assumed to be same for all asics
-                        // in the VS system.
-                        // Therefore to make VOQ chassis systems work in VS platform based setups like the setups
-                        // using KVMs, it is required that all asics have same base mac in the format given below
-                        // <lower 5 bytes of mac same for all asics>:<6th byte = switch_id>
-
                         string platform = getenv("ASIC_VENDOR") ? getenv("ASIC_VENDOR") : "";
-
-                        if (platform == VS_PLATFORM_SUBSTRING)
-                        {
-                            int8_t sw_id = -1;
-                            uint8_t egress_asic_mac[ETHER_ADDR_LEN];
-
-                            gMacAddress.getMac(egress_asic_mac);
-
-                            if (p.m_type == Port::LAG)
-                            {
-                                sw_id = (int8_t) p.m_system_lag_info.switch_id;
-                            }
-                            else if (p.m_type == Port::PHY || p.m_type == Port::SYSTEM)
-                            {
-                                sw_id = (int8_t) p.m_system_port_info.switch_id;
-                            }
-
-                            if(sw_id != -1)
-                            {
-                                egress_asic_mac[5] = sw_id;
-                                mac_address = MacAddress(egress_asic_mac);
-                            }
+                        // For VS platform, dont overwrite the MAC address
+                        if (platform != VS_PLATFORM_SUBSTRING) {
+                            mac_address = gMacAddress;
                         }
                     }
                     vector<FieldValueTuple> fvVector;

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -1385,7 +1385,7 @@ void NeighOrch::doVoqSystemNeighTask(Consumer &consumer)
                 continue;
             }
 
-            MacAddress mac_address;
+            MacAddress mac_address, original_mac_address;
             uint32_t encap_index = 0;
             for (auto i = kfvFieldsValues(t).begin();
                  i  != kfvFieldsValues(t).end(); i++)
@@ -1465,11 +1465,13 @@ void NeighOrch::doVoqSystemNeighTask(Consumer &consumer)
                     //kernel programming.
                     if(ibif.m_type != Port::VLAN)
                     {
+                        original_mac_address = mac_address;
+                        mac_address = gMacAddress;
                         string platform = getenv("ASIC_VENDOR") ? getenv("ASIC_VENDOR") : "";
-                        // For VS platform, dont overwrite the MAC address
-                        if (platform != VS_PLATFORM_SUBSTRING) 
+                        // For VS platform, use the original MAC address
+                        if (platform == VS_PLATFORM_SUBSTRING)
                         {
-                            mac_address = gMacAddress;
+                            mac_address = original_mac_address;
                         }
                     }
                     vector<FieldValueTuple> fvVector;

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -697,7 +697,7 @@ set<string> Orch::generateIdListFromMap(unsigned long idsMap, sai_uint32_t maxId
 {
     unsigned long currentIdMask = 1;
     bool started = false, needGenerateMap = false;
-    sai_uint32_t lower, upper;
+    sai_uint32_t lower = 0, upper = 0;
     set<string> idStringList;
     for (sai_uint32_t id = 0; id <= maxId; id ++)
     {

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -5,6 +5,8 @@ import time
 import pytest
 import buffer_model
 
+DVS_ENV = ["ASIC_VENDOR=vs"]
+
 class TestVirtualChassis(object):
 
     def set_lag_id_boundaries(self, vct):
@@ -216,7 +218,6 @@ class TestVirtualChassis(object):
                     # Remote system ports's switch id should not match local switch id
                     assert spcfginfo["attached_switch_id"] != lc_switch_id, "RIF system port with wrong switch_id"
 
-    @pytest.mark.skip(reason="Failing. Under investigation")
     def test_chassis_system_neigh(self, vct):
         """Test neigh record create/delete and syncing to chassis app db.
 
@@ -372,7 +373,7 @@ class TestVirtualChassis(object):
                         # Check for kernel entries
 
                         _, output = dvs.runcmd("ip neigh show")
-                        assert f"{test_neigh_ip} dev {inband_port}" in output, "Kernel neigh not found for remote neighbor"
+                        assert f"{test_neigh_ip} dev {inband_port} lladdr {mac_address}" in output, "Kernel neigh not found for remote neighbor"
 
                         _, output = dvs.runcmd("ip route show")
                         assert f"{test_neigh_ip} dev {inband_port} scope link" in output, "Kernel route not found for remote neighbor"

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -140,7 +140,6 @@ class TestVirtualChassis(object):
                 spcfg = ast.literal_eval(value)
                 assert spcfg['count'] == sp_count, "Number of systems ports configured is invalid"
 
-    @pytest.mark.skip(reason="Failing. Under investigation")
     def test_chassis_app_db_sync(self, vct):
         """Test chassis app db syncing.
 
@@ -161,7 +160,6 @@ class TestVirtualChassis(object):
                 keys = chassis_app_db.get_keys("SYSTEM_INTERFACE")
                 assert len(keys), "No chassis app db syncing is done"
 
-    @pytest.mark.skip(reason="Failing. Under investigation")
     def test_chassis_system_interface(self, vct):
         """Test RIF record creation in ASIC_DB for remote interfaces.
 
@@ -313,8 +311,8 @@ class TestVirtualChassis(object):
                     test_sysneigh = ""
                     for sysnk in sysneighkeys:
                         sysnk_tok = sysnk.split("|")
-                        assert len(sysnk_tok) == 3, "Invalid system neigh key in chassis app db"
-                        if sysnk_tok[2] == test_neigh_ip:
+                        assert len(sysnk_tok) == 4, "Invalid system neigh key in chassis app db"
+                        if sysnk_tok[3] == test_neigh_ip:
                             test_sysneigh = sysnk
                             break
 
@@ -488,7 +486,6 @@ class TestVirtualChassis(object):
         # Cleanup inband if configuration
         self.del_inbandif_port(vct, inband_port)
         
-    @pytest.mark.skip(reason="Failing. Under investigation")
     def test_chassis_system_lag(self, vct):
         """Test PortChannel in VOQ based chassis systems.
         
@@ -625,7 +622,6 @@ class TestVirtualChassis(object):
                     
                     break
 
-    @pytest.mark.skip(reason="Failing. Under investigation")
     def test_chassis_system_lag_id_allocator_table_full(self, vct):
         """Test lag id allocator table full.
         
@@ -703,7 +699,6 @@ class TestVirtualChassis(object):
                     
                     break
 
-    @pytest.mark.skip(reason="Failing. Under investigation")
     def test_chassis_system_lag_id_allocator_del_id(self, vct):
         """Test lag id allocator's release id and re-use id processing.
         


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
On T2-VOQ chassis Emulation with multi-asic linecards, iBGP sessions dont come up. Related Issue: https://github.com/sonic-net/sonic-buildimage/issues/18129
This PR fixes above issue. More details:
a. iBGP packet path is different in real target as compared to vs. 
b. In real target, iBGP packets go out via IB interface, which get recycled to ingress pipeline and it does hostTable lookup for the packet to go out over Fabric link (For this to work, in Kernel Neighbor entries were programmed differently than in asic). 
In kernel, neighbor entries were programmed with MyMAC and in Asic Neighbor entries were programmed with the received MAC. This was done to make sure that CPU generated packet can do hostlookup in asic (packet to get promoted to L3(my mac)).  
For more details, refer to https://github.com/sonic-net/SONiC/blob/master/doc/voq/voq_hld.md#2511-routing-protocol-peering-between-sonic-instances 
c. This whole packet flow is not present in VS. For vs, the CPU generated packet will go out from IB interface and go to IB Bridge and get delivered to other side. 
d. Hence all the changes done in step b, need to be restored for vs (i.e. Remote Nbr entries programming need to be done against the received MAC only). 

PS: Another thing to note is that on multi-asic VOQ linecards, we have same system-mac across asics. This would cause problem in establishing iBGP communication b/w same linecard asics. This will be fixed via another PR, where we will make sure, we have different system mac address across asics on the same linecard. 

**Why I did it**
This PR fixes https://github.com/sonic-net/sonic-buildimage/issues/18129.


**How I verified it**
Verified by emulating chassis with multi-asic linecards. I could verify that iBGP sessions come up between asics of same linecard and across linecards.
**Details if related**
