### PR TITLE
[orchagent]: VXLAN: Fix oper_status and tunnel encapsulation TTL

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -7305,7 +7305,9 @@ bool PortsOrch::addTunnel(string tunnel_alias, sai_object_id_t tunnel_id, bool h
     {
         tunnel.m_learn_mode = SAI_BRIDGE_PORT_FDB_LEARNING_MODE_DISABLE;
     }
+    tunnel.m_oper_status = SAI_PORT_OPER_STATUS_DOWN;
     m_portList[tunnel_alias] = tunnel;
+    saiOidToAlias[tunnel_id] = tunnel_alias;
 
     SWSS_LOG_INFO("addTunnel:: %" PRIx64, tunnel_id);
 
@@ -7316,6 +7318,7 @@ bool PortsOrch::removeTunnel(Port tunnel)
 {
     SWSS_LOG_ENTER();
 
+    saiOidToAlias.erase(tunnel.m_tunnel_id);
     m_portList.erase(tunnel.m_alias);
 
     return true;
@@ -8265,9 +8268,10 @@ void PortsOrch::updatePortOperStatus(Port &port, sai_port_oper_status_t status)
         return;
     }
 
+    updateDbPortOperStatus(port, status);
+
     if (port.m_type == Port::PHY)
     {
-        updateDbPortOperStatus(port, status);
         updateDbPortFlapCount(port, status);
         updateGearboxPortOperStatus(port);
 

--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -275,7 +275,7 @@ create_tunnel(
     sai_ip_address_t *dst_ip,
     sai_object_id_t underlay_rif,
     bool p2p,
-    sai_uint8_t encap_ttl=0)
+    sai_uint8_t encap_ttl)
 {
     sai_attribute_t attr;
     std::vector<sai_attribute_t> tunnel_attrs;
@@ -349,16 +349,13 @@ create_tunnel(
         tunnel_attrs.push_back(attr);
     }
 
-    if (encap_ttl != 0)
-    {
-        attr.id = SAI_TUNNEL_ATTR_ENCAP_TTL_MODE;
-        attr.value.s32 = SAI_TUNNEL_TTL_MODE_PIPE_MODEL;
-        tunnel_attrs.push_back(attr);
+    attr.id = SAI_TUNNEL_ATTR_ENCAP_TTL_MODE;
+    attr.value.s32 = SAI_TUNNEL_TTL_MODE_PIPE_MODEL;
+    tunnel_attrs.push_back(attr);
 
-        attr.id = SAI_TUNNEL_ATTR_ENCAP_TTL_VAL;
-        attr.value.u8 = encap_ttl;
-        tunnel_attrs.push_back(attr);
-    }
+    attr.id = SAI_TUNNEL_ATTR_ENCAP_TTL_VAL;
+    attr.value.u8 = encap_ttl;
+    tunnel_attrs.push_back(attr);
 
     sai_object_id_t tunnel_id;
     sai_status_t status = sai_tunnel_api->create_tunnel(

--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -275,7 +275,7 @@ create_tunnel(
     sai_ip_address_t *dst_ip,
     sai_object_id_t underlay_rif,
     bool p2p,
-    sai_uint8_t encap_ttl)
+    sai_uint8_t encap_ttl=0)
 {
     sai_attribute_t attr;
     std::vector<sai_attribute_t> tunnel_attrs;
@@ -349,13 +349,16 @@ create_tunnel(
         tunnel_attrs.push_back(attr);
     }
 
-    attr.id = SAI_TUNNEL_ATTR_ENCAP_TTL_MODE;
-    attr.value.s32 = SAI_TUNNEL_TTL_MODE_PIPE_MODEL;
-    tunnel_attrs.push_back(attr);
+    if (encap_ttl != 0)
+    {
+        attr.id = SAI_TUNNEL_ATTR_ENCAP_TTL_MODE;
+        attr.value.s32 = SAI_TUNNEL_TTL_MODE_PIPE_MODEL;
+        tunnel_attrs.push_back(attr);
 
-    attr.id = SAI_TUNNEL_ATTR_ENCAP_TTL_VAL;
-    attr.value.u8 = encap_ttl;
-    tunnel_attrs.push_back(attr);
+        attr.id = SAI_TUNNEL_ATTR_ENCAP_TTL_VAL;
+        attr.value.u8 = encap_ttl;
+        tunnel_attrs.push_back(attr);
+    }
 
     sai_object_id_t tunnel_id;
     sai_status_t status = sai_tunnel_api->create_tunnel(

--- a/orchagent/vxlanorch.h
+++ b/orchagent/vxlanorch.h
@@ -46,7 +46,7 @@ typedef enum
 #define MAX_VLAN_ID 4095
 
 #define MAX_VNI_ID 16777215
-#define DEFAULT_TUNNEL_ENCAP_TTL 64
+#define DEFAULT_TUNNEL_ENCAP_TTL 255
 
 typedef enum
 {

--- a/orchagent/vxlanorch.h
+++ b/orchagent/vxlanorch.h
@@ -46,6 +46,7 @@ typedef enum
 #define MAX_VLAN_ID 4095
 
 #define MAX_VNI_ID 16777215
+#define DEFAULT_TUNNEL_ENCAP_TTL 64
 
 typedef enum
 {
@@ -196,7 +197,7 @@ public:
 
     bool deleteMapperHw(uint8_t mapper_list, tunnel_map_use_t map_src);
     bool createMapperHw(uint8_t mapper_list, tunnel_map_use_t map_src);
-    bool createTunnelHw(uint8_t mapper_list, tunnel_map_use_t map_src, bool with_term = true, sai_uint8_t encap_ttl=0);
+    bool createTunnelHw(uint8_t mapper_list, tunnel_map_use_t map_src, bool with_term = true, sai_uint8_t encap_ttl=DEFAULT_TUNNEL_ENCAP_TTL);
     bool deleteTunnelHw(uint8_t mapper_list, tunnel_map_use_t map_src, bool with_term = true);
     void deletePendingSIPTunnel();
     void increment_spurious_imr_add(const std::string remote_vtep);
@@ -299,7 +300,7 @@ public:
 
 
     bool createVxlanTunnelMap(string tunnelName, tunnel_map_type_t mapType, uint32_t vni,
-                              sai_object_id_t encap, sai_object_id_t decap, uint8_t encap_ttl=0);
+                              sai_object_id_t encap, sai_object_id_t decap, uint8_t encap_ttl=DEFAULT_TUNNEL_ENCAP_TTL);
 
     bool removeVxlanTunnelMap(string tunnelName, uint32_t vni);
 

--- a/tests/evpn_tunnel.py
+++ b/tests/evpn_tunnel.py
@@ -569,6 +569,8 @@ class VxlanTunnel(object):
                         'SAI_TUNNEL_ATTR_ENCAP_MAPPERS': encapstr,
                         'SAI_TUNNEL_ATTR_PEER_MODE': 'SAI_TUNNEL_PEER_MODE_P2MP',
                         'SAI_TUNNEL_ATTR_ENCAP_SRC_IP': src_ip,
+                        'SAI_TUNNEL_ATTR_ENCAP_TTL_MODE': 'SAI_TUNNEL_TTL_MODE_PIPE_MODEL',
+                        'SAI_TUNNEL_ATTR_ENCAP_TTL_VAL': '255',
                     }
                 )
 
@@ -675,6 +677,8 @@ class VxlanTunnel(object):
                         'SAI_TUNNEL_ATTR_ENCAP_MAPPERS': encapstr,
                         'SAI_TUNNEL_ATTR_ENCAP_SRC_IP': src_ip,
                         'SAI_TUNNEL_ATTR_ENCAP_DST_IP': dip,
+                        'SAI_TUNNEL_ATTR_ENCAP_TTL_MODE': 'SAI_TUNNEL_TTL_MODE_PIPE_MODEL',
+                        'SAI_TUNNEL_ATTR_ENCAP_TTL_VAL': '255',
                     }
            
         ret = self.helper.get_key_with_attr(asic_db, self.ASIC_TUNNEL_TABLE, expected_tun_attributes)

--- a/tests/test_vxlan_tunnel.py
+++ b/tests/test_vxlan_tunnel.py
@@ -154,7 +154,7 @@ def check_vxlan_tunnel(dvs, src_ip, dst_ip, tunnel_map_ids, tunnel_map_entry_ids
                         'SAI_TUNNEL_ATTR_PEER_MODE': 'SAI_TUNNEL_PEER_MODE_P2MP',
                         'SAI_TUNNEL_ATTR_ENCAP_SRC_IP': src_ip,
                         'SAI_TUNNEL_ATTR_ENCAP_TTL_MODE': 'SAI_TUNNEL_TTL_MODE_PIPE_MODEL',
-                        'SAI_TUNNEL_ATTR_ENCAP_TTL_VAL': '64'
+                        'SAI_TUNNEL_ATTR_ENCAP_TTL_VAL': '255'
                     }
                 )
 

--- a/tests/test_vxlan_tunnel.py
+++ b/tests/test_vxlan_tunnel.py
@@ -152,7 +152,9 @@ def check_vxlan_tunnel(dvs, src_ip, dst_ip, tunnel_map_ids, tunnel_map_entry_ids
                         'SAI_TUNNEL_ATTR_DECAP_MAPPERS': decapstr,
                         'SAI_TUNNEL_ATTR_ENCAP_MAPPERS': encapstr,
                         'SAI_TUNNEL_ATTR_PEER_MODE': 'SAI_TUNNEL_PEER_MODE_P2MP',
-                        'SAI_TUNNEL_ATTR_ENCAP_SRC_IP': src_ip
+                        'SAI_TUNNEL_ATTR_ENCAP_SRC_IP': src_ip,
+                        'SAI_TUNNEL_ATTR_ENCAP_TTL_MODE': 'SAI_TUNNEL_TTL_MODE_PIPE_MODEL',
+                        'SAI_TUNNEL_ATTR_ENCAP_TTL_VAL': '64'
                     }
                 )
 


