### PR TITLE
SRv6: add dscp_mode configuration for MySID entry

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -220,11 +220,17 @@ bool OrchDaemon::init()
     gFgNhgOrch = new FgNhgOrch(m_configDb, m_applDb, m_stateDb, fgnhg_tables, gNeighOrch, gIntfsOrch, vrf_orch);
     gDirectory.set(gFgNhgOrch);
 
-    vector<string> srv6_tables = {
-        APP_SRV6_SID_LIST_TABLE_NAME,
-        APP_SRV6_MY_SID_TABLE_NAME
+    TableConnector srv6_sid_list_table(m_applDb, APP_SRV6_SID_LIST_TABLE_NAME);
+    TableConnector srv6_my_sid_table(m_applDb, APP_SRV6_MY_SID_TABLE_NAME);
+    TableConnector srv6_my_sid_cfg_table(m_configDb, CFG_SRV6_MY_SID_TABLE_NAME);
+
+    vector<TableConnector> srv6_tables = {
+        srv6_sid_list_table,
+        srv6_my_sid_table,
+        srv6_my_sid_cfg_table
     };
-    gSrv6Orch = new Srv6Orch(m_applDb, srv6_tables, gSwitchOrch, vrf_orch, gNeighOrch);
+
+    gSrv6Orch = new Srv6Orch(m_configDb, m_applDb, srv6_tables, gSwitchOrch, vrf_orch, gNeighOrch);
     gDirectory.set(gSrv6Orch);
 
     const int routeorch_pri = 5;

--- a/orchagent/srv6orch.cpp
+++ b/orchagent/srv6orch.cpp
@@ -15,6 +15,10 @@ using namespace swss;
 
 #define ADJ_DELIMITER ','
 #define OVERLAY_RIF_DEFAULT_MTU 9100
+#define LOCATOR_DEFAULT_BLOCK_LEN "32"
+#define LOCATOR_DEFAULT_NODE_LEN "16"
+#define LOCATOR_DEFAULT_FUNC_LEN "16"
+#define LOCATOR_DEFAULT_ARG_LEN "0"
 
 extern sai_object_id_t gSwitchId;
 extern sai_object_id_t  gVirtualRouterId;
@@ -109,17 +113,11 @@ bool Srv6Orch::getLocatorCfgFromDb(const string& locator, MySidLocatorCfg& cfg)
     auto flen = fvsGetValue(fvs, "func_len", true);
     auto alen = fvsGetValue(fvs, "arg_len", true);
 
-    if (!blen || !nlen || !flen || !alen)
-    {
-        SWSS_LOG_ERROR("Invalid configuration for SRv6 locator %s in CONFIG DB\n", locator.c_str());
-        return false;
-    }
-
     cfg = {
-        (uint8_t)stoi(blen.get_value_or("0")),
-        (uint8_t)stoi(nlen.get_value_or("0")),
-        (uint8_t)stoi(flen.get_value_or("0")),
-        (uint8_t)stoi(alen.get_value_or("0"))
+        (uint8_t)stoi(blen.get_value_or(LOCATOR_DEFAULT_BLOCK_LEN)),
+        (uint8_t)stoi(nlen.get_value_or(LOCATOR_DEFAULT_NODE_LEN)),
+        (uint8_t)stoi(flen.get_value_or(LOCATOR_DEFAULT_FUNC_LEN)),
+        (uint8_t)stoi(alen.get_value_or(LOCATOR_DEFAULT_ARG_LEN))
     };
 
     return true;

--- a/orchagent/srv6orch.cpp
+++ b/orchagent/srv6orch.cpp
@@ -361,7 +361,7 @@ bool Srv6Orch::createMySidIpInIpTunnel(sai_tunnel_dscp_mode_t dscp_mode, sai_obj
     tunnel_info.refcount++;
     tunnel_oid = tunnel_info.tunnel_oid;
 
-    SWSS_LOG_INFO("Increased refcount for MySID IPinIP tunnel to %lu", tunnel_info.refcount);
+    SWSS_LOG_INFO("Increased refcount for MySID IPinIP tunnel to %" PRIu64, tunnel_info.refcount);
 
     return true;
 }
@@ -376,7 +376,7 @@ bool Srv6Orch::removeMySidIpInIpTunnel(sai_tunnel_dscp_mode_t dscp_mode)
     MySidIpInIpTunnel& tunnel_info = (dscp_mode == SAI_TUNNEL_DSCP_MODE_UNIFORM_MODEL) ? uniform_tunnel : pipe_tunnel;
     tunnel_info.refcount--;
 
-    SWSS_LOG_INFO("Decreased refcount for MySID IPinIP tunnel to %lu", tunnel_info.refcount);
+    SWSS_LOG_INFO("Decreased refcount for MySID IPinIP tunnel to %" PRIu64, tunnel_info.refcount);
 
     if (tunnel_info.refcount == 0)
     {

--- a/orchagent/srv6orch.cpp
+++ b/orchagent/srv6orch.cpp
@@ -901,7 +901,7 @@ bool Srv6Orch::createUpdateMysidEntry(string my_sid_string, const string dt_vrf,
     sai_attribute_t attr;
     string key_string = my_sid_string;
     sai_my_sid_entry_endpoint_behavior_t end_behavior;
-    sai_my_sid_entry_endpoint_behavior_flavor_t end_flavor = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD;
+    sai_my_sid_entry_endpoint_behavior_flavor_t end_flavor = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_NONE;
 
     bool entry_exists = false;
     if (mySidExists(key_string))
@@ -1051,9 +1051,12 @@ bool Srv6Orch::createUpdateMysidEntry(string my_sid_string, const string dt_vrf,
     attr.value.s32 = end_behavior;
     attributes.push_back(attr);
 
-    attr.id = SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR_FLAVOR;
-    attr.value.s32 = end_flavor;
-    attributes.push_back(attr);
+    if (end_flavor != SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_NONE)
+    {
+        attr.id = SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR_FLAVOR;
+        attr.value.s32 = end_flavor;
+        attributes.push_back(attr);
+    }
 
     sai_status_t status = SAI_STATUS_SUCCESS;
     if (!entry_exists)

--- a/orchagent/srv6orch.cpp
+++ b/orchagent/srv6orch.cpp
@@ -125,18 +125,18 @@ bool Srv6Orch::getLocatorCfgFromDb(const string& locator, MySidLocatorCfg& cfg)
 
 bool Srv6Orch::reverseLookupLocator(const vector<string>& candidates, const MySidLocatorCfg& locator_cfg, string& locator)
 {
-    for (const auto& canididate: candidates)
+    for (const auto& candidate: candidates)
     {
         MySidLocatorCfg cfg;
-        auto ok = getLocatorCfgFromDb(canididate, cfg);
+        auto ok = getLocatorCfgFromDb(candidate, cfg);
         if (!ok) {
             continue;
         }
 
         if (locator_cfg == cfg)
         {
-            SWSS_LOG_DEBUG("Found a locator %s matching the config", canididate.c_str());
-            locator = canididate;
+            SWSS_LOG_DEBUG("Found a locator %s matching the config", candidate.c_str());
+            locator = candidate;
             return true;
         }
     }
@@ -200,7 +200,7 @@ void Srv6Orch::mySidCfgCacheRefresh()
 
 bool Srv6Orch::getMySidEntryDscpMode(const string& my_sid_addr, const MySidLocatorCfg& locator_cfg, sai_tunnel_dscp_mode_t& dscp_mode)
 {
-    auto my_sid_prefix = my_sid_addr + "/" + to_string(locator_cfg.block_len + locator_cfg.node_len);
+    auto my_sid_prefix = my_sid_addr + "/" + to_string(locator_cfg.block_len + locator_cfg.node_len + locator_cfg.func_len);
 
     auto cfg_cache = my_sid_dscp_cfg_cache_.equal_range(my_sid_prefix);
     if (cfg_cache.first == my_sid_dscp_cfg_cache_.end())

--- a/orchagent/srv6orch.h
+++ b/orchagent/srv6orch.h
@@ -44,8 +44,8 @@ struct MySidEntry
     sai_my_sid_entry_endpoint_behavior_t endBehavior;
     string            endVrfString; // Used for END.T, END.DT4, END.DT6 and END.DT46,
     string            endAdjString; // Used for END.X, END.DX4, END.DX6
-    sai_tunnel_dscp_mode_t dscp_mode; // Used for UDT46
-    sai_object_id_t   tunnel_term_entry; // Used for UDT46
+    sai_tunnel_dscp_mode_t dscp_mode;    // Used for decapsulation configuration
+    sai_object_id_t   tunnel_term_entry; // Used for decapsulation configuration
 };
 
 struct MySidIpInIpTunnel
@@ -129,7 +129,7 @@ class Srv6Orch : public Orch, public Observer
         bool mySidExists(const string mysid_string);
         bool mySidVrfRequired(const sai_my_sid_entry_endpoint_behavior_t end_behavior);
         bool mySidNextHopRequired(const sai_my_sid_entry_endpoint_behavior_t end_behavior);
-        bool mySidTunnelRequired(const sai_my_sid_entry_endpoint_behavior_t end_behavior);
+        bool mySidTunnelRequired(const string& my_sid_addr, const sai_my_sid_entry_t& sai_entry, sai_my_sid_entry_endpoint_behavior_t end_behavior, sai_tunnel_dscp_mode_t& dscp_mode);
         void srv6TunnelUpdateNexthops(const string srv6_source, const NextHopKey nhkey, bool insert);
         size_t srv6TunnelNexthopSize(const string srv6_source);
         bool initIpInIpTunnel(MySidIpInIpTunnel& tunnel, sai_tunnel_dscp_mode_t dscp_mode);

--- a/orchagent/srv6orch.h
+++ b/orchagent/srv6orch.h
@@ -248,7 +248,7 @@ class Srv6Orch : public Orch, public Observer
         Srv6PrefixAggIdSet srv6_prefix_agg_id_set_;
         Srv6TunnelMapEntryTable srv6_tunnel_map_entry_table_;
         Srv6PicContextTable srv6_pic_context_table_;
-        MySidIpInIpTunnels my_sid_ipinip_tunnels_;
+        MySidIpInIpTunnels my_sid_ipinip_tunnels_{};
         Srv6MySidDscpCfg my_sid_dscp_cfg_cache_;
 
         VRFOrch *m_vrfOrch;

--- a/orchagent/srv6orch.h
+++ b/orchagent/srv6orch.h
@@ -44,25 +44,42 @@ struct MySidEntry
     sai_my_sid_entry_endpoint_behavior_t endBehavior;
     string            endVrfString; // Used for END.T, END.DT4, END.DT6 and END.DT46,
     string            endAdjString; // Used for END.X, END.DX4, END.DX6
+    sai_tunnel_dscp_mode_t dscp_mode; // Used for UDT46
+    sai_object_id_t   tunnel_term_entry; // Used for UDT46
+};
+
+struct MySidIpInIpTunnel
+{
+    sai_object_id_t overlay_rif_oid;
+    sai_object_id_t tunnel_oid;
+    uint64_t refcount;
+};
+
+struct MySidIpInIpTunnels
+{
+    MySidIpInIpTunnel dscp_uniform_tunnel;
+    MySidIpInIpTunnel dscp_pipe_tunnel;
 };
 
 typedef unordered_map<string, SidTableEntry> SidTable;
 typedef unordered_map<string, SidTunnelEntry> Srv6TunnelTable;
 typedef map<NextHopKey, sai_object_id_t> Srv6NextHopTable;
 typedef unordered_map<string, MySidEntry> Srv6MySidTable;
+typedef unordered_map<string, sai_tunnel_dscp_mode_t> Srv6MySidDscpCfg;
 
 #define SID_LIST_DELIMITER ','
 #define MY_SID_KEY_DELIMITER ':'
 class Srv6Orch : public Orch, public Observer
 {
     public:
-        Srv6Orch(DBConnector *applDb, vector<string> &tableNames, SwitchOrch *switchOrch, VRFOrch *vrfOrch, NeighOrch *neighOrch):
-          Orch(applDb, tableNames),
+        Srv6Orch(DBConnector *cfgDb, DBConnector *applDb, const vector<TableConnector>& tables, SwitchOrch *switchOrch, VRFOrch *vrfOrch, NeighOrch *neighOrch):
+          Orch(tables),
           m_vrfOrch(vrfOrch),
           m_switchOrch(switchOrch),
           m_neighOrch(neighOrch),
           m_sidTable(applDb, APP_SRV6_SID_LIST_TABLE_NAME),
-          m_mysidTable(applDb, APP_SRV6_MY_SID_TABLE_NAME)
+          m_mysidTable(applDb, APP_SRV6_MY_SID_TABLE_NAME),
+          m_mysidCfgTable(cfgDb, CFG_SRV6_MY_SID_TABLE_NAME)
         {
             m_neighOrch->attach(this);
         }
@@ -78,6 +95,7 @@ class Srv6Orch : public Orch, public Observer
         void doTask(Consumer &consumer);
         task_process_status doTaskSidTable(const KeyOpFieldsValuesTuple &tuple);
         void doTaskMySidTable(const KeyOpFieldsValuesTuple &tuple);
+        void doTaskCfgMySidTable(const KeyOpFieldsValuesTuple &tuple);
         bool createUpdateSidList(const string seg_name, const string ips, const string sidlist_type);
         task_process_status deleteSidList(const string seg_name);
         bool createSrv6Tunnel(const string srv6_source);
@@ -87,20 +105,31 @@ class Srv6Orch : public Orch, public Observer
         bool deleteMysidEntry(const string my_sid_string);
         bool sidEntryEndpointBehavior(const string action, sai_my_sid_entry_endpoint_behavior_t &end_behavior,
                                       sai_my_sid_entry_endpoint_behavior_flavor_t &end_flavor);
+        bool getMySidEntryDscpMode(const string& my_sid, sai_tunnel_dscp_mode_t& dscp_mode);
         bool mySidExists(const string mysid_string);
         bool mySidVrfRequired(const sai_my_sid_entry_endpoint_behavior_t end_behavior);
         bool mySidNextHopRequired(const sai_my_sid_entry_endpoint_behavior_t end_behavior);
+        bool mySidTunnelRequired(const sai_my_sid_entry_endpoint_behavior_t end_behavior);
         void srv6TunnelUpdateNexthops(const string srv6_source, const NextHopKey nhkey, bool insert);
         size_t srv6TunnelNexthopSize(const string srv6_source);
+        bool initIpInIpTunnel(MySidIpInIpTunnel& tunnel, sai_tunnel_dscp_mode_t dscp_mode);
+        bool deinitIpInIpTunnel(MySidIpInIpTunnel& tunnel);
+        bool createMySidIpInIpTunnel(sai_tunnel_dscp_mode_t dscp_mode, sai_object_id_t& tunnel_oid);
+        bool removeMySidIpInIpTunnel(sai_tunnel_dscp_mode_t dscp_mode);
+        bool createMySidIpInIpTunnelTermEntry(sai_object_id_t tunnel_oid, const sai_ip6_t& sid_ip, sai_object_id_t& term_entry_oid);
+        bool removeMySidIpInIpTunnelTermEntry(sai_object_id_t term_entry_oid);
 
         void updateNeighbor(const NeighborUpdate& update);
 
         ProducerStateTable m_sidTable;
         ProducerStateTable m_mysidTable;
+        Table m_mysidCfgTable;
         SidTable sid_table_;
         Srv6TunnelTable srv6_tunnel_table_;
         Srv6NextHopTable srv6_nexthop_table_;
         Srv6MySidTable srv6_my_sid_table_;
+        MySidIpInIpTunnels my_sid_ipinip_tunnels_;
+        Srv6MySidDscpCfg my_sid_dscp_cfg_cache_;
         VRFOrch *m_vrfOrch;
         SwitchOrch *m_switchOrch;
         NeighOrch *m_neighOrch;

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -418,11 +418,16 @@ namespace aclorch_test
             gFgNhgOrch = new FgNhgOrch(m_config_db.get(), m_app_db.get(), m_state_db.get(), fgnhg_tables, gNeighOrch, gIntfsOrch, gVrfOrch);
 
             ASSERT_EQ(gSrv6Orch, nullptr);
-            vector<string> srv6_tables = {
-                APP_SRV6_SID_LIST_TABLE_NAME,
-                APP_SRV6_MY_SID_TABLE_NAME
+            TableConnector srv6_sid_list_table(m_app_db.get(), APP_SRV6_SID_LIST_TABLE_NAME);
+            TableConnector srv6_my_sid_table(m_app_db.get(), APP_SRV6_MY_SID_TABLE_NAME);
+            TableConnector srv6_my_sid_cfg_table(m_config_db.get(), CFG_SRV6_MY_SID_TABLE_NAME);
+
+            vector<TableConnector> srv6_tables = {
+                srv6_sid_list_table,
+                srv6_my_sid_table,
+                srv6_my_sid_cfg_table
             };
-            gSrv6Orch = new Srv6Orch(m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
+            gSrv6Orch = new Srv6Orch(m_config_db.get(), m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
 
             ASSERT_EQ(gRouteOrch, nullptr);
             const int routeorch_pri = 5;

--- a/tests/mock_tests/flowcounterrouteorch_ut.cpp
+++ b/tests/mock_tests/flowcounterrouteorch_ut.cpp
@@ -201,11 +201,16 @@ namespace flowcounterrouteorch_test
             gFgNhgOrch = new FgNhgOrch(m_config_db.get(), m_app_db.get(), m_state_db.get(), fgnhg_tables, gNeighOrch, gIntfsOrch, gVrfOrch);
 
             ASSERT_EQ(gSrv6Orch, nullptr);
-            vector<string> srv6_tables = {
-                APP_SRV6_SID_LIST_TABLE_NAME,
-                APP_SRV6_MY_SID_TABLE_NAME
+            TableConnector srv6_sid_list_table(m_app_db.get(), APP_SRV6_SID_LIST_TABLE_NAME);
+            TableConnector srv6_my_sid_table(m_app_db.get(), APP_SRV6_MY_SID_TABLE_NAME);
+            TableConnector srv6_my_sid_cfg_table(m_config_db.get(), CFG_SRV6_MY_SID_TABLE_NAME);
+
+            vector<TableConnector> srv6_tables = {
+                srv6_sid_list_table,
+                srv6_my_sid_table,
+                srv6_my_sid_cfg_table
             };
-            gSrv6Orch = new Srv6Orch(m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
+            gSrv6Orch = new Srv6Orch(m_config_db.get(), m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
 
             // Start FlowCounterRouteOrch
             static const  vector<string> route_pattern_tables = {

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -190,11 +190,16 @@ namespace intfsorch_test
             gFgNhgOrch = new FgNhgOrch(m_config_db.get(), m_app_db.get(), m_state_db.get(), fgnhg_tables, gNeighOrch, gIntfsOrch, gVrfOrch);
 
             ASSERT_EQ(gSrv6Orch, nullptr);
-            vector<string> srv6_tables = {
-                APP_SRV6_SID_LIST_TABLE_NAME,
-                APP_SRV6_MY_SID_TABLE_NAME
+            TableConnector srv6_sid_list_table(m_app_db.get(), APP_SRV6_SID_LIST_TABLE_NAME);
+            TableConnector srv6_my_sid_table(m_app_db.get(), APP_SRV6_MY_SID_TABLE_NAME);
+            TableConnector srv6_my_sid_cfg_table(m_config_db.get(), CFG_SRV6_MY_SID_TABLE_NAME);
+
+            vector<TableConnector> srv6_tables = {
+                srv6_sid_list_table,
+                srv6_my_sid_table,
+                srv6_my_sid_cfg_table
             };
-            gSrv6Orch = new Srv6Orch(m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
+            gSrv6Orch = new Srv6Orch(m_config_db.get(), m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
 
             // Start FlowCounterRouteOrch
             static const  vector<string> route_pattern_tables = {

--- a/tests/mock_tests/mock_orch_test.cpp
+++ b/tests/mock_tests/mock_orch_test.cpp
@@ -185,11 +185,16 @@ void MockOrchTest::SetUp()
     gDirectory.set(gNhgOrch);
     ut_orch_list.push_back((Orch **)&gNhgOrch);
 
-    vector<string> srv6_tables = {
-        APP_SRV6_SID_LIST_TABLE_NAME,
-        APP_SRV6_MY_SID_TABLE_NAME
+    TableConnector srv6_sid_list_table(m_app_db.get(), APP_SRV6_SID_LIST_TABLE_NAME);
+    TableConnector srv6_my_sid_table(m_app_db.get(), APP_SRV6_MY_SID_TABLE_NAME);
+    TableConnector srv6_my_sid_cfg_table(m_config_db.get(), CFG_SRV6_MY_SID_TABLE_NAME);
+
+    vector<TableConnector> srv6_tables = {
+        srv6_sid_list_table,
+        srv6_my_sid_table,
+        srv6_my_sid_cfg_table
     };
-    gSrv6Orch = new Srv6Orch(m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
+    gSrv6Orch = new Srv6Orch(m_config_db.get(), m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
     gDirectory.set(gSrv6Orch);
     ut_orch_list.push_back((Orch **)&gSrv6Orch);
     gCrmOrch = new CrmOrch(m_config_db.get(), CFG_CRM_TABLE_NAME);

--- a/tests/mock_tests/routeorch_ut.cpp
+++ b/tests/mock_tests/routeorch_ut.cpp
@@ -247,11 +247,16 @@ namespace routeorch_test
             gFgNhgOrch = new FgNhgOrch(m_config_db.get(), m_app_db.get(), m_state_db.get(), fgnhg_tables, gNeighOrch, gIntfsOrch, gVrfOrch);
 
             ASSERT_EQ(gSrv6Orch, nullptr);
-            vector<string> srv6_tables = {
-                APP_SRV6_SID_LIST_TABLE_NAME,
-                APP_SRV6_MY_SID_TABLE_NAME
+            TableConnector srv6_sid_list_table(m_app_db.get(), APP_SRV6_SID_LIST_TABLE_NAME);
+            TableConnector srv6_my_sid_table(m_app_db.get(), APP_SRV6_MY_SID_TABLE_NAME);
+            TableConnector srv6_my_sid_cfg_table(m_config_db.get(), CFG_SRV6_MY_SID_TABLE_NAME);
+
+            vector<TableConnector> srv6_tables = {
+                srv6_sid_list_table,
+                srv6_my_sid_table,
+                srv6_my_sid_cfg_table
             };
-            gSrv6Orch = new Srv6Orch(m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
+            gSrv6Orch = new Srv6Orch(m_config_db.get(), m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
 
             ASSERT_EQ(gRouteOrch, nullptr);
             const int routeorch_pri = 5;

--- a/tests/test_srv6.py
+++ b/tests/test_srv6.py
@@ -1334,8 +1334,6 @@ class TestSrv6MySidFpmsyncd(object):
         dvs.runcmd(sid_cmd)
         dvs.runcmd(loc_cmd)
 
-    @pytest.mark.skipif(LooseVersion(platform.release()) < LooseVersion('5.14'),
-                        reason="This test requires Linux kernel 5.14 or higher")
     def test_Srv6MySidUNTunnelDscpMode(self, dvs, testlog):
 
         _, output = dvs.runcmd(f"vtysh -c 'show zebra dplane providers'")
@@ -1430,8 +1428,6 @@ class TestSrv6MySidFpmsyncd(object):
 
         self.teardown_srv6(dvs)
 
-    @pytest.mark.skipif(LooseVersion(platform.release()) < LooseVersion('5.14'),
-                        reason="This test requires Linux kernel 5.14 or higher")
     def test_Srv6MySidUNTunnelDscpModeAmbiguity(self, dvs, testlog):
         _, output = dvs.runcmd(f"vtysh -c 'show zebra dplane providers'")
         if 'dplane_fpm_sonic' not in output:

--- a/tests/test_srv6.py
+++ b/tests/test_srv6.py
@@ -1303,13 +1303,29 @@ class TestSrv6MySidFpmsyncd(object):
             if fv[0] == attribute:
                 assert fv[1] == expected_value
 
-    def add_mysid_cfgdb(self, locator, prefix, addr, dscp_mode):
-        self.cdb.create_entry("SRV6_MY_LOCATORS", locator, {"prefix": prefix, "block_len": "32", "node_len": "16", "func_len": "16", "arg_len": "0"})
-        self.cdb.create_entry("SRV6_MY_SIDS", f'{locator}|{addr}/48', {"decap_dscp_mode": dscp_mode})
+    def add_mysid_cfgdb(self, locator, addr, prefix="", dscp_mode="uniform", func_len=0):
+        if not prefix:
+            prefix = addr
+        self.cdb.create_entry("SRV6_MY_LOCATORS", locator, {"prefix": prefix, "block_len": "32", "node_len": "16", "func_len": str(func_len), "arg_len": "0"})
+        self.cdb.create_entry("SRV6_MY_SIDS", f'{locator}|{addr}/{48 + func_len}', {"decap_dscp_mode": dscp_mode})
 
-    def remove_mysid_cfgdb(self, locator, addr):
-        self.cdb.delete_entry("SRV6_MY_SIDS", f"{locator}|{addr}/48")
+    def remove_mysid_cfgdb(self, locator, addr, func_len=0):
+        self.cdb.delete_entry("SRV6_MY_SIDS", f"{locator}|{addr}/{48 + func_len}")
         self.cdb.delete_entry("SRV6_MY_LOCATORS", locator)
+
+    def add_mysid_vtysh(self, dvs, locator, addr, prefix="", func_len=0):
+        if not prefix:
+            prefix = addr
+        loc_cmd = f'vtysh -c "configure terminal" -c "segment-routing" -c "srv6" -c "locators" -c "locator {locator}" -c "prefix {prefix}/48 block-len 32 node-len 16 func-bits {func_len}" -c "behavior usid"'
+        sid_cmd = f'vtysh -c "configure terminal" -c "segment-routing" -c "srv6" -c "static-sids" -c "sid {addr}/{48 + func_len} locator {locator} behavior uN"'
+        dvs.runcmd(loc_cmd)
+        dvs.runcmd(sid_cmd)
+
+    def remove_mysid_vtysh(self, dvs, locator, addr, func_len=0):
+        sid_cmd = f'vtysh -c "configure terminal" -c "segment-routing" -c "srv6" -c "static-sids" -c "no sid {addr}/{48 + func_len} locator {locator} behavior uN"'
+        loc_cmd = f'vtysh -c "configure terminal" -c "segment-routing" -c "srv6" -c "locators" -c "no locator {locator}"'
+        dvs.runcmd(sid_cmd)
+        dvs.runcmd(loc_cmd)
 
     @pytest.mark.skipif(LooseVersion(platform.release()) < LooseVersion('5.14'),
                         reason="This test requires Linux kernel 5.14 or higher")
@@ -1327,16 +1343,19 @@ class TestSrv6MySidFpmsyncd(object):
         tunnel_entries = get_exist_entries(self.adb.db_connection, "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL")
         tunnel_term_entries = get_exist_entries(self.adb.db_connection, "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL_TERM_TABLE_ENTRY")
 
+        mysid1 = "fc00:0:1::"
+        mysid2 = "fd00:0:1::"
+        mysid3 = "fe00:0:1:aabb::"
+
         # Confiure the dcsp_mode in config db
-        self.add_mysid_cfgdb("loc1", "fc00:0:2::", "fc00:0:2:ff05::", "uniform")
-        self.add_mysid_cfgdb("loc2", "fd00:0:2::", "fd00:0:2:ff05::", "pipe")
-        self.add_mysid_cfgdb("loc3", "fe00:0:2::", "fe00:0:2:ff05::", "pipe")
+        self.add_mysid_cfgdb("loc1", mysid1, dscp_mode="uniform")
+        self.add_mysid_cfgdb("loc2", mysid2, dscp_mode="pipe")
+        self.add_mysid_cfgdb("loc3", mysid3, "fe00:0:1::", dscp_mode="pipe", func_len=16)
 
-        # Create MySID entry with dscp_mode uniform
-        dvs.runcmd("vtysh -c \"configure terminal\" -c \"segment-routing\" -c \"srv6\" -c \"locators\" -c \"locator loc1\" -c \"prefix fc00:0:2::/48 block-len 32 node-len 16 func-bits 16\" -c \"behavior usid\"")
-        dvs.runcmd("ip -6 route add fc00:0:2:ff05::/128 encap seg6local action End vrftable {} dev sr0".format(self.vrf_table_id))
+        # Create MySID entry with dscp_mode uniformß
+        self.add_mysid_vtysh(dvs, "loc1", mysid1)
 
-        self.pdb.wait_for_entry("SRV6_MY_SID_TABLE", "32:16:16:0:fc00:0:2:ff05::")
+        self.pdb.wait_for_entry("SRV6_MY_SID_TABLE", f"32:16:0:0:{mysid1}")
         self.adb.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY", len(self.initial_my_sid_entries) + 1)
         self.adb.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL", len(tunnel_entries) + 1)
         self.adb.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL_TERM_TABLE_ENTRY", len(tunnel_term_entries) + 1)
@@ -1345,10 +1364,9 @@ class TestSrv6MySidFpmsyncd(object):
         mysid_uniform_term_entry = get_created_entry(self.adb.db_connection, "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL_TERM_TABLE_ENTRY", tunnel_term_entries)
 
         # Create MySID entry with dscp_mode pipe
-        dvs.runcmd("vtysh -c \"configure terminal\" -c \"segment-routing\" -c \"srv6\" -c \"locators\" -c \"locator loc1\" -c \"prefix fd00:0:2::/48 block-len 32 node-len 16 func-bits 16\" -c \"behavior usid\"")
-        dvs.runcmd("ip -6 route add fd00:0:2:ff05::/128 encap seg6local action End vrftable {} dev sr0".format(self.vrf_table_id))
+        self.add_mysid_vtysh(dvs, "loc2", mysid2)
 
-        self.pdb.wait_for_entry("SRV6_MY_SID_TABLE", "32:16:16:0:fd00:0:2:ff05::")
+        self.pdb.wait_for_entry("SRV6_MY_SID_TABLE", f"32:16:0:0:{mysid2}")
         self.adb.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY", len(self.initial_my_sid_entries) + 2)
         self.adb.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL", len(tunnel_entries) + 2)
         self.adb.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL_TERM_TABLE_ENTRY", len(tunnel_term_entries) + 2)
@@ -1366,15 +1384,14 @@ class TestSrv6MySidFpmsyncd(object):
 
         # Validate tunnel term configuration
         self.verify_attribute_value(tunnel_term_table, mysid_uniform_term_entry, "SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_ACTION_TUNNEL_ID", tunnel_uniform)
-        self.verify_attribute_value(tunnel_term_table, mysid_uniform_term_entry, "SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_DST_IP", "fc00:0:2:ff05::")
+        self.verify_attribute_value(tunnel_term_table, mysid_uniform_term_entry, "SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_DST_IP", mysid1)
         self.verify_attribute_value(tunnel_term_table, mysid_pipe_term_entry, "SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_ACTION_TUNNEL_ID", tunnel_pipe)
-        self.verify_attribute_value(tunnel_term_table, mysid_pipe_term_entry, "SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_DST_IP", "fd00:0:2:ff05::")
+        self.verify_attribute_value(tunnel_term_table, mysid_pipe_term_entry, "SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_DST_IP", mysid2)
 
         # Add another MySID entry with dscp_mode pipe
-        dvs.runcmd("vtysh -c \"configure terminal\" -c \"segment-routing\" -c \"srv6\" -c \"locators\" -c \"locator loc1\" -c \"prefix fe00:0:2::/48 block-len 32 node-len 16 func-bits 16\" -c \"behavior usid\"")
-        dvs.runcmd("ip -6 route add fe00:0:2:ff05::/128 encap seg6local action End vrftable {} dev sr0".format(self.vrf_table_id))
+        self.add_mysid_vtysh(dvs, "loc3", mysid3, prefix="fe00:0:1::", func_len=16)
 
-        self.pdb.wait_for_entry("SRV6_MY_SID_TABLE", "32:16:16:0:fe00:0:2:ff05::")
+        self.pdb.wait_for_entry("SRV6_MY_SID_TABLE", f"32:16:16:0:{mysid3}")
         self.adb.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY", len(self.initial_my_sid_entries) + 3)
         self.adb.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL_TERM_TABLE_ENTRY", len(tunnel_term_entries) + 3)
 
@@ -1384,17 +1401,17 @@ class TestSrv6MySidFpmsyncd(object):
         self.verify_attribute_value(my_sid_table, my_sid_pipe2, "SAI_MY_SID_ENTRY_ATTR_TUNNEL_ID", tunnel_pipe)
 
         # Remove MySID entries
-        dvs.runcmd("ip -6 route del fc00:0:2:ff05::/128 encap seg6local action End vrftable {} dev sr0".format(self.vrf_table_id))
-        dvs.runcmd("ip -6 route del fd00:0:2:ff05::/128 encap seg6local action End vrftable {} dev sr0".format(self.vrf_table_id))
-        dvs.runcmd("ip -6 route del fe00:0:2:ff05::/128 encap seg6local action End vrftable {} dev sr0".format(self.vrf_table_id))
+        self.remove_mysid_vtysh(dvs, "loc1", mysid1)
+        self.remove_mysid_vtysh(dvs, "loc2", mysid2)
+        self.remove_mysid_vtysh(dvs, "loc3", mysid3, func_len=16)
 
-        self.pdb.wait_for_deleted_entry("SRV6_MY_SID_TABLE", "32:16:16:0:fc00:0:2:ff05::")
-        self.pdb.wait_for_deleted_entry("SRV6_MY_SID_TABLE", "32:16:16:0:fd00:0:2:ff05::")
-        self.pdb.wait_for_deleted_entry("SRV6_MY_SID_TABLE", "32:16:16:0:fe00:0:2:ff05::")
+        self.pdb.wait_for_deleted_entry("SRV6_MY_SID_TABLE", f"32:16:0:0:{mysid1}")
+        self.pdb.wait_for_deleted_entry("SRV6_MY_SID_TABLE", f"32:16:0:0:{mysid2}")
+        self.pdb.wait_for_deleted_entry("SRV6_MY_SID_TABLE", f"32:16:16:0:{mysid3}")
 
-        self.remove_mysid_cfgdb("loc1", "fc00:0:2:ff05::")
-        self.remove_mysid_cfgdb("loc2", "fd00:0:2:ff05::")
-        self.remove_mysid_cfgdb("loc3", "fe00:0:2:ff05::")
+        self.remove_mysid_cfgdb("loc1", mysid1)
+        self.remove_mysid_cfgdb("loc2", mysid2)
+        self.remove_mysid_cfgdb("loc3", mysid3, func_len=16)
 
         # Verify that the MySID and tunnel configuration is removed
         self.adb.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY", len(self.initial_my_sid_entries))
@@ -1406,6 +1423,66 @@ class TestSrv6MySidFpmsyncd(object):
 
         self.teardown_srv6(dvs)
 
+    @pytest.mark.skipif(LooseVersion(platform.release()) < LooseVersion('5.14'),
+                        reason="This test requires Linux kernel 5.14 or higher")
+    def test_Srv6MySidUNTunnelDscpModeAmbiguity(self, dvs, testlog):
+        _, output = dvs.runcmd(f"vtysh -c 'show zebra dplane providers'")
+        if 'dplane_fpm_sonic' not in output:
+            pytest.skip("'dplane_fpm_sonic' required for this test is not available, skipping", allow_module_level=True)
+
+        self.setup_srv6(dvs)
+
+        tunnel_table = swsscommon.Table(self.adb.db_connection, "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL")
+        tunnel_entries = get_exist_entries(self.adb.db_connection, "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL")
+
+        loc1_prefix = "aaaa:bbbb:1::"
+        loc2_prefix = "aaaa:bbbb:1:2::"
+        sid_addr = "aaaa:bbbb:1:2::/64"
+
+        # Add locator 1
+        dvs.runcmd(f'vtysh -c "configure terminal" -c "segment-routing" -c "srv6" -c "locators" -c "locator loc1" -c "prefix {loc1_prefix}/48 block-len 32 node-len 16 func-bits 16" -c "behavior usid"')
+        self.cdb.create_entry("SRV6_MY_LOCATORS", "loc1", {"prefix": loc1_prefix, "block_len": "32", "node_len": "16", "func_len": "16", "arg_len": "0"})
+
+        # Add locator 2
+        dvs.runcmd(f'vtysh -c "configure terminal" -c "segment-routing" -c "srv6" -c "locators" -c "locator loc2" -c "prefix {loc2_prefix}/64 block-len 32 node-len 32 func-bits 0" -c "behavior usid"')
+        self.cdb.create_entry("SRV6_MY_LOCATORS", "loc2", {"prefix": loc2_prefix, "block_len": "32", "node_len": "32", "func_len": "0", "arg_len": "0"})
+
+        # Add SIDs CONIFG_DB
+        self.cdb.create_entry("SRV6_MY_SIDS", f'loc1|{sid_addr}', {"decap_dscp_mode": "uniform"})
+        self.cdb.create_entry("SRV6_MY_SIDS", f'loc2|{sid_addr}', {"decap_dscp_mode": "pipe"})
+
+        # Add first SID
+        dvs.runcmd(f'vtysh -c "configure terminal" -c "segment-routing" -c "srv6" -c "static-sids" -c "sid {sid_addr} locator loc1 behavior uN"')
+
+        self.pdb.wait_for_entry("SRV6_MY_SID_TABLE", f"32:16:16:0:aaaa:bbbb:1:2::")
+        self.adb.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY", len(self.initial_my_sid_entries) + 1)
+        self.adb.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL", len(tunnel_entries) + 1)
+        tunnel_uniform = get_created_entry(self.adb.db_connection, "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL", tunnel_entries)
+
+        # Add second SID
+        dvs.runcmd(f'vtysh -c "configure terminal" -c "segment-routing" -c "srv6" -c "static-sids" -c "sid {sid_addr} locator loc2 behavior uN"')
+
+        self.pdb.wait_for_entry("SRV6_MY_SID_TABLE", f"32:32:0:0:aaaa:bbbb:1:2::")
+        self.adb.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY", len(self.initial_my_sid_entries) + 2)
+        self.adb.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL", len(tunnel_entries) + 2)
+        tunnel_pipe = get_created_entry(self.adb.db_connection, "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL", tunnel_entries | set([tunnel_uniform]))
+
+        self.verify_attribute_value(tunnel_table, tunnel_uniform, "SAI_TUNNEL_ATTR_DECAP_DSCP_MODE", "SAI_TUNNEL_DSCP_MODE_UNIFORM_MODEL")
+        self.verify_attribute_value(tunnel_table, tunnel_pipe, "SAI_TUNNEL_ATTR_DECAP_DSCP_MODE", "SAI_TUNNEL_DSCP_MODE_PIPE_MODEL")
+
+        # Cleanup
+        dvs.runcmd(f'vtysh -c "configure terminal" -c "segment-routing" -c "srv6" -c "static-sids" -c "no sid {sid_addr} locator loc1 behavior uN"')
+        dvs.runcmd(f'vtysh -c "configure terminal" -c "segment-routing" -c "srv6" -c "static-sids" -c "no sid {sid_addr} locator loc2 behavior uN"')
+        dvs.runcmd(f'vtysh -c "configure terminal" -c "segment-routing" -c "srv6" -c "locators" -c "no locator loc1"')
+        dvs.runcmd(f'vtysh -c "configure terminal" -c "segment-routing" -c "srv6" -c "locators" -c "no locator loc2"')
+
+        self.cdb.delete_entry("SRV6_MY_SIDS", f'loc1|{sid_addr}')
+        self.cdb.delete_entry("SRV6_MY_SIDS", f'loc2|{sid_addr}')
+        self.cdb.delete_entry("SRV6_MY_LOCATORS", "loc1")
+        self.cdb.delete_entry("SRV6_MY_LOCATORS", "loc2")
+
+        dvs.runcmd("vtysh -c \"configure terminal\" -c \"segment-routing\" -c \"no srv6\"")
+        self.teardown_srv6(dvs)
 
 class TestSrv6VpnFpmsyncd(object):
     """ Functionality tests for SRv6 VPN handling in fpmsyncd """


### PR DESCRIPTION
**What I did**
Added support for the "dscp_mode" MySID entry configuration:

* add a sync with CONFIG_DB to store MySID entry dscp mode
* create a tunnel/tunnel term entry for a static uN/uDT46 MySID entry (the tunnel is reused for the same dscp_mode)
* add a new vs test

**Why I did it**
To support "dscp_mode" MySID entry configuration

**How I verified it**
New vstest `test_Srv6MySidUNTunnelDscpMode`

**Details if related**
