### PR TITLE
[P4Orch] Add notification handler for p4rt & To Add default ACL rule in PRE_INGRESS table.

### DIFF
--- a/orchagent/p4orch/acl_rule_manager.cpp
+++ b/orchagent/p4orch/acl_rule_manager.cpp
@@ -32,6 +32,8 @@ extern sai_hostif_api_t *sai_hostif_api;
 extern CrmOrch *gCrmOrch;
 extern PortsOrch *gPortsOrch;
 extern P4Orch *gP4Orch;
+extern sai_object_id_t gVirtualRouterId;
+extern IntfsOrch *gIntfsOrch;
 
 namespace p4orch
 {
@@ -2057,6 +2059,103 @@ ReturnCode AclRuleManager::processUpdateRuleRequest(const P4AclRuleAppDbEntry &a
     acl_rule.match_fvs = std::move(old_acl_rule.match_fvs);
     m_aclRuleTables[acl_rule.acl_table_name][acl_rule.acl_rule_key] = std::move(acl_rule);
     return ReturnCode();
+}
+
+ReturnCode AclRuleManager::addDefaultAclRuleInPreIngressTable(
+    const std::string &table_name) {
+  SWSS_LOG_ENTER();
+
+  const std::string cLoopbackAlias = "Loopback0";
+  const auto *acl_table =
+      gP4Orch->getAclTableManager()->getAclTable(table_name);
+  if (acl_table == nullptr) {
+    LOG_ERROR_AND_RETURN(ReturnCode(StatusCode::SWSS_RC_NOT_FOUND)
+                         << "ACL table " << QuotedVar(table_name)
+                         << " was not found when creating default ACL rule in "
+                            "PreIngress table.");
+  }
+  std::vector<sai_attribute_t> acl_entry_attrs;
+  sai_attribute_t acl_entry_attr;
+  acl_entry_attr.id = SAI_ACL_ENTRY_ATTR_TABLE_ID;
+  acl_entry_attr.value.oid = acl_table->table_oid;
+  acl_entry_attrs.push_back(acl_entry_attr);
+
+  // Priority: max uint32
+  acl_entry_attr.id = SAI_ACL_ENTRY_ATTR_PRIORITY;
+  acl_entry_attr.value.u32 = 0x7FFFFFFF;
+  acl_entry_attrs.push_back(acl_entry_attr);
+
+  acl_entry_attr.id = SAI_ACL_ENTRY_ATTR_ADMIN_STATE;
+  acl_entry_attr.value.booldata = true;
+  acl_entry_attrs.push_back(acl_entry_attr);
+
+  // Match: DIP = Loopback IP
+  const auto &intfs_table = gIntfsOrch->getSyncdIntfses();
+  const auto &lo_intfs_iter = intfs_table.find(cLoopbackAlias);
+  if (lo_intfs_iter == intfs_table.end()) {
+    LOG_ERROR_AND_RETURN(ReturnCode(StatusCode::SWSS_RC_NOT_FOUND)
+                         << "Loopback interface with alias "
+                         << QuotedVar(cLoopbackAlias)
+                         << " was not found in IntfsOrch.");
+  }
+  if (lo_intfs_iter->second.ip_addresses.empty() ||
+      lo_intfs_iter->second.ip_addresses.size() > 1) {
+    LOG_ERROR_AND_RETURN(
+        ReturnCode(StatusCode::SWSS_RC_INTERNAL)
+        << "Loopback interface with alias " << QuotedVar(cLoopbackAlias)
+        << " should have and only have 1 ip prefix defined in IntfsOrch, but "
+        << lo_intfs_iter->second.ip_addresses.size() << " was found.");
+  }
+  // With P4 SAI CL cl/461728094 submitted, the
+  // SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6 is not available in PRE_INGRESS ACL table
+  // definition SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6_WORD3 and
+  // SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6_WORD2 are used
+  acl_entry_attr.id = SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6_WORD3;
+  memcpy(&acl_entry_attr.value.aclfield.data.ip6[0],
+         &lo_intfs_iter->second.ip_addresses.begin()->getIp().getV6Addr()[0],
+         IPV6_SINGLE_WORD_BYTES_LENGTH);
+  memcpy(&acl_entry_attr.value.aclfield.mask.ip6[0],
+         &swss::IpAddress("ffff:ffff:ffff:ffff::").getV6Addr()[0],
+         IPV6_SINGLE_WORD_BYTES_LENGTH);
+  acl_entry_attr.value.aclfield.enable = true;
+  acl_entry_attrs.push_back(acl_entry_attr);
+
+  acl_entry_attr.id = SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6_WORD2;
+  memcpy(&acl_entry_attr.value.aclfield.data.ip6[IPV6_SINGLE_WORD_BYTES_LENGTH],
+         &lo_intfs_iter->second.ip_addresses.begin()
+             ->getIp()
+             .getV6Addr()[IPV6_SINGLE_WORD_BYTES_LENGTH],
+         IPV6_SINGLE_WORD_BYTES_LENGTH);
+  memcpy(&acl_entry_attr.value.aclfield.mask.ip6[IPV6_SINGLE_WORD_BYTES_LENGTH],
+         &swss::IpAddress("ffff:ffff:ffff:ffff::")
+             .getV6Addr()[IPV6_SINGLE_WORD_BYTES_LENGTH],
+         IPV6_SINGLE_WORD_BYTES_LENGTH);
+  acl_entry_attr.value.aclfield.enable = true;
+  acl_entry_attrs.push_back(acl_entry_attr);
+
+  // Action: SET_VRF = default VRF
+  acl_entry_attr.id = SAI_ACL_ENTRY_ATTR_ACTION_SET_VRF;
+  acl_entry_attr.value.aclaction.parameter.oid = gVirtualRouterId;
+  acl_entry_attr.value.aclaction.enable = true;
+  acl_entry_attrs.push_back(acl_entry_attr);
+
+  sai_object_id_t acl_entry_oid;
+  auto sai_status = sai_acl_api->create_acl_entry(
+      &acl_entry_oid, gSwitchId, (uint32_t)acl_entry_attrs.size(),
+      acl_entry_attrs.data());
+  if (sai_status != SAI_STATUS_SUCCESS) {
+    ReturnCode status = ReturnCode(sai_status)
+                        << "Failed to create ACL entry in table "
+                        << QuotedVar(table_name);
+    SWSS_LOG_ERROR("%s SAI_STATUS: %s", status.message().c_str(),
+                   sai_serialize_status(sai_status).c_str());
+    return status;
+  }
+
+  SWSS_LOG_NOTICE(
+      "Suceeded to create default ACL rule in PRE_INGRESS table %s : %s",
+      table_name.c_str(), sai_serialize_object_id(acl_entry_oid).c_str());
+  return ReturnCode();
 }
 
 std::string AclRuleManager::verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple)

--- a/orchagent/p4orch/acl_rule_manager.h
+++ b/orchagent/p4orch/acl_rule_manager.h
@@ -51,6 +51,10 @@ class AclRuleManager : public ObjectManagerInterface
     // counters are enabled in rules.
     void doAclCounterStatsTask();
 
+    // Add default ACL rule in PRE_INGRESS table
+    ReturnCode
+    addDefaultAclRuleInPreIngressTable(const std::string &table_name);
+
   private:
     // Deserializes an entry in a dynamically created ACL table.
     ReturnCodeOr<P4AclRuleAppDbEntry> deserializeAclRuleAppDbEntry(

--- a/orchagent/p4orch/acl_table_manager.cpp
+++ b/orchagent/p4orch/acl_table_manager.cpp
@@ -503,6 +503,12 @@ ReturnCode AclTableManager::processAddTableRequest(const P4AclTableDefinitionApp
         LOG_ERROR_AND_RETURN(
             status.prepend("Failed to create ACL table with key " + QuotedVar(app_db_entry.acl_table_name)));
     }
+    // Add the default rule in PRE_INGRESS table
+    if (acl_table_definition.stage == SAI_ACL_STAGE_PRE_INGRESS) {
+       gP4Orch->getAclRuleManager()
+          ->addDefaultAclRuleInPreIngressTable(
+              acl_table_definition.acl_table_name);
+    }
     return status;
 }
 

