### PR TITLE
[ssw][haorch] use kfv instead of serialized pb objects for internal tables

### DIFF
--- a/orchagent/dash/dashhaorch.cpp
+++ b/orchagent/dash/dashhaorch.cpp
@@ -9,6 +9,7 @@
 #include "table.h"
 #include "taskworker.h" 
 #include "pbutils.h"
+#include "converter.h"
 
 #include "chrono"
 
@@ -309,9 +310,22 @@ void DashHaOrch::doTaskHaSetTable(ConsumerBase &consumer)
         {
             dash::ha_set::HaSet entry;
 
-            if (!parsePbMessage(kfvFieldsValues(tuple), entry))
+            /*
+            * For HA internal tables, kfv format was used instead of serialized pb objects in the end.
+            * I decided to keep protobuf conversion still for:
+            *      - ensuring the data integrity.
+            *      - in case we need to switch to protobuf in the future.
+            */
+            // if (!parsePbMessage(kfvFieldsValues(tuple), entry))
+            // {
+            //     SWSS_LOG_WARN("Requires protobuf at HaSet :%s", key.c_str());
+            //     it = consumer.m_toSync.erase(it);
+            //     continue;
+            // }
+
+            if (!convertKfvToHaSetPb(kfvFieldsValues(tuple), entry))
             {
-                SWSS_LOG_WARN("Requires protobuf at HaSet :%s", key.c_str());
+                SWSS_LOG_WARN("Failed to convert KeyOpFieldsValuesTuple to HaSet entry for %s, invalid values probably.", key.c_str());
                 it = consumer.m_toSync.erase(it);
                 continue;
             }
@@ -426,7 +440,7 @@ bool DashHaOrch::addHaScopeEntry(const std::string &key, const dash::ha_scope::H
     SWSS_LOG_NOTICE("Created HA Scope object for %s", key.c_str());
 
     // set HA Scope ID to ENI
-    if (ha_set_it->second.metadata.scope() == dash::types::HaScope::SCOPE_ENI)
+    if (ha_set_it->second.metadata.scope() == dash::types::HaScope::HA_SCOPE_ENI)
     {
         auto eni_entry = m_dash_orch->getEni(key);
         if (eni_entry == nullptr)
@@ -437,7 +451,7 @@ bool DashHaOrch::addHaScopeEntry(const std::string &key, const dash::ha_scope::H
 
         return setEniHaScopeId(eni_entry->eni_id, sai_ha_scope_oid);
 
-    } else if (ha_set_it->second.metadata.scope() == dash::types::HaScope::SCOPE_DPU)
+    } else if (ha_set_it->second.metadata.scope() == dash::types::HaScope::HA_SCOPE_DPU)
     {
         auto eni_table = m_dash_orch->getEniTable();
         auto it = eni_table->begin();
@@ -617,9 +631,23 @@ void DashHaOrch::doTaskHaScopeTable(ConsumerBase &consumer)
         {
             dash::ha_scope::HaScope entry;
 
-            if (!parsePbMessage(kfvFieldsValues(tuple), entry))
+
+            /*
+            * For HA internal tables, kfv format was used instead of serialized pb objects in the end.
+            * I decided to keep protobuf conversion still for:
+            *      - ensuring the data integrity.
+            *      - in case we need to switch to protobuf in the future.
+            */
+            // if (!parsePbMessage(kfvFieldsValues(tuple), entry))
+            // {
+            //     SWSS_LOG_WARN("Requires protobuf at HaScope :%s", key.c_str());
+            //     it = consumer.m_toSync.erase(it);
+            //     continue;
+            // }
+
+            if (!convertKfvToHaScopePb(kfvFieldsValues(tuple), entry))
             {
-                SWSS_LOG_WARN("Requires protobuf at HaScope :%s", key.c_str());
+                SWSS_LOG_WARN("Failed to convert KeyOpFieldsValuesTuple to HaScope entry for %s, invalid values probably.", key.c_str());
                 it = consumer.m_toSync.erase(it);
                 continue;
             }
@@ -788,4 +816,190 @@ void DashHaOrch::doTask(NotificationConsumer &consumer)
             sai_deserialize_free_ha_scope_event_ntf(count, ha_scope_event);
         }
     }
+}
+
+bool DashHaOrch::convertKfvToHaSetPb(const std::vector<FieldValueTuple> &kfv, dash::ha_set::HaSet &entry)
+{
+    SWSS_LOG_ENTER();
+
+    for (const auto &fv : kfv)
+    {
+        const std::string &field = fvField(fv);
+        const std::string &value = fvValue(fv);
+
+        if (field == "version")
+        {
+            entry.set_version(value);
+        }
+        else if (field == "vip_v4")
+        {
+            swss::IpAddress ip(value);
+            if (!ip.isV4())
+            {
+                SWSS_LOG_ERROR("Invalid IPv4 address %s", value.c_str());
+                return false;
+            }
+            entry.mutable_vip_v4()->set_ipv4(ip.getV4Addr());
+        }
+        else if (field == "vip_v6")
+        {
+            swss::IpAddress ip6(value);
+            if (ip6.isV4())
+            {
+                SWSS_LOG_ERROR("Invalid IPv6 address %s", value.c_str());
+                return false;
+            }
+            entry.mutable_vip_v6()->set_ipv6(value);
+        }
+        else if (field == "owner")
+        {
+            if (value == "switch")
+            {
+                entry.set_owner(dash::types::HaOwner::HA_OWNER_DPU);
+            } else if (value == "dpu" || value == "")
+            {
+                // Default to switch owner if not specified
+                entry.set_owner(dash::types::HaOwner::HA_OWNER_SWITCH);
+            } else
+            {
+                SWSS_LOG_INFO("Unknown HA Set owner %s", value.c_str());
+                return false;
+            }
+        }
+        else if (field == "scope")
+        {
+            if (value == "eni")
+            {
+                entry.set_scope(dash::types::HaScope::HA_SCOPE_ENI);
+            } else if (value == "dpu" || value == "")
+            {
+                entry.set_scope(dash::types::HaScope::HA_SCOPE_DPU);
+            } else
+            {
+                SWSS_LOG_INFO("Unknown HA Set scope %s", value.c_str());
+                return false;
+            }
+        }
+        else if (field == "local_npu_ip")
+        {
+            swss::IpAddress ip(value);
+            if (ip.isV4())
+            {
+                entry.mutable_local_npu_ip()->set_ipv4(ip.getV4Addr());
+            } else
+            {
+                entry.mutable_local_npu_ip()->set_ipv6(value);
+            }
+        }
+        else if (field == "local_ip")
+        {
+            swss::IpAddress local_ip(value);
+            if (local_ip.isV4())
+            {
+                entry.mutable_local_ip()->set_ipv4(local_ip.getV4Addr());
+            } else
+            {
+                entry.mutable_local_ip()->set_ipv6(value);
+            }
+        }
+        else if (field == "peer_ip")
+        {
+            swss::IpAddress peer_ip(value);
+            if (peer_ip.isV4())
+            {
+                entry.mutable_peer_ip()->set_ipv4(peer_ip.getV4Addr());
+            } else
+            {
+                entry.mutable_peer_ip()->set_ipv6(value);
+            }
+        }
+        else if (field == "cp_data_channel_port")
+        {
+            entry.set_cp_data_channel_port(to_uint<uint32_t>(value));
+        }
+        else if (field == "dp_channel_dst_port")
+        {
+            entry.set_dp_channel_dst_port(to_uint<uint32_t>(value));
+        }
+        else if (field == "dp_channel_src_port_min")
+        {
+            entry.set_dp_channel_src_port_min(to_uint<uint32_t>(value));
+        }
+        else if (field == "dp_channel_src_port_max")
+        {
+            entry.set_dp_channel_src_port_max(to_uint<uint32_t>(value));
+        }
+        else if (field == "dp_channel_probe_interval_ms")
+        {
+            entry.set_dp_channel_probe_interval_ms(to_uint<uint32_t>(value));
+        }
+        else if (field == "dp_channel_probe_fail_threshold")
+        {
+            entry.set_dp_channel_probe_fail_threshold(to_uint<uint32_t>(value));
+        }
+        else
+        {
+            SWSS_LOG_WARN("Unknown field %s in HA Set entry", field.c_str());
+            return false;
+        }
+    }
+    return true;
+}
+
+bool DashHaOrch::convertKfvToHaScopePb(const std::vector<FieldValueTuple> &kfv, dash::ha_scope::HaScope &entry)
+{
+    SWSS_LOG_ENTER();
+
+    for (const auto &fv : kfv)
+    {
+        const std::string &field = fvField(fv);
+        const std::string &value = fvValue(fv);
+
+        if (field == "version")
+        {
+            entry.set_version(value);
+        }
+        else if (field == "disabled")
+        {
+            entry.set_disabled(value == "true" || value == "1");
+        }
+        else if (field == "ha_role")
+        {
+            if (value == "active")
+            {
+                entry.set_ha_role(dash::types::HaRole::HA_ROLE_ACTIVE);
+            } else if (value == "standby")
+            {
+                entry.set_ha_role(dash::types::HaRole::HA_ROLE_STANDBY);
+            } else if (value == "dead")
+            {
+                entry.set_ha_role(dash::types::HaRole::HA_ROLE_DEAD);
+            } else if (value == "standalone")
+            {
+                entry.set_ha_role(dash::types::HaRole::HA_ROLE_STANDALONE);
+            } else if (value == "switching_to_active")
+            {
+                entry.set_ha_role(dash::types::HaRole::HA_ROLE_SWITCHING_TO_ACTIVE);
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Unknown HA Scope role %s, setting to dead", value.c_str());
+                entry.set_ha_role(dash::types::HaRole::HA_ROLE_DEAD);
+            }
+        }
+        else if (field == "flow_reconcile_requested")
+        {
+            entry.set_flow_reconcile_requested(value == "true" || value == "1");
+        }
+        else if (field == "activate_role_requested")
+        {
+            entry.set_activate_role_requested(value == "true" || value == "1");
+        }
+        else
+        {
+            SWSS_LOG_WARN("Unknown field %s in HA Scope entry", field.c_str());
+            return false;
+        }
+    }
+    return true;
 }

--- a/orchagent/dash/dashhaorch.cpp
+++ b/orchagent/dash/dashhaorch.cpp
@@ -853,32 +853,21 @@ bool DashHaOrch::convertKfvToHaSetPb(const std::vector<FieldValueTuple> &kfv, da
         }
         else if (field == "owner")
         {
-            if (value == "switch")
+            dash::types::HaOwner owner;
+            if (!to_pb(value, owner))
             {
-                entry.set_owner(dash::types::HaOwner::HA_OWNER_DPU);
-            } else if (value == "dpu" || value == "")
-            {
-                // Default to switch owner if not specified
-                entry.set_owner(dash::types::HaOwner::HA_OWNER_SWITCH);
-            } else
-            {
-                SWSS_LOG_INFO("Unknown HA Set owner %s", value.c_str());
                 return false;
             }
+            entry.set_owner(owner);
         }
         else if (field == "scope")
         {
-            if (value == "eni")
+            dash::types::HaScope ha_scope;
+            if (!to_pb(value, ha_scope))
             {
-                entry.set_scope(dash::types::HaScope::HA_SCOPE_ENI);
-            } else if (value == "dpu" || value == "")
-            {
-                entry.set_scope(dash::types::HaScope::HA_SCOPE_DPU);
-            } else
-            {
-                SWSS_LOG_INFO("Unknown HA Set scope %s", value.c_str());
                 return false;
             }
+            entry.set_scope(ha_scope);
         }
         else if (field == "local_npu_ip")
         {
@@ -965,27 +954,12 @@ bool DashHaOrch::convertKfvToHaScopePb(const std::vector<FieldValueTuple> &kfv, 
         }
         else if (field == "ha_role")
         {
-            if (value == "active")
+            dash::types::HaRole ha_role;
+            if (!to_pb(value, ha_role))
             {
-                entry.set_ha_role(dash::types::HaRole::HA_ROLE_ACTIVE);
-            } else if (value == "standby")
-            {
-                entry.set_ha_role(dash::types::HaRole::HA_ROLE_STANDBY);
-            } else if (value == "dead")
-            {
-                entry.set_ha_role(dash::types::HaRole::HA_ROLE_DEAD);
-            } else if (value == "standalone")
-            {
-                entry.set_ha_role(dash::types::HaRole::HA_ROLE_STANDALONE);
-            } else if (value == "switching_to_active")
-            {
-                entry.set_ha_role(dash::types::HaRole::HA_ROLE_SWITCHING_TO_ACTIVE);
+                return false;
             }
-            else
-            {
-                SWSS_LOG_ERROR("Unknown HA Scope role %s, setting to dead", value.c_str());
-                entry.set_ha_role(dash::types::HaRole::HA_ROLE_DEAD);
-            }
+            entry.set_ha_role(ha_role);
         }
         else if (field == "flow_reconcile_requested")
         {

--- a/orchagent/dash/dashhaorch.h
+++ b/orchagent/dash/dashhaorch.h
@@ -66,6 +66,16 @@ protected:
     bool register_ha_set_notifier();
     bool register_ha_scope_notifier();
 
+    bool convertKfvToHaSetPb(
+        const std::vector<swss::FieldValueTuple> &kfv,
+        dash::ha_set::HaSet &entry
+    );
+
+    bool convertKfvToHaScopePb(
+        const std::vector<swss::FieldValueTuple> &kfv,
+        dash::ha_scope::HaScope &entry
+    );
+
     std::string getHaSetObjectKey(const sai_object_id_t ha_set_id);
     std::string getHaScopeObjectKey(const sai_object_id_t ha_scope_id);
     std::time_t getNowTime(){

--- a/orchagent/dash/pbutils.cpp
+++ b/orchagent/dash/pbutils.cpp
@@ -198,3 +198,81 @@ dash::types::HaRole to_pb(const sai_dash_ha_role_t ha_role)
             return dash::types::HA_ROLE_DEAD;
     }
 }
+
+bool to_pb(const std::string &ha_role, dash::types::HaRole &pb_ha_role)
+{
+    SWSS_LOG_ENTER();
+
+    if (ha_role == "dead")
+    {
+        pb_ha_role = dash::types::HA_ROLE_DEAD;
+    }
+    else if (ha_role == "active")
+    {
+        pb_ha_role = dash::types::HA_ROLE_ACTIVE;
+    }
+    else if (ha_role == "standby")
+    {
+        pb_ha_role = dash::types::HA_ROLE_STANDBY;
+    }
+    else if (ha_role == "standalone")
+    {
+        pb_ha_role = dash::types::HA_ROLE_STANDALONE;
+    }
+    else if (ha_role == "switching_to_active")
+    {
+        pb_ha_role = dash::types::HA_ROLE_SWITCHING_TO_ACTIVE;
+    }
+    else
+    {
+        SWSS_LOG_ERROR("Unknown HA Role %s, defaulting to dead", ha_role.c_str());
+        pb_ha_role = dash::types::HA_ROLE_DEAD;
+        return false;
+    }
+
+    return true;
+}
+
+bool to_pb(const std::string &ha_owner, dash::types::HaOwner &pb_ha_owner)
+{
+    SWSS_LOG_ENTER();
+
+    if (ha_owner == "switch")
+    {
+        pb_ha_owner = dash::types::HA_OWNER_SWITCH;
+    }
+    else if (ha_owner == "dpu")
+    {
+        pb_ha_owner = dash::types::HA_OWNER_DPU;
+    }
+    else
+    {
+        SWSS_LOG_ERROR("Unknown HA Owner %s, defaulting to DPU", ha_owner.c_str());
+        pb_ha_owner = dash::types::HA_OWNER_DPU;
+        return false;
+    }
+
+    return true;
+}
+
+bool to_pb(const std::string &ha_scope, dash::types::HaScope &pb_ha_scope)
+{
+    SWSS_LOG_ENTER();
+
+    if (ha_scope == "eni")
+    {
+        pb_ha_scope = dash::types::HA_SCOPE_ENI;
+    }
+    else if (ha_scope == "dpu")
+    {
+        pb_ha_scope = dash::types::HA_SCOPE_DPU;
+    }
+    else
+    {
+        SWSS_LOG_ERROR("Unknown HA Scope %s, defaulting to local", ha_scope.c_str());
+        pb_ha_scope = dash::types::HA_SCOPE_DPU;
+        return false;
+    }
+
+    return true;
+}

--- a/orchagent/dash/pbutils.cpp
+++ b/orchagent/dash/pbutils.cpp
@@ -225,7 +225,7 @@ bool to_pb(const std::string &ha_role, dash::types::HaRole &pb_ha_role)
     }
     else
     {
-        SWSS_LOG_ERROR("Unknown HA Role %s, defaulting to dead", ha_role.c_str());
+        SWSS_LOG_NOTICE("Unspecified HA Role %s, defaulting to dead", ha_role.c_str());
         pb_ha_role = dash::types::HA_ROLE_DEAD;
         return false;
     }
@@ -247,7 +247,7 @@ bool to_pb(const std::string &ha_owner, dash::types::HaOwner &pb_ha_owner)
     }
     else
     {
-        SWSS_LOG_ERROR("Unknown HA Owner %s, defaulting to DPU", ha_owner.c_str());
+        SWSS_LOG_NOTICE("Unspecified HA Owner %s, defaulting to DPU", ha_owner.c_str());
         pb_ha_owner = dash::types::HA_OWNER_DPU;
         return false;
     }
