### PR TITLE
[vrfmgr] Fix mgmt access loss after reboot when mgmt VRF is enabled

### DIFF
--- a/cfgmgr/vrfmgr.cpp
+++ b/cfgmgr/vrfmgr.cpp
@@ -93,21 +93,24 @@ VrfMgr::VrfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, con
         }
     }
 
-    cmd.str("");
-    cmd.clear();
-    // Get local table pref
-    cmd << IP_CMD << " rule | grep 'from all lookup local' | awk -F'[^0-9]+' '{ print $1 }'";
-    swss::exec(cmd.str(), res);
-    table = static_cast<uint32_t>(stoul(res));
-    // If local table pref is not expected, set it to be expected
-    if (table != TABLE_LOCAL_PREF)
+    for (const char *family : {" -4", " -6"})
     {
         cmd.str("");
         cmd.clear();
-        cmd << IP_CMD << " rule add pref " << TABLE_LOCAL_PREF << " table local && " << IP_CMD << " rule del pref "
-            << table << " && " << IP_CMD << " -6 rule add pref " << TABLE_LOCAL_PREF << " table local && " << IP_CMD
-            << " -6 rule del pref " << table;
+        res.clear();
+        cmd << IP_CMD << family << " rule show table local | grep 'from all lookup local'";
         EXEC_WITH_ERROR_THROW(cmd.str(), res);
+        table = static_cast<uint32_t>(stoul(res));
+
+        if (table != TABLE_LOCAL_PREF)
+        {
+            cmd.str("");
+            cmd.clear();
+            res.clear();
+            cmd << IP_CMD << family << " rule add pref " << TABLE_LOCAL_PREF << " table local && "
+                << IP_CMD << family << " rule del pref " << table << " table local";
+            EXEC_WITH_ERROR_THROW(cmd.str(), res);
+        }
     }
 
     if (!WarmStart::isWarmStart())
@@ -557,4 +560,3 @@ uint32_t VrfMgr::getVRFmappedVNI(const std::string& vrf_name)
         return 0;
     }
 }
-

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -163,6 +163,55 @@ class TestVrf(object):
         r = random.choice(values)
         return r[0], r[1]
 
+    @pytest.mark.parametrize("family", ["-4", "-6"])
+    def test_VRFMgr_LocalRulePriority(self, dvs, testlog, family):
+        other_family = "-6" if family == "-4" else "-4"
+
+        def get_local_rule_pref(rule_family):
+            status, output = dvs.runcmd(["ip", rule_family, "rule", "show", "table", "local"])
+            assert status == 0, output
+            for rule in output.splitlines():
+                preference, selector = rule.split(":", 1)
+                if selector.strip() == "from all lookup local":
+                    return int(preference.strip())
+            assert False, "Missing {} canonical local rule".format(rule_family)
+
+        original_pref = get_local_rule_pref(family)
+        assert original_pref == 1001
+        assert get_local_rule_pref(other_family) == 1001
+        try:
+            status, output = dvs.runcmd(
+                ["ip", family, "rule", "add", "pref", "32765", "table", "local"]
+            )
+            assert status == 0, output
+            status, output = dvs.runcmd(
+                ["ip", family, "rule", "del", "pref", str(original_pref), "table", "local"]
+            )
+            assert status == 0, output
+
+            status, output = dvs.runcmd(["supervisorctl", "restart", "vrfmgrd"])
+            assert status == 0, output
+
+            for _ in range(10):
+                if get_local_rule_pref(family) == 1001:
+                    break
+                time.sleep(1)
+            assert get_local_rule_pref(family) == 1001
+            assert get_local_rule_pref(other_family) == 1001
+        finally:
+            current_pref = get_local_rule_pref(family)
+            if current_pref != 1001:
+                status, output = dvs.runcmd(
+                    ["ip", family, "rule", "add", "pref", "1001", "table", "local"]
+                )
+                assert status == 0, output
+                status, output = dvs.runcmd(
+                    ["ip", family, "rule", "del", "pref", str(current_pref), "table", "local"]
+                )
+                assert status == 0, output
+            status, output = dvs.runcmd(["supervisorctl", "restart", "vrfmgrd"])
+            assert status == 0, output
+
     def test_VRFMgr_Comprehensive(self, dvs, testlog):
         self.setup_db(dvs)
 

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -163,6 +163,67 @@ class TestVrf(object):
         r = random.choice(values)
         return r[0], r[1]
 
