### PR TITLE
[orchagent] Fix a problem where resuming the pending VLAN delete operation may cause orchagent to crash.

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -5200,7 +5200,8 @@ void PortsOrch::doVlanTask(Consumer &consumer)
                     string key_v = kfvKey(t_v);
                     if (key_v == key && kfvOp(t_v) == DEL_COMMAND)
                     {
-                        SWSS_LOG_NOTICE("VLAN %s already been reused, remove the pending del.", vlan_alias.c_str());
+                        SWSS_LOG_NOTICE("Reused VLAN %s , remove the pending deletion.", 
+                                        vlan_alias.c_str());
                         it_v = consumer.m_toSync.erase(it_v);
                         break;
                     }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -5190,6 +5190,23 @@ void PortsOrch::doVlanTask(Consumer &consumer)
                     continue;
                 }
             }
+            else
+            {
+                /* loop to find the existing vlan and remove DEL_COMMAND */
+                auto it_v = consumer.m_toSync.begin();
+                while (it_v != consumer.m_toSync.end())
+                {
+                    auto &t_v = it_v->second;
+                    string key_v = kfvKey(t_v);
+                    if (key_v == key && kfvOp(t_v) == DEL_COMMAND)
+                    {
+                        SWSS_LOG_NOTICE("VLAN %s already been reused, remove the pending del.", vlan_alias.c_str());
+                        it_v = consumer.m_toSync.erase(it_v);
+                        break;
+                    }
+                    it_v++;
+                }
+            }
 
             // Process attributes
             Port vl;

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -646,6 +646,9 @@ class TestVlan(object):
         time.sleep(1)
 
     def test_VlanReuse(self, dvs):
+        """
+        Verified that the non-empty VLAN can be created and the pending DEL can be removed from the queue.
+        """
         vlan = "2"
         interface = "Ethernet0"
         

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -645,6 +645,40 @@ class TestVlan(object):
         self.dvs_vlan.remove_vlan(vlan_interface)
         time.sleep(1)
 
+    def test_VlanReuse(self, dvs):
+        vlan = "2"
+        interface = "Ethernet0"
+        
+        self.dvs_vlan.create_vlan(vlan)
+        vlan_oid = self.dvs_vlan.get_and_verify_vlan_ids(1)[0]
+        self.dvs_vlan.verify_vlan(vlan_oid, vlan)
+
+        self.dvs_vlan.create_vlan_member(vlan, interface)
+        self.dvs_vlan.verify_vlan_member(vlan_oid, interface)
+
+        # Verify the physical port configuration
+        member_port = self.dvs_vlan.asic_db.get_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT",
+                                                      dvs.asic_db.port_name_map[interface])
+        assert member_port.get("SAI_PORT_ATTR_PORT_VLAN_ID") == vlan
+
+        # Verify the host interface configuration
+        member_iface = self.dvs_vlan.asic_db.get_entry("ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF",
+                                              dvs.asic_db.hostif_name_map[interface])
+        assert member_iface.get("SAI_HOSTIF_ATTR_VLAN_TAG") == "SAI_HOSTIF_VLAN_TAG_KEEP"
+
+        self.dvs_vlan.remove_vlan(vlan)
+        time.sleep(2)
+        self.dvs_vlan.create_vlan(vlan)
+        vlan_oid = self.dvs_vlan.get_and_verify_vlan_ids(1)[0]
+        self.dvs_vlan.verify_vlan(vlan_oid, vlan) 
+        self.dvs_vlan.remove_vlan_member(vlan, interface)
+        time.sleep(2)
+        self.dvs_vlan.get_and_verify_vlan_member_ids(0)
+        self.dvs_vlan.remove_vlan(vlan)
+        self.dvs_vlan.get_and_verify_vlan_ids(0)
+        time.sleep(4)
+        _, oa_pid = dvs.runcmd("pgrep orchagent")
+        assert oa_pid != "", "Orchagent process was not found"
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When doVlanTask receives a SET_COMMAND to create a new VLAN, but the VLAN already exists, check if there is a pending DEL_COMMAND in the m_toSync queue. If found, remove the pending DEL_COMMAND and proceed with creating a non-empty VLAN.

**Why I did it**
Consider the following sequence:
1. Create a new VLAN 2.
2. Add a new VLAN member, Ethernet0, to VLAN 2.
3. Delete VLAN 2. (The DEL_COMMAND will be skipped and put back into the queue because Ethernet0 still references VLAN 2.)
4. Create VLAN 2 again.
5. Remove VLAN member Ethernet0 from VLAN 2. (The DEL_COMMAND will be resumed from the queue.)
6. Delete VLAN 2. (orchagent crashes.)

**How I verified it**
Tested by adding a new unit test:

<pre>
smci_user@sonictest:~/sonic-swss/tests$ sudo pytest --pdb -sv --max_cpu 4 --imgname=docker-sonic-vs:Azure.sonic-swss.20250311.4.asan-False test_vlan.py::TestVlan::test_VlanReuse
==================================================================== test session starts =====================================================================
platform linux -- Python 3.8.10, pytest-4.6.2, py-1.11.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/smci_user/sonic-swss/tests
plugins: flaky-3.7.0
collected 1 item


test_vlan.py::TestVlan::test_VlanReuse PASSED


</pre>
**Details if related**
