### PR TITLE
[DropCounter]Fix the ordering issue with dropcounter

### DIFF
--- a/orchagent/debugcounterorch.cpp
+++ b/orchagent/debugcounterorch.cpp
@@ -336,7 +336,6 @@ task_process_status DebugCounterOrch::uninstallDebugCounter(const string& counte
     string counter_type = counter->getCounterType();
     string counter_stat = counter->getDebugCounterSAIStat();
 
-    debug_counters.erase(it);
     uninstallDebugFlexCounters(counter_type, counter_stat);
 
     if (counter_type == PORT_INGRESS_DROPS || counter_type == PORT_EGRESS_DROPS)
@@ -347,6 +346,7 @@ task_process_status DebugCounterOrch::uninstallDebugCounter(const string& counte
     {
         m_counterNameToSwitchStatMap->hdel("", counter_name);
     }
+    debug_counters.erase(it);
 
     SWSS_LOG_NOTICE("Successfully deleted drop counter %s", counter_name.c_str());
     return task_process_status::task_success;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
Partially addresses the debug counter comment in https://github.com/sonic-net/sonic-buildimage/issues/11798#issuecomment-1366192486
**What I did**
During the removal of drop counters, the counter is deleted first followed by removing it from flexcounter. This would result in a race condition where counterpoll might try to access the counter after it is deleted.

```
Apr 22 21:55:33.131134 r-panther-01 INFO python[125700]: ansible-command Invoked with _raw_params=config dropcounters delete TEST warn=True _uses_shell=False stdin_add_newline=True strip_empty_ends=True argv=None chdir=None executable=None creates=None removes=None stdin=None
Apr 22 21:55:33.611079 r-panther-01 NOTICE syncd#SDK: [SAI_DEBUG_COUNTER.NOTICE] ./src/mlnx_sai_debug_counter.c[1817]- mlnx_remove_debug_counter: Remove DEBUG_COUNTER [OID:0x300000055] [ID:0]
Apr 22 21:55:33.634416 r-panther-01 ERR syncd#SDK: [SAI_DEBUG_COUNTER.ERR] ./src/mlnx_sai_debug_counter.c[390]- mlnx_debug_counter_db_idx_to_data: Debug counter at index 0 is removed or not created yet
Apr 22 21:55:33.634416 r-panther-01 ERR syncd#SDK: :- collectData: Failed to get stats of Switch Debug Counter 0x100000021: -1
Apr 22 21:55:33.635328 r-panther-01 NOTICE swss#orchagent: :- uninstallDebugCounter: Successfully deleted drop counter TEST
```

**Why I did it**
To fix the error log appearing when drop counter is removed. The SAI object is removed during object destroy. Hence destroying the counter after flex counter is disabled.

https://github.com/sonic-net/sonic-swss/blob/67e03128dedc061c51da7ccd7fd716f00d974bb3/orchagent/debug_counter/drop_counter.cpp#L101

**How I verified it**
The existing sonic-swss UT should verify the drop counters functionality.

**Details if related**
