### PR TITLE
Add update_only flag for fake SubscriberStateTable.

### DIFF
--- a/orchagent/p4orch/tests/fake_subscriberstatetable.cpp
+++ b/orchagent/p4orch/tests/fake_subscriberstatetable.cpp
@@ -3,7 +3,7 @@
 namespace swss
 {
 
-SubscriberStateTable::SubscriberStateTable(DBConnector *db, const std::string &tableName, int popBatchSize, int pri)
+SubscriberStateTable::SubscriberStateTable(DBConnector *db, const std::string &tableName, int popBatchSize, int pri, bool update_only)
     : ConsumerTableBase(db, tableName, popBatchSize, pri), m_table(db, tableName)
 {
 }


### PR DESCRIPTION
**What I did**
Add update_only flag for fake SubscriberStateTable.

**Why I did it**
This PR needs to merge together with https://github.com/sonic-net/sonic-swss-common/pull/791

