### PR TITLE
Enhance return code handling for queryEnumCapabilitiesSai()

### DIFF
--- a/orchagent/switch/trimming/capabilities.cpp
+++ b/orchagent/switch/trimming/capabilities.cpp
@@ -458,7 +458,15 @@ void SwitchTrimmingCapabilities::queryTrimQueueModeEnumCapabilities()
     auto status = queryEnumCapabilitiesSai(
         mList, SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_RESOLUTION_MODE
     );
-    if (status != SAI_STATUS_SUCCESS)
+    if (status == SAI_STATUS_NOT_SUPPORTED)
+    {
+        SWSS_LOG_NOTICE(
+            "Attribute not supported(%s)enum value capabilities",
+            toStr(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_RESOLUTION_MODE).c_str()
+        );
+        return;
+    }
+    else if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR(
             "Failed to get attribute(%s) enum value capabilities",
@@ -490,7 +498,15 @@ void SwitchTrimmingCapabilities::queryTrimQueueModeAttrCapabilities()
     auto status = queryAttrCapabilitiesSai(
         attrCap, SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_RESOLUTION_MODE
     );
-    if (status != SAI_STATUS_SUCCESS)
+    if (status == SAI_STATUS_NOT_SUPPORTED)
+    {
+        SWSS_LOG_NOTICE(
+            "Attribute not supported(%s)enum value capabilities",
+            toStr(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_RESOLUTION_MODE).c_str()
+        );
+        return;
+    }
+    else if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR(
             "Failed to get attribute(%s) capabilities",


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
**Backport to msft-202412, msft-202503, 202505**

**What I did**
Change the return code handling such that it does not produce an ERR level syslog in the case that SAI_STATUS_NOT_SUPPORTED is returned. Instead handle it gracefully.

**Why I did it**
Sonic seems to expect queryEnumCapabilitiesSai() to only be sucessful when it returns SAI_STATUS_SUCCESS. However, SAI_STATUS_NOT_SUPPORTED is also a valid return code if the attribute queried is not supported on a platform.

**How I verified it**
Tested with 7260CX3 on 202505, new log msg prints in place of previous ERR log

**Details if related**