### PR TITLE
Revert "[muxorch] Process nexthops using bulker during mux switchover (#3390)

### DIFF
--- a/orchagent/bulker.h
+++ b/orchagent/bulker.h
@@ -343,20 +343,6 @@ struct SaiBulkerTraits<sai_next_hop_group_api_t>
 };
 
 template<>
-struct SaiBulkerTraits<sai_next_hop_api_t>
-{
-    using entry_t = sai_object_id_t;
-    using api_t = sai_next_hop_api_t;
-    using create_entry_fn = sai_create_next_hop_fn;
-    using remove_entry_fn = sai_remove_next_hop_fn;
-    using set_entry_attribute_fn = sai_set_next_hop_attribute_fn;
-    using bulk_create_entry_fn = sai_bulk_object_create_fn;
-    using bulk_remove_entry_fn = sai_bulk_object_remove_fn;
-    // TODO: wait until available in SAI
-    //using bulk_set_entry_attribute_fn = sai_bulk_object_set_attribute_fn;
-};
-
-template<>
 struct SaiBulkerTraits<sai_mpls_api_t>
 {
     using entry_t = sai_inseg_entry_t;
@@ -1003,7 +989,6 @@ public:
         // Creating
         if (!creating_entries.empty())
         {
-            create_statuses.clear();
             std::vector<sai_object_id_t *> rs;
             std::vector<sai_attribute_t const*> tss;
             std::vector<uint32_t> cs;
@@ -1081,10 +1066,6 @@ public:
         return removing_entries.size();
     }
 
-    sai_status_t create_status(sai_object_id_t object) {
-        return create_statuses[object];
-    }
-
 private:
     struct object_entry
     {
@@ -1123,8 +1104,6 @@ private:
     typename Ts::bulk_remove_entry_fn                       remove_entries;
     // TODO: wait until available in SAI
     //typename Ts::bulk_set_entry_attribute_fn                set_entries_attribute;
-
-    std::unordered_map<sai_object_id_t, sai_status_t>       create_statuses;
 
     sai_status_t flush_removing_entries(
         _Inout_ std::vector<sai_object_id_t> &rs)
@@ -1184,7 +1163,6 @@ private:
 
         for (size_t i = 0; i < count; i++)
         {
-            create_statuses.emplace(object_ids[i], statuses[i]);
             sai_object_id_t *pid = rs[i];
             *pid = (statuses[i] == SAI_STATUS_SUCCESS) ? object_ids[i] : SAI_NULL_OBJECT_ID;
         }
@@ -1235,17 +1213,6 @@ inline ObjectBulker<sai_next_hop_group_api_t>::ObjectBulker(SaiBulkerTraits<sai_
 {
     create_entries = api->create_next_hop_group_members;
     remove_entries = api->remove_next_hop_group_members;
-    // TODO: wait until available in SAI
-    //set_entries_attribute = ;
-}
-
-template <>
-inline ObjectBulker<sai_next_hop_api_t>::ObjectBulker(SaiBulkerTraits<sai_next_hop_api_t>::api_t *api, sai_object_id_t switch_id, size_t max_bulk_size) :
-    switch_id(switch_id),
-    max_bulk_size(max_bulk_size)
-{
-    create_entries = api->create_next_hops;
-    remove_entries = api->remove_next_hops;
     // TODO: wait until available in SAI
     //set_entries_attribute = ;
 }

--- a/orchagent/mplsrouteorch.cpp
+++ b/orchagent/mplsrouteorch.cpp
@@ -520,8 +520,7 @@ bool RouteOrch::addLabelRoute(LabelRouteBulkContext& ctx, const NextHopGroupKey 
                      m_neighOrch->isNeighborResolved(nexthop))
             {
                 /* since IP neighbor NH exists, neighbor is resolved, add MPLS NH */
-                NeighborContext ctx = NeighborContext(nexthop);
-                if (m_neighOrch->addNextHop(ctx))
+                if (m_neighOrch->addNextHop(nexthop))
                 {
                     next_hop_id = m_neighOrch->getNextHopId(nexthop);
                 }

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -28,7 +28,6 @@ const int neighorch_pri = 30;
 
 NeighOrch::NeighOrch(DBConnector *appDb, string tableName, IntfsOrch *intfsOrch, FdbOrch *fdbOrch, PortsOrch *portsOrch, DBConnector *chassisAppDb) :
         gNeighBulker(sai_neighbor_api, gMaxBulkSize),
-        gNextHopBulker(sai_next_hop_api, gSwitchId, gMaxBulkSize),
         Orch(appDb, tableName, neighorch_pri),
         m_intfsOrch(intfsOrch),
         m_fdbOrch(fdbOrch),
@@ -197,10 +196,9 @@ bool NeighOrch::isNeighborResolved(const NextHopKey &nexthop)
     return hasNextHop(base_nexthop);
 }
 
-bool NeighOrch::addNextHop(NeighborContext& ctx)
+bool NeighOrch::addNextHop(const NextHopKey &nh)
 {
     SWSS_LOG_ENTER();
-    const NextHopKey nh = ctx.neighborEntry;
 
     Port p;
     if (!gPortsOrch->getPort(nh.alias, p))
@@ -269,13 +267,6 @@ bool NeighOrch::addNextHop(NeighborContext& ctx)
     next_hop_attrs.push_back(next_hop_attr);
 
     sai_object_id_t next_hop_id;
-
-    if (ctx.bulk_op)
-    {
-        gNextHopBulker.create_entry(&ctx.next_hop_id , (uint32_t)next_hop_attrs.size(), next_hop_attrs.data());
-        return true;
-    }
-
     sai_status_t status = sai_next_hop_api->create_next_hop(&next_hop_id, gSwitchId, (uint32_t)next_hop_attrs.size(), next_hop_attrs.data());
     if (status != SAI_STATUS_SUCCESS)
     {
@@ -305,98 +296,6 @@ bool NeighOrch::addNextHop(NeighborContext& ctx)
 
     NextHopEntry next_hop_entry;
     next_hop_entry.next_hop_id = next_hop_id;
-    next_hop_entry.ref_count = 0;
-    next_hop_entry.nh_flags = 0;
-    m_syncdNextHops[nexthop] = next_hop_entry;
-
-    m_intfsOrch->increaseRouterIntfsRefCount(nh.alias);
-
-    if (nexthop.isMplsNextHop())
-    {
-        gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_MPLS_NEXTHOP);
-    }
-    else
-    {
-        if (nexthop.ip_address.isV4())
-        {
-            gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_IPV4_NEXTHOP);
-        }
-        else
-        {
-            gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_IPV6_NEXTHOP);
-        }
-    }
-
-    gFgNhgOrch->validNextHopInNextHopGroup(nexthop);
-
-    // For nexthop with incoming port which has down oper status, NHFLAGS_IFDOWN
-    // flag should be set on it.
-    // This scenario may happen under race condition where buffered neighbor event
-    // is processed after incoming port is down.
-    if (p.m_oper_status == SAI_PORT_OPER_STATUS_DOWN)
-    {
-        if (setNextHopFlag(nexthop, NHFLAGS_IFDOWN) == false)
-        {
-            SWSS_LOG_WARN("Failed to set NHFLAGS_IFDOWN on nexthop %s for interface %s",
-                nexthop.ip_address.to_string().c_str(), nexthop.alias.c_str());
-        }
-    }
-    return true;
-}
-
-bool NeighOrch::processBulkAddNextHop(NeighborContext& ctx)
-{
-    SWSS_LOG_ENTER();
-
-    const NextHopKey nh = ctx.neighborEntry;
-
-    Port p;
-    if (!gPortsOrch->getPort(nh.alias, p))
-    {
-        SWSS_LOG_ERROR("Neighbor %s seen on port %s which doesn't exist",
-                        nh.ip_address.to_string().c_str(), nh.alias.c_str());
-        return false;
-    }
-    if (p.m_type == Port::SUBPORT)
-    {
-        if (!gPortsOrch->getPort(p.m_parent_port_id, p))
-        {
-            SWSS_LOG_ERROR("Neighbor %s seen on sub interface %s whose parent port doesn't exist",
-                            nh.ip_address.to_string().c_str(), nh.alias.c_str());
-            return false;
-        }
-    }
-
-    NextHopKey nexthop(nh);
-    if (ctx.next_hop_id == SAI_NULL_OBJECT_ID)
-    {
-        sai_status_t bulker_status = gNextHopBulker.create_status(ctx.next_hop_id);
-        if (bulker_status == SAI_STATUS_ITEM_ALREADY_EXISTS)
-        {
-            SWSS_LOG_NOTICE("Next hop %s on %s already exists",
-                        nexthop.ip_address.to_string().c_str(), nexthop.alias.c_str());
-            return true;
-        }
-        SWSS_LOG_ERROR("Failed to create next hop %s on %s, rv:%d",
-                       nexthop.ip_address.to_string().c_str(), nexthop.alias.c_str(), bulker_status);
-        task_process_status handle_status = handleSaiCreateStatus(SAI_API_NEXT_HOP, bulker_status);
-        if (handle_status != task_success)
-        {
-            return parseHandleSaiStatusFailure(handle_status);
-        }
-    }
-
-    SWSS_LOG_NOTICE("Created next hop %s on %s",
-                    nexthop.ip_address.to_string().c_str(), nexthop.alias.c_str());
-    if (m_neighborToResolve.find(nexthop) != m_neighborToResolve.end())
-    {
-        clearResolvedNeighborEntry(nexthop);
-        m_neighborToResolve.erase(nexthop);
-        SWSS_LOG_INFO("Resolved neighbor for %s", nexthop.to_string().c_str());
-    }
-
-    NextHopEntry next_hop_entry;
-    next_hop_entry.next_hop_id = ctx.next_hop_id;
     next_hop_entry.ref_count = 0;
     next_hop_entry.nh_flags = 0;
     m_syncdNextHops[nexthop] = next_hop_entry;
@@ -1114,7 +1013,6 @@ bool NeighOrch::addNeighbor(NeighborContext& ctx)
             SWSS_LOG_INFO("Adding neighbor entry %s on %s to bulker.", ip_address.to_string().c_str(), alias.c_str());
             object_statuses.emplace_back();
             gNeighBulker.create_entry(&object_statuses.back(), &neighbor_entry, (uint32_t)neighbor_attrs.size(), neighbor_attrs.data());
-            addNextHop(ctx);
             return true;
         }
 
@@ -1153,7 +1051,7 @@ bool NeighOrch::addNeighbor(NeighborContext& ctx)
             gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_IPV6_NEIGHBOR);
         }
 
