### PR TITLE
[202311]Update setHostTxReady() to receive Port instead of portId (#3133)

### DIFF
--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -406,7 +406,7 @@ private:
 
     bool setSaiHostTxSignal(const Port &port, bool enable);
 
-    void setHostTxReady(sai_object_id_t portId, const std::string &status);
+    void setHostTxReady(Port port, const std::string &status);
     // Get supported speeds on system side
     bool isSpeedSupported(const std::string& alias, sai_object_id_t port_id, sai_uint32_t speed);
     void getPortSupportedSpeeds(const std::string& alias, sai_object_id_t port_id, PortSupportedSpeeds &supported_speeds);


### PR DESCRIPTION
**What I did**
Cherry-picked following PR https://github.com/sonic-net/sonic-swss/pull/3133 from master sonic-swss. 

**Why I did it**
So we won't need to call getPort() inside the function, and we will be able to call setHostTxReady from within port initialization.


