### PR TITLE
Enable zmq in p4orch.

### DIFF
--- a/.azure-pipelines/build_and_install_module.sh
+++ b/.azure-pipelines/build_and_install_module.sh
@@ -86,10 +86,10 @@ build_and_install_kmodule()
     mkdir -p $SONIC_MODULES_DIR
     cp drivers/net/team/*.ko drivers/net/vrf.ko drivers/net/macsec.ko $SONIC_MODULES_DIR/
     depmod
-    modinfo team vrf macsec
-    modprobe team
-    modprobe vrf
-    modprobe macsec
+    sudo modinfo team vrf macsec
+    sudo modprobe team
+    sudo modprobe vrf
+    sudo modprobe macsec
 
     cd /tmp
     rm -rf $WORKDIR

--- a/cfgmgr/buffermgrd.cpp
+++ b/cfgmgr/buffermgrd.cpp
@@ -18,6 +18,11 @@ using namespace std;
 using namespace swss;
 using json = nlohmann::json;
 
+bool gSwssRecord = false;
+bool gLogRotate = false;
+ofstream gRecordOfs;
+string gRecordFile;
+
 /* SELECT() function timeout retry time, in millisecond */
 #define SELECT_TIMEOUT 1000
 

--- a/cfgmgr/coppmgrd.cpp
+++ b/cfgmgr/coppmgrd.cpp
@@ -13,6 +13,11 @@
 using namespace std;
 using namespace swss;
 
+bool gSwssRecord = false;
+bool gLogRotate = false;
+ofstream gRecordOfs;
+string gRecordFile;
+
 /* select() function timeout retry time, in millisecond */
 #define SELECT_TIMEOUT 1000
 

--- a/cfgmgr/fabricmgrd.cpp
+++ b/cfgmgr/fabricmgrd.cpp
@@ -12,6 +12,11 @@
 using namespace std;
 using namespace swss;
 
+bool gSwssRecord = false;
+bool gLogRotate = false;
+ofstream gRecordOfs;
+string gRecordFile;
+
 /* select() function timeout retry time, in millisecond */
 #define SELECT_TIMEOUT 1000
 

--- a/cfgmgr/intfmgrd.cpp
+++ b/cfgmgr/intfmgrd.cpp
@@ -13,6 +13,11 @@
 using namespace std;
 using namespace swss;
 
+bool gSwssRecord = false;
+bool gLogRotate = false;
+ofstream gRecordOfs;
+string gRecordFile;
+
 /* select() function timeout retry time, in millisecond */
 #define SELECT_TIMEOUT 1000
 

--- a/cfgmgr/macsecmgrd.cpp
+++ b/cfgmgr/macsecmgrd.cpp
@@ -21,6 +21,11 @@
 using namespace std;
 using namespace swss;
 
+bool gSwssRecord = false;
+bool gLogRotate = false;
+ofstream gRecordOfs;
+string gRecordFile;
+
 /* select() function timeout retry time, in millisecond */
 #define SELECT_TIMEOUT 1000
 

--- a/cfgmgr/natmgrd.cpp
+++ b/cfgmgr/natmgrd.cpp
@@ -36,6 +36,11 @@
 using namespace std;
 using namespace swss;
 
+bool gSwssRecord = false;
+bool gLogRotate = false;
+ofstream gRecordOfs;
+string gRecordFile;
+
 /* select() function timeout retry time, in millisecond */
 #define SELECT_TIMEOUT 1000
 

--- a/cfgmgr/nbrmgrd.cpp
+++ b/cfgmgr/nbrmgrd.cpp
@@ -14,6 +14,11 @@
 using namespace std;
 using namespace swss;
 
+bool gSwssRecord = false;
+bool gLogRotate = false;
+ofstream gRecordOfs;
+string gRecordFile;
+
 #define RESTORE_NEIGH_WAIT_TIME_OUT 120
 #define RESTORE_NEIGH_WAIT_TIME_INT 10
 

--- a/cfgmgr/portmgrd.cpp
+++ b/cfgmgr/portmgrd.cpp
@@ -12,6 +12,11 @@
 using namespace std;
 using namespace swss;
 
+bool gSwssRecord = false;
+bool gLogRotate = false;
+ofstream gRecordOfs;
+string gRecordFile;
+
 /* select() function timeout retry time, in millisecond */
 #define SELECT_TIMEOUT 1000
 

--- a/cfgmgr/sflowmgrd.cpp
+++ b/cfgmgr/sflowmgrd.cpp
@@ -12,6 +12,11 @@
 using namespace std;
 using namespace swss;
 
+bool gSwssRecord = false;
+bool gLogRotate = false;
+ofstream gRecordOfs;
+string gRecordFile;
+
 /* select() function timeout retry time, in millisecond */
 #define SELECT_TIMEOUT 1000
 

--- a/cfgmgr/teammgrd.cpp
+++ b/cfgmgr/teammgrd.cpp
@@ -15,6 +15,11 @@ using namespace swss;
 bool received_sigterm = false;
 static struct sigaction old_sigaction;
 
+bool gSwssRecord = false;
+bool gLogRotate = false;
+ofstream gRecordOfs;
+string gRecordFile;
+
 void sig_handler(int signo)
 {
     SWSS_LOG_ENTER();

--- a/cfgmgr/tunnelmgrd.cpp
+++ b/cfgmgr/tunnelmgrd.cpp
@@ -16,6 +16,11 @@
 using namespace std;
 using namespace swss;
 
+bool gSwssRecord = false;
+bool gLogRotate = false;
+ofstream gRecordOfs;
+string gRecordFile;
+
 /* select() function timeout retry time, in millisecond */
 #define SELECT_TIMEOUT 1000
 

--- a/cfgmgr/vlanmgrd.cpp
+++ b/cfgmgr/vlanmgrd.cpp
@@ -23,6 +23,11 @@ using namespace swss;
 
 MacAddress gMacAddress;
 
+bool gSwssRecord = false;
+bool gLogRotate = false;
+ofstream gRecordOfs;
+string gRecordFile;
+
 int main(int argc, char **argv)
 {
     Logger::linkToDbNative("vlanmgrd");

--- a/cfgmgr/vrfmgrd.cpp
+++ b/cfgmgr/vrfmgrd.cpp
@@ -13,6 +13,11 @@
 using namespace std;
 using namespace swss;
 
+bool gSwssRecord = false;
+bool gLogRotate = false;
+ofstream gRecordOfs;
+string gRecordFile;
+
 /* select() function timeout retry time, in millisecond */
 #define SELECT_TIMEOUT 1000
 

--- a/cfgmgr/vxlanmgrd.cpp
+++ b/cfgmgr/vxlanmgrd.cpp
@@ -18,6 +18,11 @@
 using namespace std;
 using namespace swss;
 
+bool gSwssRecord = false;
+bool gLogRotate = false;
+ofstream gRecordOfs;
+string gRecordFile;
+
 /* select() function timeout retry time, in millisecond */
 #define SELECT_TIMEOUT 1000
 

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -48,6 +48,13 @@ sai_object_id_t gSwitchId = SAI_NULL_OBJECT_ID;
 MacAddress gMacAddress;
 MacAddress gVxlanMacAddress;
 
+bool gSairedisRecord = true;
+bool gSwssRecord = true;
+bool gLogRotate = false;
+
+ofstream gRecordOfs;
+string gRecordFile;
+
 extern size_t gMaxBulkSize;
 
 #define DEFAULT_BATCH_SIZE  128
@@ -548,6 +555,17 @@ int main(int argc, char **argv)
     attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
     attr.value.booldata = true;
     attrs.push_back(attr);
+
+    gSairedisRecord =
+        (record_type & SAIREDIS_RECORD_ENABLE) == SAIREDIS_RECORD_ENABLE;
+    gSwssRecord = (record_type & SWSS_RECORD_ENABLE) == SWSS_RECORD_ENABLE;
+
+    if (gMySwitchType != "dpu")
+    {
+        attr.id = SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY;
+        attr.value.ptr = (void *)on_fdb_event;
+        attrs.push_back(attr);
+    }
 
     attr.id = SAI_SWITCH_ATTR_PORT_STATE_CHANGE_NOTIFY;
     attr.value.ptr = (void *)on_port_state_change;

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -56,6 +56,11 @@ const char state_db_key_delimiter  = '|';
 
 const int default_orch_pri = 0;
 
+// The maximum size of swss.rec we allow before suppressing recordings until
+// logrotate runs. Logrotate is configured with 2MB size limit and we will use
+// 6MB size limit for internal check.
+const int SWSS_LOG_FILESIZE = 6291456;  // 6 MB
+
 typedef enum
 {
     task_success,
@@ -305,6 +310,9 @@ public:
      */
     virtual void onWarmBootEnd() { }
 
+    /* TODO: refactor recording */
+    static void recordTuple(ConsumerBase &consumer, const swss::KeyOpFieldsValuesTuple &tuple);
+
     void dumpPendingTasks(std::vector<std::string> &ts);
 
     /**
@@ -315,6 +323,8 @@ protected:
     ConsumerMap m_consumerMap;
 
     Orch();
+    static void logfileReopen();
+    std::string dumpTuple(Consumer &consumer, const swss::KeyOpFieldsValuesTuple &tuple);
     ref_resolve_status resolveFieldRefValue(type_map&, const std::string&, const std::string&, swss::KeyOpFieldsValuesTuple&, sai_object_id_t&, std::string&);
     std::set<std::string> generateIdListFromMap(unsigned long idsMap, sai_uint32_t maxId);
     unsigned long generateBitMapFromIdsStr(const std::string &idsStr);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -813,7 +813,7 @@ bool OrchDaemon::init()
     m_orchList.push_back(&CounterCheckOrch::getInstance(m_configDb));
 
     vector<string> p4rt_tables = {APP_P4RT_TABLE_NAME};
-    gP4Orch = new P4Orch(m_applDb, p4rt_tables, vrf_orch, gCoppOrch);
+    gP4Orch = new P4Orch(m_applDb, p4rt_tables, m_zmqServer, vrf_orch, gCoppOrch);
     m_orchList.push_back(gP4Orch);
 
     TableConnector confDbTwampTable(m_configDb, CFG_TWAMP_SESSION_TABLE_NAME);

--- a/orchagent/p4orch/acl_rule_manager.h
+++ b/orchagent/p4orch/acl_rule_manager.h
@@ -42,7 +42,8 @@ class AclRuleManager : public ObjectManagerInterface
     virtual ~AclRuleManager() = default;
 
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
-    void drain() override;
+    ReturnCode drain() override;
+    void drainWithNotExecuted() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
     ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
                             std::string &object_key) override;

--- a/orchagent/p4orch/acl_table_manager.cpp
+++ b/orchagent/p4orch/acl_table_manager.cpp
@@ -216,29 +216,33 @@ void AclTableManager::enqueue(const std::string &table_name, const swss::KeyOpFi
     m_entries.push_back(entry);
 }
 
-void AclTableManager::drain()
-{
+void AclTableManager::drainWithNotExecuted() {
+   drainMgmtWithNotExecuted(m_entries, m_publisher);
+}
+
+ReturnCode AclTableManager::drain() {
     SWSS_LOG_ENTER();
 
-    for (const auto &key_op_fvs_tuple : m_entries)
-    {
+    ReturnCode status;
+    while (!m_entries.empty()) {
+        auto key_op_fvs_tuple = m_entries.front();
+        m_entries.pop_front();
         std::string table_name;
         std::string db_key;
         parseP4RTKey(kfvKey(key_op_fvs_tuple), &table_name, &db_key);
         SWSS_LOG_NOTICE("P4AclTableManager drain tuple for table %s", QuotedVar(table_name).c_str());
         if (table_name != APP_P4RT_ACL_TABLE_DEFINITION_NAME)
         {
-            ReturnCode status = ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                                << "Invalid table " << QuotedVar(table_name);
+            status = ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
+                << "Invalid table " << QuotedVar(table_name);
             SWSS_LOG_ERROR("%s", status.message().c_str());
             m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
                                  status,
                                  /*replace=*/true);
-            continue;
+            break;
         }
         const std::vector<swss::FieldValueTuple> &attributes = kfvFieldsValues(key_op_fvs_tuple);
 
-        ReturnCode status;
         const std::string &operation = kfvOp(key_op_fvs_tuple);
         if (operation == SET_COMMAND)
         {
@@ -251,7 +255,7 @@ void AclTableManager::drain()
                 m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
                                      status,
                                      /*replace=*/true);
-                continue;
+                break;
             }
             auto &app_db_entry = *app_db_entry_or;
 
