### PR TITLE
[PORT][RATES] add interface name kvp for FEC BER metrics FEC_PRE_BER and FEC_POST_BER

### DIFF
--- a/orchagent/port_rates.lua
+++ b/orchagent/port_rates.lua
@@ -235,6 +235,8 @@ local function compute_rate(port)
     redis.call('HSET', rates_table_name .. ':' .. port, 'SAI_PORT_STAT_IF_FEC_NOT_CORRECTABLE_FARMES_last', fec_uncorr_frames)
     redis.call('HSET', rates_table_name .. ':' .. port, 'FEC_PRE_BER', fec_corr_bits_ber_new)
     redis.call('HSET', rates_table_name .. ':' .. port, 'FEC_POST_BER', fec_uncorr_bits_ber_new)
+    redis.call('HSET', rates_table_name .. ':' .. interface_name, 'FEC_PRE_BER', fec_corr_bits_ber_new)
+    redis.call('HSET', rates_table_name .. ':' .. interface_name, 'FEC_POST_BER', fec_uncorr_bits_ber_new)
 end
 
 local n = table.getn(KEYS)


### PR DESCRIPTION
 modified port_rates.lua to add FEC BER metrics (FEC_PRE_BER and FEC_POST_BER) under both:

The OID-based Redis key (RATES:oid:...)

And now also under the interface name key (RATES:Ethernet...)

Previously 
Only OID keys like:

RATES:oid:0x1000000000001
RATES:oid:0x1000000000026:PORT
After this change
Now interface keys too are added :


RATES:Ethernet116
RATES:Ethernet148
RATES:Ethernet16  → contains "FEC_PRE_BER" and "FEC_POST_BER"
Purpose:
This makes FEC BER stats accessible via actual interface names — helpful for monitoring, or  Telemetry that reference EthernetXXX rather than OID

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
