### PR TITLE
Parse subport value added to config_db

### DIFF
--- a/orchagent/port/portcnt.h
+++ b/orchagent/port/portcnt.h
@@ -202,6 +202,11 @@ public:
         bool is_set = false;
     } description; // Port description
 
+    struct {
+        std::string value;
+        bool is_set = false;
+    } subport; // Port subport
+
     std::string key;
     std::string op;
 

--- a/orchagent/port/porthlpr.cpp
+++ b/orchagent/port/porthlpr.cpp
@@ -753,8 +753,27 @@ bool PortHelper::parsePortSubport(PortConfig &port, const std::string &field, co
 {
     SWSS_LOG_ENTER();
 
-    port.subport.value = value;
-    port.subport.is_set = true;
+    if (value.empty())
+    {
+        SWSS_LOG_ERROR("Failed to parse field(%s): empty string is prohibited", field.c_str());
+        return false;
+    }
+
+    try
+    {
+        port.subport.value = toUInt16(value);
+        if (port.subport.value < 0)
+        {
+            SWSS_LOG_ERROR("Failed to parse field(%s): negative number is prohibited", field.c_str(), value.c_str());
+            return false;
+        }
+        port.subport.is_set = true;
+    }
+    catch (const std::exception &e)
+    {
+        SWSS_LOG_ERROR("Failed to parse field(%s): %s", field.c_str(), e.what());
+        return false;
+    }
 
     return true;
 }

--- a/orchagent/port/porthlpr.cpp
+++ b/orchagent/port/porthlpr.cpp
@@ -749,6 +749,16 @@ bool PortHelper::parsePortDescription(PortConfig &port, const std::string &field
     return true;
 }
 
+bool PortHelper::parsePortSubport(PortConfig &port, const std::string &field, const std::string &value) const
+{
+    SWSS_LOG_ENTER();
+
+    port.subport.value = value;
+    port.subport.is_set = true;
+
+    return true;
+}
+
 bool PortHelper::parsePortConfig(PortConfig &port) const
 {
     SWSS_LOG_ENTER();
@@ -992,6 +1002,13 @@ bool PortHelper::parsePortConfig(PortConfig &port) const
         else if (field == PORT_DESCRIPTION)
         {
             if (!this->parsePortDescription(port, field, value))
+            {
+                return false;
+            }
+        }
+        else if (field == PORT_SUBPORT)
+        {
+            if (!this->parsePortSubport(port, field, value))
             {
                 return false;
             }

--- a/orchagent/port/porthlpr.cpp
+++ b/orchagent/port/porthlpr.cpp
@@ -764,7 +764,7 @@ bool PortHelper::parsePortSubport(PortConfig &port, const std::string &field, co
         port.subport.value = toUInt16(value);
         if (port.subport.value < 0)
         {
-            SWSS_LOG_ERROR("Failed to parse field(%s): negative number is prohibited", field.c_str(), value.c_str());
+            SWSS_LOG_ERROR("Failed to parse field(%s): negative number(%s) is prohibited", field.c_str(), value.c_str());
             return false;
         }
         port.subport.is_set = true;

--- a/orchagent/port/porthlpr.cpp
+++ b/orchagent/port/porthlpr.cpp
@@ -761,12 +761,7 @@ bool PortHelper::parsePortSubport(PortConfig &port, const std::string &field, co
 
     try
     {
-        port.subport.value = toUInt16(value);
-        if (port.subport.value < 0)
-        {
-            SWSS_LOG_ERROR("Failed to parse field(%s): negative number(%s) is prohibited", field.c_str(), value.c_str());
-            return false;
-        }
+        port.subport.value = value;
         port.subport.is_set = true;
     }
     catch (const std::exception &e)

--- a/orchagent/port/porthlpr.h
+++ b/orchagent/port/porthlpr.h
@@ -53,4 +53,5 @@ private:
     bool parsePortRole(PortConfig &port, const std::string &field, const std::string &value) const;
     bool parsePortAdminStatus(PortConfig &port, const std::string &field, const std::string &value) const;
     bool parsePortDescription(PortConfig &port, const std::string &field, const std::string &value) const;
+    bool parsePortSubport(PortConfig &port, const std::string &field, const std::string &value) const;
 };

--- a/orchagent/port/portschema.h
+++ b/orchagent/port/portschema.h
@@ -87,3 +87,4 @@
 #define PORT_ROLE                "role"
 #define PORT_ADMIN_STATUS        "admin_status"
 #define PORT_DESCRIPTION         "description"
+#define PORT_SUBPORT             "subport"


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
https://github.com/sonic-net/sonic-buildimage/pull/18499 Added support for subport values to be automatically calculated and inserted on creation of config_db.json. This change succeeds in adding the subport value into config_db.json - but it results in a log 

`WARNING #orchagent: message repeated 18564 times: [ :- parsePortConfig: Unknown field(subport): skipping ...]`

being printed. This prevents the log being printed by handling the subport value.


**Why I did it**
To prevent the orchagent log

**How I verified it**
I manually tested on an Arista device that the log no longer appears

**Details if related**
Question to reviews - should we assert on an unhandled/unknown field ? Rather than logging this message, it is easy to miss and the value still ends up in config_db