### PR TITLE
[DASH] Add support for Metering counters

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -145,8 +145,8 @@ jobs:
         params=" ${params} --num-ports=${{ parameters.num_ports }} "
       fi
 
-      all_tests=$(ls test_none*.py | xargs)
-      all_tests="${all_tests} dash"
+      all_tests=$(ls test_*.py | xargs)
+      all_tests="${all_tests} p4rt dash"
 
       if [ -n '${{ parameters.run_tests_pattern }}' ]; then
         all_tests=" $(ls ${{ parameters.run_tests_pattern }} | xargs) "

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -145,8 +145,8 @@ jobs:
         params=" ${params} --num-ports=${{ parameters.num_ports }} "
       fi
 
-      all_tests=$(ls test_*.py | xargs)
-      all_tests="${all_tests} p4rt dash"
+      all_tests=$(ls test_none*.py | xargs)
+      all_tests="${all_tests} dash"
 
       if [ -n '${{ parameters.run_tests_pattern }}' ]; then
         all_tests=" $(ls ${{ parameters.run_tests_pattern }} | xargs) "

--- a/orchagent/dash/dashmeterorch.cpp
+++ b/orchagent/dash/dashmeterorch.cpp
@@ -30,14 +30,6 @@ extern bool gTraditionalFlexCounter;
 // To be deleted after addition to sonic-swss-common/common/schema.h
 #define COUNTERS_METER_ENI_NAME_MAP "COUNTERS_METER_ENI_NAME_MAP"
 
-#if 0 // To be deleted
-const vector<sai_meter_bucket_entry_stat_t> meter_bucket_entry_stat_ids =
-{
-    SAI_METER_BUCKET_ENTRY_STAT_OUTBOUND_BYTES,
-    SAI_METER_BUCKET_ENTRY_STAT_INBOUND_BYTES
-};
-#endif
-
 
 DashMeterOrch::DashMeterOrch(DBConnector *db, const vector<string> &tables, DashOrch *dash_orch, DBConnector *app_state_db, ZmqServer *zmqServer) :
     m_meter_stat_manager(METER_STAT_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ, METER_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS, false),
@@ -46,7 +38,6 @@ DashMeterOrch::DashMeterOrch(DBConnector *db, const vector<string> &tables, Dash
     m_dash_orch(dash_orch)
 {
     SWSS_LOG_ENTER();
-    SWSS_LOG_ERROR("gsm dbg31");
 
     m_counter_db = std::shared_ptr<DBConnector>(new DBConnector("COUNTERS_DB", 0));
     m_meter_eni_name_table = std::unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_METER_ENI_NAME_MAP));
@@ -62,7 +53,6 @@ DashMeterOrch::DashMeterOrch(DBConnector *db, const vector<string> &tables, Dash
     auto executorT = new ExecutableTimer(m_meter_fc_update_timer, this, "METER_FLEX_COUNTER_UPD_TIMER");
     Orch::addExecutor(executorT);
 
-#if 1
     /* Fetch the meter bucket counter Ids */
     m_meter_counter_stats.clear();
     auto stat_enum_list = queryAvailableCounterStats((sai_object_type_t)SAI_OBJECT_TYPE_METER_BUCKET_ENTRY);
@@ -71,14 +61,6 @@ DashMeterOrch::DashMeterOrch(DBConnector *db, const vector<string> &tables, Dash
         auto counter_id = static_cast<sai_meter_bucket_entry_stat_t>(stat_enum);
         m_meter_counter_stats.emplace(sai_serialize_meter_bucket_entry_stat(counter_id));
     }
-#else
-    /* To be deleted.*/
-    m_meter_counter_stats.clear();
-    for (const auto& it: meter_bucket_entry_stat_ids)
-    {
-        m_meter_counter_stats.emplace(sai_serialize_meter_bucket_entry_stat(it));
-    }
-#endif
 }
 
 sai_object_id_t DashMeterOrch::getMeterPolicyOid(const string& meter_policy) const
@@ -671,8 +653,6 @@ void DashMeterOrch::removeEniFromMeterFC(sai_object_id_t oid, const string &name
         m_meter_stat_work_queue.erase(oid);
         return;
     }
-
-    // Deleting eni_name_map key is done in DashOrch
 
     m_meter_eni_name_table->hdel("", name);
     m_meter_stat_manager.clearCounterIdList(oid);

--- a/orchagent/dash/dashmeterorch.cpp
+++ b/orchagent/dash/dashmeterorch.cpp
@@ -27,7 +27,6 @@ extern bool gTraditionalFlexCounter;
 
 #define METER_FLEX_COUNTER_UPD_INTERVAL 1
 
-
 DashMeterOrch::DashMeterOrch(DBConnector *db, const vector<string> &tables, DashOrch *dash_orch, DBConnector *app_state_db, ZmqServer *zmqServer) :
     m_meter_stat_manager(METER_STAT_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ, METER_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS, false),
     meter_rule_bulker_(sai_dash_meter_api, gSwitchId, gMaxBulkSize),

--- a/orchagent/dash/dashmeterorch.cpp
+++ b/orchagent/dash/dashmeterorch.cpp
@@ -26,7 +26,7 @@ extern bool gTraditionalFlexCounter;
 #define METER_FLEX_COUNTER_UPD_INTERVAL 1
 
 //1234567
