### PR TITLE
[DASH] Track vnet map usage of PA validation entries

### DIFF
--- a/orchagent/crmorch.cpp
+++ b/orchagent/crmorch.cpp
@@ -569,6 +569,21 @@ void CrmOrch::decCrmResUsedCounter(CrmResourceType resource)
     }
 }
 
+bool CrmOrch::getCrmResUsedCounter(CrmResourceType resource, uint32_t &count)
+{
+    SWSS_LOG_ENTER();
+    try
+    {
+        count = m_resourcesMap.at(resource).countersMap[CRM_COUNTERS_TABLE_KEY].usedCounter;
+        return true;
+    }
+    catch (...)
+    {
+        SWSS_LOG_ERROR("Failed to get \"used\" counter for the %s CRM resource.", crmResTypeNameMap.at(resource).c_str());
+        return false;
+    }
+}
+
 void CrmOrch::incCrmAclUsedCounter(CrmResourceType resource, sai_acl_stage_t stage, sai_acl_bind_point_type_t point)
 {
     SWSS_LOG_ENTER();

--- a/orchagent/crmorch.h
+++ b/orchagent/crmorch.h
@@ -76,6 +76,7 @@ public:
     CrmOrch(swss::DBConnector *db, std::string tableName);
     void incCrmResUsedCounter(CrmResourceType resource);
     void decCrmResUsedCounter(CrmResourceType resource);
+    bool getCrmResUsedCounter(CrmResourceType resource, uint32_t &count);
     // Increment "used" counter for the ACL table/group CRM resources
     void incCrmAclUsedCounter(CrmResourceType resource, sai_acl_stage_t stage, sai_acl_bind_point_type_t point);
     // Decrement "used" counter for the ACL table/group CRM resources

--- a/orchagent/dash/dashvnetorch.h
+++ b/orchagent/dash/dashvnetorch.h
@@ -21,7 +21,7 @@ struct VnetEntry
 {
     sai_object_id_t vni;
     dash::vnet::Vnet metadata;
-    std::set<std::string> underlay_ips;
+    std::map<std::string, int> underlay_ip_refs;
 };
 
 typedef std::unordered_map<std::string, VnetEntry> DashVnetTable;
@@ -53,7 +53,8 @@ struct VnetMapBulkContext
     dash::vnet_mapping::VnetMapping metadata;
     std::deque<sai_status_t> outbound_ca_to_pa_object_statuses;
     std::deque<sai_status_t> pa_validation_object_statuses;
-    VnetMapBulkContext() {}
+    bool pa_validation_needs_removal;
+    VnetMapBulkContext() : pa_validation_needs_removal(false) {}
 
     VnetMapBulkContext(const VnetMapBulkContext&) = delete;
     VnetMapBulkContext(VnetMapBulkContext&&) = delete;
@@ -95,8 +96,11 @@ private:
     bool removeOutboundCaToPaPost(const std::string& key, const VnetMapBulkContext& ctxt);
     void addPaValidation(const std::string& key, VnetMapBulkContext& ctxt);
     bool addPaValidationPost(const std::string& key, const VnetMapBulkContext& ctxt);
-    void removePaValidation(const std::string& key, DashVnetBulkContext& ctxt);
-    bool removePaValidationPost(const std::string& key, const DashVnetBulkContext& ctxt);
+    void decrPaValidationRefCount(const std::string &key, VnetMapBulkContext &ctxt);
+    void removePaValidation(const std::string &vnet, const std::string &ip, std::deque<sai_status_t> &object_statuses);
+    void removeAllPaValidations(const std::string &key, DashVnetBulkContext &ctxt);
+    bool removePaValidationPost(const std::string &key, const VnetMapBulkContext &ctxt);
+    bool removeAllPaValidationsPost(const std::string &key, const DashVnetBulkContext &ctxt);
     bool addVnetMap(const std::string& key, VnetMapBulkContext& ctxt);
     bool addVnetMapPost(const std::string& key, const VnetMapBulkContext& ctxt);
     bool removeVnetMap(const std::string& key, VnetMapBulkContext& ctxt);

--- a/tests/mock_tests/dashvnetorch_ut.cpp
+++ b/tests/mock_tests/dashvnetorch_ut.cpp
@@ -27,17 +27,42 @@ namespace dashvnetorch_test
     using ::testing::Return;
     using ::testing::Throw;
     using ::testing::DoAll;
+    using ::testing::DoDefault;
     using ::testing::SetArrayArgument;
     using ::testing::SetArgPointee;
+    using ::testing::InSequence;
 
     class DashVnetOrchTest : public MockDashOrchTest
     {
     protected:
-        int GetCrmUsedCount(CrmResourceType type)
+        uint32_t GetCrmUsedCount(CrmResourceType type)
         {
-            CrmOrch::CrmResourceEntry entry = CrmOrch::CrmResourceEntry("", CrmThresholdType::CRM_PERCENTAGE, 0, 1);
-            gCrmOrch->getResAvailability(type, entry);
-            return entry.countersMap["STATS"].usedCounter;
+            uint32_t count;
+            if (gCrmOrch->getCrmResUsedCounter(type, count))
+            {
+                return count;
+            }
+            return 0;
+        }
+
+        std::pair<uint32_t, uint32_t> GetVnetMapCrm()
+        {
+            uint32_t used_ca_to_pa = GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_OUTBOUND_CA_TO_PA);
+            uint32_t used_pa_validation = GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_PA_VALIDATION);
+            return std::make_pair(used_ca_to_pa, used_pa_validation);
+        }
+
+        bool CheckExpectedCrmMatch(uint32_t expected_ca_to_pa, uint32_t expected_pa_validation)
+        {
+            uint32_t actual_ca_to_pa, actual_pa_validation;
+            std::tie(actual_ca_to_pa, actual_pa_validation) = GetVnetMapCrm();
+            bool matches = actual_ca_to_pa == expected_ca_to_pa && actual_pa_validation == expected_pa_validation;
+            if (!matches)
+            {
+                std::cout << "Expected CA to PA: " << expected_ca_to_pa << ", Actual CA to PA: " << actual_ca_to_pa << std::endl;
+                std::cout << "Expected PA Validation: " << expected_pa_validation << ", Actual PA Validation: " << actual_pa_validation << std::endl;
+            }
+            return matches;
         }
 
         void ApplySaiMock() override
