### PR TITLE
[orchagent] Change log level from ERR to WARN for pfc asym not supported

### DIFF
--- a/orchagent/port/port_capabilities.cpp
+++ b/orchagent/port/port_capabilities.cpp
@@ -61,7 +61,7 @@ void PortCapabilities::queryPortAttrCapabilities(T &obj, sai_port_attr_t attrId)
     );
     if (status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR(
+        SWSS_LOG_WARN(
             "Failed to get attribute(%s) capabilities",
             toStr(SAI_OBJECT_TYPE_PORT, attrId).c_str()
         );


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Change log level from ERR to WARN for pfc asym not supported

**Why I did it**
To address issue reported in https://migsonic.atlassian.net/browse/MIGSMSFT-473

**How I verified it**
Load new debian on testbed and check the log.
```
cisco@r2-lc0:~$ sudo cat /var/log/syslog | grep "queryPortAttrCapabilities"
Apr 25 22:52:26.787428 r2-lc0 WARNING swss1#orchagent: :- queryPortAttrCapabilities: Failed to get attribute(SAI_PORT_ATTR_PRIORITY_FLOW_CONTROL_TX) capabilities
Apr 25 22:52:26.787846 r2-lc0 WARNING swss1#orchagent: :- queryPortAttrCapabilities: Failed to get attribute(SAI_PORT_ATTR_PRIORITY_FLOW_CONTROL_RX) capabilities
cisco@r2-lc0:~$ 
```

**Details if related**
