### PR TITLE
Add PFC historical statistics estimation to the PFCWD Orch

### DIFF
--- a/orchagent/pfcwdorch.h
+++ b/orchagent/pfcwdorch.h
@@ -40,7 +40,7 @@ public:
 
     virtual void doTask(Consumer& consumer);
     virtual bool startWdOnPort(const Port& port,
-            uint32_t detectionTime, uint32_t restorationTime, PfcWdAction action) = 0;
+            uint32_t detectionTime, uint32_t restorationTime, PfcWdAction action, string pfcStatHistory) = 0;
     virtual bool stopWdOnPort(const Port& port) = 0;
 
     shared_ptr<Table> getCountersTable(void)
@@ -89,7 +89,7 @@ public:
 
     void doTask(Consumer& consumer) override;
     virtual bool startWdOnPort(const Port& port,
-            uint32_t detectionTime, uint32_t restorationTime, PfcWdAction action);
+            uint32_t detectionTime, uint32_t restorationTime, PfcWdAction action, string pfcStatHistory);
     virtual bool stopWdOnPort(const Port& port);
 
     task_process_status createEntry(const string& key, const vector<FieldValueTuple>& data) override;
@@ -121,7 +121,7 @@ private:
     template <typename T>
     static unordered_set<string> counterIdsToStr(const vector<T> ids, string (*convert)(T));
     bool registerInWdDb(const Port& port,
-            uint32_t detectionTime, uint32_t restorationTime, PfcWdAction action);
+            uint32_t detectionTime, uint32_t restorationTime, PfcWdAction action, string pfcStatHistory);
     void unregisterFromWdDb(const Port& port);
     void doTask(swss::NotificationConsumer &wdNotification);
 


### PR DESCRIPTION
pfcwdorch has been updated to allow pfc historical statistic estimation. The orch allows the feature to be enabled or disabled and the pfc_detect_broadcom.lua script will perform the estimation and update counters_db for ports that tracking is enabled on.

This implementation was made in accordance with comments from the community HLD review
https://zoom.us/rec/share/jWkZRs51QULsDQvrSlm-5qC4OZ3gkG6RVdB2k_vqwgLcnezsaG1XtX5Aqk6xBYCZ.YMhHymrP4jbpkLbm

HLD: https://github.com/sonic-net/SONiC/pull/1903

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Edited the pfcwdorch and the pfc_detect_broadcom.lua to allow enable/disable-able PFC statistical history tracking.

**Why I did it**
Part of the PFC Historical Statistics Feature: https://github.com/sonic-net/SONiC/issues/1904

**How I verified it**
- New Unit tests added for the pfcwdorch to ensure it correctly enables the feature
- Manual testing was performed on a SONiC switch to verify that the script and orchagent worked as expected when receiving generated pause frames

**Details if related**
