### PR TITLE
[swss] The removed interface still exits in STATE_DB PORT_TABLE

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1763,8 +1763,16 @@ bool PortsOrch::setPortAdminStatus(Port &port, bool state)
 
 void PortsOrch::setHostTxReady(Port port, const std::string &status)
 {
-    SWSS_LOG_NOTICE("Setting host_tx_ready status = %s, alias = %s, port_id = 0x%" PRIx64, status.c_str(), port.m_alias.c_str(), port.m_port_id);
-    m_portStateTable.hset(port.m_alias, "host_tx_ready", status);
+    vector<FieldValueTuple> tuples;
+    bool exist;
+
+    /* If the port is revmoed, don't need to update StateDB*/
+    exist = m_portStateTable.get(port.m_alias, tuples);
+    if (exist)
+    {
+        SWSS_LOG_NOTICE("Setting host_tx_ready status = %s, alias = %s, port_id = 0x%" PRIx64, status.c_str(), port.m_alias.c_str(), port.m_port_id);
+        m_portStateTable.hset(port.m_alias, "host_tx_ready", status);
+    }
 }
 
 bool PortsOrch::getPortAdminStatus(sai_object_id_t id, bool &up)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

Breakout port from 4x100G  to 1x100G. It still have host_tx_ready for the removed interface in STATE_DB.
```
root@as9736-64d-2:/# config interface breakout Ethernet504 1x400G -f -y

Running Breakout Mode : 4x100G
Target Breakout Mode : 1x400G

Ports to be deleted :
 {
    "Ethernet504": "100000",
    "Ethernet506": "100000",
    "Ethernet508": "100000",
    "Ethernet510": "100000"
}
Ports to be added :
 {
    "Ethernet504": "400000"
}
Breakout process got successfully completed.
Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.
root@as9736-64d-2:/# redis-cli -n 0 hgetall "PORT_TABLE:Ethernet504"
 1) "alias"
 2) "Eth64(Port64)"
 3) "index"
 4) "64"
 5) "lanes"
 6) "410,411,412,413,414,415,416,417"
 7) "speed"
 8) "400000"
 9) "subport"
10) "0"
11) "mtu"
12) "9100"
13) "oper_status"
14) "down"
15) "admin_status"
16) "down"
root@as9736-64d-2:/# redis-cli -n 0 hgetall "PORT_TABLE:Ethernet506"
(empty array)
root@as9736-64d-2:/# redis-cli -n 6 hgetall "PORT_TABLE|Ethernet506"
1) "host_tx_ready"
2) "false"
```

**What I did**
Don't set host_tx_ready when the port is removed.

**Why I did it**

**How I verified it**
```
root@as9736-64d-2:/# config interface breakout Ethernet504 1x400G -f -y

Running Breakout Mode : 4x100G
Target Breakout Mode : 1x400G

Ports to be deleted :
 {
    "Ethernet504": "100000",
    "Ethernet506": "100000",
    "Ethernet508": "100000",
    "Ethernet510": "100000"
}
Ports to be added :
 {
    "Ethernet504": "400000"
}
Breakout process got successfully completed.
Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.
root@as9736-64d-2:/# redis-cli -n 0 hgetall "PORT_TABLE:Ethernet504"
 1) "alias"
 2) "Eth64(Port64)"
 3) "index"
 4) "64"
 5) "lanes"
 6) "410,411,412,413,414,415,416,417"
 7) "speed"
 8) "400000"
 9) "subport"
10) "0"
11) "mtu"
12) "9100"
13) "oper_status"
14) "down"
15) "admin_status"
16) "down"
root@as9736-64d-2:/# redis-cli -n 0 hgetall "PORT_TABLE:Ethernet506"
(empty array)
root@as9736-64d-2:/# redis-cli -n 6 hgetall "PORT_TABLE|Ethernet506"
(empty array)
```

**Details if related**
