### PR TITLE
[portsorch] Ports initialization speedup

### DIFF
--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -243,6 +243,14 @@ public:
     virtual void doTask(swss::NotificationConsumer &consumer) { }
     virtual void doTask(swss::SelectableTimer &timer) { }
 
+    /*
+     * Called once after APPLY_VIEW in warm/fast boot scenario.
+     * Orch can override this method to perform orch specific operations after boot is finished.
+     * These operations are not meant to produce additional ASIC configuration,
+     * instead a capability fetch and STATE_DB update here is encouraged.
+     * Orch is not expected to call the base method implementation as it must remain
+     * empty for compatibility reasons.
+     */
     virtual void onWarmBootEnd() { }
 
     void dumpPendingTasks(std::vector<std::string> &ts);

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -243,6 +243,8 @@ public:
     virtual void doTask(swss::NotificationConsumer &consumer) { }
     virtual void doTask(swss::SelectableTimer &timer) { }
 
+    virtual void onWarmBootEnd() { }
+
     void dumpPendingTasks(std::vector<std::string> &ts);
 
     /**

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -938,6 +938,8 @@ void OrchDaemon::start()
  */
 bool OrchDaemon::warmRestoreAndSyncUp()
 {
+    SWSS_LOG_ENTER();
+
     WarmStart::setWarmStartState("orchagent", WarmStart::INITIALIZED);
 
     for (Orch *o : m_orchList)
@@ -1000,8 +1002,10 @@ bool OrchDaemon::warmRestoreAndSyncUp()
 
     syncd_apply_view();
 
-    /* Start dynamic state sync up */
-    gPortsOrch->refreshPortStatus();
+    for (Orch *o : m_orchList)
+    {
+        o->onWarmBootEnd();
+    }
 
     /*
      * Note. Arp sync up is handled in neighsyncd.

--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -501,6 +501,11 @@ bool PortsOrch::setPortAdminStatus(Port &port, bool up)
     return true;
 }
 
+bool PortsOrch::getPortAdminStatus(sai_object_id_t id, bool &up)
+{
+    return true;
+}
+
 bool PortsOrch::setPortMtu(const Port &port, sai_uint32_t mtu)
 {
     return true;

--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -487,7 +487,7 @@ sai_status_t PortsOrch::removePort(sai_object_id_t port_id)
     return SAI_STATUS_SUCCESS;
 }
 
-bool PortsOrch::initPort(const PortConfig &port)
+bool PortsOrch::initExistingPort(const PortConfig &port)
 {
     return true;
 }

--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -418,24 +418,11 @@ void PortsOrch::removeDefaultBridgePorts()
 {
 }
 
-bool PortsOrch::initializePort(Port &port)
-{
-    return true;
-}
-
-void PortsOrch::initializePriorityGroups(Port &port)
-{
-}
-
 void PortsOrch::initializePortBufferMaximumParameters(Port &port)
 {
 }
 
-void PortsOrch::initializeQueues(Port &port)
-{
-}
-
-bool PortsOrch::addHostIntfs(Port &port, string alias, sai_object_id_t &host_intfs_id)
+bool PortsOrch::addHostIntfs(Port &port, string alias, sai_object_id_t &host_intfs_id, bool up)
 {
     return true;
 }
@@ -510,11 +497,6 @@ void PortsOrch::deInitPort(string alias, sai_object_id_t port_id)
 }
 
 bool PortsOrch::setPortAdminStatus(Port &port, bool up)
-{
-    return true;
-}
-
-bool PortsOrch::getPortAdminStatus(sai_object_id_t id, bool &up)
 {
     return true;
 }
@@ -697,5 +679,9 @@ std::unordered_set<std::string> PortsOrch::generateCounterStats(const string &ty
 }
 
 void PortsOrch::doTask(swss::SelectableTimer &timer)
+{
+}
+
+void PortsOrch::onWarmBootEnd()
 {
 }

--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -418,7 +418,7 @@ void PortsOrch::removeDefaultBridgePorts()
 {
 }
 
-void PortsOrch::initializePortBufferMaximumParameters(Port &port)
+void PortsOrch::initializePortBufferMaximumParameters(const Port &port)
 {
 }
 

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -26,7 +26,7 @@ extern "C" {
  * Orchagent adds extra 22 bytes for Ethernet header and FCS,
  * hence setting to 1492 (1514 - 22)
  */
-#define DEFAULT_MTU             1492 - MAX_MACSEC_SECTAG_SIZE
+#define DEFAULT_MTU             (1492 - MAX_MACSEC_SECTAG_SIZE)
 
 /*
  * Default TPID is 8100
@@ -213,7 +213,6 @@ public:
     uint32_t  m_fdb_count = 0;
     uint64_t  m_flap_count = 0;
     uint32_t  m_up_member_count = 0;
-    uint32_t  m_maximum_headroom = 0;
     std::set<uint32_t> m_adv_speeds;
     sai_port_interface_type_t m_interface_type = SAI_PORT_INTERFACE_TYPE_NONE;
     std::set<sai_port_interface_type_t> m_adv_interface_types;

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -18,12 +18,15 @@ extern "C" {
 #include <sairedis.h>
 
 #define DEFAULT_PORT_VLAN_ID    1
+
+#define MAX_MACSEC_SECTAG_SIZE 32
+
 /*
  * Default MTU is derived from SAI_PORT_ATTR_MTU (1514)
  * Orchagent adds extra 22 bytes for Ethernet header and FCS,
  * hence setting to 1492 (1514 - 22)
  */
-#define DEFAULT_MTU             1492
+#define DEFAULT_MTU             1492 - MAX_MACSEC_SECTAG_SIZE
 
 /*
  * Default TPID is 8100
@@ -268,6 +271,8 @@ public:
     uint32_t m_suppress_threshold = 0;
     uint32_t m_reuse_threshold = 0;
     uint32_t m_flap_penalty = 0;
+
+    Role m_role;
 };
 
 }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -6245,14 +6245,11 @@ bool PortsOrch::addHostIntfs(Port &port, string alias, sai_object_id_t &host_int
         }
     }
 
-    if (up)
-    {
-        SWSS_LOG_NOTICE("Set operation status %s to host interface %s",
-                up ? "UP" : "DOWN", port.m_alias.c_str());
+    SWSS_LOG_NOTICE("Set operation status %s to host interface %s",
+            up ? "UP" : "DOWN", port.m_alias.c_str());
 
-        event_params_t params = {{"ifname",port.m_alias},{"status", up ? "up" : "down"}};
-        event_publish(g_events_handle, "if-state", &params);
-    }
+    event_params_t params = {{"ifname",port.m_alias},{"status", up ? "up" : "down"}};
+    event_publish(g_events_handle, "if-state", &params);
 
     SWSS_LOG_NOTICE("Create host interface for port %s", alias.c_str());
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -36,6 +36,7 @@
 #include "subscriberstatetable.h"
 
 #include "saitam.h"
+#include "warm_restart.h"
 
 extern sai_switch_api_t *sai_switch_api;
 extern sai_bridge_api_t *sai_bridge_api;
@@ -88,6 +89,50 @@ struct PortAttrValue
 
 typedef PortAttrValue PortAttrValue_t;
 typedef std::map<sai_port_serdes_attr_t, std::vector<std::uint32_t>> PortSerdesAttrMap_t;
+
+struct PortBulker
+{
+    std::vector<sai_object_id_t> oids;
+    std::vector<uint32_t> attrCount;
+    std::vector<sai_attribute_t> attrList;
+    std::vector<sai_status_t> statuses;
+
+    uint32_t count;
+
+    PortBulker(uint32_t size) :
+        oids(size),
+        attrCount(size, 1),
+        attrList(size),
+        statuses(size, SAI_STATUS_NOT_EXECUTED),
+        count(0)
+    {
+    }
+
+    void add(sai_object_id_t oid, sai_attribute_t& attr)
+    {
+        oids[count] = oid;
+        attrList[count] = attr;
+        count++;
+    }
+
+    void executeGet(sai_bulk_op_error_mode_t errorMode = SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR)
+    {
+        if (count == 0)
+        {
+            return;
+        }
+
+        std::vector<sai_attribute_t*> attrs(count);
+
+        for (size_t idx = 0; idx < count; idx++)
+        {
+            attrs[idx] = &attrList[idx];
+        }
+
+        sai_port_api->get_ports_attribute(count, oids.data(), attrCount.data(),
+            attrs.data(), errorMode, statuses.data());
+    }
+};
 
 // constants ----------------------------------------------------------------------------------------------------------
 
@@ -947,7 +992,7 @@ void PortsOrch::setPortConfigState(port_config_state_t value)
     this->m_portConfigState = value;
 }
 
-bool PortsOrch::addPortBulk(const std::vector<PortConfig> &portList)
+bool PortsOrch::addPortBulk(const std::vector<PortConfig> &portList, std::vector<Port>& addedPorts)
 {
     // The method is used to create ports in a bulk mode.
     // The action takes place when:
@@ -960,6 +1005,8 @@ bool PortsOrch::addPortBulk(const std::vector<PortConfig> &portList)
     {
         return true;
     }
+
+    addedPorts.reserve(portList.size());
 
     std::vector<PortAttrValue_t> attrValueList;
     std::vector<std::vector<sai_attribute_t>> attrDataList;
@@ -974,6 +1021,12 @@ bool PortsOrch::addPortBulk(const std::vector<PortConfig> &portList)
     {
         sai_attribute_t attr;
         std::vector<sai_attribute_t> attrList;
+
+        addedPorts.emplace_back(cit.key, Port::PHY);
+        auto& p = addedPorts.back();
+
+        p.m_role = cit.role.value;
+        p.m_index = cit.index.value;
 
         if (cit.lanes.is_set)
         {
@@ -994,6 +1047,7 @@ bool PortsOrch::addPortBulk(const std::vector<PortConfig> &portList)
             attr.id = SAI_PORT_ATTR_SPEED;
             attr.value.u32 = cit.speed.value;
             attrList.push_back(attr);
+            p.m_speed = cit.speed.value;
         }
 
         if (cit.autoneg.is_set)
@@ -1001,6 +1055,7 @@ bool PortsOrch::addPortBulk(const std::vector<PortConfig> &portList)
             attr.id = SAI_PORT_ATTR_AUTO_NEG_MODE;
             attr.value.booldata = cit.autoneg.value;
             attrList.push_back(attr);
+            p.m_autoneg = cit.autoneg.value;
         }
 
         if (cit.fec.is_set)
@@ -1008,6 +1063,7 @@ bool PortsOrch::addPortBulk(const std::vector<PortConfig> &portList)
             attr.id = SAI_PORT_ATTR_FEC_MODE;
             attr.value.s32 = cit.fec.value;
             attrList.push_back(attr);
+            p.m_fec_mode = cit.fec.value;
         }
 
         if (m_cmisModuleAsicSyncSupported)
@@ -1128,6 +1184,7 @@ bool PortsOrch::addPortBulk(const std::vector<PortConfig> &portList)
         }
 
         m_portListLaneMap[portList.at(i).lanes.value] = oidList.at(i);
+        addedPorts.at(i).m_port_id = oidList.at(i);
         m_portCount++;
     }
 
@@ -1767,75 +1824,6 @@ void PortsOrch::setHostTxReady(Port port, const std::string &status)
     m_portStateTable.hset(port.m_alias, "host_tx_ready", status);
 }
 
-bool PortsOrch::getPortAdminStatus(sai_object_id_t id, bool &up)
-{
-    SWSS_LOG_ENTER();
-
-    getDestPortId(id, LINE_PORT_TYPE, id);
-
-    sai_attribute_t attr;
-    attr.id = SAI_PORT_ATTR_ADMIN_STATE;
-
-    sai_status_t status = sai_port_api->get_port_attribute(id, 1, &attr);
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_ERROR("Failed to get admin status for port pid:%" PRIx64, id);
-        task_process_status handle_status = handleSaiGetStatus(SAI_API_PORT, status);
-        if (handle_status != task_process_status::task_success)
-        {
-            return false;
-        }
-    }
-
-    up = attr.value.booldata;
-
-    return true;
-}
-
-bool PortsOrch::getPortHostTxReady(const Port& port, bool &hostTxReadyVal)
-{
-    SWSS_LOG_ENTER();
-
-    sai_attribute_t attr;
-    attr.id = SAI_PORT_ATTR_HOST_TX_READY_STATUS;
-
-    sai_status_t status = sai_port_api->get_port_attribute(port.m_port_id, 1, &attr);
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        hostTxReadyVal = false;
-        return false;
-    }
-
-    hostTxReadyVal = attr.value.s32;
-
-    return true;
-}
-
-bool PortsOrch::getPortMtu(const Port& port, sai_uint32_t &mtu)
-{
-    SWSS_LOG_ENTER();
-
-    sai_attribute_t attr;
-    attr.id = SAI_PORT_ATTR_MTU;
-
-    sai_status_t status = sai_port_api->get_port_attribute(port.m_port_id, 1, &attr);
-
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        return false;
-    }
-
-    mtu = attr.value.u32 - (uint32_t)(sizeof(struct ether_header) + FCS_LEN + VLAN_TAG_LEN);
-
-    /* Reduce the default MTU got from ASIC by MAX_MACSEC_SECTAG_SIZE */
-    if (mtu > MAX_MACSEC_SECTAG_SIZE)
-    {
-        mtu -= MAX_MACSEC_SECTAG_SIZE;
-    }
-
-    return true;
-}
-
 bool PortsOrch::setPortMtu(const Port& port, sai_uint32_t mtu)
 {
     SWSS_LOG_ENTER();
@@ -1870,7 +1858,6 @@ bool PortsOrch::setPortMtu(const Port& port, sai_uint32_t mtu)
     SWSS_LOG_INFO("Set MTU %u to port pid:%" PRIx64, attr.value.u32, port.m_port_id);
     return true;
 }
