### PR TITLE
Fix IPv6 link-local address can't work in VRF

### DIFF
--- a/orchagent/p4orch/tests/Makefile.am
+++ b/orchagent/p4orch/tests/Makefile.am
@@ -59,9 +59,16 @@ p4orch_tests_SOURCES = $(ORCHAGENT_DIR)/orch.cpp \
 		       fake_flowcounterrouteorch.cpp \
 		       fake_dbconnector.cpp \
 		       fake_producertable.cpp \
+		       fake_producerstatetable.cpp \
 		       fake_consumerstatetable.cpp \
 		       fake_subscriberstatetable.cpp \
 		       fake_notificationconsumer.cpp \
+		       fake_fdborch.cpp \
+		       fake_intfsorch.cpp \
+		       fake_neighorch.cpp \
+		       fake_fgnhgorch.cpp \
+		       fake_srv6orch.cpp \
+		       fake_routeorch.cpp \
 		       fake_table.cpp \
 		       p4oidmapper_test.cpp \
 		       p4orch_util_test.cpp \

--- a/orchagent/p4orch/tests/fake_dbconnector.cpp
+++ b/orchagent/p4orch/tests/fake_dbconnector.cpp
@@ -9,7 +9,7 @@ namespace swss
 {
 
 static std::map<std::string, int> dbNameIdMap = {
-    {"APPL_DB", 0}, {"ASIC_DB", 1}, {"COUNTERS_DB", 2}, {"CONFIG_DB", 4}, {"FLEX_COUNTER_DB", 5}, {"STATE_DB", 6},
+    {"APPL_DB", 0}, {"ASIC_DB", 1}, {"COUNTERS_DB", 2}, {"CONFIG_DB", 4}, {"FLEX_COUNTER_DB", 5}, {"STATE_DB", 6}, {"CHASSIS_APP_DB", 12},
 };
 
 using DbDataT = std::map<int, std::map<std::string, std::map<std::string, std::string>>>;

--- a/orchagent/p4orch/tests/fake_fdborch.cpp
+++ b/orchagent/p4orch/tests/fake_fdborch.cpp
@@ -1,0 +1,94 @@
+#include "fdborch.h"
+
+const int FdbOrch::fdborch_pri = 20;
+
+FdbOrch::FdbOrch(DBConnector* applDbConnector, vector<table_name_with_pri_t> appFdbTables,
+    TableConnector stateDbFdbConnector, TableConnector stateDbMclagFdbConnector, PortsOrch *port) :
+    Orch(applDbConnector, appFdbTables),
+    m_portsOrch(port),
+    m_fdbStateTable(stateDbFdbConnector.first, stateDbFdbConnector.second),
+    m_mclagFdbStateTable(stateDbMclagFdbConnector.first, stateDbMclagFdbConnector.second)
+{
+}
+
+bool FdbOrch::bake()
+{
+    return true;
+}
+
+bool FdbOrch::storeFdbEntryState(const FdbUpdate& update)
+{
+    return true;
+}
+
+void FdbOrch::clearFdbEntry(const FdbEntry& entry)
+{
+}
+
+void FdbOrch::handleSyncdFlushNotif(const sai_object_id_t& bv_id,
+                                    const sai_object_id_t& bridge_port_id,
+                                    const MacAddress& mac,
+                                    const sai_fdb_entry_type_t& sai_fdb_type)
+{
+}
+
+void FdbOrch::update(sai_fdb_event_t        type,
+                     const sai_fdb_entry_t* entry,
+                     sai_object_id_t        bridge_port_id,
+                     const sai_fdb_entry_type_t   &sai_fdb_type)
+{
+}
+
+void FdbOrch::update(SubjectType type, void *cntx)
+{
+}
+
+bool FdbOrch::getPort(const MacAddress& mac, uint16_t vlan, Port& port)
+{
+    return true;
+}
+
+void FdbOrch::doTask(Consumer& consumer)
+{
+}
+
+void FdbOrch::doTask(NotificationConsumer& consumer)
+{
+}
+
+void FdbOrch::flushFDBEntries(sai_object_id_t bridge_port_oid,
+                              sai_object_id_t vlan_oid)
+{
+}
+
+void FdbOrch::notifyObserversFDBFlush(Port &port, sai_object_id_t& bvid)
+{
+}
+
+void FdbOrch::updatePortOperState(const PortOperStateUpdate& update)
+{
+}
+
+void FdbOrch::updateVlanMember(const VlanMemberUpdate& update)
+{
+}
+
+bool FdbOrch::addFdbEntry(const FdbEntry& entry, const string& port_name,
+        FdbData fdbData)
+{
+    return true;
+}
+
+bool FdbOrch::removeFdbEntry(const FdbEntry& entry, FdbOrigin origin)
+{
+    return true;
+}
+
+void FdbOrch::deleteFdbEntryFromSavedFDB(const MacAddress &mac,
+        const unsigned short &vlanId, FdbOrigin origin, const string portName)
+{
+}
+
+void FdbOrch::notifyTunnelOrch(Port& port)
+{
+}

--- a/orchagent/p4orch/tests/fake_fgnhgorch.cpp
+++ b/orchagent/p4orch/tests/fake_fgnhgorch.cpp
@@ -1,0 +1,146 @@
+#include "fgnhgorch.h"
+
+FgNhgOrch::FgNhgOrch(DBConnector *db, DBConnector *appDb, DBConnector *stateDb, vector<table_name_with_pri_t> &tableNames, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch) :
+        Orch(db, tableNames),
+        m_neighOrch(neighOrch),
+        m_intfsOrch(intfsOrch),
+        m_vrfOrch(vrfOrch),
+        m_stateWarmRestartRouteTable(stateDb, STATE_FG_ROUTE_TABLE_NAME),
+        m_routeTable(appDb, APP_ROUTE_TABLE_NAME)
+{
+}
+
+void FgNhgOrch::update(SubjectType type, void *cntx)
+{
+}
+
+bool FgNhgOrch::bake()
+{
+    return true;
+}
+
+void FgNhgOrch::calculateBankHashBucketStartIndices(FgNhgEntry *fgNhgEntry)
+{
+}
+
+void FgNhgOrch::setStateDbRouteEntry(const IpPrefix &ipPrefix, uint32_t index, NextHopKey nextHop)
+{
+}
+
+bool FgNhgOrch::writeHashBucketChange(FGNextHopGroupEntry *syncd_fg_route_entry, uint32_t index, sai_object_id_t nh_oid,
+        const IpPrefix &ipPrefix, NextHopKey nextHop)
+{
+    return true;
+}
+
+bool FgNhgOrch::createFineGrainedNextHopGroup(FGNextHopGroupEntry &syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
+        const NextHopGroupKey &nextHops)
+{
+    return true;
+}
+
+bool FgNhgOrch::removeFineGrainedNextHopGroup(FGNextHopGroupEntry *syncd_fg_route_entry)
+{
+    return true;
+}
+
+bool FgNhgOrch::modifyRoutesNextHopId(sai_object_id_t vrf_id, const IpPrefix &ipPrefix, sai_object_id_t next_hop_id)
+{
+    return true;
+}
+
+bool FgNhgOrch::validNextHopInNextHopGroup(const NextHopKey& nexthop)
+{
+    return true;
+}
+
+bool FgNhgOrch::invalidNextHopInNextHopGroup(const NextHopKey& nexthop)
+{
+    return true;
+}
+
+bool FgNhgOrch::setActiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
+        uint32_t bank, uint32_t syncd_bank, std::vector<BankMemberChanges> bank_member_changes,
+        std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const IpPrefix &ipPrefix)
+{
+    return true;
+}
+
+bool FgNhgOrch::setInactiveBankToNextAvailableActiveBank(FGNextHopGroupEntry *syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
+        uint32_t bank, std::vector<BankMemberChanges> bank_member_changes,
+        std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const IpPrefix &ipPrefix)
+{
+    return true;
+}
+
+bool FgNhgOrch::setInactiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
+        uint32_t bank,std::vector<BankMemberChanges> &bank_member_changes,
+        std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const IpPrefix &ipPrefix)
+{
+    return true;
+}
+
+bool FgNhgOrch::computeAndSetHashBucketChanges(FGNextHopGroupEntry *syncd_fg_route_entry,
+        FgNhgEntry *fgNhgEntry, std::vector<BankMemberChanges> &bank_member_changes,
+        std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set,
+        const IpPrefix &ipPrefix)
+{
+    return true;
+}
+
+bool FgNhgOrch::setNewNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
+        std::vector<BankMemberChanges> &bank_member_changes, std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set,
+        const IpPrefix &ipPrefix)
+{
+    return true;
+}
+
+bool FgNhgOrch::isRouteFineGrained(sai_object_id_t vrf_id, const IpPrefix &ipPrefix, const NextHopGroupKey &nextHops)
+{
+    return true;
+}
+
+bool FgNhgOrch::syncdContainsFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix)
+{
+    return true;
+}
+
+bool FgNhgOrch::setFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix, const NextHopGroupKey &nextHops,
+                                    sai_object_id_t &next_hop_id, bool &isNextHopIdChanged)
+{
+    return true;
+}
+
+bool FgNhgOrch::removeFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix)
+{
+    return true;
+}
+
+vector<FieldValueTuple> FgNhgOrch::generateRouteTableFromNhgKey(NextHopGroupKey nhg)
+{
+    vector<FieldValueTuple> fvVector;
+    return fvVector;
+}
+
+void FgNhgOrch::cleanupIpInLinkToIpMap(const string &link, const IpAddress &ip, FgNhgEntry &fgNhg_entry)
+{
+}
+
+bool FgNhgOrch::doTaskFgNhg(const KeyOpFieldsValuesTuple & t)
+{
+    return true;
+}
+
+bool FgNhgOrch::doTaskFgNhgPrefix(const KeyOpFieldsValuesTuple & t)
+{
+    return true;
+}
+
+bool FgNhgOrch::doTaskFgNhgMember(const KeyOpFieldsValuesTuple & t)
+{
+    return true;
+}
+
+void FgNhgOrch::doTask(Consumer& consumer)
+{
+}

