### PR TITLE
[portsorch]: Optimize link flap handling for single member portchannels

### DIFF
--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -519,6 +519,7 @@ private:
 
     /* Protoypes for Path tracing */
     bool setPortPtTam(const Port& port, sai_object_id_t tam_id);
+    bool isSingleMemberLagPort(Port &port);
 
 private:
     void initializeCpuPort();


### PR DESCRIPTION
* When a member link in a single-member portchannel goes down, update the portchannel state nexthop group members quicker to enable faster NHG update and route convergence after link flap.

What I did:
* To improve convergence time after link flap on a single member portchannel.

Why I did it:
* Accelerated NHG update when the one and only member link in a single-member portchannel goes down.

How I verified it:
* By shutting down member links from fanout switches and verifying that NHG updates are sent down earlier.

    2024 Jun  5 02:21:17.081264 str2-7050cx3-acs-14 NOTICE restapi#root: Waiting for certificates...
    2024 Jun  5 02:21:24.817707 str2-7050cx3-acs-14 INFO syncd#syncd: [none] SAI_API_PORT:_brcm_sai_link_event_cb:1558 
    Port 119 link down event cause: LOCAL
    2024 Jun  5 02:21:24.818583 str2-7050cx3-acs-14 NOTICE swss#orchagent: :- doTask: Get port state change notification 
    id:1000000000020 status:2
    2024 Jun  5 02:21:24.818583 str2-7050cx3-acs-14 NOTICE swss#orchagent: :- updatePortOperStatus: Port Ethernet112 oper 
    state set from up to down
    2024 Jun  5 02:21:24.827560 str2-7050cx3-acs-14 NOTICE swss#orchagent: :- setHostIntfsOperStatus: Set operation status 
    DOWN to host interface Ethernet112
    2024 Jun  5 02:21:24.827560 str2-7050cx3-acs-14 NOTICE swss#orchagent: :- publish: EVENT_PUBLISHED: {"sonic-events- 
    swss:if-state":{"ifname":"Ethernet112","status":"down","timestamp":"2024-06-05T02:21:24.825801Z"}}
    2024 Jun  5 02:21:24.827560 str2-7050cx3-acs-14 NOTICE swss#orchagent: :- updatePortOperStatus: Port PortChannel101 
    oper state set from up to down
    2024 Jun  5 02:21:24.831134 str2-7050cx3-acs-14 INFO syncd#syncd: [none] 
    SAI_API_NEXT_HOP_GROUP:brcm_sai_xgs_nexthop_group_member_remove:557 ecmp 200000 nhid 1(0) wt 0 ol-if 400002 
    ul-if 0
    2024 Jun  5 02:21:24.834889 str2-7050cx3-acs-14 INFO systemd-networkd[1107262]: Ethernet112: Lost carrier
    2024 Jun  5 02:21:24.835075 str2-7050cx3-acs-14 WARNING systemd-networkd[1107262]: PortChannel101: rtnl: failed to 
    convert received route, ignoring: No such file or directory
    2024 Jun  5 02:21:24.835275 str2-7050cx3-acs-14 INFO systemd-networkd[1107262]: PortChannel101: Lost carrier
    2024 Jun  5 02:21:24.836659 str2-7050cx3-acs-14 INFO syncd#syncd: [none] 
    SAI_API_NEXT_HOP_GROUP:brcm_sai_xgs_nexthop_group_member_remove:557 ecmp 200001 nhid 5(0) wt 0 ol-if 400006 
    ul-if 0

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