-
 
 bool PortsOrch::setPortTpid(Port &port, sai_uint16_t tpid)
 {
@@ -2704,7 +2691,6 @@ void PortsOrch::initPortSupportedSpeeds(const std::string& alias, sai_object_id_
     m_portStateTable.set(alias, v);
 }
 
-
 void PortsOrch::initPortCapAutoNeg(Port &port)
 {
     sai_status_t status;
@@ -3494,7 +3480,7 @@ string PortsOrch::getPriorityGroupDropPacketsFlexCounterTableKey(string key)
     return string(PG_DROP_STAT_COUNTER_FLEX_COUNTER_GROUP) + ":" + key;
 }
 
-bool PortsOrch::initPort(const PortConfig &port)
+bool PortsOrch::initPort(const PortConfig& port)
 {
     SWSS_LOG_ENTER();
 
@@ -3503,96 +3489,143 @@ bool PortsOrch::initPort(const PortConfig &port)
     const auto &index = port.index.value;
     const auto &lane_set = port.lanes.value;
 
-    /* Determine if the lane combination exists in switch */
-    if (m_portListLaneMap.find(lane_set) != m_portListLaneMap.end())
+    /* Determine if the port has already been initialized before */
+    auto it = m_portList.find(alias);
+    if (it != m_portList.end())
     {
-        sai_object_id_t id = m_portListLaneMap[lane_set];
-
-        /* Determine if the port has already been initialized before */
-        if (m_portList.find(alias) != m_portList.end() && m_portList[alias].m_port_id == id)
-        {
-            SWSS_LOG_DEBUG("Port has already been initialized before alias:%s", alias.c_str());
-        }
-        else
-        {
-            Port p(alias, Port::PHY);
-
-            p.m_index = index;
-            p.m_port_id = id;
-
-            /* Initialize the port and create corresponding host interface */
-            if (initializePort(p))
-            {
-                /* Create associated Gearbox lane mapping */
-                initGearboxPort(p);
-
-                /* Add port to port list */
-                m_portList[alias] = p;
-                saiOidToAlias[id] = alias;
-                m_port_ref_count[alias] = 0;
-                m_portOidToIndex[id] = index;
-
-                /* Add port name map to counter table */
-                FieldValueTuple tuple(p.m_alias, sai_serialize_object_id(p.m_port_id));
-                vector<FieldValueTuple> fields;
-                fields.push_back(tuple);
-                m_counterTable->set("", fields);
-
-                // Install a flex counter for this port to track stats
-                auto flex_counters_orch = gDirectory.get<FlexCounterOrch*>();
-                /* Delay installing the counters if they are yet enabled
-                If they are enabled, install the counters immediately */
-                if (flex_counters_orch->getPortCountersState())
-                {
-                    auto port_counter_stats = generateCounterStats(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP);
-                    port_stat_manager.setCounterIdList(p.m_port_id,
-                            CounterType::PORT, port_counter_stats);
-                    auto gbport_counter_stats = generateCounterStats(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, true);
-                    if (p.m_system_side_id)
-                        gb_port_stat_manager.setCounterIdList(p.m_system_side_id,
-                                CounterType::PORT, gbport_counter_stats, p.m_switch_id);
-                    if (p.m_line_side_id)
-                        gb_port_stat_manager.setCounterIdList(p.m_line_side_id,
-                                CounterType::PORT, gbport_counter_stats, p.m_switch_id);
-                }
-                if (flex_counters_orch->getPortBufferDropCountersState())
-                {
-                    auto port_buffer_drop_stats = generateCounterStats(PORT_BUFFER_DROP_STAT_FLEX_COUNTER_GROUP);
-                    port_buffer_drop_stat_manager.setCounterIdList(p.m_port_id, CounterType::PORT, port_buffer_drop_stats);
-                }
-
-                PortUpdate update = { p, true };
-                notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
-
-                m_portList[alias].m_init = true;
-
-                if (role == Port::Role::Rec || role == Port::Role::Inb)
-                {
-                    m_recircPortRole[alias] = role;
-                }
-
-                // We have to test the size of m_queue_ids here since it isn't initialized on some platforms (like DPU)
-                if (p.m_host_tx_queue_configured && p.m_queue_ids.size() > p.m_host_tx_queue)
-                {
-                    createPortBufferQueueCounters(p, to_string(p.m_host_tx_queue), false);
-                }
-
-                SWSS_LOG_NOTICE("Initialized port %s", alias.c_str());
-            }
-            else
-            {
-                SWSS_LOG_ERROR("Failed to initialize port %s", alias.c_str());
-                return false;
-            }
-        }
+        SWSS_LOG_DEBUG("Port has already been initialized before alias:%s", alias.c_str());
+        return true;
     }
-    else
+
+    /* Determine if the lane combination exists in switch */
+    if (m_portListLaneMap.find(lane_set) == m_portListLaneMap.end())
     {
         SWSS_LOG_ERROR("Failed to locate port lane combination alias:%s", alias.c_str());
         return false;
     }
 
-    return true;
+    sai_object_id_t id = m_portListLaneMap[lane_set];
+
+    Port p(alias, Port::PHY);
+    p.m_role = role;
+    p.m_index = index;
+    p.m_port_id = id;
+
+    // Read port speed of an already existing port
+    if (!isAutoNegEnabled(p.m_port_id) && !getPortSpeed(p.m_port_id, p.m_speed))
+    {
+        SWSS_LOG_ERROR("Failed to get initial port admin speed %d", p.m_speed);
+        return false;
+    }
+
+    return initPortsBulk({p});
+}
+
+bool PortsOrch::initPortsBulk(std::vector<Port> ports)
+{
+    SWSS_LOG_ENTER();
+
+    bool warmStart = WarmStart::isWarmStart();
+
+    bool status = true;
+
+    SWSS_LOG_TIMER(__FUNCTION__);
+
+    if (!initializePorts(ports))
+    {
+        status = false;
+    }
+
+    for (auto& p: ports)
+    {
+        const auto& alias = p.m_alias;
+
+        registerPort(p);
+
+        if (!warmStart)
+        {
+            postPortInit(m_portList[alias]);
+        }
+
+        SWSS_LOG_NOTICE("Initialized port %s", alias.c_str());
+    }
+
+    return status;
+}
+
+void PortsOrch::registerPort(Port &p)
+{
+    SWSS_LOG_ENTER();
+
+    const auto &alias = p.m_alias;
+    const auto &role = p.m_role;
+    const auto &index = p.m_index;
+    const auto id = p.m_port_id;
+
+    /* Create associated Gearbox lane mapping */
+    initGearboxPort(p);
+
+    /* Add port to port list */
+    m_portList[alias] = p;
+    saiOidToAlias[id] = alias;
+    m_port_ref_count[alias] = 0;
+    m_portOidToIndex[id] = index;
+
+    /* Add port name map to counter table */
+    FieldValueTuple tuple(p.m_alias, sai_serialize_object_id(p.m_port_id));
+    vector<FieldValueTuple> fields;
+    fields.push_back(tuple);
+    m_counterTable->set("", fields);
+
+    // Install a flex counter for this port to track stats
+    auto flex_counters_orch = gDirectory.get<FlexCounterOrch*>();
+    /* Delay installing the counters if they are yet enabled
+    If they are enabled, install the counters immediately */
+    if (flex_counters_orch->getPortCountersState())
+    {
+        auto port_counter_stats = generateCounterStats(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP);
+        port_stat_manager.setCounterIdList(p.m_port_id,
+                CounterType::PORT, port_counter_stats);
+        auto gbport_counter_stats = generateCounterStats(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, true);
+        if (p.m_system_side_id)
+            gb_port_stat_manager.setCounterIdList(p.m_system_side_id,
+                    CounterType::PORT, gbport_counter_stats, p.m_switch_id);
+        if (p.m_line_side_id)
+            gb_port_stat_manager.setCounterIdList(p.m_line_side_id,
+                    CounterType::PORT, gbport_counter_stats, p.m_switch_id);
+    }
+    if (flex_counters_orch->getPortBufferDropCountersState())
+    {
+        auto port_buffer_drop_stats = generateCounterStats(PORT_BUFFER_DROP_STAT_FLEX_COUNTER_GROUP);
+        port_buffer_drop_stat_manager.setCounterIdList(p.m_port_id, CounterType::PORT, port_buffer_drop_stats);
+    }
+
+    PortUpdate update = { p, true };
+    notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
+
+    m_portList[alias].m_init = true;
+
+    if (role == Port::Role::Rec || role == Port::Role::Inb)
+    {
+        m_recircPortRole[alias] = role;
+    }
+}
+
+void PortsOrch::postPortInit(Port& p)
+{
+    SWSS_LOG_ENTER();
+
+    initializeSchedulerGroups(p);
+    initializePortBufferMaximumParameters(p);
+
+    initPortSupportedSpeeds(p.m_alias, p.m_port_id);
+    initPortSupportedFecModes(p.m_alias, p.m_port_id);
+
+    // We have to test the size of m_queue_ids here since it isn't initialized on some platforms (like DPU)
+    if (p.m_host_tx_queue_configured && p.m_queue_ids.size() > p.m_host_tx_queue)
+    {
+        createPortBufferQueueCounters(p, to_string(p.m_host_tx_queue), false);
+    }
 }
 
 void PortsOrch::deInitPort(string alias, sai_object_id_t port_id)
@@ -3983,31 +4016,19 @@ void PortsOrch::doPortTask(Consumer &consumer)
                         continue;
                     }
 
