### PR TITLE
Skip DASH route group immutability test

### DIFF
--- a/tests/dash/test_dash_route_group.py
+++ b/tests/dash/test_dash_route_group.py
@@ -15,6 +15,7 @@ from swsscommon.swsscommon import (
     APP_DASH_ROUTE_GROUP_TABLE_NAME,
 )
 
+
 @pytest.fixture(autouse=True)
 def common_setup_teardown(dash_db: DashDB):
     dash_db.set_app_db_entry(APP_DASH_APPLIANCE_TABLE_NAME, APPLIANCE_ID, APPLIANCE_CONFIG)
@@ -37,6 +38,7 @@ def common_setup_teardown(dash_db: DashDB):
     dash_db.remove_app_db_entry(APP_DASH_ROUTING_TYPE_TABLE_NAME, PRIVATELINK)
     dash_db.remove_app_db_entry(APP_DASH_APPLIANCE_TABLE_NAME, APPLIANCE_ID)
 
+
 def test_rebind_eni_route_group(dash_db: DashDB):
     dash_db.set_app_db_entry(APP_DASH_ROUTE_GROUP_TABLE_NAME, ROUTE_GROUP1, ROUTE_GROUP1_CONFIG)
     dash_db.set_app_db_entry(APP_DASH_ROUTE_TABLE_NAME, ROUTE_GROUP1, OUTBOUND_ROUTE_PREFIX1, ROUTE_VNET_CONFIG)
@@ -58,6 +60,7 @@ def test_rebind_eni_route_group(dash_db: DashDB):
     dash_db.set_app_db_entry(APP_DASH_ENI_ROUTE_TABLE_NAME, ENI_ID, ENI_ROUTE_GROUP2_CONFIG)
     dash_db.wait_for_asic_db_field("ASIC_STATE:SAI_OBJECT_TYPE_ENI", eni_key, SAI_ENI_ATTR_OUTBOUND_ROUTING_GROUP_ID, rg2_oid)
 
+
 def test_duplicate_eni_route_group(dash_db: DashDB):
     dash_db.set_app_db_entry(APP_DASH_ROUTE_GROUP_TABLE_NAME, ROUTE_GROUP1, ROUTE_GROUP1_CONFIG)
     dash_db.set_app_db_entry(APP_DASH_ROUTE_TABLE_NAME, ROUTE_GROUP1, OUTBOUND_ROUTE_PREFIX1, ROUTE_VNET_CONFIG)
@@ -71,6 +74,8 @@ def test_duplicate_eni_route_group(dash_db: DashDB):
     dash_db.set_app_db_entry(APP_DASH_ENI_ROUTE_TABLE_NAME, ENI_ID, ENI_ROUTE_GROUP1_CONFIG)
     dash_db.wait_for_asic_db_field("ASIC_STATE:SAI_OBJECT_TYPE_ENI", eni_key, SAI_ENI_ATTR_OUTBOUND_ROUTING_GROUP_ID, rg1_oid)
 
+
+@pytest.mark.skip(reason="Test will crash orchagent until VS SAI is updated with implicit deletion for DASH objects")
 def test_bound_route_group_immutable(dash_db: DashDB):
     dash_db.set_app_db_entry(APP_DASH_ROUTE_GROUP_TABLE_NAME, ROUTE_GROUP1, ROUTE_GROUP1_CONFIG)
     num_route_groups = len(dash_db.wait_for_asic_db_keys("ASIC_STATE:SAI_OBJECT_TYPE_OUTBOUND_ROUTING_GROUP"))


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Skip VS test `dash/test_dash_route_group.py::test_bound_route_group_immutable`

**Why I did it**
This test causes orchagent to crash since the VS SAI has not been updated to include implicit deletion of high-volume DASH objects (https://github.com/sonic-net/SONiC/blob/master/doc/dash/dash-sonic-hld.md#18-implicit-deletion-of-sai-objects)

**How I verified it**

**Details if related**
