### PR TITLE
Fix setting host_tx_ready from initializePort()

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -5464,7 +5464,7 @@ bool PortsOrch::initializePort(Port &port)
         string hostTxReadyStr = hostTxReadyVal ? "true" : "false";
 
         SWSS_LOG_DEBUG("Received host_tx_ready current status: port_id: 0x%" PRIx64 " status: %s", port.m_port_id, hostTxReadyStr.c_str());
-	m_portStateTable.hset(port.m_alias, "host_tx_ready", hostTxReadyStr);
+        m_portStateTable.hset(port.m_alias, "host_tx_ready", hostTxReadyStr);
     }
 
     /*

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -5423,7 +5423,7 @@ bool PortsOrch::initializePort(Port &port)
         string hostTxReadyStr = hostTxReadyVal ? "true" : "false";
 
         SWSS_LOG_DEBUG("Received host_tx_ready current status: port_id: 0x%" PRIx64 " status: %s", port.m_port_id, hostTxReadyStr.c_str());
-        setHostTxReady(port.m_port_id, hostTxReadyStr);
+	m_portStateTable.hset(port.m_alias, "host_tx_ready", hostTxReadyStr);
     }
 
     /*


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
During port initialization, we now set Host Tx Ready key-val to DB using "hset()" instead of using the new function "setHostTxReady()"

**Why I did it**
Port must be initialized before calling setHostTxReady(). if it is not initialized, it won't find the port object and function won't set host_tx_ready. 

**How I verified it**
boot switch with new changes.

**Details if related**
