### PR TITLE
remove creating IPinIP tunnel for srv6 uN

### DIFF
--- a/orchagent/srv6orch.cpp
+++ b/orchagent/srv6orch.cpp
@@ -1416,8 +1416,7 @@ bool Srv6Orch::mySidNextHopRequired(const sai_my_sid_entry_endpoint_behavior_t e
 
 bool Srv6Orch::mySidTunnelRequired(const string& my_sid_addr, const sai_my_sid_entry_t& sai_entry, sai_my_sid_entry_endpoint_behavior_t end_behavior, sai_tunnel_dscp_mode_t& dscp_mode)
 {
-    if (end_behavior != SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UN &&
-        end_behavior != SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UDT46)
+    if (end_behavior != SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UDT46)
     {
         return false;
     }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Remove the SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UN condition in mySidTunnelRequired condition checking, do not create  IPinIP tunnel for srv6 uN

**Why I did it**
For the node support srv6 uN only (not support uDT46), it might not implement SAI_TUNNEL_TYPE_IPINIP. creating IPinIP tunnel cause SAI API failed and failed to create SAI_OBJECT_TYPE_MY_SID_ENTRY.

Here is how the function fails in a uN only node:
```
2025 Jul 30 22:58:42.290917 sonic NOTICE swss#orchagent: :- doTask: table name : SRV6_MY_SID_TABLE
2025 Jul 30 22:58:42.291081 sonic NOTICE swss#orchagent: :- createUpdateMysidEntry: MySid: sid fcbb:bbbb:1::, action un, vrf , block 32, node 16, func 0, arg 0 dt_vrf , adj 
2025 Jul 30 22:58:42.291186 sonic NOTICE swss#orchagent: :- getMySidEntryDscpMode: Found decap DSCP mode for MySID addr fcbb:bbbb:1::/48 locator loc1 in the cache
2025 Jul 30 22:58:42.328456 sonic NOTICE swss#orchagent: :- initIpInIpTunnel: Created MySID IPinIP tunnel
2025 Jul 30 22:58:42.328510 sonic NOTICE swss#orchagent: :- createMySidIpInIpTunnel: Increased refcount for MySID IPinIP tunnel to 1
2025 Jul 30 22:58:42.387983 sonic ERR syncd#syncd: 30-07-2025 22:58:42.387 -E-HLD-0- la_ip_over_ip_tunnel_port_impl_fpp::set_qos_inheritance_mode() supports only PIPE/UNIFORM mode
2025 Jul 30 22:58:42.388135 sonic ERR syncd#syncd: 30-07-2025 22:58:42.387 -E-API-0- shared/src/hld/npu/la_ip_over_ip_tunnel_port_impl_fpp.cpp::2071 set_qos_inheritance_mode API returned: status = Leaba_Err: API is not implemented: virtual la_status silicon_one::gr2::la_ip_over_ip_tunnel_port_impl_fpp::set_qos_inheritance_mode(silicon_one::la_mpls_qos_inheritance_mode_e):shared/src/hld/npu/la_ip_over_ip_tunnel_port_impl_fpp.cpp:2071, 
2025 Jul 30 22:58:42.395933 sonic ERR syncd#syncd: :- sendApiResponse: api SAI_COMMON_API_CREATE failed in syncd mode: SAI_STATUS_NOT_IMPLEMENTED
2025 Jul 30 22:58:42.396117 sonic ERR syncd#syncd: :- processQuadEvent: attr: SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_VR_ID: oid:0x3000000000085
2025 Jul 30 22:58:42.396166 sonic ERR syncd#syncd: :- processQuadEvent: attr: SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE: SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_P2MP
2025 Jul 30 22:58:42.396198 sonic ERR syncd#syncd: :- processQuadEvent: attr: SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TUNNEL_TYPE: SAI_TUNNEL_TYPE_IPINIP
2025 Jul 30 22:58:42.396227 sonic ERR syncd#syncd: :- processQuadEvent: attr: SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_ACTION_TUNNEL_ID: oid:0x2a0000000010da
2025 Jul 30 22:58:42.396265 sonic ERR syncd#syncd: :- processQuadEvent: attr: SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_DST_IP: fcbb:bbbb:1::
2025 Jul 30 22:58:42.396583 sonic ERR swss#orchagent: :- create: create status: SAI_STATUS_NOT_IMPLEMENTED
2025 Jul 30 22:58:42.396612 sonic ERR swss#orchagent: :- createMySidIpInIpTunnelTermEntry: Failed to create tunnel termination entry for MySID - -15
2025 Jul 30 22:58:42.396639 sonic NOTICE swss#orchagent: :- removeMySidIpInIpTunnel: Decreased refcount for MySID IPinIP tunnel to 0
2025 Jul 30 22:58:42.433930 sonic NOTICE swss#orchagent: :- deinitIpInIpTunnel: Removed MySID IPinIP tunnel
2025 Jul 30 22:58:42.433930 sonic ERR swss#orchagent: :- doTaskMySidTable: Failed to create/update my_sid entry for sid 32:16:0:0:fcbb:bbbb:1::
```

**How I verified it**
(will modify current mgmt test)

**Details if related**
