### PR TITLE
Orchagent SAI error handling improvements

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -127,7 +127,7 @@ void syncd_apply_view()
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to notify syncd APPLY_VIEW %d", status);
-        handleSaiFailure(true);
+        handleSaiFailure(SAI_API_SWITCH, "set", status);
     }
 }
 
@@ -701,7 +701,7 @@ int main(int argc, char **argv)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to create a switch, rv:%d", status);
-        handleSaiFailure(true);
+        handleSaiFailure(SAI_API_SWITCH, "create", status);
     }
     SWSS_LOG_NOTICE("Create a switch, id:%" PRIu64, gSwitchId);
 
@@ -732,7 +732,7 @@ int main(int argc, char **argv)
             if (status != SAI_STATUS_SUCCESS)
             {
                 SWSS_LOG_ERROR("Failed to get MAC address from switch, rv:%d", status);
-                handleSaiFailure(true);
+                handleSaiFailure(SAI_API_SWITCH, "get", status);
             }
             else
             {
@@ -747,7 +747,7 @@ int main(int argc, char **argv)
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Fail to get switch virtual router ID %d", status);
-            handleSaiFailure(true);
+            handleSaiFailure(SAI_API_SWITCH, "get", status);
         }
 
         gVirtualRouterId = attr.value.oid;
@@ -789,7 +789,7 @@ int main(int argc, char **argv)
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to create underlay router interface %d", status);
-            handleSaiFailure(true);
+            handleSaiFailure(SAI_API_ROUTER_INTERFACE, "create", status);
         }
 
         SWSS_LOG_NOTICE("Created underlay router interface ID %" PRIx64, gUnderlayIfId);

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -128,6 +128,7 @@ void syncd_apply_view()
     {
         SWSS_LOG_ERROR("Failed to notify syncd APPLY_VIEW %d", status);
         handleSaiFailure(SAI_API_SWITCH, "set", status);
+        return;
     }
 }
 
@@ -702,6 +703,7 @@ int main(int argc, char **argv)
     {
         SWSS_LOG_ERROR("Failed to create a switch, rv:%d", status);
         handleSaiFailure(SAI_API_SWITCH, "create", status);
+        return EXIT_FAILURE;
     }
     SWSS_LOG_NOTICE("Create a switch, id:%" PRIu64, gSwitchId);
 
@@ -733,6 +735,7 @@ int main(int argc, char **argv)
             {
                 SWSS_LOG_ERROR("Failed to get MAC address from switch, rv:%d", status);
                 handleSaiFailure(SAI_API_SWITCH, "get", status);
+                return EXIT_FAILURE;
             }
             else
             {
@@ -748,6 +751,7 @@ int main(int argc, char **argv)
         {
             SWSS_LOG_ERROR("Fail to get switch virtual router ID %d", status);
             handleSaiFailure(SAI_API_SWITCH, "get", status);
+            return EXIT_FAILURE;
         }
 
         gVirtualRouterId = attr.value.oid;
@@ -790,6 +794,7 @@ int main(int argc, char **argv)
         {
             SWSS_LOG_ERROR("Failed to create underlay router interface %d", status);
             handleSaiFailure(SAI_API_ROUTER_INTERFACE, "create", status);
+            return EXIT_FAILURE;
         }
 
         SWSS_LOG_NOTICE("Created underlay router interface ID %" PRIx64, gUnderlayIfId);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -836,7 +836,7 @@ void OrchDaemon::flush()
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to flush redis pipeline %d", status);
-        handleSaiFailure(true);
+        handleSaiFailure(SAI_API_SWITCH, "set", status);
     }
 
     for (auto* orch: m_orchList)

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -567,8 +567,8 @@ task_process_status handleSaiCreateStatus(sai_api_t api, sai_status_t status, vo
      *          in each orch.
      *       3. Take the type of sai api into consideration.
      */
-     switch (status)
-     {
+    switch (status)
+    {
         case SAI_STATUS_SUCCESS:
         case SAI_STATUS_ITEM_NOT_FOUND:
         case SAI_STATUS_ADDR_NOT_FOUND:
@@ -585,8 +585,8 @@ task_process_status handleSaiCreateStatus(sai_api_t api, sai_status_t status, vo
         default:
             handleSaiFailure(api, "create", status);
             break;
-      }
-      return task_failed;
+    }
+    return task_failed;
 }
 
 task_process_status handleSaiSetStatus(sai_api_t api, sai_status_t status, void *context)

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -334,7 +334,7 @@ void initSaiRedis()
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to set communication mode, rv:%d", status);
-        exit(EXIT_FAILURE);
+        return handleSaiFailure(SAI_API_SWITCH, "set", status);
     }
 
     auto record_filename = Recorder::Instance().sairedis.getFile();
@@ -352,7 +352,7 @@ void initSaiRedis()
         {
             SWSS_LOG_ERROR("Failed to set SAI Redis recording output folder to %s, rv:%d",
                 record_location.c_str(), status);
-            exit(EXIT_FAILURE);
+            return handleSaiFailure(SAI_API_SWITCH, "set", status);
         }
 
         attr.id = SAI_REDIS_SWITCH_ATTR_RECORDING_FILENAME;
@@ -364,7 +364,7 @@ void initSaiRedis()
         {
             SWSS_LOG_ERROR("Failed to set SAI Redis recording logfile to %s, rv:%d",
                 record_filename.c_str(), status);
-            exit(EXIT_FAILURE);
+            return handleSaiFailure(SAI_API_SWITCH, "set", status);
         }
 
     }
@@ -378,7 +378,7 @@ void initSaiRedis()
     {
         SWSS_LOG_ERROR("Failed to %s SAI Redis recording, rv:%d",
             Recorder::Instance().sairedis.isRecord() ? "enable" : "disable", status);
-        exit(EXIT_FAILURE);
+        return handleSaiFailure(SAI_API_SWITCH, "set", status);
     }
 
     if (gRedisCommunicationMode == SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC)
