### PR TITLE
[dash] set OUTBOUND_CA_TO_PA attributes correctly per routing type PRIVATELINK, VNET_ENCAP

### DIFF
--- a/tests/dash/test_dash_vnet.py
+++ b/tests/dash/test_dash_vnet.py
@@ -119,7 +119,6 @@ class TestDash(TestFlexCountersBase):
         route_action = RouteTypeItem()
         route_action.action_name = "action1"
         route_action.action_type = ACTION_TYPE_STATICENCAP
-        route_action.encap_type = ENCAP_TYPE_NVGRE
         route_type_msg.items.append(route_action)
         dash_db.create_routing_type(self.routing_type, {"pb": route_type_msg.SerializeToString()})
         pb = VnetMapping()
@@ -133,9 +132,10 @@ class TestDash(TestFlexCountersBase):
 
         vnet_ca_to_pa_maps = dash_db.wait_for_asic_db_keys(ASIC_OUTBOUND_CA_TO_PA_TABLE, min_keys=2)
         attrs = dash_db.get_asic_db_entry(ASIC_OUTBOUND_CA_TO_PA_TABLE, vnet_ca_to_pa_maps[0])
+        assert_sai_attribute_exists("SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_ACTION", attrs, "SAI_OUTBOUND_CA_TO_PA_ENTRY_ACTION_SET_TUNNEL_MAPPING")
         assert_sai_attribute_exists("SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_UNDERLAY_DIP", attrs, self.underlay_ip)
         assert_sai_attribute_exists("SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_OVERLAY_DMAC", attrs, self.mac_address)
-        assert_sai_attribute_exists("SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_DASH_ENCAPSULATION", attrs, "SAI_DASH_ENCAPSULATION_NVGRE")
+        assert_sai_attribute_exists("SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_USE_DST_VNET_VNI", attrs, "false")
 
         vnet_pa_validation_maps = dash_db.wait_for_asic_db_keys(ASIC_PA_VALIDATION_TABLE)
         pa_validation_attrs = dash_db.get_asic_db_entry(ASIC_PA_VALIDATION_TABLE, vnet_pa_validation_maps[0])


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Referring to [OUTBOUND_CA_TO_PA dash sai](https://github.com/opencomputeproject/SAI/blob/master/experimental/saiexperimentaldashoutboundcatopa.h) , set entry OUTBOUND_CA_TO_PA attributes correctly according to different routing type PRIVATELINK/VNET_ENCAP, referred in table vnet mapping.
**Why I did it**

**How I verified it**

**Details if related**
