### PR TITLE
Initialize Port oper error status map only once

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -869,18 +869,18 @@ void PortsOrch::initializePortOperErrors(Port &port)
 {
     SWSS_LOG_ENTER();
 
-    SWSS_LOG_NOTICE("Initialize port oper errors for port %s", port.m_alias.c_str());
-
     for (auto& error : PortOperErrorEvent::db_key_errors)
     {
         const sai_port_error_status_t error_status = error.first;
         std::string error_name = error.second;
-
-        port.m_portOperErrorToEvent[error_status] = PortOperErrorEvent(error_status, error_name);
-        SWSS_LOG_NOTICE("Initialize port %s error %s flag=0x%" PRIx32,
-                                        port.m_alias.c_str(),
-                                        error_name.c_str(),
-                                        error_status);
+        if (port.m_portOperErrorToEvent.find(error_status) == port.m_portOperErrorToEvent.end())
+        {
+            port.m_portOperErrorToEvent[error_status] = PortOperErrorEvent(error_status, error_name);
+            SWSS_LOG_INFO("Initialize port %s error %s flag=0x%" PRIx32,
+                                            port.m_alias.c_str(),
+                                            error_name.c_str(),
+                                            error_status);
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Initialize the port error status map only once 


**Why I did it**

Any change in CONFIG_DB PORT table was resulting in updating the port error status map resulting in change in error count = 0 

**How I verified it**

Verified by raising RF and LF error events on the port

**Details if related**
