### PR TITLE
Fixed Orchagent crashed when add and delete route at same time(#3436)

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -975,6 +975,7 @@ void RouteOrch::doTask(Consumer& consumer)
         // Go through the bulker results
         auto it_prev = consumer.m_toSync.begin();
         m_bulkNhgReducedRefCnt.clear();
+        m_bulkNhReducedRefCnt.clear();
         while (it_prev != it)
         {
             KeyOpFieldsValuesTuple t = it_prev->second;
@@ -1069,6 +1070,13 @@ void RouteOrch::doTask(Consumer& consumer)
             {
                 removeNextHopGroup(it_nhg.first);
             }
+        }
+        for (auto& it_nh : m_bulkNhReducedRefCnt)
+        {
+            if (it_nh.isMplsNextHop() && (m_neighOrch->getNextHopRefCount(it_nh) == 0))
+            {
+                m_neighOrch->removeMplsNextHop(it_nh);
+            } 
         }
     }
 }
@@ -2608,7 +2616,7 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
             if (nexthop.isMplsNextHop() &&
                 (m_neighOrch->getNextHopRefCount(nexthop) == 0))
             {
-                m_neighOrch->removeMplsNextHop(nexthop);
+                m_bulkNhReducedRefCnt.push_back(nexthop);
             }
             else if (nexthop.isSrv6NextHop() &&
                     (m_neighOrch->getNextHopRefCount(nexthop) == 0))

--- a/orchagent/routeorch.h
+++ b/orchagent/routeorch.h
@@ -253,6 +253,8 @@ private:
     std::set<std::pair<NextHopGroupKey, sai_object_id_t>> m_bulkNhgReducedRefCnt;
     /* m_bulkNhgReducedRefCnt: nexthop, vrf_id */
 
+    std::vector<NextHopKey> m_bulkNhReducedRefCnt;
+
     std::set<IpPrefix> m_SubnetDecapTermsCreated;
     ProducerStateTable m_appTunnelDecapTermProducer;
 


### PR DESCRIPTION
**What I did**
reference： https://github.com/sonic-net/sonic-swss/pull/1501 
Remove mpls next-hop after updating the reference counter for a bulk of routes instead of removing it in the loop of updating the reference counter.
Fix https://github.com/sonic-net/sonic-swss/issues/3436

**Why I did it**
As described in issue #1501, I did this to fixed the same problem for mpls nexthop.

**How I verified it**

**Details if related**

