### PR TITLE
Revamp module build script to make it work for 5.15 on Ubuntu 20.04

### DIFF
--- a/.azure-pipelines/build_and_install_module.sh
+++ b/.azure-pipelines/build_and_install_module.sh
@@ -26,15 +26,28 @@ function build_and_install_kmodule()
     SUBLEVEL=$(echo $KERNEL_MAINVERSION | cut -d. -f3)
 
     # Install the required debian packages to build the kernel modules
+    apt-get update
     apt-get install -y build-essential linux-headers-${KERNEL_RELEASE} autoconf pkg-config fakeroot
-    apt-get install -y flex bison libssl-dev libelf-dev
+    apt-get install -y flex bison libssl-dev libelf-dev dwarves
     apt-get install -y libnl-route-3-200 libnl-route-3-dev libnl-cli-3-200 libnl-cli-3-dev libnl-3-dev
+    # Install libs required by libswsscommon for build
+    apt-get install -y libzmq3-dev libzmq5 libboost-serialization-dev uuid-dev
 
     # Add the apt source mirrors and download the linux image source code
     cp /etc/apt/sources.list /etc/apt/sources.list.bk
     sed -i "s/^# deb-src/deb-src/g" /etc/apt/sources.list
     apt-get update
-    apt-get source linux-image-unsigned-$(uname -r) > source.log
+    KERNEL_PACKAGE_SOURCE=$(apt-cache show linux-image-unsigned-${KERNEL_RELEASE} | grep ^Source: | cut -d':' -f 2)
+    KERNEL_PACKAGE_VERSION=$(apt-cache show linux-image-unsigned-${KERNEL_RELEASE} | grep ^Version: | cut -d':' -f 2)
+    SOURCE_PACKAGE_VERSION=$(apt-cache showsrc ${KERNEL_PACKAGE_SOURCE} | grep ^Version: | cut -d':' -f 2)
+    if [ ${KERNEL_PACKAGE_VERSION} != ${SOURCE_PACKAGE_VERSION} ]; then
+        echo "WARNING: the running kernel version (${KERNEL_PACKAGE_VERSION}) doesn't match the source package " \
+            "version (${SOURCE_PACKAGE_VERSION}) being downloaded. There's no guarantee the module being downloaded " \
+            "can be loaded into the kernel or function correctly. If possible, please update your kernel and reboot " \
+            "your system so that it's running the matching kernel version." >&2
+        echo "Continuing with the build anyways" >&2
+    fi
+    apt-get source linux-image-unsigned-${KERNEL_RELEASE} > source.log
 
     # Recover the original apt sources list
     cp /etc/apt/sources.list.bk /etc/apt/sources.list
@@ -42,46 +55,33 @@ function build_and_install_kmodule()
 
     # Build the Linux kernel module drivers/net/team and vrf
     cd $(find . -maxdepth 1 -type d | grep -v "^.$")
+    if [ -e debian/debian.env ]; then
+        source debian/debian.env
+        if [ -n "${DEBIAN}" -a -e ${DEBIAN}/reconstruct ]; then
+            bash ${DEBIAN}/reconstruct
+        fi
+    fi
     make  allmodconfig
     mv .config .config.bk
     cp /boot/config-$(uname -r) .config
     grep NET_TEAM .config.bk >> .config
-    echo CONFIG_NET_VRF=m >> .config
-    echo CONFIG_MACSEC=m >> .config
-    echo CONFIG_NET_VENDOR_MICROSOFT=y >> .config
-    echo CONFIG_MICROSOFT_MANA=m >> .config
-    echo CONFIG_SYSTEM_REVOCATION_LIST=n >> .config
     make VERSION=$VERSION PATCHLEVEL=$PATCHLEVEL SUBLEVEL=$SUBLEVEL EXTRAVERSION=-${EXTRAVERSION} LOCALVERSION=-${LOCALVERSION} modules_prepare
-    make M=drivers/net/team
+    cp /usr/src/linux-headers-$(uname -r)/Module.symvers .
+    make -j$(nproc) M=drivers/net/team
     mv drivers/net/Makefile drivers/net/Makefile.bak
     echo 'obj-$(CONFIG_NET_VRF) += vrf.o' > drivers/net/Makefile
     echo 'obj-$(CONFIG_MACSEC) += macsec.o' >> drivers/net/Makefile
-    make M=drivers/net
+    make -j$(nproc) M=drivers/net
 
     # Install the module
-    TEAM_DIR=$(echo /lib/modules/$(uname -r)/kernel/net/team)
-    NET_DIR=$(echo /lib/modules/$(uname -r)/kernel/net)
-    if [ ! -e "$TEAM_DIR/team.ko" ]; then
-        mkdir -p $TEAM_DIR
-        cp drivers/net/team/*.ko $TEAM_DIR/
-        modinfo $TEAM_DIR/team.ko
-        depmod
-        modprobe team
-    fi
-    if [ ! -e "$NET_DIR/vrf.ko" ]; then
-        mkdir -p $NET_DIR
-        cp drivers/net/vrf.ko $NET_DIR/
-        modinfo $NET_DIR/vrf.ko
-        depmod
-        modprobe vrf
-    fi
-    if [ ! -e "$NET_DIR/macsec.ko" ]; then
-        mkdir -p $NET_DIR
-        cp drivers/net/macsec.ko $NET_DIR/
-        modinfo $NET_DIR/macsec.ko
-        depmod
-        modprobe macsec
-    fi
+    SONIC_MODULES_DIR=/lib/modules/$(uname -r)/updates/sonic
+    mkdir -p $SONIC_MODULES_DIR
+    cp drivers/net/team/*.ko drivers/net/vrf.ko drivers/net/macsec.ko $SONIC_MODULES_DIR/
+    depmod
+    modinfo team vrf macsec
+    modprobe team
+    modprobe vrf
+    modprobe macsec
 
     cd /tmp
     rm -rf $WORKDIR

--- a/.azure-pipelines/build_and_install_module.sh
+++ b/.azure-pipelines/build_and_install_module.sh
@@ -30,8 +30,6 @@ function build_and_install_kmodule()
     apt-get install -y build-essential linux-headers-${KERNEL_RELEASE} autoconf pkg-config fakeroot
     apt-get install -y flex bison libssl-dev libelf-dev dwarves
     apt-get install -y libnl-route-3-200 libnl-route-3-dev libnl-cli-3-200 libnl-cli-3-dev libnl-3-dev
-    # Install libs required by libswsscommon for build
-    apt-get install -y libzmq3-dev libzmq5 libboost-serialization-dev uuid-dev
 
     # Add the apt source mirrors and download the linux image source code
     cp /etc/apt/sources.list /etc/apt/sources.list.bk


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

The current version of the script does not work at all when the host kernel is Azure's 5.15 kernel on Ubuntu 20.04. It does seem to work with 5.11 and older.

Update the script to add support for building and loading the kernel modules for the 5.15 kernel, while keeping support for the non-HWE kernel.

In addition, use a separate updates/sonic directory for the kernel modules we compile, to make it clear they were compiled separately and don't come from the official kernel build packages.

Finally, add a warning if we're compiling a kernel module for a different version of the kernel than what is currently running.

This is a cherry-pick of sonic-net/sonic-swss-common#720

**Why I did it**

**How I verified it**

**Details if related**
