### PR TITLE
Support new TX_ERR field

### DIFF
--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -92,6 +92,7 @@ orchagent_SOURCES = \
             dtelorch.cpp \
             flexcounterorch.cpp \
             watermarkorch.cpp \
+            txmonorch.cpp \
             policerorch.cpp \
             sfloworch.cpp \
             chassisorch.cpp \

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -352,6 +352,13 @@ bool OrchDaemon::init()
         CFG_DTEL_EVENT_TABLE_NAME
     };
 
+    TableConnector stateDbTxErr(m_stateDb, /*"TX_ERR_STATE"*/STATE_TX_ERR_TABLE_NAME);
+    TableConnector applDbTxErr(m_applDb, /*"TX_ERR_APPL"*/APP_TX_ERR_TABLE_NAME);
+    TableConnector confDbTxErr(m_configDb, /*"TX_ERR_CFG"*/CFG_PORT_TX_ERR_TABLE_NAME);
+    TxMonOrch *gTxMonOrch = new TxMonOrch(applDbTxErr, confDbTxErr, stateDbTxErr);
+
+    SWSS_LOG_NOTICE("Create TxMonOrch object %p\n", gTxMonOrch);
+
     vector<string> wm_tables = {
         CFG_WATERMARK_TABLE_NAME,
         CFG_FLEX_COUNTER_TABLE_NAME
@@ -419,7 +426,10 @@ bool OrchDaemon::init()
      * when iterating ConsumerMap. This is ensured implicitly by the order of keys in ordered map.
      * For cases when Orch has to process tables in specific order, like PortsOrch during warm start, it has to override Orch::doTask()
      */
-    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, gFlowCounterRouteOrch, gIntfsOrch, gNeighOrch, gNhgMapOrch, gNhgOrch, gCbfNhgOrch, gRouteOrch, gCoppOrch, gQosOrch, wm_orch, gPolicerOrch, gTunneldecapOrch, sflow_orch, gDebugCounterOrch, gMacsecOrch, bgp_global_state_orch, gBfdOrch, gSrv6Orch, mux_orch, mux_cb_orch, gMonitorOrch};
+    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, gFlowCounterRouteOrch,\
+     gIntfsOrch, gNeighOrch, gNhgMapOrch, gNhgOrch, gCbfNhgOrch, gRouteOrch, gCoppOrch,\
+     gQosOrch, wm_orch, gPolicerOrch, gTunneldecapOrch, sflow_orch, gDebugCounterOrch, gMacsecOrch,\
+     bgp_global_state_orch, gBfdOrch, gSrv6Orch, mux_orch, mux_cb_orch, gMonitorOrch, gTxMonOrch};
 
     bool initialize_dtel = false;
     if (platform == BFN_PLATFORM_SUBSTRING || platform == VS_PLATFORM_SUBSTRING)

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -6,7 +6,7 @@
 #include "consumertable.h"
 #include "zmqserver.h"
 #include "select.h"
-
+#include "txmonorch.h"
 #include "portsorch.h"
 #include "fabricportsorch.h"
 #include "intfsorch.h"

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -9894,3 +9894,7 @@ void PortsOrch::doTask(swss::SelectableTimer &timer)
     }
 }
 
+bool PortsOrch::isPortReady() const
+{
+    return m_initDone && m_pendingPortSet.empty();
+}

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -246,6 +246,8 @@ public:
     bool setPortPtIntfId(const Port& port, sai_uint16_t intf_id);
     bool setPortPtTimestampTemplate(const Port& port, sai_port_path_tracing_timestamp_type_t ts_type);
 
+    bool isPortReady() const;
+
 private:
     unique_ptr<Table> m_counterTable;
     unique_ptr<Table> m_counterSysPortTable;

