### PR TITLE
[vlanmgrd]: Preventing VLAN interfaces from going down when all of their member ports are down

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -79,7 +79,8 @@ VlanMgr::VlanMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
     //               /sbin/bridge vlan del vid 1 dev Bridge self;
     //               /sbin/ip link del dummy 2>/dev/null;
     //               /sbin/ip link add dummy type dummy &&
-    //               /sbin/ip link set dummy master Bridge"
+    //               /sbin/ip link set dummy master Bridge &&
+    //               /sbin/ip link set dummy up"
 
     const std::string cmds = std::string("")
       + BASH_CMD + " -c \""
@@ -90,7 +91,8 @@ VlanMgr::VlanMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
       + BRIDGE_CMD + " vlan del vid " + DEFAULT_VLAN_ID + " dev " + DOT1Q_BRIDGE_NAME + " self; "
       + IP_CMD + " link del dev dummy 2>/dev/null; "
       + IP_CMD + " link add dummy type dummy && "
-      + IP_CMD + " link set dummy master " + DOT1Q_BRIDGE_NAME + "\"";
+      + IP_CMD + " link set dummy master " + DOT1Q_BRIDGE_NAME + " && "
+      + IP_CMD + " link set dummy up" + "\"";
 
     std::string res;
     EXEC_WITH_ERROR_THROW(cmds, res);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Started up the "dummy" interface that is already connected to the bridge named "Bridge" so that when all ports connected to the bridge are down, the bridge interface remains up. This ensures that when there is one VLAN interface connected to the bridge, it remains up even when all of the VLAN's member ports are down.

**Why I did it**
Before this change, when all member ports of a VLAN interface went down, the VLAN interface also went operationally down. This effectively disabled the advertisement of the VLAN interface's subnet IP to neighbors and prevented the IP-in-IP decapsulation feature for the VLAN interface from working properly.

**How I verified it**
I ran the tests submitted in PR #15244 for sonic-mgmt repo on a local T0 testbed and verified that when all member ports of a VLAN are brought down, the VLAN interface remains operationally up and BGP advertisement and IP-in-IP decapsulation features work as expected.
