### PR TITLE
[muxorch] Process nexthops using bulker during mux switchover

### DIFF
--- a/orchagent/mplsrouteorch.cpp
+++ b/orchagent/mplsrouteorch.cpp
@@ -520,7 +520,8 @@ bool RouteOrch::addLabelRoute(LabelRouteBulkContext& ctx, const NextHopGroupKey 
                      m_neighOrch->isNeighborResolved(nexthop))
             {
                 /* since IP neighbor NH exists, neighbor is resolved, add MPLS NH */
-                if (m_neighOrch->addNextHop(nexthop))
+                NeighborContext ctx = NeighborContext(nexthop);
+                if (m_neighOrch->addNextHop(ctx))
                 {
                     next_hop_id = m_neighOrch->getNextHopId(nexthop);
                 }

--- a/orchagent/neighorch.h
+++ b/orchagent/neighorch.h
@@ -50,9 +50,11 @@ struct NeighborUpdate
 struct NeighborContext
 {
     NeighborEntry                       neighborEntry;              // neighbor entry to process
-    std::deque<sai_status_t>            object_statuses;            // bulk statuses
+    std::deque<sai_status_t>            object_statuses;            // entity bulk statuses for neighbors
     MacAddress                          mac;                        // neighbor mac
     bool                                bulk_op = false;            // use bulker (only for mux use for now)
+    sai_object_id_t                     next_hop_id;                // next hop id
+    sai_status_t                        nexthop_status;             // next hop status
 
     NeighborContext(NeighborEntry neighborEntry)
         : neighborEntry(neighborEntry)
@@ -73,7 +75,7 @@ public:
 
     bool hasNextHop(const NextHopKey&);
     bool isNeighborResolved(const NextHopKey&);
-    bool addNextHop(const NextHopKey&);
+    bool addNextHop(NeighborContext& ctx);
     bool removeMplsNextHop(const NextHopKey&);
 
     sai_object_id_t getNextHopId(const NextHopKey&);
@@ -120,8 +122,10 @@ private:
     std::set<NextHopKey> m_neighborToResolve;
 
     EntityBulker<sai_neighbor_api_t> gNeighBulker;
+    ObjectBulker<sai_next_hop_api_t> gNextHopBulker;
 
     bool removeNextHop(const IpAddress&, const string&);
+    bool processBulkAddNextHop(NeighborContext&);
 
     bool addNeighbor(NeighborContext& ctx);
     bool removeNeighbor(NeighborContext& ctx, bool disable = false);

--- a/orchagent/nhgorch.cpp
+++ b/orchagent/nhgorch.cpp
@@ -486,7 +486,8 @@ sai_object_id_t NextHopGroupMember::getNhId() const
      */
     else if (isLabeled() && gNeighOrch->isNeighborResolved(m_key))
     {
-        if (gNeighOrch->addNextHop(m_key))
+        NeighborContext ctx = NeighborContext(m_key);
+        if (gNeighOrch->addNextHop(ctx))
         {
             nh_id = gNeighOrch->getNextHopId(m_key);
         }

--- a/orchagent/p4orch/tests/mock_sai_next_hop.h
+++ b/orchagent/p4orch/tests/mock_sai_next_hop.h
@@ -22,6 +22,13 @@ class MockSaiNextHop
 
     MOCK_METHOD3(get_next_hop_attribute, sai_status_t(_In_ sai_object_id_t next_hop_id, _In_ uint32_t attr_count,
                                                       _Inout_ sai_attribute_t *attr_list));
+
+    MOCK_METHOD7(create_next_hops, sai_status_t(_In_ sai_object_id_t switch_id, _In_ uint32_t object_count, _In_ const uint32_t *attr_count,
+                                                _In_ const sai_attribute_t **attr_list, _In_ sai_bulk_op_error_mode_t mode,
+                                                _Out_ sai_object_id_t *object_id, _Out_ sai_status_t *object_statuses));
+
+    MOCK_METHOD4(remove_next_hops, sai_status_t(_In_ uint32_t object_count, _In_ const sai_object_id_t *object_id, _In_ sai_bulk_op_error_mode_t mode,
+                                                _Out_ sai_status_t *object_statuses));
 };
 
 // Note that before mock functions below are used, mock_sai_next_hop must be
@@ -48,4 +55,18 @@ sai_status_t mock_get_next_hop_attribute(_In_ sai_object_id_t next_hop_id, _In_ 
                                          _Inout_ sai_attribute_t *attr_list)
 {
     return mock_sai_next_hop->get_next_hop_attribute(next_hop_id, attr_count, attr_list);
+}
+
+sai_status_t mock_create_next_hops(_In_ sai_object_id_t switch_id, _In_ uint32_t object_count, _In_ const uint32_t *attr_count,
+                                   _In_ const sai_attribute_t **attr_list, _In_ sai_bulk_op_error_mode_t mode,
+                                   _Out_ sai_object_id_t *object_id, _Out_ sai_status_t *object_statuses)
+{
+    return mock_sai_next_hop->create_next_hops(switch_id, object_count, attr_count, attr_list, mode,
+                                               object_id, object_statuses);
+}
+
+sai_status_t mock_remove_next_hops(_In_ uint32_t object_count, _In_ const sai_object_id_t *object_id, _In_ sai_bulk_op_error_mode_t mode,
+                                   _Out_ sai_status_t *object_statuses)
+{
+    return mock_sai_next_hop->remove_next_hops(object_count, object_id, mode, object_statuses);
 }

--- a/orchagent/p4orch/tests/next_hop_manager_test.cpp
+++ b/orchagent/p4orch/tests/next_hop_manager_test.cpp
@@ -258,6 +258,8 @@ class NextHopManagerTest : public ::testing::Test
         sai_next_hop_api->remove_next_hop = mock_remove_next_hop;
         sai_next_hop_api->set_next_hop_attribute = mock_set_next_hop_attribute;
         sai_next_hop_api->get_next_hop_attribute = mock_get_next_hop_attribute;
+        sai_next_hop_api->create_next_hops = mock_create_next_hops;
+        sai_next_hop_api->remove_next_hops = mock_remove_next_hops;
     }
 
     void TearDown() override

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1305,7 +1305,8 @@ bool RouteOrch::addNextHopGroup(const NextHopGroupKey &nexthops)
         else if (it.isMplsNextHop() &&
                  m_neighOrch->hasNextHop(NextHopKey(it.ip_address, it.alias)))
         {
-            m_neighOrch->addNextHop(it);
+            NeighborContext ctx = NeighborContext(it);
+            m_neighOrch->addNextHop(ctx);
             next_hop_id = m_neighOrch->getNextHopId(it);
         }
         else
@@ -1839,7 +1840,8 @@ bool RouteOrch::addRoute(RouteBulkContext& ctx, const NextHopGroupKey &nextHops)
                      m_neighOrch->isNeighborResolved(nexthop))
             {
                 /* since IP neighbor NH exists, neighbor is resolved, add MPLS NH */
-                m_neighOrch->addNextHop(nexthop);
+                NeighborContext ctx = NeighborContext(nexthop);
+                m_neighOrch->addNextHop(ctx);
                 next_hop_id = m_neighOrch->getNextHopId(nexthop);
             }
             /* IP neighbor is not yet resolved */

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -25,6 +25,7 @@ extern sai_vlan_api_t *sai_vlan_api;
 extern sai_bridge_api_t *sai_bridge_api;
 extern sai_route_api_t *sai_route_api;
 extern sai_route_api_t *sai_neighbor_api;
