### PR TITLE
Handle duplicate SF in coverage.info to make sure coverage.xml gets correct statistics

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -44,6 +44,7 @@ override_dh_auto_install:
 ifeq ($(ENABLE_GCOV), y)
 	mkdir -p debian/swss/tmp/gcov
 	lcov -c --directory . --no-external --exclude "$(shell pwd)/tests/*" --exclude "$(shell pwd)/**/tests/*" --ignore-errors gcov --output-file coverage.info
+	lcov --add-tracefile coverage.info -o coverage.info
 	lcov_cobertura coverage.info -o coverage.xml
 	find ./ -type f -regex '.*\.\(h\|cpp\|gcno\|info\)' | tar -cf debian/swss/tmp/gcov/gcov-source.tar -T -
 endif

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -462,7 +462,7 @@ class DockerVirtualSwitch:
                 self.runcmd('supervisorctl stop all')
 
             # Generate the converage info by lcov and copy to the host
-            cmd = f"docker exec {self.ctn.short_id} sh -c 'cd $BUILD_DIR; rm -rf **/.libs ./lib/libSaiRedis*; lcov -c --directory . --no-external --exclude tests --ignore-errors gcov,unused --output-file /tmp/coverage.info; sed -i \"s#SF:$BUILD_DIR/#SF:#\" /tmp/coverage.info; lcov_cobertura /tmp/coverage.info -o /tmp/coverage.xml'"
+            cmd = f"docker exec {self.ctn.short_id} sh -c 'cd $BUILD_DIR; rm -rf **/.libs ./lib/libSaiRedis*; lcov -c --directory . --no-external --exclude tests --ignore-errors gcov,unused --output-file /tmp/coverage.info && lcov --add-tracefile /tmp/coverage.info -o /tmp/coverage.info; sed -i \"s#SF:$BUILD_DIR/#SF:#\" /tmp/coverage.info; lcov_cobertura /tmp/coverage.info -o /tmp/coverage.xml'"
             subprocess.getstatusoutput(cmd)
             cmd = f"docker exec {self.ctn.short_id} sh -c 'cd $BUILD_DIR; find . -name *.gcda -type f   -exec tar -rf /tmp/gcda.tar {{}} \\;'"
             subprocess.getstatusoutput(cmd)


### PR DESCRIPTION
**What I did**
use `--add-tracefile` option in `debian/rules` and `tests/conftest.py` to sanitize `coverage.info` generated by `lcov`

**Why I did it**
`lcov` generates an initial `coverage.info` file based on collected `.gcno` and `.gcda` files, this `.info` file contains coverage information for different source files (marked as `SF`).  Sometimes you would observe that the same `SF` appears multiple times, it means `lcov` gets multiple copies of coverage information for this file, since this file may have appeared in multiple compilation units, and for each copy, the hit times of its lines are different. 

Then `lcov_cobertura` generates  `coverage.xml` based on `coverage.info`. However, it can't deal with duplicate SF in `coverage.info` properly. If it sees duplicate coverage information for a source file from `coverage.info`, it always overwrites the old copy with the new copy, hence only the last copy would be counted. However, if the last copy considers the functions as missing, the function is considered as missing in `coverage.xml`, which is used to determine whether the new PR passes the coverage threshold.

The proper way is to add the hit times of all the copies, which could be achieved by lcov `add-tracefile` option.

**How I verified it**
Before using `--add-tracefile`, RingBuffer related functions in this PR are considered missing, though they are covered in testcases. After adding `--add-tracefile`, it passes the coverage check.

[[orchagent] implement ring buffer feature with a flag #3242](https://github.com/sonic-net/sonic-swss/pull/3242)

**Details if related**
By downloading the artifact of PR#3242,  we could check coverage.xml, which has already had the correct statistics.