### PR TITLE
[EVPN] Skip EVPN routes with invalid VNI or router mac field

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -807,6 +807,18 @@ void RouteOrch::doTask(Consumer& consumer)
                     }
                     else
                     {
+                        if(ipv.size() != rmacv.size()){
+                            SWSS_LOG_ERROR("Skip route %s, it has an invalid router mac field %s", key.c_str(), remote_macs.c_str());
+                            it = consumer.m_toSync.erase(it);
+                            continue;
+                        }
+
+                        if(ipv.size() != vni_labelv.size()){
+                            SWSS_LOG_ERROR("Skip route %s, it has an invalid vni label field %s", key.c_str(), vni_labels.c_str());
+                            it = consumer.m_toSync.erase(it);
+                            continue;
+                        }
+
                         for (uint32_t i = 0; i < ipv.size(); i++)
                         {
                             if (i) nhg_str += NHG_DELIMITER;

--- a/tests/mock_tests/routeorch_ut.cpp
+++ b/tests/mock_tests/routeorch_ut.cpp
@@ -197,6 +197,10 @@ namespace routeorch_test
 
             ASSERT_EQ(gVrfOrch, nullptr);
             gVrfOrch = new VRFOrch(m_app_db.get(), APP_VRF_TABLE_NAME, m_state_db.get(), STATE_VRF_OBJECT_TABLE_NAME);
+            gDirectory.set(gVrfOrch);
+
+            EvpnNvoOrch *evpn_orch = new EvpnNvoOrch(m_app_db.get(), APP_VXLAN_EVPN_NVO_TABLE_NAME);
+            gDirectory.set(evpn_orch);
 
             ASSERT_EQ(gIntfsOrch, nullptr);
             gIntfsOrch = new IntfsOrch(m_app_db.get(), APP_INTF_TABLE_NAME, gVrfOrch, m_chassis_app_db.get());
@@ -505,5 +509,32 @@ namespace routeorch_test
         static_cast<Orch *>(gRouteOrch)->doTask();
 
         gMockResponsePublisher.reset();
+
+    TEST_F(RouteOrchTest, RouteOrchTestInvalidEvpnRoute)
+    {
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({"Vrf1", "SET", { {"vni", "500100"}, {"v4", "true"}}});
+        auto consumer = dynamic_cast<Consumer *>(gVrfOrch->getExecutor(APP_VRF_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gVrfOrch)->doTask();
+
+        entries.clear();
+        entries.push_back({"Vrf1:1.1.1.0/24", "SET", { {"ifname", "Ethernet0,Ethernet0"},
+                                                  {"nexthop", "10.0.0.2,10.0.0.3"},
+                                                  {"vni_label", "500100"},
+                                                  {"router_mac", "7e:f0:c0:e4:b2:5a,7e:f0:c0:e4:b2:5b"}}});
+        entries.push_back({"Vrf1:2.1.1.0/24", "SET", { {"ifname", "Ethernet0,Ethernet0"},
+                                                  {"nexthop", "10.0.0.2,10.0.0.3"},
+                                                  {"vni_label", "500100,500100"},
+                                                  {"router_mac", "7e:f0:c0:e4:b2:5b"}}});
+        consumer = dynamic_cast<Consumer *>(gRouteOrch->getExecutor(APP_ROUTE_TABLE_NAME));
+        consumer->addToSync(entries);
+
+        auto current_create_count = create_route_count;
+        auto current_set_count = set_route_count;
+
+        static_cast<Orch *>(gRouteOrch)->doTask();
+        ASSERT_EQ(current_create_count, create_route_count);
+        ASSERT_EQ(current_set_count, set_route_count);
     }
 }

--- a/tests/mock_tests/routeorch_ut.cpp
+++ b/tests/mock_tests/routeorch_ut.cpp
@@ -509,6 +509,7 @@ namespace routeorch_test
         static_cast<Orch *>(gRouteOrch)->doTask();
 
         gMockResponsePublisher.reset();
+    }
 
     TEST_F(RouteOrchTest, RouteOrchTestInvalidEvpnRoute)
     {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Skip EVPN routes with invalid VNI or router mac field

**Why I did it**
Code assumes number of next hops is equal to amount of VNIs and to amount of router macs.
Usually this is this the case however, we encountered a case of inequality due to bug in FRR. 
Bug was opened to FRR but the code should not assume equality therefore I added the check.

**How I verified it**
I ran EVPN test with code that enforced different vector length, and made sure error is printed to log and route is skipped.

**Details if related**
