### PR TITLE
Parse subport value added to config_db (#3161)

### DIFF
--- a/orchagent/port/portcnt.h
+++ b/orchagent/port/portcnt.h
@@ -171,6 +171,11 @@ public:
         bool is_set = false;
     } description; // Port description
 
+    struct {
+        std::string value;
+        bool is_set = false;
+    } subport; // Port subport
+
     std::string key;
     std::string op;
 

--- a/orchagent/port/porthlpr.cpp
+++ b/orchagent/port/porthlpr.cpp
@@ -699,6 +699,30 @@ bool PortHelper::parsePortDescription(PortConfig &port, const std::string &field
     return true;
 }
 
+bool PortHelper::parsePortSubport(PortConfig &port, const std::string &field, const std::string &value) const
+{
+    SWSS_LOG_ENTER();
+
+    if (value.empty())
+    {
+        SWSS_LOG_ERROR("Failed to parse field(%s): empty string is prohibited", field.c_str());
+        return false;
+    }
+
+    try
+    {
+        port.subport.value = value;
+        port.subport.is_set = true;
+    }
+    catch (const std::exception &e)
+    {
+        SWSS_LOG_ERROR("Failed to parse field(%s): %s", field.c_str(), e.what());
+        return false;
+    }
+
+    return true;
+}
+
 bool PortHelper::parsePortConfig(PortConfig &port) const
 {
     SWSS_LOG_ENTER();
@@ -900,6 +924,13 @@ bool PortHelper::parsePortConfig(PortConfig &port) const
         else if (field == PORT_DESCRIPTION)
         {
             if (!this->parsePortDescription(port, field, value))
+            {
+                return false;
+            }
+        }
+        else if (field == PORT_SUBPORT)
+        {
+            if (!this->parsePortSubport(port, field, value))
             {
                 return false;
             }

--- a/orchagent/port/porthlpr.h
+++ b/orchagent/port/porthlpr.h
@@ -51,4 +51,5 @@ private:
     bool parsePortRole(PortConfig &port, const std::string &field, const std::string &value) const;
     bool parsePortAdminStatus(PortConfig &port, const std::string &field, const std::string &value) const;
     bool parsePortDescription(PortConfig &port, const std::string &field, const std::string &value) const;
+    bool parsePortSubport(PortConfig &port, const std::string &field, const std::string &value) const;
 };

--- a/orchagent/port/portschema.h
+++ b/orchagent/port/portschema.h
@@ -79,3 +79,4 @@
 #define PORT_ROLE                "role"
 #define PORT_ADMIN_STATUS        "admin_status"
 #define PORT_DESCRIPTION         "description"
+#define PORT_SUBPORT             "subport"


### PR DESCRIPTION
What I did
https://github.com/sonic-net/sonic-buildimage/pull/18499 Added support for subport values to be automatically calculated and inserted on creation of config_db.json. This change succeeds in adding the subport value into config_db.json - but it results in a log

WARNING #orchagent: message repeated 18564 times: [ :- parsePortConfig: Unknown field(subport): skipping ...]

being printed. This prevents the log being printed by handling the subport value.

Why I did it
To prevent the orchagent log

How I verified it
I manually tested on an Arista device that the log no longer appears

Details if related
Question to reviews - should we assert on an unhandled/unknown field ? Rather than logging this message, it is easy to miss and the value still ends up in config_db