### PR TITLE
[Mux] Clear bulkers when rolling back mux switchover

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -553,6 +553,10 @@ void MuxCable::rollbackStateChange()
     st_chg_in_progress_ = true;
     state_ = prev_state_;
     bool success = false;
+
+    nbr_handler_->clearBulkers();
+    gNeighOrch->clearBulkers();
+
     switch (prev_state_)
     {
         case MuxState::MUX_STATE_ACTIVE:

--- a/orchagent/muxorch.h
+++ b/orchagent/muxorch.h
@@ -94,6 +94,7 @@ public:
     sai_object_id_t getNextHopId(const NextHopKey);
     MuxNeighbor getNeighbors() const { return neighbors_; };
     string getAlias() const { return alias_; };
+    void clearBulkers() { gRouteBulker.clear(); };
 
 private:
     bool removeRoutes(std::list<MuxRouteBulkContext>& bulk_ctx_list);

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -2404,3 +2404,9 @@ bool NeighOrch::ifChangeInformRemoteNextHop(const string &alias, bool if_up)
     }
     return rc;
 }
+
+void NeighOrch::clearBulkers()
+{
+    gNeighBulker.clear();
+    gNextHopBulker.clear();
+}

--- a/orchagent/neighorch.h
+++ b/orchagent/neighorch.h
@@ -110,6 +110,8 @@ public:
     void updateSrv6Nexthop(const NextHopKey &, const sai_object_id_t &);
     bool ifChangeInformRemoteNextHop(const string &, bool);
 
+    void clearBulkers();
+
 private:
     PortsOrch *m_portsOrch;
     IntfsOrch *m_intfsOrch;

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -4,6 +4,9 @@ P4_ORCH_DIR = $(top_srcdir)/orchagent/p4orch
 DASH_ORCH_DIR = $(top_srcdir)/orchagent/dash
 DASH_PROTO_DIR = $(top_srcdir)/orchagent/dash/proto
 
+CFLAGS = -g -O0
+CXXFLAGS = -g -O0
+
 CFLAGS_SAI = -I /usr/include/sai
 
 TESTS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_response_publisher

--- a/tests/mock_tests/mux_rollback_ut.cpp
+++ b/tests/mock_tests/mux_rollback_ut.cpp
@@ -277,7 +277,6 @@ namespace mux_rollback_test
 
     TEST_F(MuxRollbackTest, StandbyToActiveExceptionRollbackToStandby)
     {
-        GTEST_SKIP() << "Skip unrelated failing test";
         EXPECT_CALL(*mock_sai_next_hop_api, create_next_hops)
             .WillOnce(Throw(exception()));
         SetMuxStateFromAppDb(ACTIVE_STATE);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When a switchover failure is detected in MuxOrch, clear relevant bulkers to provide a clean slate for the rollback process.

**Why I did it**
In certain failure scenarios, if an exception is thrown inside the bulker, it's possible that the bulker is not cleared and still contains data in `creating_entries` or `removing_entries`. When the rollback process begins, these entries will be programmed to the SAI a second time, which is a) incorrect b) could potentially trigger the same exception second time.

**How I verified it**
Run the `MuxRollbackTest.StandbyToActiveExceptionRollbackToStandby` test

**Details if related**