-        if (!addNextHop(ctx))
+        if (!addNextHop(NextHopKey(ip_address, alias)))
         {
             status = sai_neighbor_api->remove_neighbor_entry(&neighbor_entry);
             if (status != SAI_STATUS_SUCCESS)
@@ -1259,15 +1157,6 @@ bool NeighOrch::removeNeighbor(NeighborContext& ctx, bool disable)
         copy(neighbor_entry.ip_address, ip_address);
 
         sai_object_id_t next_hop_id = m_syncdNextHops[nexthop].next_hop_id;
-
-        if (bulk_op)
-        {
-            object_statuses.emplace_back();
-            gNextHopBulker.remove_entry(&ctx.nexthop_status, next_hop_id);
-            gNeighBulker.remove_entry(&object_statuses.back(), &neighbor_entry);
-            return true;
-        }
-
         status = sai_next_hop_api->remove_next_hop(next_hop_id);
         if (status != SAI_STATUS_SUCCESS)
         {
@@ -1303,6 +1192,13 @@ bool NeighOrch::removeNeighbor(NeighborContext& ctx, bool disable)
 
         SWSS_LOG_NOTICE("Removed next hop %s on %s",
                         ip_address.to_string().c_str(), alias.c_str());
+
+        if (bulk_op)
+        {
+            object_statuses.emplace_back();
+            gNeighBulker.remove_entry(&object_statuses.back(), &neighbor_entry);
+            return true;
+        }
 
         status = sai_neighbor_api->remove_neighbor_entry(&neighbor_entry);
         if (status != SAI_STATUS_SUCCESS)
@@ -1435,7 +1331,7 @@ bool NeighOrch::processBulkEnableNeighbor(NeighborContext& ctx)
             gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_IPV6_NEIGHBOR);
         }
 
