### PR TITLE
[202411] [dhcp_relay]: Fix dhcp_relay issue on marvell-teralynx platform

### DIFF
--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -191,11 +191,13 @@ void CoppOrch::initDefaultTrapIds()
     /*
      * Use a default trap priority > 0 to avoid undesirable packet trapping
      * behavior on some platforms that use 0 as default SAI-internal priority.
-     * Note: Mellanox and Marvell platforms don't support trap priority setting.
+     * Note: Mellanox and Marvell Prestera platforms don't support trap priority setting.
+     * For Marvell platforms, string comparison is used to prevent sub-string matches with
+     * marvell-teralynx which does support trap priority.
      */
 
     char *platform = getenv("platform");
-    if (!platform || (!strstr(platform, MLNX_PLATFORM_SUBSTRING) && (!strstr(platform, MRVL_PLATFORM_SUBSTRING))))
+    if (!platform || (!strstr(platform, MLNX_PLATFORM_SUBSTRING) && (strcmp(platform, MRVL_PLATFORM_SUBSTRING) != 0)))
     {
         attr.id = SAI_HOSTIF_TRAP_ATTR_TRAP_PRIORITY;
         attr.value.u32 = 1;
@@ -1019,7 +1021,7 @@ bool CoppOrch::getAttribsFromTrapGroup (vector<FieldValueTuple> &fv_tuple,
             /* Mellanox platform doesn't support trap priority setting */
             /* Marvell platform doesn't support trap priority. */
 	    char *platform = getenv("platform");
-	    if (!platform || (!strstr(platform, MLNX_PLATFORM_SUBSTRING) && (!strstr(platform, MRVL_PLATFORM_SUBSTRING))))
+	    if (!platform || (!strstr(platform, MLNX_PLATFORM_SUBSTRING) && (strcmp(platform, MRVL_PLATFORM_SUBSTRING) != 0)))
             {
                 attr.id = SAI_HOSTIF_TRAP_ATTR_TRAP_PRIORITY,
                     attr.value.u32 = (uint32_t)stoul(fvValue(*i));


### PR DESCRIPTION
Fixes #3637 

Issue is applicable only to 202411 branch.

PR #3424 altered the platform string for Marvell Prestera to "marvell" causing it to become a substring of marvell-teralynx.

marvell-teralynx platform supports DHCP trap priority, which is crucial for dhcp packets getting trapped to the CPU. However, Marvell Prestera platform does not support trap priority.

Due to a substring match issue, the trap priority is not being applied correctly on the teralynx platform.
This results in DHCP packets not being trapped to the CPU.

**What I did**
Changed sub-string match to string compare, so that trap_priority is skipped only for marvell prestera platforms but not marvell-teralynx.

**Why I did it**
To fix issue with DHCP packets not gettting trapped to CPU.

**How I verified it**
By running dhcp_relay sonic-mgmt PTF.

**Details if related**
