### PR TITLE
[PHY][gearbox][fec] Configure system/line port FEC, serdes, and link training during port FEC set

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2492,6 +2492,23 @@ bool PortsOrch::setPortFec(Port &port, sai_port_fec_mode_t fec_mode, bool overri
 
     SWSS_LOG_NOTICE("Set port %s FEC mode %d", port.m_alias.c_str(), fec_mode);
 
+    if (m_gearboxEnabled && (m_portList[port.m_alias].m_init == true) && (m_gearboxInterfaceMap.find(port.m_index) != m_gearboxInterfaceMap.end()))
+    {
+         // Trigger PHY sys/line link training
+
+         status = setGearboxPortAttr(port, PHY_PORT_TYPE, SAI_PORT_ATTR_LINK_TRAINING_ENABLE, static_cast<void*>(&m_gearboxPortMap[port.m_index].system_training), override_fec);
+         if (status == false)
+         {
+             return status;
+         }
+         status = setGearboxPortAttr(port, LINE_PORT_TYPE, SAI_PORT_ATTR_LINK_TRAINING_ENABLE, static_cast<void*>(&m_gearboxPortMap[port.m_index].line_training), override_fec);
+         if (status == false)
+         {
+             return status;
+         }
+         SWSS_LOG_NOTICE("Set Link Training to PHY System/Line Gearbox ports for port %s", port.m_alias.c_str());
+    }
+
     return true;
 }
 
