### PR TITLE
Handle Port oper down error status notification

### DIFF
--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -14,7 +14,9 @@ extern "C"
 
 PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_with_pri_t> &tableNames,
                      DBConnector *chassisAppDb)
-    : Orch(db, tableNames), m_portStateTable(stateDb, STATE_PORT_TABLE_NAME),
+    : Orch(db, tableNames),
+      m_portStateTable(stateDb, STATE_PORT_TABLE_NAME),
+      m_portOpErrTable(stateDb, STATE_PORT_OPER_ERR_TABLE_NAME),
       port_stat_manager(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ,
                         PORT_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS, true),
       port_buffer_drop_stat_manager(PORT_BUFFER_DROP_STAT_FLEX_COUNTER_GROUP, StatsMode::READ,

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -308,6 +308,25 @@ static char* hostif_vlan_tag[] = {
     [SAI_HOSTIF_VLAN_TAG_ORIGINAL]  = "SAI_HOSTIF_VLAN_TAG_ORIGINAL"
 };
 
+const std::unordered_map<sai_port_error_status_t, std::string> PortOperErrorEvent::db_key_errors =
+{
+    // SAI port oper error status to error name mapping
+    { SAI_PORT_ERROR_STATUS_MAC_LOCAL_FAULT, "mac_local_fault"},
+    { SAI_PORT_ERROR_STATUS_MAC_REMOTE_FAULT, "mac_remote_fault"},
+    { SAI_PORT_ERROR_STATUS_FEC_SYNC_LOSS, "fec_sync_loss"},
+    { SAI_PORT_ERROR_STATUS_FEC_LOSS_ALIGNMENT_MARKER, "fec_alignment_loss"},
+    { SAI_PORT_ERROR_STATUS_HIGH_SER,  "high_ser_error"},
+    { SAI_PORT_ERROR_STATUS_HIGH_BER, "high ber_error"},
+    { SAI_PORT_ERROR_STATUS_CRC_RATE, "crc_rate"},
+    { SAI_PORT_ERROR_STATUS_DATA_UNIT_CRC_ERROR, "data_unit_crc_error"},
+    { SAI_PORT_ERROR_STATUS_DATA_UNIT_SIZE, "data_unit_size"},
+    { SAI_PORT_ERROR_STATUS_DATA_UNIT_MISALIGNMENT_ERROR, "data_unit_misalignment_error"},
+    { SAI_PORT_ERROR_STATUS_CODE_GROUP_ERROR, "code_group_error"},
+    { SAI_PORT_ERROR_STATUS_SIGNAL_LOCAL_ERROR, "signal_local_error"},
+    { SAI_PORT_ERROR_STATUS_NO_RX_REACHABILITY, "no_rx_reachability"}
+};
+
+
 // functions ----------------------------------------------------------------------------------------------------------
 
 static bool isValidPortTypeForLagMember(const Port& port)
@@ -509,6 +528,7 @@ bool PortsOrch::checkPathTracingCapability()
 PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_with_pri_t> &tableNames, DBConnector *chassisAppDb) :
         Orch(db, tableNames),
         m_portStateTable(stateDb, STATE_PORT_TABLE_NAME),
+        m_portOpErrTable(stateDb, STATE_PORT_OPER_ERR_TABLE_NAME),
         port_stat_manager(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ, PORT_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS, false),
         gb_port_stat_manager(true,
                 PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ,
@@ -806,6 +826,26 @@ void PortsOrch::initializeCpuPort()
     this->m_port_ref_count[m_cpuPort.m_alias] = 0;
 
     SWSS_LOG_NOTICE("Get CPU port pid:%" PRIx64, this->m_cpuPort.m_port_id);
+}
+
+// Creating mapping of various port oper errors for error handling
+void PortsOrch::initializePortOperErrors(Port &port)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("Initialize port oper errors for port %s", port.m_alias.c_str());
+
+    for (auto& error : PortOperErrorEvent::db_key_errors)
+    {
+        const sai_port_error_status_t error_status = error.first;
+        std::string error_name = error.second;
+
+        port.m_portOperErrorToEvent[error_status] = PortOperErrorEvent(error_status, error_name);
+        SWSS_LOG_NOTICE("Initialize port %s error %s flag=0x%" PRIx32,
+                                        port.m_alias.c_str(),
+                                        error_name.c_str(),
+                                        error_status);
+    }
 }
 
 void PortsOrch::initializePorts()
