### PR TITLE
Fix NextHopGroupEntry class data member not initialized bug

### DIFF
--- a/orchagent/routeorch.h
+++ b/orchagent/routeorch.h
@@ -38,7 +38,7 @@ struct NhgBase;
 struct NextHopGroupEntry
 {
     NextHopGroupEntry() :
-        next_hop_group_id(0),
+        next_hop_group_id(SAI_NULL_OBJECT_ID),
         ref_count(0),
         nh_member_install_count(0),
         eligible_for_default_route_nh_swap(false),

--- a/orchagent/routeorch.h
+++ b/orchagent/routeorch.h
@@ -37,6 +37,15 @@ struct NhgBase;
 
 struct NextHopGroupEntry
 {
+    NextHopGroupEntry() :
+        next_hop_group_id(0),
+        ref_count(0),
+        nh_member_install_count(0),
+        eligible_for_default_route_nh_swap(false),
+        is_default_route_nh_swap(false)
+    {
+    }
+
     sai_object_id_t         next_hop_group_id;      // next hop group id
     int                     ref_count;              // reference count
     NextHopGroupMembers     nhopgroup_members;      // ids of members indexed by <ip_address, if_alias>


### PR DESCRIPTION
Fix NextHopGroupEntry class data member not initialized bug

#### Why I did it
Another PR blocked by test_nhg.py test failure: https://github.com/sonic-net/sonic-swss/pull/3632
After investigation, the root cause is NextHopGroupEntry::is_default_route_nh_swap not initialized. which means when create a new instance of this class, the value of is_default_route_nh_swap is depends on the data in the new allocated memory.

Following trace log show this flag value some time is 127:

May 13 08:29:30.502308 6509aaa83e64 NOTICE #orchagent: :- addNextHopGroup: addNextHopGroup 10.0.0.1@Ethernet0,10.0.0.3@Ethernet4,10.0.0.5@Ethernet8, ID: 500000000061a, swap 127

This bug not only impact test, in production environment this also will cause nexthop not delete after interface shut, because the code in RouteOrch::invalidnexthopinNextHopGroup will ignore nexthop delete when this flag is true:

[bool RouteOrch::invalidnexthopinNextHopGroup(const NextHopKey &nexthop, uint32_t& count)](https://github.com/sonic-net/sonic-swss/blob/8c2b2ac565c4e8a4683ee0d3668459f4d9c5032c/orchagent/routeorch.cpp#L553)

This issue didn't find before because sonic-swss enable flaky test and run test case 6 times, however some code change will make this issue easier to reproduce and block those code change.

#### How I did it
Add ctor to NextHopGroupEntry and initialize all data member.

##### Work item tracking
- Microsoft ADO: 30468564

#### How to verify it
Pass all test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Fix NextHopGroupEntry class data member not initialized bug

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

