### PR TITLE
[routeorch] Handle SAI_STATUS_ITEM_NOT_FOUND when setting route entries

### DIFF
--- a/tests/mock_tests/neighorch_ut.cpp
+++ b/tests/mock_tests/neighorch_ut.cpp
@@ -4,6 +4,9 @@
 #define protected public
 #include "orch.h"
 #undef protected
+#define private public
+#include "routeorch.h"
+#undef private
 #include "ut_helper.h"
 #include "mock_orchagent_main.h"
 #include "mock_sai_api.h"

--- a/tests/mock_tests/routeorch_ut.cpp
+++ b/tests/mock_tests/routeorch_ut.cpp
@@ -8,6 +8,7 @@
 #include "mock_orchagent_main.h"
 #include "mock_table.h"
 #include "mock_response_publisher.h"
+#include "mock_sai_api.h"
 #include "bulker.h"
 
 extern string gMySwitchType;
@@ -16,9 +17,16 @@ extern std::unique_ptr<MockResponsePublisher> gMockResponsePublisher;
 
 using ::testing::_;
 
+EXTERN_MOCK_FNS
+
 namespace routeorch_test
 {
     using namespace std;
+    using ::testing::SetArrayArgument;
+    using ::testing::Return;
+    using ::testing::DoAll;
+
+    DEFINE_SAI_API_MOCK_SPECIFY_ENTRY_WITH_SET(route, route);
 
     shared_ptr<swss::DBConnector> m_app_db;
     shared_ptr<swss::DBConnector> m_config_db;
@@ -30,7 +38,7 @@ namespace routeorch_test
     int remove_route_count;
     int sai_fail_count;
 
-    sai_route_api_t ut_sai_route_api;
+    // sai_route_api_t ut_sai_route_api;
     sai_route_api_t *pold_sai_route_api;
 
     sai_bulk_create_route_entry_fn              old_create_route_entries;
@@ -109,13 +117,15 @@ namespace routeorch_test
 
             ut_helper::initSaiApi(profile);
 
+            INIT_SAI_API_MOCK(route);
+            MockSaiApis();
+
             // Hack the route create function
             old_create_route_entries = sai_route_api->create_route_entries;
             old_remove_route_entries = sai_route_api->remove_route_entries;
             old_set_route_entries_attribute = sai_route_api->set_route_entries_attribute;
 
             pold_sai_route_api = sai_route_api;
-            ut_sai_route_api = *sai_route_api;
             sai_route_api = &ut_sai_route_api;
 
             sai_route_api->create_route_entries = _ut_stub_sai_bulk_create_route_entry;
@@ -341,6 +351,9 @@ namespace routeorch_test
 
         void TearDown() override
         {
+            RestoreSaiApis();
+            DEINIT_SAI_API_MOCK(route);
+
             gDirectory.m_values.clear();
 
             delete gCrmOrch;
@@ -586,6 +599,33 @@ namespace routeorch_test
                                                         {"nexthop", "0.0.0.0"},
                                                         {"ifname", "Ethernet8"}}});
         routeConsumer->addToSync(entries);
+        static_cast<Orch *>(gRouteOrch)->doTask();
+    }
+
+    /* Tests SAI_STATUS_ITEM_NOT_FOUND error handling for setting route */
+    TEST_F(RouteOrchTest, RouteOrchSetItemNotFound)
+    {
+        IpPrefix prefix("1.1.1.0/32");
+        NextHopGroupKey nhg_key("10.0.0.2");
+        RouteNhg route_nhg(nhg_key, "");
+
+        gRouteOrch->m_syncdRoutes[gVirtualRouterId][prefix] = route_nhg;
+
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({"1.1.1.0/32", "SET", { {"ifname", "Ethernet0"},
+                                                  {"nexthop", "10.0.0.3"}}});
+
+        auto consumer = dynamic_cast<Consumer *>(gRouteOrch->getExecutor(APP_ROUTE_TABLE_NAME));
+        consumer->addToSync(entries);
+
+        std::vector<sai_status_t> exp_status{SAI_STATUS_ITEM_NOT_FOUND};
+        EXPECT_CALL(*mock_sai_route_api, set_route_entries_attribute)
+            .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_ITEM_NOT_FOUND)));
+        static_cast<Orch *>(gRouteOrch)->doTask();
+
+        exp_status = {SAI_STATUS_SUCCESS};
+        EXPECT_CALL(*mock_sai_route_api, create_route_entries)
+            .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
         static_cast<Orch *>(gRouteOrch)->doTask();
     }
 }


### PR DESCRIPTION
In dualtor systems, muxorch will program tunnel route entries for mux neighbors on standby ports. If a route with the same prefix as the mux tunnel route is learned, a cache entry will be created in routeorch. Then when the neighbor is moved to an active mux port, the tunnel route will be deleted.

In certain race-conditions the delete notification will be delayed, causing a mismatch in routeoch between the internal cache and syncd state. If a route update is processed during this time, routeorch will attempt to set the route entry in syncd. This will return an error code SAI_STATUS_ITEM_NOT_FOUND.

This adds error handling logic to remove the internal cache entry from routeorch, then attempt to retry the route set.

**What I did**
- Added error handling logic for SAI_STATUS_ITEM_NOT_FOUND in routeorch when performing a set operation on the route.
- Added unit test to verity the error handling logic performs as expected

**Why I did it**
A rare race condition could cause cache mismatch with the asic state. This caused routeorch to attemt to set a route entry that did not exist, leading to error code SAI_STATUS_ITEM_NOT_FOUND. This change adds error handling logic to remove the internal cache entry from routeorch, then attempt to retry the route set.

**How I verified it**
Added unit test that covers this path

**Details if related**
ado: #32780823