### PR TITLE
[VRF]Fixing vrf orch to update state_db when evpn nvo arrives late

### DIFF
--- a/orchagent/vrforch.cpp
+++ b/orchagent/vrforch.cpp
@@ -147,6 +147,7 @@ bool VRFOrch::addOperation(const Request& request)
             return false;
         }
 
+        m_stateVrfObjectTable.hset(vrf_name, "state", "ok");
         SWSS_LOG_NOTICE("VRF '%s' was updated", vrf_name.c_str());
     }
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Update state_db VRF_OBJECT table when there is update flow in the Vrf. 
Since there is no EVPN nvo the addOperation returns  here without updating state_db

https://github.com/sonic-net/sonic-swss/blob/2e6c5b209d575f73b867de9f3e56b3be4066acec/orchagent/vrforch.cpp#L114

However later when evpn nvo arrives there is no subsequent update operation.

This will result in removal message not getting processed due to the check in vrfmgrd

https://github.com/sonic-net/sonic-swss/blob/a821af0421de316555146615cffd4108ec566e20/cfgmgr/vrfmgr.cpp#L208

```
May  4 03:37:49.578686 r-anaconda-51 INFO swss#orchagent: :- updateVrfVNIMap: VRF 'Vrf1' vni 500200 old_vni 0
May  4 03:37:49.578701 r-anaconda-51 NOTICE swss#orchagent: :- updateVrfVNIMap: updateVrfVNIMap unable to find EVPN VTEP
May  4 03:37:49.578999 r-anaconda-51 INFO swss#orchagent: :- addOperation: VRF 'Vrf1' vni 500200 modify
May  4 03:37:49.579009 r-anaconda-51 INFO swss#orchagent: :- updateVrfVNIMap: VRF 'Vrf1' vni 500200 old_vni 0
May  4 03:37:49.579009 r-anaconda-51 INFO swss#orchagent: :- updateVrfVNIMap: addL3VniStatus vni 500200 vlan 0
May  4 03:37:49.579028 r-anaconda-51 INFO swss#orchagent: :- updateVrfVNIMap: VRF 'Vrf1' vni 500200 map update
May  4 03:37:49.579081 r-anaconda-51 NOTICE swss#orchagent: :- addOperation: VRF 'Vrf1' was updated
```

**Why I did it**
The update is missed when VRF is created and vni is set on the VRF but EVPN nvo arrives late.


**How I verified it**
Added UT to verify the flow

**Details if related**
