### PR TITLE
[bulker] Add support for bulk set object attributes

### DIFF
--- a/orchagent/p4orch/tests/mock_sai_next_hop.h
+++ b/orchagent/p4orch/tests/mock_sai_next_hop.h
@@ -29,6 +29,9 @@ class MockSaiNextHop
 
     MOCK_METHOD4(remove_next_hops, sai_status_t(_In_ uint32_t object_count, _In_ const sai_object_id_t *object_id, _In_ sai_bulk_op_error_mode_t mode,
                                                 _Out_ sai_status_t *object_statuses));
+
+    MOCK_METHOD5(set_next_hops_attribute, sai_status_t(_In_ uint32_t object_count, _In_ const sai_object_id_t *object_id, _In_ const sai_attribute_t *attr_list,
+                                                       _In_ sai_bulk_op_error_mode_t mode, _Out_ sai_status_t *object_statuses));
 };
 
 // Note that before mock functions below are used, mock_sai_next_hop must be
@@ -69,4 +72,10 @@ sai_status_t mock_remove_next_hops(_In_ uint32_t object_count, _In_ const sai_ob
                                    _Out_ sai_status_t *object_statuses)
 {
     return mock_sai_next_hop->remove_next_hops(object_count, object_id, mode, object_statuses);
+}
+
+sai_status_t mock_set_next_hops_attribute(_In_ uint32_t object_count, _In_ const sai_object_id_t *object_id, _In_ const sai_attribute_t *attr_list,
+                                          _In_ sai_bulk_op_error_mode_t mode, _Out_ sai_status_t *object_statuses)
+{
+    return mock_sai_next_hop->set_next_hops_attribute(object_count, object_id, attr_list, mode, object_statuses);
 }

--- a/tests/mock_tests/bulker_ut.cpp
+++ b/tests/mock_tests/bulker_ut.cpp
@@ -1,12 +1,24 @@
 #include "ut_helper.h"
 #include "bulker.h"
+#include "mock_sai_api.h"
 
 extern sai_route_api_t *sai_route_api;
 extern sai_neighbor_api_t *sai_neighbor_api;
 
