### PR TITLE
[tests] Attempt to fix compatibility break from SAI headers

### DIFF
--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -656,6 +656,7 @@ namespace portsorch_test
             mockReply->element[2] = (redisReply *)calloc(sizeof(redisReply), 1);
             mockReply->element[2]->type = REDIS_REPLY_STRING;
             sai_port_oper_status_notification_t port_oper_status;
+            memset(&port_oper_status, 0, sizeof(port_oper_status));
             port_oper_status.port_state = oper_status;
             port_oper_status.port_id = port.m_port_id;
             std::string data = sai_serialize_port_oper_status_ntf(1, &port_oper_status);

--- a/tests/mock_tests/switchorch_ut.cpp
+++ b/tests/mock_tests/switchorch_ut.cpp
@@ -292,7 +292,9 @@ namespace switchorch_test
         initSwitchOrch();
 
         sai_timespec_t timestamp = {.tv_sec = 1701160447, .tv_nsec = 538710245};
-        sai_switch_health_data_t data = {.data_type = SAI_HEALTH_DATA_TYPE_GENERAL};
+        sai_switch_health_data_t data;
+        memset(&data, 0, sizeof(data));
+        data.data_type = SAI_HEALTH_DATA_TYPE_GENERAL;
         vector<uint8_t> data_from_sai({100, 101, 115, 99, 114, 105, 112, 116, 105, 245, 111, 110, 245, 10, 123, 125, 100, 100});
         sai_u8_list_t description;
         description.list = data_from_sai.data();


### PR DESCRIPTION
Error is show up when we move  sai headers from v1.14 to v1.15

https://github.com/sonic-net/sonic-sairedis/pull/1431#issuecomment-2405924026

**What I did**
Fix tests so they can pass during backward compatibility break

**Why I did it**
because of breaking change in SAI headers, g++ requires all struct fields to be populated:
```
g++ -DHAVE_CONFIG_H -I. -I../..  -g -DNDEBUG  -std=c++14 -Wall ...... echo './'`warmrestarthelper_ut.cpp
switchorch_ut.cpp: In member function 'virtual void switchorch_test::SwitchOrchTest_SwitchOrchTestHandleEvent_Test::TestBody()':
switchorch_ut.cpp:295:83: error: missing initializer for member '_sai_switch_health_data_t::data' [-Werror=missing-field-initializers]
  295 |         sai_switch_health_data_t data = {.data_type = SAI_HEALTH_DATA_TYPE_GENERAL};
      |         
```

**How I verified it**
Local build

**Details if related**