@@ -263,7 +267,7 @@ void AclTableManager::drain()
                 m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
                                      status,
                                      /*replace=*/true);
-                continue;
+                break;
             }
             auto *acl_table_definition = getAclTable(app_db_entry.acl_table_name);
             if (acl_table_definition == nullptr)
@@ -294,8 +298,12 @@ void AclTableManager::drain()
         }
         m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple), status,
                              /*replace=*/true);
+        if (!status.ok()) {
+           break;
+        }
     }
-    m_entries.clear();
+    drainWithNotExecuted();
+    return status;
 }
 
 ReturnCodeOr<P4AclTableDefinitionAppDbEntry> AclTableManager::deserializeAclTableDefinitionAppDbEntry(

--- a/orchagent/p4orch/acl_table_manager.h
+++ b/orchagent/p4orch/acl_table_manager.h
@@ -32,7 +32,8 @@ class AclTableManager : public ObjectManagerInterface
     virtual ~AclTableManager();
 
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
-    void drain() override;
+    ReturnCode drain() override;
+    void drainWithNotExecuted() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
     ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
                             std::string &object_key) override;

--- a/orchagent/p4orch/ext_tables_manager.h
+++ b/orchagent/p4orch/ext_tables_manager.h
@@ -58,7 +58,8 @@ class ExtTablesManager : public ObjectManagerInterface
     virtual ~ExtTablesManager() = default;
 
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
-    void drain() override;
+    ReturnCode drain() override;
+    void drainWithNotExecuted() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
     ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
                             std::string &object_key) override;

--- a/orchagent/p4orch/gre_tunnel_manager.h
+++ b/orchagent/p4orch/gre_tunnel_manager.h
@@ -70,7 +70,8 @@ class GreTunnelManager : public ObjectManagerInterface
     virtual ~GreTunnelManager() = default;
 
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
-    void drain() override;
+    ReturnCode drain() override;
+    void drainWithNotExecuted() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
     ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
                             std::string &object_key) override;

--- a/orchagent/p4orch/l3_admit_manager.h
+++ b/orchagent/p4orch/l3_admit_manager.h
@@ -61,7 +61,8 @@ class L3AdmitManager : public ObjectManagerInterface
     virtual ~L3AdmitManager() = default;
 
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
-    void drain() override;
+    ReturnCode drain() override;
+    void drainWithNotExecuted() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
     ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
                             std::string &object_key) override;

--- a/orchagent/p4orch/mirror_session_manager.cpp
+++ b/orchagent/p4orch/mirror_session_manager.cpp
@@ -55,18 +55,22 @@ void MirrorSessionManager::enqueue(const std::string &table_name, const swss::Ke
     m_entries.push_back(entry);
 }
 
-void MirrorSessionManager::drain()
-{
+void MirrorSessionManager::drainWithNotExecuted() {
+    drainMgmtWithNotExecuted(m_entries, m_publisher);
+}
+
+ReturnCode MirrorSessionManager::drain() {
     SWSS_LOG_ENTER();
 
-    for (const auto &key_op_fvs_tuple : m_entries)
-    {
+    ReturnCode status;
+    while (!m_entries.empty()) {
+        auto key_op_fvs_tuple = m_entries.front();
+        m_entries.pop_front();
         std::string table_name;
         std::string key;
         parseP4RTKey(kfvKey(key_op_fvs_tuple), &table_name, &key);
         const std::vector<swss::FieldValueTuple> &attributes = kfvFieldsValues(key_op_fvs_tuple);
 
-        ReturnCode status;
         auto app_db_entry_or = deserializeP4MirrorSessionAppDbEntry(key, attributes);
         if (!app_db_entry_or.ok())
         {
@@ -76,7 +80,7 @@ void MirrorSessionManager::drain()
             m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
                                  status,
                                  /*replace=*/true);
-            continue;
+            break;
         }
         auto &app_db_entry = *app_db_entry_or;
 
@@ -110,8 +114,12 @@ void MirrorSessionManager::drain()
         }
         m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple), status,
                              /*replace=*/true);
+        if (!status.ok()) {
+           break;
+        }
     }
-    m_entries.clear();
+    drainWithNotExecuted();
+    return status;
 }
 
 ReturnCodeOr<std::vector<sai_attribute_t>> getSaiAttrs(const P4MirrorSessionEntry &mirror_session_entry)

--- a/orchagent/p4orch/mirror_session_manager.h
+++ b/orchagent/p4orch/mirror_session_manager.h
@@ -83,8 +83,9 @@ class MirrorSessionManager : public ObjectManagerInterface
 
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
 
-    void drain() override;
+    ReturnCode drain() override;
 
+    void drainWithNotExecuted() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
 
     ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,

--- a/orchagent/p4orch/neighbor_manager.h
+++ b/orchagent/p4orch/neighbor_manager.h
@@ -50,7 +50,8 @@ class NeighborManager : public ObjectManagerInterface
     virtual ~NeighborManager() = default;
 
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
-    void drain() override;
+    ReturnCode drain() override;
+    void drainWithNotExecuted() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
     ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
                             std::string &object_key) override;

--- a/orchagent/p4orch/next_hop_manager.cpp
+++ b/orchagent/p4orch/next_hop_manager.cpp
@@ -180,18 +180,22 @@ void NextHopManager::enqueue(const std::string &table_name, const swss::KeyOpFie
     m_entries.push_back(entry);
 }
 
-void NextHopManager::drain()
-{
+void NextHopManager::drainWithNotExecuted() {
+   drainMgmtWithNotExecuted(m_entries, m_publisher);
+}
+
+ReturnCode NextHopManager::drain() {
     SWSS_LOG_ENTER();
 
-    for (const auto &key_op_fvs_tuple : m_entries)
-    {
+    ReturnCode status;
+    while (!m_entries.empty()) {
+        auto key_op_fvs_tuple = m_entries.front();
+        m_entries.pop_front();
         std::string table_name;
         std::string key;
         parseP4RTKey(kfvKey(key_op_fvs_tuple), &table_name, &key);
         const std::vector<swss::FieldValueTuple> &attributes = kfvFieldsValues(key_op_fvs_tuple);
 
-        ReturnCode status;
         auto app_db_entry_or = deserializeP4NextHopAppDbEntry(key, attributes);
         if (!app_db_entry_or.ok())
         {
@@ -201,7 +205,7 @@ void NextHopManager::drain()
             m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
                                  status,
                                  /*replace=*/true);
-            continue;
+            break;
         }
         auto &app_db_entry = *app_db_entry_or;
 
@@ -219,7 +223,7 @@ void NextHopManager::drain()
                 m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
                                      status,
                                      /*replace=*/true);
-                continue;
+                break;
             }
             auto *next_hop_entry = getNextHopEntry(next_hop_key);
             if (next_hop_entry == nullptr)
@@ -245,8 +249,12 @@ void NextHopManager::drain()
         }
         m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple), status,
                              /*replace=*/true);
+        if (!status.ok()) {
+            break;
+        }
     }
-    m_entries.clear();
+    drainWithNotExecuted();
+    return status;
 }
 
 P4NextHopEntry *NextHopManager::getNextHopEntry(const std::string &next_hop_key)

--- a/orchagent/p4orch/next_hop_manager.h
+++ b/orchagent/p4orch/next_hop_manager.h
@@ -58,7 +58,8 @@ class NextHopManager : public ObjectManagerInterface
     virtual ~NextHopManager() = default;
 
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
-    void drain() override;
+    ReturnCode drain() override;
+    void drainWithNotExecuted() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
     ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
                             std::string &object_key) override;

--- a/orchagent/p4orch/object_manager_interface.h
+++ b/orchagent/p4orch/object_manager_interface.h
@@ -11,7 +11,11 @@ class ObjectManagerInterface
     virtual void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) = 0;
 
     // Processes all entries in the queue
-    virtual void drain() = 0;
+    // Stops on first failure, returns first error status.
+    virtual ReturnCode drain() = 0;
+ 
+    // Drains all entries in the queue without execution.
+    virtual void drainWithNotExecuted() = 0;
 
     // StateVerification helper function for the manager
     virtual std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) = 0;

--- a/orchagent/p4orch/p4orch.cpp
+++ b/orchagent/p4orch/p4orch.cpp
@@ -24,14 +24,24 @@
 #include "sai_serialize.h"
 #include "timer.h"
 
+#include "timestamp.h"
+ 
+extern bool gSwssRecord;
+extern ofstream gRecordOfs;
+extern bool gLogRotate;
+
 extern PortsOrch *gPortsOrch;
 #define P4_ACL_COUNTERS_STATS_POLL_TIMER_NAME "P4_ACL_COUNTERS_STATS_POLL_TIMER"
 #define P4_EXT_COUNTERS_STATS_POLL_TIMER_NAME "P4_EXT_COUNTERS_STATS_POLL_TIMER"
 #define APP_P4RT_EXT_TABLES_MANAGER "EXT_TABLES_MANAGER"
 