--- a/orchagent/p4orch/p4orch.cpp
+++ b/orchagent/p4orch/p4orch.cpp
@@ -23,6 +23,11 @@
 #include "return_code.h"
 #include "sai_serialize.h"
 #include "timer.h"
+#include "timestamp.h"
+
+extern bool gSwssRecord;
+extern ofstream gRecordOfs;
+extern bool gLogRotate;
 
 extern PortsOrch *gPortsOrch;
 #define P4_ACL_COUNTERS_STATS_POLL_TIMER_NAME "P4_ACL_COUNTERS_STATS_POLL_TIMER"
@@ -60,18 +65,21 @@ P4Orch::P4Orch(swss::DBConnector *db, std::vector<std::string> tableNames, VRFOr
     m_p4TableToManagerMap[APP_P4RT_L3_ADMIT_TABLE_NAME] = m_l3AdmitManager.get();
     m_p4TableToManagerMap[APP_P4RT_EXT_TABLES_MANAGER] = m_extTablesManager.get();
 
-    m_p4ManagerPrecedence.push_back(m_tablesDefnManager.get());
-    m_p4ManagerPrecedence.push_back(m_routerIntfManager.get());
-    m_p4ManagerPrecedence.push_back(m_neighborManager.get());
-    m_p4ManagerPrecedence.push_back(m_greTunnelManager.get());
-    m_p4ManagerPrecedence.push_back(m_nextHopManager.get());
-    m_p4ManagerPrecedence.push_back(m_wcmpManager.get());
-    m_p4ManagerPrecedence.push_back(m_routeManager.get());
-    m_p4ManagerPrecedence.push_back(m_mirrorSessionManager.get());
-    m_p4ManagerPrecedence.push_back(m_aclTableManager.get());
-    m_p4ManagerPrecedence.push_back(m_aclRuleManager.get());
-    m_p4ManagerPrecedence.push_back(m_l3AdmitManager.get());
-    m_p4ManagerPrecedence.push_back(m_extTablesManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_tablesDefnManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_routerIntfManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_neighborManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_greTunnelManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_nextHopManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_wcmpManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_routeManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_mirrorSessionManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_aclTableManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_aclRuleManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_l3AdmitManager.get());
+    m_p4ManagerAddPrecedence.push_back(m_extTablesManager.get());
+    for (auto* manager : m_p4ManagerAddPrecedence) {
+      m_p4ManagerDelPrecedence.insert(m_p4ManagerDelPrecedence.begin(), manager);
+    }
 
     tablesinfo = nullptr;
     // Add timer executor to update ACL counters stats in COUNTERS_DB
@@ -88,8 +96,16 @@ P4Orch::P4Orch(swss::DBConnector *db, std::vector<std::string> tableNames, VRFOr
     Orch::addExecutor(ext_executor);
     m_extCounterStatsTimer->start();
 
-    // Add port state change notification handling support
+    // Add p4rt notification handling support
     swss::DBConnector notificationsDb("ASIC_DB", 0);
+
+    m_p4rtNotificationConsumer =
+        new swss::NotificationConsumer(&notificationsDb, APP_P4RT_TABLE_NAME);
+    auto p4rtNotifier =
+        new Notifier(m_p4rtNotificationConsumer, this, "P4RT_NOTIFICATIONS");
+    Orch::addExecutor(p4rtNotifier);
+
+    // Add port state change notification handling support
     m_portStatusNotificationConsumer = new swss::NotificationConsumer(&notificationsDb, "NOTIFICATIONS");
     auto portStatusNotifier = new Notifier(m_portStatusNotificationConsumer, this, "PORT_STATUS_NOTIFICATIONS");
     Orch::addExecutor(portStatusNotifier);
@@ -114,47 +130,10 @@ void P4Orch::doTask(Consumer &consumer)
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
     {
-        const swss::KeyOpFieldsValuesTuple key_op_fvs_tuple = it->second;
-        const std::string key = kfvKey(key_op_fvs_tuple);
+        enqueue(it->second);
         it = consumer.m_toSync.erase(it);
-        std::string table_name;
-        std::string key_content;
-        parseP4RTKey(key, &table_name, &key_content);
-        if (table_name.empty())
-        {
-            auto status = ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                          << "Table name cannot be empty, but was empty in key: " << key;
-            SWSS_LOG_ERROR("%s", status.message().c_str());
-            m_publisher.publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
-                                status);
-            continue;
-        }
-        if (m_p4TableToManagerMap.find(table_name) != m_p4TableToManagerMap.end())
-        {
-            m_p4TableToManagerMap[table_name]->enqueue(table_name, key_op_fvs_tuple);
-        }
-        else
-        {
-            if (table_name.rfind(p4orch::kTablePrefixEXT, 0) != std::string::npos)
-            {
-                m_p4TableToManagerMap[APP_P4RT_EXT_TABLES_MANAGER]->enqueue(table_name, key_op_fvs_tuple);
-            }
-            else
-            {
-                auto status = ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                              << "Failed to find P4Orch Manager for " << table_name << " P4RT DB table";
-                SWSS_LOG_ERROR("%s", status.message().c_str());
-                m_publisher.publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
-                                    status);
-            }
-        }
     }
-
-    for (const auto &manager : m_p4ManagerPrecedence)
-    {
-        manager->drain();
-    }
-
+    drain(SET_COMMAND);
     m_publisher.flush();
 }
 
@@ -180,6 +159,79 @@ void P4Orch::doTask(swss::SelectableTimer &timer)
         SWSS_LOG_NOTICE("Unrecognized timer passed in P4Orch::doTask(swss::SelectableTimer& "
                         "timer)");
     }
+}
+
+void P4Orch::enqueue(const swss::KeyOpFieldsValuesTuple& entry) {
+  const std::string& key = kfvKey(entry);
+  const std::vector<swss::FieldValueTuple>& values = kfvFieldsValues(entry);
+  std::string table_name;
+  std::string key_content;
+  parseP4RTKey(key, &table_name, &key_content);
+  if (table_name.empty()) {
+    auto status = ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
+                  << "Table name cannot be empty, but was empty in key: "
+                  << key;
+    SWSS_LOG_ERROR("%s", status.message().c_str());
+    m_publisher.publish(APP_P4RT_TABLE_NAME, key, values, status,
+                        /*replace=*/true);
+    return;
+  }
+  if (m_p4TableToManagerMap.find(table_name) != m_p4TableToManagerMap.end()) {
+    m_p4TableToManagerMap[table_name]->enqueue(table_name, entry);
+  } else {
+    if (table_name.rfind(p4orch::kTablePrefixEXT, 0) != std::string::npos) {
+      m_p4TableToManagerMap[APP_P4RT_EXT_TABLES_MANAGER]->enqueue(table_name,
+                                                                  entry);
+    } else {
+      auto status = ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
+                    << "Failed to find P4Orch Manager for " << table_name
+                    << " P4RT DB table";
+      SWSS_LOG_ERROR("%s", status.message().c_str());
+      m_publisher.publish(APP_P4RT_TABLE_NAME, kfvKey(entry),
+                          kfvFieldsValues(entry), status, /*replace=*/true);
+    }
+  }
+}
+
+void P4Orch::drain(const std::string& op) {
+  if (op == SET_COMMAND) {
+    for (const auto& manager : m_p4ManagerAddPrecedence) {
+      manager->drain();
+    }
+  } else {
+    for (const auto& manager : m_p4ManagerDelPrecedence) {
+      manager->drain();
+    }
+  }
+}
+
+void P4Orch::handleP4rtNotification(
+    const std::vector<swss::FieldValueTuple>& values) {
+  std::string prev_op = "";
+  for (const auto& value : values) {
+    std::string op = DEL_COMMAND;
+    std::vector<swss::FieldValueTuple> vals;
+    if (!fvValue(value).empty()) {
+      op = SET_COMMAND;
+      JSon::readJson(fvValue(value), vals);
+    }
+    if (prev_op.empty()) {
+      prev_op = op;
+    }
+    swss::KeyOpFieldsValuesTuple key_op_fvs_tuple(fvField(value), op, vals);
+
+    // Call drain after grouping the same type of requests together.
+    if (op != prev_op) {
+      drain(prev_op);
+      prev_op = op;
+    }
+
+    // Enqueue the entry.
+    enqueue(key_op_fvs_tuple);
+  }
+  if (!prev_op.empty()) {
+    drain(prev_op);
+  }
 }
 
 void P4Orch::handlePortStatusChangeNotification(const std::string &op, const std::string &data)