--- a/orchagent/p4orch/tests/fake_intfsorch.cpp
+++ b/orchagent/p4orch/tests/fake_intfsorch.cpp
@@ -1,0 +1,177 @@
+#include "intfsorch.h"
+
+const int intfsorch_pri = 35;
+
+IntfsOrch::IntfsOrch(DBConnector *db, string tableName, VRFOrch *vrf_orch, DBConnector *chassisAppDb) :
+        Orch(db, tableName, intfsorch_pri), m_vrfOrch(vrf_orch)
+{
+}
+
+sai_object_id_t IntfsOrch::getRouterIntfsId(const string &alias)
+{
+    return 0;
+}
+
+bool IntfsOrch::isPrefixSubnet(const IpPrefix &ip_prefix, const string &alias)
+{
+    return true;
+}
+
+string IntfsOrch::getRouterIntfsAlias(const IpAddress &ip, const string &vrf_name)
+{
+    return "";
+}
+
+bool IntfsOrch::isInbandIntfInMgmtVrf(const string& alias)
+{
+    return true;
+}
+
+void IntfsOrch::increaseRouterIntfsRefCount(const string &alias)
+{
+}
+
+void IntfsOrch::decreaseRouterIntfsRefCount(const string &alias)
+{
+}
+
+bool IntfsOrch::setRouterIntfsMpls(const Port &port)
+{
+    return true;
+}
+
+bool IntfsOrch::setRouterIntfsMtu(const Port &port)
+{
+    return true;
+}
+
+bool IntfsOrch::setRouterIntfsMac(const Port &port)
+{
+    return true;
+}
+
+bool IntfsOrch::setRouterIntfsNatZoneId(Port &port)
+{
+    return true;
+}
+
+bool IntfsOrch::setRouterIntfsAdminStatus(const Port &port)
+{
+    return true;
+}
+
+bool IntfsOrch::setIntfVlanFloodType(const Port &port, sai_vlan_flood_control_type_t vlan_flood_type)
+{
+    return true;
+}
+
+bool IntfsOrch::setIntfProxyArp(const string &alias, const string &proxy_arp)
+{
+    return true;
+}
+
+bool IntfsOrch::setIntfLoopbackAction(const Port &port, string actionStr)
+{
+    return true;
+}
+
+set<IpPrefix> IntfsOrch:: getSubnetRoutes()
+{
+    set<IpPrefix> subnet_routes;
+    return subnet_routes;
+}
+
+bool IntfsOrch::setIntf(const string& alias, sai_object_id_t vrf_id, const IpPrefix *ip_prefix,
+                        const bool adminUp, const uint32_t mtu, string loopbackAction)
+
+{
+    return true;
+}
+
+bool IntfsOrch::removeIntf(const string& alias, sai_object_id_t vrf_id, const IpPrefix *ip_prefix)
+{
+    return true;
+}
+
+void IntfsOrch::doTask(Consumer &consumer)
+{
+}
+
+bool IntfsOrch::getSaiLoopbackAction(const string &actionStr, sai_packet_action_t &action)
+{
+    return true;
+}
+
+bool IntfsOrch::addRouterIntfs(sai_object_id_t vrf_id, Port &port, string loopbackActionStr)
+{
+    return true;
+}
+
+bool IntfsOrch::removeRouterIntfs(Port &port)
+{
+    return true;
+}
+
+void IntfsOrch::addIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_prefix)
+{
+}
+
+void IntfsOrch::removeIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_prefix)
+{
+}
+
+void IntfsOrch::addDirectedBroadcast(const Port &port, const IpPrefix &ip_prefix)
+{
+}
+
+void IntfsOrch::removeDirectedBroadcast(const Port &port, const IpPrefix &ip_prefix)
+{
+}
+
+void IntfsOrch::addRifToFlexCounter(const string &id, const string &name, const string &type)
+{
+}
+
+void IntfsOrch::removeRifFromFlexCounter(const string &id, const string &name)
+{
+}
+
+string IntfsOrch::getRifFlexCounterTableKey(string key)
+{
+    return "";
+}
+
+void IntfsOrch::generateInterfaceMap()
+{
+}
+
+bool IntfsOrch::updateSyncdIntfPfx(const string &alias, const IpPrefix &ip_prefix, bool add)
+{
+    return true;
+}
+
+void IntfsOrch::doTask(SelectableTimer &timer)
+{
+}
+
+bool IntfsOrch::isRemoteSystemPortIntf(string alias)
+{
+    return true;
+}
+
+bool IntfsOrch::isLocalSystemPortIntf(string alias)
+{
+    return true;
+}
+
+void IntfsOrch::voqSyncAddIntf(string &alias)
+{
+}
+
+void IntfsOrch::voqSyncDelIntf(string &alias)
+{
+}
+
+void IntfsOrch::voqSyncIntfState(string &alias, bool isUp)
+{
+}

