### PR TITLE
BFD Tx, Rx interval support for Vnet Monitored routes.

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1831,7 +1831,7 @@ void VNetRouteOrch::delRoute(const IpPrefix& ipPrefix)
 }
 
 void VNetRouteOrch::createBfdSession(const string& vnet, const NextHopKey& endpoint, const IpAddress& monitor_addr,
-                                     bool has_monitor_interval, u_int32_t tx_monitor_interval, u_int32_t rx_monitor_interval)
+                                     bool has_monitor_interval, u_int64_t tx_monitor_interval, u_int64_t rx_monitor_interval)
 {
     SWSS_LOG_ENTER();
 
@@ -1973,16 +1973,16 @@ void VNetRouteOrch::setEndpointMonitor(const string& vnet, const map<NextHopKey,
 {
     SWSS_LOG_ENTER();
     bool has_monitor_internvals = false;
-    uint32_t tx_monitor_interval = 0;
-    uint32_t rx_monitor_interval = 0;
+    uint64_t tx_monitor_interval = 0;
+    uint64_t rx_monitor_interval = 0;
 
     if (monitoring != "custom")
     {
         if (prefix_to_monitor_intervals_.find(ipPrefix) != prefix_to_monitor_intervals_.end())
         {
             has_monitor_internvals = true;
-            tx_monitor_interval = prefix_to_monitor_intervals_[ipPrefix].tx_interval;
-            rx_monitor_interval = prefix_to_monitor_intervals_[ipPrefix].rx_interval;
+            tx_monitor_interval = prefix_to_monitor_intervals_[ipPrefix].tx_monitor_timer;
+            rx_monitor_interval = prefix_to_monitor_intervals_[ipPrefix].rx_monitor_timer;
         }
     }
     for (auto monitor : monitors)
@@ -2642,8 +2642,8 @@ bool VNetRouteOrch::handleTunnel(const Request& request)
     bool has_priority_ep = false;
     bool has_adv_pfx = false;
     bool has_monitor_intervals = false;
-    uint32_t rx_monitor_timer = 0;
-    uint32_t tx_monitor_timer = 0;
+    uint64_t rx_monitor_timer = 0;
+    uint64_t tx_monitor_timer = 0;
     bool check_directly_connected = false;
     for (const auto& name: request.getAttrFieldNames())
     {
@@ -2682,14 +2682,14 @@ bool VNetRouteOrch::handleTunnel(const Request& request)
             adv_prefix = request.getAttrIpPrefix(name);
             has_adv_pfx = true;
         }
-        else if (name == "rx_interval")
+        else if (name == "rx_monitor_timer")
         {
-            rx_interval = request.getAttrUint(name);
+            rx_monitor_timer = request.getAttrUint(name);
             has_monitor_intervals = true;
        }
-        else if (name == "tx_interval")
+        else if (name == "tx_monitor_timer")
         {
-            tx_interval = request.getAttrUint(name);
+            tx_monitor_timer = request.getAttrUint(name);
             has_monitor_intervals = true;
         }
         else if (name == "check_directly_connected")
@@ -2788,8 +2788,8 @@ bool VNetRouteOrch::handleTunnel(const Request& request)
     if (has_monitor_intervals)
     {
         struct VnetRouteMonitorIntervals intervals;
-        intervals.rx_interval = rx_interval;
-        intervals.tx_interval = tx_interval;
+        intervals.rx_monitor_timer = rx_monitor_timer;
+        intervals.tx_monitor_timer = tx_monitor_timer;
         prefix_to_monitor_intervals_[ip_pfx] = intervals;
     }
     if ( op == DEL_COMMAND)

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -411,9 +411,10 @@ struct VNetTunnelRouteEntry
 struct VnetRouteMonitorIntervals
 {
     // The interval in milliseconds at which the BFD session should be monitored
-    uint32_t rx_monitor_timer;
-    uint32_t tx_monitor_timer;
+    uint64_t rx_monitor_timer;
+    uint64_t tx_monitor_timer;
 };
+
 typedef std::map<NextHopGroupKey, NextHopGroupInfo> VNetNextHopGroupInfoTable;
 typedef std::map<IpPrefix, VNetTunnelRouteEntry> VNetTunnelRouteTable;
 typedef std::map<IpAddress, BfdSessionInfo> BfdSessionTable;
@@ -459,7 +460,7 @@ private:
                             const std::map<NextHopKey,IpAddress>& monitors=std::map<NextHopKey, IpAddress>());
 
     void createBfdSession(const string& vnet, const NextHopKey& endpoint, const IpAddress& ipAddr,
-                          bool has_monitor_interval, u_int32_t tx_monitor_interval, u_int32_t rx_monitor_interval);
+                          bool has_monitor_interval, u_int64_t tx_monitor_interval, u_int64_t rx_monitor_interval);
     void removeBfdSession(const string& vnet, const NextHopKey& endpoint, const IpAddress& ipAddr);
     void createMonitoringSession(const string& vnet, const NextHopKey& endpoint, const IpAddress& ipAddr, IpPrefix& ipPrefix);
     void removeMonitoringSession(const string& vnet, const NextHopKey& endpoint, const IpAddress& ipAddr, IpPrefix& ipPrefix);

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -3687,6 +3687,8 @@ class TestVnetOrch(object):
             "src_ip_v6": "20c1:ba8::/64"
         }
         setup_subnet_decap(subnet_decap_config)
+        import pdb
+        pdb.set_trace()
 
         vnet_obj = self.get_vnet_obj()
         vnet_obj.fetch_exist_entries(dvs)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
This change add support for
 **rx_monitor_timer
tx_monitor_timer
check_directly_connected**
**Why I did it**
This change is beneficial because it adds support for BFD Tx, Rx interval for Vnet Monitored routes as required by DASH project.
**How I verified it**
Added a unit test to verify the functionality.
**Details if related**
The Tx and Rx values are added on per-route basis.  Therefore the same values are used for each nexthop. if the user needs to se different values for each next hop then they can add the values and nexthops incrementally.
e.g.
```
Add route with nexthop 10.0.0.1(1s,1s) -> BFD(10.0.0.1) with Tx =1s Rx= 1s
Update same route and add another nexthop 10.0.0.2(2s,2s) -> BFD(10.0.0.1) with Tx =1s Rx= 1s |  BFD(10.0.0.2) with Tx =2s Rx= 2s
```
The user can also update these values by selectively removing and readding a nexthop with different Tx and Rx values.
