### PR TITLE
Fix oper FEC retrieval after warmboot

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -7779,6 +7779,18 @@ void PortsOrch::refreshPortStatus()
             {
                 updateDbPortOperSpeed(port, 0);
             }
+            sai_port_fec_mode_t fec_mode;
+            string fec_str = "N/A";
+            if (oper_fec_sup && getPortOperFec(port, fec_mode))
+            {
+                if (!m_portHlpr.fecToStr(fec_str, fec_mode))
+                {
+                    SWSS_LOG_ERROR("Error unknown fec mode %d while querying port %s fec mode",
+                                   static_cast<std::int32_t>(fec_mode), port.m_alias.c_str());
+                    fec_str = "N/A";
+                }
+            }
+            updateDbPortOperFec(port,fec_str);
         }
     }
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Updating oper FEC status in state_db after warm-reboot as part of refresh port status call


**Why I did it**
Oper FEC was not properly displayed after warm-boot. Hence fixing the issue. 

With the issue
```
Interface    FEC Oper    FEC Admin
-----------  ----------  -----------
  Ethernet0         N/A          N/A
  Ethernet4         N/A         auto
  Ethernet8         N/A         auto
 Ethernet12         N/A         auto
 Ethernet14         N/A          N/A
 Ethernet16         N/A         auto
```


After the fix
```
Interface    FEC Oper    FEC Admin
-----------  ----------  -----------
  Ethernet0          rs          N/A
  Ethernet4        none         auto
  Ethernet8        none         auto
 Ethernet12          fc         auto
 Ethernet14          fc          N/A
 Ethernet16          fc         auto
```
**How I verified it**
Manual testing. Added UT as well.

**Details if related**
