### PR TITLE
[vs][mirror]: Update test to use the max TC number provided by VS lib

### DIFF
--- a/tests/test_mirror_port_span.py
+++ b/tests/test_mirror_port_span.py
@@ -40,19 +40,19 @@ class TestMirror(object):
 
         # Sub Test 2
         marker = dvs.add_log_marker()
-        self.dvs_mirror.create_span_session(session, dst_port, src_ports, direction="RX", queue="254")
+        self.dvs_mirror.create_span_session(session, dst_port, src_ports, direction="RX", queue="15")
         self.dvs_mirror.verify_session_status(session)
         self.dvs_mirror.remove_mirror_session(session)
         self.dvs_mirror.verify_no_mirror()
-        self.check_syslog(dvs, marker, "Failed to get valid queue 254", 0)
+        self.check_syslog(dvs, marker, "Failed to get valid queue 15", 0)
 
         # Sub Test 3
         marker = dvs.add_log_marker()
-        self.dvs_mirror.create_span_session(session, dst_port, src_ports, direction="TX", queue="255")
+        self.dvs_mirror.create_span_session(session, dst_port, src_ports, direction="TX", queue="16")
         self.dvs_mirror.verify_session_status(session, expected=0)
         self.dvs_mirror.remove_mirror_session(session)
         self.dvs_mirror.verify_no_mirror()
-        self.check_syslog(dvs, marker, "Failed to get valid queue 255", 1)
+        self.check_syslog(dvs, marker, "Failed to get valid queue 16", 1)
         
 
     def test_PortMirrorAddRemove(self, dvs, testlog):


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

The PR is intended to provide a fix for the change https://github.com/sonic-net/sonic-swss/pull/1957

The old test behavior relies on a hardcoded max TC value of 255. Now it needs to be updated following the `SAI_SWITCH_ATTR_QOS_MAX_NUMBER_OF_TRAFFIC_CLASSES` attribute implementation in VS lib.

Due to the circular dependency, in order to have clean `sonic-sairedis` CI,
the current changes should be merged first.

**DEPENDS:**
1. https://github.com/sonic-net/sonic-sairedis/pull/1610

**What I did**
* Updated mirror VS test

**Why I did it**
* To align the behaviour with a new VS lib implementation

**How I verified it**
1. Run VS test
```
root@sonic: tests# pytest --dvsname=vs --log-cli-level=info -vvv test_mirror_port_span.py
======================================================================== test session starts =========================================================================
platform linux -- Python 3.8.10, pytest-7.1.2, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/work/debug/trim/asym/sonic-swss/tests
plugins: flaky-3.7.0
collected 10 items

test_mirror_port_span.py::TestMirror::test_PortMirrorQueue PASSED                                                                                              [ 10%]
test_mirror_port_span.py::TestMirror::test_PortMirrorAddRemove PASSED                                                                                          [ 20%]
test_mirror_port_span.py::TestMirror::test_PortMirrorMultiSpanAddRemove PASSED                                                                                 [ 30%]
test_mirror_port_span.py::TestMirror::test_PortMirrorPolicerAddRemove PASSED                                                                                   [ 40%]
test_mirror_port_span.py::TestMirror::test_PortMultiMirrorPolicerAddRemove PASSED                                                                              [ 50%]
test_mirror_port_span.py::TestMirror::test_LAGMirrorSpanAddRemove PASSED                                                                                       [ 60%]
test_mirror_port_span.py::TestMirror::test_PortMirrorPolicerWithAcl PASSED                                                                                     [ 70%]
test_mirror_port_span.py::TestMirror::test_PortMirrorLAGPortSpanAddRemove PASSED                                                                               [ 80%]
test_mirror_port_span.py::TestMirror::test_PortLAGMirrorUpdateLAG PASSED                                                                                       [ 90%]
test_mirror_port_span.py::test_nonflaky_dummy PASSED                                                                                                           [100%]
```

**Details if related**
* N/A

#### A picture of a cute animal (not mandatory but encouraged)
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```