@@ -3440,8 +3457,29 @@ bool PortsOrch::setGearboxPortAttr(const Port &port, dest_port_type_t port_type,
             switch (id)
             {
                 case SAI_PORT_ATTR_FEC_MODE:
+                    sai_port_fec_mode_t sai_fec;
+                    switch (port_type)
+                    {
+                        case PHY_PORT_TYPE:
+                            if (!m_portHlpr.fecToSaiFecMode(m_gearboxPortMap[port.m_index].system_fec, sai_fec))
+                            {
+                                return false;
+                            }
+                            SWSS_LOG_NOTICE("BOX: Valid system FEC mode %s", m_gearboxPortMap[port.m_index].system_fec.c_str());
+                            attr.value.s32 = sai_fec;
+                            break;
+                        case LINE_PORT_TYPE:
+                            if (!m_portHlpr.fecToSaiFecMode(m_gearboxPortMap[port.m_index].line_fec, sai_fec))
+                            {
+                                return false;
+                            }
+                            SWSS_LOG_NOTICE("BOX: Valid line FEC mode %s", m_gearboxPortMap[port.m_index].line_fec.c_str());
+                            break;
+                        default:
+                            return false;
+                    }
                     attr.id = id;
-                    attr.value.s32 = *static_cast<sai_int32_t*>(value);
+                    attr.value.s32 = sai_fec;
                     SWSS_LOG_NOTICE("BOX: Set %s FEC_MODE %d", port.m_alias.c_str(), attr.value.s32);
                     break;
                 case SAI_PORT_ATTR_ADMIN_STATE:
@@ -3491,10 +3529,24 @@ bool PortsOrch::setGearboxPortAttr(const Port &port, dest_port_type_t port_type,
                     }
                     SWSS_LOG_NOTICE("BOX: Set %s MTU %d", port.m_alias.c_str(), attr.value.u32);
                     break;
+                case SAI_PORT_ATTR_LINK_TRAINING_ENABLE:
+                    attr.id = id;
+                    attr.value.booldata = *static_cast<bool*>(value);
+                    switch (port_type)
+                    {
+                        case PHY_PORT_TYPE:
+                            SWSS_LOG_NOTICE("BOX: Set %s System side training mode %d", port.m_alias.c_str(), attr.value.booldata);
+                            break;
+                        case LINE_PORT_TYPE:
+                            SWSS_LOG_NOTICE("BOX: Set %s Line side training mode %d", port.m_alias.c_str(), attr.value.booldata);
+                            break;
+                        default:
+                            return false;
+                    }
+                    break;
                 default:
                     return false;
             }
-
             status = sai_port_api->set_port_attribute(dest_port_id, &attr);
             if (status == SAI_STATUS_SUCCESS)
             {
@@ -10503,6 +10555,24 @@ bool PortsOrch::setPortMediaType(Port& port, const string &media_type)
     return true;
 }
 
+bool PortsOrch::generateSerdesTxFirAttrMap(const map<string, sai_port_serdes_attr_t> &firStringToAttrMap, const map<string, string> &firValueMap, map<sai_port_serdes_attr_t, SerdesValue> &serdesAttrOut)
+{
+    typedef pair<sai_port_serdes_attr_t, SerdesValue> serdes_attr_pair;
+    std::vector<uint32_t> attr_val;
+
+    for (const auto &pair : firStringToAttrMap)
+    {
+        auto it = firValueMap.find(pair.first);
+        if (it != firValueMap.end())
+        {
+            attr_val.clear();
+            getPortSerdesVal(it->second, attr_val, 10);
+            serdesAttrOut.insert(serdes_attr_pair(pair.second, attr_val));
+        }
+    }
+    return true;
+}
+
 void PortsOrch::removePortSerdesAttribute(sai_object_id_t port_id)
 {
     SWSS_LOG_ENTER();
@@ -10900,15 +10970,7 @@ bool PortsOrch::initGearboxPort(Port &port)
 
             /* Set serdes tx taps on system and line side */
             map<sai_port_serdes_attr_t, SerdesValue> serdes_attr;
-            typedef pair<sai_port_serdes_attr_t, SerdesValue> serdes_attr_pair;
-            vector<uint32_t> attr_val;
-            for (auto pair: tx_fir_strings_system_side) {
-                if (m_gearboxInterfaceMap[port.m_index].tx_firs.find(pair.first) != m_gearboxInterfaceMap[port.m_index].tx_firs.end() ) {
-                    attr_val.clear();
-                    getPortSerdesVal(m_gearboxInterfaceMap[port.m_index].tx_firs[pair.first], attr_val, 10);
-                    serdes_attr.insert(serdes_attr_pair(pair.second, attr_val));
-                }
-            }
+            generateSerdesTxFirAttrMap(tx_fir_strings_system_side, m_gearboxInterfaceMap[port.m_index].tx_firs, serdes_attr);
             if (serdes_attr.size() != 0)
             {
                 if (setPortSerdesAttribute(systemPort, phyOid, serdes_attr))
@@ -10922,13 +10984,7 @@ bool PortsOrch::initGearboxPort(Port &port)
                 }
             }
             serdes_attr.clear();
-            for (auto pair: tx_fir_strings_line_side) {
-                if (m_gearboxInterfaceMap[port.m_index].tx_firs.find(pair.first) != m_gearboxInterfaceMap[port.m_index].tx_firs.end() ) {
-                    attr_val.clear();
-                    getPortSerdesVal(m_gearboxInterfaceMap[port.m_index].tx_firs[pair.first], attr_val, 10);
-                    serdes_attr.insert(serdes_attr_pair(pair.second, attr_val));
-                }
-            }
+            generateSerdesTxFirAttrMap(tx_fir_strings_line_side, m_gearboxInterfaceMap[port.m_index].tx_firs, serdes_attr);
             if (serdes_attr.size() != 0)
             {
                 if (setPortSerdesAttribute(linePort, phyOid, serdes_attr))

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -584,6 +584,7 @@ private:
     void getPortSerdesVal(const std::string& s, std::vector<uint32_t> &lane_values, int base = 16);
     bool setPortSerdesAttribute(sai_object_id_t port_id, sai_object_id_t switch_id,
                                 std::map<sai_port_serdes_attr_t, SerdesValue> &serdes_attr);
+    bool generateSerdesTxFirAttrMap(const map<string, sai_port_serdes_attr_t> &firStringToAttrMap, const map<string, string> &firValueMap, map<sai_port_serdes_attr_t, SerdesValue> &serdesAttrOut);
 
     void removePortSerdesAttribute(sai_object_id_t port_id);
 

--- a/tests/mock_tests/GEARBOX_COVERAGE_GUIDE.md
+++ b/tests/mock_tests/GEARBOX_COVERAGE_GUIDE.md
@@ -1,0 +1,134 @@
+# Gearbox Coverage Guide: initGearboxPort, setGearboxPortsAttr, setGearboxPortAttr, updateGearboxPortOperStatus
+
+## Overview
+These functions only run when **m_gearboxEnabled** is true. Gearbox is enabled when:
+1. `platformHasGearbox()` returns true (checks `/usr/share/sonic/hwsku/gearbox_config.json`)
+2. `isGearboxConfigDone(gearboxTable)` returns true (GearboxConfigDone in _GEARBOX_TABLE)
+
+## Approach Options
+
+### Option A: Environment Variable (Requires Production Code Change)
+
+Add a test hook in `gearboxutils.cpp` - not used to avoid production code changes.
+
+### Option B: Wrap access() (Used - No Production Code Change)
+
+Add to Makefile.am: `tests_LDFLAGS = -Wl,-wrap,access` and `__wrap_access` in gearbox_ut.cpp.
+**Caution**: Affects ALL tests in the binary. Preferred over Option C as it works without write permissions.
+
+### Option C: Create Config File in Test
+
+In SetUp, create the file. **Fails in CI** - requires write permission to /usr/share/sonic/hwsku.
+
+## Required Test Setup
+
+### 1. Populate _GEARBOX_TABLE Before PortsOrch Creation
+
+The gearbox table must be populated **before** PortsOrch constructor runs (initGearbox is called in ctor):
+
+```cpp
+void setupGearboxTable(swss::DBConnector* app_db) {
+    swss::Table gearboxTable(app_db, "_GEARBOX_TABLE");
+
+    // Must have GearboxConfigDone for isGearboxEnabled to return true
+    gearboxTable.set("GearboxConfigDone", {});
+
+    // PHY - phy_oid must be valid SAI switch OID (use gSwitchId)
+    gearboxTable.set("phy:1", {
+        {"phy_id", "1"},
+        {"phy_oid", "oid:0x1000000000001"},  // Or sai_serialize_object_id(gSwitchId)
+        {"name", "phy1"}
+    });
+
+    // Interface - index 0 matches port index from SAI default ports
+    gearboxTable.set("interface:0", {
+        {"index", "0"},
+        {"phy_id", "1"},
+        {"line_lanes", "0, 1, 2, 3"},
+        {"system_lanes", "100, 101, 102, 103"}
+    });
+
+    // Port config for index 0
+    gearboxTable.set("phy:1:ports:0", {
+        {"index", "0"},
+        {"system_speed", "100000"},
+        {"system_fec", "rs"},
+        {"system_auto_neg", "false"},
+        {"system_loopback", "none"},
+        {"system_training", "false"},
+        {"line_speed", "100000"},
+        {"line_fec", "rs"},
+        {"line_auto_neg", "true"},
+        {"line_media_type", "fiber"},
+        {"line_intf_type", "cr4"},
+        {"line_loopback", "none"},
+        {"line_training", "false"},
+        {"line_adver_speed", "100000"},
+        {"line_adver_fec", "1"},
+        {"line_adver_auto_neg", "true"},
+        {"line_adver_asym_pause", "false"},
+        {"line_adver_media_type", "fiber"}
+    });
+}
+```
+
+### 2. Port Index Must Match Gearbox Interface
+
+`initGearboxPort` checks `m_gearboxInterfaceMap.find(port.m_index)`. The SAI default ports from `ut_helper::getInitialSaiPorts()` have indices. Ensure a port with index 0 exists (Ethernet0 typically has index 0).
+
+### 3. Mock SAI Port API for Gearbox
+
+initGearboxPort calls:
+- `sai_port_api->create_port()` - for system-side and line-side ports
+- `sai_port_api->create_port_connector()` - to connect them
+
+The SAI VS (libsaivs) may support these. If not, hook the SAI port API:
+
+```cpp
+sai_object_id_t g_mock_system_port = 0x2000;
+sai_object_id_t g_mock_line_port = 0x2001;
+
+sai_status_t mock_create_port(sai_object_id_t *port_id, sai_object_id_t switch_id, ...) {
+    static int count = 0;
+    *port_id = (count++ == 0) ? g_mock_system_port : g_mock_line_port;
+    return SAI_STATUS_SUCCESS;
+}
+sai_status_t mock_create_port_connector(...) { return SAI_STATUS_SUCCESS; }
+```
+
+### 4. Add GB_COUNTERS_DB to database_config.json
+
+initGearbox creates `DBConnector("GB_COUNTERS_DB", 0)`. Ensure tests/mock_tests/database_config.json has GB_COUNTERS_DB defined (it does per current config).
+
+### 5. Required Orchestrators
+
+PortsOrch needs BufferOrch, FlexCounterOrch, etc. for registerPort. The GearboxPortsOrchTest fixture is minimal - you may need to add BufferOrch, FlexCounterOrch, and port initialization similar to portphyattr_ut.cpp or portsorch_ut.cpp.
+
+## Test Flow for initGearboxPort
+
+1. Set GEARBOX_UT_TEST_ENABLE (or use Option B/C)
+2. setupGearboxTable(app_db) - before PortsOrch
+3. Create PortsOrch → initGearbox() will enable gearbox
+4. Add ports via PortConfigDone, PortInitDone (like portsorch_ut)
+5. doTask() → registerPort() → initGearboxPort()
+6. Verify m_gearboxPortListLaneMap has entry, port.m_system_side_id and port.m_line_side_id set
+
+## Test Flow for setGearboxPortsAttr / setGearboxPortAttr
+
+1. Complete initGearboxPort flow first (so m_gearboxPortListLaneMap is populated)
+2. Call setPortAdminStatus(port, true) → triggers setGearboxPortsAttr(SAI_PORT_ATTR_ADMIN_STATE)
+3. Or setPortMtu() → triggers setGearboxPortsAttr(SAI_PORT_ATTR_MTU)
+4. Or setPortFec() → triggers setGearboxPortsAttr(SAI_PORT_ATTR_FEC_MODE)
+
+## Test Flow for updateGearboxPortOperStatus
+
+1. Complete initGearboxPort flow (port has system_side_id, line_side_id)
+2. updateGearboxPortOperStatus is called from updatePortOperStatus when port oper status changes
+3. Simulate port status notification or call the code path that triggers it
+4. Mock sai_port_api->get_port_attribute for SAI_PORT_ATTR_OPER_STATUS
+
+## Key Dependencies
+
+- **loopback_mode_map**, **media_type_map**, **interface_type_map** - must have entries for config values ("none", "fiber", "cr4")
+- **m_portHlpr.fecToSaiFecMode()** - "rs" must map to valid SAI FEC mode
+- **isSpeedSupported()** - may need to return true for gearbox speeds

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -30,6 +30,7 @@ tests_INCLUDES = -I $(FLEX_CTR_DIR) -I $(DEBUG_CTR_DIR) -I $(top_srcdir)/lib -I$
 
 tests_SOURCES = aclorch_ut.cpp \
                 aclorch_rule_ut.cpp \
+                gearbox_ut.cpp \
                 portsorch_ut.cpp \
                 routeorch_ut.cpp \
                 qosorch_ut.cpp \
@@ -236,7 +237,7 @@ tests_SOURCES += $(P4_ORCH_DIR)/p4orch.cpp \
 
 tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
 tests_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_INCLUDES)
-tests_LDFLAGS = -Wl,--wrap=sai_query_stats_st_capability -Wl,--wrap=sai_query_attribute_capability \
+tests_LDFLAGS = -Wl,--wrap=sai_query_stats_st_capability -Wl,--wrap=sai_query_attribute_capability -Wl,-wrap,access \
                 -Wl,--wrap=sai_query_attribute_enum_values_capability -Wl,--wrap=sai_metadata_get_attr_metadata
 tests_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis -lpthread \
         -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lgmock -lgmock_main -lprotobuf -ldashapi

--- a/tests/mock_tests/gearbox_ut.cpp
+++ b/tests/mock_tests/gearbox_ut.cpp
@@ -1,0 +1,859 @@
+/**
+ * @file gearbox_ut.cpp
+ * @brief Unit tests for gearbox functionality in GearboxUtils and PortsOrch
+ *
+ * Tests gearbox configuration parsing, map loading from _GEARBOX_TABLE,
+ * and PortsOrch gearbox integration.
+ *
+ * Uses Option B: -Wl,-wrap,access to simulate gearbox_config.json (no production code change).
+ * Option C (create file) fails in CI due to /usr/share/sonic/hwsku write permission.
+ */
+
+#include "ut_helper.h"
+#include "mock_orchagent_main.h"
+#include "mock_table.h"
+#include "gearboxutils.h"
+#include "portsorch.h"
+#include "switchorch.h"
+#include "sai_serialize.h"
+#include "bufferorch.h"
+#include "flexcounterorch.h"
+#include "intfsorch.h"
+#include "fdborch.h"
+#include "neighorch.h"
+#include "vrforch.h"
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <vector>
+#include <cstdlib>
+#include <cstring>
+
+/* Wrap access() - only simulate gearbox_config.json when gearbox tests enable it.
+ * Without this, ALL tests that create PortsOrch would trigger 10s sleep in isGearboxEnabled(). */
+extern "C" int __real_access(const char *pathname, int mode);
+
+static bool g_gearbox_simulate_config_file = false;
+
+extern "C" int __wrap_access(const char *pathname, int mode)
+{
+    if (g_gearbox_simulate_config_file && pathname && strstr(pathname, "gearbox_config.json"))
+        return 0;  /* Simulate file exists */
+    return __real_access(pathname, mode);
+}
+
+extern SwitchOrch *gSwitchOrch;
+extern PortsOrch *gPortsOrch;
+extern BufferOrch *gBufferOrch;
+extern IntfsOrch *gIntfsOrch;
+extern FdbOrch *gFdbOrch;
+extern NeighOrch *gNeighOrch;
+extern VRFOrch *gVrfOrch;
+
+using namespace std;
+
+namespace gearbox_test
+{
+
+/**
+ * Test fixture for GearboxUtils - standalone tests without SAI/PortsOrch
+ */
+struct GearboxUtilsTest : public ::testing::Test
+{
+    GearboxUtilsTest() {}
+
+    void SetUp() override
+    {
+        ::testing_db::reset();
+        m_app_db = make_shared<swss::DBConnector>("APPL_DB", 0);
+    }
+
+    void TearDown() override
+    {
+        ::testing_db::reset();
+    }
+
+    shared_ptr<swss::DBConnector> m_app_db;
+};
+
+/**
+ * Test fixture for PortsOrch gearbox integration - requires SAI init
+ */
+struct GearboxPortsOrchTest : public ::testing::Test
+{
+    GearboxPortsOrchTest() {}
+
+    void SetUp() override
+    {
+        ::testing_db::reset();
+
+        m_app_db = make_shared<swss::DBConnector>("APPL_DB", 0);
+        m_config_db = make_shared<swss::DBConnector>("CONFIG_DB", 0);
+        m_state_db = make_shared<swss::DBConnector>("STATE_DB", 0);
+        m_chassis_app_db = make_shared<swss::DBConnector>("CHASSIS_APP_DB", 0);
+
+        TableConnector stateDbSwitchTable(m_state_db.get(), "SWITCH_CAPABILITY");
+        TableConnector app_switch_table(m_app_db.get(), APP_SWITCH_TABLE_NAME);
+        TableConnector conf_asic_sensors(m_config_db.get(), CFG_ASIC_SENSORS_TABLE_NAME);
+
+        vector<TableConnector> switch_tables = {
+            conf_asic_sensors,
+            app_switch_table
+        };
+
+        ASSERT_EQ(gSwitchOrch, nullptr);
+        gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
+
+        const int portsorch_base_pri = 40;
+        vector<table_name_with_pri_t> port_tables = {
+            { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },
+            { APP_SEND_TO_INGRESS_PORT_TABLE_NAME, portsorch_base_pri + 5 },
+            { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },
+            { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
+            { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },
+            { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
+        };
+
+        ASSERT_EQ(gPortsOrch, nullptr);
+        gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), port_tables, m_chassis_app_db.get());
+    }
+
+    void TearDown() override
+    {
+        ::testing_db::reset();
+
+        delete gPortsOrch;
+        gPortsOrch = nullptr;
+        delete gSwitchOrch;
+        gSwitchOrch = nullptr;
+    }
+
+    static void SetUpTestCase()
+    {
+        map<string, string> profile = {
+            { "SAI_VS_SWITCH_TYPE", "SAI_VS_SWITCH_TYPE_BCM56850" },
+            { "KV_DEVICE_MAC_ADDRESS", "20:03:04:05:06:00" }
+        };
+
+        auto status = ut_helper::initSaiApi(profile);
+        ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+        sai_attribute_t attr;
+        attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+        attr.value.booldata = true;
+        status = sai_switch_api->create_switch(&gSwitchId, 1, &attr);
+        ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+    }
+
+    static void TearDownTestCase()
+    {
+        auto status = sai_switch_api->remove_switch(gSwitchId);
+        ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+        gSwitchId = 0;
+        ut_helper::uninitSaiApi();
+    }
+
+    shared_ptr<swss::DBConnector> m_app_db;
+    shared_ptr<swss::DBConnector> m_config_db;
+    shared_ptr<swss::DBConnector> m_state_db;
+    shared_ptr<swss::DBConnector> m_chassis_app_db;
+};
+
+// ============== GearboxUtils Tests ==============
+
+TEST_F(GearboxUtilsTest, IsGearboxConfigDone_WhenNotSet_ReturnsFalse)
+{
+    swss::Table gearboxTable(m_app_db.get(), "_GEARBOX_TABLE");
+    swss::GearboxUtils gearbox;
+
+    bool result = gearbox.isGearboxConfigDone(gearboxTable);
+    EXPECT_FALSE(result);
+
+    result = gearbox.isGearboxConfigDone(&gearboxTable);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(GearboxUtilsTest, IsGearboxConfigDone_WhenSet_ReturnsTrue)
+{
+    swss::Table gearboxTable(m_app_db.get(), "_GEARBOX_TABLE");
+    gearboxTable.set("GearboxConfigDone", {});
+    swss::GearboxUtils gearbox;
+
+    bool result = gearbox.isGearboxConfigDone(gearboxTable);
+    EXPECT_TRUE(result);
+
+    result = gearbox.isGearboxConfigDone(&gearboxTable);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(GearboxUtilsTest, LoadPhyMap_EmptyTable_ReturnsEmptyMap)
+{
+    swss::Table gearboxTable(m_app_db.get(), "_GEARBOX_TABLE");
+    swss::GearboxUtils gearbox;
+
+    auto phyMap = gearbox.loadPhyMap(&gearboxTable);
+    EXPECT_TRUE(phyMap.empty());
+}
+
+TEST_F(GearboxUtilsTest, LoadPhyMap_SinglePhy_ParsesCorrectly)
+{
+    swss::Table gearboxTable(m_app_db.get(), "_GEARBOX_TABLE");
+    gearboxTable.set("phy:1", {
+        {"phy_id", "1"},
+        {"phy_oid", "oid:0x1000000000001"},
+        {"name", "phy1"},
+        {"lib_name", "libphy.so"},
+        {"firmware_path", "/firmware.bin"},
+        {"config_file", "config.json"},
+        {"sai_init_config_file", "sai_init.json"},
+        {"phy_access", "mdio"},
+        {"address", "0"},
+        {"bus_id", "1"},
+        {"context_id", "0"},
+        {"macsec_supported", "true"}
+    });
+
+    swss::GearboxUtils gearbox;
+    auto phyMap = gearbox.loadPhyMap(&gearboxTable);
+
+    ASSERT_EQ(phyMap.size(), 1u);
+    EXPECT_EQ(phyMap[1].phy_id, 1);
+    EXPECT_EQ(phyMap[1].phy_oid, "oid:0x1000000000001");
+    EXPECT_EQ(phyMap[1].name, "phy1");
+    EXPECT_EQ(phyMap[1].lib_name, "libphy.so");
+    EXPECT_TRUE(phyMap[1].macsec_supported);
+}
+
+TEST_F(GearboxUtilsTest, LoadPhyMap_MacsecNotSupported_ParsesCorrectly)
+{
+    swss::Table gearboxTable(m_app_db.get(), "_GEARBOX_TABLE");
+    gearboxTable.set("phy:1", {
+        {"phy_id", "1"},
+        {"phy_oid", "oid:0x1"},
+        {"macsec_supported", "false"}
+    });
+
+    swss::GearboxUtils gearbox;
+    auto phyMap = gearbox.loadPhyMap(&gearboxTable);
+
+    ASSERT_EQ(phyMap.size(), 1u);
+    EXPECT_FALSE(phyMap[1].macsec_supported);
+}
+
+TEST_F(GearboxUtilsTest, LoadInterfaceMap_EmptyTable_ReturnsEmptyMap)
+{
+    swss::Table gearboxTable(m_app_db.get(), "_GEARBOX_TABLE");
+    swss::GearboxUtils gearbox;
+
+    auto intfMap = gearbox.loadInterfaceMap(&gearboxTable);
+    EXPECT_TRUE(intfMap.empty());
+}
+
+TEST_F(GearboxUtilsTest, LoadInterfaceMap_SingleInterface_ParsesCorrectly)
+{
+    swss::Table gearboxTable(m_app_db.get(), "_GEARBOX_TABLE");
+    gearboxTable.set("interface:0", {
+        {"index", "0"},
+        {"phy_id", "1"},
+        {"line_lanes", "0, 1, 2, 3"},
+        {"system_lanes", "100, 101, 102, 103"}
+    });
+
+    swss::GearboxUtils gearbox;
+    auto intfMap = gearbox.loadInterfaceMap(&gearboxTable);
+
+    ASSERT_EQ(intfMap.size(), 1u);
+    EXPECT_EQ(intfMap[0].index, 0);
+    EXPECT_EQ(intfMap[0].phy_id, 1);
+    EXPECT_EQ(intfMap[0].line_lanes.size(), 4u);
+    EXPECT_EQ(intfMap[0].system_lanes.size(), 4u);
+}
+
+TEST_F(GearboxUtilsTest, LoadLaneMap_EmptyTable_ReturnsEmptyMap)
+{
+    swss::Table gearboxTable(m_app_db.get(), "_GEARBOX_TABLE");
+    swss::GearboxUtils gearbox;
+
+    auto laneMap = gearbox.loadLaneMap(&gearboxTable);
+    EXPECT_TRUE(laneMap.empty());
+}
+
+TEST_F(GearboxUtilsTest, LoadLaneMap_SingleLane_ParsesCorrectly)
+{
+    swss::Table gearboxTable(m_app_db.get(), "_GEARBOX_TABLE");
+    gearboxTable.set("phy:1:lanes:200", {
+        {"index", "200"},
+        {"system_side", "true"},
+        {"tx_polarity", "0"},
+        {"rx_polarity", "0"},
+        {"line_tx_lanemap", "0"},
+        {"line_rx_lanemap", "0"},
+        {"line_to_system_lanemap", "0"},
+        {"mdio_addr", "0x1"}
+    });
+
+    swss::GearboxUtils gearbox;
+    auto laneMap = gearbox.loadLaneMap(&gearboxTable);
+
+    ASSERT_EQ(laneMap.size(), 1u);
+    EXPECT_EQ(laneMap[200].index, 200);
+    EXPECT_TRUE(laneMap[200].system_side);
+    EXPECT_EQ(laneMap[200].mdio_addr, "0x1");
+}
+
+TEST_F(GearboxUtilsTest, LoadPortMap_EmptyTable_ReturnsEmptyMap)
+{
+    swss::Table gearboxTable(m_app_db.get(), "_GEARBOX_TABLE");
+    swss::GearboxUtils gearbox;
+
+    auto portMap = gearbox.loadPortMap(&gearboxTable);
+    EXPECT_TRUE(portMap.empty());
+}
+
+TEST_F(GearboxUtilsTest, LoadPortMap_SinglePort_ParsesCorrectly)
+{
+    swss::Table gearboxTable(m_app_db.get(), "_GEARBOX_TABLE");
+    gearboxTable.set("phy:1:ports:0", {
+        {"index", "0"},
+        {"mdio_addr", "0x1"},
+        {"system_speed", "100000"},
+        {"system_fec", "rs"},
+        {"system_auto_neg", "false"},
+        {"system_loopback", "none"},
+        {"system_training", "false"},
+        {"line_speed", "100000"},
+        {"line_fec", "rs"},
+        {"line_auto_neg", "true"},
+        {"line_media_type", "fiber"},
+        {"line_intf_type", "cr4"},
+        {"line_loopback", "none"},
+        {"line_training", "false"},
+        {"line_adver_speed", "100000, 50000"},
+        {"line_adver_fec", "1, 2"},
+        {"line_adver_auto_neg", "true"},
+        {"line_adver_asym_pause", "false"},
+        {"line_adver_media_type", "fiber"}
+    });
+
+    swss::GearboxUtils gearbox;
+    auto portMap = gearbox.loadPortMap(&gearboxTable);
+
+    ASSERT_EQ(portMap.size(), 1u);
+    EXPECT_EQ(portMap[0].index, 0);
+    EXPECT_EQ(portMap[0].system_speed, 100000);
+    EXPECT_EQ(portMap[0].system_fec, "rs");
+    EXPECT_FALSE(portMap[0].system_auto_neg);
+    EXPECT_EQ(portMap[0].line_speed, 100000);
+    EXPECT_TRUE(portMap[0].line_auto_neg);
+    EXPECT_EQ(portMap[0].line_media_type, "fiber");
+    EXPECT_EQ(portMap[0].line_intf_type, "cr4");
+    EXPECT_EQ(portMap[0].line_adver_speed.size(), 2u);
+    EXPECT_EQ(portMap[0].line_adver_fec.size(), 2u);
+}
+
+TEST_F(GearboxUtilsTest, LoadMaps_CombinedGearboxConfig_ParsesAllCorrectly)
+{
+    swss::Table gearboxTable(m_app_db.get(), "_GEARBOX_TABLE");
+
+    gearboxTable.set("phy:1", {
+        {"phy_id", "1"},
+        {"phy_oid", "oid:0x1"},
+        {"name", "phy1"}
+    });
+    gearboxTable.set("phy:1:ports:0", {
+        {"index", "0"},
+        {"system_speed", "100000"},
+        {"system_fec", "rs"},
+        {"line_speed", "100000"},
+        {"line_fec", "rs"}
+    });
+    gearboxTable.set("phy:1:lanes:100", {
+        {"index", "100"},
+        {"system_side", "true"}
+    });
+    gearboxTable.set("interface:0", {
+        {"index", "0"},
+        {"phy_id", "1"},
+        {"line_lanes", "0, 1"},
+        {"system_lanes", "100, 101"}
+    });
+
+    swss::GearboxUtils gearbox;
+
+    auto phyMap = gearbox.loadPhyMap(&gearboxTable);
+    EXPECT_EQ(phyMap.size(), 1u);
+
+    auto intfMap = gearbox.loadInterfaceMap(&gearboxTable);
+    EXPECT_EQ(intfMap.size(), 1u);
+
+    auto laneMap = gearbox.loadLaneMap(&gearboxTable);
+    EXPECT_EQ(laneMap.size(), 1u);
+
+    auto portMap = gearbox.loadPortMap(&gearboxTable);
+    EXPECT_EQ(portMap.size(), 1u);
+}
+
+// ============== PortsOrch Gearbox Integration Tests ==============
+
+TEST_F(GearboxPortsOrchTest, IsGearboxEnabled_WithoutConfigFile_ReturnsFalse)
+{
+    ASSERT_NE(gPortsOrch, nullptr);
+    EXPECT_FALSE(gPortsOrch->isGearboxEnabled());
+}
+
+TEST_F(GearboxPortsOrchTest, GetDestPortId_WhenGearboxDisabled_ReturnsFalse)
+{
+    ASSERT_NE(gPortsOrch, nullptr);
+    sai_object_id_t src_port_id = 0x1000;
+    sai_object_id_t des_port_id = 0;
+
+    bool result = gPortsOrch->getDestPortId(src_port_id, PortsOrch::PHY_PORT_TYPE, des_port_id);
+    EXPECT_FALSE(result);
+    // When gearbox disabled, des_port_id is set to src_port_id (no translation)
+    EXPECT_EQ(des_port_id, src_port_id);
+}
+
+/**
+ * Test fixture for gearbox-enabled tests - uses __wrap_access and populates
+ * _GEARBOX_TABLE before PortsOrch creation
+ */
+struct GearboxEnabledPortsOrchTest : public GearboxPortsOrchTest
+{
+    void SetUp() override
+    {
+        ::testing_db::reset();
+        g_gearbox_simulate_config_file = true;
+
+        m_app_db = make_shared<swss::DBConnector>("APPL_DB", 0);
+        m_config_db = make_shared<swss::DBConnector>("CONFIG_DB", 0);
+        m_state_db = make_shared<swss::DBConnector>("STATE_DB", 0);
+        m_chassis_app_db = make_shared<swss::DBConnector>("CHASSIS_APP_DB", 0);
+
+        setupGearboxTable();
+
+        TableConnector stateDbSwitchTable(m_state_db.get(), "SWITCH_CAPABILITY");
+        TableConnector app_switch_table(m_app_db.get(), APP_SWITCH_TABLE_NAME);
+        TableConnector conf_asic_sensors(m_config_db.get(), CFG_ASIC_SENSORS_TABLE_NAME);
+        vector<TableConnector> switch_tables = { conf_asic_sensors, app_switch_table };
+
+        ASSERT_EQ(gSwitchOrch, nullptr);
+        gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
+
+        const int portsorch_base_pri = 40;
+        vector<table_name_with_pri_t> port_tables = {
+            { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },
+            { APP_SEND_TO_INGRESS_PORT_TABLE_NAME, portsorch_base_pri + 5 },
+            { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },
+            { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
+            { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },
+            { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
+        };
+
+        ASSERT_EQ(gPortsOrch, nullptr);
+        gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), port_tables, m_chassis_app_db.get());
+    }
+
+    void TearDown() override
+    {
+        g_gearbox_simulate_config_file = false;
+        ::testing_db::reset();
+        delete gPortsOrch;
+        gPortsOrch = nullptr;
+        delete gSwitchOrch;
+        gSwitchOrch = nullptr;
+    }
+
+    void setupGearboxTable()
+    {
+        swss::Table gearboxTable(m_app_db.get(), "_GEARBOX_TABLE");
+        gearboxTable.set("GearboxConfigDone", {});
+        string phy_oid = "oid:0x1000000000001";
+        if (gSwitchId != 0)
+        {
+            phy_oid = sai_serialize_object_id(gSwitchId);
+        }
+        gearboxTable.set("phy:1", {{"phy_id", "1"}, {"phy_oid", phy_oid}, {"name", "phy1"}});
+        gearboxTable.set("interface:0", {
+            {"index", "0"}, {"phy_id", "1"},
+            {"line_lanes", "0, 1, 2, 3"}, {"system_lanes", "100, 101, 102, 103"},
+            {"system_tx_fir_main", "148,148"}, {"line_tx_fir_main", "69,69,69,69"}
+        });
+        gearboxTable.set("phy:1:ports:0", {
+            {"index", "0"}, {"system_speed", "100000"}, {"system_fec", "rs"},
+            {"system_auto_neg", "false"}, {"system_loopback", "none"}, {"system_training", "false"},
+            {"line_speed", "100000"}, {"line_fec", "rs"}, {"line_auto_neg", "true"},
+            {"line_media_type", "fiber"}, {"line_intf_type", "cr4"}, {"line_loopback", "none"},
+            {"line_training", "false"}, {"line_adver_speed", "100000"}, {"line_adver_fec", "1"},
+            {"line_adver_auto_neg", "true"}, {"line_adver_asym_pause", "false"},
+            {"line_adver_media_type", "fiber"}
+        });
+    }
+};
+
+TEST_F(GearboxEnabledPortsOrchTest, IsGearboxEnabled_WithEnvVarAndConfig_ReturnsTrue)
+{
+    ASSERT_NE(gPortsOrch, nullptr);
+    EXPECT_TRUE(gPortsOrch->isGearboxEnabled());
+}
+
+TEST_F(GearboxEnabledPortsOrchTest, GetDestPortId_WhenGearboxEnabledButNoPortMapping_ReturnsFalse)
+{
+    ASSERT_NE(gPortsOrch, nullptr);
+    sai_object_id_t src_port_id = 0x1000;
+    sai_object_id_t des_port_id = 0;
+
+    bool result = gPortsOrch->getDestPortId(src_port_id, PortsOrch::PHY_PORT_TYPE, des_port_id);
+    EXPECT_FALSE(result);
+    EXPECT_EQ(des_port_id, src_port_id);
+}
+
+/**
+ * SAI port API mocks for gearbox create_port and create_port_connector
+ */
+static sai_port_api_t *s_gearbox_orig_port_api = nullptr;
+static sai_port_api_t s_gearbox_mock_port_api;
+static sai_object_id_t s_gearbox_next_port_oid = 0x2000;
+
+static sai_status_t gearbox_mock_create_port(
+    _Out_ sai_object_id_t *port_id,
+    _In_ sai_object_id_t switch_id,
+    _In_ uint32_t attr_count,
+    _In_ const sai_attribute_t *attr_list)
+{
+    (void)switch_id;
+    (void)attr_count;
+    (void)attr_list;
+    *port_id = s_gearbox_next_port_oid++;
+    return SAI_STATUS_SUCCESS;
+}
+
+static sai_status_t gearbox_mock_create_port_connector(
+    _Out_ sai_object_id_t *port_connector_id,
+    _In_ sai_object_id_t switch_id,
+    _In_ uint32_t attr_count,
+    _In_ const sai_attribute_t *attr_list)
+{
+    (void)switch_id;
+    (void)attr_count;
+    (void)attr_list;
+    *port_connector_id = 0x3000;
+    return SAI_STATUS_SUCCESS;
+}
+
+static sai_status_t gearbox_mock_set_port_attribute(
+    _In_ sai_object_id_t port_id,
+    _In_ const sai_attribute_t *attr)
+{
+    if (port_id >= 0x2000 && port_id < 0x3000)
+    {
+        return SAI_STATUS_SUCCESS;
+    }
+    return s_gearbox_orig_port_api->set_port_attribute(port_id, attr);
+}
+
+static sai_status_t gearbox_mock_get_port_attribute(
+    _In_ sai_object_id_t port_id,
+    _In_ uint32_t attr_count,
+    _Inout_ sai_attribute_t *attr_list)
+{
+    if (port_id >= 0x2000 && port_id < 0x3000)
+    {
+        for (uint32_t i = 0; i < attr_count; i++)
+        {
+            if (attr_list[i].id == SAI_PORT_ATTR_OPER_STATUS)
+            {
+                attr_list[i].value.u32 = SAI_PORT_OPER_STATUS_UP;
+            }
+            else if (attr_list[i].id == SAI_PORT_ATTR_PORT_SERDES_ID)
+            {
+                attr_list[i].value.oid = SAI_NULL_OBJECT_ID;
+            }
+            else if (attr_list[i].id == SAI_PORT_ATTR_SUPPORTED_SPEED)
+            {
+                attr_list[i].value.u32list.count = 0;  /* Empty = isSpeedSupported returns true */
+            }
+        }
+        return SAI_STATUS_SUCCESS;
+    }
+    return s_gearbox_orig_port_api->get_port_attribute(port_id, attr_count, attr_list);
+}
+
+static sai_status_t gearbox_mock_create_port_serdes(
+    _Out_ sai_object_id_t *port_serdes_id,
+    _In_ sai_object_id_t switch_id,
+    _In_ uint32_t attr_count,
+    _In_ const sai_attribute_t *attr_list)
+{
+    (void)switch_id;
+    (void)attr_count;
+    (void)attr_list;
+    *port_serdes_id = 0x4000;
+    return SAI_STATUS_SUCCESS;
+}
+
+static void gearbox_hook_sai_port_api()
+{
+    s_gearbox_orig_port_api = sai_port_api;
+    s_gearbox_mock_port_api = *sai_port_api;
+    s_gearbox_mock_port_api.create_port = gearbox_mock_create_port;
+    s_gearbox_mock_port_api.create_port_connector = gearbox_mock_create_port_connector;
+    s_gearbox_mock_port_api.create_port_serdes = gearbox_mock_create_port_serdes;
+    s_gearbox_mock_port_api.set_port_attribute = gearbox_mock_set_port_attribute;
+    s_gearbox_mock_port_api.get_port_attribute = gearbox_mock_get_port_attribute;
+    sai_port_api = &s_gearbox_mock_port_api;
+}
+
+static void gearbox_unhook_sai_port_api()
+{
+    sai_port_api = s_gearbox_orig_port_api;
+}
+
+/**
+ * Full coverage test - initGearboxPort, setGearboxPortsAttr, updateGearboxPortOperStatus
+ */
+struct GearboxFullCoverageTest : public GearboxEnabledPortsOrchTest
+{
+    FlexCounterOrch *m_flexCounterOrch = nullptr;
+
+    void ensureGearboxPortInitialized(const string &alias, Port &port)
+    {
+        ASSERT_NE(gPortsOrch, nullptr);
+        ASSERT_TRUE(gPortsOrch->getPort(alias, port));
+        ASSERT_TRUE(gPortsOrch->isGearboxEnabled());
+
+        if (port.m_system_side_id != (sai_object_id_t)0 &&
+            port.m_line_side_id != (sai_object_id_t)0)
+        {
+            return;
+        }
+
+        ASSERT_TRUE(gPortsOrch->initGearboxPort(port));
+        ASSERT_NE(port.m_system_side_id, (sai_object_id_t)0);
+        ASSERT_NE(port.m_line_side_id, (sai_object_id_t)0);
+        gPortsOrch->setPort(alias, port);
+    }
+
+    void SetUp() override
+    {
+        ::testing_db::reset();
+        g_gearbox_simulate_config_file = true;
+        s_gearbox_next_port_oid = 0x2000;
+
+        m_app_db = make_shared<swss::DBConnector>("APPL_DB", 0);
+        m_config_db = make_shared<swss::DBConnector>("CONFIG_DB", 0);
+        m_state_db = make_shared<swss::DBConnector>("STATE_DB", 0);
+        m_chassis_app_db = make_shared<swss::DBConnector>("CHASSIS_APP_DB", 0);
+
+        setupGearboxTable();
+        gearbox_hook_sai_port_api();
+
+        TableConnector stateDbSwitchTable(m_state_db.get(), "SWITCH_CAPABILITY");
+        TableConnector app_switch_table(m_app_db.get(), APP_SWITCH_TABLE_NAME);
+        TableConnector conf_asic_sensors(m_config_db.get(), CFG_ASIC_SENSORS_TABLE_NAME);
+        vector<TableConnector> switch_tables = { conf_asic_sensors, app_switch_table };
+
+        ASSERT_EQ(gSwitchOrch, nullptr);
+        gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
+
+        vector<string> flex_counter_tables = { CFG_FLEX_COUNTER_TABLE_NAME };
+        m_flexCounterOrch = new FlexCounterOrch(m_config_db.get(), flex_counter_tables);
+        gDirectory.set(m_flexCounterOrch);
+
+        vector<string> buffer_tables = {
+            APP_BUFFER_POOL_TABLE_NAME, APP_BUFFER_PROFILE_TABLE_NAME,
+            APP_BUFFER_QUEUE_TABLE_NAME, APP_BUFFER_PG_TABLE_NAME,
+            APP_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME, APP_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME
+        };
+        ASSERT_EQ(gBufferOrch, nullptr);
+        gBufferOrch = new BufferOrch(m_app_db.get(), m_config_db.get(), m_state_db.get(), buffer_tables);
+
+        const int portsorch_base_pri = 40;
+        vector<table_name_with_pri_t> port_tables = {
+            { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },
+            { APP_SEND_TO_INGRESS_PORT_TABLE_NAME, portsorch_base_pri + 5 },
+            { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },
+            { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
+            { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },
+            { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
+        };
+
+        ASSERT_EQ(gPortsOrch, nullptr);
+        gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), port_tables, m_chassis_app_db.get());
+
+        Table portTable(m_app_db.get(), APP_PORT_TABLE_NAME);
+        auto ports = ut_helper::getInitialSaiPorts();
+        for (const auto &it : ports)
+        {
+            auto fvs = it.second;
+            if (it.first == "Ethernet0")
+            {
+                // The gearbox fixture only defines interface index 0. Seed the
+                // recovered SAI port with the matching APP_DB index so the
+                // test port can be mapped to the mocked gearbox interface.
+                fvs.push_back({"index", "0"});
+            }
+            portTable.set(it.first, fvs);
+        }
+        portTable.set("PortConfigDone", {{"count", to_string(ports.size())}});
+        gPortsOrch->addExistingData(&portTable);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        portTable.set("PortInitDone", {{"lanes", "0"}});
+        gPortsOrch->addExistingData(&portTable);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+    }
+
+    void TearDown() override
+    {
+        g_gearbox_simulate_config_file = false;
+        gearbox_unhook_sai_port_api();
+        gDirectory.m_values.clear();
+        delete gBufferOrch;
+        gBufferOrch = nullptr;
+        delete m_flexCounterOrch;
+        m_flexCounterOrch = nullptr;
+        delete gPortsOrch;
+        gPortsOrch = nullptr;
+        delete gSwitchOrch;
+        gSwitchOrch = nullptr;
+        ::testing_db::reset();
+    }
+};
+
+TEST_F(GearboxFullCoverageTest, InitGearboxPort_CreatesGearboxPortMapping)
+{
+    ASSERT_NE(gPortsOrch, nullptr);
+    ASSERT_TRUE(gPortsOrch->isGearboxEnabled());
+
+    Port port;
+    ensureGearboxPortInitialized("Ethernet0", port);
+
+    EXPECT_NE(port.m_system_side_id, (sai_object_id_t)0);
+    EXPECT_NE(port.m_line_side_id, (sai_object_id_t)0);
+
+    /* Verify port mapping via public API - getDestPortId uses m_gearboxPortListLaneMap internally */
+    sai_object_id_t des_port_id = 0;
+    EXPECT_TRUE(gPortsOrch->getDestPortId(port.m_port_id, PortsOrch::PHY_PORT_TYPE, des_port_id));
+    EXPECT_EQ(des_port_id, port.m_system_side_id);
+    des_port_id = 0;
+    EXPECT_TRUE(gPortsOrch->getDestPortId(port.m_port_id, PortsOrch::LINE_PORT_TYPE, des_port_id));
+    EXPECT_EQ(des_port_id, port.m_line_side_id);
+}
+
+TEST_F(GearboxFullCoverageTest, SetGearboxPortsAttr_ViaSetPortAdminStatus)
+{
+    ASSERT_NE(gPortsOrch, nullptr);
+    Port port;
+    ensureGearboxPortInitialized("Ethernet0", port);
+    ASSERT_NE(port.m_system_side_id, (sai_object_id_t)0);
+
+    bool success = gPortsOrch->setPortAdminStatus(port, false);
+    EXPECT_TRUE(success);
+
+    success = gPortsOrch->setPortAdminStatus(port, true);
+    EXPECT_TRUE(success);
+}
+
+TEST_F(GearboxFullCoverageTest, SetGearboxPortsAttr_ViaSetPortMtu)
+{
+    ASSERT_NE(gPortsOrch, nullptr);
+    Port port;
+    ensureGearboxPortInitialized("Ethernet0", port);
+    ASSERT_NE(port.m_system_side_id, (sai_object_id_t)0);
+
+    bool success = gPortsOrch->setPortMtu(port, 1500);
+    EXPECT_TRUE(success);
+}
+
+TEST_F(GearboxFullCoverageTest, UpdateGearboxPortOperStatus)
+{
+    ASSERT_NE(gPortsOrch, nullptr);
+    Port port;
+    ensureGearboxPortInitialized("Ethernet0", port);
+    ASSERT_NE(port.m_system_side_id, (sai_object_id_t)0);
+    ASSERT_NE(port.m_line_side_id, (sai_object_id_t)0);
+
+    gPortsOrch->updateGearboxPortOperStatus(port);
+
+    swss::Table portTable(m_app_db.get(), APP_PORT_TABLE_NAME);
+    vector<swss::FieldValueTuple> tuples;
+    ASSERT_TRUE(portTable.get(port.m_alias, tuples));
+    bool has_system_oper = false;
+    for (const auto &t : tuples)
+    {
+        if (fvField(t) == "system_oper_status")
+        {
+            has_system_oper = true;
+            EXPECT_EQ(fvValue(t), "up");
+            break;
+        }
+    }
+    EXPECT_TRUE(has_system_oper);
+}
+
+TEST_F(GearboxFullCoverageTest, GetDestPortId_WhenGearboxPortMappingExists_ReturnsTrue)
+{
+    ASSERT_NE(gPortsOrch, nullptr);
+    Port port;
+    ensureGearboxPortInitialized("Ethernet0", port);
+
+    sai_object_id_t des_port_id = 0;
+    bool result = gPortsOrch->getDestPortId(port.m_port_id, PortsOrch::PHY_PORT_TYPE, des_port_id);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(des_port_id, port.m_system_side_id);
+
+    des_port_id = 0;
+    result = gPortsOrch->getDestPortId(port.m_port_id, PortsOrch::LINE_PORT_TYPE, des_port_id);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(des_port_id, port.m_line_side_id);
+}
+
+TEST_F(GearboxFullCoverageTest, SetGearboxPortsAttr_ViaSetPortFec)
+{
+    ASSERT_NE(gPortsOrch, nullptr);
+    Port port;
+    ensureGearboxPortInitialized("Ethernet0", port);
+    ASSERT_NE(port.m_system_side_id, (sai_object_id_t)0);
+
+    bool success = gPortsOrch->setPortFec(port, SAI_PORT_FEC_MODE_RS, false);
+    EXPECT_TRUE(success);
+}
+
+TEST_F(GearboxFullCoverageTest, SetGearboxPortsAttr_ViaSetPortSpeed)
+{
+    ASSERT_NE(gPortsOrch, nullptr);
+    Port port;
+    ensureGearboxPortInitialized("Ethernet0", port);
+    ASSERT_NE(port.m_system_side_id, (sai_object_id_t)0);
+
+    auto status = gPortsOrch->setPortSpeed(port, 100000);
+    EXPECT_EQ(status, task_success);
+}
+
+TEST_F(GearboxFullCoverageTest, UpdateGearboxPortOperStatus_SetsLineOperStatus)
+{
+    ASSERT_NE(gPortsOrch, nullptr);
+    Port port;
+    ensureGearboxPortInitialized("Ethernet0", port);
+    ASSERT_NE(port.m_system_side_id, (sai_object_id_t)0);
+    ASSERT_NE(port.m_line_side_id, (sai_object_id_t)0);
+
+    gPortsOrch->updateGearboxPortOperStatus(port);
+
+    swss::Table portTable(m_app_db.get(), APP_PORT_TABLE_NAME);
+    vector<swss::FieldValueTuple> tuples;
+    ASSERT_TRUE(portTable.get(port.m_alias, tuples));
+    bool has_line_oper = false;
+    for (const auto &t : tuples)
+    {
+        if (fvField(t) == "line_oper_status")
+        {
+            has_line_oper = true;
+            EXPECT_EQ(fvValue(t), "up");
+            break;
+        }
+    }
+    EXPECT_TRUE(has_line_oper);
+}
+
+} // namespace gearbox_test


### PR DESCRIPTION
This PR enhances PortsOrch by configuring gearbox system/line-side ports with the correct FEC mode, serdes attributes, and link training enablement when the front-panel port's FEC is changed. This ensures consistent PHY/gearbox behavior and aligns with platform expectations for link stability and signal conditioning.

**What I did**
Hooked into setPortFec() to:
		○ Set serdes attributes (TX FIR pre-emphasis) on system and line-side gearbox ports using a new helper function.
		○ Enable link training using setPortLinkTraining() after FEC configuration.
Modified setGearboxPortAttr() to:
		○ Properly convert and apply FEC mode and link training enable attributes.
Refactored serdes attribute application into a reusable function:
		○ generateSerdesAttrMap() consolidates attribute generation for gearbox ports.
Updated initGearboxPort() to reuse this new serdes generation logic.

**Why I did it**
	• Gearbox PHY configurations (FEC, serdes, link training) need to match line/system-side link partner expectations.
	• These settings are essential for link bring-up and signal integrity on gearbox-enabled platforms.
	• Avoids the need for separate hardware-specific logic elsewhere by embedding this behavior directly into the port/FEC orchestration path.

**How I verified it**
	• Tested on a platform with gearbox PHY (Broadcom-based) / BCM81356 (MillenioB) / BCM81724 (Millenio) in Gearbox mode (PAM4 to NRZ).
	• Verified:
		○ Correct FEC modes are logged and applied to system/line sides.
		○ Serdes TX FIR attributes are applied.
		○ Link training enablement works and is visible via SDK logs.
	• Validated that non-gearbox ports remain unaffected.
**Details if related**

Which release branch to backport (provide reason below if selected)
 x 202505
 x 202511
