### PR TITLE
[DASH] Fix to push VNET mapping entry's port-map id to SAI

### DIFF
--- a/orchagent/dash/dashportmaporch.cpp
+++ b/orchagent/dash/dashportmaporch.cpp
@@ -168,6 +168,18 @@ void DashPortMapOrch::doTaskPortMapTable(ConsumerBase &consumer)
     }
 }
 
+sai_object_id_t DashPortMapOrch::getPortMapOid(const std::string& port_map_name)
+{
+    SWSS_LOG_ENTER();
+
+    auto it = port_map_table_.find(port_map_name);
+    if (it == port_map_table_.end())
+    {
+        return SAI_NULL_OBJECT_ID;
+    }
+    return it->second;
+}
+
 bool DashPortMapOrch::addPortMap(const std::string &port_map_id, DashPortMapBulkContext &ctxt)
 {
     SWSS_LOG_ENTER();

--- a/orchagent/dash/dashportmaporch.h
+++ b/orchagent/dash/dashportmaporch.h
@@ -43,6 +43,7 @@ class DashPortMapOrch : public ZmqOrch
 {
 public:
     DashPortMapOrch(swss::DBConnector *db, std::vector<std::string> &tables, swss::DBConnector *app_state_db, swss::ZmqServer *zmqServer);
+    sai_object_id_t getPortMapOid(const std::string& port_map_name);
 
 private:
     void doTask(ConsumerBase &consumer);

--- a/tests/mock_tests/dashvnetorch_ut.cpp
+++ b/tests/mock_tests/dashvnetorch_ut.cpp
@@ -80,8 +80,12 @@ namespace dashvnetorch_test
             .Times(1).WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
         AddVnetMap();
 
+        AddPortMap();
+        AddVnetMapPL();
+
         EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, remove_outbound_ca_to_pa_entries)
             .Times(1).WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
         RemoveVnetMap();
         EXPECT_CALL(*mock_sai_dash_pa_validation_api, remove_pa_validation_entries)
             .Times(1).WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));

--- a/tests/mock_tests/dashvnetorch_ut.cpp
+++ b/tests/mock_tests/dashvnetorch_ut.cpp
@@ -29,6 +29,7 @@ namespace dashvnetorch_test
     using ::testing::DoAll;
     using ::testing::SetArrayArgument;
     using ::testing::SetArgPointee;
+    using ::testing::InSequence;
 
     class DashVnetOrchTest : public MockDashOrchTest
     {
@@ -65,32 +66,26 @@ namespace dashvnetorch_test
     TEST_F(DashVnetOrchTest, AddRemoveVnet)
     {
         std::vector<sai_status_t> exp_status = {SAI_STATUS_SUCCESS};
-        AddRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
-        EXPECT_CALL(*mock_sai_dash_vnet_api, create_vnets)
-            .Times(1).WillOnce(DoAll(
-                SetArgPointee<5>(0x1234),
-                SetArrayArgument<6>(exp_status.begin(), exp_status.end()),
-                Return(SAI_STATUS_SUCCESS)
-            )
-            );
-        CreateVnet();
-        EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries)
-            .Times(1).WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-        EXPECT_CALL(*mock_sai_dash_pa_validation_api, create_pa_validation_entries)
-            .Times(1).WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-        AddVnetMap();
+        AddVnetEncapRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
+        AddPLRoutingType();
+        {
+            InSequence seq;
+            EXPECT_CALL(*mock_sai_dash_vnet_api, create_vnets).Times(1);
+            EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries).Times(1);
+            EXPECT_CALL(*mock_sai_dash_pa_validation_api, create_pa_validation_entries).Times(1);
+            EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries).Times(1);
+            EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, remove_outbound_ca_to_pa_entries).Times(2);
+            EXPECT_CALL(*mock_sai_dash_pa_validation_api, remove_pa_validation_entries).Times(1);
+            EXPECT_CALL(*mock_sai_dash_vnet_api, remove_vnets).Times(1);
+        }
 
+        CreateVnet();
+        AddVnetMap();
         AddPortMap();
         AddVnetMapPL();
 
-        EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, remove_outbound_ca_to_pa_entries)
-            .Times(1).WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-
         RemoveVnetMap();
-        EXPECT_CALL(*mock_sai_dash_pa_validation_api, remove_pa_validation_entries)
-            .Times(1).WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-        EXPECT_CALL(*mock_sai_dash_vnet_api, remove_vnets)
-            .Times(1).WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        RemoveVnetMapPL();
         RemoveVnet();
     }
 
