### PR TITLE
[twamporch] Explicitly initialize local variable

### DIFF
--- a/orchagent/twamporch.cpp
+++ b/orchagent/twamporch.cpp
@@ -690,6 +690,7 @@ task_process_status TwampOrch::createEntry(const string& key, const vector<Field
     if (entry.role == SAI_TWAMP_SESSION_ROLE_SENDER)
     {
         TwampStats hw_stats;
+        memset(&hw_stats, 0, sizeof(TwampStats));
         m_twampStatistics.emplace(key, hw_stats);
         initSessionStats(key);
     }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Explicitly initialized local variable.

**Why I did it**
We met below error message in sonic-buildimage armhf build (https://github.com/sonic-net/sonic-buildimage/pull/18334)
```
2024-04-16T05:39:14.6186367Z     inlined from 'task_process_status TwampOrch::createEntry(const std::string&, const std::vector<std::pair<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > >&)' at twamporch.cpp:693:34:
2024-04-16T05:39:14.6187130Z /usr/include/c++/12/bits/stl_pair.h:535:42: error: 'hw_stats' may be used uninitialized [-Werror=maybe-uninitialized]
2024-04-16T05:39:14.6187615Z   535 |         : first(std::forward<_U1>(__x)), second(std::forward<_U2>(__y)) { }
2024-04-16T05:39:14.6188040Z       |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-04-16T05:39:14.6188845Z twamporch.cpp: In member function 'task_process_status TwampOrch::createEntry(const std::string&, const std::vector<std::pair<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > >&)':
2024-04-16T05:39:14.6189547Z twamporch.cpp:692:20: note: 'hw_stats' declared here
2024-04-16T05:39:14.6189907Z   692 |         TwampStats hw_stats;
```
**How I verified it**

**Details if related**
