### PR TITLE
Fix State Db LAG_MEMBER_TABLE removal not happening.

### DIFF
--- a/tlm_teamd/values_store.cpp
+++ b/tlm_teamd/values_store.cpp
@@ -366,7 +366,13 @@ void ValuesStore::update(const std::vector<StringPair> & dumps)
     {
         const auto & storage = from_json(dumps);
         const auto & old_keys = get_old_keys(storage);
-        remove_keys_db(old_keys);
+        // Do not delete te key from State Db. State DB LAB_TABLE entry is created/deleted
+        // from teamsyncd on detecting netlink of teamd dev as up/down. For some reason 
+        // if we do not get state dump from teamdctl it might be transient issue. If it is 
+        // persistent issue then teamsyncd might be able to catch it and delete state db entry
+        // or we can keep entry in it's current state as best effort. Similar to try_add_lag which is best effort
+        // to connect to teamdctl and if it fails we do not delete State Db entry.
+        //remove_keys_db(old_keys);
         remove_keys_storage(old_keys);
         const auto & keys_to_refresh = update_storage(storage);
         update_db(storage, keys_to_refresh);

--- a/tlm_teamd/values_store.cpp
+++ b/tlm_teamd/values_store.cpp
@@ -374,13 +374,7 @@ void ValuesStore::update(const std::vector<StringPair> & dumps)
     {
         const auto & storage = from_json(dumps);
         const auto & old_keys = get_old_keys(storage);
-        // Do not delete te key from State Db. State DB LAB_TABLE entry is created/deleted
-        // from teamsyncd on detecting netlink of teamd dev as up/down. For some reason 
-        // if we do not get state dump from teamdctl it might be transient issue. If it is 
-        // persistent issue then teamsyncd might be able to catch it and delete state db entry
-        // or we can keep entry in it's current state as best effort. Similar to try_add_lag which is best effort
-        // to connect to teamdctl and if it fails we do not delete State Db entry.
-        //remove_keys_db(old_keys);
+        remove_keys_db(old_keys);
         remove_keys_storage(old_keys);
         const auto & keys_to_refresh = update_storage(storage);
         update_db(storage, keys_to_refresh);


### PR DESCRIPTION
What I did:
Original issue and and PR: https://github.com/sonic-net/sonic-swss/pull/3333


Why I did:
Fix the failure in `test_po_update.py` as seen in this PR checker: https://github.com/sonic-net/sonic-buildimage/pull/20610
Previous fix blocked State Db `LAG_MEMBER_TABLE` deletion which is not correct as this table is created by tlm_teamd (owner).
Intention was to prevent deletion of State Db `LAG_TABLE` owner of which is teamsyncd.
