### PR TITLE
Improve ZMQ consumer to support table names with priority

### DIFF
--- a/orchagent/zmqorch.cpp
+++ b/orchagent/zmqorch.cpp
@@ -37,6 +37,15 @@ ZmqOrch::ZmqOrch(DBConnector *db, const vector<string> &tableNames, ZmqServer *z
     }
 }
 
+
+ZmqOrch::ZmqOrch(DBConnector *db, const vector<table_name_with_pri_t> &tableNames_with_pri, ZmqServer *zmqServer)
+{
+    for (const auto& it : tableNames_with_pri)
+    {
+        addConsumer(db, it.first, it.second, zmqServer);
+    }
+}
+
 void ZmqOrch::addConsumer(DBConnector *db, string tableName, int pri, ZmqServer *zmqServer)
 {
     if (db->getDbId() == APPL_DB)

--- a/orchagent/zmqorch.h
+++ b/orchagent/zmqorch.h
@@ -26,6 +26,7 @@ class ZmqOrch : public Orch
 {
 public:
     ZmqOrch(swss::DBConnector *db, const std::vector<std::string> &tableNames, swss::ZmqServer *zmqServer);
+    ZmqOrch(swss::DBConnector *db, const std::vector<table_name_with_pri_t> &tableNames_with_pri, swss::ZmqServer *zmqServer);
 
     virtual void doTask(ConsumerBase &consumer) { };
     void doTask(Consumer &consumer) override;


### PR DESCRIPTION
Improve ZMQ consumer to support table names with priority

#### Why I did it
With this improve, ZMQ consumer can support more orch, for example route orch.

#### How I did it
Improve ZMQ consumer to support table names with priority

##### Work item tracking
- Microsoft ADO: 30468564

#### How to verify it
Pass all test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Improve ZMQ consumer to support table names with priority

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

