### PR TITLE
[build-docker-sonic-vs] Allowing partial build for sairedis

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -90,6 +90,7 @@ jobs:
       artifact: ${{ parameters.sairedis_artifact_name }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/${{ parameters.sairedis_artifact_branch }}'
+      allowPartiallySucceededBuilds: true
       path: $(Build.ArtifactStagingDirectory)/download/sairedis
       patterns: |
         ${{ parameters.sairedis_artifact_pattern }}/libsaivs_*.deb


### PR DESCRIPTION
Allowing partial build for sairedis to make sure build isn't skipping latest on branch.

**What I did**
add `allowPartiallySucceededBuilds: true` to docker-sonic-vs build template

**Why I did it**
swss PR is pulling from an older build, which does not have critical changes to syncd
