### PR TITLE
Add transceiver info to bake only if supported

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -553,8 +553,6 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
 
     sai_attr_capability_t capability;
 
-    bool saiHwTxSignalSupported = false;
-    bool saiTxReadyNotifySupported = false;
 
     if (sai_query_attribute_capability(gSwitchId, SAI_OBJECT_TYPE_PORT,
                                             SAI_PORT_ATTR_HOST_TX_SIGNAL_ENABLE,

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3397,8 +3397,10 @@ bool PortsOrch::bake()
     addExistingData(APP_LAG_MEMBER_TABLE_NAME);
     addExistingData(APP_VLAN_TABLE_NAME);
     addExistingData(APP_VLAN_MEMBER_TABLE_NAME);
-    addExistingData(STATE_TRANSCEIVER_INFO_TABLE_NAME);
-
+    if (saiHwTxSignalSupported && saiTxReadyNotifySupported)
+    {
+        addExistingData(STATE_TRANSCEIVER_INFO_TABLE_NAME);
+    }
     return true;
 }
 

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -337,6 +337,8 @@ private:
 
     bool fec_override_sup = false;
     bool oper_fec_sup = false;
+    bool saiHwTxSignalSupported = false;
+    bool saiTxReadyNotifySupported = false;
 
     swss::SelectableTimer *m_port_state_poller = nullptr;
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add transceiver info to bake only if saiHwTxSignalSupported and  saiTxReadyNotifySupported are supported

**Why I did it**
The executor is added only if the above flags are supported https://github.com/sonic-net/sonic-swss/blob/f62eed23fcdd62544f3a7a0e5cea15b0cafa9600/orchagent/portsorch.cpp#L596

On unsupported platforms the following error logs will be observed
```
swss#orchagent: :- addExistingData: No consumer TRANSCEIVER_INFO in Orch
```

**How I verified it**
Running warmboot with the fix

**Details if related**