@@ -269,7 +269,7 @@ bool to_pb(const std::string &ha_scope, dash::types::HaScope &pb_ha_scope)
     }
     else
     {
-        SWSS_LOG_ERROR("Unknown HA Scope %s, defaulting to local", ha_scope.c_str());
+        SWSS_LOG_NOTICE("Unspecified HA Scope %s, defaulting to DPU", ha_scope.c_str());
         pb_ha_scope = dash::types::HA_SCOPE_DPU;
         return false;
     }

--- a/orchagent/dash/pbutils.cpp
+++ b/orchagent/dash/pbutils.cpp
@@ -156,19 +156,19 @@ sai_uint16_t to_sai(const dash::types::HaRole ha_role)
 
     switch (ha_role)
     {
-        case dash::types::HA_SCOPE_ROLE_DEAD:
+        case dash::types::HA_ROLE_DEAD:
             sai_ha_role = SAI_DASH_HA_ROLE_DEAD;
             break;
-        case dash::types::HA_SCOPE_ROLE_ACTIVE:
+        case dash::types::HA_ROLE_ACTIVE:
             sai_ha_role = SAI_DASH_HA_ROLE_ACTIVE;
             break;
-        case dash::types::HA_SCOPE_ROLE_STANDBY:
+        case dash::types::HA_ROLE_STANDBY:
             sai_ha_role = SAI_DASH_HA_ROLE_STANDBY;
             break;
-        case dash::types::HA_SCOPE_ROLE_STANDALONE:
+        case dash::types::HA_ROLE_STANDALONE:
             sai_ha_role = SAI_DASH_HA_ROLE_STANDALONE;
             break;
-        case dash::types::HA_SCOPE_ROLE_SWITCHING_TO_ACTIVE:
+        case dash::types::HA_ROLE_SWITCHING_TO_ACTIVE:
             sai_ha_role = SAI_DASH_HA_ROLE_SWITCHING_TO_ACTIVE;
             break;
         default:
@@ -185,16 +185,16 @@ dash::types::HaRole to_pb(const sai_dash_ha_role_t ha_role)
     switch (ha_role)
     {
         case SAI_DASH_HA_ROLE_DEAD:
-            return dash::types::HA_SCOPE_ROLE_DEAD;
+            return dash::types::HA_ROLE_DEAD;
         case SAI_DASH_HA_ROLE_ACTIVE:
-            return dash::types::HA_SCOPE_ROLE_ACTIVE;
+            return dash::types::HA_ROLE_ACTIVE;
         case SAI_DASH_HA_ROLE_STANDBY:
-            return dash::types::HA_SCOPE_ROLE_STANDBY;
+            return dash::types::HA_ROLE_STANDBY;
         case SAI_DASH_HA_ROLE_STANDALONE:
-            return dash::types::HA_SCOPE_ROLE_STANDALONE;
+            return dash::types::HA_ROLE_STANDALONE;
         case SAI_DASH_HA_ROLE_SWITCHING_TO_ACTIVE:
-            return dash::types::HA_SCOPE_ROLE_SWITCHING_TO_ACTIVE;
+            return dash::types::HA_ROLE_SWITCHING_TO_ACTIVE;
         default:
-            return dash::types::HA_SCOPE_ROLE_DEAD;
+            return dash::types::HA_ROLE_DEAD;
     }
 }