-                    initPortSupportedSpeeds(it->second.key, m_portListLaneMap[it->first]);
-                    initPortSupportedFecModes(it->second.key, m_portListLaneMap[it->first]);
-
                     it++;
                 }
 
                 // Bulk port add
                 if (!portsToAddList.empty())
                 {
-                    if (!addPortBulk(portsToAddList))
+                    std::vector<Port> addedPorts;
+                    if (!addPortBulk(portsToAddList, addedPorts))
                     {
                         SWSS_LOG_THROW("PortsOrch initialization failure");
                     }
 
-                    for (const auto &cit : portsToAddList)
-                    {
-                        if (!initPort(cit))
-                        {
-                            // Failure has been recorded in initPort
-                            continue;
-                        }
-
-                        initPortSupportedSpeeds(cit.key, m_portListLaneMap[cit.lanes.value]);
-                        initPortSupportedFecModes(cit.key, m_portListLaneMap[cit.lanes.value]);
-                    }
+                    initPortsBulk(addedPorts);
                 }
 
                 setPortConfigState(PORT_CONFIG_DONE);
@@ -5617,6 +5638,25 @@ void PortsOrch::doTask()
     }
 }
 
+void PortsOrch::onWarmBootEnd()
+{
+    SWSS_LOG_ENTER();
+
+    /* Start dynamic state sync up */
+    refreshPortStatus();
+
+    // Do post boot port initialization
+    for (auto& it: m_portList)
+    {
+        Port& port = it.second;
+
+        if (port.m_type == Port::PHY)
+        {
+            postPortInit(it.second);
+        }
+    }
+}
+
 void PortsOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
