### PR TITLE
Clang format change.

### DIFF
--- a/orchagent/p4orch/acl_rule_manager.cpp
+++ b/orchagent/p4orch/acl_rule_manager.cpp
@@ -9,7 +9,6 @@
 #include "crmorch.h"
 #include "dbconnector.h"
 #include "intfsorch.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "orch.h"
 #include "p4orch.h"
@@ -18,6 +17,7 @@
 #include "sai_serialize.h"
 #include "table.h"
 #include "tokenize.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"
@@ -165,7 +165,8 @@ std::vector<sai_attribute_t> getMeterSaiAttrs(const P4AclMeter &p4_acl_meter)
 
 } // namespace
 
-ReturnCode AclRuleManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode AclRuleManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                        std::string &object_key)
 {
     return StatusCode::SWSS_RC_UNIMPLEMENTED;
 }

--- a/orchagent/p4orch/acl_rule_manager.h
+++ b/orchagent/p4orch/acl_rule_manager.h
@@ -44,7 +44,8 @@ class AclRuleManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
     // Update counters stats for every rule in each ACL table in COUNTERS_DB, if
     // counters are enabled in rules.

--- a/orchagent/p4orch/acl_table_manager.cpp
+++ b/orchagent/p4orch/acl_table_manager.cpp
@@ -7,7 +7,6 @@
 #include "SaiAttributeList.h"
 #include "crmorch.h"
 #include "dbconnector.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "orch.h"
 #include "p4orch.h"
@@ -16,6 +15,7 @@
 #include "switchorch.h"
 #include "table.h"
 #include "tokenize.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"
@@ -205,7 +205,8 @@ ReturnCodeOr<std::vector<sai_attribute_t>> AclTableManager::getUdfSaiAttrs(const
     return udf_attrs;
 }
 
-ReturnCode AclTableManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode AclTableManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                         std::string &object_key)
 {
     return StatusCode::SWSS_RC_UNIMPLEMENTED;
 }

--- a/orchagent/p4orch/acl_table_manager.h
+++ b/orchagent/p4orch/acl_table_manager.h
@@ -34,7 +34,8 @@ class AclTableManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
     // Get ACL table definition by table name in cache. Return nullptr if not
     // found.

--- a/orchagent/p4orch/acl_util.cpp
+++ b/orchagent/p4orch/acl_util.cpp
@@ -1,11 +1,11 @@
 #include "p4orch/acl_util.h"
 
 #include "converter.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "sai_serialize.h"
 #include "table.h"
 #include "tokenize.h"
+#include <nlohmann/json.hpp>
 
 namespace p4orch
 {

--- a/orchagent/p4orch/acl_util.h
+++ b/orchagent/p4orch/acl_util.h
@@ -5,9 +5,9 @@
 #include <string>
 #include <vector>
 
-#include <nlohmann/json.hpp>
 #include "p4orch/p4orch_util.h"
 #include "return_code.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/ext_tables_manager.cpp
+++ b/orchagent/p4orch/ext_tables_manager.cpp
@@ -1,22 +1,22 @@
 #include "p4orch/ext_tables_manager.h"
 
+#include <boost/algorithm/string.hpp>
 #include <memory>
 #include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
-#include <boost/algorithm/string.hpp>
 
-#include "directory.h"
-#include <nlohmann/json.hpp>
-#include "logger.h"
-#include "tokenize.h"
-#include "orch.h"
 #include "crmorch.h"
+#include "directory.h"
+#include "logger.h"
+#include "orch.h"
 #include "p4orch/p4orch.h"
 #include "p4orch/p4orch_util.h"
+#include "tokenize.h"
+#include <nlohmann/json.hpp>
 
-extern sai_counter_api_t*   sai_counter_api;
+extern sai_counter_api_t *sai_counter_api;
 extern sai_generic_programmable_api_t *sai_generic_programmable_api;
 
 extern Directory<Orch *> gDirectory;
@@ -43,10 +43,10 @@ std::string getCrossRefTableName(const std::string table_name)
     auto it = FixedTablesMap.find(table_name);
     if (it != FixedTablesMap.end())
     {
-        return(it->second);
+        return (it->second);
     }
 
-    return(table_name);
+    return (table_name);
 }
 
 ReturnCode ExtTablesManager::validateActionParamsCrossRef(P4ExtTableAppDbEntry &app_db_entry, ActionInfo *action)
