### PR TITLE
[subnet_decap] Unbreak orchagent on ASICs that don't support IPINIP tunnels

### DIFF
--- a/orchagent/tunneldecaporch.cpp
+++ b/orchagent/tunneldecaporch.cpp
@@ -849,6 +849,24 @@ bool TunnelDecapOrch::addDecapTunnel(
     status = sai_tunnel_api->create_tunnel(&tunnel_id, gSwitchId, (uint32_t)tunnel_attrs.size(), tunnel_attrs.data());
     if (status != SAI_STATUS_SUCCESS)
     {
+        if (status == SAI_STATUS_NOT_SUPPORTED || status == SAI_STATUS_NOT_IMPLEMENTED || status == SAI_STATUS_ATTR_NOT_IMPLEMENTED_0)
+        {
+            SWSS_LOG_WARN("SAI_API_TUNNEL (create SAI_TUNNEL_TYPE_IPINIP): unsupported (%d) for tunnel %s (%d).", (int)status, key.c_str(), (int)tunnel_id);
+
+            // Make sure we're not leaking a SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID overlayIfId here.
+            sai_status_t rm_status = sai_router_intfs_api->remove_router_interface(overlayIfId);
+            if (rm_status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to remove tunnel overlay interface: %" PRIu64, overlayIfId);
+                task_process_status rm_handle_status = handleSaiRemoveStatus(SAI_API_ROUTER_INTERFACE, rm_status);
+                if (rm_handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(rm_handle_status);
+                }
+            }
+            return false;
+        }
+
         SWSS_LOG_ERROR("Failed to create tunnel");
         task_process_status handle_status = handleSaiCreateStatus(SAI_API_TUNNEL, status);
         if (handle_status != task_success)
@@ -979,6 +997,11 @@ bool TunnelDecapOrch::addDecapTunnelTermEntry(
     sai_status_t status = sai_tunnel_api->create_tunnel_term_table_entry(&tunnel_term_table_entry_id, gSwitchId, (uint32_t)tunnel_table_entry_attrs.size(), tunnel_table_entry_attrs.data());
     if (status != SAI_STATUS_SUCCESS)
     {
+        if (status == SAI_STATUS_NOT_SUPPORTED || status == SAI_STATUS_NOT_IMPLEMENTED || status == SAI_STATUS_ATTR_NOT_IMPLEMENTED_0)
+        {
+            SWSS_LOG_WARN("SAI_API_TUNNEL (create SAI_TUNNEL_TYPE_IPINIP): unsupported (%d) for tunnel %s with IP %s.", (int)status, tunnel_name.c_str(), dst_ip.to_string().c_str());
+            return false;
+        }
         SWSS_LOG_ERROR("Failed to create tunnel decap term entry %s.", dst_ip.to_string().c_str());
         task_process_status handle_status = handleSaiCreateStatus(SAI_API_TUNNEL, status);
         if (handle_status != task_success)


### PR DESCRIPTION
The Tomahawk 3 chipset on an Accton AS9716-32D does not do SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_P2MP tunnels and returns SAI_STATUS_NOT_SUPPORTED.

Since #3117, such a tunnel is created unconditionally whenever an IP address is added to Loopback0. The SAI_STATUS_NOT_SUPPORTED is handled as an unrecoverable error. That takes the orchagent down and syncd along with it.

    root@spine2:0:~# dmidecode 2>/dev/null | grep -A1 'Manufacturer:' | head -n2
    Manufacturer: Accton
    Product Name: AS9716-32D

    root@spine2:0:~# printf '%s\n' 'bsv' 'show unit' 'ver' |
        xargs -d\\n -n1 bcmcmd -t 1 | grep '^[A-Z]'
    BRCM SAI ver: [11.2.13.1], OCP SAI ver: [1.14.0], SDK ver: [sdk-6.5.30-SP4]
    Unit 0 chip BCM56980_B0 (current)
    Broadcom Command Monitor: Copyright (c) 1998-2024 Broadcom
    Release: sdk-6.5.30-SP4 built 20241016 (Wed Oct 16 13:33:02 2024)
    From root@7ec56acb7b44:/__w/1/s/output/x86-xgsall-deb/xgs-sdk-src/hsdk-all-6.5.30
    Platform: X86
    OS: Unix (Posix)

Logs output:

    NOTICE swss#orchagent: :- addDecapTunnel: Create overlay loopback router interface oid:60000000005b2
    NOTICE swss#orchagent: :- doDecapTunnelTask: Tunnel IPINIP_TUNNEL added to ASIC_DB.
    ERR syncd#syncd: :- sendApiResponse: api SAI_COMMON_API_CREATE failed in syncd mode: SAI_STATUS_NOT_SUPPORTED
    ERR syncd#syncd: :- processQuadEvent: attr: SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_VR_ID: oid:0x3000000000021a
    ...
    ERR swss#orchagent: :- create: create status: SAI_STATUS_NOT_SUPPORTED
    ERR swss#orchagent: :- addDecapTunnelTermEntry: Failed to create tunnel decap term entry 10.1.0.1/32.
    ERR swss#orchagent: :- handleSaiCreateStatus: Encountered failure in create operation, exiting orchagent, SAI API: SAI_API_TUNNEL, status: SAI_STATUS_NOT_SUPPORTED
    NOTICE swss#orchagent: :- notifySyncd: sending syncd: SYNCD_INVOKE_DUMP
    NOTICE syncd#syncd: :- processNotifySyncd: Invoking SAI failure dump

This changeset adds a check for SAI_STATUS_NOT_SUPPORTED, turning the error into a warning and going back to behaviour before subnet_decap was added:

    ERR swss#orchagent: :- create: create status: SAI_STATUS_NOT_SUPPORTED
    WARNING swss#orchagent: :- addDecapTunnelTermEntry: Creating SAI_API_TUNNEL returned SAI_STATUS_NOT_SUPPORTED for tunnel IPINIP_TUNNEL IP 10.1.0.1/32.
    ERR swss#orchagent: :- doDecapTunnelTermTask: IPINIP_TUNNEL:10.1.0.1: failed to add tunnel decap term to ASIC_DB.

Resolves: https://github.com/sonic-net/sonic-buildimage/issues/20837

**What I did**

Replace error and failure handling with a warning and false return.

**Why I did it**

Because the Tomahawk 3 is unusable without this fix.

**How I verified it**

Adding the code resolved the issue. All IP addresses (local and remote) still responded to ping.

**Details if related**

Also needs cherry-pick to 202405.