### PR TITLE
Add NEIGHBOR_MISS trap type and its own queue

### DIFF
--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -89,7 +89,8 @@ static map<string, sai_hostif_trap_type_t> trap_id_map = {
     {"dest_nat_miss", SAI_HOSTIF_TRAP_TYPE_DNAT_MISS},
     {"ldp", SAI_HOSTIF_TRAP_TYPE_LDP},
     {"bfd_micro", SAI_HOSTIF_TRAP_TYPE_BFD_MICRO},
-    {"bfdv6_micro", SAI_HOSTIF_TRAP_TYPE_BFDV6_MICRO}
+    {"bfdv6_micro", SAI_HOSTIF_TRAP_TYPE_BFDV6_MICRO},
+    {"neigh_miss", SAI_HOSTIF_TRAP_TYPE_NEIGHBOR_MISS}
 };
 
 

--- a/tests/mock_tests/copp_cfg.json
+++ b/tests/mock_tests/copp_cfg.json
@@ -103,6 +103,10 @@
 		    "trap_ids": "src_nat_miss,dest_nat_miss",
 		    "trap_group": "queue1_group2"
 	    },
+        "neigh_miss": {
+            "trap_ids": "neigh_miss",
+            "trap_group": "queue1_group3"
+		},	
 	    "sflow": {
 		    "trap_group": "queue2_group1",
 		    "trap_ids": "sample_packet"

--- a/tests/test_copp.py
+++ b/tests/test_copp.py
@@ -71,7 +71,8 @@ traps_to_trap_type = {
         "dest_nat_miss": "SAI_HOSTIF_TRAP_TYPE_DNAT_MISS",
         "ldp": "SAI_HOSTIF_TRAP_TYPE_LDP",
         "bfd_micro": "SAI_HOSTIF_TRAP_TYPE_BFD_MICRO",
-        "bfdv6_micro": "SAI_HOSTIF_TRAP_TYPE_BFDV6_MICRO"
+        "bfdv6_micro": "SAI_HOSTIF_TRAP_TYPE_BFDV6_MICRO",
+        "neigh_miss": "SAI_HOSTIF_TRAP_TYPE_NEIGHBOR_MISS"
         }
 
 copp_group_default = {
@@ -127,6 +128,16 @@ copp_group_queue1_group2 = {
         "cbs":"600",
         "red_action":"drop"
 }
+copp_group_queue1_group3 = {
+        "trap_action":"trap",
+        "trap_priority":"1",
+        "queue": "1",
+        "meter_type":"packets",
+        "mode":"sr_tcm",
+        "cir":"200",
+        "cbs":"200",
+        "red_action":"drop"
+}
 
 copp_group_queue2_group1 = {
 	"cbs": "1000",
@@ -161,6 +172,7 @@ copp_trap = {
         "udld": ["udld", copp_group_queue4_group3, "always_enabled"],
         "ip2me": ["ip2me", copp_group_queue1_group1, "always_enabled"],
         "nat": ["src_nat_miss;dest_nat_miss", copp_group_queue1_group2],
+        "neigh_miss": ["neigh_miss", copp_group_queue1_group3],
         "sflow": ["sample_packet", copp_group_queue2_group1],
         "ttl": ["ttl_error", copp_group_default]
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add new trap type `SAI_HOSTIF_TRAP_TYPE_NEIGHBOR_MISS` and dedicated queue 
to better control those punt packets and not impact other critical punt traffic

**Why I did it**
As proposed in https://github.com/sonic-net/SONiC/blob/1fba16368a803bfeea57d93e8e39b3bcdcc3a67d/doc/copp/Copp_Neighbor_Miss_Trap_And_Enhancements.md we wanted to protect cpu from being hogged with neighbor miss packets

**How I verified it**

**Details if related**
