### PR TITLE
Revert "[vlanmgrd]: Preventing VLAN interfaces from going down when all of their member ports are down"

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -82,8 +82,7 @@ VlanMgr::VlanMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
     //               /sbin/bridge vlan del vid 1 dev Bridge self;
     //               /sbin/ip link del dummy 2>/dev/null;
     //               /sbin/ip link add dummy type dummy &&
-    //               /sbin/ip link set dummy master Bridge &&
-    //               /sbin/ip link set dummy up"
+    //               /sbin/ip link set dummy master Bridge"
 
     const std::string cmds = std::string("")
       + BASH_CMD + " -c \""
@@ -94,8 +93,7 @@ VlanMgr::VlanMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
       + BRIDGE_CMD + " vlan del vid " + DEFAULT_VLAN_ID + " dev " + DOT1Q_BRIDGE_NAME + " self; "
       + IP_CMD + " link del dev dummy 2>/dev/null; "
       + IP_CMD + " link add dummy type dummy && "
-      + IP_CMD + " link set dummy master " + DOT1Q_BRIDGE_NAME + " && "
-      + IP_CMD + " link set dummy up" + "\"";
+      + IP_CMD + " link set dummy master " + DOT1Q_BRIDGE_NAME + "\"";
 
     std::string res;
     EXEC_WITH_ERROR_THROW(cmds, res);

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -130,10 +130,10 @@ class TestVnetOrch(object):
         vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, '10.10.10.10')
 
         vid = create_vlan_interface(dvs, "Vlan100", "Ethernet24", "Vnet_2000", "100.100.3.1/24")
-        vnet_obj.check_router_interface(dvs, "Vlan100", 'Vnet_2000', vid, intf_type="vlan")
+        vnet_obj.check_router_interface(dvs, "Vlan100", 'Vnet_2000', vid)
 
         vid = create_vlan_interface(dvs, "Vlan101", "Ethernet28", "Vnet_2000", "100.100.4.1/24")
-        vnet_obj.check_router_interface(dvs, "Vlan101", 'Vnet_2000', vid, intf_type="vlan")
+        vnet_obj.check_router_interface(dvs, "Vlan101", 'Vnet_2000', vid)
 
         vnet_obj.fetch_exist_entries(dvs)
         create_vnet_routes(dvs, "100.100.1.1/32", 'Vnet_2000', '10.10.10.1')
@@ -143,12 +143,10 @@ class TestVnetOrch(object):
         check_remove_routes_advertisement(dvs, "100.100.1.1/32")
 
         create_vnet_local_routes(dvs, "100.100.3.0/24", 'Vnet_2000', 'Vlan100')
-        # The route to Vlan100's subnet must have already been added to self.ASIC_ROUTE_ENTRY
-        vnet_obj.check_vnet_local_routes(dvs, 'Vnet_2000', vlan_subnet_route=True)
+        vnet_obj.check_vnet_local_routes(dvs, 'Vnet_2000')
 
         create_vnet_local_routes(dvs, "100.100.4.0/24", 'Vnet_2000', 'Vlan101')
-        # The route to Vlan101's subnet must have already been added to self.ASIC_ROUTE_ENTRY
-        vnet_obj.check_vnet_local_routes(dvs, 'Vnet_2000', vlan_subnet_route=True)
+        vnet_obj.check_vnet_local_routes(dvs, 'Vnet_2000')
 
         #Create Physical Interface in another Vnet
 
@@ -228,7 +226,7 @@ class TestVnetOrch(object):
         tun_id = vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, '6.6.6.6')
 
         vid = create_vlan_interface(dvs, "Vlan1001", "Ethernet0", "Vnet_1", "1.1.10.1/24")
-        vnet_obj.check_router_interface(dvs, "Vlan1001", 'Vnet_1', vid, intf_type="vlan")
+        vnet_obj.check_router_interface(dvs, "Vlan1001", 'Vnet_1', vid)
 
         vnet_obj.fetch_exist_entries(dvs)
         create_vnet_routes(dvs, "1.1.1.10/32", 'Vnet_1', '100.1.1.10')
@@ -258,7 +256,7 @@ class TestVnetOrch(object):
         check_remove_routes_advertisement(dvs, "1.1.1.14/32")
 
         create_vnet_local_routes(dvs, "1.1.10.0/24", 'Vnet_1', 'Vlan1001')
