### PR TITLE
[202411] Setting default nexthop weight to 1 in `fpmsyncd`

### DIFF
--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -2181,14 +2181,15 @@ string RouteSync::getNextHopWt(struct rtnl_route *route_obj)
         struct rtnl_nexthop *nexthop = rtnl_route_nexthop_n(route_obj, i);
         /* Get the weight of next hop */
         uint8_t weight = rtnl_route_nh_get_weight(nexthop);
-        if (weight)
+        if (weight == 0)
         {
-            result += to_string(weight);
+            nl_addr* nh_addr = rtnl_route_nh_get_gateway(nexthop);
+            char nh_addr_str[MAX_ADDR_SIZE + 1] = {0};
+            nl_addr2str(nh_addr, nh_addr_str, MAX_ADDR_SIZE);
+            SWSS_LOG_INFO("Using default weight of 1 for nexthop %s", nh_addr_str);
+            weight = 1; // default weight is 1
         }
-        else
-        {
-            return "";
-        }
+        result += to_string(weight);
 
         if (i + 1 < rtnl_route_get_nnexthops(route_obj))
         {

--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -2183,10 +2183,6 @@ string RouteSync::getNextHopWt(struct rtnl_route *route_obj)
         uint8_t weight = rtnl_route_nh_get_weight(nexthop);
         if (weight == 0)
         {
-            nl_addr* nh_addr = rtnl_route_nh_get_gateway(nexthop);
-            char nh_addr_str[MAX_ADDR_SIZE + 1] = {0};
-            nl_addr2str(nh_addr, nh_addr_str, MAX_ADDR_SIZE);
-            SWSS_LOG_INFO("Using default weight of 1 for nexthop %s", nh_addr_str);
             weight = 1; // default weight is 1
         }
         result += to_string(weight);

--- a/tests/mock_tests/fpmsyncd/test_routesync.cpp
+++ b/tests/mock_tests/fpmsyncd/test_routesync.cpp
@@ -232,3 +232,52 @@ TEST_F(FpmSyncdResponseTest, testEvpn)
     ASSERT_EQ(value.get(), "0xc8");
 
 }
+
+auto create_nl_addr(const char* addr_str)
+{
+    nl_addr* addr;
+    nl_addr_parse(addr_str, AF_INET, &addr);
+    return unique_ptr<nl_addr, decltype(nl_addr_put)*>(addr, nl_addr_put);
+}
+
+auto create_route(const char* dst_addr_str)
+{
+    rtnl_route* route = rtnl_route_alloc();
+    auto dst_addr = create_nl_addr(dst_addr_str);
+    rtnl_route_set_dst(route, dst_addr.get());
+    rtnl_route_set_type(route, RTN_UNICAST);
+    rtnl_route_set_protocol(route, RTPROT_STATIC);
+    rtnl_route_set_family(route, AF_INET);
+    rtnl_route_set_scope(route, RT_SCOPE_UNIVERSE);
+    rtnl_route_set_table(route, RT_TABLE_MAIN);
+    return unique_ptr<rtnl_route, decltype(rtnl_route_put)*>(route, rtnl_route_put);
+}
+
+rtnl_nexthop* create_nexthop(const char* gateway_str)
+{
+    static int idx = 1; // interface index
+    ++idx;
+    // Create a nexthop with 0 weight
+    rtnl_nexthop* nh = rtnl_route_nh_alloc();
+    rtnl_route_nh_set_weight(nh, 0);
+    rtnl_route_nh_set_ifindex(nh, idx);
+    auto gateway_addr = create_nl_addr(gateway_str);
+    rtnl_route_nh_set_gateway(nh, gateway_addr.get());
+    return nh;
+}
+
+// Checks that when a nexthop is not assigned a weight, the default weight of 1 is used.
+TEST_F(FpmSyncdResponseTest, TestGetNextHopWt)
+{
+    auto test_route = create_route("10.1.1.0");
+
+    // Create two nexthops with 0 weight
+    rtnl_nexthop* nh1 = create_nexthop(test_gateway);
+    rtnl_nexthop* nh2 = create_nexthop(test_gateway_);
+
+    // Add new nexthops to the route
+    rtnl_route_add_nexthop(test_route.get(), nh1);
+    rtnl_route_add_nexthop(test_route.get(), nh2);
+
+    EXPECT_EQ(m_mockRouteSync.getNextHopWt(test_route.get()), "1,1");
+}

--- a/tests/mock_tests/fpmsyncd/test_routesync.cpp
+++ b/tests/mock_tests/fpmsyncd/test_routesync.cpp
@@ -272,8 +272,8 @@ TEST_F(FpmSyncdResponseTest, TestGetNextHopWt)
     auto test_route = create_route("10.1.1.0");
 
     // Create two nexthops with 0 weight
-    rtnl_nexthop* nh1 = create_nexthop(test_gateway);
-    rtnl_nexthop* nh2 = create_nexthop(test_gateway_);
+    rtnl_nexthop* nh1 = create_nexthop("192.168.1.1");
+    rtnl_nexthop* nh2 = create_nexthop("192.168.1.2");
 
     // Add new nexthops to the route
     rtnl_route_add_nexthop(test_route.get(), nh1);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
1. Nexthops are now considered to have a weight of 1 by default. This means that if `libnl` returns a weight of 0 for a nexthop, `fpmsyncd` will assume that its weight is 1.
2. Added a unit test for `getNextHopWt` to verify that it treats nexthops with a weight of 0 as having a weight of 1.
3. Every time a default weight is used for a nexthop, `fpmsyncd` will log an INFO-level message. The first time that this happens, a NOTICE-level message will also be logged.

**Why I did it**
If `libnl` reports 0 as the weight of nexthops in a nexthop group used in a route, then the route entry in the APP DB will not have a `weight` attribute. This can cause further issues.  

**How I verified it**
Ran the newly-added unit test for `getNextHopWt`.

**Details if related**