@@ -233,8 +285,10 @@ void P4Orch::doTask(NotificationConsumer &consumer)
 
     consumer.pop(op, data, values);
 
-    if (&consumer == m_portStatusNotificationConsumer)
-    {
+
+    if (&consumer == m_p4rtNotificationConsumer) {
+      handleP4rtNotification(values);
+    } else if (&consumer == m_portStatusNotificationConsumer) {
         handlePortStatusChangeNotification(op, data);
     }
 }

--- a/orchagent/p4orch/p4orch.h
+++ b/orchagent/p4orch/p4orch.h
@@ -59,10 +59,14 @@ class P4Orch : public Orch
     void doTask(Consumer &consumer);
     void doTask(swss::SelectableTimer &timer);
     void doTask(swss::NotificationConsumer &consumer);
+    void enqueue(const swss::KeyOpFieldsValuesTuple& entry);
+    void drain(const std::string& op);
+    void handleP4rtNotification(const std::vector<swss::FieldValueTuple>& values);
     void handlePortStatusChangeNotification(const std::string &op, const std::string &data);
 
     // P4 object manager request processing order.
-    std::vector<ObjectManagerInterface *> m_p4ManagerPrecedence;
+    std::vector<ObjectManagerInterface*> m_p4ManagerAddPrecedence;
+    std::vector<ObjectManagerInterface*> m_p4ManagerDelPrecedence;
 
     swss::SelectableTimer *m_aclCounterStatsTimer;
     swss::SelectableTimer *m_extCounterStatsTimer;
@@ -81,10 +85,12 @@ class P4Orch : public Orch
     std::unique_ptr<ExtTablesManager> m_extTablesManager;
 
     // Notification consumer for port state change
+    swss::NotificationConsumer* m_p4rtNotificationConsumer;
     swss::NotificationConsumer *m_portStatusNotificationConsumer;
 
     // Sepcial publisher that writes to APPL DB instead of APPL STATE DB.
     ResponsePublisher m_publisher{"APPL_DB", /*bool buffered=*/true, /*db_write_thread=*/true};
 
+    friend class P4OrchTest;
     friend class p4orch::test::WcmpManagerTest;
 };

--- a/orchagent/p4orch/tests/Makefile.am
+++ b/orchagent/p4orch/tests/Makefile.am
@@ -50,6 +50,7 @@ p4orch_tests_SOURCES = $(ORCHAGENT_DIR)/orch.cpp \
 		       $(P4ORCH_DIR)/l3_admit_manager.cpp \
 		       $(P4ORCH_DIR)/ext_tables_manager.cpp \
 		       $(top_srcdir)/tests/mock_tests/fake_response_publisher.cpp \
+		       fake_intfsorch.cpp \
 		       fake_portorch.cpp \
 		       fake_crmorch.cpp \
 		       fake_flexcounterorch.cpp \
@@ -61,6 +62,7 @@ p4orch_tests_SOURCES = $(ORCHAGENT_DIR)/orch.cpp \
 		       fake_notificationconsumer.cpp \
 		       fake_table.cpp \
 		       p4oidmapper_test.cpp \
+		       p4orch_test.cpp \
 		       p4orch_util_test.cpp \
 		       return_code_test.cpp \
 		       route_manager_test.cpp \
@@ -77,6 +79,9 @@ p4orch_tests_SOURCES = $(ORCHAGENT_DIR)/orch.cpp \
 		       mock_sai_hostif.cpp \
 		       mock_sai_serialize.cpp \
 		       mock_sai_router_interface.cpp \
+		       mock_sai_neighbor.cpp \
+		       mock_sai_next_hop.cpp \
+		       mock_sai_route.cpp \
 		       mock_sai_switch.cpp \
 		       mock_sai_udf.cpp
 

--- a/orchagent/p4orch/tests/fake_intfsorch.cpp
+++ b/orchagent/p4orch/tests/fake_intfsorch.cpp
@@ -1,0 +1,105 @@
+#include <unordered_set>
+
+#include "intfsorch.h"
+
+IntfsOrch::IntfsOrch(DBConnector *db, string tableName, VRFOrch *vrf_orch,
+                     DBConnector *chassisAppDb)
+    : Orch(db, tableName), m_vrfOrch(vrf_orch) {}
+
+sai_object_id_t IntfsOrch::getRouterIntfsId(const string &alias) {
+  return SAI_NULL_OBJECT_ID;
+}
+
+bool IntfsOrch::isPrefixSubnet(const IpPrefix &ip_prefix, const string &alias) {
+  return true;
+}
+
+string IntfsOrch::getRouterIntfsAlias(const IpAddress &ip,
+                                      const string &vrf_name) {
+  return string();
+}
+
+bool IntfsOrch::isInbandIntfInMgmtVrf(const string &alias) { return false; }
+
+void IntfsOrch::increaseRouterIntfsRefCount(const string &alias) {}
+
+void IntfsOrch::decreaseRouterIntfsRefCount(const string &alias) {}
+
+bool IntfsOrch::setRouterIntfsMpls(const Port &port) { return true; }
+
+bool IntfsOrch::setRouterIntfsMtu(const Port &port) { return true; }
+
+bool IntfsOrch::setRouterIntfsMac(const Port &port) { return true; }
+
+bool IntfsOrch::setRouterIntfsNatZoneId(Port &port) { return true; }
+
+bool IntfsOrch::setRouterIntfsAdminStatus(const Port &port) { return true; }
+
+bool IntfsOrch::setIntfVlanFloodType(
+    const Port &port, sai_vlan_flood_control_type_t vlan_flood_type) {
+  return true;
+}
+
+bool IntfsOrch::setIntfProxyArp(const string &alias, const string &proxy_arp) {
+  return true;
+}
+
+set<IpPrefix> IntfsOrch::getSubnetRoutes() {
+  set<IpPrefix> ip_prefix;
+  return ip_prefix;
+}
+
+bool IntfsOrch::setIntf(const string &alias, sai_object_id_t vrf_id,
+                        const IpPrefix *ip_prefix, const bool adminUp,
+                        const uint32_t mtu, string loopbackAction) {
+  return true;
+}
+
+bool IntfsOrch::removeIntf(const string &alias, sai_object_id_t vrf_id,
+                           const IpPrefix *ip_prefix) {
+  return true;
+}
+
+void IntfsOrch::doTask(Consumer &consumer) {}
+
+bool IntfsOrch::addRouterIntfs(sai_object_id_t vrf_id, Port &port,
+                               string loopbackAction) {
+  return true;
+}
+
+bool IntfsOrch::removeRouterIntfs(Port &port) { return true; }
+
+void IntfsOrch::addIp2MeRoute(sai_object_id_t vrf_id,
+                              const IpPrefix &ip_prefix) {}
+
+void IntfsOrch::removeIp2MeRoute(sai_object_id_t vrf_id,
+                                 const IpPrefix &ip_prefix) {}
+
+void IntfsOrch::addDirectedBroadcast(const Port &port,
+                                     const IpPrefix &ip_prefix) {}
+
+void IntfsOrch::removeDirectedBroadcast(const Port &port,
+                                        const IpPrefix &ip_prefix) {}
+
+void IntfsOrch::addRifToFlexCounter(const string &id, const string &name,
+                                    const string &type) {}
+
+void IntfsOrch::removeRifFromFlexCounter(const string &id, const string &name) {
+}
+
+string IntfsOrch::getRifFlexCounterTableKey(string key) { return string(); }
+
+void IntfsOrch::generateInterfaceMap() { m_updateMapsTimer->start(); }
+
+bool IntfsOrch::updateSyncdIntfPfx(const string &alias,
+                                   const IpPrefix &ip_prefix, bool add) {
+  return false;
+}
+
+void IntfsOrch::doTask(SelectableTimer &timer) {}
+
+bool IntfsOrch::isRemoteSystemPortIntf(string alias) { return false; }
+
+void IntfsOrch::voqSyncAddIntf(string &alias) {}
+
+void IntfsOrch::voqSyncDelIntf(string &alias) {}

