### PR TITLE
support to check SAI capability of ACL META_DATA fields

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3168,6 +3168,87 @@ void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, Mirr
     }
 
 
+
+    //check switch capability of Metadata attribute, action and range.
+    //SAI_SWITCH_ATTR_ACL_USER_META_DATA_RANGE support and range values.
+    //SAI_ACL_ENTRY_ATTR_ACTION_SET_ACL_META_DATA 
+    //SAI_ACL_ENTRY_ATTR_FIELD_ACL_USER_META
+
+    sai_status_t status = SAI_STATUS_SUCCESS;
+    sai_attr_capability_t capability;
+    status = sai_query_attribute_capability(gSwitchId, SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_ACL_USER_META_DATA_RANGE, &capability);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_WARN("Could not query ACL_USER_META_DATA_RANGE %d", status);
+        m_switchMetaDataCapabilities[TABLE_ACL_USER_META_DATA_RANGE_CAPABLE] = "false";
+    }
+    else
+    {
+        if (capability.get_implemented)
+        {
+            m_switchMetaDataCapabilities[TABLE_ACL_USER_META_DATA_RANGE_CAPABLE] = "true";
+            sai_attribute_t attrs[1];
+            attrs[0].id = SAI_SWITCH_ATTR_ACL_USER_META_DATA_RANGE;
+            sai_status_t status = sai_switch_api->get_switch_attribute(gSwitchId, 2, attrs);
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_WARN("Could not get range for ACL_USER_META_DATA_RANGE %d", status);
+                m_switchMetaDataCapabilities[TABLE_ACL_USER_META_DATA_MIN] = "-1";
+                m_switchMetaDataCapabilities[TABLE_ACL_USER_META_DATA_MAX] = "-1";
+            }
+            else
+            {
+                SWSS_LOG_NOTICE("ACL_USER_META_DATA_RANGE, min: %u, max: %u", attrs[0].value.u32range.min, attrs[0].value.u32range.max);
+                m_switchMetaDataCapabilities[TABLE_ACL_USER_META_DATA_MIN] = std::to_string(attrs[0].value.u32range.min);
+                m_switchMetaDataCapabilities[TABLE_ACL_USER_META_DATA_MAX] = std::to_string(attrs[0].value.u32range.max);
+            }
+
+        }
+        else
+        {
+            m_switchMetaDataCapabilities[TABLE_ACL_USER_META_DATA_RANGE_CAPABLE] = "false";
+        }
+        SWSS_LOG_NOTICE("ACL_USER_META_DATA_RANGE capability %d", capability.set_implemented);
+    }  
+
+    status = sai_query_attribute_capability(gSwitchId, SAI_OBJECT_TYPE_ACL_ENTRY, SAI_ACL_ENTRY_ATTR_FIELD_ACL_USER_META, &capability);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_WARN("Could not query ACL_ENTRY_ATTR_FIELD_ACL_USER_META %d", status);
+        m_switchMetaDataCapabilities[TABLE_ACL_ENTRY_ATTR_META_CAPABLE] = "false";
+    }
+    else
+    {
+        if (capability.get_implemented)
+        {
+            m_switchMetaDataCapabilities[TABLE_ACL_ENTRY_ATTR_META_CAPABLE] = "true";
+        }
+        else
+        {
+            m_switchMetaDataCapabilities[TABLE_ACL_ENTRY_ATTR_META_CAPABLE] = "false";
+        }
+        SWSS_LOG_NOTICE("ACL_ENTRY_ATTR_FIELD_ACL_USER_META capability %d", capability.get_implemented);
+    }
+
+    status = sai_query_attribute_capability(gSwitchId, SAI_OBJECT_TYPE_ACL_ENTRY, SAI_ACL_ENTRY_ATTR_ACTION_SET_ACL_META_DATA, &capability);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_WARN("Could not query ACL_ENTRY_ATTR_ACTION_SET_ACL_META_DATA %d", status);
+        m_switchMetaDataCapabilities[TABLE_ACL_ENTRY_ACTION_META_CAPABLE] = "false";
+    }
+    else
+    {
+        if (capability.get_implemented)
+        {
+            m_switchMetaDataCapabilities[TABLE_ACL_ENTRY_ACTION_META_CAPABLE] = "true";
+        }
+        else
+        {
+            m_switchMetaDataCapabilities[TABLE_ACL_ENTRY_ACTION_META_CAPABLE] = "false";
+        }
+        SWSS_LOG_NOTICE("ACL_ENTRY_ATTR_ACTION_SET_ACL_META_DATA capability %d", capability.set_implemented);
+    }
+
     // Store the capabilities in state database
     // TODO: Move this part of the code into syncd
     vector<FieldValueTuple> fvVector;

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -102,6 +102,12 @@
 
 #define ACL_COUNTER_FLEX_COUNTER_GROUP "ACL_STAT_COUNTER"
 
+#define TABLE_ACL_USER_META_DATA_RANGE_CAPABLE       "ACL_USER_META_DATA_RANGE_CAPABLE"
+#define TABLE_ACL_USER_META_DATA_MIN                 "ACL_USER_META_DATA_MIN"
+#define TABLE_ACL_USER_META_DATA_MAX                 "ACL_USER_META_DATA_MAX"
+#define TABLE_ACL_ENTRY_ATTR_META_CAPABLE            "ACL_ENTRY_ATTR_META_CAPABLE"
+#define TABLE_ACL_ENTRY_ACTION_META_CAPABLE          "ACL_ENTRY_ACTION_META_CAPABLE"
+
 enum AclObjectStatus
 {
     ACTIVE = 0,
@@ -514,7 +520,8 @@ public:
     bool m_isCombinedMirrorV6Table = true;
     map<string, bool> m_mirrorTableCapabilities;
     map<acl_stage_type_t, bool> m_L3V4V6Capability;
-
+    map<string, string> m_switchMetaDataCapabilities;
+    
     void registerFlexCounter(const AclRule& rule);
     void deregisterFlexCounter(const AclRule& rule);
 


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added support to check if the platform supports the following SAI attributes.
This changes also gets the platform supported range for matadata value.
SAI_SWITCH_ATTR_ACL_USER_META_DATA_RANGE
SAI_ACL_ENTRY_ATTR_ACTION_SET_ACL_META_DATA
SAI_ACL_ENTRY_ATTR_FIELD_ACL_USER_META

**Why I did it**
For ACL outer DSCP change feature, these attributes are required.

**How I verified it**
Basic verification done in VS enviornment

Aug 23 23:13:37.191745 0066f13dd278 WARNING #orchagent: :- init: Could not get range for ACL_USER_META_DATA_RANGE -15
Aug 23 23:13:37.191756 0066f13dd278 NOTICE #orchagent: :- init: ACL_USER_META_DATA_RANGE capability 1
Aug 23 23:13:37.192269 0066f13dd278 NOTICE #orchagent: :- init: ACL_ENTRY_ATTR_FIELD_ACL_USER_META capability 1
Aug 23 23:13:37.192705 0066f13dd278 NOTICE #orchagent: :- init: ACL_ENTRY_ATTR_ACTION_SET_ACL_META_DATA capability 1
Mlnx 2700 T1
![image](https://github.com/user-attachments/assets/4863c83a-d8da-4d40-a22c-2bc6401ae83d)

**Details if related**
