### PR TITLE
[swss/orchagent] : Correct subnet check for the same prefix using function isAddressInSubnet()

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -123,7 +123,7 @@ bool IntfsOrch::isPrefixSubnet(const IpPrefix &ip_prefix, const string &alias)
     }
     for (auto &prefixIt: m_syncdIntfses[alias].ip_addresses)
     {
-        if (prefixIt.getSubnet() == ip_prefix)
+        if (prefixIt.isAddressInSubnet(ip_prefix.getIp()))
         {
             return true;
         }


### PR DESCRIPTION
[swss/orchagent]: Correct subnet check for the same prefix using function isAddressInSubnet()

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Correct subnet check for the same prefix using function isAddressInSubnet()
**Why I did it**
The check for (prefixIt.getSubnet() == ip_prefix) is incorrect as it does not consider the mask for the 2nd parameter(ip_prefix). Ideally, for subnet check, both 1st parameter(prefixIt) and 2nd parameter(ip_prefix) must be appended by the mask. This is done in the function  isAddressInSubnet(), where the mask present in the 1st parameter will be appended to both 1st and 2nd parameter, before comparison. 

**How I verified it**
Tested using routes 30.1.0.0/24 and 30.1.0.1/32
Tested bgp docker restart
**Details if related**

Signed-off-by: [sudhanshu.kumar@broadcom.com](mailto:sudhanshu.kumar@broadcom.com)
