### PR TITLE
[202505][fpmsyncd]Fixing fpmsyncd to handle routes without protocol

### DIFF
--- a/fpmsyncd/fpmsyncd.cpp
+++ b/fpmsyncd/fpmsyncd.cpp
@@ -318,11 +318,6 @@ int main(int argc, char **argv)
         {
             cout << "Connection lost, reconnecting..." << endl;
         }
-        catch (const exception& e)
-        {
-            cout << "Exception \"" << e.what() << "\" had been thrown in daemon" << endl;
-            return 0;
-        }
     }
 
     return 1;

--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -2531,6 +2531,14 @@ void RouteSync::onRouteResponse(const std::string& key, const std::vector<FieldV
         return;
     }
 
+    // When a route is programmed without FRR knowledge protocol will be empty.
+    if (protocol.empty())
+    {
+        SWSS_LOG_NOTICE("Received response for prefix %s(%s) without protol, ignoring ",
+            prefix.to_string().c_str(), vrfName.c_str());
+        return;
+    }
+
     auto routeObject = makeUniqueWithDestructor(rtnl_route_alloc(), rtnl_route_put);
     auto dstAddr = makeNlAddr(prefix);
 

--- a/tests/mock_tests/fpmsyncd/test_routesync.cpp
+++ b/tests/mock_tests/fpmsyncd/test_routesync.cpp
@@ -905,6 +905,17 @@ TEST_F(FpmSyncdResponseTest, TestRouteMsgWithNHG)
     rtnl_route_put(test_route);
 }
 
+
+TEST_F(FpmSyncdResponseTest, RouteResponseOnNoProto)
+{
+    // Expect the message to zebra is sent
+    EXPECT_CALL(m_mockFpm, send(_)).Times(0);
+
+    m_routeSync.onRouteResponse("1.0.0.0/24", {
+        {"err_str", "SWSS_RC_SUCCESS"},
+    });
+}
+
 TEST_F(FpmSyncdResponseTest, TestBlackholeRoute)
 {
     Table route_table(m_db.get(), APP_ROUTE_TABLE_NAME);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

Cherry-pick of PR https://github.com/sonic-net/sonic-swss/pull/3657
**What I did**
When a route is programmed through swssconfig or through redis, there might be no protocol string. This would result in the response from orchagent to have emtpy protocol field. fpmsyncd would throw an exception which when handled through the try catch would exit fpmsyncd with exit code zero.

**Why I did it**
Handle empty protocol gracefully in fpmsyncd.
Remove the generic catch and exit 0 in fpmsyncd so that we will have a core dump and non zero exit on exceptions

**How I verified it**
Manually verified. Added UT to verify as well.


**Details if related**
