### PR TITLE
Pkt trim errors

### DIFF
--- a/orchagent/switch/trimming/capabilities.cpp
+++ b/orchagent/switch/trimming/capabilities.cpp
@@ -469,7 +469,7 @@ void SwitchTrimmingCapabilities::queryTrimQueueModeEnumCapabilities()
     else if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR(
-            "Failed to get attribute(%s) to query enum value capabilities",
+            "Failed to get attribute(%s) enum value capabilities",
             toStr(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_RESOLUTION_MODE).c_str()
         );
         return;

--- a/orchagent/switch/trimming/capabilities.cpp
+++ b/orchagent/switch/trimming/capabilities.cpp
@@ -461,7 +461,7 @@ void SwitchTrimmingCapabilities::queryTrimQueueModeEnumCapabilities()
     if (status == SAI_STATUS_NOT_SUPPORTED)
     {
         SWSS_LOG_NOTICE(
-            "Attribute not supported(%s)enum value capabilities",
+            "Attribute not supported(%s) to query enum value capabilities",
             toStr(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_RESOLUTION_MODE).c_str()
         );
         return;
@@ -469,7 +469,7 @@ void SwitchTrimmingCapabilities::queryTrimQueueModeEnumCapabilities()
     else if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR(
-            "Failed to get attribute(%s) enum value capabilities",
+            "Failed to get attribute(%s) to query enum value capabilities",
             toStr(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_RESOLUTION_MODE).c_str()
         );
         return;
@@ -501,7 +501,7 @@ void SwitchTrimmingCapabilities::queryTrimQueueModeAttrCapabilities()
     if (status == SAI_STATUS_NOT_SUPPORTED)
     {
         SWSS_LOG_NOTICE(
-            "Attribute not supported(%s)enum value capabilities",
+            "Attribute not supported(%s) to query attr capabilities",
             toStr(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_RESOLUTION_MODE).c_str()
         );
         return;

--- a/orchagent/switch/trimming/capabilities.cpp
+++ b/orchagent/switch/trimming/capabilities.cpp
@@ -458,7 +458,15 @@ void SwitchTrimmingCapabilities::queryTrimQueueModeEnumCapabilities()
     auto status = queryEnumCapabilitiesSai(
         mList, SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_RESOLUTION_MODE
     );
-    if (status != SAI_STATUS_SUCCESS)
+    if (status == SAI_STATUS_NOT_SUPPORTED)
+    {
+        SWSS_LOG_NOTICE(
+            "Attribute not supported(%s)enum value capabilities",
+            toStr(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_RESOLUTION_MODE).c_str()
+        );
+        return;
+    }
+    else if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR(
             "Failed to get attribute(%s) enum value capabilities",
@@ -490,7 +498,15 @@ void SwitchTrimmingCapabilities::queryTrimQueueModeAttrCapabilities()
     auto status = queryAttrCapabilitiesSai(
         attrCap, SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_RESOLUTION_MODE
     );
-    if (status != SAI_STATUS_SUCCESS)
+    if (status == SAI_STATUS_NOT_SUPPORTED)
+    {
+        SWSS_LOG_NOTICE(
+            "Attribute not supported(%s)enum value capabilities",
+            toStr(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_PACKET_TRIM_QUEUE_RESOLUTION_MODE).c_str()
+        );
+        return;
+    }
+    else if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR(
             "Failed to get attribute(%s) capabilities",


### PR DESCRIPTION
**What I did**
Change the return code handling such that it does not produce an ERR level syslog in the case that SAI_STATUS_NOT_SUPPORTED is returned. Instead handle it gracefully.

**Why I did it**
Sonic seems to expect queryEnumCapabilitiesSai() to only be sucessful when it returns SAI_STATUS_SUCCESS. However, SAI_STATUS_NOT_SUPPORTED is also a valid return code if the attribute queried is not supported on a platform.

**How I verified it**
Tested with 7260CX3 on 202505, new log msg prints in place of previous ERR log

**Details if related**
