### PR TITLE
[vstest]: Fix MACsec test in the kernel 5.15

### DIFF
--- a/tests/test_macsec.py
+++ b/tests/test_macsec.py
@@ -424,6 +424,7 @@ class TestMACsec(object):
         wpa.init_macsec_port(port_name)
         wpa.config_macsec_port(port_name, {"enable_protect": True})
         wpa.config_macsec_port(port_name, {"enable_encrypt": True})
+        wpa.config_macsec_port(port_name, {"send_sci": True})
         wpa.config_macsec_port(
             port_name,
             {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Provide an explicit value for send_sci in the macsec vstest

**Why I did it**

The kernel 5.15 requires the send_sci to be true if the sci value was provided explicitly.

**How I verified it**

```
AzDevOps@test-os-u000048:/agent/_work/1/s/sonic-swss/tests$ sudo pytest --dvsname=vs test_macsec.py  --pdb
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.8.10, pytest-4.6.2, py-1.11.0, pluggy-0.13.1
rootdir: /agent/_work/1/s/sonic-swss/tests
plugins: flaky-3.7.0
collected 4 items                                                                                                                                                                                          

test_macsec.py ....                                                                                                                                                                                  [100%]

============================================================================================= warnings summary =============================================================================================
test_macsec.py:311
  /agent/_work/1/s/sonic-swss/tests/test_macsec.py:311: PytestAssertRewriteWarning: assertion is always true, perhaps remove parentheses?
    assert(

test_macsec.py:278
  /agent/_work/1/s/sonic-swss/tests/test_macsec.py:278: PytestAssertRewriteWarning: assertion is always true, perhaps remove parentheses?
    assert(

test_macsec.py:251
  /agent/_work/1/s/sonic-swss/tests/test_macsec.py:251: PytestAssertRewriteWarning: assertion is always true, perhaps remove parentheses?
    assert(

test_macsec.py:258
  /agent/_work/1/s/sonic-swss/tests/test_macsec.py:258: PytestAssertRewriteWarning: assertion is always true, perhaps remove parentheses?
    assert(

test_macsec.py:264
  /agent/_work/1/s/sonic-swss/tests/test_macsec.py:264: PytestAssertRewriteWarning: assertion is always true, perhaps remove parentheses?
    assert(

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================== 4 passed, 5 warnings in 78.32 seconds ===================================================================================
```

**Details if related**