--- a/orchagent/p4orch/tests/fake_neighorch.cpp
+++ b/orchagent/p4orch/tests/fake_neighorch.cpp
@@ -1,0 +1,238 @@
+
+#include "neighorch.h"
+
+extern sai_neighbor_api_t* sai_neighbor_api;
+extern size_t gMaxBulkSize;
+const int neighorch_pri = 30;
+
+NeighOrch::NeighOrch(swss::DBConnector *appDb, string tableName, IntfsOrch *intfsOrch, FdbOrch *fdbOrch, PortsOrch *portsOrch, swss::DBConnector *chassisAppDb) :
+        gNeighBulker(sai_neighbor_api, gMaxBulkSize),
+        Orch(appDb, tableName, neighorch_pri),
+        m_intfsOrch(intfsOrch),
+        m_fdbOrch(fdbOrch),
+        m_portsOrch(portsOrch),
+        m_appNeighResolveProducer(appDb, APP_NEIGH_RESOLVE_TABLE_NAME)
+{
+}
+
+NeighOrch::~NeighOrch()
+{
+}
+
+bool NeighOrch::resolveNeighborEntry(const NeighborEntry &entry, const MacAddress &mac)
+{
+    return true;
+}
+
+void NeighOrch::resolveNeighbor(const NeighborEntry &entry)
+{
+}
+
+void NeighOrch::clearResolvedNeighborEntry(const NeighborEntry &entry)
+{
+}
+
+void NeighOrch::processFDBFlushUpdate(const FdbFlushUpdate& update)
+{
+}
+
+void NeighOrch::update(SubjectType type, void *cntx)
+{
+}
+
+bool NeighOrch::hasNextHop(const NextHopKey &nexthop)
+{
+    return true;
+}
+
+bool NeighOrch::isNeighborResolved(const NextHopKey &nexthop)
+{
+    return true;
+}
+
+bool NeighOrch::addNextHop(const NextHopKey &nh)
+{
+    return true;
+}
+
+bool NeighOrch::setNextHopFlag(const NextHopKey &nexthop, const uint32_t nh_flag)
+{
+    return true;
+}
+
+bool NeighOrch::clearNextHopFlag(const NextHopKey &nexthop, const uint32_t nh_flag)
+{
+    return true;
+}
+
+bool NeighOrch::isNextHopFlagSet(const NextHopKey &nexthop, const uint32_t nh_flag)
+{
+    return true;
+}
+
+bool NeighOrch::ifChangeInformNextHop(const string &alias, bool if_up)
+{
+    return true;
+}
+
+void NeighOrch::updateNextHop(const BfdUpdate& update)
+{
+}
+
+bool NeighOrch::removeNextHop(const IpAddress &ipAddress, const string &alias)
+{
+    return true;
+}
+
+bool NeighOrch::removeMplsNextHop(const NextHopKey& nh)
+{
+    return true;
+}
+
+bool NeighOrch::removeOverlayNextHop(const NextHopKey &nexthop)
+{
+    return true;
+}
+
+sai_object_id_t NeighOrch::getLocalNextHopId(const NextHopKey& nexthop)
+{
+    return 0;
+}
+
+sai_object_id_t NeighOrch::getNextHopId(const NextHopKey &nexthop)
+{
+    return 0;
+}
+
+int NeighOrch::getNextHopRefCount(const NextHopKey &nexthop)
+{
+    return 0;
+}
+
+void NeighOrch::increaseNextHopRefCount(const NextHopKey &nexthop, uint32_t count)
+{
+}
+
+void NeighOrch::decreaseNextHopRefCount(const NextHopKey &nexthop, uint32_t count)
+{
+}
+
+bool NeighOrch::getNeighborEntry(const NextHopKey &nexthop, NeighborEntry &neighborEntry, MacAddress &macAddress)
+{
+    return true;
+}
+
+bool NeighOrch::getNeighborEntry(const IpAddress &ipAddress, NeighborEntry &neighborEntry, MacAddress &macAddress)
+{
+    return true;
+}
+
+void NeighOrch::doTask(Consumer &consumer)
+{
+}
+
+bool NeighOrch::addNeighbor(NeighborContext& ctx)
+{
+    return true;
+}
+
+bool NeighOrch::removeNeighbor(NeighborContext& ctx, bool disable)
+{
+    return true;
+}
+
+bool NeighOrch::processBulkEnableNeighbor(NeighborContext& ctx)
+{
+    return true;
+}
+
+bool NeighOrch::processBulkDisableNeighbor(NeighborContext& ctx)
+{
+    return true;
+}
+
+bool NeighOrch::isHwConfigured(const NeighborEntry& neighborEntry)
+{
+    return true;
+}
+
+bool NeighOrch::enableNeighbor(const NeighborEntry& neighborEntry)
+{
+    return true;
+}
+
+bool NeighOrch::disableNeighbor(const NeighborEntry& neighborEntry)
+{
+    return true;
+}
+
+bool NeighOrch::enableNeighbors(std::list<NeighborContext>& bulk_ctx_list)
+{
+    return true;
+}
+
+bool NeighOrch::disableNeighbors(std::list<NeighborContext>& bulk_ctx_list)
+{
+    return true;
+}
+
+sai_object_id_t NeighOrch::addTunnelNextHop(const NextHopKey& nh)
+{
+    return 0;
+}
+
+bool NeighOrch::removeTunnelNextHop(const NextHopKey& nh)
+{
+    return true;
+}
+
+void NeighOrch::doVoqSystemNeighTask(Consumer &consumer)
+{
+}
+
+bool NeighOrch::addInbandNeighbor(string alias, IpAddress ip_address)
+{
+    return true;
+}
+
+bool NeighOrch::delInbandNeighbor(string alias, IpAddress ip_address)
+{
+    return true;
+}
+
+bool NeighOrch::getSystemPortNeighEncapIndex(string &alias, IpAddress &ip, uint32_t &encap_index)
+{
+    return true;
+}
+
+bool NeighOrch::addVoqEncapIndex(string &alias, IpAddress &ip, vector<sai_attribute_t> &neighbor_attrs)
+{
+    return true;
+}
+
+void NeighOrch::voqSyncAddNeigh(string &alias, IpAddress &ip_address, const MacAddress &mac, sai_neighbor_entry_t &neighbor_entry)
+{
+}
+
+void NeighOrch::voqSyncDelNeigh(string &alias, IpAddress &ip_address)
+{
+}
+
+bool NeighOrch::updateVoqNeighborEncapIndex(const NeighborEntry &neighborEntry, uint32_t encap_index)
+{
+    return true;
+}
+
+void NeighOrch::updateSrv6Nexthop(const NextHopKey &nh, const sai_object_id_t &nh_id)
+{
+}
+
+bool NeighOrch::addZeroMacTunnelRoute(const NeighborEntry& entry, const MacAddress& mac)
+{
+    return true;
+}
+
+bool NeighOrch::ifChangeInformRemoteNextHop(const string &alias, bool if_up)
+{
+    return true;
+}

