### PR TITLE
[orchagent] CoPP neighbor miss trap and enhancements

### DIFF
--- a/orchagent/copporch.h
+++ b/orchagent/copporch.h
@@ -1,9 +1,16 @@
 #ifndef SWSS_COPPORCH_H
 #define SWSS_COPPORCH_H
 
+extern "C" {
+#include <saiobject.h>
+#include <saistatus.h>
+#include <saiswitch.h>
+}
+
 #include <map>
 #include <set>
 #include <memory>
+#include <unordered_set>
 #include "dbconnector.h"
 #include "orch.h"
 #include "flex_counter_manager.h"
@@ -99,8 +106,13 @@ protected:
 
     std::shared_ptr<DBConnector> m_counter_db;
     std::shared_ptr<DBConnector> m_asic_db;
+    std::shared_ptr<DBConnector> m_state_db;
     std::unique_ptr<Table> m_counter_table;
     std::unique_ptr<Table> m_vidToRidTable;
+    std::unique_ptr<Table> m_trapCapabilityTable;
+    std::unique_ptr<Table> m_trapTable;
+
+    std::unordered_set<sai_hostif_trap_type_t> supported_trap_ids;    
 
     FlexCounterManager m_trap_counter_manager;
 
@@ -112,6 +124,9 @@ protected:
     void initDefaultTrapGroup();
     void initDefaultTrapIds();
     void initTrapRatePlugin();
+    bool isTrapIdSupported(sai_hostif_trap_type_t trap_id) const;
+    void updateTrapOperStatus(sai_hostif_trap_type_t trap_type, const std::string& hw_status);
+    void publishTrapIdsCapability();
 
     task_process_status processCoppRule(Consumer& consumer);
     bool isValidList(std::vector<std::string> &trap_id_list, std::vector<std::string> &all_items) const;
@@ -148,7 +163,7 @@ protected:
 
     bool trapGroupUpdatePolicer (std::string trap_group_name, std::vector<sai_attribute_t> &policer_attribs);
 
-    bool removeTrap(sai_object_id_t hostif_trap_id);
+    bool removeTrap(sai_object_id_t hostif_trap_id, sai_hostif_trap_type_t trap_type);
 
     bool bindTrapCounter(sai_object_id_t hostif_trap_id, sai_hostif_trap_type_t trap_type);
     void unbindTrapCounter(sai_object_id_t hostif_trap_id);

--- a/orchagent/debugcounterorch.cpp
+++ b/orchagent/debugcounterorch.cpp
@@ -227,7 +227,7 @@ void DebugCounterOrch::doTask(Consumer& consumer)
 
 // publishDropCounterCapabilities queries the SAI for available drop counter
 // capabilities on this device and publishes the information to the
-// DROP_COUNTER_CAPABILITIES table in STATE_DB.
+// DEBUG_COUNTER_CAPABILITIES table in STATE_DB.
 void DebugCounterOrch::publishDropCounterCapabilities()
 {
     supported_ingress_drop_reasons = DropCounter::getSupportedDropReasons(SAI_DEBUG_COUNTER_ATTR_IN_DROP_REASON_LIST);

--- a/tests/mock_tests/copp_cfg.json
+++ b/tests/mock_tests/copp_cfg.json
@@ -48,6 +48,16 @@
 		    "cbs":"600",
 		    "red_action":"drop"
 	    },
+	    "queue1_group3": {
+		    "trap_action":"trap",
+		    "trap_priority":"1",
+		    "queue": "1",
+		    "meter_type":"packets",
+		    "mode":"sr_tcm",
+		    "cir":"200",
+		    "cbs":"200",
+		    "red_action":"drop"
+	    },
 	    "queue2_group1": {
 		    "cbs": "1000",
 		    "cir": "1000",
@@ -106,6 +116,11 @@
 	    "sflow": {
 		    "trap_group": "queue2_group1",
 		    "trap_ids": "sample_packet"
+	    },
+	    "neighbor_miss": {
+		    "trap_ids": "neighbor_miss",
+		    "trap_group": "queue1_group3",
+		    "always_enabled": "true"
 	    }
     }
 }

