### PR TITLE
Fix ip link add command exception for portchannel being added to vlan

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -229,10 +229,16 @@ bool VlanMgr::addHostVlanMember(int vlan_id, const string &port_alias, const str
     }
     catch (const std::runtime_error& e)
     {
-        if (!isMemberStateOk(port_alias))
+        // Race conidtion can happen with portchannel removal might happen
+	// but state db is not updated yet so we can do retry instead of sending exception
+	if (!port_alias.compare(0, strlen(LAG_PREFIX), LAG_PREFIX))
+	{
             return false;
+	}
         else
+	{
             EXEC_WITH_ERROR_THROW(cmds.str(), res);
+	}
     }
 
     return true;


### PR DESCRIPTION
What I did:

With previous Fix done:  https://github.com/sonic-net/sonic-swss/pull/3367  we are still seeing the issue. As of now fix do not raise exception when vlan memeber as portchannel since it is possible statedb entry for LAG can still be 'ok'