### PR TITLE
[dashhaorch]: Fix error: stack protector not protecting local variables

### DIFF
--- a/orchagent/dash/dashhaorch.cpp
+++ b/orchagent/dash/dashhaorch.cpp
@@ -236,7 +236,7 @@ bool DashHaOrch::addHaScopeEntry(const std::string &key, const dash::ha_scope::H
     }
     sai_object_id_t ha_set_oid = ha_set_it->second.ha_set_id;
 
-    uint32_t attr_count = 2;
+    const uint32_t attr_count = 2;
     sai_attribute_t ha_scope_attrs[attr_count]={};
     sai_status_t status;
     sai_object_id_t sai_ha_scope_oid = 0UL;


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

GCC error:
```
g++ -DHAVE_CONFIG_H -I. -I.. -I ../lib -I .. -I ../warmrestart -I switch -I flex_counter -I debug_counter -I port -I pbh -I nhg -g -DNDEBUG  -std=c++14 -Wall -fPIC -Wno-write-strings -I/usr/include/swss -I/usr/include -I/usr/include/libnl3 -Werror -Wno-reorder -Wcast-align -Wcast-qual -Wconversion -Wdisabled-optimization -Wextra -Wfloat-equal -Wformat=2 -Wformat-nonliteral -Wformat-security -Wformat-y2k -Wimport -Winit-self -Winvalid-pch -Wlong-long -Wmissing-field-initializers -Wmissing-format-attribute -Wno-aggregate-return -Wno-padded -Wno-switch-enum -Wno-unused-parameter -Wpacked -Wpointer-arith -Wredundant-decls -Wstack-protector -Wstrict-aliasing=3 -Wswitch -Wswitch-default -Wunreachable-code -Wunused -Wvariadic-macros -Wno-switch-default -Wno-long-long -Wno-redundant-decls -Wno-error=missing-field-initializers -I /usr/include/sai  -Wdate-time  -g -O0 -ffile-prefix-map=/sonic/src/sonic-swss=. -fstack-protector-strong -Wformat -Werror=format-security -c -o orchagent-acl_table_manager.o `test -f 'p4orch/acl_table_manager.cpp' || echo './'`p4orch/acl_table_manager.cpp
dash/dashhaorch.cpp: In member function 'bool DashHaOrch::addHaScopeEntry(const std::string&, const dash::ha_scope::HaScope&)':
dash/dashhaorch.cpp:191:6: error: stack protector not protecting local variables: variable length buffer [-Werror=stack-protector]
  191 | bool DashHaOrch::addHaScopeEntry(const std::string &key, const dash::ha_scope::HaScope &entry)
      |      ^~~~~~~~~~
```

**What I did**
* Fixed compilation error

**Why I did it**
* Added fixed length array definition

**How I verified it**
1. Run build with `SONIC_PROFILING_ON="y"`

**Details if related**
* N/A

#### A picture of a cute animal (not mandatory but encouraged)
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```