+extern sai_route_api_t *sai_next_hop_api;
 extern sai_mpls_api_t *sai_mpls_api;
 extern sai_next_hop_group_api_t* sai_next_hop_group_api;
 extern string gMySwitchType;
@@ -320,6 +321,7 @@ namespace aclorch_test
             sai_api_query(SAI_API_VLAN, (void **)&sai_vlan_api);
             sai_api_query(SAI_API_ROUTE, (void **)&sai_route_api);
             sai_api_query(SAI_API_NEIGHBOR, (void **)&sai_neighbor_api);
+            sai_api_query(SAI_API_NEXT_HOP, (void **)&sai_next_hop_api);
             sai_api_query(SAI_API_MPLS, (void **)&sai_mpls_api);
             sai_api_query(SAI_API_ACL, (void **)&sai_acl_api);
             sai_api_query(SAI_API_NEXT_HOP_GROUP, (void **)&sai_next_hop_group_api);
@@ -493,6 +495,7 @@ namespace aclorch_test
             sai_bridge_api = nullptr;
             sai_route_api = nullptr;
             sai_neighbor_api = nullptr;
+            sai_next_hop_api = nullptr;
             sai_mpls_api = nullptr;
         }
 


### PR DESCRIPTION
Using nexthop object bulker when processing neighbors. This is only enabled during mux switchover.

When processing neighbors during mux switchover:
- add nexthop object to add/remove using nexhop bulker
- flush nexthop bulker
- post-process bulker results

**What I did**
Added nexthop bulking operations to addNexthop function in neighOrch.
This is currently only used when processing neighbors during mux switchover

**Why I did it**
Neighbor bulking during mux switchover was still limited by sai calls made to create/remove nexthops. This uses the existing sai bulk nexthop api to also bulk program nexthops

**How I verified it**
Ran switchover testing on 7260cx3 dualtor testbed running 202405