-#if 0 //B4C-->1
+#if 1 //B4C-->1
 const vector<sai_meter_bucket_entry_stat_t> meter_bucket_entry_stat_ids =
 {
     SAI_METER_BUCKET_ENTRY_STAT_OUTBOUND_BYTES,
@@ -83,7 +83,7 @@ DashMeterOrch::DashMeterOrch(DBConnector *db, const vector<string> &tables, Dash
     m_meter_counter_stats.clear();
     for (const auto& it: meter_bucket_entry_stat_ids)
     {
-#if 0 //B4C-->1
+#if 1 //B4C-->1
         m_meter_counter_stats.emplace(sai_serialize_meter_bucket_entry_stat(it));
         //m_meter_counter_stats = DashMeterOrch::generateMeterCounterStats();
 #else

--- a/orchagent/dash/dashmeterorch.cpp
+++ b/orchagent/dash/dashmeterorch.cpp
@@ -26,7 +26,7 @@ extern bool gTraditionalFlexCounter;
 #define METER_FLEX_COUNTER_UPD_INTERVAL 1
 
 //1234567
-#if 1 //B4C-->1
+#if 0 //B4C-->1
 const vector<sai_meter_bucket_entry_stat_t> meter_bucket_entry_stat_ids =
 {
     SAI_METER_BUCKET_ENTRY_STAT_OUTBOUND_BYTES,
@@ -35,8 +35,8 @@ const vector<sai_meter_bucket_entry_stat_t> meter_bucket_entry_stat_ids =
 #else
 const vector<sai_eni_stat_t> meter_bucket_entry_stat_ids =
 {
-    SAI_ENI_STAT_TX_BYTES,
-    SAI_ENI_STAT_RX_BYTES
+    SAI_ENI_STAT_RX_BYTES,
+    SAI_ENI_STAT_RX_PACKETS
 };
 #endif
 
@@ -83,7 +83,7 @@ DashMeterOrch::DashMeterOrch(DBConnector *db, const vector<string> &tables, Dash
     m_meter_counter_stats.clear();
     for (const auto& it: meter_bucket_entry_stat_ids)
     {
-#if 1 //B4C-->1
+#if 0 //B4C-->1
         m_meter_counter_stats.emplace(sai_serialize_meter_bucket_entry_stat(it));
         //m_meter_counter_stats = DashMeterOrch::generateMeterCounterStats();
 #else

--- a/orchagent/dash/dashmeterorch.cpp
+++ b/orchagent/dash/dashmeterorch.cpp
@@ -680,6 +680,8 @@ void DashMeterOrch::removeEniFromMeterFC(sai_object_id_t oid, const string &name
     }
 
     // Deleting eni_name_map key is done in DashOrch
+
+    m_eni_name_table->hdel("", name);
     m_meter_stat_manager.clearCounterIdList(oid);
     SWSS_LOG_DEBUG("Unregistered eni %s from meter Flex counter", name.c_str());
 }
@@ -722,6 +724,12 @@ void DashMeterOrch::doTask(SelectableTimer &timer)
         if (!gTraditionalFlexCounter || m_vid_to_rid_table->hget("", id, value))
         {
             // TBD.. ENI_NAME_MAP entry is added/deleted by DashOrch Code.
+
+            SWSS_LOG_INFO("Registering %s, id %s", it->second.c_str(), id.c_str());
+            std::vector<FieldValueTuple> eniNameFvs;
+            eniNameFvs.emplace_back(it->second, id);
+            m_eni_name_table->set("", eniNameFvs);
+
             m_meter_stat_manager.setCounterIdList(it->first, CounterType::DASH_METER, m_meter_counter_stats);
             it = m_meter_stat_work_queue.erase(it);
         }

--- a/orchagent/dash/dashmeterorch.cpp
+++ b/orchagent/dash/dashmeterorch.cpp
@@ -28,7 +28,7 @@ extern bool gTraditionalFlexCounter;
 #define METER_FLEX_COUNTER_UPD_INTERVAL 1
 
 // To be deleted after addition to sonic-swss-common/common/schema.h
-#define COUNTERS_METER_ENI_NAME_MAP "COUNTERS_METER_ENI_NAME_MAP"
+//#define COUNTERS_METER_ENI_NAME_MAP "COUNTERS_METER_ENI_NAME_MAP"
 
 
 DashMeterOrch::DashMeterOrch(DBConnector *db, const vector<string> &tables, DashOrch *dash_orch, DBConnector *app_state_db, ZmqServer *zmqServer) :
@@ -40,7 +40,7 @@ DashMeterOrch::DashMeterOrch(DBConnector *db, const vector<string> &tables, Dash
     SWSS_LOG_ENTER();
 
     m_counter_db = std::shared_ptr<DBConnector>(new DBConnector("COUNTERS_DB", 0));
-    m_meter_eni_name_table = std::unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_METER_ENI_NAME_MAP));
+    //m_meter_eni_name_table = std::unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_METER_ENI_NAME_MAP));
     m_asic_db = std::shared_ptr<DBConnector>(new DBConnector("ASIC_DB", 0));
 
     if (gTraditionalFlexCounter)
@@ -654,7 +654,7 @@ void DashMeterOrch::removeEniFromMeterFC(sai_object_id_t oid, const string &name
         return;
     }
 
-    m_meter_eni_name_table->hdel("", name);
+    //m_meter_eni_name_table->hdel("", name);
     m_meter_stat_manager.clearCounterIdList(oid);
     SWSS_LOG_INFO("Unregistering FC for ENI %s, oid %s", name.c_str(), sai_serialize_object_id(oid).c_str());
 }
@@ -695,7 +695,7 @@ void DashMeterOrch::doTask(SelectableTimer &timer)
             SWSS_LOG_INFO("Registering FC for ENI %s, oid %s", it->second.c_str(), id.c_str());
             std::vector<FieldValueTuple> eniNameFvs;
             eniNameFvs.emplace_back(it->second, id);
-            m_meter_eni_name_table->set("", eniNameFvs);
+            //m_meter_eni_name_table->set("", eniNameFvs);
 
             m_meter_stat_manager.setCounterIdList(it->first, CounterType::DASH_METER, m_meter_counter_stats);
             it = m_meter_stat_work_queue.erase(it);

--- a/orchagent/dash/dashmeterorch.cpp
+++ b/orchagent/dash/dashmeterorch.cpp
@@ -27,9 +27,6 @@ extern bool gTraditionalFlexCounter;
 
 #define METER_FLEX_COUNTER_UPD_INTERVAL 1
 
-// To be deleted after addition to sonic-swss-common/common/schema.h
-//#define COUNTERS_METER_ENI_NAME_MAP "COUNTERS_METER_ENI_NAME_MAP"
-
 
 DashMeterOrch::DashMeterOrch(DBConnector *db, const vector<string> &tables, DashOrch *dash_orch, DBConnector *app_state_db, ZmqServer *zmqServer) :
     m_meter_stat_manager(METER_STAT_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ, METER_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS, false),
@@ -40,7 +37,6 @@ DashMeterOrch::DashMeterOrch(DBConnector *db, const vector<string> &tables, Dash
     SWSS_LOG_ENTER();
 
     m_counter_db = std::shared_ptr<DBConnector>(new DBConnector("COUNTERS_DB", 0));
-    //m_meter_eni_name_table = std::unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_METER_ENI_NAME_MAP));
     m_asic_db = std::shared_ptr<DBConnector>(new DBConnector("ASIC_DB", 0));
 
     if (gTraditionalFlexCounter)
@@ -654,7 +650,6 @@ void DashMeterOrch::removeEniFromMeterFC(sai_object_id_t oid, const string &name
         return;
     }
 
-    //m_meter_eni_name_table->hdel("", name);
     m_meter_stat_manager.clearCounterIdList(oid);
     SWSS_LOG_INFO("Unregistering FC for ENI %s, oid %s", name.c_str(), sai_serialize_object_id(oid).c_str());
 }
@@ -695,7 +690,6 @@ void DashMeterOrch::doTask(SelectableTimer &timer)
             SWSS_LOG_INFO("Registering FC for ENI %s, oid %s", it->second.c_str(), id.c_str());
             std::vector<FieldValueTuple> eniNameFvs;
             eniNameFvs.emplace_back(it->second, id);
-            //m_meter_eni_name_table->set("", eniNameFvs);
 
             m_meter_stat_manager.setCounterIdList(it->first, CounterType::DASH_METER, m_meter_counter_stats);
             it = m_meter_stat_work_queue.erase(it);

--- a/orchagent/dash/dashmeterorch.h
+++ b/orchagent/dash/dashmeterorch.h
@@ -109,7 +109,7 @@ private:
     FlexCounterManager m_meter_stat_manager;
     std::unordered_set<std::string> m_meter_counter_stats;
     std::map<sai_object_id_t, std::string> m_meter_stat_work_queue;
-    std::unique_ptr<swss::Table> m_meter_eni_name_table;
+    //std::unique_ptr<swss::Table> m_meter_eni_name_table;
     std::unique_ptr<swss::Table> m_vid_to_rid_table;
     std::shared_ptr<swss::DBConnector> m_counter_db;
     std::shared_ptr<swss::DBConnector> m_asic_db;

--- a/orchagent/dash/dashmeterorch.h
+++ b/orchagent/dash/dashmeterorch.h
@@ -109,7 +109,6 @@ private:
     FlexCounterManager m_meter_stat_manager;
     std::unordered_set<std::string> m_meter_counter_stats;
     std::map<sai_object_id_t, std::string> m_meter_stat_work_queue;
-    //std::unique_ptr<swss::Table> m_meter_eni_name_table;
     std::unique_ptr<swss::Table> m_vid_to_rid_table;
     std::shared_ptr<swss::DBConnector> m_counter_db;
     std::shared_ptr<swss::DBConnector> m_asic_db;

--- a/orchagent/dash/dashmeterorch.h
+++ b/orchagent/dash/dashmeterorch.h
@@ -120,5 +120,5 @@ private:
     std::shared_ptr<swss::DBConnector> m_counter_db;
     std::shared_ptr<swss::DBConnector> m_asic_db;
     swss::SelectableTimer* m_meter_fc_update_timer = nullptr;
-    void clearMeterFCStats();
+    //void refreshMeterFCStats(bool install);
 };

--- a/orchagent/dash/dashmeterorch.h
+++ b/orchagent/dash/dashmeterorch.h
@@ -21,9 +21,11 @@
 #include "dash_api/meter_rule.pb.h"
 
 ///// To be deleted after sonic-swss-common/common/schema.h fix
-//B4C-->0
-//#define APP_DASH_METER_POLICY_TABLE_NAME    "DASH_METER_POLICY_TABLE"
-//#define APP_DASH_METER_RULE_TABLE_NAME      "DASH_METER_RULE_TABLE"
+#if 0 //B4C-->0
+#define APP_DASH_METER_POLICY_TABLE_NAME    "DASH_METER_POLICY_TABLE"
+#define APP_DASH_METER_RULE_TABLE_NAME      "DASH_METER_RULE_TABLE"
+#define DASH_METER_COUNTER_ID_LIST "DASH_METER_COUNTER_ID_LIST"
+#endif
 ///// End..To be deleted after sonic-swss-common/common/schema.h fix
 
 #define METER_STAT_COUNTER_FLEX_COUNTER_GROUP "METER_STAT_COUNTER"

--- a/orchagent/dash/dashmeterorch.h
+++ b/orchagent/dash/dashmeterorch.h
@@ -114,5 +114,4 @@ private:
     std::shared_ptr<swss::DBConnector> m_counter_db;
     std::shared_ptr<swss::DBConnector> m_asic_db;
     swss::SelectableTimer* m_meter_fc_update_timer = nullptr;
-    //void refreshMeterFCStats(bool install);
 };

--- a/orchagent/dash/dashmeterorch.h
+++ b/orchagent/dash/dashmeterorch.h
@@ -20,14 +20,6 @@
 #include "dash_api/meter_policy.pb.h"
 #include "dash_api/meter_rule.pb.h"
 
-///// To be deleted after sonic-swss-common/common/schema.h fix
-#if 0 //B4C-->0
-#define APP_DASH_METER_POLICY_TABLE_NAME    "DASH_METER_POLICY_TABLE"
-#define APP_DASH_METER_RULE_TABLE_NAME      "DASH_METER_RULE_TABLE"
-#define DASH_METER_COUNTER_ID_LIST "DASH_METER_COUNTER_ID_LIST"
-#endif
-///// End..To be deleted after sonic-swss-common/common/schema.h fix
-
 #define METER_STAT_COUNTER_FLEX_COUNTER_GROUP "METER_STAT_COUNTER"
 #define METER_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS 10000
 
@@ -117,7 +109,7 @@ private:
     FlexCounterManager m_meter_stat_manager;
     std::unordered_set<std::string> m_meter_counter_stats;
     std::map<sai_object_id_t, std::string> m_meter_stat_work_queue;
-    std::unique_ptr<swss::Table> m_eni_name_table;
+    std::unique_ptr<swss::Table> m_meter_eni_name_table;
     std::unique_ptr<swss::Table> m_vid_to_rid_table;
     std::shared_ptr<swss::DBConnector> m_counter_db;
     std::shared_ptr<swss::DBConnector> m_asic_db;

--- a/orchagent/dash/dashorch.cpp
+++ b/orchagent/dash/dashorch.cpp
@@ -685,7 +685,7 @@ bool DashOrch::addEniObject(const string& eni, EniEntry& entry)
         }
     }
 
