### PR TITLE
Remove unwanted newline character at end of timestamp

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3120,12 +3120,18 @@ void PortsOrch::updateDbPortFlapCount(Port& port, sai_port_oper_status_t pstatus
     std::time_t now_c = std::chrono::system_clock::to_time_t(now);
     if (pstatus == SAI_PORT_OPER_STATUS_DOWN)
     {
-        FieldValueTuple tuple("last_down_time", std::ctime(&now_c));
+        // std::ctime returns a string with an unwanted newline character so we trim it
+        char * timeStr = std::ctime(&now_c);
+        timeStr[strlen(timeStr)-1] = '\0';
+        FieldValueTuple tuple("last_down_time", timeStr);
         tuples.push_back(tuple);
     } 
     else if (pstatus == SAI_PORT_OPER_STATUS_UP) 
     {
-        FieldValueTuple tuple("last_up_time", std::ctime(&now_c));
+        // std::ctime returns a string with an unwanted newline character so we trim it
+        char * timeStr = std::ctime(&now_c);
+        timeStr[strlen(timeStr)-1] = '\0';
+        FieldValueTuple tuple("last_up_time", timeStr);
         tuples.push_back(tuple);
     }
     m_portTable->set(port.m_alias, tuples);

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3120,18 +3120,18 @@ void PortsOrch::updateDbPortFlapCount(Port& port, sai_port_oper_status_t pstatus
     std::time_t now_c = std::chrono::system_clock::to_time_t(now);
     if (pstatus == SAI_PORT_OPER_STATUS_DOWN)
     {
-        // std::ctime returns a string with an unwanted newline character so we trim it
-        char * timeStr = std::ctime(&now_c);
-        timeStr[strlen(timeStr)-1] = '\0';
-        FieldValueTuple tuple("last_down_time", timeStr);
+        char buffer[32];
+        // Format: Www Mmm dd hh:mm:ss yyyy
+        std::strftime(buffer, sizeof(buffer), "%a %b %d %H:%M:%S %Y", std::localtime(&now_c));
+        FieldValueTuple tuple("last_down_time", buffer);
         tuples.push_back(tuple);
     } 
     else if (pstatus == SAI_PORT_OPER_STATUS_UP) 
     {
-        // std::ctime returns a string with an unwanted newline character so we trim it
-        char * timeStr = std::ctime(&now_c);
-        timeStr[strlen(timeStr)-1] = '\0';
-        FieldValueTuple tuple("last_up_time", timeStr);
+        char buffer[32];
+        // Format: Www Mmm dd hh:mm:ss yyyy
+        std::strftime(buffer, sizeof(buffer), "%a %b %d %H:%M:%S %Y", std::localtime(&now_c));
+        FieldValueTuple tuple("last_up_time", buffer);
         tuples.push_back(tuple);
     }
     m_portTable->set(port.m_alias, tuples);

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3122,7 +3122,7 @@ void PortsOrch::updateDbPortFlapCount(Port& port, sai_port_oper_status_t pstatus
     {
         char buffer[32];
         // Format: Www Mmm dd hh:mm:ss yyyy
-        std::strftime(buffer, sizeof(buffer), "%a %b %d %H:%M:%S %Y", std::localtime(&now_c));
+        std::strftime(buffer, sizeof(buffer), "%a %b %d %H:%M:%S %Y", std::gmtime(&now_c));
         FieldValueTuple tuple("last_down_time", buffer);
         tuples.push_back(tuple);
     } 
@@ -3130,7 +3130,7 @@ void PortsOrch::updateDbPortFlapCount(Port& port, sai_port_oper_status_t pstatus
     {
         char buffer[32];
         // Format: Www Mmm dd hh:mm:ss yyyy
-        std::strftime(buffer, sizeof(buffer), "%a %b %d %H:%M:%S %Y", std::localtime(&now_c));
+        std::strftime(buffer, sizeof(buffer), "%a %b %d %H:%M:%S %Y", std::gmtime(&now_c));
         FieldValueTuple tuple("last_up_time", buffer);
         tuples.push_back(tuple);
     }


### PR DESCRIPTION
In https://github.com/sonic-net/sonic-swss/pull/3052 2 new fields were added the `PORT_TABLE` in `APPL_DB`: `last_down_time` and `last_up_time`.
But their value was generated with `std::ctime` which includes a newline character at the end of the character array which causes issues for parsing the output.

Output today:
```
> sonic-db-cli APPL_DB hgetall PORT_TABLE:Ethernet8
{'admin_status': 'up', 'alias': 'Ethernet3/1', 'asic_port_name': 'Eth8', 'coreId': '0', 'corePortId': '3', 'description': 'Ethernet8-connected-to-@Ethernet5/4/1', 'fec': 'rs', 'index': '3', 'lanes': '4,5', 'mtu': '9100', 'numVoq': '8', 'pfc_asym': 'off', 'role': 'Ext', 'speed': '100000', 'tpid': '0x8100', 'oper_status': 'up', 'flap_count': '1', 'last_up_time': 'Wed Apr 10 00:18:44 2024
', 'system_oper_status': 'up', 'line_oper_status': 'up'}

> config interface shutdown Ethernet8
> sonic-db-cli APPL_DB hgetall PORT_TABLE:Ethernet8
{'admin_status': 'down', 'alias': 'Ethernet3/1', 'asic_port_name': 'Eth8', 'coreId': '0', 'corePortId': '3', 'description': 'Ethernet8-connected-to-@Ethernet5/4/1', 'fec': 'rs', 'index': '3', 'lanes': '4,5', 'mtu': '9100', 'numVoq': '8', 'pfc_asym': 'off', 'role': 'Ext', 'speed': '100000', 'tpid': '0x8100', 'oper_status': 'down', 'flap_count': '2', 'last_up_time': 'Wed Apr 10 00:18:44 2024
', 'system_oper_status': 'down', 'line_oper_status': 'down', 'last_down_time': 'Wed Apr 10 16:35:11 2024
'}

>  config interface startup Ethernet8
> sonic-db-cli APPL_DB hgetall PORT_TABLE:Ethernet8
{'admin_status': 'up', 'alias': 'Ethernet3/1', 'asic_port_name': 'Eth8', 'coreId': '0', 'corePortId': '3', 'description': 'Ethernet8-connected-to-@Ethernet5/4/1', 'fec': 'rs', 'index': '3', 'lanes': '4,5', 'mtu': '9100', 'numVoq': '8', 'pfc_asym': 'off', 'role': 'Ext', 'speed': '100000', 'tpid': '0x8100', 'oper_status': 'up', 'flap_count': '3', 'last_up_time': 'Wed Apr 10 16:35:34 2024
', 'system_oper_status': 'up', 'line_oper_status': 'up', 'last_down_time': 'Wed Apr 10 16:35:11 2024
'}
```

Output after this change:
```
> sonic-db-cli APPL_DB hgetall PORT_TABLE:Ethernet8
{'admin_status': 'up', 'alias': 'Ethernet3/1', 'asic_port_name': 'Eth8', 'coreId': '0', 'corePortId': '3', 'description': 'Ethernet8-connected-to-@Ethernet5/4/1', 'fec': 'rs', 'index': '3', 'lanes': '4,5', 'mtu': '9100', 'numVoq': '8', 'pfc_asym': 'off', 'role': 'Ext', 'speed': '100000', 'tpid': '0x8100', 'oper_status': 'up', 'flap_count': '1', 'last_up_time': 'Wed Apr 10 17:01:00 2024', 'system_oper_status': 'up', 'line_oper_status': 'up'}

> config interface shutdown Ethernet8
> sonic-db-cli APPL_DB hgetall PORT_TABLE:Ethernet8
{'admin_status': 'down', 'alias': 'Ethernet3/1', 'asic_port_name': 'Eth8', 'coreId': '0', 'corePortId': '3', 'description': 'Ethernet8-connected-to-@Ethernet5/4/1', 'fec': 'rs', 'index': '3', 'lanes': '4,5', 'mtu': '9100', 'numVoq': '8', 'pfc_asym': 'off', 'role': 'Ext', 'speed': '100000', 'tpid': '0x8100', 'oper_status': 'down', 'flap_count': '2', 'last_up_time': 'Wed Apr 10 17:01:00 2024', 'system_oper_status': 'down', 'line_oper_status': 'down', 'last_down_time': 'Wed Apr 10 18:37:03 2024'}

> config interface startup Ethernet8
> sonic-db-cli APPL_DB hgetall PORT_TABLE:Ethernet8
{'admin_status': 'up', 'alias': 'Ethernet3/1', 'asic_port_name': 'Eth8', 'coreId': '0', 'corePortId': '3', 'description': 'Ethernet8-connected-to-@Ethernet5/4/1', 'fec': 'rs', 'index': '3', 'lanes': '4,5', 'mtu': '9100', 'numVoq': '8', 'pfc_asym': 'off', 'role': 'Ext', 'speed': '100000', 'tpid': '0x8100', 'oper_status': 'up', 'flap_count': '3', 'last_up_time': 'Wed Apr 10 18:37:13 2024', 'system_oper_status': 'up', 'line_oper_status': 'up', 'last_down_time': 'Wed Apr 10 18:37:03 2024'}
```