@@ -391,7 +391,7 @@ void initSaiRedis()
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to enable redis pipeline, rv:%d", status);
-            exit(EXIT_FAILURE);
+            return handleSaiFailure(SAI_API_SWITCH, "set", status);
         }
     }
 
@@ -409,7 +409,7 @@ void initSaiRedis()
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to set SAI REDIS response timeout");
-            exit(EXIT_FAILURE);
+            return handleSaiFailure(SAI_API_SWITCH, "set", status);
         }
 
         SWSS_LOG_NOTICE("SAI REDIS response timeout set successfully to %" PRIu64 " ", attr.value.u64);
@@ -422,7 +422,7 @@ void initSaiRedis()
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to notify syncd INIT_VIEW, rv:%d gSwitchId %" PRIx64, status, gSwitchId);
-        exit(EXIT_FAILURE);
+        return handleSaiFailure(SAI_API_SWITCH, "set", status);
     }
     SWSS_LOG_NOTICE("Notify syncd INIT_VIEW");
 
@@ -436,7 +436,7 @@ void initSaiRedis()
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to set SAI REDIS response timeout");
-            exit(EXIT_FAILURE);
+            return handleSaiFailure(SAI_API_SWITCH, "set", status);
         }
 
         SWSS_LOG_NOTICE("SAI REDIS response timeout set successfully to %" PRIu64 " ", attr.value.u64);
