### PR TITLE
[202311][muxorch] Fixing cache bug in updateRoute logic and Fixing bug with multiple routes pointing to nhg

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1099,6 +1099,8 @@ void MuxOrch::updateRoute(const IpPrefix &pfx, bool add)
 
     if (!add)
     {
+        SWSS_LOG_INFO("Removing route %s from mux_multi_active_nh_table",
+                      pfx.to_string().c_str());
         return;
     }
 

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1099,9 +1099,6 @@ void MuxOrch::updateRoute(const IpPrefix &pfx, bool add)
 
     if (!add)
     {
-        SWSS_LOG_INFO("Removing route %s from mux_multi_active_nh_table",
-                pfx.to_string().c_str());
-        mux_multi_active_nh_table.erase(pfx);
         return;
     }
 
@@ -1155,7 +1152,6 @@ void MuxOrch::updateRoute(const IpPrefix &pfx, bool add)
             }
             SWSS_LOG_NOTICE("setting route %s with nexthop %s %" PRIx64 "",
                 pfx.to_string().c_str(), nexthop.to_string().c_str(), next_hop_id);
-            mux_multi_active_nh_table[pfx] = nexthop;
             active_found = true;
             break;
         }
@@ -1173,7 +1169,6 @@ void MuxOrch::updateRoute(const IpPrefix &pfx, bool add)
             SWSS_LOG_ERROR("Failed to set route entry %s to tunnel",
                     pfx.getIp().to_string().c_str());
         }
-        mux_multi_active_nh_table.erase(pfx);
     }
 }
 

--- a/orchagent/muxorch.h
+++ b/orchagent/muxorch.h
@@ -194,11 +194,6 @@ public:
         return (skip_neighbors_.find(nbr) != skip_neighbors_.end());
     }
 
-    bool isMultiNexthopRoute(const IpPrefix& pfx)
-    {
-        return (mux_multi_active_nh_table.find(pfx) != mux_multi_active_nh_table.end());
-    }
-
     MuxCable* findMuxCableInSubnet(IpAddress);
     bool isNeighborActive(const IpAddress&, const MacAddress&, string&);
     void update(SubjectType, void *);
@@ -255,9 +250,6 @@ private:
     MuxCableTb mux_cable_tb_;
     MuxTunnelNHs mux_tunnel_nh_;
     NextHopTb mux_nexthop_tb_;
