### PR TITLE
Ignore failure in setPortPfcAsym if SAI_STATUS_NOT_SUPPORTED

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2075,7 +2075,7 @@ bool PortsOrch::setPortPfcAsym(Port &port, sai_port_priority_flow_control_mode_t
         SWSS_LOG_ERROR("Failed to set PFC mode %d to port id 0x%" PRIx64 " (rc:%d)", pfc_asym, port.m_port_id, status);
         if (status == SAI_STATUS_NOT_SUPPORTED)
         {
-            return false;
+            return true;
         }
         task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, status);
         if (handle_status != task_success)

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2073,6 +2073,10 @@ bool PortsOrch::setPortPfcAsym(Port &port, sai_port_priority_flow_control_mode_t
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to set PFC mode %d to port id 0x%" PRIx64 " (rc:%d)", pfc_asym, port.m_port_id, status);
+        if (status == SAI_STATUS_NOT_SUPPORTED)
+        {
+            return false;
+        }
         task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, status);
         if (handle_status != task_success)
         {

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -98,6 +98,8 @@ namespace portsorch_test
     uint32_t _sai_set_link_event_damping_algorithm_count;
     uint32_t _sai_set_link_event_damping_config_count;
     int32_t _sai_link_event_damping_algorithm = 0;
+    bool set_pfc_asym_not_supported = false;
+    uint32_t set_pfc_asym_failures;
     sai_redis_link_event_damping_algo_aied_config_t _sai_link_event_damping_config = {0, 0, 0, 0, 0};
 
     sai_status_t _ut_stub_sai_set_port_attribute(
@@ -114,9 +116,15 @@ namespace portsorch_test
             /* Simulating failure case */
             return SAI_STATUS_FAILURE;
         }
-	else if (attr[0].id == SAI_PORT_PRIORITY_FLOW_CONTROL_MODE_COMBINED)
-	{
-	    _sai_set_pfc_mode_count++;
+        else if (attr[0].id == SAI_PORT_ATTR_PRIORITY_FLOW_CONTROL_MODE)
+        {
+            _sai_set_pfc_mode_count++;
+            /* Simulating failure case */
+            if (set_pfc_asym_not_supported)
+            {
+                set_pfc_asym_failures++;
+                return SAI_STATUS_NOT_SUPPORTED;
+            }
         }
 	else if (attr[0].id == SAI_PORT_ATTR_ADMIN_STATE)
 	{
@@ -2430,6 +2438,59 @@ namespace portsorch_test
         mock_port_fec_modes = old_mock_port_fec_modes;
         _unhook_sai_port_api();
     }
+
+    /*
+     * Test case: SAI_PORT_ATTR_PRIORITY_FLOW_CONTROL_MODE is not supported by vendor
+     **/
+    TEST_F(PortsOrchTest, PortPFCNotSupported)
+    {
+        _hook_sai_port_api();
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        std::deque<KeyOpFieldsValuesTuple> entries;
+
+        set_pfc_asym_not_supported = true;
+        // Get SAI default ports to populate DB
+        auto ports = ut_helper::getInitialSaiPorts();
+
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+
+        // Set PortConfigDone
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+
+        // refill consumer
+        gPortsOrch->addExistingData(&portTable);
+
+        // Apply configuration :
+        //  create ports
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        uint32_t current_sai_api_call_count = _sai_set_pfc_mode_count;
+
+        entries.push_back({"Ethernet0", "SET",
+                           {
+                               { "pfc_asym", "off"}
+                           }});
+        auto consumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_PORT_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+        entries.clear();
+
+        ASSERT_EQ(_sai_set_pfc_mode_count, ++current_sai_api_call_count);
+        ASSERT_EQ(set_pfc_asym_failures, 1);
+
+        set_pfc_asym_not_supported = false;
+
+        vector<string> ts;
+
+        gPortsOrch->dumpPendingTasks(ts);
+        ASSERT_TRUE(ts.empty());
+
+        _unhook_sai_port_api();
+    }
+
     TEST_F(PortsOrchTest, PortTestSAIFailureHandling)
     {
         _hook_sai_port_api();


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Ignore setPortPfcAsym failure if SAI_STATUS_NOT_SUPPORTED.

**Why I did it**
Orchagent crash seen.
Some ports don't support PFC feature, if set pfc_asym to off (means SAI_PORT_PRIORITY_FLOW_CONTROL_MODE_COMBINED), it will return SAI_STATUS_NOT_SUPPORTED.

**How I verified it**
Verified it in testbed. ERR log is kept but no crash.
log:
```
cisco@m623-dut:~$ sudo config load_minigraph 
Reload config from minigraph? [y/N]: y
Acquired lock on /etc/sonic/reload.lock
Disabling container monitoring ...
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json --write-to-db
Running command: /usr/local/bin/sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/sonic-environment
Running command: config qos reload --no-dynamic-buffer --no-delay
Running command: /usr/local/bin/sonic-cfggen -d -t /usr/share/sonic/device/x86_64-8122_64ehf_o-r0/Cisco-8122-O128S2/buffers.json.j2,/tmp/cfg_buffer.json -t /usr/share/sonic/device/x86_64-8122_64ehf_o-r0/Cisco-8122-O128S2/qos.json.j2,/tmp/cfg_qos.json -y /etc/sonic/sonic_version.yml
Running command: /usr/local/bin/sonic-cfggen -j /tmp/cfg_buffer.json -j /tmp/cfg_qos.json --write-to-db
Running command: pfcwd start_default
Restarting SONiC target ...
Enabling container monitoring ...
Reloading Monit configuration ...
Reinitializing monit daemon
Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.
Released lock on /etc/sonic/reload.lock
cisco@m623-dut:~$ show interface status
      Interface                Lanes    Speed    MTU    FEC    Alias             Vlan    Oper    Admin                           Type    Asym PFC
---------------  -------------------  -------  -----  -----  -------  ---------------  ------  -------  -----------------------------  ----------
      Ethernet0  1544,1545,1546,1547     400G   9100    N/A    etp0a   PortChannel102    down       up  OSFP 8X Pluggable Transceiver         off
      Ethernet4  1548,1549,1550,1551     400G   9100    N/A    etp0b           routed    down     down  OSFP 8X Pluggable Transceiver         off
      Ethernet8  1536,1537,1538,1539     400G   9100    N/A    etp1a   PortChannel102    down       up  OSFP 8X Pluggable Transceiver         off
     Ethernet12  1540,1541,1542,1543     400G   9100    N/A    etp1b           routed    down     down  OSFP 8X Pluggable Transceiver         off
     Ethernet16  1560,1561,1562,1563     400G   9100    N/A    etp2a           routed    down     down                            N/A         off
     Ethernet20  1564,1565,1566,1567     400G   9100    N/A    etp2b           routed    down     down                            N/A         off
     Ethernet24  1552,1553,1554,1555     400G   9100    N/A    etp3a           routed    down     down                            N/A         off
     Ethernet28  1556,1557,1558,1559     400G   9100    N/A    etp3b           routed    down     down                            N/A         off
     Ethernet32  1800,1801,1802,1803     400G   9100    N/A    etp4a   PortChannel105      up       up  OSFP 8X Pluggable Transceiver         off
     Ethernet36  1804,1805,1806,1807     400G   9100    N/A    etp4b           routed    down     down  OSFP 8X Pluggable Transceiver         off
     Ethernet40  1792,1793,1794,1795     400G   9100    N/A    etp5a   PortChannel105      up       up  OSFP 8X Pluggable Transceiver         off
     Ethernet44  1796,1797,1798,1799     400G   9100    N/A    etp5b           routed    down     down  OSFP 8X Pluggable Transceiver         off
     Ethernet48  1808,1809,1810,1811     400G   9100    N/A    etp6a           routed    down     down                            N/A         off
     Ethernet52  1812,1813,1814,1815     400G   9100    N/A    etp6b           routed    down     down                            N/A         off
     Ethernet56  1816,1817,1818,1819     400G   9100    N/A    etp7a           routed    down     down                            N/A         off
     Ethernet60  1820,1821,1822,1823     400G   9100    N/A    etp7b           routed    down     down                            N/A         off
     Ethernet64  1280,1281,1282,1283     400G   9100    N/A    etp8a   PortChannel108      up       up  OSFP 8X Pluggable Transceiver         off
     Ethernet68  1284,1285,1286,1287     400G   9100    N/A    etp8b           routed    down     down  OSFP 8X Pluggable Transceiver         off
     Ethernet72  1288,1289,1290,1291     400G   9100    N/A    etp9a   PortChannel108      up       up  OSFP 8X Pluggable Transceiver         off
     Ethernet76  1292,1293,1294,1295     400G   9100    N/A    etp9b           routed    down     down  OSFP 8X Pluggable Transceiver         off
     Ethernet80  1296,1297,1298,1299     400G   9100    N/A   etp10a           routed    down     down                            N/A         off
     Ethernet84  1300,1301,1302,1303     400G   9100    N/A   etp10b           routed    down     down                            N/A         off
     Ethernet88  1304,1305,1306,1307     400G   9100    N/A   etp11a           routed    down     down                            N/A         off
     Ethernet92  1308,1309,1310,1311     400G   9100    N/A   etp11b           routed    down     down                            N/A         off
     Ethernet96  1032,1033,1034,1035     400G   9100    N/A   etp12a  PortChannel1011    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet100  1036,1037,1038,1039     400G   9100    N/A   etp12b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet104  1024,1025,1026,1027     400G   9100    N/A   etp13a  PortChannel1011    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet108  1028,1029,1030,1031     400G   9100    N/A   etp13b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet112  1048,1049,1050,1051     400G   9100    N/A   etp14a           routed    down     down                            N/A         off
    Ethernet116  1052,1053,1054,1055     400G   9100    N/A   etp14b           routed    down     down                            N/A         off
    Ethernet120  1040,1041,1042,1043     400G   9100    N/A   etp15a           routed    down     down                            N/A         off
    Ethernet124  1044,1045,1046,1047     400G   9100    N/A   etp15b           routed    down     down                            N/A         off
    Ethernet128      528,529,530,531     400G   9100    N/A   etp16a  PortChannel1014    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet132      532,533,534,535     400G   9100    N/A   etp16b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet136      536,537,538,539     400G   9100    N/A   etp17a  PortChannel1014    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet140      540,541,542,543     400G   9100    N/A   etp17b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet144      512,513,514,515     400G   9100    N/A   etp18a           routed    down     down                            N/A         off
    Ethernet148      516,517,518,519     400G   9100    N/A   etp18b           routed    down     down                            N/A         off
    Ethernet152      520,521,522,523     400G   9100    N/A   etp19a           routed    down     down                            N/A         off
    Ethernet156      524,525,526,527     400G   9100    N/A   etp19b           routed    down     down                            N/A         off
    Ethernet160      784,785,786,787     400G   9100    N/A   etp20a  PortChannel1017    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet164      788,789,790,791     400G   9100    N/A   etp20b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet168      792,793,794,795     400G   9100    N/A   etp21a  PortChannel1017      up       up  OSFP 8X Pluggable Transceiver         off
    Ethernet172      796,797,798,799     400G   9100    N/A   etp21b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet176      768,769,770,771     400G   9100    N/A   etp22a           routed    down     down                            N/A         off
    Ethernet180      772,773,774,775     400G   9100    N/A   etp22b           routed    down     down                            N/A         off
    Ethernet184      776,777,778,779     400G   9100    N/A   etp23a           routed    down     down                            N/A         off
    Ethernet188      780,781,782,783     400G   9100    N/A   etp23b           routed    down     down                            N/A         off
    Ethernet192      264,265,266,267     400G   9100    N/A   etp24a  PortChannel1020    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet196      268,269,270,271     400G   9100    N/A   etp24b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet200      256,257,258,259     400G   9100    N/A   etp25a  PortChannel1020    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet204      260,261,262,263     400G   9100    N/A   etp25b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet208      280,281,282,283     400G   9100    N/A   etp26a           routed    down     down                            N/A         off
    Ethernet212      284,285,286,287     400G   9100    N/A   etp26b           routed    down     down                            N/A         off
    Ethernet216      272,273,274,275     400G   9100    N/A   etp27a           routed    down     down                            N/A         off
    Ethernet220      276,277,278,279     400G   9100    N/A   etp27b           routed    down     down                            N/A         off
    Ethernet224            8,9,10,11     400G   9100    N/A   etp28a  PortChannel1023    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet228          12,13,14,15     400G   9100    N/A   etp28b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet232              0,1,2,3     400G   9100    N/A   etp29a  PortChannel1023    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet236              4,5,6,7     400G   9100    N/A   etp29b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet240          24,25,26,27     400G   9100    N/A   etp30a           routed    down     down                            N/A         off
    Ethernet244          28,29,30,31     400G   9100    N/A   etp30b           routed    down     down                            N/A         off
    Ethernet248          16,17,18,19     400G   9100    N/A   etp31a           routed    down     down                            N/A         off
    Ethernet252          20,21,22,23     400G   9100    N/A   etp31b           routed    down     down                            N/A         off
    Ethernet256  3600,3601,3602,3603     400G   9100    N/A   etp32a           routed    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet260  3604,3605,3606,3607     400G   9100    N/A   etp32b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet264  3608,3609,3610,3611     400G   9100    N/A   etp33a           routed    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet268  3612,3613,3614,3615     400G   9100    N/A   etp33b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet272  3592,3593,3594,3595     400G   9100    N/A   etp34a           routed    down     down                            N/A         off
    Ethernet276  3596,3597,3598,3599     400G   9100    N/A   etp34b           routed    down     down                            N/A         off
    Ethernet280  3584,3585,3586,3587     400G   9100    N/A   etp35a           routed    down     down                            N/A         off
    Ethernet284  3588,3589,3590,3591     400G   9100    N/A   etp35b           routed    down     down                            N/A         off
    Ethernet288  3856,3857,3858,3859     400G   9100    N/A   etp36a           routed    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet292  3860,3861,3862,3863     400G   9100    N/A   etp36b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet296  3864,3865,3866,3867     400G   9100    N/A   etp37a           routed    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet300  3868,3869,3870,3871     400G   9100    N/A   etp37b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet304  3848,3849,3850,3851     400G   9100    N/A   etp38a           routed    down     down                            N/A         off
    Ethernet308  3852,3853,3854,3855     400G   9100    N/A   etp38b           routed    down     down                            N/A         off
    Ethernet312  3840,3841,3842,3843     400G   9100    N/A   etp39a           routed    down     down                            N/A         off
    Ethernet316  3844,3845,3846,3847     400G   9100    N/A   etp39b           routed    down     down                            N/A         off
    Ethernet320  3344,3345,3346,3347     400G   9100    N/A   etp40a           routed    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet324  3348,3349,3350,3351     400G   9100    N/A   etp40b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet328  3352,3353,3354,3355     400G   9100    N/A   etp41a           routed    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet332  3356,3357,3358,3359     400G   9100    N/A   etp41b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet336  3336,3337,3338,3339     400G   9100    N/A   etp42a           routed    down     down                            N/A         off
    Ethernet340  3340,3341,3342,3343     400G   9100    N/A   etp42b           routed    down     down                            N/A         off
    Ethernet344  3328,3329,3330,3331     400G   9100    N/A   etp43a           routed    down     down                            N/A         off
    Ethernet348  3332,3333,3334,3335     400G   9100    N/A   etp43b           routed    down     down                            N/A         off
    Ethernet352  3088,3089,3090,3091     400G   9100    N/A   etp44a           routed    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet356  3092,3093,3094,3095     400G   9100    N/A   etp44b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet360  3096,3097,3098,3099     400G   9100    N/A   etp45a           routed      up       up  OSFP 8X Pluggable Transceiver         off
    Ethernet364  3100,3101,3102,3103     400G   9100    N/A   etp45b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet368  3072,3073,3074,3075     400G   9100    N/A   etp46a           routed    down     down                            N/A         off
    Ethernet372  3076,3077,3078,3079     400G   9100    N/A   etp46b           routed    down     down                            N/A         off
    Ethernet376  3080,3081,3082,3083     400G   9100    N/A   etp47a           routed    down     down                            N/A         off
    Ethernet380  3084,3085,3086,3087     400G   9100    N/A   etp47b           routed    down     down                            N/A         off
    Ethernet384  2568,2569,2570,2571     400G   9100    N/A   etp48a           routed    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet388  2572,2573,2574,2575     400G   9100    N/A   etp48b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet392  2560,2561,2562,2563     400G   9100    N/A   etp49a           routed    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet396  2564,2565,2566,2567     400G   9100    N/A   etp49b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet400  2584,2585,2586,2587     400G   9100    N/A   etp50a           routed    down     down                            N/A         off
    Ethernet404  2588,2589,2590,2591     400G   9100    N/A   etp50b           routed    down     down                            N/A         off
    Ethernet408  2576,2577,2578,2579     400G   9100    N/A   etp51a           routed    down     down                            N/A         off
    Ethernet412  2580,2581,2582,2583     400G   9100    N/A   etp51b           routed    down     down                            N/A         off
    Ethernet416  2824,2825,2826,2827     400G   9100    N/A   etp52a           routed    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet420  2828,2829,2830,2831     400G   9100    N/A   etp52b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet424  2816,2817,2818,2819     400G   9100    N/A   etp53a           routed    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet428  2820,2821,2822,2823     400G   9100    N/A   etp53b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet432  2840,2841,2842,2843     400G   9100    N/A   etp54a           routed    down     down                            N/A         off
    Ethernet436  2844,2845,2846,2847     400G   9100    N/A   etp54b           routed    down     down                            N/A         off
    Ethernet440  2832,2833,2834,2835     400G   9100    N/A   etp55a           routed    down     down                            N/A         off
    Ethernet444  2836,2837,2838,2839     400G   9100    N/A   etp55b           routed    down     down                            N/A         off
    Ethernet448  2312,2313,2314,2315     400G   9100    N/A   etp56a           routed    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet452  2316,2317,2318,2319     400G   9100    N/A   etp56b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet456  2304,2305,2306,2307     400G   9100    N/A   etp57a           routed    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet460  2308,2309,2310,2311     400G   9100    N/A   etp57b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet464  2320,2321,2322,2323     400G   9100    N/A   etp58a           routed    down     down                            N/A         off
    Ethernet468  2324,2325,2326,2327     400G   9100    N/A   etp58b           routed    down     down                            N/A         off
    Ethernet472  2328,2329,2330,2331     400G   9100    N/A   etp59a           routed    down     down                            N/A         off
    Ethernet476  2332,2333,2334,2335     400G   9100    N/A   etp59b           routed    down     down                            N/A         off
    Ethernet480  2056,2057,2058,2059     400G   9100    N/A   etp60a           routed      up       up  OSFP 8X Pluggable Transceiver         off
    Ethernet484  2060,2061,2062,2063     400G   9100    N/A   etp60b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet488  2048,2049,2050,2051     400G   9100    N/A   etp61a           routed    down       up  OSFP 8X Pluggable Transceiver         off
    Ethernet492  2052,2053,2054,2055     400G   9100    N/A   etp61b           routed    down     down  OSFP 8X Pluggable Transceiver         off
    Ethernet496  2064,2065,2066,2067     400G   9100    N/A   etp62a           routed    down     down                            N/A         off
    Ethernet500  2068,2069,2070,2071     400G   9100    N/A   etp62b           routed    down     down                            N/A         off
    Ethernet504  2072,2073,2074,2075     400G   9100    N/A   etp63a           routed    down     down                            N/A         off
    Ethernet508  2076,2077,2078,2079     400G   9100    N/A   etp63b           routed    down     down                            N/A         off
    Ethernet512                65520      10G   9100    N/A    etp64           routed    down     down                            N/A         off
    Ethernet513                65521      10G   9100    N/A    etp65           routed    down     down                            N/A         off
 PortChannel102                  N/A     800G   9100    N/A      N/A           routed    down       up                            N/A         N/A
 PortChannel105                  N/A     800G   9100    N/A      N/A           routed      up       up                            N/A         N/A
 PortChannel108                  N/A     800G   9100    N/A      N/A           routed      up       up                            N/A         N/A
PortChannel1011                  N/A     800G   9100    N/A      N/A           routed    down       up                            N/A         N/A
PortChannel1014                  N/A     800G   9100    N/A      N/A           routed    down       up                            N/A         N/A
PortChannel1017                  N/A     800G   9100    N/A      N/A           routed    down       up                            N/A         N/A
PortChannel1020                  N/A     800G   9100    N/A      N/A           routed    down       up                            N/A         N/A
PortChannel1023                  N/A     800G   9100    N/A      N/A           routed    down       up                            N/A         N/A
cisco@m623-dut:~$ sudo cat /var/log/syslog | grep "Failed to get attribute"
cisco@m623-dut:~$ sudo cat /var/log/syslog | grep "ERR swss#orchagent" | tail
2024 Dec 18 18:48:04.561111 m623-dut ERR swss#orchagent: :- removeLag: Failed to remove ref count 4 LAG PortChannel102
2024 Dec 18 18:48:04.561193 m623-dut ERR swss#orchagent: :- removeLag: Failed to remove ref count 4 LAG PortChannel1020
2024 Dec 18 18:48:04.561193 m623-dut ERR swss#orchagent: :- removeLag: Failed to remove ref count 4 LAG PortChannel1023
2024 Dec 18 18:48:04.561193 m623-dut ERR swss#orchagent: :- removeLag: Failed to remove ref count 4 LAG PortChannel105
2024 Dec 18 18:48:04.561193 m623-dut ERR swss#orchagent: :- removeLag: Failed to remove ref count 4 LAG PortChannel108
2024 Dec 18 18:49:11.905411 m623-dut ERR swss#orchagent: :- queryAattributeEnumValuesCapability: returned value 5 is not allowed on SAI_NEXT_HOP_GROUP_ATTR_TYPE
2024 Dec 18 18:49:14.076519 m623-dut ERR swss#orchagent: :- set: set status: SAI_STATUS_NOT_SUPPORTED
2024 Dec 18 18:49:14.076519 m623-dut ERR swss#orchagent: :- setPortPfcAsym: Failed to set PFC mode 0 to port id 0x1000000000082 (rc:-2)
2024 Dec 18 18:49:14.077839 m623-dut ERR swss#orchagent: :- set: set status: SAI_STATUS_NOT_SUPPORTED
2024 Dec 18 18:49:14.077849 m623-dut ERR swss#orchagent: :- setPortPfcAsym: Failed to set PFC mode 0 to port id 0x1000000000083 (rc:-2)
cisco@m623-dut:~$ Connection to 4.164.1.192 closed by remote host.
Connection to 4.164.1.192 closed.
sonic@sonic-ucs-m6-23:~$ client_loop: send disconnect: Broken pipe
ZHIXZHU-M-QHJX:j2_codethon zhixzhu$ ssh sonic@sonic-ucs-m6-23
sonic@sonic-ucs-m6-23's password: 
Permission denied, please try again.
sonic@sonic-ucs-m6-23's password: 
Welcome to Ubuntu 20.04.6 LTS (GNU/Linux 5.15.0-122-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/pro

Expanded Security Maintenance for Applications is not enabled.

41 updates can be applied immediately.
14 of these updates are standard security updates.
To see these additional updates run: apt list --upgradable

Enable ESM Apps to receive additional future security updates.
See https://ubuntu.com/esm or run: sudo pro status

New release '22.04.5 LTS' available.
Run 'do-release-upgrade' to upgrade to it.

Your Hardware Enablement Stack (HWE) is supported until April 2025.
*** System restart required ***
Last login: Wed Dec 18 09:56:38 2024 from 10.160.3.97
sonic@sonic-ucs-m6-23:~$ ssh cisco@4.164.1.192
Debian GNU/Linux 12 \n \l

cisco@4.164.1.192's password: 
Linux m623-dut 6.1.0-22-2-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.94-1 (2024-06-21) x86_64
You are on
  ____   ___  _   _ _  ____
 / ___| / _ \| \ | (_)/ ___|
 \___ \| | | |  \| | | |
  ___) | |_| | |\  | | |___
 |____/ \___/|_| \_|_|\____|

-- Software for Open Networking in the Cloud --

Unauthorized access and/or use are prohibited.
All access and/or use are subject to monitoring.

Help:    https://sonic-net.github.io/SONiC/

Last login: Wed Dec 18 17:54:36 2024 from 4.164.1.222
cisco@m623-dut:~$ sudo cat /var/log/syslog | grep "2024 Dec 18 18:49:14.07"
2024 Dec 18 18:49:14.070000 m623-dut NOTICE swss#orchagent: :- setHostTxReady: Setting host_tx_ready status = false, alias = Ethernet496, port_id = 0x100000000007e
2024 Dec 18 18:49:14.070074 m623-dut NOTICE swss#orchagent: :- initHostTxReadyState: initialize host_tx_ready as false for port Ethernet496
2024 Dec 18 18:49:14.070837 m623-dut NOTICE swss#orchagent: :- doPortTask: Set port Ethernet500 MTU to 9100
2024 Dec 18 18:49:14.071651 m623-dut NOTICE swss#orchagent: :- doPortTask: Set port Ethernet500 asymmetric PFC to off
2024 Dec 18 18:49:14.071692 m623-dut NOTICE swss#orchagent: :- setHostTxReady: Setting host_tx_ready status = false, alias = Ethernet500, port_id = 0x100000000007f
2024 Dec 18 18:49:14.071766 m623-dut NOTICE swss#orchagent: :- initHostTxReadyState: initialize host_tx_ready as false for port Ethernet500
2024 Dec 18 18:49:14.072614 m623-dut NOTICE swss#orchagent: :- doPortTask: Set port Ethernet504 MTU to 9100
2024 Dec 18 18:49:14.073439 m623-dut NOTICE swss#orchagent: :- doPortTask: Set port Ethernet504 asymmetric PFC to off
2024 Dec 18 18:49:14.073481 m623-dut NOTICE swss#orchagent: :- setHostTxReady: Setting host_tx_ready status = false, alias = Ethernet504, port_id = 0x1000000000080
2024 Dec 18 18:49:14.073555 m623-dut NOTICE swss#orchagent: :- initHostTxReadyState: initialize host_tx_ready as false for port Ethernet504
2024 Dec 18 18:49:14.074319 m623-dut NOTICE swss#orchagent: :- doPortTask: Set port Ethernet508 MTU to 9100
2024 Dec 18 18:49:14.075141 m623-dut NOTICE swss#orchagent: :- doPortTask: Set port Ethernet508 asymmetric PFC to off
2024 Dec 18 18:49:14.075178 m623-dut NOTICE swss#orchagent: :- setHostTxReady: Setting host_tx_ready status = false, alias = Ethernet508, port_id = 0x1000000000081
2024 Dec 18 18:49:14.075254 m623-dut NOTICE swss#orchagent: :- initHostTxReadyState: initialize host_tx_ready as false for port Ethernet508
2024 Dec 18 18:49:14.076051 m623-dut NOTICE swss#orchagent: :- doPortTask: Set port Ethernet512 MTU to 9100
2024 Dec 18 18:49:14.076330 m623-dut ERR syncd#syncd: :- sendApiResponse: api SAI_COMMON_API_SET failed in syncd mode: SAI_STATUS_NOT_SUPPORTED
2024 Dec 18 18:49:14.076358 m623-dut ERR syncd#syncd: :- processQuadEvent: VID: oid:0x1000000000082 RID: oid:0x8000000000009c
2024 Dec 18 18:49:14.076358 m623-dut ERR syncd#syncd: :- processQuadEvent: attr: SAI_PORT_ATTR_PRIORITY_FLOW_CONTROL_MODE: SAI_PORT_PRIORITY_FLOW_CONTROL_MODE_COMBINED
2024 Dec 18 18:49:14.076519 m623-dut ERR swss#orchagent: :- set: set status: SAI_STATUS_NOT_SUPPORTED
2024 Dec 18 18:49:14.076519 m623-dut ERR swss#orchagent: :- setPortPfcAsym: Failed to set PFC mode 0 to port id 0x1000000000082 (rc:-2)
2024 Dec 18 18:49:14.076555 m623-dut NOTICE swss#orchagent: :- doPortTask: Set port Ethernet512 asymmetric PFC to off
2024 Dec 18 18:49:14.076573 m623-dut NOTICE swss#orchagent: :- setHostTxReady: Setting host_tx_ready status = false, alias = Ethernet512, port_id = 0x1000000000082
2024 Dec 18 18:49:14.076648 m623-dut NOTICE swss#orchagent: :- initHostTxReadyState: initialize host_tx_ready as false for port Ethernet512
2024 Dec 18 18:49:14.077416 m623-dut NOTICE swss#orchagent: :- doPortTask: Set port Ethernet513 MTU to 9100
2024 Dec 18 18:49:14.077636 m623-dut ERR syncd#syncd: :- sendApiResponse: api SAI_COMMON_API_SET failed in syncd mode: SAI_STATUS_NOT_SUPPORTED
2024 Dec 18 18:49:14.077699 m623-dut ERR syncd#syncd: :- processQuadEvent: VID: oid:0x1000000000083 RID: oid:0x8000000000009d
2024 Dec 18 18:49:14.077712 m623-dut ERR syncd#syncd: :- processQuadEvent: attr: SAI_PORT_ATTR_PRIORITY_FLOW_CONTROL_MODE: SAI_PORT_PRIORITY_FLOW_CONTROL_MODE_COMBINED
2024 Dec 18 18:49:14.077839 m623-dut ERR swss#orchagent: :- set: set status: SAI_STATUS_NOT_SUPPORTED
2024 Dec 18 18:49:14.077849 m623-dut ERR swss#orchagent: :- setPortPfcAsym: Failed to set PFC mode 0 to port id 0x1000000000083 (rc:-2)
2024 Dec 18 18:49:14.077876 m623-dut NOTICE swss#orchagent: :- doPortTask: Set port Ethernet513 asymmetric PFC to off
2024 Dec 18 18:49:14.077895 m623-dut NOTICE swss#orchagent: :- setHostTxReady: Setting host_tx_ready status = false, alias = Ethernet513, port_id = 0x1000000000083
2024 Dec 18 18:49:14.077973 m623-dut NOTICE swss#orchagent: :- initHostTxReadyState: initialize host_tx_ready as false for port Ethernet513
2024 Dec 18 18:49:14.078742 m623-dut NOTICE swss#orchagent: :- doPortTask: Set port Ethernet52 MTU to 9100
2024 Dec 18 18:49:14.079643 m623-dut NOTICE swss#orchagent: :- doPortTask: Set port Ethernet52 asymmetric PFC to off
2024 Dec 18 18:49:14.079679 m623-dut NOTICE swss#orchagent: :- setHostTxReady: Setting host_tx_ready status = false, alias = Ethernet52, port_id = 0x100000000000f
2024 Dec 18 18:49:14.079756 m623-dut NOTICE swss#orchagent: :- initHostTxReadyState: initialize host_tx_ready as false for port Ethernet52
cisco@m623-dut:~$ sudo cat /var/log/syslog | grep "ERR swss#orchagent" | tail
2024 Dec 18 18:48:04.561111 m623-dut ERR swss#orchagent: :- removeLag: Failed to remove ref count 4 LAG PortChannel102
2024 Dec 18 18:48:04.561193 m623-dut ERR swss#orchagent: :- removeLag: Failed to remove ref count 4 LAG PortChannel1020
2024 Dec 18 18:48:04.561193 m623-dut ERR swss#orchagent: :- removeLag: Failed to remove ref count 4 LAG PortChannel1023
2024 Dec 18 18:48:04.561193 m623-dut ERR swss#orchagent: :- removeLag: Failed to remove ref count 4 LAG PortChannel105
2024 Dec 18 18:48:04.561193 m623-dut ERR swss#orchagent: :- removeLag: Failed to remove ref count 4 LAG PortChannel108
2024 Dec 18 18:49:11.905411 m623-dut ERR swss#orchagent: :- queryAattributeEnumValuesCapability: returned value 5 is not allowed on SAI_NEXT_HOP_GROUP_ATTR_TYPE
2024 Dec 18 18:49:14.076519 m623-dut ERR swss#orchagent: :- set: set status: SAI_STATUS_NOT_SUPPORTED
2024 Dec 18 18:49:14.076519 m623-dut ERR swss#orchagent: :- setPortPfcAsym: Failed to set PFC mode 0 to port id 0x1000000000082 (rc:-2)
2024 Dec 18 18:49:14.077839 m623-dut ERR swss#orchagent: :- set: set status: SAI_STATUS_NOT_SUPPORTED
2024 Dec 18 18:49:14.077849 m623-dut ERR swss#orchagent: :- setPortPfcAsym: Failed to set PFC mode 0 to port id 0x1000000000083 (rc:-2)
cisco@m623-dut:~$ docker ps
CONTAINER ID   IMAGE                                COMMAND                  CREATED      STATUS       PORTS     NAMES
a990935ca73e   docker-syncd-cisco:latest            "/usr/local/bin/supe…"   2 days ago   Up 3 hours             syncd
ea85fbae9377   docker-sonic-gnmi:latest             "/usr/local/bin/supe…"   5 days ago   Up 3 hours             gnmi
e8edb48fbd06   docker-snmp:latest                   "/usr/local/bin/supe…"   6 days ago   Up 3 hours             snmp
1532472c7157   docker-platform-monitor:latest       "/usr/bin/docker_ini…"   6 days ago   Up 3 hours             pmon
20bc7c51b49b   docker-sonic-mgmt-framework:latest   "/usr/local/bin/supe…"   6 days ago   Up 3 hours             mgmt-framework
1fa3d57d495c   docker-lldp:latest                   "/usr/bin/docker-lld…"   6 days ago   Up 3 hours             lldp
5c183b17c89f   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   6 days ago   Up 3 hours             bgp
ff049aa86c69   docker-router-advertiser:latest      "/usr/bin/docker-ini…"   6 days ago   Up 3 hours             radv
87c1b959009a   docker-teamd:latest                  "/usr/local/bin/supe…"   6 days ago   Up 3 hours             teamd
d020fbae3606   docker-orchagent:latest              "/usr/bin/docker-ini…"   6 days ago   Up 3 hours             swss
aa50d370fd54   docker-eventd:latest                 "/usr/local/bin/supe…"   6 days ago   Up 3 hours             eventd
cb00197d8b86   docker-database:latest               "/usr/local/bin/dock…"   6 days ago   Up 4 days              database
cisco@m623-dut:~$ 
cisco@m623-dut:~$ cd /var/core
cisco@m623-dut:/var/core$ ls
cisco@m623-dut:/var/core$ ls
cisco@m623-dut:/var/core$ 
```

**Details if related**