@@ -3351,6 +3391,26 @@ void PortsOrch::updateDbPortFlapCount(Port& port, sai_port_oper_status_t pstatus
     m_portTable->set(port.m_alias, tuples);
 }
 
+void PortsOrch::updateDbPortOperError(Port& port, PortOperErrorEvent *pevent)
+{
+    SWSS_LOG_ENTER();
+
+    auto key = pevent->getDbKey();
+    vector<FieldValueTuple> tuples;
+    FieldValueTuple tup1("oper_error_status", std::to_string(port.m_oper_error_status));
+    tuples.push_back(tup1);
+
+    size_t count = pevent->getErrorCount();
+    FieldValueTuple tup2(key + "_count", std::to_string(count));
+    tuples.push_back(tup2);
+
+    auto time = pevent->getEventTime();
+    FieldValueTuple tup3(key + "_time", time);
+    tuples.push_back(tup3);
+
+    m_portOpErrTable.set(port.m_alias, tuples);
+}
+
 void PortsOrch::updateDbPortOperStatus(const Port& port, sai_port_oper_status_t status) const
 {
     SWSS_LOG_ENTER();
@@ -4612,6 +4672,8 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
                 /* create host_tx_ready field in state-db */
                 initHostTxReadyState(p);
+
+                initializePortOperErrors(p);
 
                 // Restore admin status if the port was brought down
                 if (admin_status != p.m_admin_state_up)
@@ -8019,12 +8081,14 @@ void PortsOrch::doTask(NotificationConsumer &consumer)
 
         for (uint32_t i = 0; i < count; i++)
         {
+            Port port;
             sai_object_id_t id = portoperstatus[i].port_id;
             sai_port_oper_status_t status = portoperstatus[i].port_state;
+            sai_port_error_status_t port_oper_err = portoperstatus[i].port_error_status;
 
-            SWSS_LOG_NOTICE("Get port state change notification id:%" PRIx64 " status:%d", id, status);
-
-            Port port;
+            SWSS_LOG_NOTICE("Get port state change notification id:%" PRIx64 " status:%d "
+                                "oper_error_status:0x%" PRIx32,
+                                id, status, port_oper_err);
 
             if (!getPort(id, port))
             {
@@ -8061,6 +8125,11 @@ void PortsOrch::doTask(NotificationConsumer &consumer)
                 {
                     updateDbPortOperFec(port, "N/A");
                 }
+            } else {
+                if (port_oper_err)
+                {
+                    updatePortErrorStatus(port, port_oper_err);
+                }
             }
 
             /* update m_portList */
@@ -8087,6 +8156,53 @@ void PortsOrch::doTask(NotificationConsumer &consumer)
         setHostTxReady(p, host_tx_ready_status == SAI_PORT_HOST_TX_READY_STATUS_READY ? "true" : "false");
     }
 
+}
+
+void PortsOrch::updatePortErrorStatus(Port &port, sai_port_error_status_t errstatus)
+{
+    size_t errors = 0;
+    string db_port_error_name;
+    PortOperErrorEvent *portOperErrorEvent = nullptr;
+    size_t error_count = PortOperErrorEvent::db_key_errors.size();
+
+    SWSS_LOG_NOTICE("Port %s error state set from 0x%" PRIx32 "-> 0x%" PRIx32,
+                        port.m_alias.c_str(),
+                        port.m_oper_error_status,
+                        errstatus);
+
+    port.m_oper_error_status = errstatus;
+
+    // Iterate through all the port oper errors
+    while ((errstatus >> errors) && (errors < error_count))
+    {
+        sai_port_error_status_t error_status = static_cast<sai_port_error_status_t>(errstatus & (1 << errors));
+
+        if (port.m_portOperErrorToEvent.find(error_status) == port.m_portOperErrorToEvent.end())
+        {
+            ++errors;
+            continue;
+        }
+
+        portOperErrorEvent = &port.m_portOperErrorToEvent[error_status];
+
+        if (portOperErrorEvent->isErrorSet(errstatus))
+        {
+            SWSS_LOG_NOTICE("Port %s oper error event: %s occurred",
+                                port.m_alias.c_str(),
+                                portOperErrorEvent->getDbKey().c_str());
+            portOperErrorEvent->recordEventTime();
+            portOperErrorEvent->incrementErrorCount();
+            updateDbPortOperError(port, portOperErrorEvent);
+        }
+        else
+        {
+            SWSS_LOG_WARN("Port %s port oper error %s not updated in DB",
+                                port.m_alias.c_str(),
+                                portOperErrorEvent->getDbKey().c_str());
+        }
+
+        ++errors;
+    }
 }
 
 void PortsOrch::updatePortOperStatus(Port &port, sai_port_oper_status_t status)

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -146,12 +146,14 @@ public:
     void setPort(string alias, Port port);
     void getCpuPort(Port &port);
     void initHostTxReadyState(Port &port);
