### PR TITLE
Fix the tlm_teamd deleting STATE_DB LAG_TABLE entry.

### DIFF
--- a/tlm_teamd/values_store.cpp
+++ b/tlm_teamd/values_store.cpp
@@ -366,7 +366,13 @@ void ValuesStore::update(const std::vector<StringPair> & dumps)
     {
         const auto & storage = from_json(dumps);
         const auto & old_keys = get_old_keys(storage);
-        remove_keys_db(old_keys);
+        // Do not delete te key from State Db. State DB LAB_TABLE entry is created/deleted
+        // from teamsyncd on detecting netlink of teamd dev as up/down. For some reason 
+        // if we do not get state dump from teamdctl it might be transient issue. If it is 
+        // persistent issue then teamsyncd might be able to catch it and delete state db entry
+        // or we can keep entry in it's current state as best effort. Similar to try_add_lag which is best effort
+        // to connect to teamdctl and if it fails we do not delete State Db entry.
+        //remove_keys_db(old_keys);
         remove_keys_storage(old_keys);
         const auto & keys_to_refresh = update_storage(storage);
         update_db(storage, keys_to_refresh);


### PR DESCRIPTION
What I did: 
Fixes:
https://github.com/sonic-net/sonic-buildimage/issues/20059

Why  I did:
On T2 testbed with multiple backend port channel we have seen sometime Portchannel gets created fine and with entry in APP_DB and STATE_DB gets populated. tlm_teamd is able to get the teamdctl handle to get state dump view of teamd. However while getting dump if might have passed in 1st iteration but it might fail in 2nd iteration (transient issue in getting data using teamdctl) which result in deletion of State db entry which is not correct. Instead we should just clean up local cache and wait for retry done as part of Select Timeout cycle  where we try to get dump again. 

```
2024 Aug 27 20:33:56.985209 sfd-t2-sup INFO teamd0#supervisord: teammgrd Using team device "PortChannel02".
2024 Aug 27 20:33:56.985209 sfd-t2-sup INFO teamd0#supervisord: teammgrd Using PID file "/var/run/teamd/PortChannel02.pid"
2024 Aug 27 20:33:56.985506 sfd-t2-sup INFO teamd0#supervisord: teammgrd This program is not intended to be run as root.
2024 Aug 27 20:33:58.743164 sfd-t2-sup NOTICE teamd0#teammgrd: :- addLag: Start port channel PortChannel02 with teamd
2024 Aug 27 20:33:58.987897 sfd-t2-sup INFO teamd0#supervisord 2024-08-27 20:33:58,987 INFO success: teamsyncd entered RUNNING state, process has stayed up for > than 5 seconds (startsecs)
2024 Aug 27 20:33:59.079507 sfd-t2-sup NOTICE teamd0#tlm_teamd: :- try_add_lag: The LAG 'PortChannel01' has been added.
2024 Aug 27 20:33:59.084771 sfd-t2-sup NOTICE teamd0#tlm_teamd: :- try_add_lag: The LAG 'PortChannel02' has been added.
2024 Aug 27 20:33:59.198619 sfd-t2-sup NOTICE teamd0#teammgrd: :- setLagAdminStatus: Set port channel PortChannel02 admin status to up
2024 Aug 27 20:33:59.363037 sfd-t2-sup NOTICE teamd0#teammgrd: :- setLagMtu: Set port channel PortChannel02 MTU to 9100
2024 Aug 27 20:33:59.363037 sfd-t2-sup NOTICE teamd0#teammgrd: :- setLagTpid: Set port channel PortChannel02 TPID to 0x8100
2024 Aug 27 20:33:59.363049 sfd-t2-sup NOTICE teamd0#teammgrd: :- doLagTask: Configure PortChannel02 TPID to 0x8100
2024 Aug 27 20:33:59.375011 sfd-t2-sup INFO teamd0#supervisord: teammgrd Using team device "PortChannel03".
2024 Aug 27 20:33:59.377051 sfd-t2-sup INFO teamd0#supervisord: teammgrd 
2024 Aug 27 20:33:59.377051 sfd-t2-sup INFO teamd0#supervisord: teammgrd Using PID file "/var/run/teamd/PortChannel03.pid"
2024 Aug 27 20:33:59.377051 sfd-t2-sup INFO teamd0#supervisord: teammgrd 
2024 Aug 27 20:33:59.377134 sfd-t2-sup INFO teamd0#supervisord: teammgrd This program is not intended to be run as root.
2024 Aug 27 20:33:59.378066 sfd-t2-sup INFO teamd0#supervisord: teammgrd 
2024 Aug 27 20:34:00.480451 sfd-t2-sup INFO teamd0#supervisord 2024-08-27 20:34:00,479 INFO exited: dependent-startup (exit status 0; expected)
2024 Aug 27 20:34:08.515997 sfd-t2-sup NOTICE teamd0#tlm_teamd: :- remove_lag: The LAG 'PortChannel02' has been removed.
2024 Aug 27 20:34:08.516023 sfd-t2-sup NOTICE teamd0#tlm_teamd: :- remove_lag: The LAG 'PortChannel02' had errored while getting dump, removing it

```

How i verify:
Ran 20+ iteration of config reload and did not see the issue. Without fix issue will come within 1 or 2 iteration.