### PR TITLE
Improve log information when exception is caught in Orch2 class

### DIFF
--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -845,19 +845,19 @@ void Orch2::doTask(Consumer &consumer)
         }
         catch (const std::invalid_argument& e)
         {
-            SWSS_LOG_ERROR("Parse error: %s", e.what());
+            SWSS_LOG_ERROR("Parse error in %s: %s", typeid(*this).name(), e.what());
         }
         catch (const std::logic_error& e)
         {
-            SWSS_LOG_ERROR("Logic error: %s", e.what());
+            SWSS_LOG_ERROR("Logic error in %s: %s", typeid(*this).name(), e.what());
         }
         catch (const std::exception& e)
         {
-            SWSS_LOG_ERROR("Exception was catched in the request parser: %s", e.what());
+            SWSS_LOG_ERROR("Exception was caught in the request parser in %s: %s", typeid(*this).name(), e.what());
         }
         catch (...)
         {
-            SWSS_LOG_ERROR("Unknown exception was catched in the request parser");
+            SWSS_LOG_ERROR("Unknown exception was caught in the request parser");
         }
         request_.clear();
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add the information regarding which class the exception is originated from when Orch2 catches an exception.

**Why I did it**
An Exception was thrown:
`ERR swss#orchagent: :- doTask: Logic error: map::at
`
This gives almost no information on where the exception happened.

**How I verified it**
Compiled SWSS which I forced an exception to be thrown from addOperation in VxlanTunnelOrch.
The log resulted is:

`ERR swss#orchagent: :- doTask: Logic error in 15VxlanTunnelOrch: map::at
`
Which focus you to a specific class.
Bigger improvement would need a larger refactor. 

**Details if related**
