### PR TITLE
Add heartbeat interval parameter.

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -351,7 +351,7 @@ int main(int argc, char **argv)
     string responsepublisher_rec_filename = Recorder::RESPPUB_FNAME;
     int record_type = 3; // Only swss and sairedis recordings enabled by default.
 
-    while ((opt = getopt(argc, argv, "b:m:r:f:j:d:i:hsz:k:q:c:t:v:")) != -1)
+    while ((opt = getopt(argc, argv, "b:m:r:f:j:d:i:hsz:k:q:c:t:v:I:")) != -1)
     {
         switch (opt)
         {

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -73,7 +73,7 @@ uint32_t create_switch_timeout = 0;
 
 void usage()
 {
-    cout << "usage: orchagent [-h] [-r record_type] [-d record_location] [-f swss_rec_filename] [-j sairedis_rec_filename] [-b batch_size] [-m MAC] [-i INST_ID] [-s] [-z mode] [-k bulk_size] [-q zmq_server_address] [-c mode] [-t create_switch_timeout] [-v VRF]" << endl;
+    cout << "usage: orchagent [-h] [-r record_type] [-d record_location] [-f swss_rec_filename] [-j sairedis_rec_filename] [-b batch_size] [-m MAC] [-i INST_ID] [-s] [-z mode] [-k bulk_size] [-q zmq_server_address] [-c mode] [-t create_switch_timeout] [-v VRF] [-I heart_beat_interval]" << endl;
     cout << "    -h: display this message" << endl;
     cout << "    -r record_type: record orchagent logs with type (default 3)" << endl;
     cout << "                    Bit 0: sairedis.rec, Bit 1: swss.rec, Bit 2: responsepublisher.rec. For example:" << endl;
@@ -95,6 +95,7 @@ void usage()
     cout << "    -c counter mode (traditional|asic_db), default: asic_db" << endl;
     cout << "    -t Override create switch timeout, in sec" << endl;
     cout << "    -v vrf: VRF name (default empty)" << endl;
+    cout << "    -I heart_beat_interval: Heart beat interval in millisecond (default 10)" << endl;
 }
 
 void sighup_handler(int signo)
@@ -448,6 +449,12 @@ int main(int argc, char **argv)
             if (optarg)
             {
                 vrf = optarg;
+            }
+            break;
+        case 'I':
+            if (optarg)
+            {
+                g_heart_beat_interval = atoi(optarg);
             }
             break;
         default: /* '?' */

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -24,7 +24,8 @@ using namespace swss;
 #define APP_FABRIC_MONITOR_DATA_TABLE_NAME      "FABRIC_MONITOR_TABLE"
 
 /* orchagent heart beat message interval */
-#define HEART_BEAT_INTERVAL_MSECS 10 * 1000
+#define HEART_BEAT_INTERVAL_MSECS_DEFAULT 10 * 1000
+long int g_heart_beat_interval = HEART_BEAT_INTERVAL_MSECS_DEFAULT;
 
 extern sai_switch_api_t*           sai_switch_api;
 extern sai_object_id_t             gSwitchId;
@@ -1093,7 +1094,7 @@ void OrchDaemon::heartBeat(std::chrono::time_point<std::chrono::high_resolution_
 {
     // output heart beat message to SYSLOG
     auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(tcurrent - m_lastHeartBeat);
-    if (diff.count() >= HEART_BEAT_INTERVAL_MSECS)
+    if (diff.count() >= g_heart_beat_interval)
     {
         m_lastHeartBeat = tcurrent;
         // output heart beat message to supervisord with 'PROCESS_COMMUNICATION_STDOUT' event: http://supervisord.org/events.html

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -1092,6 +1092,12 @@ void OrchDaemon::addOrchList(Orch *o)
 
 void OrchDaemon::heartBeat(std::chrono::time_point<std::chrono::high_resolution_clock> tcurrent)
 {
+    if (g_heart_beat_interval <= 0)
+    {
+        // disable heart beat feature when interval is 0
+        return;
+    }
+
     // output heart beat message to SYSLOG
     auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(tcurrent - m_lastHeartBeat);
     if (diff.count() >= g_heart_beat_interval)

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -56,8 +56,6 @@
 
 using namespace swss;
 
-extern long int g_heart_beat_interval;
-
 class OrchDaemon
 {
 public:
@@ -65,7 +63,7 @@ public:
     ~OrchDaemon();
 
     virtual bool init();
-    void start();
+    void start(long heartBeatInterval);
     bool warmRestoreAndSyncUp();
     void getTaskToSync(vector<string> &ts);
     bool warmRestoreValidation();
@@ -104,9 +102,9 @@ private:
 
     void flush();
 
-    void heartBeat(std::chrono::time_point<std::chrono::high_resolution_clock> tcurrent);
+    void heartBeat(std::chrono::time_point<std::chrono::high_resolution_clock> tcurrent, long interval);
 
-    void freezeAndHeartBeat(unsigned int duration);
+    void freezeAndHeartBeat(unsigned int duration, long interval);
 };
 
 class FabricOrchDaemon : public OrchDaemon

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -56,6 +56,8 @@
 
 using namespace swss;
 
+extern long int g_heart_beat_interval;
+
 class OrchDaemon
 {
 public:

--- a/tests/test_zmq.py
+++ b/tests/test_zmq.py
@@ -137,3 +137,20 @@ class TestZmqDash(object):
         dvs.runcmd("cp /usr/bin/orchagent.sh_hb_ut_backup /usr/bin/orchagent.sh")
         dvs.stop_swss()
         dvs.start_swss()
+
+    def test_usage(self, dvs):
+        # Improve test code coverage, change orchagent to display usage
+        dvs.runcmd("cp /usr/bin/orchagent.sh /usr/bin/orchagent.sh_usage_ut_backup")
+        dvs.runcmd("sed -i.bak 's/\/usr\/bin\/orchagent /\/usr\/bin\/orchagent -h /g' /usr/bin/orchagent.sh")
+        dvs.stop_swss()
+        dvs.start_swss()
+
+        # wait orchagent start
+        time.sleep(3)
+        process_statue = dvs.runcmd("ps -ef")
+        zmq_logger.debug("Process status: {}".format(process_statue))
+
+        # revert change
+        dvs.runcmd("cp /usr/bin/orchagent.sh_usage_ut_backup /usr/bin/orchagent.sh")
+        dvs.stop_swss()
+        dvs.start_swss()

--- a/tests/test_zmq.py
+++ b/tests/test_zmq.py
@@ -120,3 +120,20 @@ class TestZmqDash(object):
         dvs.runcmd("cp /usr/bin/orchagent.sh_vrf_ut_backup /usr/bin/orchagent.sh")
         dvs.stop_swss()
         dvs.start_swss()
+
+    def test_heartbeat(self, dvs):
+        # Improve test code coverage, change orchagent to disable heartbeat
+        dvs.runcmd("cp /usr/bin/orchagent.sh /usr/bin/orchagent.sh_vrf_ut_backup")
+        dvs.runcmd("sed -i.bak 's/\/usr\/bin\/orchagent /\/usr\/bin\/orchagent -I 0 /g' /usr/bin/orchagent.sh")
+        dvs.stop_swss()
+        dvs.start_swss()
+
+        # wait orchagent start
+        time.sleep(3)
+        process_statue = dvs.runcmd("ps -ef")
+        zmq_logger.debug("Process status: {}".format(process_statue))
+
+        # revert change
+        dvs.runcmd("cp /usr/bin/orchagent.sh_vrf_ut_backup /usr/bin/orchagent.sh")
+        dvs.stop_swss()
+        dvs.start_swss()

--- a/tests/test_zmq.py
+++ b/tests/test_zmq.py
@@ -123,7 +123,7 @@ class TestZmqDash(object):
 
     def test_heartbeat(self, dvs):
         # Improve test code coverage, change orchagent to disable heartbeat
-        dvs.runcmd("cp /usr/bin/orchagent.sh /usr/bin/orchagent.sh_vrf_ut_backup")
+        dvs.runcmd("cp /usr/bin/orchagent.sh /usr/bin/orchagent.sh_hb_ut_backup")
         dvs.runcmd("sed -i.bak 's/\/usr\/bin\/orchagent /\/usr\/bin\/orchagent -I 0 /g' /usr/bin/orchagent.sh")
         dvs.stop_swss()
         dvs.start_swss()
@@ -134,6 +134,6 @@ class TestZmqDash(object):
         zmq_logger.debug("Process status: {}".format(process_statue))
 
         # revert change
-        dvs.runcmd("cp /usr/bin/orchagent.sh_vrf_ut_backup /usr/bin/orchagent.sh")
+        dvs.runcmd("cp /usr/bin/orchagent.sh_hb_ut_backup /usr/bin/orchagent.sh")
         dvs.stop_swss()
         dvs.start_swss()


### PR DESCRIPTION
Add heartbeat interval parameter.

#### Why I did it
Make this feature can be disable, because log spam issue on small disk device:
https://github.com/sonic-net/sonic-buildimage/issues/21157

##### Work item tracking
- Microsoft ADO: 30594076

#### How I did it
Add heartbeat interval parameter. and disable heartbeat  when interval is 0.

#### How to verify it
Pass all UT.


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

#### Description for the changelog
Add heartbeat interval parameter.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

