### PR TITLE
[orchagent] Do not pollute logs when unknown field is found

### DIFF
--- a/orchagent/port/porthlpr.cpp
+++ b/orchagent/port/porthlpr.cpp
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <string>
 #include <exception>
+#include <set>
 
 #include <boost/algorithm/string.hpp>
 
@@ -777,6 +778,8 @@ bool PortHelper::parsePortConfig(PortConfig &port) const
 {
     SWSS_LOG_ENTER();
 
+    std::set<std::string> unknown;
+
     for (const auto &cit : port.fieldValueMap)
     {
         const auto &field = cit.first;
@@ -1029,6 +1032,11 @@ bool PortHelper::parsePortConfig(PortConfig &port) const
         }
         else
         {
+            if (unknown.find(field) != unknown.end())
+                continue; // do not pollute logs with the same unknown field
+
+            unknown.insert(field);
+
             SWSS_LOG_WARN("Unknown field(%s): skipping ...", field.c_str());
         }
     }


### PR DESCRIPTION
This will prevent future unittest failing since there is syslog rate limitting in place, causing message drop when large amount of messages is arriving

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Reduce number of messages logged when unknown field is spotted in port config

**Why I did it**
To reduce number of logged messages

**How I verified it**
Locally

**Details if related**
