### PR TITLE
[vlanmgr] use IP command for vlan_filtering and no_linklocal_learn, remove echo command

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -96,15 +96,11 @@ VlanMgr::VlanMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
     EXEC_WITH_ERROR_THROW(cmds, res);
 
     // /sbin/ip link set Bridge type bridge vlan_filtering 1
-    const std::string vlan_filtering_cmd = std::string("")
-      + IP_CMD + " link set " + DOT1Q_BRIDGE_NAME + " type bridge vlan_filtering 1";
-
+    const std::string vlan_filtering_cmd = IP_CMD + " link set " + DOT1Q_BRIDGE_NAME + " type bridge vlan_filtering 1";
     EXEC_WITH_ERROR_THROW(vlan_filtering_cmd, res);
 
     // /sbin/ip link set Bridge type bridge no_linklocal_learn 1
-    const std::string no_ll_learn_cmd = std::string("")
-      + IP_CMD + " link set " + DOT1Q_BRIDGE_NAME + " type bridge no_linklocal_learn 1";
-
+    const std::string no_ll_learn_cmd = IP_CMD + " link set " + DOT1Q_BRIDGE_NAME + " type bridge no_linklocal_learn 1";
     EXEC_WITH_ERROR_THROW(no_ll_learn_cmd, res);
 }
 

--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -95,35 +95,17 @@ VlanMgr::VlanMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
     std::string res;
     EXEC_WITH_ERROR_THROW(cmds, res);
 
-    // The generated command is:
-    // /bin/echo 1 > /sys/class/net/Bridge/bridge/vlan_filtering
-    const std::string echo_cmd = std::string("")
-      + ECHO_CMD + " 1 > /sys/class/net/" + DOT1Q_BRIDGE_NAME + "/bridge/vlan_filtering";
+    // /sbin/ip link set Bridge type bridge vlan_filtering 1
+    const std::string vlan_filtering_cmd = std::string("")
+      + IP_CMD + " link set " + DOT1Q_BRIDGE_NAME + " type bridge vlan_filtering 1";
 
-    int ret = swss::exec(echo_cmd, res);
-    /* echo will fail in virtual switch since /sys directory is read-only.
-     * need to use ip command to setup the vlan_filtering which is not available in debian 8.
-     * Once we move sonic to debian 9, we can use IP command by default
-     * ip command available in Debian 9 to create a bridge with a vlan filtering:
-     * /sbin/ip link add Bridge up type bridge vlan_filtering 1 */
-    if (ret != 0)
-    {
-        const std::string echo_cmd_backup = std::string("")
-          + IP_CMD + " link set " + DOT1Q_BRIDGE_NAME + " type bridge vlan_filtering 1";
+    EXEC_WITH_ERROR_THROW(vlan_filtering_cmd, res);
 
-        EXEC_WITH_ERROR_THROW(echo_cmd_backup, res);
-    }
-
-    // not learn from link-local frames
-    // /bin/echo 1 > /sys/class/net/Bridge/bridge/no_linklocal_learn
+    // /sbin/ip link set Bridge type bridge no_linklocal_learn 1
     const std::string no_ll_learn_cmd = std::string("")
-      + ECHO_CMD + " 1 > /sys/class/net/" + DOT1Q_BRIDGE_NAME + "/bridge/no_linklocal_learn";
+      + IP_CMD + " link set " + DOT1Q_BRIDGE_NAME + " type bridge no_linklocal_learn 1";
 
-    ret = swss::exec(no_ll_learn_cmd, res);
-    if (ret != 0) {
-        EXEC_WITH_ERROR_THROW(no_ll_learn_cmd, res);
-    }
-
+    EXEC_WITH_ERROR_THROW(no_ll_learn_cmd, res);
 }
 
 bool VlanMgr::addHostVlan(int vlan_id)

--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -96,11 +96,11 @@ VlanMgr::VlanMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
     EXEC_WITH_ERROR_THROW(cmds, res);
 
     // /sbin/ip link set Bridge type bridge vlan_filtering 1
-    const std::string vlan_filtering_cmd = IP_CMD + " link set " + DOT1Q_BRIDGE_NAME + " type bridge vlan_filtering 1";
+    const std::string vlan_filtering_cmd = std::string(IP_CMD) + " link set " + DOT1Q_BRIDGE_NAME + " type bridge vlan_filtering 1";
     EXEC_WITH_ERROR_THROW(vlan_filtering_cmd, res);
 
     // /sbin/ip link set Bridge type bridge no_linklocal_learn 1
-    const std::string no_ll_learn_cmd = IP_CMD + " link set " + DOT1Q_BRIDGE_NAME + " type bridge no_linklocal_learn 1";
+    const std::string no_ll_learn_cmd = std::string(IP_CMD) + " link set " + DOT1Q_BRIDGE_NAME + " type bridge no_linklocal_learn 1";
     EXEC_WITH_ERROR_THROW(no_ll_learn_cmd, res);
 }
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**Why  I did**
Database privileges give RW permission to /sys. In container hardening, when remove database privileges, /sys is changed to RO permission for all Sonic containers
```
admin@vlab-08:~$ docker exec -it swss1 bash
root@vlab-08:/# mount | grep sys
sysfs on /sys type sysfs (ro,nosuid,nodev,noexec,relatime)
```
When /sys is RO, there will be some errors in vlanmgrd.
```
2024 Jun 12 22:14:30.915170 vlab-08 INFO swss1#supervisord: vlanmgrd sh: 1: cannot create /sys/class/net/Bridge/bridge/vlan_filtering: Read-only file system
2024 Jun 12 22:14:30.921253 vlab-08 INFO swss1#supervisord: vlanmgrd sh: 1: cannot create /sys/class/net/Bridge/bridge/no_linklocal_learn: Read-only file system
2024 Jun 12 22:14:30.922472 vlab-08 ERR swss1#vlanmgrd: :- main: Runtime error: /bin/echo 1 > /sys/class/net/Bridge/bridge/no_linklocal_learn :
2024 Jun 12 22:14:30.923562 vlab-08 INFO swss1#supervisord 2024-06-12 22:14:30,923 WARN exited: vlanmgrd (exit status 255; not expected)
```
**What I did it**
Use IP command (fallback method previously) for vlan_filtering and no_linklocal_learn, remove echo command
**How I verified it**
Verified locally in KVM, vlanmgrd is running
**Details if related**