@@ -5707,48 +5747,147 @@ void PortsOrch::initializeVoqs(Port &port)
     SWSS_LOG_INFO("Get voqs for port %s", port.m_alias.c_str());
 }
 
-void PortsOrch::initializeQueues(Port &port)
+bool PortsOrch::initializePorts(std::vector<Port>& ports)
 {
     SWSS_LOG_ENTER();
 
-    sai_attribute_t attr;
-    attr.id = SAI_PORT_ATTR_QOS_NUMBER_OF_QUEUES;
-    sai_status_t status = sai_port_api->get_port_attribute(port.m_port_id, 1, &attr);
-    if (status != SAI_STATUS_SUCCESS)
+    bool status = true;
+
+    if (gMySwitchType != "dpu")
     {
-        SWSS_LOG_ERROR("Failed to get number of queues for port %s rv:%d", port.m_alias.c_str(), status);
-        task_process_status handle_status = handleSaiGetStatus(SAI_API_PORT, status);
-        if (handle_status != task_process_status::task_success)
+        initializePriorityGroupsBulk(ports);
+        initializeQueuesBulk(ports);
+    }
+
+    /* initialize port host_tx_ready value (only for supporting systems) */
+    if (m_cmisModuleAsicSyncSupported)
+    {
+        initializePortHostTxReadyBulk(ports);
+    }
+
+    // Create host interfaces
+    for (auto iter = ports.begin(); iter != ports.end();)
+    {
+        Port& port = *iter;
+
+        /* Check warm start states */
+        vector<FieldValueTuple> tuples;
+        bool exist = m_portTable->get(port.m_alias, tuples);
+        string operStatus, flapCount = "0";
+        if (exist)
         {
-            throw runtime_error("PortsOrch initialization failure.");
+            for (auto i : tuples)
+            {
+                if (fvField(i) == "oper_status")
+                {
+                    operStatus = fvValue(i);
+                }
+
+                if (fvField(i) == "flap_count")
+                {
+                    flapCount = fvValue(i);
+                }
+            }
         }
-    }
-    SWSS_LOG_INFO("Get %d queues for port %s", attr.value.u32, port.m_alias.c_str());
 
-    port.m_queue_ids.resize(attr.value.u32);
-    port.m_queue_lock.resize(attr.value.u32);
+        SWSS_LOG_INFO("Port %s with oper %s flap_count=%s", port.m_alias.c_str(), operStatus.c_str(), flapCount.c_str());
 
-    if (attr.value.u32 == 0)
-    {
-        return;
-    }
-
-    attr.id = SAI_PORT_ATTR_QOS_QUEUE_LIST;
-    attr.value.objlist.count = (uint32_t)port.m_queue_ids.size();
-    attr.value.objlist.list = port.m_queue_ids.data();
-
-    status = sai_port_api->get_port_attribute(port.m_port_id, 1, &attr);
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_ERROR("Failed to get queue list for port %s rv:%d", port.m_alias.c_str(), status);
-        task_process_status handle_status = handleSaiGetStatus(SAI_API_PORT, status);
-        if (handle_status != task_process_status::task_success)
+        /**
+         * Create database port oper status as DOWN if attr missing
+         * This status will be updated upon receiving port_oper_status_notification.
+         */
+        if (operStatus == "up")
         {
-            throw runtime_error("PortsOrch initialization failure.");
+            port.m_oper_status = SAI_PORT_OPER_STATUS_UP;
         }
+        else if (operStatus.empty())
+        {
+            port.m_oper_status = SAI_PORT_OPER_STATUS_DOWN;
+            /* Fill oper_status in db with default value "down" */
+            m_portTable->hset(port.m_alias, "oper_status", "down");
+        }
+        else
+        {
+            port.m_oper_status = SAI_PORT_OPER_STATUS_DOWN;
+        }
+
+        // initalize port flap count
+        if (!flapCount.empty())
+        {
+            try
+            {
+                port.m_flap_count = stoull(flapCount);
+                m_portTable->hset(port.m_alias, "flap_count", flapCount);
+            }
+            catch (const std::exception &e)
+            {
+                SWSS_LOG_ERROR("Failed to get port (%s) flap_count: %s", port.m_alias.c_str(), e.what());
+            }
+        }
+
+        /*
+        * always initialize Port SAI_HOSTIF_ATTR_OPER_STATUS based on oper_status value in appDB.
+        */
+        bool isUp = port.m_oper_status == SAI_PORT_OPER_STATUS_UP;
+
+        /* Create host interface */
+        if (!addHostIntfs(port, port.m_alias, port.m_hif_id, isUp))
+        {
+            SWSS_LOG_ERROR("Failed to create host interface for port %s", port.m_alias.c_str());
+            iter = ports.erase(iter);
+            status = false;
+            continue;
+        }
+
+        iter++;
     }
 