-    addEniMapEntry(eni_id, eni)
+    addEniMapEntry(eni_id, eni);
     addEniToFC(eni_id, eni);
     dash_meter_orch->addEniToMeterFC(eni_id,  eni);
 

--- a/orchagent/dash/dashorch.cpp
+++ b/orchagent/dash/dashorch.cpp
@@ -1349,9 +1349,10 @@ void DashOrch::handleFCStatusUpdate(bool enabled)
 void DashOrch::addEniMapEntry(sai_object_id_t oid, const string &name) {
     SWSS_LOG_ENTER();
 
-    SWSS_LOG_INFO("Adding ENI map entry for %s, id: %s", name.c_str(), sai_serialize_object_id(oid).c_str());
+    const auto id = sai_serialize_object_id(oid);
+    SWSS_LOG_INFO("Adding ENI map entry for %s, id: %s", name.c_str(), id.c_str());
     std::vector<FieldValueTuple> eniNameFvs;
-    eniNameFvs.emplace_back(name, oid);
+    eniNameFvs.emplace_back(name, id);
     m_eni_name_table->set("", eniNameFvs);
 }
 

--- a/orchagent/dash/dashorch.cpp
+++ b/orchagent/dash/dashorch.cpp
@@ -1294,7 +1294,6 @@ void DashOrch::removeEniFromFC(sai_object_id_t oid, const string &name)
         return;
     }
 
-    ////m_eni_name_table->hdel("", name);
     m_eni_stat_manager.clearCounterIdList(oid);
     SWSS_LOG_INFO("Unregistering FC for %s, id: %s", name.c_str(), sai_serialize_object_id(oid).c_str());
 }
