### PR TITLE
[202305] [portsorch]: Optimize link flap handling for single member portchannels

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -7160,15 +7160,35 @@ void PortsOrch::doTask(NotificationConsumer &consumer)
     }
 }
 
+bool PortsOrch::isSingleMemberLagPort(Port &port)
+{
+    bool is_lag_member_port = ((port.m_lag_id != SAI_NULL_OBJECT_ID) &&
+                        (port.m_lag_member_id != SAI_NULL_OBJECT_ID));
+    if (!is_lag_member_port || (port.m_type != Port::PHY))
+    {
+        return false;
+    }
+
+    Port lag_p;
+    if (!getPort(port.m_lag_id, lag_p))
+    {
+        SWSS_LOG_ERROR("Failed to get lag port object for port id 0x%" PRIx64, port.m_lag_id);
+        return false;
+    }
+    auto lag_member_count = lag_p.m_members.size();
+    return lag_member_count == 1;
+}
+
 void PortsOrch::updatePortOperStatus(Port &port, sai_port_oper_status_t status)
 {
-    SWSS_LOG_NOTICE("Port %s oper state set from %s to %s",
-            port.m_alias.c_str(), oper_status_strings.at(port.m_oper_status).c_str(),
-            oper_status_strings.at(status).c_str());
     if (status == port.m_oper_status)
     {
         return;
     }
+
+    SWSS_LOG_NOTICE("Port %s oper state set from %s to %s",
+            port.m_alias.c_str(), oper_status_strings.at(port.m_oper_status).c_str(),
+            oper_status_strings.at(status).c_str());
 
     if (port.m_type == Port::PHY)
     {
@@ -7187,14 +7207,16 @@ void PortsOrch::updatePortOperStatus(Port &port, sai_port_oper_status_t status)
             updatePortStatePoll(port, PORT_STATE_POLL_LT, !(status == SAI_PORT_OPER_STATUS_UP));
         }
     }
+
+    bool isUp = status == SAI_PORT_OPER_STATUS_UP;
     port.m_oper_status = status;
+    setPort(port.m_alias, port);
 
     if(port.m_type == Port::TUNNEL)
     {
         return;
     }
 
-    bool isUp = status == SAI_PORT_OPER_STATUS_UP;
     if (port.m_type == Port::PHY)
     {
         if (!setHostIntfsOperStatus(port, isUp))
@@ -7202,7 +7224,19 @@ void PortsOrch::updatePortOperStatus(Port &port, sai_port_oper_status_t status)
             SWSS_LOG_ERROR("Failed to set host interface %s operational status %s", port.m_alias.c_str(),
                     isUp ? "up" : "down");
         }
+
+        if (!isUp && isSingleMemberLagPort(port))
+        {
+            Port lag_p;
+            if (!getPort(port.m_lag_id, lag_p))
+            {
+                SWSS_LOG_ERROR("Failed to get lag port object for port id 0x%" PRIx64, port.m_lag_id);
+                return;
+            }
+            updatePortOperStatus(lag_p, status);
+        }
     }
+
     if (!gNeighOrch->ifChangeInformNextHop(port.m_alias, isUp))
     {
         SWSS_LOG_WARN("Inform nexthop operation failed for interface %s", port.m_alias.c_str());

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -433,6 +433,7 @@ private:
     task_process_status setPortAdvInterfaceTypes(Port &port, std::set<sai_port_interface_type_t> &interface_types);
     task_process_status setPortLinkTraining(const Port& port, bool state);
 
+    bool isSingleMemberLagPort(Port &port);
     void updatePortOperStatus(Port &port, sai_port_oper_status_t status);
 
     bool getPortOperSpeed(const Port& port, sai_uint32_t& speed) const;


### PR DESCRIPTION
* When a member link in a single-member portchannel goes down, update the portchannel state nexthop group members quicker to enable faster NHG update and route convergence after link flap.

What I did:
* To improve convergence time after link flap on a single member portchannel.

Why I did it:
* Accelerated NHG update when the one and only member link in a single-member portchannel goes down.

How I verified it:
* By shutting down member links from fanout switches and verifying that NHG updates are sent down earlier.

    2024 Jun  5 02:21:17.081264 str2-7050cx3-acs-14 NOTICE restapi#root: Waiting for certificates...
    2024 Jun  5 02:21:24.817707 str2-7050cx3-acs-14 INFO syncd#syncd: [none] SAI_API_PORT:_brcm_sai_link_event_cb:1558 
    Port 119 link down event cause: LOCAL
    2024 Jun  5 02:21:24.818583 str2-7050cx3-acs-14 NOTICE swss#orchagent: :- doTask: Get port state change notification 
    id:1000000000020 status:2
    2024 Jun  5 02:21:24.818583 str2-7050cx3-acs-14 NOTICE swss#orchagent: :- updatePortOperStatus: Port Ethernet112 oper 
    state set from up to down
    2024 Jun  5 02:21:24.827560 str2-7050cx3-acs-14 NOTICE swss#orchagent: :- setHostIntfsOperStatus: Set operation status 
    DOWN to host interface Ethernet112
    2024 Jun  5 02:21:24.827560 str2-7050cx3-acs-14 NOTICE swss#orchagent: :- publish: EVENT_PUBLISHED: {"sonic-events- 
    swss:if-state":{"ifname":"Ethernet112","status":"down","timestamp":"2024-06-05T02:21:24.825801Z"}}
    2024 Jun  5 02:21:24.827560 str2-7050cx3-acs-14 NOTICE swss#orchagent: :- updatePortOperStatus: Port PortChannel101 
    oper state set from up to down
    2024 Jun  5 02:21:24.831134 str2-7050cx3-acs-14 INFO syncd#syncd: [none] 
    SAI_API_NEXT_HOP_GROUP:brcm_sai_xgs_nexthop_group_member_remove:557 ecmp 200000 nhid 1(0) wt 0 ol-if 400002 
    ul-if 0
    2024 Jun  5 02:21:24.834889 str2-7050cx3-acs-14 INFO systemd-networkd[1107262]: Ethernet112: Lost carrier
    2024 Jun  5 02:21:24.835075 str2-7050cx3-acs-14 WARNING systemd-networkd[1107262]: PortChannel101: rtnl: failed to 
    convert received route, ignoring: No such file or directory
    2024 Jun  5 02:21:24.835275 str2-7050cx3-acs-14 INFO systemd-networkd[1107262]: PortChannel101: Lost carrier
    2024 Jun  5 02:21:24.836659 str2-7050cx3-acs-14 INFO syncd#syncd: [none] 
    SAI_API_NEXT_HOP_GROUP:brcm_sai_xgs_nexthop_group_member_remove:557 ecmp 200001 nhid 5(0) wt 0 ol-if 400006 
    ul-if 0

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
