### PR TITLE
[portorch] Add capability to add unreliable LOS settings during a link down event

### DIFF
--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -173,6 +173,7 @@ public:
     port_learn_mode_t   m_learn_mode = SAI_BRIDGE_PORT_FDB_LEARNING_MODE_HW;
     bool                m_autoneg = false;
     bool                m_unreliable_los = false;
+    bool                m_apply_unreliable_los = false;
     bool                m_link_training = false;
     bool                m_admin_state_up = false;
     bool                m_init = false;
@@ -214,6 +215,7 @@ public:
     uint32_t  m_maximum_headroom = 0;
     std::set<uint32_t> m_adv_speeds;
     sai_port_interface_type_t m_interface_type = SAI_PORT_INTERFACE_TYPE_NONE;
+    sai_port_interface_type_t m_apply_unreliable_los_interface_type = SAI_PORT_INTERFACE_TYPE_NONE;
     std::set<sai_port_interface_type_t> m_adv_interface_types;
     bool      m_mpls = false;
     /*

--- a/orchagent/port/portcnt.h
+++ b/orchagent/port/portcnt.h
@@ -193,6 +193,12 @@ public:
     } serdes; // Port serdes
 
     struct {
+        sai_port_interface_type_t intf_type;
+        bool value;
+        bool is_set = false;
+    } apply_port_unreliable_los; // Port role
+
+    struct {
         swss::Port::Role value;
         bool is_set = false;
     } role; // Port role

--- a/orchagent/port/porthlpr.cpp
+++ b/orchagent/port/porthlpr.cpp
@@ -411,9 +411,15 @@ bool PortHelper::parsePortUnreliableLos(PortConfig &port, const std::string &fie
         SWSS_LOG_ERROR("Failed to parse field(%s): invalid value(%s)", field.c_str(), value.c_str());
         return false;
     }
+    if (field == PORT_UNRELIABLE_LOS) {
+        port.serdes.unreliable_los.value = cit->second;
+        port.serdes.unreliable_los.is_set = true;
 
-    port.serdes.unreliable_los.value = cit->second;
-    port.serdes.unreliable_los.is_set = true;
+    } else if (field == PORT_APPLY_UNRELIABLE_LOS) {
+        port.apply_port_unreliable_los.value = cit->second;
+        port.apply_port_unreliable_los.is_set = true;
+        port.apply_port_unreliable_los.intf_type = SAI_PORT_INTERFACE_TYPE_SR4;
+    }
 
     return true;
 }
@@ -1056,7 +1062,7 @@ bool PortHelper::parsePortConfig(PortConfig &port) const
                 return false;
             }
         }
-        else if (field == PORT_UNRELIABLE_LOS)
+        else if (field == PORT_UNRELIABLE_LOS || field == PORT_APPLY_UNRELIABLE_LOS)
         {
             if (!this->parsePortUnreliableLos(port, field, value))
             {

--- a/orchagent/port/portschema.h
+++ b/orchagent/port/portschema.h
@@ -103,3 +103,4 @@
 #define PORT_FLAP_PENALTY          "flap_penalty"
 #define PORT_MODE                  "mode"
 #define PORT_UNRELIABLE_LOS        "unreliable_los"
+#define PORT_APPLY_UNRELIABLE_LOS  "apply_unreliable_los"

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4665,6 +4665,14 @@ void PortsOrch::doPortTask(Consumer &consumer)
                         m_portStateTable.hset(p.m_alias, "phy_ctrl_unreliable_los", p.m_unreliable_los ? "true":"false");
                 } 
 
+                if (pCfg.apply_port_unreliable_los.is_set)
+		{
+			p.m_apply_unreliable_los = true;
+			p.m_apply_unreliable_los_interface_type = pCfg.apply_port_unreliable_los.intf_type;
+                        m_portList[p.m_alias] = p;
+
+		}
+
                 if (pCfg.adv_interface_types.is_set)
                 {
                     if (!p.m_adv_intf_cfg || p.m_adv_interface_types != pCfg.adv_interface_types.value)
@@ -8615,6 +8623,7 @@ void PortsOrch::updatePortOperStatus(Port &port, sai_port_oper_status_t status)
     SWSS_LOG_NOTICE("Port %s oper state set from %s to %s",
             port.m_alias.c_str(), oper_status_strings.at(port.m_oper_status).c_str(),
             oper_status_strings.at(status).c_str());
+
     if (status == port.m_oper_status)
     {
         return;
@@ -8647,6 +8656,40 @@ void PortsOrch::updatePortOperStatus(Port &port, sai_port_oper_status_t status)
     if(port.m_type == Port::TUNNEL)
     {
         return;
+    }
+
+
+    if(port.m_apply_unreliable_los == true && !port.m_unreliable_los)
+    {
+        SWSS_LOG_NOTICE(
+	    "Going to apply unlos settings  %s unreliable from %d to %d",
+	    port.m_alias.c_str(), port.m_unreliable_los, port.m_apply_unreliable_los
+	);
+	auto status = setPortUnreliableLOS(port, port.m_apply_unreliable_los);
+	if (status != task_success)
+	{
+	    SWSS_LOG_ERROR(
+		"Failed to set port %s unreliable from %d to %d",
+		port.m_alias.c_str(), port.m_unreliable_los, port.m_apply_unreliable_los
+	    );
+	    port.m_unreliable_los = false;
+	} else {
+
+	    port.m_unreliable_los = port.m_apply_unreliable_los;
+	    SWSS_LOG_INFO(
+		"Set port %s unreliable los to %d",
+		port.m_alias.c_str(), port.m_apply_unreliable_los
+	    );
+	}
+	m_portStateTable.hset(port.m_alias, "phy_ctrl_unreliable_los", port.m_unreliable_los ? "true":"false");
+	status = setPortInterfaceType(port, port.m_apply_unreliable_los_interface_type);
+	if (status != task_success)
+	{
+	    SWSS_LOG_ERROR(
+		"Failed to set port %s interface type to SR4",
+		port.m_alias.c_str()
+	    );
+	}
     }
 
     bool isUp = status == SAI_PORT_OPER_STATUS_UP;


### PR DESCRIPTION


<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
