### PR TITLE
[voq][chassis][orchagent][lagid] Modified the lua script to fix orhagent crash during upgrade from 202205 to 202405

### DIFF
--- a/orchagent/lagids.lua
+++ b/orchagent/lagids.lua
@@ -39,46 +39,50 @@ if op == "add" then
         -- the portchannel does not exist in the database
         -- If proposed lagid is not available, lpop the first availabe ID
         local index = redis.call("lpos", "SYSTEM_LAG_IDS_FREE_LIST", tostring(plagid))
-        if index == false then
-            if redis.call("llen", "SYSTEM_LAG_IDS_FREE_LIST") <= 0 then
-                return -1
-            end
-            local lagid = redis.call("lpop", "SYSTEM_LAG_IDS_FREE_LIST")
-            redis.call("hset", "SYSTEM_LAG_ID_TABLE", pcname, lagid)
-            redis.call("sadd", "SYSTEM_LAG_ID_SET", lagid)
-            if dblagid then
-                redis.call("srem", "SYSTEM_LAG_ID_SET", tostring(dblagid))
-                if redis.call("lpos", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid)) == false then
-                    redis.call("rpush", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid))
+        if index ~= false then
+            if redis.call("sismember", "SYSTEM_LAG_ID_SET", tostring(plagid)) == 0 then
+                redis.call("lrem", "SYSTEM_LAG_IDS_FREE_LIST", 1, tostring(plagid))
+                redis.call("hset", "SYSTEM_LAG_ID_TABLE", pcname, tostring(plagid))
+                redis.call("sadd", "SYSTEM_LAG_ID_SET", tostring(plagid))
+                if dblagid then
+                    redis.call("srem", "SYSTEM_LAG_ID_SET", tostring(dblagid))
+                    if redis.call("lpos", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid)) == false then
+                        redis.call("rpush", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid))
+                    end
                 end
+                return plagid
+            else
+                redis.call("lrem", "SYSTEM_LAG_IDS_FREE_LIST", 1, tostring(plagid))
             end
-            return tonumber(lagid)
-        else
-            redis.call("lrem", "SYSTEM_LAG_IDS_FREE_LIST", 1, tostring(plagid))
-            redis.call("hset", "SYSTEM_LAG_ID_TABLE", pcname, tostring(plagid))
-            redis.call("sadd", "SYSTEM_LAG_ID_SET", tostring(plagid))
-            if dblagid then
-                redis.call("srem", "SYSTEM_LAG_ID_SET", tostring(dblagid))
-                if redis.call("lpos", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid)) == false then
-                    redis.call("rpush", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid))
-               end
-            end
-            return plagid
         end
-    else
+    end
+
+    if redis.call("llen", "SYSTEM_LAG_IDS_FREE_LIST") <= 0 then
+        return -1
+    end
+    local lagid = redis.call("lpop", "SYSTEM_LAG_IDS_FREE_LIST")
+
+    -- check if the first one is in the SYSTEM_LAG_ID_SET (which could be set by LC which
+    -- is running previous image with the old allocation method
+    -- remove from free_list and check/get the next one from the free_list
+    while redis.call("sismember", "SYSTEM_LAG_ID_SET", tostring(lagid)) == 1 do
         if redis.call("llen", "SYSTEM_LAG_IDS_FREE_LIST") <= 0 then
             return -1
         end
-        local lagid = redis.call("lpop", "SYSTEM_LAG_IDS_FREE_LIST")
-        redis.call("hset", "SYSTEM_LAG_ID_TABLE", pcname, lagid)
-        redis.call("sadd", "SYSTEM_LAG_ID_SET", lagid)
-        if dblagid then
-            if redis.call("lpos", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid)) == false then
-                redis.call("rpush", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid))
-            end
-        end
-        return tonumber(lagid) 
+        lagid = redis.call("lpop", "SYSTEM_LAG_IDS_FREE_LIST")
     end
