### PR TITLE
[BufferOrch] Use SAI bulk API to configure port, PG and queue

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -72,6 +72,11 @@ void BufferOrch::initTableHandlers()
     m_bufferHandlerMap.insert(buffer_handler_pair(APP_BUFFER_PG_TABLE_NAME, &BufferOrch::processPriorityGroup));
     m_bufferHandlerMap.insert(buffer_handler_pair(APP_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME, &BufferOrch::processIngressBufferProfileList));
     m_bufferHandlerMap.insert(buffer_handler_pair(APP_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME, &BufferOrch::processEgressBufferProfileList));
+
+    m_bufferFlushHandlerMap.insert(buffer_flush_handler_pair(APP_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME, &BufferOrch::processIngressBufferProfileListBulk));
+    m_bufferFlushHandlerMap.insert(buffer_flush_handler_pair(APP_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME, &BufferOrch::processEgressBufferProfileListBulk));
+    m_bufferFlushHandlerMap.insert(buffer_flush_handler_pair(APP_BUFFER_PG_TABLE_NAME, &BufferOrch::processPriorityGroupBulk));
+    m_bufferFlushHandlerMap.insert(buffer_flush_handler_pair(APP_BUFFER_QUEUE_TABLE_NAME, &BufferOrch::processQueueBulk));
 }
 
 void BufferOrch::initBufferReadyLists(DBConnector *applDb, DBConnector *confDb)
@@ -861,6 +866,10 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
         }
     }
 
