### PR TITLE
Fix container crashes related to AP ports, ARP SVI, and loopback IP configuration

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -7169,7 +7169,7 @@ bool PortsOrch::setCollectionOnLagMember(Port &lagMember, bool enableCollection)
     attr.value.booldata = !enableCollection;
 
     status = sai_lag_api->set_lag_member_attribute(lagMember.m_lag_member_id, &attr);
-    if (status != SAI_STATUS_SUCCESS)
+    if (status != SAI_STATUS_SUCCESS && status != SAI_STATUS_ITEM_NOT_FOUND)
     {
         SWSS_LOG_ERROR("Failed to %s collection on LAG member %s",
             enableCollection ? "enable" : "disable",
@@ -7179,6 +7179,14 @@ bool PortsOrch::setCollectionOnLagMember(Port &lagMember, bool enableCollection)
         {
             return parseHandleSaiStatusFailure(handle_status);
         }
+    }
+    else if (status == SAI_STATUS_ITEM_NOT_FOUND)
+    {
+        SWSS_LOG_ERROR("Failed to %s collection on LAG member %s because not "
+                        "found the bridge port entry",
+                        enableCollection ? "enable" : "disable",
+                        lagMember.m_alias.c_str());
+        return true;
     }
 
     SWSS_LOG_NOTICE("%s collection on LAG member %s",
@@ -7200,7 +7208,7 @@ bool PortsOrch::setDistributionOnLagMember(Port &lagMember, bool enableDistribut
     attr.value.booldata = !enableDistribution;
 
     status = sai_lag_api->set_lag_member_attribute(lagMember.m_lag_member_id, &attr);
-    if (status != SAI_STATUS_SUCCESS)
+    if (status != SAI_STATUS_SUCCESS && status != SAI_STATUS_ITEM_NOT_FOUND)
     {
         SWSS_LOG_ERROR("Failed to %s distribution on LAG member %s",
             enableDistribution ? "enable" : "disable",
@@ -7210,6 +7218,14 @@ bool PortsOrch::setDistributionOnLagMember(Port &lagMember, bool enableDistribut
         {
             return parseHandleSaiStatusFailure(handle_status);
         }
+    }
+    else if (status == SAI_STATUS_ITEM_NOT_FOUND)
+    {
+        SWSS_LOG_ERROR("Failed to %s distribution on LAG member %s because not "
+                       "found the bridge port entry",
+                        enableDistribution ? "enable" : "disable",
+                        lagMember.m_alias.c_str());
+        return true;
     }
 
     SWSS_LOG_NOTICE("%s distribution on LAG member %s",

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -588,6 +588,7 @@ task_process_status handleSaiCreateStatus(sai_api_t api, sai_status_t status, vo
                     break;
             }
             break;
+        case SAI_API_LAG:
         case SAI_API_NEIGHBOR:
         case SAI_API_NEXT_HOP:
         case SAI_API_NEXT_HOP_GROUP:
@@ -597,6 +598,8 @@ task_process_status handleSaiCreateStatus(sai_api_t api, sai_status_t status, vo
                     SWSS_LOG_WARN("SAI_STATUS_SUCCESS is not expected in handleSaiCreateStatus");
                     return task_success;
                 case SAI_STATUS_ITEM_ALREADY_EXISTS:
+                    SWSS_LOG_NOTICE("Returning success for create operation, SAI API: %s, status: %s",
+                                sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
                     return task_success;
                 case SAI_STATUS_TABLE_FULL:
                     return task_need_retry;
@@ -734,6 +737,7 @@ task_process_status handleSaiRemoveStatus(sai_api_t api, sai_status_t status, vo
                     break;
             }
             break;
+        case SAI_API_LAG:
         case SAI_API_NEIGHBOR:
         case SAI_API_NEXT_HOP:
         case SAI_API_NEXT_HOP_GROUP:
@@ -743,6 +747,8 @@ task_process_status handleSaiRemoveStatus(sai_api_t api, sai_status_t status, vo
                     SWSS_LOG_WARN("SAI_STATUS_SUCCESS is not expected in handleSaiRemoveStatus");
                     return task_success;
                 case SAI_STATUS_ITEM_NOT_FOUND:
+                    SWSS_LOG_NOTICE("Returning success for remove operation, SAI API: %s, status: %s",
+                                sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
                     return task_success;
                 default:
                     SWSS_LOG_ERROR("Encountered failure in remove operation, exiting orchagent, SAI API: %s, status: %s",


### PR DESCRIPTION
**What I did**
    1. Fixed the issue where the AP port with member container crashes during boot.
    2. Fixed the issue where the AP port located in an already learned ARP SVI crashes when deleting any of its AP member ports.
    3. Fixed the issue where configuring IP on a loopback port causes the container to crash after saving and restarting the configuration.

**Why I did it**
  NA

**How I verified it**
  NA

**Details if related**
  NA
