### PR TITLE
[202205][intfsorch] Enable ipv6 proxy ndp along with proxy arp

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -368,6 +368,21 @@ bool IntfsOrch::setIntfVlanFloodType(const Port &port, sai_vlan_flood_control_ty
         }
     }
 
+    // Also set ipv6 multicast flood type
+    attr.id = SAI_VLAN_ATTR_UNKNOWN_MULTICAST_FLOOD_CONTROL_TYPE;
+    attr.value.s32 = vlan_flood_type;
+
+    sai_status_t status = sai_vlan_api->set_vlan_attribute(port.m_vlan_info.vlan_oid, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to set multicast flood type for VLAN %u, rv:%d", port.m_vlan_info.vlan_id, status);
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_VLAN, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
+    }
+
     return true;
 }
 


### PR DESCRIPTION
setting SAI_VLAN_ATTR_UNKNOWN_MULTICAST_FLOOD_CONTROL_TYPE to SAI_VLAN_FLOOD_CONTROL_TYPE_NONE when proxy arp is enabled. This fixes a bug where ipv6 NS packets were flooding ports with duplicate packets. We now set multicast flood type to none.

What I did
Set SAI_VLAN_ATTR_UNKNOWN_MULTICAST_FLOOD_CONTROL_TYPE to vlan_flood_type. This will either be SAI_VLAN_FLOOD_CONTROL_TYPE_NONE or SAI_VLAN_FLOOD_CONTROL_TYPE_ALL depending on if proxy arp is enabled.

Why I did it
Fixes issue where ndp packets were flooding ports ADO: 26395578

How I verified it
Tested change on a lab device, confirmed that when proxy-arp was enabled multicast packets were being blocked in the hardware

Details if related
sonic-buildimage fix to block packets in kernel to come, will link here.

ADO: 26395578