@@ -51,6 +76,7 @@ namespace dashvnetorch_test
         void PostSetUp() override
         {
             CreateApplianceEntry();
+            std::tie(orig_ca_to_pa, orig_pa_validation) = GetVnetMapCrm();
         }
         void PreTearDown() override
         {
@@ -60,93 +86,98 @@ namespace dashvnetorch_test
             DEINIT_SAI_API_MOCK(dash_vnet);
         }
 
+        int orig_ca_to_pa, orig_pa_validation, expected_ca_to_pa, expected_pa_validation;
     };
 
     TEST_F(DashVnetOrchTest, AddRemoveVnet)
     {
-        std::vector<sai_status_t> exp_status = {SAI_STATUS_SUCCESS};
+        expected_ca_to_pa = orig_ca_to_pa + 1;
+        expected_pa_validation = orig_pa_validation + 1;
+
         AddRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
-        EXPECT_CALL(*mock_sai_dash_vnet_api, create_vnets)
-            .Times(1).WillOnce(DoAll(
-                SetArgPointee<5>(0x1234),
-                SetArrayArgument<6>(exp_status.begin(), exp_status.end()),
-                Return(SAI_STATUS_SUCCESS)
-            )
-            );
+
+        {
+            InSequence seq;
+            EXPECT_CALL(*mock_sai_dash_vnet_api, create_vnets).Times(1);
+            EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries).Times(1);
+            EXPECT_CALL(*mock_sai_dash_pa_validation_api, create_pa_validation_entries).Times(1);
+            EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, remove_outbound_ca_to_pa_entries).Times(1);
+            EXPECT_CALL(*mock_sai_dash_pa_validation_api, remove_pa_validation_entries).Times(1);
+            EXPECT_CALL(*mock_sai_dash_vnet_api, remove_vnets).Times(1);
+        }
         CreateVnet();
