### PR TITLE
Don't poll FEC stats if the FEC is disabled for a port

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -341,6 +341,32 @@ const vector<sai_port_stat_t> port_stat_ids =
     SAI_PORT_STAT_DOT3_STATS_SYMBOL_ERRORS
 };
 
+const vector<sai_port_stat_t> port_stat_fec_ids =
+{
+    SAI_PORT_STAT_IF_IN_FEC_CORRECTABLE_FRAMES,
+    SAI_PORT_STAT_IF_IN_FEC_NOT_CORRECTABLE_FRAMES,
+    SAI_PORT_STAT_IF_IN_FEC_SYMBOL_ERRORS,
+    SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S0,
+    SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S1,
+    SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S2,
+    SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S3,
+    SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S4,
+    SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S5,
+    SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S6,
+    SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S7,
+    SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S8,
+    SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S9,
+    SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S10,
+    SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S11,
+    SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S12,
+    SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S13,
+    SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S14,
+    SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S15,
+    SAI_PORT_STAT_IF_IN_FEC_CORRECTED_BITS,
+};
+
+vector<sai_port_stat_t> port_stat_non_fec_ids;
+
 const vector<sai_port_stat_t> gbport_stat_ids =
 {
     SAI_PORT_STAT_IF_IN_OCTETS,
@@ -1105,6 +1131,8 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
 
     /* Initialize the stats capability in STATE_DB */
     initCounterCapabilities(gSwitchId);
+
+    prepareNonFecPortStats();
 
     auto executor = new ExecutableTimer(m_port_state_poller, this, "PORT_STATE_POLLER");
     Orch::addExecutor(executor);
@@ -4140,9 +4168,12 @@ void PortsOrch::registerPort(Port &p)
     If they are enabled, install the counters immediately */
     if (flex_counters_orch->getPortCountersState())
     {
-        auto port_counter_stats = generateCounterStats(port_stat_ids, sai_serialize_port_stat);
+        auto port_counter_stats = generateCounterStats(
+                 (p.m_fec_cfg && (p.m_fec_mode == SAI_PORT_FEC_MODE_NONE))? port_stat_non_fec_ids: port_stat_ids,
+                  sai_serialize_port_stat);
         port_stat_manager.setCounterIdList(p.m_port_id,
                 CounterType::PORT, port_counter_stats);
+                     
         auto gbport_counter_stats = generateCounterStats(gbport_stat_ids, sai_serialize_port_stat);
         if (p.m_system_side_id)
             gb_port_stat_manager.setCounterIdList(p.m_system_side_id,
@@ -5359,10 +5390,14 @@ void PortsOrch::doPortTask(Consumer &consumer)
                             it++;
                             continue;
                         }
-
+                        auto old_fec_mode = p.m_fec_mode;
                         p.m_fec_mode = pCfg.fec.value;
                         p.m_override_fec = pCfg.fec.override_fec;
                         p.m_fec_cfg = true;
+                        if (old_fec_mode != p.m_fec_mode)
+                        {
+                            updatePortCounterMap(p);
+                        }
                         m_portList[p.m_alias] = p;
 
                         SWSS_LOG_NOTICE(
@@ -9090,6 +9125,23 @@ void PortsOrch::deletePortBufferPgCounters(const Port& port, uint32_t startIndex
     CounterCheckOrch::getInstance().removePort(port);
 }
 
+void PortsOrch::prepareNonFecPortStats()
+{
+
+    // Generate The Port Stat Ids without Fec stats
+    // We can initialize const port_stat_non_fec_ids with all the stats excluding FEC stats instead of dynamically generating it,
+    // however this will force us to add the non FEC STATS to port_stats_non_fec_ids whenever someone adds the new stats to port_stat_ids.
+
+    for (auto port_stat : port_stat_ids)
+    {
+        auto it = std::find(port_stat_fec_ids.begin(), port_stat_fec_ids.end(), port_stat);
+        if (it == port_stat_fec_ids.end())
+        {
+            port_stat_non_fec_ids.push_back(port_stat);
+        }
+    }
+}
+
 void PortsOrch::generatePortCounterMap()
 {
     if (m_isPortCounterMapGenerated)
@@ -9098,6 +9150,7 @@ void PortsOrch::generatePortCounterMap()
     }
 
     auto port_counter_stats = generateCounterStats(port_stat_ids, sai_serialize_port_stat);
+    auto port_counter_non_fec_stats = generateCounterStats(port_stat_non_fec_ids, sai_serialize_port_stat);
     auto gbport_counter_stats = generateCounterStats(gbport_stat_ids, sai_serialize_port_stat);
     for (const auto& it: m_portList)
     {
@@ -9106,8 +9159,14 @@ void PortsOrch::generatePortCounterMap()
         {
             continue;
         }
-        port_stat_manager.setCounterIdList(it.second.m_port_id,
-                CounterType::PORT, port_counter_stats);
+        if(it.second.m_fec_cfg && it.second.m_fec_mode == SAI_PORT_FEC_MODE_NONE)
+        {
+            port_stat_manager.setCounterIdList(it.second.m_port_id, CounterType::PORT, port_counter_non_fec_stats);
+        }
+        else
+        {
+            port_stat_manager.setCounterIdList(it.second.m_port_id, CounterType::PORT, port_counter_stats);
+        }
         if (it.second.m_system_side_id)
             gb_port_stat_manager.setCounterIdList(it.second.m_system_side_id,
                     CounterType::PORT, gbport_counter_stats, it.second.m_switch_id);
@@ -9117,6 +9176,32 @@ void PortsOrch::generatePortCounterMap()
     }
 
     m_isPortCounterMapGenerated = true;
+}
+
+void PortsOrch::updatePortCounterMap(Port &port)
+{
+    if (!m_isPortCounterMapGenerated)
+    {
+        return;
+    }
+    if (port.m_type != Port::Type::PHY)
+    {
+        return;
+    }
+    // clear the old counters
+    port_stat_manager.clearCounterIdList(port.m_port_id);
+
+    if (port.m_fec_mode == SAI_PORT_FEC_MODE_NONE)
+    {
+        auto port_counter_non_fec_stats = generateCounterStats(port_stat_non_fec_ids, sai_serialize_port_stat);
+        port_stat_manager.setCounterIdList(port.m_port_id, CounterType::PORT, port_counter_non_fec_stats);
+    }
+    else
+    {
+        auto port_counter_stats = generateCounterStats(port_stat_ids, sai_serialize_port_stat);
+        port_stat_manager.setCounterIdList(port.m_port_id, CounterType::PORT, port_counter_stats);
+    }
+    SWSS_LOG_DEBUG("Updated Counters for %s Fec_mode:%d", port.m_alias.c_str(), port.m_fec_mode);
 }
 
 void PortsOrch::generatePortBufferDropCounterMap()

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -230,6 +230,8 @@ public:
     void addPriorityGroupWatermarkFlexCounters(map<string, FlexCounterPgStates> pgsStateVector);
 
     void generatePortCounterMap();
+    void prepareNonFecPortStats();
+    void updatePortCounterMap(Port &port);
     void generatePortBufferDropCounterMap();
 
     void generatePortPhyAttrCounterMap();

--- a/tests/mock_tests/flexcounter_ut.cpp
+++ b/tests/mock_tests/flexcounter_ut.cpp
@@ -792,15 +792,6 @@ namespace flexcounter_test
         ASSERT_FALSE(gPortsOrch->getPort(secondPortName, secondPort));
         ASSERT_FALSE(checkFlexCounter(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, second_oid, PORT_COUNTER_ID_LIST));
 
-        //Verify the Port Stats counter after re-ADD
-        entries.clear();
-        entries.push_back({secondPortName, "SET", secondPortValues});
-        port_consumer->addToSync(entries);
-        static_cast<Orch *>(gPortsOrch)->doTask();
-        ASSERT_TRUE(gPortsOrch->getPort(secondPortName, secondPort));
-        second_oid = secondPort.m_port_id;
-        ASSERT_TRUE(checkFlexCounter(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, second_oid, PORT_COUNTER_ID_LIST));
-
         // create a routing interface
         entries.clear();
         entries.push_back({firstPort.m_alias, "SET", { {"mtu", "9100"}}});

--- a/tests/mock_tests/flexcounter_ut.cpp
+++ b/tests/mock_tests/flexcounter_ut.cpp
@@ -751,10 +751,28 @@ namespace flexcounter_test
         ASSERT_TRUE(gPortsOrch->getPort(secondPortName, secondPort));
         auto second_oid = secondPort.m_port_id;
 
+        std::deque<KeyOpFieldsValuesTuple> entries;
+
+        auto port_consumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_PORT_TABLE_NAME));
+        entries.push_back({secondPortName, "SET", {{"fec", "rs"}}});
+        port_consumer->addToSync(entries);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+        ASSERT_TRUE(gPortsOrch->getPort(secondPortName, secondPort));
+        ASSERT_EQ(secondPort.m_fec_mode, SAI_PORT_FEC_MODE_RS);
+        ASSERT_EQ(secondPort.m_fec_cfg, true);
+        ASSERT_TRUE(checkFlexCounter(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, second_oid, PORT_COUNTER_ID_LIST));
+
+        entries.clear();
+        entries.push_back({secondPortName, "SET", {{"fec", "none"}}});
+        port_consumer->addToSync(entries);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+        ASSERT_TRUE(gPortsOrch->getPort(secondPortName, secondPort));
+        ASSERT_EQ(secondPort.m_fec_mode, SAI_PORT_FEC_MODE_NONE);
+        ASSERT_EQ(secondPort.m_fec_cfg, true);
+        ASSERT_TRUE(checkFlexCounter(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, second_oid, PORT_COUNTER_ID_LIST));
 
         //Verify the Port Stats counter after DEL