--- a/orchagent/dash/pbutils.h
+++ b/orchagent/dash/pbutils.h
@@ -83,3 +83,9 @@ std::string to_string(const dash::types::IpAddress &pb_address);
 sai_uint16_t to_sai(const dash::types::HaRole ha_role);
 
 dash::types::HaRole to_pb(const sai_dash_ha_role_t ha_role);
+
+bool to_pb(const std::string &ha_role, dash::types::HaRole &pb_ha_role);
+
+bool to_pb(const std::string &ha_owner, dash::types::HaOwner &pb_ha_owner);
+
+bool to_pb(const std::string &ha_scope, dash::types::HaScope &pb_ha_scope);

--- a/tests/mock_tests/dashhaorch_ut.cpp
+++ b/tests/mock_tests/dashhaorch_ut.cpp
@@ -74,7 +74,6 @@ namespace dashhaorch_ut
                 new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1, 1),
                 m_dashHaOrch, APP_DASH_HA_SET_TABLE_NAME));
 
-            // dash::ha_set::HaSet ha_set = HaSetPbObject();
             consumer->addToSync(
                 deque<KeyOpFieldsValuesTuple>(
                     {
@@ -82,7 +81,6 @@ namespace dashhaorch_ut
                             "HA_SET_1",
                             SET_COMMAND,
                             {
-                                // { "pb", ha_set.SerializeAsString() }
                                 {"version", "1"},
                                 {"vip_v4", "10.0.0.1"},
                                 {"vip_v6", "fc00::1"},
@@ -111,9 +109,6 @@ namespace dashhaorch_ut
                 new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1, 1),
                 m_dashHaOrch, APP_DASH_HA_SET_TABLE_NAME));
 
-            // dash::ha_set::HaSet ha_set = HaSetPbObject();
-            // ha_set.set_scope(dash::types::HA_SCOPE_ENI);
-
             consumer->addToSync(
                 deque<KeyOpFieldsValuesTuple>(
                     {
@@ -121,7 +116,6 @@ namespace dashhaorch_ut
                             "HA_SET_1",
                             SET_COMMAND,
                             {
-                                // { "pb", ha_set.SerializeAsString() }
                                 {"version", "1"},
                                 {"vip_v4", "10.0.0.1"},
                                 {"vip_v6", "fc00::1"},
@@ -170,10 +164,6 @@ namespace dashhaorch_ut
                 new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1, 1),
                 m_dashHaOrch, APP_DASH_HA_SCOPE_TABLE_NAME));
 
-            // dash::ha_scope::HaScope ha_scope;
-            // ha_scope.set_version("1");
-            // ha_scope.set_ha_role(dash::types::HA_ROLE_DEAD);
-
             consumer->addToSync(
                 deque<KeyOpFieldsValuesTuple>(
                     {
@@ -181,7 +171,6 @@ namespace dashhaorch_ut
                             "HA_SET_1",
                             SET_COMMAND,
                             {
-                                // { "pb", ha_scope.SerializeAsString() }
                                 {"version", "1"},
                                 {"ha_role", "dead"}
                             }
@@ -217,10 +206,6 @@ namespace dashhaorch_ut
             auto consumer = unique_ptr<Consumer>(new Consumer(
                 new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1, 1),
                 m_dashHaOrch, APP_DASH_HA_SCOPE_TABLE_NAME));
-            
-            // dash::ha_scope::HaScope ha_scope;
-            // ha_scope.set_version("1");
-            // ha_scope.set_ha_role(role);
 
             consumer->addToSync(
                 deque<KeyOpFieldsValuesTuple>(
@@ -229,7 +214,6 @@ namespace dashhaorch_ut
                             "HA_SET_1",
                             SET_COMMAND,
                             {
-                                // { "pb", ha_scope.SerializeAsString() }
                                 {"version", "1"},
                                 {"ha_role", role}
                             }
@@ -246,11 +230,6 @@ namespace dashhaorch_ut
                 new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1, 1),
                 m_dashHaOrch, APP_DASH_HA_SCOPE_TABLE_NAME));
 
-            // dash::ha_scope::HaScope ha_scope;
-            // ha_scope.set_version("1");
-            // ha_scope.set_ha_role(dash::types::HA_ROLE_ACTIVE);
-            // ha_scope.set_activate_role_requested(true);
-
             consumer->addToSync(
                 deque<KeyOpFieldsValuesTuple>(
                     {
@@ -258,7 +237,6 @@ namespace dashhaorch_ut
                             "HA_SET_1",
                             SET_COMMAND,
                             {
-                                // { "pb", ha_scope.SerializeAsString() }
                                 {"version", "1"},
                                 {"ha_role", "active"},
                                 {"activate_role_requested", "true"}
@@ -276,11 +254,6 @@ namespace dashhaorch_ut
                 new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1, 1),
                 m_dashHaOrch, APP_DASH_HA_SCOPE_TABLE_NAME));
 
-            // dash::ha_scope::HaScope ha_scope;
-            // ha_scope.set_version("1");
-            // ha_scope.set_ha_role(dash::types::HA_ROLE_ACTIVE);
-            // ha_scope.set_flow_reconcile_requested(true);
-
             consumer->addToSync(
                 deque<KeyOpFieldsValuesTuple>(
                     {
@@ -288,7 +261,6 @@ namespace dashhaorch_ut
                             "HA_SET_1",
                             SET_COMMAND,
                             {
-                                // { "pb", ha_scope.SerializeAsString() }
                                 {"version", "1"},
                                 {"ha_role", "active"},
                                 {"flow_reconcile_requested", "true"}

--- a/tests/mock_tests/dashhaorch_ut.cpp
+++ b/tests/mock_tests/dashhaorch_ut.cpp
@@ -51,7 +51,7 @@ namespace dashhaorch_ut
             swss::IpAddress peer_ip("::2");
 
             ha_set.set_version("1");
-            ha_set.set_scope(dash::types::SCOPE_DPU);
+            ha_set.set_scope(dash::types::HA_SCOPE_DPU);
             ha_set.mutable_vip_v4()->set_ipv4(vip_v4.getV4Addr());
             ha_set.mutable_vip_v6()->set_ipv6(reinterpret_cast<const char*>(vip_v6.getV6Addr()));
             ha_set.mutable_local_npu_ip()->set_ipv4(npu_ip.getV4Addr());
@@ -74,7 +74,7 @@ namespace dashhaorch_ut
                 new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1, 1),
                 m_dashHaOrch, APP_DASH_HA_SET_TABLE_NAME));
 
-            dash::ha_set::HaSet ha_set = HaSetPbObject();
+            // dash::ha_set::HaSet ha_set = HaSetPbObject();
             consumer->addToSync(
                 deque<KeyOpFieldsValuesTuple>(
                     {
@@ -82,7 +82,21 @@ namespace dashhaorch_ut
                             "HA_SET_1",
                             SET_COMMAND,
                             {
-                                { "pb", ha_set.SerializeAsString() }
+                                // { "pb", ha_set.SerializeAsString() }
+                                {"version", "1"},
+                                {"vip_v4", "10.0.0.1"},
+                                {"vip_v6", "fc00::1"},
+                                {"owner", "dpu"},
+                                {"scope", "dpu"},
+                                {"local_npu_ip", "192.168.1.10"},
+                                {"local_ip", "192.168.2.1"},
+                                {"peer_ip", "192.168.2.2"},
+                                {"cp_data_channel_port", "4789"},
+                                {"dp_channel_dst_port", "4790"},
+                                {"dp_channel_src_port_min", "5000"},
+                                {"dp_channel_src_port_max", "6000"},
+                                {"dp_channel_probe_interval_ms", "1000"},
+                                {"dp_channel_probe_fail_threshold", "3"}
                             }
                         }
                     }
@@ -97,8 +111,8 @@ namespace dashhaorch_ut
                 new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1, 1),
                 m_dashHaOrch, APP_DASH_HA_SET_TABLE_NAME));
 
-            dash::ha_set::HaSet ha_set = HaSetPbObject();
-            ha_set.set_scope(dash::types::SCOPE_ENI);
+            // dash::ha_set::HaSet ha_set = HaSetPbObject();
+            // ha_set.set_scope(dash::types::HA_SCOPE_ENI);
 
             consumer->addToSync(
                 deque<KeyOpFieldsValuesTuple>(
@@ -107,7 +121,21 @@ namespace dashhaorch_ut
                             "HA_SET_1",
                             SET_COMMAND,
                             {
-                                { "pb", ha_set.SerializeAsString() }
+                                // { "pb", ha_set.SerializeAsString() }
+                                {"version", "1"},
+                                {"vip_v4", "10.0.0.1"},
+                                {"vip_v6", "fc00::1"},
+                                {"owner", "switch"},
+                                {"scope", "eni"},
+                                {"local_npu_ip", "192.168.1.10"},
+                                {"local_ip", "192.168.2.1"},
+                                {"peer_ip", "192.168.2.2"},
+                                {"cp_data_channel_port", "4789"},
+                                {"dp_channel_dst_port", "4790"},
+                                {"dp_channel_src_port_min", "5000"},
+                                {"dp_channel_src_port_max", "6000"},
+                                {"dp_channel_probe_interval_ms", "1000"},
+                                {"dp_channel_probe_fail_threshold", "3"}
                             }
                         }
                     }
@@ -142,9 +170,9 @@ namespace dashhaorch_ut
                 new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1, 1),
                 m_dashHaOrch, APP_DASH_HA_SCOPE_TABLE_NAME));
 
