### PR TITLE
Publish oper_status time to STATE_DB

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3613,18 +3613,21 @@ void PortsOrch::updateDbPortOperError(Port& port, PortOperErrorEvent *pevent)
 {
     SWSS_LOG_ENTER();
 
+    auto time = pevent->getEventTime();
     auto key = pevent->getDbKey();
     vector<FieldValueTuple> tuples;
     FieldValueTuple tup1("oper_error_status", std::to_string(port.m_oper_error_status));
     tuples.push_back(tup1);
 
-    size_t count = pevent->getErrorCount();
-    FieldValueTuple tup2(key + "_count", std::to_string(count));
+    FieldValueTuple tup2("oper_error_status_time", time);
     tuples.push_back(tup2);
 
-    auto time = pevent->getEventTime();
-    FieldValueTuple tup3(key + "_time", time);
+    size_t count = pevent->getErrorCount();
+    FieldValueTuple tup3(key + "_count", std::to_string(count));
     tuples.push_back(tup3);
+
+    FieldValueTuple tup4(key + "_time", time);
+    tuples.push_back(tup4);
 
     m_portOpErrTable.set(port.m_alias, tuples);
 }


### PR DESCRIPTION
#### Why I did it
Mentioned in https://github.com/sonic-net/sonic-utilities/pull/3956 oper error status last timestamp always shows 'Never' because we never publish the time it last changed. 
```
Port Errors                     Count  Last timestamp(UTC)
----------------------------  -------  ---------------------
code group error                    0  Never
crc rate                            0  Never
data unit crc error                 0  Never
data unit misalignment error        0  Never
data unit size                      0  Never
fec alignment loss                  0  Never
fec sync loss                       0  Never
high ber error                      0  Never
high ser error                      0  Never
mac local fault                     7  2025-06-27 23:36:28
mac remote fault                    5  2025-06-27 23:36:28
no rx reachability                  0  Never
oper error status                   3  Never
signal local error                  0  Never
```

#### How I did it
Published the time to STATE_DB under `oper_error_status_time`

#### How to verify it
Can now see that the most recent time is up to date:
```
root@device:/var/log# show int errors Ethernet0
Port Errors                     Count  Last timestamp(UTC)
----------------------------  -------  ---------------------
code group error                    0  Never
crc rate                            0  Never
data unit crc error                 0  Never
data unit misalignment error        0  Never
data unit size                      0  Never
fec alignment loss                  0  Never
fec sync loss                       0  Never
high ber error                      0  Never
high ser error                      0  Never
mac local fault                     1  2025-07-03 17:39:12
mac remote fault                    0  Never
no rx reachability                  0  Never
oper error status                   1  2025-07-03 17:39:12
signal local error                  0  Never
```
