### PR TITLE
[muxorch] Fix handling mux neighbors learned after route

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -855,6 +855,8 @@ void FdbOrch::doTask(Consumer& consumer)
                 }
             }
 
+            // set entry port_name, which is used in mux fdb update logic
+            entry.port_name = port;
 
             FdbData fdbData;
             fdbData.bridge_port_id = SAI_NULL_OBJECT_ID;

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1825,8 +1825,8 @@ bool RouteOrch::updateNextHopRoutes(const NextHopKey& nextHop, uint32_t& numRout
             continue;
         }
 
-        SWSS_LOG_INFO("Updating route %s", (*rt).prefix.to_string().c_str());
         next_hop_id = m_neighOrch->getNextHopId(nextHop);
+        SWSS_LOG_INFO("Updating route %s with nexthop %lu", (*rt).prefix.to_string().c_str(), next_hop_id);
 
         route_entry.vr_id = (*rt).vrf_id;
         route_entry.switch_id = gSwitchId;

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -579,6 +579,59 @@ class TestMuxTunnelBase():
             " " + self.SERV1_IPV4 + "\""
         )
 
+    def create_and_test_route_learned_before_neighbor(self, appdb, asicdb, dvs, dvs_route, mac):
+        rtprefix = "2.3.4.0/24"
+        neigh = "192.168.0.100"
+        mux_port = "Ethernet0"
+
+        try:
+            # Test adding route then neighbor in standby
+            self.set_mux_state(appdb, mux_port, "standby")
+
+            self.add_route(dvs, route, ["192.168.0.100"])
+            asicdb.wait_for_entry(ASIC_ROUTE_TABLE, rtprefix)
+
+            self.add_neighbor(dvs, neigh, mac)
+            sleep(1)
+
+            # Confirm route is pointing to tunnel nh
+            self.check_route_nexthop(dvs_route, asicdb, rtprefix, tunnel_nh_id, True)
+
+            # Toggle the mux a few times
+            self.set_mux_state(appdb, mux_port, "active")
+            self.check_route_nexthop(dvs_route, asicdb, rtprefix, neigh)
+
+            self.set_mux_state(appdb, mux_port, "standby")
+            self.check_route_nexthop(dvs_route, asicdb, rtprefix, tunnel_nh_id, True)
+
+        finally:
+            self.del_route(dvs, route)
+            self.del_neighbor(dvs, neigh_info.ipv4)
+
+        try:
+            # Test adding route then neighbor in active
+            self.set_mux_state(appdb, mux_port, "active")
+
+            self.add_route(dvs, route, ["192.168.0.100"])
+            asicdb.wait_for_entry(ASIC_ROUTE_TABLE, rtprefix)
+
+            self.add_neighbor(dvs, neigh, mac)
+            sleep(1)
+
+            # Confirm route is pointing to tunnel nh
+            self.check_route_nexthop(dvs_route, asicdb, rtprefix, neigh)
+
+            # Toggle the mux a few times
+            self.set_mux_state(appdb, mux_port, "standby")
+            self.check_route_nexthop(dvs_route, asicdb, rtprefix, tunnel_nh_id, True)
+
+            self.set_mux_state(appdb, mux_port, "active")
+            self.check_route_nexthop(dvs_route, asicdb, rtprefix, neigh)
+
+        finally:
+            self.del_route(dvs, route)
+            self.del_neighbor(dvs, neigh_info.ipv4)
+
     def multi_nexthop_check(self, asicdb, dvs_route, route, nexthops, mux_states, non_mux_nexthop = None):
         if isinstance(route, list):
             route_copy = route.copy()
@@ -1539,8 +1592,10 @@ class TestMuxTunnel(TestMuxTunnelBase):
 
         appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
         asicdb = dvs.get_asic_db()
+        mac = intf_fdb_map["Ethernet0"]
 
         self.create_and_test_route(appdb, asicdb, dvs, dvs_route)
+        self.create_and_test_route_learned_before_neighbor(appdb, asicdb, dvs, dvs_route, mac)
 
     def test_NH(self, dvs, dvs_route, intf_fdb_map, setup, setup_mux_cable,
                 setup_peer_switch, setup_tunnel, testlog):


### PR DESCRIPTION
Mux neighbors that were learned in standby state when a route entry is present were not being disabled properly due to still being referenced by the route.

This change calls updateNextHopRoutes and decreases the nexthop refcount before disabling the neighbor, allowing the neighbor to be removed.

Also applies fix that passes in the port_name on initial fdb add.

**What I did**
- Update routes pointing to newly learned neighbor in standby state and update refcount
- Update refcount for routes updated when neighbor is learned in active state
- Moved update logic to after neighbor gets added to mux port
- Pass port name when adding Fdb entry
- Add vstest to test changes

**Why I did it**
Neighbors added while a route is present were not being disabled due to nonzero refcounts. This caused traffic to blackhole and dualtor_neighbor_check.py to fail due to mismatch between APPL and ASIC state.

**How I verified it**
Added vstest with test cases of adding neighbor while route exists in standby and active and toggling between the two states.

**Details if related**
ado: #34501086
