### PR TITLE
Ensure second route group OID is correct

### DIFF
--- a/tests/dash/test_dash_route_group.py
+++ b/tests/dash/test_dash_route_group.py
@@ -44,7 +44,11 @@ def test_rebind_eni_route_group(dash_db: DashDB):
 
     dash_db.set_app_db_entry(APP_DASH_ROUTE_GROUP_TABLE_NAME, ROUTE_GROUP2, ROUTE_GROUP2_CONFIG)
     dash_db.set_app_db_entry(APP_DASH_ROUTE_TABLE_NAME, ROUTE_GROUP2, OUTBOUND_ROUTE_PREFIX1, ROUTE_VNET_CONFIG_UNDERLAY_SIP)
-    rg2_oid = dash_db.wait_for_asic_db_keys("ASIC_STATE:SAI_OBJECT_TYPE_OUTBOUND_ROUTING_GROUP", min_keys=2)[1]
+    oids = dash_db.wait_for_asic_db_keys("ASIC_STATE:SAI_OBJECT_TYPE_OUTBOUND_ROUTING_GROUP", min_keys=2)
+    for oid in oids:
+        if oid != rg1_oid:
+            rg2_oid = oid
+            break
 
     dash_db.set_app_db_entry(APP_DASH_ENI_ROUTE_TABLE_NAME, ENI_ID, ENI_ROUTE_GROUP1_CONFIG)
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When grabbing the second route group OID, ensure that it is distinct from the first route group OID

**Why I did it**
The order in which DB keys are returned is not deterministic, so blindly taking the last key returned will sometimes lead to selecting the wrong OID

**How I verified it**
Run the test 10 times and verify they all pass. (Prior to the fix at least one run would fail, usually more)

**Details if related**