--- a/orchagent/p4orch/tests/fake_producerstatetable.cpp
+++ b/orchagent/p4orch/tests/fake_producerstatetable.cpp
@@ -1,0 +1,27 @@
+#include <string>
+#include <vector>
+
+#include "producerstatetable.h"
+
+namespace swss
+{
+
+ProducerStateTable::ProducerStateTable(DBConnector *db, const std::string &tableName)
+    : TableBase(tableName, ":"), TableName_KeySet(tableName)
+{
+}
+
+ProducerStateTable::~ProducerStateTable()
+{
+}
+
+void ProducerStateTable::set(const std::string &key, const std::vector<FieldValueTuple> &values, const std::string &op,
+                        const std::string &prefix)
+{
+}
+
+void ProducerStateTable::del(const std::string &key, const std::string &op, const std::string &prefix)
+{
+}
+
+} // namespace swss

--- a/orchagent/p4orch/tests/fake_routeorch.cpp
+++ b/orchagent/p4orch/tests/fake_routeorch.cpp
@@ -1,0 +1,227 @@
+#include "routeorch.h"
+#include "nhgorch.h"
+#include "cbf/cbfnhgorch.h"
+
+extern size_t gMaxBulkSize;
+extern sai_object_id_t gSwitchId;
+extern sai_next_hop_group_api_t*    sai_next_hop_group_api;
+extern sai_route_api_t*             sai_route_api;
+extern sai_mpls_api_t*              sai_mpls_api;
+extern NhgOrch *gNhgOrch;
+extern CbfNhgOrch *gCbfNhgOrch;
+
+RouteOrch::RouteOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames, SwitchOrch *switchOrch, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch, FgNhgOrch *fgNhgOrch, Srv6Orch *srv6Orch) :
+        gRouteBulker(sai_route_api, gMaxBulkSize),
+        gLabelRouteBulker(sai_mpls_api, gMaxBulkSize),
+        gNextHopGroupMemberBulker(sai_next_hop_group_api, gSwitchId, gMaxBulkSize),
+        Orch(db, tableNames),
+        m_switchOrch(switchOrch),
+        m_neighOrch(neighOrch),
+        m_intfsOrch(intfsOrch),
+        m_vrfOrch(vrfOrch),
+        m_fgNhgOrch(fgNhgOrch),
+        m_nextHopGroupCount(0),
+        m_srv6Orch(srv6Orch),
+        m_resync(false),
+        m_appTunnelDecapTermProducer(db, APP_TUNNEL_DECAP_TERM_TABLE_NAME)
+{
+}
+
+std::string RouteOrch::getLinkLocalEui64Addr(void)
+{
+    return "";
+}
+
+void RouteOrch::addLinkLocalRouteToMe(sai_object_id_t vrf_id, IpPrefix linklocal_prefix)
+{
+}
+
+void RouteOrch::delLinkLocalRouteToMe(sai_object_id_t vrf_id, IpPrefix linklocal_prefix)
+{
+}
+
+void RouteOrch::updateDefRouteState(string ip, bool add)
+{
+}
+
+bool RouteOrch::hasNextHopGroup(const NextHopGroupKey& nexthops) const
+{
+    return true;
+}
+
+sai_object_id_t RouteOrch::getNextHopGroupId(const NextHopGroupKey& nexthops)
+{
+    return m_syncdNextHopGroups[nexthops].next_hop_group_id;
+}
+
+void RouteOrch::attach(Observer *observer, const IpAddress& dstAddr, sai_object_id_t vrf_id)
+{
+}
+
+void RouteOrch::detach(Observer *observer, const IpAddress& dstAddr, sai_object_id_t vrf_id)
+{
+}
+
+bool RouteOrch::validnexthopinNextHopGroup(const NextHopKey &nexthop, uint32_t& count)
+{
+    return true;
+}
+
+bool RouteOrch::invalidnexthopinNextHopGroup(const NextHopKey &nexthop, uint32_t& count)
+{
+    return true;
+}
+
+void RouteOrch::doTask(Consumer& consumer)
+{
+}
+
+void RouteOrch::notifyNextHopChangeObservers(sai_object_id_t vrf_id, const IpPrefix &prefix, const NextHopGroupKey &nexthops, bool add)
+{
+}
+
+void RouteOrch::increaseNextHopRefCount(const NextHopGroupKey &nexthops)
+{
+}
+
+void RouteOrch::decreaseNextHopRefCount(const NextHopGroupKey &nexthops)
+{
+}
+
+bool RouteOrch::isRefCounterZero(const NextHopGroupKey &nexthops) const
+{
+    return true;
+}
+
+const NextHopGroupKey RouteOrch::getSyncdRouteNhgKey(sai_object_id_t vrf_id, const IpPrefix& ipPrefix)
+{
+    NextHopGroupKey nhg;
+    return nhg;
+}
+
+bool RouteOrch::createFineGrainedNextHopGroup(sai_object_id_t &next_hop_group_id, vector<sai_attribute_t> &nhg_attrs)
+{
+    return true;
+}
+
+bool RouteOrch::removeFineGrainedNextHopGroup(sai_object_id_t &next_hop_group_id)
+{
+    return true;
+}
+
+bool RouteOrch::addNextHopGroup(const NextHopGroupKey &nexthops)
+{
+    return true;
+}
+
+bool RouteOrch::removeNextHopGroup(const NextHopGroupKey &nexthops)
+{
+    return true;
+}
+
+void RouteOrch::addNextHopRoute(const NextHopKey& nextHop, const RouteKey& routeKey)
+{
+}
+
+void RouteOrch::removeNextHopRoute(const NextHopKey& nextHop, const RouteKey& routeKey)
+{
+}
+
+bool RouteOrch::updateNextHopRoutes(const NextHopKey& nextHop, uint32_t& numRoutes)
+{
+    return true;
+}
+
+bool RouteOrch::getRoutesForNexthop(std::set<RouteKey>& routeKeys, const NextHopKey& nexthopKey)
+{
+    return true;
+}
+
+void RouteOrch::addTempRoute(RouteBulkContext& ctx, const NextHopGroupKey &nextHops)
+{
+}
+
+bool RouteOrch::addRoute(RouteBulkContext& ctx, const NextHopGroupKey &nextHops)
+{
+    return true;
+}
+
+bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey &nextHops)
+{
+    return true;
+}
+
+bool RouteOrch::removeRoute(RouteBulkContext& ctx)
+{
+    return true;
+}
+
+bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
+{
+    return true;
+}
+
+bool RouteOrch::createRemoteVtep(sai_object_id_t vrf_id, const NextHopKey &nextHop)
+{
+    return true;
+}
+
+bool RouteOrch::deleteRemoteVtep(sai_object_id_t vrf_id, const NextHopKey &nextHop)
+{
+    return true;
+}
+
+bool RouteOrch::removeOverlayNextHops(sai_object_id_t vrf_id, const NextHopGroupKey &ol_nextHops)
+{
+    return true;
+}
+
+void RouteOrch::increaseNextHopGroupCount()
+{
+}
+
+void RouteOrch::decreaseNextHopGroupCount()
+{
+}
+
+bool RouteOrch::checkNextHopGroupCount()
+{
+    return true;
+}
+
+const NhgBase &RouteOrch::getNhg(const std::string &nhg_index)
+{
+    try
+    {
+        return gNhgOrch->getNhg(nhg_index);
+    }
+    catch (const std::out_of_range& e)
+    {
+        return gCbfNhgOrch->getNhg(nhg_index);
+    }
+}
+
+void RouteOrch::incNhgRefCount(const std::string &nhg_index)
+{
+}
+
+void RouteOrch::decNhgRefCount(const std::string &nhg_index)
+{
+}
+
+void RouteOrch::publishRouteState(const RouteBulkContext& ctx, const ReturnCode& status)
+{
+}
+
+inline bool RouteOrch::isVipRoute(const IpPrefix &ipPrefix, const NextHopGroupKey &nextHops)
+{
+    return true;
+}
+
+inline void RouteOrch::createVipRouteSubnetDecapTerm(const IpPrefix &ipPrefix)
+{
+}
+
+inline void RouteOrch::removeVipRouteSubnetDecapTerm(const IpPrefix &ipPrefix)
+{
+}