+    void initializePortOperErrors(Port &port);
     bool getInbandPort(Port &port);
     bool getVlanByVlanId(sai_vlan_id_t vlan_id, Port &vlan);
 
     bool setHostIntfsOperStatus(const Port& port, bool up) const;
     void updateDbPortOperStatus(const Port& port, sai_port_oper_status_t status) const;
     void updateDbPortFlapCount(Port& port, sai_port_oper_status_t pstatus);
+    void updateDbPortOperError(Port& port, PortOperErrorEvent *pevent);
 
     bool createVlanHostIntf(Port& vl, string hostif_name);
     bool removeVlanHostIntf(Port vl);
@@ -263,6 +265,7 @@ private:
     unique_ptr<Table> m_pgIndexTable;
     unique_ptr<Table> m_stateBufferMaximumValueTable;
     Table m_portStateTable;
+    Table m_portOpErrTable;
 
     std::string getQueueWatermarkFlexCounterTableKey(std::string s);
     std::string getPriorityGroupWatermarkFlexCounterTableKey(std::string s);
@@ -502,6 +505,7 @@ private:
     bool initGearboxPort(Port &port);
     bool getPortOperFec(const Port& port, sai_port_fec_mode_t &fec_mode) const;
     void updateDbPortOperFec(Port &port, string fec_str);
+    void updatePortErrorStatus(Port &port, sai_port_error_status_t port_oper_eror);
 
     map<string, Port::Role> m_recircPortRole;
 


### PR DESCRIPTION
Handler Port oper down error status notification as per [sai_port_error_status_t](https://github.com/opencomputeproject/SAI/blob/8b8fa85178383ae0a8bf1a64279934a6b3087837/inc/saiport.h#L84) flag as part of existing port oper status notification `sai_port_oper_status_notification_t`

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Whenever Orchagent gets the notification for `port_state_change` for link down event, OA will update the error count for the error flags that are set and the timestamp of the error port down event in new STATE_DB table `PORT_OPERR_TABLE`

**Why I did it**
To correlate various error events like MAC local and remote fault with the link oper down status notification.

**How I verified it**
Since we don't have real hardware to test this modified notification, I modified the sairedis to generate this new notification on every link down event 

```
root@smsn2700~# redis-cli -n 6 hgetall "PORT_OPERR_TABLE|Ethernet4"
 1) "oper_error_status"
 2) "5442"
 3) "mac_local_fault_count"
 4) "2"
 5) "mac_local_fault_time"
 6) "2024-11-02 04:00:05"
 7) "fec_sync_loss_count"
 8) "2"
 9) "fec_sync_loss_time"
10) "2024-11-02 04:00:05"
11) "fec_alignment_loss_count"
12) "2"
13) "fec_alignment_loss_time"
14) "2024-11-02 04:00:05"
15) "high_ser_error_count"
16) "2"
17) "high_ser_error_time"
18) "2024-11-02 04:00:05"
19) "high ber_error_count"
20) "2"
21) "high ber_error_time"
22) "2024-11-02 04:00:05"
23) "data_unit_crc_error_count"
24) "2"
25) "data_unit_crc_error_time"
26) "2024-11-02 04:00:05"
27) "data_unit_misalignment_error_count"
28) "2"
29) "data_unit_misalignment_error_time"
30) "2024-11-02 04:00:05"
31) "signal_local_error_count"
32) "2"
33) "signal_local_error_time"
34) "2024-11-02 04:00:05"
35) "mac_remote_fault_count"
36) "2"
37) "mac_remote_fault_time"
38) "2024-11-02 04:00:50"
39) "crc_rate_count"
40) "2"
41) "crc_rate_time"
42) "2024-11-02 04:00:50"
43) "data_unit_size_count"
44) "2"
45) "data_unit_size_time"
46) "2024-11-02 04:00:50"
47) "code_group_error_count"
48) "2"
49) "code_group_error_time"
50) "2024-11-02 04:00:50"
51) "no_rx_reachability_count"
52) "2"
53) "no_rx_reachability_time"
54) "2024-11-02 04:00:50"
root@msn2700~# 
``

**Details if related**