-        EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries)
-            .Times(1).WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-        EXPECT_CALL(*mock_sai_dash_pa_validation_api, create_pa_validation_entries)
-            .Times(1).WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
         AddVnetMap();
 
-        EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, remove_outbound_ca_to_pa_entries)
-            .Times(1).WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_TRUE(CheckExpectedCrmMatch(expected_ca_to_pa, expected_pa_validation));
+
         RemoveVnetMap();
-        EXPECT_CALL(*mock_sai_dash_pa_validation_api, remove_pa_validation_entries)
-            .Times(1).WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-        EXPECT_CALL(*mock_sai_dash_vnet_api, remove_vnets)
-            .Times(1).WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+        // Removing all VNET maps using a specific PA validation entry should also result in the removal
+        // of the PA validation entry, even if the VNET still exists
+        EXPECT_TRUE(CheckExpectedCrmMatch(orig_ca_to_pa, orig_pa_validation));
+
         RemoveVnet();
+
+        EXPECT_TRUE(CheckExpectedCrmMatch(orig_ca_to_pa, orig_pa_validation));
     }
 
     TEST_F(DashVnetOrchTest, AddVnetMapMissingVnetFails)
     {
+        AddRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
         EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries)
             .Times(0);
         EXPECT_CALL(*mock_sai_dash_pa_validation_api, create_pa_validation_entries)
             .Times(0);
-        AddRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
         AddVnetMap(false);
+        EXPECT_TRUE(CheckExpectedCrmMatch(orig_ca_to_pa, orig_pa_validation));
     }
 
     TEST_F(DashVnetOrchTest, AddExistingOutboundCaToPaSuccessful)
     {
-        AddRoutingType(dash::route_type::ENCAP_TYPE_VXLAN); 
+        AddRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
         CreateVnet();
-        AddVnetMap();
-        std::vector<sai_status_t> exp_status = {SAI_STATUS_ITEM_ALREADY_EXISTS};
 
-        int expectedUsed = GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_OUTBOUND_CA_TO_PA);
         EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries)
-            .Times(1).WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-        AddVnetMap(); 
-        int actualUsed = GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_OUTBOUND_CA_TO_PA);
-        EXPECT_EQ(expectedUsed, actualUsed);
+            .Times(2);
+        AddVnetMap();
+        std::tie(expected_ca_to_pa, expected_pa_validation) = GetVnetMapCrm();
+        AddVnetMap();
+        EXPECT_TRUE(CheckExpectedCrmMatch(expected_ca_to_pa, expected_pa_validation));
     }
 
     TEST_F(DashVnetOrchTest, RemoveNonexistVnetMapFails)
     {
-        int expectedUsed = GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_OUTBOUND_CA_TO_PA);
-        std::vector<sai_status_t> exp_status = {SAI_STATUS_ITEM_NOT_FOUND};
+        CreateVnet();
         EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, remove_outbound_ca_to_pa_entries)
-            .Times(1).WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-        RemoveVnetMap(); 
-        int actualUsed = GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_OUTBOUND_CA_TO_PA);
-        EXPECT_EQ(expectedUsed, actualUsed);
+            .Times(1);
+        RemoveVnetMap();
+        EXPECT_TRUE(CheckExpectedCrmMatch(orig_ca_to_pa, orig_pa_validation));
     }
 
     TEST_F(DashVnetOrchTest, InvalidEncapVnetMapFails)
     {
         AddRoutingType(dash::route_type::ENCAP_TYPE_UNSPECIFIED);
         CreateVnet();
-        AddVnetMap();
         EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries)
             .Times(0);
         AddVnetMap();
+        AddVnetMap();
+        EXPECT_TRUE(CheckExpectedCrmMatch(orig_ca_to_pa, orig_pa_validation));
     }
 
     TEST_F(DashVnetOrchTest, AddExistPaValidationSuccessful)
     {
         AddRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
         CreateVnet();
-        std::vector<sai_status_t> exp_status = {SAI_STATUS_ITEM_ALREADY_EXISTS};
-        int expectedUsed = GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_PA_VALIDATION);
+
+        // First add operation will propogate to SAI normally
+        // Second add operation will not propogate to SAI since orchagent caches PA validation entries and can check for duplicates
         EXPECT_CALL(*mock_sai_dash_pa_validation_api, create_pa_validation_entries)
