### PR TITLE
Rotate record file before writing new log.

### DIFF
--- a/lib/recorder.cpp
+++ b/lib/recorder.cpp
@@ -93,12 +93,12 @@ void RecWriter::record(const std::string& val)
     {
         return ;
     }
-    record_ofs << swss::getTimestamp() << "|" << val << std::endl;
     if (isRotate())
     {
         setRotate(false);
         logfileReopen();
     }
+    record_ofs << swss::getTimestamp() << "|" << val << std::endl;
 }
 
 


### PR DESCRIPTION
**What I did**
Rotate file before writing the log for record files.

**Why I did it**
If we configure logrotate to compress, the old file stream will write to void after the old file is rotated and compressed. This PR changes the order of write and rotate. It will always rotate first and then write. There might still be log lost if logrotate sends HUP signal too late.

**How I verified it**
N/A

**Details if related**
N/A
