### PR TITLE
[orchagent/dash]: Changes to support gNMI feedback for DASH objects

### DIFF
--- a/orchagent/dash/dashaclorch.cpp
+++ b/orchagent/dash/dashaclorch.cpp
@@ -74,7 +74,7 @@ inline void lexical_convert(const string &buffer, DashAclStage &stage)
 
 }
 
-DashAclOrch::DashAclOrch(DBConnector *db, const vector<string> &tables, DashOrch *dash_orch, ZmqServer *zmqServer) :
+DashAclOrch::DashAclOrch(DBConnector *db, const vector<string> &tables, DashOrch *dash_orch, DBConnector *app_state_db, ZmqServer *zmqServer) :
     ZmqOrch(db, tables, zmqServer),
     m_dash_orch(dash_orch),
     m_group_mgr(db, dash_orch, this),

--- a/orchagent/dash/dashorch.cpp
+++ b/orchagent/dash/dashorch.cpp
@@ -49,6 +49,11 @@ DashOrch::DashOrch(DBConnector *db, vector<string> &tableName, ZmqServer *zmqSer
     m_asic_db = std::shared_ptr<DBConnector>(new DBConnector("ASIC_DB", 0));
     m_counter_db = std::shared_ptr<DBConnector>(new DBConnector("COUNTERS_DB", 0));
     m_eni_name_table = std::unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_ENI_NAME_MAP));
+    dash_eni_result_table_ = unique_ptr<Table>(new Table(app_state_db, APP_DASH_ENI_TABLE_NAME));
+    dash_eni_route_result_table_ = unique_ptr<Table>(new Table(app_state_db, APP_DASH_ENI_ROUTE_TABLE_NAME));
+    dash_qos_result_table_ = unique_ptr<Table>(new Table(app_state_db, APP_DASH_QOS_TABLE_NAME));
+    dash_appliance_result_table_ = unique_ptr<Table>(new Table(app_state_db, APP_DASH_APPLIANCE_TABLE_NAME));
+    dash_routing_type_result_table_ = unique_ptr<Table>(new Table(app_state_db, APP_DASH_ROUTING_TYPE_TABLE_NAME));
 
     if (gTraditionalFlexCounter)
     {
@@ -242,6 +247,7 @@ void DashOrch::doTaskApplianceTable(ConsumerBase& consumer)
         KeyOpFieldsValuesTuple t = it->second;
         string appliance_id = kfvKey(t);
         string op = kfvOp(t);
+        uint32_t result = 0;
 
         if (op == SET_COMMAND)
         {
@@ -260,6 +266,7 @@ void DashOrch::doTaskApplianceTable(ConsumerBase& consumer)
             }
             else
             {
+                result = 1;
                 it++;
             }
         }
@@ -271,6 +278,7 @@ void DashOrch::doTaskApplianceTable(ConsumerBase& consumer)
             }
             else
             {
+                result = 1;
                 it++;
             }
         }
@@ -279,6 +287,7 @@ void DashOrch::doTaskApplianceTable(ConsumerBase& consumer)
             SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
             it = consumer.m_toSync.erase(it);
         }
+        writeResultToDB(dash_appliance_result_table_, appliance_id, result);
     }
 }
 
@@ -325,6 +334,7 @@ void DashOrch::doTaskRoutingTypeTable(ConsumerBase& consumer)
         string routing_type_str = kfvKey(t);
         string op = kfvOp(t);
         dash::route_type::RoutingType routing_type;
+        uint32_t result = 0;
 
         std::transform(routing_type_str.begin(), routing_type_str.end(), routing_type_str.begin(), ::toupper);
         routing_type_str = "ROUTING_TYPE_" + routing_type_str;
@@ -353,6 +363,7 @@ void DashOrch::doTaskRoutingTypeTable(ConsumerBase& consumer)
             }
             else
             {
+                result = 1;
                 it++;
             }
         }