-P4Orch::P4Orch(swss::DBConnector *db, std::vector<std::string> tableNames, VRFOrch *vrfOrch, CoppOrch *coppOrch)
-    : Orch(db, tableNames)
-{
+P4Orch::P4Orch(swss::DBConnector* db, std::vector<std::string> tableNames,
+               ZmqServer* zmqServer, VRFOrch* vrfOrch, CoppOrch* coppOrch)
+    : ZmqOrch(db, tableNames, zmqServer, /*orderedQueue=*/true,
+              /*dbPersistence=*/false),
+      m_zmqServer(zmqServer),
+      m_publisher("APPL_DB", /*bool buffered=*/true,
+                  /*db_write_thread=*/true, zmqServer) {
     SWSS_LOG_ENTER();
 
     m_tablesDefnManager = std::make_unique<TablesDefnManager>(&m_p4OidMapper, &m_publisher);
@@ -60,18 +70,21 @@ P4Orch::P4Orch(swss::DBConnector *db, std::vector<std::string> tableNames, VRFOr
     m_p4TableToManagerMap[APP_P4RT_L3_ADMIT_TABLE_NAME] = m_l3AdmitManager.get();
     m_p4TableToManagerMap[APP_P4RT_EXT_TABLES_MANAGER] = m_extTablesManager.get();
 
-    m_p4ManagerPrecedence.push_back(m_tablesDefnManager.get());
-    m_p4ManagerPrecedence.push_back(m_routerIntfManager.get());
-    m_p4ManagerPrecedence.push_back(m_neighborManager.get());
-    m_p4ManagerPrecedence.push_back(m_greTunnelManager.get());
-    m_p4ManagerPrecedence.push_back(m_nextHopManager.get());
-    m_p4ManagerPrecedence.push_back(m_wcmpManager.get());
-    m_p4ManagerPrecedence.push_back(m_routeManager.get());
-    m_p4ManagerPrecedence.push_back(m_mirrorSessionManager.get());
-    m_p4ManagerPrecedence.push_back(m_aclTableManager.get());
-    m_p4ManagerPrecedence.push_back(m_aclRuleManager.get());
-    m_p4ManagerPrecedence.push_back(m_l3AdmitManager.get());
-    m_p4ManagerPrecedence.push_back(m_extTablesManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_tablesDefnManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_routerIntfManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_neighborManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_greTunnelManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_nextHopManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_wcmpManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_routeManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_mirrorSessionManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_aclTableManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_aclRuleManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_l3AdmitManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_extTablesManager.get());
+    for (auto* manager : m_p4ManagerAddPrecedence) {
+      m_p4ManagerDelPrecedence.insert(m_p4ManagerDelPrecedence.begin(), manager);
+    }
 
     tablesinfo = nullptr;
     // Add timer executor to update ACL counters stats in COUNTERS_DB
@@ -87,7 +100,6 @@ P4Orch::P4Orch(swss::DBConnector *db, std::vector<std::string> tableNames, VRFOr
     auto ext_executor = new swss::ExecutableTimer(m_extCounterStatsTimer, this, P4_EXT_COUNTERS_STATS_POLL_TIMER_NAME);
     Orch::addExecutor(ext_executor);
     m_extCounterStatsTimer->start();
-
     // Add port state change notification handling support
     swss::DBConnector notificationsDb("ASIC_DB", 0);
     m_portStatusNotificationConsumer = new swss::NotificationConsumer(&notificationsDb, "NOTIFICATIONS");
@@ -95,7 +107,7 @@ P4Orch::P4Orch(swss::DBConnector *db, std::vector<std::string> tableNames, VRFOr
     Orch::addExecutor(portStatusNotifier);
 }
 
-void P4Orch::doTask(Consumer &consumer)
+void P4Orch::doTask(ConsumerBase &consumer)
 {
     SWSS_LOG_ENTER();
 
@@ -111,51 +123,48 @@ void P4Orch::doTask(Consumer &consumer)
         return;
     }
 
-    auto it = consumer.m_toSync.begin();
-    while (it != consumer.m_toSync.end())
-    {
-        const swss::KeyOpFieldsValuesTuple key_op_fvs_tuple = it->second;
-        const std::string key = kfvKey(key_op_fvs_tuple);
-        it = consumer.m_toSync.erase(it);
-        std::string table_name;
-        std::string key_content;
-        parseP4RTKey(key, &table_name, &key_content);
-        if (table_name.empty())
-        {
-            auto status = ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                          << "Table name cannot be empty, but was empty in key: " << key;
-            SWSS_LOG_ERROR("%s", status.message().c_str());
-            m_publisher.publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
-                                status);
-            continue;
-        }
-        if (m_p4TableToManagerMap.find(table_name) != m_p4TableToManagerMap.end())
-        {
-            m_p4TableToManagerMap[table_name]->enqueue(table_name, key_op_fvs_tuple);
-        }
-        else
-        {
-            if (table_name.rfind(p4orch::kTablePrefixEXT, 0) != std::string::npos)
-            {
-                m_p4TableToManagerMap[APP_P4RT_EXT_TABLES_MANAGER]->enqueue(table_name, key_op_fvs_tuple);
-            }
-            else
-            {
-                auto status = ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                              << "Failed to find P4Orch Manager for " << table_name << " P4RT DB table";
-                SWSS_LOG_ERROR("%s", status.message().c_str());
-                m_publisher.publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
-                                    status);
-            }
-        }
-    }
-
-    for (const auto &manager : m_p4ManagerPrecedence)
-    {
-        manager->drain();
-    }
-
-    m_publisher.flush();
+   // Warmboot scenario.
+   if (!consumer.m_toSync.empty()) {
+     auto it = consumer.m_toSync.begin();
+     while (it != consumer.m_toSync.end()) {
+       enqueue(it->second);
+       it = consumer.m_toSync.erase(it);
+     }
+     drain(SET_COMMAND);
+     m_publisher.flush(/*warmboot=*/true);
+   }
+ 
+   auto* zmq_consumer = dynamic_cast<ZmqConsumer*>(&consumer);
+   if (zmq_consumer == nullptr) {
+     return;
+   }
+ 
+   std::string prev_op = "";
+   ReturnCode status;
+   for (const auto& kco : zmq_consumer->m_queue) {
+     std::string op = kfvOp(kco);
+ 
+     // Call drain after grouping the same type of requests together.
+     if (op != prev_op && status.ok()) {
+       status = drain(prev_op);
+       prev_op = op;
+     }
+ 
+     // Stop enqueue if there is any failure.
+     if (status.ok()) {
+       enqueue(kco);
+     } else {
+       m_publisher.publish(APP_P4RT_TABLE_NAME, kfvKey(kco),
+                           kfvFieldsValues(kco),
+                           ReturnCode(StatusCode::SWSS_RC_NOT_EXECUTED),
+                           /*replace=*/true);
+     }
+   }
+   if (!prev_op.empty() && status.ok()) {
+     drain(prev_op);
+   }
+   m_publisher.flush();
+   zmq_consumer->m_queue.clear();
 }
 
 void P4Orch::doTask(swss::SelectableTimer &timer)
@@ -182,6 +191,60 @@ void P4Orch::doTask(swss::SelectableTimer &timer)
     }
 }
 
+void P4Orch::enqueue(const swss::KeyOpFieldsValuesTuple& entry) {
+   const std::string& key = kfvKey(entry);
+   const std::vector<swss::FieldValueTuple>& values = kfvFieldsValues(entry);
+   std::string table_name;
+   std::string key_content;
+   parseP4RTKey(key, &table_name, &key_content);
+   if (table_name.empty()) {
+     auto status = ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
+                   << "Table name cannot be empty, but was empty in key: "
+                   << key;
+     SWSS_LOG_ERROR("%s", status.message().c_str());
+     m_publisher.publish(APP_P4RT_TABLE_NAME, key, values, status,
+                         /*replace=*/true);
+     return;
+   }
+   if (m_p4TableToManagerMap.find(table_name) != m_p4TableToManagerMap.end()) {
+     m_p4TableToManagerMap[table_name]->enqueue(table_name, entry);
+   } else {
+     if (table_name.rfind(p4orch::kTablePrefixEXT, 0) != std::string::npos) {
+       m_p4TableToManagerMap[APP_P4RT_EXT_TABLES_MANAGER]->enqueue(table_name,
+                                                                   entry);
+     } else {
+       auto status = ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
+                     << "Failed to find P4Orch Manager for " << table_name
+                     << " P4RT DB table";
+       SWSS_LOG_ERROR("%s", status.message().c_str());
+       m_publisher.publish(APP_P4RT_TABLE_NAME, kfvKey(entry),
+                           kfvFieldsValues(entry), status, /*replace=*/true);
+     }
+   }
+}
+ReturnCode P4Orch::drain(const std::string& op) {
+   ReturnCode status;
+ 
+   if (op == SET_COMMAND) {
+     for (const auto& manager : m_p4ManagerAddPrecedence) {
+      if (status.ok()) {
+         status = manager->drain();
+       } else {
+         manager->drainWithNotExecuted();
+       }
+     }
+   } else {
+     for (const auto& manager : m_p4ManagerDelPrecedence) {
+      if (status.ok()) {
+         status = manager->drain();
+       } else {
+         manager->drainWithNotExecuted();
+       }
+     }
+   }
+   return status;
+ }
+ 
 void P4Orch::handlePortStatusChangeNotification(const std::string &op, const std::string &data)
 {
     if (op == "port_state_change")
@@ -233,8 +296,7 @@ void P4Orch::doTask(NotificationConsumer &consumer)
 
     consumer.pop(op, data, values);
 
-    if (&consumer == m_portStatusNotificationConsumer)
-    {
+    if (&consumer == m_portStatusNotificationConsumer) {
         handlePortStatusChangeNotification(op, data);
     }
 }

--- a/orchagent/p4orch/p4orch.h
+++ b/orchagent/p4orch/p4orch.h
@@ -25,7 +25,9 @@
 #include "p4orch/tables_definition_manager.h"
 #include "p4orch/wcmp_manager.h"
 #include "response_publisher.h"
+#include "return_code.h"
 #include "vrforch.h"
+#include "zmqorch.h"
 
 static const std::map<std::string, std::string> FixedTablesMap = {
     {"router_interface_table", APP_P4RT_ROUTER_INTERFACE_TABLE_NAME},
@@ -38,10 +40,10 @@ static const std::map<std::string, std::string> FixedTablesMap = {
     {"l3_admit_table", APP_P4RT_L3_ADMIT_TABLE_NAME},
     {"tunnel_table", APP_P4RT_TUNNEL_TABLE_NAME}};
 
-class P4Orch : public Orch
-{
+class P4Orch : public ZmqOrch {
   public:
-    P4Orch(swss::DBConnector *db, std::vector<std::string> tableNames, VRFOrch *vrfOrch, CoppOrch *coppOrch);
+    P4Orch(swss::DBConnector* db, std::vector<std::string> tableNames,
+           swss::ZmqServer* zmqServer, VRFOrch* vrfOrch, CoppOrch* coppOrch);
     // Add ACL table to ACLRuleManager mapping in P4Orch.
     bool addAclTableToManagerMapping(const std::string &acl_table_name);
     // Remove the ACL table name to AclRuleManager mapping in P4Orch
@@ -56,13 +58,17 @@ class P4Orch : public Orch
     std::unordered_map<std::string, ObjectManagerInterface *> m_p4TableToManagerMap;
 
   private:
-    void doTask(Consumer &consumer);
+    void doTask(ConsumerBase& consumer);
     void doTask(swss::SelectableTimer &timer);
     void doTask(swss::NotificationConsumer &consumer);
+    void enqueue(const swss::KeyOpFieldsValuesTuple& entry);
+    ReturnCode drain(const std::string& op);
+    void handleP4rtNotification(const std::vector<swss::FieldValueTuple>& values);
     void handlePortStatusChangeNotification(const std::string &op, const std::string &data);
 
     // P4 object manager request processing order.
-    std::vector<ObjectManagerInterface *> m_p4ManagerPrecedence;
+    std::vector<ObjectManagerInterface*> m_p4ManagerAddPrecedence;
+    std::vector<ObjectManagerInterface*> m_p4ManagerDelPrecedence;
 
     swss::SelectableTimer *m_aclCounterStatsTimer;
     swss::SelectableTimer *m_extCounterStatsTimer;
@@ -81,10 +87,13 @@ class P4Orch : public Orch
     std::unique_ptr<ExtTablesManager> m_extTablesManager;
 
     // Notification consumer for port state change
+    swss::NotificationConsumer* m_p4rtNotificationConsumer;
     swss::NotificationConsumer *m_portStatusNotificationConsumer;
 
+    swss::ZmqServer* m_zmqServer;
     // Sepcial publisher that writes to APPL DB instead of APPL STATE DB.
-    ResponsePublisher m_publisher{"APPL_DB", /*bool buffered=*/true, /*db_write_thread=*/true};
+    ResponsePublisher m_publisher;
 
+    friend class P4OrchTest;
     friend class p4orch::test::WcmpManagerTest;
 };

--- a/orchagent/p4orch/p4orch_util.cpp
+++ b/orchagent/p4orch/p4orch_util.cpp
@@ -120,6 +120,18 @@ std::string KeyGenerator::generateTablesInfoKey(const std::string &context)
     return generateKey(fv_map);
 }
 
+void drainMgmtWithNotExecuted(std::deque<swss::KeyOpFieldsValuesTuple>& entries,
+                               ResponsePublisherInterface* publisher) {
+  for (const auto& key_op_fvs_tuple : entries) {
+     publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple),
+                        kfvFieldsValues(key_op_fvs_tuple),
+                        ReturnCode(StatusCode::SWSS_RC_NOT_EXECUTED),
+                        /*replace=*/true);
+  }
+  entries.clear();
+  return;
+}
+
 std::string KeyGenerator::generateRouteKey(const std::string &vrf_id, const swss::IpPrefix &ip_prefix)
 {
     std::map<std::string, std::string> fv_map = {

--- a/orchagent/p4orch/p4orch_util.h
+++ b/orchagent/p4orch/p4orch_util.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <deque>
 #include <iomanip>
 #include <map>
 #include <set>
@@ -11,6 +12,8 @@
 #include "ipaddress.h"
 #include "ipprefix.h"
 #include "macaddress.h"
+#include "response_publisher_interface.h"
+#include "return_code.h"
 #include "table.h"
 extern "C"
 {
@@ -329,6 +332,10 @@ void parseP4RTKey(const std::string &key, std::string *table_name, std::string *
 std::string verifyAttrs(const std::vector<swss::FieldValueTuple> &targets,
                         const std::vector<swss::FieldValueTuple> &exp, const std::vector<swss::FieldValueTuple> &opt,
                         bool allow_unknown);
+
+// Helper function to drain all entries in the manager without execution.
+void drainMgmtWithNotExecuted(std::deque<swss::KeyOpFieldsValuesTuple>& entries,
+                               ResponsePublisherInterface* publisher);
 
 // class KeyGenerator includes member functions to generate keys for entries
 // stored in P4 Orch managers.

--- a/orchagent/p4orch/route_manager.h
+++ b/orchagent/p4orch/route_manager.h
@@ -84,7 +84,8 @@ class RouteManager : public ObjectManagerInterface
     virtual ~RouteManager() = default;
 
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
-    void drain() override;
+    ReturnCode drain() override;
+    void drainWithNotExecuted() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
     ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
                             std::string &object_key) override;

--- a/orchagent/p4orch/router_interface_manager.h
+++ b/orchagent/p4orch/router_interface_manager.h
@@ -50,7 +50,8 @@ class RouterInterfaceManager : public ObjectManagerInterface
     virtual ~RouterInterfaceManager() = default;
 
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
-    void drain() override;
+    ReturnCode drain() override;
+    void drainWithNotExecuted() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
     ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
                             std::string &object_key) override;

--- a/orchagent/p4orch/tables_definition_manager.h
+++ b/orchagent/p4orch/tables_definition_manager.h
@@ -57,7 +57,8 @@ class TablesDefnManager : public ObjectManagerInterface
     virtual ~TablesDefnManager() = default;
 
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
-    void drain() override;
+    ReturnCode drain() override;
+    void drainWithNotExecuted() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
     ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
                             std::string &object_key) override;

--- a/orchagent/p4orch/tests/Makefile.am
+++ b/orchagent/p4orch/tests/Makefile.am
@@ -27,6 +27,7 @@ p4orch_tests_SOURCES = $(ORCHAGENT_DIR)/orch.cpp \
 		       $(ORCHAGENT_DIR)/switch/trimming/helper.cpp \
 		       $(ORCHAGENT_DIR)/switchorch.cpp \
 		       $(ORCHAGENT_DIR)/request_parser.cpp \
+		       $(ORCHAGENT_DIR)/zmqorch.cpp \
 		       $(top_srcdir)/lib/recorder.cpp \
 		       $(ORCHAGENT_DIR)/flex_counter/flex_counter_manager.cpp \
 		       $(ORCHAGENT_DIR)/flex_counter/flow_counter_handler.cpp \
@@ -60,7 +61,9 @@ p4orch_tests_SOURCES = $(ORCHAGENT_DIR)/orch.cpp \
 		       fake_subscriberstatetable.cpp \
 		       fake_notificationconsumer.cpp \
 		       fake_table.cpp \
+		       fake_zmqserver.cpp \
 		       p4oidmapper_test.cpp \
+		       p4orch_test.cpp \
 		       p4orch_util_test.cpp \
 		       return_code_test.cpp \
 		       route_manager_test.cpp \
@@ -77,6 +80,9 @@ p4orch_tests_SOURCES = $(ORCHAGENT_DIR)/orch.cpp \
 		       mock_sai_hostif.cpp \
 		       mock_sai_serialize.cpp \
 		       mock_sai_router_interface.cpp \
+		       mock_sai_neighbor.cpp \
+ 		       mock_sai_next_hop.cpp \
+ 		       mock_sai_route.cpp \
 		       mock_sai_switch.cpp \
 		       mock_sai_udf.cpp
 

--- a/orchagent/p4orch/tests/acl_manager_test.cpp
+++ b/orchagent/p4orch/tests/acl_manager_test.cpp
@@ -939,7 +939,7 @@ class AclManagerTest : public ::testing::Test
                                                          kAclGroupLookupOid, std::placeholders::_1))))
             .WillRepeatedly(Return(SAI_STATUS_SUCCESS));
         std::vector<std::string> p4_tables;
