### PR TITLE
[vxlanmgr]: Add disabling of fdb learning for linux vxlan interfaces

### DIFF
--- a/cfgmgr/vxlanmgr.h
+++ b/cfgmgr/vxlanmgr.h
@@ -90,6 +90,7 @@ private:
     bool deleteVxlan(const VxlanInfo & info);
 
     void clearAllVxlanDevices();
+    void disableLearningForAllVxlanNetdevices();
 
     ProducerStateTable m_appVxlanTunnelTable,m_appVxlanTunnelMapTable,m_appEvpnNvoTable;
     Table m_cfgVxlanTunnelTable,m_cfgVnetTable,m_stateVrfTable,m_stateVxlanTable, m_appSwitchTable;


### PR DESCRIPTION
 * On sonic-vs linux vxlan interfaces serve as data plane, so disable fdb learning on them when it is disabled through SAI

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When vxlan tunnels are supposed to have fdb learning disabled, I also disabled fdb learning on vxlan linux interfaces

**Why I did it**
For EVPN feature the learing on vxlan interfaces should be disabled, but it is not disabled on vxlan linux interfaces, and thus causes trouble when testing sonic-vs EVPN setups on virtual machines.

**How I verified it**
With existing vxlan tunnel create new vlan and vxlan map, then verify that vxlan interface has fdb learning off. Save config, reboot the device and verify that vxlan interface still has learning off.
```
yaroslav_fedoriachenko@Leaf-1:~$ config vlan add 200
Root privileges are required for this operation
yaroslav_fedoriachenko@Leaf-1:~$ sudo config vlan add 200
yaroslav_fedoriachenko@Leaf-1:~$ sudo config vxlan map add vtep 200 2000
yaroslav_fedoriachenko@Leaf-1:~$ ip -d l show vtep-200
30: vtep-200: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master Bridge state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether 0c:5d:d9:3b:00:00 brd ff:ff:ff:ff:ff:ff promiscuity 1 minmtu 68 maxmtu 65535 
    vxlan id 2000 local 10.127.127.1 srcport 0 0 dstport 4789 nolearning ttl auto ageing 300 udpcsum noudp6zerocsumtx noudp6zerocsumrx 
    bridge_slave state forwarding priority 32 cost 100 hairpin off guard off root_block off fastleave off learning off flood on port_id 0x8005 port_no 0x5 designated_port 32773 designated_cost 0 designated_bridge 8000.c:5d:d9:3b:0:0 designated_root 8000.c:5d:d9:3b:0:0 hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    1.43 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 
yaroslav_fedoriachenko@Leaf-1:~$ sudo config save -y
Running command: /usr/local/bin/sonic-cfggen -d --print-data > /etc/sonic/config_db.json
yaroslav_fedoriachenko@Leaf-1:~$ sudo reboot

...

yaroslav_fedoriachenko@Leaf-1:~$ ip -d l show vtep-200
29: vtep-200: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master Bridge state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether 0c:5d:d9:3b:00:00 brd ff:ff:ff:ff:ff:ff promiscuity 1 minmtu 68 maxmtu 65535 
    vxlan id 2000 local 10.127.127.1 srcport 0 0 dstport 4789 nolearning ttl auto ageing 300 udpcsum noudp6zerocsumtx noudp6zerocsumrx 
    bridge_slave state forwarding priority 32 cost 100 hairpin off guard off root_block off fastleave off learning off flood on port_id 0x8005 port_no 0x5 designated_port 32773 designated_cost 0 designated_bridge 8000.c:5d:d9:3b:0:0 designated_root 8000.c:5d:d9:3b:0:0 hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.58 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on mcast_to_unicast off neigh_suppress off group_fwd_mask 0 group_fwd_mask_str 0x0 vlan_tunnel off isolated off addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535
```