--- a/tests/mock_tests/copporch_ut.cpp
+++ b/tests/mock_tests/copporch_ut.cpp
@@ -299,7 +299,7 @@ namespace copporch_test
 
         const auto &supportedTrapIds = Portal::CoppOrchInternal::getSupportedTrapIds(coppOrch.get());
         EXPECT_TRUE(supportedTrapIds.find(SAI_HOSTIF_TRAP_TYPE_IP2ME) != supportedTrapIds.end());
-        EXPECT_TRUE(supportedTrapIds.find(SAI_HOSTIF_TRAP_TYPE_NEIGHBOR_MISS) == supportedTrapIds.end());
+        EXPECT_TRUE(supportedTrapIds.find(SAI_HOSTIF_TRAP_TYPE_NEIGHBOR_MISS) != supportedTrapIds.end());
     }
 
     TEST_F(CoppOrchTest, TrapGroup_AddRemove)
@@ -469,7 +469,8 @@ namespace copporch_test
         const std::string trapNameList = "bgp,bgpv6,neighbor_miss";
         const std::set<sai_hostif_trap_type_t> trapIDSet = {
             SAI_HOSTIF_TRAP_TYPE_BGP,
-            SAI_HOSTIF_TRAP_TYPE_BGPV6
+            SAI_HOSTIF_TRAP_TYPE_BGPV6,
+            SAI_HOSTIF_TRAP_TYPE_NEIGHBOR_MISS
         };
 
         MockCoppOrch coppOrch;
@@ -500,10 +501,7 @@ namespace copporch_test
             const auto &tidList = Portal::CoppOrchInternal::getTrapIdsFromTrapGroup(coppOrch.get(), tgOid);
             const auto &tidSet = std::set<sai_hostif_trap_type_t>(tidList.begin(), tidList.end());
 
-            // Verify that neighbor_miss is not installed
-            EXPECT_TRUE(tidSet.find(SAI_HOSTIF_TRAP_TYPE_NEIGHBOR_MISS) == tidSet.end());
-
-            // Verify that bgp and bgpv6 are installed
+            // Verify that bgp, bgpv6 and neighbor_miss are installed
             EXPECT_TRUE(trapIDSet == tidSet);
         }
 

--- a/tests/mock_tests/copporch_ut.cpp
+++ b/tests/mock_tests/copporch_ut.cpp
@@ -293,6 +293,15 @@ namespace copporch_test
         std::vector<Orch*> resourcesList;
     };
 