-        gP4Orch = new P4Orch(gAppDb, p4_tables, gVrfOrch, copp_orch_);
+        gP4Orch = new P4Orch(gAppDb, p4_tables, nullptr, gVrfOrch, copp_orch_);
         acl_table_manager_ = gP4Orch->getAclTableManager();
         acl_rule_manager_ = gP4Orch->getAclRuleManager();
         p4_oid_mapper_ = acl_table_manager_->m_p4OidMapper;

--- a/orchagent/p4orch/tests/fake_zmqserver.cpp
+++ b/orchagent/p4orch/tests/fake_zmqserver.cpp
@@ -1,0 +1,29 @@
+#include "zmqserver.h"
+
+using namespace std;
+
+namespace swss {
+
+ZmqServer::ZmqServer(const std::string& endpoint)
+    : m_endpoint(endpoint) {}
+
+ZmqServer::~ZmqServer() {}
+
+void ZmqServer::registerMessageHandler(const std::string dbName,
+                                       const std::string tableName,
+                                       ZmqMessageHandler* handler) {}
+
+void ZmqServer::sendMsg(
+    const std::string& dbName, const std::string& tableName,
+    const std::vector<swss::KeyOpFieldsValuesTuple>& values) {}
+
+ZmqMessageHandler* ZmqServer::findMessageHandler(const std::string dbName,
+                                                 const std::string tableName) {
+  return nullptr;
+}
+
+void ZmqServer::handleReceivedData(const char* buffer, const size_t size) {}
+
+void ZmqServer::mqPollThread() {}
+
+}  // namespace swss

--- a/orchagent/p4orch/tests/mock_sai_neighbor.cpp
+++ b/orchagent/p4orch/tests/mock_sai_neighbor.cpp
@@ -1,0 +1,45 @@
+#include "mock_sai_neighbor.h"
+ 
+ MockSaiNeighbor* mock_sai_neighbor;
+ 
+ sai_status_t mock_create_neighbor_entry(
+     _In_ const sai_neighbor_entry_t* neighbor_entry, _In_ uint32_t attr_count,
+     _In_ const sai_attribute_t* attr_list) {
+   return mock_sai_neighbor->create_neighbor_entry(neighbor_entry, attr_count,
+                                                   attr_list);
+ }
+ 
+ sai_status_t mock_remove_neighbor_entry(
+     _In_ const sai_neighbor_entry_t* neighbor_entry) {
+   return mock_sai_neighbor->remove_neighbor_entry(neighbor_entry);
+ }
+ 
+ sai_status_t mock_set_neighbor_entry_attribute(
+     _In_ const sai_neighbor_entry_t* neighbor_entry,
+     _In_ const sai_attribute_t* attr) {
+   return mock_sai_neighbor->set_neighbor_entry_attribute(neighbor_entry, attr);
+ }
+ 
+ sai_status_t mock_get_neighbor_entry_attribute(
+     _In_ const sai_neighbor_entry_t* neighbor_entry, _In_ uint32_t attr_count,
+     _Inout_ sai_attribute_t* attr_list) {
+   return mock_sai_neighbor->get_neighbor_entry_attribute(neighbor_entry,
+                                                          attr_count, attr_list);
+ }
+
+sai_status_t mock_create_neighbor_entries(
+    _In_ uint32_t object_count, _In_ const sai_neighbor_entry_t* neighbor_entry,
+    _In_ const uint32_t* attr_count, _In_ const sai_attribute_t** attr_list,
+    _In_ sai_bulk_op_error_mode_t mode, _Out_ sai_status_t* object_statuses) {
+  return mock_sai_neighbor->create_neighbor_entries(
+      object_count, neighbor_entry, attr_count, attr_list, mode,
+      object_statuses);
+}
+
+sai_status_t mock_remove_neighbor_entries(
+    _In_ uint32_t object_count, _In_ const sai_neighbor_entry_t* neighbor_entry,
+    _In_ sai_bulk_op_error_mode_t mode, _Out_ sai_status_t* object_statuses) {
+  return mock_sai_neighbor->remove_neighbor_entries(
+      object_count, neighbor_entry, mode, object_statuses);
+}
+

--- a/orchagent/p4orch/tests/mock_sai_neighbor.h
+++ b/orchagent/p4orch/tests/mock_sai_neighbor.h
@@ -30,39 +30,21 @@ class MockSaiNeighbor
                               _Inout_ sai_attribute_t *attr_list));
 };
 
-MockSaiNeighbor *mock_sai_neighbor;
+extern MockSaiNeighbor *mock_sai_neighbor;
 
 sai_status_t mock_create_neighbor_entry(_In_ const sai_neighbor_entry_t *neighbor_entry, _In_ uint32_t attr_count,
-                                        _In_ const sai_attribute_t *attr_list)
-{
-    return mock_sai_neighbor->create_neighbor_entry(neighbor_entry, attr_count, attr_list);
-}
+    _In_ const sai_attribute_t* attr_list);
 
-sai_status_t mock_remove_neighbor_entry(_In_ const sai_neighbor_entry_t *neighbor_entry)
-{
-    return mock_sai_neighbor->remove_neighbor_entry(neighbor_entry);
-}
+sai_status_t mock_remove_neighbor_entry(_In_ const sai_neighbor_entry_t *neighbor_entry);
 
 sai_status_t mock_create_neighbor_entries(_In_ uint32_t object_count, _In_ const sai_neighbor_entry_t *neighbor_entry, _In_ const uint32_t *attr_count,
-                                          _In_ const sai_attribute_t **attr_list, _In_ sai_bulk_op_error_mode_t mode, _Out_ sai_status_t *object_statuses)
-{
-    return mock_sai_neighbor->create_neighbor_entries(object_count, neighbor_entry, attr_count, attr_list, mode, object_statuses);
-}
+                                          _In_ const sai_attribute_t **attr_list, _In_ sai_bulk_op_error_mode_t mode, _Out_ sai_status_t *object_statuses);
 
 sai_status_t mock_remove_neighbor_entries(_In_ uint32_t object_count, _In_ const sai_neighbor_entry_t *neighbor_entry, _In_ sai_bulk_op_error_mode_t mode,
-                                          _Out_ sai_status_t *object_statuses)
-{
-    return mock_sai_neighbor->remove_neighbor_entries(object_count, neighbor_entry, mode, object_statuses);
-}
+                                          _Out_ sai_status_t *object_statuses);
 
 sai_status_t mock_set_neighbor_entry_attribute(_In_ const sai_neighbor_entry_t *neighbor_entry,
-                                               _In_ const sai_attribute_t *attr)
-{
-    return mock_sai_neighbor->set_neighbor_entry_attribute(neighbor_entry, attr);
-}
+    _In_ const sai_attribute_t* attr);
 
