### PR TITLE
[202311][portsorch] Handle TRANSCEIVER_INFO table on warm boot

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3367,6 +3367,7 @@ bool PortsOrch::bake()
     addExistingData(APP_LAG_MEMBER_TABLE_NAME);
     addExistingData(APP_VLAN_TABLE_NAME);
     addExistingData(APP_VLAN_MEMBER_TABLE_NAME);
+    addExistingData(STATE_TRANSCEIVER_INFO_TABLE_NAME);
 
     return true;
 }

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -40,6 +40,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 mock_orchagent_main.cpp \
                 mock_dbconnector.cpp \
                 mock_consumerstatetable.cpp \
+                mock_subscriberstatetable.cpp \
                 common/mock_shell_command.cpp \
                 mock_table.cpp \
                 mock_hiredis.cpp \

--- a/tests/mock_tests/mock_subscriberstatetable.cpp
+++ b/tests/mock_tests/mock_subscriberstatetable.cpp
@@ -1,0 +1,30 @@
+#include "subscriberstatetable.h"
+
+namespace swss
+{
+    SubscriberStateTable::SubscriberStateTable(DBConnector *db, const std::string &tableName, int popBatchSize, int pri) :
+        ConsumerTableBase(db, tableName, popBatchSize, pri),
+	m_table(db, tableName)
+    {
+    }
+
+    void SubscriberStateTable::pops(std::deque<KeyOpFieldsValuesTuple> &vkco, const std::string& /*prefix*/)
+    {
+        std::vector<std::string> keys;
+        m_table.getKeys(keys);
+        for (const auto &key: keys)
+        {
+            KeyOpFieldsValuesTuple kco;
+
+            kfvKey(kco) = key;
+            kfvOp(kco) = SET_COMMAND;
+
+            if (!m_table.get(key, kfvFieldsValues(kco)))
+            {
+                continue;
+            }
+            m_table.del(key);
+            vkco.push_back(kco);
+        }
+    }
+}

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -1378,6 +1378,7 @@ namespace portsorch_test
         Table pgTable = Table(m_app_db.get(), APP_BUFFER_PG_TABLE_NAME);
         Table profileTable = Table(m_app_db.get(), APP_BUFFER_PROFILE_TABLE_NAME);
         Table poolTable = Table(m_app_db.get(), APP_BUFFER_POOL_TABLE_NAME);
+        Table transceieverInfoTable = Table(m_state_db.get(), STATE_TRANSCEIVER_INFO_TABLE_NAME);
 
         // Get SAI default ports to populate DB
 
@@ -1411,6 +1412,7 @@ namespace portsorch_test
         for (const auto &it : ports)
         {
             portTable.set(it.first, it.second);
+            transceieverInfoTable.set(it.first, {});
         }
 
         // Set PortConfigDone, PortInitDone
@@ -1458,6 +1460,25 @@ namespace portsorch_test
 
         gBufferOrch->dumpPendingTasks(ts);
         ASSERT_TRUE(ts.empty());
+
+        // Verify port configuration
+        vector<sai_object_id_t> port_list;
+        port_list.resize(ports.size());
+        sai_attribute_t attr;
+        sai_status_t status;
+        attr.id = SAI_SWITCH_ATTR_PORT_LIST;
+        attr.value.objlist.count = static_cast<uint32_t>(port_list.size());
+        attr.value.objlist.list = port_list.data();
+        status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+        ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+        for (uint32_t i = 0; i < port_list.size(); i++)
+        {
+            attr.id = SAI_PORT_ATTR_HOST_TX_SIGNAL_ENABLE;
+            status = sai_port_api->get_port_attribute(port_list[i], 1, &attr);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+            ASSERT_TRUE(attr.value.booldata);
+        }
     }
 
     TEST_F(PortsOrchTest, PfcDlrHandlerCallingDlrInitAttribute)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

Backport of https://github.com/sonic-net/sonic-swss/pull/3087

**What I did**

Process TRANSCEIVER_INFO STATE_DB table on warm start to configure SAI_PORT_ATTR_HOST_TX_SIGNAL_ENABLE on warm boot.

**Why I did it**

Fix an issue that the port becomes operationally down after APPLY_VIEW.

**How I verified it**

Run warm-reboot.

**Details if related**