+    @pytest.mark.parametrize("family", ["-4", "-6"])
+    def test_VRFMgr_LocalRulePriority(self, dvs, testlog, family):
+        other_family = "-6" if family == "-4" else "-4"
+
+        def get_local_rule_prefs(rule_family):
+            status, output = dvs.runcmd(["ip", rule_family, "rule", "show", "table", "local"])
+            assert status == 0, output
+            preferences = []
+            for rule in output.splitlines():
+                preference, selector = rule.split(":", 1)
+                if selector.strip() == "from all lookup local":
+                    preferences.append(int(preference.strip()))
+            return preferences
+
+        def get_local_rule_pref(rule_family):
+            preferences = get_local_rule_prefs(rule_family)
+            assert preferences, "Missing {} canonical local rule".format(rule_family)
+            return preferences[0]
+
+        original_pref = get_local_rule_pref(family)
+        assert original_pref == 1001
+        assert get_local_rule_pref(other_family) == 1001
+        try:
+            status, output = dvs.runcmd(
+                ["ip", family, "rule", "add", "pref", "32765", "table", "local"]
+            )
+            assert status == 0, output
+            status, output = dvs.runcmd(
+                ["ip", family, "rule", "del", "pref", str(original_pref), "table", "local"]
+            )
+            assert status == 0, output
+
+            status, output = dvs.runcmd(["supervisorctl", "restart", "vrfmgrd"])
+            assert status == 0, output
+
+            for _ in range(10):
+                if get_local_rule_pref(family) == 1001:
+                    break
+                time.sleep(1)
+            assert get_local_rule_pref(family) == 1001
+            assert get_local_rule_pref(other_family) == 1001
+        finally:
+            current_prefs = get_local_rule_prefs(family)
+            if 1001 not in current_prefs:
+                status, output = dvs.runcmd(
+                    ["ip", family, "rule", "add", "pref", "1001", "table", "local"]
+                )
+                assert status == 0, output
+            for current_pref in current_prefs:
+                if current_pref == 1001:
+                    continue
+                status, output = dvs.runcmd(
+                    [
+                        "ip", family, "rule", "del", "pref", str(current_pref),
+                        "from", "all", "table", "local",
+                    ]
+                )
+                assert status == 0, output
+            status, output = dvs.runcmd(["supervisorctl", "restart", "vrfmgrd"])
+            assert status == 0, output
+
     def test_VRFMgr_Comprehensive(self, dvs, testlog):
         self.setup_db(dvs)
 


### PR DESCRIPTION
**What I did**

- Normalize the canonical `from all lookup local` rule to preference `1001` when `VrfMgr` starts.
- Detect the rule's actual preference instead of only handling the kernel's cold-boot preference `0`.
- Apply the correction independently to IPv4 and IPv6.
- Add DVS regression coverage that moves the rule to a stale preference and verifies that `vrfmgrd` restores it.

**Why I did it**

When management VRF has been enabled, a reboot can restore the `local` lookup rule at preference `32765` instead of the normal cold-boot preference `0`:

```text
1000:  from all lookup [l3mdev-table]
32765: from all lookup local
32765: from <management IP> lookup <mgmt/default>
```

The existing startup logic only searches for a rule at preference `0`. It therefore skips normalization in this warm-state case. The `local` rule can then take precedence over the management source rule at the same preference, causing management traffic to be routed incorrectly and making `eth0` unreachable by SSH or ping.

This change finds the canonical `from all lookup local` rule directly and moves it to preference `1001` whenever necessary:

```text
1000:  from all lookup [l3mdev-table]   # present when management VRF is enabled
1001:  from all lookup local
32765: from <management IP> lookup <mgmt/default>
32766: from all lookup main
32767: from all lookup default
```

The behavior now covers cold boot (`0`), the observed stale reboot state (`32765`), an already-correct rule (`1001`), and any other detected preference. IPv4 and IPv6 are normalized separately so a correct rule in one family does not prevent recovery of the other.

**How I verified it**

- Reproduced the original failure on physical DUT `bjw2-can-7050-1`: after enabling management VRF and rebooting, the IPv4 and IPv6 `local` rules moved from preference `1001` to `32765`, and management connectivity was disrupted.
- Ran the complete management-VRF test module plus standalone cold-, warm-, and fast-reboot coverage against the master PR build: 12 test bodies in total. Confirmed after every run that the canonical IPv4 and IPv6 rules remained at preference `1001`, `vrfmgrd` remained healthy, and the DUT remained reachable.
- Added DVS regression coverage for both address families.
- Completed the full Azure pipeline for this master-targeted PR successfully, including normal and ASAN VSTest lanes.
- Validated the exact `202605` backport from https://github.com/sonic-net/sonic-swss/pull/4779 on physical hardware:
  - Azure build: https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1171731
  - Artifact: `sonic-swss-trixie`
  - DUT image: `SONiC.20260510.06`, Debian 13/Trixie
  - Candidate `vrfmgrd` SHA-256: `b85628d5bda90c6bd75b9b6e4eef591b217c8a3391f0cc03edf4272d5864982d`
  - Test: `mvrf/test_mgmtvrf.py::TestReboot::test_reboot`
  - Result: `1 passed in 1051.68s`
  - Reboot proof: DUT boot time changed to `2026-07-22 17:07:23 UTC` / `2026-07-23 03:07:23 Sydney`
  - Post-reboot: management SSH reachable; IPv4 and IPv6 `from all lookup local` rules both at preference `1001`; `vrfmgrd` `RUNNING`; system state `running`; management VRF disabled
  - Restored stock `vrfmgrd` SHA-256 `a031378563fa4d2e22b11c3c11c4c34200cec4787200e717e9a52778a9617b2e` and re-verified daemon, system, and rule health

**Details if related**

| Boot-time `local` rule | Previous behavior | Behavior with this change |
|---|---|---|
| `0: from all lookup local` | Move to `1001` | Move to `1001` |
| `32765: from all lookup local` | No-op; management access can be lost | Move to `1001` |
| `1001: from all lookup local` | No-op | No-op |
| Any other preference | No-op | Move to `1001` |

The `202605` physical run used `--skip-yang` only to bypass an unrelated module-level empty-patch validation failure caused by pre-existing `EVERFLOW|RULE_8` data. The management-VRF reboot test body and its connectivity/rule assertions remained enabled.

**Backport request**

- [x] 202605
- Backport PR: https://github.com/sonic-net/sonic-swss/pull/4779
- 202605 branch-specific physical validation: passed



##### Work item tracking
- Microsoft ADO (number only): 39058191
