### PR TITLE
Issue:SAI initializes break out ports as part of default vlan

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1079,6 +1079,7 @@ bool PortsOrch::addPortBulk(const std::vector<PortConfig> &portList)
         removeDefaultVlanMembers();
         removeDefaultBridgePorts();
     }
+    removeNonDefaultConfig(oidList);
 
     SWSS_LOG_NOTICE("Created ports: %s", swss::join(',', oidList.begin(), oidList.end()).c_str());
 
@@ -1173,6 +1174,69 @@ bool PortsOrch::removePortBulk(const std::vector<sai_object_id_t> &portList)
     return true;
 }
 
+void PortsOrch::removeNonDefaultConfig(const std::vector<sai_object_id_t> &oidList)
+{
+    /* Get VLAN members in default VLAN */
+    vector<sai_object_id_t> vlan_member_list(m_portCount + m_systemPortCount);
+
+    sai_attribute_t bport_attr[2];
+    sai_attribute_t attr2;
+    sai_attribute_t attr;
+    attr.id = SAI_VLAN_ATTR_MEMBER_LIST;
+    attr.value.objlist.count = (uint32_t)vlan_member_list.size();
+    attr.value.objlist.list = vlan_member_list.data();
+
+    sai_status_t status = sai_vlan_api->get_vlan_attribute(m_defaultVlan, 1, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to get VLAN member list in default VLAN, rv:%d", status);
+        task_process_status handle_status = handleSaiGetStatus(SAI_API_VLAN, status);
+        if (handle_status != task_process_status::task_success)
+        {
+            throw runtime_error("PortsOrch initialization failure");
+        }
+    }
+
+    for (uint32_t i = 0; i < attr.value.objlist.count; i++)
+    {
+        attr2.id = SAI_VLAN_MEMBER_ATTR_BRIDGE_PORT_ID;
+
+        status = sai_vlan_api->get_vlan_member_attribute(vlan_member_list[i], 1 , &attr2);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to Get Vlan member %" PRIx64 " bridge port information, rv:%d",
+                            vlan_member_list[i], status);
+            continue;
+        }
+        bport_attr[0].id = SAI_BRIDGE_PORT_ATTR_TYPE;
+        bport_attr[1].id = SAI_BRIDGE_PORT_ATTR_PORT_ID;
+        status = sai_bridge_api->get_bridge_port_attribute(attr2.value.oid, 2, &bport_attr[0]);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to Get bridge port %" PRIx64 " type rv:%d",
+                    attr2.value.oid, status);
+            continue;
+        }
+        bool found = std::find(oidList.begin(), oidList.end(), bport_attr[1].value.oid) != oidList.end();
+        if ((bport_attr[0].value.s32 == SAI_BRIDGE_PORT_TYPE_PORT) && (true == found))
+        {
+            /* remove vlan member from default vlan */
+            status = sai_vlan_api->remove_vlan_member(vlan_member_list[i]);
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to remove VLAN member, rv:%d", status);
+            }
+
+            /* remove bridge port */
+            status = sai_bridge_api->remove_bridge_port(attr2.value.oid);
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to remove bridge port, rv:%d", status);
+            }
+        }
+    }
+
+}
 void PortsOrch::removeDefaultVlanMembers()
 {
     /* Get VLAN members in default VLAN */

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -365,6 +365,7 @@ private:
     void removePortFromPortListMap(sai_object_id_t port_id);
     void removeDefaultVlanMembers();
     void removeDefaultBridgePorts();
+    void removeNonDefaultConfig(const std::vector<sai_object_id_t> &oidList);
 
     bool initializePort(Port &port);
     void initializePriorityGroups(Port &port);


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

When port-break-out is created (new ports are created in SAI), Remove the vlan member for the [new-break-out-port, default-vlan] and default bridge port created for the new break-out ports that created by SAI.

**Why I did it**
When SAI port OID is created as part of trigger from break-out operations, SAI makes this new port part of default vlan (creates a vlan member ) as well as creates a default bridge port. per sonic Orchagent, default vlan association or default bridge port creation must be done only as a part of operator configuration, cannot be SAI default.

**How I verified it**
create port-break-out dynamically, ensure they are not
a) part of default default vlan membership
b) having any bridge port by default.

**Which release branch to backport (provide reason below if selected)**

202311
**Details if related**

Issue:SAI initializes break out ports as part of default vlan
RCA:when a break out port is created in SAI, it make it as a vlan member for default vlan.
Fix: after SAI creates a port, Orchagent gets the default vlan port membership, if any of the vlan member or bridge port is part of newly created portlist, then its removed.