### PR TITLE
[portorch] Add capability to add unreliable LOS setting to a PORT via config

### DIFF
--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -172,6 +172,7 @@ public:
     uint32_t            m_speed = 0;    // Mbps
     port_learn_mode_t   m_learn_mode = SAI_BRIDGE_PORT_FDB_LEARNING_MODE_HW;
     bool                m_autoneg = false;
+    bool                m_unreliable_los = false;
     bool                m_link_training = false;
     bool                m_admin_state_up = false;
     bool                m_init = false;

--- a/orchagent/port/portcnt.h
+++ b/orchagent/port/portcnt.h
@@ -53,6 +53,12 @@ public:
     } autoneg; // Port autoneg
 
     struct {
+        bool value;
+        bool is_set = false;
+    } unreliable_los; // Port unreliable_los
+
+
+    struct {
         std::set<std::uint32_t> value;
         bool is_set = false;
     } adv_speeds; // Port advertised speeds

--- a/orchagent/port/porthlpr.cpp
+++ b/orchagent/port/porthlpr.cpp
@@ -213,6 +213,11 @@ std::string PortHelper::getAutonegStr(const PortConfig &port) const
     return this->getFieldValueStr(port, PORT_AUTONEG);
 }
 
+std::string PortHelper::getUnreliableLosStr(const PortConfig &port) const
+{
+    return this->getFieldValueStr(port, PORT_UNRELIABLE_LOS);
+}
+
 std::string PortHelper::getPortInterfaceTypeStr(const PortConfig &port) const
 {
     return this->getFieldValueStr(port, PORT_INTERFACE_TYPE);
@@ -388,6 +393,31 @@ bool PortHelper::parsePortAutoneg(PortConfig &port, const std::string &field, co
 
     return true;
 }
+
+
+bool PortHelper::parsePortUnreliableLos(PortConfig &port, const std::string &field, const std::string &value) const
+{
+    SWSS_LOG_ENTER();
+
+    if (value.empty())
+    {
+        SWSS_LOG_ERROR("Failed to parse field(%s): empty value is prohibited", field.c_str());
+        return false;
+    }
+
+    const auto &cit = portModeMap.find(value);
+    if (cit == portModeMap.cend())
+    {
+        SWSS_LOG_ERROR("Failed to parse field(%s): invalid value(%s)", field.c_str(), value.c_str());
+        return false;
+    }
+
+    port.unreliable_los.value = cit->second;
+    port.unreliable_los.is_set = true;
+
+    return true;
+}
+
 
 bool PortHelper::parsePortAdvSpeeds(PortConfig &port, const std::string &field, const std::string &value) const
 {
@@ -1022,6 +1052,13 @@ bool PortHelper::parsePortConfig(PortConfig &port) const
         else if (field == PORT_LINK_TRAINING)
         {
             if (!this->parsePortLinkTraining(port, field, value))
+            {
+                return false;
+            }
+        }
+        else if (field == PORT_UNRELIABLE_LOS)
+        {
+            if (!this->parsePortUnreliableLos(port, field, value))
             {
                 return false;
             }

--- a/orchagent/port/porthlpr.h
+++ b/orchagent/port/porthlpr.h
@@ -19,6 +19,7 @@ public:
     bool fecIsOverrideRequired(const std::string &str) const;
 
     std::string getAutonegStr(const PortConfig &port) const;
+    std::string PortHelper::getUnreliableLosStr(const PortConfig &port) const
     std::string getPortInterfaceTypeStr(const PortConfig &port) const;
     std::string getAdvInterfaceTypesStr(const PortConfig &port) const;
     std::string getFecStr(const PortConfig &port) const;
@@ -47,6 +48,7 @@ private:
     bool parsePortLanes(PortConfig &port, const std::string &field, const std::string &value) const;
     bool parsePortSpeed(PortConfig &port, const std::string &field, const std::string &value) const;
     bool parsePortAutoneg(PortConfig &port, const std::string &field, const std::string &value) const;
+    bool parsePortUnreliableLos(PortConfig &port, const std::string &field, const std::string &value) const
     bool parsePortAdvSpeeds(PortConfig &port, const std::string &field, const std::string &value) const;
     bool parsePortInterfaceType(PortConfig &port, const std::string &field, const std::string &value) const;
     bool parsePortAdvInterfaceTypes(PortConfig &port, const std::string &field, const std::string &value) const;

--- a/orchagent/port/portschema.h
+++ b/orchagent/port/portschema.h
@@ -102,3 +102,4 @@
 #define PORT_REUSE_THRESHOLD       "reuse_threshold"
 #define PORT_FLAP_PENALTY          "flap_penalty"
 #define PORT_MODE                  "mode"
+#define PORT_UNRELIABLE_LOS        "unreliable_los"

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3062,6 +3062,21 @@ bool PortsOrch::getPortAdvSpeeds(const Port& port, bool remote, string& adv_spee
     return rc;
 }
 
+task_process_status PortsOrch::setPortUnreliableLOS(Port &port, bool enabled)
+{
+    SWSS_LOG_ENTER();
+    sai_attribute_t attr;
+    sai_status_t status;
+    attr.id = SAI_PORT_ATTR_UNRELIABLE_LOS_ENABLE;
+    attr.value.booldata = enabled;
+    status = sai_port_api->set_port_attribute(port.m_port_id, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        return handleSaiSetStatus(SAI_API_PORT, status);
+    }
+    return task_success;
+}
+
 task_process_status PortsOrch::setPortAdvSpeeds(Port &port, std::set<sai_uint32_t> &speed_list)
 {
     SWSS_LOG_ENTER();
@@ -4413,6 +4428,20 @@ void PortsOrch::doPortTask(Consumer &consumer)
                             p.m_alias.c_str(), m_portHlpr.getPortInterfaceTypeStr(pCfg).c_str()
                         );
                     }
+                }
+
+
+                if (pCfg.unreliable_los.is_set)
+		{
+			auto status = setPortUnreliableLOS(p, pCfg.unreliable_los.value);
+			if (status != task_success)
+			{
+			    SWSS_LOG_ERROR(
+				"Failed to set port %s AN from %d to %d",
+				p.m_alias.c_str(), p.m_unreloable_los, pCfg.unreliable_los.value
+                            );
+			}
+                        p.m_unreliable_los = pCfg.unreliable_los.value;
                 }
 
                 if (pCfg.adv_interface_types.is_set)

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -462,6 +462,7 @@ private:
 
     bool isAutoNegEnabled(sai_object_id_t id);
     task_process_status setPortAutoNeg(Port &port, bool autoneg);
+    task_process_status setPortUnreliableLOS(Port &port, bool enabled)
     task_process_status setPortInterfaceType(Port &port, sai_port_interface_type_t interface_type);
     task_process_status setPortAdvInterfaceTypes(Port &port, std::set<sai_port_interface_type_t> &interface_types);
     task_process_status setPortLinkTraining(const Port& port, bool state);


### PR DESCRIPTION


<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
This pull request introduces a new capability in the SONiC system: support for handling ports with "unreliable loss of signal" (unreliable LOS). The aim is to improve how the system manages situations where ports intermittently fail to detect signals reliably. To enable this, a new configuration field called unreliable_los has been added, giving users the flexibility to configure and control this behavior.

. A new field, m_unreliable_los, has been added to the Port class to track whether this feature is enabled for a specific port. Similarly, the PortConfig structure now includes a section dedicated to the unreliable LOS configuration. This addition makes it possible to specify whether unreliable LOS should be enabled and whether it has been explicitly set by the user.


The schema has also been updated to incorporate this feature. . This ensures a consistent and predictable experience for users and developers when working with the unreliable LOS functionality.

**Why I did it**
The implementation includes new helper methods. Functions like getUnreliableLosStr and parsePortUnreliableLos have been introduced to handle the conversion and parsing of the unreliable LOS field during configuration processing. The existing parsePortConfig method has been updated to integrate these changes seamlessly, ensuring the system correctly interprets and applies the new settings.

A new schema entry, PORT_UNRELIABLE_LOS, has been defined to standardize how this configuration is represented and handled across the system

**How I verified it**

**Details if related**