--- a/orchagent/p4orch/tests/mock_sai_neighbor.cpp
+++ b/orchagent/p4orch/tests/mock_sai_neighbor.cpp
@@ -1,0 +1,40 @@
+#include "mock_sai_neighbor.h"
+
+MockSaiNeighbor* mock_sai_neighbor;
+
+sai_status_t mock_create_neighbor_entry(
+    _In_ const sai_neighbor_entry_t* neighbor_entry, _In_ uint32_t attr_count,
+    _In_ const sai_attribute_t* attr_list) {
+  return mock_sai_neighbor->create_neighbor_entry(neighbor_entry, attr_count,
+                                                  attr_list);
+}
+
+sai_status_t mock_remove_neighbor_entry(
+    _In_ const sai_neighbor_entry_t* neighbor_entry) {
+  return mock_sai_neighbor->remove_neighbor_entry(neighbor_entry);
+}
+
+sai_status_t mock_create_neighbor_entries(_In_ uint32_t object_count, _In_ const sai_neighbor_entry_t *neighbor_entry, _In_ const uint32_t *attr_count,
+                                          _In_ const sai_attribute_t **attr_list, _In_ sai_bulk_op_error_mode_t mode, _Out_ sai_status_t *object_statuses)
+{
+    return mock_sai_neighbor->create_neighbor_entries(object_count, neighbor_entry, attr_count, attr_list, mode, object_statuses);
+}
+
+sai_status_t mock_remove_neighbor_entries(_In_ uint32_t object_count, _In_ const sai_neighbor_entry_t *neighbor_entry, _In_ sai_bulk_op_error_mode_t mode,
+                                          _Out_ sai_status_t *object_statuses)
+{
+    return mock_sai_neighbor->remove_neighbor_entries(object_count, neighbor_entry, mode, object_statuses);
+}
+
+sai_status_t mock_set_neighbor_entry_attribute(
+    _In_ const sai_neighbor_entry_t* neighbor_entry,
+    _In_ const sai_attribute_t* attr) {
+  return mock_sai_neighbor->set_neighbor_entry_attribute(neighbor_entry, attr);
+}
+
+sai_status_t mock_get_neighbor_entry_attribute(
+    _In_ const sai_neighbor_entry_t* neighbor_entry, _In_ uint32_t attr_count,
+    _Inout_ sai_attribute_t* attr_list) {
+  return mock_sai_neighbor->get_neighbor_entry_attribute(neighbor_entry,
+                                                         attr_count, attr_list);
+}

--- a/orchagent/p4orch/tests/mock_sai_neighbor.h
+++ b/orchagent/p4orch/tests/mock_sai_neighbor.h
@@ -30,39 +30,21 @@ class MockSaiNeighbor
                               _Inout_ sai_attribute_t *attr_list));
 };
 
-MockSaiNeighbor *mock_sai_neighbor;
+extern MockSaiNeighbor *mock_sai_neighbor;
 
 sai_status_t mock_create_neighbor_entry(_In_ const sai_neighbor_entry_t *neighbor_entry, _In_ uint32_t attr_count,
-                                        _In_ const sai_attribute_t *attr_list)
-{
-    return mock_sai_neighbor->create_neighbor_entry(neighbor_entry, attr_count, attr_list);
-}
+                                        _In_ const sai_attribute_t *attr_list);
 
-sai_status_t mock_remove_neighbor_entry(_In_ const sai_neighbor_entry_t *neighbor_entry)
-{
-    return mock_sai_neighbor->remove_neighbor_entry(neighbor_entry);
-}
+sai_status_t mock_remove_neighbor_entry(_In_ const sai_neighbor_entry_t *neighbor_entry);
 
 sai_status_t mock_create_neighbor_entries(_In_ uint32_t object_count, _In_ const sai_neighbor_entry_t *neighbor_entry, _In_ const uint32_t *attr_count,
-                                          _In_ const sai_attribute_t **attr_list, _In_ sai_bulk_op_error_mode_t mode, _Out_ sai_status_t *object_statuses)
-{
-    return mock_sai_neighbor->create_neighbor_entries(object_count, neighbor_entry, attr_count, attr_list, mode, object_statuses);
-}
+                                          _In_ const sai_attribute_t **attr_list, _In_ sai_bulk_op_error_mode_t mode, _Out_ sai_status_t *object_statuses);
 
 sai_status_t mock_remove_neighbor_entries(_In_ uint32_t object_count, _In_ const sai_neighbor_entry_t *neighbor_entry, _In_ sai_bulk_op_error_mode_t mode,
-                                          _Out_ sai_status_t *object_statuses)
-{
-    return mock_sai_neighbor->remove_neighbor_entries(object_count, neighbor_entry, mode, object_statuses);
-}
+                                          _Out_ sai_status_t *object_statuses);
 
 sai_status_t mock_set_neighbor_entry_attribute(_In_ const sai_neighbor_entry_t *neighbor_entry,
-                                               _In_ const sai_attribute_t *attr)
-{
-    return mock_sai_neighbor->set_neighbor_entry_attribute(neighbor_entry, attr);
-}
+                                               _In_ const sai_attribute_t *attr);
 
 sai_status_t mock_get_neighbor_entry_attribute(_In_ const sai_neighbor_entry_t *neighbor_entry,
-                                               _In_ uint32_t attr_count, _Inout_ sai_attribute_t *attr_list)
-{
-    return mock_sai_neighbor->get_neighbor_entry_attribute(neighbor_entry, attr_count, attr_list);
-}
+                                               _In_ uint32_t attr_count, _Inout_ sai_attribute_t *attr_list);

--- a/orchagent/p4orch/tests/mock_sai_next_hop.cpp
+++ b/orchagent/p4orch/tests/mock_sai_next_hop.cpp
@@ -1,0 +1,42 @@
+#include "mock_sai_next_hop.h"
+
+MockSaiNextHop* mock_sai_next_hop;
+
+sai_status_t mock_create_next_hop(_Out_ sai_object_id_t* next_hop_id,
+                                  _In_ sai_object_id_t switch_id,
+                                  _In_ uint32_t attr_count,
+                                  _In_ const sai_attribute_t* attr_list) {
+  return mock_sai_next_hop->create_next_hop(next_hop_id, switch_id, attr_count,
+                                            attr_list);
+}
+
+sai_status_t mock_remove_next_hop(_In_ sai_object_id_t next_hop_id) {
+  return mock_sai_next_hop->remove_next_hop(next_hop_id);
+}
+
+sai_status_t mock_create_next_hops(_In_ sai_object_id_t switch_id, _In_ uint32_t object_count, _In_ const uint32_t *attr_count,
+                                   _In_ const sai_attribute_t **attr_list, _In_ sai_bulk_op_error_mode_t mode,
+                                   _Out_ sai_object_id_t *object_id, _Out_ sai_status_t *object_statuses)
+{
+    return mock_sai_next_hop->create_next_hops(switch_id, object_count, attr_count, attr_list, mode,
+                                               object_id, object_statuses);
+}
+
+sai_status_t mock_remove_next_hops(_In_ uint32_t object_count, _In_ const sai_object_id_t *object_id, _In_ sai_bulk_op_error_mode_t mode,
+                                   _Out_ sai_status_t *object_statuses)
+{
+    return mock_sai_next_hop->remove_next_hops(object_count, object_id, mode, object_statuses);
+}
+
+sai_status_t mock_set_next_hop_attribute(_In_ sai_object_id_t next_hop_id,
+                                         _In_ const sai_attribute_t* attr) {
+  return mock_sai_next_hop->set_next_hop_attribute(next_hop_id, attr);
+}
+
+sai_status_t mock_get_next_hop_attribute(_In_ sai_object_id_t next_hop_id,
+                                         _In_ uint32_t attr_count,
+                                         _Inout_ sai_attribute_t* attr_list) {
+  return mock_sai_next_hop->get_next_hop_attribute(next_hop_id, attr_count,
+                                                   attr_list);
+}
+

--- a/orchagent/p4orch/tests/mock_sai_next_hop.h
+++ b/orchagent/p4orch/tests/mock_sai_next_hop.h
@@ -33,40 +33,21 @@ class MockSaiNextHop
 
 // Note that before mock functions below are used, mock_sai_next_hop must be
 // initialized to point to an instance of MockSaiNextHop.