+    TEST_F(CoppOrchTest, VerifySupportedTrapIds)
+    {
+        MockCoppOrch coppOrch;
+
+        const auto &supportedTrapIds = Portal::CoppOrchInternal::getSupportedTrapIds(coppOrch.get());
+        EXPECT_TRUE(supportedTrapIds.find(SAI_HOSTIF_TRAP_TYPE_IP2ME) != supportedTrapIds.end());
+        EXPECT_TRUE(supportedTrapIds.find(SAI_HOSTIF_TRAP_TYPE_NEIGHBOR_MISS) == supportedTrapIds.end());
+    }
+
     TEST_F(CoppOrchTest, TrapGroup_AddRemove)
     {
         const std::string trapGroupName = "queue4_group1";
@@ -457,7 +466,7 @@ namespace copporch_test
     TEST_F(CoppOrchTest, Trap_AddRemove)
     {
         const std::string trapGroupName = "queue4_group1";
-        const std::string trapNameList = "bgp,bgpv6";
+        const std::string trapNameList = "bgp,bgpv6,neighbor_miss";
         const std::set<sai_hostif_trap_type_t> trapIDSet = {
             SAI_HOSTIF_TRAP_TYPE_BGP,
             SAI_HOSTIF_TRAP_TYPE_BGPV6
@@ -490,6 +499,11 @@ namespace copporch_test
             const auto &tgOid = cit->second;
             const auto &tidList = Portal::CoppOrchInternal::getTrapIdsFromTrapGroup(coppOrch.get(), tgOid);
             const auto &tidSet = std::set<sai_hostif_trap_type_t>(tidList.begin(), tidList.end());
+
+            // Verify that neighbor_miss is not installed
+            EXPECT_TRUE(tidSet.find(SAI_HOSTIF_TRAP_TYPE_NEIGHBOR_MISS) == tidSet.end());
+
+            // Verify that bgp and bgpv6 are installed
             EXPECT_TRUE(trapIDSet == tidSet);
         }
 

--- a/tests/mock_tests/portal.h
+++ b/tests/mock_tests/portal.h
@@ -87,6 +87,11 @@ struct Portal
         {
             return obj.processCoppRule(processCoppRule);
         }
+
+        static const std::unordered_set<sai_hostif_trap_type_t>& getSupportedTrapIds(const CoppOrch &obj)
+        {
+            return obj.supported_trap_ids;
+        }
     };
 
     struct SflowOrchInternal

--- a/tests/test_copp.py
+++ b/tests/test_copp.py
@@ -71,7 +71,8 @@ traps_to_trap_type = {
         "dest_nat_miss": "SAI_HOSTIF_TRAP_TYPE_DNAT_MISS",
         "ldp": "SAI_HOSTIF_TRAP_TYPE_LDP",
         "bfd_micro": "SAI_HOSTIF_TRAP_TYPE_BFD_MICRO",
-        "bfdv6_micro": "SAI_HOSTIF_TRAP_TYPE_BFDV6_MICRO"
+        "bfdv6_micro": "SAI_HOSTIF_TRAP_TYPE_BFDV6_MICRO",
+        "neighbor_miss": "SAI_HOSTIF_TRAP_TYPE_NEIGHBOR_MISS"
         }
 
 copp_group_default = {
@@ -128,6 +129,17 @@ copp_group_queue1_group2 = {
         "red_action":"drop"
 }
 
+copp_group_queue1_group3 = {
+        "trap_action":"trap",
+        "trap_priority":"1",
+        "queue": "1",
+        "meter_type":"packets",
+        "mode":"sr_tcm",
+        "cir":"200",
+        "cbs":"200",
+        "red_action":"drop"
+}
+
 copp_group_queue2_group1 = {
 	"cbs": "1000",
 	"cir": "1000",
@@ -162,7 +174,8 @@ copp_trap = {
         "ip2me": ["ip2me", copp_group_queue1_group1, "always_enabled"],
         "nat": ["src_nat_miss;dest_nat_miss", copp_group_queue1_group2],
         "sflow": ["sample_packet", copp_group_queue2_group1],
-        "ttl": ["ttl_error", copp_group_default]
+        "ttl": ["ttl_error", copp_group_default],
+        "neighbor_miss": ["neighbor_miss", copp_group_queue1_group3, "always_enabled"]
 }
 
 disabled_traps = ["sample_packet"]
@@ -194,6 +207,7 @@ class TestCopp(object):
     def setup_copp(self, dvs):
         self.adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
         self.cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+        self.sdb = swsscommon.DBConnector(6, dvs.redis_sock, 0)
         self.trap_atbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF_TRAP")
         self.trap_group_atbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF_TRAP_GROUP")
         self.policer_atbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_POLICER")
@@ -202,10 +216,24 @@ class TestCopp(object):
         self.trap_ctbl = swsscommon.Table(self.cdb, "COPP_TRAP")
         self.trap_group_ctbl = swsscommon.Table(self.cdb, "COPP_GROUP")
         self.feature_tbl = swsscommon.Table(self.cdb, "FEATURE")
+        self.state_stbl = swsscommon.Table(self.sdb, "COPP_TRAP_TABLE")
+        self.capability_stbl = swsscommon.Table(self.sdb, "COPP_TRAP_CAPABILITY_TABLE")
         fvs = swsscommon.FieldValuePairs([("state", "disabled")])
         self.feature_tbl.set("sflow", fvs)
         time.sleep(2)
 
+    def validate_trap_hw_status(self, trap_id, trap_status):
+        (status, fvs) = self.state_stbl.get(trap_id)
+        if trap_status == True:
+            assert status == True
+
+        if status:
+            for fv in fvs:
+                if fv[0] == "hw_status":
+                    if trap_status == True:
+                        assert fv[1] == "installed"
+                    else:
+                        assert fv[1] == "not-installed"
 
     def validate_policer(self, policer_oid, field, value):
         (status, fvs) = self.policer_atbl.get(policer_oid)
@@ -337,6 +365,15 @@ class TestCopp(object):
                 if trap_id not in disabled_traps:
                     assert trap_found == True
 
+        (status, fvs) = self.capability_stbl.get("traps")
+        assert status == True
+        trap_list = []
+        for fv in fvs:
+            if fv[0] == "trap_ids":
+                trap_list = fv[1].split(",")
+                break
+
+        assert len(trap_list) != 0
 
     def test_restricted_trap_sflow(self, dvs, testlog):
         self.setup_copp(dvs)
@@ -477,6 +514,7 @@ class TestCopp(object):
                 assert trap_found == True
             elif trap_id == "bgpv6":
                 assert trap_found == False
+            self.validate_trap_hw_status(trap_id, trap_found)
 
         traps = "bgp,bgpv6"
         fvs = swsscommon.FieldValuePairs([("trap_ids", traps)])
@@ -501,6 +539,8 @@ class TestCopp(object):
                     self.validate_trap_group(key,trap_group)
                     break
             assert trap_found == True
+            self.validate_trap_hw_status(trap_id, trap_found)
+
 
     def test_trap_action_set(self, dvs, testlog):
         self.setup_copp(dvs)
@@ -565,6 +605,7 @@ class TestCopp(object):
                     break
             if trap_id not in disabled_traps:
                 assert trap_found == True
+                self.validate_trap_hw_status(trap_id, trap_found)
 
     def test_new_trap_del(self, dvs, testlog):
         self.setup_copp(dvs)
@@ -602,6 +643,7 @@ class TestCopp(object):
                     break
             if trap_id not in disabled_traps:
                 assert trap_found == False
+                self.validate_trap_hw_status(trap_id, trap_found)
 
     def test_new_trap_group_add(self, dvs, testlog):
         self.setup_copp(dvs)
@@ -641,6 +683,7 @@ class TestCopp(object):
                     break
             if trap_id not in disabled_traps:
                 assert trap_found == True
+                self.validate_trap_hw_status(trap_id, trap_found)
 
     def test_new_trap_group_del(self, dvs, testlog):
         self.setup_copp(dvs)
@@ -682,6 +725,7 @@ class TestCopp(object):
                     break
             if trap_id not in disabled_traps:
                 assert trap_found != True
+                self.validate_trap_hw_status(trap_id, trap_found)
 
     def test_override_trap_grp_cfg_del (self, dvs, testlog):
         self.setup_copp(dvs)
@@ -751,6 +795,7 @@ class TestCopp(object):
                     assert trap_found == True
                 elif trap_id == "ssh":
                     assert trap_found == False
+                self.validate_trap_hw_status(trap_id, trap_found)
 
     def test_empty_trap_cfg(self, dvs, testlog):
         self.setup_copp(dvs)
@@ -776,6 +821,7 @@ class TestCopp(object):
                 self.validate_trap_group(key,trap_group)
                 break
         assert trap_found == False
+        self.validate_trap_hw_status(trap_id, trap_found)
 
         self.trap_ctbl._del("ip2me")
         time.sleep(2)
@@ -795,6 +841,7 @@ class TestCopp(object):
                 self.validate_trap_group(key,trap_group)
                 break
         assert trap_found == True
+        self.validate_trap_hw_status(trap_id, trap_found)
 
 
     def test_disabled_feature_always_enabled_trap(self, dvs, testlog):

--- a/tests/test_copp.py
+++ b/tests/test_copp.py
@@ -174,8 +174,7 @@ copp_trap = {
         "ip2me": ["ip2me", copp_group_queue1_group1, "always_enabled"],
         "nat": ["src_nat_miss;dest_nat_miss", copp_group_queue1_group2],
         "sflow": ["sample_packet", copp_group_queue2_group1],
-        "ttl": ["ttl_error", copp_group_default],
-        "neighbor_miss": ["neighbor_miss", copp_group_queue1_group3, "always_enabled"]
+        "ttl": ["ttl_error", copp_group_default]
 }
 
 disabled_traps = ["sample_packet"]


### PR DESCRIPTION
**What I did**

- Added neighbor_miss trap type support
- enum capability query for hostif trap type in copporch.cpp
- Added hw_status field to COPP_TRAP_TABLE table in state_db

**Why I did it**

HLD: [sonic-net/SONiC#1943](https://github.com/sonic-net/SONiC/pull/1943)

**How I verified it**

Verified with test_copp.py DVS test
Verified on Sonic switch with and without neighbor_miss trap support by vendorSAI.

**Details if related**

PR Dependencies:

- Depends on: sonic-net/sonic-swss-common#1010
- Depends on: sonic-net/sonic-sairedis#1586

Signed-off-by: Ravi Minnikanti <rminnikanti@marvell.com>