-            dash::ha_scope::HaScope ha_scope;
-            ha_scope.set_version("1");
-            ha_scope.set_ha_role(dash::types::HA_SCOPE_ROLE_DEAD);
+            // dash::ha_scope::HaScope ha_scope;
+            // ha_scope.set_version("1");
+            // ha_scope.set_ha_role(dash::types::HA_ROLE_DEAD);
 
             consumer->addToSync(
                 deque<KeyOpFieldsValuesTuple>(
@@ -153,7 +181,9 @@ namespace dashhaorch_ut
                             "HA_SET_1",
                             SET_COMMAND,
                             {
-                                { "pb", ha_scope.SerializeAsString() }
+                                // { "pb", ha_scope.SerializeAsString() }
+                                {"version", "1"},
+                                {"ha_role", "dead"}
                             }
                         }
                     }
@@ -182,15 +212,15 @@ namespace dashhaorch_ut
             static_cast<Orch *>(m_dashHaOrch)->doTask(*consumer.get());
         }
 
-        void SetHaScopeHaRole(dash::types::HaRole role=dash::types::HA_SCOPE_ROLE_ACTIVE)
+        void SetHaScopeHaRole(std::string role="active")
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
                 new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1, 1),
                 m_dashHaOrch, APP_DASH_HA_SCOPE_TABLE_NAME));
             
