### PR TITLE
[ssw][ha] fix dpu_state_db connection issue and zmq not supporting dpu_appl_db

### DIFF
--- a/orchagent/dash/dashhaorch.cpp
+++ b/orchagent/dash/dashhaorch.cpp
@@ -66,7 +66,8 @@ DashHaOrch::DashHaOrch(DBConnector *db, const vector<string> &tables, DashOrch *
     dash_ha_set_result_table_ = make_unique<Table>(app_state_db, APP_DASH_HA_SET_TABLE_NAME);
     dash_ha_scope_result_table_ = make_unique<Table>(app_state_db, APP_DASH_HA_SCOPE_TABLE_NAME);
 
-    m_dpuStateDbConnector = make_unique<DBConnector>("DPU_STATE_DB", 0);
+    m_dpuStateDbConnector = make_unique<DBConnector>("DPU_STATE_DB", 0, true);
+
     m_dpuStateDbHaSetTable = make_unique<Table>(m_dpuStateDbConnector.get(), STATE_DASH_HA_SET_STATE_TABLE_NAME);
     m_dpuStateDbHaScopeTable = make_unique<Table>(m_dpuStateDbConnector.get(), STATE_DASH_HA_SCOPE_STATE_TABLE_NAME);
 

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -1264,7 +1264,7 @@ bool DpuOrchDaemon::init()
         APP_DASH_HA_SCOPE_TABLE_NAME
     };
 
-    DashHaOrch *dash_ha_orch = new DashHaOrch(m_dpu_appDb, dash_ha_tables, dash_orch, m_dpu_appstateDb, m_zmqServer);
+    DashHaOrch *dash_ha_orch = new DashHaOrch(m_dpu_appDb, dash_ha_tables, dash_orch, m_dpu_appstateDb, dash_zmq_server);
     gDirectory.set(dash_ha_orch);
 
     vector<string> dash_route_tables = {

--- a/orchagent/zmqorch.cpp
+++ b/orchagent/zmqorch.cpp
@@ -48,7 +48,7 @@ ZmqOrch::ZmqOrch(DBConnector *db, const vector<table_name_with_pri_t> &tableName
 
 void ZmqOrch::addConsumer(DBConnector *db, string tableName, int pri, ZmqServer *zmqServer)
 {
-    if (db->getDbId() == APPL_DB)
+    if (db->getDbId() == APPL_DB || db->getDbId() == DPU_APPL_DB)
     {
         if (zmqServer != nullptr)
         {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
[ssw][ha] fix dpu_state_db connection issue and zmq not supporting dpu_appl_db

sign-off: Jing Zhang zhangjing@microsoft.com 

**What I did**
1. use tcp connection for remote db connect (dpu to dpu_state_db hosted on npu).
2. adapt zmqorch to consume dpu_appl_db

**Why I did it**
1 was cause crash. 2 was needed for ha to work. 

**How I verified it**
* Load the binary to 4280's DPU. 

2025 Jul 11 22:06:28.332176 sonic DEBUG swss#orchagent: :- addConsumer: ZmqConsumer initialize for: DASH_HA_SET_TABLE
2025 Jul 11 22:06:28.332401 sonic DEBUG swss#orchagent: :- addConsumer: ZmqConsumer initialize for: DASH_HA_SCOPE_TABLE

**Details if related**
