### PR TITLE
Add support for ECMP and LAG hash offset

### DIFF
--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -584,20 +584,24 @@ void SwitchOrch::doAppSwitchTableTask(Consumer &consumer)
 
                     case SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_OFFSET:
                         ret = querySwitchCapability(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_OFFSET);
-                        if(ret == false) {
-                          SWSS_LOG_INFO("ECMP_HASH_OFFSET attribute is not supported");
-                          unsupported_attr = true;
-                        } else {
-                          attr.value.u8 = to_uint<uint8_t>(value);
+                        if (ret == false)
+                        {
+                            unsupported_attr = true;
+                        }
+                        else
+                        {
+                            attr.value.u8 = to_uint<uint8_t>(value);
                         }
                         break;
                     case SAI_SWITCH_ATTR_LAG_DEFAULT_HASH_OFFSET:
                         ret = querySwitchCapability(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_LAG_DEFAULT_HASH_OFFSET);
-                        if(ret == false) {
-                          SWSS_LOG_INFO("LAG_HASH_OFFSET attribute is not supported");
-                          unsupported_attr = true;
-                        } else {
-                          attr.value.u8 = to_uint<uint8_t>(value);
+                        if (ret == false)
+                        {
+                            unsupported_attr = true;
+                        }
+                        else
+                        {
+                            attr.value.u8 = to_uint<uint8_t>(value);
                         }
                         break;
 

--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -37,7 +37,9 @@ const map<string, sai_switch_attr_t> switch_attribute_map =
     {"fdb_aging_time",                      SAI_SWITCH_ATTR_FDB_AGING_TIME},
     {"debug_shell_enable",                  SAI_SWITCH_ATTR_SWITCH_SHELL_ENABLE},
     {"vxlan_port",                          SAI_SWITCH_ATTR_VXLAN_DEFAULT_PORT},
-    {"vxlan_router_mac",                    SAI_SWITCH_ATTR_VXLAN_DEFAULT_ROUTER_MAC}
+    {"vxlan_router_mac",                    SAI_SWITCH_ATTR_VXLAN_DEFAULT_ROUTER_MAC},
+    {"ecmp_hash_offset",                    SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_OFFSET},
+    {"lag_hash_offset",                     SAI_SWITCH_ATTR_LAG_DEFAULT_HASH_OFFSET}
 };
 
 const map<string, sai_switch_tunnel_attr_t> switch_tunnel_attribute_map =
@@ -541,6 +543,8 @@ void SwitchOrch::doAppSwitchTableTask(Consumer &consumer)
 
                 MacAddress mac_addr;
                 bool invalid_attr = false;
+                bool ret = false;
+                bool unsupported_attr = false;
                 switch (attr.id)
                 {
                     case SAI_SWITCH_ATTR_FDB_UNICAST_MISS_PACKET_ACTION:
@@ -578,11 +582,30 @@ void SwitchOrch::doAppSwitchTableTask(Consumer &consumer)
                         memcpy(attr.value.mac, mac_addr.getMac(), sizeof(sai_mac_t));
                         break;
 
+                    case SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_OFFSET:
+                        ret = querySwitchCapability(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_OFFSET);
+                        if(ret == false) {
+                          SWSS_LOG_INFO("ECMP_HASH_OFFSET attribute is not supported");
+                          unsupported_attr = true;
+                        } else {
+                          attr.value.u8 = to_uint<uint8_t>(value);
+                        }
+                        break;
+                    case SAI_SWITCH_ATTR_LAG_DEFAULT_HASH_OFFSET:
+                        ret = querySwitchCapability(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_LAG_DEFAULT_HASH_OFFSET);
+                        if(ret == false) {
+                          SWSS_LOG_INFO("LAG_HASH_OFFSET attribute is not supported");
+                          unsupported_attr = true;
+                        } else {
+                          attr.value.u8 = to_uint<uint8_t>(value);
+                        }
+                        break;
+
                     default:
                         invalid_attr = true;
                         break;
                 }
-                if (invalid_attr)
+                if (invalid_attr || unsupported_attr)
                 {
                     /* break from kfvFieldsValues for loop */
                     break;

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -65,6 +65,27 @@ def vxlan_switch_test(dvs, oid, port, mac, mask, sport):
     )
 
 
+def ecmp_lag_hash_offset_test(dvs, oid, lag_offset, ecmp_offset):
+    app_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+    create_entry_pst(
+        app_db,
+        "SWITCH_TABLE", ':', "switch",
+        [
+            ("ecmp_hash_offset", ecmp_offset),
+            ("lag_hash_offset", lag_offset)
+        ],
+    )
+    time.sleep(2)
+
+    asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
+    check_object(asic_db, "ASIC_STATE:SAI_OBJECT_TYPE_SWITCH", oid,
+        {
+            'SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_OFFSET': ecmp_offset,
+            'SAI_SWITCH_ATTR_LAG_DEFAULT_HASH_OFFSET': lag_offset,
+        }
+    )
+
+
 class TestSwitch(object):
     '''
     Test- Check switch attributes
@@ -74,6 +95,8 @@ class TestSwitch(object):
         vxlan_switch_test(dvs, switch_oid, "12345", "00:01:02:03:04:05", "20", "54321")
 
         vxlan_switch_test(dvs, switch_oid, "56789", "00:0A:0B:0C:0D:0E", "15", "56789")
+
+        ecmp_lag_hash_offset_test(dvs, switch_oid, "10", "10")
 
 
 # Add Dummy always-pass test at end as workaroud


### PR DESCRIPTION
**What I did**
Add support to update ECMP and LAG hash offset. Orchagent checks for SAI attribute capability and configure the offset values.

**Why I did it**
To avoid ECMP hash imbalance across T0 and T1s, different hash offsets can be configured.

**How I verified it**
sonic-mgmt tests ipfwd/test_nhop_group.py

sonic-mgmt PR to update the existing test with the nexthop rewrites after default hash_offset changes: https://github.com/sonic-net/sonic-mgmt/pull/12765