@@ -364,6 +375,7 @@ void DashOrch::doTaskRoutingTypeTable(ConsumerBase& consumer)
             }
             else
             {
+                result = 1;
                 it++;
             }
         }
@@ -372,6 +384,7 @@ void DashOrch::doTaskRoutingTypeTable(ConsumerBase& consumer)
             SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
             it = consumer.m_toSync.erase(it);
         }
+        writeResultToDB(dash_routing_type_result_table_, routing_type_str, result);
     }
 }
 
@@ -654,14 +667,13 @@ void DashOrch::doTaskEniTable(ConsumerBase& consumer)
 {
     SWSS_LOG_ENTER();
 
-    const auto& tn = consumer.getTableName();
-
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
     {
         auto t = it->second;
         string eni = kfvKey(t);
         string op = kfvOp(t);
+        uint32_t result = 0;
         if (op == SET_COMMAND)
         {
             EniEntry entry;
@@ -679,6 +691,7 @@ void DashOrch::doTaskEniTable(ConsumerBase& consumer)
             }
             else
             {
+                result = 1;
                 it++;
             }
         }
@@ -690,6 +703,7 @@ void DashOrch::doTaskEniTable(ConsumerBase& consumer)
             }
             else
             {
+                result = 1;
                 it++;
             }
         }
@@ -698,6 +712,7 @@ void DashOrch::doTaskEniTable(ConsumerBase& consumer)
             SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
             it = consumer.m_toSync.erase(it);
         }
+        writeResultToDB(dash_eni_result_table_, eni, result);
     }
 }
 
@@ -738,6 +753,7 @@ void DashOrch::doTaskQosTable(ConsumerBase& consumer)
         KeyOpFieldsValuesTuple t = it->second;
         string qos_name = kfvKey(t);
         string op = kfvOp(t);
+        uint32_t result = 0;
 
         if (op == SET_COMMAND)
         {
@@ -756,6 +772,7 @@ void DashOrch::doTaskQosTable(ConsumerBase& consumer)
             }
             else
             {
+                result = 1;
                 it++;
             }
         }
@@ -767,6 +784,7 @@ void DashOrch::doTaskQosTable(ConsumerBase& consumer)
             }
             else
             {
+                result = 1;
                 it++;
             }
         }
@@ -775,6 +793,7 @@ void DashOrch::doTaskQosTable(ConsumerBase& consumer)
             SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
             it = consumer.m_toSync.erase(it);
         }
+        writeResultToDB(dash_eni_qos_table_, qos_name, result);
     }
 }
 
@@ -886,6 +905,7 @@ void DashOrch::doTaskEniRouteTable(ConsumerBase& consumer)
         KeyOpFieldsValuesTuple t = it->second;
         string eni = kfvKey(t);
         string op = kfvOp(t);
+        uint32_t result = 0;
 
         if (op == SET_COMMAND)
         {
@@ -904,6 +924,7 @@ void DashOrch::doTaskEniRouteTable(ConsumerBase& consumer)
             }
             else
             {
+                result = 1;
                 it++;
             }
         }
@@ -915,6 +936,7 @@ void DashOrch::doTaskEniRouteTable(ConsumerBase& consumer)
             }
             else
             {
+                result = 1;
                 it++;
             }
         }
@@ -923,6 +945,7 @@ void DashOrch::doTaskEniRouteTable(ConsumerBase& consumer)
             SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
             it = consumer.m_toSync.erase(it);
         }
+        writeResultToDB(dash_eni_route_result_table_, eni, result);
     }
 }
 

