### PR TITLE
[Chassis][LAG_ID] Address the same lagid been used in two different LCs issue

### DIFF
--- a/orchagent/lagids.lua
+++ b/orchagent/lagids.lua
@@ -40,42 +40,45 @@ if op == "add" then
         -- If proposed lagid is not available, lpop the first availabe ID
         local index = redis.call("lpos", "SYSTEM_LAG_IDS_FREE_LIST", tostring(plagid))
         if index == false then
+            if redis.call("llen", "SYSTEM_LAG_IDS_FREE_LIST") <= 0 then
+                return -1
+            end
             local lagid = redis.call("lpop", "SYSTEM_LAG_IDS_FREE_LIST")
             redis.call("hset", "SYSTEM_LAG_ID_TABLE", pcname, lagid)
             redis.call("sadd", "SYSTEM_LAG_ID_SET", lagid)
             if dblagid then
-               redis.call("srem", "SYSTEM_LAG_ID_SET", tostring(dblagid))
-               if redis.call("lpos", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid)) == false then
-                  redis.call("rpush", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid))
-               end
+                redis.call("srem", "SYSTEM_LAG_ID_SET", tostring(dblagid))
+                if redis.call("lpos", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid)) == false then
+                    redis.call("rpush", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid))
+                end
             end
             return tonumber(lagid)
         else
-           redis.call("lrem", "SYSTEM_LAG_IDS_FREE_LIST", 1, tostring(plagid))
-           redis.call("hset", "SYSTEM_LAG_ID_TABLE", pcname, tostring(plagid))
-           redis.call("sadd", "SYSTEM_LAG_ID_SET", tostring(plagid))
-           if dblagid then
-              redis.call("srem", "SYSTEM_LAG_ID_SET", tostring(dblagid))
-              if redis.call("lpos", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid)) == false then
-                 redis.call("rpush", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid))
-              end
-           end
-           return plagid
+            redis.call("lrem", "SYSTEM_LAG_IDS_FREE_LIST", 1, tostring(plagid))
+            redis.call("hset", "SYSTEM_LAG_ID_TABLE", pcname, tostring(plagid))
+            redis.call("sadd", "SYSTEM_LAG_ID_SET", tostring(plagid))
+            if dblagid then
+                redis.call("srem", "SYSTEM_LAG_ID_SET", tostring(dblagid))
+                if redis.call("lpos", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid)) == false then
+                    redis.call("rpush", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid))
+               end
+            end
+            return plagid
         end
     else
+        if redis.call("llen", "SYSTEM_LAG_IDS_FREE_LIST") <= 0 then
+            return -1
+        end
         local lagid = redis.call("lpop", "SYSTEM_LAG_IDS_FREE_LIST")
         redis.call("hset", "SYSTEM_LAG_ID_TABLE", pcname, lagid)
         redis.call("sadd", "SYSTEM_LAG_ID_SET", lagid)
         if dblagid then
-           if redis.call("lpos", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid)) == false then
-              redis.call("rpush", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid))
-           end
+            if redis.call("lpos", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid)) == false then
+                redis.call("rpush", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid))
+            end
         end
         return tonumber(lagid) 
     end
-
-    return -1
-
 end
 
 if op == "del" then

--- a/orchagent/lagids.lua
+++ b/orchagent/lagids.lua
@@ -37,24 +37,41 @@ if op == "add" then
         end
         -- proposed lag id is different than that in database OR
         -- the portchannel does not exist in the database
-        -- If proposed lagid is available, return the same proposed lag id
-        if redis.call("sismember", "SYSTEM_LAG_ID_SET", tostring(plagid)) == 0 then
-            redis.call("sadd", "SYSTEM_LAG_ID_SET", tostring(plagid))
-            redis.call("srem", "SYSTEM_LAG_ID_SET", tostring(dblagid))
-            redis.call("hset", "SYSTEM_LAG_ID_TABLE", pcname, tostring(plagid))
-            return plagid
+        -- If proposed lagid is not available, lpop the first availabe ID
+        local index = redis.call("lpos", "SYSTEM_LAG_IDS_FREE_LIST", tostring(plagid))
+        if index == false then
+            local lagid = redis.call("lpop", "SYSTEM_LAG_IDS_FREE_LIST")
+            redis.call("hset", "SYSTEM_LAG_ID_TABLE", pcname, lagid)
+            redis.call("sadd", "SYSTEM_LAG_ID_SET", lagid)
+            if dblagid then
+               redis.call("srem", "SYSTEM_LAG_ID_SET", tostring(dblagid))
+               if redis.call("lpos", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid)) == false then
+                  redis.call("rpush", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid))
+               end
+            end
+            return tonumber(lagid)
+        else
+           redis.call("lrem", "SYSTEM_LAG_IDS_FREE_LIST", 1, tostring(plagid))
+           redis.call("hset", "SYSTEM_LAG_ID_TABLE", pcname, tostring(plagid))
+           redis.call("sadd", "SYSTEM_LAG_ID_SET", tostring(plagid))
+           if dblagid then
+              redis.call("srem", "SYSTEM_LAG_ID_SET", tostring(dblagid))
+              if redis.call("lpos", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid)) == false then
+                 redis.call("rpush", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid))
+              end
+           end
+           return plagid
         end
