### PR TITLE
Add a check if OID exists before setting Host Tx Ready Signal Enable 

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -958,7 +958,7 @@ bool PortsOrch::addPortBulk(const std::vector<PortConfig> &portList)
             attr.value.booldata = false;
             attrList.push_back(attr);
         }
-        
+
         if (cit.pt_intf_id.is_set)
         {
             if (!m_isPathTracingSupported)
@@ -5128,14 +5128,19 @@ bool PortsOrch::setSaiHostTxSignal(const Port &port, bool enable)
     sai_attribute_t attr;
     attr.id = SAI_PORT_ATTR_HOST_TX_SIGNAL_ENABLE;
     attr.value.booldata = enable;
-    sai_status_t status = sai_port_api->set_port_attribute(port.m_port_id, &attr);
 
-    if (status != SAI_STATUS_SUCCESS)
+    if (saiOidToAlias.find(port.m_port_id) != saiOidToAlias.end())
     {
-        SWSS_LOG_ERROR("Could not setSAI_PORT_ATTR_HOST_TX_SIGNAL_ENABLE to port 0x%" PRIx64, port.m_port_id);
-        return false;
+        sai_status_t status = sai_port_api->set_port_attribute(port.m_port_id, &attr);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Could not set SAI_PORT_ATTR_HOST_TX_SIGNAL_ENABLE to port 0x%" PRIx64, port.m_port_id);
+            return false;
+        }
+        return true;
     }
 
+    SWSS_LOG_NOTICE("Could not set SAI_PORT_ATTR_HOST_TX_SIGNAL_ENABLE - OID does not exist 0x%" PRIx64, port.m_port_id);
     return true;
 }
 
@@ -8122,7 +8127,7 @@ void PortsOrch::updatePortOperStatus(Port &port, sai_port_oper_status_t status)
         }
     }
     SWSS_LOG_INFO("Updating the nexthop for port %s and operational status %s", port.m_alias.c_str(), isUp ? "up" : "down");
-    
+
     if (!gNeighOrch->ifChangeInformNextHop(port.m_alias, isUp))
     {
         SWSS_LOG_WARN("Inform nexthop operation failed for interface %s", port.m_alias.c_str());


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I added a query before setting host tx ready - must check that Oid exists before setting attribute to SAI.

**Why I did it**

When we do dynamic port breakout to a Fw-control port, portsorch receives a notification that something was deleted in TRANSCEIVER_INFO table from State DB, and tries to set HOST_TX_READY_SIGNAL_ENABLE attribute to false for the deleted OID. 
The issue is the Oid is already deleted and we receive an error from SAI. 

**How I verified it**
Run DPB on the switch
**Details if related**