--- a/orchagent/dash/dashorch.h
+++ b/orchagent/dash/dashorch.h
@@ -49,7 +49,7 @@ typedef std::map<std::string, dash::eni_route::EniRoute> EniRouteTable;
 class DashOrch : public ZmqOrch
 {
 public:
-    DashOrch(swss::DBConnector *db, std::vector<std::string> &tables, swss::ZmqServer *zmqServer);
+    DashOrch(swss::DBConnector *db, std::vector<std::string> &tables, swss::DBConnector *app_state_db, swss::ZmqServer *zmqServer);
     const EniEntry *getEni(const std::string &eni) const;
     bool getRouteTypeActions(dash::route_type::RoutingType routing_type, dash::route_type::RouteType& route_type);
     void handleFCStatusUpdate(bool is_enabled);
@@ -60,6 +60,11 @@ private:
     EniTable eni_entries_;
     QosTable qos_entries_;
     EniRouteTable eni_route_entries_;
+    std::unique_ptr<swss::Table> dash_eni_result_table_;
+    std::unique_ptr<swss::Table> dash_qos_result_table_;
+    std::unique_ptr<swss::Table> dash_appliance_result_table_;
+    std::unique_ptr<swss::Table> dash_eni_route_result_table_;
+    std::unique_ptr<swss::Table> dash_routing_type_result_table_;
     void doTask(ConsumerBase &consumer);
     void doTaskApplianceTable(ConsumerBase &consumer);
     void doTaskRoutingTypeTable(ConsumerBase &consumer);
@@ -98,4 +103,5 @@ private:
     void addEniToFC(sai_object_id_t oid, const std::string& name);
     void removeEniFromFC(sai_object_id_t oid, const std::string& name);
     void refreshEniFCStats(bool);
+    void clearEniFCStats();
 };

--- a/orchagent/dash/dashrouteorch.h
+++ b/orchagent/dash/dashrouteorch.h
@@ -77,7 +77,7 @@ struct InboundRoutingBulkContext
 class DashRouteOrch : public ZmqOrch
 {
 public:
-    DashRouteOrch(swss::DBConnector *db, std::vector<std::string> &tables, DashOrch *dash_orch, swss::ZmqServer *zmqServer);
+    DashRouteOrch(swss::DBConnector *db, std::vector<std::string> &tables, DashOrch *dash_orch, swss::DBConnector *app_state_db, swss::ZmqServer *zmqServer);
     sai_object_id_t getRouteGroupOid(const std::string& route_group) const;
     void bindRouteGroup(const std::string& route_group);
     void unbindRouteGroup(const std::string& route_group);
@@ -91,6 +91,9 @@ private:
     DashOrch *dash_orch_;
     std::unordered_map<std::string, sai_object_id_t> route_group_oid_map_;
     std::unordered_map<std::string, int> route_group_bind_count_;
+    std::unique_ptr<swss::Table> dash_route_result_table_;
+    std::unique_ptr<swss::Table> dash_route_rule_result_table_;
+    std::unique_ptr<swss::Table> dash_route_group_result_table_;
 
     void doTask(ConsumerBase &consumer);
     void doTaskRouteTable(ConsumerBase &consumer);

--- a/orchagent/dash/dashvnetorch.cpp
+++ b/orchagent/dash/dashvnetorch.cpp
@@ -37,13 +37,15 @@ extern size_t gMaxBulkSize;
 extern CrmOrch *gCrmOrch;
 extern Directory<Orch*> gDirectory;
 
-DashVnetOrch::DashVnetOrch(DBConnector *db, vector<string> &tables, ZmqServer *zmqServer) :
+DashVnetOrch::DashVnetOrch(DBConnector *db, vector<string> &tables, DBConnector *app_state_db, ZmqServer *zmqServer) :
     vnet_bulker_(sai_dash_vnet_api, gSwitchId, gMaxBulkSize),
     outbound_ca_to_pa_bulker_(sai_dash_outbound_ca_to_pa_api, gMaxBulkSize),
     pa_validation_bulker_(sai_dash_pa_validation_api, gMaxBulkSize),
     ZmqOrch(db, tables, zmqServer)
 {
     SWSS_LOG_ENTER();
+    dash_vnet_result_table_ = unique_ptr<Table>(new Table(app_state_db, APP_DASH_VNET_TABLE_NAME));
+    dash_vnet_map_result_table_ = unique_ptr<Table>(new Table(app_state_db, APP_DASH_VNET_MAPPING_TABLE_NAME));
 }
 
 bool DashVnetOrch::addVnet(const string& vnet_name, DashVnetBulkContext& ctxt)

--- a/orchagent/dash/dashvnetorch.h
+++ b/orchagent/dash/dashvnetorch.h
@@ -74,7 +74,7 @@ struct VnetMapBulkContext
 class DashVnetOrch : public ZmqOrch
 {
 public:
-    DashVnetOrch(swss::DBConnector *db, std::vector<std::string> &tables, swss::ZmqServer *zmqServer);
+    DashVnetOrch(swss::DBConnector *db, std::vector<std::string> &tables, swss::DBConnector *app_state_db, swss::ZmqServer *zmqServer);
 
 private:
     DashVnetTable vnet_table_;
@@ -83,6 +83,8 @@ private:
     ObjectBulker<sai_dash_vnet_api_t> vnet_bulker_;
     EntityBulker<sai_dash_outbound_ca_to_pa_api_t> outbound_ca_to_pa_bulker_;
     EntityBulker<sai_dash_pa_validation_api_t> pa_validation_bulker_;
+    std::unique_ptr<swss::Table> dash_vnet_result_table_;
+    std::unique_ptr<swss::Table> dash_vnet_map_result_table_;
 
     void doTask(ConsumerBase &consumer);
     void doTaskVnetTable(ConsumerBase &consumer);

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -648,6 +648,10 @@ int main(int argc, char **argv)
         attr.value.u32 = gVoqMySwitchId;
         attrs.push_back(attr);
     }
+    else if (gMySwitchType == "dpu")
+    {
+        app_state_db = make_shared<DBConnector>("DPU_APPL_STATE_DB", 0, true);
+    }
 
     /* Must be last Attribute */
     attr.id = SAI_REDIS_SWITCH_ATTR_CONTEXT;
@@ -806,9 +810,16 @@ int main(int argc, char **argv)
     }
 
     shared_ptr<OrchDaemon> orchDaemon;