+EXTERN_MOCK_FNS
+
 namespace bulker_test
 {
     using namespace std;
+    using ::testing::SetArrayArgument;
+    using ::testing::Return;
+    using ::testing::DoAll;
+
+    DEFINE_SAI_GENERIC_API_OBJECT_BULK_MOCK_WITH_SET(next_hop, next_hop);
+
+    sai_bulk_object_create_fn old_object_create;
+    sai_bulk_object_remove_fn old_object_remove;
+    sai_bulk_object_set_attribute_fn old_object_set_attribute;
 
     struct BulkerTest : public ::testing::Test
     {
@@ -21,6 +33,30 @@ namespace bulker_test
 
             ASSERT_EQ(sai_neighbor_api, nullptr);
             sai_neighbor_api = new sai_neighbor_api_t();
+
+            ASSERT_EQ(sai_next_hop_api, nullptr);
+            sai_next_hop_api = new sai_next_hop_api_t();
+        }
+
+        void PostSetUp()
+        {
+            INIT_SAI_API_MOCK(next_hop);
+            MockSaiApis();
+            old_object_create = sai_next_hop_api->create_next_hops;
+            old_object_remove = sai_next_hop_api->remove_next_hops;
+            old_object_set_attribute = sai_next_hop_api->set_next_hops_attribute;
+            sai_next_hop_api->create_next_hops = mock_create_next_hops;
+            sai_next_hop_api->remove_next_hops = mock_remove_next_hops;
+            sai_next_hop_api->set_next_hops_attribute = mock_set_next_hops_attribute;
+        }
+
+        void PreTearDown()
+        {
+            RestoreSaiApis();
+            DEINIT_SAI_API_MOCK(next_hop);
+            sai_next_hop_api->create_next_hops = old_object_create;
+            sai_next_hop_api->remove_next_hops = old_object_remove;
+            sai_next_hop_api->set_next_hops_attribute = old_object_set_attribute;
         }
 
         void TearDown() override
@@ -172,5 +208,82 @@ namespace bulker_test
 
         // Confirm neighbor entry is pending removal
         ASSERT_TRUE(gNeighBulker.bulk_entry_pending_removal(neighbor_entry_remove));
+    }
+
+    TEST_F(BulkerTest, ObjectBulkSet)
+    {
+        // Create bulker
+        ObjectBulker<sai_next_hop_api_t> gNextHopBulker(sai_next_hop_api, 0x0, 1000);
+        vector<sai_attribute_t> next_hop_attrs;
+        sai_attribute_t next_hop_attr;
+        sai_object_id_t next_hop_id_0 = 0x0;
+        sai_object_id_t next_hop_id_1 = 0x1;
+        std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+
+        // Create 2 next hops
+        next_hop_attr.id = SAI_NEXT_HOP_ATTR_TYPE;
+        next_hop_attr.value.s32 = SAI_NEXT_HOP_TYPE_IP;
+        next_hop_attrs.push_back(next_hop_attr);
+
+        next_hop_attr.id = SAI_NEXT_HOP_ATTR_IP;
+        next_hop_attr.value.ipaddr.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+        next_hop_attr.value.ipaddr.addr.ip4 = 0x10000001;
+        next_hop_attrs.push_back(next_hop_attr);
+
+        next_hop_attr.id = SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID;
+        next_hop_attr.value.oid = 0x0;
+        next_hop_attrs.push_back(next_hop_attr);
+
+        gNextHopBulker.create_entry(&next_hop_id_0 , (uint32_t)next_hop_attrs.size(), next_hop_attrs.data());
+        next_hop_attrs.clear();
+
+        next_hop_attr.id = SAI_NEXT_HOP_ATTR_TYPE;
+        next_hop_attr.value.s32 = SAI_NEXT_HOP_TYPE_IP;
+        next_hop_attrs.push_back(next_hop_attr);
+
+        next_hop_attr.id = SAI_NEXT_HOP_ATTR_IP;
+        next_hop_attr.value.ipaddr.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+        next_hop_attr.value.ipaddr.addr.ip4 = 0x10000002;
+        next_hop_attrs.push_back(next_hop_attr);
+
+        next_hop_attr.id = SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID;
+        next_hop_attr.value.oid = 0x0;
+        next_hop_attrs.push_back(next_hop_attr);
+
+        gNextHopBulker.create_entry(&next_hop_id_1 , (uint32_t)next_hop_attrs.size(), next_hop_attrs.data());
+        next_hop_attrs.clear();
+
+        EXPECT_CALL(*mock_sai_next_hop_api, create_next_hops)
+            .WillOnce(DoAll(SetArrayArgument<6>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        gNextHopBulker.flush();
+
+        // Update the nexthops
+        next_hop_attr.id = SAI_NEXT_HOP_ATTR_IP;
+        next_hop_attr.value.ipaddr.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+        next_hop_attr.value.ipaddr.addr.ip4 = 0x10000003;
+
+        gNextHopBulker.set_entry_attribute(next_hop_id_0, &next_hop_attr);
+
+        next_hop_attr.id = SAI_NEXT_HOP_ATTR_IP;
+        next_hop_attr.value.ipaddr.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+        next_hop_attr.value.ipaddr.addr.ip4 = 0x10000004;
+        next_hop_attrs.push_back(next_hop_attr);
+
+        gNextHopBulker.set_entry_attribute(next_hop_id_1, &next_hop_attr);
+
+        EXPECT_CALL(*mock_sai_next_hop_api, set_next_hops_attribute)
+            .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        gNextHopBulker.flush();
+
+        // Delete the nexthops
+        vector<sai_status_t> statuses;
+        statuses.emplace_back();
+        gNextHopBulker.remove_entry(&statuses.back(), next_hop_id_0);
+        statuses.emplace_back();
+        gNextHopBulker.remove_entry(&statuses.back(), next_hop_id_1);
+
+        EXPECT_CALL(*mock_sai_next_hop_api, remove_next_hops)
+            .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        gNextHopBulker.flush();
     }
 }

--- a/tests/mock_tests/mock_sai_api.h
+++ b/tests/mock_tests/mock_sai_api.h
@@ -35,10 +35,12 @@ EXTERN_MOCK_FNS
 #define GENERIC_REMOVE_PARAMS(sai_object_type) _In_ sai_object_id_t sai_object_type##_id
 #define GENERIC_BULK_CREATE_PARAMS(sai_object_type) _In_ sai_object_id_t switch_id, _In_ uint32_t object_count, _In_ const uint32_t *attr_count, _In_ const sai_attribute_t **attr_list, _In_ sai_bulk_op_error_mode_t mode, _Out_ sai_object_id_t *object_id, _Out_ sai_status_t *object_statuses
 #define GENERIC_BULK_REMOVE_PARAMS(sai_object_type) _In_ uint32_t object_count, _In_ const sai_object_id_t *object_id, _In_ sai_bulk_op_error_mode_t mode, _Out_ sai_status_t *object_statuses
+#define GENERIC_BULK_SET_ATTR_PARAMS(sai_object_type) _In_ uint32_t object_count, _In_ const sai_object_id_t *object_id, _In_ const sai_attribute_t *attr_list, _In_ sai_bulk_op_error_mode_t mode, _Out_ sai_status_t *object_statuses
 #define GENERIC_CREATE_ARGS(sai_object_type) sai_object_type##_id, switch_id, attr_count, attr_list
 #define GENERIC_REMOVE_ARGS(sai_object_type) sai_object_type##_id
 #define GENERIC_BULK_CREATE_ARGS(sai_object_type) switch_id, object_count, attr_count, attr_list, mode, object_id, object_statuses
 #define GENERIC_BULK_REMOVE_ARGS(sai_object_type) object_count, object_id, mode, object_statuses
+#define GENERIC_BULK_SET_ATTR_ARGS(sai_object_type) object_count, object_id, attr_list, mode, object_statuses
 
 /*
 The macro DEFINE_SAI_API_MOCK will perform the steps to mock the SAI API for the sai_object_type it is called on:
@@ -305,6 +307,87 @@ The macro DEFINE_SAI_API_MOCK will perform the steps to mock the SAI API for the
         sai_##sai_api_name##_api->remove_##sai_object_type = mock_remove_##sai_object_type;                                          \
         sai_##sai_api_name##_api->create_##sai_object_type##s = mock_create_##sai_object_type##s;                                    \
         sai_##sai_api_name##_api->remove_##sai_object_type##s = mock_remove_##sai_object_type##s;                                    \
+    }                                                                                                                                \
+    inline void remove_sai_##sai_api_name##_api_mock()                                                                               \
+    {                                                                                                                                \
+        sai_##sai_api_name##_api = old_sai_##sai_api_name##_api;                                                                     \
+        delete mock_sai_##sai_api_name##_api;                                                                                        \
+    }                                                                                                                                \
+
+#define DEFINE_SAI_GENERIC_API_OBJECT_BULK_MOCK_WITH_SET(sai_api_name, sai_object_type)                                              \
+    static sai_##sai_api_name##_api_t *old_sai_##sai_api_name##_api;                                                                 \
+    static sai_##sai_api_name##_api_t ut_sai_##sai_api_name##_api;                                                                   \
+    class mock_sai_##sai_api_name##_api_t                                                                                            \
+    {                                                                                                                                \
+    public:                                                                                                                          \
+        mock_sai_##sai_api_name##_api_t()                                                                                            \
+        {                                                                                                                            \
+            ON_CALL(*this, create_##sai_object_type)                                                                                 \
+                .WillByDefault(                                                                                                      \
+                    [this](GENERIC_CREATE_PARAMS(sai_object_type)) {                                                                 \
+                        return old_sai_##sai_api_name##_api->create_##sai_object_type(GENERIC_CREATE_ARGS(sai_object_type));         \
+                    });                                                                                                              \
+            ON_CALL(*this, remove_##sai_object_type)                                                                                 \
+                .WillByDefault(                                                                                                      \
+                    [this](GENERIC_REMOVE_PARAMS(sai_object_type)) {                                                                 \
+                        return old_sai_##sai_api_name##_api->remove_##sai_object_type(GENERIC_REMOVE_ARGS(sai_object_type));         \
+                    });                                                                                                              \
+            ON_CALL(*this, create_##sai_object_type##s)                                                                              \
+                .WillByDefault(                                                                                                      \
+                    [this](GENERIC_BULK_CREATE_PARAMS(sai_object_type)) {                                                            \
+                        return old_sai_##sai_api_name##_api->create_##sai_object_type##s(GENERIC_BULK_CREATE_ARGS(sai_object_type)); \
+                    });                                                                                                              \
+            ON_CALL(*this, remove_##sai_object_type##s)                                                                              \
+                .WillByDefault(                                                                                                      \
+                    [this](GENERIC_BULK_REMOVE_PARAMS(sai_object_type)) {                                                            \
+                        return old_sai_##sai_api_name##_api->remove_##sai_object_type##s(GENERIC_BULK_REMOVE_ARGS(sai_object_type)); \
+                    });                                                                                                              \
+            ON_CALL(*this, set_##sai_object_type##s_attribute)                                                                       \
+                .WillByDefault(                                                                                                      \
+                    [this](GENERIC_BULK_SET_ATTR_PARAMS(sai_object_type)) {                                                     \
+                        return old_sai_##sai_api_name##_api->set_##sai_object_type##s_attribute(GENERIC_BULK_SET_ATTR_ARGS(sai_object_type)); \
+                    });                                                                                                              \
+        }                                                                                                                            \
+        MOCK_METHOD4(create_##sai_object_type, sai_status_t(GENERIC_CREATE_PARAMS(sai_object_type)));                                \
+        MOCK_METHOD1(remove_##sai_object_type, sai_status_t(GENERIC_REMOVE_PARAMS(sai_object_type)));                                \
+        MOCK_METHOD7(create_##sai_object_type##s, sai_status_t(GENERIC_BULK_CREATE_PARAMS(sai_object_type)));                        \
+        MOCK_METHOD4(remove_##sai_object_type##s, sai_status_t(GENERIC_BULK_REMOVE_PARAMS(sai_object_type)));                        \
+        MOCK_METHOD5(set_##sai_object_type##s_attribute, sai_status_t(GENERIC_BULK_SET_ATTR_PARAMS(sai_object_type)));               \
+    };                                                                                                                               \
+    static mock_sai_##sai_api_name##_api_t *mock_sai_##sai_api_name##_api;                                                           \
+    inline sai_status_t mock_create_##sai_object_type(GENERIC_CREATE_PARAMS(sai_object_type))                                        \
+    {                                                                                                                                \
+        return mock_sai_##sai_api_name##_api->create_##sai_object_type(GENERIC_CREATE_ARGS(sai_object_type));                        \
+    }                                                                                                                                \
+    inline sai_status_t mock_remove_##sai_object_type(GENERIC_REMOVE_PARAMS(sai_object_type))                                        \
+    {                                                                                                                                \
+        return mock_sai_##sai_api_name##_api->remove_##sai_object_type(GENERIC_REMOVE_ARGS(sai_object_type));                        \
+    }                                                                                                                                \
+    inline sai_status_t mock_create_##sai_object_type##s(GENERIC_BULK_CREATE_PARAMS(sai_object_type))                                \
+    {                                                                                                                                \
+        return mock_sai_##sai_api_name##_api->create_##sai_object_type##s(GENERIC_BULK_CREATE_ARGS(sai_object_type));                \
+    }                                                                                                                                \
+    inline sai_status_t mock_remove_##sai_object_type##s(GENERIC_BULK_REMOVE_PARAMS(sai_object_type))                                \
+    {                                                                                                                                \
+        return mock_sai_##sai_api_name##_api->remove_##sai_object_type##s(GENERIC_BULK_REMOVE_ARGS(sai_object_type));                \
+    }                                                                                                                                \
+    inline sai_status_t mock_set_##sai_object_type##s_attribute(GENERIC_BULK_SET_ATTR_PARAMS(sai_object_type))                       \
+    {                                                                                                                                \
+        return mock_sai_##sai_api_name##_api->set_##sai_object_type##s_attribute(GENERIC_BULK_SET_ATTR_ARGS(sai_object_type));       \
+    }                                                                                                                                \
+    inline void apply_sai_##sai_api_name##_api_mock()                                                                                \
+    {                                                                                                                                \
+        mock_sai_##sai_api_name##_api = new NiceMock<mock_sai_##sai_api_name##_api_t>();                                             \
+                                                                                                                                     \
+        old_sai_##sai_api_name##_api = sai_##sai_api_name##_api;                                                                     \
+        ut_sai_##sai_api_name##_api = *sai_##sai_api_name##_api;                                                                     \
+        sai_##sai_api_name##_api = &ut_sai_##sai_api_name##_api;                                                                     \
+                                                                                                                                     \
+        sai_##sai_api_name##_api->create_##sai_object_type = mock_create_##sai_object_type;                                          \
+        sai_##sai_api_name##_api->remove_##sai_object_type = mock_remove_##sai_object_type;                                          \
+        sai_##sai_api_name##_api->create_##sai_object_type##s = mock_create_##sai_object_type##s;                                    \
+        sai_##sai_api_name##_api->remove_##sai_object_type##s = mock_remove_##sai_object_type##s;                                    \
+        sai_##sai_api_name##_api->set_##sai_object_type##s_attribute = mock_set_##sai_object_type##s_attribute;                      \
     }                                                                                                                                \
     inline void remove_sai_##sai_api_name##_api_mock()                                                                               \
     {                                                                                                                                \


### PR DESCRIPTION
- Adds bulker API to allow bulk set attribute operations in orchagent.
- Adds unit test for bulker to test adding nexthops, setting nexthop attributes, and removing nexthops

**What I did**
Added support for bulk setting object attributes in orchagent

**Why I did it**
bulk nexthop attribute setting is supported in SAI and will help with efforts in imporoving dualtor switchover times.

**How I verified it**
Added a unit test to test bulker operations.

Test cases added:
- Adds bulk nexthop entries to object bulker and flush to test sai_api is called
- Sets nexthop attributes to new values in bulker and flush to test sai_api is called
- Removes bulk nexthop entries in bulker and flush to test sai_api is called

**Details if related**
ado: #33050940