-        std::deque<KeyOpFieldsValuesTuple> entries;
-        auto port_consumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_PORT_TABLE_NAME));
+        entries.clear();
         entries.push_back({secondPortName, "DEL",  {} });
         port_consumer->addToSync(entries);
         static_cast<Orch *>(gPortsOrch)->doTask();
@@ -773,6 +791,15 @@ namespace flexcounter_test
         }
         ASSERT_FALSE(gPortsOrch->getPort(secondPortName, secondPort));
         ASSERT_FALSE(checkFlexCounter(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, second_oid, PORT_COUNTER_ID_LIST));
+
+        //Verify the Port Stats counter after re-ADD
+        entries.clear();
+        entries.push_back({secondPortName, "SET", secondPortValues});
+        port_consumer->addToSync(entries);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+        ASSERT_TRUE(gPortsOrch->getPort(secondPortName, secondPort));
+        second_oid = secondPort.m_port_id;
+        ASSERT_TRUE(checkFlexCounter(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, second_oid, PORT_COUNTER_ID_LIST));
 
         // create a routing interface
         entries.clear();

--- a/tests/test_flex_counters.py
+++ b/tests/test_flex_counters.py
@@ -177,8 +177,10 @@ class TestFlexCounters(TestFlexCountersBase):
         time.sleep(2)
         self.wait_for_port_attribute_set(port, field, value)
 
