### PR TITLE
[ci]Use sonictest instead of sonic-common for test stage.

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -45,7 +45,7 @@ jobs:
   displayName: vstest
   timeoutInMinutes: ${{ parameters.timeout }}
 
-  pool: sonic-common
+  pool: sonictest
 
   steps:
   - script: |


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Something wrong in agent pool sonictest and sonic-common. No one maintain the agent initial script.
Now I did a quick fix on these two agent pool. sonictest agent pool works but sonic-common still has issues.

**Why I did it**
1. sonictest is by design to run swss related tests. swss-common and sairedis tests run on sonictest. Only swss run on sonic-common. It is not as expected.

**How I verified it**

**Details if related**