-    SWSS_LOG_INFO("Get queues for port %s", port.m_alias.c_str());
+    return status;
+}
+
+void PortsOrch::initializePortHostTxReadyBulk(std::vector<Port>& ports)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_TIMER(__FUNCTION__);
+
+    const auto portCount = static_cast<uint32_t>(ports.size());
+
+    PortBulker bulker(portCount);
+
+    for (auto& port: ports)
+    {
+        sai_attribute_t attr;
+        attr.id = SAI_PORT_ATTR_HOST_TX_READY_STATUS;
+        bulker.add(port.m_port_id, attr);
+    }
+
+    bulker.executeGet();
+
+    size_t idx = 0;
+    for (auto& port: ports)
+    {
+        const auto status = bulker.statuses[idx];
+        const auto& attr = bulker.attrList[idx];
+
+        idx++;
+
+        bool hostTxReady = false;
+
+        if (status == SAI_STATUS_SUCCESS)
+        {
+            hostTxReady = attr.value.booldata;
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Failed to get host_tx_ready value from SAI to Port %" PRIx64 , port.m_port_id);
+        }
+
+        string hostTxReadyStr = hostTxReady ? "true" : "false";
+
+        SWSS_LOG_DEBUG("Received host_tx_ready current status: port_id: 0x%" PRIx64 " status: %s", port.m_port_id, hostTxReadyStr.c_str());
+        setHostTxReady(port, hostTxReadyStr);
+    }
 }
 
 void PortsOrch::initializeSchedulerGroups(Port &port)
@@ -5795,46 +5934,167 @@ void PortsOrch::initializeSchedulerGroups(Port &port)
     SWSS_LOG_INFO("Got scheduler groups for port %s", port.m_alias.c_str());
 }
 