--- a/orchagent/txmonorch.cpp
+++ b/orchagent/txmonorch.cpp
@@ -1,0 +1,306 @@
+#include <linux/if_ether.h>
+#include <unordered_map>
+#include <vector>
+#include <memory>
+#include <utility>
+#include <exception>
+#include "txmonorch.h"
+#include "orch.h"
+#include "port.h"
+#include "logger.h"
+#include "sai_serialize.h"
+#include "converter.h"
+#include "portsorch.h"
+
+extern sai_port_api_t *sai_port_api;
+extern PortsOrch* gPortsOrch;
+
+using namespace std;
+
+string tx_status_name[] = {"ok", "error", "unknown"};
+
+TxMonOrch::TxMonOrch(TableConnector appDbConnector, TableConnector confDbConnector, TableConnector stateDbConnector) :
+    Orch(confDbConnector.first, confDbConnector.second),
+    m_countersDb(COUNTERS_DB, DBConnector::DEFAULT_UNIXSOCKET, 0),
+    m_countersTable(&m_countersDb, COUNTERS_TABLE),
+    m_pollTimer(new SelectableTimer(timespec { .tv_sec = 0, .tv_nsec = 0 })),
+    m_TxErrorTable(appDbConnector.first, appDbConnector.second),
+    m_stateTxErrorTable(stateDbConnector.first, stateDbConnector.second),
+    m_pollPeriod(0)
+{
+    // executor and m_pollTimer will both be released by Orch
+    // Design assumption
+    // 1. one Orch can have one or more Executor
+    // 2. one Executor must belong to one and only one Orch
+    // 3. Executor will hold an pointer to new-ed selectable, and delete it during dtor
+    auto executor = new ExecutableTimer(m_pollTimer, this, TXMONORCH_SEL_TIMER);
+    Orch::addExecutor(executor);
+    SWSS_LOG_NOTICE("TxMonOrch initialized with table %s %s %s\n",
+                    appDbConnector.second.c_str(),
+                    stateDbConnector.second.c_str(),
+                    confDbConnector.second.c_str());
+}
+
+void TxMonOrch::startTimer(uint32_t interval)
+{
+    SWSS_LOG_ENTER();
+
+    try
+    {
+        timespec interv{ .tv_sec = interval, .tv_nsec = 0 };
+        SWSS_LOG_INFO("startTimer, find executor %p\n", m_pollTimer);
+        // Is it ok to stop without having it started?
+        m_pollTimer->stop();
+        m_pollTimer->setInterval(interv);
+        m_pollTimer->start();
+        m_pollPeriod = interval;
+    }
+    catch (...)
+    {
+        SWSS_LOG_ERROR("Failed to start timer which might be due to failed to get timer\n");
+    }
+}
+
+int TxMonOrch::handlePeriodUpdate(const vector<FieldValueTuple>& data)
+{
+    bool needStart = false;
+    uint32_t periodToSet = 0;
+
+    SWSS_LOG_ENTER();
+
+    // Is it possible for redis to combine multiple updates and notify once?
+    // If so, we handle it in this way.
+    // However, in case of that, does it respect the order in which multiple updates comming?
+    // Suppose it does.
+    for (const auto& i : data)
+    {
+        try
+        {
+            if (fvField(i) == TXMONORCH_FIELD_CFG_PERIOD)
+            {
+                periodToSet = to_uint<uint32_t>(fvValue(i));
+                needStart |= (periodToSet != m_pollPeriod);
+                SWSS_LOG_INFO("TX_ERR handle cfg update period new %d\n", periodToSet);
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Unknown field type %s\n", fvField(i).c_str());
+                return -1;
+            }
+        }
+        catch (...)
+        {
+            SWSS_LOG_ERROR("Failed to handle period update\n");
+        }
+    }
+
+    if (needStart)
+    {
+        startTimer(periodToSet);
+        SWSS_LOG_INFO("TX_ERR poll timer restarted with interval %d\n", periodToSet);
+    }
+
+    return 0;
+}
+
+int TxMonOrch::handleThresholdUpdate(const string &port, const vector<FieldValueTuple>& data, bool clear)
+{
+    SWSS_LOG_ENTER();
+    try
+    {
+        if (clear)
+        {
+            //attention, for clear, no data is empty
+            //txErrThreshold(m_PortsTxErrStat[port]) = 0;
+            m_PortsTxErrStat.erase(port);
+            m_TxErrorTable.del(port);
+            m_stateTxErrorTable.del(port);
+            // TODO: remove data from state_db and appl_db
+            SWSS_LOG_INFO("TX_ERR threshold cleared for port %s\n", port.c_str());
+            return 0;
+        }
+
+        for (auto i : data)
+        {
+            if (TXMONORCH_FIELD_CFG_THRESHOLD == fvField(i))
+            {
+                TxErrorStatistics &stat = m_PortsTxErrStat[port];
+                if (stat.txErrPortId == TXMONORCH_INVALID_PORT_ID)
+                {
+                    //the first time this port is configured
+                    Port saiport;
+                    //what if port doesn't stand for a valid port?
+                    //that is, getPort returns false?
+                    //what if the interface is removed with threshold configured?
+                    if (gPortsOrch->getPort(port, saiport))
+                    {
+                        stat.txErrPortId = saiport.m_port_id;
+                    }
+                    stat.txErrState = TXMONORCH_PORT_STATE_UNKNOWN;
+                }
+                stat.txErrThreshold = to_uint<uint64_t>(fvValue(i));
+                SWSS_LOG_INFO("TX_ERR threshold reset to %ld for port %s\n",
+                              stat.txErrThreshold, port.c_str());
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Unknown field type %s when handle threshold for %s\n",
+                               fvField(i).c_str(), port.c_str());
+                return -1;
+            }
+        }
+    }
+    catch (...)
+    {
+        SWSS_LOG_ERROR("Fail to startTimer handle periodic update\n");
+    }
+
+    return 0;
+}
+
+/*handle configuration update*/
+void TxMonOrch::doTask(Consumer& consumer)
+{
+    SWSS_LOG_ENTER();
+    SWSS_LOG_INFO("TxMonOrch doTask consumer\n");
+
+    if (!gPortsOrch->isPortReady())
+    {
+        SWSS_LOG_INFO("Ports not ready\n");
+        return;
+    }
+
+    auto it = consumer.m_toSync.begin();
+    while (it != consumer.m_toSync.end())
+    {
+        KeyOpFieldsValuesTuple& t = it->second;
+
+        string key = kfvKey(t);
+        string op = kfvOp(t);
+        vector<FieldValueTuple> fvs = kfvFieldsValues(t);
+
+        int rc = -1;
+
+        SWSS_LOG_INFO("TX_ERR %s operation %s set %s del %s\n",
+                      key.c_str(),
+                      op.c_str(), SET_COMMAND, DEL_COMMAND);
+        if (key == TXMONORCH_KEY_CFG_PERIOD)
+        {
+            if (op == SET_COMMAND)
+            {
+                rc = handlePeriodUpdate(fvs);
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Unknown operation type %s when set period\n", op.c_str());
+            }
+        }
+        else //key should be the alias of interface
+        {
+            if (op == SET_COMMAND)
+            {
+                //fetch the value which reprsents threshold
+                rc = handleThresholdUpdate(key, fvs, false);
+            }
+            else if (op == DEL_COMMAND)
+            {
+                //reset to default
+                rc = handleThresholdUpdate(key, fvs, true);
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Unknown operation type %s when set threshold\n", op.c_str());
+            }
+        }
+
+        if (rc)
+        {
+            SWSS_LOG_ERROR("Handle configuration update failed index %s\n", key.c_str());
+        }
+
+        consumer.m_toSync.erase(it++);
+    }
+}
+
+int TxMonOrch::pollOnePortErrorStatistics(const string &port, TxErrorStatistics &stat)
+{
+    uint64_t txErrStat = 0;
+    uint64_t txErrStatLasttime = stat.txErrStat;
+    uint64_t txErrStatThreshold = stat.txErrThreshold;
+    int txErrPortState;
+    int txErrPortStateLastTime = stat.txErrState;
+
+    SWSS_LOG_ENTER();
+
+    static const vector<sai_stat_id_t> txErrStatId = {SAI_PORT_STAT_IF_OUT_ERRORS};
+    //get statistics from hal
+    //check FlexCounter::saiUpdateSupportedPortCounters in sai-redis for reference
+    sai_port_api->get_port_stats(stat.txErrPortId,
+                                static_cast<uint32_t>(txErrStatId.size()),
+                                txErrStatId.data(),
+                                &txErrStat);
+    SWSS_LOG_INFO("TX_ERR_POLL: got port %s txErr Stat %ld, lasttime %ld threshold %ld\n",
+                    port.c_str(), txErrStat, txErrStatLasttime, txErrStatThreshold);
+
+    if (txErrStat - txErrStatLasttime > txErrStatThreshold)
+    {
+        txErrPortState = TXMONORCH_PORT_STATE_ERROR;
+    }
+    else
+    {
+        txErrPortState = TXMONORCH_PORT_STATE_OK;
+    }
+
+    if (txErrPortState != txErrPortStateLastTime)
+    {
+        stat.txErrState = txErrPortState;
+        //set status in STATE_DB
+        vector<FieldValueTuple> fvs;
+        if (txErrPortState < TXMONORCH_PORT_STATE_MAX)
+            fvs.emplace_back(TXMONORCH_FIELD_STATE_TX_STATE, tx_status_name[txErrPortState]);
+        else
+            fvs.emplace_back(TXMONORCH_FIELD_STATE_TX_STATE, "invalid");
+        m_stateTxErrorTable.set(port, fvs);
+        SWSS_LOG_INFO("TX_ERR_CFG: port %s state changed to %d, push to db\n", port.c_str(), txErrPortState);
+    }
+
+    //refresh the local copy of last time statistics
+    stat.txErrStat = txErrStat;
+
+    return 0;
+}
+
+void TxMonOrch::pollErrorStatistics()
+{
+    SWSS_LOG_ENTER();
+
+    for (auto& i : m_PortsTxErrStat) {
+        auto& port = i.first;
+        auto& stat = i.second;
+        vector<FieldValueTuple> fields;
+
+        SWSS_LOG_INFO("TX_ERR_APPL: port %s tx_err_stat %ld, before get\n", port.c_str(), stat.txErrStat);
+        int rc = pollOnePortErrorStatistics(port, stat);
+        if (rc != 0) {
+            SWSS_LOG_ERROR("TX_ERR_APPL: got port %s tx_err_stat failed with rc %d\n", port.c_str(), rc);
+            continue;
+        }
+        fields.emplace_back(TXMONORCH_FIELD_APPL_STATI, to_string(stat.txErrStat));
+        fields.emplace_back(TXMONORCH_FIELD_APPL_TIMESTAMP, "0");
+        fields.emplace_back(TXMONORCH_FIELD_APPL_SAIPORTID, to_string(stat.txErrPortId));
+        m_TxErrorTable.set(port, fields);
+        SWSS_LOG_INFO("TX_ERR_APPL: port %s tx_err_stat %ld, push to db\n", port.c_str(),
+                      stat.txErrStat);
+    }
+
+    m_TxErrorTable.flush();
+    m_stateTxErrorTable.flush();
+    SWSS_LOG_INFO("TX_ERR_APPL: flush tables finish\n");
+}
+
+void TxMonOrch::doTask(SelectableTimer &timer)
+{
+    SWSS_LOG_INFO("TxMonOrch doTask selectable timer\n");
+    // For each port, check the statisticis
+    pollErrorStatistics();
+}