-            dash::ha_scope::HaScope ha_scope;
-            ha_scope.set_version("1");
-            ha_scope.set_ha_role(role);
+            // dash::ha_scope::HaScope ha_scope;
+            // ha_scope.set_version("1");
+            // ha_scope.set_ha_role(role);
 
             consumer->addToSync(
                 deque<KeyOpFieldsValuesTuple>(
@@ -199,7 +229,9 @@ namespace dashhaorch_ut
                             "HA_SET_1",
                             SET_COMMAND,
                             {
-                                { "pb", ha_scope.SerializeAsString() }
+                                // { "pb", ha_scope.SerializeAsString() }
+                                {"version", "1"},
+                                {"ha_role", role}
                             }
                         }
                     }
@@ -214,10 +246,10 @@ namespace dashhaorch_ut
                 new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1, 1),
                 m_dashHaOrch, APP_DASH_HA_SCOPE_TABLE_NAME));
 
-            dash::ha_scope::HaScope ha_scope;
-            ha_scope.set_version("1");
-            ha_scope.set_ha_role(dash::types::HA_SCOPE_ROLE_ACTIVE);
-            ha_scope.set_activate_role_requested(true);
+            // dash::ha_scope::HaScope ha_scope;
+            // ha_scope.set_version("1");
+            // ha_scope.set_ha_role(dash::types::HA_ROLE_ACTIVE);
+            // ha_scope.set_activate_role_requested(true);
 
             consumer->addToSync(
                 deque<KeyOpFieldsValuesTuple>(
@@ -226,7 +258,10 @@ namespace dashhaorch_ut
                             "HA_SET_1",
                             SET_COMMAND,
                             {
-                                { "pb", ha_scope.SerializeAsString() }
+                                // { "pb", ha_scope.SerializeAsString() }
+                                {"version", "1"},
+                                {"ha_role", "active"},
+                                {"activate_role_requested", "true"}
                             }
                         }
                     }
