### PR TITLE
Fix the issue where the test case randomly fails due to not waiting after updating the config DB.

### DIFF
--- a/tests/dash/dash_db.py
+++ b/tests/dash/dash_db.py
@@ -59,11 +59,11 @@ class ProducerStateTable(swsscommon.ProducerStateTable):
         for k, v in pairs:
             pairs_str.append((to_string(k), to_string(v)))
         self.set(key, pairs_str)
-        time.sleep(3)
+        time.sleep(1)
 
     def __delitem__(self, key: str):
         self.delete(str(key))
-        time.sleep(3)
+        time.sleep(1)
 
 
 class Table(swsscommon.Table):

--- a/tests/dash/dash_db.py
+++ b/tests/dash/dash_db.py
@@ -2,6 +2,7 @@ from swsscommon import swsscommon
 from dvslib.dvs_common import wait_for_result
 import typing
 import pytest
+import time
 
 from dash_api.appliance_pb2 import *
 from dash_api.vnet_pb2 import *
@@ -58,9 +59,11 @@ class ProducerStateTable(swsscommon.ProducerStateTable):
         for k, v in pairs:
             pairs_str.append((to_string(k), to_string(v)))
         self.set(key, pairs_str)
+        time.sleep(3)
 
     def __delitem__(self, key: str):
         self.delete(str(key))
+        time.sleep(3)
 
 
 class Table(swsscommon.Table):

--- a/tests/dash/test_dash_acl.py
+++ b/tests/dash/test_dash_acl.py
@@ -87,10 +87,12 @@ class ProduceStateTable(object):
             pairs_str.append((to_string(k), to_string(v)))
         self.table.set(key, pairs_str)
         self.keys.add(key)
+        time.sleep(3)
 
     def __delitem__(self, key: str):
         self.table.delete(str(key))
         self.keys.discard(key)
+        time.sleep(3)
 
     def get_keys(self):
         return self.keys

--- a/tests/dash/test_dash_acl.py
+++ b/tests/dash/test_dash_acl.py
@@ -87,12 +87,12 @@ class ProduceStateTable(object):
             pairs_str.append((to_string(k), to_string(v)))
         self.table.set(key, pairs_str)
         self.keys.add(key)
-        time.sleep(3)
+        time.sleep(1)
 
     def __delitem__(self, key: str):
         self.table.delete(str(key))
         self.keys.discard(key)
-        time.sleep(3)
+        time.sleep(1)
 
     def get_keys(self):
         return self.keys

--- a/tests/dvslib/dvs_hash.py
+++ b/tests/dvslib/dvs_hash.py
@@ -1,5 +1,6 @@
 """Utilities for interacting with HASH objects when writing VS tests."""
 from typing import Dict, List
+import time
 
 
 class DVSHash:
@@ -21,6 +22,7 @@ class DVSHash:
     ) -> None:
         """Update switch hash global in Config DB."""
         self.config_db.update_entry(self.CDB_SWITCH_HASH, self.KEY_SWITCH_HASH_GLOBAL, qualifiers)
+        time.sleep(1)
 
     def get_hash_ids(
         self,

--- a/tests/test_ipv6_link_local.py
+++ b/tests/test_ipv6_link_local.py
@@ -59,10 +59,10 @@ class TestIPv6LinkLocal(object):
         time.sleep(2)
 
         # Neigh entries should contain Ipv6-link-local neighbors, should be 4
-        neigh_entries = self.pdb.get_keys("NEIGH_TABLE")
-        assert (len(neigh_entries) == 4)
+        self.pdb.wait_for_n_keys("NEIGH_TABLE", 4)
 
         found_entry = False
+        neigh_entries = self.pdb.get_keys("NEIGH_TABLE")
         for key in neigh_entries:
             if (key.find("Ethernet4:2001::2") or key.find("Ethernet0:2000::2")):
                 found_entry = True


### PR DESCRIPTION
Fix the issue where the test case randomly fails due to not waiting after updating the config DB.

#### Why I did it
Some test case randomly fails due to not waiting after updating the config DB.

##### Work item tracking

#### How I did it
Add few seconds wait after update config DB.

#### How to verify it
Pass all UT.
Manually verify issue fixed.


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->


#### Description for the changelog
Fix the issue where the test case randomly fails due to not waiting after updating the config DB.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

