### PR TITLE
solving out of boundaries vulnerability

### DIFF
--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -2150,10 +2150,14 @@ string RouteSync::getNextHopIf(struct rtnl_route *route_obj)
         char if_name[IFNAMSIZ] = "0";
 
         /* If we cannot get the interface name */
-        if (!getIfName(if_index, if_name, IFNAMSIZ))
+       if (!getIfName(if_index, if_name, IFNAMSIZ))
         {
-            strcpy(if_name, "unknown");
+              strncpy(if_name, "unknown", IFNAMSIZ - 1); // replacing the strcpy with the strncpy to ensure that the copied string will not exceed the size
+              if_name[IFNAMSIZ - 1] = '\0'; // Enssuring last element in the string is NULL character 
+             
+            
         }
+
 
         result += if_name;
 


### PR DESCRIPTION

**What I did**
replaced strcpy with strncpy and added last element of the string to be null 
**Why I did it**
to ensure that the string will not get out of boundaries and to ensure last element of the string will be null
**How I verified it**
by using scurity tool (checkmarx) as it give it to me as vulnerability and by these edits vulnerability was solved

