### PR TITLE
Avoid removing a VRF routing table when there are pending creation entries in gRouteBulker

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -2433,13 +2433,21 @@ bool RouteOrch::removeRoute(RouteBulkContext& ctx)
     size_t creating = gRouteBulker.creating_entries_count(route_entry);
     if (it_route == it_route_table->second.end() && creating == 0)
     {
-       if (it_route_table->second.size() == 0)
-       {
+        /*
+         * Clean up the VRF routing table if
+         * 1. there is no routing entry in the VRF routing table and
+         * 2. there is no pending creating rouing entry in gRouteBulker
+         * The ideal way of the 2nd condition is to check pending creating entries of a certain VRF, which we can not do.
+         * However, we can not check whether there is a pending creating entry of a certain VRF in the gRouteBulker
+         * So, we use a strict condition here.
+         */
+        if (it_route_table->second.size() == 0 && gRouteBulker.creating_entries_count() == 0)
+        {
             m_syncdRoutes.erase(vrf_id);
             m_vrfOrch->decreaseVrfRefCount(vrf_id);
-       }
-       SWSS_LOG_INFO("Failed to find route entry, vrf_id 0x%" PRIx64 ", prefix %s\n", vrf_id,
-                     ipPrefix.to_string().c_str());
+        }
+        SWSS_LOG_INFO("Failed to find route entry, vrf_id 0x%" PRIx64 ", prefix %s\n", vrf_id,
+                      ipPrefix.to_string().c_str());
  
         return true;
     }

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -2436,10 +2436,10 @@ bool RouteOrch::removeRoute(RouteBulkContext& ctx)
         /*
          * Clean up the VRF routing table if
          * 1. there is no routing entry in the VRF routing table and
-         * 2. there is no pending creating rouing entry in gRouteBulker
-         * The ideal way of the 2nd condition is to check pending creating entries of a certain VRF, which we can not do.
-         * However, we can not check whether there is a pending creating entry of a certain VRF in the gRouteBulker
-         * So, we use a strict condition here.
+         * 2. there is no pending bulk creation routing entry in gRouteBulker
+         * The ideal way of the 2nd condition is to check pending bulk creation entries of a certain VRF.
+         * However, we can not do that unless going over all entries in gRouteBulker.
+         * So, we use above strict conditions here
          */
         if (it_route_table->second.size() == 0 && gRouteBulker.creating_entries_count() == 0)
         {

--- a/orchagent/swssnet.h
+++ b/orchagent/swssnet.h
@@ -64,6 +64,7 @@ inline static sai_ip_prefix_t& copy(sai_ip_prefix_t& dst, const IpAddress& src)
     switch(sip.family)
     {
         case AF_INET:
+            memset((void*)&dst, 0, sizeof(dst));
             dst.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
             dst.addr.ip4 = sip.ip_addr.ipv4_addr;
             dst.mask.ip4 = 0xFFFFFFFF;

--- a/orchagent/swssnet.h
+++ b/orchagent/swssnet.h
@@ -21,6 +21,7 @@ inline static sai_ip_address_t& copy(sai_ip_address_t& dst, const IpAddress& src
     switch(sip.family)
     {
         case AF_INET:
+            memset((void*)&dst.addr, 0, sizeof(dst.addr));
             dst.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
             dst.addr.ip4 = sip.ip_addr.ipv4_addr;
             break;
@@ -41,6 +42,7 @@ inline static sai_ip_prefix_t& copy(sai_ip_prefix_t& dst, const IpPrefix& src)
     switch(ia.family)
     {
         case AF_INET:
+            memset((void*)&dst, 0, sizeof(dst));
             dst.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
             dst.addr.ip4 = ia.ip_addr.ipv4_addr;
             dst.mask.ip4 = ma.ip_addr.ipv4_addr;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Avoid removing a VRF routing table when there are pending creation entries in gRouteBulker

1. Remove a VRF routing table when a routing entry is removed only if there is no pending creation entry in gRouteBulker
2. Avoid uninitialized value SAI IP address/prefix structure

**Why I did it**

Fix issue: out of range exception can be thrown in `addRoutePost` due to non exist VRF

```
(gdb) bt
#0  0x00007f5791aedebc in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007f5791a9efb2 in raise () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x00007f5791a89472 in abort () from /lib/x86_64-linux-gnu/libc.so.6
#3  0x00007f5791de0919 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f5791debe1a in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x00007f5791debe85 in std::terminate() () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f5791dec0d8 in __cxa_throw () from /lib/x86_64-linux-gnu/libstdc++.so.6
#7  0x00007f5791de3240 in std::__throw_out_of_range(char const*) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#8  0x00005594e856d956 in std::map<unsigned long, std::map<swss::IpPrefix, RouteNhg, std::less<swss::IpPrefix>, std::allocator<std::pair<swss::IpPrefix const, RouteNhg> > >, std::less<unsigned long>, std::allocator<std::pair<unsigned long const, std::map<swss::IpPrefix, RouteNhg, std::less<swss::IpPrefix>, std::allocator<std::pair<swss::IpPrefix const, RouteNhg> > > > > >::at (this=<optimized out>, __k=<optimized out>) at /usr/include/c++/12/bits/stl_map.h:551
#9  0x00005594e8564beb in RouteOrch::addRoutePost (this=this@entry=0x5594ea13e080, ctx=..., nextHops=...) at ./orchagent/routeorch.cpp:2145
#10 0x00005594e856b0b2 in RouteOrch::doTask (this=0x5594ea13e080, consumer=...) at ./orchagent/routeorch.cpp:1021
#11 0x00005594e85282d2 in Orch::doTask (this=0x5594ea13e080) at ./orchagent/orch.cpp:553
#12 0x00005594e851909a in OrchDaemon::start (this=this@entry=0x5594ea0a0950) at ./orchagent/orchdaemon.cpp:895
#13 0x00005594e8485632 in main (argc=<optimized out>, argv=<optimized out>) at ./orchagent/main.cpp:818
```

**How I verified it**

Unit (mock) test

**Details if related**

Originally, it cleaned up a VRF routing table whenever a prefix of the VRF was removed if
1. there was no routing entry in the VRF routing table and
2. the prefix was not pending creation in gRouteBulker

The motivation is to remove a VRF routing table if there is no routing entry in the VRF and no routing entry pending creation for that VRF. However, condition 2 does not guarantee that.

The ideal way of the 2nd condition is to check pending creation entries of a certain VRF, which we can not do.
So, we are using strict conditions here as the following:
1. there is no routing entry in the VRF routing table and
2. there is no pending creating routing entry in gRouteBulker regardless of which VRF it belongs to
