### PR TITLE
Capability query for MACSEC ACL attribute

### DIFF
--- a/orchagent/macsecorch.cpp
+++ b/orchagent/macsecorch.cpp
@@ -38,6 +38,7 @@ extern sai_switch_api_t *sai_switch_api;
 constexpr bool DEFAULT_ENABLE_ENCRYPT = true;
 constexpr bool DEFAULT_SCI_IN_SECTAG = false;
 constexpr sai_macsec_cipher_suite_t DEFAULT_CIPHER_SUITE = SAI_MACSEC_CIPHER_SUITE_GCM_AES_128;
+bool saiAclFieldSciMatchSupported = true;
 
 static const std::vector<std::string> macsec_sa_attrs =
     {
@@ -637,6 +638,17 @@ MACsecOrch::MACsecOrch(
                                 MACSEC_STAT_POLLING_INTERVAL_MS, true)
 {
     SWSS_LOG_ENTER();
+    sai_attr_capability_t capability;
+    if (sai_query_attribute_capability(gSwitchId, SAI_OBJECT_TYPE_ACL_TABLE,
+                                            SAI_ACL_TABLE_ATTR_FIELD_MACSEC_SCI,
+                                            &capability) == SAI_STATUS_SUCCESS)
+    {
+        if (capability.create_implemented == false)
+        {
+            SWSS_LOG_DEBUG("SAI_ACL_TABLE_ATTR_FIELD_MACSEC_SCI is not supported");
+            saiAclFieldSciMatchSupported = false;
+        }
+    }
 }
 
 MACsecOrch::~MACsecOrch()
@@ -2570,9 +2582,12 @@ bool MACsecOrch::createMACsecACLTable(
     attr.value.booldata = true;
     attrs.push_back(attr);
 
-    attr.id = SAI_ACL_TABLE_ATTR_FIELD_MACSEC_SCI;
-    attr.value.booldata = sci_in_sectag;
-    attrs.push_back(attr);
+    if (saiAclFieldSciMatchSupported == true)
+    {
+       attr.id = SAI_ACL_TABLE_ATTR_FIELD_MACSEC_SCI;
+       attr.value.booldata = sci_in_sectag;
+       attrs.push_back(attr);
+    }
 
     sai_status_t status = sai_acl_api->create_acl_table(
                                 &table_id,
@@ -2738,7 +2753,7 @@ bool MACsecOrch::createMACsecACLDataEntry(
     attr.value.aclaction.parameter.s32 = SAI_PACKET_ACTION_DROP;
     attr.value.aclaction.enable = true;
     attrs.push_back(attr);
-    if (sci_in_sectag)
+    if ((saiAclFieldSciMatchSupported == true) && sci_in_sectag)
     {
         attr.id = SAI_ACL_ENTRY_ATTR_FIELD_MACSEC_SCI;
         attr.value.aclfield.enable = true;


### PR DESCRIPTION
What I did
-Modified the MACsec orchestration logic to conditionally include or exclude the ability to match the SCI in ACL configurations based on the ASIC's capabilities.
-Implemented a capability check in SONiC to determine whether the SAI_ACL_TABLE_ATTR_FIELD_MACSEC_SCI attribute is supported by the ASIC, thus ensuring that neither SAI_ACL_TABLE_ATTR_FIELD_MACSEC_SCI nor SAI_ACL_ENTRY_ATTR_FIELD_MACSEC_SCI is used when unsupported.

Why I did it

The current implementation attempts to use the SAI_ACL_ENTRY_ATTR_FIELD_MACSEC_SCI attribute even when it's not supported by the underlying ASIC or driver, causing failures in the vendor's SAI/SDK code.
The capability check prevents these errors, ensuring compatibility with different hardware.

How I verified it

Compiled the code successfully without errors.
Conducted manual tests on Marvell platforms without support for the SAI_ACL_TABLE_ATTR_FIELD_MACSEC_SCI attribute to validate the conditional logic.
Details if related
Fixes the issue raised in https://github.com/sonic-net/sonic-swss/issues/3134