--- a/orchagent/p4orch/tests/fake_srv6orch.cpp
+++ b/orchagent/p4orch/tests/fake_srv6orch.cpp
@@ -1,0 +1,96 @@
+#include "srv6orch.h"
+
+void Srv6Orch::srv6TunnelUpdateNexthops(const string srv6_source, const NextHopKey nhkey, bool insert)
+{
+}
+
+size_t Srv6Orch::srv6TunnelNexthopSize(const string srv6_source)
+{
+    return 0;
+}
+
+bool Srv6Orch::createSrv6Tunnel(const string srv6_source)
+{
+    return true;
+}
+
+bool Srv6Orch::srv6NexthopExists(const NextHopKey &nhKey)
+{
+    return true;
+}
+
+bool Srv6Orch::removeSrv6Nexthops(const NextHopGroupKey &nhg)
+{
+    return true;
+}
+
+bool Srv6Orch::createSrv6Nexthop(const NextHopKey &nh)
+{
+    return true;
+}
+
+bool Srv6Orch::srv6Nexthops(const NextHopGroupKey &nhgKey, sai_object_id_t &nexthop_id)
+{
+    return true;
+}
+
+bool Srv6Orch::createUpdateSidList(const string sid_name, const string sid_list, const string sidlist_type)
+{
+    return true;
+}
+
+bool Srv6Orch::deleteSidList(const string sid_name)
+{
+    return true;
+}
+
+void Srv6Orch::doTaskSidTable(const KeyOpFieldsValuesTuple & tuple)
+{
+}
+
+bool Srv6Orch::mySidExists(string my_sid_string)
+{
+    return false;
+}
+
+void Srv6Orch::updateNeighbor(const NeighborUpdate& update)
+{
+}
+
+void Srv6Orch::update(SubjectType type, void *cntx)
+{
+}
+
+bool Srv6Orch::sidEntryEndpointBehavior(string action, sai_my_sid_entry_endpoint_behavior_t &end_behavior,
+                                        sai_my_sid_entry_endpoint_behavior_flavor_t &end_flavor)
+{
+    return true;
+}
+
+bool Srv6Orch::mySidVrfRequired(const sai_my_sid_entry_endpoint_behavior_t end_behavior)
+{
+    return false;
+}
+
+bool Srv6Orch::mySidNextHopRequired(const sai_my_sid_entry_endpoint_behavior_t end_behavior)
+{
+    return false;
+}
+
+bool Srv6Orch::createUpdateMysidEntry(string my_sid_string, const string dt_vrf, const string adj, const string end_action)
+{
+    return true;
+}
+
+bool Srv6Orch::deleteMysidEntry(const string my_sid_string)
+{
+    return true;
+}
+
+void Srv6Orch::doTaskMySidTable(const KeyOpFieldsValuesTuple & tuple)
+{
+}
+
+void Srv6Orch::doTask(Consumer &consumer)
+{
+}

