### PR TITLE
Remove buffer maximum parameter table when the port is removed

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3551,6 +3551,9 @@ void PortsOrch::deInitPort(string alias, sai_object_id_t port_id)
     /* Remove the associated port serdes attribute */
     removePortSerdesAttribute(p.m_port_id);
 
+    /* Remove the entry from buffer maximum parameter table*/
+    m_stateBufferMaximumValueTable->del(alias);
+
     m_portList[alias].m_init = false;
     SWSS_LOG_NOTICE("De-Initialized port %s", alias.c_str());
 }

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -735,6 +735,12 @@ namespace portsorch_test
 
         // Cleanup ports
         cleanupPorts(gPortsOrch);
+
+        // Check buffer maximum parameter table entries are removed
+        auto bufferMaxParameterTable = Table(m_state_db.get(), STATE_BUFFER_MAXIMUM_VALUE_TABLE);
+        std::vector<std::string> keys;
+        bufferMaxParameterTable.getKeys(keys);
+        ASSERT_TRUE(keys.empty());
     }
 
     TEST_F(PortsOrchTest, PortBasicConfig)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Remove the buffer maximum parameter table entry when the port is removed.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**

To avoid the informational message `handleBufferMaxParam: BUFFER_MAX_PARAM: Port Ethernet190 is not configured, need retry` after the port is removed.

**How I verified it**

Unit test and manual test

**Details if related**
