### PR TITLE
[copp]: Use non-zero trap priority for default trap group

### DIFF
--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -188,13 +188,17 @@ void CoppOrch::initDefaultTrapIds()
     attr.value.oid = m_trap_group_map[default_trap_group];
     trap_id_attrs.push_back(attr);
 
-    /* Mellanox platform doesn't support trap priority setting */
-    /* Marvell platform doesn't support trap priority. */
+    /*
+     * Use a default trap priority > 0 to avoid undesirable packet trapping
+     * behavior on some platforms that use 0 as default SAI-internal priority.
+     * Note: Mellanox and Marvell platforms don't support trap priority setting.
+     */
+
     char *platform = getenv("platform");
     if (!platform || (!strstr(platform, MLNX_PLATFORM_SUBSTRING) && (!strstr(platform, MRVL_PRST_PLATFORM_SUBSTRING))))
     {
         attr.id = SAI_HOSTIF_TRAP_ATTR_TRAP_PRIORITY;
-        attr.value.u32 = 0;
+        attr.value.u32 = 1;
         trap_id_attrs.push_back(attr);
     }
 

--- a/tests/test_copp.py
+++ b/tests/test_copp.py
@@ -232,6 +232,8 @@ class TestCopp(object):
         queue = ""
         trap_action = ""
         trap_priority = ""
+        default_trap_queue = "0"
+        default_trap_prio = "1"
 
         for fv in trap_fvs:
             if fv[0] == "SAI_HOSTIF_TRAP_ATTR_PACKET_ACTION":
@@ -262,6 +264,11 @@ class TestCopp(object):
                 assert trap_group_oid != "oid:0x0"
                 if keys == "queue":
                     assert queue == trap_group[keys]
+                    # default trap in copp config doesn't specify a trap priority
+                    # this is instead set internally in swss
+                    # confirm that default trap uses a priority 1
+                    if queue == default_trap_queue:
+                        assert trap_priority == default_trap_prio
                 else:
                     assert 0
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Microsoft ADO **29981358**
Updated swss code to use a priority of 1 instead of 0 for default trap group.

**Why I did it**

Some vendor SAI implementations use zero as a default lowest priority internally which can impact TTL 1 packet trapping behavior in certain platforms.

**How I verified it**
 * By running copp tests which include rate-limiting tests for TTL 1 packets on on Cisco/Mellanox/Arista platforms.
 * By manual tests with TTL 1 packets generated by scapy
 
**Details if related**
Example packet:
def send_pkt(intf):
    pkt = Ether(src='00:06:07:08:09:0a',dst='84:7f:c2:88:57:a7') \
            /IP(dst='20.0.0.46',src='20.0.0.47',ttl=1) \
            /TCP(sport=1025,dport=179)
    sendp(pkt,count=50000,iface=intf)