-        if (!processBulkAddNextHop(ctx))
+        if (!addNextHop(NextHopKey(ip_address, alias)))
         {
             status = sai_neighbor_api->remove_neighbor_entry(&neighbor_entry);
             if (status != SAI_STATUS_SUCCESS)
@@ -1499,40 +1395,6 @@ bool NeighOrch::processBulkDisableNeighbor(NeighborContext& ctx)
         neighbor_entry.rif_id = rif_id;
         neighbor_entry.switch_id = gSwitchId;
         copy(neighbor_entry.ip_address, ip_address);
-
-        if (ctx.nexthop_status != SAI_STATUS_SUCCESS)
-        {
-            /* When next hop is not found, we continue to remove neighbor entry. */
-            if (ctx.nexthop_status == SAI_STATUS_ITEM_NOT_FOUND)
-            {
-                SWSS_LOG_NOTICE("Next hop %s on %s doesn't exist, rv:%d",
-                               ip_address.to_string().c_str(), alias.c_str(), ctx.nexthop_status);
-            }
-            else
-            {
-                SWSS_LOG_ERROR("Failed to remove next hop %s on %s, rv:%d",
-                               ip_address.to_string().c_str(), alias.c_str(), ctx.nexthop_status);
-                task_process_status handle_status = handleSaiRemoveStatus(SAI_API_NEXT_HOP, ctx.nexthop_status);
-                if (handle_status != task_success)
-                {
-                    return parseHandleSaiStatusFailure(handle_status);
-                }
-            }
-        }
-
-        if (ctx.nexthop_status != SAI_STATUS_ITEM_NOT_FOUND)
-        {
-            if (neighbor_entry.ip_address.addr_family == SAI_IP_ADDR_FAMILY_IPV4)
-            {
-                gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_IPV4_NEXTHOP);
-            }
-            else
-            {
-                gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_IPV6_NEXTHOP);
-            }
-        }
-
-        SWSS_LOG_NOTICE("Bulk removed next hop %s on %s", ip_address.to_string().c_str(), alias.c_str());
 
         status = *it_status++;
         if (status != SAI_STATUS_SUCCESS)
@@ -1662,7 +1524,6 @@ bool NeighOrch::enableNeighbors(std::list<NeighborContext>& bulk_ctx_list)
     }
 
     gNeighBulker.flush();
-    gNextHopBulker.flush();
 
     for (auto ctx = bulk_ctx_list.begin(); ctx != bulk_ctx_list.end(); ctx++)
     {
@@ -1708,7 +1569,6 @@ bool NeighOrch::disableNeighbors(std::list<NeighborContext>& bulk_ctx_list)
         }
     }
 
