### PR TITLE
Avoid segment fault in ASIC/SDK health event handling when vendor SAI passes an invalid timestamp

### DIFF
--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -1120,6 +1120,11 @@ void SwitchOrch::onSwitchAsicSdkHealthEvent(sai_object_id_t switch_id,
     const double year_in_seconds = 86400 * 365;
     stringstream time_ss;
 
+    /*
+     * In case vendor SAI passed a very large timestamp, put_time can cause segment fault which can not be caught by try/catch infra
+     * We check the difference between the timestamp from SAI and the current time and force to use current time if the gap is too large
+     * By doing so, we can avoid the segment fault
+     */
     if (difftime(t, now) > year_in_seconds)
     {
         SWSS_LOG_ERROR("Invalid timestamp second %" PRIx64 " in received ASIC/SDK health event, reset to current time", timestamp.tv_sec);

--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -1122,7 +1122,7 @@ void SwitchOrch::onSwitchAsicSdkHealthEvent(sai_object_id_t switch_id,
 
     if (difftime(t, now) > year_in_seconds)
     {
-        SWSS_LOG_ERROR("Invalid timestamp second %lu in received ASIC/SDK health event, reset to current time", timestamp.tv_sec);
+        SWSS_LOG_ERROR("Invalid timestamp second %" PRIx64 " in received ASIC/SDK health event, reset to current time", timestamp.tv_sec);
         t = now;
     }
 

--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -1115,8 +1115,17 @@ void SwitchOrch::onSwitchAsicSdkHealthEvent(sai_object_id_t switch_id,
     const string &severity_str = switch_asic_sdk_health_event_severity_reverse_map.at(severity);
     const string &category_str = switch_asic_sdk_health_event_category_reverse_map.at(category);
     string description_str;
-    const std::time_t &t = (std::time_t)timestamp.tv_sec;
+    std::time_t t = (std::time_t)timestamp.tv_sec;
+    const std::time_t now = std::time(0);
+    const double year_in_seconds = 86400 * 365;
     stringstream time_ss;
+
+    if (difftime(t, now) > year_in_seconds)
+    {
+        SWSS_LOG_ERROR("Invalid timestamp second %lu in received ASIC/SDK health event, reset to current time", timestamp.tv_sec);
+        t = now;
+    }
+
     time_ss << std::put_time(std::localtime(&t), "%Y-%m-%d %H:%M:%S");
 
     switch (data.data_type)


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Prevent orchagent from being segment fault when it receives a timestamp indicating a time in the far future (2^31 years later) in the ASIC/SDK health event from the vendor SAI.
It's vendor SAI's failure to pass such a large timestamp but we need to protect such invalid input.

**Why I did it**

**How I verified it**

Mock test

**Details if related**

In case vendor SAI passed a very large timestamp, put_time can cause segment fault which can not be caught by try/catch infra
We check the difference between the timestamp from SAI and the current time and force to use current time if the gap is too large
By doing so, we can avoid the segment fault