--- a/orchagent/p4orch/tests/test_main.cpp
+++ b/orchagent/p4orch/tests/test_main.cpp
@@ -18,6 +18,14 @@ extern "C"
 #include "sai_serialize.h"
 #include "switchorch.h"
 #include "vrforch.h"
+#include "fdborch.h"
+#include "intfsorch.h"
+#include "neighorch.h"
+#include "fgnhgorch.h"
+#include "srv6orch.h"
+#include "routeorch.h"
+#include "nhgorch.h"
+#include "cbf/cbfnhgorch.h"
 #include "gtest/gtest.h"
 
 using ::testing::StrictMock;
@@ -51,12 +59,21 @@ CrmOrch *gCrmOrch;
 P4Orch *gP4Orch;
 VRFOrch *gVrfOrch;
 FlowCounterRouteOrch *gFlowCounterRouteOrch;
+FdbOrch *gFdbOrch;
+IntfsOrch *gIntfsOrch;
+NeighOrch *gNeighOrch;
+FgNhgOrch *gFgNhgOrch;
+Srv6Orch *gSrv6Orch;
+RouteOrch *gRouteOrch;
+NhgOrch *gNhgOrch;
+CbfNhgOrch *gCbfNhgOrch;
 SwitchOrch *gSwitchOrch;
 Directory<Orch *> gDirectory;
 swss::DBConnector *gAppDb;
 swss::DBConnector *gStateDb;
 swss::DBConnector *gConfigDb;
 swss::DBConnector *gCountersDb;
