### PR TITLE
[DVS] Remove framework package during DVS build

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -144,7 +144,7 @@ jobs:
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/${{ parameters.buildimage_artifact_branch }}'
       path: $(Build.ArtifactStagingDirectory)/download
-      patterns: '**/target/debs/${{ debian_version }}/framework_*.deb'
+      patterns: '**/target/debs/${{ parameters.debian_version }}/framework_*.deb'
     displayName: "Download sonic-buildimage ${{ parameters.artifact_name }}"
 
   - script: |

--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -21,6 +21,9 @@ parameters:
   type: string
   default: '$(BUILD_BRANCH)'
 
+- name: debian_version
+  type: string
+
 - name: artifact_name
   type: string
 
@@ -132,6 +135,18 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/${{ parameters.artifact_name }}.gz'
     displayName: "Download sonic-buildimage ${{ parameters.artifact_name }}"
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: specific
+      project: ${{ parameters.buildimage_artifact_project }}
+      pipeline: ${{ parameters.buildimage_artifact_pipeline }}
+      artifact: ${{ parameters.buildimage_artifact_name }}
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/${{ parameters.buildimage_artifact_branch }}'
+      path: $(Build.ArtifactStagingDirectory)/download
+      patterns: '**/target/debs/${{ debian_version }}/framework_*.deb'
+    displayName: "Download sonic-buildimage ${{ parameters.artifact_name }}"
+
   - script: |
       set -ex
       echo $(Build.DefinitionName).$(Build.BuildNumber)

--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -145,7 +145,7 @@ jobs:
       runBranch: 'refs/heads/${{ parameters.buildimage_artifact_branch }}'
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/debs/${{ parameters.debian_version }}/framework_*.deb'
-    displayName: "Download sonic-buildimage ${{ parameters.artifact_name }}"
+    displayName: "Download sonic-buildimage sonic-framework package"
 
   - script: |
       set -ex
@@ -163,6 +163,7 @@ jobs:
       fi
 
       pushd .azure-pipelines
+      ls -l docker-sonic-vs/debs
 
       build_dir=$(grep BUILD_DIR $(Build.ArtifactStagingDirectory)/download/build.info | cut -d= -f2)
       build_args="--build-arg build_dir=$build_dir"

--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -22,8 +22,7 @@ RUN apt install -y /debs/libdashapi_1.0.0_amd64.deb \
             /debs/libsairedis_1.0.0_amd64.deb \
             /debs/libsaivs_1.0.0_amd64.deb \
             /debs/syncd-vs_1.0.0_amd64.deb \
-            /debs/swss_1.0.0_amd64.deb \
-            /debs/framework_1.0.0_amd64.deb
+            /debs/swss_1.0.0_amd64.deb
 
 RUN if [ "$need_dbg" = "y" ] ; then dpkg -i /debs/swss-dbg_1.0.0_amd64.deb ; fi
 

--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -10,7 +10,7 @@ COPY ["debs", "/debs"]
 # Remove existing packages first before installing the new/current packages. This is to overcome limitations with
 # Docker's diff detection mechanism, where only the file size and the modification timestamp (which will remain the
 # same, even though contents have changed) are checked between the previous and current layer.
-RUN dpkg --purge libswsscommon python3-swsscommon sonic-db-cli libsaimetadata libsairedis libsaivs syncd-vs swss sonic-eventd libdashapi
+RUN dpkg --purge libswsscommon python3-swsscommon sonic-db-cli libsaimetadata libsairedis libsaivs syncd-vs swss sonic-eventd libdashapi framework
 
 RUN apt-get update
 
@@ -22,7 +22,8 @@ RUN apt install -y /debs/libdashapi_1.0.0_amd64.deb \
             /debs/libsairedis_1.0.0_amd64.deb \
             /debs/libsaivs_1.0.0_amd64.deb \
             /debs/syncd-vs_1.0.0_amd64.deb \
-            /debs/swss_1.0.0_amd64.deb
+            /debs/swss_1.0.0_amd64.deb \
+            /debs/framework_1.0.0_amd64.deb
 
 RUN if [ "$need_dbg" = "y" ] ; then dpkg -i /debs/swss-dbg_1.0.0_amd64.deb ; fi
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,6 +106,7 @@ stages:
       swss_common_artifact_name: sonic-swss-common-${{ parameters.debian_version }}
       sairedis_artifact_name: sonic-sairedis-${{ parameters.debian_version }}
       swss_artifact_name: sonic-swss-${{ parameters.debian_version }}
+      debian_version: ${{ parameters.debian_version }}
       artifact_name: docker-sonic-vs
 
 - stage: BuildDockerAsan
@@ -118,6 +119,7 @@ stages:
       sairedis_artifact_name: sonic-sairedis-${{ parameters.debian_version }}
       swss_artifact_name: sonic-swss-asan-${{ parameters.debian_version }}
       artifact_name: docker-sonic-vs-asan
+      debian_version: ${{ parameters.debian_version }}
       asan: true
 
 - stage: Test


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When building the DVS image, remove the framework package when purging libswsscommon and other related packages. Re-install framework package when installing other packages.

**Why I did it**
DVS build is failing as swsscommon is a dependency of the framework package, so during the build the purge of libswsscommon fails. This package is not currently used for VS tests

**How I verified it**

**Details if related**
