### PR TITLE
portsorch: don't call updateDbPortOperStatus on all port types

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -8268,7 +8268,10 @@ void PortsOrch::updatePortOperStatus(Port &port, sai_port_oper_status_t status)
         return;
     }
 
-    updateDbPortOperStatus(port, status);
+    if (port.m_type == Port::PHY || port.m_type == Port::TUNNEL)
+    {
+        updateDbPortOperStatus(port, status);
+    }
 
     if (port.m_type == Port::PHY)
     {

--- a/tests/test_portchannel.py
+++ b/tests/test_portchannel.py
@@ -454,7 +454,7 @@ class TestPortchannel(object):
 
         # verify a PORT_TABLE entry containing the PortChannel is NOT created
         # in APPDB (sonic-buildimage Issue #21688)
-        tbl = swsscommon.Table(app_db, "PORTCHANNEL_MEMBER")
+        tbl = swsscommon.Table(app_db, "PORT_TABLE")
         status, _ = tbl.get("PortChannel111")
         assert status is False
 

--- a/tests/test_portchannel.py
+++ b/tests/test_portchannel.py
@@ -452,6 +452,12 @@ class TestPortchannel(object):
         fvs = dict(fvs)
         assert fvs['netdev_oper_status'] == 'up'
 
+        # verify a PORT_TABLE entry containing the PortChannel is NOT created
+        # in APPDB (sonic-buildimage Issue #21688)
+        tbl = swsscommon.Table(app_db, "PORTCHANNEL_MEMBER")
+        status, _ = tbl.get("PortChannel111")
+        assert status is False
+
         # remove port-channel members
         tbl = swsscommon.Table(config_db, "PORTCHANNEL_MEMBER")
         tbl._del("PortChannel111|Ethernet0")


### PR DESCRIPTION
**What I did**

Only call `updateDbPortOperStatus()` on PHY and TUNNEL ports.

**Why I did it**

PORT_TABLE contains PortChannel oper_status entries which are not expected by portsorch which leads to warm/fastreboot failures like:
```
2025 Feb 10 09:33:07.111055 sonic NOTICE swss#orchagent: :- bake: foundPortConfigDone = 1
2025 Feb 10 09:33:07.111080 sonic NOTICE swss#orchagent: :- bake: foundPortInitDone = 1
2025 Feb 10 09:33:07.111395 sonic NOTICE swss#orchagent: :- bake: m_portTable->getKeys 263
2025 Feb 10 09:33:07.111403 sonic NOTICE swss#orchagent: :- bake: portCount = 257, m_portCount = 0
2025 Feb 10 09:33:07.111403 sonic ERR swss#orchagent: :- bake: Invalid port table: portCount, expecting 257, got 261
```

Regression caused by #3383

**How I verified it**

Asked @stepanblyschak to verify who reported issue.

**Details if related**
Fixes https://github.com/sonic-net/sonic-buildimage/issues/21688

Signed-off-by: Brad House (@bradh352)