@@ -55,8 +55,7 @@ ReturnCode ExtTablesManager::validateActionParamsCrossRef(P4ExtTableAppDbEntry &
     std::unordered_map<std::string, nlohmann::json> cross_ref_key_j;
     ReturnCode status;
 
-    for (auto param_defn_it = action->params.begin();
-              param_defn_it != action->params.end(); param_defn_it++)
+    for (auto param_defn_it = action->params.begin(); param_defn_it != action->params.end(); param_defn_it++)
     {
         ActionParamInfo action_param_defn = param_defn_it->second;
         if (action_param_defn.table_reference_map.empty())
@@ -71,16 +70,16 @@ ReturnCode ExtTablesManager::validateActionParamsCrossRef(P4ExtTableAppDbEntry &
         {
             SWSS_LOG_ERROR("Required param not specified for action %s\n", action_name.c_str());
             return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                     << "Required param not specified for action %s " << action_name.c_str();
+                   << "Required param not specified for action %s " << action_name.c_str();
         }
 
         for (auto cross_ref_it = action_param_defn.table_reference_map.begin();
-                  cross_ref_it != action_param_defn.table_reference_map.end(); cross_ref_it++)
+             cross_ref_it != action_param_defn.table_reference_map.end(); cross_ref_it++)
         {
-            cross_ref_key_j[cross_ref_it->first].push_back(nlohmann::json::object_t::value_type(prependMatchField(cross_ref_it->second), app_db_param_it->second));
+            cross_ref_key_j[cross_ref_it->first].push_back(
+                nlohmann::json::object_t::value_type(prependMatchField(cross_ref_it->second), app_db_param_it->second));
         }
     }
-
 
     for (auto it = cross_ref_key_j.begin(); it != cross_ref_key_j.end(); it++)
     {
@@ -88,7 +87,7 @@ ReturnCode ExtTablesManager::validateActionParamsCrossRef(P4ExtTableAppDbEntry &
         const std::string table_key = it->second.dump();
         std::string key;
         sai_object_type_t object_type;
-        sai_object_id_t   oid;
+        sai_object_id_t oid;
         DepObject dep_object = {};
 
         if (gP4Orch->m_p4TableToManagerMap.find(table_name) != gP4Orch->m_p4TableToManagerMap.end())
@@ -98,10 +97,10 @@ ReturnCode ExtTablesManager::validateActionParamsCrossRef(P4ExtTableAppDbEntry &
             {
                 SWSS_LOG_ERROR("Cross-table reference validation failed from fixed-table %s", table_name.c_str());
                 return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                                   << "Cross-table reference valdiation failed from fixed-table";
+                       << "Cross-table reference valdiation failed from fixed-table";
             }
         }
-       	else 
+        else
         {
             if (getTableInfo(table_name))
             {
@@ -109,16 +108,18 @@ ReturnCode ExtTablesManager::validateActionParamsCrossRef(P4ExtTableAppDbEntry &
                 status = getSaiObject(ext_table_key, object_type, key);
                 if (!status.ok())
                 {
-                    SWSS_LOG_ERROR("Cross-table reference validation failed from extension-table %s", table_name.c_str());
+                    SWSS_LOG_ERROR("Cross-table reference validation failed from extension-table %s",
+                                   table_name.c_str());
                     return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                                       << "Cross-table reference valdiation failed from extension table";
+                           << "Cross-table reference valdiation failed from extension table";
                 }
             }
             else
             {
-                SWSS_LOG_ERROR("Cross-table reference validation failed due to non-existent table %s", table_name.c_str());
+                SWSS_LOG_ERROR("Cross-table reference validation failed due to non-existent table %s",
+                               table_name.c_str());
                 return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                                       << "Cross-table reference valdiation failed due to non-existent table";
+                       << "Cross-table reference valdiation failed due to non-existent table";
             }
         }
 
@@ -126,19 +127,19 @@ ReturnCode ExtTablesManager::validateActionParamsCrossRef(P4ExtTableAppDbEntry &
         {
             SWSS_LOG_ERROR("Cross-table reference validation failed, no OID found from table %s", table_name.c_str());
             return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                               << "Cross-table reference valdiation failed, no OID found";
+                   << "Cross-table reference valdiation failed, no OID found";
         }
 
         if (oid == SAI_NULL_OBJECT_ID)
         {
-            SWSS_LOG_ERROR("Cross-table reference validation failed, null OID expected from table %s", table_name.c_str());
-            return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                               << "Cross-table reference valdiation failed, null OID";
+            SWSS_LOG_ERROR("Cross-table reference validation failed, null OID expected from table %s",
+                           table_name.c_str());
+            return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM) << "Cross-table reference valdiation failed, null OID";
         }
 
-        dep_object.sai_object  = object_type;
-        dep_object.key         = key;
-        dep_object.oid         = oid;
+        dep_object.sai_object = object_type;
+        dep_object.key = key;
+        dep_object.oid = oid;
         app_db_entry.action_dep_objects[action_name] = dep_object;
     }
 
@@ -157,7 +158,7 @@ ReturnCode ExtTablesManager::validateP4ExtTableAppDbEntry(P4ExtTableAppDbEntry &
     {
         SWSS_LOG_ERROR("Not a valid extension table %s", app_db_entry.table_name.c_str());
         return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                       << "Not a valid extension table " << app_db_entry.table_name.c_str();
+               << "Not a valid extension table " << app_db_entry.table_name.c_str();
     }
 
     if (table->action_ref_tables.empty())
@@ -167,15 +168,15 @@ ReturnCode ExtTablesManager::validateP4ExtTableAppDbEntry(P4ExtTableAppDbEntry &
 
     ActionInfo *action;
     for (auto app_db_action_it = app_db_entry.action_params.begin();
-              app_db_action_it != app_db_entry.action_params.end(); app_db_action_it++)
+         app_db_action_it != app_db_entry.action_params.end(); app_db_action_it++)
     {
         auto action_name = app_db_action_it->first;
         action = getTableActionInfo(table, action_name);
         if (action == nullptr)
         {
             return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                     << "Not a valid action " << action_name.c_str()
-                     << " in extension table " << app_db_entry.table_name.c_str();
+                   << "Not a valid action " << action_name.c_str() << " in extension table "
+                   << app_db_entry.table_name.c_str();
         }
 
         if (!action->refers_to)
@@ -186,25 +187,23 @@ ReturnCode ExtTablesManager::validateP4ExtTableAppDbEntry(P4ExtTableAppDbEntry &
         status = validateActionParamsCrossRef(app_db_entry, action);
         if (!status.ok())
         {
-           return status;
+            return status;
         }
     }
 
     return ReturnCode();
 }
 
-
 ReturnCodeOr<P4ExtTableAppDbEntry> ExtTablesManager::deserializeP4ExtTableEntry(
-    const std::string &table_name,
-    const std::string &key, const std::vector<swss::FieldValueTuple> &attributes)
+    const std::string &table_name, const std::string &key, const std::vector<swss::FieldValueTuple> &attributes)
 {
-    std::string  action_name;
+    std::string action_name;
 
     SWSS_LOG_ENTER();
 
     P4ExtTableAppDbEntry app_db_entry_or = {};
     app_db_entry_or.table_name = table_name;
-    app_db_entry_or.table_key  = key;
+    app_db_entry_or.table_key = key;
 
     action_name = "";
     for (const auto &it : attributes)
@@ -223,7 +222,7 @@ ReturnCodeOr<P4ExtTableAppDbEntry> ExtTablesManager::deserializeP4ExtTableEntry(
         {
             SWSS_LOG_ERROR("Unknown extension entry field");
             return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                     << "Unknown extension entry field " << QuotedVar(field);
+                   << "Unknown extension entry field " << QuotedVar(field);
         }
 
         const auto &prefix = tokenized_fields[0];
@@ -244,11 +243,10 @@ ReturnCodeOr<P4ExtTableAppDbEntry> ExtTablesManager::deserializeP4ExtTableEntry(
     return app_db_entry_or;
 }
 
-
 ReturnCode ExtTablesManager::prepareP4SaiExtAPIParams(const P4ExtTableAppDbEntry &app_db_entry,
                                                       std::string &ext_table_entry_attr)
 {
-    nlohmann::json   sai_j, sai_metadata_j, sai_array_j = {}, sai_entry_j;
+    nlohmann::json sai_j, sai_metadata_j, sai_array_j = {}, sai_entry_j;
 
     SWSS_LOG_ENTER();
 
@@ -260,37 +258,37 @@ ReturnCode ExtTablesManager::prepareP4SaiExtAPIParams(const P4ExtTableAppDbEntry
         {
             SWSS_LOG_ERROR("extension entry for invalid table %s", app_db_entry.table_name.c_str());
             return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                         << "extension entry for invalid table " << app_db_entry.table_name.c_str();
+                   << "extension entry for invalid table " << app_db_entry.table_name.c_str();
         }
 
         nlohmann::json j = nlohmann::json::parse(app_db_entry.table_key);
         for (auto it = j.begin(); it != j.end(); ++it)
         {
-            std::string   match, value, prefix;
-            std::size_t   pos;
+            std::string match, value, prefix;
+            std::size_t pos;
 
             match = it.key();
             value = it.value();
 
-	    prefix = p4orch::kMatchPrefix;
+            prefix = p4orch::kMatchPrefix;
             pos = match.rfind(prefix);
             if (pos != std::string::npos)
             {
                 match.erase(0, prefix.length());
             }
-	    else
+            else
             {
                 SWSS_LOG_ERROR("Failed to encode match fields for sai call");
                 return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM) << "Failed to encode match fields for sai call";
             }
 
-	    prefix = p4orch::kFieldDelimiter;
+            prefix = p4orch::kFieldDelimiter;
             pos = match.rfind(prefix);
             if (pos != std::string::npos)
             {
                 match.erase(0, prefix.length());
             }
-	    else
+            else
             {
                 SWSS_LOG_ERROR("Failed to encode match fields for sai call");
                 return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM) << "Failed to encode match fields for sai call";
@@ -301,7 +299,7 @@ ReturnCode ExtTablesManager::prepareP4SaiExtAPIParams(const P4ExtTableAppDbEntry
             {
                 SWSS_LOG_ERROR("extension entry for invalid match field %s", match.c_str());
                 return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                         << "extension entry for invalid match field " << match.c_str();
+                       << "extension entry for invalid match field " << match.c_str();
             }
 
             sai_metadata_j = nlohmann::json::object({});
@@ -315,7 +313,7 @@ ReturnCode ExtTablesManager::prepareP4SaiExtAPIParams(const P4ExtTableAppDbEntry
         }
 
         for (auto app_db_action_it = app_db_entry.action_params.begin();
-                  app_db_action_it != app_db_entry.action_params.end(); app_db_action_it++)
+             app_db_action_it != app_db_entry.action_params.end(); app_db_action_it++)
         {
             sai_j = nlohmann::json::object({});
             auto action_dep_object_it = app_db_entry.action_dep_objects.find(app_db_action_it->first);
@@ -323,9 +321,9 @@ ReturnCode ExtTablesManager::prepareP4SaiExtAPIParams(const P4ExtTableAppDbEntry
             {
                 auto action_defn_it = table->action_fields.find(app_db_action_it->first);
                 for (auto app_db_param_it = app_db_action_it->second.begin();
-                          app_db_param_it != app_db_action_it->second.end(); app_db_param_it++)
+                     app_db_param_it != app_db_action_it->second.end(); app_db_param_it++)
                 {
-                    nlohmann::json  params_j = nlohmann::json::object({});
+                    nlohmann::json params_j = nlohmann::json::object({});
                     if (action_defn_it != table->action_fields.end())
                     {
                         auto param_defn_it = action_defn_it->second.params.find(app_db_param_it->first);
@@ -396,9 +394,8 @@ bool createGenericCounter(sai_object_id_t &counter_id)
     return true;
 }
 
-
 ReturnCode ExtTablesManager::createP4ExtTableEntry(const P4ExtTableAppDbEntry &app_db_entry,
-                                              P4ExtTableEntry &ext_table_entry)
+                                                   P4ExtTableEntry &ext_table_entry)
 {
     ReturnCode status;
     sai_object_type_t object_type;
@@ -428,22 +425,20 @@ ReturnCode ExtTablesManager::createP4ExtTableEntry(const P4ExtTableAppDbEntry &a
     generic_programmable_attr.value.json.json.list = (int8_t *)const_cast<char *>(ext_table_entry_attr.c_str());
     generic_programmable_attrs.push_back(generic_programmable_attr);
 
-
     auto *table = getTableInfo(app_db_entry.table_name);
     if (!table)
     {
         SWSS_LOG_ERROR("extension entry for invalid table %s", app_db_entry.table_name.c_str());
         return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                          << "extension entry for invalid table " << app_db_entry.table_name.c_str();
+               << "extension entry for invalid table " << app_db_entry.table_name.c_str();
     }
 
     if (table->counter_bytes_enabled || table->counter_packets_enabled)
     {
         if (!createGenericCounter(counter_id))
         {
-            SWSS_LOG_WARN("Failed to create counter for table %s, key %s\n",
-       	                  app_db_entry.table_name.c_str(),
-       	                  app_db_entry.table_key.c_str());
+            SWSS_LOG_WARN("Failed to create counter for table %s, key %s\n", app_db_entry.table_name.c_str(),
+                          app_db_entry.table_key.c_str());
         }
         else
         {
@@ -457,32 +452,28 @@ ReturnCode ExtTablesManager::createP4ExtTableEntry(const P4ExtTableAppDbEntry &a
 
     sai_object_id_t sai_generic_programmable_oid = SAI_NULL_OBJECT_ID;
     sai_status_t sai_status = sai_generic_programmable_api->create_generic_programmable(
-                              &sai_generic_programmable_oid, gSwitchId,
-                              (uint32_t)generic_programmable_attrs.size(),
-                              generic_programmable_attrs.data());
+        &sai_generic_programmable_oid, gSwitchId, (uint32_t)generic_programmable_attrs.size(),
+        generic_programmable_attrs.data());
     if (sai_status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("create sai api call failed for extension entry table %s, entry %s",
-      	                app_db_entry.table_name.c_str(), app_db_entry.table_key.c_str());
+                       app_db_entry.table_name.c_str(), app_db_entry.table_key.c_str());
         return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                           << "create sai api call failed for extension entry table "
-                           << app_db_entry.table_name.c_str()
-                           << " , entry " << app_db_entry.table_key.c_str();
+               << "create sai api call failed for extension entry table " << app_db_entry.table_name.c_str()
+               << " , entry " << app_db_entry.table_key.c_str();
     }
     std::string crm_table_name = "EXT_" + app_db_entry.table_name;
     boost::algorithm::to_upper(crm_table_name);
     gCrmOrch->incCrmExtTableUsedCounter(CrmResourceType::CRM_EXT_TABLE, crm_table_name);
 
-
     ext_table_entry.sai_entry_oid = sai_generic_programmable_oid;
     for (auto action_dep_object_it = app_db_entry.action_dep_objects.begin();
-              action_dep_object_it != app_db_entry.action_dep_objects.end(); action_dep_object_it++)
+         action_dep_object_it != app_db_entry.action_dep_objects.end(); action_dep_object_it++)
     {
         auto action_dep_object = action_dep_object_it->second;
         m_p4OidMapper->increaseRefCount(action_dep_object.sai_object, action_dep_object.key);
         ext_table_entry.action_dep_objects[action_dep_object_it->first] = action_dep_object;
     }
-
 
     auto ext_table_key = KeyGenerator::generateExtTableKey(app_db_entry.table_name, app_db_entry.table_key);
     status = getSaiObject(ext_table_key, object_type, key);
@@ -497,9 +488,8 @@ ReturnCode ExtTablesManager::createP4ExtTableEntry(const P4ExtTableAppDbEntry &a
     return ReturnCode();
 }
 
-
 ReturnCode ExtTablesManager::updateP4ExtTableEntry(const P4ExtTableAppDbEntry &app_db_entry,
-                                              P4ExtTableEntry *ext_table_entry)
+                                                   P4ExtTableEntry *ext_table_entry)
 {
     ReturnCode status;
     std::string ext_table_entry_attr;
@@ -510,11 +500,10 @@ ReturnCode ExtTablesManager::updateP4ExtTableEntry(const P4ExtTableAppDbEntry &a
     if (ext_table_entry->sai_entry_oid == SAI_NULL_OBJECT_ID)
     {
         SWSS_LOG_ERROR("update sai api call for NULL extension entry table %s, entry %s",
-      	                app_db_entry.table_name.c_str(), ext_table_entry->table_key.c_str());
+                       app_db_entry.table_name.c_str(), ext_table_entry->table_key.c_str());
         return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                           << "update sai api call for NULL extension entry table "
-                           << app_db_entry.table_name.c_str()
-                           << " , entry " << ext_table_entry->table_key.c_str();
+               << "update sai api call for NULL extension entry table " << app_db_entry.table_name.c_str()
+               << " , entry " << ext_table_entry->table_key.c_str();
     }
 
     status = prepareP4SaiExtAPIParams(app_db_entry, ext_table_entry_attr);
@@ -531,24 +520,21 @@ ReturnCode ExtTablesManager::updateP4ExtTableEntry(const P4ExtTableAppDbEntry &a
     generic_programmable_attr.value.json.json.list = (int8_t *)const_cast<char *>(ext_table_entry_attr.c_str());
 
     sai_status_t sai_status = sai_generic_programmable_api->set_generic_programmable_attribute(
-                              ext_table_entry->sai_entry_oid,
-                              &generic_programmable_attr);
+        ext_table_entry->sai_entry_oid, &generic_programmable_attr);
     if (sai_status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("update sai api call failed for extension entry table %s, entry %s",
-      	                app_db_entry.table_name.c_str(), ext_table_entry->table_key.c_str());
+                       app_db_entry.table_name.c_str(), ext_table_entry->table_key.c_str());
         return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                           << "update sai api call failed for extension entry table "
-                           << app_db_entry.table_name.c_str()
-                           << " , entry " << ext_table_entry->table_key.c_str();
+               << "update sai api call failed for extension entry table " << app_db_entry.table_name.c_str()
+               << " , entry " << ext_table_entry->table_key.c_str();
     }
-
 
     old_action_dep_objects = ext_table_entry->action_dep_objects;
     ext_table_entry->action_dep_objects.clear();
 
     for (auto action_dep_object_it = app_db_entry.action_dep_objects.begin();
-              action_dep_object_it != app_db_entry.action_dep_objects.end(); action_dep_object_it++)
+         action_dep_object_it != app_db_entry.action_dep_objects.end(); action_dep_object_it++)
     {
         auto action_dep_object = action_dep_object_it->second;
         m_p4OidMapper->increaseRefCount(action_dep_object.sai_object, action_dep_object.key);
@@ -556,7 +542,7 @@ ReturnCode ExtTablesManager::updateP4ExtTableEntry(const P4ExtTableAppDbEntry &a
     }
 
     for (auto old_action_dep_object_it = old_action_dep_objects.begin();
-              old_action_dep_object_it != old_action_dep_objects.end(); old_action_dep_object_it++)
+         old_action_dep_object_it != old_action_dep_objects.end(); old_action_dep_object_it++)
     {
         auto old_action_dep_object = old_action_dep_object_it->second;
         m_p4OidMapper->decreaseRefCount(old_action_dep_object.sai_object, old_action_dep_object.key);
@@ -565,8 +551,7 @@ ReturnCode ExtTablesManager::updateP4ExtTableEntry(const P4ExtTableAppDbEntry &a
     return ReturnCode();
 }
 
-ReturnCode ExtTablesManager::removeP4ExtTableEntry(const std::string &table_name,
-                                              const std::string &table_key)
+ReturnCode ExtTablesManager::removeP4ExtTableEntry(const std::string &table_name, const std::string &table_key)
 {
     ReturnCode status;
     sai_object_type_t object_type;
@@ -578,35 +563,30 @@ ReturnCode ExtTablesManager::removeP4ExtTableEntry(const std::string &table_name
     if (!ext_table_entry)
     {
         LOG_ERROR_AND_RETURN(ReturnCode(StatusCode::SWSS_RC_NOT_FOUND)
-                             << "extension entry with key " << QuotedVar(table_key)
-                             << " does not exist for table " << QuotedVar(table_name));
+                             << "extension entry with key " << QuotedVar(table_key) << " does not exist for table "
+                             << QuotedVar(table_name));
     }
 
     if (ext_table_entry->sai_entry_oid == SAI_NULL_OBJECT_ID)
     {
-        SWSS_LOG_ERROR("remove sai api call for NULL extension entry table %s, entry %s",
-      	                table_name.c_str(), table_key.c_str());
-        return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                           << "remove sai api call for NULL extension entry table "
-                           << table_name.c_str() << " , entry " << table_key.c_str();
+        SWSS_LOG_ERROR("remove sai api call for NULL extension entry table %s, entry %s", table_name.c_str(),
+                       table_key.c_str());
+        return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM) << "remove sai api call for NULL extension entry table "
+                                                             << table_name.c_str() << " , entry " << table_key.c_str();
     }
 
-    SWSS_LOG_ERROR("table: %s, key: %s", ext_table_entry->table_name.c_str(),
-                                         ext_table_entry->table_key.c_str());
-    sai_status_t sai_status = sai_generic_programmable_api->remove_generic_programmable(
-                              ext_table_entry->sai_entry_oid);
+    SWSS_LOG_ERROR("table: %s, key: %s", ext_table_entry->table_name.c_str(), ext_table_entry->table_key.c_str());
+    sai_status_t sai_status = sai_generic_programmable_api->remove_generic_programmable(ext_table_entry->sai_entry_oid);
     if (sai_status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR("remove sai api call failed for extension entry table %s, entry %s",
-      	                table_name.c_str(), table_key.c_str());
-        return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                           << "remove sai api call failed for extension entry table "
-                           << table_name.c_str() << " , entry " << table_key.c_str();
+        SWSS_LOG_ERROR("remove sai api call failed for extension entry table %s, entry %s", table_name.c_str(),
+                       table_key.c_str());
+        return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM) << "remove sai api call failed for extension entry table "
+                                                             << table_name.c_str() << " , entry " << table_key.c_str();
     }
     std::string crm_table_name = "EXT_" + table_name;
     boost::algorithm::to_upper(crm_table_name);
     gCrmOrch->decCrmExtTableUsedCounter(CrmResourceType::CRM_EXT_TABLE, crm_table_name);
-
 
     auto ext_table_key = KeyGenerator::generateExtTableKey(table_name, table_key);
     status = getSaiObject(ext_table_key, object_type, key);
@@ -630,7 +610,7 @@ ReturnCode ExtTablesManager::removeP4ExtTableEntry(const std::string &table_name
     m_p4OidMapper->eraseOID(object_type, key);
 
     for (auto action_dep_object_it = ext_table_entry->action_dep_objects.begin();
-              action_dep_object_it != ext_table_entry->action_dep_objects.end(); action_dep_object_it++)
+         action_dep_object_it != ext_table_entry->action_dep_objects.end(); action_dep_object_it++)
     {
         auto action_dep_object = action_dep_object_it->second;
         m_p4OidMapper->decreaseRefCount(action_dep_object.sai_object, action_dep_object.key);
@@ -647,7 +627,6 @@ ReturnCode ExtTablesManager::removeP4ExtTableEntry(const std::string &table_name
     return ReturnCode();
 }
 
-
 ReturnCode ExtTablesManager::processAddRequest(const P4ExtTableAppDbEntry &app_db_entry)
 {
     SWSS_LOG_ENTER();
@@ -662,15 +641,14 @@ ReturnCode ExtTablesManager::processAddRequest(const P4ExtTableAppDbEntry &app_d
 }
 
 ReturnCode ExtTablesManager::processUpdateRequest(const P4ExtTableAppDbEntry &app_db_entry,
-                                               P4ExtTableEntry *ext_table_entry)
+                                                  P4ExtTableEntry *ext_table_entry)
 {
     SWSS_LOG_ENTER();
 
     auto status = updateP4ExtTableEntry(app_db_entry, ext_table_entry);
     if (!status.ok())
     {
-        SWSS_LOG_ERROR("Failed to update extension entry with key %s",
-       	                app_db_entry.table_key.c_str());
+        SWSS_LOG_ERROR("Failed to update extension entry with key %s", app_db_entry.table_key.c_str());
     }
     return ReturnCode();
 }
@@ -682,14 +660,13 @@ ReturnCode ExtTablesManager::processDeleteRequest(const P4ExtTableAppDbEntry &ap
     auto status = removeP4ExtTableEntry(app_db_entry.table_name, app_db_entry.table_key);
     if (!status.ok())
     {
-        SWSS_LOG_ERROR("Failed to remove extension entry with key %s",
-       	                app_db_entry.table_key.c_str());
+        SWSS_LOG_ERROR("Failed to remove extension entry with key %s", app_db_entry.table_key.c_str());
     }
     return ReturnCode();
 }
 
-
-ReturnCode ExtTablesManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode ExtTablesManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                          std::string &object_key)
 {
     object_type = SAI_OBJECT_TYPE_GENERIC_PROGRAMMABLE;
     object_key = json_key;
@@ -707,97 +684,99 @@ void ExtTablesManager::drain()
     SWSS_LOG_ENTER();
     std::string table_prefix = "EXT_";
 
-    if (gP4Orch->tablesinfo) {
-      for (auto table_it = gP4Orch->tablesinfo->m_tablePrecedenceMap.begin();
-                table_it != gP4Orch->tablesinfo->m_tablePrecedenceMap.end(); ++table_it)
-      {
-        auto table_name = table_prefix + table_it->second;
-        boost::algorithm::to_upper(table_name);
-        auto it_m = m_entriesTables.find(table_name);
-        if (it_m == m_entriesTables.end())
+    if (gP4Orch->tablesinfo)
+    {
+        for (auto table_it = gP4Orch->tablesinfo->m_tablePrecedenceMap.begin();
+             table_it != gP4Orch->tablesinfo->m_tablePrecedenceMap.end(); ++table_it)
         {
-            continue;
-        }
-
-        for (const auto &key_op_fvs_tuple : it_m->second)
-        {
-            std::string table_name;
-            std::string table_key;
-
-            parseP4RTKey(kfvKey(key_op_fvs_tuple), &table_name, &table_key);
-            const std::vector<swss::FieldValueTuple> &attributes = kfvFieldsValues(key_op_fvs_tuple);
-
-            if (table_name.rfind(table_prefix, 0) == std::string::npos)
+            auto table_name = table_prefix + table_it->second;
+            boost::algorithm::to_upper(table_name);
+            auto it_m = m_entriesTables.find(table_name);
+            if (it_m == m_entriesTables.end())
             {
-                SWSS_LOG_ERROR("Table %s is without prefix %s", table_name.c_str(), table_prefix.c_str());
-                m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
-                                     StatusCode::SWSS_RC_INVALID_PARAM, /*replace=*/true);
-                continue;
-            }
-            table_name = table_name.substr(table_prefix.length());
-            boost::algorithm::to_lower(table_name);
-
-            ReturnCode status;
-            auto app_db_entry_or = deserializeP4ExtTableEntry(table_name, table_key, attributes);
-            if (!app_db_entry_or.ok())
-            {
-                status = app_db_entry_or.status();
-                SWSS_LOG_ERROR("Unable to deserialize APP DB entry with key %s: %s",
-                               QuotedVar(kfvKey(key_op_fvs_tuple)).c_str(), status.message().c_str());
-                m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
-                                     status, /*replace=*/true);
                 continue;
             }
 
-            auto &app_db_entry = *app_db_entry_or;
-            status = validateP4ExtTableAppDbEntry(app_db_entry);
-            if (!status.ok())
+            for (const auto &key_op_fvs_tuple : it_m->second)
             {
-                SWSS_LOG_ERROR("Validation failed for extension APP DB entry with key %s: %s",
-                               QuotedVar(kfvKey(key_op_fvs_tuple)).c_str(), status.message().c_str());
-                m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
-                                     status, /*replace=*/true);
-                continue;
-            }
+                std::string table_name;
+                std::string table_key;
 
-            const std::string &operation = kfvOp(key_op_fvs_tuple);
-            if (operation == SET_COMMAND)
-            {
-                auto *ext_table_entry = getP4ExtTableEntry(app_db_entry.table_name, app_db_entry.table_key);
-                if (ext_table_entry == nullptr)
+                parseP4RTKey(kfvKey(key_op_fvs_tuple), &table_name, &table_key);
+                const std::vector<swss::FieldValueTuple> &attributes = kfvFieldsValues(key_op_fvs_tuple);
+
+                if (table_name.rfind(table_prefix, 0) == std::string::npos)
                 {
-                    // Create extension entry
-                    app_db_entry.db_key = kfvKey(key_op_fvs_tuple);
-                    status = processAddRequest(app_db_entry);
+                    SWSS_LOG_ERROR("Table %s is without prefix %s", table_name.c_str(), table_prefix.c_str());
+                    m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple),
+                                         kfvFieldsValues(key_op_fvs_tuple), StatusCode::SWSS_RC_INVALID_PARAM,
+                                         /*replace=*/true);
+                    continue;
+                }
+                table_name = table_name.substr(table_prefix.length());
+                boost::algorithm::to_lower(table_name);
+
+                ReturnCode status;
+                auto app_db_entry_or = deserializeP4ExtTableEntry(table_name, table_key, attributes);
+                if (!app_db_entry_or.ok())
+                {
+                    status = app_db_entry_or.status();
+                    SWSS_LOG_ERROR("Unable to deserialize APP DB entry with key %s: %s",
+                                   QuotedVar(kfvKey(key_op_fvs_tuple)).c_str(), status.message().c_str());
+                    m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple),
+                                         kfvFieldsValues(key_op_fvs_tuple), status, /*replace=*/true);
+                    continue;
+                }
+
+                auto &app_db_entry = *app_db_entry_or;
+                status = validateP4ExtTableAppDbEntry(app_db_entry);
+                if (!status.ok())
+                {
+                    SWSS_LOG_ERROR("Validation failed for extension APP DB entry with key %s: %s",
+                                   QuotedVar(kfvKey(key_op_fvs_tuple)).c_str(), status.message().c_str());
+                    m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple),
+                                         kfvFieldsValues(key_op_fvs_tuple), status, /*replace=*/true);
+                    continue;
+                }
+
+                const std::string &operation = kfvOp(key_op_fvs_tuple);
+                if (operation == SET_COMMAND)
+                {
+                    auto *ext_table_entry = getP4ExtTableEntry(app_db_entry.table_name, app_db_entry.table_key);
+                    if (ext_table_entry == nullptr)
+                    {
+                        // Create extension entry
+                        app_db_entry.db_key = kfvKey(key_op_fvs_tuple);
+                        status = processAddRequest(app_db_entry);
+                    }
+                    else
+                    {
+                        // Modify existing extension entry
+                        status = processUpdateRequest(app_db_entry, ext_table_entry);
+                    }
+                }
+                else if (operation == DEL_COMMAND)
+                {
+                    // Delete extension entry
+                    status = processDeleteRequest(app_db_entry);
                 }
                 else
                 {
-                    // Modify existing extension entry
-                    status = processUpdateRequest(app_db_entry, ext_table_entry);
+                    status = ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
+                             << "Unknown operation type " << QuotedVar(operation);
+                    SWSS_LOG_ERROR("%s", status.message().c_str());
                 }
+                if (!status.ok())
+                {
+                    SWSS_LOG_ERROR("Processing failed for extension APP_DB entry with key %s: %s",
+                                   QuotedVar(kfvKey(key_op_fvs_tuple)).c_str(), status.message().c_str());
+                }
+                m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
+                                     status, /*replace=*/true);
             }
-            else if (operation == DEL_COMMAND)
-            {
-                // Delete extension entry
-                status = processDeleteRequest(app_db_entry);
-            }
-            else
-            {
-                status = ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-       	                   << "Unknown operation type " << QuotedVar(operation);
-                SWSS_LOG_ERROR("%s", status.message().c_str());
-            }
-            if (!status.ok())
-            {
-                SWSS_LOG_ERROR("Processing failed for extension APP_DB entry with key %s: %s",
-                               QuotedVar(kfvKey(key_op_fvs_tuple)).c_str(), status.message().c_str());
-            }
-            m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
-                                 status, /*replace=*/true);
-        }
 
-        it_m->second.clear();
-      }
+            it_m->second.clear();
+        }
     }
 
     // Now report error for all remaining un-processed entries