-sai_status_t mock_get_neighbor_entry_attribute(_In_ const sai_neighbor_entry_t *neighbor_entry,
-                                               _In_ uint32_t attr_count, _Inout_ sai_attribute_t *attr_list)
-{
-    return mock_sai_neighbor->get_neighbor_entry_attribute(neighbor_entry, attr_count, attr_list);
-}
+sai_status_t mock_get_neighbor_entry_attribute(_In_ const sai_neighbor_entry_t *neighbor_entry, _In_ uint32_t attr_count,
+    _Inout_ sai_attribute_t* attr_list);

--- a/orchagent/p4orch/tests/mock_sai_next_hop.cpp
+++ b/orchagent/p4orch/tests/mock_sai_next_hop.cpp
@@ -1,0 +1,47 @@
+#include "mock_sai_next_hop.h"
+ 
+ MockSaiNextHop* mock_sai_next_hop;
+ 
+ sai_status_t mock_create_next_hop(_Out_ sai_object_id_t* next_hop_id,
+                                   _In_ sai_object_id_t switch_id,
+                                   _In_ uint32_t attr_count,
+                                   _In_ const sai_attribute_t* attr_list) {
+   return mock_sai_next_hop->create_next_hop(next_hop_id, switch_id, attr_count,
+                                             attr_list);
+ }
+ 
+ sai_status_t mock_remove_next_hop(_In_ sai_object_id_t next_hop_id) {
+   return mock_sai_next_hop->remove_next_hop(next_hop_id);
+ }
+ 
+ sai_status_t mock_set_next_hop_attribute(_In_ sai_object_id_t next_hop_id,
+                                          _In_ const sai_attribute_t* attr) {
+   return mock_sai_next_hop->set_next_hop_attribute(next_hop_id, attr);
+ }
+ 
+ sai_status_t mock_get_next_hop_attribute(_In_ sai_object_id_t next_hop_id,
+                                          _In_ uint32_t attr_count,
+                                          _Inout_ sai_attribute_t* attr_list) {
+   return mock_sai_next_hop->get_next_hop_attribute(next_hop_id, attr_count,
+                                                    attr_list);
+ }
+
+sai_status_t mock_create_next_hops(_In_ sai_object_id_t switch_id,
+                                   _In_ uint32_t object_count,
+                                   _In_ const uint32_t *attr_count,
+                                   _In_ const sai_attribute_t **attr_list,
+                                   _In_ sai_bulk_op_error_mode_t mode,
+                                   _Out_ sai_object_id_t *object_id,
+                                   _Out_ sai_status_t *object_statuses) {
+  return mock_sai_next_hop->create_next_hops(switch_id, object_count, attr_count,
+                                         attr_list, mode, object_id,
+                                         object_statuses);
+}
+
+sai_status_t mock_remove_next_hops(_In_ uint32_t object_count,
+                                   _In_ const sai_object_id_t *object_id,
+                                   _In_ sai_bulk_op_error_mode_t mode,
+                                   _Out_ sai_status_t *object_statuses) {
+  return mock_sai_next_hop->remove_next_hops(object_count, object_id, mode,
+                                         object_statuses);
+}

--- a/orchagent/p4orch/tests/mock_sai_next_hop.h
+++ b/orchagent/p4orch/tests/mock_sai_next_hop.h
@@ -33,40 +33,21 @@ class MockSaiNextHop
 
 // Note that before mock functions below are used, mock_sai_next_hop must be
 // initialized to point to an instance of MockSaiNextHop.
-MockSaiNextHop *mock_sai_next_hop;
+extern MockSaiNextHop *mock_sai_next_hop;
 
 sai_status_t mock_create_next_hop(_Out_ sai_object_id_t *next_hop_id, _In_ sai_object_id_t switch_id,
-                                  _In_ uint32_t attr_count, _In_ const sai_attribute_t *attr_list)
-{
-    return mock_sai_next_hop->create_next_hop(next_hop_id, switch_id, attr_count, attr_list);
-}
+                                  _In_ uint32_t attr_count, _In_ const sai_attribute_t *attr_list);
 
-sai_status_t mock_remove_next_hop(_In_ sai_object_id_t next_hop_id)
-{
-    return mock_sai_next_hop->remove_next_hop(next_hop_id);
-}
+sai_status_t mock_remove_next_hop(_In_ sai_object_id_t next_hop_id);
 
-sai_status_t mock_set_next_hop_attribute(_In_ sai_object_id_t next_hop_id, _In_ const sai_attribute_t *attr)
-{
-    return mock_sai_next_hop->set_next_hop_attribute(next_hop_id, attr);
-}
+sai_status_t mock_set_next_hop_attribute(_In_ sai_object_id_t next_hop_id, _In_ const sai_attribute_t *attr);
 
 sai_status_t mock_get_next_hop_attribute(_In_ sai_object_id_t next_hop_id, _In_ uint32_t attr_count,
-                                         _Inout_ sai_attribute_t *attr_list)
-{
-    return mock_sai_next_hop->get_next_hop_attribute(next_hop_id, attr_count, attr_list);
-}
+                                         _Inout_ sai_attribute_t *attr_list);
 
 sai_status_t mock_create_next_hops(_In_ sai_object_id_t switch_id, _In_ uint32_t object_count, _In_ const uint32_t *attr_count,
                                    _In_ const sai_attribute_t **attr_list, _In_ sai_bulk_op_error_mode_t mode,
-                                   _Out_ sai_object_id_t *object_id, _Out_ sai_status_t *object_statuses)
-{
-    return mock_sai_next_hop->create_next_hops(switch_id, object_count, attr_count, attr_list, mode,
-                                               object_id, object_statuses);
-}
+                                   _Out_ sai_object_id_t *object_id, _Out_ sai_status_t *object_statuses);
 
 sai_status_t mock_remove_next_hops(_In_ uint32_t object_count, _In_ const sai_object_id_t *object_id, _In_ sai_bulk_op_error_mode_t mode,
-                                   _Out_ sai_status_t *object_statuses)
-{
-    return mock_sai_next_hop->remove_next_hops(object_count, object_id, mode, object_statuses);
-}
+                                   _Out_ sai_status_t *object_statuses);

--- a/orchagent/p4orch/tests/mock_sai_route.cpp
+++ b/orchagent/p4orch/tests/mock_sai_route.cpp
@@ -1,0 +1,62 @@
+#include "mock_sai_route.h"
+
+MockSaiRoute* mock_sai_route;
+
+sai_status_t create_route_entry(const sai_route_entry_t* route_entry,
+                                uint32_t attr_count,
+                                const sai_attribute_t* attr_list) {
+  return mock_sai_route->create_route_entry(route_entry, attr_count, attr_list);
+}
+
+sai_status_t remove_route_entry(const sai_route_entry_t* route_entry) {
+  return mock_sai_route->remove_route_entry(route_entry);
+}
+
+sai_status_t set_route_entry_attribute(const sai_route_entry_t* route_entry,
+                                       const sai_attribute_t* attr) {
+  return mock_sai_route->set_route_entry_attribute(route_entry, attr);
+}
+
+sai_status_t get_route_entry_attribute(const sai_route_entry_t* route_entry,
+                                       uint32_t attr_count,
+                                       sai_attribute_t* attr_list) {
+  return mock_sai_route->get_route_entry_attribute(route_entry, attr_count,
+                                                   attr_list);
+}
+
+sai_status_t create_route_entries(uint32_t object_count,
+                                  const sai_route_entry_t* route_entry,
+                                  const uint32_t* attr_count,
+                                  const sai_attribute_t** attr_list,
+                                  sai_bulk_op_error_mode_t mode,
+                                  sai_status_t* object_statuses) {
+  return mock_sai_route->create_route_entries(
+      object_count, route_entry, attr_count, attr_list, mode, object_statuses);
+}
+
+sai_status_t remove_route_entries(uint32_t object_count,
+                                  const sai_route_entry_t* route_entry,
+                                  sai_bulk_op_error_mode_t mode,
+                                  sai_status_t* object_statuses) {
+  return mock_sai_route->remove_route_entries(object_count, route_entry, mode,
+                                              object_statuses);
+}
+
+sai_status_t set_route_entries_attribute(uint32_t object_count,
+                                         const sai_route_entry_t* route_entry,
+                                         const sai_attribute_t* attr_list,
+                                         sai_bulk_op_error_mode_t mode,
+                                         sai_status_t* object_statuses) {
+  return mock_sai_route->set_route_entries_attribute(
+      object_count, route_entry, attr_list, mode, object_statuses);
+}
+
+sai_status_t get_route_entries_attribute(uint32_t object_count,
+                                         const sai_route_entry_t* route_entry,
+                                         const uint32_t* attr_count,
+                                         sai_attribute_t** attr_list,
+                                         sai_bulk_op_error_mode_t mode,
+                                         sai_status_t* object_statuses) {
+  return mock_sai_route->get_route_entries_attribute(
+      object_count, route_entry, attr_count, attr_list, mode, object_statuses);
+}

--- a/orchagent/p4orch/tests/mock_sai_route.h
+++ b/orchagent/p4orch/tests/mock_sai_route.h
@@ -1,36 +1,14 @@
 #pragma once
 
+#include <gmock/gmock.h>
+
 extern "C"
 {
 #include "sai.h"
 #include "sairoute.h"
 }
 
-class SaiRouteInterface
-{
-  public:
-    virtual sai_status_t create_route_entry(const sai_route_entry_t *route_entry, uint32_t attr_count,
-                                            const sai_attribute_t *attr_list) = 0;
-    virtual sai_status_t remove_route_entry(const sai_route_entry_t *route_entry) = 0;
-    virtual sai_status_t set_route_entry_attribute(const sai_route_entry_t *route_entry,
-                                                   const sai_attribute_t *attr) = 0;
-    virtual sai_status_t get_route_entry_attribute(const sai_route_entry_t *route_entry, uint32_t attr_count,
-                                                   sai_attribute_t *attr_list) = 0;
-    virtual sai_status_t create_route_entries(uint32_t object_count, const sai_route_entry_t *route_entry,
-                                              const uint32_t *attr_count, const sai_attribute_t **attr_list,
-                                              sai_bulk_op_error_mode_t mode, sai_status_t *object_statuses) = 0;
-    virtual sai_status_t remove_route_entries(uint32_t object_count, const sai_route_entry_t *route_entry,
-                                              sai_bulk_op_error_mode_t mode, sai_status_t *object_statuses) = 0;
-    virtual sai_status_t set_route_entries_attribute(uint32_t object_count, const sai_route_entry_t *route_entry,
-                                                     const sai_attribute_t *attr_list, sai_bulk_op_error_mode_t mode,
-                                                     sai_status_t *object_statuses) = 0;
-    virtual sai_status_t get_route_entries_attribute(uint32_t object_count, const sai_route_entry_t *route_entry,
-                                                     const uint32_t *attr_count, sai_attribute_t **attr_list,
-                                                     sai_bulk_op_error_mode_t mode, sai_status_t *object_statuses) = 0;
-};
-
-class MockSaiRoute : public SaiRouteInterface
-{
+class MockSaiRoute {
   public:
     MOCK_METHOD3(create_route_entry, sai_status_t(const sai_route_entry_t *route_entry, uint32_t attr_count,
                                                   const sai_attribute_t *attr_list));
@@ -54,55 +32,29 @@ class MockSaiRoute : public SaiRouteInterface
                               sai_status_t *object_statuses));
 };
 
