### PR TITLE
solving vulnerability of  string last element not null neighsync.cpp

### DIFF
--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -135,12 +135,32 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
 
     if (use_zero_mac)
     {
+       try
+    {
         std::string zero_mac = "00:00:00:00:00:00";
         strncpy(macStr, zero_mac.c_str(), zero_mac.length());
+         macStr[sizeof(macStr) - 1] = '\0';
+    }
+	catch (const std::exception &e)
+    {
+        SWSS_LOG_ERROR("Exception during zero MAC address null termination: %s", e.what());
+        return;
+    }
+       
     }
     else
     {
+         try
+    {
         nl_addr2str(rtnl_neigh_get_lladdr(neigh), macStr, MAX_ADDR_SIZE);
+        macStr[MAX_ADDR_SIZE] = '\0';
+    }
+	 catch (const std::exception &e)
+    {
+        SWSS_LOG_ERROR("Exception during MAC address null termination: %s", e.what());
+        return;
+    }
+	 
     }
 
     if (!delete_key && !strncmp(macStr, "none", MAX_ADDR_SIZE))


### PR DESCRIPTION

**What I did**
added try and catch for the string  macstr and making last element = NULL 
**Why I did it**
as it gives vulnerability of being not sure that the last element of the string is not NULL
**How I verified it**
by using checkmarx  it gave vulnerability of that string last element is not assigned to zero by these edits it was solved 