@@ -1349,6 +1348,12 @@ void DashOrch::handleFCStatusUpdate(bool enabled)
 void DashOrch::addEniMapEntry(sai_object_id_t oid, const string &name) {
     SWSS_LOG_ENTER();
 
+    if (oid == SAI_NULL_OBJECT_ID)
+    {
+        SWSS_LOG_WARN("Cannot add ENI map entry with NULL OID for eni %s", name.c_str());
+        return;
+    }
+
     const auto id = sai_serialize_object_id(oid);
     SWSS_LOG_INFO("Adding ENI map entry for %s, id: %s", name.c_str(), id.c_str());
     std::vector<FieldValueTuple> eniNameFvs;
@@ -1401,9 +1406,6 @@ void DashOrch::doTask(SelectableTimer &timer)
         if (!gTraditionalFlexCounter || m_vid_to_rid_table->hget("", id, value))
         {
             SWSS_LOG_INFO("Registering FC for ENI: %s, id %s", it->second.c_str(), id.c_str());
-            //std::vector<FieldValueTuple> eniNameFvs;
-            //eniNameFvs.emplace_back(it->second, id);
-            //m_eni_name_table->set("", eniNameFvs);
 
             m_eni_stat_manager.setCounterIdList(it->first, CounterType::ENI, m_counter_stats);
             it = m_eni_stat_work_queue.erase(it);

--- a/orchagent/dash/dashorch.cpp
+++ b/orchagent/dash/dashorch.cpp
@@ -1312,12 +1312,19 @@ void DashOrch::refreshEniFCStats(bool install)
     }
 }
 
-void DashOrch::clearMeterFCStats()
+void DashOrch::refreshMeterFCStats(bool install)
 {
     DashMeterOrch *dash_meter_orch = gDirectory.get<DashMeterOrch*>();
     for (auto it = eni_entries_.begin(); it != eni_entries_.end(); it++)
     {
-        dash_meter_orch->removeEniFromMeterFC(it->second.eni_id, it->first);
+        if (install)
+        {
+            dash_meter_orch->addEniToMeterFC(it->second.eni_id, it->first);
+        }
+        else
+        {
+            dash_meter_orch->removeEniFromMeterFC(it->second.eni_id, it->first);
+        }
     }
 }
 

--- a/orchagent/dash/dashorch.cpp
+++ b/orchagent/dash/dashorch.cpp
@@ -686,6 +686,7 @@ bool DashOrch::addEniObject(const string& eni, EniEntry& entry)
     }
 
     addEniToFC(eni_id, eni);
+    dash_meter_orch->addEniToMeterFC(eni_id,  eni);
 
     gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_DASH_ENI);
 
@@ -823,8 +824,10 @@ bool DashOrch::removeEniObject(const string& eni)
     SWSS_LOG_ENTER();
 
     EniEntry entry = eni_entries_[eni];
+    DashMeterOrch *dash_meter_orch = gDirectory.get<DashMeterOrch*>();
 
     removeEniFromFC(entry.eni_id, eni);
+    dash_meter_orch->removeEniFromMeterFC(entry.eni_id, eni);
 
     sai_status_t status = sai_dash_eni_api->remove_eni(entry.eni_id);
     if (status != SAI_STATUS_SUCCESS)
@@ -842,7 +845,6 @@ bool DashOrch::removeEniObject(const string& eni)
         }
     }
 
-    DashMeterOrch *dash_meter_orch = gDirectory.get<DashMeterOrch*>();
     const string &v4_meter_policy  = entry.metadata.has_v4_meter_policy_id() ? 
                                      entry.metadata.v4_meter_policy_id() : "";
     const string &v6_meter_policy  = entry.metadata.has_v6_meter_policy_id() ? 
@@ -1307,6 +1309,15 @@ void DashOrch::refreshEniFCStats(bool install)
         {
             removeEniFromFC(it->second.eni_id, it->first);
         }
+    }
+}
+
+void DashOrch::clearMeterFCStats()
+{
+    DashMeterOrch *dash_meter_orch = gDirectory.get<DashMeterOrch*>();
+    for (auto it = eni_entries_.begin(); it != eni_entries_.end(); it++)
+    {
+        dash_meter_orch->removeEniFromMeterFC(it->second.eni_id, it->first);
     }
 }
 

--- a/orchagent/dash/dashorch.h
+++ b/orchagent/dash/dashorch.h
@@ -59,6 +59,7 @@ public:
     void handleFCStatusUpdate(bool is_enabled);
     dash::types::IpAddress getApplianceVip();
     bool hasApplianceEntry();
+    void clearMeterFCStats();
 
 private:
     ApplianceTable appliance_entries_;

--- a/orchagent/dash/dashorch.h
+++ b/orchagent/dash/dashorch.h
@@ -112,6 +112,8 @@ private:
     swss::SelectableTimer* m_fc_update_timer = nullptr;
 
     void doTask(swss::SelectableTimer&);
+    void addEniMapEntry(sai_object_id_t oid, const std::string& name);
+    void removeEniMapEntry(sai_object_id_t oid, const std::string& name);
     void addEniToFC(sai_object_id_t oid, const std::string& name);
     void removeEniFromFC(sai_object_id_t oid, const std::string& name);
     void refreshEniFCStats(bool);

--- a/orchagent/dash/dashorch.h
+++ b/orchagent/dash/dashorch.h
@@ -60,6 +60,7 @@ public:
     dash::types::IpAddress getApplianceVip();
     bool hasApplianceEntry();
     void clearMeterFCStats();
+    void refreshMeterFCStats(bool);
 
 private:
     ApplianceTable appliance_entries_;

--- a/orchagent/flex_counter/flex_counter_manager.cpp
+++ b/orchagent/flex_counter/flex_counter_manager.cpp
@@ -8,9 +8,6 @@
 
 #include <macsecorch.h>
 
-//B4C
-////#define DASH_METER_COUNTER_ID_LIST "DASH_METER_COUNTER_ID_LIST"
-
 using std::shared_ptr;
 using std::string;
 using std::unordered_map;

--- a/orchagent/flex_counter/flex_counter_manager.cpp
+++ b/orchagent/flex_counter/flex_counter_manager.cpp
@@ -8,6 +8,9 @@
 
 #include <macsecorch.h>
 
+//B4C
+////#define DASH_METER_COUNTER_ID_LIST "DASH_METER_COUNTER_ID_LIST"
+
 using std::shared_ptr;
 using std::string;
 using std::unordered_map;
@@ -50,6 +53,7 @@ const unordered_map<CounterType, string> FlexCounterManager::counter_id_field_lo
     { CounterType::HOSTIF_TRAP,     FLOW_COUNTER_ID_LIST },
     { CounterType::ROUTE,           FLOW_COUNTER_ID_LIST },
     { CounterType::ENI,             ENI_COUNTER_ID_LIST },
+    { CounterType::DASH_METER,      DASH_METER_COUNTER_ID_LIST },
     { CounterType::SRV6,            SRV6_COUNTER_ID_LIST },
 };
 

--- a/orchagent/flex_counter/flex_counter_manager.h
+++ b/orchagent/flex_counter/flex_counter_manager.h
@@ -39,6 +39,7 @@ enum class CounterType
     HOSTIF_TRAP,
     ROUTE,
     ENI,
+    DASH_METER,
     SRV6
 };
 

--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -14,6 +14,7 @@
 #include "routeorch.h"
 #include "macsecorch.h"
 #include "dash/dashorch.h"
+#include "dash/dashmeterorch.h"
 #include "flowcounterrouteorch.h"
 #include "warm_restart.h"
 
