### PR TITLE
[neighsync] bug: VXLAN EVPN neighbors not in NEIGH_TABLE

### DIFF
--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -14,11 +14,7 @@
 #include "neighsync.h"
 #include "warm_restart.h"
 #include <algorithm>
-
-#ifndef NTF_EXT_LEARNED
-/* from include/uapi/linux/neighbour.h */
-#  define NTF_EXT_LEARNED (1 << 4)
-#endif
+#include <linux/neighbour.h>
 
 using namespace std;
 using namespace swss;

--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -15,6 +15,11 @@
 #include "warm_restart.h"
 #include <algorithm>
 
+#ifndef NTF_EXT_LEARNED
+/* from include/uapi/linux/neighbour.h */
+#  define NTF_EXT_LEARNED (1 << 4)
+#endif
+
 using namespace std;
 using namespace swss;
 
@@ -98,18 +103,28 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     {
         if ((isLinkLocalEnabled(intfName) == false) && (nlmsg_type != RTM_DELNEIGH))
         {
+            SWSS_LOG_INFO("LinkLocal address received, ignoring for %s", ipStr);
             return;
         }
     }
     /* Ignore IPv6 multicast link-local addresses as neighbors */
     if (family == IPV6_NAME && IN6_IS_ADDR_MC_LINKLOCAL(nl_addr_get_binary_addr(rtnl_neigh_get_dst(neigh))))
+    {
+        SWSS_LOG_INFO("Multicast LinkLocal address received, ignoring for %s", ipStr);
         return;
+    }
     key+= ipStr;
 
     int state = rtnl_neigh_get_state(neigh);
     if (state == NUD_NOARP)
     {
-        return;
+        /* For externally learned neighbors, e.g. VXLAN EVPN, we want to keep
+         * these neighbors. */
+        if (!(rtnl_neigh_get_flags(neigh) & NTF_EXT_LEARNED))
+        {
+            SWSS_LOG_INFO("NOARP address received, ignoring for %s", ipStr);
+            return;
+        }
     }
 
     bool delete_key = false;


### PR DESCRIPTION
**Why I did it**

VXLAN EVPN learned routes are not entered into NEIGH_TABLE as per Issue #3384.

The EVPN VXLAN HLD specifically states this should be populated so it triggers an update to the SAI database:

https://github.com/sonic-net/SONiC/blob/master/doc/vxlan/EVPN/EVPN_VXLAN_HLD.md#438-mac-ip-route-handling

> The remote MAC-IP routes will be installed by BGP (Zebra) in Linux neighbor table against Vlan netdevice. Neighsyncd subscribes to neighbor entries and will receive remote MAC-IP bindings as well. These entries will continue to go into NEIGH_TABLE in APP_DB, and neighorch will update SAI database.

It appears this was mistakingly introduced in #943 with a short conversation here about the reason, but it didn't take into account other reasons for NOARP entries: https://github.com/sonic-net/sonic-swss/pull/943/files#r332867379

**What I did**

The reason it was not occurring is NOARP entries were being rejected, this patch adds an exception for externally learned neighbors (which have NOARP set).

**How I verified it**

Installed on a physical switch and observe remotely learned neighbors are present in NEIGH_TABLE

**Details if related**

Fixes #3384
Signed-off-by: Brad House (@bradh352)