### PR TITLE
Revert "Set Port UPDATE_DSCP attribute when TC_TO_DSCP map is attached"

### DIFF
--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -2088,25 +2088,6 @@ task_process_status QosOrch::handlePortQosMapTable(Consumer& consumer, KeyOpFiel
                         return task_process_status::task_invalid_entry;
                     }
                 }
-                if (attr.id == SAI_PORT_ATTR_QOS_TC_AND_COLOR_TO_DSCP_MAP)
-                {
-                    /* Query Port's UPDATE_DSCP Capability */
-                    bool rv = gSwitchOrch->querySwitchCapability(SAI_OBJECT_TYPE_PORT, SAI_PORT_ATTR_UPDATE_DSCP);
-                    if (rv == true)
-                    {
-                        sai_attribute_t update_dscp_attr;
-                        memset(&update_dscp_attr, 0, sizeof(update_dscp_attr));
-                        update_dscp_attr.id = SAI_PORT_ATTR_UPDATE_DSCP;
-                        update_dscp_attr.value.booldata = false;
-                        sai_status_t status = sai_port_api->set_port_attribute(port.m_port_id, &update_dscp_attr);
-                        if (status != SAI_STATUS_SUCCESS)
-                        {
-                            SWSS_LOG_ERROR("Failed to reset UPDATE_DSCP attribute on port %s, rv:%d",
-                                           port_name.c_str(), status);
-                            return task_process_status::task_invalid_entry;
-                        }
-                    }
-                }
                 SWSS_LOG_INFO("Removed %s on port %s", mapRef.first.c_str(), port_name.c_str());
             }
 
@@ -2212,25 +2193,6 @@ task_process_status QosOrch::handlePortQosMapTable(Consumer& consumer, KeyOpFiel
                 if (handle_status != task_process_status::task_success)
                 {
                     return task_process_status::task_invalid_entry;
-                }
-            }
-            if (attr.id == SAI_PORT_ATTR_QOS_TC_AND_COLOR_TO_DSCP_MAP)
-            {
-                /* Query Port's UPDATE_DSCP Capability */
-                bool rv = gSwitchOrch->querySwitchCapability(SAI_OBJECT_TYPE_PORT, SAI_PORT_ATTR_UPDATE_DSCP);
-                if (rv == true)
-                {
-                    sai_attribute_t update_dscp_attr;
-                    memset(&update_dscp_attr, 0, sizeof(update_dscp_attr));
-                    update_dscp_attr.id = SAI_PORT_ATTR_UPDATE_DSCP;
-                    update_dscp_attr.value.booldata = true;
-                    sai_status_t status = sai_port_api->set_port_attribute(port.m_port_id, &update_dscp_attr);
-                    if (status != SAI_STATUS_SUCCESS)
-                    {
-                        SWSS_LOG_ERROR("Failed to set UPDATE_DSCP attribute on port %s, rv:%d",
-                                       port_name.c_str(), status);
-                        return task_process_status::task_invalid_entry;
-                    }
                 }
             }
             SWSS_LOG_INFO("Applied %s to port %s", it->second.first.c_str(), port_name.c_str());

--- a/tests/test_qos_map.py
+++ b/tests/test_qos_map.py
@@ -69,9 +69,9 @@ class TestTcDscp(object):
         self.config_db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
 
     def create_tc_dscp_profile(self):
-        tc_dscp_tbl = swsscommon.Table(self.config_db, CFG_TC_TO_DSCP_MAP_TABLE_NAME)
+        tbl = swsscommon.Table(self.config_db, CFG_TC_TO_DSCP_MAP_TABLE_NAME)
         fvs = swsscommon.FieldValuePairs(list(TC_TO_DSCP_MAP.items()))
-        tc_dscp_tbl.set(CFG_TC_TO_DSCP_MAP_KEY, fvs)
+        tbl.set(CFG_TC_TO_DSCP_MAP_KEY, fvs)
         time.sleep(1)
 
     def find_tc_dscp_profile(self):
@@ -95,14 +95,6 @@ class TestTcDscp(object):
         assert found == True
 
         return (key, tc_dscp_map_raw)
-
-    def delete_tc_dscp_profile_on_all_ports(self):
-        tbl = swsscommon.Table(self.config_db, CFG_PORT_QOS_MAP_TABLE_NAME)
-        ports = swsscommon.Table(self.config_db, CFG_PORT_TABLE_NAME).getKeys()
-        for port in ports:
-            tbl._del(port)
-
-        time.sleep(1)
 
     def apply_tc_dscp_profile_on_all_ports(self):
         tbl = swsscommon.Table(self.config_db, CFG_PORT_QOS_MAP_TABLE_NAME)
@@ -147,7 +139,6 @@ class TestTcDscp(object):
         port_cnt = len(swsscommon.Table(self.config_db, CFG_PORT_TABLE_NAME).getKeys())
         assert port_cnt == cnt
 
-        self.delete_tc_dscp_profile_on_all_ports()
 
 #Tests for TC-to-Dot1p qos map configuration
 class TestTcDot1p(object):


### PR DESCRIPTION
Reverts sonic-net/sonic-swss#3517

For some vendors this attribute is applicable at the ingress level, which should be evaluated by additional attribute in global metadata object. This enhancement will be taken later.