@@ -241,10 +276,10 @@ namespace dashhaorch_ut
                 new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1, 1),
                 m_dashHaOrch, APP_DASH_HA_SCOPE_TABLE_NAME));
 
-            dash::ha_scope::HaScope ha_scope;
-            ha_scope.set_version("1");
-            ha_scope.set_ha_role(dash::types::HA_SCOPE_ROLE_ACTIVE);
-            ha_scope.set_flow_reconcile_requested(true);
+            // dash::ha_scope::HaScope ha_scope;
+            // ha_scope.set_version("1");
+            // ha_scope.set_ha_role(dash::types::HA_ROLE_ACTIVE);
+            // ha_scope.set_flow_reconcile_requested(true);
 
             consumer->addToSync(
                 deque<KeyOpFieldsValuesTuple>(
@@ -253,7 +288,10 @@ namespace dashhaorch_ut
                             "HA_SET_1",
                             SET_COMMAND,
                             {
-                                { "pb", ha_scope.SerializeAsString() }
+                                // { "pb", ha_scope.SerializeAsString() }
+                                {"version", "1"},
+                                {"ha_role", "active"},
+                                {"flow_reconcile_requested", "true"}
                             }
                         }
                     }
@@ -336,7 +374,7 @@ namespace dashhaorch_ut
 
             dash::ha_set::HaSet ha_set = dash::ha_set::HaSet();
             ha_set.set_version("1");
