### PR TITLE
Fix the switch level Voq counter to use switch_id Oid instead of counter name for PACKET_INTEGRITY counter

### DIFF
--- a/orchagent/fabricportsorch.cpp
+++ b/orchagent/fabricportsorch.cpp
@@ -29,7 +29,7 @@
 #define SWITCH_DEBUG_COUNTER_FLEX_COUNTER_GROUP  "SWITCH_DEBUG_COUNTER"
 #define SWITCH_DEBUG_COUNTER_POLLING_INTERVAL_MS 500
 #define FABRIC_SWITCH_DEBUG_COUNTER_POLLING_INTERVAL_MS 60000
-#define SWITCH_STANDARD_DROP_COUNTERS  "SWITCH_STD_DROP_COUNTER-"
+#define SWITCH_STANDARD_DROP_COUNTERS  "SWITCH_ID"
 
 // constants for link monitoring
 #define MAX_SKIP_CRCERR_ON_LNKUP_POLLS 20
@@ -1589,9 +1589,11 @@ void FabricPortsOrch::createSwitchDropCounters(void)
     {
          std::string drop_stats = sai_serialize_switch_stat(it);
          counter_stats.emplace(drop_stats);
-         vector<FieldValueTuple> switchNameSwitchCounterMap;
-         switchNameSwitchCounterMap.emplace_back((SWITCH_STANDARD_DROP_COUNTERS + drop_stats), drop_stats);
-         m_counterNameToSwitchStatMap->set("", switchNameSwitchCounterMap);
     }
+    const auto switch_id= sai_serialize_object_id(gSwitchId);
+    vector<FieldValueTuple> switchNameSwitchCounterMap;
+    switchNameSwitchCounterMap.emplace_back(SWITCH_STANDARD_DROP_COUNTERS, switch_id);
+    m_counterNameToSwitchStatMap->set("", switchNameSwitchCounterMap);
+
     switch_drop_counter_manager->setCounterIdList(gSwitchId, CounterType::SWITCH_DEBUG, counter_stats);
 }

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -1283,14 +1283,14 @@ class TestVirtualChassis(object):
                       value = drop_entry.get("SWITCH_DEBUG_COUNTER_ID_LIST")
                       assert value == "SAI_SWITCH_STAT_PACKET_INTEGRITY_DROP", "Got error in getting Voq Switch Drop counter from FLEX_COUNTER_DB"
 
-                cntr_db = dvs.get_counters_db()
-                stat_name_entry = cntr_db.get_entry("COUNTERS_DEBUG_NAME_SWITCH_STAT_MAP", "")
-                value = stat_name_entry.get("SWITCH_STD_DROP_COUNTER-SAI_SWITCH_STAT_PACKET_INTEGRITY_DROP")
-                assert value == "SAI_SWITCH_STAT_PACKET_INTEGRITY_DROP", "Got error in getting Voq Switch Drop counter name map from COUNTERS_DB"
-
                 asic_db = dvs.get_asic_db()
                 keys = asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_SWITCH")
                 switch_oid_key = keys[0]
+                cntr_db = dvs.get_counters_db()
+                stat_name_entry = cntr_db.get_entry("COUNTERS_DEBUG_NAME_SWITCH_STAT_MAP", "")
+                value = stat_name_entry.get("SWITCH_ID")
+                assert value == switch_oid_key, "Wrong Switch Id"
+
                 stat_entry = cntr_db.get_entry("COUNTERS", switch_oid_key)
                 value = stat_entry.get("SAI_SWITCH_STAT_PACKET_INTEGRITY_DROP")
                 assert value == "0", "SAI_SWITCH_STAT_PACKET_INTEGRITY_DROP is non zero in COUNTERS_DB"


### PR DESCRIPTION
…

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix the switch level Voq counter to use switch_id Oid instead of counter name for PACKET_INTEGRITY counter
**Why I did it**
The counter:oid table was using switch_id oid, but the COUNTERS_DEBUG_NAME_SWITCH_STAT_MAP was adding the counter name instead of the switch_id oid. So changed the COUNTERS_DEBUG_NAME_SWITCH_STAT_MAP to set the switch_id oid so that using the switch_id, the counters:oid:<switch-id-id> can be queried to get the counters for the packet_integrity counters.

**How I verified it**
Verified by dumping the counters_db tables and the show command
admin@ixre-egl-board7: sudo ip netns exec asic0 sonic-db-dump -n COUNTERS_DB -y -k "*SWITCH*"
{
  "COUNTERS_DEBUG_NAME_SWITCH_STAT_MAP": {
    "expireat": 1739911359.7264578,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "SWITCH_ID": "oid:0x21000000000000"
    }
  }
}admin@ixre-egl-board7:
admin@ixre-egl-board7: sudo ip netns exec asic0 sonic-db-dump -n COUNTERS_DB -y -k "COUNTERS:oid:0x21000000000000"
{
  "COUNTERS:oid:0x21000000000000": {
    "expireat": 1739911363.9230428,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "SAI_SWITCH_STAT_PACKET_INTEGRITY_DROP": "474"
    }
  }
}
**Details if related**