-            .Times(1).WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+            .Times(1);
         AddVnetMap();
-        int actualUsed = GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_PA_VALIDATION);
-        EXPECT_EQ(expectedUsed, actualUsed);
+        std::tie(expected_ca_to_pa, expected_pa_validation) = GetVnetMapCrm();
+        AddVnetMap();
+        EXPECT_TRUE(CheckExpectedCrmMatch(expected_ca_to_pa, expected_pa_validation));
     }
 
     TEST_F(DashVnetOrchTest, RemovePaValidationInUseFails)
@@ -155,14 +186,42 @@ namespace dashvnetorch_test
         CreateVnet();
         AddVnetMap();
 
-        int expectedUsed = GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_PA_VALIDATION);
-        std::vector<sai_status_t> exp_status = {SAI_STATUS_OBJECT_IN_USE};
+        std::vector<sai_status_t> exp_status = { SAI_STATUS_OBJECT_IN_USE };
 
         EXPECT_CALL(*mock_sai_dash_pa_validation_api, remove_pa_validation_entries)
-            .Times(1).WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+            .Times(1)
+            .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        std::tie(expected_ca_to_pa, expected_pa_validation) = GetVnetMapCrm();
         RemoveVnet(false);
 
-        int actualUsed = GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_PA_VALIDATION);
-        EXPECT_EQ(expectedUsed, actualUsed);
+        EXPECT_TRUE(CheckExpectedCrmMatch(expected_ca_to_pa, expected_pa_validation));
+    }
+
+    TEST_F(DashVnetOrchTest, AddRemoveMultipleVnetMapsWithSameUnderlayIp)
+    {
+        AddRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
+        CreateVnet();
+        EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries).Times(2);
+        EXPECT_CALL(*mock_sai_dash_pa_validation_api, create_pa_validation_entries).Times(1); 
+        EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, remove_outbound_ca_to_pa_entries).Times(2);
+        EXPECT_CALL(*mock_sai_dash_pa_validation_api, remove_pa_validation_entries).Times(1); 
+
+        expected_ca_to_pa = orig_ca_to_pa + 1;
+        expected_pa_validation = orig_pa_validation + 1;
+        AddVnetMap();
+        EXPECT_TRUE(CheckExpectedCrmMatch(expected_ca_to_pa, expected_pa_validation));
+
+        expected_ca_to_pa++;
+        AddVnetMap(true, vnet_map_ip2);
+        EXPECT_TRUE(CheckExpectedCrmMatch(expected_ca_to_pa, expected_pa_validation));
+
+        expected_ca_to_pa--;
+        RemoveVnetMap();
+        EXPECT_TRUE(CheckExpectedCrmMatch(expected_ca_to_pa, expected_pa_validation));
+
+        expected_ca_to_pa--;
+        expected_pa_validation--;
+        RemoveVnetMap(true, vnet_map_ip2);
+        EXPECT_TRUE(CheckExpectedCrmMatch(orig_ca_to_pa, orig_pa_validation));
     }
 }