-    gNextHopBulker.flush();
     gNeighBulker.flush();
 
     for (auto ctx = bulk_ctx_list.begin(); ctx != bulk_ctx_list.end(); ctx++)

--- a/orchagent/neighorch.h
+++ b/orchagent/neighorch.h
@@ -50,11 +50,9 @@ struct NeighborUpdate
 struct NeighborContext
 {
     NeighborEntry                       neighborEntry;              // neighbor entry to process
-    std::deque<sai_status_t>            object_statuses;            // entity bulk statuses for neighbors
+    std::deque<sai_status_t>            object_statuses;            // bulk statuses
     MacAddress                          mac;                        // neighbor mac
     bool                                bulk_op = false;            // use bulker (only for mux use for now)
-    sai_object_id_t                     next_hop_id;                // next hop id
-    sai_status_t                        nexthop_status;             // next hop status
 
     NeighborContext(NeighborEntry neighborEntry)
         : neighborEntry(neighborEntry)
@@ -75,7 +73,7 @@ public:
 
     bool hasNextHop(const NextHopKey&);
     bool isNeighborResolved(const NextHopKey&);
-    bool addNextHop(NeighborContext& ctx);
+    bool addNextHop(const NextHopKey&);
     bool removeMplsNextHop(const NextHopKey&);
 
     sai_object_id_t getNextHopId(const NextHopKey&);
@@ -122,10 +120,8 @@ private:
     std::set<NextHopKey> m_neighborToResolve;
 
     EntityBulker<sai_neighbor_api_t> gNeighBulker;
-    ObjectBulker<sai_next_hop_api_t> gNextHopBulker;
 
     bool removeNextHop(const IpAddress&, const string&);
-    bool processBulkAddNextHop(NeighborContext&);
 
     bool addNeighbor(NeighborContext& ctx);
     bool removeNeighbor(NeighborContext& ctx, bool disable = false);

--- a/orchagent/nhgorch.cpp
+++ b/orchagent/nhgorch.cpp
@@ -486,8 +486,7 @@ sai_object_id_t NextHopGroupMember::getNhId() const
      */
     else if (isLabeled() && gNeighOrch->isNeighborResolved(m_key))
     {
-        NeighborContext ctx = NeighborContext(m_key);
-        if (gNeighOrch->addNextHop(ctx))
+        if (gNeighOrch->addNextHop(m_key))
         {
             nh_id = gNeighOrch->getNextHopId(m_key);
         }

--- a/orchagent/p4orch/tests/mock_sai_next_hop.h
+++ b/orchagent/p4orch/tests/mock_sai_next_hop.h
@@ -22,13 +22,6 @@ class MockSaiNextHop
 
     MOCK_METHOD3(get_next_hop_attribute, sai_status_t(_In_ sai_object_id_t next_hop_id, _In_ uint32_t attr_count,
                                                       _Inout_ sai_attribute_t *attr_list));
-
-    MOCK_METHOD7(create_next_hops, sai_status_t(_In_ sai_object_id_t switch_id, _In_ uint32_t object_count, _In_ const uint32_t *attr_count,
-                                                _In_ const sai_attribute_t **attr_list, _In_ sai_bulk_op_error_mode_t mode,
-                                                _Out_ sai_object_id_t *object_id, _Out_ sai_status_t *object_statuses));
-
-    MOCK_METHOD4(remove_next_hops, sai_status_t(_In_ uint32_t object_count, _In_ const sai_object_id_t *object_id, _In_ sai_bulk_op_error_mode_t mode,
-                                                _Out_ sai_status_t *object_statuses));
 };
 
 // Note that before mock functions below are used, mock_sai_next_hop must be
@@ -55,18 +48,4 @@ sai_status_t mock_get_next_hop_attribute(_In_ sai_object_id_t next_hop_id, _In_ 
                                          _Inout_ sai_attribute_t *attr_list)
 {
     return mock_sai_next_hop->get_next_hop_attribute(next_hop_id, attr_count, attr_list);
-}
-
-sai_status_t mock_create_next_hops(_In_ sai_object_id_t switch_id, _In_ uint32_t object_count, _In_ const uint32_t *attr_count,
-                                   _In_ const sai_attribute_t **attr_list, _In_ sai_bulk_op_error_mode_t mode,
-                                   _Out_ sai_object_id_t *object_id, _Out_ sai_status_t *object_statuses)
-{
-    return mock_sai_next_hop->create_next_hops(switch_id, object_count, attr_count, attr_list, mode,
-                                               object_id, object_statuses);
-}
-
-sai_status_t mock_remove_next_hops(_In_ uint32_t object_count, _In_ const sai_object_id_t *object_id, _In_ sai_bulk_op_error_mode_t mode,
-                                   _Out_ sai_status_t *object_statuses)
-{
-    return mock_sai_next_hop->remove_next_hops(object_count, object_id, mode, object_statuses);
 }

--- a/orchagent/p4orch/tests/next_hop_manager_test.cpp
+++ b/orchagent/p4orch/tests/next_hop_manager_test.cpp
@@ -258,8 +258,6 @@ class NextHopManagerTest : public ::testing::Test
         sai_next_hop_api->remove_next_hop = mock_remove_next_hop;
         sai_next_hop_api->set_next_hop_attribute = mock_set_next_hop_attribute;
         sai_next_hop_api->get_next_hop_attribute = mock_get_next_hop_attribute;
-        sai_next_hop_api->create_next_hops = mock_create_next_hops;
-        sai_next_hop_api->remove_next_hops = mock_remove_next_hops;
     }
 
     void TearDown() override

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1305,8 +1305,7 @@ bool RouteOrch::addNextHopGroup(const NextHopGroupKey &nexthops)
         else if (it.isMplsNextHop() &&
                  m_neighOrch->hasNextHop(NextHopKey(it.ip_address, it.alias)))
         {
-            NeighborContext ctx = NeighborContext(it);
-            m_neighOrch->addNextHop(ctx);
+            m_neighOrch->addNextHop(it);
             next_hop_id = m_neighOrch->getNextHopId(it);
         }
         else