-void PortsOrch::initializePriorityGroups(Port &port)
+void PortsOrch::initializePriorityGroupsBulk(std::vector<Port>& ports)
 {
     SWSS_LOG_ENTER();
 
-    sai_attribute_t attr;
-    attr.id = SAI_PORT_ATTR_NUMBER_OF_INGRESS_PRIORITY_GROUPS;
-    sai_status_t status = sai_port_api->get_port_attribute(port.m_port_id, 1, &attr);
-    if (status != SAI_STATUS_SUCCESS)
+    SWSS_LOG_TIMER(__FUNCTION__);
+
+    const auto portCount = static_cast<uint32_t>(ports.size());
+
+    // Query number of ingress priority groups
     {
-        SWSS_LOG_ERROR("Failed to get number of priority groups for port %s rv:%d", port.m_alias.c_str(), status);
-        task_process_status handle_status = handleSaiGetStatus(SAI_API_PORT, status);
-        if (handle_status != task_process_status::task_success)
+        PortBulker bulker(portCount);
+
+        for (const auto& port: ports)
         {
-            throw runtime_error("PortsOrch initialization failure.");
+            sai_attribute_t attr;
+            attr.id = SAI_PORT_ATTR_NUMBER_OF_INGRESS_PRIORITY_GROUPS;
+            bulker.add(port.m_port_id, attr);
+        }
+
+        bulker.executeGet();
+
+        size_t idx = 0;
+        for (auto& port: ports)
+        {
+            const auto status = bulker.statuses[idx];
+            const auto& attr = bulker.attrList[idx];
+
+            idx++;
+
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to get number of priority groups for port %s rv:%d", port.m_alias.c_str(), status);
+                handleSaiGetStatus(SAI_API_PORT, status);
+                throw runtime_error("PortsOrch initialization failure.");
+            }
+
+            SWSS_LOG_INFO("Get %d priority groups for port %s", attr.value.u32, port.m_alias.c_str());
+            port.m_priority_group_ids.resize(attr.value.u32);
         }
     }
-    SWSS_LOG_INFO("Get %d priority groups for port %s", attr.value.u32, port.m_alias.c_str());
 
-    port.m_priority_group_ids.resize(attr.value.u32);
-
-    if (attr.value.u32 == 0)
+    // Query ingress priority groups lists
     {
-        return;
-    }
+        PortBulker bulker(portCount);
 
-    attr.id = SAI_PORT_ATTR_INGRESS_PRIORITY_GROUP_LIST;
-    attr.value.objlist.count = (uint32_t)port.m_priority_group_ids.size();
-    attr.value.objlist.list = port.m_priority_group_ids.data();
-
-    status = sai_port_api->get_port_attribute(port.m_port_id, 1, &attr);
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_ERROR("Fail to get priority group list for port %s rv:%d", port.m_alias.c_str(), status);
-        task_process_status handle_status = handleSaiGetStatus(SAI_API_PORT, status);
-        if (handle_status != task_process_status::task_success)
+        for (auto& port: ports)
         {
-            throw runtime_error("PortsOrch initialization failure.");
+            sai_attribute_t attr;
+
+            if (port.m_priority_group_ids.size() == 0)
+            {
+                continue;
+            }
+
+            attr.id = SAI_PORT_ATTR_INGRESS_PRIORITY_GROUP_LIST;
+            attr.value.objlist.list = port.m_priority_group_ids.data();
+            attr.value.objlist.count = static_cast<uint32_t>(port.m_priority_group_ids.size());
+            bulker.add(port.m_port_id, attr);
+        }
+
+        bulker.executeGet();
+
+        size_t idx = 0;
+        for (auto& port: ports)
+        {
+            const auto status = bulker.statuses[idx];
+
+            idx++;
+
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Fail to get priority group list for port %s rv:%d", port.m_alias.c_str(), status);
+                handleSaiGetStatus(SAI_API_PORT, status);
+                throw runtime_error("PortsOrch initialization failure.");
+            }
+
+            SWSS_LOG_INFO("Get priority groups for port %s", port.m_alias.c_str());
         }
     }
-    SWSS_LOG_INFO("Get priority groups for port %s", port.m_alias.c_str());
+}
+
+void PortsOrch::initializeQueuesBulk(std::vector<Port>& ports)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_TIMER(__FUNCTION__);
+
+    const auto portCount = static_cast<uint32_t>(ports.size());
+
+    // Query number of queues
+    {
+        PortBulker bulker(portCount);
+
+        for (auto& port: ports)
+        {
+            sai_attribute_t attr;
+            attr.id = SAI_PORT_ATTR_QOS_NUMBER_OF_QUEUES;
+            bulker.add(port.m_port_id, attr);
+        }
+
+        bulker.executeGet();
+
+        size_t idx = 0;
+        for (auto& port: ports)
+        {
+            const auto status = bulker.statuses[idx];
+            const auto& attr = bulker.attrList[idx];
+
+            idx++;
+
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to get number of queues for port %s rv:%d", port.m_alias.c_str(), status);
+                handleSaiGetStatus(SAI_API_PORT, status);
+                throw runtime_error("PortsOrch initialization failure.");
+            }
+
+            SWSS_LOG_INFO("Get %d queues for port %s", attr.value.u32, port.m_alias.c_str());
+            port.m_queue_ids.resize(attr.value.u32);
+            port.m_queue_lock.resize(attr.value.u32);
+        }
+    }
+
+    // Query queue lists
+    {
+        PortBulker bulker(portCount);
+
+        for (auto& port: ports)
+        {
+            sai_attribute_t attr;
+
+            if (port.m_queue_ids.size() == 0)
+            {
+                continue;
+            }
+
+            attr.id = SAI_PORT_ATTR_QOS_QUEUE_LIST;
+            attr.value.objlist.list = port.m_queue_ids.data();
+            attr.value.objlist.count = static_cast<uint32_t>(port.m_queue_ids.size());
+            bulker.add(port.m_port_id, attr);
+        }
+
+        bulker.executeGet();
+
+        size_t idx = 0;
+        for (auto& port: ports)
+        {
+            const auto status = bulker.statuses[idx];
+
+            idx++;
+
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Fail to get queue list for port %s rv:%d", port.m_alias.c_str(), status);
+                handleSaiGetStatus(SAI_API_PORT, status);
+                throw runtime_error("PortsOrch initialization failure.");
+            }
+
+            SWSS_LOG_INFO("Get queues for port %s", port.m_alias.c_str());
+        }
+    }
 }
 
 void PortsOrch::initializePortBufferMaximumParameters(Port &port)