-            ha_set.set_scope(dash::types::SCOPE_UNSPECIFIED);
+            ha_set.set_scope(dash::types::HA_SCOPE_UNSPECIFIED);
 
             consumer->addToSync(
                 deque<KeyOpFieldsValuesTuple>(
@@ -536,27 +574,27 @@ namespace dashhaorch_ut
                     SAI_DASH_HA_ROLE_ACTIVE, SAI_DASH_HA_STATE_ACTIVE);
         EXPECT_EQ(to_sai(m_dashHaOrch->getHaScopeEntries().find("HA_SET_1")->second.metadata.ha_role()), SAI_DASH_HA_ROLE_ACTIVE);
 
-        SetHaScopeHaRole(dash::types::HA_SCOPE_ROLE_UNSPECIFIED);
+        SetHaScopeHaRole("");
         HaScopeEvent(SAI_HA_SCOPE_EVENT_STATE_CHANGED,
                     SAI_DASH_HA_ROLE_DEAD, SAI_DASH_HA_STATE_DEAD);
         EXPECT_EQ(to_sai(m_dashHaOrch->getHaScopeEntries().find("HA_SET_1")->second.metadata.ha_role()), SAI_DASH_HA_ROLE_DEAD);
 
-        SetHaScopeHaRole(dash::types::HA_SCOPE_ROLE_DEAD);
+        SetHaScopeHaRole("dead");
         HaScopeEvent(SAI_HA_SCOPE_EVENT_STATE_CHANGED,
                     SAI_DASH_HA_ROLE_DEAD, SAI_DASH_HA_STATE_DEAD);
         EXPECT_EQ(to_sai(m_dashHaOrch->getHaScopeEntries().find("HA_SET_1")->second.metadata.ha_role()), SAI_DASH_HA_ROLE_DEAD);
 
-        SetHaScopeHaRole(dash::types::HA_SCOPE_ROLE_STANDBY);
+        SetHaScopeHaRole("standby");
         HaScopeEvent(SAI_HA_SCOPE_EVENT_STATE_CHANGED,
                     SAI_DASH_HA_ROLE_STANDBY, SAI_DASH_HA_STATE_STANDBY);
         EXPECT_EQ(to_sai(m_dashHaOrch->getHaScopeEntries().find("HA_SET_1")->second.metadata.ha_role()), SAI_DASH_HA_ROLE_STANDBY);
 
-        SetHaScopeHaRole(dash::types::HA_SCOPE_ROLE_STANDALONE);
+        SetHaScopeHaRole("standalone");
         HaScopeEvent(SAI_HA_SCOPE_EVENT_STATE_CHANGED,
                     SAI_DASH_HA_ROLE_STANDALONE, SAI_DASH_HA_STATE_STANDALONE);
         EXPECT_EQ(to_sai(m_dashHaOrch->getHaScopeEntries().find("HA_SET_1")->second.metadata.ha_role()), SAI_DASH_HA_ROLE_STANDALONE);
 
-        SetHaScopeHaRole(dash::types::HA_SCOPE_ROLE_SWITCHING_TO_ACTIVE);
+        SetHaScopeHaRole("switching_to_active");
         HaScopeEvent(SAI_HA_SCOPE_EVENT_STATE_CHANGED,
                     SAI_DASH_HA_ROLE_SWITCHING_TO_ACTIVE, SAI_DASH_HA_STATE_PENDING_ACTIVE_ACTIVATION);
         EXPECT_EQ(to_sai(m_dashHaOrch->getHaScopeEntries().find("HA_SET_1")->second.metadata.ha_role()), SAI_DASH_HA_ROLE_SWITCHING_TO_ACTIVE);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
1. Adapt to recent sonic-dash-api changes
2. instead of expecting hamgrd to write serialized pb object to DPU_APPL_DB, now haorch will expect plain kfv. 

sign-off: Jing Zhang zhangjing@microsoft.com 

**Why I did it**
Otherwise integrated tests won't work. 

**How I verified it**
1. UTs.
2. Load binary to DPU (pending). 

**Details if related**