@@ -1850,8 +1849,7 @@ bool RouteOrch::addRoute(RouteBulkContext& ctx, const NextHopGroupKey &nextHops)
                      m_neighOrch->isNeighborResolved(nexthop))
             {
                 /* since IP neighbor NH exists, neighbor is resolved, add MPLS NH */
-                NeighborContext ctx = NeighborContext(nexthop);
-                m_neighOrch->addNextHop(ctx);
+                m_neighOrch->addNextHop(nexthop);
                 next_hop_id = m_neighOrch->getNextHopId(nexthop);
             }
             /* IP neighbor is not yet resolved */

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -25,7 +25,6 @@ extern sai_vlan_api_t *sai_vlan_api;
 extern sai_bridge_api_t *sai_bridge_api;
 extern sai_route_api_t *sai_route_api;
 extern sai_route_api_t *sai_neighbor_api;
-extern sai_route_api_t *sai_next_hop_api;
 extern sai_mpls_api_t *sai_mpls_api;
 extern sai_next_hop_group_api_t* sai_next_hop_group_api;
 extern string gMySwitchType;
@@ -321,7 +320,6 @@ namespace aclorch_test
             sai_api_query(SAI_API_VLAN, (void **)&sai_vlan_api);
             sai_api_query(SAI_API_ROUTE, (void **)&sai_route_api);
             sai_api_query(SAI_API_NEIGHBOR, (void **)&sai_neighbor_api);
-            sai_api_query(SAI_API_NEXT_HOP, (void **)&sai_next_hop_api);
             sai_api_query(SAI_API_MPLS, (void **)&sai_mpls_api);
             sai_api_query(SAI_API_ACL, (void **)&sai_acl_api);
             sai_api_query(SAI_API_NEXT_HOP_GROUP, (void **)&sai_next_hop_group_api);
@@ -495,7 +493,6 @@ namespace aclorch_test
             sai_bridge_api = nullptr;
             sai_route_api = nullptr;
             sai_neighbor_api = nullptr;
-            sai_next_hop_api = nullptr;
             sai_mpls_api = nullptr;
         }
 

--- a/tests/mock_tests/mock_sai_api.h
+++ b/tests/mock_tests/mock_sai_api.h
@@ -32,12 +32,8 @@ EXTERN_MOCK_FNS
 #define REMOVE_BULK_ARGS(sai_object_type) object_count, sai_object_type##_entry, mode, object_statuses
 #define GENERIC_CREATE_PARAMS(sai_object_type) _Out_ sai_object_id_t *sai_object_type##_id, _In_ sai_object_id_t switch_id, _In_ uint32_t attr_count, _In_ const sai_attribute_t *attr_list
 #define GENERIC_REMOVE_PARAMS(sai_object_type) _In_ sai_object_id_t sai_object_type##_id
-#define GENERIC_BULK_CREATE_PARAMS(sai_object_type) _In_ sai_object_id_t switch_id, _In_ uint32_t object_count, _In_ const uint32_t *attr_count, _In_ const sai_attribute_t **attr_list, _In_ sai_bulk_op_error_mode_t mode, _Out_ sai_object_id_t *object_id, _Out_ sai_status_t *object_statuses
-#define GENERIC_BULK_REMOVE_PARAMS(sai_object_type) _In_ uint32_t object_count, _In_ const sai_object_id_t *object_id, _In_ sai_bulk_op_error_mode_t mode, _Out_ sai_status_t *object_statuses
 #define GENERIC_CREATE_ARGS(sai_object_type) sai_object_type##_id, switch_id, attr_count, attr_list
 #define GENERIC_REMOVE_ARGS(sai_object_type) sai_object_type##_id
