### PR TITLE
[Zmq] Make sure empty namespace is treated as global namespace

### DIFF
--- a/lib/orch_zmq_config.cpp
+++ b/lib/orch_zmq_config.cpp
@@ -35,12 +35,20 @@ std::set<std::string> swss::load_zmq_tables()
 int swss::get_zmq_port()
 {
     auto zmq_port = ORCH_ZMQ_PORT;
-    if (const char* nsid = std::getenv("NAMESPACE_ID"))
+    const char* nsid = std::getenv("NAMESPACE_ID");
+    std::string nsid_str = nsid ? std::string(nsid) : "";
+    if (!nsid_str.empty())
     {
-        // namespace start from 0, using original ZMQ port for global namespace
-        zmq_port += atoi(nsid) + 1;
+        try
+        {
+            // namespace start from 0, using original ZMQ port for global namespace
+            zmq_port += std::stoi(nsid) + 1;
+        }
+        catch (...)
+        {
+            SWSS_LOG_ERROR("Failed to convert %s to int, fallback to default port", nsid_str.c_str());
+        }
     }
-
     return zmq_port;
 }
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Make sure empty namespace is treated as global namespace

**Why I did it**

NAMESPACE_ID env variable is set as "" and this is leading to zmq_port being 8101. This breaks all the NPU-DPU channel needed for DASH configuration

```
root@sonic:/ netstat -tulpn | grep orch
tcp        0      0 169.254.200.1:8101      0.0.0.0:*               LISTEN      1302652/orchagent
```

```
root@sonic:/ docker inspect swss
"Env": [
                "RUNTIME_OWNER=local",
                "DEV=",
                "PLATFORM=arm64-nvda_bf-bf3comdpu",
                "ASIC_VENDOR=nvidia-bluefield",
                "NAMESPACE_ID=",
                "NAMESPACE_PREFIX=asic",
                "NAMESPACE_COUNT=",
                "CONTAINER_NAME=swss",
                 .....
            ]
```


**How I verified it**

Built and verified if orchagent starts on 8100 on DPU 

**Details if related**
