### PR TITLE
Support SAI_PORT_SERDES_ATTR_CUSTOM_COLLECTION

### DIFF
--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -243,6 +243,7 @@ public:
 
     /* pre-emphasis */
     std::map<sai_port_serdes_attr_t, std::vector<uint32_t>> m_preemphasis;
+    std::string m_custom_serdes_attrs;
 
     /* Force initial parameter configuration flags */
     bool m_an_cfg = false;        // Auto-negotiation (AN)

--- a/orchagent/port/portcnt.h
+++ b/orchagent/port/portcnt.h
@@ -190,6 +190,11 @@ public:
             bool is_set = false;
         } unreliable_los; // Port unreliable_los
 
+        struct {
+            std::string value;
+            bool is_set = false;
+        } custom_collection; // Port serdes custom_collection
+
     } serdes; // Port serdes
 
     struct {

--- a/orchagent/port/porthlpr.cpp
+++ b/orchagent/port/porthlpr.cpp
@@ -20,7 +20,6 @@ using namespace swss;
 
 // types --------------------------------------------------------------------------------------------------------------
 
-typedef decltype(PortConfig::serdes) PortSerdes_t;
 typedef decltype(PortConfig::link_event_damping_config) PortDampingConfig_t;
 
 // constants ----------------------------------------------------------------------------------------------------------
@@ -697,6 +696,27 @@ bool PortHelper::parsePortLinkTraining(PortConfig &port, const std::string &fiel
     return true;
 }
 
+// custom_collection specialization
+bool PortHelper::parsePortSerdes(
+    decltype(PortSerdes_t::custom_collection)& serdes,
+    const std::string& field,
+    const std::string& value) const
+{
+    SWSS_LOG_ENTER();
+
+    if (value.empty())
+    {
+        SWSS_LOG_ERROR("Failed to parse field(%s): empty string is prohibited",
+                       field.c_str());
+        return false;
+    }
+
+    // directly assign the raw string
+    serdes.value  = value;
+    serdes.is_set = true;
+    return true;
+}
+
 template<typename T>
 bool PortHelper::parsePortSerdes(T &serdes, const std::string &field, const std::string &value) const
 {
@@ -1178,6 +1198,13 @@ bool PortHelper::parsePortConfig(PortConfig &port) const
         else if (field == PORT_REGN_BFM1N)
         {
             if (!this->parsePortSerdes(port.serdes.regn_bfm1n, field, value))
+            {
+                return false;
+            }
+        }
+        else if (field == PORT_CUSTOM_SERDES_ATTRS)
+        {
+            if (!this->parsePortSerdes(port.serdes.custom_collection, field, value))
             {
                 return false;
             }

--- a/orchagent/port/porthlpr.h
+++ b/orchagent/port/porthlpr.h
@@ -7,6 +7,9 @@
 
 #include "portcnt.h"
 
+typedef decltype(PortConfig::serdes) PortSerdes_t;
+typedef decltype(PortSerdes_t::custom_collection) CustomSerdes_t;
+
 class PortHelper final
 {
 public:
@@ -36,6 +39,7 @@ public:
 private:
     std::string getFieldValueStr(const PortConfig &port, const std::string &field) const;
 
+    bool parsePortSerdes(CustomSerdes_t& serdes, const std::string& field, const std::string& value) const;
     template<typename T>
     bool parsePortSerdes(T &serdes, const std::string &field, const std::string &value) const;
 

--- a/orchagent/port/portschema.h
+++ b/orchagent/port/portschema.h
@@ -89,6 +89,7 @@
 #define PORT_OBNLEV                "obnlev"
 #define PORT_REGN_BFM1P            "regn_bfm1p"
 #define PORT_REGN_BFM1N            "regn_bfm1n"
+#define PORT_CUSTOM_SERDES_ATTRS   "custom_serdes_attrs"
 #define PORT_ROLE                  "role"
 #define PORT_ADMIN_STATUS          "admin_status"
 #define PORT_DESCRIPTION           "description"

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -517,7 +517,8 @@ private:
 
     void getPortSerdesVal(const std::string& s, std::vector<uint32_t> &lane_values, int base = 16);
     bool setPortSerdesAttribute(sai_object_id_t port_id, sai_object_id_t switch_id,
-                                std::map<sai_port_serdes_attr_t, std::vector<uint32_t>> &serdes_attr);
+                                std::map<sai_port_serdes_attr_t, std::vector<uint32_t>> &serdes_attr,
+                                const std::string &custom_serdes_attrs_str = "");
 
 
     void removePortSerdesAttribute(sai_object_id_t port_id);

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -1088,7 +1088,8 @@ namespace portsorch_test
                 { "obplev",        "0x69,0x6b,0x6a,0x6c"         },
                 { "obnlev",        "0x5f,0x61,0x60,0x62"         },
                 { "regn_bfm1p",    "0x1e,0x20,0x1f,0x21"         },
-                { "regn_bfm1n",    "0xaa,0xac,0xab,0xad"         }
+                { "regn_bfm1n",    "0xaa,0xac,0xab,0xad"         },
+                { "custom_serdes_attrs", "{'attributes':[]}"     }
             }
         }};
 
@@ -1173,6 +1174,10 @@ namespace portsorch_test
 
         // Verify unreliablelos
         ASSERT_EQ(p.m_unreliable_los, false);
+
+        // Verify custom_serdes_attrs
+        std::string custom_serdes_attrs = "{'attributes':[]}";
+        ASSERT_EQ(p.m_custom_serdes_attrs, custom_serdes_attrs);
 
         // Dump pending tasks
         std::vector<std::string> taskList;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

> [!NOTE]  
> This PR has dependency on latest OCP SAI attribute [SAI_PORT_SERDES_ATTR_CUSTOM_COLLECTION](https://github.com/opencomputeproject/SAI/commit/a08584b535c8715b15c9c02a200f0366672531f8), which hasn't been released to [sonic-sairedis/SAI](https://github.com/sonic-net/sonic-sairedis/tree/master). Thus, before its release, it's expected to see build error on this attribute in pre-commit pipeline.


sonic-platform-daemon side change: https://github.com/sonic-net/sonic-platform-daemons/pull/643

**What I did**
Support [SAI_PORT_SERDES_ATTR_CUSTOM_COLLECTION](https://github.com/opencomputeproject/SAI/pull/2156)

**Why I did it**

**How I verified it**
Tested end-to-end xcvrd->OA->SAI/SDK

**Details if related**
