### PR TITLE
[Bridge] Disable MAC learning for Link Local Mulitcast Frames on the linux Bridge

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -113,6 +113,17 @@ VlanMgr::VlanMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
 
         EXEC_WITH_ERROR_THROW(echo_cmd_backup, res);
     }
+
+    // not learn from link-local frames
+    // /bin/echo 1 > /sys/class/net/Bridge/bridge/no_linklocal_learn
+    const std::string no_ll_learn_cmd = std::string("")
+      + ECHO_CMD + " 1 > /sys/class/net/" + DOT1Q_BRIDGE_NAME + "/bridge/no_linklocal_learn";
+
+    ret = swss::exec(no_ll_learn_cmd, res);
+    if (ret != 0) {
+        EXEC_WITH_ERROR_THROW(no_ll_learn_cmd, res);
+    }
+
 }
 
 bool VlanMgr::addHostVlan(int vlan_id)


### PR DESCRIPTION
**What I did**
Disable MAC learning for Link Local Multicast Frames on the Linux Bridge

**Why I did it**
The 01:80:c2 link local frame is used to control the purpose. To disable the MAC learning for these frames to prevent MAC flap if there are multiple links between 2 switches.

**How I verified it**
Inject LLDP frame and use `sudo bridge fdb show` to check

**Details if related**
