### PR TITLE
[202305][muxorch] Fixing bug with updateRoute and mux neighbors

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1134,9 +1134,8 @@ void MuxOrch::updateRoute(const IpPrefix &pfx, bool add)
         MacAddress mac;
 
         gNeighOrch->getNeighborEntry(nexthop, neighbor, mac);
-        auto standalone = standalone_tunnel_neighbors_.find(neighbor.ip_address);
 
-        if (isNeighborActive(neighbor.ip_address, mac, neighbor.alias) && standalone == standalone_tunnel_neighbors_.end())
+        if (isNeighborActive(neighbor.ip_address, mac, neighbor.alias))
         {
             /* Here we pull from local nexthop ID because neighbor update occurs during state change
              * before nexthopID is updated in neighorch. This ensures that if a neighbor is Active

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1130,14 +1130,13 @@ void MuxOrch::updateRoute(const IpPrefix &pfx, bool add)
     for (auto it = nextHops.begin(); it != nextHops.end(); it++)
     {
         NextHopKey nexthop = *it;
-        /* This will only work for configured MUX neighbors (most cases)
-         * TODO: add way to find MUX from neighbor
-         */
-        MuxCable* cable = findMuxCableInSubnet(nexthop.ip_address);
-        auto standalone = standalone_tunnel_neighbors_.find(nexthop.ip_address);
+        NeighborEntry neighbor;
+        MacAddress mac;
 
-        if ((cable == nullptr && standalone == standalone_tunnel_neighbors_.end()) ||
-             cable->isActive())
+        gNeighOrch->getNeighborEntry(nexthop, neighbor, mac);
+        auto standalone = standalone_tunnel_neighbors_.find(neighbor.ip_address);
+
+        if (isNeighborActive(neighbor.ip_address, mac, neighbor.alias) && standalone == standalone_tunnel_neighbors_.end())
         {
             /* Here we pull from local nexthop ID because neighbor update occurs during state change
              * before nexthopID is updated in neighorch. This ensures that if a neighbor is Active
@@ -1149,11 +1148,11 @@ void MuxOrch::updateRoute(const IpPrefix &pfx, bool add)
             if (status != SAI_STATUS_SUCCESS)
             {
                 SWSS_LOG_ERROR("Failed to set route entry %s to nexthop %s",
-                        pfx.to_string().c_str(), nexthop.to_string().c_str());
+                        pfx.to_string().c_str(), neighbor.to_string().c_str());
                 continue;
             }
             SWSS_LOG_NOTICE("setting route %s with nexthop %s %" PRIx64 "",
-                pfx.to_string().c_str(), nexthop.to_string().c_str(), next_hop_id);
+                pfx.to_string().c_str(), neighbor.to_string().c_str(), next_hop_id);
             active_found = true;
             break;
         }

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -739,14 +739,20 @@ class TestMuxTunnelBase():
             self.multi_nexthop_test_route_update_decrease_size(appdb, asicdb, dvs, dvs_route, route_ipv4, mux_ports, ipv4_nexthops)
             self.multi_nexthop_test_route_update_decrease_size(appdb, asicdb, dvs, dvs_route, route_ipv6, mux_ports, ipv6_nexthops)
 
+            # Testing mux neighbors that do not match mux configured ip
+            self.add_route(dvs, route_ipv4, [self.SERV1_IPV4, mux_neighbor_ipv4])
+            self.add_route(dvs, route_ipv6, [self.SERV1_IPV6, mux_neighbor_ipv6])
+            self.multi_nexthop_test_toggle(appdb, asicdb, dvs_route, route_ipv4, mux_ports, [self.SERV1_IPV4, mux_neighbor_ipv4])
+            self.multi_nexthop_test_toggle(appdb, asicdb, dvs_route, route_ipv6, mux_ports, [self.SERV1_IPV6, mux_neighbor_ipv6])
+            self.del_route(dvs,route_ipv4)
+            self.del_route(dvs,route_ipv6)
+
             # # These tests do not create route, so create beforehand:
             self.add_route(dvs, route_ipv4, ipv4_nexthops)
             self.add_route(dvs, route_ipv6, ipv6_nexthops)
             self.add_route(dvs, route_B_ipv4, ipv4_nexthops)
             self.add_route(dvs, route_B_ipv6, ipv6_nexthops)
 
-            self.multi_nexthop_test_toggle(appdb, asicdb, dvs_route, route_ipv4, mux_ports, [self.SERV1_IPV4, mux_neighbor_ipv4])
-            self.multi_nexthop_test_toggle(appdb, asicdb, dvs_route, route_ipv6, mux_ports, [self.SERV1_IPV6, mux_neighbor_ipv6])
             self.multi_nexthop_test_fdb(appdb, asicdb, dvs, dvs_route, [route_ipv4, route_B_ipv4], mux_ports, ipv4_nexthops, macs)
             self.multi_nexthop_test_fdb(appdb, asicdb, dvs, dvs_route, [route_ipv6, route_B_ipv6], mux_ports, ipv6_nexthops, macs)
             self.multi_nexthop_test_toggle(appdb, asicdb, dvs, dvs_route, [route_ipv4, route_B_ipv4], mux_ports, ipv4_nexthops)

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -707,6 +707,8 @@ class TestMuxTunnelBase():
         new_ipv6_nexthop = self.SERV3_IPV6
         non_mux_ipv4 = ["11.11.11.11", "12.12.12.12"]
         non_mux_ipv6 = ["2222::100", "2222::101"]
+        mux_neighbor_ipv4 = "192.170.0.100"
+        mux_neighbor_ipv6 = "fc02:1000:100::100"
         non_mux_mac = "00:aa:aa:aa:aa:aa"
         mux_ports = ["Ethernet0", "Ethernet4"]
         new_mux_port = "Ethernet8"
@@ -717,6 +719,10 @@ class TestMuxTunnelBase():
 
         self.add_neighbor(dvs, new_ipv4_nexthop, new_mac)
         self.add_neighbor(dvs, new_ipv6_nexthop, new_mac)
+        self.add_neighbor(dvs, non_mux_ipv4, non_mux_mac)
+        self.add_neighbor(dvs, non_mux_ipv6, non_mux_mac)
+        self.add_neighbor(dvs, mux_neighbor_ipv4, macs[1])
+        self.add_neighbor(dvs, mux_neighbor_ipv6, macs[1])
 
         for port in mux_ports:
             self.set_mux_state(appdb, port, ACTIVE)
@@ -739,6 +745,8 @@ class TestMuxTunnelBase():
             self.add_route(dvs, route_B_ipv4, ipv4_nexthops)
             self.add_route(dvs, route_B_ipv6, ipv6_nexthops)
 
+            self.multi_nexthop_test_toggle(appdb, asicdb, dvs_route, route_ipv4, mux_ports, [self.SERV1_IPV4, mux_neighbor_ipv4])
+            self.multi_nexthop_test_toggle(appdb, asicdb, dvs_route, route_ipv6, mux_ports, [self.SERV1_IPV6, mux_neighbor_ipv6])
             self.multi_nexthop_test_fdb(appdb, asicdb, dvs, dvs_route, [route_ipv4, route_B_ipv4], mux_ports, ipv4_nexthops, macs)
             self.multi_nexthop_test_fdb(appdb, asicdb, dvs, dvs_route, [route_ipv6, route_B_ipv6], mux_ports, ipv6_nexthops, macs)
             self.multi_nexthop_test_toggle(appdb, asicdb, dvs, dvs_route, [route_ipv4, route_B_ipv4], mux_ports, ipv4_nexthops)
@@ -759,6 +767,8 @@ class TestMuxTunnelBase():
                 self.del_neighbor(dvs, neighbor)
             self.del_neighbor(dvs, new_ipv4_nexthop)
             self.del_neighbor(dvs, new_ipv6_nexthop)
+            self.del_neighbor(dvs, mux_neighbor_ipv4)
+            self.del_neighbor(dvs, mux_neighbor_ipv6)
 
     def create_and_test_NH_routes(self, appdb, asicdb, dvs, dvs_route, mac):
         '''


### PR DESCRIPTION
mux neighbors that were not the configured mux ip were being treated as active.

cherry-pick of: https://github.com/sonic-net/sonic-swss/pull/3187

**What I did**
use isNeighborActive to determine if neighbor is active for updateRoute logic

**Why I did it**
bug was causing crash when neighbor was not the same as the mux configured neighbor

**How I verified it**
added new vstests and ran locally
tests passed on master PR
tested on 202305 dualtor testbed:

```
w/out fix:
Jun  9 06:05:46.642266 svcstr-7050-acs-4 NOTICE swss#orchagent: :- setState: [Ethernet12] Set MUX state from active to standby
Jun  9 06:05:46.642559 svcstr-7050-acs-4 NOTICE swss#orchagent: :- nbrHandler: Processing neighbors for mux Ethernet12, enable 0, state 2
Jun  9 06:05:46.642719 svcstr-7050-acs-4 NOTICE swss#orchagent: :- updateRoute: Updating route 11.11.11.11/32 pointing to Mux nexthops 192.168.0.2@Vlan1000,192.168.100.4@Vlan1000
Jun  9 06:05:46.644840 svcstr-7050-acs-4 NOTICE swss#orchagent: :- updateRoute: setting route 11.11.11.11/32 with nexthop 192.168.100.4@Vlan1000 400000000081d
Jun  9 06:05:46.648190 svcstr-7050-acs-4 NOTICE swss#orchagent: :- create_route: Created tunnel route to 192.168.0.4/32
Jun  9 06:05:46.648287 svcstr-7050-acs-4 NOTICE swss#orchagent: :- disableNeighbor: Neighbor disable request for 192.168.0.4
Jun  9 06:05:46.650488 svcstr-7050-acs-4 NOTICE swss#orchagent: :- removeNeighbor: Removed next hop 192.168.0.4 on Vlan1000
Jun  9 06:05:46.654161 svcstr-7050-acs-4 NOTICE swss#orchagent: :- removeNeighbor: Removed neighbor aa:f4:6e:25:d3:03 on Vlan1000
Jun  9 06:05:46.662224 svcstr-7050-acs-4 NOTICE swss#orchagent: :- create_route: Created tunnel route to 192.168.100.4/32
Jun  9 06:05:46.662224 svcstr-7050-acs-4 NOTICE swss#orchagent: :- disableNeighbor: Neighbor disable request for 192.168.100.4
Jun  9 06:05:46.662224 svcstr-7050-acs-4 ERR swss#orchagent: :- meta_generic_validation_remove: object 0x400000000081d reference count is 1, can't remove
Jun  9 06:05:46.662224 svcstr-7050-acs-4 ERR swss#orchagent: :- removeNeighbor: Failed to remove next hop 192.168.100.4 on Vlan1000, rv:-17
Jun  9 06:05:46.662282 svcstr-7050-acs-4 ERR swss#orchagent: :- handleSaiRemoveStatus: Encountered failure in remove operation, exiting orchagent, SAI API: SAI_API_NEXT_HOP, status: SAI_STATUS_OBJECT_IN_USE

w/fix:
Jun  9 06:03:08.374440 svcstr-7050-acs-3 NOTICE swss#orchagent: :- setState: [Ethernet12] Set MUX state from active to standby
Jun  9 06:03:08.374785 svcstr-7050-acs-3 INFO swss#orchagent: :- stateStandby: Set state to Standby for Ethernet12
Jun  9 06:03:08.375067 svcstr-7050-acs-3 NOTICE swss#orchagent: :- nbrHandler: Processing neighbors for mux Ethernet12, enable 0, state 2
Jun  9 06:03:08.375210 svcstr-7050-acs-3 INFO swss#orchagent: :- updateRoutes: Updating routes pointing to multiple mux nexthops
Jun  9 06:03:08.375553 svcstr-7050-acs-3 NOTICE swss#orchagent: :- updateRoute: Updating route 11.11.11.11/32 pointing to Mux nexthops 192.168.0.2@Vlan1000,192.168.100.4@Vlan1000
Jun  9 06:03:08.375553 svcstr-7050-acs-3 INFO swss#orchagent: :- updateRoute: No Active neighbors found, setting route 11.11.11.11 to point to tun
Jun  9 06:03:08.377446 svcstr-7050-acs-3 INFO swss#orchagent: :- disable: Disabling neigh 192.168.100.4 on Vlan1000
Jun  9 06:03:08.377446 svcstr-7050-acs-3 INFO swss#orchagent: :- updateNextHopRoutes: Route 11.11.11.11/32 is mux multi nexthop route, skipping.
Jun  9 06:03:08.382395 svcstr-7050-acs-3 INFO swss#orchagent: :- addTunnelRoute: Add tunnel route DB 'Vlan1000:192.168.100.4/32'
Jun  9 06:03:08.389626 svcstr-7050-acs-3 NOTICE swss#orchagent: :- create_route: Created tunnel route to 192.168.100.4/32
Jun  9 06:03:08.389626 svcstr-7050-acs-3 NOTICE swss#orchagent: :- disableNeighbor: Neighbor disable request for 192.168.100.4
Jun  9 06:03:08.392097 svcstr-7050-acs-3 NOTICE swss#orchagent: :- removeNeighbor: Removed next hop 192.168.100.4 on Vlan1000
Jun  9 06:03:08.394777 svcstr-7050-acs-3 INFO swss#orchagent: :- decreaseRouterIntfsRefCount: Router interface Vlan1000 ref count is decreased to 93
Jun  9 06:03:08.395137 svcstr-7050-acs-3 INFO swss#orchagent: :- decreaseRouterIntfsRefCount: Router interface Vlan1000 ref count is decreased to 92
Jun  9 06:03:08.395313 svcstr-7050-acs-3 NOTICE swss#orchagent: :- removeNeighbor: Removed neighbor aa:f4:6e:25:d3:03 on Vlan1000
Jun  9 06:03:08.395491 svcstr-7050-acs-3 INFO swss#orchagent: :- disable: Disabling neigh fc02:1000:100::4 on Vlan1000
Jun  9 06:03:08.395645 svcstr-7050-acs-3 INFO swss#orchagent: :- updateNextHopRoutes: No routes found for NH fc02:1000:100::4
Jun  9 06:03:08.395793 svcstr-7050-acs-3 INFO swss#orchagent: :- addTunnelRoute: Add tunnel route DB 'Vlan1000:fc02:1000:100::4/128'
Jun  9 06:03:08.400434 svcstr-7050-acs-3 NOTICE swss#orchagent: :- create_route: Created tunnel route to fc02:1000:100::4/128
Jun  9 06:03:08.400908 svcstr-7050-acs-3 NOTICE swss#orchagent: :- disableNeighbor: Neighbor disable request for fc02:1000:100::4
Jun  9 06:03:08.403559 svcstr-7050-acs-3 NOTICE swss#orchagent: :- removeNeighbor: Removed next hop fc02:1000:100::4 on Vlan1000
Jun  9 06:03:08.406318 svcstr-7050-acs-3 INFO swss#orchagent: :- decreaseRouterIntfsRefCount: Router interface Vlan1000 ref count is decreased to 91
Jun  9 06:03:08.406318 svcstr-7050-acs-3 INFO swss#orchagent: :- decreaseRouterIntfsRefCount: Router interface Vlan1000 ref count is decreased to 90
Jun  9 06:03:08.406318 svcstr-7050-acs-3 NOTICE swss#orchagent: :- removeNeighbor: Removed neighbor aa:f4:6e:25:d3:03 on Vlan1000
Jun  9 06:03:08.409735 svcstr-7050-acs-3 INFO swss#orchagent: :- createMuxAclTable: ACL table IngressTableDrop exists, reuse the same
Jun  9 06:03:08.409735 svcstr-7050-acs-3 NOTICE swss#orchagent: :- MuxAclHandler: Binding port 1000000000005
Jun  9 06:03:08.411635 svcstr-7050-acs-3 INFO swss#orchagent: :- setState: Changed state to standby
```