### PR TITLE
[fpmsyncd] skip routes for `eth1-midplane`

### DIFF
--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -1727,21 +1727,21 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
 
         if (alsv.size() == 1)
         {
-            if (alsv[0] == "eth0" || alsv[0] == "docker0")
+            if (alsv[0] == "eth0" || alsv[0] == "docker0" || alsv[0] == "eth1-midplane")
             {
-                SWSS_LOG_DEBUG("Skip routes to eth0 or docker0: %s %s %s",
+                SWSS_LOG_DEBUG("Skip routes to eth0 or docker0 or eth1-midplane: %s %s %s",
                             destipprefix, gw_list.c_str(), intf_list.c_str());
 
                 if (!warmRestartInProgress)
                 {
-                    SWSS_LOG_NOTICE("RouteTable del msg for route with only one nh on eth0/docker0: %s %s %s %s",
+                    SWSS_LOG_NOTICE("RouteTable del msg for route with only one nh on eth0/docker0/eth1-midplane: %s %s %s %s",
                                     destipprefix, gw_list.c_str(), intf_list.c_str(), mpls_list.c_str());
 
                     m_routeTable->del(destipprefix);
                 }
                 else
                 {
-                    SWSS_LOG_NOTICE("Warm-Restart mode: Receiving delete msg for route with only nh on eth0/docker0: %s %s %s %s",
+                    SWSS_LOG_NOTICE("Warm-Restart mode: Receiving delete msg for route with only nh on eth0/docker0/eth1-midplane: %s %s %s %s",
                                     destipprefix, gw_list.c_str(), intf_list.c_str(), mpls_list.c_str());
 
                     vector<FieldValueTuple> fvVector;
@@ -1761,9 +1761,9 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
                 * A change in FRR behavior from version 7.2 to 7.5 causes the default route to be updated to eth0
                 * during interface up/down events. This skips routes to eth0 or docker0 to avoid such behavior.
                 */
-                if (alias == "eth0" || alias == "docker0")
+                if (alias == "eth0" || alias == "docker0" || alias == "eth1-midplane")
                 {
-                    SWSS_LOG_DEBUG("Skip routes to eth0 or docker0: %s %s %s",
+                    SWSS_LOG_DEBUG("Skip routes to eth0 or docker0 or eth1-midplane: %s %s %s",
                                 destipprefix, gw_list.c_str(), intf_list.c_str());
                     continue;
                 }
@@ -1924,7 +1924,7 @@ void RouteSync::onNextHopMsg(struct nlmsghdr *h, int len)
                     strcpy(if_name, ifname_unknown);
                 }
                 ifname = string(if_name);
-                if (ifname == "eth0" || ifname == "docker0")
+                if (ifname == "eth0" || ifname == "docker0" || ifname =="eth1-midplane")
                 {
                     SWSS_LOG_DEBUG("Skip routes to interface: %s id[%d]", ifname.c_str(), id);
                     return;


### PR DESCRIPTION
When FRR was bumped up to 10.3 we started getting kernel routes for eth1-midplane.
Similar to https://github.com/sonic-net/sonic-swss/pull/1606 we'll skip these routes to avoid failures like
https://github.com/sonic-net/sonic-mgmt/issues/18505

More details about the failure this is fixing in: https://github.com/sonic-net/sonic-mgmt/issues/18505