### PR TITLE
Add argument parsing to mock_tests to enable SWSS debugs

### DIFF
--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -25,7 +25,8 @@ LDADD_GTEST = -L/usr/src/gtest
 
 tests_INCLUDES = -I $(FLEX_CTR_DIR) -I $(DEBUG_CTR_DIR) -I $(top_srcdir)/lib -I$(top_srcdir)/cfgmgr -I$(top_srcdir)/orchagent -I$(P4_ORCH_DIR)/tests -I$(DASH_ORCH_DIR) -I$(top_srcdir)/warmrestart
 
-tests_SOURCES = aclorch_ut.cpp \
+tests_SOURCES = swss_ut_main.cpp \
+		aclorch_ut.cpp \
                 portsorch_ut.cpp \
                 routeorch_ut.cpp \
                 qosorch_ut.cpp \
@@ -164,11 +165,12 @@ tests_SOURCES += $(P4_ORCH_DIR)/p4orch.cpp \
 tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
 tests_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_INCLUDES)
 tests_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis -lpthread \
-        -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lgmock -lgmock_main -lprotobuf -ldashapi
+        -lswsscommon -lswsscommon -lgtest -lzmq -lnl-3 -lnl-route-3 -lgmock -lprotobuf -ldashapi -lboost_program_options
 
 ## portsyncd unit tests
 
-tests_portsyncd_SOURCES = portsyncd/portsyncd_ut.cpp \
+tests_portsyncd_SOURCES = swss_ut_main.cpp \
+			  portsyncd/portsyncd_ut.cpp \
                           $(top_srcdir)/lib/recorder.cpp \
                           $(top_srcdir)/portsyncd/linksync.cpp \
                           mock_dbconnector.cpp \
@@ -182,11 +184,12 @@ tests_portsyncd_CXXFLAGS = -Wl,-wrap,if_nameindex -Wl,-wrap,if_freenameindex
 tests_portsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST)
 tests_portsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(tests_portsyncd_INCLUDES)
 tests_portsyncd_LDADD = $(LDADD_GTEST) -lnl-genl-3 -lhiredis -lhiredis \
-        -lswsscommon -lswsscommon -lgtest -lgtest_main -lnl-3 -lnl-route-3 -lpthread
+        -lswsscommon -lswsscommon -lgtest -lgmock -lnl-3 -lnl-route-3 -lpthread -lboost_program_options
 
 ## intfmgrd unit tests
 
-tests_intfmgrd_SOURCES = intfmgrd/intfmgr_ut.cpp \
+tests_intfmgrd_SOURCES = swss_ut_main.cpp \
+			 intfmgrd/intfmgr_ut.cpp \
                          $(top_srcdir)/cfgmgr/intfmgr.cpp \
                          $(top_srcdir)/lib/subintf.cpp \
                          $(top_srcdir)/lib/recorder.cpp \
@@ -204,11 +207,12 @@ tests_intfmgrd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/cfgmgr -I$(top_srcdi
 tests_intfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
 tests_intfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_intfmgrd_INCLUDES)
 tests_intfmgrd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
-        -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lgmock_main
+        -lswsscommon -lswsscommon -lgtest -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lboost_program_options
 
 ## teammgrd unit tests
 
-tests_teammgrd_SOURCES = teammgrd/teammgr_ut.cpp \
+tests_teammgrd_SOURCES = swss_ut_main.cpp \
+			 teammgrd/teammgr_ut.cpp \
                          $(top_srcdir)/cfgmgr/teammgr.cpp \
                          $(top_srcdir)/lib/subintf.cpp \
                          $(top_srcdir)/lib/recorder.cpp \
@@ -226,11 +230,12 @@ tests_teammgrd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/cfgmgr -I$(top_srcdi
 tests_teammgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
 tests_teammgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_teammgrd_INCLUDES)
 tests_teammgrd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
-        -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lgmock_main
+        -lswsscommon -lswsscommon -lgtest -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lboost_program_options
 
 ## fpmsyncd unit tests
 
-tests_fpmsyncd_SOURCES = fpmsyncd/test_fpmlink.cpp \
+tests_fpmsyncd_SOURCES = swss_ut_main.cpp \
+			 fpmsyncd/test_fpmlink.cpp \
                          fpmsyncd/test_routesync.cpp \
                          fake_netlink.cpp \
                          fake_warmstarthelper.cpp \
@@ -246,11 +251,12 @@ tests_fpmsyncd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/tests_fpmsyncd -I$(t
 tests_fpmsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
 tests_fpmsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_fpmsyncd_INCLUDES)
 tests_fpmsyncd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
-        -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lgmock_main
+        -lswsscommon -lswsscommon -lgtest -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lboost_program_options
 
 ## response publisher unit tests
 
-tests_response_publisher_SOURCES = response_publisher/response_publisher_ut.cpp \
+tests_response_publisher_SOURCES = swss_ut_main.cpp \
+				   response_publisher/response_publisher_ut.cpp \
                                    $(top_srcdir)/orchagent/response_publisher.cpp \
                                    $(top_srcdir)/lib/recorder.cpp \
                                    mock_orchagent_main.cpp \
