### PR TITLE
[acl] Add IN_PORTS qualifier for L3 table

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3223,6 +3223,7 @@ void AclOrch::initDefaultTableTypes()
             .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_L4_SRC_PORT))
             .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_L4_DST_PORT))
             .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_TCP_FLAGS))
+            .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_IN_PORTS))
             .build()
     );
 
@@ -3240,6 +3241,7 @@ void AclOrch::initDefaultTableTypes()
             .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_L4_SRC_PORT))
             .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_L4_DST_PORT))
             .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_TCP_FLAGS))
+            .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_IN_PORTS))
             .build()
     );
 

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -220,10 +220,10 @@ class TestAcl:
         dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
-    def test_AclRuleInPorts(self, dvs_acl, mirror_acl_table):
+    def test_AclRuleInPorts(self, dvs_acl, l3_acl_table):
         """
         Verify IN_PORTS matches on ACL rule.
-        Using MIRROR table type for IN_PORTS matches.
+        Using L3 table type for IN_PORTS matches.
         """
         config_qualifiers = {
             "IN_PORTS": "Ethernet8,Ethernet12",
@@ -233,14 +233,14 @@ class TestAcl:
             "SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS": dvs_acl.get_port_list_comparator(["Ethernet8", "Ethernet12"])
         }
 
-        dvs_acl.create_acl_rule(MIRROR_TABLE_NAME, MIRROR_RULE_NAME, config_qualifiers)
+        dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
         # Verify status is written into STATE_DB
-        dvs_acl.verify_acl_rule_status(MIRROR_TABLE_NAME, MIRROR_RULE_NAME, "Active")
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, "Active")
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        dvs_acl.remove_acl_rule(MIRROR_TABLE_NAME, MIRROR_RULE_NAME)
+        dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
         # Verify the STATE_DB entry is removed
-        dvs_acl.verify_acl_rule_status(MIRROR_TABLE_NAME, MIRROR_RULE_NAME, None)
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     def test_AclRuleOutPorts(self, dvs_acl, mclag_acl_table):

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -220,7 +220,30 @@ class TestAcl:
         dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
-    def test_AclRuleInPorts(self, dvs_acl, l3_acl_table):
+    def test_AclRuleInPorts(self, dvs_acl, mirror_acl_table):
+        """
+        Verify IN_PORTS matches on ACL rule.
+        Using MIRROR table type for IN_PORTS matches.
+        """
+        config_qualifiers = {
+            "IN_PORTS": "Ethernet8,Ethernet12",
+        }
+
+        expected_sai_qualifiers = {
+            "SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS": dvs_acl.get_port_list_comparator(["Ethernet8", "Ethernet12"])
+        }
+
+        dvs_acl.create_acl_rule(MIRROR_TABLE_NAME, MIRROR_RULE_NAME, config_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(MIRROR_TABLE_NAME, MIRROR_RULE_NAME, "Active")
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+
+        dvs_acl.remove_acl_rule(MIRROR_TABLE_NAME, MIRROR_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(MIRROR_TABLE_NAME, MIRROR_RULE_NAME, None)
+        dvs_acl.verify_no_acl_rules()
+
+    def test_AclRuleInPortsL3(self, dvs_acl, l3_acl_table):
         """
         Verify IN_PORTS matches on ACL rule.
         Using L3 table type for IN_PORTS matches.
@@ -534,6 +557,25 @@ class TestAcl:
         config_qualifiers = {"VLAN_ID": "100"}
         expected_sai_qualifiers = {
             "SAI_ACL_ENTRY_ATTR_FIELD_OUTER_VLAN_ID": dvs_acl.get_simple_qualifier_comparator("100&mask:0xfff")
+        }
+
+        dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        # Verify status is written into STATE_DB
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, "Active")
+
+        dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        # Verify the STATE_DB entry is removed
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, None)
+        dvs_acl.verify_no_acl_rules()
+
+    def test_v6AclRuleInPorts(self, dvs_acl, l3v6_acl_table):
+        config_qualifiers = {
+            "IN_PORTS": "Ethernet8,Ethernet12",
+        }
+
+        expected_sai_qualifiers = {
+            "SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS": dvs_acl.get_port_list_comparator(["Ethernet8", "Ethernet12"])
         }
 
         dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -220,10 +220,10 @@ class TestAcl:
         dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
-    def test_AclRuleInPorts(self, dvs_acl, l3_acl_table):
+    def test_AclRuleInPorts(self, dvs_acl, mirror_acl_table):
         """
         Verify IN_PORTS matches on ACL rule.
-        Using L3 table type for IN_PORTS matches.
+        Using MIRROR table type for IN_PORTS matches.
         """
         config_qualifiers = {
             "IN_PORTS": "Ethernet8,Ethernet12",
@@ -233,14 +233,14 @@ class TestAcl:
             "SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS": dvs_acl.get_port_list_comparator(["Ethernet8", "Ethernet12"])
         }
 
-        dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
+        dvs_acl.create_acl_rule(MIRROR_TABLE_NAME, MIRROR_RULE_NAME, config_qualifiers)
         # Verify status is written into STATE_DB
-        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, "Active")
+        dvs_acl.verify_acl_rule_status(MIRROR_TABLE_NAME, MIRROR_RULE_NAME, "Active")
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        dvs_acl.remove_acl_rule(MIRROR_TABLE_NAME, MIRROR_RULE_NAME)
         # Verify the STATE_DB entry is removed
-        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, None)
+        dvs_acl.verify_acl_rule_status(MIRROR_TABLE_NAME, MIRROR_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
     def test_AclRuleInPortsL3(self, dvs_acl, l3_acl_table):


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added IN_PORTS for L3 v4 and v6 tables

**Why I did it**
IN_PORTS qualifier was allowed for L3 table in 202012 release and below. Changes in #1982 removed that support leading to regression in some of our testcases. The following error was observed
ERR swss#orchagent: :- validateAclRuleMatch: Match SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS in rule RULE_1 is not supported by table DATAACL

**How I verified it**
Build swss deb with the changes and rule creation is successful. Rules are installed in the asic as well
/var/log/syslog.3.gz:Mar 13 23:01:55.331230 str2-7050qx-32s-acs-02 INFO swss#orchagent: :- doAclRuleTask: OP: SET, TABLE_ID: DATAACL, RULE_ID: RULE_1
/var/log/syslog.3.gz:Mar 13 23:01:55.355294 str2-7050qx-32s-acs-02 INFO swss#orchagent: :- createCounter: Created counter for the rule RULE_1 in table DATAACL
/var/log/syslog.3.gz:Mar 13 23:01:55.380069 str2-7050qx-32s-acs-02 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_1 in table DATAACL
```
admin@str2-7050qx-32s-acs-02:~$ show acl rule
Table    Rule          Priority    Action   Match                                                                                                                                                                                                                    Status
-------  ------------ ----------  -------- ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  --------
DATAACL  RULE_1       9999        FORWARD   ETHER_TYPE: 2048                                                                                                                                                                                                         Active
                                           IN_PORTS: Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet4,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet8
                                           VLAN_ID: 1000
DATAACL  DEFAULT_RULE 1           DROP      ETHER_TYPE: 2048                                                                                                                                                                                                         Active
```
