### PR TITLE
[bfdorch] Must have mandatory attribute SAI_BFD_SESSION_ATTR_NEXT_HOP_ID in creating bfd session

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -91,9 +91,12 @@ jobs:
       project: ${{ parameters.sairedis_artifact_project }}
       pipeline: ${{ parameters.sairedis_artifact_pipeline }}
       artifact: ${{ parameters.sairedis_artifact_name }}
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/${{ parameters.sairedis_artifact_branch }}'
+      runVersion: 'specific'
+      pipelineId: 844893
+      # runVersion: 'latestFromBranch'
+      # runBranch: 'refs/heads/${{ parameters.sairedis_artifact_branch }}'
       allowPartiallySucceededBuilds: true
+      allowFailedBuilds: true
       path: $(Build.ArtifactStagingDirectory)/download/sairedis
       patterns: |
         ${{ parameters.sairedis_artifact_pattern }}/libsaivs_*.deb

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -127,9 +127,12 @@ jobs:
       project: ${{ parameters.sairedis_artifact_project }}
       pipeline: ${{ parameters.sairedis_artifact_pipeline }}
       artifact: ${{ parameters.sairedis_artifact_name }}
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/${{ parameters.sairedis_artifact_branch }}'
+      runVersion: 'specific'
+      pipelineId: 844893
+      # runVersion: 'latestFromBranch'
+      # runBranch: 'refs/heads/${{ parameters.sairedis_artifact_branch }}'
       allowPartiallySucceededBuilds: true
+      allowFailedBuilds: true
       path: $(Build.ArtifactStagingDirectory)/download/sairedis
       patterns: |
         ${{ parameters.sairedis_artifact_pattern }}/libsaivs_*.deb

--- a/orchagent/bfdorch.cpp
+++ b/orchagent/bfdorch.cpp
@@ -348,6 +348,7 @@ bool BfdOrch::create_bfd_session(const string& key, const vector<FieldValueTuple
     MacAddress dst_mac;
     bool dst_mac_provided = false;
     bool src_ip_provided = false;
+    sai_object_id_t next_hop_id = SAI_NULL_OBJECT_ID;
 
     sai_attribute_t attr;
     vector<sai_attribute_t> attrs;
@@ -516,6 +517,14 @@ bool BfdOrch::create_bfd_session(const string& key, const vector<FieldValueTuple
 
         attr.id = SAI_BFD_SESSION_ATTR_DST_MAC_ADDRESS;
         memcpy(attr.value.mac, dst_mac.getMac(), sizeof(sai_mac_t));
+        attrs.emplace_back(attr);
+
+        attr.id = SAI_BFD_SESSION_ATTR_USE_NEXT_HOP;
+        attr.value.booldata = true;
+        attrs.emplace_back(attr);
+
+        attr.id = SAI_BFD_SESSION_ATTR_NEXT_HOP_ID;
+        attr.value.oid = next_hop_id;
         attrs.emplace_back(attr);
     }
     else


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

- Add a mandatory attribute SAI_BFD_SESSION_ATTR_NEXT_HOP_ID in creating bfd session
- Update AZP build to take artifacts from the sonic-saireds PR https://github.com/sonic-net/sonic-sairedis/pull/1589 build to allow bfd testcase pass in vstest with updating SAI headers.

**Why I did it**
In PR https://github.com/sonic-net/sonic-sairedis/pull/1589 check, vstest is being blocked due to bfd session creation failure, which is caused by the new mandatory attribute SAI_BFD_SESSION_ATTR_NEXT_HOP_ID not being added in the bfd session creation.

**How I verified it**

**Details if related**
