### PR TITLE
[orchagent] Fix: ERR swss#orchagent: :- setPortPvid: pvid setting for tunnel Port_EVPN_XXX is not allowed

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -5099,7 +5099,7 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
 
         if (op == SET_COMMAND)
         {
-            string tagging_mode = "untagged";
+            string tagging_mode = (port.m_type == Port::TUNNEL)?"tagged":"untagged";
 
             for (auto i : kfvFieldsValues(t))
             {

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -6496,7 +6496,8 @@ bool PortsOrch::addVlanMember(Port &vlan, Port &port, string &tagging_mode, stri
             port.m_alias.c_str(), vlan.m_alias.c_str(), vlan.m_vlan_info.vlan_id, port.m_port_id);
 
     /* Use untagged VLAN as pvid of the member port */
-    if (sai_tagging_mode == SAI_VLAN_TAGGING_MODE_UNTAGGED)
+    if (sai_tagging_mode == SAI_VLAN_TAGGING_MODE_UNTAGGED &&
+        port.m_type != Port::TUNNEL)
     {
         if(!setPortPvid(port, vlan.m_vlan_info.vlan_id))
         {
@@ -6831,7 +6832,8 @@ bool PortsOrch::removeVlanMember(Port &vlan, Port &port, string end_point_ip)
             port.m_alias.c_str(), vlan.m_alias.c_str(), vlan.m_vlan_info.vlan_id, vlan_member_id);
 
     /* Restore to default pvid if this port joined this VLAN in untagged mode previously */
-    if (sai_tagging_mode == SAI_VLAN_TAGGING_MODE_UNTAGGED)
+    if (sai_tagging_mode == SAI_VLAN_TAGGING_MODE_UNTAGGED &&
+        port.m_type != Port::TUNNEL)
     {
         if (!setPortPvid(port, DEFAULT_PORT_VLAN_ID))
         {

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -5099,7 +5099,7 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
 
         if (op == SET_COMMAND)
         {
-            string tagging_mode = (port.m_type == Port::TUNNEL)?"tagged":"untagged";
+            string tagging_mode = "untagged";
 
             for (auto i : kfvFieldsValues(t))
             {

--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -2409,8 +2409,8 @@ bool EvpnRemoteVnip2pOrch::addOperation(const Request& request)
     }
 
     // SAI Call to add tunnel to the VLAN flood domain
-
-    string tagging_mode = "tagged";
+    // NOTE: does 'untagged' make the most sense here?
+    string tagging_mode = "untagged";
     gPortsOrch->addVlanMember(vlanPort, tunnelPort, tagging_mode);
 
     SWSS_LOG_INFO("remote_vtep=%s vni=%d vlanid=%d ",
@@ -2569,8 +2569,8 @@ bool EvpnRemoteVnip2mpOrch::addOperation(const Request& request)
     }
 
     // SAI Call to add tunnel to the VLAN flood domain
-
-    string tagging_mode = "tagged";
+    // NOTE: does 'untagged' make the most sense here?
+    string tagging_mode = "untagged";
     gPortsOrch->addVlanMember(vlanPort, tunnelPort, tagging_mode, end_point_ip);
 
     SWSS_LOG_INFO("end_point_ip=%s vni=%d vlanid=%d ",

--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -2410,7 +2410,7 @@ bool EvpnRemoteVnip2pOrch::addOperation(const Request& request)
 
     // SAI Call to add tunnel to the VLAN flood domain
 
-    string tagging_mode = "untagged"; 
+    string tagging_mode = "tagged";
     gPortsOrch->addVlanMember(vlanPort, tunnelPort, tagging_mode);
 
     SWSS_LOG_INFO("remote_vtep=%s vni=%d vlanid=%d ",
@@ -2570,7 +2570,7 @@ bool EvpnRemoteVnip2mpOrch::addOperation(const Request& request)
 
     // SAI Call to add tunnel to the VLAN flood domain
 
-    string tagging_mode = "untagged";
+    string tagging_mode = "tagged";
     gPortsOrch->addVlanMember(vlanPort, tunnelPort, tagging_mode, end_point_ip);
 
     SWSS_LOG_INFO("end_point_ip=%s vni=%d vlanid=%d ",


### PR DESCRIPTION
**What I did**
Tunnel ports are always considered tagged and we can't create an untagged/pvid vlan.  But the code currently tries to set a pvid on a tunnel which is disallowed leading to an error in the logs.

This is a simple fix to get rid of the error in the logs.  It does not actually change behavior in any way other than getting rid of an error thus helping debugability.

**Why I did it**

To get rid of confusing log message:
```
ERR swss#orchagent: :- setPortPvid: pvid setting for tunnel Port_EVPN_XXX is not allowed
```

**How I verified it**

Applied patch, notice error no longer printed in logs.

**Details if related**

Signed-off-by: Brad House (@bradh352)