-#define GENERIC_BULK_CREATE_ARGS(sai_object_type) switch_id, object_count, attr_count, attr_list, mode, object_id, object_statuses
-#define GENERIC_BULK_REMOVE_ARGS(sai_object_type) object_count, object_id, mode, object_statuses
 
 /*
 The macro DEFINE_SAI_API_MOCK will perform the steps to mock the SAI API for the sai_object_type it is called on:
@@ -160,76 +156,6 @@ The macro DEFINE_SAI_API_MOCK will perform the steps to mock the SAI API for the
                                                                                                                              \
         sai_##sai_api_name##_api->create_##sai_object_type = mock_create_##sai_object_type;                                  \
         sai_##sai_api_name##_api->remove_##sai_object_type = mock_remove_##sai_object_type;                                  \
-    }                                                                                                                        \
-    inline void remove_sai_##sai_api_name##_api_mock()                                                                       \
-    {                                                                                                                        \
-        sai_##sai_api_name##_api = old_sai_##sai_api_name##_api;                                                             \
-        delete mock_sai_##sai_api_name##_api;                                                                                \
-    }
-
-#define DEFINE_SAI_GENERIC_API_OBJECT_BULK_MOCK(sai_api_name, sai_object_type)                                               \
-    static sai_##sai_api_name##_api_t *old_sai_##sai_api_name##_api;                                                         \
-    static sai_##sai_api_name##_api_t ut_sai_##sai_api_name##_api;                                                           \
-    class mock_sai_##sai_api_name##_api_t                                                                                    \
-    {                                                                                                                        \
-    public:                                                                                                                  \
-        mock_sai_##sai_api_name##_api_t()                                                                                    \
-        {                                                                                                                    \
-            ON_CALL(*this, create_##sai_object_type)                                                                         \
-                .WillByDefault(                                                                                              \
-                    [this](GENERIC_CREATE_PARAMS(sai_object_type)) {                                                         \
-                        return old_sai_##sai_api_name##_api->create_##sai_object_type(GENERIC_CREATE_ARGS(sai_object_type)); \
-                    });                                                                                                      \
-            ON_CALL(*this, remove_##sai_object_type)                                                                         \
-                .WillByDefault(                                                                                              \
-                    [this](GENERIC_REMOVE_PARAMS(sai_object_type)) {                                                         \
-                        return old_sai_##sai_api_name##_api->remove_##sai_object_type(GENERIC_REMOVE_ARGS(sai_object_type)); \
-                    });                                                                                                      \
-            ON_CALL(*this, create_##sai_object_type##s)                                                                      \
-                .WillByDefault(                                                                                              \
-                    [this](GENERIC_BULK_CREATE_PARAMS(sai_object_type)) {                                                    \
-                        return old_sai_##sai_api_name##_api->create_##sai_object_type##s(GENERIC_BULK_CREATE_ARGS(sai_object_type)); \
-                    });                                                                                                      \
-            ON_CALL(*this, remove_##sai_object_type##s)                                                                         \
-                .WillByDefault(                                                                                              \
-                    [this](GENERIC_BULK_REMOVE_PARAMS(sai_object_type)) {                                                         \
-                        return old_sai_##sai_api_name##_api->remove_##sai_object_type##s(GENERIC_BULK_REMOVE_ARGS(sai_object_type)); \
-                    });                                                                                                      \
-        }                                                                                                                    \
-        MOCK_METHOD4(create_##sai_object_type, sai_status_t(GENERIC_CREATE_PARAMS(sai_object_type)));                        \
-        MOCK_METHOD1(remove_##sai_object_type, sai_status_t(GENERIC_REMOVE_PARAMS(sai_object_type)));                        \
-        MOCK_METHOD7(create_##sai_object_type##s, sai_status_t(GENERIC_BULK_CREATE_PARAMS(sai_object_type)));                \
-        MOCK_METHOD4(remove_##sai_object_type##s, sai_status_t(GENERIC_BULK_REMOVE_PARAMS(sai_object_type)));                \
-    };                                                                                                                       \
-    static mock_sai_##sai_api_name##_api_t *mock_sai_##sai_api_name##_api;                                                   \
-    inline sai_status_t mock_create_##sai_object_type(GENERIC_CREATE_PARAMS(sai_object_type))                                \
-    {                                                                                                                        \
-        return mock_sai_##sai_api_name##_api->create_##sai_object_type(GENERIC_CREATE_ARGS(sai_object_type));                \
-    }                                                                                                                        \
-    inline sai_status_t mock_remove_##sai_object_type(GENERIC_REMOVE_PARAMS(sai_object_type))                                \
-    {                                                                                                                        \
-        return mock_sai_##sai_api_name##_api->remove_##sai_object_type(GENERIC_REMOVE_ARGS(sai_object_type));                \
-    }                                                                                                                        \
-    inline sai_status_t mock_create_##sai_object_type##s(GENERIC_BULK_CREATE_PARAMS(sai_object_type))                        \
-    {                                                                                                                        \
-        return mock_sai_##sai_api_name##_api->create_##sai_object_type##s(GENERIC_BULK_CREATE_ARGS(sai_object_type));        \
-    }                                                                                                                        \
-    inline sai_status_t mock_remove_##sai_object_type##s(GENERIC_BULK_REMOVE_PARAMS(sai_object_type))                        \
-    {                                                                                                                        \
-        return mock_sai_##sai_api_name##_api->remove_##sai_object_type##s(GENERIC_BULK_REMOVE_ARGS(sai_object_type));        \
-    }                                                                                                                        \
-    inline void apply_sai_##sai_api_name##_api_mock()                                                                        \
-    {                                                                                                                        \
-        mock_sai_##sai_api_name##_api = new NiceMock<mock_sai_##sai_api_name##_api_t>();                                     \
-                                                                                                                             \
-        old_sai_##sai_api_name##_api = sai_##sai_api_name##_api;                                                             \
-        ut_sai_##sai_api_name##_api = *sai_##sai_api_name##_api;                                                             \
-        sai_##sai_api_name##_api = &ut_sai_##sai_api_name##_api;                                                             \
-                                                                                                                             \
-        sai_##sai_api_name##_api->create_##sai_object_type = mock_create_##sai_object_type;                                  \
-        sai_##sai_api_name##_api->remove_##sai_object_type = mock_remove_##sai_object_type;                                  \
-        sai_##sai_api_name##_api->create_##sai_object_type##s = mock_create_##sai_object_type##s;                            \
-        sai_##sai_api_name##_api->remove_##sai_object_type##s = mock_remove_##sai_object_type##s;                            \
     }                                                                                                                        \
     inline void remove_sai_##sai_api_name##_api_mock()                                                                       \
     {                                                                                                                        \

--- a/tests/mock_tests/mux_rollback_ut.cpp
+++ b/tests/mock_tests/mux_rollback_ut.cpp
@@ -22,7 +22,7 @@ namespace mux_rollback_test
     DEFINE_SAI_API_MOCK(neighbor);
     DEFINE_SAI_API_MOCK(route);
     DEFINE_SAI_GENERIC_API_MOCK(acl, acl_entry);
-    DEFINE_SAI_GENERIC_API_OBJECT_BULK_MOCK(next_hop, next_hop);
+    DEFINE_SAI_GENERIC_API_MOCK(next_hop, next_hop);
     using ::testing::_;
     using namespace std;
     using namespace mock_orch_test;
@@ -37,8 +37,6 @@ namespace mux_rollback_test
     sai_bulk_remove_neighbor_entry_fn old_remove_neighbor_entries;
     sai_bulk_create_route_entry_fn old_create_route_entries;
     sai_bulk_remove_route_entry_fn old_remove_route_entries;
-    sai_bulk_object_create_fn old_object_create;
-    sai_bulk_object_remove_fn old_object_remove;
 
     class MuxRollbackTest : public MockOrchTest
     {
@@ -147,14 +145,10 @@ namespace mux_rollback_test
             MockSaiApis();
             old_create_neighbor_entries = gNeighOrch->gNeighBulker.create_entries;
             old_remove_neighbor_entries = gNeighOrch->gNeighBulker.remove_entries;
-            old_object_create = gNeighOrch->gNextHopBulker.create_entries;
-            old_object_remove = gNeighOrch->gNextHopBulker.remove_entries;
             old_create_route_entries = m_MuxCable->nbr_handler_->gRouteBulker.create_entries;
             old_remove_route_entries = m_MuxCable->nbr_handler_->gRouteBulker.remove_entries;
             gNeighOrch->gNeighBulker.create_entries = mock_create_neighbor_entries;
             gNeighOrch->gNeighBulker.remove_entries = mock_remove_neighbor_entries;
-            gNeighOrch->gNextHopBulker.create_entries = mock_create_next_hops;
-            gNeighOrch->gNextHopBulker.remove_entries = mock_remove_next_hops;
             m_MuxCable->nbr_handler_->gRouteBulker.create_entries = mock_create_route_entries;
             m_MuxCable->nbr_handler_->gRouteBulker.remove_entries = mock_remove_route_entries;
         }
@@ -164,8 +158,6 @@ namespace mux_rollback_test
             RestoreSaiApis();
             gNeighOrch->gNeighBulker.create_entries = old_create_neighbor_entries;
             gNeighOrch->gNeighBulker.remove_entries = old_remove_neighbor_entries;
-            gNeighOrch->gNextHopBulker.create_entries = old_object_create;
-            gNeighOrch->gNextHopBulker.remove_entries = old_object_remove;
             m_MuxCable->nbr_handler_->gRouteBulker.create_entries = old_create_route_entries;
             m_MuxCable->nbr_handler_->gRouteBulker.remove_entries = old_remove_route_entries;
         }
@@ -222,18 +214,16 @@ namespace mux_rollback_test
 
     TEST_F(MuxRollbackTest, StandbyToActiveNextHopAlreadyExists)
     {
-        std::vector<sai_status_t> exp_status{SAI_STATUS_ITEM_ALREADY_EXISTS};
-        EXPECT_CALL(*mock_sai_next_hop_api, create_next_hops)
-            .WillOnce(DoAll(SetArrayArgument<6>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_ITEM_ALREADY_EXISTS)));
+        EXPECT_CALL(*mock_sai_next_hop_api, create_next_hop)
+            .WillOnce(Return(SAI_STATUS_ITEM_ALREADY_EXISTS));
         SetAndAssertMuxState(ACTIVE_STATE);
     }
 
     TEST_F(MuxRollbackTest, ActiveToStandbyNextHopNotFound)
     {
         SetAndAssertMuxState(ACTIVE_STATE);
-        std::vector<sai_status_t> exp_status{SAI_STATUS_ITEM_NOT_FOUND};
-        EXPECT_CALL(*mock_sai_next_hop_api, remove_next_hops)
-            .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_ITEM_NOT_FOUND)));
+        EXPECT_CALL(*mock_sai_next_hop_api, remove_next_hop)
+            .WillOnce(Return(SAI_STATUS_ITEM_NOT_FOUND));
         SetAndAssertMuxState(STANDBY_STATE);
     }
 
@@ -273,7 +263,7 @@ namespace mux_rollback_test
 
     TEST_F(MuxRollbackTest, StandbyToActiveExceptionRollbackToStandby)
     {
-        EXPECT_CALL(*mock_sai_next_hop_api, create_next_hops)
+        EXPECT_CALL(*mock_sai_next_hop_api, create_next_hop)
             .WillOnce(Throw(exception()));
         SetMuxStateFromAppDb(ACTIVE_STATE);
         EXPECT_EQ(STANDBY_STATE, m_MuxCable->getState());
@@ -282,7 +272,7 @@ namespace mux_rollback_test
     TEST_F(MuxRollbackTest, ActiveToStandbyExceptionRollbackToActive)
     {
         SetAndAssertMuxState(ACTIVE_STATE);
-        EXPECT_CALL(*mock_sai_next_hop_api, remove_next_hops)
+        EXPECT_CALL(*mock_sai_next_hop_api, remove_next_hop)
             .WillOnce(Throw(exception()));
         SetMuxStateFromAppDb(STANDBY_STATE);
         EXPECT_EQ(ACTIVE_STATE, m_MuxCable->getState());
@@ -290,9 +280,8 @@ namespace mux_rollback_test
 
     TEST_F(MuxRollbackTest, StandbyToActiveNextHopTableFullRollbackToActive)
     {
-        std::vector<sai_status_t> exp_status{SAI_STATUS_TABLE_FULL};
-        EXPECT_CALL(*mock_sai_next_hop_api, create_next_hops)
-            .WillOnce(DoAll(SetArrayArgument<6>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_TABLE_FULL)));
+        EXPECT_CALL(*mock_sai_next_hop_api, create_next_hop)
+            .WillOnce(Return(SAI_STATUS_TABLE_FULL));
         SetMuxStateFromAppDb(ACTIVE_STATE);
         EXPECT_EQ(STANDBY_STATE, m_MuxCable->getState());
     }


### PR DESCRIPTION
This reverts commit 39e5a675a93f3d1c8772cfb85b02a32a45a3a241.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Revert "[muxorch] Process nexthops using bulker during mux switchover (#3390)
**Why I did it**
This PR would introduce log analyzer error in T0 mock dualtor tests: https://elastictest.org/scheduler/testplan/67633aadc381fc7238aa9d21?testcase=dualtor%2Ftest_orch_stress.py%7C%7C%7C2&type=console
```
E               Failed: Processes "['analyze_logs--<MultiAsicSonicHost vlab-01>']" failed with exit code "1"
E               Exception:
E               match: 336
E               expected_match: 0
E               expected_missing_match: 0
E               
E               Match Messages:
E               2024 Dec 18 21:56:20.137188 vlab-01 ERR syncd#syncd: :- bulkCreate: not implemented SAI_OBJECT_TYPE_NEXT_HOP, FIXME
E               
E               2024 Dec 18 21:56:20.137188 vlab-01 ERR syncd#syncd: :- processBulkOidCreate: bulkCreate api is not implemented or not supported, object_type = SAI_OBJECT_TYPE_NEXT_HOP
E               
E               2024 Dec 18 21:56:20.166358 vlab-01 ERR syncd#syncd: :- bulkCreate: not implemented SAI_OBJECT_TYPE_NEXT_HOP, FIXME
E               
E               2024 Dec 18 21:56:20.166408 vlab-01 ERR syncd#syncd: :- processBulkOidCreate: bulkCreate api is not implemented or not supported, object_type = SAI_OBJECT_TYPE_NEXT_HOP
E               
E               2024 Dec 18 21:56:20.179731 vlab-01 ERR syncd#syncd: :- bulkCreate: not implemented SAI_OBJECT_TYPE_NEXT_HOP, FIXME
E               
E               2024 Dec 18 21:56:20.179731 vlab-01 ERR syncd#syncd: :- processBulkOidCreate: bulkCreate api is not implemented or not supported, object_type = SAI_OBJECT_TYPE_NEXT_HOP
```
**How I verified it**

**Details if related**
