### PR TITLE
Reduce log verbosity when the capability is not implemented

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -440,7 +440,12 @@ static bool isPathTracingSupported()
             }
         }
     }
-    else
+    else if (status == SAI_STATUS_ATTR_NOT_IMPLEMENTED_0)
+    {
+        SWSS_LOG_INFO("Querying OBJECT_TYPE_LIST is not supported on this platform");
+        return false;
+    }
+    else 
     {
         SWSS_LOG_ERROR(
             "Failed to get a list of supported switch capabilities. Error=%d", status

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -27,6 +27,8 @@ namespace portsorch_test
 {
     using namespace std;
 
+    bool support_object_type_list = true;
+
     // SAI default ports
     std::map<std::string, std::vector<swss::FieldValueTuple>> defaultPortList;
 
@@ -197,6 +199,10 @@ namespace portsorch_test
         sai_status_t status;
         if (attr_count == 1 && attr_list[0].id == SAI_SWITCH_ATTR_SUPPORTED_OBJECT_TYPE_LIST)
         {
+            if (!support_object_type_list)
+            {
+                return SAI_STATUS_ATTR_NOT_IMPLEMENTED_0;
+            }
             uint32_t i;
             for (i = 0; i < attr_list[0].value.s32list.count && i < supported_sai_objects.size(); i++)
             {
@@ -1625,6 +1631,11 @@ namespace portsorch_test
 
         // Port count: 32 Data + 1 CPU
         ASSERT_EQ(gPortsOrch->getAllPorts().size(), ports.size() + 1);
+
+        // Scenario 0: Query to fetch OBJECT_TYPE_LIST is not Implemented by the vendor
+        support_object_type_list = false;
+        ASSERT_FALSE(gPortsOrch->checkPathTracingCapability());
+        support_object_type_list = true;
 
         // Scenario 1: Path Tracing supported
         ASSERT_TRUE(gPortsOrch->checkPathTracingCapability());


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**Why I did**

SAI_SWITCH_ATTR_SUPPORTED_OBJECT_TYPE_LIST is not a mandatory attribute and is not supported in some platforms. 

There is an error log seen for such platforms. Reduce noise by changing the verbosity to INFO. 

**How I verified it**

**Details if related**
