### PR TITLE
[subport] Allow to add Subport without vlan argument

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1449,13 +1449,21 @@ bool PortsOrch::addSubPort(Port &port, const string &alias, const string &vlan, 
     subIntf subIf(alias);
     string parentAlias = subIf.parentIntf();
     sai_vlan_id_t vlan_id;
+
     try
     {
-        vlan_id = static_cast<sai_vlan_id_t>(stoul(vlan));
+        if (vlan.empty())
+        {
+            vlan_id = static_cast<sai_vlan_id_t>(subIf.subIntfIdx());
+        }
+        else
+        {
+            vlan_id = static_cast<sai_vlan_id_t>(stoul(vlan));
+        }
     }
     catch (const std::invalid_argument &e)
     {
-        SWSS_LOG_ERROR("Invalid argument %s to %s()", vlan.c_str(), e.what());
+        SWSS_LOG_ERROR("Invalid arguments alias %s or vlan %s to %s()", alias.c_str(), vlan.c_str(), e.what());
         return false;
     }
     catch (const std::out_of_range &e)


### PR DESCRIPTION
**What I did**
Allow to add Subport without vlan argument

**Why I did it**
The alias of subport already contains the VLAN ID information. If no vlan be specified in the input argument, it would use the vlan in the alias as the vlan id

**How I verified it**
Use swssconfig to generate config to make sure the subport be created

**Details if related**
