### PR TITLE
Clang format change.

### DIFF
--- a/orchagent/p4orch/acl_rule_manager.cpp
+++ b/orchagent/p4orch/acl_rule_manager.cpp
@@ -1,5 +1,6 @@
 #include "p4orch/acl_rule_manager.h"
 
+#include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -17,7 +18,6 @@
 #include "sai_serialize.h"
 #include "table.h"
 #include "tokenize.h"
-#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/acl_table_manager.cpp
+++ b/orchagent/p4orch/acl_table_manager.cpp
@@ -1,5 +1,6 @@
 #include "p4orch/acl_table_manager.h"
 
+#include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -15,7 +16,6 @@
 #include "switchorch.h"
 #include "table.h"
 #include "tokenize.h"
-#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/acl_util.cpp
+++ b/orchagent/p4orch/acl_util.cpp
@@ -1,11 +1,12 @@
 #include "p4orch/acl_util.h"
 
+#include <nlohmann/json.hpp>
+
 #include "converter.h"
 #include "logger.h"
 #include "sai_serialize.h"
 #include "table.h"
 #include "tokenize.h"
-#include <nlohmann/json.hpp>
 
 namespace p4orch
 {

--- a/orchagent/p4orch/acl_util.h
+++ b/orchagent/p4orch/acl_util.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <map>
+#include <nlohmann/json.hpp>
 #include <set>
 #include <string>
 #include <vector>
 
 #include "p4orch/p4orch_util.h"
 #include "return_code.h"
-#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"
@@ -243,7 +243,7 @@ struct P4AclTableDefinition
     P4AclTableDefinition(const std::string &acl_table_name, const sai_acl_stage_t stage, const uint32_t priority,
                          const uint32_t size, const std::string &meter_unit, const std::string &counter_unit)
         : acl_table_name(acl_table_name), stage(stage), priority(priority), size(size), meter_unit(meter_unit),
-          counter_unit(counter_unit){};
+          counter_unit(counter_unit) {};
 };
 
 struct P4UserDefinedTrapHostifTableEntry
@@ -251,7 +251,7 @@ struct P4UserDefinedTrapHostifTableEntry
     sai_object_id_t user_defined_trap;
     sai_object_id_t hostif_table_entry;
     P4UserDefinedTrapHostifTableEntry()
-        : user_defined_trap(SAI_NULL_OBJECT_ID), hostif_table_entry(SAI_NULL_OBJECT_ID){};
+        : user_defined_trap(SAI_NULL_OBJECT_ID), hostif_table_entry(SAI_NULL_OBJECT_ID) {};
 };
 
 using acl_rule_attr_lookup_t = std::map<std::string, acl_entry_attr_union_t>;

--- a/orchagent/p4orch/ext_tables_manager.cpp
+++ b/orchagent/p4orch/ext_tables_manager.cpp
@@ -2,6 +2,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <memory>
+#include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -14,7 +15,6 @@
 #include "p4orch/p4orch.h"
 #include "p4orch/p4orch_util.h"
 #include "tokenize.h"
-#include <nlohmann/json.hpp>
 
 extern sai_counter_api_t *sai_counter_api;
 extern sai_generic_programmable_api_t *sai_generic_programmable_api;
@@ -111,15 +111,18 @@ ReturnCode ExtTablesManager::validateActionParamsCrossRef(P4ExtTableAppDbEntry &
                     SWSS_LOG_ERROR("Cross-table reference validation failed from extension-table %s",
                                    table_name.c_str());
                     return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                           << "Cross-table reference valdiation failed from extension table";
+                           << "Cross-table reference valdiation failed from extension "
+                              "table";
                 }
             }
             else
             {
-                SWSS_LOG_ERROR("Cross-table reference validation failed due to non-existent table %s",
+                SWSS_LOG_ERROR("Cross-table reference validation failed due to non-existent table "
+                               "%s",
                                table_name.c_str());
                 return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                       << "Cross-table reference valdiation failed due to non-existent table";
+                       << "Cross-table reference valdiation failed due to non-existent "
+                          "table";
             }
         }
 
