### PR TITLE
solving out of boundaries vulnerability in fpmlink.cpp

### DIFF
--- a/fpmsyncd/fpmlink.cpp
+++ b/fpmsyncd/fpmlink.cpp
@@ -208,7 +208,14 @@ uint64_t FpmLink::readData()
     size_t start = 0, left;
     ssize_t read;
 
-    read = ::read(m_connection_socket, m_messageBuffer + m_pos, m_bufSize - m_pos);
+ try
+    {
+         read = ::read(m_connection_socket, m_messageBuffer + m_pos, m_bufSize - m_pos);
+    }
+    catch(const std::exception& e)
+    {
+        std::cerr << e.what() << 'ERROR: exceeding buffer size ...';
+    }
     if (read == 0)
         throw FpmConnectionClosedException();
     if (read < 0)


### PR DESCRIPTION


**What I did**
i added try and catch in line 211

**Why I did it**
to solve vulnerability as it is adding m_messageBuffer to m_pos without ensuring it is more than the m_bufSize - m_pos

**How I verified it**
by using checkmarx as it was marked high severity risk at the beginning and then it is solved after the edits

