### PR TITLE
[tests]: Fix `test_MirrorDestMoveLag` test failure

### DIFF
--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -403,6 +403,9 @@ class TestMirror(object):
         tbl = swsscommon.Table(self.sdb, "LAG_TABLE")
         tbl._del("PortChannel" + channel)
         time.sleep(1)
+        tbl = swsscommon.Table(self.cdb, "PORTCHANNEL")
+        tbl._del("PortChannel" + channel)
+        time.sleep(1)
 
     def create_port_channel_member(self, channel, interface):
         tbl = swsscommon.ProducerStateTable(self.pdb, "LAG_MEMBER_TABLE")

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -779,7 +779,6 @@ class TestMirror(object):
         # remove mirror session
         self.remove_mirror_session(session)
 
-    @pytest.mark.skip(reason="This test is failing consistently")
     def test_MirrorDestMoveLag(self, dvs, testlog):
         self.setup_db(dvs)
 
@@ -820,7 +819,6 @@ class TestMirror(object):
         tbl._del(table + "|" + rule)
         time.sleep(1)
 
-    @pytest.mark.skip(reason="This test is failing consistently")
     def test_AclBindMirrorPerStage(self, dvs, testlog):
         """
         This test configures mirror rules with specifying explicitely
@@ -989,7 +987,6 @@ class TestMirror(object):
         self.remove_ip_address("Ethernet32", "20.0.0.0/31")
         self.set_interface_status(dvs, "Ethernet32", "down")
 
-    @pytest.mark.skip(reason="This test is failing consistently")
     def test_AclBindMirror(self, dvs, testlog):
         self.setup_db(dvs)
 


### PR DESCRIPTION
`test_MirrorDestMoveLag` performs the following steps:
1. Create mirror session
2. Enable non-LAG monitor port
3. Create LAG; move to LAG with one member
4. Remove LAG member
5. Create LAG member
6. Remove LAG; move to non-LAG
7. Disable non-LAG monitor port
8. Remove mirror session

At Step3, we call `create_port_channel` and `set_interface_status` to create LAG and set admin_status "up".

This creates a "PortChannel080" entry in the "PORTCHANNEL" table of CONFIG_DB, which results in the creation of a team device "PortChannel080" in Linux.

When step 6 calls `remove_port_channel` to remove the LAG, it is expected that the "PortChannel080" entry created previously will be removed and the team device will be deleted.

However, the current code does not remove the "PortChannel080" entry from CONFIG_DB and consequently the team device is not deleted.

This issue causes a test failure. The reason is that subsequent tests try to create a "PortChannel080" and since the "PortChannel080" already exists, unexpected behavior occurs.

This PR fixes the issue by changing the `remove_port_channel` code to delete the PortChannel entry.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:


**What I did**

**Why I did it**

**How I verified it**

**Details if related**
-->