-    end
-
-    local lagid = lagid_start
-    while lagid <= lagid_end do
-        if redis.call("sismember", "SYSTEM_LAG_ID_SET", tostring(lagid)) == 0 then
-            redis.call("sadd", "SYSTEM_LAG_ID_SET", tostring(lagid))
-            redis.call("srem", "SYSTEM_LAG_ID_SET", tostring(dblagid))
-            redis.call("hset", "SYSTEM_LAG_ID_TABLE", pcname, tostring(lagid))
-            return lagid
+    else
+        local lagid = redis.call("lpop", "SYSTEM_LAG_IDS_FREE_LIST")
+        redis.call("hset", "SYSTEM_LAG_ID_TABLE", pcname, lagid)
+        redis.call("sadd", "SYSTEM_LAG_ID_SET", lagid)
+        if dblagid then
+           if redis.call("lpos", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid)) == false then
+              redis.call("rpush", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid))
+           end
         end
-        lagid = lagid + 1
+        return tonumber(lagid) 
     end
 
     return -1
@@ -67,6 +84,9 @@ if op == "del" then
         local lagid = redis.call("hget", "SYSTEM_LAG_ID_TABLE", pcname)
         redis.call("srem", "SYSTEM_LAG_ID_SET", lagid)
         redis.call("hdel", "SYSTEM_LAG_ID_TABLE", pcname)
+        if redis.call("lpos", "SYSTEM_LAG_IDS_FREE_LIST", lagid) == false then
+           redis.call("rpush", "SYSTEM_LAG_IDS_FREE_LIST", lagid)
+        end
         return tonumber(lagid)
     end
 

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -27,8 +27,8 @@ class TestVirtualChassis(object):
                 chassis_app_db = DVSDatabase(swsscommon.CHASSIS_APP_DB, dvs.redis_chassis_sock)
                 chassis_app_db.db_connection.set("SYSTEM_LAG_ID_START", "1")
                 chassis_app_db.db_connection.set("SYSTEM_LAG_ID_END", "2")
-                chassis_app_db_db_connection.rpush("SYSTEM_LAG_IDS_FREE_LIST", "1")
-                chassis_app_db_db_connection.rpush("SYSTEM_LAG_IDS_FREE_LIST", "2")
+                chassis_app_db.db_connection.rpush("SYSTEM_LAG_IDS_FREE_LIST", "1")
+                chassis_app_db.db_connection.rpush("SYSTEM_LAG_IDS_FREE_LIST", "2")
                 break
             
     def config_inbandif_port(self, vct, ibport):

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -27,6 +27,8 @@ class TestVirtualChassis(object):
                 chassis_app_db = DVSDatabase(swsscommon.CHASSIS_APP_DB, dvs.redis_chassis_sock)
                 chassis_app_db.db_connection.set("SYSTEM_LAG_ID_START", "1")
                 chassis_app_db.db_connection.set("SYSTEM_LAG_ID_END", "2")
+                chassis_app_db_db_connection.rpush("SYSTEM_LAG_IDS_FREE_LIST", "1")
+                chassis_app_db_db_connection.rpush("SYSTEM_LAG_IDS_FREE_LIST", "2")
                 break
             
     def config_inbandif_port(self, vct, ibport):


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Create SYSTEM_LAG_IDS_FREE_LIST for assign lagId for all portchannel creation.  
1)  Portchannel creation
   a)  If Portchannel is created with a valid plagid
        *  check if plagid is in free list, use plagid and remove it from SYSTEM_LAG_IDS_FREE_LIST.  Add this lagid to the SYSTEM_LAG_ID_SET for debug info
        * If plagid is not in the FREE_LIST,  lpop and use the first lagid from the SYSTEM_LAG_IDS_FREE_LIST.  Add this lagid to the SYSTEM_LAG_ID_SET for debug info
   b) If Portchannel is created with invalid plagid or without any lagid
       * lpop and use the first lagid from the SYSTEM_LAG_IDS_FREE_LIST.  Add this lagid to the SYSTEM_LAG_ID_SET for debug info  
2) Portchannel delection
    * Append the lagid to the end of SYSTEM_LAG_IDS_FREE_LIST.  Also remove it from SYSTEM_LAG_ID_SET.

This PR works with the following 2 PRs:
https://github.com/sonic-net/sonic-platform-daemons/pull/542
https://github.com/sonic-net/sonic-buildimage/pull/20369

Based on the dependency, the below order to merge these 3 PRs can help to avoid breaking the image run:
First:  PR https://github.com/sonic-net/sonic-buildimage/pull/20369
second: PR https://github.com/sonic-net/sonic-swss/pull/3303 (This PR)
Third: PR https://github.com/sonic-net/sonic-platform-daemons/pull/542

**Why I did it**
To address the issue of the same lagid could be used by two Portchannels in two different linecards.  This issue occurs when reboot many Linecards  together with 20 seconds delay in each LC reboot. 
 
**How I verified it**

**Details if related**
