### PR TITLE
[202405] Resolve circular dependencies to sonic-swss-common repo/build

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -80,6 +80,7 @@ jobs:
       artifact: ${{ parameters.swss_common_artifact_name }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/${{ parameters.swss_common_branch }}'
+      allowPartiallySucceededBuilds: true
       path: $(Build.ArtifactStagingDirectory)/download
     displayName: "Download sonic swss common deb packages"
   - task: DownloadPipelineArtifact@2

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -71,6 +71,7 @@ jobs:
       artifact: sonic-swss-common.amd64.ubuntu20_04
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/${{ parameters.swss_common_branch }}'
+      allowPartiallySucceededBuilds: true
       path: $(Build.ArtifactStagingDirectory)/download
     displayName: "Download sonic swss common deb packages"
   - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Allow partially succeeded builds when downloading sonic-swss-common artifacts
**Why I did it**
sonic-swss-common pipeline requires sonic-swss's source code to build and test.
sonic-swss pipeline requires sonic-swss-common's artifact to build and test.

Currently, there's test failure in sonic-swss-common which causes the pipeline to be partiallySucceeded rather than succeeded.
Then sonic-swss's build is blocked because no sonic-swss-common succeeded could be found.
And all the sync to 202405 from master got blocked, so the fixes are blocked also.

Hence allow partiallySucceededBuilds to resolve the circular dependencies 

**How I verified it**

**Details if related**