-    def verify_fec_counters(self, meta_data):
-        port_name = 'Ethernet0'
+    def verify_fec_counters(self, meta_data, test_port, is_fec_none=False):
+        port_name = 'None'
+        if (is_fec_none == True):
+            port_name = test_port
         port_oid = None
         port_counters_keys = self.counters_db.db_connection.hgetall(meta_data['name_map']).items()
         for counter_key in port_counters_keys:
@@ -288,7 +290,16 @@ class TestFlexCounters(TestFlexCountersBase):
 
     def post_port_counter_test(self, meta_data):
         self.verify_only_phy_ports_created(meta_data)
-        self.verify_fec_counters(meta_data)
+        self.verify_fec_counters(meta_data, 'Ethernet0', True)
+        self.set_port_attribute(meta_data, 'Ethernet0', 'fec', 'rs')
+        self.verify_fec_counters(meta_data, 'Ethernet0', False)
+        attr_dict = {
+            "lanes": "1000,1001,1002,1003",
+            "speed": "100000",
+            "fec": "none"
+        }
+        self.config_db.create_entry("PORT", "Ethernet1000", attr_dict)
+        self.verify_fec_counters(meta_data, 'Ethernet1000', True)
 
     def post_trap_flow_counter_test(self, meta_data):
         """Post verification for test_flex_counters for trap_flow_counter. Steps:

--- a/tests/test_flex_counters.py
+++ b/tests/test_flex_counters.py
@@ -13,6 +13,7 @@ counter_group_meta = {
         'key': 'PORT',
         'group_name': 'PORT_STAT_COUNTER',
         'name_map': 'COUNTERS_PORT_NAME_MAP',
+        'pre_test': 'pre_port_counter_test',
         'post_test':  'post_port_counter_test',
     },
     'queue_counter': {
@@ -98,6 +99,29 @@ counter_group_meta = {
     }
 }
 
+port_stat_fec_ids = [
+    "SAI_PORT_STAT_IF_IN_FEC_CORRECTABLE_FRAMES",
+    "SAI_PORT_STAT_IF_IN_FEC_NOT_CORRECTABLE_FRAMES",
+    "SAI_PORT_STAT_IF_IN_FEC_SYMBOL_ERRORS",
+    "SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S0",
+    "SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S1",
+    "SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S2",
+    "SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S3",
+    "SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S4",
+    "SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S5",
+    "SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S6",
+    "SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S7",
+    "SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S8",
+    "SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S9",
+    "SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S10",
+    "SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S11",
+    "SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S12",
+    "SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S13",
+    "SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S14",
+    "SAI_PORT_STAT_IF_IN_FEC_CODEWORD_ERRORS_S15",
+    "SAI_PORT_STAT_IF_IN_FEC_CORRECTED_BITS"
+ ]
+
 
 class TestFlexCounters(TestFlexCountersBase):
 
@@ -135,6 +159,47 @@ class TestFlexCounters(TestFlexCountersBase):
         port_counters_stat_keys = self.flex_db.get_keys("FLEX_COUNTER_TABLE:" + meta_data['group_name'])
         for port_stat in port_counters_stat_keys:
             assert port_stat in dict(port_counters_keys.items()).values(), "Non PHY port created on PORT_STAT_COUNTER group: {}".format(port_stat)
+
+    def wait_for_port_attribute_set(self, port, field, value):
+        attr_value = None
+        for retry in range(NUMBER_OF_RETRIES):
+            attr_value = self.config_db.db_connection.hget("PORT|" + port, field)
+            if attr_value == value:
+                return
+            else:
+                time.sleep(1)
+        assert False, "Port Attribute {} is not applied to Port {}, expect={}, actual={}".format(field, port, value, attr_value)
+
+    def set_port_attribute(self, meta_data, port, field, value):
+        entry = {field: value}
+        self.config_db.create_entry("PORT", port, entry)
+        #wait for the orchagent to get the config update
+        time.sleep(2)
+        self.wait_for_port_attribute_set(port, field, value)
+
+    def verify_fec_counters(self, meta_data):
+        port_name = 'Ethernet0'
+        port_oid = None
+        port_counters_keys = self.counters_db.db_connection.hgetall(meta_data['name_map']).items()
+        for counter_key in port_counters_keys:
+            if counter_key[0] == port_name:
+                port_oid = counter_key[1]
+            port_counters_stats = self.flex_db.db_connection.hgetall("FLEX_COUNTER_TABLE:" + meta_data['group_name']+ ":" + counter_key[1]).values()
+            for fec_stat in port_stat_fec_ids:
+                for flex_stat in port_counters_stats:
+                    if counter_key[0] == port_name:
+                        assert fec_stat not in flex_stat, "fec_stat {} found in flex_counter stats for FEC disabled port :{} ".format(fec_stat,counter_key[0])
+                    else:
+                        assert fec_stat in flex_stat, "fec_stat {} not found in flex_counter stats for FEC enabled port:{} ".format(fec_stat,counter_key[0])
+        #Enable fec and check the FEC counters are added to FLEX_COUNTER_DB
+        self.set_port_attribute(meta_data, port_name, 'fec', 'rs')
+        if port_oid is not None:
+            port_counters_stats = self.flex_db.db_connection.hgetall("FLEX_COUNTER_TABLE:" + meta_data['group_name']+ ":" + port_oid).values()
+            for fec_stat in port_stat_fec_ids:
+                for flex_stat in port_counters_stats:
+                    assert fec_stat in flex_stat, "fec_stat {} not found in flex_counter stats for FEC enabled port:{} ".format(fec_stat,port_name)
+        #Remove the FEC config since the original PORT config did not have FEC configured
+        self.config_db.delete_field("PORT", port_name, "fec")
 
     def set_only_config_db_buffers_field(self, value):
         fvs = {'create_only_config_db_buffers' : value}
@@ -217,8 +282,13 @@ class TestFlexCounters(TestFlexCountersBase):
     def post_rif_counter_test(self, meta_data):
         self.config_db.db_connection.hdel('INTERFACE|Ethernet0|192.168.0.1/24', "NULL")
 
+    def pre_port_counter_test(self, meta_data):
+        #set FEC to none to verify the FEC counters in FLEX_COUNTER_DB
+        self.set_port_attribute(meta_data, 'Ethernet0', 'fec', 'none')
+
     def post_port_counter_test(self, meta_data):
         self.verify_only_phy_ports_created(meta_data)
+        self.verify_fec_counters(meta_data)
 
     def post_trap_flow_counter_test(self, meta_data):
         """Post verification for test_flex_counters for trap_flow_counter. Steps:


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add the FEC related Port stats counter to FLEX_COUNTER polling only if the FEC is enabled for that port (https://github.com/sonic-net/sonic-buildimage/issues/23168). This addresses the issue reported in https://github.com/sonic-net/sonic-buildimage/issues/23168  which gives more information about BCM SAI change.

**Why I did it**
If the FEC is disabled for port, the BCM SAI returns error. If all the ports stats counters are queried in bulk for the FEC disabled port, since SAI returns error when it processes the FEC stats, none of the port stats counters for that are polled and updated to COUNTER_DB. So the show int counter does not work for the FEC disabled port.
**How I verified it**
Verified the FEC related stats are added to FLEX_COUNTER_DB for only FEC enabled ports and FEC not configured ports. Also verified the show int counter stats output with the traffic.
**Details if related**
Please note that this PR depends on https://github.com/sonic-net/sonic-swss/pull/3654 since the Port stats use the flex counter cache