@@ -45,6 +46,7 @@ extern sai_object_id_t gSwitchId;
 #define FLOW_CNT_TRAP_KEY           "FLOW_CNT_TRAP"
 #define FLOW_CNT_ROUTE_KEY          "FLOW_CNT_ROUTE"
 #define ENI_KEY                     "ENI"
+#define DASH_METER_KEY              "DASH_METER"
 #define WRED_QUEUE_KEY              "WRED_ECN_QUEUE"
 #define WRED_PORT_KEY               "WRED_ECN_PORT"
 #define SRV6_KEY                    "SRV6"
@@ -71,6 +73,7 @@ unordered_map<string, string> flexCounterGroupMap =
     {"MACSEC_SA_ATTR", COUNTERS_MACSEC_SA_ATTR_GROUP},
     {"MACSEC_FLOW", COUNTERS_MACSEC_FLOW_GROUP},
     {"ENI", ENI_STAT_COUNTER_FLEX_COUNTER_GROUP},
+    {"DASH_METER", METER_STAT_COUNTER_FLEX_COUNTER_GROUP},
     {"WRED_ECN_PORT", WRED_PORT_STAT_COUNTER_FLEX_COUNTER_GROUP},
     {"WRED_ECN_QUEUE", WRED_QUEUE_STAT_COUNTER_FLEX_COUNTER_GROUP},
     {SRV6_KEY, SRV6_STAT_COUNTER_FLEX_COUNTER_GROUP},
@@ -113,6 +116,7 @@ void FlexCounterOrch::doTask(Consumer &consumer)
 
     VxlanTunnelOrch* vxlan_tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
     DashOrch* dash_orch = gDirectory.get<DashOrch*>();
