### PR TITLE
[Portsorch[ Recreate any port(s) if the configured speed does not match

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -495,7 +495,7 @@ static bool isPathTracingSupported()
         SWSS_LOG_INFO("Querying OBJECT_TYPE_LIST is not supported on this platform");
         return false;
     }
-    else 
+    else
     {
         SWSS_LOG_ERROR(
             "Failed to get a list of supported switch capabilities. Error=%d", status
@@ -4186,6 +4186,46 @@ void PortsOrch::doPortTask(Consumer &consumer)
                         it = m_portListLaneMap.erase(it);
                         continue;
                     }
+                    else
+                    {
+                        /*
+                         * There could be cases where only port speed is changed as part of port breakout (no change in lane map)
+                         * In such cases, due to hardware limitation and the serial processing of speed change in SAI, there could
+                         * be a scenario where say speed is changed from 2x400G(PAM4) to say 2x100G (NRZ), the HW will then see one
+                         * subport is at 400G(x4 PAM4) and the other subport is at 100G(x4 NRZ) which is not supported by hardware
+                        */
+                        auto pCfg = m_lanesAliasSpeedMap[it->first];
+                        sai_uint32_t per_lane_cfg_speed = pCfg.speed.value / static_cast<sai_uint32_t>(pCfg.lanes.value.size());
+                        sai_uint32_t speed = 0;
+
+                        if (getPortSpeed(it->second, speed))
+                        {
+                            sai_uint32_t per_lane_speed = 0;
+                            if (speed > 0)
+                            {
+                                per_lane_speed = speed / static_cast<sai_uint32_t>(it->first.size());
+                            }
+                            // If speed is set in config DB, check if it matches with the HW speed
+                            if ((pCfg.speed.is_set && speed != pCfg.speed.value) &&
+                                    // PAM4 speed
+                                    (per_lane_speed >= 50000 || per_lane_cfg_speed >= 50000))
+                            {
+                                /*
+                                 * Speed mismatch, remove the port so that this port can be re-added later in
+                                 * port bulk add with configured speed
+                                 */
+                                SWSS_LOG_NOTICE("Port %" PRIx64 " speed mismatch: cfg speed %u, hw speed %u lane: %s",
+                                        it->second,
+                                        pCfg.speed.value,
+                                        speed,
+                                        swss::join(" ", it->first.cbegin(), it->first.cend()).c_str()
+                                );
+                                portsToRemoveList.push_back(it->second);
+                                it = m_portListLaneMap.erase(it);
+                                continue;
+                            }
+                        }
+                    }
 
                     it++;
                 }
@@ -4199,11 +4239,13 @@ void PortsOrch::doPortTask(Consumer &consumer)
                     }
                 }
 
-                // Port add comparison logic
+                // Port add comparison logic, add the ports in config DB that are not yet created in HW
                 for (auto it = m_lanesAliasSpeedMap.begin(); it != m_lanesAliasSpeedMap.end();)
                 {
                     if (m_portListLaneMap.find(it->first) == m_portListLaneMap.end())
                     {
+                        SWSS_LOG_NOTICE("Port %s with speed=%u is not in port list, adding it",
+                                    it->second.key.c_str(), it->second.speed.value);
                         portsToAddList.push_back(it->second);
                         it++;
                         continue;
@@ -4663,7 +4705,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                             );
                         }
                         m_portStateTable.hset(p.m_alias, "phy_ctrl_unreliable_los", p.m_unreliable_los ? "true":"false");
-                } 
+                }
 
                 if (pCfg.adv_interface_types.is_set)
                 {
@@ -6513,7 +6555,7 @@ bool PortsOrch::removeBridgePort(Port &port)
                 hostif_vlan_tag[SAI_HOSTIF_VLAN_TAG_STRIP], port.m_alias.c_str());
         return false;
     }
-    
+
     /* Remove STP ports before bridge port deletion*/
     gStpOrch->removeStpPorts(port);
 
@@ -8344,7 +8386,7 @@ void PortsOrch::generateWredPortCounterMap()
 
 /****
 *  Func Name  : addWredQueueFlexCounters
-*  Parameters : queueStateVector 
+*  Parameters : queueStateVector
 *  Returns    : void
 *  Description: Top level API to Set WRED flex counters for Queues
 **/
@@ -8414,9 +8456,9 @@ void PortsOrch::addWredQueueFlexCountersPerPort(const Port& port, FlexCounterQue
 }
 /****
 *  Func Name  : addWredQueueFlexCountersPerPortPerQueueIndex
-*  Parameters : port, queueIndex, is_voq 
+*  Parameters : port, queueIndex, is_voq
 *  Returns    : void
-*  Description: Sets the Stats list to be polled by the flexcounter 
+*  Description: Sets the Stats list to be polled by the flexcounter
 **/
 
 void PortsOrch::addWredQueueFlexCountersPerPortPerQueueIndex(const Port& port, size_t queueIndex,  bool voq, sai_queue_type_t queueType)

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -544,7 +544,7 @@ namespace portsorch_test
 
             ASSERT_EQ(gMlagOrch, nullptr);
             gMlagOrch = new MlagOrch(m_config_db.get(), mlag_tables);
- 
+
         }
 
         virtual void TearDown() override
@@ -1213,7 +1213,7 @@ namespace portsorch_test
         std::deque<KeyOpFieldsValuesTuple> kfvBasic = {{
             "Ethernet0",
             SET_COMMAND, {
-                { "speed",               "100000"            },
+                { "speed",               "1000"            },
                 { "fec",                 "rs"                },
                 { "mtu",                 "9100"              },
                 { "admin_status",        "up"                }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Delete the port if the speed mismatch with that in config DB and recreate it with the speed as per config DB

**Why I did it**

There could be scenarios where a platform creates default port with a speed/lane configuration other than in the config DB. If so, OA should delete those port during configuration ingestion and create them as per the speed specified in the 


**How I verified it**

Verified on a switch where the default speed is 400G(x4) and changed the speed in config DB to 100G(x4) and ensured the OA does not crash and the link is UP at 100G NRZ speed

**Details if related**