-        vnet_obj.check_vnet_local_routes(dvs, 'Vnet_1', vlan_subnet_route=True)
+        vnet_obj.check_vnet_local_routes(dvs, 'Vnet_1')
 
         create_vnet_entry(dvs, 'Vnet_2', tunnel_name, '2222', "")
 
@@ -266,7 +264,7 @@ class TestVnetOrch(object):
         vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, 'Vnet_2', '2222')
 
         vid = create_vlan_interface(dvs, "Vlan1002", "Ethernet4", "Vnet_2", "2.2.10.1/24")
-        vnet_obj.check_router_interface(dvs, "Vlan1002", 'Vnet_2', vid, intf_type="vlan")
+        vnet_obj.check_router_interface(dvs, "Vlan1002", 'Vnet_2', vid)
 
         vnet_obj.fetch_exist_entries(dvs)
         create_vnet_routes(dvs, "2.2.2.10/32", 'Vnet_2', '100.1.1.20')
@@ -283,7 +281,7 @@ class TestVnetOrch(object):
         check_remove_routes_advertisement(dvs, "2.2.2.11/32")
 
         create_vnet_local_routes(dvs, "2.2.10.0/24", 'Vnet_2', 'Vlan1002')
-        vnet_obj.check_vnet_local_routes(dvs, 'Vnet_2', vlan_subnet_route=True)
+        vnet_obj.check_vnet_local_routes(dvs, 'Vnet_2')
 
         # Clean-up and verify remove flows
 
@@ -363,10 +361,10 @@ class TestVnetOrch(object):
         tun_id = vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, '7.7.7.7')
 
         vid = create_vlan_interface(dvs, "Vlan2001", "Ethernet8", "Vnet_10", "5.5.10.1/24")
-        vnet_obj.check_router_interface(dvs, "Vlan2001", 'Vnet_10', vid, intf_type="vlan-one-peer")
+        vnet_obj.check_router_interface(dvs, "Vlan2001", 'Vnet_10', vid)
 
         vid = create_vlan_interface(dvs, "Vlan2002", "Ethernet12", "Vnet_20", "8.8.10.1/24")
-        vnet_obj.check_router_interface(dvs, "Vlan2002", 'Vnet_20', vid, intf_type="vlan-one-peer")
+        vnet_obj.check_router_interface(dvs, "Vlan2002", 'Vnet_20', vid)
 
         vnet_obj.fetch_exist_entries(dvs)
         create_vnet_routes(dvs, "5.5.5.10/32", 'Vnet_10', '50.1.1.10')
@@ -383,10 +381,10 @@ class TestVnetOrch(object):
         check_remove_routes_advertisement(dvs, "8.8.8.10/32")
 
         create_vnet_local_routes(dvs, "5.5.10.0/24", 'Vnet_10', 'Vlan2001')
-        vnet_obj.check_vnet_local_routes(dvs, 'Vnet_10', vlan_subnet_route=True)
+        vnet_obj.check_vnet_local_routes(dvs, 'Vnet_10')
 
         create_vnet_local_routes(dvs, "8.8.10.0/24", 'Vnet_20', 'Vlan2002')
-        vnet_obj.check_vnet_local_routes(dvs, 'Vnet_20', vlan_subnet_route=True)
+        vnet_obj.check_vnet_local_routes(dvs, 'Vnet_20')
 
         # Clean-up and verify remove flows
 
@@ -440,10 +438,10 @@ class TestVnetOrch(object):
         vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, 'fd:2::32')
 
         vid = create_vlan_interface(dvs, "Vlan300", "Ethernet24", 'Vnet3001', "100.100.3.1/24")
-        vnet_obj.check_router_interface(dvs, "Vlan300", 'Vnet3001', vid, intf_type="vlan")
+        vnet_obj.check_router_interface(dvs, "Vlan300", 'Vnet3001', vid)
 
         vid = create_vlan_interface(dvs, "Vlan301", "Ethernet28", 'Vnet3001', "100.100.4.1/24")
-        vnet_obj.check_router_interface(dvs, "Vlan301",  'Vnet3001', vid, intf_type="vlan")
+        vnet_obj.check_router_interface(dvs, "Vlan301",  'Vnet3001', vid)
 
         create_vnet_routes(dvs, "100.100.1.1/32", 'Vnet3001', '2000:1000:2000:3000:4000:5000:6000:7000')
         vnet_obj.check_vnet_routes(dvs, 'Vnet3001', '2000:1000:2000:3000:4000:5000:6000:7000', tunnel_name)