+    DashMeterOrch* dash_meter_orch = gDirectory.get<DashMeterOrch*>();
     if (gPortsOrch && !gPortsOrch->allPortsReady())
     {
         return;
@@ -246,6 +250,10 @@ void FlexCounterOrch::doTask(Consumer &consumer)
                     if (dash_orch && (key == ENI_KEY))
                     {
                         dash_orch->handleFCStatusUpdate((value == "enable"));
+                    }
+                    if (dash_meter_orch && (key == DASH_METER_KEY))
+                    {
+                        dash_meter_orch->handleMeterFCStatusUpdate((value == "enable"));
                     }
                     if (gCoppOrch && (key == FLOW_CNT_TRAP_KEY))
                     {

--- a/tests/dash/test_dash_meter.py
+++ b/tests/dash/test_dash_meter.py
@@ -101,18 +101,17 @@ class TestDashMeter(TestFlexCountersBase):
         assert_sai_attribute_exists("SAI_METER_RULE_ATTR_DIP_MASK", rule_attrs, METER_RULE_2_IP_MASK)
 
     def post_eni_counter_test(self, meta_data):
-        #counters_keys = self.counters_db.db_connection.hgetall(meta_data['name_map'])
-        #self.set_flex_counter_group_status(meta_data['key'], meta_data['name_map'], 'disable')
+        counters_keys = self.counters_db.db_connection.hgetall(meta_data['name_map'])
+        self.set_flex_counter_group_status(meta_data['key'], meta_data['name_map'], 'disable')
 
-        #for counter_entry in counters_keys.items():
-        #    self.wait_for_id_list_remove(meta_data['group_name'], counter_entry[0], counter_entry[1])
-        #self.wait_for_table_empty(meta_data['name_map'])
-        pass
+        for counter_entry in counters_keys.items():
+            self.wait_for_id_list_remove(meta_data['group_name'], counter_entry[0], counter_entry[1])
+        self.wait_for_table_empty(meta_data['name_map'])
 
     def post_meter_counter_test(self, meta_data):
         counters_keys = self.counters_db.db_connection.hgetall(meta_data['name_map'])
         self.set_flex_counter_group_status(meta_data['key'], meta_data['name_map'], 'disable')
-        
+
         for counter_entry in counters_keys.items():
             self.wait_for_id_list_remove(meta_data['group_name'], counter_entry[0], counter_entry[1])
         self.wait_for_table_empty(meta_data['name_map'])
@@ -139,6 +138,8 @@ class TestDashMeter(TestFlexCountersBase):
 
         time.sleep(1)
         self.verify_flex_counter_flow(dash_db.dvs, eni_counter_group_meta)
+        self.setup_dbs(dash_db.dvs)
+        self.set_flex_counter_group_status(eni_counter_group_meta['key'], eni_counter_group_meta['name_map'], 'enable')
         time.sleep(1)
         self.verify_flex_counter_flow(dash_db.dvs, meter_counter_group_meta)
 

--- a/tests/dash/test_dash_meter.py
+++ b/tests/dash/test_dash_meter.py
@@ -35,7 +35,7 @@ from swsscommon.swsscommon import (
 meter_counter_group_meta = {
     'key': 'DASH_METER',
     'group_name': 'METER_STAT_COUNTER',
-    'name_map': 'COUNTERS_METER_ENI_NAME_MAP',
+    'name_map': 'COUNTERS_ENI_NAME_MAP',
     'post_test': 'post_meter_counter_test'
 }
 

--- a/tests/dash/test_dash_meter.py
+++ b/tests/dash/test_dash_meter.py
@@ -35,14 +35,14 @@ from swsscommon.swsscommon import (
 eni_counter_group_meta = {
     'key': 'ENI',
     'group_name': 'ENI_STAT_COUNTER',
-    'name_map': 'COUNTERS_ENI_NAME_MAP',
+    'name_map': 'COUNTERS_METER_ENI_NAME_MAP',
     'post_test': 'post_eni_counter_test'
 }
 
 meter_counter_group_meta = {
     'key': 'DASH_METER',
     'group_name': 'METER_STAT_COUNTER',
-    'name_map': 'COUNTERS_ENI_NAME_MAP',
+    'name_map': 'COUNTERS_METER_ENI_NAME_MAP',
     'post_test': 'post_meter_counter_test'
 }
 

--- a/tests/dash/test_dash_meter.py
+++ b/tests/dash/test_dash_meter.py
@@ -144,7 +144,6 @@ class TestDashMeter(TestFlexCountersBase):
         dash_db.remove_eni(self.mac_string)
         dash_db.remove_app_db_entry(APP_DASH_VNET_TABLE_NAME, VNET1)
         dash_db.remove_app_db_entry(APP_DASH_APPLIANCE_TABLE_NAME, APPLIANCE_ID)
-        self.wait_for_table_empty(meter_counter_group_meta['name_map'])
 
         dash_db.remove_app_db_entry(APP_DASH_METER_RULE_TABLE_NAME, METER_POLICY_V4, METER_RULE_1_NUM)
         dash_db.remove_app_db_entry(APP_DASH_METER_POLICY_TABLE_NAME, METER_POLICY_V4)

--- a/tests/dash/test_dash_meter.py
+++ b/tests/dash/test_dash_meter.py
@@ -32,13 +32,6 @@ from swsscommon.swsscommon import (
     APP_DASH_APPLIANCE_TABLE_NAME,
 )
 
-eni_counter_group_meta = {
-    'key': 'ENI',
-    'group_name': 'ENI_STAT_COUNTER',
-    'name_map': 'COUNTERS_METER_ENI_NAME_MAP',
-    'post_test': 'post_eni_counter_test'
-}
-
 meter_counter_group_meta = {
     'key': 'DASH_METER',
     'group_name': 'METER_STAT_COUNTER',
@@ -100,14 +93,6 @@ class TestDashMeter(TestFlexCountersBase):
         assert_sai_attribute_exists("SAI_METER_RULE_ATTR_DIP", rule_attrs, METER_RULE_2_IP)
         assert_sai_attribute_exists("SAI_METER_RULE_ATTR_DIP_MASK", rule_attrs, METER_RULE_2_IP_MASK)
 
-    def post_eni_counter_test(self, meta_data):
-        counters_keys = self.counters_db.db_connection.hgetall(meta_data['name_map'])
-        self.set_flex_counter_group_status(meta_data['key'], meta_data['name_map'], 'disable')
-
-        for counter_entry in counters_keys.items():
-            self.wait_for_id_list_remove(meta_data['group_name'], counter_entry[0], counter_entry[1])
-        self.wait_for_table_empty(meta_data['name_map'])
-
     def post_meter_counter_test(self, meta_data):
         counters_keys = self.counters_db.db_connection.hgetall(meta_data['name_map'])
         self.set_flex_counter_group_status(meta_data['key'], meta_data['name_map'], 'disable')
@@ -136,10 +121,6 @@ class TestDashMeter(TestFlexCountersBase):
         assert_sai_attribute_exists("SAI_ENI_ATTR_V4_METER_POLICY_ID", attrs, policy_v4_oid);
         assert_sai_attribute_exists("SAI_ENI_ATTR_V6_METER_POLICY_ID", attrs, policy_v6_oid);
 
-        time.sleep(1)
-        #self.verify_flex_counter_flow(dash_db.dvs, eni_counter_group_meta)
-        #self.setup_dbs(dash_db.dvs)
-        #self.set_flex_counter_group_status(eni_counter_group_meta['key'], eni_counter_group_meta['name_map'], 'enable')
         time.sleep(1)
         self.verify_flex_counter_flow(dash_db.dvs, meter_counter_group_meta)
 

--- a/tests/dash/test_dash_meter.py
+++ b/tests/dash/test_dash_meter.py
@@ -99,7 +99,6 @@ class TestDashMeter(TestFlexCountersBase):
 
         for counter_entry in counters_keys.items():
             self.wait_for_id_list_remove(meta_data['group_name'], counter_entry[0], counter_entry[1])
-        self.wait_for_table_empty(meta_data['name_map'])
 
     def test_eni(self, dash_db: DashDB):
         dash_db.set_app_db_entry(APP_DASH_APPLIANCE_TABLE_NAME, APPLIANCE_ID, APPLIANCE_CONFIG)

--- a/tests/dash/test_dash_meter.py
+++ b/tests/dash/test_dash_meter.py
@@ -95,7 +95,7 @@ class TestDashMeter(TestFlexCountersBase):
 
     def post_meter_counter_test(self, meta_data):
         counters_keys = self.counters_db.db_connection.hgetall(meta_data['name_map'])
-        self.set_flex_counter_group_status(meta_data['key'], meta_data['name_map'], 'disable')
+        self.set_flex_counter_group_status(meta_data['key'], meta_data['name_map'], 'disable', check_name_map=False)
 
         for counter_entry in counters_keys.items():
             self.wait_for_id_list_remove(meta_data['group_name'], counter_entry[0], counter_entry[1])
@@ -150,6 +150,7 @@ class TestDashMeter(TestFlexCountersBase):
         dash_db.remove_eni(self.mac_string)
         dash_db.remove_app_db_entry(APP_DASH_VNET_TABLE_NAME, VNET1)
         dash_db.remove_app_db_entry(APP_DASH_APPLIANCE_TABLE_NAME, APPLIANCE_ID)
+        self.wait_for_table_empty(meter_counter_group_meta['name_map'])
 
         dash_db.remove_app_db_entry(APP_DASH_METER_RULE_TABLE_NAME, METER_POLICY_V4, METER_RULE_1_NUM)
         dash_db.remove_app_db_entry(APP_DASH_METER_POLICY_TABLE_NAME, METER_POLICY_V4)

--- a/tests/dash/test_dash_meter.py
+++ b/tests/dash/test_dash_meter.py
@@ -137,7 +137,7 @@ class TestDashMeter(TestFlexCountersBase):
         assert_sai_attribute_exists("SAI_ENI_ATTR_V6_METER_POLICY_ID", attrs, policy_v6_oid);
 
         time.sleep(1)
-        self.verify_flex_counter_flow(dash_db.dvs, eni_counter_group_meta)
+        #self.verify_flex_counter_flow(dash_db.dvs, eni_counter_group_meta)
         self.setup_dbs(dash_db.dvs)
         self.set_flex_counter_group_status(eni_counter_group_meta['key'], eni_counter_group_meta['name_map'], 'enable')
         time.sleep(1)

--- a/tests/dash/test_dash_meter.py
+++ b/tests/dash/test_dash_meter.py
@@ -131,18 +131,12 @@ class TestDashMeter(TestFlexCountersBase):
         rule_found = False
 
         ### verify meter policy cannot be removed with ENI bound to policy
-        dash_db.remove_app_db_entry(APP_DASH_METER_RULE_TABLE_NAME, self.meter_policy_id, self.meter_rule_num)
         dash_db.remove_app_db_entry(APP_DASH_METER_POLICY_TABLE_NAME, self.meter_policy_id)
         time.sleep(20)
-        meter_rule_oids = dash_db.wait_for_asic_db_keys(ASIC_METER_RULE_TABLE, min_keys=ENTRIES)
         meter_policy_oids = dash_db.wait_for_asic_db_keys(ASIC_METER_POLICY_TABLE, min_keys=ENTRIES)
         for oid in meter_policy_oids:
             if oid == policy_v4_oid:
                 policy_found = True
-                break
-        for oid in meter_rule_oids:
-            if oid == rule_v4_oid:
-                rule_found = True
                 break
         assert(policy_found)
 

--- a/tests/dash/test_dash_meter.py
+++ b/tests/dash/test_dash_meter.py
@@ -138,8 +138,8 @@ class TestDashMeter(TestFlexCountersBase):
 
         time.sleep(1)
         #self.verify_flex_counter_flow(dash_db.dvs, eni_counter_group_meta)
-        self.setup_dbs(dash_db.dvs)
-        self.set_flex_counter_group_status(eni_counter_group_meta['key'], eni_counter_group_meta['name_map'], 'enable')
+        #self.setup_dbs(dash_db.dvs)
+        #self.set_flex_counter_group_status(eni_counter_group_meta['key'], eni_counter_group_meta['name_map'], 'enable')
         time.sleep(1)
         self.verify_flex_counter_flow(dash_db.dvs, meter_counter_group_meta)
 

--- a/tests/dash/test_dash_meter.py
+++ b/tests/dash/test_dash_meter.py
@@ -32,6 +32,20 @@ from swsscommon.swsscommon import (
     APP_DASH_APPLIANCE_TABLE_NAME,
 )
 
+eni_counter_group_meta = {
+    'key': 'ENI',
+    'group_name': 'ENI_STAT_COUNTER',
+    'name_map': 'COUNTERS_ENI_NAME_MAP',
+    'post_test': 'post_eni_counter_test'
+}
+
+meter_counter_group_meta = {
+    'key': 'DASH_METER',
+    'group_name': 'METER_STAT_COUNTER',
+    'name_map': 'COUNTERS_ENI_NAME_MAP',
+    'post_test': 'post_meter_counter_test'
+}
+
 DVS_ENV = ["HWSKU=DPU-2P"]
 NUM_PORTS = 2
 
@@ -86,6 +100,23 @@ class TestDashMeter(TestFlexCountersBase):
         assert_sai_attribute_exists("SAI_METER_RULE_ATTR_DIP", rule_attrs, METER_RULE_2_IP)
         assert_sai_attribute_exists("SAI_METER_RULE_ATTR_DIP_MASK", rule_attrs, METER_RULE_2_IP_MASK)
 
+    def post_eni_counter_test(self, meta_data):
+        #counters_keys = self.counters_db.db_connection.hgetall(meta_data['name_map'])
+        #self.set_flex_counter_group_status(meta_data['key'], meta_data['name_map'], 'disable')
+
+        #for counter_entry in counters_keys.items():
+        #    self.wait_for_id_list_remove(meta_data['group_name'], counter_entry[0], counter_entry[1])
+        #self.wait_for_table_empty(meta_data['name_map'])
+        pass
+
+    def post_meter_counter_test(self, meta_data):
+        counters_keys = self.counters_db.db_connection.hgetall(meta_data['name_map'])
+        self.set_flex_counter_group_status(meta_data['key'], meta_data['name_map'], 'disable')
+        
+        for counter_entry in counters_keys.items():
+            self.wait_for_id_list_remove(meta_data['group_name'], counter_entry[0], counter_entry[1])
+        self.wait_for_table_empty(meta_data['name_map'])
+
     def test_eni(self, dash_db: DashDB):
         dash_db.set_app_db_entry(APP_DASH_APPLIANCE_TABLE_NAME, APPLIANCE_ID, APPLIANCE_CONFIG)
         dash_db.set_app_db_entry(APP_DASH_VNET_TABLE_NAME, VNET1, VNET_CONFIG)
@@ -105,6 +136,11 @@ class TestDashMeter(TestFlexCountersBase):
         attrs = dash_db.get_asic_db_entry(ASIC_ENI_TABLE, eni_oid)
         assert_sai_attribute_exists("SAI_ENI_ATTR_V4_METER_POLICY_ID", attrs, policy_v4_oid);
         assert_sai_attribute_exists("SAI_ENI_ATTR_V6_METER_POLICY_ID", attrs, policy_v6_oid);
+
+        time.sleep(1)
+        self.verify_flex_counter_flow(dash_db.dvs, eni_counter_group_meta)
+        time.sleep(1)
+        self.verify_flex_counter_flow(dash_db.dvs, meter_counter_group_meta)
 
     def test_remove(self, dash_db: DashDB):
         self.meter_policy_id = METER_POLICY_V4

--- a/tests/dash/test_dash_vnet.py
+++ b/tests/dash/test_dash_vnet.py
@@ -144,7 +144,7 @@ class TestDash(TestFlexCountersBase):
         assert_sai_attribute_exists("SAI_ENI_ATTR_ADMIN_STATE", attrs, "true")
 
         time.sleep(1)
-        #self.verify_flex_counter_flow(dash_db.dvs, eni_counter_group_meta)
+        self.verify_flex_counter_flow(dash_db.dvs, eni_counter_group_meta)
 
         eni_addr_maps = dash_db.wait_for_asic_db_keys(ASIC_ENI_ETHER_ADDR_MAP_TABLE)
         attrs = dash_db.get_asic_db_entry(ASIC_ENI_ETHER_ADDR_MAP_TABLE, eni_addr_maps[0])

--- a/tests/dash/test_dash_vnet.py
+++ b/tests/dash/test_dash_vnet.py
@@ -117,7 +117,6 @@ class TestDash(TestFlexCountersBase):
 
         for counter_entry in counters_keys.items():
             self.wait_for_id_list_remove(meta_data['group_name'], counter_entry[0], counter_entry[1])
-        self.wait_for_table_empty(meta_data['name_map'])
 
     def test_eni(self, dash_db: DashDB):
         self.vnet = "Vnet1"

--- a/tests/dash/test_dash_vnet.py
+++ b/tests/dash/test_dash_vnet.py
@@ -144,7 +144,7 @@ class TestDash(TestFlexCountersBase):
         assert_sai_attribute_exists("SAI_ENI_ATTR_ADMIN_STATE", attrs, "true")
 
         time.sleep(1)
-        self.verify_flex_counter_flow(dash_db.dvs, eni_counter_group_meta)
+        #self.verify_flex_counter_flow(dash_db.dvs, eni_counter_group_meta)
 
         eni_addr_maps = dash_db.wait_for_asic_db_keys(ASIC_ENI_ETHER_ADDR_MAP_TABLE)
         attrs = dash_db.get_asic_db_entry(ASIC_ENI_ETHER_ADDR_MAP_TABLE, eni_addr_maps[0])

--- a/tests/dash/test_dash_vnet.py
+++ b/tests/dash/test_dash_vnet.py
@@ -113,7 +113,7 @@ class TestDash(TestFlexCountersBase):
 
     def post_eni_counter_test(self, meta_data):
         counters_keys = self.counters_db.db_connection.hgetall(meta_data['name_map'])
-        self.set_flex_counter_group_status(meta_data['key'], meta_data['name_map'], 'disable')
+        self.set_flex_counter_group_status(meta_data['key'], meta_data['name_map'], 'disable', check_name_map=False)
 
         for counter_entry in counters_keys.items():
             self.wait_for_id_list_remove(meta_data['group_name'], counter_entry[0], counter_entry[1])

--- a/tests/mock_tests/flexcounter_ut.cpp
+++ b/tests/mock_tests/flexcounter_ut.cpp
@@ -1118,7 +1118,7 @@ namespace flexcounter_test
         tmp_entry.eni_id = 0x7008000000021;
         m_DashOrch->eni_entries_["497f23d7-f0ac-4c99-a98f-59b470e8c7c"] = tmp_entry;
 
-        /* Should create ENI Counter stats for existing ENI's */
+        /* Should create Meter Counter stats for existing ENI's */
         m_DashMeterOrch->handleMeterFCStatusUpdate(true);
         m_DashMeterOrch->doTask(*(m_DashMeterOrch->m_meter_fc_update_timer));
         ASSERT_TRUE(checkFlexCounter(METER_STAT_COUNTER_FLEX_COUNTER_GROUP, tmp_entry.eni_id, DASH_METER_COUNTER_ID_LIST));

--- a/tests/mock_tests/flexcounter_ut.cpp
+++ b/tests/mock_tests/flexcounter_ut.cpp
@@ -7,6 +7,7 @@
 #include "mock_orchagent_main.h"
 #include "mock_orch_test.h"
 #include "dashorch.h"
+#include "dashmeterorch.h"
 #include "mock_table.h"
 #include "notifier.h"
 #define private public
@@ -1097,5 +1098,33 @@ namespace flexcounter_test
                                           "SAI_PORT_STAT_IF_IN_ERRORS"
                                          }
                                      }));
+    }
+
+    class MeterStatFlexCounterTest : public MockOrchTest
+    {
+        virtual void PostSetUp() {
+            _hook_sai_switch_api();
+        }
+
+        virtual void PreTearDown() {
+           _unhook_sai_switch_api();
+        }
+    };
+
+    TEST_F(MeterStatFlexCounterTest, TestStatusUpdate)
+    {
+        /* Add a mock ENI */
+        EniEntry tmp_entry;
+        tmp_entry.eni_id = 0x7008000000021;
+        m_DashOrch->eni_entries_["497f23d7-f0ac-4c99-a98f-59b470e8c7c"] = tmp_entry;
+
+        /* Should create ENI Counter stats for existing ENI's */
+        m_DashMeterOrch->handleMeterFCStatusUpdate(true);
+        m_DashMeterOrch->doTask(*(m_DashMeterOrch->m_meter_fc_update_timer));
+        ASSERT_TRUE(checkFlexCounter(METER_STAT_COUNTER_FLEX_COUNTER_GROUP, tmp_entry.eni_id, DASH_METER_COUNTER_ID_LIST));
+
+        /* This should delete the STATS */
+        m_DashMeterOrch->handleMeterFCStatusUpdate(false);
+        ASSERT_FALSE(checkFlexCounter(METER_STAT_COUNTER_FLEX_COUNTER_GROUP, tmp_entry.eni_id, DASH_METER_COUNTER_ID_LIST));
     }
 }