-
-    /* contains reference of programmed routes by updateRoute */
-    MuxRouteTb mux_multi_active_nh_table;
 
     handler_map handler_map_;
 

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -2481,20 +2481,21 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
             {
                 SWSS_LOG_NOTICE("Remove Nexthop Group %s", ol_nextHops.to_string().c_str());
                 m_bulkNhgReducedRefCnt.emplace(it_route->second.nhg_key, 0);
-                if (mux_orch->isMuxNexthops(ol_nextHops))
+            }
+            if (mux_orch->isMuxNexthops(ol_nextHops))
+            {
+                SWSS_LOG_NOTICE("Remove mux Nexthop %s", ol_nextHops.to_string().c_str());
+                RouteKey routekey = { vrf_id, ipPrefix };
+                auto nexthop_list = ol_nextHops.getNextHops();
+                for (auto nh = nexthop_list.begin(); nh != nexthop_list.end(); nh++)
                 {
-                    SWSS_LOG_NOTICE("Remove mux Nexthop %s", ol_nextHops.to_string().c_str());
-                    RouteKey routekey = { vrf_id, ipPrefix };
-                    auto nexthop_list = ol_nextHops.getNextHops();
-                    for (auto nh = nexthop_list.begin(); nh != nexthop_list.end(); nh++)
+                    if (!nh->ip_address.isZero())
                     {
-                        if (!nh->ip_address.isZero())
-                        {
-                            removeNextHopRoute(*nh, routekey);
-                        }
+                        SWSS_LOG_NOTICE("removeNextHopRoute");
+                        removeNextHopRoute(*nh, routekey);
                     }
-                    mux_orch->updateRoute(ipPrefix, false);
                 }
+                mux_orch->updateRoute(ipPrefix, false);
             }
         }
         else if (ol_nextHops.is_overlay_nexthop())

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1572,13 +1572,9 @@ bool RouteOrch::updateNextHopRoutes(const NextHopKey& nextHop, uint32_t& numRout
     auto rt = it->second.begin();
     while(rt != it->second.end())
     {
-        /* Check if route is mux multi-nexthop route
-         * we define this as a route present in
-         * mux_multi_active_nh_table
-         * These routes originally point to NHG and should be handled by updateRoute()
-         */
-        MuxOrch* mux_orch = gDirectory.get<MuxOrch*>();
-        if (mux_orch->isMultiNexthopRoute((*rt).prefix))
+        /* Check if route points to nexthop group and skip */
+        NextHopGroupKey nhg_key = gRouteOrch->getSyncdRouteNhgKey(gVirtualRouterId, (*rt).prefix);
+        if (nhg_key.getSize() > 1)
         {
             /* multiple mux nexthop case:
              * skip for now, muxOrch::updateRoute() will handle route

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -637,6 +637,30 @@ class TestMuxTunnelBase():
                 self.del_neighbor(dvs, neighbor)
             self.del_neighbor(dvs, self.SERV3_IPV4)
 
+            print("Testing route update to single nexthop")
+            for start in starting_states:
+                self.set_mux_state(appdb, mux_ports[0], start[0])
+                self.set_mux_state(appdb, mux_ports[1], start[1])
+                self.add_route(dvs, route, neighbors)
+
+                print("route update to single nexthop")
+                # add new neighbor to route to force route update
+                self.add_route(dvs, route, [neighbors[0]])
+                if start[0] == ACTIVE:
+                    self.check_route_nexthop(dvs_route, asicdb, route, neighbors[0])
+                else:
+                    self.check_route_nexthop(dvs_route, asicdb, route, tunnel_nh_id, True)
+
+                print("change state of nexthop")
+                if start[0] == ACTIVE:
+                    self.set_mux_state(appdb, mux_ports[0], STANDBY)
+                    self.check_route_nexthop(dvs_route, asicdb, route, tunnel_nh_id, True)
+                else:
+                    self.set_mux_state(appdb, mux_ports[0], ACTIVE)
+                    self.check_route_nexthop(dvs_route, asicdb, route, neighbors[0])
+
+                self.del_route(dvs,route)
+
             print("Testing add/remove of neighbors")
             for start in starting_states:
                 print("Testing add/remove of neighbors in %s, %s" % start)

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -309,10 +309,18 @@ class TestMuxTunnelBase():
 
     def add_route(self, dvs, route, nexthops, ifaces=[]):
         apdb = dvs.get_app_db()
-        nexthop_str = ",".join(nexthops)
-        if len(ifaces) == 0:
-            ifaces = [self.VLAN_1000 for k in range(len(nexthops))]
-        iface_str = ",".join(ifaces)
+        if len(nexthops) > 1:
+            nexthop_str = ",".join(nexthops)
+            if len(ifaces) == 0:
+                ifaces = [self.VLAN_1000 for k in range(len(nexthops))]
+            iface_str = ",".join(ifaces)
+        else:
+            nexthop_str = str(nexthops[0])
+            if len(ifaces) == 0:
+                iface_str = self.VLAN_1000
+            else:
+                iface_str = ifaces[0]
+
         ps = swsscommon.ProducerStateTable(apdb.db_connection, self.APP_ROUTE_TABLE)
         fvs = swsscommon.FieldValuePairs(
                 [
@@ -633,8 +641,6 @@ class TestMuxTunnelBase():
             self.check_route_nexthop(dvs_route, asicdb, route, tunnel_nh_id, True)
             self.del_route(dvs,route)
 
-            for neighbor in neighbors:
-                self.del_neighbor(dvs, neighbor)
             self.del_neighbor(dvs, self.SERV3_IPV4)
 
             print("Testing route update to single nexthop")
@@ -660,6 +666,9 @@ class TestMuxTunnelBase():
                     self.check_route_nexthop(dvs_route, asicdb, route, neighbors[0])
 
                 self.del_route(dvs,route)
+
+            for neighbor in neighbors:
+                self.del_neighbor(dvs, neighbor)
 
             print("Testing add/remove of neighbors")
             for start in starting_states:


### PR DESCRIPTION
**What I did**
Manual cherry-pick of https://github.com/sonic-net/sonic-swss/pull/2982 and https://github.com/sonic-net/sonic-swss/pull/2999

- Fixed a bug where cache was not removing entry when an ecmp mux route gets updated to a single nexthop route. And added test case to cover the edge case.

- Fixed a bug where multiple routes pointing to the same nhg would not remove the route from m_nextHops cache in routeorch

- Refactored multi_mux_nexthops tests and added new test cases

**Why I did it**
Mux switchover was failing because it was skipping over the route in updateNextHopRoutes.
Caught the bug while refactoring, this will cause issues with switchover if one of the routes is removed
MSFT ADO - 26099588

**How I verified it**
Ran refactored tests on local vstest setup, and all test cases passed

**Details if related**
will fix dualtor tests on 202311

ADO:#26458505
ADO:#26099588
ADO:#26099588