@@ -1044,7 +1044,7 @@ std::vector<sai_stat_id_t> queryAvailableCounterStats(const sai_object_type_t ob
 
     if (!info)
     {
-        SWSS_LOG_WARN("Metadata info query failed, invalid object: %d", object_type);
+        SWSS_LOG_ERROR("Metadata info query failed, invalid object: %d", object_type);
         return stat_list;
     }
 

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -678,15 +678,21 @@ task_process_status handleSaiGetStatus(sai_api_t api, sai_status_t status, void 
      *          in each orch.
      *       3. Take the type of sai api into consideration.
      */
+    string s_api = sai_serialize_api(api);
+    string s_status = sai_serialize_status(status);
+
     switch (status)
     {
         case SAI_STATUS_SUCCESS:
             SWSS_LOG_WARN("SAI_STATUS_SUCCESS is not expected in handleSaiGetStatus");
             return task_success;
-        case SAI_STATUS_NOT_IMPLEMENTED:
-            throw std::logic_error("SAI get function not implemented");
         default:
-            handleSaiFailure(api, "get", status);
+            /*
+             * handleSaiFailure() is not called for GET failures as it might
+             * overwhelm the system if there are too many such calls
+             */
+            SWSS_LOG_NOTICE("Encountered failure in GET operation, SAI API: %s, status: %s",
+                        s_api.c_str(), s_status.c_str());
             break;
     }
     return task_failed;

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -567,15 +567,22 @@ task_process_status handleSaiCreateStatus(sai_api_t api, sai_status_t status, vo
      *          in each orch.
      *       3. Take the type of sai api into consideration.
      */
+    string s_api = sai_serialize_api(api);
+    string s_status = sai_serialize_status(status);
+
     switch (status)
     {
         case SAI_STATUS_SUCCESS:
+            return task_success;
         case SAI_STATUS_ITEM_NOT_FOUND:
         case SAI_STATUS_ADDR_NOT_FOUND:
         case SAI_STATUS_OBJECT_IN_USE:
-            SWSS_LOG_WARN("Status %d is not expected in handleSaiCreateStatus", status);
+            SWSS_LOG_WARN("Status %s is not expected for create operation, SAI API: %s",
+                            s_status.c_str(), s_api.c_str());
             return task_success;
         case SAI_STATUS_ITEM_ALREADY_EXISTS:
+            SWSS_LOG_NOTICE("Returning success for create operation, SAI API: %s, status: %s",
+                                s_api.c_str(), s_status.c_str());
             return task_success;
         case SAI_STATUS_INSUFFICIENT_RESOURCES:
         case SAI_STATUS_TABLE_FULL:
@@ -602,11 +609,16 @@ task_process_status handleSaiSetStatus(sai_api_t api, sai_status_t status, void 
      *          in each orch.
      *       3. Take the type of sai api into consideration.
      */
+    string s_api = sai_serialize_api(api);
+    string s_status = sai_serialize_status(status);
+
     switch (status)
     {
         case SAI_STATUS_SUCCESS:
+            return task_success;
         case SAI_STATUS_OBJECT_IN_USE:
-            SWSS_LOG_WARN("Status %d is not expected in handleSaiSetStatus", status);
+            SWSS_LOG_WARN("Status %s is not expected for set operation, SAI API: %s",
+                            s_status.c_str(), s_api.c_str());
             return task_success;
         case SAI_STATUS_ITEM_ALREADY_EXISTS:
         case SAI_STATUS_ITEM_NOT_FOUND:
@@ -616,6 +628,8 @@ task_process_status handleSaiSetStatus(sai_api_t api, sai_status_t status, void 
              * which can potentially lead to conditions where ITEM_NOT_FOUND can
              * be returned. This needs special handling in muxorch/routeorch.
              */
+            SWSS_LOG_NOTICE("Returning success for set operation, SAI API: %s, status: %s",
+                                s_api.c_str(), s_status.c_str());
             return task_success;
         case SAI_STATUS_INSUFFICIENT_RESOURCES:
         case SAI_STATUS_TABLE_FULL:
@@ -643,18 +657,25 @@ task_process_status handleSaiRemoveStatus(sai_api_t api, sai_status_t status, vo
      *          in each orch.
      *       3. Take the type of sai api into consideration.
      */
+    string s_api = sai_serialize_api(api);
+    string s_status = sai_serialize_status(status);
+
     switch (status)
     {
         case SAI_STATUS_SUCCESS:
+            return task_success;
         case SAI_STATUS_ITEM_ALREADY_EXISTS:
         case SAI_STATUS_INSUFFICIENT_RESOURCES:
         case SAI_STATUS_TABLE_FULL:
         case SAI_STATUS_NO_MEMORY:
         case SAI_STATUS_NV_STORAGE_FULL:
-            SWSS_LOG_WARN("Status %d is not expected in handleSaiRemoveStatus", status);
+            SWSS_LOG_WARN("Status %s is not expected for remove operation, SAI API: %s",
+                            s_status.c_str(), s_api.c_str());
             return task_success;
         case SAI_STATUS_ITEM_NOT_FOUND:
         case SAI_STATUS_ADDR_NOT_FOUND:
+            SWSS_LOG_NOTICE("Returning success for remove operation, SAI API: %s, status: %s",
+                                s_api.c_str(), s_status.c_str());
             return task_success;
         case SAI_STATUS_OBJECT_IN_USE:
             return task_need_retry;
@@ -684,7 +705,6 @@ task_process_status handleSaiGetStatus(sai_api_t api, sai_status_t status, void 
     switch (status)
     {
         case SAI_STATUS_SUCCESS:
-            SWSS_LOG_WARN("SAI_STATUS_SUCCESS is not expected in handleSaiGetStatus");
             return task_success;
         default:
             /*

--- a/orchagent/saihelper.h
+++ b/orchagent/saihelper.h
@@ -5,6 +5,7 @@
 #include <string>
 #include "orch.h"
 #include "producertable.h"
+#include "events.h"
 
 #define IS_ATTR_ID_IN_RANGE(attrId, objectType, attrPrefix) \
     ((attrId) >= SAI_ ## objectType ## _ATTR_ ## attrPrefix ## _START && (attrId) <= SAI_ ## objectType ## _ATTR_ ## attrPrefix ## _END)
@@ -20,7 +21,7 @@ task_process_status handleSaiSetStatus(sai_api_t api, sai_status_t status, void 
 task_process_status handleSaiRemoveStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
 task_process_status handleSaiGetStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
 bool parseHandleSaiStatusFailure(task_process_status status);
-void handleSaiFailure(bool abort_on_failure);
+void handleSaiFailure(sai_api_t api, std::string oper, sai_status_t status);
 
 void setFlexCounterGroupParameter(const std::string &group,
                                   const std::string &poll_interval,

--- a/tests/mock_tests/mock_saihelper.cpp
+++ b/tests/mock_tests/mock_saihelper.cpp
@@ -310,6 +310,26 @@ namespace saihelper_test
         ASSERT_EQ(*_sai_syncd_notifications_count, 0);
         ASSERT_EQ(status, task_success);
 
+        status = handleSaiCreateStatus(SAI_API_VLAN, SAI_STATUS_ITEM_ALREADY_EXISTS);
+        ASSERT_EQ(*_sai_syncd_notifications_count, 0);
+        ASSERT_EQ(status, task_success);
+
+        status = handleSaiSetStatus(SAI_API_ROUTE, SAI_STATUS_ITEM_ALREADY_EXISTS);
+        ASSERT_EQ(*_sai_syncd_notifications_count, 0);
+        ASSERT_EQ(status, task_success);
+
+        status = handleSaiCreateStatus(SAI_API_MIRROR, SAI_STATUS_ITEM_NOT_FOUND);
+        ASSERT_EQ(*_sai_syncd_notifications_count, 0);
+        ASSERT_EQ(status, task_success);
+
+        status = handleSaiSetStatus(SAI_API_NEIGHBOR, SAI_STATUS_ITEM_NOT_FOUND);
+        ASSERT_EQ(*_sai_syncd_notifications_count, 0);
+        ASSERT_EQ(status, task_success);
+
+        status = handleSaiRemoveStatus(SAI_API_LAG, SAI_STATUS_ITEM_NOT_FOUND);
+        ASSERT_EQ(*_sai_syncd_notifications_count, 0);
+        ASSERT_EQ(status, task_success);
+
         _unhook_sai_apis();
     }
 

--- a/tests/mock_tests/mock_saihelper.cpp
+++ b/tests/mock_tests/mock_saihelper.cpp
@@ -24,6 +24,10 @@ namespace saihelper_test
 
     bool set_comm_mode_not_supported;
     bool use_pipeline_not_supported;
+    bool record_output_dir_failure;
+    bool record_filename_failure;
+    bool record_failure;
+    bool response_timeout_failure;
     uint32_t *_sai_syncd_notifications_count;
     int32_t *_sai_syncd_notification_event;
 
@@ -38,19 +42,35 @@ namespace saihelper_test
                 {
                     return SAI_STATUS_NOT_SUPPORTED;
                 }
-                else
-                {
-                    return SAI_STATUS_SUCCESS;
-                }
                 break;
             case SAI_REDIS_SWITCH_ATTR_USE_PIPELINE:
                 if (use_pipeline_not_supported)
                 {
                     return SAI_STATUS_NOT_SUPPORTED;
                 }
-                else
+                break;
+            case SAI_REDIS_SWITCH_ATTR_RECORDING_OUTPUT_DIR:
+                if (record_output_dir_failure)
                 {
-                    return SAI_STATUS_SUCCESS;
+                    return SAI_STATUS_FAILURE;
+                }
+                break;
+            case SAI_REDIS_SWITCH_ATTR_RECORDING_FILENAME:
+                if (record_filename_failure)
+                {
+                    return SAI_STATUS_FAILURE;
+                }
+                break;
+            case SAI_REDIS_SWITCH_ATTR_RECORD:
+                if (record_failure)
+                {
+                    return SAI_STATUS_FAILURE;
+                }
+                break;
+            case SAI_REDIS_SWITCH_ATTR_SYNC_OPERATION_RESPONSE_TIMEOUT:
+                if (response_timeout_failure)
+                {
+                    return SAI_STATUS_FAILURE;
                 }
                 break;
             case SAI_REDIS_SWITCH_ATTR_NOTIFY_SYNCD:
@@ -97,6 +117,10 @@ namespace saihelper_test
 
                 set_comm_mode_not_supported = false;
                 use_pipeline_not_supported = false;
+                record_output_dir_failure = false;
+                record_filename_failure = false;
+                record_failure = false;
+                response_timeout_failure = false;
 
                 map<string, string> profile = {
                     { "SAI_VS_SWITCH_TYPE", "SAI_VS_SWITCH_TYPE_BCM56850" },
@@ -181,6 +205,88 @@ namespace saihelper_test
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
 
         use_pipeline_not_supported = false;
+        _unhook_sai_apis();
+    }
+
+    TEST_F(SaihelperTest, TestSetRecordingOutputDirFailure) {
+        record_output_dir_failure = true;
+        _hook_sai_apis();
+        initSwitchOrch();
+
+        _sai_syncd_notifications_count = (uint32_t*)mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        _sai_syncd_notification_event = (int32_t*)mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        *_sai_syncd_notifications_count = 0;
+        uint32_t notif_count = *_sai_syncd_notifications_count;
+
+        initSaiRedis();
+        ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
+        ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+
+        record_output_dir_failure = false;
+        _unhook_sai_apis();
+    }
+
+    TEST_F(SaihelperTest, TestSetRecordingFilenameFailure) {
+        record_filename_failure = true;
+        _hook_sai_apis();
+        initSwitchOrch();
+
+        _sai_syncd_notifications_count = (uint32_t*)mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        _sai_syncd_notification_event = (int32_t*)mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        *_sai_syncd_notifications_count = 0;
+        uint32_t notif_count = *_sai_syncd_notifications_count;
+
+        initSaiRedis();
+        ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
+        ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+
+        record_filename_failure = false;
+        _unhook_sai_apis();
+    }
+
+    TEST_F(SaihelperTest, TestSetRecordFailure) {
+        record_failure = true;
+        _hook_sai_apis();
+        initSwitchOrch();
+
+        _sai_syncd_notifications_count = (uint32_t*)mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        _sai_syncd_notification_event = (int32_t*)mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        *_sai_syncd_notifications_count = 0;
+        uint32_t notif_count = *_sai_syncd_notifications_count;
+
+        initSaiRedis();
+        ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
+        ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+
+        record_failure = false;
+        _unhook_sai_apis();
+    }
+
+    TEST_F(SaihelperTest, TestSetResponseTimeoutFailure) {
+        response_timeout_failure = true;
+        _hook_sai_apis();
+        initSwitchOrch();
+
+        _sai_syncd_notifications_count = (uint32_t*)mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        _sai_syncd_notification_event = (int32_t*)mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        *_sai_syncd_notifications_count = 0;
+        uint32_t notif_count = *_sai_syncd_notifications_count;
+        (void) setenv("platform", "mellanox", 1);
+
+        initSaiRedis();
+        ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
+        ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+
+        response_timeout_failure = false;
+        (void) unsetenv("platform");
         _unhook_sai_apis();
     }
 

--- a/tests/mock_tests/mock_saihelper.cpp
+++ b/tests/mock_tests/mock_saihelper.cpp
@@ -472,7 +472,15 @@ namespace saihelper_test
         ASSERT_EQ(*_sai_syncd_notifications_count, 0);
         ASSERT_EQ(status, task_success);
 
+        status = handleSaiSetStatus(SAI_API_NEXT_HOP, SAI_STATUS_OBJECT_IN_USE);
+        ASSERT_EQ(*_sai_syncd_notifications_count, 0);
+        ASSERT_EQ(status, task_success);
+
         status = handleSaiRemoveStatus(SAI_API_LAG, SAI_STATUS_ITEM_NOT_FOUND);
+        ASSERT_EQ(*_sai_syncd_notifications_count, 0);
+        ASSERT_EQ(status, task_success);
+
+        status = handleSaiRemoveStatus(SAI_API_PORT, SAI_STATUS_ITEM_ALREADY_EXISTS);
         ASSERT_EQ(*_sai_syncd_notifications_count, 0);
         ASSERT_EQ(status, task_success);
 

--- a/tests/mock_tests/mock_saihelper.cpp
+++ b/tests/mock_tests/mock_saihelper.cpp
@@ -273,5 +273,66 @@ namespace saihelper_test
 
         _unhook_sai_apis();
     }
+
+    TEST_F(SaihelperTest, TestAllSuccess) {
+        _hook_sai_apis();
+        initSwitchOrch();
+
+        _sai_syncd_notifications_count = (uint32_t*)mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        *_sai_syncd_notifications_count = 0;
+        task_process_status status;
+
+        status = handleSaiCreateStatus(SAI_API_NEXT_HOP_GROUP, SAI_STATUS_SUCCESS);
+        ASSERT_EQ(*_sai_syncd_notifications_count, 0);
+        ASSERT_EQ(status, task_success);
+
+        status = handleSaiSetStatus(SAI_API_ROUTE, SAI_STATUS_SUCCESS);
+        ASSERT_EQ(*_sai_syncd_notifications_count, 0);
+        ASSERT_EQ(status, task_success);
+
+        status = handleSaiRemoveStatus(SAI_API_NEXT_HOP, SAI_STATUS_SUCCESS);
+        ASSERT_EQ(*_sai_syncd_notifications_count, 0);
+        ASSERT_EQ(status, task_success);
+
+        _unhook_sai_apis();
+    }
+
+    TEST_F(SaihelperTest, TestCreateSetResourceFailure) {
+        _hook_sai_apis();
+        initSwitchOrch();
+
+        _sai_syncd_notifications_count = (uint32_t*)mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        *_sai_syncd_notifications_count = 0;
+        task_process_status status;
+
+        status = handleSaiCreateStatus(SAI_API_ACL, SAI_STATUS_INSUFFICIENT_RESOURCES);
+        ASSERT_EQ(*_sai_syncd_notifications_count, 0);
+        ASSERT_EQ(status, task_need_retry);
+
+        status = handleSaiSetStatus(SAI_API_PORT, SAI_STATUS_INSUFFICIENT_RESOURCES);
+        ASSERT_EQ(*_sai_syncd_notifications_count, 0);
+        ASSERT_EQ(status, task_need_retry);
+
+        status = handleSaiCreateStatus(SAI_API_TUNNEL, SAI_STATUS_TABLE_FULL);
+        ASSERT_EQ(*_sai_syncd_notifications_count, 0);
+        ASSERT_EQ(status, task_need_retry);
+
+        status = handleSaiSetStatus(SAI_API_ROUTER_INTERFACE, SAI_STATUS_TABLE_FULL);
+        ASSERT_EQ(*_sai_syncd_notifications_count, 0);
+        ASSERT_EQ(status, task_need_retry);
+
+        status = handleSaiCreateStatus(SAI_API_NEXT_HOP_GROUP, SAI_STATUS_NO_MEMORY);
+        ASSERT_EQ(*_sai_syncd_notifications_count, 0);
+        ASSERT_EQ(status, task_need_retry);
+
+        status = handleSaiSetStatus(SAI_API_NEXT_HOP_GROUP, SAI_STATUS_NO_MEMORY);
+        ASSERT_EQ(*_sai_syncd_notifications_count, 0);
+        ASSERT_EQ(status, task_need_retry);
+
+        _unhook_sai_apis();
+    }
+
 }
 

--- a/tests/mock_tests/mock_saihelper.cpp
+++ b/tests/mock_tests/mock_saihelper.cpp
@@ -274,6 +274,21 @@ namespace saihelper_test
         _unhook_sai_apis();
     }
 
+    TEST_F(SaihelperTest, TestGetFailure) {
+        _hook_sai_apis();
+        initSwitchOrch();
+
+        _sai_syncd_notifications_count = (uint32_t*)mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        *_sai_syncd_notifications_count = 0;
+        task_process_status status;
+
+        status = handleSaiGetStatus(SAI_API_FDB, SAI_STATUS_INVALID_PARAMETER);
+        ASSERT_EQ(*_sai_syncd_notifications_count, 0);
+        ASSERT_EQ(status, task_failed);
+        _unhook_sai_apis();
+    }
+
     TEST_F(SaihelperTest, TestAllSuccess) {
         _hook_sai_apis();
         initSwitchOrch();
@@ -328,6 +343,22 @@ namespace saihelper_test
         ASSERT_EQ(status, task_need_retry);
 
         status = handleSaiSetStatus(SAI_API_NEXT_HOP_GROUP, SAI_STATUS_NO_MEMORY);
+        ASSERT_EQ(*_sai_syncd_notifications_count, 0);
+        ASSERT_EQ(status, task_need_retry);
+
+        _unhook_sai_apis();
+    }
+
+    TEST_F(SaihelperTest, TestRemoveObjectInUse) {
+        _hook_sai_apis();
+        initSwitchOrch();
+
+        _sai_syncd_notifications_count = (uint32_t*)mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        *_sai_syncd_notifications_count = 0;
+        task_process_status status;
+
+        status = handleSaiRemoveStatus(SAI_API_NEXT_HOP_GROUP, SAI_STATUS_OBJECT_IN_USE);
         ASSERT_EQ(*_sai_syncd_notifications_count, 0);
         ASSERT_EQ(status, task_need_retry);
 

--- a/tests/mock_tests/mock_saihelper.cpp
+++ b/tests/mock_tests/mock_saihelper.cpp
@@ -149,8 +149,17 @@ namespace saihelper_test
         _hook_sai_apis();
         initSwitchOrch();
 
-        // Assert that the program terminates after initSaiRedis() call
-        ASSERT_DEATH({initSaiRedis();}, "");
+        _sai_syncd_notifications_count = (uint32_t*)mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        _sai_syncd_notification_event = (int32_t*)mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        *_sai_syncd_notifications_count = 0;
+        uint32_t notif_count = *_sai_syncd_notifications_count;
+
+        initSaiRedis();
+        ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
+        ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+
         set_comm_mode_not_supported = false;
         _unhook_sai_apis();
     }
@@ -160,8 +169,17 @@ namespace saihelper_test
         _hook_sai_apis();
         initSwitchOrch();
 
-        // Assert that the program terminates after initSaiRedis() call
-        ASSERT_DEATH({initSaiRedis();}, "");
+        _sai_syncd_notifications_count = (uint32_t*)mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        _sai_syncd_notification_event = (int32_t*)mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        *_sai_syncd_notifications_count = 0;
+        uint32_t notif_count = *_sai_syncd_notifications_count;
+
+        initSaiRedis();
+        ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
+        ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+
         use_pipeline_not_supported = false;
         _unhook_sai_apis();
     }
@@ -176,58 +194,72 @@ namespace saihelper_test
                     MAP_SHARED | MAP_ANONYMOUS, -1, 0);
         *_sai_syncd_notifications_count = 0;
         uint32_t notif_count = *_sai_syncd_notifications_count;
+        task_process_status status;
 
-        handleSaiCreateStatus(SAI_API_ROUTE, SAI_STATUS_FAILURE);
+        status = handleSaiCreateStatus(SAI_API_ROUTE, SAI_STATUS_FAILURE);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+        ASSERT_EQ(status, task_failed);
 
-        handleSaiCreateStatus(SAI_API_PORT, SAI_STATUS_FAILURE);
+        status = handleSaiCreateStatus(SAI_API_PORT, SAI_STATUS_FAILURE);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+        ASSERT_EQ(status, task_failed);
 
-        handleSaiCreateStatus(SAI_API_TUNNEL, SAI_STATUS_NOT_SUPPORTED);
+        status = handleSaiCreateStatus(SAI_API_TUNNEL, SAI_STATUS_NOT_SUPPORTED);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+        ASSERT_EQ(status, task_failed);
 
-        handleSaiCreateStatus(SAI_API_TUNNEL, SAI_STATUS_NOT_IMPLEMENTED);
+        status = handleSaiCreateStatus(SAI_API_TUNNEL, SAI_STATUS_NOT_IMPLEMENTED);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+        ASSERT_EQ(status, task_failed);
 
-        handleSaiCreateStatus(SAI_API_NEXT_HOP_GROUP, SAI_STATUS_INVALID_PARAMETER);
+        status = handleSaiCreateStatus(SAI_API_NEXT_HOP_GROUP, SAI_STATUS_INVALID_PARAMETER);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+        ASSERT_EQ(status, task_failed);
 
-        handleSaiCreateStatus(SAI_API_SWITCH, SAI_STATUS_UNINITIALIZED);
+        status = handleSaiCreateStatus(SAI_API_SWITCH, SAI_STATUS_UNINITIALIZED);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+        ASSERT_EQ(status, task_failed);
 
-        handleSaiCreateStatus((sai_api_t) SAI_API_DASH_OUTBOUND_ROUTING, SAI_STATUS_INVALID_OBJECT_ID);
+        status = handleSaiCreateStatus((sai_api_t) SAI_API_DASH_OUTBOUND_ROUTING, SAI_STATUS_INVALID_OBJECT_ID);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+        ASSERT_EQ(status, task_failed);
 
-        handleSaiCreateStatus(SAI_API_ACL, SAI_STATUS_MANDATORY_ATTRIBUTE_MISSING);
+        status = handleSaiCreateStatus(SAI_API_ACL, SAI_STATUS_MANDATORY_ATTRIBUTE_MISSING);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+        ASSERT_EQ(status, task_failed);
 
-        handleSaiCreateStatus(SAI_API_QOS_MAP, SAI_STATUS_INVALID_ATTR_VALUE_MAX);
+        status = handleSaiCreateStatus(SAI_API_QOS_MAP, SAI_STATUS_INVALID_ATTR_VALUE_MAX);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+        ASSERT_EQ(status, task_failed);
 
-        handleSaiCreateStatus(SAI_API_TUNNEL, SAI_STATUS_ATTR_NOT_IMPLEMENTED_6);
+        status = handleSaiCreateStatus(SAI_API_TUNNEL, SAI_STATUS_ATTR_NOT_IMPLEMENTED_6);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+        ASSERT_EQ(status, task_failed);
 
-        handleSaiCreateStatus(SAI_API_ROUTER_INTERFACE, SAI_STATUS_UNKNOWN_ATTRIBUTE_0);
+        status = handleSaiCreateStatus(SAI_API_ROUTER_INTERFACE, SAI_STATUS_UNKNOWN_ATTRIBUTE_0);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+        ASSERT_EQ(status, task_failed);
 
-        handleSaiCreateStatus(SAI_API_ROUTER_INTERFACE, SAI_STATUS_ATTR_NOT_SUPPORTED_0);
+        status = handleSaiCreateStatus(SAI_API_ROUTER_INTERFACE, SAI_STATUS_ATTR_NOT_SUPPORTED_0);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+        ASSERT_EQ(status, task_failed);
 
-        handleSaiCreateStatus(SAI_API_LAG, SAI_STATUS_INVALID_PORT_NUMBER);
+        status = handleSaiCreateStatus(SAI_API_LAG, SAI_STATUS_INVALID_PORT_NUMBER);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+        ASSERT_EQ(status, task_failed);
 
         _unhook_sai_apis();
     }
@@ -242,34 +274,42 @@ namespace saihelper_test
                     MAP_SHARED | MAP_ANONYMOUS, -1, 0);
         *_sai_syncd_notifications_count = 0;
         uint32_t notif_count = *_sai_syncd_notifications_count;
+        task_process_status status;
 
-        handleSaiSetStatus(SAI_API_ROUTE, SAI_STATUS_FAILURE);
+        status = handleSaiSetStatus(SAI_API_ROUTE, SAI_STATUS_FAILURE);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+        ASSERT_EQ(status, task_failed);
 
-        handleSaiSetStatus(SAI_API_ROUTE, SAI_STATUS_NOT_EXECUTED);
+        status = handleSaiSetStatus(SAI_API_ROUTE, SAI_STATUS_NOT_EXECUTED);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+        ASSERT_EQ(status, task_failed);
 
-        handleSaiSetStatus(SAI_API_PORT, SAI_STATUS_FAILURE);
+        status = handleSaiSetStatus(SAI_API_PORT, SAI_STATUS_FAILURE);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+        ASSERT_EQ(status, task_failed);
 
-        handleSaiSetStatus(SAI_API_TUNNEL, SAI_STATUS_NOT_IMPLEMENTED);
+        status = handleSaiSetStatus(SAI_API_TUNNEL, SAI_STATUS_NOT_IMPLEMENTED);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+        ASSERT_EQ(status, task_failed);
 
-        handleSaiSetStatus(SAI_API_HOSTIF, SAI_STATUS_INVALID_PARAMETER);
+        status = handleSaiSetStatus(SAI_API_HOSTIF, SAI_STATUS_INVALID_PARAMETER);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+        ASSERT_EQ(status, task_failed);
 
-        handleSaiSetStatus(SAI_API_PORT, SAI_STATUS_ATTR_NOT_SUPPORTED_0);
+        status = handleSaiSetStatus(SAI_API_PORT, SAI_STATUS_ATTR_NOT_SUPPORTED_0);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+        ASSERT_EQ(status, task_failed);
 
-        handleSaiSetStatus(SAI_API_LAG, SAI_STATUS_INVALID_PORT_NUMBER);
+        status = handleSaiSetStatus(SAI_API_LAG, SAI_STATUS_INVALID_PORT_NUMBER);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+        ASSERT_EQ(status, task_failed);
 
         _unhook_sai_apis();
     }

--- a/tests/mock_tests/orchdaemon_ut.cpp
+++ b/tests/mock_tests/orchdaemon_ut.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include "mock_sai_switch.h"
+#include "saihelper.h"
 
 extern sai_switch_api_t* sai_switch_api;
 sai_switch_api_t test_sai_switch;
@@ -16,6 +17,7 @@ namespace orchdaemon_test
     using ::testing::_;
     using ::testing::Return;
     using ::testing::StrictMock;
+    using ::testing::InSequence;
 
     DBConnector appl_db("APPL_DB", 0);
     DBConnector state_db("STATE_DB", 0);
@@ -163,6 +165,16 @@ namespace orchdaemon_test
         EXPECT_TRUE(gRingBuffer->IsEmpty() && x==5);
 
         orchd->disableRingBuffer();
+    }
+
+    TEST_F(OrchDaemonTest, TestRedisFlushFailure)
+    {
+        InSequence s;
+
+        EXPECT_CALL(mock_sai_switch_, set_switch_attribute( _, _)).WillOnce(Return(SAI_STATUS_FAILURE));
+        EXPECT_CALL(mock_sai_switch_, set_switch_attribute(_, _));
+
+        orchd->flush();
     }
 
 }

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -93,9 +93,9 @@ namespace portsorch_test
     uint32_t set_pt_interface_id_count = false;
     uint32_t set_pt_timestamp_template_count = false;
     uint32_t set_port_tam_count = false;
-    uint32_t set_pt_interface_id_failures;
-    uint32_t set_pt_timestamp_template_failures;
-    uint32_t set_port_tam_failures;
+    uint32_t set_pt_interface_id_failures = 0;
+    uint32_t set_pt_timestamp_template_failures = 0;
+    uint32_t set_port_tam_failures = 0;
     bool set_link_event_damping_success = true;
     uint32_t _sai_set_link_event_damping_algorithm_count;
     uint32_t _sai_set_link_event_damping_config_count;
@@ -238,7 +238,7 @@ namespace portsorch_test
     {
         if (attr[0].id == SAI_REDIS_SWITCH_ATTR_NOTIFY_SYNCD)
         {
-            *_sai_syncd_notifications_count =+ 1;
+            *_sai_syncd_notifications_count = *_sai_syncd_notifications_count + 1;
             *_sai_syncd_notification_event = attr[0].value.s32;
         }
 	else if (attr[0].id == SAI_SWITCH_ATTR_PFC_DLR_PACKET_ACTION)
@@ -1686,6 +1686,12 @@ namespace portsorch_test
         _hook_sai_port_api();
         _hook_sai_switch_api();
 
+        _sai_syncd_notifications_count = (uint32_t*)mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        _sai_syncd_notification_event = (int32_t*)mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        *_sai_syncd_notifications_count = 0;
+        uint32_t notif_count = *_sai_syncd_notifications_count;
         auto portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
         Port p;
         std::deque<KeyOpFieldsValuesTuple> kfvList;
@@ -1738,8 +1744,9 @@ namespace portsorch_test
         consumer->addToSync(kfvList);
 
         static_cast<Orch*>(gPortsOrch)->doTask();
-
-        ASSERT_EQ(set_pt_interface_id_fail, 1);
+        ASSERT_EQ(set_pt_interface_id_failures, 1);
+        ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
+        ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
 
         set_pt_interface_id_fail = false;
 
@@ -1762,6 +1769,8 @@ namespace portsorch_test
         static_cast<Orch*>(gPortsOrch)->doTask();
 
         ASSERT_EQ(set_pt_timestamp_template_failures, 1);
+        ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
+        ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
 
         set_pt_timestamp_template_fail = false;
 
@@ -1783,7 +1792,9 @@ namespace portsorch_test
 
         static_cast<Orch*>(gPortsOrch)->doTask();
 
-        ASSERT_EQ(set_port_tam_fail, 1);
+        ASSERT_EQ(set_port_tam_failures, 1);
+        ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
+        ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
 
         set_port_tam_fail = false;
 
@@ -2554,7 +2565,7 @@ namespace portsorch_test
                            }});
         auto consumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_PORT_TABLE_NAME));
         consumer->addToSync(entries);
-        ASSERT_DEATH({static_cast<Orch *>(gPortsOrch)->doTask();}, "");
+        gPortsOrch->doTask();
 
         ASSERT_EQ(*_sai_syncd_notifications_count, 1);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);

--- a/tests/mock_tests/test_failure_handling.cpp
+++ b/tests/mock_tests/test_failure_handling.cpp
@@ -58,31 +58,31 @@ namespace saifailure_test
         *_sai_syncd_notifications_count = 0;
         uint32_t notif_count = *_sai_syncd_notifications_count;
 
-        ASSERT_DEATH({handleSaiCreateStatus(SAI_API_FDB, SAI_STATUS_FAILURE);}, "");
+        handleSaiCreateStatus(SAI_API_FDB, SAI_STATUS_FAILURE);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
 
-        ASSERT_DEATH({handleSaiCreateStatus(SAI_API_HOSTIF, SAI_STATUS_INVALID_PARAMETER);}, "");
+        handleSaiCreateStatus(SAI_API_HOSTIF, SAI_STATUS_INVALID_PARAMETER);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
 
-        ASSERT_DEATH({handleSaiCreateStatus(SAI_API_PORT, SAI_STATUS_FAILURE);}, "");
+        handleSaiCreateStatus(SAI_API_PORT, SAI_STATUS_FAILURE);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
 
-        ASSERT_DEATH({handleSaiSetStatus(SAI_API_HOSTIF, SAI_STATUS_FAILURE);}, "");
+        handleSaiSetStatus(SAI_API_HOSTIF, SAI_STATUS_FAILURE);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
 
-        ASSERT_DEATH({handleSaiSetStatus(SAI_API_PORT, SAI_STATUS_FAILURE);}, "");
+        handleSaiSetStatus(SAI_API_PORT, SAI_STATUS_FAILURE);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
 
-        ASSERT_DEATH({handleSaiSetStatus(SAI_API_TUNNEL, SAI_STATUS_FAILURE);}, "");
+        handleSaiSetStatus(SAI_API_TUNNEL, SAI_STATUS_FAILURE);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
 
-        ASSERT_DEATH({handleSaiRemoveStatus(SAI_API_LAG, SAI_STATUS_FAILURE);}, "");
+        handleSaiRemoveStatus(SAI_API_LAG, SAI_STATUS_FAILURE);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
This change aims to reduce self-induced orchagent exit when any SAI API call fails (i.e returns anything other than SAI_STATUS_SUCCESS). This change is the first set of changes that does the following:

1.  handleSaiCreateStatus() / handleSaiSetStatus() changes
- Return 'task_success' for SAI_STATUS_ITEM_ALREADY_EXISTS, SAI_STATUS_ITEM_NOT_FOUND, SAI_STATUS_ADDR_NOT_FOUND and SAI_STATUS_OBJECT_IN_USE irrespective of the object type.
- Return 'task_need_retry' for SAI_STATUS_INSUFFICIENT_RESOURCES, SAI_STATUS_TABLE_FULL, SAI_STATUS_NO_MEMORY and 
SAI_STATUS_NV_STORAGE_FULL.
-  Call handleSaiFailure() and return 'task_failed' for other SAI errors. This will log a structured syslog via eventd and also take a SAI dump.

2. handleSaiRemoveStatus() changes
- Return 'task_success' for SAI_STATUS_ITEM_ALREADY_EXISTS, SAI_STATUS_ITEM_NOT_FOUND, SAI_STATUS_ADDR_NOT_FOUND, SAI_STATUS_INSUFFICIENT_RESOURCES,  SAI_STATUS_TABLE_FULL, SAI_STATUS_NO_MEMORY, SAI_STATUS_NV_STORAGE_FULL
- Return 'task_need_retry' for SAI_STATUS_OBJECT_IN_USE
- Call handleSaiFailure() and return 'task_failed' for other SAI errors. This will log a structured syslog via eventd and also take a SAI dump.

3. handleSaiGetStatus() changes
- Log a NOTICE message and return task_failed. This is similar to what is being done today for GET calls.

4. handleSaiFailure() changes
- Update handleSaiFailure() to take 3 arguments - namely the SAI API, operation type string and SAI API return status. This will be used in crafting a structured syslog error message when the failure happens. All callers of this function are updated accordingly.

5. Mock test changes
- Added new tests for coverage and updated existing tests that do "ASSERT_DEATH" assertions when SAI API calls fail.
- Fixed errors in existing portsorch_ut test cases

**What is not done**
There are changes needed to all orchs to handle scenarios where orchagent doesn't crash anymore when SAI API calls fail. There are also places in different orchs where an explicit exception is thrown in case of SAI errors. These and the remaining items in https://github.com/sonic-net/SONiC/pull/1698 will be handled in phase-2.
 
**Why I did it**
Crashing orchagent on every SAI error is an overkill. Instead, we follow the approach that is called out in the HLD above to handle these errors in a more graceful manner.

**How I verified it**
By adding mock tests to verify that orchagent no longer exits when there are SAI API call failures. 

**Details if related**
Sample error handling snippet showing eventd log and SAI dump invocation.
```
2025 Jun  6 17:53:24.448168 sonic ERR swss#orchagent: :- meta_sai_validate_route_entry: object key SAI_OBJECT_TYPE_ROUTE_ENTRY:{"dest":"10.1.0.32/32","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000023"} already exists
2025 Jun  6 17:53:24.448547 sonic ERR swss#orchagent: :- flush_creating_entries: EntityBulker.flush create entries failed, number of entries to create: 1, status: SAI_STATUS_ITEM_ALREADY_EXISTS
2025 Jun  6 17:53:24.448750 sonic ERR swss#orchagent: :- addRoutePost: Failed to create route 10.1.0.32/32 with next hop(s) 30.1.0.2@PortChannel101
2025 Jun  6 17:53:24.448933 sonic ERR swss#orchagent: :- handleSaiFailure: Encountered failure in create operation, SAI API: SAI_API_ROUTE, status: SAI_STATUS_NOT_EXECUTED
2025 Jun  6 17:53:24.449276 sonic NOTICE syncd#syncd: :- processNotifySyncd: Invoking SAI failure dump
2025 Jun  6 17:53:24.449276 sonic NOTICE swss#orchagent: :- publish: EVENT_PUBLISHED: {"sonic-events-swss:sai-operation-failure":{"api":"SAI_API_ROUTE","operation":"create","status":"SAI_STATUS_NOT_EXECUTED","timestamp":"2025-06-06T17:53:24.447963Z"}}
2025 Jun  6 17:53:24.449309 sonic NOTICE swss#orchagent: :- notifySyncd: sending syncd: SYNCD_INVOKE_DUMP
2025 Jun  6 17:53:24.465408 sonic NOTICE swss#orchagent: :- sai_redis_notify_syncd: invoked DUMP succeeded
```