### PR TITLE
[portsorch] Make exception handling when Remove Bridge fails

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -5055,13 +5055,29 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
                 {
                     if (m_portVlanMember[port.m_alias].empty())
                     {
-                        removeBridgePort(port);
+                        if (!removeBridgePort(port))
+                        {
+                            it = consumer.m_toSync.upper_bound(it->first);
+                            continue;
+                        }
                     }
                     it = consumer.m_toSync.erase(it);
                 }
                 else
                 {
                     it++;
+                }
+            }
+            else if (m_portVlanMember[port.m_alias].empty() && port.m_bridge_port_id != SAI_NULL_OBJECT_ID)
+            {
+                if (!removeBridgePort(port))
+                {
+                    it = consumer.m_toSync.upper_bound(it->first);
+                    continue;
+                }
+                else
+                {
+                    it = consumer.m_toSync.erase(it);
                 }
             }
             else


### PR DESCRIPTION
Why I did it
Add static mac to Ethernet1 (Vlan 100 member) and remove Ethernet1 from Vlan 100 with static mac 00:00:00:01:01:01, then orchagent process would crash

Jun 28 05:35:41.148167 DUT-1 ERR swss#orchagent: :- meta_generic_validation_remove: object 0x3a000000000a97 reference count is 1, can't remove
Jun 28 05:35:41.148167 DUT-1 ERR swss#orchagent: :- removeBridgePort: Failed to remove bridge port Ethernet1 from default 1Q bridge, rv:-17
Jun 28 05:35:41.148174 DUT-1 ERR swss#orchagent: :- handleSaiRemoveStatus: Encountered failure in remove operation, exiting orchagent, SAI API: SAI_API_BRIDGE, status: SAI_STATUS_OBJECT_IN_USE
Jun 28 05:35:42.586693 DUT-1 ERR swss#supervisor-proc-exit-listener: orchagent process crash in swss container

What I did
Make exception handling when Remove Bridge fails, still let it sync, but try to delete BridgePort again when vlanMember has been deleted.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
