### PR TITLE
Change VLAN_TABLE priority as same as VLAN_MEMBER_TABLE.

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -188,7 +188,7 @@ bool OrchDaemon::init()
     vector<table_name_with_pri_t> ports_tables = {
         { APP_PORT_TABLE_NAME,        portsorch_base_pri + 5 },
         { APP_SEND_TO_INGRESS_PORT_TABLE_NAME,        portsorch_base_pri + 5 },
-        { APP_VLAN_TABLE_NAME,        portsorch_base_pri + 2 },
+        { APP_VLAN_TABLE_NAME,        portsorch_base_pri     },
         { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri     },
         { APP_LAG_TABLE_NAME,         portsorch_base_pri + 4 },
         { APP_LAG_MEMBER_TABLE_NAME,  portsorch_base_pri     }


### PR DESCRIPTION
Change VLAN_TABLE priority as same as VLAN_MEMBER_TABLE.

#### Why I did it
Fix issue https://github.com/sonic-net/sonic-buildimage/issues/20941
This issue caused by 2 reason:
1. VLAN_TABLE has higher priority than VLAN_MEMBER_TABLE
2. select return object by recent used time, it should return by event happen time. this issue fix by another PR: https://github.com/sonic-net/sonic-swss-common/pull/981

#### How I did it
Change VLAN_TABLE has same priority with VLAN_MEMBER_TABLE


##### Work item tracking
- Microsoft ADO: 30468564
- 
#### How to verify it
Pass all test cases.
Manually build a POC and verify with following test steps:

sudo config vlan add 4094
sudo config vlan member add 4094 Ethernet64

sudo kill -s SIGSTOP $(pgrep -f /usr/bin/orchagent)

sudo config vlan member del 4094 Ethernet64
sudo config vlan del 4094

sudo truncate -s 0 /var/log/syslog
sudo kill -s SIGCONT $(pgrep -f /usr/bin/orchagent)
sudo cat /var/log/syslog

Result:

// VLAN_MEMBER delete event happen first and pop first:
2025 Feb 27 02:06:51.606321 vlab-01 NOTICE swss#orchagent: :- removeVlanMember: Remove member Ethernet64 from VLAN Vlan4094 lid:ffe vmid:2700000000069e
2025 Feb 27 02:06:51.606687 vlab-01 NOTICE swss#orchagent: :- flushFdbEntries: flush key: SAI_OBJECT_TYPE_FDB_FLUSH:oid:0x21000000000000, fields: 3
2025 Feb 27 02:06:51.606769 vlab-01 NOTICE swss#orchagent: :- recordFlushFdbEntries: flush key: SAI_OBJECT_TYPE_FDB_FLUSH:oid:0x21000000000000, fields: 3


2025 Feb 27 02:06:51.689459 vlab-01 NOTICE swss#orchagent: :- removeVlan: Remove VLAN Vlan4094 vid:4094
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Change VLAN_TABLE priority as same as VLAN_MEMBER_TABLE.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