--- a/tests/mock_tests/mock_orch_test.cpp
+++ b/tests/mock_tests/mock_orch_test.cpp
@@ -256,7 +256,7 @@ void MockOrchTest::SetUp()
         APP_DASH_METER_RULE_TABLE_NAME
     };
 
-    m_DashMeterOrch = new DashMeterOrch(m_app_db.get(), dash_meter_tables, m_DashOrch, nullptr);
+    m_DashMeterOrch = new DashMeterOrch(m_app_db.get(), dash_meter_tables, m_DashOrch, m_dpu_app_state_db.get(), nullptr);
     gDirectory.set(m_DashMeterOrch);
     ut_orch_list.push_back((Orch **)&m_DashMeterOrch);
 

--- a/tests/mock_tests/mock_orch_test.cpp
+++ b/tests/mock_tests/mock_orch_test.cpp
@@ -251,6 +251,15 @@ void MockOrchTest::SetUp()
     gDirectory.set(m_DashOrch);
     ut_orch_list.push_back((Orch **)&m_DashOrch);
 
+    vector<string> dash_meter_tables = {
+        APP_DASH_METER_POLICY_TABLE_NAME,
+        APP_DASH_METER_RULE_TABLE_NAME
+    };
+
+    m_DashMeterOrch = new DashMeterOrch(m_app_db.get(), dash_meter_tables, m_DashOrch, nullptr);
+    gDirectory.set(m_DashMeterOrch);
+    ut_orch_list.push_back((Orch **)&m_DashMeterOrch);
+
     TableConnector confDbAclTable(m_config_db.get(), CFG_ACL_TABLE_TABLE_NAME);
     TableConnector confDbAclTableType(m_config_db.get(), CFG_ACL_TABLE_TYPE_TABLE_NAME);
     TableConnector confDbAclRuleTable(m_config_db.get(), CFG_ACL_RULE_TABLE_NAME);

