### PR TITLE
[subinterface] Keep VLAN tag when adding member port into a portchannel with a subinterface

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -7038,7 +7038,7 @@ bool PortsOrch::addLagMember(Port &lag, Port &port, string member_status)
 
     m_portList[lag.m_alias] = lag;
 
-    if (lag.m_bridge_port_id > 0)
+    if ((lag.m_bridge_port_id > 0) || !lag.m_child_ports.empty())
     {
         if (!setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_KEEP))
         {
@@ -7086,7 +7086,7 @@ bool PortsOrch::removeLagMember(Port &lag, Port &port)
     lag.m_members.erase(port.m_alias);
     m_portList[lag.m_alias] = lag;
 
-    if (lag.m_bridge_port_id > 0)
+    if ((lag.m_bridge_port_id > 0) || !lag.m_child_ports.empty())
     {
         if (!setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_STRIP))
         {


### PR DESCRIPTION


When adding member port into portchannel, if the portchannel has a subinterface, the port should keep the VLAN tag.
And the VLAN tag should be stripped while removing a port from portchannel with subinterface.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
-->