@@ -132,7 +135,8 @@ ReturnCode ExtTablesManager::validateActionParamsCrossRef(P4ExtTableAppDbEntry &
 
         if (oid == SAI_NULL_OBJECT_ID)
         {
-            SWSS_LOG_ERROR("Cross-table reference validation failed, null OID expected from table %s",
+            SWSS_LOG_ERROR("Cross-table reference validation failed, null OID expected from "
+                           "table %s",
                            table_name.c_str());
             return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM) << "Cross-table reference valdiation failed, null OID";
         }
@@ -724,7 +728,8 @@ void ExtTablesManager::drain()
                     SWSS_LOG_ERROR("Unable to deserialize APP DB entry with key %s: %s",
                                    QuotedVar(kfvKey(key_op_fvs_tuple)).c_str(), status.message().c_str());
                     m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple),
-                                         kfvFieldsValues(key_op_fvs_tuple), status, /*replace=*/true);
+                                         kfvFieldsValues(key_op_fvs_tuple), status,
+                                         /*replace=*/true);
                     continue;
                 }
 
@@ -735,7 +740,8 @@ void ExtTablesManager::drain()
                     SWSS_LOG_ERROR("Validation failed for extension APP DB entry with key %s: %s",
                                    QuotedVar(kfvKey(key_op_fvs_tuple)).c_str(), status.message().c_str());
                     m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple),
-                                         kfvFieldsValues(key_op_fvs_tuple), status, /*replace=*/true);
+                                         kfvFieldsValues(key_op_fvs_tuple), status,
+                                         /*replace=*/true);
                     continue;
                 }
 
@@ -772,7 +778,8 @@ void ExtTablesManager::drain()
                                    QuotedVar(kfvKey(key_op_fvs_tuple)).c_str(), status.message().c_str());
                 }
                 m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
-                                     status, /*replace=*/true);
+                                     status,
+                                     /*replace=*/true);
             }
 
             it_m->second.clear();
