### PR TITLE
Apply port speed again after disabling port AN

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3573,6 +3573,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
         if (op == SET_COMMAND)
         {
             auto parsePortFvs = [&](auto& fvMap) -> bool
+            bool apply_port_speed_on_an_change_to_disabled = false;
             {
                 for (const auto &cit : kfvFieldsValues(keyOpFieldsValues))
                 {
@@ -3804,6 +3805,14 @@ void PortsOrch::doPortTask(Consumer &consumer)
                             "Set port %s autoneg to %s",
                             p.m_alias.c_str(), m_portHlpr.getAutonegStr(pCfg).c_str()
                         );
+
+                        /* Reapply port speed after AN disabled */
+                        if (p.m_autoneg < 1)
+                        {
+                            pCfg.speed.is_set = true;
+                            pCfg.speed.value = p.m_speed;
+                            apply_port_speed_on_an_change_to_disabled = true;
+                        }
                     }
                 }
 
@@ -3863,7 +3872,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
                 if (pCfg.speed.is_set)
                 {
-                    if (p.m_speed != pCfg.speed.value)
+                    if (p.m_speed != pCfg.speed.value || apply_port_speed_on_an_change_to_disabled)
                     {
                         if (!isSpeedSupported(p.m_alias, p.m_port_id, pCfg.speed.value))
                         {


### PR DESCRIPTION
**What I did**
Apply port speed again after disabling port AN.

**Why I did it**
In PortsOrch, the port speed configuration will not be set to SAI when port AN is enabled.
Changing the port speed while port AN is enabled will not take effect after port AN is disabled.

**How I verified it**

1. Enable port AN.
2. Set port speed from speed1 to speed2
3. Disable port AN.
4. Make sure port speed is speed2 instead of speed1.

**Details if related**
