### PR TITLE
[COPP]Fix coppmgr when there are multiple features using same trap

### DIFF
--- a/cfgmgr/coppmgr.cpp
+++ b/cfgmgr/coppmgr.cpp
@@ -183,14 +183,13 @@ bool CoppMgr::isTrapIdDisabled(string trap_id)
             {
                 return false;
             }
-            break;
+            if (isFeatureEnabled(trap_name))
+            {
+                return false;
+            }
         }
     }
 
-    if (isFeatureEnabled(trap_name))
-    {
-        return false;
-    }
     return true;
 }
 
@@ -941,7 +940,9 @@ void CoppMgr::doFeatureTask(Consumer &consumer)
         {
             if (m_featuresCfgTable.find(key) == m_featuresCfgTable.end())
             {
-                m_featuresCfgTable.emplace(key, kfvFieldsValues(t));
+                // Init with empty feature state which will be updated  in setFeatureTrapIdsStatus
+                FieldValueTuple fv("state", "");
+                m_featuresCfgTable[key].push_back(fv);
             }
             for (auto i : kfvFieldsValues(t))
             {

--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -633,7 +633,7 @@ task_process_status CoppOrch::processCoppRule(Consumer& consumer)
         if (!trap_id_attribs.empty())
         {
             vector<sai_hostif_trap_type_t> group_trap_ids;
-            TrapIdAttribs trap_attr;
+            TrapIdAttribs trap_attr = m_trap_group_trap_id_attrs[trap_group_name];
             getTrapIdsFromTrapGroup(m_trap_group_map[trap_group_name],
                                     group_trap_ids);
             for (auto trap_id : group_trap_ids)

--- a/tests/test_copp.py
+++ b/tests/test_copp.py
@@ -841,3 +841,38 @@ class TestCopp(object):
         self.feature_tbl.set("lldp", fvs)
 
         assert table_found == False
+
+    def test_multi_feature_trap_add(self, dvs, testlog):
+        self.setup_copp(dvs)
+        global copp_trap
+        traps = "eapol"
+        fvs = swsscommon.FieldValuePairs([("state", "disbled")])
+        self.feature_tbl.set("macsec", fvs)
+        fvs = swsscommon.FieldValuePairs([("state", "enabled")])
+        self.feature_tbl.set("pac", fvs)
+        fvs = swsscommon.FieldValuePairs([("trap_group", "queue4_group1"),("trap_ids", traps)])
+        self.trap_ctbl.set("pac", fvs)
+
+
+        copp_trap["eapol"] = [traps, copp_group_queue4_group1]
+        time.sleep(2)
+
+        trap_keys = self.trap_atbl.getKeys()
+        trap_ids = traps.split(",")
+        trap_group = copp_group_queue4_group1
+        for trap_id in trap_ids:
+            trap_type = traps_to_trap_type[trap_id]
+            trap_found = False
+            trap_group_oid = ""
+            for key in trap_keys:
+                (status, fvs) = self.trap_atbl.get(key)
+                assert status == True
+                for fv in fvs:
+                    if fv[0] == "SAI_HOSTIF_TRAP_ATTR_TRAP_TYPE":
+                        if fv[1] == trap_type:
+                            trap_found = True
+                if trap_found:
+                    self.validate_trap_group(key,trap_group)
+                    break
+            if trap_id not in disabled_traps:
+                assert trap_found == True


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
Fixes https://github.com/sonic-net/sonic-buildimage/issues/18226

**What I did**
Fix coppmgr when there are multiple feature tables using same trap.

In addition fixed the following issues
1) When a new feature is added which is not present during the init, the copp entry will not get programmed. 
2) When a copp trap attribute is set, it overrides the other existing attributes

**Why I did it**
Fix copp issues

**How I verified it**
Added UT to verify
**Details if related**
