### PR TITLE
Preventing dynamic generation of BUFFER_PROFILE and BUFFER_PG entries in CONFIG_DB

### DIFF
--- a/cfgmgr/buffermgr.cpp
+++ b/cfgmgr/buffermgr.cpp
@@ -45,6 +45,7 @@ BufferMgr::BufferMgr(DBConnector *cfgDb, DBConnector *applDb, string pg_lookup_f
     }
 
     dynamic_buffer_model = false;
+    fixed_cable_speed_len = true;
 }
 
 //# speed, cable, size,    xon,  xoff, threshold,  xon_offset
@@ -499,6 +500,12 @@ void BufferMgr::doTask(Consumer &consumer)
     if (table_name == CFG_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME)
     {
         doBufferTableTask(consumer, m_applBufferEgressProfileListTable);
+        return;
+    }
+
+    if (fixed_cable_speed_len)
+    {
+        SWSS_LOG_DEBUG("Will not dynamically generate BUFFER_PG and BUFFER_PROFILE entries.");
         return;
     }
 

--- a/cfgmgr/buffermgr.h
+++ b/cfgmgr/buffermgr.h
@@ -54,6 +54,12 @@ private:
 
     bool m_pgfile_processed;
     bool dynamic_buffer_model;
+    /*
+     * True if cable lengths and speeds are predetermined. If it is true, we
+     * do not dynamically generate BUFFER_PROFILE and BUFFER_PG entries in
+     * APPL_DB (i.e., we just copy static entries from CONFIG_DB).
+     */
+    bool fixed_cable_speed_len;
 
     pg_profile_lookup_t m_pgProfileLookup;
     port_cable_length_t m_cableLenLookup;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Prevented buffermgrd from dynamically generating lossless BUFFER_PROFILE and BUFFER_PG entries based on port speeds and cable lengths that are configured on the switch.

**Why I did it**
The automatic generation of these entries can create an invalid config diff between the golden config and the running config.

**How I verified it**
Starting with a `config_db.json` file that did not contain `pg_lossless_*` buffer profiles, I verified that after reloading the configuration with `sudo config reload -y`, these buffer profiles and their corresponding entries in the BUFFER_PG table were not automatically created in CONFIG_DB. Also, verified the same thing after doing a warm-reboot.

**Details if related**
The dynamically-generated buffer profiles have the format `pg_lossless_<port_speed>_<cable_length>_profile`. This PR prevents their creation and also the creation of corresponding BUFFER_PG entries.