### PR TITLE
[portsorch] postpone non-critical port init part in warm/fast-reboot

### DIFF
--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -295,6 +295,16 @@ public:
     virtual void doTask(swss::NotificationConsumer &consumer) { }
     virtual void doTask(swss::SelectableTimer &timer) { }
 
+    /*
+     * Called once after APPLY_VIEW in warm/fast boot scenario.
+     * Orch can override this method to perform orch specific operations after boot is finished.
+     * These operations are not meant to produce additional ASIC configuration,
+     * instead a capability fetch and STATE_DB update here is encouraged.
+     * Orch is not expected to call the base method implementation as it must remain
+     * empty for compatibility reasons.
+     */
+    virtual void onWarmBootEnd() { }
+
     void dumpPendingTasks(std::vector<std::string> &ts);
 
     /**

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -1094,8 +1094,10 @@ bool OrchDaemon::warmRestoreAndSyncUp()
 
     syncd_apply_view();
 
-    /* Start dynamic state sync up */
-    gPortsOrch->refreshPortStatus();
+    for (Orch *o : m_orchList)
+    {
+        o->onWarmBootEnd();
+    }
 
     /*
      * Note. Arp sync up is handled in neighsyncd.

--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -709,3 +709,7 @@ std::unordered_set<std::string> PortsOrch::generateCounterStats(const vector<T> 
 void PortsOrch::doTask(swss::SelectableTimer &timer)
 {
 }
+
+void PortsOrch::onWarmBootEnd()
+{
+}

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -34,6 +34,7 @@
 #include "switchorch.h"
 #include "stringutility.h"
 #include "subscriberstatetable.h"
+#include "warm_restart.h"
 
 #include "saitam.h"
 
@@ -579,7 +580,8 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
                 ref(wred_port_stat_manager),
                 ref(wred_queue_stat_manager)
             }),
-        m_port_state_poller(new SelectableTimer(timespec { .tv_sec = PORT_STATE_POLLING_SEC, .tv_nsec = 0 }))
+        m_port_state_poller(new SelectableTimer(timespec { .tv_sec = PORT_STATE_POLLING_SEC, .tv_nsec = 0 })),
+        m_isWarmRestoreStage(WarmStart::isWarmStart())
 {
     SWSS_LOG_ENTER();
 
@@ -3776,6 +3778,12 @@ bool PortsOrch::initPort(const PortConfig &port)
                     createPortBufferQueueCounters(p, to_string(p.m_host_tx_queue), false);
                 }
 
+                // In warm-reboot postPortInit is postponed.
+                if (!m_isWarmRestoreStage)
+                {
+                    postPortInit(m_portList[alias]);
+                }
+
                 SWSS_LOG_NOTICE("Initialized port %s", alias.c_str());
             }
             else
@@ -4186,9 +4194,6 @@ void PortsOrch::doPortTask(Consumer &consumer)
                         continue;
                     }
 
-                    initPortSupportedSpeeds(it->second.key, m_portListLaneMap[it->first]);
-                    initPortSupportedFecModes(it->second.key, m_portListLaneMap[it->first]);
-
                     it++;
                 }
 
@@ -4207,9 +4212,6 @@ void PortsOrch::doPortTask(Consumer &consumer)
                             // Failure has been recorded in initPort
                             continue;
                         }
-
-                        initPortSupportedSpeeds(cit.key, m_portListLaneMap[cit.lanes.value]);
-                        initPortSupportedFecModes(cit.key, m_portListLaneMap[cit.lanes.value]);
                     }
                 }
 
@@ -5792,6 +5794,40 @@ void PortsOrch::doLagMemberTask(Consumer &consumer)
     }
 }
 
+void PortsOrch::onWarmBootEnd()
+{
+    SWSS_LOG_ENTER();
+
+    m_isWarmRestoreStage = false;
+
+    /* Start dynamic state sync up */
+    refreshPortStatus();
+
+    // Do post boot port initialization
+    for (auto& it: m_portList)
+    {
+        Port& port = it.second;
+
+        if (port.m_type == Port::PHY)
+        {
+            postPortInit(it.second);
+        }
+    }
+}
+
+void PortsOrch::postPortInit(Port& p)
+{
+    SWSS_LOG_ENTER();
+
+    if (gMySwitchType != "dpu")
+    {
+        initializePortBufferMaximumParameters(p);
+    }
+
+    initPortSupportedSpeeds(p.m_alias, p.m_port_id);
+    initPortSupportedFecModes(p.m_alias, p.m_port_id);
+}
+
 void PortsOrch::doTask()
 {
     auto tableOrder = {
@@ -6076,7 +6112,6 @@ bool PortsOrch::initializePort(Port &port)
         initializePriorityGroups(port);
         initializeQueues(port);
         initializeSchedulerGroups(port);
-        initializePortBufferMaximumParameters(port);
     }
 
     /* Create host interface */

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -369,6 +369,7 @@ private:
     bool m_cmisModuleAsicSyncSupported = false;
 
     void doTask() override;
+    void onWarmBootEnd() override;
     void doTask(Consumer &consumer);
     void doPortTask(Consumer &consumer);
     void doSendToIngressPortTask(Consumer &consumer);
@@ -415,6 +416,8 @@ private:
 
     void initPortCapAutoNeg(Port &port);
     void initPortCapLinkTraining(Port &port);
+
+    void postPortInit(Port &p);
 
     bool setPortAdminStatus(Port &port, bool up);
     bool getPortAdminStatus(sai_object_id_t id, bool& up);
@@ -589,5 +592,6 @@ private:
 
     // Port OA helper
     PortHelper m_portHlpr;
+    bool m_isWarmRestoreStage = false;
 };
 #endif /* SWSS_PORTSORCH_H */


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Port initialization that has no dependncy on subsequent data plane configuration are extracted into a seperate "post initialization" routine and executed after data plane configuration is done.

**Why I did it**

To save time in fast-boot.

**How I verified it**

Boot system with many ports, notice a time difference in port intialization time

**Details if related**
