### PR TITLE
Enhance return code handling for queryEnumCapabilitiesSai

### DIFF
--- a/orchagent/switch/trimming/capabilities.cpp
+++ b/orchagent/switch/trimming/capabilities.cpp
@@ -324,7 +324,15 @@ void SwitchTrimmingCapabilities::queryTrimDscpModeEnumCapabilities()
     auto status = queryEnumCapabilitiesSai(
         mList, SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_PACKET_TRIM_DSCP_RESOLUTION_MODE
     );
-    if (status != SAI_STATUS_SUCCESS)
+    if (status == SAI_STATUS_NOT_SUPPORTED)
+    {
+        SWSS_LOG_NOTICE(
+            "Attribute not supported(%s) to query enum value capabilities",
+            toStr(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_PACKET_TRIM_DSCP_RESOLUTION_MODE).c_str()
+        );
+        return;
+    }
+    else if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR(
             "Failed to get attribute(%s) enum value capabilities",
@@ -369,7 +377,15 @@ void SwitchTrimmingCapabilities::queryTrimDscpModeAttrCapabilities()
     auto status = queryAttrCapabilitiesSai(
         attrCap, SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_PACKET_TRIM_DSCP_RESOLUTION_MODE
     );
-    if (status != SAI_STATUS_SUCCESS)
+    if (status == SAI_STATUS_NOT_SUPPORTED)
+    {
+        SWSS_LOG_NOTICE(
+            "Attribute not supported(%s) to query attr vapabilities",
+            toStr(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_PACKET_TRIM_DSCP_RESOLUTION_MODE).c_str()
+        );
+        return;
+    }
+    else if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR(
             "Failed to get attribute(%s) capabilities",


### PR DESCRIPTION
Backport to msft-202412, msft-202503, 202505
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Change the return code handling such that it does not produce an ERR level syslog in the case that SAI_STATUS_NOT_SUPPORTED is returned. Instead handle it gracefully.

**Why I did it**
Sonic seems to expect queryEnumCapabilitiesSai() to only be sucessful when it returns SAI_STATUS_SUCCESS. However, SAI_STATUS_NOT_SUPPORTED is also a valid return code if the attribute queried is not supported on a platform.

**How I verified it**
Verified that the new LOG messages are printed at NOTICE level rather than ERROR level.

SONiC Software Version: SONiC.branch.202505-ars.ca6b34cb-buildimage.origin.202505-review.478334.1-2025.07.30.06.38
admin@ldp412:~$ show log "SAI_SWITCH_ATTR_PACKET_TRIM_"
2025 Jul 31 01:24:26.140966 ldp412 NOTICE swss#orchagent: :- queryTrimDscpModeEnumCapabilities: Attribute not supported(SAI_SWITCH_ATTR_PACKET_TRIM_DSCP_RESOLUTION_MODE) to query enum capabilities
2025 Jul 31 01:24:26.143248 ldp412 NOTICE swss#orchagent: :- queryTrimQueueModeEnumCapabilities: Attribute not supported(SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_RESOLUTION_MODE)enum value capabilities

**Details if related**
This is a follow up for https://github.com/sonic-net/sonic-swss/pull/3778