-    if (gMySwitchType != "fabric")
+    if (gMySwitchType == "dpu")
     {
-        orchDaemon = make_shared<OrchDaemon>(&appl_db, &config_db, &state_db, chassis_app_db.get(), zmq_server.get());
+        shared_ptr<DBConnector> dpu_app_db;
+        dpu_app_db = make_shared<DBConnector>("DPU_APPL_DB", 0, true);
+        orchDaemon = make_shared<DpuOrchDaemon>(&appl_db, &config_db, &state_db, dpu_app_db.get(), chassis_app_db.get(), zmq_server.get());
+    }
+
+    else if (gMySwitchType != "fabric")
+    {
+        orchDaemon = make_shared<OrchDaemon>(&appl_db, &config_db, &state_db, chassis_app_db.get(), app_state_db.get(), zmq_server.get());
         if (gMySwitchType == "voq")
         {
             orchDaemon->setFabricEnabled(true);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -71,10 +71,11 @@ event_handle_t g_events_handle;
 #define DEFAULT_MAX_BULK_SIZE 1000
 size_t gMaxBulkSize = DEFAULT_MAX_BULK_SIZE;
 
-OrchDaemon::OrchDaemon(DBConnector *applDb, DBConnector *configDb, DBConnector *stateDb, DBConnector *chassisAppDb, ZmqServer *zmqServer) :
+OrchDaemon::OrchDaemon(DBConnector *applDb, DBConnector *configDb, DBConnector *stateDb, DBConnector *chassisAppDb, DBConnector *appstateDb, ZmqServer *zmqServer) :
         m_applDb(applDb),
         m_configDb(configDb),
         m_stateDb(stateDb),
+        m_appstateDb(appstateDb),
         m_chassisAppDb(chassisAppDb),
         m_zmqServer(zmqServer)
 {
@@ -263,7 +264,7 @@ bool OrchDaemon::init()
         APP_DASH_VNET_TABLE_NAME,
         APP_DASH_VNET_MAPPING_TABLE_NAME
     };
-    DashVnetOrch *dash_vnet_orch = new DashVnetOrch(m_applDb, dash_vnet_tables, m_zmqServer);
+    DashVnetOrch *dash_vnet_orch = new DashVnetOrch(m_applDb, dash_vnet_tables, m_appstateDb, m_zmqServer);
     gDirectory.set(dash_vnet_orch);
 
     vector<string> dash_tables = {
@@ -274,7 +275,7 @@ bool OrchDaemon::init()
         APP_DASH_QOS_TABLE_NAME
     };
 
-    DashOrch *dash_orch = new DashOrch(m_applDb, dash_tables, m_zmqServer);
+    DashOrch *dash_orch = new DashOrch(m_applDb, m_dash_tables, m_appstateDb, m_zmqServer);
     gDirectory.set(dash_orch);
 
     vector<string> dash_route_tables = {
@@ -283,7 +284,7 @@ bool OrchDaemon::init()
         APP_DASH_ROUTE_GROUP_TABLE_NAME
     };
 
-    DashRouteOrch *dash_route_orch = new DashRouteOrch(m_applDb, dash_route_tables, dash_orch, m_zmqServer);
+    DashRouteOrch *dash_route_orch = new DashRouteOrch(m_applDb, dash_route_tables, dash_orch, m_appstateDb, m_zmqServer);
     gDirectory.set(dash_route_orch);
 
     vector<string> dash_acl_tables = {
@@ -293,7 +294,7 @@ bool OrchDaemon::init()
         APP_DASH_ACL_GROUP_TABLE_NAME,
         APP_DASH_ACL_RULE_TABLE_NAME
     };
-    DashAclOrch *dash_acl_orch = new DashAclOrch(m_applDb, dash_acl_tables, dash_orch, m_zmqServer);
+    DashAclOrch *dash_acl_orch = new DashAclOrch(m_applDb, dash_acl_tables, dash_orch, m_appstateDb, m_zmqServer);
     gDirectory.set(dash_acl_orch);
 
     vector<string> qos_tables = {
@@ -1146,4 +1147,15 @@ bool FabricOrchDaemon::init()
     addOrchList(new FlexCounterOrch(m_configDb, flex_counter_tables));
 
     return true;
+}
+
+DpuOrchDaemon::DpuOrchDaemon(DBConnector *applDb, DBConnector *configDb, DBConnector *stateDb, DBConnector *dpuAppDb, DBConnector *chassisAppDb, ZmqServer *zmqServer) :
+    OrchDaemon(applDb, configDb, stateDb, chassisAppDb, zmqServer),
+    m_applDb(applDb),
+    m_configDb(configDb),
+    m_stateDb(stateDb),
+    m_dpu_appDb(dpuAppDb)
+{
+    SWSS_LOG_ENTER();
+    SWSS_LOG_NOTICE("DpuOrchDaemon starting...");
 }

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -59,7 +59,7 @@ using namespace swss;
 class OrchDaemon
 {
 public:
-    OrchDaemon(DBConnector *, DBConnector *, DBConnector *, DBConnector *, ZmqServer *);
+    OrchDaemon(DBConnector *, DBConnector *, DBConnector *, DBConnector *, DBConnector *, ZmqServer *);
     ~OrchDaemon();
 
     virtual bool init();
@@ -117,4 +117,16 @@ private:
     DBConnector *m_configDb;
 };
 
+
+class DpuOrchDaemon : public OrchDaemon
+{
+public:
+    DpuOrchDaemon(DBConnector *, DBConnector *, DBConnector *, DBConnector *, DBConnector *, ZmqServer *);
+    ~DpuOrchDaemon();
+private:
+    DBConnector *m_applDb;
+    DBConnector *m_configDb;
+    DBConnector *m_stateDb;
+    DBConnector *m_dpu_appDb;
+};
 #endif /* SWSS_ORCHDAEMON_H */

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -1135,3 +1135,23 @@ std::vector<sai_stat_id_t> queryAvailableCounterStats(const sai_object_type_t ob
     }
     return stat_list;
 }
+
+FieldValueTuple makeResultDbEntry(uint32_t res)
+{
+    auto field = "result";
+    auto value = std::to_string(res);
+
+    return FieldValueTuple(field, value);
+}
+
+void writeResultToDB(const std::unique_ptr<swss::Table>& table, const string& key, uint32_t res)
+{
+    SWSS_LOG_ENTER();
+
+    std::vector<FieldValueTuple> fvList = {
+        makeResultDbEntry(res)
+    };
+
+    table_->set(key, fvList);
+    SWSS_LOG_NOTICE("Wrote result to DB for key %s", key.c_str());
+}

--- a/orchagent/saihelper.h
+++ b/orchagent/saihelper.h
@@ -49,5 +49,6 @@ void startFlexCounterPolling(sai_object_id_t switch_oid,
                              const std::string &stats_mode="");
 void stopFlexCounterPolling(sai_object_id_t switch_oid,
                             const std::string &key);
-
 std::vector<sai_stat_id_t> queryAvailableCounterStats(const sai_object_type_t);
+swss::FieldValueTuple makeResultDbEntry(uint32_t res);
+void writeResultToDB(const std::unique_ptr<swss::Table>&, const std::string& key, uint32_t res);

--- a/tests/mock_tests/database_config.json
+++ b/tests/mock_tests/database_config.json
@@ -76,6 +76,16 @@
             "id" : 14,
             "separator": ":",
             "instance" : "redis"
+        },
+        "DPU_APPL_DB" : {
+            "id" : 15,
+            "separator": ":",
+            "instance" : "redis"
+        },
+        "DPU_APPL_STATE_DB" : {
+            "id" : 16,
+            "separator": "|",
+            "instance" : "redis"
         }
     },
     "VERSION" : "1.0"