-MockSaiNextHop *mock_sai_next_hop;
+extern MockSaiNextHop *mock_sai_next_hop;
 
 sai_status_t mock_create_next_hop(_Out_ sai_object_id_t *next_hop_id, _In_ sai_object_id_t switch_id,
-                                  _In_ uint32_t attr_count, _In_ const sai_attribute_t *attr_list)
-{
-    return mock_sai_next_hop->create_next_hop(next_hop_id, switch_id, attr_count, attr_list);
-}
+                                  _In_ uint32_t attr_count, _In_ const sai_attribute_t *attr_list);
 
-sai_status_t mock_remove_next_hop(_In_ sai_object_id_t next_hop_id)
-{
-    return mock_sai_next_hop->remove_next_hop(next_hop_id);
-}
+sai_status_t mock_remove_next_hop(_In_ sai_object_id_t next_hop_id);
 
-sai_status_t mock_set_next_hop_attribute(_In_ sai_object_id_t next_hop_id, _In_ const sai_attribute_t *attr)
-{
-    return mock_sai_next_hop->set_next_hop_attribute(next_hop_id, attr);
-}
+sai_status_t mock_set_next_hop_attribute(_In_ sai_object_id_t next_hop_id, _In_ const sai_attribute_t *attr);
 
 sai_status_t mock_get_next_hop_attribute(_In_ sai_object_id_t next_hop_id, _In_ uint32_t attr_count,
-                                         _Inout_ sai_attribute_t *attr_list)
-{
-    return mock_sai_next_hop->get_next_hop_attribute(next_hop_id, attr_count, attr_list);
-}
+                                         _Inout_ sai_attribute_t *attr_list);
 
 sai_status_t mock_create_next_hops(_In_ sai_object_id_t switch_id, _In_ uint32_t object_count, _In_ const uint32_t *attr_count,
                                    _In_ const sai_attribute_t **attr_list, _In_ sai_bulk_op_error_mode_t mode,
-                                   _Out_ sai_object_id_t *object_id, _Out_ sai_status_t *object_statuses)
-{
-    return mock_sai_next_hop->create_next_hops(switch_id, object_count, attr_count, attr_list, mode,
-                                               object_id, object_statuses);
-}
+                                   _Out_ sai_object_id_t *object_id, _Out_ sai_status_t *object_statuses);
 
 sai_status_t mock_remove_next_hops(_In_ uint32_t object_count, _In_ const sai_object_id_t *object_id, _In_ sai_bulk_op_error_mode_t mode,
-                                   _Out_ sai_status_t *object_statuses)
-{
-    return mock_sai_next_hop->remove_next_hops(object_count, object_id, mode, object_statuses);
-}
+                                   _Out_ sai_status_t *object_statuses);

--- a/orchagent/p4orch/tests/mock_sai_route.cpp
+++ b/orchagent/p4orch/tests/mock_sai_route.cpp
@@ -1,0 +1,62 @@
+#include "mock_sai_route.h"
+
+MockSaiRoute* mock_sai_route;
+
+sai_status_t create_route_entry(const sai_route_entry_t* route_entry,
+                                uint32_t attr_count,
+                                const sai_attribute_t* attr_list) {
+  return mock_sai_route->create_route_entry(route_entry, attr_count, attr_list);
+}
+
+sai_status_t remove_route_entry(const sai_route_entry_t* route_entry) {
+  return mock_sai_route->remove_route_entry(route_entry);
+}
+
+sai_status_t set_route_entry_attribute(const sai_route_entry_t* route_entry,
+                                       const sai_attribute_t* attr) {
+  return mock_sai_route->set_route_entry_attribute(route_entry, attr);
+}
+
+sai_status_t get_route_entry_attribute(const sai_route_entry_t* route_entry,
+                                       uint32_t attr_count,
+                                       sai_attribute_t* attr_list) {
+  return mock_sai_route->get_route_entry_attribute(route_entry, attr_count,
+                                                   attr_list);
+}
+
+sai_status_t create_route_entries(uint32_t object_count,
+                                  const sai_route_entry_t* route_entry,
+                                  const uint32_t* attr_count,
+                                  const sai_attribute_t** attr_list,
+                                  sai_bulk_op_error_mode_t mode,
+                                  sai_status_t* object_statuses) {
+  return mock_sai_route->create_route_entries(
+      object_count, route_entry, attr_count, attr_list, mode, object_statuses);
+}
+
+sai_status_t remove_route_entries(uint32_t object_count,
+                                  const sai_route_entry_t* route_entry,
+                                  sai_bulk_op_error_mode_t mode,
+                                  sai_status_t* object_statuses) {
+  return mock_sai_route->remove_route_entries(object_count, route_entry, mode,
+                                              object_statuses);
+}
+
+sai_status_t set_route_entries_attribute(uint32_t object_count,
+                                         const sai_route_entry_t* route_entry,
+                                         const sai_attribute_t* attr_list,
+                                         sai_bulk_op_error_mode_t mode,
+                                         sai_status_t* object_statuses) {
+  return mock_sai_route->set_route_entries_attribute(
+      object_count, route_entry, attr_list, mode, object_statuses);
+}
+
+sai_status_t get_route_entries_attribute(uint32_t object_count,
+                                         const sai_route_entry_t* route_entry,
+                                         const uint32_t* attr_count,
+                                         sai_attribute_t** attr_list,
+                                         sai_bulk_op_error_mode_t mode,
+                                         sai_status_t* object_statuses) {
+  return mock_sai_route->get_route_entries_attribute(
+      object_count, route_entry, attr_count, attr_list, mode, object_statuses);
+}

--- a/orchagent/p4orch/tests/mock_sai_route.h
+++ b/orchagent/p4orch/tests/mock_sai_route.h
@@ -1,36 +1,14 @@
 #pragma once
 
+#include <gmock/gmock.h>
+
 extern "C"
 {
 #include "sai.h"
 #include "sairoute.h"
 }
 
-class SaiRouteInterface
-{
-  public:
-    virtual sai_status_t create_route_entry(const sai_route_entry_t *route_entry, uint32_t attr_count,
-                                            const sai_attribute_t *attr_list) = 0;
-    virtual sai_status_t remove_route_entry(const sai_route_entry_t *route_entry) = 0;
-    virtual sai_status_t set_route_entry_attribute(const sai_route_entry_t *route_entry,
-                                                   const sai_attribute_t *attr) = 0;
-    virtual sai_status_t get_route_entry_attribute(const sai_route_entry_t *route_entry, uint32_t attr_count,
-                                                   sai_attribute_t *attr_list) = 0;
-    virtual sai_status_t create_route_entries(uint32_t object_count, const sai_route_entry_t *route_entry,
-                                              const uint32_t *attr_count, const sai_attribute_t **attr_list,
-                                              sai_bulk_op_error_mode_t mode, sai_status_t *object_statuses) = 0;
-    virtual sai_status_t remove_route_entries(uint32_t object_count, const sai_route_entry_t *route_entry,
-                                              sai_bulk_op_error_mode_t mode, sai_status_t *object_statuses) = 0;
-    virtual sai_status_t set_route_entries_attribute(uint32_t object_count, const sai_route_entry_t *route_entry,
-                                                     const sai_attribute_t *attr_list, sai_bulk_op_error_mode_t mode,
-                                                     sai_status_t *object_statuses) = 0;
-    virtual sai_status_t get_route_entries_attribute(uint32_t object_count, const sai_route_entry_t *route_entry,
-                                                     const uint32_t *attr_count, sai_attribute_t **attr_list,
-                                                     sai_bulk_op_error_mode_t mode, sai_status_t *object_statuses) = 0;
-};
-
-class MockSaiRoute : public SaiRouteInterface
-{
+class MockSaiRoute {
   public:
     MOCK_METHOD3(create_route_entry, sai_status_t(const sai_route_entry_t *route_entry, uint32_t attr_count,
                                                   const sai_attribute_t *attr_list));
@@ -54,55 +32,29 @@ class MockSaiRoute : public SaiRouteInterface
                               sai_status_t *object_statuses));
 };
 
-MockSaiRoute *mock_sai_route;
+extern MockSaiRoute *mock_sai_route;
 
 sai_status_t create_route_entry(const sai_route_entry_t *route_entry, uint32_t attr_count,
-                                const sai_attribute_t *attr_list)
-{
-    return mock_sai_route->create_route_entry(route_entry, attr_count, attr_list);
-}
+                                const sai_attribute_t *attr_list);
 
