### PR TITLE
Add support for local ports with asic and dut name in getPort

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -1652,17 +1652,20 @@ bool IntfsOrch::isRemoteSystemPortIntf(string alias)
     return false;
 }
 
+bool IntfsOrch::isLocalSystemPortIntf(Port& port)
+{
+    if (port.m_type == Port::LAG)
+        return(port.m_system_lag_info.switch_id == gVoqMySwitchId);
+    else
+        return(port.m_system_port_info.type != SAI_SYSTEM_PORT_TYPE_REMOTE);
+}
+
 bool IntfsOrch::isLocalSystemPortIntf(string alias)
 {
     Port port;
     if(gPortsOrch->getPort(alias, port))
     {
-        if (port.m_type == Port::LAG)
-        {
-            return(port.m_system_lag_info.switch_id == gVoqMySwitchId);
-        }
-
-        return(port.m_system_port_info.type != SAI_SYSTEM_PORT_TYPE_REMOTE);
+        return isLocalSystemPortIntf(port);
     }
     //Given alias is system port alias of the local port/LAG
     return false;

--- a/orchagent/intfsorch.h
+++ b/orchagent/intfsorch.h
@@ -72,6 +72,7 @@ public:
 
     bool isRemoteSystemPortIntf(string alias);
     bool isLocalSystemPortIntf(string alias);
+    bool isLocalSystemPortIntf(Port& port);
     void voqSyncIntfState(string &alias, bool);
 
 private:

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1458,6 +1458,22 @@ bool PortsOrch::getPort(string alias, Port &p)
 
     if (m_portList.find(alias) == m_portList.end())
     {
+        // For local ports strip the asic names and check for interface name
+        size_t pos = alias.find('|');
+        if (pos != std::string::npos) {
+            pos = alias.find_last_of('|');
+            string intf_name = alias.substr(pos + 1);
+
+            if (m_portList.find(intf_name) != m_portList.end())
+            {
+                Port port = m_portList[intf_name];
+                if (gIntfsOrch->isLocalSystemPortIntf(port))
+                {
+                    p = port;
+                    return true;
+                }
+            }
+        }
         return false;
     }
     else


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Modified `PortsOrch::getPort(string alias, Port &p)` method to search for system port name stripped from the device and namespaces. To implement this we introduced `isLocalSystemPortIntf(Port& port)` method to decouple getPort and `isLocalSystemPortIntf(string alias)`

**Why I did it**
Currently, we store local ports and remote ports using different convention in m_portList. Remote ports follow: <dut name>|<asic>|<interface> format and local ports are saved as <interface>. Hence when <dut name>|<asic>|<interface> format is used to 'get' a local port it returns false. This generates a number of "port not found" info messages in the syslog.

**How I verified it**
Testing:
- [x] Verified syntax by compiling the orchagent
- [x] Tested on a multi-asic LC by running T2 tests and identified no failures related to the change. 
- [x] Verified the logs no longer appear in syslog when loglevel is set to INFO

**Details if related**
Fixes https://github.com/sonic-net/sonic-buildimage/issues/20214