### PR TITLE
switchorch: fixed unsupported attribute causes skipping of processing the rest of the configurations

### DIFF
--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -609,10 +609,17 @@ void SwitchOrch::doAppSwitchTableTask(Consumer &consumer)
                         invalid_attr = true;
                         break;
                 }
-                if (invalid_attr || unsupported_attr)
+                if (invalid_attr)
                 {
                     /* break from kfvFieldsValues for loop */
+                    SWSS_LOG_ERROR("Invalid Attribute %s", attribute.c_str());
+                    // Will not continue to set the rest of the attributes
                     break;
+                }
+                if (unsupported_attr){
+                    SWSS_LOG_ERROR("Unsupported Attribute %s", attribute.c_str());
+                    // Continue to set the rest of the attributes, even if current attribute is unsupported
+                    continue;
                 }
 
                 sai_status_t status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);


### PR DESCRIPTION

**What I did**
Changed it so that if the configuration has an unsupported attribute, it would continue processing the rest of the configuration rather than break out of the loop and end the processing immediately.
Also added syslogs to make it more clear.

**Why I did it**
Would cause FDB aging time to stay default (0) and never cause aging to occur. Fixes this bug in sonic-mgmt: https://github.com/sonic-net/sonic-mgmt/issues/13375

Caused by this commit `https://github.com/sonic-net/sonic-swss/commit/2f8bd9cf6df839abec0ecc9bf31fc9c4b06a6c47`

**How I verified it**
TBD
**Details if related**