+    m_queueBulk.emplace_back();
+    auto& task = m_queueBulk.back();
+    task.kofvs = tuple;
+
     if (op == SET_COMMAND)
     {
         ref_resolve_status resolve_result = resolveFieldRefValue(m_buffer_type_maps, buffer_profile_field_name,
@@ -940,6 +949,13 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
             SWSS_LOG_ERROR("Port with alias:%s not found", port_name.c_str());
             return task_process_status::task_invalid_entry;
         }
+
+        task.ports.emplace_back();
+        auto& portContext = task.ports.back();
+        portContext.port_name = port_name;
+        portContext.local_port = local_port;
+        portContext.local_port_name = local_port_name;
+
         for (size_t ind = range_low; ind <= range_high; ind++)
         {
             SWSS_LOG_DEBUG("processing queue:%zd", ind);
@@ -971,10 +987,51 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
                 queue_id = port.m_queue_ids[ind];
             }
 
+            portContext.queues.emplace_back();
+            auto& queueContext = portContext.queues.back();
+
             if (need_update_sai)
             {
                 SWSS_LOG_DEBUG("Applying buffer profile:0x%" PRIx64 " to queue index:%zd, queue sai_id:0x%" PRIx64, sai_buffer_profile, ind, queue_id);
-                sai_status_t sai_status = sai_queue_api->set_queue_attribute(queue_id, &attr);
+            }
+
+            queueContext.queue_id = queue_id;
+            queueContext.attr = SaiAttrWrapper(SAI_OBJECT_TYPE_QUEUE, attr);
+            queueContext.counter_was_added = counter_was_added;
+            queueContext.counter_needs_to_add = counter_needs_to_add;
+            queueContext.index = ind;
+            queueContext.update_sai = need_update_sai;
+        }
+    }
+
+    return task_process_status::task_success;
+}
+
+task_process_status BufferOrch::processQueuePost(const QueueTask& task)
+{
+    SWSS_LOG_ENTER();
+
+    const auto& key = kfvKey(task.kofvs);
+    const auto& op = kfvOp(task.kofvs);
+    const auto tokens = tokenize(key, delimiter);
+    Port port;
+
+    for (const auto& portContext: task.ports)
+    {
+        const auto& port_name = portContext.port_name;
+        if (!gPortsOrch->getPort(port_name, port))
+        {
+            SWSS_LOG_ERROR("Port with alias:%s not found", port_name.c_str());
+            return task_process_status::task_invalid_entry;
+        }
+        for (const auto& queueContext: portContext.queues)
+        {
+            const auto ind = queueContext.index;
+
+            if (queueContext.update_sai)
+            {
+                const auto sai_status = queueContext.status;
+
                 if (sai_status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("Failed to set queue's buffer profile attribute, status:%d", sai_status);
@@ -991,14 +1048,14 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
                 {
                     auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
                     auto queues = tokens[1];
-                    if (!counter_was_added && counter_needs_to_add &&
+                    if (!queueContext.counter_was_added && queueContext.counter_needs_to_add &&
                         (flexCounterOrch->getQueueCountersState() || flexCounterOrch->getQueueWatermarkCountersState()))
                     {
                         SWSS_LOG_INFO("Creating counters for %s %zd", port_name.c_str(), ind);
                         gPortsOrch->createPortBufferQueueCounters(port, queues);
                     }
-                    else if (counter_was_added && !counter_needs_to_add &&
-                             (flexCounterOrch->getQueueCountersState() || flexCounterOrch->getQueueWatermarkCountersState()))
+                    else if (queueContext.counter_was_added && !queueContext.counter_needs_to_add &&
+                                (flexCounterOrch->getQueueCountersState() || flexCounterOrch->getQueueWatermarkCountersState()))
                     {
                         SWSS_LOG_INFO("Removing counters for %s %zd", port_name.c_str(), ind);
                         gPortsOrch->removePortBufferQueueCounters(port, queues);
@@ -1054,17 +1111,23 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
         // should be applied to a physical port before the physical port is brought up to
         // carry traffic. Here, we alert to application through syslog when such a wrong
         // set order is detected.
-        for (const auto &port_name : port_names)
+        for (const auto &portContext : task.ports)
         {
+            const auto& port_name = portContext.port_name;
+            const auto& local_port_name = portContext.local_port_name;
+            const auto local_port = portContext.local_port;
+
             if(local_port == true)
             {
-                if (gPortsOrch->isPortAdminUp(local_port_name)) {
+                if (gPortsOrch->isPortAdminUp(local_port_name))
+                {
                     SWSS_LOG_WARN("Queue profile '%s' applied after port %s is up", key.c_str(), port_name.c_str());
                 }
             }
             else
             {
-                if (gPortsOrch->isPortAdminUp(port_name)) {
+                if (gPortsOrch->isPortAdminUp(port_name))
+                {
                     SWSS_LOG_WARN("Queue profile '%s' applied after port %s is up", key.c_str(), port_name.c_str());
                 }
             }
@@ -1072,6 +1135,64 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
     }
 
     return task_process_status::task_success;
+}
+
+void BufferOrch::processQueueBulk(Consumer& consumer)
+{
+    std::vector<sai_object_id_t> oids;
+    std::vector<sai_attribute_t> attrs;
+    std::vector<sai_status_t> statuses;
+
+    for (const auto& task: m_queueBulk)
+    {
+        for (const auto& port: task.ports)
+            for (const auto& queue: port.queues)
+            {
+                if (queue.update_sai)
+                {
+                    oids.push_back(queue.queue_id);
+                    attrs.push_back(queue.attr.getSaiAttr());
+                    statuses.push_back(SAI_STATUS_NOT_EXECUTED);
+                }
+            }
+    }
+
+    const auto objectCount = static_cast<uint32_t>(oids.size());
+
+    if (objectCount > 0)
+    {
+        SWSS_LOG_TIMER("Set %u queues buffer profile", objectCount);
+
+        sai_queue_api->set_queues_attribute(objectCount, oids.data(), attrs.data(),
+            SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR, statuses.data());
+    }
+
+    size_t i = 0;
+    for (auto& task: m_queueBulk)
+    {
+        for (auto& port: task.ports)
+        {
+            for (auto& queue: port.queues)
+            {
+                if (queue.update_sai)
+                {
+                    queue.status = statuses[i];
+                    i++;
+                }
+            }
+        }
+    }
+
+    for (const auto& task: m_queueBulk)
+    {
+        auto task_status = processQueuePost(task);
+        if (task_status == task_process_status::task_need_retry)
+        {
+            consumer.m_toSync.emplace(kfvKey(task.kofvs), task.kofvs);
+        }
+    }
+
+    m_queueBulk.clear();
 }
 
 /*
@@ -1104,6 +1225,10 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
         SWSS_LOG_ERROR("Failed to obtain pg range values");
         return task_process_status::task_invalid_entry;
     }
+
+    m_priorityGroupBulk.emplace_back();
+    auto& task = m_priorityGroupBulk.back();
+    task.kofvs = tuple;
 
     if (op == SET_COMMAND)
     {
@@ -1169,6 +1294,11 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
             SWSS_LOG_ERROR("Port with alias:%s not found", port_name.c_str());
             return task_process_status::task_invalid_entry;
         }
+
+        task.ports.emplace_back();
+        auto& portContext = task.ports.back();
+        portContext.port_name = port_name;
+
         for (size_t ind = range_low; ind <= range_high; ind++)
         {
             SWSS_LOG_DEBUG("processing pg:%zd", ind);
@@ -1179,38 +1309,79 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
             }
             else
             {
+                portContext.pgs.emplace_back();
+                auto& pgContext = portContext.pgs.back();
+
+                sai_object_id_t pg_id = port.m_priority_group_ids[ind];
+
                 if (need_update_sai)
                 {
-                    sai_object_id_t pg_id;
-                    pg_id = port.m_priority_group_ids[ind];
                     SWSS_LOG_DEBUG("Applying buffer profile:0x%" PRIx64 " to port:%s pg index:%zd, pg sai_id:0x%" PRIx64, sai_buffer_profile, port_name.c_str(), ind, pg_id);
-                    sai_status_t sai_status = sai_buffer_api->set_ingress_priority_group_attribute(pg_id, &attr);
-                    if (sai_status != SAI_STATUS_SUCCESS)
+                }
+
+                pgContext.pg_id = pg_id;
+                pgContext.attr = SaiAttrWrapper(SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP, attr);
+                pgContext.counter_was_added = counter_was_added;
+                pgContext.counter_needs_to_add = counter_needs_to_add;
+                pgContext.index = ind;
+                pgContext.update_sai = need_update_sai;
+            }
+        }
+    }
+
+    return task_process_status::task_success;
+}
+
+task_process_status BufferOrch::processPriorityGroupPost(const PriorityGroupTask& task)
+{
+    SWSS_LOG_ENTER();
+
+    const auto& key = kfvKey(task.kofvs);
+    const auto& op = kfvOp(task.kofvs);
+    const auto tokens = tokenize(key, delimiter);
+    Port port;
+
+    for (const auto& portContext: task.ports)
+    {
+        const auto& port_name = portContext.port_name;
+        if (!gPortsOrch->getPort(port_name, port))
+        {
+            SWSS_LOG_ERROR("Port with alias:%s not found", port_name.c_str());
+            return task_process_status::task_invalid_entry;
+        }
+        for (const auto& pg: portContext.pgs)
+        {
+            const auto ind = pg.index;
+
+            if (pg.update_sai)
+            {
+                const auto sai_status = pg.status;
+
+                if (sai_status != SAI_STATUS_SUCCESS)
+                {
+                    SWSS_LOG_ERROR("Failed to set port:%s pg:%zd buffer profile attribute, status:%d", port_name.c_str(), ind, sai_status);
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_BUFFER, sai_status);
+                    if (handle_status != task_process_status::task_success)
                     {
-                        SWSS_LOG_ERROR("Failed to set port:%s pg:%zd buffer profile attribute, status:%d", port_name.c_str(), ind, sai_status);
-                        task_process_status handle_status = handleSaiSetStatus(SAI_API_BUFFER, sai_status);
-                        if (handle_status != task_process_status::task_success)
-                        {
-                            return handle_status;
-                        }
+                        return handle_status;
                     }
-                    // create or remove a port PG counter for the PG buffer
-                    else
+                }
+                // create or remove a port PG counter for the PG buffer
+                else
+                {
+                    auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
+                    auto pgs = tokens[1];
+                    if (!pg.counter_was_added && pg.counter_needs_to_add &&
+                        (flexCounterOrch->getPgCountersState() || flexCounterOrch->getPgWatermarkCountersState()))
                     {
-                        auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
-                        auto pgs = tokens[1];
-                        if (!counter_was_added && counter_needs_to_add &&
-                            (flexCounterOrch->getPgCountersState() || flexCounterOrch->getPgWatermarkCountersState()))
-                        {
-                            SWSS_LOG_INFO("Creating counters for priority group %s %zd", port_name.c_str(), ind);
-                            gPortsOrch->createPortBufferPgCounters(port, pgs);
-                        }
-                        else if (counter_was_added && !counter_needs_to_add &&
-                                 (flexCounterOrch->getPgCountersState() || flexCounterOrch->getPgWatermarkCountersState()))
-                        {
-                            SWSS_LOG_INFO("Removing counters for priority group %s %zd", port_name.c_str(), ind);
-                            gPortsOrch->removePortBufferPgCounters(port, pgs);
-                        }
+                        SWSS_LOG_INFO("Creating counters for priority group %s %zd", port_name.c_str(), ind);
+                        gPortsOrch->createPortBufferPgCounters(port, pgs);
+                    }
+                    else if (pg.counter_was_added && !pg.counter_needs_to_add &&
+                                (flexCounterOrch->getPgCountersState() || flexCounterOrch->getPgWatermarkCountersState()))
+                    {
+                        SWSS_LOG_INFO("Removing counters for priority group %s %zd", port_name.c_str(), ind);
+                        gPortsOrch->removePortBufferPgCounters(port, pgs);
                     }
                 }
             }
@@ -1246,7 +1417,6 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
             }
             /* save the last command (set or delete) */
             pg_port_flags[port_name][ind] = op;
-
         }
     }
 
@@ -1263,9 +1433,11 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
         // should be applied to a physical port before the physical port is brought up to
         // carry traffic. Here, we alert to application through syslog when such a wrong
         // set order is detected.
-        for (const auto &port_name : port_names)
+        for (const auto &portContext : task.ports)
         {
-            if (gPortsOrch->isPortAdminUp(port_name)) {
+            const auto& port_name = portContext.port_name;
+            if (gPortsOrch->isPortAdminUp(port_name))
+            {
                 SWSS_LOG_WARN("PG profile '%s' applied after port %s is up", key.c_str(), port_name.c_str());
             }
         }
@@ -1273,6 +1445,65 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
 
     return task_process_status::task_success;
 }
+
+void BufferOrch::processPriorityGroupBulk(Consumer& consumer)
+{
+    std::vector<sai_object_id_t> oids;
+    std::vector<sai_attribute_t> attrs;
+    std::vector<sai_status_t> statuses;
+
+    for (const auto& task: m_priorityGroupBulk)
+    {
+        for (const auto& port: task.ports)
+            for (const auto& pg: port.pgs)
+            {
+                if (pg.update_sai)
+                {
+                    oids.push_back(pg.pg_id);
+                    attrs.push_back(pg.attr.getSaiAttr());
+                    statuses.push_back(SAI_STATUS_NOT_EXECUTED);
+                }
+            }
+    }
+
+    const auto objectCount = static_cast<uint32_t>(oids.size());
+
+    if (objectCount > 0)
+    {
+        SWSS_LOG_TIMER("Set %u ingress priority groups buffer profile", objectCount);
+
+        sai_buffer_api->set_ingress_priority_groups_attribute(objectCount, oids.data(), attrs.data(),
+            SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR, statuses.data());
+    }
+
+    size_t i = 0;
+    for (auto& task: m_priorityGroupBulk)
+    {
+        for (auto& port: task.ports)
+        {
+            for (auto& pg: port.pgs)
+            {
+                if (pg.update_sai)
+                {
+                    pg.status = statuses[i];
+                    i++;
+                }
+            }
+        }
+    }
+
+    for (const auto& task: m_priorityGroupBulk)
+    {
+        auto task_status = processPriorityGroupPost(task);
+        if (task_status == task_process_status::task_need_retry)
+        {
+            consumer.m_toSync.emplace(kfvKey(task.kofvs), task.kofvs);
+        }
+    }
+
+    m_priorityGroupBulk.clear();
+}
+
 
 /*
 Input sample:"i_port.profile0,i_port.profile1"
@@ -1333,6 +1564,9 @@ task_process_status BufferOrch::processIngressBufferProfileList(KeyOpFieldsValue
         SWSS_LOG_ERROR("Unknown command %s when handling BUFFER_PORT_INGRESS_PROFILE_LIST_TABLE key %s", op.c_str(), key.c_str());
     }
 
+    PortBufferProfileListTask task;
+    task.kofvs = tuple;
+
     for (string port_name : port_names)
     {
         if (!gPortsOrch->getPort(port_name, port))
@@ -1340,7 +1574,21 @@ task_process_status BufferOrch::processIngressBufferProfileList(KeyOpFieldsValue
             SWSS_LOG_ERROR("Port with alias:%s not found", port_name.c_str());
             return task_process_status::task_invalid_entry;
         }
-        sai_status_t sai_status = sai_port_api->set_port_attribute(port.m_port_id, &attr);
+
+        task.ports.emplace_back(PortBufferProfileListTask::PortContext{port_name, port.m_port_id, SaiAttrWrapper{SAI_OBJECT_TYPE_PORT, attr}, SAI_STATUS_NOT_EXECUTED});
+    }
+
+    m_portIngressBufferProfileListBulk.push_back(task);
+
+    return task_process_status::task_success;
+}
+
+task_process_status BufferOrch::processIngressBufferProfileListPost(const PortBufferProfileListTask& task)
+{
+    for (const auto& portContext: task.ports)
+    {
+        const auto& port_name = portContext.port_name;
+        sai_status_t sai_status = portContext.status;
         if (sai_status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to set ingress buffer profile list on port, status:%d, key:%s", sai_status, port_name.c_str());
@@ -1353,6 +1601,54 @@ task_process_status BufferOrch::processIngressBufferProfileList(KeyOpFieldsValue
     }
 
     return task_process_status::task_success;
+}
+
+void BufferOrch::processIngressBufferProfileListBulk(Consumer& consumer)
+{
+    std::vector<sai_object_id_t> oids;
+    std::vector<sai_attribute_t> attrs;
+    std::vector<sai_status_t> statuses;
+
+    for (const auto& task: m_portIngressBufferProfileListBulk)
+    {
+        for (const auto& port: task.ports)
+        {
+            oids.push_back(port.port_oid);
+            attrs.push_back(port.attr.getSaiAttr());
+            statuses.push_back(SAI_STATUS_NOT_EXECUTED);
+        }
+    }
+
+    const auto objectCount = static_cast<uint32_t>(oids.size());
+
+    if (objectCount > 0)
+    {
+        SWSS_LOG_TIMER("Set %u ports ingress buffer profile list", objectCount);
+
+        sai_port_api->set_ports_attribute(objectCount, oids.data(), attrs.data(),
+            SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR, statuses.data());
+    }
+
+    size_t i = 0;
+    for (auto& task: m_portIngressBufferProfileListBulk)
+    {
+        for (auto& port: task.ports)
+        {
+            port.status = statuses[i];
+            i++;
+        }
+    }
+
+    for (const auto& task: m_portIngressBufferProfileListBulk)
+    {
+        auto task_status = processIngressBufferProfileListPost(task);
+        if (task_status == task_process_status::task_need_retry)
+        {
+            consumer.m_toSync.emplace(kfvKey(task.kofvs), task.kofvs);
+        }
+    }
+
+    m_portIngressBufferProfileListBulk.clear();
 }
 
 /*
@@ -1412,6 +1708,9 @@ task_process_status BufferOrch::processEgressBufferProfileList(KeyOpFieldsValues
         SWSS_LOG_ERROR("Unknown command %s when handling BUFFER_PORT_EGRESS_PROFILE_LIST_TABLE key %s", op.c_str(), key.c_str());
     }
 
+    PortBufferProfileListTask task;
+    task.kofvs = tuple;
+
     for (string port_name : port_names)
     {
         if (!gPortsOrch->getPort(port_name, port))
@@ -1419,7 +1718,21 @@ task_process_status BufferOrch::processEgressBufferProfileList(KeyOpFieldsValues
             SWSS_LOG_ERROR("Port with alias:%s not found", port_name.c_str());
             return task_process_status::task_invalid_entry;
         }
-        sai_status_t sai_status = sai_port_api->set_port_attribute(port.m_port_id, &attr);
+
+        task.ports.emplace_back(PortBufferProfileListTask::PortContext{port_name, port.m_port_id, SaiAttrWrapper{SAI_OBJECT_TYPE_PORT, attr}, SAI_STATUS_NOT_EXECUTED});
+    }
+
+    m_portEgressBufferProfileListBulk.push_back(task);
+
+    return task_process_status::task_success;
+}
+
+task_process_status BufferOrch::processEgressBufferProfileListPost(const PortBufferProfileListTask& task)
+{
+    for (const auto& portContext: task.ports)
+    {
+        const auto& port_name = portContext.port_name;
+        sai_status_t sai_status = portContext.status;
         if (sai_status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to set egress buffer profile list on port, status:%d, key:%s", sai_status, port_name.c_str());
@@ -1432,6 +1745,54 @@ task_process_status BufferOrch::processEgressBufferProfileList(KeyOpFieldsValues
     }
 
     return task_process_status::task_success;
+}
+
+void BufferOrch::processEgressBufferProfileListBulk(Consumer& consumer)
+{
+    std::vector<sai_object_id_t> oids;
+    std::vector<sai_attribute_t> attrs;
+    std::vector<sai_status_t> statuses;
+
+    for (const auto& task: m_portEgressBufferProfileListBulk)
+    {
+        for (const auto& port: task.ports)
+        {
+            oids.push_back(port.port_oid);
+            attrs.push_back(port.attr.getSaiAttr());
+            statuses.push_back(SAI_STATUS_NOT_EXECUTED);
+        }
+    }
+
+    const auto objectCount = static_cast<uint32_t>(oids.size());
+
+    if (objectCount > 0)
+    {
+        SWSS_LOG_TIMER("Set %u ports egress buffer profile list", objectCount);
+
+        sai_port_api->set_ports_attribute(objectCount, oids.data(), attrs.data(),
+            SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR, statuses.data());
+    }
+
+    size_t i = 0;
+    for (auto& task: m_portEgressBufferProfileListBulk)
+    {
+        for (auto& port: task.ports)
+        {
+            port.status = statuses[i];
+            i++;
+        }
+    }
+
+    for (const auto& task: m_portEgressBufferProfileListBulk)
+    {
+        auto task_status = processEgressBufferProfileListPost(task);
+        if (task_status == task_process_status::task_need_retry)
+        {
+            consumer.m_toSync.emplace(kfvKey(task.kofvs), task.kofvs);
+        }
+    }
+
+    m_portEgressBufferProfileListBulk.clear();
 }
 
 void BufferOrch::doTask()
@@ -1486,11 +1847,12 @@ void BufferOrch::doTask(Consumer &consumer)
         return;
     }
 
+    auto map_type_name = consumer.getTableName();
+
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
     {
         /* Make sure the handler is initialized for the task */
-        auto map_type_name = consumer.getTableName();
         if (m_bufferHandlerMap.find(map_type_name) == m_bufferHandlerMap.end())
         {
             SWSS_LOG_ERROR("No handler for key:%s found.", map_type_name.c_str());
@@ -1522,5 +1884,10 @@ void BufferOrch::doTask(Consumer &consumer)
                 it = consumer.m_toSync.erase(it);
                 break;
         }
+    }
+
+    if (m_bufferFlushHandlerMap.find(map_type_name) != m_bufferFlushHandlerMap.end())
+    {
+        (this->*(m_bufferFlushHandlerMap[map_type_name]))(consumer);
     }
 }

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -1141,6 +1141,8 @@ task_process_status BufferOrch::processQueuePost(const QueueTask& task)
 
 void BufferOrch::processQueueBulk(Consumer& consumer)
 {
+    SWSS_LOG_ENTER();
+
     for (const auto op: {DEL_COMMAND, SET_COMMAND})
     {
         std::vector<sai_object_id_t> oids;
@@ -1457,6 +1459,8 @@ task_process_status BufferOrch::processPriorityGroupPost(const PriorityGroupTask
 
 void BufferOrch::processPriorityGroupBulk(Consumer& consumer)
 {
+    SWSS_LOG_ENTER();
+
     for (const auto op: {DEL_COMMAND, SET_COMMAND})
     {
         std::vector<sai_object_id_t> oids;
@@ -1620,6 +1624,8 @@ task_process_status BufferOrch::processIngressBufferProfileListPost(const PortBu
 
 void BufferOrch::processIngressBufferProfileListBulk(Consumer& consumer)
 {
+    SWSS_LOG_ENTER();
+
     for (const auto op: {DEL_COMMAND, SET_COMMAND})
     {
         std::vector<sai_object_id_t> oids;
@@ -1768,6 +1774,8 @@ task_process_status BufferOrch::processEgressBufferProfileListPost(const PortBuf
 
 void BufferOrch::processEgressBufferProfileListBulk(Consumer& consumer)
 {
+    SWSS_LOG_ENTER();
+
     for (const auto op: {DEL_COMMAND, SET_COMMAND})
     {
         std::vector<sai_object_id_t> oids;

--- a/orchagent/bufferorch.h
+++ b/orchagent/bufferorch.h
@@ -123,16 +123,21 @@ private:
     void initBufferConstants();
     task_process_status processBufferPool(KeyOpFieldsValuesTuple &tuple);
     task_process_status processBufferProfile(KeyOpFieldsValuesTuple &tuple);
+
+    // These methods process input task and add operations to the bulk buffer. This is first stage.
     task_process_status processQueue(KeyOpFieldsValuesTuple &tuple);
     task_process_status processPriorityGroup(KeyOpFieldsValuesTuple &tuple);
     task_process_status processIngressBufferProfileList(KeyOpFieldsValuesTuple &tuple);
     task_process_status processEgressBufferProfileList(KeyOpFieldsValuesTuple &tuple);
 
+    // These methods flush the bulk buffer and update SAI return status codes per task.
     void processQueueBulk(Consumer& consumer);
     void processPriorityGroupBulk(Consumer& consumer);
     void processIngressBufferProfileListBulk(Consumer& consumer);
     void processEgressBufferProfileListBulk(Consumer& consumer);
 
+    // These methods are invoked by the corresponding *Bulk methods after SAI operations complete.
+    // These handle SAI return status code per task. This is second stage.
     task_process_status processQueuePost(const QueueTask& task);
     task_process_status processPriorityGroupPost(const PriorityGroupTask& task);
     task_process_status processIngressBufferProfileListPost(const PortBufferProfileListTask& task);
@@ -150,6 +155,7 @@ private:
     bool m_isBufferPoolWatermarkCounterIdListGenerated = false;
     set<string> m_partiallyAppliedQueues;
 
+    // Bulk task buffers per DB operation
     std::map<std::string, std::vector<PortBufferProfileListTask>> m_portIngressBufferProfileListBulk;
     std::map<std::string, std::vector<PortBufferProfileListTask>> m_portEgressBufferProfileListBulk;
     std::map<std::string, std::vector<PriorityGroupTask>> m_priorityGroupBulk;

--- a/orchagent/bufferorch.h
+++ b/orchagent/bufferorch.h
@@ -7,6 +7,7 @@
 #include "orch.h"
 #include "portsorch.h"
 #include "redisapi.h"
+#include "saiattr.h"
 
 #define BUFFER_POOL_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP "BUFFER_POOL_WATERMARK_STAT_COUNTER"
 #define BUFFER_POOL_WATERMARK_FLEX_STAT_COUNTER_POLL_MSECS  "60000"
@@ -30,6 +31,68 @@ const string buffer_value_both              = "both";
 const string buffer_profile_list_field_name = "profile_list";
 const string buffer_headroom_type_field_name= "headroom_type";
 
+struct PortBufferProfileListTask
+{
+    struct PortContext
+    {
+        std::string port_name;
+        sai_object_id_t port_oid = SAI_NULL_OBJECT_ID;
+        SaiAttrWrapper attr = {};
+        sai_status_t status = SAI_STATUS_NOT_EXECUTED;
+    };
+
+    KeyOpFieldsValuesTuple kofvs;
+    std::vector<PortContext> ports;
+};
+
+struct PriorityGroupTask
+{
+    struct PgContext
+    {
+        size_t index;
+        bool update_sai = true;
+        bool counter_was_added = false;
+        bool counter_needs_to_add = false;
+        sai_object_id_t pg_id = SAI_NULL_OBJECT_ID;
+        SaiAttrWrapper attr = {};
+        sai_status_t status = SAI_STATUS_NOT_EXECUTED;
+    };
+
+    struct PortContext
+    {
+        std::string port_name;
+        std::vector<PgContext> pgs;
+    };
+
+    KeyOpFieldsValuesTuple kofvs;
+    std::vector<PortContext> ports;
+};
+
+struct QueueTask
+{
+    struct QueueContext
+    {
+        size_t index;
+        bool update_sai = true;
+        bool counter_was_added = false;
+        bool counter_needs_to_add = false;
+        sai_object_id_t queue_id = SAI_NULL_OBJECT_ID;
+        SaiAttrWrapper attr = {};
+        sai_status_t status = SAI_STATUS_NOT_EXECUTED;
+    };
+
+    struct PortContext
+    {
+        std::string port_name;
+        bool local_port = false;
+        std::string local_port_name;
+        std::vector<QueueContext> queues;
+    };
+
+    KeyOpFieldsValuesTuple kofvs;
+    std::vector<PortContext> ports;
+};
+
 class BufferOrch : public Orch
 {
 public:
@@ -44,6 +107,10 @@ private:
     typedef task_process_status (BufferOrch::*buffer_table_handler)(KeyOpFieldsValuesTuple &tuple);
     typedef map<string, buffer_table_handler> buffer_table_handler_map;
     typedef pair<string, buffer_table_handler> buffer_handler_pair;
+
+    typedef void (BufferOrch::*buffer_table_flush_handler)(Consumer& consumer);
+    typedef map<string, buffer_table_flush_handler> buffer_table_flush_handler_map;
+    typedef pair<string, buffer_table_flush_handler> buffer_flush_handler_pair;
 
     void doTask() override;
     virtual void doTask(Consumer& consumer);
@@ -61,7 +128,18 @@ private:
     task_process_status processIngressBufferProfileList(KeyOpFieldsValuesTuple &tuple);
     task_process_status processEgressBufferProfileList(KeyOpFieldsValuesTuple &tuple);
 
+    void processQueueBulk(Consumer& consumer);
+    void processPriorityGroupBulk(Consumer& consumer);
+    void processIngressBufferProfileListBulk(Consumer& consumer);
+    void processEgressBufferProfileListBulk(Consumer& consumer);
+
+    task_process_status processQueuePost(const QueueTask& task);
+    task_process_status processPriorityGroupPost(const PriorityGroupTask& task);
+    task_process_status processIngressBufferProfileListPost(const PortBufferProfileListTask& task);
+    task_process_status processEgressBufferProfileListPost(const PortBufferProfileListTask& task);
+
     buffer_table_handler_map m_bufferHandlerMap;
+    buffer_table_flush_handler_map m_bufferFlushHandlerMap;
     std::unordered_map<std::string, bool> m_ready_list;
     std::unordered_map<std::string, std::vector<std::string>> m_port_ready_list_ref;
 
@@ -71,6 +149,11 @@ private:
 
     bool m_isBufferPoolWatermarkCounterIdListGenerated = false;
     set<string> m_partiallyAppliedQueues;
+
+    std::vector<PortBufferProfileListTask> m_portIngressBufferProfileListBulk;
+    std::vector<PortBufferProfileListTask> m_portEgressBufferProfileListBulk;
+    std::vector<PriorityGroupTask> m_priorityGroupBulk;
+    std::vector<QueueTask> m_queueBulk;
 };
 #endif /* SWSS_BUFFORCH_H */
 

--- a/orchagent/bufferorch.h
+++ b/orchagent/bufferorch.h
@@ -150,10 +150,10 @@ private:
     bool m_isBufferPoolWatermarkCounterIdListGenerated = false;
     set<string> m_partiallyAppliedQueues;
 
-    std::vector<PortBufferProfileListTask> m_portIngressBufferProfileListBulk;
-    std::vector<PortBufferProfileListTask> m_portEgressBufferProfileListBulk;
-    std::vector<PriorityGroupTask> m_priorityGroupBulk;
-    std::vector<QueueTask> m_queueBulk;
+    std::map<std::string, std::vector<PortBufferProfileListTask>> m_portIngressBufferProfileListBulk;
+    std::map<std::string, std::vector<PortBufferProfileListTask>> m_portEgressBufferProfileListBulk;
+    std::map<std::string, std::vector<PriorityGroupTask>> m_priorityGroupBulk;
+    std::map<std::string, std::vector<QueueTask>> m_queueBulk;
 };
 #endif /* SWSS_BUFFORCH_H */
 

--- a/tests/mock_tests/bufferorch_ut.cpp
+++ b/tests/mock_tests/bufferorch_ut.cpp
@@ -120,22 +120,67 @@ namespace bufferorch_test
         return pold_sai_queue_api->set_queue_attribute(queue_id, attr);
     }
 
+    sai_status_t _ut_stub_sai_set_ports_attribute(
+        uint32_t object_count,
+        const sai_object_id_t *object_id,
+        const sai_attribute_t *attr_list,
+        sai_bulk_op_error_mode_t mode,
+        sai_status_t *object_statuses)
+    {
+        for (size_t i = 0; i < object_count; i++)
+        {
+            object_statuses[i] = _ut_stub_sai_set_port_attribute(object_id[i], attr_list + i);
+        }
+        return SAI_STATUS_SUCCESS;
+    }
+
+    sai_status_t _ut_stub_sai_set_ingress_priority_groups_attribute(
+        uint32_t object_count,
+        const sai_object_id_t *object_id,
+        const sai_attribute_t *attr_list,
+        sai_bulk_op_error_mode_t mode,
+        sai_status_t *object_statuses)
+    {
+        for (size_t i = 0; i < object_count; i++)
+        {
+            object_statuses[i] = _ut_stub_sai_set_ingress_priority_group_attribute(object_id[i], attr_list + i);
+        }
+        return SAI_STATUS_SUCCESS;
+    }
+
+    sai_status_t _ut_stub_sai_set_queues_attribute(
+        uint32_t object_count,
+        const sai_object_id_t *object_id,
+        const sai_attribute_t *attr_list,
+        sai_bulk_op_error_mode_t mode,
+        sai_status_t *object_statuses)
+    {
+        for (size_t i = 0; i < object_count; i++)
+        {
+            object_statuses[i] = _ut_stub_sai_set_queue_attribute(object_id[i], attr_list + i);
+        }
+        return SAI_STATUS_SUCCESS;
+    }
+
     void _hook_sai_apis()
     {
         ut_sai_port_api = *sai_port_api;
         pold_sai_port_api = sai_port_api;
         ut_sai_port_api.set_port_attribute = _ut_stub_sai_set_port_attribute;
+        ut_sai_port_api.set_ports_attribute = _ut_stub_sai_set_ports_attribute;
         sai_port_api = &ut_sai_port_api;
 
         ut_sai_buffer_api = *sai_buffer_api;
         pold_sai_buffer_api = sai_buffer_api;
         ut_sai_buffer_api.set_ingress_priority_group_attribute = _ut_stub_sai_set_ingress_priority_group_attribute;
+        ut_sai_buffer_api.set_ingress_priority_groups_attribute = _ut_stub_sai_set_ingress_priority_groups_attribute;
         ut_sai_buffer_api.set_buffer_profile_attribute = _ut_stub_sai_set_buffer_profile_attribute;
         sai_buffer_api = &ut_sai_buffer_api;
 
         ut_sai_queue_api = *sai_queue_api;
         pold_sai_queue_api = sai_queue_api;
         ut_sai_queue_api.set_queue_attribute = _ut_stub_sai_set_queue_attribute;
+        ut_sai_queue_api.set_queues_attribute = _ut_stub_sai_set_queues_attribute;
         sai_queue_api = &ut_sai_queue_api;
     }
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Make use of SAI set bulk API to improve switch boot up performance, especially in warm-boot and fast-boot scenarios.

The general concept:
1. First, tasks are processed one by one by corresponding ```process*``` methods which add the SAI operation with a context to a bulk buffer. Bulk buffers are split by DB operation.
2. Bulk buffer is flushed to syncd using SAI bulk API, first DELETE operations are pushed in bulk then SET operations are pushed. Status code for each operation is updated in the task context structure.
3. Lastly, corresponding ```process*Post``` methods are invoked to handle SAI status code and perform post set operations like enabling FC counter for a PG/queue upon success.

This design allows re-use of all existing code that is written to handle one task at a time and a small change is needed to maintain task context persistence throughout steps 1-3.

**Why I did it**

To improve fast-boot/warm-boot convergence time.

**How I verified it**

Manual verification by booting up the T0 topology configuration and running basic tests with static and dynamic buffer models. Fast-boot tested and observed ~2 times improvement in buffer configuration time on 256 port system from 3 sec to 1.7 sec when syncd falls back to single SET API. A bigger improvement is expected with proper SAI driver bulk SET support.

**Details if related**