--- a/tests/mock_tests/mock_dash_orch_test.cpp
+++ b/tests/mock_tests/mock_dash_orch_test.cpp
@@ -2,6 +2,15 @@
 
 namespace mock_orch_test
 {
+    std::string MockDashOrchTest::vnet1 = "VNET_1";
+    std::string MockDashOrchTest::vnet_map_ip1 = "2.2.2.2";
+    std::string MockDashOrchTest::vnet_map_ip2 = "3.3.3.3";
+    std::string MockDashOrchTest::vnet_map_underlay_ip = "7.7.7.7";
+    std::string MockDashOrchTest::appliance1 = "APPLIANCE_1";
+    std::string MockDashOrchTest::route_group1 = "ROUTE_GROUP_1";
+    std::string MockDashOrchTest::tunnel1 = "TUNNEL_1";
+    std::string MockDashOrchTest::eni1 = "ENI_1";
+
 
     void MockDashOrchTest::SetDashTable(std::string table_name, std::string key, const google::protobuf::Message &message, bool set, bool expect_empty)
     {
@@ -96,17 +105,20 @@ namespace mock_orch_test
         SetDashTable(APP_DASH_TUNNEL_TABLE_NAME, tunnel1, tunnel);
     }
 
-    void MockDashOrchTest::AddVnetMap(bool expect_empty)
+    void MockDashOrchTest::AddVnetMap(bool expect_empty, std::string vnet_ip)
     {
         dash::vnet_mapping::VnetMapping vnet_map = dash::vnet_mapping::VnetMapping();
         vnet_map.set_routing_type(dash::route_type::ROUTING_TYPE_VNET_ENCAP);
-        vnet_map.mutable_underlay_ip()->set_ipv4(swss::IpAddress("7.7.7.7").getV4Addr());
-        SetDashTable(APP_DASH_VNET_MAPPING_TABLE_NAME, vnet1 + ":" + vnet_map_ip1, vnet_map, true, expect_empty);
+        vnet_map.mutable_underlay_ip()->set_ipv4(swss::IpAddress(vnet_map_underlay_ip).getV4Addr());
+        SetDashTable(APP_DASH_VNET_MAPPING_TABLE_NAME, vnet1 + ":" + vnet_ip, vnet_map, true, expect_empty);
     }
 
-    void MockDashOrchTest::RemoveVnetMap()
+    void MockDashOrchTest::RemoveVnetMap(bool expect_empty, std::string vnet_ip)
     {
-        SetDashTable(APP_DASH_VNET_MAPPING_TABLE_NAME, vnet1 + ":" + vnet_map_ip1, dash::vnet_mapping::VnetMapping(), false);
+        dash::vnet_mapping::VnetMapping vnet_map = dash::vnet_mapping::VnetMapping();
+        vnet_map.set_routing_type(dash::route_type::ROUTING_TYPE_VNET_ENCAP);
+        vnet_map.mutable_underlay_ip()->set_ipv4(swss::IpAddress(vnet_map_underlay_ip).getV4Addr());
+        SetDashTable(APP_DASH_VNET_MAPPING_TABLE_NAME, vnet1 + ":" + vnet_ip, vnet_map, false, expect_empty);
     }
 
     dash::eni::Eni MockDashOrchTest::BuildEniEntry()

--- a/tests/mock_tests/mock_dash_orch_test.h
+++ b/tests/mock_tests/mock_dash_orch_test.h
@@ -25,18 +25,20 @@ namespace mock_orch_test
             void AddRoutingType(dash::route_type::EncapType encap_type);
             void CreateVnet();
             void RemoveVnet(bool expect_empty = true);
-            void AddVnetMap(bool expect_empty = true);
-            void RemoveVnetMap();
+            void AddVnetMap(bool expect_empty = true, std::string vnet_ip = vnet_map_ip1);
+            void RemoveVnetMap(bool expect_empty = true, std::string vnet_ip = vnet_map_ip1);
             void AddOutboundRoutingGroup();
             void AddOutboundRoutingEntry(bool expect_empty = true);
             void AddTunnel();
             dash::eni::Eni BuildEniEntry();
 
-            std::string vnet1 = "VNET_1";
-            std::string vnet_map_ip1 = "2.2.2.2";
-            std::string appliance1 = "APPLIANCE_1";
-            std::string route_group1 = "ROUTE_GROUP_1";
-            std::string tunnel1 = "TUNNEL_1";
-            std::string eni1 = "ENI_1";
+            static std::string vnet1;
+            static std::string vnet_map_ip1;
+            static std::string vnet_map_ip2;
+            static std::string vnet_map_underlay_ip;
+            static std::string appliance1;
+            static std::string route_group1;
+            static std::string tunnel1;
+            static std::string eni1;
     };
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

Fixes https://github.com/sonic-net/sonic-buildimage/issues/23470

**What I did**
Keep track of how many VNET mappings are using a given PA validation entry. When deleting the last VNET mapping using a given PA validation entry, also delete the entry.

For this to work, the delete op for a VNET mapping must have the `underlay_ip` protobuf field filled.

Also add CRM checks to the DashVnetOrch unit tests.

**Why I did it**
Fix inaccurate CRM use stats.

**How I verified it**
Run the unit tests.

**Details if related**