@@ -100,13 +95,13 @@ namespace dashvnetorch_test
             .Times(0);
         EXPECT_CALL(*mock_sai_dash_pa_validation_api, create_pa_validation_entries)
             .Times(0);
-        AddRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
+        AddVnetEncapRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
         AddVnetMap(false);
     }
 
     TEST_F(DashVnetOrchTest, AddExistingOutboundCaToPaSuccessful)
     {
-        AddRoutingType(dash::route_type::ENCAP_TYPE_VXLAN); 
+        AddVnetEncapRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
         CreateVnet();
         AddVnetMap();
         std::vector<sai_status_t> exp_status = {SAI_STATUS_ITEM_ALREADY_EXISTS};
@@ -132,7 +127,7 @@ namespace dashvnetorch_test
 
     TEST_F(DashVnetOrchTest, InvalidEncapVnetMapFails)
     {
-        AddRoutingType(dash::route_type::ENCAP_TYPE_UNSPECIFIED);
+        AddVnetEncapRoutingType(dash::route_type::ENCAP_TYPE_UNSPECIFIED);
         CreateVnet();
         AddVnetMap();
         EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries)
@@ -142,7 +137,7 @@ namespace dashvnetorch_test
 
     TEST_F(DashVnetOrchTest, AddExistPaValidationSuccessful)
     {
-        AddRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
+        AddVnetEncapRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
         CreateVnet();
         std::vector<sai_status_t> exp_status = {SAI_STATUS_ITEM_ALREADY_EXISTS};
         int expectedUsed = GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_PA_VALIDATION);
@@ -155,7 +150,7 @@ namespace dashvnetorch_test
 
     TEST_F(DashVnetOrchTest, RemovePaValidationInUseFails)
     {
-        AddRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
+        AddVnetEncapRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
         CreateVnet();
         AddVnetMap();
 

--- a/tests/mock_tests/mock_dash_orch_test.cpp
+++ b/tests/mock_tests/mock_dash_orch_test.cpp
@@ -63,13 +63,25 @@ namespace mock_orch_test
         SetDashTable(APP_DASH_VNET_TABLE_NAME, vnet1, dash::vnet::Vnet(), false, expect_empty);
     }
 
-    void MockDashOrchTest::AddRoutingType(dash::route_type::EncapType encap_type)
+    void MockDashOrchTest::AddVnetEncapRoutingType(dash::route_type::EncapType encap_type)
     {
         dash::route_type::RouteType route_type = dash::route_type::RouteType();
         dash::route_type::RouteTypeItem *rt_item = route_type.add_items();
         rt_item->set_action_type(dash::route_type::ACTION_TYPE_STATICENCAP);
         rt_item->set_encap_type(encap_type);
         SetDashTable(APP_DASH_ROUTING_TYPE_TABLE_NAME, "VNET_ENCAP", route_type);
+    }
+
+    void MockDashOrchTest::AddPLRoutingType()
+    {
+        dash::route_type::RouteType route_type = dash::route_type::RouteType();
+        dash::route_type::RouteTypeItem *rt_item = route_type.add_items();
+        rt_item->set_action_type(dash::route_type::ACTION_TYPE_4_to_6);
+        rt_item = route_type.add_items();
+        rt_item->set_action_type(dash::route_type::ACTION_TYPE_STATICENCAP);
+        rt_item->set_encap_type(dash::route_type::ENCAP_TYPE_VXLAN);
+        rt_item->set_vni(100);
+        SetDashTable(APP_DASH_ROUTING_TYPE_TABLE_NAME, "PRIVATELINK", route_type);
     }
 
     void MockDashOrchTest::AddOutboundRoutingGroup()
@@ -118,6 +130,11 @@ namespace mock_orch_test
 
         vnet_map.set_port_map(portmap1);
         SetDashTable(APP_DASH_VNET_MAPPING_TABLE_NAME, vnet1 + ":" + vnet_map_ip2, vnet_map, true, expect_empty);
+    }
+
+    void MockDashOrchTest::RemoveVnetMapPL(bool expect_empty)
+    {
+        SetDashTable(APP_DASH_VNET_MAPPING_TABLE_NAME, vnet1 + ":" + vnet_map_ip2, dash::vnet_mapping::VnetMapping(), false, expect_empty);
     }
 
     void MockDashOrchTest::RemoveVnetMap()

--- a/tests/mock_tests/mock_dash_orch_test.cpp
+++ b/tests/mock_tests/mock_dash_orch_test.cpp
@@ -1,4 +1,5 @@
 #include "mock_dash_orch_test.h"
+#include "dash_api/outbound_port_map.pb.h"
 
 namespace mock_orch_test
 {
@@ -104,9 +105,30 @@ namespace mock_orch_test
         SetDashTable(APP_DASH_VNET_MAPPING_TABLE_NAME, vnet1 + ":" + vnet_map_ip1, vnet_map, true, expect_empty);
     }
 