@@ -813,7 +792,6 @@ void ExtTablesManager::drain()
     }
 }
 
-
 void ExtTablesManager::doExtCounterStatsTask()
 {
     SWSS_LOG_ENTER();
@@ -823,12 +801,12 @@ void ExtTablesManager::doExtCounterStatsTask()
         return;
     }
 
-    sai_stat_id_t stat_ids[] = { SAI_COUNTER_STAT_PACKETS, SAI_COUNTER_STAT_BYTES };
+    sai_stat_id_t stat_ids[] = {SAI_COUNTER_STAT_PACKETS, SAI_COUNTER_STAT_BYTES};
     uint64_t stats[2];
     std::vector<swss::FieldValueTuple> counter_stats_values;
 
     for (auto table_it = gP4Orch->tablesinfo->m_tableInfoMap.begin();
-              table_it != gP4Orch->tablesinfo->m_tableInfoMap.end(); ++table_it)
+         table_it != gP4Orch->tablesinfo->m_tableInfoMap.end(); ++table_it)
     {
         if (!table_it->second.counter_bytes_enabled && !table_it->second.counter_packets_enabled)
         {
@@ -842,8 +820,8 @@ void ExtTablesManager::doExtCounterStatsTask()
             continue;
         }
 
-        for (auto ext_table_entry_it = ext_table_it->second.begin();
-                  ext_table_entry_it != ext_table_it->second.end(); ++ext_table_entry_it)
+        for (auto ext_table_entry_it = ext_table_it->second.begin(); ext_table_entry_it != ext_table_it->second.end();
+             ++ext_table_entry_it)
         {
             auto *ext_table_entry = &ext_table_entry_it->second;
             if (ext_table_entry->sai_counter_oid == SAI_NULL_OBJECT_ID)
@@ -852,18 +830,16 @@ void ExtTablesManager::doExtCounterStatsTask()
             }
 
             sai_status_t sai_status =
-                    sai_counter_api->get_counter_stats(ext_table_entry->sai_counter_oid, 2, stat_ids, stats);
+                sai_counter_api->get_counter_stats(ext_table_entry->sai_counter_oid, 2, stat_ids, stats);
             if (sai_status != SAI_STATUS_SUCCESS)
             {
                 SWSS_LOG_WARN("Failed to set counters stats for extension entry %s:%s in COUNTERS_DB: ",
-       	                       table_name.c_str(), ext_table_entry->table_key.c_str());
+                              table_name.c_str(), ext_table_entry->table_key.c_str());
                 continue;
             }
 