+
+    -- Remove it from free list in case there is duplicated one 
+    redis.call("lrem", "SYSTEM_LAG_IDS_FREE_LIST", 1, lagid)
+
+    redis.call("hset", "SYSTEM_LAG_ID_TABLE", pcname, lagid)
+    redis.call("sadd", "SYSTEM_LAG_ID_SET", lagid)
+    if dblagid then
+        if redis.call("lpos", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid)) == false then
+            redis.call("rpush", "SYSTEM_LAG_IDS_FREE_LIST", tostring(dblagid))
+        end
+    end
+    return tonumber(lagid)
 end
 
 if op == "del" then
@@ -88,7 +92,7 @@ if op == "del" then
         redis.call("srem", "SYSTEM_LAG_ID_SET", lagid)
         redis.call("hdel", "SYSTEM_LAG_ID_TABLE", pcname)
         if redis.call("lpos", "SYSTEM_LAG_IDS_FREE_LIST", lagid) == false then
-           redis.call("rpush", "SYSTEM_LAG_IDS_FREE_LIST", lagid)
+            redis.call("rpush", "SYSTEM_LAG_IDS_FREE_LIST", lagid)
         end
         return tonumber(lagid)
     end

--- a/orchagent/lagids.lua
+++ b/orchagent/lagids.lua
@@ -41,7 +41,7 @@ if op == "add" then
         local index = redis.call("lpos", "SYSTEM_LAG_IDS_FREE_LIST", tostring(plagid))
         if index ~= false then
             if redis.call("sismember", "SYSTEM_LAG_ID_SET", tostring(plagid)) == 0 then
-                redis.call("lrem", "SYSTEM_LAG_IDS_FREE_LIST", 1, tostring(plagid))
+                redis.call("lrem", "SYSTEM_LAG_IDS_FREE_LIST", 0, tostring(plagid))
                 redis.call("hset", "SYSTEM_LAG_ID_TABLE", pcname, tostring(plagid))
                 redis.call("sadd", "SYSTEM_LAG_ID_SET", tostring(plagid))
                 if dblagid then
@@ -52,7 +52,7 @@ if op == "add" then
                 end
                 return plagid
             else
-                redis.call("lrem", "SYSTEM_LAG_IDS_FREE_LIST", 1, tostring(plagid))
+                redis.call("lrem", "SYSTEM_LAG_IDS_FREE_LIST", 0, tostring(plagid))
             end
         end
     end
@@ -73,7 +73,7 @@ if op == "add" then
     end
 
     -- Remove it from free list in case there is duplicated one 
-    redis.call("lrem", "SYSTEM_LAG_IDS_FREE_LIST", 1, lagid)
+    redis.call("lrem", "SYSTEM_LAG_IDS_FREE_LIST", 0, lagid)
 
     redis.call("hset", "SYSTEM_LAG_ID_TABLE", pcname, lagid)
     redis.call("sadd", "SYSTEM_LAG_ID_SET", lagid)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Modify the lagids.lua script to check both SYSTEM_LAG_IDS_FREE_LIST and SYSTEM_LAG_ID_SET to make sure the LagId is really free before it is assigned.  If it is in the FREE_LIST and also in the SYSTEM_LAG_ID_SET, remove it from the FREE_LIST and check/use the next one in the FREE_LIST. This will avoid using the ID which has been using by the LC which is still running the 202205 image.  This will address the orchagent    

**Why I did it**
The orhcgent crash during upgrade from 202205 to 202405 is caused by the same lagid used by multiple PortChannels.  On chassis with mulitple LCs,  upgrade LCs image from 202205 to 202405.   orchagent crash could be occured when one LC is running with latest image while other LCs is still running with the old image. This PR fixes issue #https://github.com/Nokia-ION/ndk/issues/84

**How I verified it**
While chassis with multiple LCs are running 202205 image, Upgrade Supervisor first, then upgrade LCs.  Check there is not be any orchagent crashed in any LC.           

**Which release branch to backport (provide reason below if selected)**
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405
- [x] 202411

**Details if related**