+    void MockDashOrchTest::AddVnetMapPL(bool expect_empty)
+    {
+        dash::vnet_mapping::VnetMapping vnet_map = dash::vnet_mapping::VnetMapping();
+        vnet_map.set_routing_type(dash::route_type::ROUTING_TYPE_PRIVATELINK);
+        vnet_map.mutable_underlay_ip()->set_ipv4(swss::IpAddress("7.7.7.7").getV4Addr());
+
+        vnet_map.mutable_overlay_sip_prefix()->mutable_ip()->set_ipv6(reinterpret_cast<const char*>(swss::IpAddress("fd40:108:0:d204:0:200::0").getV6Addr()));
+        vnet_map.mutable_overlay_sip_prefix()->mutable_mask()->set_ipv6(reinterpret_cast<const char*>(swss::IpAddress("ffff:ffff:ffff:ffff:ffff:ffff::").getV6Addr()));
+        vnet_map.mutable_overlay_dip_prefix()->mutable_ip()->set_ipv6(reinterpret_cast<const char*>(swss::IpAddress("2603:10e1:100:2::3401:203").getV6Addr()));
+        vnet_map.mutable_overlay_dip_prefix()->mutable_mask()->set_ipv6(reinterpret_cast<const char*>(swss::IpAddress("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").getV6Addr()));
+
+        vnet_map.set_port_map(portmap1);
+        SetDashTable(APP_DASH_VNET_MAPPING_TABLE_NAME, vnet1 + ":" + vnet_map_ip2, vnet_map, true, expect_empty);
+    }
+
     void MockDashOrchTest::RemoveVnetMap()
     {
         SetDashTable(APP_DASH_VNET_MAPPING_TABLE_NAME, vnet1 + ":" + vnet_map_ip1, dash::vnet_mapping::VnetMapping(), false);
+    }
+
+    void MockDashOrchTest::AddPortMap()
+    {
+        dash::outbound_port_map::OutboundPortMap portmap = dash::outbound_port_map::OutboundPortMap();
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, portmap1, portmap);
     }
 
     dash::eni::Eni MockDashOrchTest::BuildEniEntry()

--- a/tests/mock_tests/mock_dash_orch_test.h
+++ b/tests/mock_tests/mock_dash_orch_test.h
@@ -30,13 +30,17 @@ namespace mock_orch_test
             void AddOutboundRoutingGroup();
             void AddOutboundRoutingEntry(bool expect_empty = true);
             void AddTunnel();
+            void AddVnetMapPL(bool expect_empty = true);
+            void AddPortMap();
             dash::eni::Eni BuildEniEntry();
 
             std::string vnet1 = "VNET_1";
             std::string vnet_map_ip1 = "2.2.2.2";
+            std::string vnet_map_ip2 = "2.3.3.3";
             std::string appliance1 = "APPLIANCE_1";
             std::string route_group1 = "ROUTE_GROUP_1";
             std::string tunnel1 = "TUNNEL_1";
             std::string eni1 = "ENI_1";
+            std::string portmap1 = "PORTMAP_1";
     };
 }

--- a/tests/mock_tests/mock_dash_orch_test.h
+++ b/tests/mock_tests/mock_dash_orch_test.h
@@ -22,7 +22,8 @@ namespace mock_orch_test
             void SetDashTable(std::string table_name, std::string key, const google::protobuf::Message &message, bool set = true, bool expect_empty = true);
             dash::appliance::Appliance BuildApplianceEntry();
             void CreateApplianceEntry();
-            void AddRoutingType(dash::route_type::EncapType encap_type);
+            void AddVnetEncapRoutingType(dash::route_type::EncapType encap_type);
+            void AddPLRoutingType();
             void CreateVnet();
             void RemoveVnet(bool expect_empty = true);
             void AddVnetMap(bool expect_empty = true);
@@ -31,6 +32,7 @@ namespace mock_orch_test
             void AddOutboundRoutingEntry(bool expect_empty = true);
             void AddTunnel();
             void AddVnetMapPL(bool expect_empty = true);
+            void RemoveVnetMapPL(bool expect_empty = true);
             void AddPortMap();
             dash::eni::Eni BuildEniEntry();
 


### PR DESCRIPTION
**What I did**
Push VNET mapping table entry port-map attribute to SAI as  SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_OUTBOUND_PORT_MAP_ID 

**Why I did it**
Without this the VNET mapping entry will not be associated with the port-map in datapath.

**How I verified it**

**Details if related**
