### PR TITLE
Fix Voq chassis orchagent crash with 34K routes

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -1750,6 +1750,15 @@ void NeighOrch::doVoqSystemNeighTask(Consumer &consumer)
                 it++;
                 continue;
             }
+            if (m_syncdNeighbors.find(neighbor_entry) == m_syncdNeighbors.end())
+            {
+                NextHopKey nexthop = { ip_address, ibif.m_alias};
+                if (hasNextHop(nexthop))
+                {
+                   it++;
+                   continue;
+                }
+            }
 
             if (m_syncdNeighbors.find(neighbor_entry) == m_syncdNeighbors.end() ||
                     m_syncdNeighbors[neighbor_entry].mac != mac_address ||

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -1755,8 +1755,8 @@ void NeighOrch::doVoqSystemNeighTask(Consumer &consumer)
                 NextHopKey nexthop = { ip_address, ibif.m_alias};
                 if (hasNextHop(nexthop))
                 {
-                   it++;
-                   continue;
+                    it++;
+                    continue;
                 }
             }
 

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -1122,6 +1122,114 @@ class TestVirtualChassis(object):
 
         # Cleanup inband if configuration
         self.del_inbandif_port(vct, inband_port)
+        self.configure_neighbor(local_lc_dvs, "del", test_neigh_ip_2, test_neigh_mac_2, test_neigh_dev_2)
+
+
+    def test_remote_neighbor_add(self, vct):
+        # test params
+        local_lc_switch_id = '0'
+        remote_lc_switch_id = '2'
+        test_prefix = "14.14.0.0/16"
+        inband_port = "Ethernet0"
+        test_neigh_ip_1 = "10.8.104.50"
+        test_neigh_dev_1 = "Ethernet4"
+        test_neigh_mac_1 = "00:09:03:04:05:06"
+        test_neigh_dev_2 = "Ethernet8"
+
+        local_lc_dvs = self.get_lc_dvs(vct, local_lc_switch_id)
+        remote_lc_dvs = self.get_lc_dvs(vct, remote_lc_switch_id)
+
+        # config inband port
+        self.config_inbandif_port(vct, inband_port)
+
+        # add neighbor
+        self.configure_neighbor(local_lc_dvs, "add", test_neigh_ip_1, test_neigh_mac_1, test_neigh_dev_1)
+
+        time.sleep(10)
+
+        asic_db = remote_lc_dvs.get_asic_db()
+        asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY", 1)
+        neighkeys = asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY")
+        assert len(neighkeys), "No neigh entries in ASIC_DB"
+
+        # Check for presence of the remote neighbor in ASIC_DB
+        remote_neigh = ""
+        for nkey in neighkeys:
+            ne = ast.literal_eval(nkey)
+            if ne['ip'] == test_neigh_ip_1:
+               remote_neigh = nkey
+               break
+
+        assert remote_neigh != "", "Remote neigh not found in ASIC_DB"
+
+        # Preserve remote neigh asic db neigh key for delete verification later
+        test_remote_neigh_asic_db_key = remote_neigh
+
+        asic_db = remote_lc_dvs.get_asic_db()
+        nexthop_keys = asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP", 1)
+        assert len(nexthop_keys), "No Nexthop entries in ASIC_DB"
+
+        nexthop_entry = asic_db.get_entry("ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP", nexthop_keys[0])
+        ip = nexthop_entry.get("SAI_NEXT_HOP_ATTR_IP")
+        assert ip != "", "Ip address not found for nexthop entry in asic db"
+
+        # add route of LC1(pretend learnt via bgp)
+        _, res = remote_lc_dvs.runcmd(['sh', '-c', f"ip route add {test_prefix} nexthop via {test_neigh_ip_1}"])
+        assert res == "", "Error configuring route"
+        time.sleep(5)
+
+        # del neighbor on first port and add it on second port
+        self.configure_neighbor(local_lc_dvs, "del", test_neigh_ip_1, test_neigh_mac_1, test_neigh_dev_1)
+        time.sleep(5)
+        self.configure_neighbor(local_lc_dvs, "add", test_neigh_ip_1, test_neigh_mac_1, test_neigh_dev_2)
+
+        time.sleep(10)
+
+        asic_db = remote_lc_dvs.get_asic_db()
+        asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY", 1)
+        neighkeys = asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY")
+        assert len(neighkeys), "No neigh entries in ASIC_DB"
+
+        # Check for presence of the remote neighbor in ASIC_DB
+        remote_neigh = ""
+        for nkey in neighkeys:
+            ne = ast.literal_eval(nkey)
+            if ne['ip'] == test_neigh_ip_1:
+               remote_neigh = nkey
+               break
+
+        assert remote_neigh != "", "Remote neigh not found in ASIC_DB"
+
+        #del the route
+        _, res = remote_lc_dvs.runcmd(['sh', '-c', f"ip route del {test_prefix} nexthop via {test_neigh_ip_1} "])
+        assert res == "", "Error configuring route"
+
+        time.sleep(10)
+
+        asic_db = remote_lc_dvs.get_asic_db()
+        asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY", 1)
+        neighkeys = asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY")
+        assert len(neighkeys), "No neigh entries in ASIC_DB"
+
+        # Check for presence of the remote neighbor in ASIC_DB
+        remote_neigh = ""
+        for nkey in neighkeys:
+            ne = ast.literal_eval(nkey)
+            if ne['ip'] == test_neigh_ip_1:
+               remote_neigh = nkey
+               break
+        assert remote_neigh != "", "Remote neigh not found in ASIC_DB"
+
+        #del the neighbor
+        self.configure_neighbor(local_lc_dvs, "del", test_neigh_ip_1, test_neigh_mac_1, test_neigh_dev_2)
+        time.sleep(10)
+        asic_db = remote_lc_dvs.get_asic_db()
+        asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY", 0)
+        neighkeys = asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY")
+        assert len(neighkeys) == 0, "No neigh entries in ASIC_DB"
+
+        # Cleanup inband if configuration
+        self.del_inbandif_port(vct, inband_port)
 
     def test_voq_drop_counters(self, vct):
         """Test VOQ switch drop counters.


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Don't add the remote system neighbor if the same neighbor exists.
**Why I did it**
The IMM has two asics and has 2 port channels in each asic and 2 port members in each port channel.
The ip address is configured on each port channel and bgp is enabled. The neighbor and routes are learned on these port channel.
In sonic-mgmt pc suite, the test case po-update removes the port members from one of the port channel, removes the ip address configured on that port channel, creates new port channel, adds the same port members to the new port channel, adds the same ip address to the new port channel.
In the remote asic, before all the routes learned on the old port channel are removed by routeOrch, orchagent trries to remove the neighbor and nexthop for the old portchannel. But since the routes are pending, the old nexthop and neighbor are not removed. Then the neighbor and nexthop for the new port channel are being added. If the neighbor is learned on remote system port in remote asic, the nexthop is added with alias as inband port's alias, so the key (ip,alias) is same for both old nexthop and new nexthop. When the new nexthop is added , it calls hasNextHop function to check if the nexthop with (ip-address, alias) as key and since the old nexthop is not removed yet, the hasNextHop returns true, however the assert(!hasNextHop) does n't trigger the crash. So addNextHop function replace the old nexthop with old rif-id with new nexthop with new old rif-id in the nexthop map. Then after all the routes learned on old port channel is removed, the old neighbor and old nexthop are being removed. Sine the old nexthop was replaced with new nexthop, when orchagent tries to delete the old nexthop, it actually deletes the new nexthop from SAI. Then when it tries to remove the old neighbor, SAI returns error since orchagent removed the new nexthop from SAI instead of old nexthop and old neighbor is still referenced by the old nexthop in SAI. So orchagent crashes when SAI returns error.
**How I verified it**
Ran pc and voq suite and verified it passes.
**Details if related**