-MockSaiRoute *mock_sai_route;
+extern MockSaiRoute *mock_sai_route;
 
 sai_status_t create_route_entry(const sai_route_entry_t *route_entry, uint32_t attr_count,
-                                const sai_attribute_t *attr_list)
-{
-    return mock_sai_route->create_route_entry(route_entry, attr_count, attr_list);
-}
+                                const sai_attribute_t *attr_list);
 
-sai_status_t remove_route_entry(const sai_route_entry_t *route_entry)
-{
-    return mock_sai_route->remove_route_entry(route_entry);
-}
+sai_status_t remove_route_entry(const sai_route_entry_t *route_entry);
 
-sai_status_t set_route_entry_attribute(const sai_route_entry_t *route_entry, const sai_attribute_t *attr)
-{
-    return mock_sai_route->set_route_entry_attribute(route_entry, attr);
-}
+sai_status_t set_route_entry_attribute(const sai_route_entry_t *route_entry, const sai_attribute_t *attr);
 
 sai_status_t get_route_entry_attribute(const sai_route_entry_t *route_entry, uint32_t attr_count,
-                                       sai_attribute_t *attr_list)
-{
-    return mock_sai_route->get_route_entry_attribute(route_entry, attr_count, attr_list);
-}
+                                       sai_attribute_t *attr_list);
 
 sai_status_t create_route_entries(uint32_t object_count, const sai_route_entry_t *route_entry,
                                   const uint32_t *attr_count, const sai_attribute_t **attr_list,
-                                  sai_bulk_op_error_mode_t mode, sai_status_t *object_statuses)
-{
-    return mock_sai_route->create_route_entries(object_count, route_entry, attr_count, attr_list, mode,
-                                                object_statuses);
-}
+                                  sai_bulk_op_error_mode_t mode, sai_status_t *object_statuses);
 
 sai_status_t remove_route_entries(uint32_t object_count, const sai_route_entry_t *route_entry,
-                                  sai_bulk_op_error_mode_t mode, sai_status_t *object_statuses)
-{
-    return mock_sai_route->remove_route_entries(object_count, route_entry, mode, object_statuses);
-}
+                                  sai_bulk_op_error_mode_t mode, sai_status_t *object_statuses);
 
 sai_status_t set_route_entries_attribute(uint32_t object_count, const sai_route_entry_t *route_entry,
                                          const sai_attribute_t *attr_list, sai_bulk_op_error_mode_t mode,
-                                         sai_status_t *object_statuses)
-{
-    return mock_sai_route->set_route_entries_attribute(object_count, route_entry, attr_list, mode, object_statuses);
-}
+                                         sai_status_t *object_statuses);
 
 sai_status_t get_route_entries_attribute(uint32_t object_count, const sai_route_entry_t *route_entry,
                                          const uint32_t *attr_count, sai_attribute_t **attr_list,
-                                         sai_bulk_op_error_mode_t mode, sai_status_t *object_statuses)
-{
-    return mock_sai_route->get_route_entries_attribute(object_count, route_entry, attr_count, attr_list, mode,
-                                                       object_statuses);
-}
+                                         sai_bulk_op_error_mode_t mode, sai_status_t *object_statuses);

--- a/orchagent/p4orch/tests/next_hop_manager_test.cpp
+++ b/orchagent/p4orch/tests/next_hop_manager_test.cpp
@@ -241,7 +241,7 @@ class NextHopManagerTest : public ::testing::Test
         EXPECT_CALL(mock_sai_switch_, get_switch_attribute(_, _, _)).WillRepeatedly(Return(SAI_STATUS_SUCCESS));
         copp_orch_ = new CoppOrch(gAppDb, APP_COPP_TABLE_NAME);
         std::vector<std::string> p4_tables;
-        gP4Orch = new P4Orch(gAppDb, p4_tables, gVrfOrch, copp_orch_);
+        gP4Orch = new P4Orch(gAppDb, p4_tables, nullptr, gVrfOrch, copp_orch_);
     }
 
     ~NextHopManagerTest()