--- a/tests/mock_tests/mock_orch_test.h
+++ b/tests/mock_tests/mock_orch_test.h
@@ -60,6 +60,7 @@ namespace mock_orch_test
         DashRouteOrch *m_DashRouteOrch;
         DashTunnelOrch *m_DashTunnelOrch;
         DashPortMapOrch *m_dashPortMapOrch;
+        DashMeterOrch *m_DashMeterOrch;
 
         void PrepareSai();
         void SetUp();

--- a/tests/mock_tests/mock_orchagent_main.h
+++ b/tests/mock_tests/mock_orchagent_main.h
@@ -13,6 +13,7 @@
 #define private public
 #include "dashorch.h"
 #include "dashrouteorch.h"
+#include "dashmeterorch.h"
 #include "bufferorch.h"
 #include "qosorch.h"
 #define protected public
@@ -113,6 +114,7 @@ extern sai_dash_vnet_api_t* sai_dash_vnet_api;
 extern sai_dash_appliance_api_t* sai_dash_appliance_api;
 extern sai_dash_outbound_routing_api_t* sai_dash_outbound_routing_api;
 extern sai_dash_inbound_routing_api_t* sai_dash_inbound_routing_api;
+extern sai_dash_meter_api_t* sai_dash_meter_api;
 extern sai_dash_tunnel_api_t* sai_dash_tunnel_api;
 extern sai_dash_outbound_port_map_api_t* sai_dash_outbound_port_map_api;
 extern sai_dash_trusted_vni_api_t* sai_dash_trusted_vni_api;

--- a/tests/mock_tests/ut_saihelper.cpp
+++ b/tests/mock_tests/ut_saihelper.cpp
@@ -105,6 +105,7 @@ namespace ut_helper
         sai_api_query((sai_api_t)SAI_API_DASH_OUTBOUND_PORT_MAP, (void**)&sai_dash_outbound_port_map_api);
         sai_api_query((sai_api_t)SAI_API_DASH_TRUSTED_VNI, (void**)&sai_dash_trusted_vni_api);
         sai_api_query(SAI_API_STP, (void**)&sai_stp_api);
+        sai_api_query((sai_api_t)SAI_API_DASH_METER, (void**)&sai_dash_meter_api);
         return SAI_STATUS_SUCCESS;
     }
 
@@ -140,6 +141,7 @@ namespace ut_helper
         sai_dash_eni_api = nullptr;
         sai_dash_ha_api = nullptr;
         sai_stp_api = nullptr;
+        sai_dash_meter_api = nullptr;
 
         return SAI_STATUS_SUCCESS;
     }


### PR DESCRIPTION
**What I did**
This PR  enables SWSS support for DASH Metering countering using flex counter .
Added a new table COUNTERS_METER_ENI_NAME_MAP  for use by meter stats. 
This is currently manually defined in dashmeterorch.cpp . 
This definition needs to be added to sonic-swss-common/common/schema.h  before this PR gets merged.

**Why I did it**
To enabled support for metering counters .

**How I verified it**
Added new  UT test case in test_dash_meter.py and   in tests/mock_tests.

**Details if related**
The  existing COUNTERS_ENI_NAME_MAP is being used for ENI  counters and  entries are added/deleted based on  ENI Counters enable/disable. 
Hence  added a new table   COUNTERS_METER_ENI_NAME_MAP to be used by meter counters.