@@ -5861,132 +6121,7 @@ void PortsOrch::initializePortBufferMaximumParameters(Port &port)
     m_stateBufferMaximumValueTable->set(port.m_alias, fvVector);
 }
 
-bool PortsOrch::initializePort(Port &port)
-{
-    SWSS_LOG_ENTER();
-
-    SWSS_LOG_NOTICE("Initializing port alias:%s pid:%" PRIx64, port.m_alias.c_str(), port.m_port_id);
-
-    if (gMySwitchType != "dpu")
-    {
-        initializePriorityGroups(port);
-        initializeQueues(port);
-        initializeSchedulerGroups(port);
-        initializePortBufferMaximumParameters(port);
-    }
-
-    /* Create host interface */
-    if (!addHostIntfs(port, port.m_alias, port.m_hif_id))
-    {
-        SWSS_LOG_ERROR("Failed to create host interface for port %s", port.m_alias.c_str());
-        return false;
-    }
-
-    /* Check warm start states */
-    vector<FieldValueTuple> tuples;
-    bool exist = m_portTable->get(port.m_alias, tuples);
-    string operStatus, flapCount = "0";
-    if (exist)
-    {
-        for (auto i : tuples)
-        {
-            if (fvField(i) == "oper_status")
-            {
-                operStatus = fvValue(i);
-            }
-
-            if (fvField(i) == "flap_count")
-            {
-                flapCount = fvValue(i);
-            }
-        }
-    }
-    SWSS_LOG_INFO("Port %s with oper %s flap_count=%s", port.m_alias.c_str(), operStatus.c_str(), flapCount.c_str());
-
-    /**
-     * Create database port oper status as DOWN if attr missing
-     * This status will be updated upon receiving port_oper_status_notification.
-     */
-    if (operStatus == "up")
-    {
-        port.m_oper_status = SAI_PORT_OPER_STATUS_UP;
-    }
-    else if (operStatus.empty())
-    {
-        port.m_oper_status = SAI_PORT_OPER_STATUS_DOWN;
-        /* Fill oper_status in db with default value "down" */
-        m_portTable->hset(port.m_alias, "oper_status", "down");
-    }
-    else
-    {
-        port.m_oper_status = SAI_PORT_OPER_STATUS_DOWN;
-    }
-
-    // initalize port flap count
-    if (!flapCount.empty())
-    {
-        try
-        {
-            port.m_flap_count = stoull(flapCount);
-            m_portTable->hset(port.m_alias, "flap_count", flapCount);
-        }
-        catch (const std::exception &e)
-        {
-            SWSS_LOG_ERROR("Failed to get port (%s) flap_count: %s", port.m_alias.c_str(), e.what());
-        }
-    }
-
-    /* initialize port admin status */
-    if (!getPortAdminStatus(port.m_port_id, port.m_admin_state_up))
-    {
-        SWSS_LOG_ERROR("Failed to get initial port admin status %s", port.m_alias.c_str());
-        return false;
-    }
-
-    /* initialize port admin speed */
-    if (!isAutoNegEnabled(port.m_port_id) && !getPortSpeed(port.m_port_id, port.m_speed))
-    {
-        SWSS_LOG_ERROR("Failed to get initial port admin speed %d", port.m_speed);
-        return false;
-    }
-
-    /* initialize port mtu */
-    if (!getPortMtu(port, port.m_mtu))
-    {
-        SWSS_LOG_ERROR("Failed to get initial port mtu %d", port.m_mtu);
-    }
-
-    /* initialize port host_tx_ready value (only for supporting systems) */
-    if (m_cmisModuleAsicSyncSupported)
-    {
-        bool hostTxReadyVal;
-        if (!getPortHostTxReady(port, hostTxReadyVal))
-        {
-            SWSS_LOG_ERROR("Failed to get host_tx_ready value from SAI to Port %" PRIx64 , port.m_port_id);
-        }
-        /* set value to state DB */
-
-        string hostTxReadyStr = hostTxReadyVal ? "true" : "false";
-
-        SWSS_LOG_DEBUG("Received host_tx_ready current status: port_id: 0x%" PRIx64 " status: %s", port.m_port_id, hostTxReadyStr.c_str());
-        setHostTxReady(port, hostTxReadyStr);
-    }
-
-    /*
-     * always initialize Port SAI_HOSTIF_ATTR_OPER_STATUS based on oper_status value in appDB.
-     */
-    bool isUp = port.m_oper_status == SAI_PORT_OPER_STATUS_UP;
-    if (!setHostIntfsOperStatus(port, isUp))
-    {
-        SWSS_LOG_WARN("Failed to set operation status %s to host interface %s",
-                      operStatus.c_str(), port.m_alias.c_str());
-        return false;
-    }
-
-    return true;
-}
-
-bool PortsOrch::addHostIntfs(Port &port, string alias, sai_object_id_t &host_intfs_id)
+bool PortsOrch::addHostIntfs(Port &port, string alias, sai_object_id_t &host_intfs_id, bool up)
 {
     SWSS_LOG_ENTER();
 
@@ -6020,6 +6155,13 @@ bool PortsOrch::addHostIntfs(Port &port, string alias, sai_object_id_t &host_int
         port.m_host_tx_queue_configured = true;
     }
 
+    if (up)
+    {
+        attr.id = SAI_HOSTIF_ATTR_OPER_STATUS;
+        attr.value.booldata = up;
+        attrs.push_back(attr);
+    }
+
     sai_status_t status = sai_hostif_api->create_hostif(&host_intfs_id, gSwitchId, (uint32_t)attrs.size(), attrs.data());
     if (status != SAI_STATUS_SUCCESS)
     {
@@ -6029,6 +6171,15 @@ bool PortsOrch::addHostIntfs(Port &port, string alias, sai_object_id_t &host_int
         {
             return parseHandleSaiStatusFailure(handle_status);
         }
+    }
+
+    if (up)
+    {
+        SWSS_LOG_NOTICE("Set operation status %s to host interface %s",
+                up ? "UP" : "DOWN", port.m_alias.c_str());
+
+        event_params_t params = {{"ifname",port.m_alias},{"status", up ? "up" : "down"}};
+        event_publish(g_events_handle, "if-state", &params);
     }
 
     SWSS_LOG_NOTICE("Create host interface for port %s", alias.c_str());

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3562,6 +3562,8 @@ bool PortsOrch::initExistingPort(const PortConfig& port)
 
     if (gMySwitchType != "dpu")
     {
+        /* Query scheduler groups to work around an issue where scheduler groups get removed after SWSS warm restart.
+         * https://github.com/sonic-net/sonic-swss/pull/2174 for more details. */
         initializeSchedulerGroups(p);
     }
 

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -397,7 +397,7 @@ private:
     bool setDistributionOnLagMember(Port &lagMember, bool enableDistribution);
 
     sai_status_t removePort(sai_object_id_t port_id);
-    bool initPort(const PortConfig &port);
+    bool initExistingPort(const PortConfig &port);
 
     bool initPortsBulk(std::vector<Port> ports);
 
@@ -411,6 +411,8 @@ private:
     void initPortCapLinkTraining(Port &port);
 
     bool setPortAdminStatus(Port &port, bool up);
+    bool getPortAdminStatus(sai_object_id_t id, bool& up);
+    bool getPortMtu(const Port& port, sai_uint32_t &mtu);
     bool getPortHostTxReady(const Port& port, bool &hostTxReadyVal);
     bool setPortMtu(const Port& port, sai_uint32_t mtu);
     bool setPortTpid(Port &port, sai_uint16_t tpid);

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -376,7 +376,7 @@ private:
     void initializeQueuesBulk(std::vector<Port>& ports);
     void initializePortHostTxReadyBulk(std::vector<Port>& ports);
 
-    void initializePortBufferMaximumParameters(Port &port);
+    void initializePortBufferMaximumParameters(const Port &port);
     void initializeSchedulerGroups(Port &port);
     void initializeVoqs(Port &port);
 
@@ -399,11 +399,11 @@ private:
     sai_status_t removePort(sai_object_id_t port_id);
     bool initExistingPort(const PortConfig &port);
 
-    bool initPortsBulk(std::vector<Port> ports);
+    bool initPortsBulk(std::vector<Port>& ports);
 
     void registerPort(Port &p);
 
-    void postPortInit(Port &p);
+    void postPortInit(const Port &p);
     
     void deInitPort(string alias, sai_object_id_t port_id);
 

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -23,7 +23,6 @@
 
 #define FCS_LEN 4
 #define VLAN_TAG_LEN 4
-#define MAX_MACSEC_SECTAG_SIZE 32
 #define PORT_STAT_COUNTER_FLEX_COUNTER_GROUP "PORT_STAT_COUNTER"
 #define PORT_RATE_COUNTER_FLEX_COUNTER_GROUP "PORT_RATE_COUNTER"
 #define PORT_BUFFER_DROP_STAT_FLEX_COUNTER_GROUP "PORT_BUFFER_DROP_STAT"
@@ -353,6 +352,7 @@ private:
     bool m_cmisModuleAsicSyncSupported = false;
 
     void doTask() override;
+    void onWarmBootEnd() override;
     void doTask(Consumer &consumer);
     void doPortTask(Consumer &consumer);
     void doSendToIngressPortTask(Consumer &consumer);
@@ -370,14 +370,17 @@ private:
     void removeDefaultVlanMembers();
     void removeDefaultBridgePorts();
 
-    bool initializePort(Port &port);
-    void initializePriorityGroups(Port &port);
+    bool initializePorts(std::vector<Port>& ports);
+
+    void initializePriorityGroupsBulk(std::vector<Port>& ports);
+    void initializeQueuesBulk(std::vector<Port>& ports);
+    void initializePortHostTxReadyBulk(std::vector<Port>& ports);
+
     void initializePortBufferMaximumParameters(Port &port);
-    void initializeQueues(Port &port);
     void initializeSchedulerGroups(Port &port);
     void initializeVoqs(Port &port);
 
-    bool addHostIntfs(Port &port, string alias, sai_object_id_t &host_intfs_id);
+    bool addHostIntfs(Port &port, string alias, sai_object_id_t &host_intfs_id, bool up = false);
     bool setHostIntfsStripTag(Port &port, sai_hostif_vlan_tag_t strip);
 
     bool setBridgePortLearnMode(Port &port, sai_bridge_port_fdb_learning_mode_t learn_mode);
@@ -395,14 +398,19 @@ private:
 
     sai_status_t removePort(sai_object_id_t port_id);
     bool initPort(const PortConfig &port);
+
+    bool initPortsBulk(std::vector<Port> ports);
+
+    void registerPort(Port &p);
+
+    void postPortInit(Port &p);
+    
     void deInitPort(string alias, sai_object_id_t port_id);
 
     void initPortCapAutoNeg(Port &port);
     void initPortCapLinkTraining(Port &port);
 
     bool setPortAdminStatus(Port &port, bool up);
-    bool getPortAdminStatus(sai_object_id_t id, bool& up);
-    bool getPortMtu(const Port& port, sai_uint32_t &mtu);
     bool getPortHostTxReady(const Port& port, bool &hostTxReadyVal);
     bool setPortMtu(const Port& port, sai_uint32_t mtu);
     bool setPortTpid(Port &port, sai_uint16_t tpid);
@@ -537,7 +545,7 @@ private:
     auto getPortConfigState() const -> port_config_state_t;
     void setPortConfigState(port_config_state_t value);
 
-    bool addPortBulk(const std::vector<PortConfig> &portList);
+    bool addPortBulk(const std::vector<PortConfig> &portList, std::vector<Port>& addedPorts);
     bool removePortBulk(const std::vector<sai_object_id_t> &portList);
 
     /* Prototypes for Path Tracing */


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

DEPENDS ON: https://github.com/sonic-net/sonic-sairedis/pull/1509

**What I did**

Optimized port initialization process using the following approach:
1. Attributes that are known at initialization (whether because their default values are defined by the SAI spec or because we created the port with a value we already know) like speed and MTU.
2. Heavy operations like querying list of PGs and queues are done in bulk to save on SAIRedis call overhead.
3. Port initialization that has no dependncy on subsequent data plane configuration are extracted into a seperate "post initialization" routine and executed after data plane configuration is done.
4. Save SAI set API call when possible to provide a value during creation.

**Why I did it**

To improve boot time for systems with many ports.

**How I verified it**

Ran fast-reboot and measure. Observed 45% reduction in time.

**Details if related**