-            counter_stats_values.push_back(
-                    swss::FieldValueTuple{P4_COUNTER_STATS_PACKETS, std::to_string(stats[0])});
-            counter_stats_values.push_back(
-                    swss::FieldValueTuple{P4_COUNTER_STATS_BYTES, std::to_string(stats[1])});
+            counter_stats_values.push_back(swss::FieldValueTuple{P4_COUNTER_STATS_PACKETS, std::to_string(stats[0])});
+            counter_stats_values.push_back(swss::FieldValueTuple{P4_COUNTER_STATS_BYTES, std::to_string(stats[1])});
 
             // Set field value tuples for counters stats in COUNTERS_DB
             m_countersTable->set(ext_table_entry->db_key, counter_stats_values);
@@ -878,4 +854,3 @@ std::string ExtTablesManager::verifyState(const std::string &key, const std::vec
 
     return result;
 }
-

--- a/orchagent/p4orch/ext_tables_manager.h
+++ b/orchagent/p4orch/ext_tables_manager.h
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "macaddress.h"
-#include <nlohmann/json.hpp>
 #include "orch.h"
 #include "p4orch/object_manager_interface.h"
 #include "p4orch/p4oidmapper.h"
@@ -15,6 +14,7 @@
 #include "response_publisher_interface.h"
 #include "return_code.h"
 #include "vrforch.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"
@@ -29,9 +29,9 @@ struct P4ExtTableEntry
     sai_object_id_t sai_counter_oid = SAI_NULL_OBJECT_ID;
     std::unordered_map<std::string, DepObject> action_dep_objects;
 
-    P4ExtTableEntry() {};
+    P4ExtTableEntry(){};
     P4ExtTableEntry(const std::string &db_key, const std::string &table_name, const std::string &table_key)
-            : db_key(db_key), table_name(table_name), table_key(table_key)
+        : db_key(db_key), table_name(table_name), table_key(table_key)
     {
     }
 };
@@ -44,10 +44,9 @@ class ExtTablesManager : public ObjectManagerInterface
 {
   public:
     ExtTablesManager(P4OidMapper *p4oidMapper, VRFOrch *vrfOrch, ResponsePublisherInterface *publisher)
-      : m_vrfOrch(vrfOrch),
-        m_countersDb(std::make_unique<swss::DBConnector>("COUNTERS_DB", 0)),
-        m_countersTable(std::make_unique<swss::Table>(
-            m_countersDb.get(), std::string(COUNTERS_TABLE) + DEFAULT_KEY_SEPARATOR + APP_P4RT_TABLE_NAME))
+        : m_vrfOrch(vrfOrch), m_countersDb(std::make_unique<swss::DBConnector>("COUNTERS_DB", 0)),
+          m_countersTable(std::make_unique<swss::Table>(
+              m_countersDb.get(), std::string(COUNTERS_TABLE) + DEFAULT_KEY_SEPARATOR + APP_P4RT_TABLE_NAME))
     {
         SWSS_LOG_ENTER();
 
@@ -61,21 +60,20 @@ class ExtTablesManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
     // For every extension entry, update counters stats in COUNTERS_DB, if
     // counters are enabled for those entries
     void doExtCounterStatsTask();
 
   private:
-    ReturnCodeOr<P4ExtTableAppDbEntry> deserializeP4ExtTableEntry(
-        const std::string &table_name,
-        const std::string &key, const std::vector<swss::FieldValueTuple> &attributes);
+    ReturnCodeOr<P4ExtTableAppDbEntry> deserializeP4ExtTableEntry(const std::string &table_name, const std::string &key,
+                                                                  const std::vector<swss::FieldValueTuple> &attributes);
     ReturnCode validateActionParamsCrossRef(P4ExtTableAppDbEntry &app_db_entry, ActionInfo *action);
     ReturnCode validateP4ExtTableAppDbEntry(P4ExtTableAppDbEntry &app_db_entry);
     P4ExtTableEntry *getP4ExtTableEntry(const std::string &table_name, const std::string &table_key);
-    ReturnCode prepareP4SaiExtAPIParams(const P4ExtTableAppDbEntry &app_db_entry,
-                                        std::string &ext_table_entry_attr);
+    ReturnCode prepareP4SaiExtAPIParams(const P4ExtTableAppDbEntry &app_db_entry, std::string &ext_table_entry_attr);
     ReturnCode createP4ExtTableEntry(const P4ExtTableAppDbEntry &app_db_entry, P4ExtTableEntry &ext_table_entry);
     ReturnCode updateP4ExtTableEntry(const P4ExtTableAppDbEntry &app_db_entry, P4ExtTableEntry *ext_table_entry);
     ReturnCode removeP4ExtTableEntry(const std::string &table_name, const std::string &table_key);

--- a/orchagent/p4orch/gre_tunnel_manager.cpp
+++ b/orchagent/p4orch/gre_tunnel_manager.cpp
@@ -9,12 +9,12 @@
 #include "crmorch.h"
 #include "dbconnector.h"
 #include "ipaddress.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "p4orch/p4orch_util.h"
 #include "sai_serialize.h"
 #include "swssnet.h"
 #include "table.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"
@@ -98,7 +98,8 @@ P4GreTunnelEntry::P4GreTunnelEntry(const std::string &tunnel_id, const std::stri
     tunnel_key = KeyGenerator::generateTunnelKey(tunnel_id);
 }
 
-ReturnCode GreTunnelManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode GreTunnelManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                          std::string &object_key)
 {
     return StatusCode::SWSS_RC_UNIMPLEMENTED;
 }

--- a/orchagent/p4orch/gre_tunnel_manager.h
+++ b/orchagent/p4orch/gre_tunnel_manager.h
@@ -72,7 +72,8 @@ class GreTunnelManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
     ReturnCodeOr<const P4GreTunnelEntry> getConstGreTunnelEntry(const std::string &gre_tunnel_key);
 

--- a/orchagent/p4orch/l3_admit_manager.cpp
+++ b/orchagent/p4orch/l3_admit_manager.cpp
@@ -7,7 +7,6 @@
 
 #include "SaiAttributeList.h"
 #include "dbconnector.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "p4orch/p4orch_util.h"
 #include "portsorch.h"
@@ -15,6 +14,7 @@
 #include "sai_serialize.h"
 #include "table.h"
 #include "tokenize.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"
@@ -64,7 +64,8 @@ ReturnCodeOr<std::vector<sai_attribute_t>> getSaiAttrs(const P4L3AdmitEntry &l3_
 
 } // namespace
 
-ReturnCode L3AdmitManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode L3AdmitManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                        std::string &object_key)
 {
     return StatusCode::SWSS_RC_UNIMPLEMENTED;
 }

