### PR TITLE
[teamsyncd] Update "oper_status" of LAG_TABLE in state_db (#3192)

### DIFF
--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -162,9 +162,10 @@ void TeamSync::addLag(const string &lagName, int ifindex, bool admin_state,
     if (m_teamSelectables.find(lagName) != m_teamSelectables.end())
     {
         auto tsync = m_teamSelectables[lagName];
-        if (tsync->admin_state == admin_state && tsync->mtu == mtu)
+        if (tsync->admin_state == admin_state && tsync->oper_state == oper_state && tsync->mtu == mtu)
             return;
         tsync->admin_state = admin_state;
+        tsync->oper_state = oper_state;
         tsync->mtu = mtu;
         lag_update = false;
     }

--- a/teamsyncd/teamsync.h
+++ b/teamsyncd/teamsync.h
@@ -44,6 +44,7 @@ public:
         /* member_name -> enabled|disabled */
         std::map<std::string, bool> m_lagMembers;
         bool admin_state;
+        bool oper_state;
         unsigned int mtu;
     protected:
         int onChange();


### PR DESCRIPTION
#### What I did

Fix for [#3192](https://github.com/sonic-net/sonic-swss/issues/3192)

#### How I did it

In teamSync::addLag method, update lag "oper_status" status in both state_db and appl_db.

#### How to verify it

Manual Testing