### PR DESCRIPTION
**What I did**

This fixes 2 issues across a range of open tickets building upon patches created by others with modifications as requested by @VladimirKuk.

The first issue this resolves is the status shown for remote vteps which in the fact that it is wrong makes debugging nearly impossible:
```
# show vxlan remotevtep
+------------+------------+-------------------+--------------+
| SIP        | DIP        | Creation Source   | OperStatus   |
+============+============+===================+==============+
| 172.16.0.1 | 172.16.0.2 | EVPN              | oper_down    |
+------------+------------+-------------------+--------------+
Total count : 1
```

The remote VTEP is really up.

Original PR for that is #2080.

Also fixes https://github.com/sonic-net/sonic-buildimage/issues/10004 or at least the error message which hurts debugging.

The next issue is in reachabiity across VXLANs.  This fixes IP/MAC learning via ARP.  The original PR for that is #3216, however it appears it has its origins in
https://github.com/sonic-net/sonic-buildimage/issues/10050 which goes into greater detail about the issue itself.  Also there is talk about it here https://github.com/kamelnetworks/sonic/issues/9 as well as another similar patch here: https://github.com/kamelnetworks/sonic-swss/commit/02ee3e3

**Why I did it**

Fixes #3216
Fixes #2080
Fixes https://github.com/sonic-net/sonic-buildimage/issues/10050
Fixes https://github.com/sonic-net/sonic-buildimage/issues/10004

**How I verified it**

Pulled into my private sonic-swss fork:
https://github.com/bradh352/sonic-swss/commits/bradh352/master

Which is pulled in by my private sonic-buildimage fork:
https://github.com/bradh352/sonic-buildimage/tree/bradh352/master

Which is then automatically built when changes are made.  Then the uploaded asset of sonic-broadcom.bin is installed onto Dell S5248F switches and tested.

Update: also now tested by me on Mellanox/NVidia SN2201

**Details if related**

 Signed-off-by: Brad House (@bradh352)

This should also be backported to 202411, 202405
