### PR TITLE
[Copp]Refactor coppmgr tests

### DIFF
--- a/cfgmgr/coppmgr.cpp
+++ b/cfgmgr/coppmgr.cpp
@@ -21,10 +21,11 @@ static set<string> g_copp_init_set;
 
 void CoppMgr::parseInitFile(void)
 {
-    std::ifstream ifs(COPP_INIT_FILE);
+    std::ifstream ifs(m_coppCfgfile);
+
     if (ifs.fail())
     {
-        SWSS_LOG_ERROR("COPP init file %s not found", COPP_INIT_FILE);
+        SWSS_LOG_ERROR("COPP init file %s not found", m_coppCfgfile.c_str());
         return;
     }
     json j = json::parse(ifs);
@@ -293,7 +294,7 @@ bool CoppMgr::isDupEntry(const std::string &key, std::vector<FieldValueTuple> &f
     return true;
 }
 
-CoppMgr::CoppMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const vector<string> &tableNames) :
+CoppMgr::CoppMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const vector<string> &tableNames, const string copp_init_file) :
         Orch(cfgDb, tableNames),
         m_cfgCoppTrapTable(cfgDb, CFG_COPP_TRAP_TABLE_NAME),
         m_cfgCoppGroupTable(cfgDb, CFG_COPP_GROUP_TABLE_NAME),
@@ -301,7 +302,8 @@ CoppMgr::CoppMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
         m_appCoppTable(appDb, APP_COPP_TABLE_NAME),
         m_stateCoppTrapTable(stateDb, STATE_COPP_TRAP_TABLE_NAME),
         m_stateCoppGroupTable(stateDb, STATE_COPP_GROUP_TABLE_NAME),
-        m_coppTable(appDb, APP_COPP_TABLE_NAME)
+        m_coppTable(appDb, APP_COPP_TABLE_NAME),
+        m_coppCfgfile(copp_init_file)
 {
     SWSS_LOG_ENTER();
     parseInitFile();

--- a/cfgmgr/coppmgr.h
+++ b/cfgmgr/coppmgr.h
@@ -62,7 +62,7 @@ class CoppMgr : public Orch
 {
 public:
     CoppMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb,
-        const std::vector<std::string> &tableNames);
+        const std::vector<std::string> &tableNames, const std::string copp_init_file = COPP_INIT_FILE);
 
     using Orch::doTask;
 private:
@@ -75,6 +75,7 @@ private:
     CoppCfg                m_coppGroupInitCfg;
     CoppCfg                m_coppTrapInitCfg;
     CoppCfg                m_featuresCfgTable;
+    std::string            m_coppCfgfile;
 
 
     void doTask(Consumer &consumer);

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -130,7 +130,8 @@ tests_SOURCES = aclorch_ut.cpp \
                 $(top_srcdir)/orchagent/dash/dashvnetorch.cpp \
                 $(top_srcdir)/cfgmgr/buffermgrdyn.cpp \
                 $(top_srcdir)/warmrestart/warmRestartAssist.cpp \
-                $(top_srcdir)/orchagent/dash/pbutils.cpp
+                $(top_srcdir)/orchagent/dash/pbutils.cpp \
+                $(top_srcdir)/cfgmgr/coppmgr.cpp
 
 tests_SOURCES += $(FLEX_CTR_DIR)/flex_counter_manager.cpp $(FLEX_CTR_DIR)/flex_counter_stat_manager.cpp $(FLEX_CTR_DIR)/flow_counter_handler.cpp $(FLEX_CTR_DIR)/flowcounterrouteorch.cpp
 tests_SOURCES += $(DEBUG_CTR_DIR)/debug_counter.cpp $(DEBUG_CTR_DIR)/drop_counter.cpp

--- a/tests/mock_tests/copp_ut.cpp
+++ b/tests/mock_tests/copp_ut.cpp
@@ -4,34 +4,14 @@
 #include "warm_restart.h"
 #include "ut_helper.h"
 #include "coppmgr.h"
-#include "coppmgr.cpp"
 #include <fstream>
 #include <streambuf>
+
 using namespace std;
 using namespace swss;
 
-void create_init_file()
-{
-    int status = system("sudo mkdir /etc/sonic/");
-    ASSERT_EQ(status, 0);
-
-    status = system("sudo chmod 777 /etc/sonic/");
-    ASSERT_EQ(status, 0);
-    
-    status = system("sudo cp copp_cfg.json /etc/sonic/");
-    ASSERT_EQ(status, 0);
-}
-
-void cleanup()
-{
-    int status = system("sudo rm -rf /etc/sonic/");
-    ASSERT_EQ(status, 0);
-}
-
 TEST(CoppMgrTest, CoppTest)
 {
-    create_init_file();
-
     const vector<string> cfg_copp_tables = {
                 CFG_COPP_TRAP_TABLE_NAME,
                 CFG_COPP_GROUP_TABLE_NAME,
@@ -65,12 +45,10 @@ TEST(CoppMgrTest, CoppTest)
                     {"trap_ids", "ip2me"}
                 });
 
-    CoppMgr coppmgr(&cfgDb, &appDb, &stateDb, cfg_copp_tables);
+    CoppMgr coppmgr(&cfgDb, &appDb, &stateDb, cfg_copp_tables, "./copp_cfg.json");
 
     string overide_val;
     coppTable.hget("queue1_group1", "cbs",overide_val);
     EXPECT_EQ( overide_val, "6000");
-
-    cleanup();
 }
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Refactoring coppmgr mock tests

**Why I did it**
After migration to bookworm, coppmgr tests started failing due to the use of sudo commands.

```
[----------] 1 test from CoppMgrTest
[ RUN      ] CoppMgrTest.CoppTest
sudo: pam_open_session: Too many open files
sudo: policy plugin failed session initialization
copp_ut.cpp:28: Failure
Expected equality of these values:
 status
Which is: 256
 0
CoppMgrTest.CoppTest (107 ms)
1 test from CoppMgrTest (107 ms total)
```

Avoided the logic of replacing the files using sudo by slightly refactoring the code.
**How I verified it**
Run the UT to verify.

**Details if related**