-sai_status_t remove_route_entry(const sai_route_entry_t *route_entry)
-{
-    return mock_sai_route->remove_route_entry(route_entry);
-}
+sai_status_t remove_route_entry(const sai_route_entry_t *route_entry);
 
-sai_status_t set_route_entry_attribute(const sai_route_entry_t *route_entry, const sai_attribute_t *attr)
-{
-    return mock_sai_route->set_route_entry_attribute(route_entry, attr);
-}
+sai_status_t set_route_entry_attribute(const sai_route_entry_t *route_entry, const sai_attribute_t *attr);
 
 sai_status_t get_route_entry_attribute(const sai_route_entry_t *route_entry, uint32_t attr_count,
-                                       sai_attribute_t *attr_list)
-{
-    return mock_sai_route->get_route_entry_attribute(route_entry, attr_count, attr_list);
-}
+                                       sai_attribute_t *attr_list);
 
 sai_status_t create_route_entries(uint32_t object_count, const sai_route_entry_t *route_entry,
                                   const uint32_t *attr_count, const sai_attribute_t **attr_list,
-                                  sai_bulk_op_error_mode_t mode, sai_status_t *object_statuses)
-{
-    return mock_sai_route->create_route_entries(object_count, route_entry, attr_count, attr_list, mode,
-                                                object_statuses);
-}
+                                  sai_bulk_op_error_mode_t mode, sai_status_t *object_statuses);
 
 sai_status_t remove_route_entries(uint32_t object_count, const sai_route_entry_t *route_entry,
-                                  sai_bulk_op_error_mode_t mode, sai_status_t *object_statuses)
-{
-    return mock_sai_route->remove_route_entries(object_count, route_entry, mode, object_statuses);
-}
+                                  sai_bulk_op_error_mode_t mode, sai_status_t *object_statuses);
 
 sai_status_t set_route_entries_attribute(uint32_t object_count, const sai_route_entry_t *route_entry,
                                          const sai_attribute_t *attr_list, sai_bulk_op_error_mode_t mode,
-                                         sai_status_t *object_statuses)
-{
-    return mock_sai_route->set_route_entries_attribute(object_count, route_entry, attr_list, mode, object_statuses);
-}
+                                         sai_status_t *object_statuses);
 
 sai_status_t get_route_entries_attribute(uint32_t object_count, const sai_route_entry_t *route_entry,
                                          const uint32_t *attr_count, sai_attribute_t **attr_list,
-                                         sai_bulk_op_error_mode_t mode, sai_status_t *object_statuses)
-{
-    return mock_sai_route->get_route_entries_attribute(object_count, route_entry, attr_count, attr_list, mode,
-                                                       object_statuses);
-}
+                                         sai_bulk_op_error_mode_t mode, sai_status_t *object_statuses);

