### PR TITLE
Gracefully handle errors when accessing dpu app_state DB on NPU from DPU

### DIFF
--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -1103,7 +1103,15 @@ void writeResultToDB(const std::unique_ptr<swss::Table>& table, const string& ke
         fvVector.emplace_back("version", version);
     }
 
-    table->set(key, fvVector);
+    try
+    {
+        table->set(key, fvVector);
+    }
+    catch (const exception &e)
+    {
+        SWSS_LOG_ERROR("Exception caught while writing to DB: %s", e.what());
+        return;
+    }
     SWSS_LOG_INFO("Wrote result to DB for key %s", key.c_str());
 }
 
@@ -1117,6 +1125,14 @@ void removeResultFromDB(const std::unique_ptr<swss::Table>& table, const string&
         return;
     }
 
-    table->del(key);
+    try
+    {
+        table->del(key);
+    }
+    catch (const exception &e)
+    {
+        SWSS_LOG_ERROR("Exception caught while removing from DB: %s", e.what());
+        return;
+    }
     SWSS_LOG_INFO("Removed result from DB for key %s", key.c_str());
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
* Gracefully handle errors when accessing dpu app_state DB on NPU from DPU

**Why I did it**
* If DPU cannot reach NPU DBs for some reason, redis operations can throw exceptions, that need to be handled gracefully.

**How I verified it**

**Details if related**