--- a/orchagent/p4orch/tests/p4orch_test.cpp
+++ b/orchagent/p4orch/tests/p4orch_test.cpp
@@ -1,0 +1,220 @@
+#include "p4orch.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "mock_response_publisher.h"
+#include "mock_sai_hostif.h"
+#include "mock_sai_neighbor.h"
+#include "mock_sai_next_hop.h"
+#include "mock_sai_route.h"
+#include "mock_sai_router_interface.h"
+#include "mock_sai_switch.h"
+
+using ::p4orch::kTableKeyDelimiter;
+
+extern P4Orch* gP4Orch;
+extern VRFOrch* gVrfOrch;
+extern std::unique_ptr<MockResponsePublisher> gMockResponsePublisher;
+extern VRFOrch* gVrfOrch;
+extern swss::DBConnector* gAppDb;
+extern sai_hostif_api_t* sai_hostif_api;
+extern sai_switch_api_t* sai_switch_api;
+extern sai_router_interface_api_t* sai_router_intfs_api;
+extern sai_neighbor_api_t* sai_neighbor_api;
+extern sai_next_hop_api_t* sai_next_hop_api;
+extern sai_route_api_t* sai_route_api;
+
+using ::testing::Eq;
+using ::testing::InSequence;
+using ::testing::NiceMock;
+using ::testing::StrictMock;
+
+class P4OrchTest : public ::testing::Test {
+ protected:
+  P4OrchTest() {
+    mock_sai_hostif = &mock_sai_hostif_;
+    sai_hostif_api->create_hostif_trap = mock_create_hostif_trap;
+    sai_hostif_api->create_hostif_table_entry = mock_create_hostif_table_entry;
+    mock_sai_switch = &mock_sai_switch_;
+    sai_switch_api->get_switch_attribute = mock_get_switch_attribute;
+    mock_sai_router_intf = &mock_sai_router_intf_;
+    sai_router_intfs_api->create_router_interface =
+        mock_create_router_interface;
+    sai_router_intfs_api->remove_router_interface =
+        mock_remove_router_interface;
+    sai_router_intfs_api->set_router_interface_attribute =
+        mock_set_router_interface_attribute;
+    sai_router_intfs_api->get_router_interface_attribute =
+        mock_get_router_interface_attribute;
+    mock_sai_neighbor = &mock_sai_neighbor_;
+    sai_neighbor_api->create_neighbor_entry = mock_create_neighbor_entry;
+    sai_neighbor_api->remove_neighbor_entry = mock_remove_neighbor_entry;
+    sai_neighbor_api->set_neighbor_entry_attribute =
+        mock_set_neighbor_entry_attribute;
+    sai_neighbor_api->get_neighbor_entry_attribute =
+        mock_get_neighbor_entry_attribute;
+    mock_sai_next_hop = &mock_sai_next_hop_;
+    sai_next_hop_api->create_next_hop = mock_create_next_hop;
+    sai_next_hop_api->remove_next_hop = mock_remove_next_hop;
+    sai_next_hop_api->set_next_hop_attribute = mock_set_next_hop_attribute;
+    sai_next_hop_api->get_next_hop_attribute = mock_get_next_hop_attribute;
+    mock_sai_route = &mock_sai_route_;
+    sai_route_api->create_route_entry = create_route_entry;
+    sai_route_api->remove_route_entry = remove_route_entry;
+    sai_route_api->set_route_entry_attribute = set_route_entry_attribute;
+    sai_route_api->get_route_entry_attribute = get_route_entry_attribute;
+    sai_route_api->create_route_entries = create_route_entries;
+    sai_route_api->remove_route_entries = remove_route_entries;
+    sai_route_api->set_route_entries_attribute = set_route_entries_attribute;
+    sai_route_api->get_route_entries_attribute = get_route_entries_attribute;
+    copp_orch_ = new CoppOrch(gAppDb, APP_COPP_TABLE_NAME);
+    std::vector<std::string> p4_tables{APP_P4RT_TABLE_NAME};
+    gP4Orch = new P4Orch(gAppDb, p4_tables, nullptr, gVrfOrch, copp_orch_);
+    gMockResponsePublisher = std::make_unique<MockResponsePublisher>();
+  }
+
+  ~P4OrchTest() {
+    delete gP4Orch;
+    delete copp_orch_;
+    gMockResponsePublisher.reset();
+  }
+
+  void DoTask(ConsumerBase& consumer) { gP4Orch->doTask(consumer); }
+
+  NiceMock<MockSaiHostif> mock_sai_hostif_;
+  NiceMock<MockSaiSwitch> mock_sai_switch_;
+  NiceMock<MockSaiRouterInterface> mock_sai_router_intf_;
+  NiceMock<MockSaiNeighbor> mock_sai_neighbor_;
+  NiceMock<MockSaiNextHop> mock_sai_next_hop_;
+  NiceMock<MockSaiRoute> mock_sai_route_;
+  CoppOrch* copp_orch_;
+};
+
+TEST_F(P4OrchTest, ProcessInvalidEntry) {
+  InSequence s;
+  ZmqServer zmq_server("endpoint");
+  DBConnector db("APPL_DB", 0);
+  ZmqConsumerStateTable* table =
+      new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
+                                 TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,
+                                 /*dbPersistence=*/false);
+  ZmqConsumer consumer(table, nullptr, APP_P4RT_TABLE_NAME,
+                        /*orderedQueue=*/true);
+  consumer.m_queue.push_back(swss::KeyOpFieldsValuesTuple{
+       "invalid", DEL_COMMAND, std::vector<swss::FieldValueTuple>{}});
+  consumer.m_queue.push_back(swss::KeyOpFieldsValuesTuple{
+       "invalid:invalid", DEL_COMMAND, std::vector<swss::FieldValueTuple>{}});
+  std::vector<swss::FieldValueTuple> exp_values;
+  EXPECT_CALL(*gMockResponsePublisher,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq("invalid"), Eq(exp_values),
+                      Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)));
+  EXPECT_CALL(
+      *gMockResponsePublisher,
+      publish(Eq(APP_P4RT_TABLE_NAME), Eq("invalid:invalid"), Eq(exp_values),
+              Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)));
+  DoTask(consumer);
+}
+
+TEST_F(P4OrchTest, ProcessP4Notification) {
+  InSequence s;
+  ZmqServer zmq_server("endpoint");
+   DBConnector db("APPL_DB", 0);
+   ZmqConsumerStateTable* table =
+       new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
+                                 TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,
+                                 /*dbPersistence=*/false);
+   ZmqConsumer consumer(table, nullptr, APP_P4RT_TABLE_NAME,
+                        /*orderedQueue=*/true);
+
+  // Router interface
+  const std::string ritf_key =
+      std::string(APP_P4RT_ROUTER_INTERFACE_TABLE_NAME) + kTableKeyDelimiter +
+      "{\"match/router_interface_id\":\"intf-3/4\"}";
+  std::vector<swss::FieldValueTuple> ritf_attrs;
+  ritf_attrs.push_back(
+      swss::FieldValueTuple{prependParamField(p4orch::kPort), "Ethernet1"});
+  ritf_attrs.push_back(swss::FieldValueTuple{prependParamField(p4orch::kSrcMac),
+                                             "00:01:02:03:04:05"});
+  consumer.m_queue.push_back(
+       swss::KeyOpFieldsValuesTuple{ritf_key, SET_COMMAND, ritf_attrs});
+
+  // Neighbor
+  const std::string neighbor_key = std::string(APP_P4RT_NEIGHBOR_TABLE_NAME) +
+                                   kTableKeyDelimiter +
+                                   "{\"match/router_interface_id\":\"intf-3/"
+                                   "4\",\"match/neighbor_id\":\"10.0.0.22\"}";
+  std::vector<swss::FieldValueTuple> neighbor_attrs;
+  neighbor_attrs.push_back(swss::FieldValueTuple{
+      prependParamField(p4orch::kDstMac), "00:01:02:03:04:05"});
+  consumer.m_queue.push_back(
+      swss::KeyOpFieldsValuesTuple{neighbor_key, SET_COMMAND, neighbor_attrs});
+
+  // Nexthop
+  const std::string nexthop_key =
+      std::string(APP_P4RT_NEXTHOP_TABLE_NAME) + kTableKeyDelimiter +
+      "{\"match/nexthop_id\":\"ju1u32m1.atl11:qe-3/7\"}";
+  std::vector<swss::FieldValueTuple> nexthop_attrs;
+  nexthop_attrs.push_back(
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetIpNexthop});
+  nexthop_attrs.push_back(swss::FieldValueTuple{
+      prependParamField(p4orch::kNeighborId), "10.0.0.22"});
+  nexthop_attrs.push_back(swss::FieldValueTuple{
+      prependParamField(p4orch::kRouterInterfaceId), "intf-3/4"});
+  consumer.m_queue.push_back(
+      swss::KeyOpFieldsValuesTuple{nexthop_key, SET_COMMAND, nexthop_attrs});
+
+  // Route
+  const std::string route_key =
+      std::string(APP_P4RT_IPV4_TABLE_NAME) + kTableKeyDelimiter +
+      "{\"match/vrf_id\":\"b4-traffic\",\"match/ipv4_dst\":\"10.11.12.0/24\"}";
+  std::vector<swss::FieldValueTuple> route_attrs;
+  route_attrs.push_back(
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
+  route_attrs.push_back(swss::FieldValueTuple{
+      prependParamField(p4orch::kNexthopId), "ju1u32m1.atl11:qe-3/7"});
+  consumer.m_queue.push_back(
+      swss::KeyOpFieldsValuesTuple{route_key, SET_COMMAND, route_attrs});
+
+  // Delete
+  consumer.m_queue.push_back(swss::KeyOpFieldsValuesTuple{
+       ritf_key, DEL_COMMAND, std::vector<swss::FieldValueTuple>{}});
+   consumer.m_queue.push_back(swss::KeyOpFieldsValuesTuple{
+       neighbor_key, DEL_COMMAND, std::vector<swss::FieldValueTuple>{}});
+   consumer.m_queue.push_back(swss::KeyOpFieldsValuesTuple{
+       nexthop_key, DEL_COMMAND, std::vector<swss::FieldValueTuple>{}});
+   consumer.m_queue.push_back(swss::KeyOpFieldsValuesTuple{
+       route_key, DEL_COMMAND, std::vector<swss::FieldValueTuple>{}});
+
+  EXPECT_CALL(*gMockResponsePublisher,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(ritf_key), Eq(ritf_attrs),
+                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+  EXPECT_CALL(
+      *gMockResponsePublisher,
+      publish(Eq(APP_P4RT_TABLE_NAME), Eq(neighbor_key), Eq(neighbor_attrs),
+              Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+  EXPECT_CALL(
+      *gMockResponsePublisher,
+      publish(Eq(APP_P4RT_TABLE_NAME), Eq(nexthop_key), Eq(nexthop_attrs),
+              Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+  EXPECT_CALL(*gMockResponsePublisher,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(route_key), Eq(route_attrs),
+                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+  std::vector<swss::FieldValueTuple> exp_values;
+  EXPECT_CALL(*gMockResponsePublisher,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(route_key), Eq(exp_values),
+                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+  EXPECT_CALL(*gMockResponsePublisher,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(nexthop_key), Eq(exp_values),
+                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+  EXPECT_CALL(*gMockResponsePublisher,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(neighbor_key), Eq(exp_values),
+                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+  EXPECT_CALL(*gMockResponsePublisher,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(ritf_key), Eq(exp_values),
+                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+  DoTask(consumer);
+}
+

--- a/orchagent/p4orch/tests/test_main.cpp
+++ b/orchagent/p4orch/tests/test_main.cpp
@@ -22,6 +22,11 @@ extern "C"
 
 using ::testing::StrictMock;
 
+bool gLogRotate = false;
+
+ofstream gRecordOfs;
+string gRecordFile;
+
 /* Global variables */
 sai_object_id_t gVirtualRouterId = SAI_NULL_OBJECT_ID;
 sai_object_id_t gSwitchId = SAI_NULL_OBJECT_ID;
@@ -43,6 +48,8 @@ event_handle_t g_events_handle;
 extern int gBatchSize;
 size_t gMaxBulkSize = DEFAULT_MAX_BULK_SIZE;
 bool gSyncMode = false;
+bool gSairedisRecord = false;
+bool gSwssRecord = false;
 bool gIsNatSupported = false;
 bool gTraditionalFlexCounter = false;
 sai_redis_communication_mode_t gRedisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC;

--- a/orchagent/p4orch/tests/wcmp_manager_test.cpp
+++ b/orchagent/p4orch/tests/wcmp_manager_test.cpp
@@ -268,7 +268,7 @@ class WcmpManagerTest : public ::testing::Test
 
         // init P4 orch
         std::vector<std::string> p4_tables;
-        gP4Orch = new P4Orch(gAppDb, p4_tables, gVrfOrch, copp_orch_);
+        gP4Orch = new P4Orch(gAppDb, p4_tables, nullptr, gVrfOrch, copp_orch_);
     }
 
     void Enqueue(const swss::KeyOpFieldsValuesTuple &entry)

--- a/orchagent/p4orch/wcmp_manager.h
+++ b/orchagent/p4orch/wcmp_manager.h
@@ -70,7 +70,8 @@ class WcmpManager : public ObjectManagerInterface
     virtual ~WcmpManager() = default;
 
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
-    void drain() override;
+    ReturnCode drain() override;
+    void drainWithNotExecuted() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
     ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
                             std::string &object_key) override;

--- a/orchagent/response_publisher.cpp
+++ b/orchagent/response_publisher.cpp
@@ -5,6 +5,13 @@
 #include <string>
 #include <vector>
 
+extern bool gResponsePublisherRecord;
+extern bool gResponsePublisherLogRotate;
+extern std::ofstream gResponsePublisherRecordOfs;
+extern std::string gResponsePublisherRecordFile;
+size_t gResponsePublisherRecordSize = 0;
+uint32_t gResponsePublisherLostLogRecords = 0;
+
 namespace
 {
 
@@ -64,8 +71,12 @@ void RecordResponse(const std::string &response_channel, const std::string &key,
 
 } // namespace
 
-ResponsePublisher::ResponsePublisher(const std::string &dbName, bool buffered, bool db_write_thread)
-    : m_db(std::make_unique<swss::DBConnector>(dbName, 0)), m_buffered(buffered)
+ResponsePublisher::ResponsePublisher(const std::string& dbName, bool buffered,
+                                     bool db_write_thread,
+                                     swss::ZmqServer* zmqServer)
+    : m_db(std::make_unique<swss::DBConnector>(dbName, 0)),
+      m_buffered(buffered),
+      m_zmqServer(zmqServer)
 {
     if (m_buffered)
     {
@@ -101,15 +112,28 @@ void ResponsePublisher::publish(const std::string &table, const std::string &key
                                 const std::vector<swss::FieldValueTuple> &intent_attrs, const ReturnCode &status,
                                 const std::vector<swss::FieldValueTuple> &state_attrs, bool replace)
 {
-    std::string response_channel = "APPL_DB_" + table + "_RESPONSE_CHANNEL";
-    swss::NotificationProducer notificationProducer{m_ntf_pipe.get(), response_channel, m_buffered};
-
     auto intent_attrs_copy = intent_attrs;
     // Add error message as the first field-value-pair.
     swss::FieldValueTuple err_str("err_str", PrependedComponent(status) + status.message());
     intent_attrs_copy.insert(intent_attrs_copy.begin(), err_str);
-    // Sends the response to the notification channel.
-    notificationProducer.send(status.codeStr(), key, intent_attrs_copy);
+    std::string response_channel = "APPL_DB_" + table + "_RESPONSE_CHANNEL";
+
+    if (m_zmqServer != nullptr) {
+      auto intent_attrs_zmq_copy = intent_attrs;
+      // Add status code and error message as the first field-value-pair.
+      swss::FieldValueTuple fvs(status.codeStr(),
+                                PrependedComponent(status) + status.message());
+      intent_attrs_zmq_copy.insert(intent_attrs_zmq_copy.begin(), fvs);
+      // Queue the response.
+      responses[table].push_back(
+          swss::KeyOpFieldsValuesTuple{key, SET_COMMAND, intent_attrs_zmq_copy});
+    } else {
+      // Sends the response to the notification channel.
+      swss::NotificationProducer notificationProducer{
+          m_ntf_pipe.get(), response_channel, m_buffered};
+      notificationProducer.send(status.codeStr(), key, intent_attrs_copy);
+    }
+
     RecordResponse(response_channel, key, intent_attrs_copy, status.codeStr());
 
     // Write to the DB only if:
@@ -203,9 +227,20 @@ void ResponsePublisher::writeToDBInternal(const std::string &table, const std::s
     }
 }
 
-void ResponsePublisher::flush()
+void ResponsePublisher::flush(bool warmboot)
 {
-    m_ntf_pipe->flush();
+    if (m_zmqServer != nullptr) {
+      // During warmboot, we cannot send response message over ZMQ in one-to-one
+      // sync mode.
+      if (!warmboot) {
+        for (const auto& response : responses) {
+          m_zmqServer->sendMsg("APPL_DB", response.first, response.second);
+        }
+      }
+      responses.clear();
+    } else {
+      m_ntf_pipe->flush();
+    }
     if (m_update_thread != nullptr)
     {
         {

--- a/orchagent/response_publisher.h
+++ b/orchagent/response_publisher.h
@@ -14,6 +14,7 @@
 #include "recorder.h"
 #include "response_publisher_interface.h"
 #include "table.h"
+#include "zmqserver.h"
 
 // This class performs two tasks when publish is called:
 // 1. Sends a notification into the redis channel.
@@ -21,7 +22,9 @@
 class ResponsePublisher : public ResponsePublisherInterface
 {
   public:
-    explicit ResponsePublisher(const std::string &dbName, bool buffered = false, bool db_write_thread = false);
+    explicit ResponsePublisher(const std::string& dbName, bool buffered = false,
+                             bool db_write_thread = false,
+                             swss::ZmqServer* zmqServer = nullptr);
 
     virtual ~ResponsePublisher();
 
@@ -51,7 +54,7 @@ class ResponsePublisher : public ResponsePublisherInterface
     /**
      * @brief Flush pending responses
      */
-    void flush();
+    void flush(bool warmboot = false);
 
     /**
      * @brief Set buffering mode
@@ -91,6 +94,10 @@ class ResponsePublisher : public ResponsePublisherInterface
     std::unique_ptr<swss::RedisPipeline> m_db_pipe;
 
     bool m_buffered{false};
+    swss::ZmqServer* m_zmqServer;
+    std::unordered_map<std::string, std::vector<swss::KeyOpFieldsValuesTuple>>
+        responses;  // Cache the responses to send them together in flush(). Only
+                   // used when ZMQ is enabled.
     // Thread to write to DB.
     std::unique_ptr<std::thread> m_update_thread;
     std::queue<entry> m_queue;

--- a/orchagent/zmqorch.cpp
+++ b/orchagent/zmqorch.cpp
@@ -4,6 +4,7 @@ using namespace swss;
 using namespace std;
 
 extern int gBatchSize;
+extern bool gSwssRecord;
 
 void ZmqConsumer::execute()
 {
@@ -15,7 +16,23 @@ void ZmqConsumer::execute()
     {
         std::deque<KeyOpFieldsValuesTuple> entries;
         table->pops(entries);
-        update_size = addToSync(entries);
+        if (!m_ordered_queue)
+        {
+            update_size = addToSync(entries);
+        }
+        else
+        {
+            /* Record incoming tasks */
+            if (gSwssRecord)
+            {
+                for (auto& entry: entries)
+                {
+                    Orch::recordTuple(*this, entry);
+                }
+            }
+            update_size = entries.size();
+            m_queue.insert(m_queue.end(), entries.begin(), entries.end());
+        }
     } while (update_size != 0);
 
     drain();
@@ -23,37 +40,35 @@ void ZmqConsumer::execute()
 
 void ZmqConsumer::drain()
 {
-    if (!m_toSync.empty())
+    if (!m_toSync.empty() || !m_queue.empty())
         (static_cast<ZmqOrch*>(m_orch))->doTask(*this);
 }
 
-
-ZmqOrch::ZmqOrch(DBConnector *db, const vector<string> &tableNames, ZmqServer *zmqServer)
+ZmqOrch::ZmqOrch(DBConnector *db, const vector<string> &tableNames, ZmqServer *zmqServer, bool orderedQueue, bool dbPersistence)
 : Orch()
 {
     for (auto it : tableNames)
     {
-        addConsumer(db, it, default_orch_pri, zmqServer);
+        addConsumer(db, it, default_orch_pri, zmqServer, orderedQueue, dbPersistence);
     }
 }
 
-
-ZmqOrch::ZmqOrch(DBConnector *db, const vector<table_name_with_pri_t> &tableNames_with_pri, ZmqServer *zmqServer)
+ZmqOrch::ZmqOrch(DBConnector *db, const vector<table_name_with_pri_t> &tableNames_with_pri, ZmqServer *zmqServer, bool orderedQueue, bool dbPersistence)
 {
     for (const auto& it : tableNames_with_pri)
     {
-        addConsumer(db, it.first, it.second, zmqServer);
+        addConsumer(db, it.first, it.second, zmqServer, orderedQueue, dbPersistence);
     }
 }
 
-void ZmqOrch::addConsumer(DBConnector *db, string tableName, int pri, ZmqServer *zmqServer)
+void ZmqOrch::addConsumer(DBConnector *db, string tableName, int pri, ZmqServer *zmqServer, bool orderedQueue, bool dbPersistence)
 {
     if (db->getDbId() == APPL_DB)
     {
         if (zmqServer != nullptr)
         {
             SWSS_LOG_DEBUG("ZmqConsumer initialize for: %s", tableName.c_str());
-            addExecutor(new ZmqConsumer(new ZmqConsumerStateTable(db, tableName, *zmqServer, gBatchSize, pri), this, tableName));
+            addExecutor(new ZmqConsumer(new ZmqConsumerStateTable(db, tableName, *zmqServer, gBatchSize, pri, dbPersistence), this, tableName, orderedQueue));
         }
         else
         {

--- a/orchagent/zmqorch.h
+++ b/orchagent/zmqorch.h
@@ -2,13 +2,14 @@
 
 #include <vector>
 #include <string>
+#include <deque>
 #include <orch.h>
 #include "zmqserver.h"
 
 class ZmqConsumer : public ConsumerBase {
 public:
-    ZmqConsumer(swss::ZmqConsumerStateTable *select, Orch *orch, const std::string &name)
-        : ConsumerBase(select, orch, name)
+    ZmqConsumer(swss::ZmqConsumerStateTable *select, Orch *orch, const std::string &name, bool orderedQueue = false)
+        : ConsumerBase(select, orch, name), m_ordered_queue(orderedQueue)
     {
     }
 
@@ -20,17 +21,23 @@ public:
 
     void execute() override;
     void drain() override;
+
+
+    // If m_ordered_queue is set, m_queue will be used instead of m_toSync for
+    // storing requests.
+    bool m_ordered_queue;
+    std::deque<swss::KeyOpFieldsValuesTuple> m_queue;
 };
 
 class ZmqOrch : public Orch
 {
 public:
-    ZmqOrch(swss::DBConnector *db, const std::vector<std::string> &tableNames, swss::ZmqServer *zmqServer);
-    ZmqOrch(swss::DBConnector *db, const std::vector<table_name_with_pri_t> &tableNames_with_pri, swss::ZmqServer *zmqServer);
+    ZmqOrch(swss::DBConnector *db, const std::vector<std::string> &tableNames, swss::ZmqServer *zmqServer, bool orderedQueue = false, bool dbPersistence = true);
+    ZmqOrch(swss::DBConnector *db, const std::vector<table_name_with_pri_t> &tableNames_with_pri, swss::ZmqServer *zmqServer, bool orderedQueue = false, bool dbPersistence = true);
 
     virtual void doTask(ConsumerBase &consumer) { };
     void doTask(Consumer &consumer) override;
 
 private:
-    void addConsumer(swss::DBConnector *db, std::string tableName, int pri, swss::ZmqServer *zmqServer);
+    void addConsumer(swss::DBConnector *db, std::string tableName, int pri, swss::ZmqServer *zmqServer, bool orderedQueue = false, bool dbPersistence = true);
 };

--- a/tests/dvslib/dvs_database.py
+++ b/tests/dvslib/dvs_database.py
@@ -4,7 +4,7 @@ FIXME:
     - Reference DBs by name rather than ID/socket
     - Add support for ProducerStateTable
 """
-from typing import Dict, List
+from typing import Dict, List, Tuple
 from swsscommon import swsscommon
 from swsscommon.swsscommon import SonicDBConfig
 from dvslib.dvs_common import wait_for_result, PollingConfig
@@ -56,7 +56,7 @@ class DVSDatabase:
         table.set(key, formatted_entry)
 
         if status:
-            for f in [ k for k, v in dict(fv_pairs).items() if k not in entry.keys() ]:
+            for f in [k for k, v in dict(fv_pairs).items() if k not in entry.keys()]:
                 table.hdel(key, f)
 
     def update_entry(self, table_name: str, key: str, entry: Dict[str, str]) -> None:
@@ -160,7 +160,9 @@ class DVSDatabase:
             fv_pairs = self.get_entry(table_name, key)
             return (bool(fv_pairs), fv_pairs)
 
-        message = failure_message or f'Entry not found: key="{key}", table="{table_name}"'
+        message = (
+            failure_message or f'Entry not found: key="{key}", table="{table_name}"'
+        )
         _, result = wait_for_result(access_function, polling_config, message)
 
         return result
@@ -206,6 +208,7 @@ class DVSDatabase:
             assert not polling_config.strict, message
 
         return result
+
 
     def wait_for_field_match(
         self,

--- a/tests/mock_tests/fake_response_publisher.cpp
+++ b/tests/mock_tests/fake_response_publisher.cpp
@@ -8,8 +8,10 @@
  * when needed to test code that uses response publisher. */
 std::unique_ptr<MockResponsePublisher> gMockResponsePublisher;
 
-ResponsePublisher::ResponsePublisher(const std::string& dbName, bool buffered, bool db_write_thread) :
-    m_db(std::make_unique<swss::DBConnector>(dbName, 0)), m_buffered(buffered) {}
+ResponsePublisher::ResponsePublisher(const std::string& dbName, bool buffered,
+                                     bool db_write_thread,
+                                     swss::ZmqServer* zmqServer)
+    : m_db(std::make_unique<swss::DBConnector>(dbName, 0)), m_buffered(buffered) {}
 
 ResponsePublisher::~ResponsePublisher() {}
 
@@ -41,6 +43,6 @@ void ResponsePublisher::writeToDB(
     const std::vector<swss::FieldValueTuple>& values, const std::string& op,
     bool replace) {}
 
-void ResponsePublisher::flush() {}
+void ResponsePublisher::flush(bool warmboot) {}
 
 void ResponsePublisher::setBuffered(bool buffered) {}

--- a/tests/mock_tests/mock_orchagent_main.cpp
+++ b/tests/mock_tests/mock_orchagent_main.cpp
@@ -12,6 +12,12 @@ sai_object_id_t gSwitchId = SAI_NULL_OBJECT_ID;
 MacAddress gMacAddress;
 MacAddress gVxlanMacAddress;
 
+bool gSairedisRecord = true;
+bool gSwssRecord = true;
+bool gLogRotate = false;
+ofstream gRecordOfs;
+string gRecordFile;
+
 string gMySwitchType = "switch";
 string gMySwitchSubType = "SmartSwitch";
 int32_t gVoqMySwitchId = 0;

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -10,5 +10,6 @@ JUNITXML=$(echo "$TESTS" | cut -d "." -f1)_tr.xml
 set -x
 for ((i=1; i<=$RETRY; i++)); do
     echo "Running the py test for tests: $TESTS, $i/$RETRY..."
-    py.test -v --force-flaky --junitxml="$JUNITXML" $PY_TEST_PARAMS --imgname="$IMAGE_NAME" $TESTS && break
+    sudo py.test -v --force-flaky --junitxml="$JUNITXML" $PY_TEST_PARAMS --imgname="$IMAGE_NAME" $TESTS && exit 0
 done
+exit 1

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -130,6 +130,10 @@ class TestRouteBase(object):
         dvs.servers[1].runcmd("ip address flush dev eth0")
         dvs.servers[2].runcmd("ip address flush dev eth0")
         dvs.servers[3].runcmd("ip address flush dev eth0")
+        dvs.servers[0].runcmd("ip address flush dev eth4")
+        dvs.servers[1].runcmd("ip address flush dev eth4")
+        dvs.servers[2].runcmd("ip address flush dev eth4")
+        dvs.servers[3].runcmd("ip address flush dev eth4")
 
 class TestRoute(TestRouteBase):
     """ Functionality tests for route """


### PR DESCRIPTION
Enable zmq between p4rt & swss

Summary:
Add ordered queue for zmq consumer, Enable zmq in p4orch & Reduce zmq wait time in pytest.

Build Results:
```
...
/bin/sh ../libtool  --tag=CXX   --mode=link g++  -g -O2   -o gearsyncd gearsyncd-gearboxutils.o gearsyncd-gearsyncd.o gearsyncd-gearparserbase.o gearsyncd-gearboxparser.o gearsyncd-phyparser.o   -lnl-3 -lnl-route-3 -lswsscommon   -lnl-nf-3 -lnl-route-3 -lnl-genl-3 -lnl-3 -lhiredis 
libtool: link: g++ -g -O2 -o gearsyncd gearsyncd-gearboxutils.o gearsyncd-gearsyncd.o gearsyncd-gearparserbase.o gearsyncd-gearboxparser.o gearsyncd-phyparser.o  -lswsscommon -lnl-nf-3 -lnl-route-3 -lnl-genl-3 -lnl-3 -lhiredis
make[2]: Leaving directory '/usr/local/google/home/divyagayathris/sonic_swss_changes/sonic-buildimage/src/sonic-swss/gearsyncd'
make[2]: Entering directory '/usr/local/google/home/divyagayathris/sonic_swss_changes/sonic-buildimage/src/sonic-swss'
make[2]: Leaving directory '/usr/local/google/home/divyagayathris/sonic_swss_changes/sonic-buildimage/src/sonic-swss'
make[1]: Leaving directory '/usr/local/google/home/divyagayathris/sonic_swss_changes/sonic-buildimage/src/sonic-swss'
```

Test Results:
```
...

[----------] Global test environment tear-down
[==========] 419 tests from 12 test suites ran. (136 ms total)
[  PASSED  ] 419 tests.
```