--- a/orchagent/p4orch/tests/p4orch_test.cpp
+++ b/orchagent/p4orch/tests/p4orch_test.cpp
@@ -1,0 +1,202 @@
+#include "p4orch.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "mock_response_publisher.h"
+#include "mock_sai_hostif.h"
+#include "mock_sai_neighbor.h"
+#include "mock_sai_next_hop.h"
+#include "mock_sai_route.h"
+#include "mock_sai_router_interface.h"
+#include "mock_sai_switch.h"
+
+using ::p4orch::kTableKeyDelimiter;
+
+extern P4Orch* gP4Orch;
+extern VRFOrch* gVrfOrch;
+extern std::unique_ptr<MockResponsePublisher> gMockResponsePublisher;
+extern VRFOrch* gVrfOrch;
+extern swss::DBConnector* gAppDb;
+extern sai_hostif_api_t* sai_hostif_api;
+extern sai_switch_api_t* sai_switch_api;
+extern sai_router_interface_api_t* sai_router_intfs_api;
+extern sai_neighbor_api_t* sai_neighbor_api;
+extern sai_next_hop_api_t* sai_next_hop_api;
+extern sai_route_api_t* sai_route_api;
+
+using ::testing::Eq;
+using ::testing::InSequence;
+using ::testing::NiceMock;
+using ::testing::StrictMock;
+
+class P4OrchTest : public ::testing::Test {
+ protected:
+  P4OrchTest() {
+    mock_sai_hostif = &mock_sai_hostif_;
+    sai_hostif_api->create_hostif_trap = mock_create_hostif_trap;
+    sai_hostif_api->create_hostif_table_entry = mock_create_hostif_table_entry;
+    mock_sai_switch = &mock_sai_switch_;
+    sai_switch_api->get_switch_attribute = mock_get_switch_attribute;
+    mock_sai_router_intf = &mock_sai_router_intf_;
+    sai_router_intfs_api->create_router_interface =
+        mock_create_router_interface;
+    sai_router_intfs_api->remove_router_interface =
+        mock_remove_router_interface;
+    sai_router_intfs_api->set_router_interface_attribute =
+        mock_set_router_interface_attribute;
+    sai_router_intfs_api->get_router_interface_attribute =
+        mock_get_router_interface_attribute;
+    mock_sai_neighbor = &mock_sai_neighbor_;
+    sai_neighbor_api->create_neighbor_entry = mock_create_neighbor_entry;
+    sai_neighbor_api->remove_neighbor_entry = mock_remove_neighbor_entry;
+    sai_neighbor_api->set_neighbor_entry_attribute =
+        mock_set_neighbor_entry_attribute;
+    sai_neighbor_api->get_neighbor_entry_attribute =
+        mock_get_neighbor_entry_attribute;
+    mock_sai_next_hop = &mock_sai_next_hop_;
+    sai_next_hop_api->create_next_hop = mock_create_next_hop;
+    sai_next_hop_api->remove_next_hop = mock_remove_next_hop;
+    sai_next_hop_api->set_next_hop_attribute = mock_set_next_hop_attribute;
+    sai_next_hop_api->get_next_hop_attribute = mock_get_next_hop_attribute;
+    mock_sai_route = &mock_sai_route_;
+    sai_route_api->create_route_entry = create_route_entry;
+    sai_route_api->remove_route_entry = remove_route_entry;
+    sai_route_api->set_route_entry_attribute = set_route_entry_attribute;
+    sai_route_api->get_route_entry_attribute = get_route_entry_attribute;
+    sai_route_api->create_route_entries = create_route_entries;
+    sai_route_api->remove_route_entries = remove_route_entries;
+    sai_route_api->set_route_entries_attribute = set_route_entries_attribute;
+    sai_route_api->get_route_entries_attribute = get_route_entries_attribute;
+    copp_orch_ = new CoppOrch(gAppDb, APP_COPP_TABLE_NAME);
+    std::vector<std::string> p4_tables{APP_P4RT_TABLE_NAME};
+    gP4Orch = new P4Orch(gAppDb, p4_tables, gVrfOrch, copp_orch_);
+    gMockResponsePublisher = std::make_unique<MockResponsePublisher>();
+  }
+
+  ~P4OrchTest() {
+    delete gP4Orch;
+    delete copp_orch_;
+    gMockResponsePublisher.reset();
+  }
+
+  void HandleP4rtNotification(
+      const std::vector<swss::FieldValueTuple>& values) {
+    gP4Orch->handleP4rtNotification(values);
+  }
+
+  NiceMock<MockSaiHostif> mock_sai_hostif_;
+  NiceMock<MockSaiSwitch> mock_sai_switch_;
+  NiceMock<MockSaiRouterInterface> mock_sai_router_intf_;
+  NiceMock<MockSaiNeighbor> mock_sai_neighbor_;
+  NiceMock<MockSaiNextHop> mock_sai_next_hop_;
+  NiceMock<MockSaiRoute> mock_sai_route_;
+  CoppOrch* copp_orch_;
+};
+
+TEST_F(P4OrchTest, ProcessInvalidEntry) {
+  InSequence s;
+  std::vector<swss::FieldValueTuple> values;
+  values.push_back(swss::FieldValueTuple{"invalid", ""});
+  values.push_back(swss::FieldValueTuple{"invalid:invalid", ""});
+  std::vector<swss::FieldValueTuple> exp_values;
+  EXPECT_CALL(*gMockResponsePublisher,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq("invalid"), Eq(exp_values),
+                      Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)));
+  EXPECT_CALL(
+      *gMockResponsePublisher,
+      publish(Eq(APP_P4RT_TABLE_NAME), Eq("invalid:invalid"), Eq(exp_values),
+              Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)));
+  HandleP4rtNotification(values);
+}
+
+TEST_F(P4OrchTest, ProcessP4Notification) {
+  InSequence s;
+  std::vector<swss::FieldValueTuple> values;
+
+  // Router interface
+  const std::string ritf_key =
+      std::string(APP_P4RT_ROUTER_INTERFACE_TABLE_NAME) + kTableKeyDelimiter +
+      "{\"match/router_interface_id\":\"intf-3/4\"}";
+  std::vector<swss::FieldValueTuple> ritf_attrs;
+  ritf_attrs.push_back(
+      swss::FieldValueTuple{prependParamField(p4orch::kPort), "Ethernet1"});
+  ritf_attrs.push_back(swss::FieldValueTuple{prependParamField(p4orch::kSrcMac),
+                                             "00:01:02:03:04:05"});
+  values.push_back(
+      swss::FieldValueTuple{ritf_key, swss::JSon::buildJson(ritf_attrs)});
+
+  // Neighbor
+  const std::string neighbor_key = std::string(APP_P4RT_NEIGHBOR_TABLE_NAME) +
+                                   kTableKeyDelimiter +
+                                   "{\"match/router_interface_id\":\"intf-3/"
+                                   "4\",\"match/neighbor_id\":\"10.0.0.22\"}";
+  std::vector<swss::FieldValueTuple> neighbor_attrs;
+  neighbor_attrs.push_back(swss::FieldValueTuple{
+      prependParamField(p4orch::kDstMac), "00:01:02:03:04:05"});
+  values.push_back(swss::FieldValueTuple{
+      neighbor_key, swss::JSon::buildJson(neighbor_attrs)});
+
+  // Nexthop
+  const std::string nexthop_key =
+      std::string(APP_P4RT_NEXTHOP_TABLE_NAME) + kTableKeyDelimiter +
+      "{\"match/nexthop_id\":\"ju1u32m1.atl11:qe-3/7\"}";
+  std::vector<swss::FieldValueTuple> nexthop_attrs;
+  nexthop_attrs.push_back(
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetIpNexthop});
+  nexthop_attrs.push_back(swss::FieldValueTuple{
+      prependParamField(p4orch::kNeighborId), "10.0.0.22"});
+  nexthop_attrs.push_back(swss::FieldValueTuple{
+      prependParamField(p4orch::kRouterInterfaceId), "intf-3/4"});
+  values.push_back(
+      swss::FieldValueTuple{nexthop_key, swss::JSon::buildJson(nexthop_attrs)});
+
+  // Route
+  const std::string route_key =
+      std::string(APP_P4RT_IPV4_TABLE_NAME) + kTableKeyDelimiter +
+      "{\"match/vrf_id\":\"b4-traffic\",\"match/ipv4_dst\":\"10.11.12.0/24\"}";
+  std::vector<swss::FieldValueTuple> route_attrs;
+  route_attrs.push_back(
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetNexthopId});
+  route_attrs.push_back(swss::FieldValueTuple{
+      prependParamField(p4orch::kNexthopId), "ju1u32m1.atl11:qe-3/7"});
+  values.push_back(
+      swss::FieldValueTuple{route_key, swss::JSon::buildJson(route_attrs)});
+
+  // Delete
+  values.push_back(swss::FieldValueTuple{ritf_key, ""});
+  values.push_back(swss::FieldValueTuple{neighbor_key, ""});
+  values.push_back(swss::FieldValueTuple{nexthop_key, ""});
+  values.push_back(swss::FieldValueTuple{route_key, ""});
+
+  EXPECT_CALL(*gMockResponsePublisher,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(ritf_key), Eq(ritf_attrs),
+                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+  EXPECT_CALL(
+      *gMockResponsePublisher,
+      publish(Eq(APP_P4RT_TABLE_NAME), Eq(neighbor_key), Eq(neighbor_attrs),
+              Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+  EXPECT_CALL(
+      *gMockResponsePublisher,
+      publish(Eq(APP_P4RT_TABLE_NAME), Eq(nexthop_key), Eq(nexthop_attrs),
+              Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+  EXPECT_CALL(*gMockResponsePublisher,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(route_key), Eq(route_attrs),
+                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+  std::vector<swss::FieldValueTuple> exp_values;
+  EXPECT_CALL(*gMockResponsePublisher,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(route_key), Eq(exp_values),
+                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+  EXPECT_CALL(*gMockResponsePublisher,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(nexthop_key), Eq(exp_values),
+                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+  EXPECT_CALL(*gMockResponsePublisher,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(neighbor_key), Eq(exp_values),
+                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+  EXPECT_CALL(*gMockResponsePublisher,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(ritf_key), Eq(exp_values),
+                      Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+  HandleP4rtNotification(values);
+}

--- a/orchagent/p4orch/tests/test_main.cpp
+++ b/orchagent/p4orch/tests/test_main.cpp
@@ -12,6 +12,7 @@ extern "C"
 #include "dbconnector.h"
 #include "directory.h"
 #include "flowcounterrouteorch.h"
+#include "intfsorch.h"
 #include "mock_sai_virtual_router.h"
 #include "p4orch.h"
 #include "portsorch.h"
@@ -42,6 +43,8 @@ event_handle_t g_events_handle;
 #define DEFAULT_MAX_BULK_SIZE 1000
 extern int gBatchSize;
 size_t gMaxBulkSize = DEFAULT_MAX_BULK_SIZE;
+bool gSairedisRecord = false;
+bool gSwssRecord = false;
 bool gSyncMode = false;
 bool gIsNatSupported = false;
 bool gTraditionalFlexCounter = false;
@@ -53,6 +56,7 @@ P4Orch *gP4Orch;
 VRFOrch *gVrfOrch;
 FlowCounterRouteOrch *gFlowCounterRouteOrch;
 SwitchOrch *gSwitchOrch;
+IntfsOrch *gIntfsOrch;
 Directory<Orch *> gDirectory;
 swss::DBConnector *gAppDb;
 swss::DBConnector *gStateDb;
@@ -236,6 +240,9 @@ int main(int argc, char *argv[])
     FlowCounterRouteOrch flow_counter_route_orch(gConfigDb, std::vector<std::string>{});
     gFlowCounterRouteOrch = &flow_counter_route_orch;
     gDirectory.set(static_cast<FlowCounterRouteOrch *>(&flow_counter_route_orch));
+
+    IntfsOrch intfsOrch(gAppDb, APP_INTF_TABLE_NAME, gVrfOrch, gAppDb);
+    gIntfsOrch = &intfsOrch;
 
     // Setup ports for all tests.
     SetupPorts();

--- a/tests/p4rt/test_l3.py
+++ b/tests/p4rt/test_l3.py
@@ -23,6 +23,9 @@ class TestP4RTL3(object):
         self._p4rt_nexthop_obj.set_up_databases(dvs)
         self._p4rt_route_obj.set_up_databases(dvs)
         self._p4rt_wcmp_group_obj.set_up_databases(dvs)
+        self.p4rt_notifier = swsscommon.NotificationProducer(
+            self._p4rt_route_obj.appl_db, swsscommon.APP_P4RT_TABLE_NAME
+        )
         self.response_consumer = swsscommon.NotificationConsumer(
             self._p4rt_route_obj.appl_db, "APPL_DB_" +
             swsscommon.APP_P4RT_TABLE_NAME + "_RESPONSE_CHANNEL"
@@ -2366,4 +2369,144 @@ class TestP4RTL3(object):
             self._p4rt_nexthop_obj.get_original_asic_db_entries_count()
         )
 
+        self._clean_vrf(dvs)
+
+    def test_P4rtNotification(self, dvs, testlog):
+        # Initialize L3 objects and database connectors.
+        self._set_up(dvs)
+        self._set_vrf(dvs)
+
+        # Set IP type for route object.
+        self._p4rt_route_obj.set_ip_type("IPV4")
+
+        # Maintain list of original Application and ASIC DB entries before
+        # adding new route.
+        db_list = (
+            (
+                self._p4rt_route_obj.appl_db,
+                "%s:%s"
+                % (self._p4rt_route_obj.APP_DB_TBL_NAME, self._p4rt_route_obj.TBL_NAME),
+            ),
+            (self._p4rt_route_obj.asic_db, self._p4rt_route_obj.ASIC_DB_TBL_NAME),
+        )
+        self._p4rt_route_obj.get_original_redis_entries(db_list)
+
+        values = []
+        # Add router interface.
+        router_intf_key = self._p4rt_router_intf_obj.generate_app_db_key(
+            self._p4rt_router_intf_obj.DEFAULT_ROUTER_INTERFACE_ID)
+        ritf_attrs = [
+            (util.prepend_param_field(self._p4rt_router_intf_obj.PORT_FIELD),
+             self._p4rt_router_intf_obj.DEFAULT_PORT_ID),
+            (util.prepend_param_field(self._p4rt_router_intf_obj.SRC_MAC_FIELD),
+             self._p4rt_router_intf_obj.DEFAULT_SRC_MAC),
+            (self._p4rt_router_intf_obj.ACTION_FIELD,
+             self._p4rt_router_intf_obj.DEFAULT_ACTION)
+        ]
+        attr_list = [
+            util.prepend_param_field(
+                self._p4rt_router_intf_obj.PORT_FIELD), self._p4rt_router_intf_obj.DEFAULT_PORT_ID,
+            util.prepend_param_field(
+                self._p4rt_router_intf_obj.SRC_MAC_FIELD), self._p4rt_router_intf_obj.DEFAULT_SRC_MAC,
+            self._p4rt_router_intf_obj.ACTION_FIELD, self._p4rt_router_intf_obj.DEFAULT_ACTION
+        ]
+        values.append((router_intf_key, json.dumps(attr_list)))
+        # Add neighbor.
+        neighbor_key = self._p4rt_neighbor_obj.generate_app_db_key(
+            self._p4rt_neighbor_obj.DEFAULT_ROUTER_INTERFACE_ID, self._p4rt_neighbor_obj.DEFAULT_IPV4_NEIGHBOR_ID)
+        neighbor_attrs = [
+            (util.prepend_param_field(self._p4rt_neighbor_obj.DST_MAC_FIELD),
+             self._p4rt_neighbor_obj.DEFAULT_DST_MAC),
+            (self._p4rt_neighbor_obj.ACTION_FIELD,
+             self._p4rt_neighbor_obj.DEFAULT_ACTION)
+        ]
+        attr_list = [
+            util.prepend_param_field(
+                self._p4rt_neighbor_obj.DST_MAC_FIELD), self._p4rt_neighbor_obj.DEFAULT_DST_MAC,
+            self._p4rt_neighbor_obj.ACTION_FIELD, self._p4rt_neighbor_obj.DEFAULT_ACTION
+        ]
+        values.append((neighbor_key, json.dumps(attr_list)))
+        # Add nexthop.
+        nexthop_key = self._p4rt_nexthop_obj.generate_app_db_key(
+            self._p4rt_nexthop_obj.DEFAULT_NEXTHOP_ID)
+        nexthop_attrs = [
+            (self._p4rt_nexthop_obj.ACTION_FIELD,
+             self._p4rt_nexthop_obj.DEFAULT_ACTION),
+            (util.prepend_param_field(self._p4rt_nexthop_obj.RIF_FIELD),
+             self._p4rt_nexthop_obj.DEFAULT_ROUTER_INTERFACE_ID),
+            (util.prepend_param_field(self._p4rt_nexthop_obj.NEIGHBOR_ID_FIELD),
+             self._p4rt_nexthop_obj.DEFAULT_IPV4_NEIGHBOR_ID)
+        ]
+        attr_list = [
+            self._p4rt_nexthop_obj.ACTION_FIELD, self._p4rt_nexthop_obj.DEFAULT_ACTION,
+            util.prepend_param_field(
+                self._p4rt_nexthop_obj.RIF_FIELD), self._p4rt_nexthop_obj.DEFAULT_ROUTER_INTERFACE_ID,
+            util.prepend_param_field(
+                self._p4rt_nexthop_obj.NEIGHBOR_ID_FIELD), self._p4rt_nexthop_obj.DEFAULT_IPV4_NEIGHBOR_ID
+        ]
+        values.append((nexthop_key, json.dumps(attr_list)))
+        # Add route.
+        route_key = self._p4rt_route_obj.generate_app_db_key(
+            self._p4rt_route_obj.DEFAULT_VRF_ID, self._p4rt_route_obj.DEFAULT_DST)
+        route_attrs = [
+            (self._p4rt_route_obj.ACTION_FIELD,
+             self._p4rt_route_obj.DEFAULT_ACTION),
+            (util.prepend_param_field(self._p4rt_route_obj.NEXTHOP_ID_FIELD),
+             self._p4rt_route_obj.DEFAULT_NEXTHOP_ID),
+        ]
+        attr_list = [
+            self._p4rt_route_obj.ACTION_FIELD, self._p4rt_route_obj.DEFAULT_ACTION,
+            util.prepend_param_field(
+                self._p4rt_route_obj.NEXTHOP_ID_FIELD), self._p4rt_route_obj.DEFAULT_NEXTHOP_ID
+        ]
+        values.append((route_key, json.dumps(attr_list)))
+        # Delete route.
+        values.append((route_key, ""))
+        # Delete nexthop.
+        values.append((nexthop_key, ""))
+        # Delete neighbor.
+        values.append((neighbor_key, ""))
+        # Delete router interface.
+        values.append((router_intf_key, ""))
+
+        self.p4rt_notifier.send("", "", swsscommon.FieldValuePairs(values))
+
+        util.verify_response(
+            self.response_consumer, router_intf_key, ritf_attrs, "SWSS_RC_SUCCESS"
+        )
+        util.verify_response(
+            self.response_consumer, neighbor_key, neighbor_attrs, "SWSS_RC_SUCCESS"
+        )
+        util.verify_response(
+            self.response_consumer, nexthop_key, nexthop_attrs, "SWSS_RC_SUCCESS"
+        )
+        util.verify_response(
+            self.response_consumer, route_key, route_attrs, "SWSS_RC_SUCCESS"
+        )
+        util.verify_response(self.response_consumer,
+                             route_key, [], "SWSS_RC_SUCCESS")
+        util.verify_response(self.response_consumer,
+                             nexthop_key, [], "SWSS_RC_SUCCESS")
+        util.verify_response(
+            self.response_consumer, neighbor_key, [], "SWSS_RC_SUCCESS"
+        )
+        util.verify_response(
+            self.response_consumer, router_intf_key, [], "SWSS_RC_SUCCESS"
+        )
+
+        # Query application database for route entries.
+        route_entries = util.get_keys(
+            self._p4rt_route_obj.appl_db,
+            self._p4rt_route_obj.APP_DB_TBL_NAME + ":" + self._p4rt_route_obj.TBL_NAME,
+        )
+        assert len(route_entries) == (
+            self._p4rt_route_obj.get_original_appl_db_entries_count()
+        )
+        # Query ASIC database for route entries.
+        route_entries = util.get_keys(
+            self._p4rt_route_obj.asic_db, self._p4rt_route_obj.ASIC_DB_TBL_NAME
+        )
+        assert len(route_entries) == (
+            self._p4rt_route_obj.get_original_asic_db_entries_count()
+        )
         self._clean_vrf(dvs)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

- Added a new function AclRuleManager::addDefaultAclRuleInPreIngressTable to insert a default ACL rule into a PreIngress table targeting the Loopback0 DIP.
- Created a fake implementation fake_intfsorch.cpp for IntfsOrch to support unit testing without depending on the real IntfsOrch implementation.
- Implemented handleP4rtNotification() to process runtime P4RT notifications received via AppDb.
Used enqueue() and drain() calls to apply updates to the P4 pipeline.

**Why I did it**
- To ensure that a default ACL rule is present in the PreIngress table to handle Loopback0 traffic consistently, improving control plane protection and predictability.
- To enable dynamic, event-driven updates in SONiC’s P4RT pipeline.
P4RT-capable switches publish notification entries to AppDb; without this handler, P4Orch would ignore these updates.

**How I verified it**
- Verified through debug logs (SWSS_LOG_ENTER and error logs) that the ACL table was retrieved and the default ACL rule attributes were applied as expected.
- Wrote unit tests that simulate SET and DEL notification entries.

**Details if related**
- Test fixture P4OrchTest now initializes all required SAI mocks for independent verification.