### PR TITLE
Revert "[buffer] indicate shared pool by putting a very small shared buffer pool size"

### DIFF
--- a/cfgmgr/buffer_pool_mellanox.lua
+++ b/cfgmgr/buffer_pool_mellanox.lua
@@ -166,11 +166,7 @@ local function fetch_buffer_pool_size_from_appldb(shp_enabled)
                 -- In case the orchagent starts handling buffer configuration between 2 and 3,
                 -- It is inconsistent between buffer pools and profiles, which fails Mellanox SAI sanity check
                 -- To avoid it, it indicates the shared headroom pool is enabled by setting a very small buffer pool and shared headroom pool sizes
-                if size == "0" then
-                    table.insert(result, buffer_pools[i] .. ':2048:1024')
-                else
-                    table.insert(result, buffer_pools[i] .. ":" .. size .. ':1024')
-                end
+                table.insert(result, buffer_pools[i] .. ':2048:1024')
             else
                 table.insert(result, buffer_pools[i] .. ':' .. size)
             end


### PR DESCRIPTION
Reverts sonic-net/sonic-swss#3387