--- a/tests/mock_tests/mock_orch_test.cpp
+++ b/tests/mock_tests/mock_orch_test.cpp
@@ -65,6 +65,8 @@ void MockOrchTest::SetUp()
     m_app_db = make_shared<swss::DBConnector>("APPL_DB", 0);
     m_config_db = make_shared<swss::DBConnector>("CONFIG_DB", 0);
     m_state_db = make_shared<swss::DBConnector>("STATE_DB", 0);
+    m_dpu_app_db = make_shared<swss::DBConnector>("DPU_APPL_DB", 0);
+    m_dpu_app_state_db = make_shared<swss::DBConnector>("DPU_APPL_STATE_DB", 0);
     m_chassis_app_db = make_shared<swss::DBConnector>("CHASSIS_APP_DB", 0);
 
     PrepareSai();

--- a/tests/mock_tests/mock_orch_test.h
+++ b/tests/mock_tests/mock_orch_test.h
@@ -42,6 +42,8 @@ namespace mock_orch_test
         shared_ptr<swss::DBConnector> m_app_db;
         shared_ptr<swss::DBConnector> m_config_db;
         shared_ptr<swss::DBConnector> m_state_db;
+        shared_ptr<swss::DBConnector> m_dpu_app_db;
+        shared_ptr<swss::DBConnector> m_dpu_app_state_db;
         shared_ptr<swss::DBConnector> m_chassis_app_db;
         MuxOrch *m_MuxOrch;
         MuxCableOrch *m_MuxCableOrch;


### PR DESCRIPTION
 This PR makes the following changes:

   * Write result of SAI API call to APP_STATE_DB for DASH objects
   * Instantiate DpuOrchDaemon for smartswitch DPUs and make it listen to DPU_APPL_DB

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
