### PR TITLE
Fix portmgr write partial port config to app DB issue.

### DIFF
--- a/cfgmgr/portmgr.cpp
+++ b/cfgmgr/portmgr.cpp
@@ -192,6 +192,15 @@ void PortMgr::doTask(Consumer &consumer)
                 }
             }
 
+            if (!portOk)
+            {
+                // Port configuration is handled by the orchagent. If the configuration is written to the APP DB using
+                // multiple Redis write commands, the orchagent may receive a partial configuration and create a port
+                // with incorrect settings.
+                field_values.emplace_back("mtu", mtu);
+                field_values.emplace_back("admin_status", admin_status);
+            }
+
             if (field_values.size())
             {
                 writeConfigToAppDb(alias, field_values);
@@ -201,8 +210,6 @@ void PortMgr::doTask(Consumer &consumer)
             {
                 SWSS_LOG_INFO("Port %s is not ready, pending...", alias.c_str());
 
-                writeConfigToAppDb(alias, "mtu", mtu);
-                writeConfigToAppDb(alias, "admin_status", admin_status);
                 /* Retry setting these params after the netdev is created */
                 field_values.clear();
                 field_values.emplace_back("mtu", mtu);


### PR DESCRIPTION
Fix portmgr write partial port config to app DB issue.

#### Why I did it
Test case test_add_remove_neg_admin_status unstable.

##### Work item tracking

#### How I did it
Improve portmgr code to write all port config with one API call.

#### How to verify it
Pass all UT.
Manually verify issue fixed.


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Fix portmgr write partial port config to app DB issue.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

