### PR TITLE
Make bulk SAI calls in order for non-OID objects in the bulker API

### DIFF
--- a/orchagent/bulker.h
+++ b/orchagent/bulker.h
@@ -470,6 +470,7 @@ public:
             return *object_status;
         }
 
+        create_order.push_back(it->first);
         auto& attrs = it->second.first;
         attrs.insert(attrs.end(), attr_list, attr_list + attr_count);
         it->second.second = object_status;
@@ -515,6 +516,7 @@ public:
         auto rc = removing_entries.emplace(std::piecewise_construct,
                 std::forward_as_tuple(*entry),
                 std::forward_as_tuple(object_status));
+        remove_order.push_back(rc.first->first);
         bool inserted = rc.second;
         SWSS_LOG_INFO("EntityBulker.remove_entry %zu, %d\n", removing_entries.size(), inserted);
 
@@ -534,11 +536,14 @@ public:
         assert(attr);
         if (!attr) throw std::invalid_argument("attr is null");
 
-        // Insert or find the key (entry)
-        auto& attrs = setting_entries.emplace(std::piecewise_construct,
+        auto rc = setting_entries.emplace(std::piecewise_construct,
                 std::forward_as_tuple(*entry),
-                std::forward_as_tuple()
-        ).first->second;
+                std::forward_as_tuple());
+        auto it = rc.first;
+        set_order.push_back(it->first);
+
+        // Insert or find the key (entry)
+        auto& attrs = it->second;
 
         // Insert attr
         attrs.emplace_back(std::piecewise_construct,
@@ -554,10 +559,14 @@ public:
         {
             std::vector<Te> rs;
 
-            for (auto& i: removing_entries)
+            for (auto const& entry : remove_order)
             {
-                auto const& entry = i.first;
-                sai_status_t *object_status = i.second;
+                auto i = removing_entries.find(entry);
+                if (i == removing_entries.end())
+                {
+                    continue;
+                }
+                sai_status_t *object_status = i->second;
                 if (*object_status == SAI_STATUS_NOT_EXECUTED)
                 {
                     rs.push_back(entry);
@@ -571,6 +580,7 @@ public:
             flush_removing_entries(rs);
 
             removing_entries.clear();
+            remove_order.clear();
         }
 
         // Creating
@@ -580,11 +590,15 @@ public:
             std::vector<sai_attribute_t const*> tss;
             std::vector<uint32_t> cs;
 
-            for (auto const& i: creating_entries)
+            for (auto const& entry : create_order)
             {
-                auto const& entry = i.first;
-                auto const& attrs = i.second.first;
-                sai_status_t *object_status = i.second.second;
+                auto i = creating_entries.find(entry);
+                if (i == creating_entries.end())
+                {
+                    continue;
+                }
+                auto const& attrs = i->second.first;
+                sai_status_t *object_status = i->second.second;
                 if (*object_status == SAI_STATUS_NOT_EXECUTED)
                 {
                     rs.push_back(entry);
@@ -600,6 +614,7 @@ public:
             flush_creating_entries(rs, tss, cs);
 
             creating_entries.clear();
+            create_order.clear();
         }
 
         // Setting
@@ -609,10 +624,14 @@ public:
             std::vector<sai_attribute_t> ts;
             std::vector<sai_status_t*> status_vector;
 
-            for (auto const& i: setting_entries)
+            for (auto const& entry : set_order)
             {
-                auto const& entry = i.first;
-                auto const& attrs = i.second;
+                auto i = setting_entries.find(entry);
+                if (i == setting_entries.end())
+                {
+                    continue;
+                }
+                auto const& attrs = i->second;
                 for (auto const& ia: attrs)
                 {
                     auto const& attr = ia.first;
@@ -633,6 +652,7 @@ public:
             flush_setting_entries(rs, ts, status_vector);
 
             setting_entries.clear();
+            set_order.clear();
         }
     }
 
@@ -641,6 +661,9 @@ public:
         removing_entries.clear();
         creating_entries.clear();
         setting_entries.clear();
+        remove_order.clear();
+        create_order.clear();
+        set_order.clear();
     }
 
     size_t creating_entries_count() const
@@ -691,6 +714,10 @@ private:
             Te,                                             // entry ->
             sai_status_t *                                  // OUT object_status
     >                                                       removing_entries;
+
+    std::vector<Te>                                         create_order;
+    std::vector<Te>                                         set_order;
+    std::vector<Te>                                         remove_order;
 
     size_t max_bulk_size;
 

--- a/orchagent/p4orch/tests/route_manager_test.cpp
+++ b/orchagent/p4orch/tests/route_manager_test.cpp
@@ -30,3896 +30,3259 @@ using ::testing::StrictMock;
 extern sai_object_id_t gSwitchId;
 extern sai_object_id_t gVirtualRouterId;
 extern sai_object_id_t gVrfOid;
-extern char* gVrfName;
+extern char *gVrfName;
 extern size_t gMaxBulkSize;
-extern sai_route_api_t* sai_route_api;
-extern VRFOrch* gVrfOrch;
+extern sai_route_api_t *sai_route_api;
+extern VRFOrch *gVrfOrch;
 
-namespace {
+namespace
+{
 
-constexpr char* kIpv4Prefix = "10.11.12.0/24";
-constexpr char* kIpv4Prefix2 = "10.12.12.0/24";
-constexpr char* kIpv6Prefix = "2001:db8:1::/32";
-constexpr char* kNexthopId1 = "ju1u32m1.atl11:qe-3/7";
+constexpr char *kIpv4Prefix = "10.11.12.0/24";
+constexpr char *kIpv4Prefix2 = "10.12.12.0/24";
+constexpr char *kIpv6Prefix = "2001:db8:1::/32";
+constexpr char *kNexthopId1 = "ju1u32m1.atl11:qe-3/7";
 constexpr sai_object_id_t kNexthopOid1 = 1;
-constexpr char* kNexthopId2 = "ju1u32m2.atl11:qe-3/7";
+constexpr char *kNexthopId2 = "ju1u32m2.atl11:qe-3/7";
 constexpr sai_object_id_t kNexthopOid2 = 2;
-constexpr char* kWcmpGroup1 = "wcmp-group-1";
+constexpr char *kWcmpGroup1 = "wcmp-group-1";
 constexpr sai_object_id_t kWcmpGroupOid1 = 3;
-constexpr char* kWcmpGroup2 = "wcmp-group-2";
+constexpr char *kWcmpGroup2 = "wcmp-group-2";
 constexpr sai_object_id_t kWcmpGroupOid2 = 4;
-constexpr char* kMetadata1 = "1";
-constexpr char* kMetadata2 = "2";
+constexpr char *kMetadata1 = "1";
+constexpr char *kMetadata2 = "2";
 uint32_t kMetadataInt1 = 1;
 uint32_t kMetadataInt2 = 2;
 
 // Returns true if the two prefixes are equal. False otherwise.
 // Arguments must be non-nullptr.
-bool PrefixCmp(const sai_ip_prefix_t* x, const sai_ip_prefix_t* y) {
-  if (x->addr_family != y->addr_family) {
-    return false;
-  }
-  if (x->addr_family == SAI_IP_ADDR_FAMILY_IPV4) {
-    return memcmp(&x->addr.ip4, &y->addr.ip4, sizeof(sai_ip4_t)) == 0 &&
-           memcmp(&x->mask.ip4, &y->mask.ip4, sizeof(sai_ip4_t)) == 0;
-  }
-  return memcmp(&x->addr.ip6, &y->addr.ip6, sizeof(sai_ip6_t)) == 0 &&
-         memcmp(&x->mask.ip6, &y->mask.ip6, sizeof(sai_ip6_t)) == 0;
+bool PrefixCmp(const sai_ip_prefix_t *x, const sai_ip_prefix_t *y)
+{
+    if (x->addr_family != y->addr_family)
+    {
+        return false;
+    }
+    if (x->addr_family == SAI_IP_ADDR_FAMILY_IPV4)
+    {
+        return memcmp(&x->addr.ip4, &y->addr.ip4, sizeof(sai_ip4_t)) == 0 &&
+               memcmp(&x->mask.ip4, &y->mask.ip4, sizeof(sai_ip4_t)) == 0;
+    }
+    return memcmp(&x->addr.ip6, &y->addr.ip6, sizeof(sai_ip6_t)) == 0 &&
+           memcmp(&x->mask.ip6, &y->mask.ip6, sizeof(sai_ip6_t)) == 0;
 }
 
 // Matches two SAI route entries.
-bool MatchSaiRouteEntry(const sai_route_entry_t& route_entry,
-                        const sai_route_entry_t& exp_route_entry) {
-  if (route_entry.switch_id != exp_route_entry.switch_id) {
-    return false;
-  }
-  if (route_entry.vr_id != exp_route_entry.vr_id) {
-    return false;
-  }
-  if (!PrefixCmp(&route_entry.destination, &exp_route_entry.destination)) {
-    return false;
-  }
-  return true;
+bool MatchSaiRouteEntry(const sai_route_entry_t &route_entry, const sai_route_entry_t &exp_route_entry)
+{
+    if (route_entry.switch_id != exp_route_entry.switch_id)
+    {
+        return false;
+    }
+    if (route_entry.vr_id != exp_route_entry.vr_id)
+    {
+        return false;
+    }
+    if (!PrefixCmp(&route_entry.destination, &exp_route_entry.destination))
+    {
+        return false;
+    }
+    return true;
 }
 
 // Matches two SAI attributes.
-bool MatchSaiAttribute(const sai_attribute_t& attr,
-                       const sai_attribute_t& exp_attr) {
-  if (exp_attr.id == SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION) {
-    if (attr.id != SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION ||
-        attr.value.s32 != exp_attr.value.s32) {
-      return false;
+bool MatchSaiAttribute(const sai_attribute_t &attr, const sai_attribute_t &exp_attr)
+{
+    if (exp_attr.id == SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION)
+    {
+        if (attr.id != SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION || attr.value.s32 != exp_attr.value.s32)
+        {
+            return false;
+        }
     }
-  }
-  if (exp_attr.id == SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID) {
-    if (attr.id != SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID ||
-        attr.value.oid != exp_attr.value.oid) {
-      return false;
+    if (exp_attr.id == SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID)
+    {
+        if (attr.id != SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID || attr.value.oid != exp_attr.value.oid)
+        {
+            return false;
+        }
     }
-  }
-  if (exp_attr.id == SAI_ROUTE_ENTRY_ATTR_META_DATA) {
-    if (attr.id != SAI_ROUTE_ENTRY_ATTR_META_DATA ||
-        attr.value.u32 != exp_attr.value.u32) {
-      return false;
+    if (exp_attr.id == SAI_ROUTE_ENTRY_ATTR_META_DATA)
+    {
+        if (attr.id != SAI_ROUTE_ENTRY_ATTR_META_DATA || attr.value.u32 != exp_attr.value.u32)
+        {
+            return false;
+        }
     }
-  }
-  return true;
+    return true;
 }
 
-MATCHER_P(ArrayEq, array, "") {
-  for (size_t i = 0; i < array.size(); ++i) {
-    if (arg[i] != array[i]) {
-      return false;
+MATCHER_P(ArrayEq, array, "")
+{
+    for (size_t i = 0; i < array.size(); ++i)
+    {
+        if (arg[i] != array[i])
+        {
+            return false;
+        }
     }
-  }
-  return true;
+    return true;
 }
 
-MATCHER_P(RouteEntryArrayEq, array, "") {
-  for (size_t i = 0; i < array.size(); ++i) {
-    if (!MatchSaiRouteEntry(arg[i], array[i])) {
-      return false;
+MATCHER_P(RouteEntryArrayEq, array, "")
+{
+    for (size_t i = 0; i < array.size(); ++i)
+    {
+        if (!MatchSaiRouteEntry(arg[i], array[i]))
+        {
+            return false;
+        }
     }
-  }
-  return true;
+    return true;
 }
 
-MATCHER_P(AttrArrayEq, array, "") {
-  for (size_t i = 0; i < array.size(); ++i) {
-    if (!MatchSaiAttribute(arg[i], array[i])) {
-      return false;
+MATCHER_P(AttrArrayEq, array, "")
+{
+    for (size_t i = 0; i < array.size(); ++i)
+    {
+        if (!MatchSaiAttribute(arg[i], array[i]))
+        {
+            return false;
+        }
     }
-  }
-  return true;
+    return true;
 }
 
-MATCHER_P(AttrArrayArrayEq, array, "") {
-  for (size_t i = 0; i < array.size(); ++i) {
-    for (size_t j = 0; j < array[i].size(); j++) {
-      if (!MatchSaiAttribute(arg[i][j], array[i][j])) {
-        return false;
-      }
+MATCHER_P(AttrArrayArrayEq, array, "")
+{
+    for (size_t i = 0; i < array.size(); ++i)
+    {
+        for (size_t j = 0; j < array[i].size(); j++)
+        {
+            if (!MatchSaiAttribute(arg[i][j], array[i][j]))
+            {
+                return false;
+            }
+        }
     }
-  }
-  return true;
+    return true;
 }
 
-MATCHER_P(FieldValueTupleArrayEq, array, "") {
-  for (size_t i = 0; i < array.size(); ++i) {
-    if (fvField(arg[i]) != fvField(array[i])) {
-      return false;
+MATCHER_P(FieldValueTupleArrayEq, array, "")
+{
+    for (size_t i = 0; i < array.size(); ++i)
+    {
+        if (fvField(arg[i]) != fvField(array[i]))
+        {
+            return false;
+        }
+        if (fvValue(arg[i]) != fvValue(array[i]))
+        {
+            return false;
+        }
     }
-    if (fvValue(arg[i]) != fvValue(array[i])) {
-      return false;
-    }
-  }
-  return true;
+    return true;
 }
 
-}  // namespace
+} // namespace
 
-class RouteManagerTest : public ::testing::Test {
- protected:
-  RouteManagerTest() : route_manager_(&p4_oid_mapper_, gVrfOrch, &publisher_) {}
-
-  void SetUp() override {
-    mock_sai_route = &mock_sai_route_;
-    sai_route_api->create_route_entry = create_route_entry;
-    sai_route_api->remove_route_entry = remove_route_entry;
-    sai_route_api->set_route_entry_attribute = set_route_entry_attribute;
-    sai_route_api->get_route_entry_attribute = get_route_entry_attribute;
-    sai_route_api->create_route_entries = create_route_entries;
-    sai_route_api->remove_route_entries = remove_route_entries;
-    sai_route_api->set_route_entries_attribute = set_route_entries_attribute;
-    sai_route_api->get_route_entries_attribute = get_route_entries_attribute;
-  }
-
-  bool MergeRouteEntry(const P4RouteEntry& dest, const P4RouteEntry& src,
-                       P4RouteEntry* ret) {
-    return route_manager_.mergeRouteEntry(dest, src, ret);
-  }
-
-  ReturnCodeOr<P4RouteEntry> DeserializeRouteEntry(
-      const std::string& key,
-      const std::vector<swss::FieldValueTuple>& attributes,
-      const std::string& table_name) {
-    return route_manager_.deserializeRouteEntry(key, attributes, table_name);
-  }
-
-  P4RouteEntry* GetRouteEntry(const std::string& route_entry_key) {
-    return route_manager_.getRouteEntry(route_entry_key);
-  }
-
-  ReturnCode ValidateRouteEntry(const P4RouteEntry& route_entry,
-                                const std::string& operation) {
-    return route_manager_.validateRouteEntry(route_entry, operation);
-  }
-
-  std::vector<ReturnCode> CreateRouteEntries(
-      const std::vector<P4RouteEntry>& route_entries) {
-    return route_manager_.createRouteEntries(route_entries);
-  }
-
-  std::vector<ReturnCode> UpdateRouteEntries(
-      const std::vector<P4RouteEntry>& route_entries) {
-    return route_manager_.updateRouteEntries(route_entries);
-  }
-
-  std::vector<ReturnCode> DeleteRouteEntries(
-      const std::vector<P4RouteEntry>& route_entries) {
-    return route_manager_.deleteRouteEntries(route_entries);
-  }
-
-  void Enqueue(const std::string& table_name,
-               const swss::KeyOpFieldsValuesTuple& entry) {
-    route_manager_.enqueue(table_name, entry);
-  }
-
-  void Drain() { route_manager_.drain(); }
-
-  std::string VerifyState(const std::string& key,
-                          const std::vector<swss::FieldValueTuple>& tuple) {
-    return route_manager_.verifyState(key, tuple);
-  }
-
-  // Generates a KeyOpFieldsValuesTuple.
-  swss::KeyOpFieldsValuesTuple GenerateKeyOpFieldsValuesTuple(
-      const std::string& vrf_id, const swss::IpPrefix& route_prefix,
-      const std::string& command, const std::string& action,
-      const std::string& action_param, const std::string& route_metadata = "") {
-    nlohmann::json j;
-    std::string key_prefix;
-    j[prependMatchField(p4orch::kVrfId)] = vrf_id;
-    if (route_prefix.isV4()) {
-      j[prependMatchField(p4orch::kIpv4Dst)] = route_prefix.to_string();
-      key_prefix = std::string(APP_P4RT_IPV4_TABLE_NAME) + kTableKeyDelimiter;
-    } else {
-      j[prependMatchField(p4orch::kIpv6Dst)] = route_prefix.to_string();
-      key_prefix = std::string(APP_P4RT_IPV6_TABLE_NAME) + kTableKeyDelimiter;
+class RouteManagerTest : public ::testing::Test
+{
+  protected:
+    RouteManagerTest() : route_manager_(&p4_oid_mapper_, gVrfOrch, &publisher_)
+    {
     }
-    std::vector<swss::FieldValueTuple> attributes;
-    if (command == SET_COMMAND) {
-      attributes.push_back(swss::FieldValueTuple{p4orch::kAction, action});
-      if (action == p4orch::kSetNexthopId || p4orch::kSetNexthopIdAndMetadata) {
-        attributes.push_back(swss::FieldValueTuple{
-            prependParamField(p4orch::kNexthopId), action_param});
-      } else if (action == p4orch::kSetWcmpGroupId ||
-                 action == p4orch::kSetWcmpGroupIdAndMetadata) {
-        attributes.push_back(swss::FieldValueTuple{
-            prependParamField(p4orch::kWcmpGroupId), action_param});
-      }
-      if (action == p4orch::kSetNexthopIdAndMetadata ||
-          action == p4orch::kSetWcmpGroupIdAndMetadata ||
-          action == p4orch::kSetMetadataAndDrop) {
-        attributes.push_back(swss::FieldValueTuple{
-            prependParamField(p4orch::kRouteMetadata), route_metadata});
-      }
+
+    void SetUp() override
+    {
+        mock_sai_route = &mock_sai_route_;
+        sai_route_api->create_route_entry = create_route_entry;
+        sai_route_api->remove_route_entry = remove_route_entry;
+        sai_route_api->set_route_entry_attribute = set_route_entry_attribute;
+        sai_route_api->get_route_entry_attribute = get_route_entry_attribute;
+        sai_route_api->create_route_entries = create_route_entries;
+        sai_route_api->remove_route_entries = remove_route_entries;
+        sai_route_api->set_route_entries_attribute = set_route_entries_attribute;
+        sai_route_api->get_route_entries_attribute = get_route_entries_attribute;
     }
-    return swss::KeyOpFieldsValuesTuple(key_prefix + j.dump(), command,
-                                        attributes);
-  }
 
-  // Generates a P4RouteEntry.
-  P4RouteEntry GenerateP4RouteEntry(const std::string& vrf_id,
-                                    const swss::IpPrefix& route_prefix,
-                                    const std::string& action,
-                                    const std::string& action_param,
-                                    const std::string& route_metadata = "") {
-    P4RouteEntry route_entry = {};
-    route_entry.vrf_id = vrf_id;
-    route_entry.route_prefix = route_prefix;
-    route_entry.route_metadata = route_metadata;
-    route_entry.action = action;
-    if (action == p4orch::kSetNexthopId ||
-        action == p4orch::kSetNexthopIdAndMetadata) {
-      route_entry.nexthop_id = action_param;
-    } else if (action == p4orch::kSetWcmpGroupId ||
-               action == p4orch::kSetWcmpGroupIdAndMetadata) {
-      route_entry.wcmp_group = action_param;
+    bool MergeRouteEntry(const P4RouteEntry &dest, const P4RouteEntry &src, P4RouteEntry *ret)
+    {
+        return route_manager_.mergeRouteEntry(dest, src, ret);
     }
-    route_entry.route_entry_key = KeyGenerator::generateRouteKey(
-        route_entry.vrf_id, route_entry.route_prefix);
-    return route_entry;
-  }
 
-  // Sets up a nexthop route entry for test.
-  void SetupNexthopIdRouteEntry(const std::string& vrf_id,
-                                const swss::IpPrefix& route_prefix,
-                                const std::string& nexthop_id,
-                                sai_object_id_t nexthop_oid,
-                                const std::string& metadata = "") {
-    auto route_entry = GenerateP4RouteEntry(
-        vrf_id, route_prefix,
-        (metadata.empty()) ? p4orch::kSetNexthopId
-                           : p4orch::kSetNexthopIdAndMetadata,
-        nexthop_id, metadata);
-    p4_oid_mapper_.setOID(
-        SAI_OBJECT_TYPE_NEXT_HOP,
-        KeyGenerator::generateNextHopKey(route_entry.nexthop_id), nexthop_oid);
+    ReturnCodeOr<P4RouteEntry> DeserializeRouteEntry(const std::string &key,
+                                                     const std::vector<swss::FieldValueTuple> &attributes,
+                                                     const std::string &table_name)
+    {
+        return route_manager_.deserializeRouteEntry(key, attributes, table_name);
+    }
 
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
-        .WillOnce(
-            DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                  Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  }
+    P4RouteEntry *GetRouteEntry(const std::string &route_entry_key)
+    {
+        return route_manager_.getRouteEntry(route_entry_key);
+    }
 
-  // Sets up a wcmp route entry for test.
-  void SetupWcmpGroupRouteEntry(const std::string& vrf_id,
-                                const swss::IpPrefix& route_prefix,
-                                const std::string& wcmp_group_id,
-                                sai_object_id_t wcmp_group_oid,
-                                const std::string& metadata = "") {
-    auto route_entry = GenerateP4RouteEntry(
-        vrf_id, route_prefix,
-        (metadata.empty()) ? p4orch::kSetWcmpGroupId
-                           : p4orch::kSetWcmpGroupIdAndMetadata,
-        wcmp_group_id, metadata);
-    p4_oid_mapper_.setOID(
-        SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-        KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-        wcmp_group_oid);
+    ReturnCode ValidateRouteEntry(const P4RouteEntry &route_entry, const std::string &operation)
+    {
+        return route_manager_.validateRouteEntry(route_entry, operation);
+    }
 
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
-        .WillOnce(
-            DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                  Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  }
+    std::vector<ReturnCode> CreateRouteEntries(const std::vector<P4RouteEntry> &route_entries)
+    {
+        return route_manager_.createRouteEntries(route_entries);
+    }
 
-  // Sets up a drop route entry for test.
-  void SetupDropRouteEntry(const std::string& vrf_id,
-                           const swss::IpPrefix& route_prefix) {
-    auto route_entry =
-        GenerateP4RouteEntry(vrf_id, route_prefix, p4orch::kDrop, "");
+    std::vector<ReturnCode> UpdateRouteEntries(const std::vector<P4RouteEntry> &route_entries)
+    {
+        return route_manager_.updateRouteEntries(route_entries);
+    }
 
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
-        .WillOnce(
-            DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                  Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  }
+    std::vector<ReturnCode> DeleteRouteEntries(const std::vector<P4RouteEntry> &route_entries)
+    {
+        return route_manager_.deleteRouteEntries(route_entries);
+    }
 
-  // Sets up a trap route entry for test.
-  void SetupTrapRouteEntry(const std::string& vrf_id,
-                           const swss::IpPrefix& route_prefix) {
-    auto route_entry =
-        GenerateP4RouteEntry(vrf_id, route_prefix, p4orch::kTrap, "");
+    void Enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry)
+    {
+        route_manager_.enqueue(table_name, entry);
+    }
 
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
-        .WillOnce(
-            DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                  Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  }
+    void Drain()
+    {
+        route_manager_.drain();
+    }
 
-  // Verifies the two given route entries are identical.
-  void VerifyRouteEntriesEq(const P4RouteEntry& x, const P4RouteEntry& y) {
-    EXPECT_EQ(x.route_entry_key, y.route_entry_key);
-    EXPECT_EQ(x.vrf_id, y.vrf_id);
-    EXPECT_EQ(x.route_prefix, y.route_prefix);
-    EXPECT_EQ(x.action, y.action);
-    EXPECT_EQ(x.nexthop_id, y.nexthop_id);
-    EXPECT_EQ(x.wcmp_group, y.wcmp_group);
-    EXPECT_EQ(x.route_metadata, y.route_metadata);
-    EXPECT_EQ(x.sai_route_entry.vr_id, y.sai_route_entry.vr_id);
-    EXPECT_EQ(x.sai_route_entry.switch_id, y.sai_route_entry.switch_id);
-    EXPECT_TRUE(PrefixCmp(&x.sai_route_entry.destination,
-                          &y.sai_route_entry.destination));
-  }
+    std::string VerifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple)
+    {
+        return route_manager_.verifyState(key, tuple);
+    }
 
-  // Verifies the given route entry exists and matches.
-  void VerifyRouteEntry(const P4RouteEntry& route_entry,
-                        const sai_ip_prefix_t& sai_route_prefix,
-                        const sai_object_id_t vrf_oid) {
-    auto* route_entry_ptr = GetRouteEntry(route_entry.route_entry_key);
-    P4RouteEntry expect_entry = route_entry;
-    expect_entry.sai_route_entry.vr_id = vrf_oid;
-    expect_entry.sai_route_entry.switch_id = gSwitchId;
-    expect_entry.sai_route_entry.destination = sai_route_prefix;
-    VerifyRouteEntriesEq(expect_entry, *route_entry_ptr);
-    EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY,
-                                         route_entry.route_entry_key));
-  }
+    // Generates a KeyOpFieldsValuesTuple.
+    swss::KeyOpFieldsValuesTuple GenerateKeyOpFieldsValuesTuple(const std::string &vrf_id,
+                                                                const swss::IpPrefix &route_prefix,
+                                                                const std::string &command, const std::string &action,
+                                                                const std::string &action_param,
+                                                                const std::string &route_metadata = "")
+    {
+        nlohmann::json j;
+        std::string key_prefix;
+        j[prependMatchField(p4orch::kVrfId)] = vrf_id;
+        if (route_prefix.isV4())
+        {
+            j[prependMatchField(p4orch::kIpv4Dst)] = route_prefix.to_string();
+            key_prefix = std::string(APP_P4RT_IPV4_TABLE_NAME) + kTableKeyDelimiter;
+        }
+        else
+        {
+            j[prependMatchField(p4orch::kIpv6Dst)] = route_prefix.to_string();
+            key_prefix = std::string(APP_P4RT_IPV6_TABLE_NAME) + kTableKeyDelimiter;
+        }
+        std::vector<swss::FieldValueTuple> attributes;
+        if (command == SET_COMMAND)
+        {
+            attributes.push_back(swss::FieldValueTuple{p4orch::kAction, action});
+            if (action == p4orch::kSetNexthopId || p4orch::kSetNexthopIdAndMetadata)
+            {
+                attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kNexthopId), action_param});
+            }
+            else if (action == p4orch::kSetWcmpGroupId || action == p4orch::kSetWcmpGroupIdAndMetadata)
+            {
+                attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kWcmpGroupId), action_param});
+            }
+            if (action == p4orch::kSetNexthopIdAndMetadata || action == p4orch::kSetWcmpGroupIdAndMetadata ||
+                action == p4orch::kSetMetadataAndDrop)
+            {
+                attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kRouteMetadata), route_metadata});
+            }
+        }
+        return swss::KeyOpFieldsValuesTuple(key_prefix + j.dump(), command, attributes);
+    }
 
-  StrictMock<MockSaiRoute> mock_sai_route_;
-  StrictMock<MockResponsePublisher> publisher_;
-  P4OidMapper p4_oid_mapper_;
-  RouteManager route_manager_;
+    // Generates a P4RouteEntry.
+    P4RouteEntry GenerateP4RouteEntry(const std::string &vrf_id, const swss::IpPrefix &route_prefix,
+                                      const std::string &action, const std::string &action_param,
+                                      const std::string &route_metadata = "")
+    {
+        P4RouteEntry route_entry = {};
+        route_entry.vrf_id = vrf_id;
+        route_entry.route_prefix = route_prefix;
+        route_entry.route_metadata = route_metadata;
+        route_entry.action = action;
+        if (action == p4orch::kSetNexthopId || action == p4orch::kSetNexthopIdAndMetadata)
+        {
+            route_entry.nexthop_id = action_param;
+        }
+        else if (action == p4orch::kSetWcmpGroupId || action == p4orch::kSetWcmpGroupIdAndMetadata)
+        {
+            route_entry.wcmp_group = action_param;
+        }
+        route_entry.route_entry_key = KeyGenerator::generateRouteKey(route_entry.vrf_id, route_entry.route_prefix);
+        return route_entry;
+    }
+
+    // Sets up a nexthop route entry for test.
+    void SetupNexthopIdRouteEntry(const std::string &vrf_id, const swss::IpPrefix &route_prefix,
+                                  const std::string &nexthop_id, sai_object_id_t nexthop_oid,
+                                  const std::string &metadata = "")
+    {
+        auto route_entry = GenerateP4RouteEntry(
+            vrf_id, route_prefix, (metadata.empty()) ? p4orch::kSetNexthopId : p4orch::kSetNexthopIdAndMetadata,
+            nexthop_id, metadata);
+        p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                              nexthop_oid);
+
+        std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+        EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
+            .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                    ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    }
+
+    // Sets up a wcmp route entry for test.
+    void SetupWcmpGroupRouteEntry(const std::string &vrf_id, const swss::IpPrefix &route_prefix,
+                                  const std::string &wcmp_group_id, sai_object_id_t wcmp_group_oid,
+                                  const std::string &metadata = "")
+    {
+        auto route_entry = GenerateP4RouteEntry(
+            vrf_id, route_prefix, (metadata.empty()) ? p4orch::kSetWcmpGroupId : p4orch::kSetWcmpGroupIdAndMetadata,
+            wcmp_group_id, metadata);
+        p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                              KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group), wcmp_group_oid);
+
+        std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+        EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
+            .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                    ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    }
+
+    // Sets up a drop route entry for test.
+    void SetupDropRouteEntry(const std::string &vrf_id, const swss::IpPrefix &route_prefix)
+    {
+        auto route_entry = GenerateP4RouteEntry(vrf_id, route_prefix, p4orch::kDrop, "");
+
+        std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+        EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
+            .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                    ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    }
+
+    // Sets up a trap route entry for test.
+    void SetupTrapRouteEntry(const std::string &vrf_id, const swss::IpPrefix &route_prefix)
+    {
+        auto route_entry = GenerateP4RouteEntry(vrf_id, route_prefix, p4orch::kTrap, "");
+
+        std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+        EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
+            .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                    ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    }
+
+    // Verifies the two given route entries are identical.
+    void VerifyRouteEntriesEq(const P4RouteEntry &x, const P4RouteEntry &y)
+    {
+        EXPECT_EQ(x.route_entry_key, y.route_entry_key);
+        EXPECT_EQ(x.vrf_id, y.vrf_id);
+        EXPECT_EQ(x.route_prefix, y.route_prefix);
+        EXPECT_EQ(x.action, y.action);
+        EXPECT_EQ(x.nexthop_id, y.nexthop_id);
+        EXPECT_EQ(x.wcmp_group, y.wcmp_group);
+        EXPECT_EQ(x.route_metadata, y.route_metadata);
+        EXPECT_EQ(x.sai_route_entry.vr_id, y.sai_route_entry.vr_id);
+        EXPECT_EQ(x.sai_route_entry.switch_id, y.sai_route_entry.switch_id);
+        EXPECT_TRUE(PrefixCmp(&x.sai_route_entry.destination, &y.sai_route_entry.destination));
+    }
+
+    // Verifies the given route entry exists and matches.
+    void VerifyRouteEntry(const P4RouteEntry &route_entry, const sai_ip_prefix_t &sai_route_prefix,
+                          const sai_object_id_t vrf_oid)
+    {
+        auto *route_entry_ptr = GetRouteEntry(route_entry.route_entry_key);
+        P4RouteEntry expect_entry = route_entry;
+        expect_entry.sai_route_entry.vr_id = vrf_oid;
+        expect_entry.sai_route_entry.switch_id = gSwitchId;
+        expect_entry.sai_route_entry.destination = sai_route_prefix;
+        VerifyRouteEntriesEq(expect_entry, *route_entry_ptr);
+        EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, route_entry.route_entry_key));
+    }
+
+    StrictMock<MockSaiRoute> mock_sai_route_;
+    StrictMock<MockResponsePublisher> publisher_;
+    P4OidMapper p4_oid_mapper_;
+    RouteManager route_manager_;
 };
 
-TEST_F(RouteManagerTest, MergeRouteEntryWithNexthopIdActionDestTest) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto dest = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                   p4orch::kSetNexthopId, kNexthopId1);
-  dest.sai_route_entry.vr_id = gVrfOid;
-  dest.sai_route_entry.switch_id = gSwitchId;
-  copy(dest.sai_route_entry.destination, swss_ipv4_route_prefix);
-
-  // Source is identical to destination.
-  auto src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                  p4orch::kSetNexthopId, kNexthopId1);
-  P4RouteEntry ret = {};
-  EXPECT_FALSE(MergeRouteEntry(dest, src, &ret));
-  VerifyRouteEntriesEq(dest, ret);
-
-  // Source has different nexthop ID.
-  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                             p4orch::kSetNexthopId, kNexthopId2);
-  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-  P4RouteEntry expect_entry = dest;
-  expect_entry.nexthop_id = kNexthopId2;
-  VerifyRouteEntriesEq(expect_entry, ret);
-
-  // Source has set nexthop ID and metadata action and dest has set nexthop ID
-  // action.
-  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                             p4orch::kSetNexthopIdAndMetadata, kNexthopId1,
-                             kMetadata1);
-  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-  expect_entry = dest;
-  expect_entry.action = p4orch::kSetNexthopIdAndMetadata;
-  expect_entry.route_metadata = kMetadata1;
-  VerifyRouteEntriesEq(expect_entry, ret);
-
-  // Source has wcmp group action and dest has nexhop ID action.
-  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                             p4orch::kSetWcmpGroupId, kWcmpGroup1);
-  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-  expect_entry = dest;
-  expect_entry.nexthop_id = "";
-  expect_entry.action = p4orch::kSetWcmpGroupId;
-  expect_entry.wcmp_group = kWcmpGroup1;
-  VerifyRouteEntriesEq(expect_entry, ret);
-
-  // Source has drop action and dest has nexhop ID action.
-  src =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-  expect_entry = dest;
-  expect_entry.nexthop_id = "";
-  expect_entry.action = p4orch::kDrop;
-  VerifyRouteEntriesEq(expect_entry, ret);
-}
-
-TEST_F(RouteManagerTest,
-       MergeRouteEntryWithNexthopIdAndMetadataActionDestTest) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto dest = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                   p4orch::kSetNexthopIdAndMetadata,
-                                   kNexthopId1, kMetadata1);
-  dest.sai_route_entry.vr_id = gVrfOid;
-  dest.sai_route_entry.switch_id = gSwitchId;
-  copy(dest.sai_route_entry.destination, swss_ipv4_route_prefix);
-
-  // Source is identical to destination.
-  auto src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                  p4orch::kSetNexthopIdAndMetadata, kNexthopId1,
-                                  kMetadata1);
-  P4RouteEntry ret = {};
-  EXPECT_FALSE(MergeRouteEntry(dest, src, &ret));
-  VerifyRouteEntriesEq(dest, ret);
-
-  // Source has different metadata.
-  src.route_metadata = kMetadata2;
-  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-  P4RouteEntry expect_entry = dest;
-  expect_entry.route_metadata = kMetadata2;
-  VerifyRouteEntriesEq(expect_entry, ret);
-
-  // Source has different nexthop ID and metadata.
-  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                             p4orch::kSetNexthopIdAndMetadata, kNexthopId2,
-                             kMetadata2);
-  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-  expect_entry = dest;
-  expect_entry.nexthop_id = kNexthopId2;
-  expect_entry.route_metadata = kMetadata2;
-  VerifyRouteEntriesEq(expect_entry, ret);
-
-  // Source has wcmp group action and dest has nexhop ID and metadata action.
-  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                             p4orch::kSetWcmpGroupId, kWcmpGroup1);
-  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-  expect_entry = dest;
-  expect_entry.nexthop_id = "";
-  expect_entry.action = p4orch::kSetWcmpGroupId;
-  expect_entry.wcmp_group = kWcmpGroup1;
-  expect_entry.route_metadata = "";
-  VerifyRouteEntriesEq(expect_entry, ret);
-
-  // Source has drop action and dest has nexhop ID and metadata action.
-  src =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-  expect_entry = dest;
-  expect_entry.nexthop_id = "";
-  expect_entry.action = p4orch::kDrop;
-  expect_entry.route_metadata = "";
-  VerifyRouteEntriesEq(expect_entry, ret);
-
-  // Source has wcmp group and metadata action and dest has nexhop ID and
-  // metadata action.
-  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                             p4orch::kSetWcmpGroupIdAndMetadata, kWcmpGroup1,
-                             kMetadata2);
-  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-  expect_entry = dest;
-  expect_entry.nexthop_id = "";
-  expect_entry.action = p4orch::kSetWcmpGroupIdAndMetadata;
-  expect_entry.wcmp_group = kWcmpGroup1;
-  expect_entry.route_metadata = kMetadata2;
-  VerifyRouteEntriesEq(expect_entry, ret);
-}
-
-TEST_F(RouteManagerTest, MergeRouteEntryWithWcmpGroupActionDestTest) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto dest = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                   p4orch::kSetWcmpGroupId, kWcmpGroup1);
-  dest.sai_route_entry.vr_id = gVrfOid;
-  dest.sai_route_entry.switch_id = gSwitchId;
-  copy(dest.sai_route_entry.destination, swss_ipv4_route_prefix);
-
-  // Source is identical to destination.
-  auto src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                  p4orch::kSetWcmpGroupId, kWcmpGroup1);
-  P4RouteEntry ret = {};
-  EXPECT_FALSE(MergeRouteEntry(dest, src, &ret));
-  VerifyRouteEntriesEq(dest, ret);
-
-  // Source has different wcmp group.
-  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                             p4orch::kSetWcmpGroupId, kWcmpGroup2);
-  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-  P4RouteEntry expect_entry = dest;
-  expect_entry.wcmp_group = kWcmpGroup2;
-  VerifyRouteEntriesEq(expect_entry, ret);
-
-  // Source has nexthop ID action and dest has wcmp group action.
-  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                             p4orch::kSetNexthopId, kNexthopId1);
-  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-  expect_entry = dest;
-  expect_entry.wcmp_group = "";
-  expect_entry.action = p4orch::kSetNexthopId;
-  expect_entry.nexthop_id = kNexthopId1;
-  VerifyRouteEntriesEq(expect_entry, ret);
-
-  // Source has drop action and dest has wcmp group action.
-  src =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-  expect_entry = dest;
-  expect_entry.wcmp_group = "";
-  expect_entry.action = p4orch::kDrop;
-  VerifyRouteEntriesEq(expect_entry, ret);
-}
-
-TEST_F(RouteManagerTest, MergeRouteEntryWithDropActionDestTest) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto dest =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-  dest.sai_route_entry.vr_id = gVrfOid;
-  dest.sai_route_entry.switch_id = gSwitchId;
-  copy(dest.sai_route_entry.destination, swss_ipv4_route_prefix);
-
-  // Source is identical to destination.
-  auto src =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-  P4RouteEntry ret = {};
-  EXPECT_FALSE(MergeRouteEntry(dest, src, &ret));
-  VerifyRouteEntriesEq(dest, ret);
-
-  // Source has nexthop ID action and dest has drop action.
-  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                             p4orch::kSetNexthopId, kNexthopId1);
-  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-  P4RouteEntry expect_entry = dest;
-  expect_entry.action = p4orch::kSetNexthopId;
-  expect_entry.nexthop_id = kNexthopId1;
-  VerifyRouteEntriesEq(expect_entry, ret);
-
-  // Source has wcmp group and metadata action and dest has drop action.
-  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                             p4orch::kSetWcmpGroupIdAndMetadata, kWcmpGroup1,
-                             kMetadata1);
-  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-  expect_entry = dest;
-  expect_entry.action = p4orch::kSetWcmpGroupIdAndMetadata;
-  expect_entry.nexthop_id = "";
-  expect_entry.wcmp_group = kWcmpGroup1;
-  expect_entry.route_metadata = kMetadata1;
-  VerifyRouteEntriesEq(expect_entry, ret);
-}
-
-TEST_F(RouteManagerTest, MergeRouteEntryWithTrapActionDestTest) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto dest =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
-  dest.sai_route_entry.vr_id = gVrfOid;
-  dest.sai_route_entry.switch_id = gSwitchId;
-  copy(dest.sai_route_entry.destination, swss_ipv4_route_prefix);
-
-  // Source is identical to destination.
-  auto src =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
-  P4RouteEntry ret = {};
-  EXPECT_FALSE(MergeRouteEntry(dest, src, &ret));
-  VerifyRouteEntriesEq(dest, ret);
-
-  // Source has nexthop ID action and dest has trap action.
-  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                             p4orch::kSetNexthopId, kNexthopId1);
-  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-  P4RouteEntry expect_entry = dest;
-  expect_entry.action = p4orch::kSetNexthopId;
-  expect_entry.nexthop_id = kNexthopId1;
-  VerifyRouteEntriesEq(expect_entry, ret);
-
-  // Source has wcmp group action and dest has trap action.
-  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                             p4orch::kSetWcmpGroupId, kWcmpGroup1);
-  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-  expect_entry = dest;
-  expect_entry.action = p4orch::kSetWcmpGroupId;
-  expect_entry.wcmp_group = kWcmpGroup1;
-  VerifyRouteEntriesEq(expect_entry, ret);
-}
-
-TEST_F(RouteManagerTest, DeserializeRouteEntryWithNexthopIdActionTest) {
-  std::string key =
-      R"({"match/vrf_id":"b4-traffic","match/ipv4_dst":"10.11.12.0/24"})";
-  std::vector<swss::FieldValueTuple> attributes;
-  attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
-  attributes.push_back(swss::FieldValueTuple{
-      prependParamField(p4orch::kNexthopId), kNexthopId1});
-  auto route_entry_or =
-      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV4_TABLE_NAME);
-  EXPECT_TRUE(route_entry_or.ok());
-  auto& route_entry = *route_entry_or;
-  auto expect_entry =
-      GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("10.11.12.0/24"),
-                           p4orch::kSetNexthopId, kNexthopId1);
-  VerifyRouteEntriesEq(expect_entry, route_entry);
-}
-
-TEST_F(RouteManagerTest, DeserializeRouteEntryWithWcmpGroupActionTest) {
-  std::string key =
-      R"({"match/vrf_id":"b4-traffic","match/ipv4_dst":"10.11.12.0/24"})";
-  std::vector<swss::FieldValueTuple> attributes;
-  attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetWcmpGroupId});
-  attributes.push_back(swss::FieldValueTuple{
-      prependParamField(p4orch::kWcmpGroupId), kWcmpGroup1});
-  auto route_entry_or =
-      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV4_TABLE_NAME);
-  EXPECT_TRUE(route_entry_or.ok());
-  auto& route_entry = *route_entry_or;
-  auto expect_entry =
-      GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("10.11.12.0/24"),
-                           p4orch::kSetWcmpGroupId, kWcmpGroup1);
-  VerifyRouteEntriesEq(expect_entry, route_entry);
-}
-
-TEST_F(RouteManagerTest,
-       DeserializeRouteEntryWithNexthopIdAdnMetadataActionTest) {
-  std::string key =
-      R"({"match/vrf_id":"b4-traffic","match/ipv4_dst":"10.11.12.0/24"})";
-  std::vector<swss::FieldValueTuple> attributes;
-  attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopIdAndMetadata});
-  attributes.push_back(swss::FieldValueTuple{
-      prependParamField(p4orch::kNexthopId), kNexthopId1});
-  attributes.push_back(swss::FieldValueTuple{
-      prependParamField(p4orch::kRouteMetadata), kMetadata1});
-  auto route_entry_or =
-      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV4_TABLE_NAME);
-  EXPECT_TRUE(route_entry_or.ok());
-  auto& route_entry = *route_entry_or;
-  auto expect_entry = GenerateP4RouteEntry(
-      "b4-traffic", swss::IpPrefix("10.11.12.0/24"),
-      p4orch::kSetNexthopIdAndMetadata, kNexthopId1, kMetadata1);
-  VerifyRouteEntriesEq(expect_entry, route_entry);
-}
-
-TEST_F(RouteManagerTest,
-       DeserializeRouteEntryWithWcmpGroupAndMetadataActionTest) {
-  std::string key =
-      R"({"match/vrf_id":"b4-traffic","match/ipv4_dst":"10.11.12.0/24"})";
-  std::vector<swss::FieldValueTuple> attributes;
-  attributes.push_back(swss::FieldValueTuple{
-      p4orch::kAction, p4orch::kSetWcmpGroupIdAndMetadata});
-  attributes.push_back(swss::FieldValueTuple{
-      prependParamField(p4orch::kWcmpGroupId), kWcmpGroup1});
-  attributes.push_back(swss::FieldValueTuple{
-      prependParamField(p4orch::kRouteMetadata), kMetadata1});
-  auto route_entry_or =
-      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV4_TABLE_NAME);
-  EXPECT_TRUE(route_entry_or.ok());
-  auto& route_entry = *route_entry_or;
-  auto expect_entry = GenerateP4RouteEntry(
-      "b4-traffic", swss::IpPrefix("10.11.12.0/24"),
-      p4orch::kSetWcmpGroupIdAndMetadata, kWcmpGroup1, kMetadata1);
-  VerifyRouteEntriesEq(expect_entry, route_entry);
-}
-
-TEST_F(RouteManagerTest, DeserializeRouteEntryWithDropActionTest) {
-  std::string key =
-      R"({"match/vrf_id":"b4-traffic","match/ipv6_dst":"2001:db8:1::/32"})";
-  std::vector<swss::FieldValueTuple> attributes;
-  attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
-  auto route_entry_or =
-      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
-  EXPECT_TRUE(route_entry_or.ok());
-  auto& route_entry = *route_entry_or;
-  auto expect_entry = GenerateP4RouteEntry(
-      "b4-traffic", swss::IpPrefix("2001:db8:1::/32"), p4orch::kDrop, "");
-  VerifyRouteEntriesEq(expect_entry, route_entry);
-}
-
-TEST_F(RouteManagerTest, DeserializeRouteEntryWithTrapActionTest) {
-  std::string key =
-      R"({"match/vrf_id":"b4-traffic","match/ipv6_dst":"2001:db8:1::/32"})";
-  std::vector<swss::FieldValueTuple> attributes;
-  attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kTrap});
-  auto route_entry_or =
-      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
-  EXPECT_TRUE(route_entry_or.ok());
-  auto& route_entry = *route_entry_or;
-  auto expect_entry = GenerateP4RouteEntry(
-      "b4-traffic", swss::IpPrefix("2001:db8:1::/32"), p4orch::kTrap, "");
-  VerifyRouteEntriesEq(expect_entry, route_entry);
-}
-
-TEST_F(RouteManagerTest, DeserializeRouteEntryWithInvalidKeyShouldFail) {
-  std::string key = "{{{{{{{{{{{{";
-  std::vector<swss::FieldValueTuple> attributes;
-  attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
-  auto route_entry_or =
-      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
-  EXPECT_FALSE(route_entry_or.ok());
-}
-
-TEST_F(RouteManagerTest, DeserializeRouteEntryWithInvalidFieldShouldFail) {
-  std::string key =
-      R"({"match/vrf_id":"b4-traffic","match/ipv6_dst":"2001:db8:1::/32"})";
-  std::vector<swss::FieldValueTuple> attributes;
-  attributes.push_back(swss::FieldValueTuple{"invalid", "invalid"});
-  auto route_entry_or =
-      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
-  EXPECT_FALSE(route_entry_or.ok());
-}
-
-TEST_F(RouteManagerTest, DeserializeRouteEntryWithInvalidRouteShouldFail) {
-  std::string key =
-      R"({"match/vrf_id":"b4-traffic","match/ipv6_dst":"invalid"})";
-  std::vector<swss::FieldValueTuple> attributes;
-  attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
-  auto route_entry_or =
-      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
-  EXPECT_FALSE(route_entry_or.ok());
-}
-
-TEST_F(RouteManagerTest,
-       DeserializeRouteEntryWithoutIpv4WildcardLpmMatchShouldSucceed) {
-  std::string key = R"({"match/vrf_id":"b4-traffic"})";
-  std::vector<swss::FieldValueTuple> attributes;
-  attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
-  auto route_entry_or =
-      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV4_TABLE_NAME);
-  EXPECT_TRUE(route_entry_or.ok());
-  auto& route_entry = *route_entry_or;
-  auto expect_entry = GenerateP4RouteEntry(
-      "b4-traffic", swss::IpPrefix("0.0.0.0/0"), p4orch::kDrop, "");
-  VerifyRouteEntriesEq(expect_entry, route_entry);
-}
-
-TEST_F(RouteManagerTest,
-       DeserializeRouteEntryWithoutIpv6WildcardLpmMatchShouldSucceed) {
-  std::string key = R"({"match/vrf_id":"b4-traffic"})";
-  std::vector<swss::FieldValueTuple> attributes;
-  attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
-  auto route_entry_or =
-      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
-  EXPECT_TRUE(route_entry_or.ok());
-  auto& route_entry = *route_entry_or;
-  auto expect_entry = GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("::/0"),
-                                           p4orch::kDrop, "");
-  VerifyRouteEntriesEq(expect_entry, route_entry);
-}
-
-TEST_F(RouteManagerTest,
-       ValidateRouteEntryNexthopActionWithInvalidNexthopShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, kNexthopId1);
-  EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND,
-            ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest,
-       ValidateRouteEntryNexthopActionWithValidNexthopShouldSucceed) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, kNexthopId1);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
-  EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
-            ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest,
-       ValidateRouteEntryWcmpGroupActionWithInvalidWcmpGroupShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetWcmpGroupId, kWcmpGroup1);
-  EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND,
-            ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest,
-       ValidateRouteEntryWcmpGroupActionWithValidWcmpGroupShouldSucceed) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetWcmpGroupId, kWcmpGroup1);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-      kWcmpGroupOid1);
-  EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
-            ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateRouteEntryWithInvalidCommandShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
-            ValidateRouteEntry(route_entry, "invalid"));
-}
-
-TEST_F(RouteManagerTest, ValidateSetRouteEntryDoesNotExistInManagerShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, kNexthopId1);
-  route_entry.action = "";
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
-  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
-            ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest,
-       ValidateSetRouteEntryExistsInMapperDoesNotExistInManagerShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, kNexthopId1);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
-  p4_oid_mapper_.setDummyOID(SAI_OBJECT_TYPE_ROUTE_ENTRY,
-                             route_entry.route_entry_key);
-  EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND,
-            ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest,
-       ValidateSetRouteEntryExistsInManagerDoesNotExistInMapperShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, kNexthopId1);
-  p4_oid_mapper_.eraseOID(SAI_OBJECT_TYPE_ROUTE_ENTRY,
-                          route_entry.route_entry_key);
-  EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND,
-            ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest,
-       ValidateSetRouteEntryNexthopIdActionWithoutNexthopIdShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, "");
-  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
-            ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest,
-       ValidateSetRouteEntryNexthopIdActionWithWcmpGroupShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, kNexthopId1);
-  route_entry.wcmp_group = kWcmpGroup1;
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-      kWcmpGroupOid1);
-  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
-            ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest,
-       ValidateSetRouteEntryWcmpGroupActionWithoutWcmpGroupShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetWcmpGroupId, "");
-  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
-            ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest,
-       ValidateSetRouteEntryWcmpGroupActionWithNexthopIdShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetWcmpGroupId, kWcmpGroup1);
-  route_entry.nexthop_id = kNexthopId1;
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-      kWcmpGroupOid1);
-  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
-            ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest,
-       ValidateSetRouteEntryDropActionWithNexthopIdShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-  route_entry.nexthop_id = kNexthopId1;
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
-  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
-            ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest,
-       ValidateSetRouteEntryWcmpGroupActionWithNonemptyMetadataShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                           p4orch::kSetWcmpGroupId, kWcmpGroup1, kMetadata1);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-      kWcmpGroupOid1);
-  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
-            ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(
-    RouteManagerTest,
-    ValidateSetRouteEntryNexthopIdAndMetadataActionWithEmptyMetadataShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                           p4orch::kSetNexthopIdAndMetadata, kNexthopId1);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
-  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
-            ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(
-    RouteManagerTest,
-    ValidateSetRouteEntryNexthopIdAndMetadataActionWithInvalidMetadataShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopIdAndMetadata,
-                                          kNexthopId1, "invalid_int");
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
-  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
-            ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest,
-       ValidateSetRouteEntryDropActionWithWcmpGroupShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-  route_entry.wcmp_group = kWcmpGroup1;
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-      kWcmpGroupOid1);
-  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
-            ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest,
-       ValidateSetRouteEntryTrapActionWithNexthopIdShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
-  route_entry.nexthop_id = kNexthopId1;
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
-  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
-            ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest,
-       ValidateSetRouteEntryTrapActionWithWcmpGroupShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
-  route_entry.wcmp_group = kWcmpGroup1;
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-      kWcmpGroupOid1);
-  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
-            ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateSetRouteEntryInvalidActionShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-  route_entry.action = "invalid";
-  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
-            ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateSetRouteEntrySucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, kNexthopId2);
-  route_entry.action = "";
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid2);
-  EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
-            ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateDelRouteEntryDoesNotExistInManagerShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "");
-  EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND,
-            ValidateRouteEntry(route_entry, DEL_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateDelRouteEntryDoesNotExistInMapperShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "");
-  p4_oid_mapper_.eraseOID(SAI_OBJECT_TYPE_ROUTE_ENTRY,
-                          route_entry.route_entry_key);
-  // TODO: Expect critical state.
-  EXPECT_EQ(StatusCode::SWSS_RC_INTERNAL,
-            ValidateRouteEntry(route_entry, DEL_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateDelRouteEntryHasActionShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, "");
-  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
-            ValidateRouteEntry(route_entry, DEL_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateDelRouteEntryHasNexthopIdShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, kNexthopId1);
-  route_entry.action = "";
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
-  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
-            ValidateRouteEntry(route_entry, DEL_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateDelRouteEntryHasWcmpGroupShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetWcmpGroupId, kWcmpGroup1);
-  route_entry.action = "";
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-      kWcmpGroupOid1);
-  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
-            ValidateRouteEntry(route_entry, DEL_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateDelRouteEntryHasMetadataShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "",
-                                          "", kMetadata1);
-  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
-            ValidateRouteEntry(route_entry, DEL_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateDelRouteEntrySucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "");
-  EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
-            ValidateRouteEntry(route_entry, DEL_COMMAND));
-}
-
-TEST_F(RouteManagerTest, CreateRouteEntryWithSaiErrorShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE};
-  EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
-      .Times(3)
-      .WillRepeatedly(
-          DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                Return(SAI_STATUS_FAILURE)));
-  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-
-  route_entry.action = p4orch::kSetNexthopId;
-  route_entry.nexthop_id = kNexthopId1;
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
-  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-
-  route_entry.action = p4orch::kSetWcmpGroupId;
-  route_entry.wcmp_group = kWcmpGroup1;
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-      kWcmpGroupOid1);
-  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(RouteManagerTest, CreateNexthopIdIpv4RouteSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, kNexthopId1);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr.value.oid = kNexthopOid1;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              create_route_entries(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  ArrayEq(std::vector<uint32_t>{1}),
-                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                      {exp_sai_attr}}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, CreateNexthopIdIpv6RouteSucceeds) {
-  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-  sai_ip_prefix_t sai_ipv6_route_prefix;
-  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix,
-                                          p4orch::kSetNexthopId, kNexthopId1);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv6_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr.value.oid = kNexthopOid1;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              create_route_entries(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  ArrayEq(std::vector<uint32_t>{1}),
-                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                      {exp_sai_attr}}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv6_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, CreateNexthopIdWithMetadataIpv4RouteSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopIdAndMetadata,
-                                          kNexthopId1, kMetadata1);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  std::vector<sai_attribute_t> exp_sai_attrs;
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr.value.oid = kNexthopOid1;
-  exp_sai_attrs.push_back(exp_sai_attr);
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
-  exp_sai_attr.value.u32 = kMetadataInt1;
-  exp_sai_attrs.push_back(exp_sai_attr);
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              create_route_entries(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  ArrayEq(std::vector<uint32_t>{
-                      static_cast<uint32_t>(exp_sai_attrs.size())}),
-                  AttrArrayArrayEq(
-                      std::vector<std::vector<sai_attribute_t>>{exp_sai_attrs}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, CreateDropSetMetadataRouteSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                           p4orch::kSetMetadataAndDrop, "", kMetadata1);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  std::vector<sai_attribute_t> exp_sai_attrs;
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
-  exp_sai_attrs.push_back(exp_sai_attr);
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
-  exp_sai_attr.value.u32 = kMetadataInt1;
-  exp_sai_attrs.push_back(exp_sai_attr);
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              create_route_entries(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  ArrayEq(std::vector<uint32_t>{
-                      static_cast<uint32_t>(exp_sai_attrs.size())}),
-                  AttrArrayArrayEq(
-                      std::vector<std::vector<sai_attribute_t>>{exp_sai_attrs}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-
-  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-}
-
-TEST_F(RouteManagerTest, CreateDropIpv4RouteSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              create_route_entries(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  ArrayEq(std::vector<uint32_t>{1}),
-                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                      {exp_sai_attr}}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-}
-
-TEST_F(RouteManagerTest, CreateDropIpv6RouteSucceeds) {
-  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-  sai_ip_prefix_t sai_ipv6_route_prefix;
-  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kDrop, "");
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv6_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              create_route_entries(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  ArrayEq(std::vector<uint32_t>{1}),
-                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                      {exp_sai_attr}}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv6_route_prefix, gVrfOid);
-}
-
-TEST_F(RouteManagerTest, CreateTrapIpv4RouteSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_TRAP;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              create_route_entries(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  ArrayEq(std::vector<uint32_t>{1}),
-                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                      {exp_sai_attr}}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-}
-
-TEST_F(RouteManagerTest, CreateTrapIpv6RouteSucceeds) {
-  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-  sai_ip_prefix_t sai_ipv6_route_prefix;
-  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kTrap, "");
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv6_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_TRAP;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              create_route_entries(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  ArrayEq(std::vector<uint32_t>{1}),
-                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                      {exp_sai_attr}}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv6_route_prefix, gVrfOid);
-}
-
-TEST_F(RouteManagerTest, CreateWcmpIpv4RouteSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetWcmpGroupId, kWcmpGroup1);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-      kWcmpGroupOid1);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr.value.oid = kWcmpGroupOid1;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              create_route_entries(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  ArrayEq(std::vector<uint32_t>{1}),
-                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                      {exp_sai_attr}}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, CreateWcmpIpv6RouteSucceeds) {
-  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-  sai_ip_prefix_t sai_ipv6_route_prefix;
-  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix,
-                                          p4orch::kSetWcmpGroupId, kWcmpGroup1);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-      kWcmpGroupOid1);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv6_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr.value.oid = kWcmpGroupOid1;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              create_route_entries(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  ArrayEq(std::vector<uint32_t>{1}),
-                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                      {exp_sai_attr}}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv6_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, CreateWcmpWithMetadataIpv6RouteSucceeds) {
-  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-  sai_ip_prefix_t sai_ipv6_route_prefix;
-  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix,
-                                          p4orch::kSetWcmpGroupIdAndMetadata,
-                                          kWcmpGroup1, kMetadata1);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-      kWcmpGroupOid1);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv6_route_prefix;
-
-  std::vector<sai_attribute_t> exp_sai_attrs;
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr.value.oid = kWcmpGroupOid1;
-  exp_sai_attrs.push_back(exp_sai_attr);
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
-  exp_sai_attr.value.u32 = kMetadataInt1;
-  exp_sai_attrs.push_back(exp_sai_attr);
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              create_route_entries(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  ArrayEq(std::vector<uint32_t>{
-                      static_cast<uint32_t>(exp_sai_attrs.size())}),
-                  AttrArrayArrayEq(
-                      std::vector<std::vector<sai_attribute_t>>{exp_sai_attrs}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv6_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteEntryWcmpWithSaiErrorShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupWcmpGroupRouteEntry(gVrfName, swss_ipv4_route_prefix, kWcmpGroup1,
-                           kWcmpGroupOid1);
-
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetWcmpGroupId, kWcmpGroup2);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-      kWcmpGroupOid2);
-  std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE};
-  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_FAILURE)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(RouteManagerTest,
-       UpdateRouteEntryWcmpNotExistInMapperShouldRaiseCriticalState) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupWcmpGroupRouteEntry(gVrfName, swss_ipv4_route_prefix, kWcmpGroup1,
-                           kWcmpGroupOid1);
-
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetWcmpGroupId, kWcmpGroup2);
-  std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE};
-  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_FAILURE)));
-  // TODO: Expect critical state.
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromSetWcmpToSetNextHopSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupWcmpGroupRouteEntry(gVrfName, swss_ipv4_route_prefix, kWcmpGroup1,
-                           kWcmpGroupOid1);
-
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, kNexthopId2);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid2);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr.value.oid = kNexthopOid2;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2),
-      &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest,
-       UpdateRouteFromSetWcmpToSetNextHopAndMetadataSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupWcmpGroupRouteEntry(gVrfName, swss_ipv4_route_prefix, kWcmpGroup1,
-                           kWcmpGroupOid1);
-
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopIdAndMetadata,
-                                          kNexthopId2, kMetadata2);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid2);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
-  exp_sai_attr.value.u32 = kMetadataInt2;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr.value.oid = kNexthopOid2;
-
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2),
-      &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromSetNexthopIdToSetWcmpSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetWcmpGroupId, kWcmpGroup2);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-      kWcmpGroupOid2);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr.value.oid = kWcmpGroupOid2;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  route_entry.action = p4orch::kSetWcmpGroupId;
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(kWcmpGroup2), &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest,
-       UpdateRouteFromSetNexthopIdAndMetadataToSetWcmpSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1, kMetadata2);
-
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetWcmpGroupId, kWcmpGroup2);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-      kWcmpGroupOid2);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
-  exp_sai_attr.value.u32 = 0;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr.value.oid = kWcmpGroupOid2;
-
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(kWcmpGroup2), &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteEntryNexthopIdWithSaiErrorShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, kNexthopId2);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid2);
-  std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
-  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
-                                          exp_failure_status.end()),
-                      Return(SAI_STATUS_FAILURE)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(RouteManagerTest,
-       UpdateRouteEntryNexthopIdNotExistInMapperShouldRaiseCriticalState) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, kNexthopId2);
-  std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
-  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
-                                          exp_failure_status.end()),
-                      Return(SAI_STATUS_FAILURE)));
-  // TODO: Expect critical state.
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(RouteManagerTest, UpdateRouteEntryDropWithSaiErrorShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-  std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
-  std::vector<sai_status_t> exp_success_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
-                                          exp_failure_status.end()),
-                      Return(SAI_STATUS_FAILURE)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
-                                          exp_success_status.end()),
-                      Return(SAI_STATUS_SUCCESS)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
-                                          exp_failure_status.end()),
-                      Return(SAI_STATUS_FAILURE)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
-                                          exp_success_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
-                                          exp_success_status.end()),
-                      Return(SAI_STATUS_SUCCESS)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
-                                          exp_failure_status.end()),
-                      Return(SAI_STATUS_FAILURE)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
-                                          exp_failure_status.end()),
-                      Return(SAI_STATUS_FAILURE)));
-  // TODO: Expect critical state.
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(RouteManagerTest, UpdateRouteEntryTrapWithSaiErrorShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
-  std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
-  std::vector<sai_status_t> exp_success_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
-                                          exp_failure_status.end()),
-                      Return(SAI_STATUS_FAILURE)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
-                                          exp_success_status.end()),
-                      Return(SAI_STATUS_SUCCESS)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
-                                          exp_failure_status.end()),
-                      Return(SAI_STATUS_FAILURE)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
-                                          exp_success_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
-                                          exp_success_status.end()),
-                      Return(SAI_STATUS_SUCCESS)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
-                                          exp_failure_status.end()),
-                      Return(SAI_STATUS_FAILURE)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
-                                          exp_failure_status.end()),
-                      Return(SAI_STATUS_FAILURE)));
-  // TODO: Expect critical state.
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(RouteManagerTest, UpdateRouteWithDifferentNexthopIdsSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, kNexthopId2);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid2);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr.value.oid = kNexthopOid2;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  route_entry.action = p4orch::kSetNexthopId;
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2),
-      &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest,
-       UpdateRouteWithDifferentNexthopIdsAndMetadatasSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1, kMetadata1);
-
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopIdAndMetadata,
-                                          kNexthopId2, kMetadata2);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid2);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
-  exp_sai_attr.value.u32 = kMetadataInt2;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr.value.oid = kNexthopOid2;
-
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2),
-      &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromNexthopIdToDropSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr.value.oid = SAI_NULL_OBJECT_ID;
-
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromNexthopIdToRouteMetadataSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                           p4orch::kSetMetadataAndDrop, "", kMetadata1);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
-  exp_sai_attr.value.s32 = kMetadataInt1;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr.value.oid = SAI_NULL_OBJECT_ID;
-
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
-
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromNexthopIdAndMetadataToDropSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1, kMetadata2);
-
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr.value.oid = SAI_NULL_OBJECT_ID;
-
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
-  exp_sai_attr.value.u32 = 0;
-
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromDropToNexthopIdSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupDropRouteEntry(gVrfName, swss_ipv4_route_prefix);
-
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, kNexthopId2);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid2);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr.value.oid = kNexthopOid2;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_FORWARD;
-
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2),
-      &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromDropToWcmpWithMetadataSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupDropRouteEntry(gVrfName, swss_ipv4_route_prefix);
-
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetWcmpGroupIdAndMetadata,
-                                          kWcmpGroup1, kMetadata2);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-      kWcmpGroupOid1);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
-  exp_sai_attr.value.u32 = kMetadataInt2;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr.value.oid = kWcmpGroupOid1;
-
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_FORWARD;
-
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromTrapToDropAndSetMetadataSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupTrapRouteEntry(gVrfName, swss_ipv4_route_prefix);
-
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                           p4orch::kSetMetadataAndDrop, "", kMetadata2);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
-  exp_sai_attr.value.u32 = kMetadataInt2;
-
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromTrapToDropSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupTrapRouteEntry(gVrfName, swss_ipv4_route_prefix);
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromDropToTrapSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupDropRouteEntry(gVrfName, swss_ipv4_route_prefix);
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_TRAP;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromNexthopIdToTrapSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_TRAP;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr.value.oid = SAI_NULL_OBJECT_ID;
-
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromTrapToNexthopIdSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupTrapRouteEntry(gVrfName, swss_ipv4_route_prefix);
-
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, kNexthopId2);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid2);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr.value.oid = kNexthopOid2;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_FORWARD;
-
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2),
-      &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(
-    RouteManagerTest,
-    UpdateRouteFromTrapToNexthopIdAndMetadataRecoverFailureShouldRaiseCriticalState) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupTrapRouteEntry(gVrfName, swss_ipv4_route_prefix);
-
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopIdAndMetadata,
-                                          kNexthopId2, kMetadata1);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid2);
-  std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
-  std::vector<sai_status_t> exp_success_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
-                                          exp_success_status.end()),
-                      Return(SAI_STATUS_SUCCESS)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
-                                          exp_success_status.end()),
-                      Return(SAI_STATUS_SUCCESS)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
-                                          exp_failure_status.end()),
-                      Return(SAI_STATUS_FAILURE)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
-                                          exp_success_status.end()),
-                      Return(SAI_STATUS_SUCCESS)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
-                                          exp_success_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-
-  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
-                                          exp_success_status.end()),
-                      Return(SAI_STATUS_SUCCESS)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
-                                          exp_success_status.end()),
-                      Return(SAI_STATUS_SUCCESS)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
-                                          exp_failure_status.end()),
-                      Return(SAI_STATUS_FAILURE)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
-                                          exp_success_status.end()),
-                      Return(SAI_STATUS_SUCCESS)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
-                                          exp_failure_status.end()),
-                      Return(SAI_STATUS_FAILURE)));
-  // TODO: Expect critical state.
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(RouteManagerTest, UpdateRouteWithDifferentWcmpGroupsSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupWcmpGroupRouteEntry(gVrfName, swss_ipv4_route_prefix, kWcmpGroup1,
-                           kWcmpGroupOid1);
-
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetWcmpGroupId, kWcmpGroup2);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-      kWcmpGroupOid2);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr.value.oid = kWcmpGroupOid2;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  route_entry.action = p4orch::kSetWcmpGroupId;
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(kWcmpGroup2), &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateNexthopIdRouteWithNoChangeSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, kNexthopId1);
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(
-    RouteManagerTest,
-    UpdateRouteFromNexthopIdAndMetadataToDropRecoverFailureShouldRaiseCriticalState) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1, kMetadata2);
-
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-
-  std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
-  std::vector<sai_status_t> exp_success_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
-                                          exp_failure_status.end()),
-                      Return(SAI_STATUS_FAILURE)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-
-  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
-                                          exp_success_status.end()),
-                      Return(SAI_STATUS_SUCCESS)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
-                                          exp_success_status.end()),
-                      Return(SAI_STATUS_SUCCESS)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
-                                          exp_failure_status.end()),
-                      Return(SAI_STATUS_FAILURE)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
-                                          exp_success_status.end()),
-                      Return(SAI_STATUS_SUCCESS)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
-                                          exp_failure_status.end()),
-                      Return(SAI_STATUS_FAILURE)));
-  // TODO: Expect critical state.
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(
-    RouteManagerTest,
-    UpdateRouteFromDifferentNexthopIdAndMetadataRecoverFailureShouldRaiseCriticalState) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1, kMetadata1);
-
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopIdAndMetadata,
-                                          kNexthopId2, kMetadata2);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid2);
-
-  std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
-  std::vector<sai_status_t> exp_success_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
-                                          exp_failure_status.end()),
-                      Return(SAI_STATUS_FAILURE)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-
-  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
-                                          exp_success_status.end()),
-                      Return(SAI_STATUS_SUCCESS)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
-                                          exp_failure_status.end()),
-                      Return(SAI_STATUS_FAILURE)))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
-                                          exp_failure_status.end()),
-                      Return(SAI_STATUS_FAILURE)));
-  // TODO: Expect critical state.
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(RouteManagerTest, DeleteRouteEntryWithSaiErrorShouldFail) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE};
-  EXPECT_CALL(mock_sai_route_, remove_route_entries(_, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_FAILURE)));
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "");
-  EXPECT_THAT(DeleteRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(RouteManagerTest, DeleteIpv4RouteSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(
-      mock_sai_route_,
-      remove_route_entries(Eq(1),
-                           RouteEntryArrayEq(std::vector<sai_route_entry_t>{
-                               exp_sai_route_entry}),
-                           Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "");
-  EXPECT_THAT(DeleteRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  auto* route_entry_ptr = GetRouteEntry(route_entry.route_entry_key);
-  EXPECT_EQ(nullptr, route_entry_ptr);
-  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY,
-                                        route_entry.route_entry_key));
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, DeleteIpv6RouteSucceeds) {
-  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-  sai_ip_prefix_t sai_ipv6_route_prefix;
-  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-  SetupWcmpGroupRouteEntry(gVrfName, swss_ipv6_route_prefix, kWcmpGroup1,
-                           kWcmpGroupOid1);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVrfOid;
-  exp_sai_route_entry.destination = sai_ipv6_route_prefix;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(
-      mock_sai_route_,
-      remove_route_entries(Eq(1),
-                           RouteEntryArrayEq(std::vector<sai_route_entry_t>{
-                               exp_sai_route_entry}),
-                           Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, "", "");
-  EXPECT_THAT(DeleteRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-  auto* route_entry_ptr = GetRouteEntry(route_entry.route_entry_key);
-  EXPECT_EQ(nullptr, route_entry_ptr);
-  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY,
-                                        route_entry.route_entry_key));
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, RouteCreateAndUpdateInDrainSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP,
-                        KeyGenerator::generateNextHopKey(kNexthopId1),
-                        kNexthopOid1);
-  auto key_op_fvs_1 = GenerateKeyOpFieldsValuesTuple(
-      gVrfName, swss_ipv4_route_prefix, SET_COMMAND, p4orch::kSetNexthopId,
-      kNexthopId1);
-  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_1);
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_CALL(publisher_,
-              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_1)),
-                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_1)),
-                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
-      .Times(1);
-  Drain();
-
-  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP,
-                        KeyGenerator::generateNextHopKey(kNexthopId2),
-                        kNexthopOid2);
-  auto key_op_fvs_2 = GenerateKeyOpFieldsValuesTuple(
-      gVrfName, swss_ipv4_route_prefix, SET_COMMAND, p4orch::kSetNexthopId,
-      kNexthopId2);
-  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_2);
-  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_CALL(publisher_,
-              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_2)),
-                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_2)),
-                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
-      .Times(1);
-  Drain();
-
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, kNexthopId2);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2),
-      &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-
-  auto key_op_fvs_3 = GenerateKeyOpFieldsValuesTuple(
-      gVrfName, swss_ipv4_route_prefix, SET_COMMAND,
-      p4orch::kSetMetadataAndDrop, "", kMetadata1);
-  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_3);
-  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-      .WillRepeatedly(
-          DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                Return(SAI_STATUS_SUCCESS)));
-  EXPECT_CALL(publisher_,
-              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_3)),
-                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_3)),
-                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
-      .Times(1);
-  Drain();
-
-  route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                           p4orch::kSetMetadataAndDrop, "", kMetadata1);
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2),
-      &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, RouteCreateAndDeleteInDrainSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP,
-                        KeyGenerator::generateNextHopKey(kNexthopId1),
-                        kNexthopOid1);
-  auto key_op_fvs_1 = GenerateKeyOpFieldsValuesTuple(
-      gVrfName, swss_ipv4_route_prefix, SET_COMMAND, p4orch::kSetNexthopId,
-      kNexthopId1);
-  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_1);
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_CALL(publisher_,
-              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_1)),
-                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_1)),
-                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
-      .Times(1);
-  Drain();
-
-  auto key_op_fvs_2 = GenerateKeyOpFieldsValuesTuple(
-      gVrfName, swss_ipv4_route_prefix, DEL_COMMAND, "", "");
-  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_2);
-  EXPECT_CALL(mock_sai_route_, remove_route_entries(_, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_CALL(publisher_,
-              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_2)),
-                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_2)),
-                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
-      .Times(1);
-  Drain();
-
-  std::string key =
-      KeyGenerator::generateRouteKey(gVrfName, swss_ipv4_route_prefix);
-  auto* route_entry_ptr = GetRouteEntry(key);
-  EXPECT_EQ(nullptr, route_entry_ptr);
-  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, key));
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateFailsWhenCreateAndUpdateTheSameRouteInDrain) {
-  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP,
-                        KeyGenerator::generateNextHopKey(kNexthopId1),
-                        kNexthopOid1);
-  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP,
-                        KeyGenerator::generateNextHopKey(kNexthopId2),
-                        kNexthopOid2);
-  auto key_op_fvs_1 = GenerateKeyOpFieldsValuesTuple(
-      gVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND, p4orch::kSetNexthopId,
-      kNexthopId1);
-  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_1);
-  auto key_op_fvs_2 = GenerateKeyOpFieldsValuesTuple(
-      gVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND, p4orch::kSetNexthopId,
-      kNexthopId2);
-  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_2);
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_CALL(publisher_,
-              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_1)),
-                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_1)),
-                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
-      .Times(1);
-  EXPECT_CALL(publisher_,
-              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_2)),
-                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_2)),
-                      Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)))
-      .Times(1);
-
-  Drain();
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, kNexthopId1);
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2),
-      &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, DeleteFailsWhenCreateAndDeleteTheSameRouteInDrain) {
-  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP,
-                        KeyGenerator::generateNextHopKey(kNexthopId1),
-                        kNexthopOid1);
-  auto key_op_fvs_1 = GenerateKeyOpFieldsValuesTuple(
-      gVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND, p4orch::kSetNexthopId,
-      kNexthopId1);
-  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_1);
-  auto key_op_fvs_2 = GenerateKeyOpFieldsValuesTuple(
-      gVrfName, swss::IpPrefix(kIpv4Prefix), DEL_COMMAND, "", "");
-  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_2);
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_CALL(publisher_,
-              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_1)),
-                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_1)),
-                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
-      .Times(1);
-  EXPECT_CALL(publisher_,
-              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_2)),
-                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_2)),
-                      Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)))
-      .Times(1);
-  Drain();
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, kNexthopId1);
-  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, RouteCreateInDrainSucceedsWhenVrfIsEmpty) {
-  const std::string kDefaultVrfName = "";  // Default Vrf
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP,
-                        KeyGenerator::generateNextHopKey(kNexthopId1),
-                        kNexthopOid1);
-  auto key_op_fvs = GenerateKeyOpFieldsValuesTuple(
-      kDefaultVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND,
-      p4orch::kSetNexthopId, kNexthopId1);
-  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
-
-  sai_route_entry_t exp_sai_route_entry;
-  exp_sai_route_entry.switch_id = gSwitchId;
-  exp_sai_route_entry.vr_id = gVirtualRouterId;
-  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr;
-  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr.value.oid = kNexthopOid1;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              create_route_entries(
-                  Eq(1),
-                  RouteEntryArrayEq(
-                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                  ArrayEq(std::vector<uint32_t>{1}),
-                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                      {exp_sai_attr}}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_CALL(publisher_,
-              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
-                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
-                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
-      .Times(1);
-
-  Drain();
-  std::string key = KeyGenerator::generateRouteKey(kDefaultVrfName,
-                                                   swss::IpPrefix(kIpv4Prefix));
-  auto* route_entry_ptr = GetRouteEntry(key);
-  EXPECT_NE(nullptr, route_entry_ptr);
-  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, key));
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, DeserializeRouteEntryInDrainFails) {
-  const std::string kKeyPrefix =
-      std::string(APP_P4RT_IPV4_TABLE_NAME) + kTableKeyDelimiter;
-  auto key_op_fvs =
-      swss::KeyOpFieldsValuesTuple(kKeyPrefix + "{{{{{{{{{{{{", SET_COMMAND,
-                                   std::vector<swss::FieldValueTuple>{});
-  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
-  EXPECT_CALL(publisher_,
-              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
-                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
-                      Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)))
-      .Times(1);
-  Drain();
-}
-
-TEST_F(RouteManagerTest, ValidateRouteEntryInDrainFailsWhenVrfDoesNotExist) {
-  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP,
-                        KeyGenerator::generateNextHopKey(kNexthopId1),
-                        kNexthopOid1);
-  auto key_op_fvs = GenerateKeyOpFieldsValuesTuple(
-      "Invalid-Vrf", swss::IpPrefix(kIpv4Prefix), SET_COMMAND,
-      p4orch::kSetNexthopId, kNexthopId1);
-  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
-  EXPECT_CALL(publisher_,
-              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
-                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
-                      Eq(StatusCode::SWSS_RC_NOT_FOUND), Eq(true)))
-      .Times(1);
-  Drain();
-}
-
-TEST_F(RouteManagerTest,
-       ValidateRouteEntryInDrainFailsWhenNexthopDoesNotExist) {
-  auto key_op_fvs = GenerateKeyOpFieldsValuesTuple(
-      gVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND, p4orch::kSetNexthopId,
-      kNexthopId1);
-  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
-  EXPECT_CALL(publisher_,
-              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
-                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
-                      Eq(StatusCode::SWSS_RC_NOT_FOUND), Eq(true)))
-      .Times(1);
-  Drain();
-}
-
-TEST_F(RouteManagerTest, InvalidateSetRouteEntryInDrainFails) {
-  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP,
-                        KeyGenerator::generateNextHopKey(kNexthopId1),
-                        kNexthopOid1);
-  // No nexthop ID with kSetNexthopId action.
-  auto key_op_fvs =
-      GenerateKeyOpFieldsValuesTuple(gVrfName, swss::IpPrefix(kIpv4Prefix),
-                                     SET_COMMAND, p4orch::kSetNexthopId, "");
-  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
-  EXPECT_CALL(publisher_,
-              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
-                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
-                      Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)))
-      .Times(1);
-  Drain();
-}
-
-TEST_F(RouteManagerTest, InvalidateDelRouteEntryInDrainFails) {
-  // Route does not exist.
-  auto key_op_fvs = GenerateKeyOpFieldsValuesTuple(
-      gVrfName, swss::IpPrefix(kIpv4Prefix), DEL_COMMAND, p4orch::kSetNexthopId,
-      kNexthopId1);
-  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
-  EXPECT_CALL(publisher_,
-              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
-                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
-                      Eq(StatusCode::SWSS_RC_NOT_FOUND), Eq(true)))
-      .Times(1);
-  Drain();
-}
-
-TEST_F(RouteManagerTest, InvalidCommandInDrainFails) {
-  const std::string kKeyPrefix =
-      std::string(APP_P4RT_IPV4_TABLE_NAME) + kTableKeyDelimiter;
-  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP,
-                        KeyGenerator::generateNextHopKey(kNexthopId1),
-                        kNexthopOid1);
-  nlohmann::json j;
-  j[prependMatchField(p4orch::kVrfId)] = gVrfName;
-  j[prependMatchField(p4orch::kIpv4Dst)] = kIpv4Prefix;
-  std::vector<swss::FieldValueTuple> attributes;
-  attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
-  attributes.push_back(swss::FieldValueTuple{
-      prependParamField(p4orch::kNexthopId), kNexthopId1});
-  auto key_op_fvs = swss::KeyOpFieldsValuesTuple(kKeyPrefix + j.dump(),
-                                                 "INVALID_COMMAND", attributes);
-  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
-  EXPECT_CALL(publisher_,
-              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
-                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
-                      Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)))
-      .Times(1);
-  Drain();
-}
-
-TEST_F(RouteManagerTest, BatchedCreateSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  auto route_entry_ipv4 = GenerateP4RouteEntry(
-      gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry_ipv4.nexthop_id),
-      kNexthopOid1);
-
-  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-  sai_ip_prefix_t sai_ipv6_route_prefix;
-  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-  auto route_entry_ipv6 = GenerateP4RouteEntry(
-      gVrfName, swss_ipv6_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(route_entry_ipv6.wcmp_group),
-      kWcmpGroupOid1);
-
-  sai_route_entry_t exp_sai_route_entry_ipv4;
-  exp_sai_route_entry_ipv4.switch_id = gSwitchId;
-  exp_sai_route_entry_ipv4.vr_id = gVrfOid;
-  exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr_ipv4;
-  exp_sai_attr_ipv4.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr_ipv4.value.oid = kNexthopOid1;
-
-  sai_route_entry_t exp_sai_route_entry_ipv6;
-  exp_sai_route_entry_ipv6.switch_id = gSwitchId;
-  exp_sai_route_entry_ipv6.vr_id = gVrfOid;
-  exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
-
-  sai_attribute_t exp_sai_attr_ipv6;
-  exp_sai_attr_ipv6.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr_ipv6.value.oid = kWcmpGroupOid1;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              create_route_entries(
-                  Eq(2),
-                  RouteEntryArrayEq(std::vector<sai_route_entry_t>{
-                      exp_sai_route_entry_ipv4, exp_sai_route_entry_ipv6}),
-                  ArrayEq(std::vector<uint32_t>{1, 1}),
-                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                      {exp_sai_attr_ipv4}, {exp_sai_attr_ipv6}}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4,
-                                                           route_entry_ipv6}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS,
-                                              StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry_ipv4, sai_ipv4_route_prefix, gVrfOid);
-  VerifyRouteEntry(route_entry_ipv6, sai_ipv6_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, BatchedCreatePartiallySucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  auto route_entry_ipv4 = GenerateP4RouteEntry(
-      gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP,
-      KeyGenerator::generateNextHopKey(route_entry_ipv4.nexthop_id),
-      kNexthopOid1);
-
-  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-  sai_ip_prefix_t sai_ipv6_route_prefix;
-  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-  auto route_entry_ipv6 = GenerateP4RouteEntry(
-      gVrfName, swss_ipv6_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
-  p4_oid_mapper_.setOID(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(route_entry_ipv6.wcmp_group),
-      kWcmpGroupOid1);
-
-  sai_route_entry_t exp_sai_route_entry_ipv4;
-  exp_sai_route_entry_ipv4.switch_id = gSwitchId;
-  exp_sai_route_entry_ipv4.vr_id = gVrfOid;
-  exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr_ipv4;
-  exp_sai_attr_ipv4.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr_ipv4.value.oid = kNexthopOid1;
-
-  sai_route_entry_t exp_sai_route_entry_ipv6;
-  exp_sai_route_entry_ipv6.switch_id = gSwitchId;
-  exp_sai_route_entry_ipv6.vr_id = gVrfOid;
-  exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
-
-  sai_attribute_t exp_sai_attr_ipv6;
-  exp_sai_attr_ipv6.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr_ipv6.value.oid = kWcmpGroupOid1;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS, SAI_STATUS_FAILURE};
-  EXPECT_CALL(mock_sai_route_,
-              create_route_entries(
-                  Eq(2),
-                  RouteEntryArrayEq(std::vector<sai_route_entry_t>{
-                      exp_sai_route_entry_ipv4, exp_sai_route_entry_ipv6}),
-                  ArrayEq(std::vector<uint32_t>{1, 1}),
-                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                      {exp_sai_attr_ipv4}, {exp_sai_attr_ipv6}}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_FAILURE)));
-  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4,
-                                                           route_entry_ipv6}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS,
-                                              StatusCode::SWSS_RC_UNKNOWN}));
-  VerifyRouteEntry(route_entry_ipv4, sai_ipv4_route_prefix, gVrfOid);
-  auto* route_entry_ptr_ipv6 = GetRouteEntry(route_entry_ipv6.route_entry_key);
-  EXPECT_EQ(nullptr, route_entry_ptr_ipv6);
-  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY,
-                                        route_entry_ipv6.route_entry_key));
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, BatchedUpdateSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  auto route_entry_ipv4 = GenerateP4RouteEntry(
-      gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                        KeyGenerator::generateWcmpGroupKey(kWcmpGroup1),
-                        kWcmpGroupOid1);
-
-  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-  sai_ip_prefix_t sai_ipv6_route_prefix;
-  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-  auto route_entry_ipv6 = GenerateP4RouteEntry(
-      gVrfName, swss_ipv6_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup2);
-  SetupDropRouteEntry(gVrfName, swss_ipv6_route_prefix);
-  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                        KeyGenerator::generateWcmpGroupKey(kWcmpGroup2),
-                        kWcmpGroupOid2);
-
-  sai_route_entry_t exp_sai_route_entry_ipv4;
-  exp_sai_route_entry_ipv4.switch_id = gSwitchId;
-  exp_sai_route_entry_ipv4.vr_id = gVrfOid;
-  exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr_ipv4;
-  exp_sai_attr_ipv4.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr_ipv4.value.oid = kWcmpGroupOid1;
-
-  sai_route_entry_t exp_sai_route_entry_ipv6;
-  exp_sai_route_entry_ipv6.switch_id = gSwitchId;
-  exp_sai_route_entry_ipv6.vr_id = gVrfOid;
-  exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
-
-  sai_attribute_t exp_sai_attr_ipv6;
-  exp_sai_attr_ipv6.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr_ipv6.value.oid = kWcmpGroupOid2;
-
-  std::vector<sai_status_t> exp_status_1{SAI_STATUS_SUCCESS,
-                                         SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(2),
-                  RouteEntryArrayEq(std::vector<sai_route_entry_t>{
-                      exp_sai_route_entry_ipv4, exp_sai_route_entry_ipv6}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr_ipv4,
-                                                           exp_sai_attr_ipv6}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(
-          DoAll(SetArrayArgument<4>(exp_status_1.begin(), exp_status_1.end()),
-                Return(SAI_STATUS_SUCCESS)));
-
-  sai_attribute_t exp_sai_attr_ipv6_2;
-  exp_sai_attr_ipv6_2.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-  exp_sai_attr_ipv6_2.value.s32 = SAI_PACKET_ACTION_FORWARD;
-
-  std::vector<sai_status_t> exp_status_2{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(
-      mock_sai_route_,
-      set_route_entries_attribute(
-          Eq(1),
-          RouteEntryArrayEq(
-              std::vector<sai_route_entry_t>{exp_sai_route_entry_ipv6}),
-          AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr_ipv6_2}),
-          Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(
-          DoAll(SetArrayArgument<4>(exp_status_2.begin(), exp_status_2.end()),
-                Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4,
-                                                           route_entry_ipv6}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS,
-                                              StatusCode::SWSS_RC_SUCCESS}));
-  VerifyRouteEntry(route_entry_ipv4, sai_ipv4_route_prefix, gVrfOid);
-  VerifyRouteEntry(route_entry_ipv6, sai_ipv6_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(kWcmpGroup2), &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, BatchedUpdatePartiallySucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  auto route_entry_ipv4 = GenerateP4RouteEntry(
-      gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                        KeyGenerator::generateWcmpGroupKey(kWcmpGroup1),
-                        kWcmpGroupOid1);
-
-  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-  sai_ip_prefix_t sai_ipv6_route_prefix;
-  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-  auto route_entry_ipv6 = GenerateP4RouteEntry(
-      gVrfName, swss_ipv6_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup2);
-  SetupDropRouteEntry(gVrfName, swss_ipv6_route_prefix);
-  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                        KeyGenerator::generateWcmpGroupKey(kWcmpGroup2),
-                        kWcmpGroupOid2);
-
-  sai_route_entry_t exp_sai_route_entry_ipv4;
-  exp_sai_route_entry_ipv4.switch_id = gSwitchId;
-  exp_sai_route_entry_ipv4.vr_id = gVrfOid;
-  exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
-
-  sai_attribute_t exp_sai_attr_ipv4;
-  exp_sai_attr_ipv4.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr_ipv4.value.oid = kWcmpGroupOid1;
-
-  sai_route_entry_t exp_sai_route_entry_ipv6;
-  exp_sai_route_entry_ipv6.switch_id = gSwitchId;
-  exp_sai_route_entry_ipv6.vr_id = gVrfOid;
-  exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
-
-  sai_attribute_t exp_sai_attr_ipv6;
-  exp_sai_attr_ipv6.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-  exp_sai_attr_ipv6.value.oid = kWcmpGroupOid2;
-
-  std::vector<sai_status_t> exp_status_1{SAI_STATUS_SUCCESS,
-                                         SAI_STATUS_FAILURE};
-  EXPECT_CALL(mock_sai_route_,
-              set_route_entries_attribute(
-                  Eq(2),
-                  RouteEntryArrayEq(std::vector<sai_route_entry_t>{
-                      exp_sai_route_entry_ipv4, exp_sai_route_entry_ipv6}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr_ipv4,
-                                                           exp_sai_attr_ipv6}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(
-          DoAll(SetArrayArgument<4>(exp_status_1.begin(), exp_status_1.end()),
-                Return(SAI_STATUS_FAILURE)));
-  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4,
-                                                           route_entry_ipv6}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS,
-                                              StatusCode::SWSS_RC_UNKNOWN}));
-  VerifyRouteEntry(route_entry_ipv4, sai_ipv4_route_prefix, gVrfOid);
-  route_entry_ipv6 =
-      GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kDrop, "");
-  VerifyRouteEntry(route_entry_ipv6, sai_ipv6_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-  EXPECT_EQ(1, ref_cnt);
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-      KeyGenerator::generateWcmpGroupKey(kWcmpGroup2), &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, BatchedDeleteSucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  auto route_entry_ipv4 = GenerateP4RouteEntry(
-      gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-
-  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-  sai_ip_prefix_t sai_ipv6_route_prefix;
-  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-  auto route_entry_ipv6 =
-      GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kDrop, "");
-  SetupDropRouteEntry(gVrfName, swss_ipv6_route_prefix);
-
-  sai_route_entry_t exp_sai_route_entry_ipv4;
-  exp_sai_route_entry_ipv4.switch_id = gSwitchId;
-  exp_sai_route_entry_ipv4.vr_id = gVrfOid;
-  exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
-
-  sai_route_entry_t exp_sai_route_entry_ipv6;
-  exp_sai_route_entry_ipv6.switch_id = gSwitchId;
-  exp_sai_route_entry_ipv6.vr_id = gVrfOid;
-  exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_,
-              remove_route_entries(
-                  Eq(2),
-                  RouteEntryArrayEq(std::vector<sai_route_entry_t>{
-                      exp_sai_route_entry_ipv4, exp_sai_route_entry_ipv6}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(DeleteRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4,
-                                                           route_entry_ipv6}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS,
-                                              StatusCode::SWSS_RC_SUCCESS}));
-  auto* route_entry_ptr_ipv4 = GetRouteEntry(route_entry_ipv4.route_entry_key);
-  EXPECT_EQ(nullptr, route_entry_ptr_ipv4);
-  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY,
-                                        route_entry_ipv4.route_entry_key));
-  auto* route_entry_ptr_ipv6 = GetRouteEntry(route_entry_ipv6.route_entry_key);
-  EXPECT_EQ(nullptr, route_entry_ptr_ipv6);
-  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY,
-                                        route_entry_ipv6.route_entry_key));
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, BatchedDeletePartiallySucceeds) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  sai_ip_prefix_t sai_ipv4_route_prefix;
-  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-  auto route_entry_ipv4 = GenerateP4RouteEntry(
-      gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-
-  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-  sai_ip_prefix_t sai_ipv6_route_prefix;
-  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-  auto route_entry_ipv6 =
-      GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kDrop, "");
-  SetupDropRouteEntry(gVrfName, swss_ipv6_route_prefix);
-
-  sai_route_entry_t exp_sai_route_entry_ipv4;
-  exp_sai_route_entry_ipv4.switch_id = gSwitchId;
-  exp_sai_route_entry_ipv4.vr_id = gVrfOid;
-  exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
-
-  sai_route_entry_t exp_sai_route_entry_ipv6;
-  exp_sai_route_entry_ipv6.switch_id = gSwitchId;
-  exp_sai_route_entry_ipv6.vr_id = gVrfOid;
-  exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS, SAI_STATUS_FAILURE};
-  EXPECT_CALL(mock_sai_route_,
-              remove_route_entries(
-                  Eq(2),
-                  RouteEntryArrayEq(std::vector<sai_route_entry_t>{
-                      exp_sai_route_entry_ipv4, exp_sai_route_entry_ipv6}),
-                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-      .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_FAILURE)));
-  EXPECT_THAT(DeleteRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4,
-                                                           route_entry_ipv6}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS,
-                                              StatusCode::SWSS_RC_UNKNOWN}));
-  auto* route_entry_ptr_ipv4 = GetRouteEntry(route_entry_ipv4.route_entry_key);
-  EXPECT_EQ(nullptr, route_entry_ptr_ipv4);
-  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY,
-                                        route_entry_ipv4.route_entry_key));
-  VerifyRouteEntry(route_entry_ipv6, sai_ipv6_route_prefix, gVrfOid);
-  uint32_t ref_cnt;
-  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
-      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
-      &ref_cnt));
-  EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, VerifyStateTest) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
-                           kNexthopOid1);
-  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
-                                          p4orch::kSetNexthopId, kNexthopId1);
-
-  // Setup ASIC DB.
-  swss::Table table(nullptr, "ASIC_STATE");
-  table.set(
-      "SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.11.12.0/"
-      "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
-      std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{
-          "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x1"}});
-
-  nlohmann::json j;
-  j[prependMatchField(p4orch::kVrfId)] = gVrfName;
-  j[prependMatchField(p4orch::kIpv4Dst)] = kIpv4Prefix;
-  const std::string db_key = std::string(APP_P4RT_TABLE_NAME) +
-                             kTableKeyDelimiter + APP_P4RT_IPV4_TABLE_NAME +
-                             kTableKeyDelimiter + j.dump();
-  std::vector<swss::FieldValueTuple> attributes;
-
-  // Verification should succeed with vaild key and value.
-  attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
-  attributes.push_back(swss::FieldValueTuple{
-      prependParamField(p4orch::kNexthopId), kNexthopId1});
-  EXPECT_EQ(VerifyState(db_key, attributes), "");
-
-  // TODO: Expect critical state.
-
-  // Invalid key should fail verification.
-  EXPECT_FALSE(VerifyState("invalid", attributes).empty());
-  EXPECT_FALSE(VerifyState("invalid:invalid", attributes).empty());
-  EXPECT_FALSE(
-      VerifyState(std::string(APP_P4RT_TABLE_NAME) + ":invalid", attributes)
-          .empty());
-  EXPECT_FALSE(
-      VerifyState(std::string(APP_P4RT_TABLE_NAME) + ":invalid:invalid",
-                  attributes)
-          .empty());
-  EXPECT_FALSE(VerifyState(std::string(APP_P4RT_TABLE_NAME) +
-                               ":FIXED_IPV4_TABLE:invalid",
-                           attributes)
-                   .empty());
-
-  // Verification should fail if nexthop ID does not exist.
-  attributes.clear();
-  attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
-  attributes.push_back(swss::FieldValueTuple{
-      prependParamField(p4orch::kNexthopId), kNexthopId2});
-  EXPECT_FALSE(VerifyState(db_key, attributes).empty());
-  attributes.clear();
-  attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
-  attributes.push_back(swss::FieldValueTuple{
-      prependParamField(p4orch::kNexthopId), kNexthopId1});
-
-  // Verification should fail if entry does not exist.
-  j[prependMatchField(p4orch::kIpv4Dst)] = "1.1.1.0/24";
-  EXPECT_FALSE(VerifyState(std::string(APP_P4RT_TABLE_NAME) +
-                               kTableKeyDelimiter + APP_P4RT_IPV4_TABLE_NAME +
-                               kTableKeyDelimiter + j.dump(),
-                           attributes)
-                   .empty());
-
-  auto* route_entry_ptr = GetRouteEntry(
-      KeyGenerator::generateRouteKey(gVrfName, swss_ipv4_route_prefix));
-  EXPECT_NE(route_entry_ptr, nullptr);
-
-  // Verification should fail if route entry key mismatches.
-  auto saved_route_entry_key = route_entry_ptr->route_entry_key;
-  route_entry_ptr->route_entry_key = "invalid";
-  EXPECT_FALSE(VerifyState(db_key, attributes).empty());
-  route_entry_ptr->route_entry_key = saved_route_entry_key;
-
-  // Verification should fail if VRF ID mismatches.
-  auto saved_vrf_id = route_entry_ptr->vrf_id;
-  route_entry_ptr->vrf_id = "invalid";
-  EXPECT_FALSE(VerifyState(db_key, attributes).empty());
-  route_entry_ptr->vrf_id = saved_vrf_id;
-
-  // Verification should fail if route prefix mismatches.
-  auto saved_route_prefix = route_entry_ptr->route_prefix;
-  route_entry_ptr->route_prefix = swss::IpPrefix(kIpv6Prefix);
-  EXPECT_FALSE(VerifyState(db_key, attributes).empty());
-  route_entry_ptr->route_prefix = saved_route_prefix;
-
-  // Verification should fail if action mismatches.
-  auto saved_action = route_entry_ptr->action;
-  route_entry_ptr->action = p4orch::kSetWcmpGroupId;
-  EXPECT_FALSE(VerifyState(db_key, attributes).empty());
-  route_entry_ptr->action = saved_action;
-
-  // Verification should fail if nexthop ID mismatches.
-  auto saved_nexthop_id = route_entry_ptr->nexthop_id;
-  route_entry_ptr->nexthop_id = kNexthopId2;
-  EXPECT_FALSE(VerifyState(db_key, attributes).empty());
-  route_entry_ptr->nexthop_id = saved_nexthop_id;
-
-  // Verification should fail if WCMP group mismatches.
-  auto saved_wcmp_group = route_entry_ptr->wcmp_group;
-  route_entry_ptr->wcmp_group = kWcmpGroup1;
-  EXPECT_FALSE(VerifyState(db_key, attributes).empty());
-  route_entry_ptr->wcmp_group = saved_wcmp_group;
-
-  // Verification should fail if WCMP group mismatches.
-  auto saved_route_metadata = route_entry_ptr->route_metadata;
-  route_entry_ptr->route_metadata = kMetadata1;
-  EXPECT_FALSE(VerifyState(db_key, attributes).empty());
-  route_entry_ptr->route_metadata = saved_route_metadata;
-}
-
-TEST_F(RouteManagerTest, VerifyStateAsicDbTest) {
-  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-  SetupDropRouteEntry(gVrfName, swss_ipv4_route_prefix);
-  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-  SetupNexthopIdRouteEntry(gVrfName, swss_ipv6_route_prefix, kNexthopId1,
-                           kNexthopOid1, kMetadata1);
-
-  auto swss_ipv4_route_prefix2 = swss::IpPrefix(kIpv4Prefix2);
-  auto route_entry =
-      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix2,
-                           p4orch::kSetMetadataAndDrop, "", kMetadata2);
-
-  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-  EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
-      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-
-  // Setup ASIC DB.
-  swss::Table table(nullptr, "ASIC_STATE");
-  table.set(
-      "SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.11.12.0/"
-      "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
-      std::vector<swss::FieldValueTuple>{
-          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION",
-                                "SAI_PACKET_ACTION_DROP"},
-          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID",
-                                "oid:0x0"}});
-  table.set(
-      "SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"2001:db8:1::/"
-      "32\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
-      std::vector<swss::FieldValueTuple>{
-          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x1"},
-          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_META_DATA", "1"}});
-
-  table.set(
-      "SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.12.12.0/"
-      "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
-      std::vector<swss::FieldValueTuple>{
-          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION",
-                                "SAI_PACKET_ACTION_DROP"},
-          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_META_DATA", "2"}});
-
-  nlohmann::json j_1;
-  j_1[prependMatchField(p4orch::kVrfId)] = gVrfName;
-  j_1[prependMatchField(p4orch::kIpv4Dst)] = kIpv4Prefix;
-  const std::string db_key_1 = std::string(APP_P4RT_TABLE_NAME) +
-                               kTableKeyDelimiter + APP_P4RT_IPV4_TABLE_NAME +
-                               kTableKeyDelimiter + j_1.dump();
-  std::vector<swss::FieldValueTuple> attributes_1;
-  attributes_1.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
-  nlohmann::json j_2;
-  j_2[prependMatchField(p4orch::kVrfId)] = gVrfName;
-  j_2[prependMatchField(p4orch::kIpv6Dst)] = kIpv6Prefix;
-  const std::string db_key_2 = std::string(APP_P4RT_TABLE_NAME) +
-                               kTableKeyDelimiter + APP_P4RT_IPV6_TABLE_NAME +
-                               kTableKeyDelimiter + j_2.dump();
-  std::vector<swss::FieldValueTuple> attributes_2;
-  attributes_2.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopIdAndMetadata});
-  attributes_2.push_back(swss::FieldValueTuple{
-      prependParamField(p4orch::kNexthopId), kNexthopId1});
-  attributes_2.push_back(swss::FieldValueTuple{
-      prependParamField(p4orch::kRouteMetadata), kMetadata1});
-
-  nlohmann::json j_3;
-  j_3[prependMatchField(p4orch::kVrfId)] = gVrfName;
-  j_3[prependMatchField(p4orch::kIpv6Dst)] = kIpv4Prefix2;
-  const std::string db_key_3 = std::string(APP_P4RT_TABLE_NAME) +
-                               kTableKeyDelimiter + APP_P4RT_IPV6_TABLE_NAME +
-                               kTableKeyDelimiter + j_3.dump();
-  std::vector<swss::FieldValueTuple> attributes_3;
-  attributes_3.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMetadataAndDrop});
-  attributes_3.push_back(swss::FieldValueTuple{
-      prependParamField(p4orch::kRouteMetadata), kMetadata2});
-
-  // Verification should succeed with correct ASIC DB values.
-  EXPECT_EQ(VerifyState(db_key_1, attributes_1), "");
-  EXPECT_EQ(VerifyState(db_key_2, attributes_2), "");
-  EXPECT_EQ(VerifyState(db_key_3, attributes_3), "");
-
-  // Verification should fail if ASIC DB values mismatch.
-  table.set(
-      "SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.11.12.0/"
-      "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
-      std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{
-          "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_FORWARD"}});
-  table.set(
-      "SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"2001:db8:1::/"
-      "32\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
-      std::vector<swss::FieldValueTuple>{
-          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_META_DATA", "2"}});
-  EXPECT_FALSE(VerifyState(db_key_1, attributes_1).empty());
-  EXPECT_FALSE(VerifyState(db_key_2, attributes_2).empty());
-
-  // Verification should fail if ASIC DB table is missing.
-  table.del(
-      "SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.11.12.0/"
-      "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}");
-  table.del(
-      "SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"2001:db8:1::/"
-      "32\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}");
-  EXPECT_FALSE(VerifyState(db_key_1, attributes_1).empty());
-  EXPECT_FALSE(VerifyState(db_key_2, attributes_2).empty());
-  table.set(
-      "SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.11.12.0/"
-      "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
-      std::vector<swss::FieldValueTuple>{
-          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION",
-                                "SAI_PACKET_ACTION_DROP"},
-          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID",
-                                "oid:0x0"}});
-  table.set(
-      "SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"2001:db8:1::/"
-      "32\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
-      std::vector<swss::FieldValueTuple>{
-          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x1"},
-          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_META_DATA", "1"}});
+TEST_F(RouteManagerTest, MergeRouteEntryWithNexthopIdActionDestTest)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto dest = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+    dest.sai_route_entry.vr_id = gVrfOid;
+    dest.sai_route_entry.switch_id = gSwitchId;
+    copy(dest.sai_route_entry.destination, swss_ipv4_route_prefix);
+
+    // Source is identical to destination.
+    auto src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+    P4RouteEntry ret = {};
+    EXPECT_FALSE(MergeRouteEntry(dest, src, &ret));
+    VerifyRouteEntriesEq(dest, ret);
+
+    // Source has different nexthop ID.
+    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId2);
+    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+    P4RouteEntry expect_entry = dest;
+    expect_entry.nexthop_id = kNexthopId2;
+    VerifyRouteEntriesEq(expect_entry, ret);
+
+    // Source has set nexthop ID and metadata action and dest has set nexthop ID
+    // action.
+    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata, kNexthopId1,
+                               kMetadata1);
+    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+    expect_entry = dest;
+    expect_entry.action = p4orch::kSetNexthopIdAndMetadata;
+    expect_entry.route_metadata = kMetadata1;
+    VerifyRouteEntriesEq(expect_entry, ret);
+
+    // Source has wcmp group action and dest has nexhop ID action.
+    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
+    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+    expect_entry = dest;
+    expect_entry.nexthop_id = "";
+    expect_entry.action = p4orch::kSetWcmpGroupId;
+    expect_entry.wcmp_group = kWcmpGroup1;
+    VerifyRouteEntriesEq(expect_entry, ret);
+
+    // Source has drop action and dest has nexhop ID action.
+    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+    expect_entry = dest;
+    expect_entry.nexthop_id = "";
+    expect_entry.action = p4orch::kDrop;
+    VerifyRouteEntriesEq(expect_entry, ret);
+}
+
+TEST_F(RouteManagerTest, MergeRouteEntryWithNexthopIdAndMetadataActionDestTest)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto dest = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata, kNexthopId1,
+                                     kMetadata1);
+    dest.sai_route_entry.vr_id = gVrfOid;
+    dest.sai_route_entry.switch_id = gSwitchId;
+    copy(dest.sai_route_entry.destination, swss_ipv4_route_prefix);
+
+    // Source is identical to destination.
+    auto src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata, kNexthopId1,
+                                    kMetadata1);
+    P4RouteEntry ret = {};
+    EXPECT_FALSE(MergeRouteEntry(dest, src, &ret));
+    VerifyRouteEntriesEq(dest, ret);
+
+    // Source has different metadata.
+    src.route_metadata = kMetadata2;
+    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+    P4RouteEntry expect_entry = dest;
+    expect_entry.route_metadata = kMetadata2;
+    VerifyRouteEntriesEq(expect_entry, ret);
+
+    // Source has different nexthop ID and metadata.
+    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata, kNexthopId2,
+                               kMetadata2);
+    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+    expect_entry = dest;
+    expect_entry.nexthop_id = kNexthopId2;
+    expect_entry.route_metadata = kMetadata2;
+    VerifyRouteEntriesEq(expect_entry, ret);
+
+    // Source has wcmp group action and dest has nexhop ID and metadata action.
+    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
+    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+    expect_entry = dest;
+    expect_entry.nexthop_id = "";
+    expect_entry.action = p4orch::kSetWcmpGroupId;
+    expect_entry.wcmp_group = kWcmpGroup1;
+    expect_entry.route_metadata = "";
+    VerifyRouteEntriesEq(expect_entry, ret);
+
+    // Source has drop action and dest has nexhop ID and metadata action.
+    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+    expect_entry = dest;
+    expect_entry.nexthop_id = "";
+    expect_entry.action = p4orch::kDrop;
+    expect_entry.route_metadata = "";
+    VerifyRouteEntriesEq(expect_entry, ret);
+
+    // Source has wcmp group and metadata action and dest has nexhop ID and
+    // metadata action.
+    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupIdAndMetadata, kWcmpGroup1,
+                               kMetadata2);
+    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+    expect_entry = dest;
+    expect_entry.nexthop_id = "";
+    expect_entry.action = p4orch::kSetWcmpGroupIdAndMetadata;
+    expect_entry.wcmp_group = kWcmpGroup1;
+    expect_entry.route_metadata = kMetadata2;
+    VerifyRouteEntriesEq(expect_entry, ret);
+}
+
+TEST_F(RouteManagerTest, MergeRouteEntryWithWcmpGroupActionDestTest)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto dest = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
+    dest.sai_route_entry.vr_id = gVrfOid;
+    dest.sai_route_entry.switch_id = gSwitchId;
+    copy(dest.sai_route_entry.destination, swss_ipv4_route_prefix);
+
+    // Source is identical to destination.
+    auto src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
+    P4RouteEntry ret = {};
+    EXPECT_FALSE(MergeRouteEntry(dest, src, &ret));
+    VerifyRouteEntriesEq(dest, ret);
+
+    // Source has different wcmp group.
+    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup2);
+    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+    P4RouteEntry expect_entry = dest;
+    expect_entry.wcmp_group = kWcmpGroup2;
+    VerifyRouteEntriesEq(expect_entry, ret);
+
+    // Source has nexthop ID action and dest has wcmp group action.
+    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+    expect_entry = dest;
+    expect_entry.wcmp_group = "";
+    expect_entry.action = p4orch::kSetNexthopId;
+    expect_entry.nexthop_id = kNexthopId1;
+    VerifyRouteEntriesEq(expect_entry, ret);
+
+    // Source has drop action and dest has wcmp group action.
+    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+    expect_entry = dest;
+    expect_entry.wcmp_group = "";
+    expect_entry.action = p4orch::kDrop;
+    VerifyRouteEntriesEq(expect_entry, ret);
+}
+
+TEST_F(RouteManagerTest, MergeRouteEntryWithDropActionDestTest)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto dest = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+    dest.sai_route_entry.vr_id = gVrfOid;
+    dest.sai_route_entry.switch_id = gSwitchId;
+    copy(dest.sai_route_entry.destination, swss_ipv4_route_prefix);
+
+    // Source is identical to destination.
+    auto src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+    P4RouteEntry ret = {};
+    EXPECT_FALSE(MergeRouteEntry(dest, src, &ret));
+    VerifyRouteEntriesEq(dest, ret);
+
+    // Source has nexthop ID action and dest has drop action.
+    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+    P4RouteEntry expect_entry = dest;
+    expect_entry.action = p4orch::kSetNexthopId;
+    expect_entry.nexthop_id = kNexthopId1;
+    VerifyRouteEntriesEq(expect_entry, ret);
+
+    // Source has wcmp group and metadata action and dest has drop action.
+    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupIdAndMetadata, kWcmpGroup1,
+                               kMetadata1);
+    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+    expect_entry = dest;
+    expect_entry.action = p4orch::kSetWcmpGroupIdAndMetadata;
+    expect_entry.nexthop_id = "";
+    expect_entry.wcmp_group = kWcmpGroup1;
+    expect_entry.route_metadata = kMetadata1;
+    VerifyRouteEntriesEq(expect_entry, ret);
+}
+
+TEST_F(RouteManagerTest, MergeRouteEntryWithTrapActionDestTest)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto dest = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
+    dest.sai_route_entry.vr_id = gVrfOid;
+    dest.sai_route_entry.switch_id = gSwitchId;
+    copy(dest.sai_route_entry.destination, swss_ipv4_route_prefix);
+
+    // Source is identical to destination.
+    auto src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
+    P4RouteEntry ret = {};
+    EXPECT_FALSE(MergeRouteEntry(dest, src, &ret));
+    VerifyRouteEntriesEq(dest, ret);
+
+    // Source has nexthop ID action and dest has trap action.
+    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+    P4RouteEntry expect_entry = dest;
+    expect_entry.action = p4orch::kSetNexthopId;
+    expect_entry.nexthop_id = kNexthopId1;
+    VerifyRouteEntriesEq(expect_entry, ret);
+
+    // Source has wcmp group action and dest has trap action.
+    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
+    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+    expect_entry = dest;
+    expect_entry.action = p4orch::kSetWcmpGroupId;
+    expect_entry.wcmp_group = kWcmpGroup1;
+    VerifyRouteEntriesEq(expect_entry, ret);
+}
+
+TEST_F(RouteManagerTest, DeserializeRouteEntryWithNexthopIdActionTest)
+{
+    std::string key = R"({"match/vrf_id":"b4-traffic","match/ipv4_dst":"10.11.12.0/24"})";
+    std::vector<swss::FieldValueTuple> attributes;
+    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
+    attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kNexthopId), kNexthopId1});
+    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV4_TABLE_NAME);
+    EXPECT_TRUE(route_entry_or.ok());
+    auto &route_entry = *route_entry_or;
+    auto expect_entry =
+        GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("10.11.12.0/24"), p4orch::kSetNexthopId, kNexthopId1);
+    VerifyRouteEntriesEq(expect_entry, route_entry);
+}
+
+TEST_F(RouteManagerTest, DeserializeRouteEntryWithWcmpGroupActionTest)
+{
+    std::string key = R"({"match/vrf_id":"b4-traffic","match/ipv4_dst":"10.11.12.0/24"})";
+    std::vector<swss::FieldValueTuple> attributes;
+    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kSetWcmpGroupId});
+    attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kWcmpGroupId), kWcmpGroup1});
+    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV4_TABLE_NAME);
+    EXPECT_TRUE(route_entry_or.ok());
+    auto &route_entry = *route_entry_or;
+    auto expect_entry =
+        GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("10.11.12.0/24"), p4orch::kSetWcmpGroupId, kWcmpGroup1);
+    VerifyRouteEntriesEq(expect_entry, route_entry);
+}
+
+TEST_F(RouteManagerTest, DeserializeRouteEntryWithNexthopIdAdnMetadataActionTest)
+{
+    std::string key = R"({"match/vrf_id":"b4-traffic","match/ipv4_dst":"10.11.12.0/24"})";
+    std::vector<swss::FieldValueTuple> attributes;
+    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopIdAndMetadata});
+    attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kNexthopId), kNexthopId1});
+    attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kRouteMetadata), kMetadata1});
+    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV4_TABLE_NAME);
+    EXPECT_TRUE(route_entry_or.ok());
+    auto &route_entry = *route_entry_or;
+    auto expect_entry = GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("10.11.12.0/24"),
+                                             p4orch::kSetNexthopIdAndMetadata, kNexthopId1, kMetadata1);
+    VerifyRouteEntriesEq(expect_entry, route_entry);
+}
+
+TEST_F(RouteManagerTest, DeserializeRouteEntryWithWcmpGroupAndMetadataActionTest)
+{
+    std::string key = R"({"match/vrf_id":"b4-traffic","match/ipv4_dst":"10.11.12.0/24"})";
+    std::vector<swss::FieldValueTuple> attributes;
+    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kSetWcmpGroupIdAndMetadata});
+    attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kWcmpGroupId), kWcmpGroup1});
+    attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kRouteMetadata), kMetadata1});
+    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV4_TABLE_NAME);
+    EXPECT_TRUE(route_entry_or.ok());
+    auto &route_entry = *route_entry_or;
+    auto expect_entry = GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("10.11.12.0/24"),
+                                             p4orch::kSetWcmpGroupIdAndMetadata, kWcmpGroup1, kMetadata1);
+    VerifyRouteEntriesEq(expect_entry, route_entry);
+}
+
+TEST_F(RouteManagerTest, DeserializeRouteEntryWithDropActionTest)
+{
+    std::string key = R"({"match/vrf_id":"b4-traffic","match/ipv6_dst":"2001:db8:1::/32"})";
+    std::vector<swss::FieldValueTuple> attributes;
+    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
+    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
+    EXPECT_TRUE(route_entry_or.ok());
+    auto &route_entry = *route_entry_or;
+    auto expect_entry = GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("2001:db8:1::/32"), p4orch::kDrop, "");
+    VerifyRouteEntriesEq(expect_entry, route_entry);
+}
+
+TEST_F(RouteManagerTest, DeserializeRouteEntryWithTrapActionTest)
+{
+    std::string key = R"({"match/vrf_id":"b4-traffic","match/ipv6_dst":"2001:db8:1::/32"})";
+    std::vector<swss::FieldValueTuple> attributes;
+    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kTrap});
+    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
+    EXPECT_TRUE(route_entry_or.ok());
+    auto &route_entry = *route_entry_or;
+    auto expect_entry = GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("2001:db8:1::/32"), p4orch::kTrap, "");
+    VerifyRouteEntriesEq(expect_entry, route_entry);
+}
+
+TEST_F(RouteManagerTest, DeserializeRouteEntryWithInvalidKeyShouldFail)
+{
+    std::string key = "{{{{{{{{{{{{";
+    std::vector<swss::FieldValueTuple> attributes;
+    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
+    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
+    EXPECT_FALSE(route_entry_or.ok());
+}
+
+TEST_F(RouteManagerTest, DeserializeRouteEntryWithInvalidFieldShouldFail)
+{
+    std::string key = R"({"match/vrf_id":"b4-traffic","match/ipv6_dst":"2001:db8:1::/32"})";
+    std::vector<swss::FieldValueTuple> attributes;
+    attributes.push_back(swss::FieldValueTuple{"invalid", "invalid"});
+    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
+    EXPECT_FALSE(route_entry_or.ok());
+}
+
+TEST_F(RouteManagerTest, DeserializeRouteEntryWithInvalidRouteShouldFail)
+{
+    std::string key = R"({"match/vrf_id":"b4-traffic","match/ipv6_dst":"invalid"})";
+    std::vector<swss::FieldValueTuple> attributes;
+    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
+    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
+    EXPECT_FALSE(route_entry_or.ok());
+}
+
+TEST_F(RouteManagerTest, DeserializeRouteEntryWithoutIpv4WildcardLpmMatchShouldSucceed)
+{
+    std::string key = R"({"match/vrf_id":"b4-traffic"})";
+    std::vector<swss::FieldValueTuple> attributes;
+    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
+    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV4_TABLE_NAME);
+    EXPECT_TRUE(route_entry_or.ok());
+    auto &route_entry = *route_entry_or;
+    auto expect_entry = GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("0.0.0.0/0"), p4orch::kDrop, "");
+    VerifyRouteEntriesEq(expect_entry, route_entry);
+}
+
+TEST_F(RouteManagerTest, DeserializeRouteEntryWithoutIpv6WildcardLpmMatchShouldSucceed)
+{
+    std::string key = R"({"match/vrf_id":"b4-traffic"})";
+    std::vector<swss::FieldValueTuple> attributes;
+    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
+    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
+    EXPECT_TRUE(route_entry_or.ok());
+    auto &route_entry = *route_entry_or;
+    auto expect_entry = GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("::/0"), p4orch::kDrop, "");
+    VerifyRouteEntriesEq(expect_entry, route_entry);
+}
+
+TEST_F(RouteManagerTest, ValidateRouteEntryNexthopActionWithInvalidNexthopShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+    EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND, ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateRouteEntryNexthopActionWithValidNexthopShouldSucceed)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid1);
+    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateRouteEntryWcmpGroupActionWithInvalidWcmpGroupShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
+    EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND, ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateRouteEntryWcmpGroupActionWithValidWcmpGroupShouldSucceed)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+                          kWcmpGroupOid1);
+    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateRouteEntryWithInvalidCommandShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, "invalid"));
+}
+
+TEST_F(RouteManagerTest, ValidateSetRouteEntryDoesNotExistInManagerShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+    route_entry.action = "";
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid1);
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateSetRouteEntryExistsInMapperDoesNotExistInManagerShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid1);
+    p4_oid_mapper_.setDummyOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, route_entry.route_entry_key);
+    EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND, ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateSetRouteEntryExistsInManagerDoesNotExistInMapperShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+    p4_oid_mapper_.eraseOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, route_entry.route_entry_key);
+    EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND, ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateSetRouteEntryNexthopIdActionWithoutNexthopIdShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, "");
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateSetRouteEntryNexthopIdActionWithWcmpGroupShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+    route_entry.wcmp_group = kWcmpGroup1;
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid1);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+                          kWcmpGroupOid1);
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateSetRouteEntryWcmpGroupActionWithoutWcmpGroupShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, "");
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateSetRouteEntryWcmpGroupActionWithNexthopIdShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
+    route_entry.nexthop_id = kNexthopId1;
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid1);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+                          kWcmpGroupOid1);
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateSetRouteEntryDropActionWithNexthopIdShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+    route_entry.nexthop_id = kNexthopId1;
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid1);
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateSetRouteEntryWcmpGroupActionWithNonemptyMetadataShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto route_entry =
+        GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1, kMetadata1);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+                          kWcmpGroupOid1);
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateSetRouteEntryNexthopIdAndMetadataActionWithEmptyMetadataShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto route_entry =
+        GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata, kNexthopId1);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid1);
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateSetRouteEntryNexthopIdAndMetadataActionWithInvalidMetadataShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata,
+                                            kNexthopId1, "invalid_int");
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid1);
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateSetRouteEntryDropActionWithWcmpGroupShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+    route_entry.wcmp_group = kWcmpGroup1;
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+                          kWcmpGroupOid1);
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateSetRouteEntryTrapActionWithNexthopIdShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
+    route_entry.nexthop_id = kNexthopId1;
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid1);
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateSetRouteEntryTrapActionWithWcmpGroupShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
+    route_entry.wcmp_group = kWcmpGroup1;
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+                          kWcmpGroupOid1);
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateSetRouteEntryInvalidActionShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+    route_entry.action = "invalid";
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateSetRouteEntrySucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId2);
+    route_entry.action = "";
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid2);
+    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateDelRouteEntryDoesNotExistInManagerShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "");
+    EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND, ValidateRouteEntry(route_entry, DEL_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateDelRouteEntryDoesNotExistInMapperShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "");
+    p4_oid_mapper_.eraseOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, route_entry.route_entry_key);
+    // TODO: Expect critical state.
+    EXPECT_EQ(StatusCode::SWSS_RC_INTERNAL, ValidateRouteEntry(route_entry, DEL_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateDelRouteEntryHasActionShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, "");
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, DEL_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateDelRouteEntryHasNexthopIdShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+    route_entry.action = "";
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid1);
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, DEL_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateDelRouteEntryHasWcmpGroupShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
+    route_entry.action = "";
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+                          kWcmpGroupOid1);
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, DEL_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateDelRouteEntryHasMetadataShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "", kMetadata1);
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, DEL_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateDelRouteEntrySucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "");
+    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ValidateRouteEntry(route_entry, DEL_COMMAND));
+}
+
+TEST_F(RouteManagerTest, CreateRouteEntryWithSaiErrorShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE};
+    EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
+        .Times(3)
+        .WillRepeatedly(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_FAILURE)));
+    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+
+    route_entry.action = p4orch::kSetNexthopId;
+    route_entry.nexthop_id = kNexthopId1;
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid1);
+    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+
+    route_entry.action = p4orch::kSetWcmpGroupId;
+    route_entry.wcmp_group = kWcmpGroup1;
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+                          kWcmpGroupOid1);
+    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(RouteManagerTest, CreateNexthopIdIpv4RouteSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid1);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr.value.oid = kNexthopOid1;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_,
+                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     ArrayEq(std::vector<uint32_t>{1}),
+                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr}}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, CreateNexthopIdIpv6RouteSucceeds)
+{
+    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+    sai_ip_prefix_t sai_ipv6_route_prefix;
+    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid1);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv6_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr.value.oid = kNexthopOid1;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_,
+                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     ArrayEq(std::vector<uint32_t>{1}),
+                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr}}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv6_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, CreateNexthopIdWithMetadataIpv4RouteSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata,
+                                            kNexthopId1, kMetadata1);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid1);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    std::vector<sai_attribute_t> exp_sai_attrs;
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr.value.oid = kNexthopOid1;
+    exp_sai_attrs.push_back(exp_sai_attr);
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
+    exp_sai_attr.value.u32 = kMetadataInt1;
+    exp_sai_attrs.push_back(exp_sai_attr);
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_,
+                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     ArrayEq(std::vector<uint32_t>{static_cast<uint32_t>(exp_sai_attrs.size())}),
+                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{exp_sai_attrs}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, CreateDropSetMetadataRouteSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    auto route_entry =
+        GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetMetadataAndDrop, "", kMetadata1);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    std::vector<sai_attribute_t> exp_sai_attrs;
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
+    exp_sai_attrs.push_back(exp_sai_attr);
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
+    exp_sai_attr.value.u32 = kMetadataInt1;
+    exp_sai_attrs.push_back(exp_sai_attr);
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_,
+                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     ArrayEq(std::vector<uint32_t>{static_cast<uint32_t>(exp_sai_attrs.size())}),
+                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{exp_sai_attrs}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+}
+
+TEST_F(RouteManagerTest, CreateDropIpv4RouteSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_,
+                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     ArrayEq(std::vector<uint32_t>{1}),
+                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr}}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+}
+
+TEST_F(RouteManagerTest, CreateDropIpv6RouteSucceeds)
+{
+    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+    sai_ip_prefix_t sai_ipv6_route_prefix;
+    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kDrop, "");
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv6_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_,
+                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     ArrayEq(std::vector<uint32_t>{1}),
+                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr}}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv6_route_prefix, gVrfOid);
+}
+
+TEST_F(RouteManagerTest, CreateTrapIpv4RouteSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_TRAP;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_,
+                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     ArrayEq(std::vector<uint32_t>{1}),
+                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr}}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+}
+
+TEST_F(RouteManagerTest, CreateTrapIpv6RouteSucceeds)
+{
+    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+    sai_ip_prefix_t sai_ipv6_route_prefix;
+    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kTrap, "");
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv6_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_TRAP;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_,
+                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     ArrayEq(std::vector<uint32_t>{1}),
+                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr}}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv6_route_prefix, gVrfOid);
+}
+
+TEST_F(RouteManagerTest, CreateWcmpIpv4RouteSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+                          kWcmpGroupOid1);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr.value.oid = kWcmpGroupOid1;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_,
+                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     ArrayEq(std::vector<uint32_t>{1}),
+                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr}}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, CreateWcmpIpv6RouteSucceeds)
+{
+    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+    sai_ip_prefix_t sai_ipv6_route_prefix;
+    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+                          kWcmpGroupOid1);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv6_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr.value.oid = kWcmpGroupOid1;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_,
+                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     ArrayEq(std::vector<uint32_t>{1}),
+                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr}}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv6_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, CreateWcmpWithMetadataIpv6RouteSucceeds)
+{
+    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+    sai_ip_prefix_t sai_ipv6_route_prefix;
+    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kSetWcmpGroupIdAndMetadata,
+                                            kWcmpGroup1, kMetadata1);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+                          kWcmpGroupOid1);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv6_route_prefix;
+
+    std::vector<sai_attribute_t> exp_sai_attrs;
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr.value.oid = kWcmpGroupOid1;
+    exp_sai_attrs.push_back(exp_sai_attr);
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
+    exp_sai_attr.value.u32 = kMetadataInt1;
+    exp_sai_attrs.push_back(exp_sai_attr);
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_,
+                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     ArrayEq(std::vector<uint32_t>{static_cast<uint32_t>(exp_sai_attrs.size())}),
+                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{exp_sai_attrs}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv6_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteEntryWcmpWithSaiErrorShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupWcmpGroupRouteEntry(gVrfName, swss_ipv4_route_prefix, kWcmpGroup1, kWcmpGroupOid1);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup2);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+                          kWcmpGroupOid2);
+    std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_FAILURE)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(RouteManagerTest, UpdateRouteEntryWcmpNotExistInMapperShouldRaiseCriticalState)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupWcmpGroupRouteEntry(gVrfName, swss_ipv4_route_prefix, kWcmpGroup1, kWcmpGroupOid1);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup2);
+    std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_FAILURE)));
+    // TODO: Expect critical state.
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromSetWcmpToSetNextHopSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupWcmpGroupRouteEntry(gVrfName, swss_ipv4_route_prefix, kWcmpGroup1, kWcmpGroupOid1);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId2);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid2);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr.value.oid = kNexthopOid2;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromSetWcmpToSetNextHopAndMetadataSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupWcmpGroupRouteEntry(gVrfName, swss_ipv4_route_prefix, kWcmpGroup1, kWcmpGroupOid1);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata,
+                                            kNexthopId2, kMetadata2);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid2);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
+    exp_sai_attr.value.u32 = kMetadataInt2;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr.value.oid = kNexthopOid2;
+
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromSetNexthopIdToSetWcmpSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup2);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+                          kWcmpGroupOid2);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr.value.oid = kWcmpGroupOid2;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    route_entry.action = p4orch::kSetWcmpGroupId;
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup2), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromSetNexthopIdAndMetadataToSetWcmpSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1, kMetadata2);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup2);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+                          kWcmpGroupOid2);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
+    exp_sai_attr.value.u32 = 0;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr.value.oid = kWcmpGroupOid2;
+
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup2), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteEntryNexthopIdWithSaiErrorShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId2);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid2);
+    std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
+                        Return(SAI_STATUS_FAILURE)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(RouteManagerTest, UpdateRouteEntryNexthopIdNotExistInMapperShouldRaiseCriticalState)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId2);
+    std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
+                        Return(SAI_STATUS_FAILURE)));
+    // TODO: Expect critical state.
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(RouteManagerTest, UpdateRouteEntryDropWithSaiErrorShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+    std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
+    std::vector<sai_status_t> exp_success_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
+                        Return(SAI_STATUS_FAILURE)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
+                        Return(SAI_STATUS_SUCCESS)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
+                        Return(SAI_STATUS_FAILURE)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
+                        Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
+                        Return(SAI_STATUS_SUCCESS)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
+                        Return(SAI_STATUS_FAILURE)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
+                        Return(SAI_STATUS_FAILURE)));
+    // TODO: Expect critical state.
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(RouteManagerTest, UpdateRouteEntryTrapWithSaiErrorShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
+    std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
+    std::vector<sai_status_t> exp_success_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
+                        Return(SAI_STATUS_FAILURE)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
+                        Return(SAI_STATUS_SUCCESS)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
+                        Return(SAI_STATUS_FAILURE)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
+                        Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
+                        Return(SAI_STATUS_SUCCESS)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
+                        Return(SAI_STATUS_FAILURE)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
+                        Return(SAI_STATUS_FAILURE)));
+    // TODO: Expect critical state.
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(RouteManagerTest, UpdateRouteWithDifferentNexthopIdsSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId2);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid2);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr.value.oid = kNexthopOid2;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    route_entry.action = p4orch::kSetNexthopId;
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteWithDifferentNexthopIdsAndMetadatasSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1, kMetadata1);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata,
+                                            kNexthopId2, kMetadata2);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid2);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
+    exp_sai_attr.value.u32 = kMetadataInt2;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr.value.oid = kNexthopOid2;
+
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromNexthopIdToDropSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr.value.oid = SAI_NULL_OBJECT_ID;
+
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromNexthopIdToRouteMetadataSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+
+    auto route_entry =
+        GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetMetadataAndDrop, "", kMetadata1);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
+    exp_sai_attr.value.s32 = kMetadataInt1;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr.value.oid = SAI_NULL_OBJECT_ID;
+
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
+
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromNexthopIdAndMetadataToDropSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1, kMetadata2);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr.value.oid = SAI_NULL_OBJECT_ID;
+
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
+    exp_sai_attr.value.u32 = 0;
+
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromDropToNexthopIdSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupDropRouteEntry(gVrfName, swss_ipv4_route_prefix);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId2);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid2);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr.value.oid = kNexthopOid2;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_FORWARD;
+
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromDropToWcmpWithMetadataSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupDropRouteEntry(gVrfName, swss_ipv4_route_prefix);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupIdAndMetadata,
+                                            kWcmpGroup1, kMetadata2);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+                          kWcmpGroupOid1);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
+    exp_sai_attr.value.u32 = kMetadataInt2;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr.value.oid = kWcmpGroupOid1;
+
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_FORWARD;
+
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromTrapToDropAndSetMetadataSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupTrapRouteEntry(gVrfName, swss_ipv4_route_prefix);
+
+    auto route_entry =
+        GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetMetadataAndDrop, "", kMetadata2);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
+    exp_sai_attr.value.u32 = kMetadataInt2;
+
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromTrapToDropSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupTrapRouteEntry(gVrfName, swss_ipv4_route_prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromDropToTrapSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupDropRouteEntry(gVrfName, swss_ipv4_route_prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_TRAP;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromNexthopIdToTrapSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_TRAP;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr.value.oid = SAI_NULL_OBJECT_ID;
+
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromTrapToNexthopIdSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupTrapRouteEntry(gVrfName, swss_ipv4_route_prefix);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId2);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid2);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr.value.oid = kNexthopOid2;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_FORWARD;
+
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromTrapToNexthopIdAndMetadataRecoverFailureShouldRaiseCriticalState)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupTrapRouteEntry(gVrfName, swss_ipv4_route_prefix);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata,
+                                            kNexthopId2, kMetadata1);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid2);
+    std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
+    std::vector<sai_status_t> exp_success_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
+                        Return(SAI_STATUS_SUCCESS)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
+                        Return(SAI_STATUS_SUCCESS)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
+                        Return(SAI_STATUS_FAILURE)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
+                        Return(SAI_STATUS_SUCCESS)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
+                        Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
+                        Return(SAI_STATUS_SUCCESS)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
+                        Return(SAI_STATUS_SUCCESS)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
+                        Return(SAI_STATUS_FAILURE)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
+                        Return(SAI_STATUS_SUCCESS)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
+                        Return(SAI_STATUS_FAILURE)));
+    // TODO: Expect critical state.
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(RouteManagerTest, UpdateRouteWithDifferentWcmpGroupsSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupWcmpGroupRouteEntry(gVrfName, swss_ipv4_route_prefix, kWcmpGroup1, kWcmpGroupOid1);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup2);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+                          kWcmpGroupOid2);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr.value.oid = kWcmpGroupOid2;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    route_entry.action = p4orch::kSetWcmpGroupId;
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup2), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateNexthopIdRouteWithNoChangeSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromNexthopIdAndMetadataToDropRecoverFailureShouldRaiseCriticalState)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1, kMetadata2);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+
+    std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
+    std::vector<sai_status_t> exp_success_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
+                        Return(SAI_STATUS_FAILURE)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
+                        Return(SAI_STATUS_SUCCESS)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
+                        Return(SAI_STATUS_SUCCESS)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
+                        Return(SAI_STATUS_FAILURE)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
+                        Return(SAI_STATUS_SUCCESS)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
+                        Return(SAI_STATUS_FAILURE)));
+    // TODO: Expect critical state.
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromDifferentNexthopIdAndMetadataRecoverFailureShouldRaiseCriticalState)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1, kMetadata1);
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata,
+                                            kNexthopId2, kMetadata2);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
+                          kNexthopOid2);
+
+    std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
+    std::vector<sai_status_t> exp_success_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
+                        Return(SAI_STATUS_FAILURE)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
+                        Return(SAI_STATUS_SUCCESS)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
+                        Return(SAI_STATUS_FAILURE)))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
+                        Return(SAI_STATUS_FAILURE)));
+    // TODO: Expect critical state.
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(RouteManagerTest, DeleteRouteEntryWithSaiErrorShouldFail)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE};
+    EXPECT_CALL(mock_sai_route_, remove_route_entries(_, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_FAILURE)));
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "");
+    EXPECT_THAT(DeleteRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(RouteManagerTest, DeleteIpv4RouteSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_,
+                remove_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "");
+    EXPECT_THAT(DeleteRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    auto *route_entry_ptr = GetRouteEntry(route_entry.route_entry_key);
+    EXPECT_EQ(nullptr, route_entry_ptr);
+    EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, route_entry.route_entry_key));
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, DeleteIpv6RouteSucceeds)
+{
+    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+    sai_ip_prefix_t sai_ipv6_route_prefix;
+    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+    SetupWcmpGroupRouteEntry(gVrfName, swss_ipv6_route_prefix, kWcmpGroup1, kWcmpGroupOid1);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVrfOid;
+    exp_sai_route_entry.destination = sai_ipv6_route_prefix;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_,
+                remove_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, "", "");
+    EXPECT_THAT(DeleteRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+    auto *route_entry_ptr = GetRouteEntry(route_entry.route_entry_key);
+    EXPECT_EQ(nullptr, route_entry_ptr);
+    EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, route_entry.route_entry_key));
+    uint32_t ref_cnt;
+    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, RouteCreateAndUpdateInDrainSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), kNexthopOid1);
+    auto key_op_fvs_1 = GenerateKeyOpFieldsValuesTuple(gVrfName, swss_ipv4_route_prefix, SET_COMMAND,
+                                                       p4orch::kSetNexthopId, kNexthopId1);
+    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_1);
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_1)),
+                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_1)),
+                                    Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
+        .Times(1);
+    Drain();
+
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), kNexthopOid2);
+    auto key_op_fvs_2 = GenerateKeyOpFieldsValuesTuple(gVrfName, swss_ipv4_route_prefix, SET_COMMAND,
+                                                       p4orch::kSetNexthopId, kNexthopId2);
+    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_2);
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_2)),
+                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_2)),
+                                    Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
+        .Times(1);
+    Drain();
+
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId2);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+
+    auto key_op_fvs_3 = GenerateKeyOpFieldsValuesTuple(gVrfName, swss_ipv4_route_prefix, SET_COMMAND,
+                                                       p4orch::kSetMetadataAndDrop, "", kMetadata1);
+    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_3);
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+        .WillRepeatedly(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_3)),
+                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_3)),
+                                    Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
+        .Times(1);
+    Drain();
+
+    route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetMetadataAndDrop, "", kMetadata1);
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, RouteCreateAndDeleteInDrainSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), kNexthopOid1);
+    auto key_op_fvs_1 = GenerateKeyOpFieldsValuesTuple(gVrfName, swss_ipv4_route_prefix, SET_COMMAND,
+                                                       p4orch::kSetNexthopId, kNexthopId1);
+    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_1);
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_1)),
+                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_1)),
+                                    Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
+        .Times(1);
+    Drain();
+
+    auto key_op_fvs_2 = GenerateKeyOpFieldsValuesTuple(gVrfName, swss_ipv4_route_prefix, DEL_COMMAND, "", "");
+    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_2);
+    EXPECT_CALL(mock_sai_route_, remove_route_entries(_, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_2)),
+                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_2)),
+                                    Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
+        .Times(1);
+    Drain();
+
+    std::string key = KeyGenerator::generateRouteKey(gVrfName, swss_ipv4_route_prefix);
+    auto *route_entry_ptr = GetRouteEntry(key);
+    EXPECT_EQ(nullptr, route_entry_ptr);
+    EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, key));
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateFailsWhenCreateAndUpdateTheSameRouteInDrain)
+{
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), kNexthopOid1);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), kNexthopOid2);
+    auto key_op_fvs_1 = GenerateKeyOpFieldsValuesTuple(gVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND,
+                                                       p4orch::kSetNexthopId, kNexthopId1);
+    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_1);
+    auto key_op_fvs_2 = GenerateKeyOpFieldsValuesTuple(gVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND,
+                                                       p4orch::kSetNexthopId, kNexthopId2);
+    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_2);
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_1)),
+                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_1)),
+                                    Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
+        .Times(1);
+    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_2)),
+                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_2)),
+                                    Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)))
+        .Times(1);
+
+    Drain();
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, DeleteFailsWhenCreateAndDeleteTheSameRouteInDrain)
+{
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), kNexthopOid1);
+    auto key_op_fvs_1 = GenerateKeyOpFieldsValuesTuple(gVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND,
+                                                       p4orch::kSetNexthopId, kNexthopId1);
+    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_1);
+    auto key_op_fvs_2 = GenerateKeyOpFieldsValuesTuple(gVrfName, swss::IpPrefix(kIpv4Prefix), DEL_COMMAND, "", "");
+    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_2);
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_1)),
+                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_1)),
+                                    Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
+        .Times(1);
+    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_2)),
+                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_2)),
+                                    Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)))
+        .Times(1);
+    Drain();
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, RouteCreateInDrainSucceedsWhenVrfIsEmpty)
+{
+    const std::string kDefaultVrfName = ""; // Default Vrf
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), kNexthopOid1);
+    auto key_op_fvs = GenerateKeyOpFieldsValuesTuple(kDefaultVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND,
+                                                     p4orch::kSetNexthopId, kNexthopId1);
+    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
+
+    sai_route_entry_t exp_sai_route_entry;
+    exp_sai_route_entry.switch_id = gSwitchId;
+    exp_sai_route_entry.vr_id = gVirtualRouterId;
+    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr;
+    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr.value.oid = kNexthopOid1;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_,
+                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                                     ArrayEq(std::vector<uint32_t>{1}),
+                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr}}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_CALL(publisher_,
+                publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
+                        FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)), Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
+        .Times(1);
+
+    Drain();
+    std::string key = KeyGenerator::generateRouteKey(kDefaultVrfName, swss::IpPrefix(kIpv4Prefix));
+    auto *route_entry_ptr = GetRouteEntry(key);
+    EXPECT_NE(nullptr, route_entry_ptr);
+    EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, key));
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, DeserializeRouteEntryInDrainFails)
+{
+    const std::string kKeyPrefix = std::string(APP_P4RT_IPV4_TABLE_NAME) + kTableKeyDelimiter;
+    auto key_op_fvs =
+        swss::KeyOpFieldsValuesTuple(kKeyPrefix + "{{{{{{{{{{{{", SET_COMMAND, std::vector<swss::FieldValueTuple>{});
+    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
+    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
+                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
+                                    Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)))
+        .Times(1);
+    Drain();
+}
+
+TEST_F(RouteManagerTest, ValidateRouteEntryInDrainFailsWhenVrfDoesNotExist)
+{
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), kNexthopOid1);
+    auto key_op_fvs = GenerateKeyOpFieldsValuesTuple("Invalid-Vrf", swss::IpPrefix(kIpv4Prefix), SET_COMMAND,
+                                                     p4orch::kSetNexthopId, kNexthopId1);
+    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
+    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
+                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
+                                    Eq(StatusCode::SWSS_RC_NOT_FOUND), Eq(true)))
+        .Times(1);
+    Drain();
+}
+
+TEST_F(RouteManagerTest, ValidateRouteEntryInDrainFailsWhenNexthopDoesNotExist)
+{
+    auto key_op_fvs = GenerateKeyOpFieldsValuesTuple(gVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND,
+                                                     p4orch::kSetNexthopId, kNexthopId1);
+    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
+    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
+                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
+                                    Eq(StatusCode::SWSS_RC_NOT_FOUND), Eq(true)))
+        .Times(1);
+    Drain();
+}
+
+TEST_F(RouteManagerTest, InvalidateSetRouteEntryInDrainFails)
+{
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), kNexthopOid1);
+    // No nexthop ID with kSetNexthopId action.
+    auto key_op_fvs =
+        GenerateKeyOpFieldsValuesTuple(gVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND, p4orch::kSetNexthopId, "");
+    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
+    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
+                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
+                                    Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)))
+        .Times(1);
+    Drain();
+}
+
+TEST_F(RouteManagerTest, InvalidateDelRouteEntryInDrainFails)
+{
+    // Route does not exist.
+    auto key_op_fvs = GenerateKeyOpFieldsValuesTuple(gVrfName, swss::IpPrefix(kIpv4Prefix), DEL_COMMAND,
+                                                     p4orch::kSetNexthopId, kNexthopId1);
+    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
+    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
+                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
+                                    Eq(StatusCode::SWSS_RC_NOT_FOUND), Eq(true)))
+        .Times(1);
+    Drain();
+}
+
+TEST_F(RouteManagerTest, InvalidCommandInDrainFails)
+{
+    const std::string kKeyPrefix = std::string(APP_P4RT_IPV4_TABLE_NAME) + kTableKeyDelimiter;
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), kNexthopOid1);
+    nlohmann::json j;
+    j[prependMatchField(p4orch::kVrfId)] = gVrfName;
+    j[prependMatchField(p4orch::kIpv4Dst)] = kIpv4Prefix;
+    std::vector<swss::FieldValueTuple> attributes;
+    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
+    attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kNexthopId), kNexthopId1});
+    auto key_op_fvs = swss::KeyOpFieldsValuesTuple(kKeyPrefix + j.dump(), "INVALID_COMMAND", attributes);
+    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
+    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
+                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
+                                    Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)))
+        .Times(1);
+    Drain();
+}
+
+TEST_F(RouteManagerTest, BatchedCreateSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    auto route_entry_ipv4 = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry_ipv4.nexthop_id),
+                          kNexthopOid1);
+
+    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+    sai_ip_prefix_t sai_ipv6_route_prefix;
+    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+    auto route_entry_ipv6 =
+        GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                          KeyGenerator::generateWcmpGroupKey(route_entry_ipv6.wcmp_group), kWcmpGroupOid1);
+
+    sai_route_entry_t exp_sai_route_entry_ipv4;
+    exp_sai_route_entry_ipv4.switch_id = gSwitchId;
+    exp_sai_route_entry_ipv4.vr_id = gVrfOid;
+    exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr_ipv4;
+    exp_sai_attr_ipv4.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr_ipv4.value.oid = kNexthopOid1;
+
+    sai_route_entry_t exp_sai_route_entry_ipv6;
+    exp_sai_route_entry_ipv6.switch_id = gSwitchId;
+    exp_sai_route_entry_ipv6.vr_id = gVrfOid;
+    exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
+
+    sai_attribute_t exp_sai_attr_ipv6;
+    exp_sai_attr_ipv6.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr_ipv6.value.oid = kWcmpGroupOid1;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
+    EXPECT_CALL(
+        mock_sai_route_,
+        create_route_entries(
+            Eq(2),
+            RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry_ipv4, exp_sai_route_entry_ipv6}),
+            ArrayEq(std::vector<uint32_t>{1, 1}),
+            AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr_ipv4}, {exp_sai_attr_ipv6}}),
+            Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4, route_entry_ipv6}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS, StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry_ipv4, sai_ipv4_route_prefix, gVrfOid);
+    VerifyRouteEntry(route_entry_ipv6, sai_ipv6_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, BatchedCreatePartiallySucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    auto route_entry_ipv4 = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry_ipv4.nexthop_id),
+                          kNexthopOid1);
+
+    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+    sai_ip_prefix_t sai_ipv6_route_prefix;
+    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+    auto route_entry_ipv6 =
+        GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                          KeyGenerator::generateWcmpGroupKey(route_entry_ipv6.wcmp_group), kWcmpGroupOid1);
+
+    sai_route_entry_t exp_sai_route_entry_ipv4;
+    exp_sai_route_entry_ipv4.switch_id = gSwitchId;
+    exp_sai_route_entry_ipv4.vr_id = gVrfOid;
+    exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr_ipv4;
+    exp_sai_attr_ipv4.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr_ipv4.value.oid = kNexthopOid1;
+
+    sai_route_entry_t exp_sai_route_entry_ipv6;
+    exp_sai_route_entry_ipv6.switch_id = gSwitchId;
+    exp_sai_route_entry_ipv6.vr_id = gVrfOid;
+    exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
+
+    sai_attribute_t exp_sai_attr_ipv6;
+    exp_sai_attr_ipv6.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr_ipv6.value.oid = kWcmpGroupOid1;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS, SAI_STATUS_FAILURE};
+    EXPECT_CALL(
+        mock_sai_route_,
+        create_route_entries(
+            Eq(2),
+            RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry_ipv4, exp_sai_route_entry_ipv6}),
+            ArrayEq(std::vector<uint32_t>{1, 1}),
+            AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr_ipv4}, {exp_sai_attr_ipv6}}),
+            Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_FAILURE)));
+    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4, route_entry_ipv6}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS, StatusCode::SWSS_RC_UNKNOWN}));
+    VerifyRouteEntry(route_entry_ipv4, sai_ipv4_route_prefix, gVrfOid);
+    auto *route_entry_ptr_ipv6 = GetRouteEntry(route_entry_ipv6.route_entry_key);
+    EXPECT_EQ(nullptr, route_entry_ptr_ipv6);
+    EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, route_entry_ipv6.route_entry_key));
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, BatchedUpdateSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    auto route_entry_ipv4 =
+        GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(kWcmpGroup1),
+                          kWcmpGroupOid1);
+
+    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+    sai_ip_prefix_t sai_ipv6_route_prefix;
+    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+    auto route_entry_ipv6 =
+        GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup2);
+    SetupDropRouteEntry(gVrfName, swss_ipv6_route_prefix);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(kWcmpGroup2),
+                          kWcmpGroupOid2);
+
+    sai_route_entry_t exp_sai_route_entry_ipv4;
+    exp_sai_route_entry_ipv4.switch_id = gSwitchId;
+    exp_sai_route_entry_ipv4.vr_id = gVrfOid;
+    exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr_ipv4;
+    exp_sai_attr_ipv4.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr_ipv4.value.oid = kWcmpGroupOid1;
+
+    sai_route_entry_t exp_sai_route_entry_ipv6;
+    exp_sai_route_entry_ipv6.switch_id = gSwitchId;
+    exp_sai_route_entry_ipv6.vr_id = gVrfOid;
+    exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
+
+    sai_attribute_t exp_sai_attr_ipv6;
+    exp_sai_attr_ipv6.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr_ipv6.value.oid = kWcmpGroupOid2;
+
+    std::vector<sai_status_t> exp_status_1{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(2),
+                                     RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry_ipv4,
+                                                                                      exp_sai_route_entry_ipv6}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr_ipv4, exp_sai_attr_ipv6}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status_1.begin(), exp_status_1.end()), Return(SAI_STATUS_SUCCESS)));
+
+    sai_attribute_t exp_sai_attr_ipv6_2;
+    exp_sai_attr_ipv6_2.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+    exp_sai_attr_ipv6_2.value.s32 = SAI_PACKET_ACTION_FORWARD;
+
+    std::vector<sai_status_t> exp_status_2{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry_ipv6}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr_ipv6_2}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status_2.begin(), exp_status_2.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4, route_entry_ipv6}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS, StatusCode::SWSS_RC_SUCCESS}));
+    VerifyRouteEntry(route_entry_ipv4, sai_ipv4_route_prefix, gVrfOid);
+    VerifyRouteEntry(route_entry_ipv6, sai_ipv6_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup2), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, BatchedUpdatePartiallySucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    auto route_entry_ipv4 =
+        GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(kWcmpGroup1),
+                          kWcmpGroupOid1);
+
+    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+    sai_ip_prefix_t sai_ipv6_route_prefix;
+    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+    auto route_entry_ipv6 =
+        GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup2);
+    SetupDropRouteEntry(gVrfName, swss_ipv6_route_prefix);
+    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(kWcmpGroup2),
+                          kWcmpGroupOid2);
+
+    sai_route_entry_t exp_sai_route_entry_ipv4;
+    exp_sai_route_entry_ipv4.switch_id = gSwitchId;
+    exp_sai_route_entry_ipv4.vr_id = gVrfOid;
+    exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
+
+    sai_attribute_t exp_sai_attr_ipv4;
+    exp_sai_attr_ipv4.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr_ipv4.value.oid = kWcmpGroupOid1;
+
+    sai_route_entry_t exp_sai_route_entry_ipv6;
+    exp_sai_route_entry_ipv6.switch_id = gSwitchId;
+    exp_sai_route_entry_ipv6.vr_id = gVrfOid;
+    exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
+
+    sai_attribute_t exp_sai_attr_ipv6;
+    exp_sai_attr_ipv6.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+    exp_sai_attr_ipv6.value.oid = kWcmpGroupOid2;
+
+    std::vector<sai_status_t> exp_status_1{SAI_STATUS_SUCCESS, SAI_STATUS_FAILURE};
+    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
+                                     Eq(2),
+                                     RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry_ipv4,
+                                                                                      exp_sai_route_entry_ipv6}),
+                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr_ipv4, exp_sai_attr_ipv6}),
+                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<4>(exp_status_1.begin(), exp_status_1.end()), Return(SAI_STATUS_FAILURE)));
+    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4, route_entry_ipv6}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS, StatusCode::SWSS_RC_UNKNOWN}));
+    VerifyRouteEntry(route_entry_ipv4, sai_ipv4_route_prefix, gVrfOid);
+    route_entry_ipv6 = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kDrop, "");
+    VerifyRouteEntry(route_entry_ipv6, sai_ipv6_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+    EXPECT_EQ(1, ref_cnt);
+    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup2), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, BatchedDeleteSucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    auto route_entry_ipv4 = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+
+    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+    sai_ip_prefix_t sai_ipv6_route_prefix;
+    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+    auto route_entry_ipv6 = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kDrop, "");
+    SetupDropRouteEntry(gVrfName, swss_ipv6_route_prefix);
+
+    sai_route_entry_t exp_sai_route_entry_ipv4;
+    exp_sai_route_entry_ipv4.switch_id = gSwitchId;
+    exp_sai_route_entry_ipv4.vr_id = gVrfOid;
+    exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
+
+    sai_route_entry_t exp_sai_route_entry_ipv6;
+    exp_sai_route_entry_ipv6.switch_id = gSwitchId;
+    exp_sai_route_entry_ipv6.vr_id = gVrfOid;
+    exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, remove_route_entries(Eq(2),
+                                                      RouteEntryArrayEq(std::vector<sai_route_entry_t>{
+                                                          exp_sai_route_entry_ipv4, exp_sai_route_entry_ipv6}),
+                                                      Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(DeleteRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4, route_entry_ipv6}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS, StatusCode::SWSS_RC_SUCCESS}));
+    auto *route_entry_ptr_ipv4 = GetRouteEntry(route_entry_ipv4.route_entry_key);
+    EXPECT_EQ(nullptr, route_entry_ptr_ipv4);
+    EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, route_entry_ipv4.route_entry_key));
+    auto *route_entry_ptr_ipv6 = GetRouteEntry(route_entry_ipv6.route_entry_key);
+    EXPECT_EQ(nullptr, route_entry_ptr_ipv6);
+    EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, route_entry_ipv6.route_entry_key));
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, BatchedDeletePartiallySucceeds)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    sai_ip_prefix_t sai_ipv4_route_prefix;
+    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+    auto route_entry_ipv4 = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+
+    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+    sai_ip_prefix_t sai_ipv6_route_prefix;
+    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+    auto route_entry_ipv6 = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kDrop, "");
+    SetupDropRouteEntry(gVrfName, swss_ipv6_route_prefix);
+
+    sai_route_entry_t exp_sai_route_entry_ipv4;
+    exp_sai_route_entry_ipv4.switch_id = gSwitchId;
+    exp_sai_route_entry_ipv4.vr_id = gVrfOid;
+    exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
+
+    sai_route_entry_t exp_sai_route_entry_ipv6;
+    exp_sai_route_entry_ipv6.switch_id = gSwitchId;
+    exp_sai_route_entry_ipv6.vr_id = gVrfOid;
+    exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS, SAI_STATUS_FAILURE};
+    EXPECT_CALL(mock_sai_route_, remove_route_entries(Eq(2),
+                                                      RouteEntryArrayEq(std::vector<sai_route_entry_t>{
+                                                          exp_sai_route_entry_ipv4, exp_sai_route_entry_ipv6}),
+                                                      Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+        .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_FAILURE)));
+    EXPECT_THAT(DeleteRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4, route_entry_ipv6}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS, StatusCode::SWSS_RC_UNKNOWN}));
+    auto *route_entry_ptr_ipv4 = GetRouteEntry(route_entry_ipv4.route_entry_key);
+    EXPECT_EQ(nullptr, route_entry_ptr_ipv4);
+    EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, route_entry_ipv4.route_entry_key));
+    VerifyRouteEntry(route_entry_ipv6, sai_ipv6_route_prefix, gVrfOid);
+    uint32_t ref_cnt;
+    EXPECT_TRUE(
+        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
+    EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, VerifyStateTest)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
+    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+
+    // Setup ASIC DB.
+    swss::Table table(nullptr, "ASIC_STATE");
+    table.set("SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.11.12.0/"
+              "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
+              std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x1"}});
+
+    nlohmann::json j;
+    j[prependMatchField(p4orch::kVrfId)] = gVrfName;
+    j[prependMatchField(p4orch::kIpv4Dst)] = kIpv4Prefix;
+    const std::string db_key = std::string(APP_P4RT_TABLE_NAME) + kTableKeyDelimiter + APP_P4RT_IPV4_TABLE_NAME +
+                               kTableKeyDelimiter + j.dump();
+    std::vector<swss::FieldValueTuple> attributes;
+
+    // Verification should succeed with vaild key and value.
+    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
+    attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kNexthopId), kNexthopId1});
+    EXPECT_EQ(VerifyState(db_key, attributes), "");
+
+    // TODO: Expect critical state.
+
+    // Invalid key should fail verification.
+    EXPECT_FALSE(VerifyState("invalid", attributes).empty());
+    EXPECT_FALSE(VerifyState("invalid:invalid", attributes).empty());
+    EXPECT_FALSE(VerifyState(std::string(APP_P4RT_TABLE_NAME) + ":invalid", attributes).empty());
+    EXPECT_FALSE(VerifyState(std::string(APP_P4RT_TABLE_NAME) + ":invalid:invalid", attributes).empty());
+    EXPECT_FALSE(VerifyState(std::string(APP_P4RT_TABLE_NAME) + ":FIXED_IPV4_TABLE:invalid", attributes).empty());
+
+    // Verification should fail if nexthop ID does not exist.
+    attributes.clear();
+    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
+    attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kNexthopId), kNexthopId2});
+    EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+    attributes.clear();
+    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
+    attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kNexthopId), kNexthopId1});
+
+    // Verification should fail if entry does not exist.
+    j[prependMatchField(p4orch::kIpv4Dst)] = "1.1.1.0/24";
+    EXPECT_FALSE(VerifyState(std::string(APP_P4RT_TABLE_NAME) + kTableKeyDelimiter + APP_P4RT_IPV4_TABLE_NAME +
+                                 kTableKeyDelimiter + j.dump(),
+                             attributes)
+                     .empty());
+
+    auto *route_entry_ptr = GetRouteEntry(KeyGenerator::generateRouteKey(gVrfName, swss_ipv4_route_prefix));
+    EXPECT_NE(route_entry_ptr, nullptr);
+
+    // Verification should fail if route entry key mismatches.
+    auto saved_route_entry_key = route_entry_ptr->route_entry_key;
+    route_entry_ptr->route_entry_key = "invalid";
+    EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+    route_entry_ptr->route_entry_key = saved_route_entry_key;
+
+    // Verification should fail if VRF ID mismatches.
+    auto saved_vrf_id = route_entry_ptr->vrf_id;
+    route_entry_ptr->vrf_id = "invalid";
+    EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+    route_entry_ptr->vrf_id = saved_vrf_id;
+
+    // Verification should fail if route prefix mismatches.
+    auto saved_route_prefix = route_entry_ptr->route_prefix;
+    route_entry_ptr->route_prefix = swss::IpPrefix(kIpv6Prefix);
+    EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+    route_entry_ptr->route_prefix = saved_route_prefix;
+
+    // Verification should fail if action mismatches.
+    auto saved_action = route_entry_ptr->action;
+    route_entry_ptr->action = p4orch::kSetWcmpGroupId;
+    EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+    route_entry_ptr->action = saved_action;
+
+    // Verification should fail if nexthop ID mismatches.
+    auto saved_nexthop_id = route_entry_ptr->nexthop_id;
+    route_entry_ptr->nexthop_id = kNexthopId2;
+    EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+    route_entry_ptr->nexthop_id = saved_nexthop_id;
+
+    // Verification should fail if WCMP group mismatches.
+    auto saved_wcmp_group = route_entry_ptr->wcmp_group;
+    route_entry_ptr->wcmp_group = kWcmpGroup1;
+    EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+    route_entry_ptr->wcmp_group = saved_wcmp_group;
+
+    // Verification should fail if WCMP group mismatches.
+    auto saved_route_metadata = route_entry_ptr->route_metadata;
+    route_entry_ptr->route_metadata = kMetadata1;
+    EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+    route_entry_ptr->route_metadata = saved_route_metadata;
+}
+
+TEST_F(RouteManagerTest, VerifyStateAsicDbTest)
+{
+    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+    SetupDropRouteEntry(gVrfName, swss_ipv4_route_prefix);
+    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+    SetupNexthopIdRouteEntry(gVrfName, swss_ipv6_route_prefix, kNexthopId1, kNexthopOid1, kMetadata1);
+
+    auto swss_ipv4_route_prefix2 = swss::IpPrefix(kIpv4Prefix2);
+    auto route_entry =
+        GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix2, p4orch::kSetMetadataAndDrop, "", kMetadata2);
+
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
+        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+
+    // Setup ASIC DB.
+    swss::Table table(nullptr, "ASIC_STATE");
+    table.set("SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.11.12.0/"
+              "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
+              std::vector<swss::FieldValueTuple>{
+                  swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_DROP"},
+                  swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x0"}});
+    table.set("SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"2001:db8:1::/"
+              "32\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
+              std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x1"},
+                                                 swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_META_DATA", "1"}});
+
+    table.set("SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.12.12.0/"
+              "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
+              std::vector<swss::FieldValueTuple>{
+                  swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_DROP"},
+                  swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_META_DATA", "2"}});
+
+    nlohmann::json j_1;
+    j_1[prependMatchField(p4orch::kVrfId)] = gVrfName;
+    j_1[prependMatchField(p4orch::kIpv4Dst)] = kIpv4Prefix;
+    const std::string db_key_1 = std::string(APP_P4RT_TABLE_NAME) + kTableKeyDelimiter + APP_P4RT_IPV4_TABLE_NAME +
+                                 kTableKeyDelimiter + j_1.dump();
+    std::vector<swss::FieldValueTuple> attributes_1;
+    attributes_1.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
+    nlohmann::json j_2;
+    j_2[prependMatchField(p4orch::kVrfId)] = gVrfName;
+    j_2[prependMatchField(p4orch::kIpv6Dst)] = kIpv6Prefix;
+    const std::string db_key_2 = std::string(APP_P4RT_TABLE_NAME) + kTableKeyDelimiter + APP_P4RT_IPV6_TABLE_NAME +
+                                 kTableKeyDelimiter + j_2.dump();
+    std::vector<swss::FieldValueTuple> attributes_2;
+    attributes_2.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopIdAndMetadata});
+    attributes_2.push_back(swss::FieldValueTuple{prependParamField(p4orch::kNexthopId), kNexthopId1});
+    attributes_2.push_back(swss::FieldValueTuple{prependParamField(p4orch::kRouteMetadata), kMetadata1});
+
+    nlohmann::json j_3;
+    j_3[prependMatchField(p4orch::kVrfId)] = gVrfName;
+    j_3[prependMatchField(p4orch::kIpv6Dst)] = kIpv4Prefix2;
+    const std::string db_key_3 = std::string(APP_P4RT_TABLE_NAME) + kTableKeyDelimiter + APP_P4RT_IPV6_TABLE_NAME +
+                                 kTableKeyDelimiter + j_3.dump();
+    std::vector<swss::FieldValueTuple> attributes_3;
+    attributes_3.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMetadataAndDrop});
+    attributes_3.push_back(swss::FieldValueTuple{prependParamField(p4orch::kRouteMetadata), kMetadata2});
+
+    // Verification should succeed with correct ASIC DB values.
+    EXPECT_EQ(VerifyState(db_key_1, attributes_1), "");
+    EXPECT_EQ(VerifyState(db_key_2, attributes_2), "");
+    EXPECT_EQ(VerifyState(db_key_3, attributes_3), "");
+
+    // Verification should fail if ASIC DB values mismatch.
+    table.set("SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.11.12.0/"
+              "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
+              std::vector<swss::FieldValueTuple>{
+                  swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_FORWARD"}});
+    table.set("SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"2001:db8:1::/"
+              "32\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
+              std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_META_DATA", "2"}});
+    EXPECT_FALSE(VerifyState(db_key_1, attributes_1).empty());
+    EXPECT_FALSE(VerifyState(db_key_2, attributes_2).empty());
+
+    // Verification should fail if ASIC DB table is missing.
+    table.del("SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.11.12.0/"
+              "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}");
+    table.del("SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"2001:db8:1::/"
+              "32\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}");
+    EXPECT_FALSE(VerifyState(db_key_1, attributes_1).empty());
+    EXPECT_FALSE(VerifyState(db_key_2, attributes_2).empty());
+    table.set("SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.11.12.0/"
+              "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
+              std::vector<swss::FieldValueTuple>{
+                  swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_DROP"},
+                  swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x0"}});
+    table.set("SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"2001:db8:1::/"
+              "32\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
+              std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x1"},
+                                                 swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_META_DATA", "1"}});
 }

--- a/orchagent/p4orch/tests/route_manager_test.cpp
+++ b/orchagent/p4orch/tests/route_manager_test.cpp
@@ -30,3259 +30,3896 @@ using ::testing::StrictMock;
 extern sai_object_id_t gSwitchId;
 extern sai_object_id_t gVirtualRouterId;
 extern sai_object_id_t gVrfOid;
-extern char *gVrfName;
+extern char* gVrfName;
 extern size_t gMaxBulkSize;
-extern sai_route_api_t *sai_route_api;
-extern VRFOrch *gVrfOrch;
+extern sai_route_api_t* sai_route_api;
+extern VRFOrch* gVrfOrch;
 
-namespace
-{
+namespace {
 
-constexpr char *kIpv4Prefix = "10.11.12.0/24";
-constexpr char *kIpv4Prefix2 = "10.12.12.0/24";
-constexpr char *kIpv6Prefix = "2001:db8:1::/32";
-constexpr char *kNexthopId1 = "ju1u32m1.atl11:qe-3/7";
+constexpr char* kIpv4Prefix = "10.11.12.0/24";
+constexpr char* kIpv4Prefix2 = "10.12.12.0/24";
+constexpr char* kIpv6Prefix = "2001:db8:1::/32";
+constexpr char* kNexthopId1 = "ju1u32m1.atl11:qe-3/7";
 constexpr sai_object_id_t kNexthopOid1 = 1;
-constexpr char *kNexthopId2 = "ju1u32m2.atl11:qe-3/7";
+constexpr char* kNexthopId2 = "ju1u32m2.atl11:qe-3/7";
 constexpr sai_object_id_t kNexthopOid2 = 2;
-constexpr char *kWcmpGroup1 = "wcmp-group-1";
+constexpr char* kWcmpGroup1 = "wcmp-group-1";
 constexpr sai_object_id_t kWcmpGroupOid1 = 3;
-constexpr char *kWcmpGroup2 = "wcmp-group-2";
+constexpr char* kWcmpGroup2 = "wcmp-group-2";
 constexpr sai_object_id_t kWcmpGroupOid2 = 4;
-constexpr char *kMetadata1 = "1";
-constexpr char *kMetadata2 = "2";
+constexpr char* kMetadata1 = "1";
+constexpr char* kMetadata2 = "2";
 uint32_t kMetadataInt1 = 1;
 uint32_t kMetadataInt2 = 2;
 
 // Returns true if the two prefixes are equal. False otherwise.
 // Arguments must be non-nullptr.
-bool PrefixCmp(const sai_ip_prefix_t *x, const sai_ip_prefix_t *y)
-{
-    if (x->addr_family != y->addr_family)
-    {
-        return false;
-    }
-    if (x->addr_family == SAI_IP_ADDR_FAMILY_IPV4)
-    {
-        return memcmp(&x->addr.ip4, &y->addr.ip4, sizeof(sai_ip4_t)) == 0 &&
-               memcmp(&x->mask.ip4, &y->mask.ip4, sizeof(sai_ip4_t)) == 0;
-    }
-    return memcmp(&x->addr.ip6, &y->addr.ip6, sizeof(sai_ip6_t)) == 0 &&
-           memcmp(&x->mask.ip6, &y->mask.ip6, sizeof(sai_ip6_t)) == 0;
+bool PrefixCmp(const sai_ip_prefix_t* x, const sai_ip_prefix_t* y) {
+  if (x->addr_family != y->addr_family) {
+    return false;
+  }
+  if (x->addr_family == SAI_IP_ADDR_FAMILY_IPV4) {
+    return memcmp(&x->addr.ip4, &y->addr.ip4, sizeof(sai_ip4_t)) == 0 &&
+           memcmp(&x->mask.ip4, &y->mask.ip4, sizeof(sai_ip4_t)) == 0;
+  }
+  return memcmp(&x->addr.ip6, &y->addr.ip6, sizeof(sai_ip6_t)) == 0 &&
+         memcmp(&x->mask.ip6, &y->mask.ip6, sizeof(sai_ip6_t)) == 0;
 }
 
 // Matches two SAI route entries.
-bool MatchSaiRouteEntry(const sai_route_entry_t &route_entry, const sai_route_entry_t &exp_route_entry)
-{
-    if (route_entry.switch_id != exp_route_entry.switch_id)
-    {
-        return false;
-    }
-    if (route_entry.vr_id != exp_route_entry.vr_id)
-    {
-        return false;
-    }
-    if (!PrefixCmp(&route_entry.destination, &exp_route_entry.destination))
-    {
-        return false;
-    }
-    return true;
+bool MatchSaiRouteEntry(const sai_route_entry_t& route_entry,
+                        const sai_route_entry_t& exp_route_entry) {
+  if (route_entry.switch_id != exp_route_entry.switch_id) {
+    return false;
+  }
+  if (route_entry.vr_id != exp_route_entry.vr_id) {
+    return false;
+  }
+  if (!PrefixCmp(&route_entry.destination, &exp_route_entry.destination)) {
+    return false;
+  }
+  return true;
 }
 
 // Matches two SAI attributes.
-bool MatchSaiAttribute(const sai_attribute_t &attr, const sai_attribute_t &exp_attr)
-{
-    if (exp_attr.id == SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION)
-    {
-        if (attr.id != SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION || attr.value.s32 != exp_attr.value.s32)
-        {
-            return false;
-        }
+bool MatchSaiAttribute(const sai_attribute_t& attr,
+                       const sai_attribute_t& exp_attr) {
+  if (exp_attr.id == SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION) {
+    if (attr.id != SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION ||
+        attr.value.s32 != exp_attr.value.s32) {
+      return false;
     }
-    if (exp_attr.id == SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID)
-    {
-        if (attr.id != SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID || attr.value.oid != exp_attr.value.oid)
-        {
-            return false;
-        }
+  }
+  if (exp_attr.id == SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID) {
+    if (attr.id != SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID ||
+        attr.value.oid != exp_attr.value.oid) {
+      return false;
     }
-    if (exp_attr.id == SAI_ROUTE_ENTRY_ATTR_META_DATA)
-    {
-        if (attr.id != SAI_ROUTE_ENTRY_ATTR_META_DATA || attr.value.u32 != exp_attr.value.u32)
-        {
-            return false;
-        }
+  }
+  if (exp_attr.id == SAI_ROUTE_ENTRY_ATTR_META_DATA) {
+    if (attr.id != SAI_ROUTE_ENTRY_ATTR_META_DATA ||
+        attr.value.u32 != exp_attr.value.u32) {
+      return false;
     }
-    return true;
+  }
+  return true;
 }
 
-MATCHER_P(ArrayEq, array, "")
-{
-    for (size_t i = 0; i < array.size(); ++i)
-    {
-        if (arg[i] != array[i])
-        {
-            return false;
-        }
+MATCHER_P(ArrayEq, array, "") {
+  for (size_t i = 0; i < array.size(); ++i) {
+    if (arg[i] != array[i]) {
+      return false;
     }
-    return true;
+  }
+  return true;
 }
 
-MATCHER_P(RouteEntryArrayEq, array, "")
-{
-    for (size_t i = 0; i < array.size(); ++i)
-    {
-        if (!MatchSaiRouteEntry(arg[i], array[i]))
-        {
-            return false;
-        }
+MATCHER_P(RouteEntryArrayEq, array, "") {
+  for (size_t i = 0; i < array.size(); ++i) {
+    if (!MatchSaiRouteEntry(arg[i], array[i])) {
+      return false;
     }
-    return true;
+  }
+  return true;
 }
 
-MATCHER_P(AttrArrayEq, array, "")
-{
-    for (size_t i = 0; i < array.size(); ++i)
-    {
-        if (!MatchSaiAttribute(arg[i], array[i]))
-        {
-            return false;
-        }
+MATCHER_P(AttrArrayEq, array, "") {
+  for (size_t i = 0; i < array.size(); ++i) {
+    if (!MatchSaiAttribute(arg[i], array[i])) {
+      return false;
     }
-    return true;
+  }
+  return true;
 }
 
-MATCHER_P(AttrArrayArrayEq, array, "")
-{
-    for (size_t i = 0; i < array.size(); ++i)
-    {
-        for (size_t j = 0; j < array[i].size(); j++)
-        {
-            if (!MatchSaiAttribute(arg[i][j], array[i][j]))
-            {
-                return false;
-            }
-        }
+MATCHER_P(AttrArrayArrayEq, array, "") {
+  for (size_t i = 0; i < array.size(); ++i) {
+    for (size_t j = 0; j < array[i].size(); j++) {
+      if (!MatchSaiAttribute(arg[i][j], array[i][j])) {
+        return false;
+      }
     }
-    return true;
+  }
+  return true;
 }
 
-MATCHER_P(FieldValueTupleArrayEq, array, "")
-{
-    for (size_t i = 0; i < array.size(); ++i)
-    {
-        if (fvField(arg[i]) != fvField(array[i]))
-        {
-            return false;
-        }
-        if (fvValue(arg[i]) != fvValue(array[i]))
-        {
-            return false;
-        }
+MATCHER_P(FieldValueTupleArrayEq, array, "") {
+  for (size_t i = 0; i < array.size(); ++i) {
+    if (fvField(arg[i]) != fvField(array[i])) {
+      return false;
     }
-    return true;
+    if (fvValue(arg[i]) != fvValue(array[i])) {
+      return false;
+    }
+  }
+  return true;
 }
 
-} // namespace
+}  // namespace
 
-class RouteManagerTest : public ::testing::Test
-{
-  protected:
-    RouteManagerTest() : route_manager_(&p4_oid_mapper_, gVrfOrch, &publisher_)
-    {
+class RouteManagerTest : public ::testing::Test {
+ protected:
+  RouteManagerTest() : route_manager_(&p4_oid_mapper_, gVrfOrch, &publisher_) {}
+
+  void SetUp() override {
+    mock_sai_route = &mock_sai_route_;
+    sai_route_api->create_route_entry = create_route_entry;
+    sai_route_api->remove_route_entry = remove_route_entry;
+    sai_route_api->set_route_entry_attribute = set_route_entry_attribute;
+    sai_route_api->get_route_entry_attribute = get_route_entry_attribute;
+    sai_route_api->create_route_entries = create_route_entries;
+    sai_route_api->remove_route_entries = remove_route_entries;
+    sai_route_api->set_route_entries_attribute = set_route_entries_attribute;
+    sai_route_api->get_route_entries_attribute = get_route_entries_attribute;
+  }
+
+  bool MergeRouteEntry(const P4RouteEntry& dest, const P4RouteEntry& src,
+                       P4RouteEntry* ret) {
+    return route_manager_.mergeRouteEntry(dest, src, ret);
+  }
+
+  ReturnCodeOr<P4RouteEntry> DeserializeRouteEntry(
+      const std::string& key,
+      const std::vector<swss::FieldValueTuple>& attributes,
+      const std::string& table_name) {
+    return route_manager_.deserializeRouteEntry(key, attributes, table_name);
+  }
+
+  P4RouteEntry* GetRouteEntry(const std::string& route_entry_key) {
+    return route_manager_.getRouteEntry(route_entry_key);
+  }
+
+  ReturnCode ValidateRouteEntry(const P4RouteEntry& route_entry,
+                                const std::string& operation) {
+    return route_manager_.validateRouteEntry(route_entry, operation);
+  }
+
+  std::vector<ReturnCode> CreateRouteEntries(
+      const std::vector<P4RouteEntry>& route_entries) {
+    return route_manager_.createRouteEntries(route_entries);
+  }
+
+  std::vector<ReturnCode> UpdateRouteEntries(
+      const std::vector<P4RouteEntry>& route_entries) {
+    return route_manager_.updateRouteEntries(route_entries);
+  }
+
+  std::vector<ReturnCode> DeleteRouteEntries(
+      const std::vector<P4RouteEntry>& route_entries) {
+    return route_manager_.deleteRouteEntries(route_entries);
+  }
+
+  void Enqueue(const std::string& table_name,
+               const swss::KeyOpFieldsValuesTuple& entry) {
+    route_manager_.enqueue(table_name, entry);
+  }
+
+  void Drain() { route_manager_.drain(); }
+
+  std::string VerifyState(const std::string& key,
+                          const std::vector<swss::FieldValueTuple>& tuple) {
+    return route_manager_.verifyState(key, tuple);
+  }
+
+  // Generates a KeyOpFieldsValuesTuple.
+  swss::KeyOpFieldsValuesTuple GenerateKeyOpFieldsValuesTuple(
+      const std::string& vrf_id, const swss::IpPrefix& route_prefix,
+      const std::string& command, const std::string& action,
+      const std::string& action_param, const std::string& route_metadata = "") {
+    nlohmann::json j;
+    std::string key_prefix;
+    j[prependMatchField(p4orch::kVrfId)] = vrf_id;
+    if (route_prefix.isV4()) {
+      j[prependMatchField(p4orch::kIpv4Dst)] = route_prefix.to_string();
+      key_prefix = std::string(APP_P4RT_IPV4_TABLE_NAME) + kTableKeyDelimiter;
+    } else {
+      j[prependMatchField(p4orch::kIpv6Dst)] = route_prefix.to_string();
+      key_prefix = std::string(APP_P4RT_IPV6_TABLE_NAME) + kTableKeyDelimiter;
     }
-
-    void SetUp() override
-    {
-        mock_sai_route = &mock_sai_route_;
-        sai_route_api->create_route_entry = create_route_entry;
-        sai_route_api->remove_route_entry = remove_route_entry;
-        sai_route_api->set_route_entry_attribute = set_route_entry_attribute;
-        sai_route_api->get_route_entry_attribute = get_route_entry_attribute;
-        sai_route_api->create_route_entries = create_route_entries;
-        sai_route_api->remove_route_entries = remove_route_entries;
-        sai_route_api->set_route_entries_attribute = set_route_entries_attribute;
-        sai_route_api->get_route_entries_attribute = get_route_entries_attribute;
+    std::vector<swss::FieldValueTuple> attributes;
+    if (command == SET_COMMAND) {
+      attributes.push_back(swss::FieldValueTuple{p4orch::kAction, action});
+      if (action == p4orch::kSetNexthopId || p4orch::kSetNexthopIdAndMetadata) {
+        attributes.push_back(swss::FieldValueTuple{
+            prependParamField(p4orch::kNexthopId), action_param});
+      } else if (action == p4orch::kSetWcmpGroupId ||
+                 action == p4orch::kSetWcmpGroupIdAndMetadata) {
+        attributes.push_back(swss::FieldValueTuple{
+            prependParamField(p4orch::kWcmpGroupId), action_param});
+      }
+      if (action == p4orch::kSetNexthopIdAndMetadata ||
+          action == p4orch::kSetWcmpGroupIdAndMetadata ||
+          action == p4orch::kSetMetadataAndDrop) {
+        attributes.push_back(swss::FieldValueTuple{
+            prependParamField(p4orch::kRouteMetadata), route_metadata});
+      }
     }
+    return swss::KeyOpFieldsValuesTuple(key_prefix + j.dump(), command,
+                                        attributes);
+  }
 
-    bool MergeRouteEntry(const P4RouteEntry &dest, const P4RouteEntry &src, P4RouteEntry *ret)
-    {
-        return route_manager_.mergeRouteEntry(dest, src, ret);
+  // Generates a P4RouteEntry.
+  P4RouteEntry GenerateP4RouteEntry(const std::string& vrf_id,
+                                    const swss::IpPrefix& route_prefix,
+                                    const std::string& action,
+                                    const std::string& action_param,
+                                    const std::string& route_metadata = "") {
+    P4RouteEntry route_entry = {};
+    route_entry.vrf_id = vrf_id;
+    route_entry.route_prefix = route_prefix;
+    route_entry.route_metadata = route_metadata;
+    route_entry.action = action;
+    if (action == p4orch::kSetNexthopId ||
+        action == p4orch::kSetNexthopIdAndMetadata) {
+      route_entry.nexthop_id = action_param;
+    } else if (action == p4orch::kSetWcmpGroupId ||
+               action == p4orch::kSetWcmpGroupIdAndMetadata) {
+      route_entry.wcmp_group = action_param;
     }
+    route_entry.route_entry_key = KeyGenerator::generateRouteKey(
+        route_entry.vrf_id, route_entry.route_prefix);
+    return route_entry;
+  }
 
-    ReturnCodeOr<P4RouteEntry> DeserializeRouteEntry(const std::string &key,
-                                                     const std::vector<swss::FieldValueTuple> &attributes,
-                                                     const std::string &table_name)
-    {
-        return route_manager_.deserializeRouteEntry(key, attributes, table_name);
-    }
+  // Sets up a nexthop route entry for test.
+  void SetupNexthopIdRouteEntry(const std::string& vrf_id,
+                                const swss::IpPrefix& route_prefix,
+                                const std::string& nexthop_id,
+                                sai_object_id_t nexthop_oid,
+                                const std::string& metadata = "") {
+    auto route_entry = GenerateP4RouteEntry(
+        vrf_id, route_prefix,
+        (metadata.empty()) ? p4orch::kSetNexthopId
+                           : p4orch::kSetNexthopIdAndMetadata,
+        nexthop_id, metadata);
+    p4_oid_mapper_.setOID(
+        SAI_OBJECT_TYPE_NEXT_HOP,
+        KeyGenerator::generateNextHopKey(route_entry.nexthop_id), nexthop_oid);
 
-    P4RouteEntry *GetRouteEntry(const std::string &route_entry_key)
-    {
-        return route_manager_.getRouteEntry(route_entry_key);
-    }
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
+        .WillOnce(
+            DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                  Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  }
 
-    ReturnCode ValidateRouteEntry(const P4RouteEntry &route_entry, const std::string &operation)
-    {
-        return route_manager_.validateRouteEntry(route_entry, operation);
-    }
+  // Sets up a wcmp route entry for test.
+  void SetupWcmpGroupRouteEntry(const std::string& vrf_id,
+                                const swss::IpPrefix& route_prefix,
+                                const std::string& wcmp_group_id,
+                                sai_object_id_t wcmp_group_oid,
+                                const std::string& metadata = "") {
+    auto route_entry = GenerateP4RouteEntry(
+        vrf_id, route_prefix,
+        (metadata.empty()) ? p4orch::kSetWcmpGroupId
+                           : p4orch::kSetWcmpGroupIdAndMetadata,
+        wcmp_group_id, metadata);
+    p4_oid_mapper_.setOID(
+        SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+        KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+        wcmp_group_oid);
 
-    std::vector<ReturnCode> CreateRouteEntries(const std::vector<P4RouteEntry> &route_entries)
-    {
-        return route_manager_.createRouteEntries(route_entries);
-    }
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
+        .WillOnce(
+            DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                  Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  }
 
-    std::vector<ReturnCode> UpdateRouteEntries(const std::vector<P4RouteEntry> &route_entries)
-    {
-        return route_manager_.updateRouteEntries(route_entries);
-    }
+  // Sets up a drop route entry for test.
+  void SetupDropRouteEntry(const std::string& vrf_id,
+                           const swss::IpPrefix& route_prefix) {
+    auto route_entry =
+        GenerateP4RouteEntry(vrf_id, route_prefix, p4orch::kDrop, "");
 
-    std::vector<ReturnCode> DeleteRouteEntries(const std::vector<P4RouteEntry> &route_entries)
-    {
-        return route_manager_.deleteRouteEntries(route_entries);
-    }
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
+        .WillOnce(
+            DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                  Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  }
 
-    void Enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry)
-    {
-        route_manager_.enqueue(table_name, entry);
-    }
+  // Sets up a trap route entry for test.
+  void SetupTrapRouteEntry(const std::string& vrf_id,
+                           const swss::IpPrefix& route_prefix) {
+    auto route_entry =
+        GenerateP4RouteEntry(vrf_id, route_prefix, p4orch::kTrap, "");
 
-    void Drain()
-    {
-        route_manager_.drain();
-    }
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+    EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
+        .WillOnce(
+            DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                  Return(SAI_STATUS_SUCCESS)));
+    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  }
 
-    std::string VerifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple)
-    {
-        return route_manager_.verifyState(key, tuple);
-    }
+  // Verifies the two given route entries are identical.
+  void VerifyRouteEntriesEq(const P4RouteEntry& x, const P4RouteEntry& y) {
+    EXPECT_EQ(x.route_entry_key, y.route_entry_key);
+    EXPECT_EQ(x.vrf_id, y.vrf_id);
+    EXPECT_EQ(x.route_prefix, y.route_prefix);
+    EXPECT_EQ(x.action, y.action);
+    EXPECT_EQ(x.nexthop_id, y.nexthop_id);
+    EXPECT_EQ(x.wcmp_group, y.wcmp_group);
+    EXPECT_EQ(x.route_metadata, y.route_metadata);
+    EXPECT_EQ(x.sai_route_entry.vr_id, y.sai_route_entry.vr_id);
+    EXPECT_EQ(x.sai_route_entry.switch_id, y.sai_route_entry.switch_id);
+    EXPECT_TRUE(PrefixCmp(&x.sai_route_entry.destination,
+                          &y.sai_route_entry.destination));
+  }
 
-    // Generates a KeyOpFieldsValuesTuple.
-    swss::KeyOpFieldsValuesTuple GenerateKeyOpFieldsValuesTuple(const std::string &vrf_id,
-                                                                const swss::IpPrefix &route_prefix,
-                                                                const std::string &command, const std::string &action,
-                                                                const std::string &action_param,
-                                                                const std::string &route_metadata = "")
-    {
-        nlohmann::json j;
-        std::string key_prefix;
-        j[prependMatchField(p4orch::kVrfId)] = vrf_id;
-        if (route_prefix.isV4())
-        {
-            j[prependMatchField(p4orch::kIpv4Dst)] = route_prefix.to_string();
-            key_prefix = std::string(APP_P4RT_IPV4_TABLE_NAME) + kTableKeyDelimiter;
-        }
-        else
-        {
-            j[prependMatchField(p4orch::kIpv6Dst)] = route_prefix.to_string();
-            key_prefix = std::string(APP_P4RT_IPV6_TABLE_NAME) + kTableKeyDelimiter;
-        }
-        std::vector<swss::FieldValueTuple> attributes;
-        if (command == SET_COMMAND)
-        {
-            attributes.push_back(swss::FieldValueTuple{p4orch::kAction, action});
-            if (action == p4orch::kSetNexthopId || p4orch::kSetNexthopIdAndMetadata)
-            {
-                attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kNexthopId), action_param});
-            }
-            else if (action == p4orch::kSetWcmpGroupId || action == p4orch::kSetWcmpGroupIdAndMetadata)
-            {
-                attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kWcmpGroupId), action_param});
-            }
-            if (action == p4orch::kSetNexthopIdAndMetadata || action == p4orch::kSetWcmpGroupIdAndMetadata ||
-                action == p4orch::kSetMetadataAndDrop)
-            {
-                attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kRouteMetadata), route_metadata});
-            }
-        }
-        return swss::KeyOpFieldsValuesTuple(key_prefix + j.dump(), command, attributes);
-    }
+  // Verifies the given route entry exists and matches.
+  void VerifyRouteEntry(const P4RouteEntry& route_entry,
+                        const sai_ip_prefix_t& sai_route_prefix,
+                        const sai_object_id_t vrf_oid) {
+    auto* route_entry_ptr = GetRouteEntry(route_entry.route_entry_key);
+    P4RouteEntry expect_entry = route_entry;
+    expect_entry.sai_route_entry.vr_id = vrf_oid;
+    expect_entry.sai_route_entry.switch_id = gSwitchId;
+    expect_entry.sai_route_entry.destination = sai_route_prefix;
+    VerifyRouteEntriesEq(expect_entry, *route_entry_ptr);
+    EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY,
+                                         route_entry.route_entry_key));
+  }
 
-    // Generates a P4RouteEntry.
-    P4RouteEntry GenerateP4RouteEntry(const std::string &vrf_id, const swss::IpPrefix &route_prefix,
-                                      const std::string &action, const std::string &action_param,
-                                      const std::string &route_metadata = "")
-    {
-        P4RouteEntry route_entry = {};
-        route_entry.vrf_id = vrf_id;
-        route_entry.route_prefix = route_prefix;
-        route_entry.route_metadata = route_metadata;
-        route_entry.action = action;
-        if (action == p4orch::kSetNexthopId || action == p4orch::kSetNexthopIdAndMetadata)
-        {
-            route_entry.nexthop_id = action_param;
-        }
-        else if (action == p4orch::kSetWcmpGroupId || action == p4orch::kSetWcmpGroupIdAndMetadata)
-        {
-            route_entry.wcmp_group = action_param;
-        }
-        route_entry.route_entry_key = KeyGenerator::generateRouteKey(route_entry.vrf_id, route_entry.route_prefix);
-        return route_entry;
-    }
-
-    // Sets up a nexthop route entry for test.
-    void SetupNexthopIdRouteEntry(const std::string &vrf_id, const swss::IpPrefix &route_prefix,
-                                  const std::string &nexthop_id, sai_object_id_t nexthop_oid,
-                                  const std::string &metadata = "")
-    {
-        auto route_entry = GenerateP4RouteEntry(
-            vrf_id, route_prefix, (metadata.empty()) ? p4orch::kSetNexthopId : p4orch::kSetNexthopIdAndMetadata,
-            nexthop_id, metadata);
-        p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                              nexthop_oid);
-
-        std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-        EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
-            .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-        EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                    ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    }
-
-    // Sets up a wcmp route entry for test.
-    void SetupWcmpGroupRouteEntry(const std::string &vrf_id, const swss::IpPrefix &route_prefix,
-                                  const std::string &wcmp_group_id, sai_object_id_t wcmp_group_oid,
-                                  const std::string &metadata = "")
-    {
-        auto route_entry = GenerateP4RouteEntry(
-            vrf_id, route_prefix, (metadata.empty()) ? p4orch::kSetWcmpGroupId : p4orch::kSetWcmpGroupIdAndMetadata,
-            wcmp_group_id, metadata);
-        p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                              KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group), wcmp_group_oid);
-
-        std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-        EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
-            .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-        EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                    ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    }
-
-    // Sets up a drop route entry for test.
-    void SetupDropRouteEntry(const std::string &vrf_id, const swss::IpPrefix &route_prefix)
-    {
-        auto route_entry = GenerateP4RouteEntry(vrf_id, route_prefix, p4orch::kDrop, "");
-
-        std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-        EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
-            .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-        EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                    ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    }
-
-    // Sets up a trap route entry for test.
-    void SetupTrapRouteEntry(const std::string &vrf_id, const swss::IpPrefix &route_prefix)
-    {
-        auto route_entry = GenerateP4RouteEntry(vrf_id, route_prefix, p4orch::kTrap, "");
-
-        std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-        EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
-            .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-        EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                    ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    }
-
-    // Verifies the two given route entries are identical.
-    void VerifyRouteEntriesEq(const P4RouteEntry &x, const P4RouteEntry &y)
-    {
-        EXPECT_EQ(x.route_entry_key, y.route_entry_key);
-        EXPECT_EQ(x.vrf_id, y.vrf_id);
-        EXPECT_EQ(x.route_prefix, y.route_prefix);
-        EXPECT_EQ(x.action, y.action);
-        EXPECT_EQ(x.nexthop_id, y.nexthop_id);
-        EXPECT_EQ(x.wcmp_group, y.wcmp_group);
-        EXPECT_EQ(x.route_metadata, y.route_metadata);
-        EXPECT_EQ(x.sai_route_entry.vr_id, y.sai_route_entry.vr_id);
-        EXPECT_EQ(x.sai_route_entry.switch_id, y.sai_route_entry.switch_id);
-        EXPECT_TRUE(PrefixCmp(&x.sai_route_entry.destination, &y.sai_route_entry.destination));
-    }
-
-    // Verifies the given route entry exists and matches.
-    void VerifyRouteEntry(const P4RouteEntry &route_entry, const sai_ip_prefix_t &sai_route_prefix,
-                          const sai_object_id_t vrf_oid)
-    {
-        auto *route_entry_ptr = GetRouteEntry(route_entry.route_entry_key);
-        P4RouteEntry expect_entry = route_entry;
-        expect_entry.sai_route_entry.vr_id = vrf_oid;
-        expect_entry.sai_route_entry.switch_id = gSwitchId;
-        expect_entry.sai_route_entry.destination = sai_route_prefix;
-        VerifyRouteEntriesEq(expect_entry, *route_entry_ptr);
-        EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, route_entry.route_entry_key));
-    }
-
-    StrictMock<MockSaiRoute> mock_sai_route_;
-    StrictMock<MockResponsePublisher> publisher_;
-    P4OidMapper p4_oid_mapper_;
-    RouteManager route_manager_;
+  StrictMock<MockSaiRoute> mock_sai_route_;
+  StrictMock<MockResponsePublisher> publisher_;
+  P4OidMapper p4_oid_mapper_;
+  RouteManager route_manager_;
 };
 
-TEST_F(RouteManagerTest, MergeRouteEntryWithNexthopIdActionDestTest)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto dest = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-    dest.sai_route_entry.vr_id = gVrfOid;
-    dest.sai_route_entry.switch_id = gSwitchId;
-    copy(dest.sai_route_entry.destination, swss_ipv4_route_prefix);
-
-    // Source is identical to destination.
-    auto src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-    P4RouteEntry ret = {};
-    EXPECT_FALSE(MergeRouteEntry(dest, src, &ret));
-    VerifyRouteEntriesEq(dest, ret);
-
-    // Source has different nexthop ID.
-    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId2);
-    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-    P4RouteEntry expect_entry = dest;
-    expect_entry.nexthop_id = kNexthopId2;
-    VerifyRouteEntriesEq(expect_entry, ret);
-
-    // Source has set nexthop ID and metadata action and dest has set nexthop ID
-    // action.
-    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata, kNexthopId1,
-                               kMetadata1);
-    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-    expect_entry = dest;
-    expect_entry.action = p4orch::kSetNexthopIdAndMetadata;
-    expect_entry.route_metadata = kMetadata1;
-    VerifyRouteEntriesEq(expect_entry, ret);
-
-    // Source has wcmp group action and dest has nexhop ID action.
-    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
-    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-    expect_entry = dest;
-    expect_entry.nexthop_id = "";
-    expect_entry.action = p4orch::kSetWcmpGroupId;
-    expect_entry.wcmp_group = kWcmpGroup1;
-    VerifyRouteEntriesEq(expect_entry, ret);
-
-    // Source has drop action and dest has nexhop ID action.
-    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-    expect_entry = dest;
-    expect_entry.nexthop_id = "";
-    expect_entry.action = p4orch::kDrop;
-    VerifyRouteEntriesEq(expect_entry, ret);
-}
-
-TEST_F(RouteManagerTest, MergeRouteEntryWithNexthopIdAndMetadataActionDestTest)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto dest = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata, kNexthopId1,
-                                     kMetadata1);
-    dest.sai_route_entry.vr_id = gVrfOid;
-    dest.sai_route_entry.switch_id = gSwitchId;
-    copy(dest.sai_route_entry.destination, swss_ipv4_route_prefix);
-
-    // Source is identical to destination.
-    auto src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata, kNexthopId1,
-                                    kMetadata1);
-    P4RouteEntry ret = {};
-    EXPECT_FALSE(MergeRouteEntry(dest, src, &ret));
-    VerifyRouteEntriesEq(dest, ret);
-
-    // Source has different metadata.
-    src.route_metadata = kMetadata2;
-    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-    P4RouteEntry expect_entry = dest;
-    expect_entry.route_metadata = kMetadata2;
-    VerifyRouteEntriesEq(expect_entry, ret);
-
-    // Source has different nexthop ID and metadata.
-    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata, kNexthopId2,
-                               kMetadata2);
-    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-    expect_entry = dest;
-    expect_entry.nexthop_id = kNexthopId2;
-    expect_entry.route_metadata = kMetadata2;
-    VerifyRouteEntriesEq(expect_entry, ret);
-
-    // Source has wcmp group action and dest has nexhop ID and metadata action.
-    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
-    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-    expect_entry = dest;
-    expect_entry.nexthop_id = "";
-    expect_entry.action = p4orch::kSetWcmpGroupId;
-    expect_entry.wcmp_group = kWcmpGroup1;
-    expect_entry.route_metadata = "";
-    VerifyRouteEntriesEq(expect_entry, ret);
-
-    // Source has drop action and dest has nexhop ID and metadata action.
-    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-    expect_entry = dest;
-    expect_entry.nexthop_id = "";
-    expect_entry.action = p4orch::kDrop;
-    expect_entry.route_metadata = "";
-    VerifyRouteEntriesEq(expect_entry, ret);
-
-    // Source has wcmp group and metadata action and dest has nexhop ID and
-    // metadata action.
-    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupIdAndMetadata, kWcmpGroup1,
-                               kMetadata2);
-    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-    expect_entry = dest;
-    expect_entry.nexthop_id = "";
-    expect_entry.action = p4orch::kSetWcmpGroupIdAndMetadata;
-    expect_entry.wcmp_group = kWcmpGroup1;
-    expect_entry.route_metadata = kMetadata2;
-    VerifyRouteEntriesEq(expect_entry, ret);
-}
-
-TEST_F(RouteManagerTest, MergeRouteEntryWithWcmpGroupActionDestTest)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto dest = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
-    dest.sai_route_entry.vr_id = gVrfOid;
-    dest.sai_route_entry.switch_id = gSwitchId;
-    copy(dest.sai_route_entry.destination, swss_ipv4_route_prefix);
-
-    // Source is identical to destination.
-    auto src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
-    P4RouteEntry ret = {};
-    EXPECT_FALSE(MergeRouteEntry(dest, src, &ret));
-    VerifyRouteEntriesEq(dest, ret);
-
-    // Source has different wcmp group.
-    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup2);
-    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-    P4RouteEntry expect_entry = dest;
-    expect_entry.wcmp_group = kWcmpGroup2;
-    VerifyRouteEntriesEq(expect_entry, ret);
-
-    // Source has nexthop ID action and dest has wcmp group action.
-    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-    expect_entry = dest;
-    expect_entry.wcmp_group = "";
-    expect_entry.action = p4orch::kSetNexthopId;
-    expect_entry.nexthop_id = kNexthopId1;
-    VerifyRouteEntriesEq(expect_entry, ret);
-
-    // Source has drop action and dest has wcmp group action.
-    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-    expect_entry = dest;
-    expect_entry.wcmp_group = "";
-    expect_entry.action = p4orch::kDrop;
-    VerifyRouteEntriesEq(expect_entry, ret);
-}
-
-TEST_F(RouteManagerTest, MergeRouteEntryWithDropActionDestTest)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto dest = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-    dest.sai_route_entry.vr_id = gVrfOid;
-    dest.sai_route_entry.switch_id = gSwitchId;
-    copy(dest.sai_route_entry.destination, swss_ipv4_route_prefix);
-
-    // Source is identical to destination.
-    auto src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-    P4RouteEntry ret = {};
-    EXPECT_FALSE(MergeRouteEntry(dest, src, &ret));
-    VerifyRouteEntriesEq(dest, ret);
-
-    // Source has nexthop ID action and dest has drop action.
-    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-    P4RouteEntry expect_entry = dest;
-    expect_entry.action = p4orch::kSetNexthopId;
-    expect_entry.nexthop_id = kNexthopId1;
-    VerifyRouteEntriesEq(expect_entry, ret);
-
-    // Source has wcmp group and metadata action and dest has drop action.
-    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupIdAndMetadata, kWcmpGroup1,
-                               kMetadata1);
-    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-    expect_entry = dest;
-    expect_entry.action = p4orch::kSetWcmpGroupIdAndMetadata;
-    expect_entry.nexthop_id = "";
-    expect_entry.wcmp_group = kWcmpGroup1;
-    expect_entry.route_metadata = kMetadata1;
-    VerifyRouteEntriesEq(expect_entry, ret);
-}
-
-TEST_F(RouteManagerTest, MergeRouteEntryWithTrapActionDestTest)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto dest = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
-    dest.sai_route_entry.vr_id = gVrfOid;
-    dest.sai_route_entry.switch_id = gSwitchId;
-    copy(dest.sai_route_entry.destination, swss_ipv4_route_prefix);
-
-    // Source is identical to destination.
-    auto src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
-    P4RouteEntry ret = {};
-    EXPECT_FALSE(MergeRouteEntry(dest, src, &ret));
-    VerifyRouteEntriesEq(dest, ret);
-
-    // Source has nexthop ID action and dest has trap action.
-    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-    P4RouteEntry expect_entry = dest;
-    expect_entry.action = p4orch::kSetNexthopId;
-    expect_entry.nexthop_id = kNexthopId1;
-    VerifyRouteEntriesEq(expect_entry, ret);
-
-    // Source has wcmp group action and dest has trap action.
-    src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
-    EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
-    expect_entry = dest;
-    expect_entry.action = p4orch::kSetWcmpGroupId;
-    expect_entry.wcmp_group = kWcmpGroup1;
-    VerifyRouteEntriesEq(expect_entry, ret);
-}
-
-TEST_F(RouteManagerTest, DeserializeRouteEntryWithNexthopIdActionTest)
-{
-    std::string key = R"({"match/vrf_id":"b4-traffic","match/ipv4_dst":"10.11.12.0/24"})";
-    std::vector<swss::FieldValueTuple> attributes;
-    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
-    attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kNexthopId), kNexthopId1});
-    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV4_TABLE_NAME);
-    EXPECT_TRUE(route_entry_or.ok());
-    auto &route_entry = *route_entry_or;
-    auto expect_entry =
-        GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("10.11.12.0/24"), p4orch::kSetNexthopId, kNexthopId1);
-    VerifyRouteEntriesEq(expect_entry, route_entry);
-}
-
-TEST_F(RouteManagerTest, DeserializeRouteEntryWithWcmpGroupActionTest)
-{
-    std::string key = R"({"match/vrf_id":"b4-traffic","match/ipv4_dst":"10.11.12.0/24"})";
-    std::vector<swss::FieldValueTuple> attributes;
-    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kSetWcmpGroupId});
-    attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kWcmpGroupId), kWcmpGroup1});
-    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV4_TABLE_NAME);
-    EXPECT_TRUE(route_entry_or.ok());
-    auto &route_entry = *route_entry_or;
-    auto expect_entry =
-        GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("10.11.12.0/24"), p4orch::kSetWcmpGroupId, kWcmpGroup1);
-    VerifyRouteEntriesEq(expect_entry, route_entry);
-}
-
-TEST_F(RouteManagerTest, DeserializeRouteEntryWithNexthopIdAdnMetadataActionTest)
-{
-    std::string key = R"({"match/vrf_id":"b4-traffic","match/ipv4_dst":"10.11.12.0/24"})";
-    std::vector<swss::FieldValueTuple> attributes;
-    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopIdAndMetadata});
-    attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kNexthopId), kNexthopId1});
-    attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kRouteMetadata), kMetadata1});
-    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV4_TABLE_NAME);
-    EXPECT_TRUE(route_entry_or.ok());
-    auto &route_entry = *route_entry_or;
-    auto expect_entry = GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("10.11.12.0/24"),
-                                             p4orch::kSetNexthopIdAndMetadata, kNexthopId1, kMetadata1);
-    VerifyRouteEntriesEq(expect_entry, route_entry);
-}
-
-TEST_F(RouteManagerTest, DeserializeRouteEntryWithWcmpGroupAndMetadataActionTest)
-{
-    std::string key = R"({"match/vrf_id":"b4-traffic","match/ipv4_dst":"10.11.12.0/24"})";
-    std::vector<swss::FieldValueTuple> attributes;
-    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kSetWcmpGroupIdAndMetadata});
-    attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kWcmpGroupId), kWcmpGroup1});
-    attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kRouteMetadata), kMetadata1});
-    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV4_TABLE_NAME);
-    EXPECT_TRUE(route_entry_or.ok());
-    auto &route_entry = *route_entry_or;
-    auto expect_entry = GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("10.11.12.0/24"),
-                                             p4orch::kSetWcmpGroupIdAndMetadata, kWcmpGroup1, kMetadata1);
-    VerifyRouteEntriesEq(expect_entry, route_entry);
-}
-
-TEST_F(RouteManagerTest, DeserializeRouteEntryWithDropActionTest)
-{
-    std::string key = R"({"match/vrf_id":"b4-traffic","match/ipv6_dst":"2001:db8:1::/32"})";
-    std::vector<swss::FieldValueTuple> attributes;
-    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
-    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
-    EXPECT_TRUE(route_entry_or.ok());
-    auto &route_entry = *route_entry_or;
-    auto expect_entry = GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("2001:db8:1::/32"), p4orch::kDrop, "");
-    VerifyRouteEntriesEq(expect_entry, route_entry);
-}
-
-TEST_F(RouteManagerTest, DeserializeRouteEntryWithTrapActionTest)
-{
-    std::string key = R"({"match/vrf_id":"b4-traffic","match/ipv6_dst":"2001:db8:1::/32"})";
-    std::vector<swss::FieldValueTuple> attributes;
-    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kTrap});
-    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
-    EXPECT_TRUE(route_entry_or.ok());
-    auto &route_entry = *route_entry_or;
-    auto expect_entry = GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("2001:db8:1::/32"), p4orch::kTrap, "");
-    VerifyRouteEntriesEq(expect_entry, route_entry);
-}
-
-TEST_F(RouteManagerTest, DeserializeRouteEntryWithInvalidKeyShouldFail)
-{
-    std::string key = "{{{{{{{{{{{{";
-    std::vector<swss::FieldValueTuple> attributes;
-    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
-    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
-    EXPECT_FALSE(route_entry_or.ok());
-}
-
-TEST_F(RouteManagerTest, DeserializeRouteEntryWithInvalidFieldShouldFail)
-{
-    std::string key = R"({"match/vrf_id":"b4-traffic","match/ipv6_dst":"2001:db8:1::/32"})";
-    std::vector<swss::FieldValueTuple> attributes;
-    attributes.push_back(swss::FieldValueTuple{"invalid", "invalid"});
-    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
-    EXPECT_FALSE(route_entry_or.ok());
-}
-
-TEST_F(RouteManagerTest, DeserializeRouteEntryWithInvalidRouteShouldFail)
-{
-    std::string key = R"({"match/vrf_id":"b4-traffic","match/ipv6_dst":"invalid"})";
-    std::vector<swss::FieldValueTuple> attributes;
-    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
-    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
-    EXPECT_FALSE(route_entry_or.ok());
-}
-
-TEST_F(RouteManagerTest, DeserializeRouteEntryWithoutIpv4WildcardLpmMatchShouldSucceed)
-{
-    std::string key = R"({"match/vrf_id":"b4-traffic"})";
-    std::vector<swss::FieldValueTuple> attributes;
-    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
-    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV4_TABLE_NAME);
-    EXPECT_TRUE(route_entry_or.ok());
-    auto &route_entry = *route_entry_or;
-    auto expect_entry = GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("0.0.0.0/0"), p4orch::kDrop, "");
-    VerifyRouteEntriesEq(expect_entry, route_entry);
-}
-
-TEST_F(RouteManagerTest, DeserializeRouteEntryWithoutIpv6WildcardLpmMatchShouldSucceed)
-{
-    std::string key = R"({"match/vrf_id":"b4-traffic"})";
-    std::vector<swss::FieldValueTuple> attributes;
-    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
-    auto route_entry_or = DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
-    EXPECT_TRUE(route_entry_or.ok());
-    auto &route_entry = *route_entry_or;
-    auto expect_entry = GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("::/0"), p4orch::kDrop, "");
-    VerifyRouteEntriesEq(expect_entry, route_entry);
-}
-
-TEST_F(RouteManagerTest, ValidateRouteEntryNexthopActionWithInvalidNexthopShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-    EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND, ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateRouteEntryNexthopActionWithValidNexthopShouldSucceed)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid1);
-    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateRouteEntryWcmpGroupActionWithInvalidWcmpGroupShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
-    EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND, ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateRouteEntryWcmpGroupActionWithValidWcmpGroupShouldSucceed)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-                          kWcmpGroupOid1);
-    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateRouteEntryWithInvalidCommandShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, "invalid"));
-}
-
-TEST_F(RouteManagerTest, ValidateSetRouteEntryDoesNotExistInManagerShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-    route_entry.action = "";
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid1);
-    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateSetRouteEntryExistsInMapperDoesNotExistInManagerShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid1);
-    p4_oid_mapper_.setDummyOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, route_entry.route_entry_key);
-    EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND, ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateSetRouteEntryExistsInManagerDoesNotExistInMapperShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-    p4_oid_mapper_.eraseOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, route_entry.route_entry_key);
-    EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND, ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateSetRouteEntryNexthopIdActionWithoutNexthopIdShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, "");
-    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateSetRouteEntryNexthopIdActionWithWcmpGroupShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-    route_entry.wcmp_group = kWcmpGroup1;
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid1);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-                          kWcmpGroupOid1);
-    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateSetRouteEntryWcmpGroupActionWithoutWcmpGroupShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, "");
-    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateSetRouteEntryWcmpGroupActionWithNexthopIdShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
-    route_entry.nexthop_id = kNexthopId1;
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid1);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-                          kWcmpGroupOid1);
-    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateSetRouteEntryDropActionWithNexthopIdShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-    route_entry.nexthop_id = kNexthopId1;
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid1);
-    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateSetRouteEntryWcmpGroupActionWithNonemptyMetadataShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto route_entry =
-        GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1, kMetadata1);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-                          kWcmpGroupOid1);
-    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateSetRouteEntryNexthopIdAndMetadataActionWithEmptyMetadataShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto route_entry =
-        GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata, kNexthopId1);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid1);
-    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateSetRouteEntryNexthopIdAndMetadataActionWithInvalidMetadataShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata,
-                                            kNexthopId1, "invalid_int");
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid1);
-    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateSetRouteEntryDropActionWithWcmpGroupShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-    route_entry.wcmp_group = kWcmpGroup1;
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-                          kWcmpGroupOid1);
-    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateSetRouteEntryTrapActionWithNexthopIdShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
-    route_entry.nexthop_id = kNexthopId1;
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid1);
-    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateSetRouteEntryTrapActionWithWcmpGroupShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
-    route_entry.wcmp_group = kWcmpGroup1;
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-                          kWcmpGroupOid1);
-    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateSetRouteEntryInvalidActionShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-    route_entry.action = "invalid";
-    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateSetRouteEntrySucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId2);
-    route_entry.action = "";
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid2);
-    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ValidateRouteEntry(route_entry, SET_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateDelRouteEntryDoesNotExistInManagerShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "");
-    EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND, ValidateRouteEntry(route_entry, DEL_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateDelRouteEntryDoesNotExistInMapperShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "");
-    p4_oid_mapper_.eraseOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, route_entry.route_entry_key);
-    // TODO: Expect critical state.
-    EXPECT_EQ(StatusCode::SWSS_RC_INTERNAL, ValidateRouteEntry(route_entry, DEL_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateDelRouteEntryHasActionShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, "");
-    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, DEL_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateDelRouteEntryHasNexthopIdShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-    route_entry.action = "";
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid1);
-    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, DEL_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateDelRouteEntryHasWcmpGroupShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
-    route_entry.action = "";
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-                          kWcmpGroupOid1);
-    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, DEL_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateDelRouteEntryHasMetadataShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "", kMetadata1);
-    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ValidateRouteEntry(route_entry, DEL_COMMAND));
-}
-
-TEST_F(RouteManagerTest, ValidateDelRouteEntrySucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "");
-    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ValidateRouteEntry(route_entry, DEL_COMMAND));
-}
-
-TEST_F(RouteManagerTest, CreateRouteEntryWithSaiErrorShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE};
-    EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
-        .Times(3)
-        .WillRepeatedly(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_FAILURE)));
-    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-
-    route_entry.action = p4orch::kSetNexthopId;
-    route_entry.nexthop_id = kNexthopId1;
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid1);
-    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-
-    route_entry.action = p4orch::kSetWcmpGroupId;
-    route_entry.wcmp_group = kWcmpGroup1;
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-                          kWcmpGroupOid1);
-    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(RouteManagerTest, CreateNexthopIdIpv4RouteSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid1);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr.value.oid = kNexthopOid1;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_,
-                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     ArrayEq(std::vector<uint32_t>{1}),
-                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr}}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, CreateNexthopIdIpv6RouteSucceeds)
-{
-    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-    sai_ip_prefix_t sai_ipv6_route_prefix;
-    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid1);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv6_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr.value.oid = kNexthopOid1;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_,
-                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     ArrayEq(std::vector<uint32_t>{1}),
-                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr}}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv6_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, CreateNexthopIdWithMetadataIpv4RouteSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata,
-                                            kNexthopId1, kMetadata1);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid1);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    std::vector<sai_attribute_t> exp_sai_attrs;
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr.value.oid = kNexthopOid1;
-    exp_sai_attrs.push_back(exp_sai_attr);
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
-    exp_sai_attr.value.u32 = kMetadataInt1;
-    exp_sai_attrs.push_back(exp_sai_attr);
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_,
-                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     ArrayEq(std::vector<uint32_t>{static_cast<uint32_t>(exp_sai_attrs.size())}),
-                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{exp_sai_attrs}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, CreateDropSetMetadataRouteSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    auto route_entry =
-        GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetMetadataAndDrop, "", kMetadata1);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    std::vector<sai_attribute_t> exp_sai_attrs;
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
-    exp_sai_attrs.push_back(exp_sai_attr);
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
-    exp_sai_attr.value.u32 = kMetadataInt1;
-    exp_sai_attrs.push_back(exp_sai_attr);
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_,
-                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     ArrayEq(std::vector<uint32_t>{static_cast<uint32_t>(exp_sai_attrs.size())}),
-                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{exp_sai_attrs}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-
-    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-}
-
-TEST_F(RouteManagerTest, CreateDropIpv4RouteSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_,
-                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     ArrayEq(std::vector<uint32_t>{1}),
-                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr}}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-}
-
-TEST_F(RouteManagerTest, CreateDropIpv6RouteSucceeds)
-{
-    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-    sai_ip_prefix_t sai_ipv6_route_prefix;
-    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kDrop, "");
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv6_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_,
-                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     ArrayEq(std::vector<uint32_t>{1}),
-                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr}}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv6_route_prefix, gVrfOid);
-}
-
-TEST_F(RouteManagerTest, CreateTrapIpv4RouteSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_TRAP;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_,
-                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     ArrayEq(std::vector<uint32_t>{1}),
-                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr}}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-}
-
-TEST_F(RouteManagerTest, CreateTrapIpv6RouteSucceeds)
-{
-    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-    sai_ip_prefix_t sai_ipv6_route_prefix;
-    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kTrap, "");
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv6_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_TRAP;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_,
-                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     ArrayEq(std::vector<uint32_t>{1}),
-                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr}}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv6_route_prefix, gVrfOid);
-}
-
-TEST_F(RouteManagerTest, CreateWcmpIpv4RouteSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-                          kWcmpGroupOid1);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr.value.oid = kWcmpGroupOid1;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_,
-                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     ArrayEq(std::vector<uint32_t>{1}),
-                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr}}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, CreateWcmpIpv6RouteSucceeds)
-{
-    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-    sai_ip_prefix_t sai_ipv6_route_prefix;
-    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-                          kWcmpGroupOid1);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv6_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr.value.oid = kWcmpGroupOid1;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_,
-                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     ArrayEq(std::vector<uint32_t>{1}),
-                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr}}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv6_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, CreateWcmpWithMetadataIpv6RouteSucceeds)
-{
-    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-    sai_ip_prefix_t sai_ipv6_route_prefix;
-    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kSetWcmpGroupIdAndMetadata,
-                                            kWcmpGroup1, kMetadata1);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-                          kWcmpGroupOid1);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv6_route_prefix;
-
-    std::vector<sai_attribute_t> exp_sai_attrs;
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr.value.oid = kWcmpGroupOid1;
-    exp_sai_attrs.push_back(exp_sai_attr);
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
-    exp_sai_attr.value.u32 = kMetadataInt1;
-    exp_sai_attrs.push_back(exp_sai_attr);
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_,
-                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     ArrayEq(std::vector<uint32_t>{static_cast<uint32_t>(exp_sai_attrs.size())}),
-                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{exp_sai_attrs}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv6_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteEntryWcmpWithSaiErrorShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupWcmpGroupRouteEntry(gVrfName, swss_ipv4_route_prefix, kWcmpGroup1, kWcmpGroupOid1);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup2);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-                          kWcmpGroupOid2);
-    std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_FAILURE)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(RouteManagerTest, UpdateRouteEntryWcmpNotExistInMapperShouldRaiseCriticalState)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupWcmpGroupRouteEntry(gVrfName, swss_ipv4_route_prefix, kWcmpGroup1, kWcmpGroupOid1);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup2);
-    std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_FAILURE)));
-    // TODO: Expect critical state.
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromSetWcmpToSetNextHopSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupWcmpGroupRouteEntry(gVrfName, swss_ipv4_route_prefix, kWcmpGroup1, kWcmpGroupOid1);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId2);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid2);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr.value.oid = kNexthopOid2;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromSetWcmpToSetNextHopAndMetadataSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupWcmpGroupRouteEntry(gVrfName, swss_ipv4_route_prefix, kWcmpGroup1, kWcmpGroupOid1);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata,
-                                            kNexthopId2, kMetadata2);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid2);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
-    exp_sai_attr.value.u32 = kMetadataInt2;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr.value.oid = kNexthopOid2;
-
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromSetNexthopIdToSetWcmpSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup2);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-                          kWcmpGroupOid2);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr.value.oid = kWcmpGroupOid2;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    route_entry.action = p4orch::kSetWcmpGroupId;
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup2), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromSetNexthopIdAndMetadataToSetWcmpSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1, kMetadata2);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup2);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-                          kWcmpGroupOid2);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
-    exp_sai_attr.value.u32 = 0;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr.value.oid = kWcmpGroupOid2;
-
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup2), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteEntryNexthopIdWithSaiErrorShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId2);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid2);
-    std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
-                        Return(SAI_STATUS_FAILURE)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(RouteManagerTest, UpdateRouteEntryNexthopIdNotExistInMapperShouldRaiseCriticalState)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId2);
-    std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
-                        Return(SAI_STATUS_FAILURE)));
-    // TODO: Expect critical state.
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(RouteManagerTest, UpdateRouteEntryDropWithSaiErrorShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-    std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
-    std::vector<sai_status_t> exp_success_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
-                        Return(SAI_STATUS_FAILURE)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
-                        Return(SAI_STATUS_SUCCESS)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
-                        Return(SAI_STATUS_FAILURE)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
-                        Return(SAI_STATUS_SUCCESS)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
-                        Return(SAI_STATUS_FAILURE)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
-                        Return(SAI_STATUS_FAILURE)));
-    // TODO: Expect critical state.
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(RouteManagerTest, UpdateRouteEntryTrapWithSaiErrorShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
-    std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
-    std::vector<sai_status_t> exp_success_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
-                        Return(SAI_STATUS_FAILURE)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
-                        Return(SAI_STATUS_SUCCESS)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
-                        Return(SAI_STATUS_FAILURE)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
-                        Return(SAI_STATUS_SUCCESS)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
-                        Return(SAI_STATUS_FAILURE)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
-                        Return(SAI_STATUS_FAILURE)));
-    // TODO: Expect critical state.
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(RouteManagerTest, UpdateRouteWithDifferentNexthopIdsSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId2);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid2);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr.value.oid = kNexthopOid2;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    route_entry.action = p4orch::kSetNexthopId;
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteWithDifferentNexthopIdsAndMetadatasSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1, kMetadata1);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata,
-                                            kNexthopId2, kMetadata2);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid2);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
-    exp_sai_attr.value.u32 = kMetadataInt2;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr.value.oid = kNexthopOid2;
-
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromNexthopIdToDropSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr.value.oid = SAI_NULL_OBJECT_ID;
-
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromNexthopIdToRouteMetadataSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-
-    auto route_entry =
-        GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetMetadataAndDrop, "", kMetadata1);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
-    exp_sai_attr.value.s32 = kMetadataInt1;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr.value.oid = SAI_NULL_OBJECT_ID;
-
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
-
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromNexthopIdAndMetadataToDropSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1, kMetadata2);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr.value.oid = SAI_NULL_OBJECT_ID;
-
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
-    exp_sai_attr.value.u32 = 0;
-
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromDropToNexthopIdSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupDropRouteEntry(gVrfName, swss_ipv4_route_prefix);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId2);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid2);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr.value.oid = kNexthopOid2;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_FORWARD;
-
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromDropToWcmpWithMetadataSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupDropRouteEntry(gVrfName, swss_ipv4_route_prefix);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupIdAndMetadata,
-                                            kWcmpGroup1, kMetadata2);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-                          kWcmpGroupOid1);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
-    exp_sai_attr.value.u32 = kMetadataInt2;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr.value.oid = kWcmpGroupOid1;
-
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_FORWARD;
-
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromTrapToDropAndSetMetadataSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupTrapRouteEntry(gVrfName, swss_ipv4_route_prefix);
-
-    auto route_entry =
-        GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetMetadataAndDrop, "", kMetadata2);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
-    exp_sai_attr.value.u32 = kMetadataInt2;
-
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromTrapToDropSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupTrapRouteEntry(gVrfName, swss_ipv4_route_prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromDropToTrapSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupDropRouteEntry(gVrfName, swss_ipv4_route_prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_TRAP;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromNexthopIdToTrapSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_TRAP;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr.value.oid = SAI_NULL_OBJECT_ID;
-
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromTrapToNexthopIdSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupTrapRouteEntry(gVrfName, swss_ipv4_route_prefix);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId2);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid2);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr.value.oid = kNexthopOid2;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-    exp_sai_attr.value.s32 = SAI_PACKET_ACTION_FORWARD;
-
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromTrapToNexthopIdAndMetadataRecoverFailureShouldRaiseCriticalState)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupTrapRouteEntry(gVrfName, swss_ipv4_route_prefix);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata,
-                                            kNexthopId2, kMetadata1);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid2);
-    std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
-    std::vector<sai_status_t> exp_success_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
-                        Return(SAI_STATUS_SUCCESS)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
-                        Return(SAI_STATUS_SUCCESS)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
-                        Return(SAI_STATUS_FAILURE)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
-                        Return(SAI_STATUS_SUCCESS)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
-                        Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
-                        Return(SAI_STATUS_SUCCESS)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
-                        Return(SAI_STATUS_SUCCESS)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
-                        Return(SAI_STATUS_FAILURE)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
-                        Return(SAI_STATUS_SUCCESS)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
-                        Return(SAI_STATUS_FAILURE)));
-    // TODO: Expect critical state.
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(RouteManagerTest, UpdateRouteWithDifferentWcmpGroupsSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupWcmpGroupRouteEntry(gVrfName, swss_ipv4_route_prefix, kWcmpGroup1, kWcmpGroupOid1);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup2);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
-                          kWcmpGroupOid2);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr.value.oid = kWcmpGroupOid2;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    route_entry.action = p4orch::kSetWcmpGroupId;
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup2), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateNexthopIdRouteWithNoChangeSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromNexthopIdAndMetadataToDropRecoverFailureShouldRaiseCriticalState)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1, kMetadata2);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
-
-    std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
-    std::vector<sai_status_t> exp_success_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
-                        Return(SAI_STATUS_FAILURE)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
-                        Return(SAI_STATUS_SUCCESS)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
-                        Return(SAI_STATUS_SUCCESS)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
-                        Return(SAI_STATUS_FAILURE)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
-                        Return(SAI_STATUS_SUCCESS)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
-                        Return(SAI_STATUS_FAILURE)));
-    // TODO: Expect critical state.
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(RouteManagerTest, UpdateRouteFromDifferentNexthopIdAndMetadataRecoverFailureShouldRaiseCriticalState)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1, kMetadata1);
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopIdAndMetadata,
-                                            kNexthopId2, kMetadata2);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry.nexthop_id),
-                          kNexthopOid2);
-
-    std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
-    std::vector<sai_status_t> exp_success_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
-                        Return(SAI_STATUS_FAILURE)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(), exp_success_status.end()),
-                        Return(SAI_STATUS_SUCCESS)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
-                        Return(SAI_STATUS_FAILURE)))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(), exp_failure_status.end()),
-                        Return(SAI_STATUS_FAILURE)));
-    // TODO: Expect critical state.
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(RouteManagerTest, DeleteRouteEntryWithSaiErrorShouldFail)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE};
-    EXPECT_CALL(mock_sai_route_, remove_route_entries(_, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_FAILURE)));
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "");
-    EXPECT_THAT(DeleteRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
-}
-
-TEST_F(RouteManagerTest, DeleteIpv4RouteSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_,
-                remove_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "");
-    EXPECT_THAT(DeleteRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    auto *route_entry_ptr = GetRouteEntry(route_entry.route_entry_key);
-    EXPECT_EQ(nullptr, route_entry_ptr);
-    EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, route_entry.route_entry_key));
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, DeleteIpv6RouteSucceeds)
-{
-    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-    sai_ip_prefix_t sai_ipv6_route_prefix;
-    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-    SetupWcmpGroupRouteEntry(gVrfName, swss_ipv6_route_prefix, kWcmpGroup1, kWcmpGroupOid1);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVrfOid;
-    exp_sai_route_entry.destination = sai_ipv6_route_prefix;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_,
-                remove_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, "", "");
-    EXPECT_THAT(DeleteRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    auto *route_entry_ptr = GetRouteEntry(route_entry.route_entry_key);
-    EXPECT_EQ(nullptr, route_entry_ptr);
-    EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, route_entry.route_entry_key));
-    uint32_t ref_cnt;
-    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, RouteCreateAndUpdateInDrainSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), kNexthopOid1);
-    auto key_op_fvs_1 = GenerateKeyOpFieldsValuesTuple(gVrfName, swss_ipv4_route_prefix, SET_COMMAND,
-                                                       p4orch::kSetNexthopId, kNexthopId1);
-    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_1);
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_1)),
-                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_1)),
-                                    Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
-        .Times(1);
-    Drain();
-
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), kNexthopOid2);
-    auto key_op_fvs_2 = GenerateKeyOpFieldsValuesTuple(gVrfName, swss_ipv4_route_prefix, SET_COMMAND,
-                                                       p4orch::kSetNexthopId, kNexthopId2);
-    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_2);
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_2)),
-                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_2)),
-                                    Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
-        .Times(1);
-    Drain();
-
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId2);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-
-    auto key_op_fvs_3 = GenerateKeyOpFieldsValuesTuple(gVrfName, swss_ipv4_route_prefix, SET_COMMAND,
-                                                       p4orch::kSetMetadataAndDrop, "", kMetadata1);
-    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_3);
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
-        .WillRepeatedly(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_3)),
-                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_3)),
-                                    Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
-        .Times(1);
-    Drain();
-
-    route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetMetadataAndDrop, "", kMetadata1);
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, RouteCreateAndDeleteInDrainSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), kNexthopOid1);
-    auto key_op_fvs_1 = GenerateKeyOpFieldsValuesTuple(gVrfName, swss_ipv4_route_prefix, SET_COMMAND,
-                                                       p4orch::kSetNexthopId, kNexthopId1);
-    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_1);
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_1)),
-                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_1)),
-                                    Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
-        .Times(1);
-    Drain();
-
-    auto key_op_fvs_2 = GenerateKeyOpFieldsValuesTuple(gVrfName, swss_ipv4_route_prefix, DEL_COMMAND, "", "");
-    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_2);
-    EXPECT_CALL(mock_sai_route_, remove_route_entries(_, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_2)),
-                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_2)),
-                                    Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
-        .Times(1);
-    Drain();
-
-    std::string key = KeyGenerator::generateRouteKey(gVrfName, swss_ipv4_route_prefix);
-    auto *route_entry_ptr = GetRouteEntry(key);
-    EXPECT_EQ(nullptr, route_entry_ptr);
-    EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, key));
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, UpdateFailsWhenCreateAndUpdateTheSameRouteInDrain)
-{
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), kNexthopOid1);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), kNexthopOid2);
-    auto key_op_fvs_1 = GenerateKeyOpFieldsValuesTuple(gVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND,
-                                                       p4orch::kSetNexthopId, kNexthopId1);
-    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_1);
-    auto key_op_fvs_2 = GenerateKeyOpFieldsValuesTuple(gVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND,
-                                                       p4orch::kSetNexthopId, kNexthopId2);
-    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_2);
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_1)),
-                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_1)),
-                                    Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
-        .Times(1);
-    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_2)),
-                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_2)),
-                                    Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)))
-        .Times(1);
-
-    Drain();
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, DeleteFailsWhenCreateAndDeleteTheSameRouteInDrain)
-{
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), kNexthopOid1);
-    auto key_op_fvs_1 = GenerateKeyOpFieldsValuesTuple(gVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND,
-                                                       p4orch::kSetNexthopId, kNexthopId1);
-    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_1);
-    auto key_op_fvs_2 = GenerateKeyOpFieldsValuesTuple(gVrfName, swss::IpPrefix(kIpv4Prefix), DEL_COMMAND, "", "");
-    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_2);
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_1)),
-                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_1)),
-                                    Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
-        .Times(1);
-    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_2)),
-                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_2)),
-                                    Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)))
-        .Times(1);
-    Drain();
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-    VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, RouteCreateInDrainSucceedsWhenVrfIsEmpty)
-{
-    const std::string kDefaultVrfName = ""; // Default Vrf
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), kNexthopOid1);
-    auto key_op_fvs = GenerateKeyOpFieldsValuesTuple(kDefaultVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND,
-                                                     p4orch::kSetNexthopId, kNexthopId1);
-    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
-
-    sai_route_entry_t exp_sai_route_entry;
-    exp_sai_route_entry.switch_id = gSwitchId;
-    exp_sai_route_entry.vr_id = gVirtualRouterId;
-    exp_sai_route_entry.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr;
-    exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr.value.oid = kNexthopOid1;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_,
-                create_route_entries(Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry}),
-                                     ArrayEq(std::vector<uint32_t>{1}),
-                                     AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr}}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(publisher_,
-                publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
-                        FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)), Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
-        .Times(1);
-
-    Drain();
-    std::string key = KeyGenerator::generateRouteKey(kDefaultVrfName, swss::IpPrefix(kIpv4Prefix));
-    auto *route_entry_ptr = GetRouteEntry(key);
-    EXPECT_NE(nullptr, route_entry_ptr);
-    EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, key));
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, DeserializeRouteEntryInDrainFails)
-{
-    const std::string kKeyPrefix = std::string(APP_P4RT_IPV4_TABLE_NAME) + kTableKeyDelimiter;
-    auto key_op_fvs =
-        swss::KeyOpFieldsValuesTuple(kKeyPrefix + "{{{{{{{{{{{{", SET_COMMAND, std::vector<swss::FieldValueTuple>{});
-    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
-    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
-                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
-                                    Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)))
-        .Times(1);
-    Drain();
-}
-
-TEST_F(RouteManagerTest, ValidateRouteEntryInDrainFailsWhenVrfDoesNotExist)
-{
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), kNexthopOid1);
-    auto key_op_fvs = GenerateKeyOpFieldsValuesTuple("Invalid-Vrf", swss::IpPrefix(kIpv4Prefix), SET_COMMAND,
-                                                     p4orch::kSetNexthopId, kNexthopId1);
-    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
-    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
-                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
-                                    Eq(StatusCode::SWSS_RC_NOT_FOUND), Eq(true)))
-        .Times(1);
-    Drain();
-}
-
-TEST_F(RouteManagerTest, ValidateRouteEntryInDrainFailsWhenNexthopDoesNotExist)
-{
-    auto key_op_fvs = GenerateKeyOpFieldsValuesTuple(gVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND,
-                                                     p4orch::kSetNexthopId, kNexthopId1);
-    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
-    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
-                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
-                                    Eq(StatusCode::SWSS_RC_NOT_FOUND), Eq(true)))
-        .Times(1);
-    Drain();
-}
-
-TEST_F(RouteManagerTest, InvalidateSetRouteEntryInDrainFails)
-{
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), kNexthopOid1);
-    // No nexthop ID with kSetNexthopId action.
-    auto key_op_fvs =
-        GenerateKeyOpFieldsValuesTuple(gVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND, p4orch::kSetNexthopId, "");
-    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
-    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
-                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
-                                    Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)))
-        .Times(1);
-    Drain();
-}
-
-TEST_F(RouteManagerTest, InvalidateDelRouteEntryInDrainFails)
-{
-    // Route does not exist.
-    auto key_op_fvs = GenerateKeyOpFieldsValuesTuple(gVrfName, swss::IpPrefix(kIpv4Prefix), DEL_COMMAND,
-                                                     p4orch::kSetNexthopId, kNexthopId1);
-    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
-    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
-                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
-                                    Eq(StatusCode::SWSS_RC_NOT_FOUND), Eq(true)))
-        .Times(1);
-    Drain();
-}
-
-TEST_F(RouteManagerTest, InvalidCommandInDrainFails)
-{
-    const std::string kKeyPrefix = std::string(APP_P4RT_IPV4_TABLE_NAME) + kTableKeyDelimiter;
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), kNexthopOid1);
-    nlohmann::json j;
-    j[prependMatchField(p4orch::kVrfId)] = gVrfName;
-    j[prependMatchField(p4orch::kIpv4Dst)] = kIpv4Prefix;
-    std::vector<swss::FieldValueTuple> attributes;
-    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
-    attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kNexthopId), kNexthopId1});
-    auto key_op_fvs = swss::KeyOpFieldsValuesTuple(kKeyPrefix + j.dump(), "INVALID_COMMAND", attributes);
-    Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
-    EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
-                                    FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
-                                    Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)))
-        .Times(1);
-    Drain();
-}
-
-TEST_F(RouteManagerTest, BatchedCreateSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    auto route_entry_ipv4 = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry_ipv4.nexthop_id),
-                          kNexthopOid1);
-
-    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-    sai_ip_prefix_t sai_ipv6_route_prefix;
-    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-    auto route_entry_ipv6 =
-        GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                          KeyGenerator::generateWcmpGroupKey(route_entry_ipv6.wcmp_group), kWcmpGroupOid1);
-
-    sai_route_entry_t exp_sai_route_entry_ipv4;
-    exp_sai_route_entry_ipv4.switch_id = gSwitchId;
-    exp_sai_route_entry_ipv4.vr_id = gVrfOid;
-    exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr_ipv4;
-    exp_sai_attr_ipv4.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr_ipv4.value.oid = kNexthopOid1;
-
-    sai_route_entry_t exp_sai_route_entry_ipv6;
-    exp_sai_route_entry_ipv6.switch_id = gSwitchId;
-    exp_sai_route_entry_ipv6.vr_id = gVrfOid;
-    exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
-
-    sai_attribute_t exp_sai_attr_ipv6;
-    exp_sai_attr_ipv6.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr_ipv6.value.oid = kWcmpGroupOid1;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
-    EXPECT_CALL(
-        mock_sai_route_,
-        create_route_entries(
-            Eq(2),
-            RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry_ipv6, exp_sai_route_entry_ipv4}),
-            ArrayEq(std::vector<uint32_t>{1, 1}),
-            AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr_ipv6}, {exp_sai_attr_ipv4}}),
-            Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4, route_entry_ipv6}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS, StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry_ipv4, sai_ipv4_route_prefix, gVrfOid);
-    VerifyRouteEntry(route_entry_ipv6, sai_ipv6_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, BatchedCreatePartiallySucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    auto route_entry_ipv4 = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(route_entry_ipv4.nexthop_id),
-                          kNexthopOid1);
-
-    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-    sai_ip_prefix_t sai_ipv6_route_prefix;
-    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-    auto route_entry_ipv6 =
-        GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                          KeyGenerator::generateWcmpGroupKey(route_entry_ipv6.wcmp_group), kWcmpGroupOid1);
-
-    sai_route_entry_t exp_sai_route_entry_ipv4;
-    exp_sai_route_entry_ipv4.switch_id = gSwitchId;
-    exp_sai_route_entry_ipv4.vr_id = gVrfOid;
-    exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr_ipv4;
-    exp_sai_attr_ipv4.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr_ipv4.value.oid = kNexthopOid1;
-
-    sai_route_entry_t exp_sai_route_entry_ipv6;
-    exp_sai_route_entry_ipv6.switch_id = gSwitchId;
-    exp_sai_route_entry_ipv6.vr_id = gVrfOid;
-    exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
-
-    sai_attribute_t exp_sai_attr_ipv6;
-    exp_sai_attr_ipv6.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr_ipv6.value.oid = kWcmpGroupOid1;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE, SAI_STATUS_SUCCESS};
-    EXPECT_CALL(
-        mock_sai_route_,
-        create_route_entries(
-            Eq(2),
-            RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry_ipv6, exp_sai_route_entry_ipv4}),
-            ArrayEq(std::vector<uint32_t>{1, 1}),
-            AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{{exp_sai_attr_ipv6}, {exp_sai_attr_ipv4}}),
-            Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_FAILURE)));
-    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4, route_entry_ipv6}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS, StatusCode::SWSS_RC_UNKNOWN}));
-    VerifyRouteEntry(route_entry_ipv4, sai_ipv4_route_prefix, gVrfOid);
-    auto *route_entry_ptr_ipv6 = GetRouteEntry(route_entry_ipv6.route_entry_key);
-    EXPECT_EQ(nullptr, route_entry_ptr_ipv6);
-    EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, route_entry_ipv6.route_entry_key));
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, BatchedUpdateSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    auto route_entry_ipv4 =
-        GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(kWcmpGroup1),
-                          kWcmpGroupOid1);
-
-    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-    sai_ip_prefix_t sai_ipv6_route_prefix;
-    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-    auto route_entry_ipv6 =
-        GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup2);
-    SetupDropRouteEntry(gVrfName, swss_ipv6_route_prefix);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(kWcmpGroup2),
-                          kWcmpGroupOid2);
-
-    sai_route_entry_t exp_sai_route_entry_ipv4;
-    exp_sai_route_entry_ipv4.switch_id = gSwitchId;
-    exp_sai_route_entry_ipv4.vr_id = gVrfOid;
-    exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr_ipv4;
-    exp_sai_attr_ipv4.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr_ipv4.value.oid = kWcmpGroupOid1;
-
-    sai_route_entry_t exp_sai_route_entry_ipv6;
-    exp_sai_route_entry_ipv6.switch_id = gSwitchId;
-    exp_sai_route_entry_ipv6.vr_id = gVrfOid;
-    exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
-
-    sai_attribute_t exp_sai_attr_ipv6;
-    exp_sai_attr_ipv6.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr_ipv6.value.oid = kWcmpGroupOid2;
-
-    std::vector<sai_status_t> exp_status_1{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(2),
-                                     RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry_ipv6,
-                                                                                      exp_sai_route_entry_ipv4}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr_ipv6, exp_sai_attr_ipv4}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status_1.begin(), exp_status_1.end()), Return(SAI_STATUS_SUCCESS)));
-
-    sai_attribute_t exp_sai_attr_ipv6_2;
-    exp_sai_attr_ipv6_2.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
-    exp_sai_attr_ipv6_2.value.s32 = SAI_PACKET_ACTION_FORWARD;
-
-    std::vector<sai_status_t> exp_status_2{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(1), RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry_ipv6}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr_ipv6_2}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status_2.begin(), exp_status_2.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4, route_entry_ipv6}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS, StatusCode::SWSS_RC_SUCCESS}));
-    VerifyRouteEntry(route_entry_ipv4, sai_ipv4_route_prefix, gVrfOid);
-    VerifyRouteEntry(route_entry_ipv6, sai_ipv6_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup2), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, BatchedUpdatePartiallySucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    auto route_entry_ipv4 =
-        GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(kWcmpGroup1),
-                          kWcmpGroupOid1);
-
-    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-    sai_ip_prefix_t sai_ipv6_route_prefix;
-    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-    auto route_entry_ipv6 =
-        GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup2);
-    SetupDropRouteEntry(gVrfName, swss_ipv6_route_prefix);
-    p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP, KeyGenerator::generateWcmpGroupKey(kWcmpGroup2),
-                          kWcmpGroupOid2);
-
-    sai_route_entry_t exp_sai_route_entry_ipv4;
-    exp_sai_route_entry_ipv4.switch_id = gSwitchId;
-    exp_sai_route_entry_ipv4.vr_id = gVrfOid;
-    exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
-
-    sai_attribute_t exp_sai_attr_ipv4;
-    exp_sai_attr_ipv4.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr_ipv4.value.oid = kWcmpGroupOid1;
-
-    sai_route_entry_t exp_sai_route_entry_ipv6;
-    exp_sai_route_entry_ipv6.switch_id = gSwitchId;
-    exp_sai_route_entry_ipv6.vr_id = gVrfOid;
-    exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
-
-    sai_attribute_t exp_sai_attr_ipv6;
-    exp_sai_attr_ipv6.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-    exp_sai_attr_ipv6.value.oid = kWcmpGroupOid2;
-
-    std::vector<sai_status_t> exp_status_1{SAI_STATUS_FAILURE, SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(
-                                     Eq(2),
-                                     RouteEntryArrayEq(std::vector<sai_route_entry_t>{exp_sai_route_entry_ipv6,
-                                                                                      exp_sai_route_entry_ipv4}),
-                                     AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr_ipv6, exp_sai_attr_ipv4}),
-                                     Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<4>(exp_status_1.begin(), exp_status_1.end()), Return(SAI_STATUS_FAILURE)));
-    EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4, route_entry_ipv6}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS, StatusCode::SWSS_RC_UNKNOWN}));
-    VerifyRouteEntry(route_entry_ipv4, sai_ipv4_route_prefix, gVrfOid);
-    route_entry_ipv6 = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kDrop, "");
-    VerifyRouteEntry(route_entry_ipv6, sai_ipv6_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
-    EXPECT_EQ(1, ref_cnt);
-    EXPECT_TRUE(p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
-                                           KeyGenerator::generateWcmpGroupKey(kWcmpGroup2), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, BatchedDeleteSucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    auto route_entry_ipv4 = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-
-    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-    sai_ip_prefix_t sai_ipv6_route_prefix;
-    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-    auto route_entry_ipv6 = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kDrop, "");
-    SetupDropRouteEntry(gVrfName, swss_ipv6_route_prefix);
-
-    sai_route_entry_t exp_sai_route_entry_ipv4;
-    exp_sai_route_entry_ipv4.switch_id = gSwitchId;
-    exp_sai_route_entry_ipv4.vr_id = gVrfOid;
-    exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
-
-    sai_route_entry_t exp_sai_route_entry_ipv6;
-    exp_sai_route_entry_ipv6.switch_id = gSwitchId;
-    exp_sai_route_entry_ipv6.vr_id = gVrfOid;
-    exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, remove_route_entries(Eq(2),
-                                                      RouteEntryArrayEq(std::vector<sai_route_entry_t>{
-                                                          exp_sai_route_entry_ipv6, exp_sai_route_entry_ipv4}),
-                                                      Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(DeleteRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4, route_entry_ipv6}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS, StatusCode::SWSS_RC_SUCCESS}));
-    auto *route_entry_ptr_ipv4 = GetRouteEntry(route_entry_ipv4.route_entry_key);
-    EXPECT_EQ(nullptr, route_entry_ptr_ipv4);
-    EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, route_entry_ipv4.route_entry_key));
-    auto *route_entry_ptr_ipv6 = GetRouteEntry(route_entry_ipv6.route_entry_key);
-    EXPECT_EQ(nullptr, route_entry_ptr_ipv6);
-    EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, route_entry_ipv6.route_entry_key));
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, BatchedDeletePartiallySucceeds)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    sai_ip_prefix_t sai_ipv4_route_prefix;
-    copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
-    auto route_entry_ipv4 = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-
-    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-    sai_ip_prefix_t sai_ipv6_route_prefix;
-    copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
-    auto route_entry_ipv6 = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kDrop, "");
-    SetupDropRouteEntry(gVrfName, swss_ipv6_route_prefix);
-
-    sai_route_entry_t exp_sai_route_entry_ipv4;
-    exp_sai_route_entry_ipv4.switch_id = gSwitchId;
-    exp_sai_route_entry_ipv4.vr_id = gVrfOid;
-    exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
-
-    sai_route_entry_t exp_sai_route_entry_ipv6;
-    exp_sai_route_entry_ipv6.switch_id = gSwitchId;
-    exp_sai_route_entry_ipv6.vr_id = gVrfOid;
-    exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE, SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, remove_route_entries(Eq(2),
-                                                      RouteEntryArrayEq(std::vector<sai_route_entry_t>{
-                                                          exp_sai_route_entry_ipv6, exp_sai_route_entry_ipv4}),
-                                                      Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
-        .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_FAILURE)));
-    EXPECT_THAT(DeleteRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4, route_entry_ipv6}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS, StatusCode::SWSS_RC_UNKNOWN}));
-    auto *route_entry_ptr_ipv4 = GetRouteEntry(route_entry_ipv4.route_entry_key);
-    EXPECT_EQ(nullptr, route_entry_ptr_ipv4);
-    EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, route_entry_ipv4.route_entry_key));
-    VerifyRouteEntry(route_entry_ipv6, sai_ipv6_route_prefix, gVrfOid);
-    uint32_t ref_cnt;
-    EXPECT_TRUE(
-        p4_oid_mapper_.getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1), &ref_cnt));
-    EXPECT_EQ(0, ref_cnt);
-}
-
-TEST_F(RouteManagerTest, VerifyStateTest)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1, kNexthopOid1);
-    auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
-
-    // Setup ASIC DB.
-    swss::Table table(nullptr, "ASIC_STATE");
-    table.set("SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.11.12.0/"
-              "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
-              std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x1"}});
-
-    nlohmann::json j;
-    j[prependMatchField(p4orch::kVrfId)] = gVrfName;
-    j[prependMatchField(p4orch::kIpv4Dst)] = kIpv4Prefix;
-    const std::string db_key = std::string(APP_P4RT_TABLE_NAME) + kTableKeyDelimiter + APP_P4RT_IPV4_TABLE_NAME +
-                               kTableKeyDelimiter + j.dump();
-    std::vector<swss::FieldValueTuple> attributes;
-
-    // Verification should succeed with vaild key and value.
-    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
-    attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kNexthopId), kNexthopId1});
-    EXPECT_EQ(VerifyState(db_key, attributes), "");
-
-    // TODO: Expect critical state.
-
-    // Invalid key should fail verification.
-    EXPECT_FALSE(VerifyState("invalid", attributes).empty());
-    EXPECT_FALSE(VerifyState("invalid:invalid", attributes).empty());
-    EXPECT_FALSE(VerifyState(std::string(APP_P4RT_TABLE_NAME) + ":invalid", attributes).empty());
-    EXPECT_FALSE(VerifyState(std::string(APP_P4RT_TABLE_NAME) + ":invalid:invalid", attributes).empty());
-    EXPECT_FALSE(VerifyState(std::string(APP_P4RT_TABLE_NAME) + ":FIXED_IPV4_TABLE:invalid", attributes).empty());
-
-    // Verification should fail if nexthop ID does not exist.
-    attributes.clear();
-    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
-    attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kNexthopId), kNexthopId2});
-    EXPECT_FALSE(VerifyState(db_key, attributes).empty());
-    attributes.clear();
-    attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
-    attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kNexthopId), kNexthopId1});
-
-    // Verification should fail if entry does not exist.
-    j[prependMatchField(p4orch::kIpv4Dst)] = "1.1.1.0/24";
-    EXPECT_FALSE(VerifyState(std::string(APP_P4RT_TABLE_NAME) + kTableKeyDelimiter + APP_P4RT_IPV4_TABLE_NAME +
-                                 kTableKeyDelimiter + j.dump(),
-                             attributes)
-                     .empty());
-
-    auto *route_entry_ptr = GetRouteEntry(KeyGenerator::generateRouteKey(gVrfName, swss_ipv4_route_prefix));
-    EXPECT_NE(route_entry_ptr, nullptr);
-
-    // Verification should fail if route entry key mismatches.
-    auto saved_route_entry_key = route_entry_ptr->route_entry_key;
-    route_entry_ptr->route_entry_key = "invalid";
-    EXPECT_FALSE(VerifyState(db_key, attributes).empty());
-    route_entry_ptr->route_entry_key = saved_route_entry_key;
-
-    // Verification should fail if VRF ID mismatches.
-    auto saved_vrf_id = route_entry_ptr->vrf_id;
-    route_entry_ptr->vrf_id = "invalid";
-    EXPECT_FALSE(VerifyState(db_key, attributes).empty());
-    route_entry_ptr->vrf_id = saved_vrf_id;
-
-    // Verification should fail if route prefix mismatches.
-    auto saved_route_prefix = route_entry_ptr->route_prefix;
-    route_entry_ptr->route_prefix = swss::IpPrefix(kIpv6Prefix);
-    EXPECT_FALSE(VerifyState(db_key, attributes).empty());
-    route_entry_ptr->route_prefix = saved_route_prefix;
-
-    // Verification should fail if action mismatches.
-    auto saved_action = route_entry_ptr->action;
-    route_entry_ptr->action = p4orch::kSetWcmpGroupId;
-    EXPECT_FALSE(VerifyState(db_key, attributes).empty());
-    route_entry_ptr->action = saved_action;
-
-    // Verification should fail if nexthop ID mismatches.
-    auto saved_nexthop_id = route_entry_ptr->nexthop_id;
-    route_entry_ptr->nexthop_id = kNexthopId2;
-    EXPECT_FALSE(VerifyState(db_key, attributes).empty());
-    route_entry_ptr->nexthop_id = saved_nexthop_id;
-
-    // Verification should fail if WCMP group mismatches.
-    auto saved_wcmp_group = route_entry_ptr->wcmp_group;
-    route_entry_ptr->wcmp_group = kWcmpGroup1;
-    EXPECT_FALSE(VerifyState(db_key, attributes).empty());
-    route_entry_ptr->wcmp_group = saved_wcmp_group;
-
-    // Verification should fail if WCMP group mismatches.
-    auto saved_route_metadata = route_entry_ptr->route_metadata;
-    route_entry_ptr->route_metadata = kMetadata1;
-    EXPECT_FALSE(VerifyState(db_key, attributes).empty());
-    route_entry_ptr->route_metadata = saved_route_metadata;
-}
-
-TEST_F(RouteManagerTest, VerifyStateAsicDbTest)
-{
-    auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
-    SetupDropRouteEntry(gVrfName, swss_ipv4_route_prefix);
-    auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
-    SetupNexthopIdRouteEntry(gVrfName, swss_ipv6_route_prefix, kNexthopId1, kNexthopOid1, kMetadata1);
-
-    auto swss_ipv4_route_prefix2 = swss::IpPrefix(kIpv4Prefix2);
-    auto route_entry =
-        GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix2, p4orch::kSetMetadataAndDrop, "", kMetadata2);
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
-        .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
-                ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-
-    // Setup ASIC DB.
-    swss::Table table(nullptr, "ASIC_STATE");
-    table.set("SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.11.12.0/"
-              "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
-              std::vector<swss::FieldValueTuple>{
-                  swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_DROP"},
-                  swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x0"}});
-    table.set("SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"2001:db8:1::/"
-              "32\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
-              std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x1"},
-                                                 swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_META_DATA", "1"}});
-
-    table.set("SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.12.12.0/"
-              "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
-              std::vector<swss::FieldValueTuple>{
-                  swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_DROP"},
-                  swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_META_DATA", "2"}});
-
-    nlohmann::json j_1;
-    j_1[prependMatchField(p4orch::kVrfId)] = gVrfName;
-    j_1[prependMatchField(p4orch::kIpv4Dst)] = kIpv4Prefix;
-    const std::string db_key_1 = std::string(APP_P4RT_TABLE_NAME) + kTableKeyDelimiter + APP_P4RT_IPV4_TABLE_NAME +
-                                 kTableKeyDelimiter + j_1.dump();
-    std::vector<swss::FieldValueTuple> attributes_1;
-    attributes_1.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
-    nlohmann::json j_2;
-    j_2[prependMatchField(p4orch::kVrfId)] = gVrfName;
-    j_2[prependMatchField(p4orch::kIpv6Dst)] = kIpv6Prefix;
-    const std::string db_key_2 = std::string(APP_P4RT_TABLE_NAME) + kTableKeyDelimiter + APP_P4RT_IPV6_TABLE_NAME +
-                                 kTableKeyDelimiter + j_2.dump();
-    std::vector<swss::FieldValueTuple> attributes_2;
-    attributes_2.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopIdAndMetadata});
-    attributes_2.push_back(swss::FieldValueTuple{prependParamField(p4orch::kNexthopId), kNexthopId1});
-    attributes_2.push_back(swss::FieldValueTuple{prependParamField(p4orch::kRouteMetadata), kMetadata1});
-
-    nlohmann::json j_3;
-    j_3[prependMatchField(p4orch::kVrfId)] = gVrfName;
-    j_3[prependMatchField(p4orch::kIpv6Dst)] = kIpv4Prefix2;
-    const std::string db_key_3 = std::string(APP_P4RT_TABLE_NAME) + kTableKeyDelimiter + APP_P4RT_IPV6_TABLE_NAME +
-                                 kTableKeyDelimiter + j_3.dump();
-    std::vector<swss::FieldValueTuple> attributes_3;
-    attributes_3.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMetadataAndDrop});
-    attributes_3.push_back(swss::FieldValueTuple{prependParamField(p4orch::kRouteMetadata), kMetadata2});
-
-    // Verification should succeed with correct ASIC DB values.
-    EXPECT_EQ(VerifyState(db_key_1, attributes_1), "");
-    EXPECT_EQ(VerifyState(db_key_2, attributes_2), "");
-    EXPECT_EQ(VerifyState(db_key_3, attributes_3), "");
-
-    // Verification should fail if ASIC DB values mismatch.
-    table.set("SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.11.12.0/"
-              "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
-              std::vector<swss::FieldValueTuple>{
-                  swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_FORWARD"}});
-    table.set("SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"2001:db8:1::/"
-              "32\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
-              std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_META_DATA", "2"}});
-    EXPECT_FALSE(VerifyState(db_key_1, attributes_1).empty());
-    EXPECT_FALSE(VerifyState(db_key_2, attributes_2).empty());
-
-    // Verification should fail if ASIC DB table is missing.
-    table.del("SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.11.12.0/"
-              "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}");
-    table.del("SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"2001:db8:1::/"
-              "32\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}");
-    EXPECT_FALSE(VerifyState(db_key_1, attributes_1).empty());
-    EXPECT_FALSE(VerifyState(db_key_2, attributes_2).empty());
-    table.set("SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.11.12.0/"
-              "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
-              std::vector<swss::FieldValueTuple>{
-                  swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_DROP"},
-                  swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x0"}});
-    table.set("SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"2001:db8:1::/"
-              "32\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
-              std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x1"},
-                                                 swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_META_DATA", "1"}});
+TEST_F(RouteManagerTest, MergeRouteEntryWithNexthopIdActionDestTest) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto dest = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                   p4orch::kSetNexthopId, kNexthopId1);
+  dest.sai_route_entry.vr_id = gVrfOid;
+  dest.sai_route_entry.switch_id = gSwitchId;
+  copy(dest.sai_route_entry.destination, swss_ipv4_route_prefix);
+
+  // Source is identical to destination.
+  auto src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                  p4orch::kSetNexthopId, kNexthopId1);
+  P4RouteEntry ret = {};
+  EXPECT_FALSE(MergeRouteEntry(dest, src, &ret));
+  VerifyRouteEntriesEq(dest, ret);
+
+  // Source has different nexthop ID.
+  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                             p4orch::kSetNexthopId, kNexthopId2);
+  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+  P4RouteEntry expect_entry = dest;
+  expect_entry.nexthop_id = kNexthopId2;
+  VerifyRouteEntriesEq(expect_entry, ret);
+
+  // Source has set nexthop ID and metadata action and dest has set nexthop ID
+  // action.
+  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                             p4orch::kSetNexthopIdAndMetadata, kNexthopId1,
+                             kMetadata1);
+  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+  expect_entry = dest;
+  expect_entry.action = p4orch::kSetNexthopIdAndMetadata;
+  expect_entry.route_metadata = kMetadata1;
+  VerifyRouteEntriesEq(expect_entry, ret);
+
+  // Source has wcmp group action and dest has nexhop ID action.
+  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                             p4orch::kSetWcmpGroupId, kWcmpGroup1);
+  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+  expect_entry = dest;
+  expect_entry.nexthop_id = "";
+  expect_entry.action = p4orch::kSetWcmpGroupId;
+  expect_entry.wcmp_group = kWcmpGroup1;
+  VerifyRouteEntriesEq(expect_entry, ret);
+
+  // Source has drop action and dest has nexhop ID action.
+  src =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+  expect_entry = dest;
+  expect_entry.nexthop_id = "";
+  expect_entry.action = p4orch::kDrop;
+  VerifyRouteEntriesEq(expect_entry, ret);
+}
+
+TEST_F(RouteManagerTest,
+       MergeRouteEntryWithNexthopIdAndMetadataActionDestTest) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto dest = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                   p4orch::kSetNexthopIdAndMetadata,
+                                   kNexthopId1, kMetadata1);
+  dest.sai_route_entry.vr_id = gVrfOid;
+  dest.sai_route_entry.switch_id = gSwitchId;
+  copy(dest.sai_route_entry.destination, swss_ipv4_route_prefix);
+
+  // Source is identical to destination.
+  auto src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                  p4orch::kSetNexthopIdAndMetadata, kNexthopId1,
+                                  kMetadata1);
+  P4RouteEntry ret = {};
+  EXPECT_FALSE(MergeRouteEntry(dest, src, &ret));
+  VerifyRouteEntriesEq(dest, ret);
+
+  // Source has different metadata.
+  src.route_metadata = kMetadata2;
+  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+  P4RouteEntry expect_entry = dest;
+  expect_entry.route_metadata = kMetadata2;
+  VerifyRouteEntriesEq(expect_entry, ret);
+
+  // Source has different nexthop ID and metadata.
+  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                             p4orch::kSetNexthopIdAndMetadata, kNexthopId2,
+                             kMetadata2);
+  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+  expect_entry = dest;
+  expect_entry.nexthop_id = kNexthopId2;
+  expect_entry.route_metadata = kMetadata2;
+  VerifyRouteEntriesEq(expect_entry, ret);
+
+  // Source has wcmp group action and dest has nexhop ID and metadata action.
+  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                             p4orch::kSetWcmpGroupId, kWcmpGroup1);
+  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+  expect_entry = dest;
+  expect_entry.nexthop_id = "";
+  expect_entry.action = p4orch::kSetWcmpGroupId;
+  expect_entry.wcmp_group = kWcmpGroup1;
+  expect_entry.route_metadata = "";
+  VerifyRouteEntriesEq(expect_entry, ret);
+
+  // Source has drop action and dest has nexhop ID and metadata action.
+  src =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+  expect_entry = dest;
+  expect_entry.nexthop_id = "";
+  expect_entry.action = p4orch::kDrop;
+  expect_entry.route_metadata = "";
+  VerifyRouteEntriesEq(expect_entry, ret);
+
+  // Source has wcmp group and metadata action and dest has nexhop ID and
+  // metadata action.
+  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                             p4orch::kSetWcmpGroupIdAndMetadata, kWcmpGroup1,
+                             kMetadata2);
+  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+  expect_entry = dest;
+  expect_entry.nexthop_id = "";
+  expect_entry.action = p4orch::kSetWcmpGroupIdAndMetadata;
+  expect_entry.wcmp_group = kWcmpGroup1;
+  expect_entry.route_metadata = kMetadata2;
+  VerifyRouteEntriesEq(expect_entry, ret);
+}
+
+TEST_F(RouteManagerTest, MergeRouteEntryWithWcmpGroupActionDestTest) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto dest = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                   p4orch::kSetWcmpGroupId, kWcmpGroup1);
+  dest.sai_route_entry.vr_id = gVrfOid;
+  dest.sai_route_entry.switch_id = gSwitchId;
+  copy(dest.sai_route_entry.destination, swss_ipv4_route_prefix);
+
+  // Source is identical to destination.
+  auto src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                  p4orch::kSetWcmpGroupId, kWcmpGroup1);
+  P4RouteEntry ret = {};
+  EXPECT_FALSE(MergeRouteEntry(dest, src, &ret));
+  VerifyRouteEntriesEq(dest, ret);
+
+  // Source has different wcmp group.
+  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                             p4orch::kSetWcmpGroupId, kWcmpGroup2);
+  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+  P4RouteEntry expect_entry = dest;
+  expect_entry.wcmp_group = kWcmpGroup2;
+  VerifyRouteEntriesEq(expect_entry, ret);
+
+  // Source has nexthop ID action and dest has wcmp group action.
+  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                             p4orch::kSetNexthopId, kNexthopId1);
+  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+  expect_entry = dest;
+  expect_entry.wcmp_group = "";
+  expect_entry.action = p4orch::kSetNexthopId;
+  expect_entry.nexthop_id = kNexthopId1;
+  VerifyRouteEntriesEq(expect_entry, ret);
+
+  // Source has drop action and dest has wcmp group action.
+  src =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+  expect_entry = dest;
+  expect_entry.wcmp_group = "";
+  expect_entry.action = p4orch::kDrop;
+  VerifyRouteEntriesEq(expect_entry, ret);
+}
+
+TEST_F(RouteManagerTest, MergeRouteEntryWithDropActionDestTest) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto dest =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+  dest.sai_route_entry.vr_id = gVrfOid;
+  dest.sai_route_entry.switch_id = gSwitchId;
+  copy(dest.sai_route_entry.destination, swss_ipv4_route_prefix);
+
+  // Source is identical to destination.
+  auto src =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+  P4RouteEntry ret = {};
+  EXPECT_FALSE(MergeRouteEntry(dest, src, &ret));
+  VerifyRouteEntriesEq(dest, ret);
+
+  // Source has nexthop ID action and dest has drop action.
+  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                             p4orch::kSetNexthopId, kNexthopId1);
+  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+  P4RouteEntry expect_entry = dest;
+  expect_entry.action = p4orch::kSetNexthopId;
+  expect_entry.nexthop_id = kNexthopId1;
+  VerifyRouteEntriesEq(expect_entry, ret);
+
+  // Source has wcmp group and metadata action and dest has drop action.
+  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                             p4orch::kSetWcmpGroupIdAndMetadata, kWcmpGroup1,
+                             kMetadata1);
+  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+  expect_entry = dest;
+  expect_entry.action = p4orch::kSetWcmpGroupIdAndMetadata;
+  expect_entry.nexthop_id = "";
+  expect_entry.wcmp_group = kWcmpGroup1;
+  expect_entry.route_metadata = kMetadata1;
+  VerifyRouteEntriesEq(expect_entry, ret);
+}
+
+TEST_F(RouteManagerTest, MergeRouteEntryWithTrapActionDestTest) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto dest =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
+  dest.sai_route_entry.vr_id = gVrfOid;
+  dest.sai_route_entry.switch_id = gSwitchId;
+  copy(dest.sai_route_entry.destination, swss_ipv4_route_prefix);
+
+  // Source is identical to destination.
+  auto src =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
+  P4RouteEntry ret = {};
+  EXPECT_FALSE(MergeRouteEntry(dest, src, &ret));
+  VerifyRouteEntriesEq(dest, ret);
+
+  // Source has nexthop ID action and dest has trap action.
+  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                             p4orch::kSetNexthopId, kNexthopId1);
+  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+  P4RouteEntry expect_entry = dest;
+  expect_entry.action = p4orch::kSetNexthopId;
+  expect_entry.nexthop_id = kNexthopId1;
+  VerifyRouteEntriesEq(expect_entry, ret);
+
+  // Source has wcmp group action and dest has trap action.
+  src = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                             p4orch::kSetWcmpGroupId, kWcmpGroup1);
+  EXPECT_TRUE(MergeRouteEntry(dest, src, &ret));
+  expect_entry = dest;
+  expect_entry.action = p4orch::kSetWcmpGroupId;
+  expect_entry.wcmp_group = kWcmpGroup1;
+  VerifyRouteEntriesEq(expect_entry, ret);
+}
+
+TEST_F(RouteManagerTest, DeserializeRouteEntryWithNexthopIdActionTest) {
+  std::string key =
+      R"({"match/vrf_id":"b4-traffic","match/ipv4_dst":"10.11.12.0/24"})";
+  std::vector<swss::FieldValueTuple> attributes;
+  attributes.push_back(
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
+  attributes.push_back(swss::FieldValueTuple{
+      prependParamField(p4orch::kNexthopId), kNexthopId1});
+  auto route_entry_or =
+      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV4_TABLE_NAME);
+  EXPECT_TRUE(route_entry_or.ok());
+  auto& route_entry = *route_entry_or;
+  auto expect_entry =
+      GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("10.11.12.0/24"),
+                           p4orch::kSetNexthopId, kNexthopId1);
+  VerifyRouteEntriesEq(expect_entry, route_entry);
+}
+
+TEST_F(RouteManagerTest, DeserializeRouteEntryWithWcmpGroupActionTest) {
+  std::string key =
+      R"({"match/vrf_id":"b4-traffic","match/ipv4_dst":"10.11.12.0/24"})";
+  std::vector<swss::FieldValueTuple> attributes;
+  attributes.push_back(
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetWcmpGroupId});
+  attributes.push_back(swss::FieldValueTuple{
+      prependParamField(p4orch::kWcmpGroupId), kWcmpGroup1});
+  auto route_entry_or =
+      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV4_TABLE_NAME);
+  EXPECT_TRUE(route_entry_or.ok());
+  auto& route_entry = *route_entry_or;
+  auto expect_entry =
+      GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("10.11.12.0/24"),
+                           p4orch::kSetWcmpGroupId, kWcmpGroup1);
+  VerifyRouteEntriesEq(expect_entry, route_entry);
+}
+
+TEST_F(RouteManagerTest,
+       DeserializeRouteEntryWithNexthopIdAdnMetadataActionTest) {
+  std::string key =
+      R"({"match/vrf_id":"b4-traffic","match/ipv4_dst":"10.11.12.0/24"})";
+  std::vector<swss::FieldValueTuple> attributes;
+  attributes.push_back(
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopIdAndMetadata});
+  attributes.push_back(swss::FieldValueTuple{
+      prependParamField(p4orch::kNexthopId), kNexthopId1});
+  attributes.push_back(swss::FieldValueTuple{
+      prependParamField(p4orch::kRouteMetadata), kMetadata1});
+  auto route_entry_or =
+      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV4_TABLE_NAME);
+  EXPECT_TRUE(route_entry_or.ok());
+  auto& route_entry = *route_entry_or;
+  auto expect_entry = GenerateP4RouteEntry(
+      "b4-traffic", swss::IpPrefix("10.11.12.0/24"),
+      p4orch::kSetNexthopIdAndMetadata, kNexthopId1, kMetadata1);
+  VerifyRouteEntriesEq(expect_entry, route_entry);
+}
+
+TEST_F(RouteManagerTest,
+       DeserializeRouteEntryWithWcmpGroupAndMetadataActionTest) {
+  std::string key =
+      R"({"match/vrf_id":"b4-traffic","match/ipv4_dst":"10.11.12.0/24"})";
+  std::vector<swss::FieldValueTuple> attributes;
+  attributes.push_back(swss::FieldValueTuple{
+      p4orch::kAction, p4orch::kSetWcmpGroupIdAndMetadata});
+  attributes.push_back(swss::FieldValueTuple{
+      prependParamField(p4orch::kWcmpGroupId), kWcmpGroup1});
+  attributes.push_back(swss::FieldValueTuple{
+      prependParamField(p4orch::kRouteMetadata), kMetadata1});
+  auto route_entry_or =
+      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV4_TABLE_NAME);
+  EXPECT_TRUE(route_entry_or.ok());
+  auto& route_entry = *route_entry_or;
+  auto expect_entry = GenerateP4RouteEntry(
+      "b4-traffic", swss::IpPrefix("10.11.12.0/24"),
+      p4orch::kSetWcmpGroupIdAndMetadata, kWcmpGroup1, kMetadata1);
+  VerifyRouteEntriesEq(expect_entry, route_entry);
+}
+
+TEST_F(RouteManagerTest, DeserializeRouteEntryWithDropActionTest) {
+  std::string key =
+      R"({"match/vrf_id":"b4-traffic","match/ipv6_dst":"2001:db8:1::/32"})";
+  std::vector<swss::FieldValueTuple> attributes;
+  attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
+  auto route_entry_or =
+      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
+  EXPECT_TRUE(route_entry_or.ok());
+  auto& route_entry = *route_entry_or;
+  auto expect_entry = GenerateP4RouteEntry(
+      "b4-traffic", swss::IpPrefix("2001:db8:1::/32"), p4orch::kDrop, "");
+  VerifyRouteEntriesEq(expect_entry, route_entry);
+}
+
+TEST_F(RouteManagerTest, DeserializeRouteEntryWithTrapActionTest) {
+  std::string key =
+      R"({"match/vrf_id":"b4-traffic","match/ipv6_dst":"2001:db8:1::/32"})";
+  std::vector<swss::FieldValueTuple> attributes;
+  attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kTrap});
+  auto route_entry_or =
+      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
+  EXPECT_TRUE(route_entry_or.ok());
+  auto& route_entry = *route_entry_or;
+  auto expect_entry = GenerateP4RouteEntry(
+      "b4-traffic", swss::IpPrefix("2001:db8:1::/32"), p4orch::kTrap, "");
+  VerifyRouteEntriesEq(expect_entry, route_entry);
+}
+
+TEST_F(RouteManagerTest, DeserializeRouteEntryWithInvalidKeyShouldFail) {
+  std::string key = "{{{{{{{{{{{{";
+  std::vector<swss::FieldValueTuple> attributes;
+  attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
+  auto route_entry_or =
+      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
+  EXPECT_FALSE(route_entry_or.ok());
+}
+
+TEST_F(RouteManagerTest, DeserializeRouteEntryWithInvalidFieldShouldFail) {
+  std::string key =
+      R"({"match/vrf_id":"b4-traffic","match/ipv6_dst":"2001:db8:1::/32"})";
+  std::vector<swss::FieldValueTuple> attributes;
+  attributes.push_back(swss::FieldValueTuple{"invalid", "invalid"});
+  auto route_entry_or =
+      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
+  EXPECT_FALSE(route_entry_or.ok());
+}
+
+TEST_F(RouteManagerTest, DeserializeRouteEntryWithInvalidRouteShouldFail) {
+  std::string key =
+      R"({"match/vrf_id":"b4-traffic","match/ipv6_dst":"invalid"})";
+  std::vector<swss::FieldValueTuple> attributes;
+  attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
+  auto route_entry_or =
+      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
+  EXPECT_FALSE(route_entry_or.ok());
+}
+
+TEST_F(RouteManagerTest,
+       DeserializeRouteEntryWithoutIpv4WildcardLpmMatchShouldSucceed) {
+  std::string key = R"({"match/vrf_id":"b4-traffic"})";
+  std::vector<swss::FieldValueTuple> attributes;
+  attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
+  auto route_entry_or =
+      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV4_TABLE_NAME);
+  EXPECT_TRUE(route_entry_or.ok());
+  auto& route_entry = *route_entry_or;
+  auto expect_entry = GenerateP4RouteEntry(
+      "b4-traffic", swss::IpPrefix("0.0.0.0/0"), p4orch::kDrop, "");
+  VerifyRouteEntriesEq(expect_entry, route_entry);
+}
+
+TEST_F(RouteManagerTest,
+       DeserializeRouteEntryWithoutIpv6WildcardLpmMatchShouldSucceed) {
+  std::string key = R"({"match/vrf_id":"b4-traffic"})";
+  std::vector<swss::FieldValueTuple> attributes;
+  attributes.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
+  auto route_entry_or =
+      DeserializeRouteEntry(key, attributes, APP_P4RT_IPV6_TABLE_NAME);
+  EXPECT_TRUE(route_entry_or.ok());
+  auto& route_entry = *route_entry_or;
+  auto expect_entry = GenerateP4RouteEntry("b4-traffic", swss::IpPrefix("::/0"),
+                                           p4orch::kDrop, "");
+  VerifyRouteEntriesEq(expect_entry, route_entry);
+}
+
+TEST_F(RouteManagerTest,
+       ValidateRouteEntryNexthopActionWithInvalidNexthopShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, kNexthopId1);
+  EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND,
+            ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest,
+       ValidateRouteEntryNexthopActionWithValidNexthopShouldSucceed) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, kNexthopId1);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
+  EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
+            ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest,
+       ValidateRouteEntryWcmpGroupActionWithInvalidWcmpGroupShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetWcmpGroupId, kWcmpGroup1);
+  EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND,
+            ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest,
+       ValidateRouteEntryWcmpGroupActionWithValidWcmpGroupShouldSucceed) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetWcmpGroupId, kWcmpGroup1);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+      kWcmpGroupOid1);
+  EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
+            ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateRouteEntryWithInvalidCommandShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+            ValidateRouteEntry(route_entry, "invalid"));
+}
+
+TEST_F(RouteManagerTest, ValidateSetRouteEntryDoesNotExistInManagerShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, kNexthopId1);
+  route_entry.action = "";
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
+  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+            ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest,
+       ValidateSetRouteEntryExistsInMapperDoesNotExistInManagerShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, kNexthopId1);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
+  p4_oid_mapper_.setDummyOID(SAI_OBJECT_TYPE_ROUTE_ENTRY,
+                             route_entry.route_entry_key);
+  EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND,
+            ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest,
+       ValidateSetRouteEntryExistsInManagerDoesNotExistInMapperShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, kNexthopId1);
+  p4_oid_mapper_.eraseOID(SAI_OBJECT_TYPE_ROUTE_ENTRY,
+                          route_entry.route_entry_key);
+  EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND,
+            ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest,
+       ValidateSetRouteEntryNexthopIdActionWithoutNexthopIdShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, "");
+  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+            ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest,
+       ValidateSetRouteEntryNexthopIdActionWithWcmpGroupShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, kNexthopId1);
+  route_entry.wcmp_group = kWcmpGroup1;
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+      kWcmpGroupOid1);
+  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+            ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest,
+       ValidateSetRouteEntryWcmpGroupActionWithoutWcmpGroupShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetWcmpGroupId, "");
+  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+            ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest,
+       ValidateSetRouteEntryWcmpGroupActionWithNexthopIdShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetWcmpGroupId, kWcmpGroup1);
+  route_entry.nexthop_id = kNexthopId1;
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+      kWcmpGroupOid1);
+  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+            ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest,
+       ValidateSetRouteEntryDropActionWithNexthopIdShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+  route_entry.nexthop_id = kNexthopId1;
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
+  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+            ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest,
+       ValidateSetRouteEntryWcmpGroupActionWithNonemptyMetadataShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                           p4orch::kSetWcmpGroupId, kWcmpGroup1, kMetadata1);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+      kWcmpGroupOid1);
+  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+            ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(
+    RouteManagerTest,
+    ValidateSetRouteEntryNexthopIdAndMetadataActionWithEmptyMetadataShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                           p4orch::kSetNexthopIdAndMetadata, kNexthopId1);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
+  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+            ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(
+    RouteManagerTest,
+    ValidateSetRouteEntryNexthopIdAndMetadataActionWithInvalidMetadataShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopIdAndMetadata,
+                                          kNexthopId1, "invalid_int");
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
+  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+            ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest,
+       ValidateSetRouteEntryDropActionWithWcmpGroupShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+  route_entry.wcmp_group = kWcmpGroup1;
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+      kWcmpGroupOid1);
+  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+            ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest,
+       ValidateSetRouteEntryTrapActionWithNexthopIdShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
+  route_entry.nexthop_id = kNexthopId1;
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
+  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+            ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest,
+       ValidateSetRouteEntryTrapActionWithWcmpGroupShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
+  route_entry.wcmp_group = kWcmpGroup1;
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+      kWcmpGroupOid1);
+  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+            ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateSetRouteEntryInvalidActionShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+  route_entry.action = "invalid";
+  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+            ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateSetRouteEntrySucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, kNexthopId2);
+  route_entry.action = "";
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid2);
+  EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
+            ValidateRouteEntry(route_entry, SET_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateDelRouteEntryDoesNotExistInManagerShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "");
+  EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND,
+            ValidateRouteEntry(route_entry, DEL_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateDelRouteEntryDoesNotExistInMapperShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "");
+  p4_oid_mapper_.eraseOID(SAI_OBJECT_TYPE_ROUTE_ENTRY,
+                          route_entry.route_entry_key);
+  // TODO: Expect critical state.
+  EXPECT_EQ(StatusCode::SWSS_RC_INTERNAL,
+            ValidateRouteEntry(route_entry, DEL_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateDelRouteEntryHasActionShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, "");
+  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+            ValidateRouteEntry(route_entry, DEL_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateDelRouteEntryHasNexthopIdShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, kNexthopId1);
+  route_entry.action = "";
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
+  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+            ValidateRouteEntry(route_entry, DEL_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateDelRouteEntryHasWcmpGroupShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetWcmpGroupId, kWcmpGroup1);
+  route_entry.action = "";
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+      kWcmpGroupOid1);
+  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+            ValidateRouteEntry(route_entry, DEL_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateDelRouteEntryHasMetadataShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "",
+                                          "", kMetadata1);
+  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+            ValidateRouteEntry(route_entry, DEL_COMMAND));
+}
+
+TEST_F(RouteManagerTest, ValidateDelRouteEntrySucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "");
+  EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
+            ValidateRouteEntry(route_entry, DEL_COMMAND));
+}
+
+TEST_F(RouteManagerTest, CreateRouteEntryWithSaiErrorShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE};
+  EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
+      .Times(3)
+      .WillRepeatedly(
+          DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                Return(SAI_STATUS_FAILURE)));
+  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+
+  route_entry.action = p4orch::kSetNexthopId;
+  route_entry.nexthop_id = kNexthopId1;
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
+  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+
+  route_entry.action = p4orch::kSetWcmpGroupId;
+  route_entry.wcmp_group = kWcmpGroup1;
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+      kWcmpGroupOid1);
+  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(RouteManagerTest, CreateNexthopIdIpv4RouteSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, kNexthopId1);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr.value.oid = kNexthopOid1;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              create_route_entries(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  ArrayEq(std::vector<uint32_t>{1}),
+                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
+                      {exp_sai_attr}}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, CreateNexthopIdIpv6RouteSucceeds) {
+  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+  sai_ip_prefix_t sai_ipv6_route_prefix;
+  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix,
+                                          p4orch::kSetNexthopId, kNexthopId1);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv6_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr.value.oid = kNexthopOid1;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              create_route_entries(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  ArrayEq(std::vector<uint32_t>{1}),
+                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
+                      {exp_sai_attr}}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv6_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, CreateNexthopIdWithMetadataIpv4RouteSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopIdAndMetadata,
+                                          kNexthopId1, kMetadata1);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid1);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  std::vector<sai_attribute_t> exp_sai_attrs;
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr.value.oid = kNexthopOid1;
+  exp_sai_attrs.push_back(exp_sai_attr);
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
+  exp_sai_attr.value.u32 = kMetadataInt1;
+  exp_sai_attrs.push_back(exp_sai_attr);
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              create_route_entries(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  ArrayEq(std::vector<uint32_t>{
+                      static_cast<uint32_t>(exp_sai_attrs.size())}),
+                  AttrArrayArrayEq(
+                      std::vector<std::vector<sai_attribute_t>>{exp_sai_attrs}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, CreateDropSetMetadataRouteSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                           p4orch::kSetMetadataAndDrop, "", kMetadata1);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  std::vector<sai_attribute_t> exp_sai_attrs;
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
+  exp_sai_attrs.push_back(exp_sai_attr);
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
+  exp_sai_attr.value.u32 = kMetadataInt1;
+  exp_sai_attrs.push_back(exp_sai_attr);
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              create_route_entries(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  ArrayEq(std::vector<uint32_t>{
+                      static_cast<uint32_t>(exp_sai_attrs.size())}),
+                  AttrArrayArrayEq(
+                      std::vector<std::vector<sai_attribute_t>>{exp_sai_attrs}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+}
+
+TEST_F(RouteManagerTest, CreateDropIpv4RouteSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              create_route_entries(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  ArrayEq(std::vector<uint32_t>{1}),
+                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
+                      {exp_sai_attr}}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+}
+
+TEST_F(RouteManagerTest, CreateDropIpv6RouteSucceeds) {
+  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+  sai_ip_prefix_t sai_ipv6_route_prefix;
+  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kDrop, "");
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv6_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              create_route_entries(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  ArrayEq(std::vector<uint32_t>{1}),
+                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
+                      {exp_sai_attr}}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv6_route_prefix, gVrfOid);
+}
+
+TEST_F(RouteManagerTest, CreateTrapIpv4RouteSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_TRAP;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              create_route_entries(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  ArrayEq(std::vector<uint32_t>{1}),
+                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
+                      {exp_sai_attr}}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+}
+
+TEST_F(RouteManagerTest, CreateTrapIpv6RouteSucceeds) {
+  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+  sai_ip_prefix_t sai_ipv6_route_prefix;
+  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kTrap, "");
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv6_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_TRAP;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              create_route_entries(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  ArrayEq(std::vector<uint32_t>{1}),
+                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
+                      {exp_sai_attr}}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv6_route_prefix, gVrfOid);
+}
+
+TEST_F(RouteManagerTest, CreateWcmpIpv4RouteSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetWcmpGroupId, kWcmpGroup1);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+      kWcmpGroupOid1);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr.value.oid = kWcmpGroupOid1;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              create_route_entries(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  ArrayEq(std::vector<uint32_t>{1}),
+                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
+                      {exp_sai_attr}}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, CreateWcmpIpv6RouteSucceeds) {
+  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+  sai_ip_prefix_t sai_ipv6_route_prefix;
+  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix,
+                                          p4orch::kSetWcmpGroupId, kWcmpGroup1);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+      kWcmpGroupOid1);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv6_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr.value.oid = kWcmpGroupOid1;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              create_route_entries(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  ArrayEq(std::vector<uint32_t>{1}),
+                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
+                      {exp_sai_attr}}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv6_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, CreateWcmpWithMetadataIpv6RouteSucceeds) {
+  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+  sai_ip_prefix_t sai_ipv6_route_prefix;
+  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix,
+                                          p4orch::kSetWcmpGroupIdAndMetadata,
+                                          kWcmpGroup1, kMetadata1);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+      kWcmpGroupOid1);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv6_route_prefix;
+
+  std::vector<sai_attribute_t> exp_sai_attrs;
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr.value.oid = kWcmpGroupOid1;
+  exp_sai_attrs.push_back(exp_sai_attr);
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
+  exp_sai_attr.value.u32 = kMetadataInt1;
+  exp_sai_attrs.push_back(exp_sai_attr);
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              create_route_entries(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  ArrayEq(std::vector<uint32_t>{
+                      static_cast<uint32_t>(exp_sai_attrs.size())}),
+                  AttrArrayArrayEq(
+                      std::vector<std::vector<sai_attribute_t>>{exp_sai_attrs}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv6_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteEntryWcmpWithSaiErrorShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupWcmpGroupRouteEntry(gVrfName, swss_ipv4_route_prefix, kWcmpGroup1,
+                           kWcmpGroupOid1);
+
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetWcmpGroupId, kWcmpGroup2);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+      kWcmpGroupOid2);
+  std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE};
+  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_FAILURE)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(RouteManagerTest,
+       UpdateRouteEntryWcmpNotExistInMapperShouldRaiseCriticalState) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupWcmpGroupRouteEntry(gVrfName, swss_ipv4_route_prefix, kWcmpGroup1,
+                           kWcmpGroupOid1);
+
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetWcmpGroupId, kWcmpGroup2);
+  std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE};
+  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_FAILURE)));
+  // TODO: Expect critical state.
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromSetWcmpToSetNextHopSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupWcmpGroupRouteEntry(gVrfName, swss_ipv4_route_prefix, kWcmpGroup1,
+                           kWcmpGroupOid1);
+
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, kNexthopId2);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid2);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr.value.oid = kNexthopOid2;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2),
+      &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest,
+       UpdateRouteFromSetWcmpToSetNextHopAndMetadataSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupWcmpGroupRouteEntry(gVrfName, swss_ipv4_route_prefix, kWcmpGroup1,
+                           kWcmpGroupOid1);
+
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopIdAndMetadata,
+                                          kNexthopId2, kMetadata2);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid2);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
+  exp_sai_attr.value.u32 = kMetadataInt2;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr.value.oid = kNexthopOid2;
+
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2),
+      &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromSetNexthopIdToSetWcmpSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetWcmpGroupId, kWcmpGroup2);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+      kWcmpGroupOid2);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr.value.oid = kWcmpGroupOid2;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  route_entry.action = p4orch::kSetWcmpGroupId;
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(kWcmpGroup2), &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest,
+       UpdateRouteFromSetNexthopIdAndMetadataToSetWcmpSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1, kMetadata2);
+
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetWcmpGroupId, kWcmpGroup2);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+      kWcmpGroupOid2);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
+  exp_sai_attr.value.u32 = 0;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr.value.oid = kWcmpGroupOid2;
+
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(kWcmpGroup2), &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteEntryNexthopIdWithSaiErrorShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, kNexthopId2);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid2);
+  std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
+  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
+                                          exp_failure_status.end()),
+                      Return(SAI_STATUS_FAILURE)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(RouteManagerTest,
+       UpdateRouteEntryNexthopIdNotExistInMapperShouldRaiseCriticalState) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, kNexthopId2);
+  std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
+  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
+                                          exp_failure_status.end()),
+                      Return(SAI_STATUS_FAILURE)));
+  // TODO: Expect critical state.
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(RouteManagerTest, UpdateRouteEntryDropWithSaiErrorShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+  std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
+  std::vector<sai_status_t> exp_success_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
+                                          exp_failure_status.end()),
+                      Return(SAI_STATUS_FAILURE)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
+                                          exp_success_status.end()),
+                      Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
+                                          exp_failure_status.end()),
+                      Return(SAI_STATUS_FAILURE)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
+                                          exp_success_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
+                                          exp_success_status.end()),
+                      Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
+                                          exp_failure_status.end()),
+                      Return(SAI_STATUS_FAILURE)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
+                                          exp_failure_status.end()),
+                      Return(SAI_STATUS_FAILURE)));
+  // TODO: Expect critical state.
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(RouteManagerTest, UpdateRouteEntryTrapWithSaiErrorShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
+  std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
+  std::vector<sai_status_t> exp_success_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
+                                          exp_failure_status.end()),
+                      Return(SAI_STATUS_FAILURE)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
+                                          exp_success_status.end()),
+                      Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
+                                          exp_failure_status.end()),
+                      Return(SAI_STATUS_FAILURE)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
+                                          exp_success_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
+                                          exp_success_status.end()),
+                      Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
+                                          exp_failure_status.end()),
+                      Return(SAI_STATUS_FAILURE)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
+                                          exp_failure_status.end()),
+                      Return(SAI_STATUS_FAILURE)));
+  // TODO: Expect critical state.
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(RouteManagerTest, UpdateRouteWithDifferentNexthopIdsSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, kNexthopId2);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid2);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr.value.oid = kNexthopOid2;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  route_entry.action = p4orch::kSetNexthopId;
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2),
+      &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest,
+       UpdateRouteWithDifferentNexthopIdsAndMetadatasSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1, kMetadata1);
+
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopIdAndMetadata,
+                                          kNexthopId2, kMetadata2);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid2);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
+  exp_sai_attr.value.u32 = kMetadataInt2;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr.value.oid = kNexthopOid2;
+
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2),
+      &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromNexthopIdToDropSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr.value.oid = SAI_NULL_OBJECT_ID;
+
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromNexthopIdToRouteMetadataSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                           p4orch::kSetMetadataAndDrop, "", kMetadata1);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
+  exp_sai_attr.value.s32 = kMetadataInt1;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr.value.oid = SAI_NULL_OBJECT_ID;
+
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
+
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromNexthopIdAndMetadataToDropSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1, kMetadata2);
+
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr.value.oid = SAI_NULL_OBJECT_ID;
+
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
+  exp_sai_attr.value.u32 = 0;
+
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromDropToNexthopIdSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupDropRouteEntry(gVrfName, swss_ipv4_route_prefix);
+
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, kNexthopId2);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid2);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr.value.oid = kNexthopOid2;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_FORWARD;
+
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2),
+      &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromDropToWcmpWithMetadataSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupDropRouteEntry(gVrfName, swss_ipv4_route_prefix);
+
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetWcmpGroupIdAndMetadata,
+                                          kWcmpGroup1, kMetadata2);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+      kWcmpGroupOid1);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
+  exp_sai_attr.value.u32 = kMetadataInt2;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr.value.oid = kWcmpGroupOid1;
+
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_FORWARD;
+
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromTrapToDropAndSetMetadataSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupTrapRouteEntry(gVrfName, swss_ipv4_route_prefix);
+
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                           p4orch::kSetMetadataAndDrop, "", kMetadata2);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_META_DATA;
+  exp_sai_attr.value.u32 = kMetadataInt2;
+
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromTrapToDropSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupTrapRouteEntry(gVrfName, swss_ipv4_route_prefix);
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_DROP;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromDropToTrapSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupDropRouteEntry(gVrfName, swss_ipv4_route_prefix);
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_TRAP;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromNexthopIdToTrapSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kTrap, "");
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_TRAP;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr.value.oid = SAI_NULL_OBJECT_ID;
+
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateRouteFromTrapToNexthopIdSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupTrapRouteEntry(gVrfName, swss_ipv4_route_prefix);
+
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, kNexthopId2);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid2);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr.value.oid = kNexthopOid2;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+  exp_sai_attr.value.s32 = SAI_PACKET_ACTION_FORWARD;
+
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2),
+      &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(
+    RouteManagerTest,
+    UpdateRouteFromTrapToNexthopIdAndMetadataRecoverFailureShouldRaiseCriticalState) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupTrapRouteEntry(gVrfName, swss_ipv4_route_prefix);
+
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopIdAndMetadata,
+                                          kNexthopId2, kMetadata1);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid2);
+  std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
+  std::vector<sai_status_t> exp_success_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
+                                          exp_success_status.end()),
+                      Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
+                                          exp_success_status.end()),
+                      Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
+                                          exp_failure_status.end()),
+                      Return(SAI_STATUS_FAILURE)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
+                                          exp_success_status.end()),
+                      Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
+                                          exp_success_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+
+  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
+                                          exp_success_status.end()),
+                      Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
+                                          exp_success_status.end()),
+                      Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
+                                          exp_failure_status.end()),
+                      Return(SAI_STATUS_FAILURE)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
+                                          exp_success_status.end()),
+                      Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
+                                          exp_failure_status.end()),
+                      Return(SAI_STATUS_FAILURE)));
+  // TODO: Expect critical state.
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(RouteManagerTest, UpdateRouteWithDifferentWcmpGroupsSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupWcmpGroupRouteEntry(gVrfName, swss_ipv4_route_prefix, kWcmpGroup1,
+                           kWcmpGroupOid1);
+
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetWcmpGroupId, kWcmpGroup2);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(route_entry.wcmp_group),
+      kWcmpGroupOid2);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr.value.oid = kWcmpGroupOid2;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  route_entry.action = p4orch::kSetWcmpGroupId;
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(kWcmpGroup2), &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateNexthopIdRouteWithNoChangeSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, kNexthopId1);
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(
+    RouteManagerTest,
+    UpdateRouteFromNexthopIdAndMetadataToDropRecoverFailureShouldRaiseCriticalState) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1, kMetadata2);
+
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, p4orch::kDrop, "");
+
+  std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
+  std::vector<sai_status_t> exp_success_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
+                                          exp_failure_status.end()),
+                      Return(SAI_STATUS_FAILURE)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+
+  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
+                                          exp_success_status.end()),
+                      Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
+                                          exp_success_status.end()),
+                      Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
+                                          exp_failure_status.end()),
+                      Return(SAI_STATUS_FAILURE)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
+                                          exp_success_status.end()),
+                      Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
+                                          exp_failure_status.end()),
+                      Return(SAI_STATUS_FAILURE)));
+  // TODO: Expect critical state.
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(
+    RouteManagerTest,
+    UpdateRouteFromDifferentNexthopIdAndMetadataRecoverFailureShouldRaiseCriticalState) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1, kMetadata1);
+
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopIdAndMetadata,
+                                          kNexthopId2, kMetadata2);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry.nexthop_id), kNexthopOid2);
+
+  std::vector<sai_status_t> exp_failure_status{SAI_STATUS_FAILURE};
+  std::vector<sai_status_t> exp_success_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
+                                          exp_failure_status.end()),
+                      Return(SAI_STATUS_FAILURE)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+
+  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_success_status.begin(),
+                                          exp_success_status.end()),
+                      Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
+                                          exp_failure_status.end()),
+                      Return(SAI_STATUS_FAILURE)))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_failure_status.begin(),
+                                          exp_failure_status.end()),
+                      Return(SAI_STATUS_FAILURE)));
+  // TODO: Expect critical state.
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(RouteManagerTest, DeleteRouteEntryWithSaiErrorShouldFail) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE};
+  EXPECT_CALL(mock_sai_route_, remove_route_entries(_, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_FAILURE)));
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "");
+  EXPECT_THAT(DeleteRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_UNKNOWN}));
+}
+
+TEST_F(RouteManagerTest, DeleteIpv4RouteSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(
+      mock_sai_route_,
+      remove_route_entries(Eq(1),
+                           RouteEntryArrayEq(std::vector<sai_route_entry_t>{
+                               exp_sai_route_entry}),
+                           Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix, "", "");
+  EXPECT_THAT(DeleteRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  auto* route_entry_ptr = GetRouteEntry(route_entry.route_entry_key);
+  EXPECT_EQ(nullptr, route_entry_ptr);
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY,
+                                        route_entry.route_entry_key));
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, DeleteIpv6RouteSucceeds) {
+  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+  sai_ip_prefix_t sai_ipv6_route_prefix;
+  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+  SetupWcmpGroupRouteEntry(gVrfName, swss_ipv6_route_prefix, kWcmpGroup1,
+                           kWcmpGroupOid1);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVrfOid;
+  exp_sai_route_entry.destination = sai_ipv6_route_prefix;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(
+      mock_sai_route_,
+      remove_route_entries(Eq(1),
+                           RouteEntryArrayEq(std::vector<sai_route_entry_t>{
+                               exp_sai_route_entry}),
+                           Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, "", "");
+  EXPECT_THAT(DeleteRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+  auto* route_entry_ptr = GetRouteEntry(route_entry.route_entry_key);
+  EXPECT_EQ(nullptr, route_entry_ptr);
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY,
+                                        route_entry.route_entry_key));
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, RouteCreateAndUpdateInDrainSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP,
+                        KeyGenerator::generateNextHopKey(kNexthopId1),
+                        kNexthopOid1);
+  auto key_op_fvs_1 = GenerateKeyOpFieldsValuesTuple(
+      gVrfName, swss_ipv4_route_prefix, SET_COMMAND, p4orch::kSetNexthopId,
+      kNexthopId1);
+  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_1);
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_1)),
+                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_1)),
+                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
+      .Times(1);
+  Drain();
+
+  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP,
+                        KeyGenerator::generateNextHopKey(kNexthopId2),
+                        kNexthopOid2);
+  auto key_op_fvs_2 = GenerateKeyOpFieldsValuesTuple(
+      gVrfName, swss_ipv4_route_prefix, SET_COMMAND, p4orch::kSetNexthopId,
+      kNexthopId2);
+  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_2);
+  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_2)),
+                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_2)),
+                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
+      .Times(1);
+  Drain();
+
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, kNexthopId2);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2),
+      &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+
+  auto key_op_fvs_3 = GenerateKeyOpFieldsValuesTuple(
+      gVrfName, swss_ipv4_route_prefix, SET_COMMAND,
+      p4orch::kSetMetadataAndDrop, "", kMetadata1);
+  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_3);
+  EXPECT_CALL(mock_sai_route_, set_route_entries_attribute(_, _, _, _, _))
+      .WillRepeatedly(
+          DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                Return(SAI_STATUS_SUCCESS)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_3)),
+                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_3)),
+                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
+      .Times(1);
+  Drain();
+
+  route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                           p4orch::kSetMetadataAndDrop, "", kMetadata1);
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2),
+      &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, RouteCreateAndDeleteInDrainSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP,
+                        KeyGenerator::generateNextHopKey(kNexthopId1),
+                        kNexthopOid1);
+  auto key_op_fvs_1 = GenerateKeyOpFieldsValuesTuple(
+      gVrfName, swss_ipv4_route_prefix, SET_COMMAND, p4orch::kSetNexthopId,
+      kNexthopId1);
+  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_1);
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_1)),
+                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_1)),
+                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
+      .Times(1);
+  Drain();
+
+  auto key_op_fvs_2 = GenerateKeyOpFieldsValuesTuple(
+      gVrfName, swss_ipv4_route_prefix, DEL_COMMAND, "", "");
+  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_2);
+  EXPECT_CALL(mock_sai_route_, remove_route_entries(_, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_2)),
+                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_2)),
+                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
+      .Times(1);
+  Drain();
+
+  std::string key =
+      KeyGenerator::generateRouteKey(gVrfName, swss_ipv4_route_prefix);
+  auto* route_entry_ptr = GetRouteEntry(key);
+  EXPECT_EQ(nullptr, route_entry_ptr);
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, key));
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, UpdateFailsWhenCreateAndUpdateTheSameRouteInDrain) {
+  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP,
+                        KeyGenerator::generateNextHopKey(kNexthopId1),
+                        kNexthopOid1);
+  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP,
+                        KeyGenerator::generateNextHopKey(kNexthopId2),
+                        kNexthopOid2);
+  auto key_op_fvs_1 = GenerateKeyOpFieldsValuesTuple(
+      gVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND, p4orch::kSetNexthopId,
+      kNexthopId1);
+  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_1);
+  auto key_op_fvs_2 = GenerateKeyOpFieldsValuesTuple(
+      gVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND, p4orch::kSetNexthopId,
+      kNexthopId2);
+  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_2);
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_1)),
+                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_1)),
+                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
+      .Times(1);
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_2)),
+                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_2)),
+                      Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)))
+      .Times(1);
+
+  Drain();
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, kNexthopId1);
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId2),
+      &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, DeleteFailsWhenCreateAndDeleteTheSameRouteInDrain) {
+  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP,
+                        KeyGenerator::generateNextHopKey(kNexthopId1),
+                        kNexthopOid1);
+  auto key_op_fvs_1 = GenerateKeyOpFieldsValuesTuple(
+      gVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND, p4orch::kSetNexthopId,
+      kNexthopId1);
+  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_1);
+  auto key_op_fvs_2 = GenerateKeyOpFieldsValuesTuple(
+      gVrfName, swss::IpPrefix(kIpv4Prefix), DEL_COMMAND, "", "");
+  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs_2);
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_1)),
+                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_1)),
+                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
+      .Times(1);
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs_2)),
+                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs_2)),
+                      Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)))
+      .Times(1);
+  Drain();
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, kNexthopId1);
+  VerifyRouteEntry(route_entry, sai_ipv4_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, RouteCreateInDrainSucceedsWhenVrfIsEmpty) {
+  const std::string kDefaultVrfName = "";  // Default Vrf
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP,
+                        KeyGenerator::generateNextHopKey(kNexthopId1),
+                        kNexthopOid1);
+  auto key_op_fvs = GenerateKeyOpFieldsValuesTuple(
+      kDefaultVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND,
+      p4orch::kSetNexthopId, kNexthopId1);
+  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
+
+  sai_route_entry_t exp_sai_route_entry;
+  exp_sai_route_entry.switch_id = gSwitchId;
+  exp_sai_route_entry.vr_id = gVirtualRouterId;
+  exp_sai_route_entry.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr;
+  exp_sai_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr.value.oid = kNexthopOid1;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              create_route_entries(
+                  Eq(1),
+                  RouteEntryArrayEq(
+                      std::vector<sai_route_entry_t>{exp_sai_route_entry}),
+                  ArrayEq(std::vector<uint32_t>{1}),
+                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
+                      {exp_sai_attr}}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
+                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
+                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)))
+      .Times(1);
+
+  Drain();
+  std::string key = KeyGenerator::generateRouteKey(kDefaultVrfName,
+                                                   swss::IpPrefix(kIpv4Prefix));
+  auto* route_entry_ptr = GetRouteEntry(key);
+  EXPECT_NE(nullptr, route_entry_ptr);
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY, key));
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, DeserializeRouteEntryInDrainFails) {
+  const std::string kKeyPrefix =
+      std::string(APP_P4RT_IPV4_TABLE_NAME) + kTableKeyDelimiter;
+  auto key_op_fvs =
+      swss::KeyOpFieldsValuesTuple(kKeyPrefix + "{{{{{{{{{{{{", SET_COMMAND,
+                                   std::vector<swss::FieldValueTuple>{});
+  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
+                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
+                      Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)))
+      .Times(1);
+  Drain();
+}
+
+TEST_F(RouteManagerTest, ValidateRouteEntryInDrainFailsWhenVrfDoesNotExist) {
+  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP,
+                        KeyGenerator::generateNextHopKey(kNexthopId1),
+                        kNexthopOid1);
+  auto key_op_fvs = GenerateKeyOpFieldsValuesTuple(
+      "Invalid-Vrf", swss::IpPrefix(kIpv4Prefix), SET_COMMAND,
+      p4orch::kSetNexthopId, kNexthopId1);
+  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
+                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
+                      Eq(StatusCode::SWSS_RC_NOT_FOUND), Eq(true)))
+      .Times(1);
+  Drain();
+}
+
+TEST_F(RouteManagerTest,
+       ValidateRouteEntryInDrainFailsWhenNexthopDoesNotExist) {
+  auto key_op_fvs = GenerateKeyOpFieldsValuesTuple(
+      gVrfName, swss::IpPrefix(kIpv4Prefix), SET_COMMAND, p4orch::kSetNexthopId,
+      kNexthopId1);
+  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
+                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
+                      Eq(StatusCode::SWSS_RC_NOT_FOUND), Eq(true)))
+      .Times(1);
+  Drain();
+}
+
+TEST_F(RouteManagerTest, InvalidateSetRouteEntryInDrainFails) {
+  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP,
+                        KeyGenerator::generateNextHopKey(kNexthopId1),
+                        kNexthopOid1);
+  // No nexthop ID with kSetNexthopId action.
+  auto key_op_fvs =
+      GenerateKeyOpFieldsValuesTuple(gVrfName, swss::IpPrefix(kIpv4Prefix),
+                                     SET_COMMAND, p4orch::kSetNexthopId, "");
+  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
+                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
+                      Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)))
+      .Times(1);
+  Drain();
+}
+
+TEST_F(RouteManagerTest, InvalidateDelRouteEntryInDrainFails) {
+  // Route does not exist.
+  auto key_op_fvs = GenerateKeyOpFieldsValuesTuple(
+      gVrfName, swss::IpPrefix(kIpv4Prefix), DEL_COMMAND, p4orch::kSetNexthopId,
+      kNexthopId1);
+  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
+                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
+                      Eq(StatusCode::SWSS_RC_NOT_FOUND), Eq(true)))
+      .Times(1);
+  Drain();
+}
+
+TEST_F(RouteManagerTest, InvalidCommandInDrainFails) {
+  const std::string kKeyPrefix =
+      std::string(APP_P4RT_IPV4_TABLE_NAME) + kTableKeyDelimiter;
+  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP,
+                        KeyGenerator::generateNextHopKey(kNexthopId1),
+                        kNexthopOid1);
+  nlohmann::json j;
+  j[prependMatchField(p4orch::kVrfId)] = gVrfName;
+  j[prependMatchField(p4orch::kIpv4Dst)] = kIpv4Prefix;
+  std::vector<swss::FieldValueTuple> attributes;
+  attributes.push_back(
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
+  attributes.push_back(swss::FieldValueTuple{
+      prependParamField(p4orch::kNexthopId), kNexthopId1});
+  auto key_op_fvs = swss::KeyOpFieldsValuesTuple(kKeyPrefix + j.dump(),
+                                                 "INVALID_COMMAND", attributes);
+  Enqueue(APP_P4RT_IPV4_TABLE_NAME, key_op_fvs);
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(kfvKey(key_op_fvs)),
+                      FieldValueTupleArrayEq(kfvFieldsValues(key_op_fvs)),
+                      Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)))
+      .Times(1);
+  Drain();
+}
+
+TEST_F(RouteManagerTest, BatchedCreateSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  auto route_entry_ipv4 = GenerateP4RouteEntry(
+      gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry_ipv4.nexthop_id),
+      kNexthopOid1);
+
+  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+  sai_ip_prefix_t sai_ipv6_route_prefix;
+  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+  auto route_entry_ipv6 = GenerateP4RouteEntry(
+      gVrfName, swss_ipv6_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(route_entry_ipv6.wcmp_group),
+      kWcmpGroupOid1);
+
+  sai_route_entry_t exp_sai_route_entry_ipv4;
+  exp_sai_route_entry_ipv4.switch_id = gSwitchId;
+  exp_sai_route_entry_ipv4.vr_id = gVrfOid;
+  exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr_ipv4;
+  exp_sai_attr_ipv4.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr_ipv4.value.oid = kNexthopOid1;
+
+  sai_route_entry_t exp_sai_route_entry_ipv6;
+  exp_sai_route_entry_ipv6.switch_id = gSwitchId;
+  exp_sai_route_entry_ipv6.vr_id = gVrfOid;
+  exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
+
+  sai_attribute_t exp_sai_attr_ipv6;
+  exp_sai_attr_ipv6.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr_ipv6.value.oid = kWcmpGroupOid1;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              create_route_entries(
+                  Eq(2),
+                  RouteEntryArrayEq(std::vector<sai_route_entry_t>{
+                      exp_sai_route_entry_ipv6, exp_sai_route_entry_ipv4}),
+                  ArrayEq(std::vector<uint32_t>{1, 1}),
+                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
+                      {exp_sai_attr_ipv6}, {exp_sai_attr_ipv4}}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4,
+                                                           route_entry_ipv6}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS,
+                                              StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry_ipv4, sai_ipv4_route_prefix, gVrfOid);
+  VerifyRouteEntry(route_entry_ipv6, sai_ipv6_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, BatchedCreatePartiallySucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  auto route_entry_ipv4 = GenerateP4RouteEntry(
+      gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP,
+      KeyGenerator::generateNextHopKey(route_entry_ipv4.nexthop_id),
+      kNexthopOid1);
+
+  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+  sai_ip_prefix_t sai_ipv6_route_prefix;
+  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+  auto route_entry_ipv6 = GenerateP4RouteEntry(
+      gVrfName, swss_ipv6_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
+  p4_oid_mapper_.setOID(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(route_entry_ipv6.wcmp_group),
+      kWcmpGroupOid1);
+
+  sai_route_entry_t exp_sai_route_entry_ipv4;
+  exp_sai_route_entry_ipv4.switch_id = gSwitchId;
+  exp_sai_route_entry_ipv4.vr_id = gVrfOid;
+  exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr_ipv4;
+  exp_sai_attr_ipv4.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr_ipv4.value.oid = kNexthopOid1;
+
+  sai_route_entry_t exp_sai_route_entry_ipv6;
+  exp_sai_route_entry_ipv6.switch_id = gSwitchId;
+  exp_sai_route_entry_ipv6.vr_id = gVrfOid;
+  exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
+
+  sai_attribute_t exp_sai_attr_ipv6;
+  exp_sai_attr_ipv6.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr_ipv6.value.oid = kWcmpGroupOid1;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE, SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              create_route_entries(
+                  Eq(2),
+                  RouteEntryArrayEq(std::vector<sai_route_entry_t>{
+                      exp_sai_route_entry_ipv6, exp_sai_route_entry_ipv4}),
+                  ArrayEq(std::vector<uint32_t>{1, 1}),
+                  AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
+                      {exp_sai_attr_ipv6}, {exp_sai_attr_ipv4}}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_FAILURE)));
+  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4,
+                                                           route_entry_ipv6}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS,
+                                              StatusCode::SWSS_RC_UNKNOWN}));
+  VerifyRouteEntry(route_entry_ipv4, sai_ipv4_route_prefix, gVrfOid);
+  auto* route_entry_ptr_ipv6 = GetRouteEntry(route_entry_ipv6.route_entry_key);
+  EXPECT_EQ(nullptr, route_entry_ptr_ipv6);
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY,
+                                        route_entry_ipv6.route_entry_key));
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, BatchedUpdateSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  auto route_entry_ipv4 = GenerateP4RouteEntry(
+      gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                        KeyGenerator::generateWcmpGroupKey(kWcmpGroup1),
+                        kWcmpGroupOid1);
+
+  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+  sai_ip_prefix_t sai_ipv6_route_prefix;
+  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+  auto route_entry_ipv6 = GenerateP4RouteEntry(
+      gVrfName, swss_ipv6_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup2);
+  SetupDropRouteEntry(gVrfName, swss_ipv6_route_prefix);
+  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                        KeyGenerator::generateWcmpGroupKey(kWcmpGroup2),
+                        kWcmpGroupOid2);
+
+  sai_route_entry_t exp_sai_route_entry_ipv4;
+  exp_sai_route_entry_ipv4.switch_id = gSwitchId;
+  exp_sai_route_entry_ipv4.vr_id = gVrfOid;
+  exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr_ipv4;
+  exp_sai_attr_ipv4.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr_ipv4.value.oid = kWcmpGroupOid1;
+
+  sai_route_entry_t exp_sai_route_entry_ipv6;
+  exp_sai_route_entry_ipv6.switch_id = gSwitchId;
+  exp_sai_route_entry_ipv6.vr_id = gVrfOid;
+  exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
+
+  sai_attribute_t exp_sai_attr_ipv6;
+  exp_sai_attr_ipv6.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr_ipv6.value.oid = kWcmpGroupOid2;
+
+  std::vector<sai_status_t> exp_status_1{SAI_STATUS_SUCCESS,
+                                         SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(2),
+                  RouteEntryArrayEq(std::vector<sai_route_entry_t>{
+                      exp_sai_route_entry_ipv6, exp_sai_route_entry_ipv4}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr_ipv6,
+                                                           exp_sai_attr_ipv4}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(
+          DoAll(SetArrayArgument<4>(exp_status_1.begin(), exp_status_1.end()),
+                Return(SAI_STATUS_SUCCESS)));
+
+  sai_attribute_t exp_sai_attr_ipv6_2;
+  exp_sai_attr_ipv6_2.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+  exp_sai_attr_ipv6_2.value.s32 = SAI_PACKET_ACTION_FORWARD;
+
+  std::vector<sai_status_t> exp_status_2{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(
+      mock_sai_route_,
+      set_route_entries_attribute(
+          Eq(1),
+          RouteEntryArrayEq(
+              std::vector<sai_route_entry_t>{exp_sai_route_entry_ipv6}),
+          AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr_ipv6_2}),
+          Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(
+          DoAll(SetArrayArgument<4>(exp_status_2.begin(), exp_status_2.end()),
+                Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4,
+                                                           route_entry_ipv6}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS,
+                                              StatusCode::SWSS_RC_SUCCESS}));
+  VerifyRouteEntry(route_entry_ipv4, sai_ipv4_route_prefix, gVrfOid);
+  VerifyRouteEntry(route_entry_ipv6, sai_ipv6_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(kWcmpGroup2), &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, BatchedUpdatePartiallySucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  auto route_entry_ipv4 = GenerateP4RouteEntry(
+      gVrfName, swss_ipv4_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup1);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                        KeyGenerator::generateWcmpGroupKey(kWcmpGroup1),
+                        kWcmpGroupOid1);
+
+  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+  sai_ip_prefix_t sai_ipv6_route_prefix;
+  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+  auto route_entry_ipv6 = GenerateP4RouteEntry(
+      gVrfName, swss_ipv6_route_prefix, p4orch::kSetWcmpGroupId, kWcmpGroup2);
+  SetupDropRouteEntry(gVrfName, swss_ipv6_route_prefix);
+  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+                        KeyGenerator::generateWcmpGroupKey(kWcmpGroup2),
+                        kWcmpGroupOid2);
+
+  sai_route_entry_t exp_sai_route_entry_ipv4;
+  exp_sai_route_entry_ipv4.switch_id = gSwitchId;
+  exp_sai_route_entry_ipv4.vr_id = gVrfOid;
+  exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
+
+  sai_attribute_t exp_sai_attr_ipv4;
+  exp_sai_attr_ipv4.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr_ipv4.value.oid = kWcmpGroupOid1;
+
+  sai_route_entry_t exp_sai_route_entry_ipv6;
+  exp_sai_route_entry_ipv6.switch_id = gSwitchId;
+  exp_sai_route_entry_ipv6.vr_id = gVrfOid;
+  exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
+
+  sai_attribute_t exp_sai_attr_ipv6;
+  exp_sai_attr_ipv6.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+  exp_sai_attr_ipv6.value.oid = kWcmpGroupOid2;
+
+  std::vector<sai_status_t> exp_status_1{SAI_STATUS_FAILURE,
+                                         SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              set_route_entries_attribute(
+                  Eq(2),
+                  RouteEntryArrayEq(std::vector<sai_route_entry_t>{
+                      exp_sai_route_entry_ipv6, exp_sai_route_entry_ipv4}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr_ipv6,
+                                                           exp_sai_attr_ipv4}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(
+          DoAll(SetArrayArgument<4>(exp_status_1.begin(), exp_status_1.end()),
+                Return(SAI_STATUS_FAILURE)));
+  EXPECT_THAT(UpdateRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4,
+                                                           route_entry_ipv6}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS,
+                                              StatusCode::SWSS_RC_UNKNOWN}));
+  VerifyRouteEntry(route_entry_ipv4, sai_ipv4_route_prefix, gVrfOid);
+  route_entry_ipv6 =
+      GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kDrop, "");
+  VerifyRouteEntry(route_entry_ipv6, sai_ipv6_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(kWcmpGroup1), &ref_cnt));
+  EXPECT_EQ(1, ref_cnt);
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP_GROUP,
+      KeyGenerator::generateWcmpGroupKey(kWcmpGroup2), &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, BatchedDeleteSucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  auto route_entry_ipv4 = GenerateP4RouteEntry(
+      gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+
+  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+  sai_ip_prefix_t sai_ipv6_route_prefix;
+  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+  auto route_entry_ipv6 =
+      GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kDrop, "");
+  SetupDropRouteEntry(gVrfName, swss_ipv6_route_prefix);
+
+  sai_route_entry_t exp_sai_route_entry_ipv4;
+  exp_sai_route_entry_ipv4.switch_id = gSwitchId;
+  exp_sai_route_entry_ipv4.vr_id = gVrfOid;
+  exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
+
+  sai_route_entry_t exp_sai_route_entry_ipv6;
+  exp_sai_route_entry_ipv6.switch_id = gSwitchId;
+  exp_sai_route_entry_ipv6.vr_id = gVrfOid;
+  exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              remove_route_entries(
+                  Eq(2),
+                  RouteEntryArrayEq(std::vector<sai_route_entry_t>{
+                      exp_sai_route_entry_ipv6, exp_sai_route_entry_ipv4}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(DeleteRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4,
+                                                           route_entry_ipv6}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS,
+                                              StatusCode::SWSS_RC_SUCCESS}));
+  auto* route_entry_ptr_ipv4 = GetRouteEntry(route_entry_ipv4.route_entry_key);
+  EXPECT_EQ(nullptr, route_entry_ptr_ipv4);
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY,
+                                        route_entry_ipv4.route_entry_key));
+  auto* route_entry_ptr_ipv6 = GetRouteEntry(route_entry_ipv6.route_entry_key);
+  EXPECT_EQ(nullptr, route_entry_ptr_ipv6);
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY,
+                                        route_entry_ipv6.route_entry_key));
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, BatchedDeletePartiallySucceeds) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  sai_ip_prefix_t sai_ipv4_route_prefix;
+  copy(sai_ipv4_route_prefix, swss_ipv4_route_prefix);
+  auto route_entry_ipv4 = GenerateP4RouteEntry(
+      gVrfName, swss_ipv4_route_prefix, p4orch::kSetNexthopId, kNexthopId1);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+
+  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+  sai_ip_prefix_t sai_ipv6_route_prefix;
+  copy(sai_ipv6_route_prefix, swss_ipv6_route_prefix);
+  auto route_entry_ipv6 =
+      GenerateP4RouteEntry(gVrfName, swss_ipv6_route_prefix, p4orch::kDrop, "");
+  SetupDropRouteEntry(gVrfName, swss_ipv6_route_prefix);
+
+  sai_route_entry_t exp_sai_route_entry_ipv4;
+  exp_sai_route_entry_ipv4.switch_id = gSwitchId;
+  exp_sai_route_entry_ipv4.vr_id = gVrfOid;
+  exp_sai_route_entry_ipv4.destination = sai_ipv4_route_prefix;
+
+  sai_route_entry_t exp_sai_route_entry_ipv6;
+  exp_sai_route_entry_ipv6.switch_id = gSwitchId;
+  exp_sai_route_entry_ipv6.vr_id = gVrfOid;
+  exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE, SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_,
+              remove_route_entries(
+                  Eq(2),
+                  RouteEntryArrayEq(std::vector<sai_route_entry_t>{
+                      exp_sai_route_entry_ipv6, exp_sai_route_entry_ipv4}),
+                  Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
+      .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_FAILURE)));
+  EXPECT_THAT(DeleteRouteEntries(std::vector<P4RouteEntry>{route_entry_ipv4,
+                                                           route_entry_ipv6}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS,
+                                              StatusCode::SWSS_RC_UNKNOWN}));
+  auto* route_entry_ptr_ipv4 = GetRouteEntry(route_entry_ipv4.route_entry_key);
+  EXPECT_EQ(nullptr, route_entry_ptr_ipv4);
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_ROUTE_ENTRY,
+                                        route_entry_ipv4.route_entry_key));
+  VerifyRouteEntry(route_entry_ipv6, sai_ipv6_route_prefix, gVrfOid);
+  uint32_t ref_cnt;
+  EXPECT_TRUE(p4_oid_mapper_.getRefCount(
+      SAI_OBJECT_TYPE_NEXT_HOP, KeyGenerator::generateNextHopKey(kNexthopId1),
+      &ref_cnt));
+  EXPECT_EQ(0, ref_cnt);
+}
+
+TEST_F(RouteManagerTest, VerifyStateTest) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv4_route_prefix, kNexthopId1,
+                           kNexthopOid1);
+  auto route_entry = GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix,
+                                          p4orch::kSetNexthopId, kNexthopId1);
+
+  // Setup ASIC DB.
+  swss::Table table(nullptr, "ASIC_STATE");
+  table.set(
+      "SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.11.12.0/"
+      "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
+      std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{
+          "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x1"}});
+
+  nlohmann::json j;
+  j[prependMatchField(p4orch::kVrfId)] = gVrfName;
+  j[prependMatchField(p4orch::kIpv4Dst)] = kIpv4Prefix;
+  const std::string db_key = std::string(APP_P4RT_TABLE_NAME) +
+                             kTableKeyDelimiter + APP_P4RT_IPV4_TABLE_NAME +
+                             kTableKeyDelimiter + j.dump();
+  std::vector<swss::FieldValueTuple> attributes;
+
+  // Verification should succeed with vaild key and value.
+  attributes.push_back(
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
+  attributes.push_back(swss::FieldValueTuple{
+      prependParamField(p4orch::kNexthopId), kNexthopId1});
+  EXPECT_EQ(VerifyState(db_key, attributes), "");
+
+  // TODO: Expect critical state.
+
+  // Invalid key should fail verification.
+  EXPECT_FALSE(VerifyState("invalid", attributes).empty());
+  EXPECT_FALSE(VerifyState("invalid:invalid", attributes).empty());
+  EXPECT_FALSE(
+      VerifyState(std::string(APP_P4RT_TABLE_NAME) + ":invalid", attributes)
+          .empty());
+  EXPECT_FALSE(
+      VerifyState(std::string(APP_P4RT_TABLE_NAME) + ":invalid:invalid",
+                  attributes)
+          .empty());
+  EXPECT_FALSE(VerifyState(std::string(APP_P4RT_TABLE_NAME) +
+                               ":FIXED_IPV4_TABLE:invalid",
+                           attributes)
+                   .empty());
+
+  // Verification should fail if nexthop ID does not exist.
+  attributes.clear();
+  attributes.push_back(
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
+  attributes.push_back(swss::FieldValueTuple{
+      prependParamField(p4orch::kNexthopId), kNexthopId2});
+  EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+  attributes.clear();
+  attributes.push_back(
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
+  attributes.push_back(swss::FieldValueTuple{
+      prependParamField(p4orch::kNexthopId), kNexthopId1});
+
+  // Verification should fail if entry does not exist.
+  j[prependMatchField(p4orch::kIpv4Dst)] = "1.1.1.0/24";
+  EXPECT_FALSE(VerifyState(std::string(APP_P4RT_TABLE_NAME) +
+                               kTableKeyDelimiter + APP_P4RT_IPV4_TABLE_NAME +
+                               kTableKeyDelimiter + j.dump(),
+                           attributes)
+                   .empty());
+
+  auto* route_entry_ptr = GetRouteEntry(
+      KeyGenerator::generateRouteKey(gVrfName, swss_ipv4_route_prefix));
+  EXPECT_NE(route_entry_ptr, nullptr);
+
+  // Verification should fail if route entry key mismatches.
+  auto saved_route_entry_key = route_entry_ptr->route_entry_key;
+  route_entry_ptr->route_entry_key = "invalid";
+  EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+  route_entry_ptr->route_entry_key = saved_route_entry_key;
+
+  // Verification should fail if VRF ID mismatches.
+  auto saved_vrf_id = route_entry_ptr->vrf_id;
+  route_entry_ptr->vrf_id = "invalid";
+  EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+  route_entry_ptr->vrf_id = saved_vrf_id;
+
+  // Verification should fail if route prefix mismatches.
+  auto saved_route_prefix = route_entry_ptr->route_prefix;
+  route_entry_ptr->route_prefix = swss::IpPrefix(kIpv6Prefix);
+  EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+  route_entry_ptr->route_prefix = saved_route_prefix;
+
+  // Verification should fail if action mismatches.
+  auto saved_action = route_entry_ptr->action;
+  route_entry_ptr->action = p4orch::kSetWcmpGroupId;
+  EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+  route_entry_ptr->action = saved_action;
+
+  // Verification should fail if nexthop ID mismatches.
+  auto saved_nexthop_id = route_entry_ptr->nexthop_id;
+  route_entry_ptr->nexthop_id = kNexthopId2;
+  EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+  route_entry_ptr->nexthop_id = saved_nexthop_id;
+
+  // Verification should fail if WCMP group mismatches.
+  auto saved_wcmp_group = route_entry_ptr->wcmp_group;
+  route_entry_ptr->wcmp_group = kWcmpGroup1;
+  EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+  route_entry_ptr->wcmp_group = saved_wcmp_group;
+
+  // Verification should fail if WCMP group mismatches.
+  auto saved_route_metadata = route_entry_ptr->route_metadata;
+  route_entry_ptr->route_metadata = kMetadata1;
+  EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+  route_entry_ptr->route_metadata = saved_route_metadata;
+}
+
+TEST_F(RouteManagerTest, VerifyStateAsicDbTest) {
+  auto swss_ipv4_route_prefix = swss::IpPrefix(kIpv4Prefix);
+  SetupDropRouteEntry(gVrfName, swss_ipv4_route_prefix);
+  auto swss_ipv6_route_prefix = swss::IpPrefix(kIpv6Prefix);
+  SetupNexthopIdRouteEntry(gVrfName, swss_ipv6_route_prefix, kNexthopId1,
+                           kNexthopOid1, kMetadata1);
+
+  auto swss_ipv4_route_prefix2 = swss::IpPrefix(kIpv4Prefix2);
+  auto route_entry =
+      GenerateP4RouteEntry(gVrfName, swss_ipv4_route_prefix2,
+                           p4orch::kSetMetadataAndDrop, "", kMetadata2);
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_route_, create_route_entries(_, _, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_THAT(CreateRouteEntries(std::vector<P4RouteEntry>{route_entry}),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+
+  // Setup ASIC DB.
+  swss::Table table(nullptr, "ASIC_STATE");
+  table.set(
+      "SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.11.12.0/"
+      "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
+      std::vector<swss::FieldValueTuple>{
+          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION",
+                                "SAI_PACKET_ACTION_DROP"},
+          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID",
+                                "oid:0x0"}});
+  table.set(
+      "SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"2001:db8:1::/"
+      "32\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
+      std::vector<swss::FieldValueTuple>{
+          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x1"},
+          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_META_DATA", "1"}});
+
+  table.set(
+      "SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.12.12.0/"
+      "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
+      std::vector<swss::FieldValueTuple>{
+          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION",
+                                "SAI_PACKET_ACTION_DROP"},
+          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_META_DATA", "2"}});
+
+  nlohmann::json j_1;
+  j_1[prependMatchField(p4orch::kVrfId)] = gVrfName;
+  j_1[prependMatchField(p4orch::kIpv4Dst)] = kIpv4Prefix;
+  const std::string db_key_1 = std::string(APP_P4RT_TABLE_NAME) +
+                               kTableKeyDelimiter + APP_P4RT_IPV4_TABLE_NAME +
+                               kTableKeyDelimiter + j_1.dump();
+  std::vector<swss::FieldValueTuple> attributes_1;
+  attributes_1.push_back(swss::FieldValueTuple{p4orch::kAction, p4orch::kDrop});
+  nlohmann::json j_2;
+  j_2[prependMatchField(p4orch::kVrfId)] = gVrfName;
+  j_2[prependMatchField(p4orch::kIpv6Dst)] = kIpv6Prefix;
+  const std::string db_key_2 = std::string(APP_P4RT_TABLE_NAME) +
+                               kTableKeyDelimiter + APP_P4RT_IPV6_TABLE_NAME +
+                               kTableKeyDelimiter + j_2.dump();
+  std::vector<swss::FieldValueTuple> attributes_2;
+  attributes_2.push_back(
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopIdAndMetadata});
+  attributes_2.push_back(swss::FieldValueTuple{
+      prependParamField(p4orch::kNexthopId), kNexthopId1});
+  attributes_2.push_back(swss::FieldValueTuple{
+      prependParamField(p4orch::kRouteMetadata), kMetadata1});
+
+  nlohmann::json j_3;
+  j_3[prependMatchField(p4orch::kVrfId)] = gVrfName;
+  j_3[prependMatchField(p4orch::kIpv6Dst)] = kIpv4Prefix2;
+  const std::string db_key_3 = std::string(APP_P4RT_TABLE_NAME) +
+                               kTableKeyDelimiter + APP_P4RT_IPV6_TABLE_NAME +
+                               kTableKeyDelimiter + j_3.dump();
+  std::vector<swss::FieldValueTuple> attributes_3;
+  attributes_3.push_back(
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMetadataAndDrop});
+  attributes_3.push_back(swss::FieldValueTuple{
+      prependParamField(p4orch::kRouteMetadata), kMetadata2});
+
+  // Verification should succeed with correct ASIC DB values.
+  EXPECT_EQ(VerifyState(db_key_1, attributes_1), "");
+  EXPECT_EQ(VerifyState(db_key_2, attributes_2), "");
+  EXPECT_EQ(VerifyState(db_key_3, attributes_3), "");
+
+  // Verification should fail if ASIC DB values mismatch.
+  table.set(
+      "SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.11.12.0/"
+      "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
+      std::vector<swss::FieldValueTuple>{swss::FieldValueTuple{
+          "SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION", "SAI_PACKET_ACTION_FORWARD"}});
+  table.set(
+      "SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"2001:db8:1::/"
+      "32\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
+      std::vector<swss::FieldValueTuple>{
+          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_META_DATA", "2"}});
+  EXPECT_FALSE(VerifyState(db_key_1, attributes_1).empty());
+  EXPECT_FALSE(VerifyState(db_key_2, attributes_2).empty());
+
+  // Verification should fail if ASIC DB table is missing.
+  table.del(
+      "SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.11.12.0/"
+      "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}");
+  table.del(
+      "SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"2001:db8:1::/"
+      "32\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}");
+  EXPECT_FALSE(VerifyState(db_key_1, attributes_1).empty());
+  EXPECT_FALSE(VerifyState(db_key_2, attributes_2).empty());
+  table.set(
+      "SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"10.11.12.0/"
+      "24\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
+      std::vector<swss::FieldValueTuple>{
+          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION",
+                                "SAI_PACKET_ACTION_DROP"},
+          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID",
+                                "oid:0x0"}});
+  table.set(
+      "SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"2001:db8:1::/"
+      "32\",\"switch_id\":\"oid:0x0\",\"vr\":\"oid:0x6f\"}",
+      std::vector<swss::FieldValueTuple>{
+          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "oid:0x1"},
+          swss::FieldValueTuple{"SAI_ROUTE_ENTRY_ATTR_META_DATA", "1"}});
 }

--- a/orchagent/p4orch/tests/route_manager_test.cpp
+++ b/orchagent/p4orch/tests/route_manager_test.cpp
@@ -3320,10 +3320,10 @@ TEST_F(RouteManagerTest, BatchedCreateSucceeds) {
               create_route_entries(
                   Eq(2),
                   RouteEntryArrayEq(std::vector<sai_route_entry_t>{
-                      exp_sai_route_entry_ipv6, exp_sai_route_entry_ipv4}),
+                      exp_sai_route_entry_ipv4, exp_sai_route_entry_ipv6}),
                   ArrayEq(std::vector<uint32_t>{1, 1}),
                   AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                      {exp_sai_attr_ipv6}, {exp_sai_attr_ipv4}}),
+                      {exp_sai_attr_ipv4}, {exp_sai_attr_ipv6}}),
                   Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
       .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
                       Return(SAI_STATUS_SUCCESS)));
@@ -3383,15 +3383,15 @@ TEST_F(RouteManagerTest, BatchedCreatePartiallySucceeds) {
   exp_sai_attr_ipv6.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
   exp_sai_attr_ipv6.value.oid = kWcmpGroupOid1;
 
-  std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE, SAI_STATUS_SUCCESS};
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS, SAI_STATUS_FAILURE};
   EXPECT_CALL(mock_sai_route_,
               create_route_entries(
                   Eq(2),
                   RouteEntryArrayEq(std::vector<sai_route_entry_t>{
-                      exp_sai_route_entry_ipv6, exp_sai_route_entry_ipv4}),
+                      exp_sai_route_entry_ipv4, exp_sai_route_entry_ipv6}),
                   ArrayEq(std::vector<uint32_t>{1, 1}),
                   AttrArrayArrayEq(std::vector<std::vector<sai_attribute_t>>{
-                      {exp_sai_attr_ipv6}, {exp_sai_attr_ipv4}}),
+                      {exp_sai_attr_ipv4}, {exp_sai_attr_ipv6}}),
                   Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
       .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()),
                       Return(SAI_STATUS_FAILURE)));
@@ -3461,9 +3461,9 @@ TEST_F(RouteManagerTest, BatchedUpdateSucceeds) {
               set_route_entries_attribute(
                   Eq(2),
                   RouteEntryArrayEq(std::vector<sai_route_entry_t>{
-                      exp_sai_route_entry_ipv6, exp_sai_route_entry_ipv4}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr_ipv6,
-                                                           exp_sai_attr_ipv4}),
+                      exp_sai_route_entry_ipv4, exp_sai_route_entry_ipv6}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr_ipv4,
+                                                           exp_sai_attr_ipv6}),
                   Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
       .WillOnce(
           DoAll(SetArrayArgument<4>(exp_status_1.begin(), exp_status_1.end()),
@@ -3546,15 +3546,15 @@ TEST_F(RouteManagerTest, BatchedUpdatePartiallySucceeds) {
   exp_sai_attr_ipv6.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
   exp_sai_attr_ipv6.value.oid = kWcmpGroupOid2;
 
-  std::vector<sai_status_t> exp_status_1{SAI_STATUS_FAILURE,
-                                         SAI_STATUS_SUCCESS};
+  std::vector<sai_status_t> exp_status_1{SAI_STATUS_SUCCESS,
+                                         SAI_STATUS_FAILURE};
   EXPECT_CALL(mock_sai_route_,
               set_route_entries_attribute(
                   Eq(2),
                   RouteEntryArrayEq(std::vector<sai_route_entry_t>{
-                      exp_sai_route_entry_ipv6, exp_sai_route_entry_ipv4}),
-                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr_ipv6,
-                                                           exp_sai_attr_ipv4}),
+                      exp_sai_route_entry_ipv4, exp_sai_route_entry_ipv6}),
+                  AttrArrayEq(std::vector<sai_attribute_t>{exp_sai_attr_ipv4,
+                                                           exp_sai_attr_ipv6}),
                   Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
       .WillOnce(
           DoAll(SetArrayArgument<4>(exp_status_1.begin(), exp_status_1.end()),
@@ -3613,7 +3613,7 @@ TEST_F(RouteManagerTest, BatchedDeleteSucceeds) {
               remove_route_entries(
                   Eq(2),
                   RouteEntryArrayEq(std::vector<sai_route_entry_t>{
-                      exp_sai_route_entry_ipv6, exp_sai_route_entry_ipv4}),
+                      exp_sai_route_entry_ipv4, exp_sai_route_entry_ipv6}),
                   Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
       .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()),
                       Return(SAI_STATUS_SUCCESS)));
@@ -3662,12 +3662,12 @@ TEST_F(RouteManagerTest, BatchedDeletePartiallySucceeds) {
   exp_sai_route_entry_ipv6.vr_id = gVrfOid;
   exp_sai_route_entry_ipv6.destination = sai_ipv6_route_prefix;
 
-  std::vector<sai_status_t> exp_status{SAI_STATUS_FAILURE, SAI_STATUS_SUCCESS};
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS, SAI_STATUS_FAILURE};
   EXPECT_CALL(mock_sai_route_,
               remove_route_entries(
                   Eq(2),
                   RouteEntryArrayEq(std::vector<sai_route_entry_t>{
-                      exp_sai_route_entry_ipv6, exp_sai_route_entry_ipv4}),
+                      exp_sai_route_entry_ipv4, exp_sai_route_entry_ipv6}),
                   Eq(SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR), _))
       .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()),
                       Return(SAI_STATUS_FAILURE)));


### PR DESCRIPTION
**What I did**
Today, the bulker library does not maintain order for non-OID objects. This PR changes it to keep the requested order.

**Why I did it**
As part of the performance improvement effort, we updated P4Orch route manager to use bulk SAI API. With the current bulker library, it does not maintain the order. For the SDN use case, keeping the route programming order is important (for example, the default route needs to be programmed first to avoid packet drop).

**How I verified it**
Unit test

**Details if related**
N/A
