### PR TITLE
Fixed compile errors caused by conversion from `int` to `uint16_t`

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -5938,7 +5938,7 @@ bool MetaDataMgr::isValidMetaData(uint16_t metadata)
 
 uint16_t MetaDataMgr::getFreeMetaData(uint8_t dscp)
 {
-    uint16_t metadata = metaMax + 1;
+    uint16_t metadata = (uint16_t)(metaMax + 1);
     SWSS_LOG_INFO("Metadata Request for dscp %d", dscp);
 
     if (initComplete)
@@ -5962,7 +5962,7 @@ uint16_t MetaDataMgr::getFreeMetaData(uint8_t dscp)
             m_dscpMetadata[dscp] = metadata;
             SWSS_LOG_INFO("New Metadata %d allocated for dscp %d", metadata, dscp);
         }
-        m_MetadataRef[metadata] += 1;
+        m_MetadataRef[metadata] = (uint16_t)(m_MetadataRef[metadata] + 1);
     }
     else
     {
@@ -5975,7 +5975,7 @@ void MetaDataMgr::recycleMetaData(uint16_t metadata)
 {
     if (initComplete)
     {
-        m_MetadataRef[metadata] -= 1;
+        m_MetadataRef[metadata] = (uint16_t)(m_MetadataRef[metadata] - 1);
         SWSS_LOG_INFO("Freeing Metadata %d refcount %d", metadata, m_MetadataRef[metadata]);
         if (m_MetadataRef[metadata] == 0)
         {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixed 3 narrowing conversion issues in the code.

**Why I did it**
g++ 9.4.0 and 10.5.0 both reported compile errors when trying to compile `aclorch.cpp` using `-Werror` and `-Wconversion` flags.

**How I verified it**
I compiled the code using g++ 10.5.0 after the changes it was successful.

**Details if related**
