### PR TITLE
sonic-swss: Key to check if entry in DB has a no-host-route entry. 

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -1709,6 +1709,15 @@ bool NeighOrch::addVoqEncapIndex(string &alias, IpAddress &ip, vector<sai_attrib
 
     if(gIntfsOrch->isRemoteSystemPortIntf(alias))
     {
+        string route_value;
+        string key = alias + m_tableVoqSystemNeighTable->getTableNameSeparator().c_str() + ip.to_string();
+        
+        if(m_tableVoqSystemNeighTable->hget(key, "no-host-route", route_value))
+        {   
+            attr.id = SAI_NEIGHBOR_ENTRY_ATTR_NO_HOST_ROUTE;
+            attr.value.booldata = true;
+            neighbor_attrs.push_back(attr);
+        }
         if(getSystemPortNeighEncapIndex(alias, ip, encap_index))
         {
             attr.id = SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_INDEX;


### PR DESCRIPTION
Added a check in NeighOrch::addVoqEncapIndex to validate if the there is a key called "no-host-route" in the DB. If there is one then treat that neighbor entry with SAI_NEIGHBOR_ENTRY_ATTR_NO_HOST_ROUTE.

Justification for this change: required for Disaggregated networking support.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added a check in NeighOrch::addVoqEncapIndex to validate if the there is a key called "no-host-route" in the DB. If there is one then treat that neighbor entry with SAI_NEIGHBOR_ENTRY_ATTR_NO_HOST_ROUTE.

**Why I did it**

This is required for identifying if the route for remote neighbor needs to be differently for diaggregated network topology

**How I verified it**



What I did

Added a check in NeighOrch::addVoqEncapIndex to validate if the there is a key called "no-host-route" in the DB.
If there is one then treat that neighbor entry with SAI_NEIGHBOR_ENTRY_ATTR_NO_HOST_ROUTE

Why I did it

This is required for DSF static programming

How I verified it

},
"SYSTEM_NEIGH|Leaf2|Asic0|Ethernet256|77.0.0.1": {
"expireat": 1710262652.593254,
"ttl": -0.001,
"type": "hash",
"value": {
"encap_index": "1168",
"neigh": "f8:e5:7e:61:60:02"
}
},
"SYSTEM_NEIGH|Leaf3|Asic0|Ethernet256|78.0.0.1": {
"expireat": 1710262652.5932121,
"ttl": -0.001,
"type": "hash",
"value": {
"encap_index": "1216",
"neigh": "f8:e5:7e:61:60:03"
}
},
"SYSTEM_NEIGH|Leaf3|Asic0|Ethernet256|fc00:78::1": {
"expireat": 1710262652.5932224,
"ttl": -0.001,
"type": "hash",
"value": {
"encap_index": "1416",
"neigh": "f8:e5:7e:61:60:03"
}
}
}
root@Leaf3:/home/cisco# show chassis system-neighbors
System Port Interface Neighbor MAC Encap Index

Leaf0|Asic0|Ethernet256 75.0.0.1 f8:e5:7e:61:60:00 1072
Leaf1|Asic0|Ethernet256 76.0.0.1 f8:e5:7e:61:60:01 1120
Leaf2|Asic0|Ethernet256 77.0.0.1 f8:e5:7e:61:60:02 1168
Leaf3|Asic0|Ethernet256 78.0.0.1 f8:e5:7e:61:60:03 1216
Leaf3|Asic0|Ethernet256 fc00:78::1 f8:e5:7e:61:60:03 1416

logs:
syslog.20.gz:Mar 9 07:00:56.006094 Leaf3 INFO config_system_neigh.sh[3731]: Executing: sonic-db-cli CHASSIS_APP_DB hset "SYSTEM_NEIGH|Leaf0|Asic0|Ethernet256|75.0.0.1" "encap_index" "1072" "neigh" "f8:e5:7e:61:60:00" "no-host-route" "null"
syslog.20.gz:Mar 9 07:00:56.021578 Leaf3 INFO config_system_neigh.sh[3731]: Executing: sonic-db-cli CHASSIS_APP_DB hset "SYSTEM_NEIGH|Leaf1|Asic0|Ethernet256|76.0.0.1" "encap_index" "1120" "neigh" "f8:e5:7e:61:60:01" "no-host-route" "null"
syslog.20.gz:Mar 9 07:00:56.037819 Leaf3 INFO config_system_neigh.sh[3731]: Executing: sonic-db-cli CHASSIS_APP_DB hset "SYSTEM_NEIGH|Leaf2|Asic0|Ethernet256|77.0.0.1" "encap_index" "1168" "neigh" "f8:e5:7e:61:60:02" "no-host-route" "null"
syslog.20.gz:Mar 9 07:00:56.054838 Leaf3 INFO config_system_neigh.sh[3731]: Executing: sonic-db-cli CHASSIS_APP_DB hset "SYSTEM_NEIGH|Leaf3|Asic0|Ethernet256|78.0.0.1" "encap_index" "1216" "neigh" "f8:e5:7e:61:60:03" "no-host-route" "null"
syslog.20.gz:Mar 9 07:01:11.757862 Leaf3 NOTICE syncd#syncd#syncd: :- saiLoglevelNotify: Setting SAI loglevel SAI_LOG_LEVEL_NOTICE on SAI_API_NEIGHBOR
syslog.20.gz:Mar 9 07:45:56.063693 Leaf3 NOTICE syncd#syncd#syncd: :- saiLoglevelNotify: Setting SAI loglevel SAI_LOG_LEVEL_NOTICE on SAI_API_NEIGHBOR
syslog.20.gz:Mar 9 07:57:58.089596 Leaf3 NOTICE syncd#syncd#syncd: :- saiLoglevelNotify: Setting SAI loglevel SAI_LOG_LEVEL_NOTICE on SAI_API_NEIGHBOR


**Details if related**