--- a/orchagent/txmonorch.h
+++ b/orchagent/txmonorch.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include "orch.h"
+#include "producerstatetable.h"
+#include "observer.h"
+#include "portsorch.h"
+#include "selectabletimer.h"
+#include "table.h"
+#include "select.h"
+#include "timer.h"
+
+#include <map>
+#include <algorithm>
+#include <tuple>
+#include <inttypes.h>
+
+extern "C" {
+    #include "sai.h"
+}
+
+/*fields definition*/
+#define TXMONORCH_FIELD_CFG_PERIOD      "tx_error_check_period"
+#define TXMONORCH_FIELD_CFG_THRESHOLD   "tx_error_threshold"
+
+#define TXMONORCH_FIELD_APPL_STATI      "tx_error_stati"
+#define TXMONORCH_FIELD_APPL_TIMESTAMP  "tx_error_timestamp"
+#define TXMONORCH_FIELD_APPL_SAIPORTID  "tx_error_portid"
+
+#define TXMONORCH_FIELD_STATE_TX_STATE  "tx_status"
+
+/*key name definition*/
+/*key name for each port is its intf name*/
+/*key name of global period*/
+#define TXMONORCH_KEY_CFG_PERIOD        "GLOBAL_PERIOD"
+
+/*table names are defined in schema.h*/
+
+#define TXMONORCH_ERR_STATE             "tx_status"
+
+#define TXMONORCH_SEL_TIMER             "TX_ERR_COUNTERS_POLL"
+
+enum TxMonOrchPortState {
+    TXMONORCH_PORT_STATE_OK = 0,
+    TXMONORCH_PORT_STATE_ERROR = 1,
+    TXMONORCH_PORT_STATE_UNKNOWN = 2,
+    TXMONORCH_PORT_STATE_MAX = 3
+};
+
+#define TXMONORCH_INVALID_PORT_ID       (0xFFFFUL)
+
+typedef struct {
+    int txErrState;
+    sai_object_id_t txErrPortId;
+    uint64_t txErrStat;
+    uint64_t txErrThreshold;
+} TxErrorStatistics;
+
+typedef std::map<std::string, TxErrorStatistics> TxErrorStatMap;
+
+class TxMonOrch : public Orch
+{
+public:
+    TxMonOrch(TableConnector appDbConnector,
+              TableConnector confDbConnector,
+              TableConnector stateDbConnector);
+
+    void startTimer(uint32_t interval);
+    int handlePeriodUpdate(const vector<FieldValueTuple>& data);
+    int handleThresholdUpdate(const string &key, const vector<FieldValueTuple>& data, bool clear);
+    int pollOnePortErrorStatistics(const string &port, TxErrorStatistics &stat);
+    void pollErrorStatistics();
+
+private:
+    //ProducerStateTable is designed to provide a IPC ability,
+    //Table is designed for data persistence.
+    //representing PORT_TX_STATISTICS_TABLE in APPL_DB
+    Table m_TxErrorTable;
+    //representing PORT_TX_STAT_TABLE in STATE_DB
+    Table m_stateTxErrorTable;
+
+    //for fetching statistics
+    DBConnector m_countersDb;
+    Table m_countersTable;
+
+    TxErrorStatMap m_PortsTxErrStat;
+
+    /*should be accessed via an atomic approach?*/
+    uint32_t m_pollPeriod;
+    int m_poolPeriodChanged;
+    SelectableTimer* m_pollTimer;
+
+    void doTask(Consumer& consumer);
+    void doTask(SelectableTimer& timer);
+};

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -57,6 +57,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 intfsorch_ut.cpp \
                 mux_rollback_ut.cpp \
                 warmrestartassist_ut.cpp \