+swss::DBConnector *gChassisAppDb;
 MacAddress gVxlanMacAddress;
 
 sai_router_interface_api_t *sai_router_intfs_api;
@@ -76,6 +93,7 @@ sai_tunnel_api_t *sai_tunnel_api;
 sai_my_mac_api_t *sai_my_mac_api;
 sai_counter_api_t *sai_counter_api;
 sai_generic_programmable_api_t *sai_generic_programmable_api;
+sai_mpls_api_t* sai_mpls_api;
 
 task_process_status handleSaiCreateStatus(sai_api_t api, sai_status_t status, void *context)
 {
@@ -196,6 +214,7 @@ int main(int argc, char *argv[])
     sai_tunnel_api_t tunnel_api;
     sai_counter_api_t counter_api;
     sai_generic_programmable_api_t generic_programmable_api;
+    sai_mpls_api_t mpls_api;
     sai_router_intfs_api = &router_intfs_api;
     sai_neighbor_api = &neighbor_api;
     sai_next_hop_api = &next_hop_api;
@@ -213,21 +232,26 @@ int main(int argc, char *argv[])
     sai_tunnel_api = &tunnel_api;
     sai_counter_api = &counter_api;
     sai_generic_programmable_api = &generic_programmable_api;
+    sai_mpls_api = &mpls_api;
 
     swss::DBConnector appl_db("APPL_DB", 0);
     swss::DBConnector state_db("STATE_DB", 0);
     swss::DBConnector config_db("CONFIG_DB", 0);
     swss::DBConnector counters_db("COUNTERS_DB", 0);
+    swss::DBConnector chassis_app_db("CHASSIS_APP_DB", 0);
     gAppDb = &appl_db;
     gStateDb = &state_db;
     gConfigDb = &config_db;
     gCountersDb = &counters_db;
+    gChassisAppDb = &chassis_app_db;
+
     std::vector<table_name_with_pri_t> ports_tables;
     PortsOrch ports_orch(gAppDb, gStateDb, ports_tables, gAppDb);
     gPortsOrch = &ports_orch;
-    CrmOrch crm_orch(gConfigDb, CFG_CRM_TABLE_NAME);
 
+    CrmOrch crm_orch(gConfigDb, CFG_CRM_TABLE_NAME);
     gCrmOrch = &crm_orch;
+
     VRFOrch vrf_orch(gAppDb, APP_VRF_TABLE_NAME, gStateDb, STATE_VRF_OBJECT_TABLE_NAME);
     gVrfOrch = &vrf_orch;
     gDirectory.set(static_cast<VRFOrch *>(&vrf_orch));
@@ -235,6 +259,31 @@ int main(int argc, char *argv[])
     FlowCounterRouteOrch flow_counter_route_orch(gConfigDb, std::vector<std::string>{});
     gFlowCounterRouteOrch = &flow_counter_route_orch;
     gDirectory.set(static_cast<FlowCounterRouteOrch *>(&flow_counter_route_orch));
+
+    std::vector<table_name_with_pri_t> app_fdb_tables;
+    TableConnector stateDbFdb(gStateDb, STATE_FDB_TABLE_NAME);
+    TableConnector stateMclagDbFdb(gStateDb, STATE_MCLAG_REMOTE_FDB_TABLE_NAME);
+    FdbOrch fdb_orch(gAppDb, app_fdb_tables, stateDbFdb, stateMclagDbFdb, gPortsOrch);
+    gFdbOrch = &fdb_orch;
+
+    IntfsOrch intfs_orch(gAppDb, APP_INTF_TABLE_NAME, gVrfOrch, gChassisAppDb);
+    gIntfsOrch = &intfs_orch;
+
+    NeighOrch neigh_orch(gAppDb, APP_NEIGH_TABLE_NAME, gIntfsOrch, gFdbOrch, gPortsOrch, gChassisAppDb);
+    gNeighOrch = &neigh_orch;
+
+    std::vector<table_name_with_pri_t> fgnhg_tables;
+    FgNhgOrch fgnhg_orch(gConfigDb, gAppDb, gStateDb, fgnhg_tables, gNeighOrch, gIntfsOrch, gVrfOrch);
+    gFgNhgOrch = &fgnhg_orch;
+
+    std::vector<string> srv6_tables;
+    Srv6Orch srv6_orch(gAppDb, srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
+    gSrv6Orch = &srv6_orch;
+
+    std::vector<table_name_with_pri_t> route_tables;
+    RouteOrch route_orch(gAppDb, route_tables, gSwitchOrch, gNeighOrch, gIntfsOrch, gVrfOrch, gFgNhgOrch, gSrv6Orch);
+    gRouteOrch = &route_orch;
+    gDirectory.set(static_cast<RouteOrch *>(&route_orch));
 
     // Setup ports for all tests.
     SetupPorts();

--- a/orchagent/vrforch.cpp
+++ b/orchagent/vrforch.cpp
@@ -13,6 +13,7 @@
 #include "vxlanorch.h"
 #include "flowcounterrouteorch.h"
 #include "directory.h"
+#include "routeorch.h"
 
 using namespace std;
 using namespace swss;
@@ -23,6 +24,7 @@ extern sai_object_id_t gSwitchId;
 extern Directory<Orch*>      gDirectory;
 extern PortsOrch*            gPortsOrch;
 extern FlowCounterRouteOrch* gFlowCounterRouteOrch;
+extern RouteOrch*            gRouteOrch;
 
 bool VRFOrch::addOperation(const Request& request)
 {
@@ -104,6 +106,20 @@ bool VRFOrch::addOperation(const Request& request)
             }
         }
 
+        /* Add link-local fe80::/10 CPU route for the VRF. */
+        IpPrefix default_link_local_prefix("fe80::/10");
+        gRouteOrch->addLinkLocalRouteToMe(router_id, default_link_local_prefix);
+        SWSS_LOG_NOTICE("Created link local ipv6 route %s to cpu in VRF %s", default_link_local_prefix.to_string().c_str(), vrf_name.c_str());
+
+        /* All the interfaces have the same MAC address and hence the same
+         * auto-generated link-local ipv6 address with eui64 interface-id.
+         * Hence add a single /128 route entry for the link-local interface
+         * address pointing to the CPU port.
+         */
+        IpPrefix linklocal_prefix = gRouteOrch->getLinkLocalEui64Addr();
+        gRouteOrch->addLinkLocalRouteToMe(router_id, linklocal_prefix);
+        SWSS_LOG_NOTICE("Created link local ipv6 route %s to cpu in VRF %s", linklocal_prefix.to_string().c_str(), vrf_name.c_str());
+
         vrf_table_[vrf_name].vrf_id = router_id;
         vrf_table_[vrf_name].ref_count = 0;
         vrf_id_table_[router_id] = vrf_name;
@@ -170,6 +186,17 @@ bool VRFOrch::delOperation(const Request& request)
         return false;
 
     sai_object_id_t router_id = vrf_table_[vrf_name].vrf_id;
+
+    /* Delete link-local ipv6 address with eui64 /128 CPU route for the VRF. */
+    IpPrefix linklocal_prefix = gRouteOrch->getLinkLocalEui64Addr();
+    gRouteOrch->delLinkLocalRouteToMe(router_id, linklocal_prefix);
+    SWSS_LOG_NOTICE("Deleted link local ipv6 route %s to cpu in VRF %s", linklocal_prefix.to_string().c_str(), vrf_name.c_str());
+
+    /* Delete link-local fe80::/10 CPU route for the VRF. */
+    IpPrefix default_link_local_prefix("fe80::/10");
+    gRouteOrch->delLinkLocalRouteToMe(router_id, default_link_local_prefix);
+    SWSS_LOG_NOTICE("Deleted link local ipv6 route %s to cpu in VRF %s", default_link_local_prefix.to_string().c_str(), vrf_name.c_str());
+
     sai_status_t status = sai_virtual_router_api->remove_virtual_router(router_id);
     if (status != SAI_STATUS_SUCCESS)
     {


### PR DESCRIPTION
#### What I did
Add/Delete IPv6 link-local route to me in VRF when VRF add/delete to trap packet to CPU

#### Why I did it
The IPv6 link-local address can't work in VRF.
The packet which ip destination is IPv6 link-local address would be dropped.
The root cause is that there is not route to me for the IPv6 link-local address on VRF

#### How to verify it
Ping the IPv6 link-local address of DUT via the interface which is added in VRF