--- a/orchagent/p4orch/l3_admit_manager.h
+++ b/orchagent/p4orch/l3_admit_manager.h
@@ -63,7 +63,8 @@ class L3AdmitManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
   private:
     // Gets the internal cached next hop entry by its key.

--- a/orchagent/p4orch/mirror_session_manager.cpp
+++ b/orchagent/p4orch/mirror_session_manager.cpp
@@ -4,13 +4,13 @@
 
 #include "SaiAttributeList.h"
 #include "dbconnector.h"
-#include <nlohmann/json.hpp>
 #include "p4orch/p4orch_util.h"
 #include "portsorch.h"
 #include "sai_serialize.h"
 #include "swss/logger.h"
 #include "swssnet.h"
 #include "table.h"
+#include <nlohmann/json.hpp>
 
 using ::p4orch::kTableKeyDelimiter;
 
@@ -21,13 +21,14 @@ extern sai_object_id_t gSwitchId;
 namespace p4orch
 {
 
-ReturnCode MirrorSessionManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode MirrorSessionManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                              std::string &object_key)
 {
-    std::string     value;
+    std::string value;
 
     try
     {
-        nlohmann::json  j = nlohmann::json::parse(json_key);
+        nlohmann::json j = nlohmann::json::parse(json_key);
         if (j.find(prependMatchField(p4orch::kMirrorSessionId)) != j.end())
         {
             value = j.at(prependMatchField(p4orch::kMirrorSessionId)).get<std::string>();

--- a/orchagent/p4orch/mirror_session_manager.h
+++ b/orchagent/p4orch/mirror_session_manager.h
@@ -87,7 +87,8 @@ class MirrorSessionManager : public ObjectManagerInterface
 
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
 
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
   private:
     ReturnCodeOr<P4MirrorSessionAppDbEntry> deserializeP4MirrorSessionAppDbEntry(

--- a/orchagent/p4orch/neighbor_manager.cpp
+++ b/orchagent/p4orch/neighbor_manager.cpp
@@ -7,13 +7,13 @@
 #include "SaiAttributeList.h"
 #include "crmorch.h"
 #include "dbconnector.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "orch.h"
 #include "p4orch/p4orch_util.h"
 #include "sai_serialize.h"
 #include "swssnet.h"
 #include "table.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"
@@ -324,14 +324,15 @@ ReturnCode NeighborManager::processDeleteRequest(const std::string &neighbor_key
     return status;
 }
 
-ReturnCode NeighborManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode NeighborManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                         std::string &object_key)
 {
-    std::string     router_intf_id, neighbor_id;
+    std::string router_intf_id, neighbor_id;
     swss::IpAddress neighbor;
 
     try
     {
-        nlohmann::json  j = nlohmann::json::parse(json_key);
+        nlohmann::json j = nlohmann::json::parse(json_key);
         if (j.find(prependMatchField(p4orch::kRouterInterfaceId)) != j.end())
         {
             router_intf_id = j.at(prependMatchField(p4orch::kRouterInterfaceId)).get<std::string>();
@@ -350,7 +351,8 @@ ReturnCode NeighborManager::getSaiObject(const std::string &json_key, sai_object
         }
         else
         {
-            SWSS_LOG_ERROR("%s match parameter absent: required for dependent object query", p4orch::kRouterInterfaceId);
+            SWSS_LOG_ERROR("%s match parameter absent: required for dependent object query",
+                           p4orch::kRouterInterfaceId);
         }
     }
     catch (std::exception &ex)

--- a/orchagent/p4orch/neighbor_manager.h
+++ b/orchagent/p4orch/neighbor_manager.h
@@ -52,7 +52,8 @@ class NeighborManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
   private:
     ReturnCodeOr<P4NeighborAppDbEntry> deserializeNeighborEntry(const std::string &key,

--- a/orchagent/p4orch/next_hop_manager.cpp
+++ b/orchagent/p4orch/next_hop_manager.cpp
@@ -8,13 +8,13 @@
 #include "crmorch.h"
 #include "dbconnector.h"
 #include "ipaddress.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "p4orch/p4orch.h"
 #include "p4orch/p4orch_util.h"
 #include "sai_serialize.h"
 #include "swssnet.h"
 #include "table.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"
@@ -147,13 +147,14 @@ ReturnCodeOr<std::vector<sai_attribute_t>> NextHopManager::getSaiAttrs(const P4N
     return next_hop_attrs;
 }
 
-ReturnCode NextHopManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode NextHopManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                        std::string &object_key)
 {
-    std::string     value;
+    std::string value;
 
     try
     {
-        nlohmann::json  j = nlohmann::json::parse(json_key);
+        nlohmann::json j = nlohmann::json::parse(json_key);
         if (j.find(prependMatchField(p4orch::kNexthopId)) != j.end())
         {
             value = j.at(prependMatchField(p4orch::kNexthopId)).get<std::string>();

--- a/orchagent/p4orch/next_hop_manager.h
+++ b/orchagent/p4orch/next_hop_manager.h
@@ -60,7 +60,8 @@ class NextHopManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
   private:
     // Gets the internal cached next hop entry by its key.

--- a/orchagent/p4orch/object_manager_interface.h
+++ b/orchagent/p4orch/object_manager_interface.h
@@ -18,5 +18,6 @@ class ObjectManagerInterface
 
     // For sai extension objects depending on a sai object
     // return sai object id for a given table with a given key
-    virtual ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) = 0;
+    virtual ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                    std::string &object_key) = 0;
 };

--- a/orchagent/p4orch/p4orch.cpp
+++ b/orchagent/p4orch/p4orch.cpp
@@ -8,17 +8,17 @@
 #include "copporch.h"
 #include "logger.h"
 #include "orch.h"
-#include "p4orch/p4orch_util.h"
-#include "p4orch/tables_definition_manager.h"
 #include "p4orch/acl_rule_manager.h"
 #include "p4orch/acl_table_manager.h"
+#include "p4orch/ext_tables_manager.h"
 #include "p4orch/gre_tunnel_manager.h"
 #include "p4orch/l3_admit_manager.h"
 #include "p4orch/neighbor_manager.h"
 #include "p4orch/next_hop_manager.h"
+#include "p4orch/p4orch_util.h"
 #include "p4orch/route_manager.h"
 #include "p4orch/router_interface_manager.h"
-#include "p4orch/ext_tables_manager.h"
+#include "p4orch/tables_definition_manager.h"
 #include "portsorch.h"
 #include "return_code.h"
 #include "sai_serialize.h"
@@ -142,7 +142,7 @@ void P4Orch::doTask(Consumer &consumer)
             else
             {
                 auto status = ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                                  << "Failed to find P4Orch Manager for " << table_name << " P4RT DB table";
+                              << "Failed to find P4Orch Manager for " << table_name << " P4RT DB table";
                 SWSS_LOG_ERROR("%s", status.message().c_str());
                 m_publisher.publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
                                     status);

--- a/orchagent/p4orch/p4orch.h
+++ b/orchagent/p4orch/p4orch.h
@@ -10,9 +10,9 @@
 #include "notificationconsumer.h"
 #include "notifier.h"
 #include "orch.h"
-#include "p4orch/tables_definition_manager.h"
 #include "p4orch/acl_rule_manager.h"
 #include "p4orch/acl_table_manager.h"
+#include "p4orch/ext_tables_manager.h"
 #include "p4orch/gre_tunnel_manager.h"
 #include "p4orch/l3_admit_manager.h"
 #include "p4orch/mirror_session_manager.h"
@@ -22,22 +22,21 @@
 #include "p4orch/p4oidmapper.h"
 #include "p4orch/route_manager.h"
 #include "p4orch/router_interface_manager.h"
+#include "p4orch/tables_definition_manager.h"
 #include "p4orch/wcmp_manager.h"
-#include "p4orch/ext_tables_manager.h"
 #include "response_publisher.h"
 #include "vrforch.h"
 
 static const std::map<std::string, std::string> FixedTablesMap = {
-    {"router_interface_table", APP_P4RT_ROUTER_INTERFACE_TABLE_NAME },
-    {"neighbor_table",         APP_P4RT_NEIGHBOR_TABLE_NAME},
-    {"nexthop_table",          APP_P4RT_NEXTHOP_TABLE_NAME},
-    {"wcmp_group_table",       APP_P4RT_WCMP_GROUP_TABLE_NAME},
-    {"ipv4_table",             APP_P4RT_IPV4_TABLE_NAME},
-    {"ipv6_table",             APP_P4RT_IPV6_TABLE_NAME},
-    {"mirror_session_table",   APP_P4RT_MIRROR_SESSION_TABLE_NAME},
-    {"l3_admit_table",         APP_P4RT_L3_ADMIT_TABLE_NAME},
-    {"tunnel_table",           APP_P4RT_TUNNEL_TABLE_NAME}
-};
+    {"router_interface_table", APP_P4RT_ROUTER_INTERFACE_TABLE_NAME},
+    {"neighbor_table", APP_P4RT_NEIGHBOR_TABLE_NAME},
+    {"nexthop_table", APP_P4RT_NEXTHOP_TABLE_NAME},
+    {"wcmp_group_table", APP_P4RT_WCMP_GROUP_TABLE_NAME},
+    {"ipv4_table", APP_P4RT_IPV4_TABLE_NAME},
+    {"ipv6_table", APP_P4RT_IPV6_TABLE_NAME},
+    {"mirror_session_table", APP_P4RT_MIRROR_SESSION_TABLE_NAME},
+    {"l3_admit_table", APP_P4RT_L3_ADMIT_TABLE_NAME},
+    {"tunnel_table", APP_P4RT_TUNNEL_TABLE_NAME}};
 
 class P4Orch : public Orch
 {
@@ -55,7 +54,6 @@ class P4Orch : public Orch
 
     // m_p4TableToManagerMap: P4 APP DB table name, P4 Object Manager
     std::unordered_map<std::string, ObjectManagerInterface *> m_p4TableToManagerMap;
- 
 
   private:
     void doTask(Consumer &consumer);

--- a/orchagent/p4orch/p4orch_util.cpp
+++ b/orchagent/p4orch/p4orch_util.cpp
@@ -1,5 +1,5 @@
-#include "p4orch/p4orch.h"
 #include "p4orch/p4orch_util.h"
+#include "p4orch/p4orch.h"
 
 #include "schema.h"
 
@@ -116,9 +116,7 @@ ActionInfo *getTableActionInfo(TableInfo *table, const std::string &action_name)
 
 std::string KeyGenerator::generateTablesInfoKey(const std::string &context)
 {
-    std::map<std::string, std::string> fv_map = {
-            {"context", context}
-    };
+    std::map<std::string, std::string> fv_map = {{"context", context}};
     return generateKey(fv_map);
 }
 

--- a/orchagent/p4orch/p4orch_util.h
+++ b/orchagent/p4orch/p4orch_util.h
@@ -5,8 +5,8 @@
 #include <set>
 #include <sstream>
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 #include "ipaddress.h"
 #include "ipprefix.h"
@@ -16,7 +16,6 @@ extern "C"
 {
 #include "saitypes.h"
 }
- 
 
 namespace p4orch
 {
@@ -110,55 +109,54 @@ std::string prependParamField(const std::string &str);
 
 struct ActionParamInfo
 {
-    std::string     name;
-    std::string     fieldtype;
-    std::string     datatype;
-    std::unordered_map<std::string, std::string>  table_reference_map;
+    std::string name;
+    std::string fieldtype;
+    std::string datatype;
+    std::unordered_map<std::string, std::string> table_reference_map;
 };
 
 struct ActionInfo
 {
-    std::string     name;
+    std::string name;
     std::unordered_map<std::string, ActionParamInfo> params;
-    bool            refers_to;
+    bool refers_to;
 };
 
 struct TableMatchInfo
 {
-    std::string        name;
-    std::string        fieldtype;
-    std::string        datatype;
-    std::unordered_map<std::string, std::string>  table_reference_map;
+    std::string name;
+    std::string fieldtype;
+    std::string datatype;
+    std::unordered_map<std::string, std::string> table_reference_map;
 };
 
 /**
- * Dervied table definition 
+ * Dervied table definition
  * This is a derived state out of table definition provided by P4RT-APP
  */
 struct TableInfo
 {
-    std::string                                      name;
-    int                                              id;
-    int                                              precedence;
-    std::unordered_map<std::string, TableMatchInfo>  match_fields;
-    std::unordered_map<std::string, ActionInfo>      action_fields;
-    bool                                             counter_bytes_enabled;
-    bool                                             counter_packets_enabled;
-    std::vector<std::string>                         action_ref_tables;
-                                                     // list of tables across all actions, of current table, refer to
+    std::string name;
+    int id;
+    int precedence;
+    std::unordered_map<std::string, TableMatchInfo> match_fields;
+    std::unordered_map<std::string, ActionInfo> action_fields;
+    bool counter_bytes_enabled;
+    bool counter_packets_enabled;
+    std::vector<std::string> action_ref_tables;
+    // list of tables across all actions, of current table, refer to
 };
 
 /**
  * table-name to table-definition map
  */
-typedef std::unordered_map<std::string, TableInfo>   TableInfoMap;
+typedef std::unordered_map<std::string, TableInfo> TableInfoMap;
 
 struct TablesInfoAppDbEntry
 {
     std::string context;
     std::string info;
 };
-
 
 struct P4RouterInterfaceAppDbEntry
 {
@@ -296,8 +294,8 @@ struct P4AclRuleAppDbEntry
 struct DepObject
 {
     sai_object_type_t sai_object;
-    std::string       key;
-    sai_object_id_t   oid;
+    std::string key;
+    sai_object_id_t oid;
 };
 
 struct P4ExtTableAppDbEntry
@@ -308,7 +306,6 @@ struct P4ExtTableAppDbEntry
     std::unordered_map<std::string, std::unordered_map<std::string, std::string>> action_params;
     std::unordered_map<std::string, DepObject> action_dep_objects;
 };
-
 
 TableInfo *getTableInfo(const std::string &table_name);
 ActionInfo *getTableActionInfo(TableInfo *table, const std::string &action_name);

--- a/orchagent/p4orch/route_manager.cpp
+++ b/orchagent/p4orch/route_manager.cpp
@@ -11,12 +11,12 @@
 #include "converter.h"
 #include "crmorch.h"
 #include "dbconnector.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "p4orch/p4orch_util.h"
 #include "sai_serialize.h"
 #include "swssnet.h"
 #include "table.h"
+#include <nlohmann/json.hpp>
 
 using ::p4orch::kTableKeyDelimiter;
 
@@ -837,7 +837,8 @@ std::vector<ReturnCode> RouteManager::deleteRouteEntries(const std::vector<P4Rou
     return statuses;
 }
 
-ReturnCode RouteManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode RouteManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                      std::string &object_key)
 {
     return StatusCode::SWSS_RC_UNIMPLEMENTED;
 }

--- a/orchagent/p4orch/route_manager.h
+++ b/orchagent/p4orch/route_manager.h
@@ -86,7 +86,8 @@ class RouteManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
   private:
     // Applies route entry updates from src to dest. The merged result will be

--- a/orchagent/p4orch/router_interface_manager.cpp
+++ b/orchagent/p4orch/router_interface_manager.cpp
@@ -10,7 +10,6 @@
 #include "SaiAttributeList.h"
 #include "dbconnector.h"
 #include "directory.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "orch.h"
 #include "p4orch/p4orch_util.h"
@@ -18,6 +17,7 @@
 #include "sai_serialize.h"
 #include "table.h"
 #include "vrforch.h"
+#include <nlohmann/json.hpp>
 
 using ::p4orch::kTableKeyDelimiter;
 
@@ -337,13 +337,14 @@ ReturnCode RouterInterfaceManager::processDeleteRequest(const std::string &route
     return status;
 }
 
-ReturnCode RouterInterfaceManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode RouterInterfaceManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                                std::string &object_key)
 {
-    std::string     value;
+    std::string value;
 
     try
     {
-        nlohmann::json  j = nlohmann::json::parse(json_key);
+        nlohmann::json j = nlohmann::json::parse(json_key);
         if (j.find(prependMatchField(p4orch::kRouterInterfaceId)) != j.end())
         {
             value = j.at(prependMatchField(p4orch::kRouterInterfaceId)).get<std::string>();
@@ -353,7 +354,8 @@ ReturnCode RouterInterfaceManager::getSaiObject(const std::string &json_key, sai
         }
         else
         {
-            SWSS_LOG_ERROR("%s match parameter absent: required for dependent object query", p4orch::kRouterInterfaceId);
+            SWSS_LOG_ERROR("%s match parameter absent: required for dependent object query",
+                           p4orch::kRouterInterfaceId);
         }
     }
     catch (std::exception &ex)

--- a/orchagent/p4orch/router_interface_manager.h
+++ b/orchagent/p4orch/router_interface_manager.h
@@ -52,7 +52,8 @@ class RouterInterfaceManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
   private:
     ReturnCodeOr<P4RouterInterfaceAppDbEntry> deserializeRouterIntfEntry(

--- a/orchagent/p4orch/tables_definition_manager.cpp
+++ b/orchagent/p4orch/tables_definition_manager.cpp
@@ -7,30 +7,23 @@
 #include <vector>
 
 #include "directory.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
-#include "tokenize.h"
 #include "orch.h"
 #include "p4orch/p4orch.h"
 #include "p4orch/p4orch_util.h"
+#include "tokenize.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "saitypes.h"
 }
 
-
 extern Directory<Orch *> gDirectory;
 extern P4Orch *gP4Orch;
-const std::map<std::string, std::string> format_datatype_map =
-{
-    {"MAC",    "SAI_ATTR_VALUE_TYPE_MAC"},
-    {"IPV4",   "SAI_ATTR_VALUE_TYPE_IPV4"},
-    {"IPV6",   "SAI_ATTR_VALUE_TYPE_IPV6"}
-};
+const std::map<std::string, std::string> format_datatype_map = {
+    {"MAC", "SAI_ATTR_VALUE_TYPE_MAC"}, {"IPV4", "SAI_ATTR_VALUE_TYPE_IPV4"}, {"IPV6", "SAI_ATTR_VALUE_TYPE_IPV6"}};
 
-
-std::string
-BitwidthToDatatype (int bitwidth)
+std::string BitwidthToDatatype(int bitwidth)
 {
     std::string datatype = "SAI_ATTR_VALUE_TYPE_CHARDATA";
 
@@ -58,8 +51,7 @@ BitwidthToDatatype (int bitwidth)
     return datatype;
 }
 
-std::string
-parseBitwidthToDatatype (const nlohmann::json &json)
+std::string parseBitwidthToDatatype(const nlohmann::json &json)
 {
     int bitwidth;
     std::string datatype = "SAI_ATTR_VALUE_TYPE_CHARDATA";
@@ -73,8 +65,7 @@ parseBitwidthToDatatype (const nlohmann::json &json)
     return datatype;
 }
 
-std::string
-parseFormatToDatatype (const nlohmann::json &json, std::string datatype)
+std::string parseFormatToDatatype(const nlohmann::json &json, std::string datatype)
 {
     std::string format;
 
@@ -92,8 +83,7 @@ parseFormatToDatatype (const nlohmann::json &json, std::string datatype)
     return datatype;
 }
 
-ReturnCode
-parseTableMatchReferences (const nlohmann::json &match_json, TableMatchInfo &match)
+ReturnCode parseTableMatchReferences(const nlohmann::json &match_json, TableMatchInfo &match)
 {
     std::string table, field;
 
@@ -110,7 +100,7 @@ parseTableMatchReferences (const nlohmann::json &match_json, TableMatchInfo &mat
             catch (std::exception &ex)
             {
                 return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                     << "can not parse tables from app-db supplied table definition info";
+                       << "can not parse tables from app-db supplied table definition info";
             }
         }
     }
@@ -118,8 +108,7 @@ parseTableMatchReferences (const nlohmann::json &match_json, TableMatchInfo &mat
     return ReturnCode();
 }
 
-ReturnCode
-parseActionParamReferences (const nlohmann::json &param_json, ActionParamInfo &param)
+ReturnCode parseActionParamReferences(const nlohmann::json &param_json, ActionParamInfo &param)
 {
     std::string table, field;
 
@@ -136,7 +125,7 @@ parseActionParamReferences (const nlohmann::json &param_json, ActionParamInfo &p
             catch (std::exception &ex)
             {
                 return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                     << "can not parse tables from app-db supplied table definition info";
+                       << "can not parse tables from app-db supplied table definition info";
             }
         }
     }
@@ -144,8 +133,7 @@ parseActionParamReferences (const nlohmann::json &param_json, ActionParamInfo &p
     return ReturnCode();
 }
 
-ReturnCode
-parseTableActionParams (const nlohmann::json &action_json, ActionInfo &action)
+ReturnCode parseTableActionParams(const nlohmann::json &action_json, ActionInfo &action)
 {
     action.refers_to = false;
     if (action_json.find(p4orch::kActionParams) != action_json.end())
@@ -175,7 +163,7 @@ parseTableActionParams (const nlohmann::json &action_json, ActionInfo &action)
             catch (std::exception &ex)
             {
                 return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                     << "can not parse tables from app-db supplied table definition info";
+                       << "can not parse tables from app-db supplied table definition info";
             }
         }
     }
@@ -183,8 +171,7 @@ parseTableActionParams (const nlohmann::json &action_json, ActionInfo &action)
     return ReturnCode();
 }
 
-ReturnCode
-parseTableCounter (const nlohmann::json &table_json, TableInfo &table)
+ReturnCode parseTableCounter(const nlohmann::json &table_json, TableInfo &table)
 {
     if (table_json.find(p4orch::kCounterUnit) != table_json.end())
     {
@@ -207,8 +194,7 @@ parseTableCounter (const nlohmann::json &table_json, TableInfo &table)
     return ReturnCode();
 }
 
-ReturnCode
-parseTablesInfo (const nlohmann::json &info_json, TablesInfo &info_entry)
+ReturnCode parseTablesInfo(const nlohmann::json &info_json, TablesInfo &info_entry)
 {
     ReturnCode status;
     int table_id;
@@ -216,8 +202,7 @@ parseTablesInfo (const nlohmann::json &info_json, TablesInfo &info_entry)
 
     if (info_json.find(p4orch::kTables) == info_json.end())
     {
-        return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-       	         << "no tables in app-db supplied table definition info";
+        return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM) << "no tables in app-db supplied table definition info";
     }
 
     for (const auto &table_json : info_json[p4orch::kTables])
@@ -230,18 +215,17 @@ parseTablesInfo (const nlohmann::json &info_json, TablesInfo &info_entry)
         catch (std::exception &ex)
         {
             return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                     << "can not parse tables from app-db supplied table definition info";
+                   << "can not parse tables from app-db supplied table definition info";
         }
 
-
-	TableInfo table = {};
+        TableInfo table = {};
         table.name = table_name;
-        table.id   = table_id;
+        table.id = table_id;
         try
         {
             for (const auto &match_json : table_json[p4orch::kmatchFields])
             {
-		TableMatchInfo match = {};
+                TableMatchInfo match = {};
                 std::string match_name;
 
                 match_name = match_json.at(p4orch::kName).get<std::string>();
@@ -254,7 +238,7 @@ parseTablesInfo (const nlohmann::json &info_json, TablesInfo &info_entry)
 
             for (const auto &action_json : table_json[p4orch::kActions])
             {
-		ActionInfo action = {};
+                ActionInfo action = {};
                 std::string action_name;
 
                 action_name = action_json.at(p4orch::kAlias).get<std::string>();
@@ -266,20 +250,18 @@ parseTablesInfo (const nlohmann::json &info_json, TablesInfo &info_entry)
                  * If any parameter of action refers to another table, add that one in the
                  * cross-reference list of current table
                  */
-                for (auto param_it = action.params.begin();
-                          param_it != action.params.end(); param_it++)
+                for (auto param_it = action.params.begin(); param_it != action.params.end(); param_it++)
                 {
                     ActionParamInfo action_param = param_it->second;
                     for (auto ref_it = action_param.table_reference_map.begin();
-                              ref_it != action_param.table_reference_map.end(); ref_it++)
+                         ref_it != action_param.table_reference_map.end(); ref_it++)
                     {
-                        if (std::find(table.action_ref_tables.begin(),
-                                      table.action_ref_tables.end(),
-                                      ref_it->first) == table.action_ref_tables.end())
+                        if (std::find(table.action_ref_tables.begin(), table.action_ref_tables.end(), ref_it->first) ==
+                            table.action_ref_tables.end())
                         {
                             table.action_ref_tables.push_back(ref_it->first);
                         }
-                   }
+                    }
                 }
             }
 
@@ -288,9 +270,8 @@ parseTablesInfo (const nlohmann::json &info_json, TablesInfo &info_entry)
         catch (std::exception &ex)
         {
             return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                     << "can not parse table " << QuotedVar(table_name.c_str()) << "match fields";
+                   << "can not parse table " << QuotedVar(table_name.c_str()) << "match fields";
         }
-
 
         info_entry.m_tableIdNameMap[std::to_string(table_id)] = table_name;
         info_entry.m_tableInfoMap[table_name] = table;
@@ -298,7 +279,6 @@ parseTablesInfo (const nlohmann::json &info_json, TablesInfo &info_entry)
 
     return ReturnCode();
 }
-
 
 ReturnCodeOr<TablesInfoAppDbEntry> TablesDefnManager::deserializeTablesInfoEntry(
     const std::string &key, const std::vector<swss::FieldValueTuple> &attributes)
@@ -327,7 +307,7 @@ ReturnCodeOr<TablesInfoAppDbEntry> TablesDefnManager::deserializeTablesInfoEntry
         else
         {
             return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                       << "Unexpected field " << QuotedVar(field) << " in table entry";
+                   << "Unexpected field " << QuotedVar(field) << " in table entry";
         }
     }
 
@@ -416,14 +396,13 @@ ReturnCode TablesDefnManager::processDeleteRequest(const std::string &context_ke
     return ReturnCode();
 }
 
-ReturnCode TablesDefnManager::getSaiObject(const std::string &json_key,
-       	                                   sai_object_type_t &object_type, std::string &object_key)
+ReturnCode TablesDefnManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                           std::string &object_key)
 {
     return StatusCode::SWSS_RC_INVALID_PARAM;
 }
 
-std::unordered_map<int, std::unordered_set<int>>
-createGraph (std::vector<std::pair<int, int>> preReq)
+std::unordered_map<int, std::unordered_set<int>> createGraph(std::vector<std::pair<int, int>> preReq)
 {
     std::unordered_map<int, std::unordered_set<int>> graph;
 
@@ -443,8 +422,7 @@ createGraph (std::vector<std::pair<int, int>> preReq)
     return graph;
 }
 
-std::unordered_map<int, int>
-computeIndegree (std::unordered_map<int, std::unordered_set<int>> &graph)
+std::unordered_map<int, int> computeIndegree(std::unordered_map<int, std::unordered_set<int>> &graph)
 {
     std::unordered_map<int, int> degrees;
 
@@ -467,19 +445,16 @@ computeIndegree (std::unordered_map<int, std::unordered_set<int>> &graph)
     return degrees;
 }
 
-
-std::vector<int>
-findTablePrecedence (int tables, std::vector<std::pair<int, int>> preReq, TablesInfo *tables_info)
+std::vector<int> findTablePrecedence(int tables, std::vector<std::pair<int, int>> preReq, TablesInfo *tables_info)
 {
     std::unordered_map<int, std::unordered_set<int>> graph = createGraph(preReq);
     std::unordered_map<int, int> degrees = computeIndegree(graph);
     std::vector<int> visited;
     std::vector<int> toposort;
-    std::queue<int>  zeros;
+    std::queue<int> zeros;
 
     // initialize queue with tables having no dependencies
-    for (auto table_it = tables_info->m_tableInfoMap.begin();
-              table_it != tables_info->m_tableInfoMap.end(); table_it++)
+    for (auto table_it = tables_info->m_tableInfoMap.begin(); table_it != tables_info->m_tableInfoMap.end(); table_it++)
     {
         TableInfo table_info = table_it->second;
         if (degrees.find(table_info.id) == degrees.end())
@@ -530,21 +505,19 @@ findTablePrecedence (int tables, std::vector<std::pair<int, int>> preReq, Tables
     return toposort;
 }
 
-
-void
-buildTablePrecedence (TablesInfo *tables_info)
+void buildTablePrecedence(TablesInfo *tables_info)
 {
     std::vector<std::pair<int, int>> preReq;
     std::vector<int> orderedTables;
     int tables = 0;
 
-    if (!tables_info) {
+    if (!tables_info)
+    {
         return;
     }
 
     // build dependencies
-    for (auto table_it = tables_info->m_tableInfoMap.begin();
-              table_it != tables_info->m_tableInfoMap.end(); table_it++)
+    for (auto table_it = tables_info->m_tableInfoMap.begin(); table_it != tables_info->m_tableInfoMap.end(); table_it++)
     {
         TableInfo table_info = table_it->second;
         tables++;
@@ -552,18 +525,18 @@ buildTablePrecedence (TablesInfo *tables_info)
         for (std::size_t i = 0; i < table_info.action_ref_tables.size(); i++)
         {
             /**
-	     * For now processing precedence order is only amongst extension tables
-	     * Skip fixed tables, include them in precedence calculations when fixed
-	     * and extension tables processing precedence may be interleaved
-	     */
+             * For now processing precedence order is only amongst extension tables
+             * Skip fixed tables, include them in precedence calculations when fixed
+             * and extension tables processing precedence may be interleaved
+             */
             if (FixedTablesMap.find(table_info.action_ref_tables[i]) != FixedTablesMap.end())
             {
                 continue;
             }
 
             TableInfo ref_table_info = tables_info->m_tableInfoMap[table_info.action_ref_tables[i]];
-            if (std::find(preReq.begin(), preReq.end(),
-                          std::make_pair(table_info.id, ref_table_info.id)) == preReq.end())
+            if (std::find(preReq.begin(), preReq.end(), std::make_pair(table_info.id, ref_table_info.id)) ==
+                preReq.end())
             {
                 preReq.push_back(std::make_pair(table_info.id, ref_table_info.id));
             }
@@ -595,7 +568,6 @@ buildTablePrecedence (TablesInfo *tables_info)
 
     return;
 }
-
 
 void TablesDefnManager::enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry)
 {
@@ -672,8 +644,8 @@ void TablesDefnManager::drain()
         {
             buildTablePrecedence(gP4Orch->tablesinfo);
         }
-        m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
-                             status, /*replace=*/true);
+        m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple), status,
+                             /*replace=*/true);
     }
     m_entries.clear();
 }

--- a/orchagent/p4orch/tables_definition_manager.h
+++ b/orchagent/p4orch/tables_definition_manager.h
@@ -6,13 +6,13 @@
 #include <vector>
 
 #include "macaddress.h"
-#include <nlohmann/json.hpp>
 #include "orch.h"
 #include "p4orch/object_manager_interface.h"
 #include "p4orch/p4oidmapper.h"
 #include "p4orch/p4orch_util.h"
 #include "response_publisher_interface.h"
 #include "return_code.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"
@@ -23,13 +23,13 @@ extern "C"
  */
 struct TablesInfo
 {
-    std::string     context;
-    nlohmann::json  info;
+    std::string context;
+    nlohmann::json info;
     std::unordered_map<std::string, std::string> m_tableIdNameMap;
     std::unordered_map<std::string, TableInfo> m_tableInfoMap;
     std::map<int, std::string> m_tablePrecedenceMap;
 
-    TablesInfo() {};
+    TablesInfo(){};
     TablesInfo(const std::string &context_key, const nlohmann::json &info_value)
         : context(context_key), info(info_value)
     {
@@ -59,11 +59,12 @@ class TablesDefnManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
   private:
-    ReturnCodeOr<TablesInfoAppDbEntry> deserializeTablesInfoEntry(
-        const std::string &key, const std::vector<swss::FieldValueTuple> &attributes);
+    ReturnCodeOr<TablesInfoAppDbEntry> deserializeTablesInfoEntry(const std::string &key,
+                                                                  const std::vector<swss::FieldValueTuple> &attributes);
     TablesInfo *getTablesInfoEntry(const std::string &context_key);
     ReturnCode createTablesInfo(const std::string &context_key, TablesInfo &tablesinfo_entry);
     ReturnCode removeTablesInfo(const std::string &context_key);

--- a/orchagent/p4orch/tests/acl_manager_test.cpp
+++ b/orchagent/p4orch/tests/acl_manager_test.cpp
@@ -9,7 +9,6 @@
 #include "acl_table_manager.h"
 #include "acl_util.h"
 #include "acltable.h"
-#include <nlohmann/json.hpp>
 #include "mock_sai_acl.h"
 #include "mock_sai_hostif.h"
 #include "mock_sai_policer.h"
@@ -22,6 +21,7 @@
 #include "table.h"
 #include "tokenize.h"
 #include "vrforch.h"
+#include <nlohmann/json.hpp>
 
 using ::p4orch::kTableKeyDelimiter;
 

--- a/orchagent/p4orch/tests/fake_flexcounterorch.cpp
+++ b/orchagent/p4orch/tests/fake_flexcounterorch.cpp
@@ -1,12 +1,10 @@
 #include "copporch.h"
 #include "flexcounterorch.h"
 
-FlexCounterOrch::FlexCounterOrch(swss::DBConnector *db, std::vector<std::string> &tableNames) :
-    Orch(db, tableNames),
-    m_flexCounterConfigTable(db, CFG_FLEX_COUNTER_TABLE_NAME),
-    m_bufferQueueConfigTable(db, CFG_BUFFER_QUEUE_TABLE_NAME),
-    m_bufferPgConfigTable(db, CFG_BUFFER_PG_TABLE_NAME),
-    m_deviceMetadataConfigTable(db, CFG_DEVICE_METADATA_TABLE_NAME)
+FlexCounterOrch::FlexCounterOrch(swss::DBConnector *db, std::vector<std::string> &tableNames)
+    : Orch(db, tableNames), m_flexCounterConfigTable(db, CFG_FLEX_COUNTER_TABLE_NAME),
+      m_bufferQueueConfigTable(db, CFG_BUFFER_QUEUE_TABLE_NAME), m_bufferPgConfigTable(db, CFG_BUFFER_PG_TABLE_NAME),
+      m_deviceMetadataConfigTable(db, CFG_DEVICE_METADATA_TABLE_NAME)
 {
 }
 

--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -185,7 +185,7 @@ void PortsOrch::generateQueueMap(std::map<string, FlexCounterQueueStates> queues
 {
 }
 
-void PortsOrch::generateQueueMapPerPort(const Port& port, FlexCounterQueueStates& queuesState, bool voq)
+void PortsOrch::generateQueueMapPerPort(const Port &port, FlexCounterQueueStates &queuesState, bool voq)
 {
 }
 
@@ -201,15 +201,15 @@ void PortsOrch::generatePriorityGroupMap(std::map<string, FlexCounterPgStates> p
 {
 }
 
-void PortsOrch::generatePriorityGroupMapPerPort(const Port& port, FlexCounterPgStates& pgsState)
+void PortsOrch::generatePriorityGroupMapPerPort(const Port &port, FlexCounterPgStates &pgsState)
 {
 }
 
-void PortsOrch::createPortBufferPgCounters(const Port& port, string pgs)
+void PortsOrch::createPortBufferPgCounters(const Port &port, string pgs)
 {
 }
 
-void PortsOrch::removePortBufferPgCounters(const Port& port, string pgs)
+void PortsOrch::removePortBufferPgCounters(const Port &port, string pgs)
 {
 }
 
@@ -591,7 +591,8 @@ bool PortsOrch::setGearboxPortsAttr(const Port &port, sai_port_attr_t id, void *
     return true;
 }
 
-bool PortsOrch::setGearboxPortAttr(const Port &port, dest_port_type_t port_type, sai_port_attr_t id, void *value, bool override_fec)
+bool PortsOrch::setGearboxPortAttr(const Port &port, dest_port_type_t port_type, sai_port_attr_t id, void *value,
+                                   bool override_fec)
 {
     return true;
 }
@@ -621,7 +622,8 @@ task_process_status PortsOrch::setPortInterfaceType(Port &port, sai_port_interfa
     return task_success;
 }
 
-task_process_status PortsOrch::setPortAdvInterfaceTypes(Port &port, std::set<sai_port_interface_type_t> &interface_types)
+task_process_status PortsOrch::setPortAdvInterfaceTypes(Port &port,
+                                                        std::set<sai_port_interface_type_t> &interface_types)
 {
     return task_success;
 }

--- a/orchagent/p4orch/tests/gre_tunnel_manager_test.cpp
+++ b/orchagent/p4orch/tests/gre_tunnel_manager_test.cpp
@@ -8,7 +8,6 @@
 #include <unordered_map>
 
 #include "ipaddress.h"
-#include <nlohmann/json.hpp>
 #include "mock_response_publisher.h"
 #include "mock_sai_router_interface.h"
 #include "mock_sai_serialize.h"
@@ -18,6 +17,7 @@
 #include "p4orch_util.h"
 #include "return_code.h"
 #include "swssnet.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/tests/l3_admit_manager_test.cpp
+++ b/orchagent/p4orch/tests/l3_admit_manager_test.cpp
@@ -7,13 +7,13 @@
 #include <string>
 #include <unordered_map>
 
-#include <nlohmann/json.hpp>
 #include "mock_response_publisher.h"
 #include "mock_sai_my_mac.h"
 #include "p4oidmapper.h"
 #include "p4orch/p4orch_util.h"
 #include "p4orch_util.h"
 #include "return_code.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/tests/mirror_session_manager_test.cpp
+++ b/orchagent/p4orch/tests/mirror_session_manager_test.cpp
@@ -6,7 +6,6 @@
 #include <string>
 #include <vector>
 
-#include <nlohmann/json.hpp>
 #include "mock_response_publisher.h"
 #include "mock_sai_mirror.h"
 #include "p4oidmapper.h"
@@ -15,6 +14,7 @@
 #include "swss/ipaddress.h"
 #include "swss/macaddress.h"
 #include "swssnet.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/tests/neighbor_manager_test.cpp
+++ b/orchagent/p4orch/tests/neighbor_manager_test.cpp
@@ -6,13 +6,13 @@
 #include <string>
 #include <unordered_set>
 
-#include <nlohmann/json.hpp>
 #include "mock_response_publisher.h"
 #include "mock_sai_neighbor.h"
 #include "p4orch.h"
 #include "p4orch/p4orch_util.h"
 #include "return_code.h"
 #include "swssnet.h"
+#include <nlohmann/json.hpp>
 
 using ::p4orch::kTableKeyDelimiter;
 

--- a/orchagent/p4orch/tests/next_hop_manager_test.cpp
+++ b/orchagent/p4orch/tests/next_hop_manager_test.cpp
@@ -8,7 +8,6 @@
 #include <unordered_map>
 
 #include "ipaddress.h"
-#include <nlohmann/json.hpp>
 #include "mock_response_publisher.h"
 #include "mock_sai_hostif.h"
 #include "mock_sai_next_hop.h"
@@ -18,6 +17,7 @@
 #include "p4orch.h"
 #include "return_code.h"
 #include "swssnet.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/tests/route_manager_test.cpp
+++ b/orchagent/p4orch/tests/route_manager_test.cpp
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "ipprefix.h"
-#include <nlohmann/json.hpp>
 #include "mock_response_publisher.h"
 #include "mock_sai_route.h"
 #include "p4orch.h"
@@ -17,6 +16,7 @@
 #include "return_code.h"
 #include "swssnet.h"
 #include "vrforch.h"
+#include <nlohmann/json.hpp>
 
 using ::p4orch::kTableKeyDelimiter;
 

--- a/orchagent/p4orch/tests/test_main.cpp
+++ b/orchagent/p4orch/tests/test_main.cpp
@@ -99,7 +99,6 @@ bool parseHandleSaiStatusFailure(task_process_status status)
     return true;
 }
 
-
 namespace
 {
 
@@ -173,7 +172,7 @@ void AddVrf()
 } // namespace
 
 int main(int argc, char *argv[])
-{   
+{
     gBatchSize = DEFAULT_BATCH_SIZE;
     testing::InitGoogleTest(&argc, argv);
 

--- a/orchagent/p4orch/tests/wcmp_manager_test.cpp
+++ b/orchagent/p4orch/tests/wcmp_manager_test.cpp
@@ -5,7 +5,6 @@
 
 #include <string>
 
-#include <nlohmann/json.hpp>
 #include "mock_response_publisher.h"
 #include "mock_sai_acl.h"
 #include "mock_sai_hostif.h"
@@ -18,6 +17,7 @@
 #include "p4orch_util.h"
 #include "return_code.h"
 #include "sai_serialize.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/wcmp_manager.cpp
+++ b/orchagent/p4orch/wcmp_manager.cpp
@@ -7,12 +7,12 @@
 #include "SaiAttributeList.h"
 #include "crmorch.h"
 #include "dbconnector.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "p4orch/p4orch_util.h"
 #include "portsorch.h"
 #include "sai_serialize.h"
 #include "table.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"
@@ -734,13 +734,14 @@ void WcmpManager::updatePortOperStatusMap(const std::string &port, const sai_por
     port_oper_status_map[port] = status;
 }
 
-ReturnCode WcmpManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode WcmpManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                     std::string &object_key)
 {
-    std::string     value;
+    std::string value;
 
     try
     {
-        nlohmann::json  j = nlohmann::json::parse(json_key);
+        nlohmann::json j = nlohmann::json::parse(json_key);
         if (j.find(prependMatchField(p4orch::kWcmpGroupId)) != j.end())
         {
             value = j.at(prependMatchField(p4orch::kWcmpGroupId)).get<std::string>();

--- a/orchagent/p4orch/wcmp_manager.h
+++ b/orchagent/p4orch/wcmp_manager.h
@@ -72,7 +72,8 @@ class WcmpManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
     // Prunes next hop members egressing through the given port.
     void pruneNextHops(const std::string &port);

--- a/orchagent/response_publisher.cpp
+++ b/orchagent/response_publisher.cpp
@@ -50,7 +50,7 @@ void RecordResponse(const std::string &response_channel, const std::string &key,
 {
     if (!swss::Recorder::Instance().respub.isRecord())
     {
-       return;
+        return;
     }
 
     std::string s = response_channel + ":" + key + "|" + status;
@@ -64,10 +64,9 @@ void RecordResponse(const std::string &response_channel, const std::string &key,
 
 } // namespace
 
-ResponsePublisher::ResponsePublisher(bool buffered) :
-    m_db(std::make_unique<swss::DBConnector>("APPL_STATE_DB", 0)),
-    m_pipe(std::make_unique<swss::RedisPipeline>(m_db.get())),
-    m_buffered(buffered)
+ResponsePublisher::ResponsePublisher(bool buffered)
+    : m_db(std::make_unique<swss::DBConnector>("APPL_STATE_DB", 0)),
+      m_pipe(std::make_unique<swss::RedisPipeline>(m_db.get())), m_buffered(buffered)
 {
 }
 

--- a/orchagent/response_publisher.h
+++ b/orchagent/response_publisher.h
@@ -7,9 +7,9 @@
 
 #include "dbconnector.h"
 #include "notificationproducer.h"
+#include "recorder.h"
 #include "response_publisher_interface.h"
 #include "table.h"
-#include "recorder.h"
 
 // This class performs two tasks when publish is called:
 // 1. Sends a notification into the redis channel.
@@ -46,14 +46,14 @@ class ResponsePublisher : public ResponsePublisherInterface
 
     /**
      * @brief Flush pending responses
-    */
+     */
     void flush();
 
     /**
      * @brief Set buffering mode
      *
      * @param buffered Flag whether responses are buffered
-    */
+     */
     void setBuffered(bool buffered);
 
   private:


### PR DESCRIPTION
**What I did**
This PR has no real code change. It is purely clang formatting. It only applies to the P4Orch codes.
Commands that I run:
find orchagent/p4orch -name *.h -o -name *.cpp | xargs clang-format -i -style="{BasedOnStyle: Microsoft, DerivePointerAlignment: false}"
find orchagent -name response_publisher* -o -name return_code.h | xargs clang-format -i -style="{BasedOnStyle: Microsoft, DerivePointerAlignment: false}"

**Why I did it**
In Google, we follow the Google clang format style, but SONiC uses Microsoft style. In order to upstream our changes, we have to translate the SONiC code into Google style first, then we can cherry-pick our changes. After that, we translate back to Microsoft style. The existing codes do not fully follow the clang Microsoft style. And hence causes many unnecessary file changes in a PR: https://github.com/sonic-net/sonic-swss/pull/3066.

**How I verified it**
N/A

**Details if related**
This PR might not meet the code coverage requirement. But it is purely formatting changes.
