### PR TITLE
[mclagsyncd]: Initialize the `client_len` before calling `::accept`

### DIFF
--- a/mclagsyncd/mclaglink.cpp
+++ b/mclagsyncd/mclaglink.cpp
@@ -1844,7 +1844,7 @@ MclagLink::~MclagLink()
 void MclagLink::accept()
 {
     struct sockaddr_in client_addr;
-    socklen_t client_len;
+    socklen_t client_len = sizeof(struct sockaddr_in);
 
     m_connection_socket = ::accept(m_server_socket, (struct sockaddr *)&client_addr,
             &client_len);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Initialize the `client_len` before calling `::accept`.

**Why I did it**

Otherwise the `::accept` syscall may return with EINVAL and `mclagsyncd` will exit with the following exception:

```
Exception "Invalid argument" had been thrown in daemon
```

**How I verified it**

It is easy to verify it by running iccpd and mclagsyncd with the fix.

**Details if related**

This is the syslog of the iccpd container when this issue occurs:
```
Apr 22 19:04:16.101881 sonic INFO iccpd#supervisord: iccpd Waiting for connection...
Apr 22 19:04:16.186615 sonic NOTICE iccpd#iccpd: [iccp_connect_syncd.NOTICE] Success to link syncd
Apr 22 19:04:16.187665 sonic WARNING iccpd#iccpd: [ICCP_FSM.WARN] Recv fom Mclagsyncd read erro:0 
Apr 22 19:04:16.188201 sonic INFO iccpd#supervisord: iccpd Exception "Invalid argument" had been thrown in daemon
```