### PR TITLE
[Chassis][voq] do not synchronize the system interface state if there is no rif assciated with the port

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -1721,6 +1721,11 @@ void IntfsOrch::voqSyncIntfState(string &alias, bool isUp)
     string port_alias;
     if(gPortsOrch->getPort(alias, port))
     {
+        //if route interface is not created no need sync the state
+        if(port.m_rif_id == 0)
+        {
+            return;
+        }
         if (port.m_type == Port::LAG)
         {
             if (port.m_system_lag_info.switch_id != gVoqMySwitchId)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixes: https://github.com/sonic-net/sonic-buildimage/issues/19357

**Why I did it**
In the  sonic-mgmt pc test suite. When an empty lag is created. The portchannel changed is sync'ed to the remote LC even if there portchannel has no route interface created. This results in a dummy route interface created on the remote LC.

So when the empty port channel is removed on the local card, the removal fails in the remote LC because of the dummy route interface.

Add a fix to sync the portchannel interface state to the remote LC only when there routeinterface is created on the local LC.


**How I verified it**
Run sonic-mgmt failed PC tests on chassis
```
pc/test_po_update.py::test_po_update_io_no_loss[str2-sonic-lc5-1-0] PASSED 
pc/test_po_update.py::test_po_update[str2-sonic-lc5-1-1] PASSED           
pc/test_po_update.py::test_po_update_io_no_loss[str2-sonic-lc5-1-1] PASSED 
pc/test_po_update.py::test_po_update[str2-sonic-lc3-1-None] PASSED        
pc/test_po_update.py::test_po_update_io_no_loss[str2-sonic-lc3-1-None] PASSED 
```
**Details if related**
