### PR TITLE
[buffer] indicate shared pool by putting a very small shared buffer pool size

### DIFF
--- a/cfgmgr/buffer_pool_mellanox.lua
+++ b/cfgmgr/buffer_pool_mellanox.lua
@@ -166,7 +166,11 @@ local function fetch_buffer_pool_size_from_appldb(shp_enabled)
                 -- In case the orchagent starts handling buffer configuration between 2 and 3,
                 -- It is inconsistent between buffer pools and profiles, which fails Mellanox SAI sanity check
                 -- To avoid it, it indicates the shared headroom pool is enabled by setting a very small buffer pool and shared headroom pool sizes
-                table.insert(result, buffer_pools[i] .. ':2048:1024')
+                if size == "0" then
+                    table.insert(result, buffer_pools[i] .. ':2048:1024')
+                else
+                    table.insert(result, buffer_pools[i] .. ":" .. size .. ':1024')
+                end
             else
                 table.insert(result, buffer_pools[i] .. ':' .. size)
             end


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Put a very small shared buffer pool size when shared pool is detected enabling.

**Why I did it**

Avoid a timing issue like following:

1. the buffer pool sizes, xoff have initialized to 0, which means the shared headroom pool is disabled
2. but the buffer profiles already indicate the shared headroom pool is enabled
3. later on the buffer pool sizes are updated with xoff being non-zero

In case the orchagent starts handling buffer configuration between 2 and 3, it is inconsistent between buffer pools and profiles, which fails Mellanox SAI sanity check and causes orchagent abort

**How I verified it**

Manual test
Run sonic-mgmt regression

**Details if related**