@@ -263,5 +269,5 @@ tests_response_publisher_INCLUDES = $(tests_INCLUDES)
 tests_response_publisher_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
 tests_response_publisher_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_response_publisher_INCLUDES)
 tests_response_publisher_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
-        -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread
+        -lswsscommon -lswsscommon -lgtest -lgmock -lzmq -lnl-3 -lnl-route-3 -lpthread -lboost_program_options
 

--- a/tests/mock_tests/swss_ut_main.cpp
+++ b/tests/mock_tests/swss_ut_main.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Cisco Systems.  The term "Cisco Systems" refers to Cisco Systems Inc.
+ * and/or its subsidiaries.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <boost/program_options.hpp>
+
+#include "logger.h"
+
+namespace po = boost::program_options;
+using namespace std;
+
+void parseArgs(int argc, char **argv)
+{
+    try {
+        string swss_log_level;
+        string swss_log_location;
+        po::options_description log_desc("Supported logging options");
+        log_desc.add_options()
+            ("help", "Display program help")
+            ("swss-log-level,l", po::value<string>(&swss_log_level)->default_value("NOTICE"),
+             "Sets the SWSS logging level. Supported levels are: "
+             "EMERG, ALERT, CRIT, ERROR, WARN, NOTICE, INFO, DEBUG")
+            ("swss-log-output", po::value<string>(&swss_log_location)->default_value("SYSLOG"),
+             "Sends SWSS logs to the desired output stream. Supported locations are: SYSLOG, STDOUT, STDERR")
+        ;
+
+        po::variables_map vm;
+        po::store(po::command_line_parser(argc, argv).options(log_desc).allow_unregistered().run(), vm);
+        po::notify(vm);
+
+        if (vm.count("help")) {
+            cout << log_desc << "\n";
+        }
+
+        swss::Logger::getInstance().swssPrioNotify("UT", swss_log_level);
+        swss::Logger::getInstance().swssOutputNotify("UT", swss_log_location);
+    } catch (exception &e) {
+        cerr << "Error while parsing arguments: " << e.what() << "\n";
+    }
+}
+
+int main(int argc, char **argv)
+{
+    parseArgs(argc, argv);
+    testing::InitGoogleMock(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added new program options to the SWSS Mock Tests to enable dumping SWSS debugs:
```
Supported logging options:                                                         
  --help                                Display program help
  -l [ --swss-log-level ] arg (=NOTICE) Sets the SWSS logging level. Supported 
                                        levels are: EMERG, ALERT, CRIT, ERROR, 
                                        WARN, NOTICE, INFO, DEBUG
  --swss-log-output                     Sends SWSS logs to stdout
```

**Why I did it**
- Debugging without the logs is painful

**How I verified it**
- `./tests --help`:
```
Supported logging options:     
  --help                                Display program help
  -l [ --swss-log-level ] arg (=NOTICE) Sets the SWSS logging level. Supported 
                                        levels are: EMERG, ALERT, CRIT, ERROR, 
                                        WARN, NOTICE, INFO, DEBUG           
  --swss-log-output arg (=SYSLOG)       Sends SWSS logs to the desired output 
                                        stream. Supported locations are: 
                                        SYSLOG, STDOUT, STDERR

This program contains tests written using Google Test. You can use the
following command line flags to control its behavior:

<snip>
```

- `./tests --swss-log-level DEBUG --swss-log-output STDOUT --gtest_filter=RouteOrch*`:
```
NOTICE:- doTask: Route 10.10.10.10/32: resize ipv to match alsv, 0 -> 1.
NOTICE:- doTask: Route 10.10.10.10/32: set the empty nexthop ip to zero.
  INFO:- create_entry: EntityBulker.create_entry 1, 1, 1

  WARN:- doTask: Route 192.168.0.1/32 is received on non L3 VNI 5000
  INFO:- flush_creating_entries: EntityBulker.flush creating_entries 1

  INFO:- increaseRouterIntfsRefCount: Router interface Ethernet0 ref count is increased to 5
  INFO:- addRoutePost: Post create route 10.10.10.10/32 with next hop(s) 0.0.0.0@Ethernet0
  INFO:- isMuxNexthops: No mux nexthop found
NOTICE:- uninitialize: begin
NOTICE:- uninitialize: stopping threads
NOTICE:- stopUnittestThread: begin
NOTICE:- unittestChannelThreadProc: exit VS unittest channel thread
NOTICE:- stopUnittestThread: end
NOTICE:- stopFdbAgingThread: begin
NOTICE:- fdbAgingThreadProc: end
[Thread 0x7ffff5d89700 (LWP 47996) exited]
NOTICE:- stopFdbAgingThread: end
NOTICE:- stopEventQueueThread: begin
NOTICE:- processQueueEvent: received EVENT_TYPE_END_THREAD, will process all messages and end
[Thread 0x7ffff658a700 (LWP 47997) exited]
NOTICE:- stopEventQueueThread: end
[Thread 0x7ffff6d8b700 (LWP 47995) exited]
NOTICE:- ~SwitchState: begin
NOTICE:- ~SwitchState: switch oid:0x2100000000
NOTICE:- ~SwitchState: end
NOTICE:- uninitialize: end                                                                                                        
```