### PR TITLE
[orchagent] fix "parsePortConfig: Unknown field(mode)"

### DIFF
--- a/orchagent/port/porthlpr.cpp
+++ b/orchagent/port/porthlpr.cpp
@@ -1229,6 +1229,12 @@ bool PortHelper::parsePortConfig(PortConfig &port) const
                 return false;
             }
         }
+        else if (field == PORT_MODE)
+        {
+            /* Placeholder to prevent warning. Not needed to be parsed here.
+             * Setting exists in sonic-port.yang with possible values: routed|access|trunk
+             */
+        }
         else
         {
             SWSS_LOG_WARN("Unknown field(%s): skipping ...", field.c_str());

--- a/orchagent/port/portschema.h
+++ b/orchagent/port/portschema.h
@@ -101,3 +101,4 @@
 #define PORT_SUPPRESS_THRESHOLD    "suppress_threshold"
 #define PORT_REUSE_THRESHOLD       "reuse_threshold"
 #define PORT_FLAP_PENALTY          "flap_penalty"
+#define PORT_MODE                  "mode"


### PR DESCRIPTION
**What I did**

When using "mode" as defined in
https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/yang-models/sonic-port.yang this warning is emitted for each interface:
```
WARNING swss#orchagent: :- parsePortConfig: Unknown field(mode): skipping ...
```

It appears this field is not needed in orchagent at all, so we need to at least recognize it as valid then skip processing.

**Why I did it**

Warnings harm debugging and can cause wasted cycles when debugging real issues.

**How I verified it**

built via my private fork https://github.com/bradh352/sonic-buildimage and installed on physical switches

**Details if related**

Signed-off-by: Brad House (@bradh352)
