### PR TITLE
Do not start counter polling for queues with zero buffer profiles if create_only_config_db_buffers is enabled

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -797,6 +797,9 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
     sai_uint32_t range_low, range_high;
     bool need_update_sai = true;
     bool local_port = false;
+    bool counter_was_added = false;
+    bool counter_needs_to_add = false;
+    string old_buffer_profile_name;
     string local_port_name;
 
     SWSS_LOG_DEBUG("Processing:%s", key.c_str());
@@ -856,7 +859,6 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
             return task_process_status::task_failed;
         }
 
-        string old_buffer_profile_name;
         if (doesObjectExist(m_buffer_type_maps, APP_BUFFER_QUEUE_TABLE_NAME, key, buffer_profile_field_name, old_buffer_profile_name)
             && (old_buffer_profile_name == buffer_profile_name))
         {
@@ -874,11 +876,14 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
         SWSS_LOG_NOTICE("Set buffer queue %s to %s", key.c_str(), buffer_profile_name.c_str());
 
         setObjectReference(m_buffer_type_maps, APP_BUFFER_QUEUE_TABLE_NAME, key, buffer_profile_field_name, buffer_profile_name);
+
+        // Counter operation
+        counter_needs_to_add = buffer_profile_name.find("_zero_") == std::string::npos;
+        SWSS_LOG_INFO("%s to create counter for %s with new profile %s", counter_needs_to_add ? "Need" : "No need", key.c_str(), buffer_profile_name.c_str());
     }
     else if (op == DEL_COMMAND)
     {
-        auto &typemap = (*m_buffer_type_maps[APP_BUFFER_QUEUE_TABLE_NAME]);
-        if (typemap.find(key) == typemap.end())
+        if (!doesObjectExist(m_buffer_type_maps, APP_BUFFER_QUEUE_TABLE_NAME, key, buffer_profile_field_name, old_buffer_profile_name))
         {
             SWSS_LOG_INFO("%s doesn't not exist, don't need to notfiy SAI", key.c_str());
             need_update_sai = false;
@@ -887,12 +892,16 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
         SWSS_LOG_NOTICE("Remove buffer queue %s", key.c_str());
         removeObject(m_buffer_type_maps, APP_BUFFER_QUEUE_TABLE_NAME, key);
         m_partiallyAppliedQueues.erase(key);
+        counter_needs_to_add = false;
     }
     else
     {
         SWSS_LOG_ERROR("Unknown operation type %s", op.c_str());
         return task_process_status::task_invalid_entry;
     }
+
+    counter_was_added = !old_buffer_profile_name.empty() && old_buffer_profile_name.find("_zero_") == std::string::npos;
+    SWSS_LOG_INFO("%s to remove counter for %s with old profile %s", counter_was_added ? "Need" : "No need", key.c_str(), old_buffer_profile_name.c_str());
 
     sai_attribute_t attr;
     attr.id = SAI_QUEUE_ATTR_BUFFER_PROFILE_ID;
@@ -963,14 +972,16 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
                 {
                     auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
                     auto queues = tokens[1];
-                    if (op == SET_COMMAND &&
+                    if (!counter_was_added && counter_needs_to_add &&
                         (flexCounterOrch->getQueueCountersState() || flexCounterOrch->getQueueWatermarkCountersState()))
                     {
+                        SWSS_LOG_INFO("Creating counters for %s %lu", port_name.c_str(), ind);
                         gPortsOrch->createPortBufferQueueCounters(port, queues);
                     }
-                    else if (op == DEL_COMMAND &&
+                    else if (counter_was_added && !counter_needs_to_add &&
                              (flexCounterOrch->getQueueCountersState() || flexCounterOrch->getQueueWatermarkCountersState()))
                     {
+                        SWSS_LOG_INFO("Removing counters for %s %lu", port_name.c_str(), ind);
                         gPortsOrch->removePortBufferQueueCounters(port, queues);
                     }
                 }
@@ -1042,6 +1053,25 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
     }
 
     return task_process_status::task_success;
+}
+
+void BufferOrch::getNonZeroQueues(vector<string> &nonZeroQueues)
+{
+    for (auto &&queueRef: (*m_buffer_type_maps[APP_BUFFER_QUEUE_TABLE_NAME]))
+    {
+        for (auto &&profileRef: queueRef.second.m_objsReferencingByMe)
+        {
+            if (profileRef.second.find("_zero_") == std::string::npos)
+            {
+                SWSS_LOG_INFO("Selected key %s with profile %s", queueRef.first.c_str(), profileRef.second.c_str());
+                nonZeroQueues.push_back(queueRef.first);
+            }
+            else
+            {
+                SWSS_LOG_INFO("Skipped key %s with profile %s", queueRef.first.c_str(), profileRef.second.c_str());
+            }
+        }
+    }
 }
 
 /*

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -994,13 +994,13 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
                     if (!counter_was_added && counter_needs_to_add &&
                         (flexCounterOrch->getQueueCountersState() || flexCounterOrch->getQueueWatermarkCountersState()))
                     {
-                        SWSS_LOG_INFO("Creating counters for %s %lu", port_name.c_str(), ind);
+                        SWSS_LOG_INFO("Creating counters for %s %zd", port_name.c_str(), ind);
                         gPortsOrch->createPortBufferQueueCounters(port, queues);
                     }
                     else if (counter_was_added && !counter_needs_to_add &&
                              (flexCounterOrch->getQueueCountersState() || flexCounterOrch->getQueueWatermarkCountersState()))
                     {
-                        SWSS_LOG_INFO("Removing counters for %s %lu", port_name.c_str(), ind);
+                        SWSS_LOG_INFO("Removing counters for %s %zd", port_name.c_str(), ind);
                         gPortsOrch->removePortBufferQueueCounters(port, queues);
                     }
                 }
@@ -1202,13 +1202,13 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
                         if (!counter_was_added && counter_needs_to_add &&
                             (flexCounterOrch->getPgCountersState() || flexCounterOrch->getPgWatermarkCountersState()))
                         {
-                            SWSS_LOG_INFO("Creating counters for priority group %s %lu", port_name.c_str(), ind);
+                            SWSS_LOG_INFO("Creating counters for priority group %s %zd", port_name.c_str(), ind);
                             gPortsOrch->createPortBufferPgCounters(port, pgs);
                         }
                         else if (counter_was_added && !counter_needs_to_add &&
                                  (flexCounterOrch->getPgCountersState() || flexCounterOrch->getPgWatermarkCountersState()))
                         {
-                            SWSS_LOG_INFO("Removing counters for priority group %s %lu", port_name.c_str(), ind);
+                            SWSS_LOG_INFO("Removing counters for priority group %s %zd", port_name.c_str(), ind);
                             gPortsOrch->removePortBufferPgCounters(port, pgs);
                         }
                     }

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -1139,8 +1139,7 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
     }
     else if (op == DEL_COMMAND)
     {
-        auto &typemap = (*m_buffer_type_maps[APP_BUFFER_PG_TABLE_NAME]);
-        if (typemap.find(key) == typemap.end())
+        if (!doesObjectExist(m_buffer_type_maps, APP_BUFFER_PG_TABLE_NAME, key, buffer_profile_field_name, old_buffer_profile_name))
         {
             SWSS_LOG_INFO("%s doesn't not exist, don't need to notfiy SAI", key.c_str());
             need_update_sai = false;

--- a/orchagent/bufferorch.h
+++ b/orchagent/bufferorch.h
@@ -38,6 +38,7 @@ public:
     static type_map m_buffer_type_maps;
     void generateBufferPoolWatermarkCounterIdList(void);
     const object_reference_map &getBufferPoolNameOidMap(void);
+    void getNonZeroQueues(std::vector<std::string> &nonZeroQueues);
 
 private:
     typedef task_process_status (BufferOrch::*buffer_table_handler)(KeyOpFieldsValuesTuple &tuple);

--- a/orchagent/bufferorch.h
+++ b/orchagent/bufferorch.h
@@ -38,7 +38,7 @@ public:
     static type_map m_buffer_type_maps;
     void generateBufferPoolWatermarkCounterIdList(void);
     const object_reference_map &getBufferPoolNameOidMap(void);
-    void getNonZeroQueues(std::vector<std::string> &nonZeroQueues);
+    void getBufferObjectsWithNonZeroProfile(vector<string> &nonZeroQueues, const string &table);
 
 private:
     typedef task_process_status (BufferOrch::*buffer_table_handler)(KeyOpFieldsValuesTuple &tuple);

--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -370,11 +370,11 @@ map<string, FlexCounterQueueStates> FlexCounterOrch::getQueueConfigurations()
     }
 
     std::vector<std::string> portQueueKeys;
-    m_bufferQueueConfigTable.getKeys(portQueueKeys);
+    gBufferOrch->getNonZeroQueues(portQueueKeys);
 
     for (const auto& portQueueKey : portQueueKeys)
     {
-        auto toks = tokenize(portQueueKey, '|');
+        auto toks = tokenize(portQueueKey, ':');
         if (toks.size() != 2)
         {
             SWSS_LOG_ERROR("Invalid BUFFER_QUEUE key: [%s]", portQueueKey.c_str());

--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -370,7 +370,7 @@ map<string, FlexCounterQueueStates> FlexCounterOrch::getQueueConfigurations()
     }
 
     std::vector<std::string> portQueueKeys;
-    gBufferOrch->getNonZeroQueues(portQueueKeys);
+    gBufferOrch->getBufferObjectsWithNonZeroProfile(portQueueKeys, APP_BUFFER_QUEUE_TABLE_NAME);
 
     for (const auto& portQueueKey : portQueueKeys)
     {
@@ -439,11 +439,11 @@ map<string, FlexCounterPgStates> FlexCounterOrch::getPgConfigurations()
     }
 
     std::vector<std::string> portPgKeys;
-    m_bufferPgConfigTable.getKeys(portPgKeys);
+    gBufferOrch->getBufferObjectsWithNonZeroProfile(portPgKeys, APP_BUFFER_PG_TABLE_NAME);
 
     for (const auto& portPgKey : portPgKeys)
     {
-        auto toks = tokenize(portPgKey, '|');
+        auto toks = tokenize(portPgKey, ':');
         if (toks.size() != 2)
         {
             SWSS_LOG_ERROR("Invalid BUFFER_PG key: [%s]", portPgKey.c_str());


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Do not start counter-polling for queues with zero buffer profiles if create_only_config_db_buffers is enabled.

**Why I did it**

If create_only_config_db_buffers is enabled, counters will be polled only on queues with a buffer configured based on the hypothesis that a customer must configure a buffer profile before using the queue.
The system performance can be optimized by reducing the number of counter polled.

However, zero buffer profiles are configured on queues of inactive ports to reclaim unused buffers. Those queues are not used by customers. Hence, we do not need to start counter polling for queues with such buffer profiles configured.

**How I verified it**

Manual and regression test.

Flows verified:
1. System starts up with inactive ports
2. Shutdown a port
3. Start up a port

**Details if related**

Regarding `create_only_config_db_buffers`, it was introduced in PR #2883 for polling configured buffer counters only.
The idea is that a customer does not want to use certain buffer objects, like queues, and priority groups, if he/she does not configure a buffer profile on the BUFFER_PG or BUFFER_QUEUE table. In that case, it does not make sense to poll counters for unconfigured buffer objects.
However, zero buffer profile, which is a special type of buffer profile, can be configured on a BUFFER_PG or BUFFER_QUEUE table just to [reclaim unused buffers](https://github.com/sonic-net/SONiC/blob/master/doc/qos/reclaim-reserved-buffer.md) on inactive ports. In this case, we should not poll counters for those buffer objects as well.