@@ -833,7 +840,8 @@ void ExtTablesManager::doExtCounterStatsTask()
                 sai_counter_api->get_counter_stats(ext_table_entry->sai_counter_oid, 2, stat_ids, stats);
             if (sai_status != SAI_STATUS_SUCCESS)
             {
-                SWSS_LOG_WARN("Failed to set counters stats for extension entry %s:%s in COUNTERS_DB: ",
+                SWSS_LOG_WARN("Failed to set counters stats for extension entry %s:%s in "
+                              "COUNTERS_DB: ",
                               table_name.c_str(), ext_table_entry->table_key.c_str());
                 continue;
             }

--- a/orchagent/p4orch/ext_tables_manager.h
+++ b/orchagent/p4orch/ext_tables_manager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <nlohmann/json.hpp>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -14,7 +15,6 @@
 #include "response_publisher_interface.h"
 #include "return_code.h"
 #include "vrforch.h"
-#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"
@@ -29,7 +29,7 @@ struct P4ExtTableEntry
     sai_object_id_t sai_counter_oid = SAI_NULL_OBJECT_ID;
     std::unordered_map<std::string, DepObject> action_dep_objects;
 
-    P4ExtTableEntry(){};
+    P4ExtTableEntry() {};
     P4ExtTableEntry(const std::string &db_key, const std::string &table_name, const std::string &table_key)
         : db_key(db_key), table_name(table_name), table_key(table_key)
     {

--- a/orchagent/p4orch/gre_tunnel_manager.cpp
+++ b/orchagent/p4orch/gre_tunnel_manager.cpp
@@ -1,6 +1,7 @@
 #include "p4orch/gre_tunnel_manager.h"
 
 #include <map>
+#include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -14,7 +15,6 @@
 #include "sai_serialize.h"
 #include "swssnet.h"
 #include "table.h"
-#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/l3_admit_manager.cpp
+++ b/orchagent/p4orch/l3_admit_manager.cpp
@@ -1,6 +1,7 @@
 #include "p4orch/l3_admit_manager.h"
 
 #include <map>
+#include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -14,7 +15,6 @@
 #include "sai_serialize.h"
 #include "table.h"
 #include "tokenize.h"
-#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/mirror_session_manager.cpp
+++ b/orchagent/p4orch/mirror_session_manager.cpp
@@ -1,6 +1,7 @@
 #include "p4orch/mirror_session_manager.h"
 
 #include <map>
+#include <nlohmann/json.hpp>
 
 #include "SaiAttributeList.h"
 #include "dbconnector.h"
@@ -10,7 +11,6 @@
 #include "swss/logger.h"
 #include "swssnet.h"
 #include "table.h"
-#include <nlohmann/json.hpp>
 
 using ::p4orch::kTableKeyDelimiter;
 

--- a/orchagent/p4orch/neighbor_manager.cpp
+++ b/orchagent/p4orch/neighbor_manager.cpp
@@ -1,5 +1,6 @@
 #include "p4orch/neighbor_manager.h"
 
+#include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -13,7 +14,6 @@
 #include "sai_serialize.h"
 #include "swssnet.h"
 #include "table.h"
-#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/next_hop_manager.cpp
+++ b/orchagent/p4orch/next_hop_manager.cpp
@@ -1,5 +1,6 @@
 #include "p4orch/next_hop_manager.h"
 
+#include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -14,7 +15,6 @@
 #include "sai_serialize.h"
 #include "swssnet.h"
 #include "table.h"
-#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/p4orch_util.cpp
+++ b/orchagent/p4orch/p4orch_util.cpp
@@ -1,6 +1,6 @@
 #include "p4orch/p4orch_util.h"
-#include "p4orch/p4orch.h"
 
+#include "p4orch/p4orch.h"
 #include "schema.h"
 
 using ::p4orch::kTableKeyDelimiter;

--- a/orchagent/p4orch/route_manager.cpp
+++ b/orchagent/p4orch/route_manager.cpp
@@ -1,6 +1,7 @@
 #include "p4orch/route_manager.h"
 
 #include <memory>
+#include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
 #include <unordered_set>
@@ -16,7 +17,6 @@
 #include "sai_serialize.h"
 #include "swssnet.h"
 #include "table.h"
-#include <nlohmann/json.hpp>
 
 using ::p4orch::kTableKeyDelimiter;
 

--- a/orchagent/p4orch/router_interface_manager.cpp
+++ b/orchagent/p4orch/router_interface_manager.cpp
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <memory>
+#include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -17,7 +18,6 @@
 #include "sai_serialize.h"
 #include "table.h"
 #include "vrforch.h"
-#include <nlohmann/json.hpp>
 
 using ::p4orch::kTableKeyDelimiter;
 

--- a/orchagent/p4orch/tables_definition_manager.cpp
+++ b/orchagent/p4orch/tables_definition_manager.cpp
@@ -1,6 +1,7 @@
 #include "p4orch/tables_definition_manager.h"
 
 #include <memory>
+#include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -12,7 +13,6 @@
 #include "p4orch/p4orch.h"
 #include "p4orch/p4orch_util.h"
 #include "tokenize.h"
-#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "saitypes.h"
@@ -100,7 +100,8 @@ ReturnCode parseTableMatchReferences(const nlohmann::json &match_json, TableMatc
             catch (std::exception &ex)
             {
                 return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                       << "can not parse tables from app-db supplied table definition info";
+                       << "can not parse tables from app-db supplied table definition "
+                          "info";
             }
         }
     }
@@ -125,7 +126,8 @@ ReturnCode parseActionParamReferences(const nlohmann::json &param_json, ActionPa
             catch (std::exception &ex)
             {
                 return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                       << "can not parse tables from app-db supplied table definition info";
+                       << "can not parse tables from app-db supplied table definition "
+                          "info";
             }
         }
     }
@@ -155,7 +157,8 @@ ReturnCode parseTableActionParams(const nlohmann::json &action_json, ActionInfo 
                 if (!param.table_reference_map.empty())
                 {
                     /**
-                     * Helps avoid walk of action parameters if this is set to false at action level
+                     * Helps avoid walk of action parameters if this is set to false at
+                     * action level
                      */
                     action.refers_to = true;
                 }
@@ -163,7 +166,8 @@ ReturnCode parseTableActionParams(const nlohmann::json &action_json, ActionInfo 
             catch (std::exception &ex)
             {
                 return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                       << "can not parse tables from app-db supplied table definition info";
+                       << "can not parse tables from app-db supplied table definition "
+                          "info";
             }
         }
     }
