### PR TITLE
Update INIT_VIEW timeout for marvell-prestera platforms

### DIFF
--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -396,7 +396,7 @@ void initSaiRedis()
     }
 
     char *platform = getenv("platform");
-    if (platform && (strstr(platform, MLNX_PLATFORM_SUBSTRING) || strstr(platform, XS_PLATFORM_SUBSTRING)))
+    if (platform && (strstr(platform, MLNX_PLATFORM_SUBSTRING) || strstr(platform, XS_PLATFORM_SUBSTRING) || strstr(platform, MRVL_PRST_PLATFORM_SUBSTRING)))
     {
         /* We set this long timeout in order for Orchagent to wait enough time for
          * response from syncd. It is needed since in init, systemd syncd startup


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Update INIT_VIEW timeout for marvell-prestera platforms

**Why I did it**
Some cost-effective platforms like the Nokia-7215 need additional time for the SYNCD docker to be up after the SWSS docker. There is no strict coupling between SWSS and Syncd, if there are other docker that start up between these 2 then it is possible that SYNCD docker starts more than 60 seconds after SWSS is up causing intermittent INIT_VIEW failures 

**How I verified it**

Build a marvel-Prestera image and run full OC on M0 and Mx topologies 

**Details if related**
