### PR TITLE
Fix DPU restart message drop by Zmq lazy bind.

### DIFF
--- a/lib/orch_zmq_config.cpp
+++ b/lib/orch_zmq_config.cpp
@@ -72,7 +72,10 @@ std::shared_ptr<swss::ZmqServer> swss::create_zmq_server(std::string zmq_address
     }
 
     SWSS_LOG_NOTICE("Create ZMQ server with address: %s, vrf: %s", zmq_address.c_str(), vrf.c_str());
-    return std::make_shared<ZmqServer>(zmq_address, vrf);
+
+    // To prevent message loss between ZmqServer's bind operation and the creation of ZmqProducerStateTable,
+    // use lazy binding and call bind() only after the handler has been registered.
+    return std::make_shared<ZmqServer>(zmq_address, vrf, true);
 }
 
 bool swss::get_feature_status(std::string feature, bool default_value)

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -854,6 +854,14 @@ int main(int argc, char **argv)
         syncd_apply_view();
     }
 
+    if (zmq_server)
+    {
+        // To prevent message loss between ZmqServer's bind operation and the creation of ZmqProducerStateTable,
+        // use lazy binding and call bind() only after the handler has been registered.
+        zmq_server->bind();
+        SWSS_LOG_NOTICE("ZMQ channel on the northbound side of Orchagent successfully bound: %s, %s", zmq_server_address.c_str(), vrf.c_str());
+    }
+
     orchDaemon->start(heartBeatInterval);
 
     return 0;


### PR DESCRIPTION
Fix DPU restart message drop by Zmq lazy bind.

#### Why I did it
Fix issue: 
https://github.com/sonic-net/sonic-buildimage/issues/23110

When creating a ZmqServer followed by a ZmqProducerStateTable, there may be a time gap between the server starting to receive messages and the producer state table registering its handler. 

This gap can lead to dropped messages. To avoid this, use lazy binding and invoke bind() only after the handler is registered.

#### How I did it
Update Orchagent to use lazy binding for ZMQ.
ZMQ is now created with lazy bind in Orchagent, and the bind() operation is deferred until all ZmqProducerStateTable instances have been initialized. This ensures handlers are registered before any messages are received, preventing potential data loss during startup.

This PR depends on https://github.com/sonic-net/sonic-swss-common/pull/1068

##### Work item tracking
- Microsoft ADO: 33995986

#### How to verify it
Pass all test cases.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Fix DPU restart message drop by Zmq lazy bind.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

