### PR TITLE
Restore preemphasis when AN is transitioned from ON to OFF

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3805,6 +3805,15 @@ void PortsOrch::doPortTask(Consumer &consumer)
                             "Set port %s autoneg to %s",
                             p.m_alias.c_str(), m_portHlpr.getAutonegStr(pCfg).c_str()
                         );
+
+                        /* If no explicit pre-emphasis settings exist when AN is changed from
+                         * ON to OFF, apply the pre-emphasis settings cached in p.m_preemphasis,
+                         * which contains the settings from the upper layer at the last time.
+                         */
+                        if (p.m_autoneg == false && serdes_attr.size() == 0)
+                        {
+                            serdes_attr = p.m_preemphasis;
+                        }
                     }
                 }
 
@@ -4264,7 +4273,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
                 if (!serdes_attr.empty())
                 {
-                    if (p.m_link_training)
+                    if (p.m_link_training || p.m_autoneg)
                     {
                         SWSS_LOG_NOTICE("Save port %s preemphasis for LT", p.m_alias.c_str());
                         p.m_preemphasis = serdes_attr;


### PR DESCRIPTION
In certain switches, link training is enabled along with auto-negotiation(AN) enabled. In this case, the preemphasis settings may be changed due to the presence of enabled link training. Therefore, it's essential to restore the preemphasis value when auto-negotiation transitions from ON to OFF.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Restore preemphasis when AN is transitioned from ON to OFF

**Why I did it**
In certain switches, link training is enabled along with auto-negotiation(AN) enabled. In this case, the preemphasis settings may be changed due to the presence of enabled link training. Therefore, it's essential to restore the preemphasis value when auto-negotiation transitions from ON to OFF.

**How I verified it**
1. Check the current pre-emphasis value P1 by bcmcmd.
2. Enable AN on a port, make sure the port is up and the pre-emphasis is changed to P2 by link-training.
3. Disable AN on the testing port, check the pre-emphasis value is restored to P1 by bcmcmd.

**Details if related**