+                txmonorch_ut.cpp \
                 test_failure_handling.cpp \
                 switchorch_ut.cpp \
                 warmrestarthelper_ut.cpp \
@@ -114,6 +115,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 $(top_srcdir)/orchagent/dtelorch.cpp \
                 $(top_srcdir)/orchagent/flexcounterorch.cpp \
                 $(top_srcdir)/orchagent/watermarkorch.cpp \
+                $(top_srcdir)/orchagent/txmonorch.cpp \
                 $(top_srcdir)/orchagent/chassisorch.cpp \
                 $(top_srcdir)/orchagent/sfloworch.cpp \
                 $(top_srcdir)/orchagent/debugcounterorch.cpp \

--- a/tests/mock_tests/txmonorch_ut.cpp
+++ b/tests/mock_tests/txmonorch_ut.cpp
@@ -1,0 +1,345 @@
+#define private public // make Directory::m_values available to clean it.
+#include "directory.h"
+#undef private
+
+#include "gtest/gtest.h"
+#include "mock_table.h"
+#include "ut_helper.h"
+#include "mock_orchagent_main.h"
+#include "txmonorch.h"
+
+namespace txmonorch_test
+{
+    using namespace std;
+
+    // copy from portorch_ut.cpp, logic to mock some sai APIs.
+
+    // SAI default ports
+    std::map<std::string, std::vector<swss::FieldValueTuple>> defaultPortList;
+
+    sai_port_api_t ut_sai_port_api;
+    sai_port_api_t *old_sai_port_api_ptr;
+
+    // return counters num with _sai_set_tx_err_counters.
+    uint32_t _sai_set_tx_err_counters;
+    sai_status_t _ut_stub_sai_get_port_stats(
+        _In_ sai_object_id_t port_id,
+        _In_ uint32_t number_of_counters,
+        _In_ const sai_stat_id_t *counter_ids,
+        _Out_ uint64_t *counters)
+    {
+        (void)port_id;
+        (void)number_of_counters;
+        (void)counter_ids;
+        *counters = _sai_set_tx_err_counters;
+        return SAI_STATUS_SUCCESS;
+    }
+
+    void _hook_sai_port_api()
+    {
+        ut_sai_port_api = *sai_port_api;
+        old_sai_port_api_ptr = sai_port_api;
+        ut_sai_port_api.get_port_stats = _ut_stub_sai_get_port_stats;
+
+        sai_port_api = &ut_sai_port_api;
+    }
+
+    void _unhook_sai_port_api()
+    {
+        sai_port_api = old_sai_port_api_ptr;
+    }
+
+    // Define a test fixture class
+    struct TxMonOrchTest : public ::testing::Test
+    {
+        shared_ptr<swss::DBConnector> m_app_db;
+        shared_ptr<swss::DBConnector> m_config_db;
+        shared_ptr<swss::DBConnector> m_state_db;
+        shared_ptr<swss::DBConnector> m_counters_db;
+        shared_ptr<swss::DBConnector> m_chassis_app_db;
+        shared_ptr<swss::DBConnector> m_asic_db;
+
+        TxMonOrchTest()
+        {
+            // again, logics come from portorch_ut.cpp
+
+            // FIXME: move out from constructor
+            m_app_db = make_shared<swss::DBConnector>(
+                "APPL_DB", 0);
+            m_counters_db = make_shared<swss::DBConnector>(
+                "COUNTERS_DB", 0);
+            m_config_db = make_shared<swss::DBConnector>(
+                "CONFIG_DB", 0);
+            m_state_db = make_shared<swss::DBConnector>(
+                "STATE_DB", 0);
+            m_chassis_app_db = make_shared<swss::DBConnector>(
+                "CHASSIS_APP_DB", 0);
+            m_asic_db = make_shared<swss::DBConnector>(
+                "ASIC_DB", 0);
+        }
+
+        virtual void SetUp() override
+        {
+            ::testing_db::reset();
+
+            // Create dependencies ...
+            TableConnector stateDbSwitchTable(m_state_db.get(), "SWITCH_CAPABILITY");
+            TableConnector app_switch_table(m_app_db.get(), APP_SWITCH_TABLE_NAME);
+            TableConnector conf_asic_sensors(m_config_db.get(), CFG_ASIC_SENSORS_TABLE_NAME);
+
+            vector<TableConnector> switch_tables = {
+                conf_asic_sensors,
+                app_switch_table
+            };
+
+            ASSERT_EQ(gSwitchOrch, nullptr);
+            gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
+
+            const int portsorch_base_pri = 40;
+
+            vector<table_name_with_pri_t> ports_tables = {
+                { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },
+                { APP_SEND_TO_INGRESS_PORT_TABLE_NAME, portsorch_base_pri + 5 },
+                { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },
+                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
+                { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },
+                { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
+            };
+
+            ASSERT_EQ(gPortsOrch, nullptr);
+
+            gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
+
+            vector<string> flex_counter_tables = {
+                CFG_FLEX_COUNTER_TABLE_NAME
+            };
+            auto* flexCounterOrch = new FlexCounterOrch(m_config_db.get(), flex_counter_tables);
+            gDirectory.set(flexCounterOrch);
+
+            vector<string> buffer_tables = { APP_BUFFER_POOL_TABLE_NAME,
+                                             APP_BUFFER_PROFILE_TABLE_NAME,
+                                             APP_BUFFER_QUEUE_TABLE_NAME,
+                                             APP_BUFFER_PG_TABLE_NAME,
+                                             APP_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME,
+                                             APP_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME };
+
+            ASSERT_EQ(gIntfsOrch, nullptr);
+            gIntfsOrch = new IntfsOrch(m_app_db.get(), APP_INTF_TABLE_NAME, gVrfOrch, m_chassis_app_db.get());
+
+            const int fdborch_pri = 20;
+
+            vector<table_name_with_pri_t> app_fdb_tables = {
+                { APP_FDB_TABLE_NAME,        FdbOrch::fdborch_pri},
+                { APP_VXLAN_FDB_TABLE_NAME,  FdbOrch::fdborch_pri},
+                { APP_MCLAG_FDB_TABLE_NAME,  fdborch_pri}
+            };
+
+            TableConnector stateDbFdb(m_state_db.get(), STATE_FDB_TABLE_NAME);
+            TableConnector stateMclagDbFdb(m_state_db.get(), STATE_MCLAG_REMOTE_FDB_TABLE_NAME);
+            ASSERT_EQ(gFdbOrch, nullptr);
+            gFdbOrch = new FdbOrch(m_app_db.get(), app_fdb_tables, stateDbFdb, stateMclagDbFdb, gPortsOrch);
+
+            ASSERT_EQ(gNeighOrch, nullptr);
+            gNeighOrch = new NeighOrch(m_app_db.get(), APP_NEIGH_TABLE_NAME, gIntfsOrch, gFdbOrch, gPortsOrch, m_chassis_app_db.get());
+
+            vector<string> qos_tables = {
+                CFG_TC_TO_QUEUE_MAP_TABLE_NAME,
+                CFG_SCHEDULER_TABLE_NAME,
+                CFG_DSCP_TO_TC_MAP_TABLE_NAME,
+                CFG_MPLS_TC_TO_TC_MAP_TABLE_NAME,
+                CFG_DOT1P_TO_TC_MAP_TABLE_NAME,
+                CFG_QUEUE_TABLE_NAME,
+                CFG_PORT_QOS_MAP_TABLE_NAME,
+                CFG_WRED_PROFILE_TABLE_NAME,
+                CFG_TC_TO_PRIORITY_GROUP_MAP_TABLE_NAME,
+                CFG_PFC_PRIORITY_TO_PRIORITY_GROUP_MAP_TABLE_NAME,
+                CFG_PFC_PRIORITY_TO_QUEUE_MAP_TABLE_NAME,
+                CFG_DSCP_TO_FC_MAP_TABLE_NAME,
+                CFG_EXP_TO_FC_MAP_TABLE_NAME,
+                CFG_TC_TO_DSCP_MAP_TABLE_NAME
+            };
+            gQosOrch = new QosOrch(m_config_db.get(), qos_tables);
+
+            vector<string> pfc_wd_tables = {
+                CFG_PFC_WD_TABLE_NAME
+            };
+
+            static const vector<sai_port_stat_t> portStatIds =
+            {
+                SAI_PORT_STAT_PFC_0_RX_PKTS,
+                SAI_PORT_STAT_PFC_1_RX_PKTS,
+                SAI_PORT_STAT_PFC_2_RX_PKTS,
+                SAI_PORT_STAT_PFC_3_RX_PKTS,
+                SAI_PORT_STAT_PFC_4_RX_PKTS,
+                SAI_PORT_STAT_PFC_5_RX_PKTS,
+                SAI_PORT_STAT_PFC_6_RX_PKTS,
+                SAI_PORT_STAT_PFC_7_RX_PKTS,
+                SAI_PORT_STAT_PFC_0_ON2OFF_RX_PKTS,
+                SAI_PORT_STAT_PFC_1_ON2OFF_RX_PKTS,
+                SAI_PORT_STAT_PFC_2_ON2OFF_RX_PKTS,
+                SAI_PORT_STAT_PFC_3_ON2OFF_RX_PKTS,
+                SAI_PORT_STAT_PFC_4_ON2OFF_RX_PKTS,
+                SAI_PORT_STAT_PFC_5_ON2OFF_RX_PKTS,
+                SAI_PORT_STAT_PFC_6_ON2OFF_RX_PKTS,
+                SAI_PORT_STAT_PFC_7_ON2OFF_RX_PKTS,
+            };
+
+            static const vector<sai_queue_stat_t> queueStatIds =
+            {
+                SAI_QUEUE_STAT_PACKETS,
+                SAI_QUEUE_STAT_CURR_OCCUPANCY_BYTES,
+            };
+
+            static const vector<sai_queue_attr_t> queueAttrIds =
+            {
+                SAI_QUEUE_ATTR_PAUSE_STATUS,
+            };
+            ASSERT_EQ((gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler>), nullptr);
+            gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler> = new PfcWdSwOrch<PfcWdDlrHandler, PfcWdDlrHandler>(m_config_db.get(), pfc_wd_tables, portStatIds, queueStatIds, queueAttrIds, 100);
+
+        }
+
+        virtual void TearDown() override
+        {
+            ::testing_db::reset();
+
+            auto buffer_maps = BufferOrch::m_buffer_type_maps;
+            for (auto &i : buffer_maps)
+            {
+                i.second->clear();
+            }
+
+            delete gNeighOrch;
+            gNeighOrch = nullptr;
+            delete gFdbOrch;
+            gFdbOrch = nullptr;
+            delete gIntfsOrch;
+            gIntfsOrch = nullptr;
+            delete gPortsOrch;
+            gPortsOrch = nullptr;
+            delete gBufferOrch;
+            gBufferOrch = nullptr;
+            delete gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler>;
+            gPfcwdOrch<PfcWdDlrHandler, PfcWdDlrHandler> = nullptr;
+            delete gQosOrch;
+            gQosOrch = nullptr;
+            delete gSwitchOrch;
+            gSwitchOrch = nullptr;
+
+            // clear orchs saved in directory
+            gDirectory.m_values.clear();
+        }
+
+        static void SetUpTestCase()
+        {
+            // Init switch and create dependencies
+
+            map<string, string> profile = {
+                { "SAI_VS_SWITCH_TYPE", "SAI_VS_SWITCH_TYPE_BCM56850" },
+                { "KV_DEVICE_MAC_ADDRESS", "20:03:04:05:06:00" }
+            };
+
+            auto status = ut_helper::initSaiApi(profile);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            sai_attribute_t attr;
+
+            attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+            attr.value.booldata = true;
+
+            status = sai_switch_api->create_switch(&gSwitchId, 1, &attr);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            // Get switch source MAC address
+            attr.id = SAI_SWITCH_ATTR_SRC_MAC_ADDRESS;
+            status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            gMacAddress = attr.value.mac;
+
+            // Get the default virtual router ID
+            attr.id = SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID;
+            status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            gVirtualRouterId = attr.value.oid;
+
+            // Get SAI default ports
+            defaultPortList = ut_helper::getInitialSaiPorts();
+            ASSERT_TRUE(!defaultPortList.empty());
+        }
+
+        static void TearDownTestCase()
+        {
+            auto status = sai_switch_api->remove_switch(gSwitchId);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+            gSwitchId = 0;
+
+            ut_helper::uninitSaiApi();
+        }
+    };
+
+    // We don't have API for checking period and threshold independtly
+    // Test with TX_ERR_STATE, TX_ERR_APPL and TX_ERR_CFG.
+    TEST_F(TxMonOrchTest, pollOnePortErrorStatisticsErr9SmallerThanThres10Test) {
+        // Given TX ERR DBs state, appl and cfg and last stat.
+        _hook_sai_port_api();
+        TableConnector stateDbTxErr(m_state_db.get(), STATE_TX_ERR_TABLE_NAME);
+        TableConnector applDbTxErr(m_app_db.get(), APP_TX_ERR_TABLE_NAME);
+        TableConnector confDbTxErr(m_config_db.get(), CFG_PORT_TX_ERR_TABLE_NAME);
+        TxMonOrch txMonOrch(applDbTxErr, confDbTxErr, stateDbTxErr);
+        vector<FieldValueTuple> period {{TXMONORCH_FIELD_CFG_PERIOD, "1"}};
+        vector<FieldValueTuple> threshold {{TXMONORCH_FIELD_CFG_THRESHOLD, "10"}};
+        // port ID 2, error count 0, threshold 10.
+        sai_object_id_t portId = 2;
+        uint64_t oriTxErrCnt = 0;
+        uint64_t thres = 10;
+        TxErrorStatistics stat = {TXMONORCH_PORT_STATE_UNKNOWN, portId, oriTxErrCnt, thres};
+
+        // When set tx err counter to 9, smaller than thres 10.
+        _sai_set_tx_err_counters = 9;
+        txMonOrch.pollOnePortErrorStatistics("2", stat);
+
+        // Then expect PORT state OK.
+        cout << "txErrState: " << stat.txErrState << endl;
+        cout << "txErrPortId: " << stat.txErrPortId << endl;
+        cout << "txErrStat: " << stat.txErrStat << endl;
+        cout << "txErrThreshold: " << stat.txErrThreshold << endl;
+        EXPECT_TRUE(stat.txErrState == TXMONORCH_PORT_STATE_OK);
+        EXPECT_TRUE(stat.txErrPortId == portId);
+        EXPECT_TRUE(stat.txErrStat == _sai_set_tx_err_counters);
+        EXPECT_TRUE(stat.txErrThreshold == thres);
+    }
+
+    TEST_F(TxMonOrchTest, pollOnePortErrorStatisticsErr100ExceedThres10Test) {
+        // Given TX ERR DBs state, appl and cfg and last stat.
+        _hook_sai_port_api();
+        TableConnector stateDbTxErr(m_state_db.get(), STATE_TX_ERR_TABLE_NAME);
+        TableConnector applDbTxErr(m_app_db.get(), APP_TX_ERR_TABLE_NAME);
+        TableConnector confDbTxErr(m_config_db.get(), CFG_PORT_TX_ERR_TABLE_NAME);
+        TxMonOrch txMonOrch(applDbTxErr, confDbTxErr, stateDbTxErr);
+        vector<FieldValueTuple> period {{TXMONORCH_FIELD_CFG_PERIOD, "1"}};
+        vector<FieldValueTuple> threshold {{TXMONORCH_FIELD_CFG_THRESHOLD, "10"}};
+        // port ID 2, error count 0, threshold 10.
+        sai_object_id_t portId = 2;
+        uint64_t oriTxErrCnt = 0;
+        uint64_t thres = 10;
+        TxErrorStatistics stat = {TXMONORCH_PORT_STATE_UNKNOWN, portId, oriTxErrCnt, thres};
+
+        // When set tx err counter to 100, bigger than thres 10.
+        _sai_set_tx_err_counters = 100;
+        txMonOrch.pollOnePortErrorStatistics("2", stat);
+
+        // Then expect PORT state ERROR.
+        cout << "txErrState: " << stat.txErrState << endl;
+        cout << "txErrPortId: " << stat.txErrPortId << endl;
+        cout << "txErrStat: " << stat.txErrStat << endl;
+        cout << "txErrThreshold: " << stat.txErrThreshold << endl;
+        EXPECT_TRUE(stat.txErrState == TXMONORCH_PORT_STATE_ERROR);
+        EXPECT_TRUE(stat.txErrPortId == portId);
+        EXPECT_TRUE(stat.txErrStat == _sai_set_tx_err_counters);
+        EXPECT_TRUE(stat.txErrThreshold == thres);
+    }
+}


### PR DESCRIPTION
Note, this PR has dependency on:
https://github.com/jianyuewu/sonic-utilities/pull/1

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
[Orchagent]: Support new TX_ERR field
Add TX_ERR_CFG table in CONFIG_DB
Add TX_ERR_APPL table in APPL_DB
Add TX_ERR_STATE table in STATE_DB

**What I did**
Add TX_ERR_CFG table in CONFIG_DB
Add TX_ERR_APPL table in APPL_DB
Add TX_ERR_STATE table in STATE_DB

Add TxMonOrch to monitor the tx error counters.
Start a timer with period from user, so it will periodically monitor the tx error counter value changes.
Handle threshold update, when tx error counter exceeds threshold, interface status will be marked as not OK.
It will traverse all ports to get tx error counters.

**Why I did it**
In current scenario, we need some tx error counters to indicate there is some issue happen.
So we need add new table and configuration update in orchagent.

**How I verified it**
Add UT to verify.
Verify via utility commands in ENV.

**Details if related**