### PR TITLE
[intfmgr][vlanmgr] Support arp_ignore through new field "arp_reply"

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -599,6 +599,45 @@ bool IntfMgr::setIntfGratArp(const string &alias, const string &grat_arp)
     return true;
 }
 
+bool IntfMgr::setArpReplyMode(const std::string &alias, const std::string &mode)
+{
+    stringstream cmd;
+    string res;
+    string arp_mode;
+
+    // 0 : reply_all
+    // 1 : reply_iface
+    // 2 : reply_subnet
+    // 8 : ignore_all
+
+    if (mode == "reply_all")
+    {
+        arp_mode = "0";
+    }
+    else if (mode == "reply_iface")
+    {
+        arp_mode = "1";
+    }
+    else if (mode == "reply_subnet")
+    {
+        arp_mode = "2";
+    }
+    else if (mode == "ignore_all")
+    {
+        arp_mode = "8";
+    }
+    else
+    {
+        SWSS_LOG_ERROR("arp reply mode  is invalid: \"%s\"", mode.c_str());
+        return false;
+    }
+    cmd << "sysctl -w net.ipv4.conf." << alias << ".arp_ignore=" << arp_mode;
+    EXEC_WITH_ERROR_THROW(cmd.str(), res);
+    SWSS_LOG_INFO("ARP reply mode set to \"%s\" on interface \"%s\"",  mode.c_str(), alias.c_str());
+
+    return true;
+}
+
 bool IntfMgr::setIntfProxyArp(const string &alias, const string &proxy_arp)
 {
     stringstream cmd;
@@ -763,6 +802,7 @@ bool IntfMgr::doIntfGeneralTask(const vector<string>& keys,
     string nat_zone = "";
     string proxy_arp = "";
     string grat_arp = "";
+    string arp_reply = "reply_subnet";
     string mpls = "";
     string ipv6_link_local_mode = "";
     string loopback_action = "";
@@ -791,6 +831,10 @@ bool IntfMgr::doIntfGeneralTask(const vector<string>& keys,
         else if (field == "grat_arp")
         {
             grat_arp = value;
+        }
+        else if (field == "arp_reply")
+        {
+            arp_reply = value;
         }
         else if (field == "mpls")
         {
@@ -1011,6 +1055,12 @@ bool IntfMgr::doIntfGeneralTask(const vector<string>& keys,
                 FieldValueTuple fvTuple("grat_arp", grat_arp);
                 data.push_back(fvTuple);
             }
+        }
+
+        if (!setArpReplyMode(alias, arp_reply))
+        {
+            SWSS_LOG_ERROR("Failed to set ARP reply to \"%s\" mode for the \"%s\" interface", arp_reply.c_str(), alias.c_str());
+            return false;
         }
 
         m_appIntfTableProducer.set(alias, data);

--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -72,6 +72,7 @@ private:
 
     bool setIntfProxyArp(const std::string &alias, const std::string &proxy_arp);
     bool setIntfGratArp(const std::string &alias, const std::string &grat_arp);
+    bool setArpReplyMode(const std::string &alias, const std::string &mode);
 
     void updateSubIntfAdminStatus(const std::string &alias, const std::string &admin);
     void updateSubIntfMtu(const std::string &alias, const std::string &mtu);

--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -139,6 +139,8 @@ bool VlanMgr::addHostVlan(int vlan_id)
       + ECHO_CMD + " 0 > /proc/sys/net/ipv4/conf/" + VLAN_PREFIX + std::to_string(vlan_id) + "/arp_evict_nocarrier";
     swss::exec(echo_cmd, res);
 
+    addVlanArpReply(vlan_id);
+
     return true;
 }
 
@@ -158,6 +160,20 @@ bool VlanMgr::removeHostVlan(int vlan_id)
     EXEC_WITH_ERROR_THROW(cmds, res);
 
     return true;
+}
+
+void VlanMgr::addVlanArpReply(int vlan_id)
+{
+    // set default vlan arp_ignore to 2(reply_subnet)
+    stringstream arp_cmd;
+    arp_cmd << "sysctl -w net/ipv4/conf/Vlan" << std::to_string(vlan_id) << "/arp_ignore=2";
+
+    std::string res;
+    int ret = swss::exec(arp_cmd.str(), res);
+    if (ret)
+    {
+        SWSS_LOG_ERROR("Command '%s' failed with rc %d, arp_reply is not supported", arp_cmd.str().c_str(), ret);
+    }
 }
 
 bool VlanMgr::setHostVlanAdminState(int vlan_id, const string &admin_status)

--- a/cfgmgr/vlanmgr.h
+++ b/cfgmgr/vlanmgr.h
@@ -34,6 +34,7 @@ private:
 
     bool addHostVlan(int vlan_id);
     bool removeHostVlan(int vlan_id);
+    void addVlanArpReply(int vlan_id);
     bool setHostVlanAdminState(int vlan_id, const std::string &admin_status);
     bool setHostVlanMtu(int vlan_id, uint32_t mtu);
     bool setHostVlanMac(int vlan_id, const std::string &mac);


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Relax the restrictions on the arp_ignore global settings, and support a new field that allows dynamic modification of arp_ignore for different interfaces.

**Why I did it**
arp_ignore has different modes for sending replies in response to received ARP requests that resolve the local target IP address.
Due to the strict settings of the arp_ignore global configuration, there are more restrictions.

**How I verified it**
```
admin@sonic:/$ sudo sysctl -a | grep all.arp_ignore
net.ipv4.conf.all.arp_ignore = 0
admin@sonic:/$ sudo sysctl -a | grep Ethernet4.arp_ignore
net.ipv4.conf.Ethernet4.arp_ignore = 2
admin@sonic:/$ redis-cli -n 4 -c HSET "INTERFACE|Ethernet4" arp_reply reply_iface
(integer) 1
admin@sonic:/$ sudo sysctl -a | grep Ethernet4.arp_ignore
net.ipv4.conf.Ethernet4.arp_ignore = 1
```
**Details if related**
