### PR TITLE
[ACL] Remove flex counter when updating ACL rule

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -2586,6 +2586,12 @@ bool AclTable::add(shared_ptr<AclRule> newRule)
     if (ruleIter != rules.end())
     {
         // If ACL rule already exists, delete it first
+        if (ruleIter->second->hasCounter())
+        {
+            // Deregister the flex counter before deleting the rule
+            // A new flex counter will be created when the new rule is added
+            m_pAclOrch->deregisterFlexCounter(*(ruleIter->second));
+        }
         if (ruleIter->second->remove())
         {
             rules.erase(ruleIter);

--- a/tests/dvslib/dvs_acl.py
+++ b/tests/dvslib/dvs_acl.py
@@ -685,6 +685,14 @@ class DVSAcl:
             return True
 
         return _match_acl_range
+    
+    def get_acl_counter_oid(self, acl_rule_id=None) -> str:
+        if not acl_rule_id:
+            acl_rule_id = self._get_acl_rule_id()
+        
+        entry = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", acl_rule_id)
+        counter_oid = entry.get("SAI_ACL_ENTRY_ATTR_ACTION_COUNTER")
+        return counter_oid
 
     def _get_acl_rule_id(self) -> str:
         num_keys = len(self.asic_db.default_acl_entries) + 1
@@ -742,7 +750,12 @@ class DVSAcl:
             return
         rule_to_counter_map = self.counters_db.get_entry("ACL_COUNTER_RULE_MAP", "")
         counter_to_rule_map = {v: k for k, v in rule_to_counter_map.items()}
-        assert counter_oid in counter_to_rule_map
+        assert counter_oid in counter_to_rule_map       
+
+    def check_acl_counter_not_in_counters_map(self, acl_counter_oid: str):
+        rule_to_counter_map = self.counters_db.get_entry("ACL_COUNTER_RULE_MAP", "")
+        counter_to_rule_map = {v: k for k, v in rule_to_counter_map.items()}
+        assert acl_counter_oid not in counter_to_rule_map
 
     def verify_acl_table_status(
             self,

--- a/tests/dvslib/dvs_acl.py
+++ b/tests/dvslib/dvs_acl.py
@@ -693,6 +693,9 @@ class DVSAcl:
         entry = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", acl_rule_id)
         counter_oid = entry.get("SAI_ACL_ENTRY_ATTR_ACTION_COUNTER")
         return counter_oid
+    
+    def get_acl_rule_id(self) -> str:
+        return self._get_acl_rule_id()
 
     def _get_acl_rule_id(self) -> str:
         num_keys = len(self.asic_db.default_acl_entries) + 1


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
This PR is to fix https://github.com/sonic-net/sonic-buildimage/issues/18719 

When ACL rule is created for the first time, a flex counter is created and registered https://github.com/sonic-net/sonic-swss/blob/9e183a650cf38e0d5af46adc1342dcde85ecb84d/orchagent/aclorch.cpp#L4076

When the same ACL rule is being updated, the FlexCounter created before is not removed, and another FlexCounter is created and registered.

**Why I did it**
Fix the issue that FlexCounter is duplicated when updating existing ACL rule.

**How I verified it**
1. Verified by VS test
2. Verified by building orchagent and run on a physical device

**Details if related**
