### PR TITLE
VNET_ROUTE_ADVERTISE_TABLE for limiting downstream route advertisement

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -731,7 +731,7 @@ VNetRouteOrch::VNetRouteOrch(DBConnector *db, vector<string> &tableNames, VNetOr
     app_db_ = shared_ptr<DBConnector>(new DBConnector("APPL_DB", 0));
 
     state_vnet_rt_tunnel_table_ = unique_ptr<Table>(new Table(state_db_.get(), STATE_VNET_RT_TUNNEL_TABLE_NAME));
-    state_vnet_rt_adv_table_ = unique_ptr<Table>(new Table(state_db_.get(), STATE_ADVERTISE_NETWORK_TABLE_NAME));
+    state_vnet_rt_adv_table_ = unique_ptr<Table>(new Table(state_db_.get(), STATE_VNET_RT_ADVERTISE_TABLE));
     monitor_session_producer_ = unique_ptr<Table>(new Table(app_db_.get(), APP_VNET_MONITOR_TABLE_NAME));
 
     gBfdOrch->attach(this);
@@ -2159,6 +2159,7 @@ void VNetRouteOrch::addRouteAdvertisement(IpPrefix& ipPrefix, string& profile)
 {
     const string key = ipPrefix.to_string();
     vector<FieldValueTuple> fvs;
+    fvs.push_back(FieldValueTuple("disable_downstream_adv", "true"));
     if (profile.empty())
     {
         fvs.push_back(FieldValueTuple("", ""));

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -517,15 +517,18 @@ def check_remove_state_db_routes(dvs, vnet, prefix):
 
 def check_routes_advertisement(dvs, prefix, profile=""):
     state_db = swsscommon.DBConnector(swsscommon.STATE_DB, dvs.redis_sock, 0)
-    tbl =  swsscommon.Table(state_db, "ADVERTISE_NETWORK_TABLE")
+    tbl =  swsscommon.Table(state_db, "VNET_ROUTE_ADVERTISE_TABLE")
     keys = tbl.getKeys()
 
     assert prefix in keys
+    status, fvs = tbl.get(prefix)
+
+    assert status, "Got an error when get a key"
+
+    fvs = dict(fvs)
+    assert fvs['disable_downstream_adv'] == 'true'
 
     if profile:
-        status, fvs = tbl.get(prefix)
-        assert status, "Got an error when get a key"
-        fvs = dict(fvs)
         assert fvs['profile'] == profile
 
 


### PR DESCRIPTION
This PR replaces the ADVERTISE_NETWORK_TABLE with VNET_ROUTE_ADVERTISE_TABLE and adds a new attribute **disable_downstream_adv**. 
In the exisitng implementation, the vnetorch adds the route prefixes to ADVERTISE_NETWORK_TABLE table for BGP advertisement.
This new table would be monitored by a bgpCfgd and based on the attribute disable_downstream_adv advertise the route to upstream devices.

Updated the unit tests to cover the new table.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
