### PR TITLE
[ci] Fix reportgenerator installation error

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -90,7 +90,7 @@ jobs:
         curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
         sudo apt-add-repository https://packages.microsoft.com/ubuntu/20.04/prod
         sudo apt-get update
-        sudo apt-get install -y dotnet-sdk-7.0
+        sudo apt-get install -y dotnet-sdk-8.0
         sudo dotnet tool install dotnet-reportgenerator-globaltool --tool-path /usr/bin 2>&1 | tee log.log || grep 'already installed' log.log
         rm log.log
     displayName: "Install .NET CORE"


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix pipeline error.
here is the error message:
```
/tmp/823d4a0e-75c7-4ca8-b487-06e1f38eae6d/restore.csproj : error NU1202: Package dotnet-reportgenerator-globaltool 5.4.1 is not compatible with net7.0 (.NETCoreApp,Version=v7.0) / any. Package dotnet-reportgenerator-globaltool 5.4.1 supports:
/tmp/823d4a0e-75c7-4ca8-b487-06e1f38eae6d/restore.csproj : error NU1202:   - net8.0 (.NETCoreApp,Version=v8.0) / any
/tmp/823d4a0e-75c7-4ca8-b487-06e1f38eae6d/restore.csproj : error NU1202:   - net9.0 (.NETCoreApp,Version=v9.0) / any

+ reportgenerator -reporttypes:Cobertura '-reports:tests/*coverage.xml' -targetdir:.
/agent/_work/_temp/057fa35b-9e5b-426a-bd88-2c5956cb8dcf.sh: line 2: reportgenerator: command not found
```
**Why I did it**

**How I verified it**
pipeline in this PR didn't shows that error message.
**Details if related**
