### PR TITLE
[muxorch] Catch error when checking active state of missing neighbor

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1643,7 +1643,7 @@ void MuxOrch::update(SubjectType type, void *cntx)
                 }
                 catch (const std::exception& e)
                 {
-                    SWSS_LOG_ERROR("Exception caught while updating neighbor");
+                    SWSS_LOG_ERROR("Exception caught while updating neighbor. Error: %s", e.what());
                 }
             }
             break;
@@ -1657,7 +1657,7 @@ void MuxOrch::update(SubjectType type, void *cntx)
             }
             catch (const std::exception& e)
             {
-                SWSS_LOG_ERROR("Exception caught while updating FDB");
+                SWSS_LOG_ERROR("Exception caught while updating FDB. Error: %s", e.what());
             }
             break;
         }

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1286,7 +1286,9 @@ void MuxOrch::updateRoute(const IpPrefix &pfx, bool add)
         NeighborEntry neighbor;
         MacAddress mac;
 
-        gNeighOrch->getNeighborEntry(nexthop, neighbor, mac);
+        if (!gNeighOrch->getNeighborEntry(nexthop, neighbor, mac)){
+            continue;
+        }
 
         if (isNeighborActive(neighbor.ip_address, mac, neighbor.alias))
         {
@@ -1353,6 +1355,12 @@ bool MuxOrch::isNeighborActive(const IpAddress& nbr, const MacAddress& mac, stri
         return ptr->isActive();
     }
 
+    if (alias == nullptr || alias == ""){
+        SWSS_LOG_ERROR("Interface alias is empty", alias.c_str());
+        // Likely not a mux interface (default to active)
+        return true;
+    }
+
     string port;
     if (!getMuxPort(mac, alias, port))
     {
@@ -1382,6 +1390,11 @@ bool MuxOrch::getMuxPort(const MacAddress& mac, const string& alias, string& por
 {
     portName = std::string();
     Port rif, port;
+
+    if (alias == nullptr || alias == ""){
+        SWSS_LOG_ERROR("Interface alias is empty", alias.c_str());
+        return false;
+    }
 
     if (!gPortsOrch->getPort(alias, rif))
     {

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1355,8 +1355,8 @@ bool MuxOrch::isNeighborActive(const IpAddress& nbr, const MacAddress& mac, stri
         return ptr->isActive();
     }
 
-    if (alias == nullptr || alias == ""){
-        SWSS_LOG_ERROR("Interface alias is empty", alias.c_str());
+    if (alias.empty()){
+        SWSS_LOG_ERROR("Interface alias is empty");
         // Likely not a mux interface (default to active)
         return true;
     }
@@ -1391,8 +1391,8 @@ bool MuxOrch::getMuxPort(const MacAddress& mac, const string& alias, string& por
     portName = std::string();
     Port rif, port;
 
-    if (alias == nullptr || alias == ""){
-        SWSS_LOG_ERROR("Interface alias is empty", alias.c_str());
+    if (alias.empty()){
+        SWSS_LOG_ERROR("Interface alias is empty");
         return false;
     }
 

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1286,7 +1286,10 @@ void MuxOrch::updateRoute(const IpPrefix &pfx, bool add)
         NeighborEntry neighbor;
         MacAddress mac;
 
-        if (!gNeighOrch->getNeighborEntry(nexthop, neighbor, mac)){
+        if (!gNeighOrch->getNeighborEntry(nexthop, neighbor, mac))
+        {
+            SWSS_LOG_NOTICE("Neighbor entry for nexthop %s not found.",
+                            nexthop.to_string().c_str());
             continue;
         }
 
@@ -1355,8 +1358,9 @@ bool MuxOrch::isNeighborActive(const IpAddress& nbr, const MacAddress& mac, stri
         return ptr->isActive();
     }
 
-    if (alias.empty()){
-        SWSS_LOG_ERROR("Interface alias is empty");
+    if (alias.empty())
+    {
+        SWSS_LOG_WARN("Interface alias is empty");
         // Likely not a mux interface (default to active)
         return true;
     }
@@ -1391,8 +1395,9 @@ bool MuxOrch::getMuxPort(const MacAddress& mac, const string& alias, string& por
     portName = std::string();
     Port rif, port;
 
-    if (alias.empty()){
-        SWSS_LOG_ERROR("Interface alias is empty");
+    if (alias.empty())
+    {
+        SWSS_LOG_WARN("Interface alias is empty");
         return false;
     }
 

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -763,7 +763,7 @@ class TestMuxTunnelBase():
         '''
 
         print("Test delete while mux ports are standby")
-        print("Create route with mux ports: %s in states: %s" % (str(mux_ports), str(states)))
+        print("Create route with mux ports: %s in states: %s" % (str(mux_ports), str([STANDBY, STANDBY])))
         # Set mux states to standby
         for i,port in enumerate(mux_ports):
             self.set_mux_state(appdb, port, STANDBY)

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -757,6 +757,32 @@ class TestMuxTunnelBase():
 
         self.del_route(dvs, route)
 
+    def multi_nexthop_test_neighbor_delete_standby(self, appdb, asicdb, dvs, dvs_route, route, mux_ports, nexthops, macs):
+        '''
+        Tests neighbors getting deleted while mux ports are standby
+        '''
+
+        print("Test delete while mux ports are standby")
+        print("Create route with mux ports: %s in states: %s" % (str(mux_ports), str(states)))
+        # Set mux states to standby
+        for i,port in enumerate(mux_ports):
+            self.set_mux_state(appdb, port, STANDBY)
+
+        # Add route
+        self.add_route(dvs, route, nexthops)
+
+        # delete both neighbors and ensure that the route is still pointing to tunnel
+        for nexthop in nexthops:
+            self.del_neighbor(dvs, nexthop)
+            self.multi_nexthop_check(asicdb, dvs_route, route, nexthops, [STANDBY, STANDBY])
+
+        # add both neighbors back and ensure that the route is still pointing to tunnel
+        for i,nexthop in enumerate(nexthops):
+            self.add_neighbor(dvs, nexthop, macs[i])
+            self.multi_nexthop_check(asicdb, dvs_route, route, nexthops, [STANDBY, STANDBY])
+
+        self.del_route(dvs, route)
+
     def multi_nexthop_test_neighbor_add(self, appdb, asicdb, dvs, dvs_route, route, mux_ports, nexthops, macs):
         '''
         Tests adding neighbors for a route with multiple nexthops
@@ -829,6 +855,8 @@ class TestMuxTunnelBase():
             self.multi_nexthop_test_route_update_increase_size(appdb, asicdb, dvs, dvs_route, route_ipv6, mux_ports, ipv6_nexthops, non_mux_nexthop=non_mux_ipv6)
             self.multi_nexthop_test_route_update_decrease_size(appdb, asicdb, dvs, dvs_route, route_ipv4, mux_ports, ipv4_nexthops, non_mux_nexthop=non_mux_ipv4)
             self.multi_nexthop_test_route_update_decrease_size(appdb, asicdb, dvs, dvs_route, route_ipv6, mux_ports, ipv6_nexthops, non_mux_nexthop=non_mux_ipv6)
+            self.multi_nexthop_test_neighbor_delete_standby(appdb, asicdb, dvs, dvs_route, route_ipv4, mux_ports, ipv4_nexthops, macs)
+            self.multi_nexthop_test_neighbor_delete_standby(appdb, asicdb, dvs, dvs_route, route_ipv6, mux_ports, ipv6_nexthops, macs)
 
             # Testing mux neighbors that do not match mux configured ip
             self.add_route(dvs, route_ipv4, [self.SERV1_IPV4, mux_neighbor_ipv4])


### PR DESCRIPTION
Orchagent crashes when looking for mux port based on missing interface alias. Add a check to ensure that alias is present.

**What I did**
Added checks to prevent mux port lookup when interface alias is missing

**Why I did it**
Orchagent was crashing with std::logic_error when trying to parse non-existant interface alias

**How I verified it**
build in progress (will update once completed)
test will be added in full fix for the issue ETA: 6/6

**Details if related**
ado: #33039282

lab repro logs:
```
025 May 30 23:18:47.134652 str2-7050cx3-acs-06 NOTICE test.py: SET ROUTE_TABLE:2603:10e2:112b:152::/64:{'nexthop': '2603:10c0:14:917a:0:100:aa2:2c8,2603:10c0:14:917a:0:100:aa2:2d5', 'ifname': 'Vlan1000,Vlan1000'}
2025 May 30 23:18:47.136654 str2-7050cx3-acs-06 INFO swss#orchagent: :- set: setting attribute 0x10000004 status: SAI_STATUS_SUCCESS
2025 May 30 23:18:47.157831 str2-7050cx3-acs-06 NOTICE swss#orchagent: :- addNextHopGroup: Create next hop group 2603:10c0:14:917a:0:100:aa2:2c8@Vlan1000,2603:10c0:14:917a:0:100:aa2:2d5@Vlan1000
2025 May 30 23:18:47.157831 str2-7050cx3-acs-06 INFO swss#orchagent: :- create_entry: ObjectBulker.create_entry 1, 2, 0
2025 May 30 23:18:47.157831 str2-7050cx3-acs-06 INFO swss#orchagent: :- create_entry: ObjectBulker.create_entry 2, 2, 0
2025 May 30 23:18:47.159976 str2-7050cx3-acs-06 NOTICE syncd#syncd: [none] SAI_API_NEXT_HOP_GROUP:brcm_sai_create_next_hop_group_member:1185 ecmp intf 200002 nhid 1 seq-id 0 eg-if 202048 wt 0
2025 May 30 23:18:47.162595 str2-7050cx3-acs-06 INFO swss#orchagent: :- flush_creating_entries: ObjectBulker.flush creating_entries 2
2025 May 30 23:18:47.162595 str2-7050cx3-acs-06 INFO swss#orchagent: :- create_entry: EntityBulker.create_entry 1, 1, 1
2025 May 30 23:18:47.165020 str2-7050cx3-acs-06 INFO swss#orchagent: :- flush_creating_entries: EntityBulker.flush creating_entries 1
2025 May 30 23:18:47.165020 str2-7050cx3-acs-06 INFO swss#orchagent: :- addRoutePost: Post create route 2603:10e2:112b:152::/64 with next hop(s) 2603:10c0:14:917a:0:100:aa2:2c8@Vlan1000,2603:10c0:14:917a:0:100:aa2:2d5@Vlan1000
2025 May 30 23:18:47.165097 str2-7050cx3-acs-06 INFO swss#orchagent: :- isMuxNexthops: Found mux nexthop 2603:10c0:14:917a:0:100:aa2:2c8@Vlan1000
2025 May 30 23:18:47.165152 str2-7050cx3-acs-06 INFO swss#orchagent: :- isMuxNexthops: Found mux nexthop 2603:10c0:14:917a:0:100:aa2:2c8@Vlan1000
2025 May 30 23:18:47.165152 str2-7050cx3-acs-06 NOTICE swss#orchagent: :- updateRoute: Updating route 2603:10e2:112b:152::/64 pointing to Mux nexthops 2603:10c0:14:917a:0:100:aa2:2c8@Vlan1000,2603:10c0:14:917a:0:100:aa2:2d5@Vlan1000
2025 May 30 23:18:47.165762 str2-7050cx3-acs-06 INFO swss#orchagent: :- updateRoute: No Active neighbors found, setting route 2603:10e2:112b:152:: to point to tun


2025 May 30 23:18:48.137640 str2-7050cx3-acs-06 NOTICE test.py: DEL NEIGH_TABLE:Vlan1000:2603:10c0:14:917a:0:100:aa2:2c8
2025 May 30 23:18:48.137806 str2-7050cx3-acs-06 INFO swss#orchagent: :- set: setting attribute 0x10000004 status: SAI_STATUS_SUCCESS
2025 May 30 23:18:48.139078 str2-7050cx3-acs-06 INFO swss#orchagent: :- updateNeighbor: Neighbor DELETE event: 2603:10c0:14:917a:0:100:aa2:2c8 alias 'Vlan1000', removing associated SRv6 SIDs
2025 May 30 23:18:48.139078 str2-7050cx3-acs-06 NOTICE swss#orchagent: :- updateNeighbor: Processing update on neighbor 2603:10c0:14:917a:0:100:aa2:2c8 for mux Ethernet4, add 0, state 2
2025 May 30 23:18:48.139173 str2-7050cx3-acs-06 INFO swss#orchagent: :- update: Neigh 2603:10c0:14:917a:0:100:aa2:2c8 on Vlan1000, add 0, state 2
2025 May 30 23:18:48.142202 str2-7050cx3-acs-06 NOTICE swss#orchagent: :- remove_route: Removed tunnel route to 2603:10c0:14:917a:0:100:aa2:2c8/128
2025 May 30 23:18:48.142202 str2-7050cx3-acs-06 INFO swss#orchagent: :- removeTunnelRoute: Remove tunnel route DB 'Vlan1000:2603:10c0:14:917a:0:100:aa2:2c8/128'
2025 May 30 23:18:48.142867 str2-7050cx3-acs-06 INFO swss#orchagent: :- updateRoutes: Updating routes pointing to multiple mux nexthops
2025 May 30 23:18:48.163936 str2-7050cx3-acs-06 INFO swss#orchagent: :- removeRoute: Failed to find route entry, vrf_id 0x3000000000023, prefix 2603:10c0:14:917a:0:100:aa2:2c8/128


2025 May 30 23:18:49.138604 str2-7050cx3-acs-06 NOTICE test.py: DEL NEIGH_TABLE:Vlan1000:2603:10c0:14:917a:0:200:aa2:2d5
2025 May 30 23:18:49.138837 str2-7050cx3-acs-06 INFO swss#orchagent: :- set: setting attribute 0x10000004 status: SAI_STATUS_SUCCESS
2025 May 30 23:18:49.139837 str2-7050cx3-acs-06 INFO swss#orchagent: :- updateNeighbor: Neighbor DELETE event: 2603:10c0:14:917a:0:200:aa2:2d5 alias 'Vlan1000', removing associated SRv6 SIDs
2025 May 30 23:18:49.139904 str2-7050cx3-acs-06 NOTICE swss#orchagent: :- updateNeighbor: Processing update on neighbor 2603:10c0:14:917a:0:200:aa2:2d5 for mux Ethernet12, add 0, state 2
2025 May 30 23:18:49.139937 str2-7050cx3-acs-06 INFO swss#orchagent: :- update: Neigh 2603:10c0:14:917a:0:200:aa2:2d5 on Vlan1000, add 0, state 2
2025 May 30 23:18:49.142831 str2-7050cx3-acs-06 NOTICE swss#orchagent: :- remove_route: Removed tunnel route to 2603:10c0:14:917a:0:200:aa2:2d5/128
2025 May 30 23:18:49.142831 str2-7050cx3-acs-06 INFO swss#orchagent: :- removeTunnelRoute: Remove tunnel route DB 'Vlan1000:2603:10c0:14:917a:0:200:aa2:2d5/128'
2025 May 30 23:18:49.143828 str2-7050cx3-acs-06 INFO swss#orchagent: :- updateRoutes: Updating routes pointing to multiple mux nexthops
2025 May 30 23:18:49.143828 str2-7050cx3-acs-06 NOTICE swss#orchagent: :- updateRoute: Updating route 2603:10e2:112b:152::/64 pointing to Mux nexthops 2603:10c0:14:917a:0:100:aa2:2c8@Vlan1000,2603:10c0:14:917a:0:100:aa2:2d5@Vlan1000
2025 May 30 23:18:49.144140 str2-7050cx3-acs-06 ERR swss#orchagent: :- getMuxPort: Interface '' not found in port table
2025 May 30 23:18:49.145466 str2-7050cx3-acs-06 INFO swss#supervisord: orchagent terminate called after throwing an instance of 'std::logic_error'
2025 May 30 23:18:49.146224 str2-7050cx3-acs-06 INFO swss#supervisord: orchagent   what():  basic_string: construction from null is not valid
```