@@ -458,10 +456,10 @@ class TestVnetOrch(object):
         check_remove_routes_advertisement(dvs, "100.100.1.2/32")
 
         create_vnet_local_routes(dvs, "100.100.3.0/24", 'Vnet3001', 'Vlan300')
-        vnet_obj.check_vnet_local_routes(dvs, 'Vnet3001', vlan_subnet_route=True)
+        vnet_obj.check_vnet_local_routes(dvs, 'Vnet3001')
 
         create_vnet_local_routes(dvs, "100.100.4.0/24", 'Vnet3001', 'Vlan301')
-        vnet_obj.check_vnet_local_routes(dvs, 'Vnet3001', vlan_subnet_route=True)
+        vnet_obj.check_vnet_local_routes(dvs, 'Vnet3001')
 
         #Create Physical Interface in another Vnet
 

--- a/tests/vnet_lib.py
+++ b/tests/vnet_lib.py
@@ -599,10 +599,6 @@ def delete_subnet_decap_tunnel(dvs, tunnel_name):
 loopback_id = 0
 def_vr_id = 0
 switch_mac = None
-# Creation of a physical interface should only add one route to 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY' (i.e., a route to the interface's IP).
-# But after creating a VLAN interface, two entries should be added to this table: One for the VLAN interface's IP and one for the VLAN's subnet.
-# Creating a VLAN in a VNet that is peered with another Vnet will create an additional entry for the VLAN's subnet in the peer Vnet.
-intf_route_count = {"physical": 1, "vlan": 2, "vlan-one-peer": 3}
 
 def update_bgp_global_dev_state(dvs, state):
     config_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
@@ -897,18 +893,10 @@ class VnetVxlanVrfTunnel(object):
 
         return vr_set
 
-    def check_router_interface(self, dvs, intf_name, name, vlan_oid=0, intf_type="physical"):
-        '''
-            :param str intf_type Indicates whether the interface named 'intf_name' is a physical interface,
-            a VLAN interface in a peerless VNet, or a VLAN interface in a VNet with one peer. This is important since
-            it determines how many new routes we should expect to be added to the 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY'
-            table after the creation of the interface. Entries for more than one peers are currently not added
-            to the 'intf_route_count' dictionary since no test uses them.
-        '''
+    def check_router_interface(self, dvs, intf_name, name, vlan_oid=0):
         # Check RIF in ingress VRF
         asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
         global switch_mac
-        global intf_route_count
 
         expected_attr = {
                         "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": self.vr_map[name].get('ing'),
@@ -926,7 +914,7 @@ class VnetVxlanVrfTunnel(object):
         check_object(asic_db, self.ASIC_RIF_TABLE, new_rif, expected_attr)
 
         #IP2ME route will be created with every router interface
-        new_route = get_created_entries(asic_db, self.ASIC_ROUTE_ENTRY, self.routes, intf_route_count[intf_type])
+        new_route = get_created_entries(asic_db, self.ASIC_ROUTE_ENTRY, self.routes, 1)
 
         if vlan_oid:
             expected_attr = { 'SAI_VLAN_ATTR_BROADCAST_FLOOD_CONTROL_TYPE': 'SAI_VLAN_FLOOD_CONTROL_TYPE_NONE' }
@@ -948,22 +936,20 @@ class VnetVxlanVrfTunnel(object):
 
         self.rifs.remove(old_rif[0])
 
-    def check_vnet_local_routes(self, dvs, name, vlan_subnet_route=False):
+    def check_vnet_local_routes(self, dvs, name):
         asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
 
         vr_ids = self.vnet_route_ids(dvs, name, True)
         count = len(vr_ids)
-        # The route to the VLAN subnet must have been added when the VLAN was created.
-        # We are not expecting any new routes in that case.
-        expected_route_count = 0 if vlan_subnet_route else count
-        new_route = get_created_entries(asic_db, self.ASIC_ROUTE_ENTRY, self.routes, expected_route_count)
+
+        new_route = get_created_entries(asic_db, self.ASIC_ROUTE_ENTRY, self.routes, count)
 
         #Routes are not replicated to egress VRF, return if count is 0, else check peering
-        if not expected_route_count:
+        if not count:
             return
 
         asic_vrs = set()
-        for idx in range(expected_route_count):
+        for idx in range(count):
             rt_key = json.loads(new_route[idx])
             asic_vrs.add(rt_key['vr'])
 


### PR DESCRIPTION
Reverts sonic-net/sonic-swss#3370 since it's causing PR test failure in KVM dualtor IPv6