@@ -215,7 +219,8 @@ ReturnCode parseTablesInfo(const nlohmann::json &info_json, TablesInfo &info_ent
         catch (std::exception &ex)
         {
             return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                   << "can not parse tables from app-db supplied table definition info";
+                   << "can not parse tables from app-db supplied table definition "
+                      "info";
         }
 
         TableInfo table = {};
@@ -247,8 +252,8 @@ ReturnCode parseTablesInfo(const nlohmann::json &info_json, TablesInfo &info_ent
                 table.action_fields[action_name] = action;
 
                 /**
-                 * If any parameter of action refers to another table, add that one in the
-                 * cross-reference list of current table
+                 * If any parameter of action refers to another table, add that one in
+                 * the cross-reference list of current table
                  */
                 for (auto param_it = action.params.begin(); param_it != action.params.end(); param_it++)
                 {
@@ -466,7 +471,8 @@ std::vector<int> findTablePrecedence(int tables, std::vector<std::pair<int, int>
 
     for (int i = 0; i < tables; i++)
     {
-        // Err input data like possible cyclic dependencies, could not build precedence order
+        // Err input data like possible cyclic dependencies, could not build
+        // precedence order
         if (zeros.empty())
         {
             SWSS_LOG_ERROR("Filed to build table precedence order");
@@ -546,7 +552,8 @@ void buildTablePrecedence(TablesInfo *tables_info)
     // find precedence of tables based on dependencies
     orderedTables = findTablePrecedence(tables, preReq, tables_info);
 
-    // update each table with calculated precedence value and build table precedence map
+    // update each table with calculated precedence value and build table
+    // precedence map
     for (std::size_t i = 0; i < orderedTables.size(); i++)
     {
         auto table_id = orderedTables[i];
@@ -593,7 +600,8 @@ void TablesDefnManager::drain()
             SWSS_LOG_ERROR("Unable to deserialize APP DB entry with key %s: %s",
                            QuotedVar(table_name + ":" + key).c_str(), status.message().c_str());
             m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
-                                 status, /*replace=*/true);
+                                 status,
+                                 /*replace=*/true);
             continue;
         }
         auto &app_db_entry = *app_db_entry_or;
@@ -601,10 +609,12 @@ void TablesDefnManager::drain()
         status = validateTablesInfoAppDbEntry(app_db_entry);
         if (!status.ok())
         {
-            SWSS_LOG_ERROR("Validation failed for tables definition APP DB entry with key %s: %s",
+            SWSS_LOG_ERROR("Validation failed for tables definition APP DB entry with key %s: "
+                           "%s",
                            QuotedVar(table_name + ":" + key).c_str(), status.message().c_str());
             m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
-                                 status, /*replace=*/true);
+                                 status,
+                                 /*replace=*/true);
             continue;
         }
 
@@ -637,7 +647,8 @@ void TablesDefnManager::drain()
         }
         if (!status.ok())
         {
-            SWSS_LOG_ERROR("Processing failed for tables definition APP DB entry with key %s: %s",
+            SWSS_LOG_ERROR("Processing failed for tables definition APP DB entry with key %s: "
+                           "%s",
                            QuotedVar(table_name + ":" + key).c_str(), status.message().c_str());
         }
         else

--- a/orchagent/p4orch/tables_definition_manager.h
+++ b/orchagent/p4orch/tables_definition_manager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <nlohmann/json.hpp>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -12,7 +13,6 @@
 #include "p4orch/p4orch_util.h"
 #include "response_publisher_interface.h"
 #include "return_code.h"
-#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"
@@ -29,7 +29,7 @@ struct TablesInfo
     std::unordered_map<std::string, TableInfo> m_tableInfoMap;
     std::map<int, std::string> m_tablePrecedenceMap;
 
-    TablesInfo(){};
+    TablesInfo() {};
     TablesInfo(const std::string &context_key, const nlohmann::json &info_value)
         : context(context_key), info(info_value)
     {

--- a/orchagent/p4orch/tests/acl_manager_test.cpp
+++ b/orchagent/p4orch/tests/acl_manager_test.cpp
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <memory>
+#include <nlohmann/json.hpp>
 #include <string>
 
 #include "acl_rule_manager.h"
@@ -21,7 +22,6 @@
 #include "table.h"
 #include "tokenize.h"
 #include "vrforch.h"
-#include <nlohmann/json.hpp>
 
 using ::p4orch::kTableKeyDelimiter;
 

--- a/orchagent/p4orch/tests/gre_tunnel_manager_test.cpp
+++ b/orchagent/p4orch/tests/gre_tunnel_manager_test.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include <functional>
+#include <nlohmann/json.hpp>
 #include <string>
 #include <unordered_map>
 
@@ -17,7 +18,6 @@
 #include "p4orch_util.h"
 #include "return_code.h"
 #include "swssnet.h"
-#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/tests/l3_admit_manager_test.cpp
+++ b/orchagent/p4orch/tests/l3_admit_manager_test.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include <functional>
+#include <nlohmann/json.hpp>
 #include <string>
 #include <unordered_map>
 
@@ -13,7 +14,6 @@
 #include "p4orch/p4orch_util.h"
 #include "p4orch_util.h"
 #include "return_code.h"
-#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/tests/mirror_session_manager_test.cpp
+++ b/orchagent/p4orch/tests/mirror_session_manager_test.cpp
@@ -3,6 +3,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
 
@@ -14,7 +15,6 @@
 #include "swss/ipaddress.h"
 #include "swss/macaddress.h"
 #include "swssnet.h"
-#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/tests/neighbor_manager_test.cpp
+++ b/orchagent/p4orch/tests/neighbor_manager_test.cpp
@@ -3,6 +3,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <nlohmann/json.hpp>
 #include <string>
 #include <unordered_set>
 
@@ -12,7 +13,6 @@
 #include "p4orch/p4orch_util.h"
 #include "return_code.h"
 #include "swssnet.h"
-#include <nlohmann/json.hpp>
 
 using ::p4orch::kTableKeyDelimiter;
 

--- a/orchagent/p4orch/tests/next_hop_manager_test.cpp
+++ b/orchagent/p4orch/tests/next_hop_manager_test.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include <functional>
+#include <nlohmann/json.hpp>
 #include <string>
 #include <unordered_map>
 
@@ -17,7 +18,6 @@
 #include "p4orch.h"
 #include "return_code.h"
 #include "swssnet.h"
-#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/tests/route_manager_test.cpp
+++ b/orchagent/p4orch/tests/route_manager_test.cpp
@@ -5,6 +5,7 @@
 
 #include <functional>
 #include <map>
+#include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
 
@@ -16,7 +17,6 @@
 #include "return_code.h"
 #include "swssnet.h"
 #include "vrforch.h"
-#include <nlohmann/json.hpp>
 
 using ::p4orch::kTableKeyDelimiter;
 

--- a/orchagent/p4orch/tests/wcmp_manager_test.cpp
+++ b/orchagent/p4orch/tests/wcmp_manager_test.cpp
@@ -3,6 +3,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <nlohmann/json.hpp>
 #include <string>
 
 #include "mock_response_publisher.h"
@@ -17,7 +18,6 @@
 #include "p4orch_util.h"
 #include "return_code.h"
 #include "sai_serialize.h"
-#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/wcmp_manager.cpp
+++ b/orchagent/p4orch/wcmp_manager.cpp
@@ -1,5 +1,6 @@
 #include "p4orch/wcmp_manager.h"
 
+#include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -12,7 +13,6 @@
 #include "portsorch.h"
 #include "sai_serialize.h"
 #include "table.h"
-#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"


### PR DESCRIPTION
**What I did**
This PR has no real code change. It is purely clang formatting.
It does the same as https://github.com/sonic-net/sonic-swss/pull/3080.
However, there are some mystery of the clang tool result in weird behaviors in the previous PR.

The previous PR run the following clang commands:
find orchagent/p4orch -name *.h -o -name .cpp | xargs clang-format -i -style="{BasedOnStyle: Microsoft, DerivePointerAlignment: false}"
find orchagent -name response_publisher -o -name return_code.h | xargs clang-format -i -style="{BasedOnStyle: Microsoft, DerivePointerAlignment: false}"

However, if we first convert the format to google style and change it back to Microsoft style, there are differences (mainly on the #include statement):
find orchagent/p4orch -name *.h -o -name *.cpp | xargs clang-format -i -style="{BasedOnStyle: google, DerivePointerAlignment: false}"
find orchagent -name response_publisher* -o -name return_code.h | xargs clang-format -i -style="{BasedOnStyle: google, DerivePointerAlignment: false}"
find orchagent/p4orch -name *.h -o -name *.cpp | xargs clang-format -i -style="{BasedOnStyle: Microsoft, DerivePointerAlignment: false}"
find orchagent -name response_publisher* -o -name return_code.h | xargs clang-format -i -style="{BasedOnStyle: Microsoft, DerivePointerAlignment: false}"

So what this PR does is to apply the Google format first and then change it to Microsoft. Change is only applied to P4Orch codes.

**Why I did it**
We need to first apply Google format in order to cherry-pick Google changes. And we need to convert back to Microsoft format when we create the PR. Somehow changing to Google format first makes a difference.

**How I verified it**
N/A

**Details if related**
N/A
