### PR TITLE
[ssw][ha] set `SAI_HA_SCOPE_ATTR_ADMIN_STATE`  

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -79,21 +79,6 @@ jobs:
     inputs:
       source: specific
       project: build
-      pipeline: Azure.sonic-buildimage.common_libs
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/$(BUILD_BRANCH)'
-      path: $(Build.ArtifactStagingDirectory)/download
-      artifact: common-lib
-      patterns: |
-        target/debs/bookworm/libyang-*_1.0*.deb
-        target/debs/bookworm/libyang_1.0*.deb
-        target/debs/bookworm/libyang-cpp_*.deb
-        target/debs/bookworm/python3-yang_*.deb
-    displayName: "Download libyang from common lib"
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      source: specific
-      project: build
       pipeline: sonic-net.sonic-buildimage-ubuntu22.04
       artifact: sonic-buildimage.amd64.ubuntu22_04
       runVersion: 'latestFromBranch'
@@ -127,15 +112,9 @@ jobs:
           libboost1.74-dev \
           libboost-dev \
           libhiredis0.14 \
-          libpcre3-dev
+          libyang-dev \
 
       sudo .azure-pipelines/build_and_install_module.sh
-
-      # Install libyang packages from downloaded artifacts
-      sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/target/debs/bookworm/libyang-*_1.0*.deb \
-                   $(Build.ArtifactStagingDirectory)/download/target/debs/bookworm/libyang_1.0*.deb \
-                   $(Build.ArtifactStagingDirectory)/download/target/debs/bookworm/libyang-cpp_*.deb \
-                   $(Build.ArtifactStagingDirectory)/download/target/debs/bookworm/python3-yang_*.deb
 
       sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libprotobuf*_amd64.deb $(Build.ArtifactStagingDirectory)/download/libprotobuf-lite*_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-protobuf*_amd64.deb
       sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libdashapi*.deb

--- a/orchagent/dash/dashhaorch.cpp
+++ b/orchagent/dash/dashhaorch.cpp
@@ -748,6 +748,13 @@ void DashHaOrch::doTaskHaScopeTable(ConsumerBase &consumer)
         {
             dash::ha_scope::HaScope entry;
 
+            // Check if this is an update to existing entry
+            auto existing_it = m_ha_scope_entries.find(key);
+            if (existing_it != m_ha_scope_entries.end())
+            {
+                // Start with existing entry to preserve unmodified fields
+                entry.CopyFrom(existing_it->second.metadata);
+            }
 
             /*
             * For HA internal tables, kfv format was used instead of serialized pb objects in the end.

--- a/orchagent/dash/dashhaorch.cpp
+++ b/orchagent/dash/dashhaorch.cpp
@@ -441,6 +441,11 @@ bool DashHaOrch::addHaScopeEntry(const std::string &key, const dash::ha_scope::H
     ha_role_attr.value.u16 = to_sai(entry.ha_role());
     ha_scope_attrs.push_back(ha_role_attr);
 
+    sai_attribute_t disabled_attr = {};
+    disabled_attr.id = SAI_HA_SCOPE_ATTR_ADMIN_STATE;
+    disabled_attr.value.booldata = entry.disabled();
+    ha_scope_attrs.push_back(disabled_attr);
+
     if (entry.has_vip_v4() && entry.vip_v4().has_ipv4())
     {
         sai_ip_address_t sai_vip_v4 = {};
@@ -666,6 +671,8 @@ bool DashHaOrch::setHaScopeDisabled(const std::string &key, bool disabled)
             return parseHandleSaiStatusFailure(handle_status);
         }
     }
+
+    m_ha_scope_entries[key].metadata.set_disabled(disabled);
     SWSS_LOG_NOTICE("Set HA Scope admin state for %s to %d", key.c_str(), disabled);
 
     return true;

--- a/orchagent/dash/dashhaorch.cpp
+++ b/orchagent/dash/dashhaorch.cpp
@@ -408,7 +408,17 @@ bool DashHaOrch::addHaScopeEntry(const std::string &key, const dash::ha_scope::H
         return success;
     }
 
-    auto ha_set_it = m_ha_set_entries.find(entry.ha_set_id());
+    std::map<std::string, HaSetEntry>::iterator ha_set_it;
+    if (!entry.ha_set_id().empty())
+    {
+        ha_set_it = m_ha_set_entries.find(entry.ha_set_id());
+    }
+    else
+    {
+        /* ha_set_id field in ha_scope_table was added as a revision of detailed HLD, adding backward compatibility for ha_set_id mapping. */
+        ha_set_it = m_ha_set_entries.find(key);
+    }
+
     if (ha_set_it == m_ha_set_entries.end())
     {
         // If there is no HA Set entry, we cannot create HA Scope.
@@ -1020,7 +1030,6 @@ bool DashHaOrch::convertKfvToHaSetPb(const std::vector<FieldValueTuple> &kfv, da
         else
         {
             SWSS_LOG_WARN("Unknown field %s in HA Set entry", field.c_str());
-            return false;
         }
     }
     return true;

--- a/orchagent/dash/dashhaorch.cpp
+++ b/orchagent/dash/dashhaorch.cpp
@@ -408,18 +408,12 @@ bool DashHaOrch::addHaScopeEntry(const std::string &key, const dash::ha_scope::H
         return success;
     }
 
-    if (m_ha_set_entries.empty())
-    {
-        SWSS_LOG_ERROR("HA Set entry does not exist for %s", key.c_str());
-        return false;
-    }
-
-    auto ha_set_it = m_ha_set_entries.find(key);
+    auto ha_set_it = m_ha_set_entries.find(entry.ha_set_id());
     if (ha_set_it == m_ha_set_entries.end())
     {
-        // If it's ENI level HA, ha_set id won't map to ha_scope id.
-        // So we will use the first HA Set entry.
-        ha_set_it = m_ha_set_entries.begin();
+        // If there is no HA Set entry, we cannot create HA Scope.
+        SWSS_LOG_ERROR("HA Set entry does not exist for %s", key.c_str());
+        return false;
     }
     sai_object_id_t ha_set_oid = ha_set_it->second.ha_set_id;
 
@@ -432,18 +426,34 @@ bool DashHaOrch::addHaScopeEntry(const std::string &key, const dash::ha_scope::H
     ha_set_attr.value.oid = ha_set_oid;
     ha_scope_attrs.push_back(ha_set_attr);
 
-    // TODO: add ha_role to attribute value enum
     sai_attribute_t ha_role_attr = {};
     ha_role_attr.id = SAI_HA_SCOPE_ATTR_DASH_HA_ROLE;
     ha_role_attr.value.u16 = to_sai(entry.ha_role());
     ha_scope_attrs.push_back(ha_role_attr);
 
-    if (ha_set_it->second.metadata.has_vip_v4() && ha_set_it->second.metadata.vip_v4().has_ipv4())
+    if (entry.has_vip_v4() && entry.vip_v4().has_ipv4())
     {
+        sai_ip_address_t sai_vip_v4 = {};
+        if(to_sai(entry.vip_v4(), sai_vip_v4))
+        {
+            sai_attribute_t vip_v4_attr = {};
+            vip_v4_attr.id = SAI_HA_SCOPE_ATTR_VIP_V4;
+            vip_v4_attr.value.ipaddr = sai_vip_v4;
+            ha_scope_attrs.push_back(vip_v4_attr);
+        }
+        else
+        {
+            SWSS_LOG_WARN("Failed to convert VIP V4 for HA Scope %s", key.c_str());
+        }
+    }
+    else if (ha_set_it->second.metadata.has_vip_v4() && ha_set_it->second.metadata.vip_v4().has_ipv4())
+    {
+        SWSS_LOG_NOTICE("HA Scope entry %s does not have VIP V4, using HA Set metadata", key.c_str());
+
         sai_ip_address_t sai_vip_v4 = {};
         if (to_sai(ha_set_it->second.metadata.vip_v4(), sai_vip_v4))
         {
-            sai_attribute_t vip_v4_attr = {};  // Create new attribute for V4
+            sai_attribute_t vip_v4_attr = {};
             vip_v4_attr.id = SAI_HA_SCOPE_ATTR_VIP_V4;
             vip_v4_attr.value.ipaddr = sai_vip_v4;
             ha_scope_attrs.push_back(vip_v4_attr);
@@ -454,12 +464,27 @@ bool DashHaOrch::addHaScopeEntry(const std::string &key, const dash::ha_scope::H
         }
     }
 
-    if (ha_set_it->second.metadata.has_vip_v6() && !ha_set_it->second.metadata.vip_v6().ipv6().empty())
+    if (entry.has_vip_v6() && entry.vip_v6().has_ipv6())
+    {
+        sai_ip_address_t sai_vip_v6 = {};
+        if(to_sai(entry.vip_v6(), sai_vip_v6))
+        {
+            sai_attribute_t vip_v6_attr = {};
+            vip_v6_attr.id = SAI_HA_SCOPE_ATTR_VIP_V6;
+            vip_v6_attr.value.ipaddr = sai_vip_v6;
+            ha_scope_attrs.push_back(vip_v6_attr);
+        }
+        else
+        {
+            SWSS_LOG_WARN("Failed to convert VIP V6 for HA Scope %s", key.c_str());
+        }
+    }
+    else if (ha_set_it->second.metadata.has_vip_v6() && !ha_set_it->second.metadata.vip_v6().ipv6().empty())
     {
         sai_ip_address_t sai_vip_v6 = {};
         if (to_sai(ha_set_it->second.metadata.vip_v6(), sai_vip_v6))
         {
-            sai_attribute_t vip_v6_attr = {};  // Create new attribute for V6
+            sai_attribute_t vip_v6_attr = {};
             vip_v6_attr.id = SAI_HA_SCOPE_ATTR_VIP_V6;
             vip_v6_attr.value.ipaddr = sai_vip_v6;
             ha_scope_attrs.push_back(vip_v6_attr);
@@ -1035,10 +1060,33 @@ bool DashHaOrch::convertKfvToHaScopePb(const std::vector<FieldValueTuple> &kfv, 
         {
             entry.set_activate_role_requested(value == "true" || value == "1");
         }
+        else if (field == "vip_v4")
+        {
+            dash::types::IpAddress temp_ip;
+            if (!to_pb(value, temp_ip) || !temp_ip.has_ipv4())
+            {
+                SWSS_LOG_ERROR("Invalid IPv4 address %s", value.c_str());
+                return false;
+            }
+            entry.mutable_vip_v4()->CopyFrom(temp_ip);
+        }
+        else if (field == "vip_v6")
+        {
+            dash::types::IpAddress temp_ip;
+            if (!to_pb(value, temp_ip) || !temp_ip.has_ipv6())
+            {
+                SWSS_LOG_ERROR("Invalid IPv6 address %s", value.c_str());
+                return false;
+            }
+            entry.mutable_vip_v6()->CopyFrom(temp_ip);
+        }
+        else if (field == "ha_set_id")
+        {
+            entry.set_ha_set_id(value);
+        }
         else
         {
             SWSS_LOG_WARN("Unknown field %s in HA Scope entry", field.c_str());
-            return false;
         }
     }
     return true;

--- a/orchagent/dash/dashhaorch.cpp
+++ b/orchagent/dash/dashhaorch.cpp
@@ -410,17 +410,7 @@ bool DashHaOrch::addHaScopeEntry(const std::string &key, const dash::ha_scope::H
 
     std::map<std::string, HaSetEntry>::iterator ha_set_it;
     if (!entry.ha_set_id().empty())
-    std::map<std::string, HaSetEntry>::iterator ha_set_it;
-    if (!entry.ha_set_id().empty())
     {
-        ha_set_it = m_ha_set_entries.find(entry.ha_set_id());
-    }
-    else
-    {
-        /* ha_set_id field in ha_scope_table was added as a revision of detailed HLD, adding backward compatibility for ha_set_id mapping. */
-        ha_set_it = m_ha_set_entries.find(key);
-    }
-
         ha_set_it = m_ha_set_entries.find(entry.ha_set_id());
     }
     else
@@ -475,12 +465,9 @@ bool DashHaOrch::addHaScopeEntry(const std::string &key, const dash::ha_scope::H
     {
         SWSS_LOG_NOTICE("HA Scope entry %s does not have VIP V4, using HA Set metadata", key.c_str());
 
-        SWSS_LOG_NOTICE("HA Scope entry %s does not have VIP V4, using HA Set metadata", key.c_str());
-
         sai_ip_address_t sai_vip_v4 = {};
         if (to_sai(ha_set_it->second.metadata.vip_v4(), sai_vip_v4))
         {
-            sai_attribute_t vip_v4_attr = {};
             sai_attribute_t vip_v4_attr = {};
             vip_v4_attr.id = SAI_HA_SCOPE_ATTR_VIP_V4;
             vip_v4_attr.value.ipaddr = sai_vip_v4;
@@ -492,22 +479,6 @@ bool DashHaOrch::addHaScopeEntry(const std::string &key, const dash::ha_scope::H
         }
     }
 
-    if (entry.has_vip_v6() && entry.vip_v6().has_ipv6())
-    {
-        sai_ip_address_t sai_vip_v6 = {};
-        if(to_sai(entry.vip_v6(), sai_vip_v6))
-        {
-            sai_attribute_t vip_v6_attr = {};
-            vip_v6_attr.id = SAI_HA_SCOPE_ATTR_VIP_V6;
-            vip_v6_attr.value.ipaddr = sai_vip_v6;
-            ha_scope_attrs.push_back(vip_v6_attr);
-        }
-        else
-        {
-            SWSS_LOG_WARN("Failed to convert VIP V6 for HA Scope %s", key.c_str());
-        }
-    }
-    else if (ha_set_it->second.metadata.has_vip_v6() && !ha_set_it->second.metadata.vip_v6().ipv6().empty())
     if (entry.has_vip_v6() && entry.vip_v6().has_ipv6())
     {
         sai_ip_address_t sai_vip_v6 = {};

--- a/orchagent/dash/dashhaorch.cpp
+++ b/orchagent/dash/dashhaorch.cpp
@@ -443,7 +443,7 @@ bool DashHaOrch::addHaScopeEntry(const std::string &key, const dash::ha_scope::H
 
     sai_attribute_t disabled_attr = {};
     disabled_attr.id = SAI_HA_SCOPE_ATTR_ADMIN_STATE;
-    disabled_attr.value.booldata = entry.disabled();
+    disabled_attr.value.booldata = !entry.disabled();
     ha_scope_attrs.push_back(disabled_attr);
 
     if (entry.has_vip_v4() && entry.vip_v4().has_ipv4())
@@ -657,7 +657,7 @@ bool DashHaOrch::setHaScopeDisabled(const std::string &key, bool disabled)
 
     sai_attribute_t ha_scope_attr;
     ha_scope_attr.id = SAI_HA_SCOPE_ATTR_ADMIN_STATE;
-    ha_scope_attr.value.booldata = disabled;
+    ha_scope_attr.value.booldata = !disabled;
 
     sai_status_t status = sai_dash_ha_api->set_ha_scope_attribute(ha_scope_id,
                                                                 &ha_scope_attr);
@@ -748,7 +748,6 @@ void DashHaOrch::doTaskHaScopeTable(ConsumerBase &consumer)
         {
             dash::ha_scope::HaScope entry;
 
-            // Check if this is an update to existing entry
             auto existing_it = m_ha_scope_entries.find(key);
             if (existing_it != m_ha_scope_entries.end())
             {

--- a/orchagent/dash/dashhaorch.cpp
+++ b/orchagent/dash/dashhaorch.cpp
@@ -673,7 +673,7 @@ bool DashHaOrch::setHaScopeDisabled(const std::string &key, bool disabled)
     }
 
     m_ha_scope_entries[key].metadata.set_disabled(disabled);
-    SWSS_LOG_NOTICE("Set HA Scope admin state for %s to %d", key.c_str(), disabled);
+    SWSS_LOG_NOTICE("Set HA Scope admin state for %s to %d", key.c_str(), !disabled);
 
     return true;
 }

--- a/orchagent/dash/dashhaorch.h
+++ b/orchagent/dash/dashhaorch.h
@@ -62,6 +62,7 @@ protected:
     bool setHaScopeHaRole(const std::string &key, const dash::ha_scope::HaScope &entry);
     bool setHaScopeFlowReconcileRequest(const  std::string &key);
     bool setHaScopeActivateRoleRequest(const std::string &key);
+    bool setHaScopeDisabled(const std::string &key, bool disabled);
     bool setEniHaScopeId(const sai_object_id_t eni_id, const sai_object_id_t ha_scope_id);
     bool register_ha_set_notifier();
     bool register_ha_scope_notifier();

--- a/tests/mock_tests/dashhaorch_ut.cpp
+++ b/tests/mock_tests/dashhaorch_ut.cpp
@@ -246,7 +246,8 @@ namespace dashhaorch_ut
                                 {"ha_role", "dead"},
                                 {"ha_set_id", "HA_SET_1"},
                                 {"vip_v4", "10.0.0.1"},
-                                {"vip_v6", "3:2::1:0"}
+                                {"vip_v6", "3:2::1:0"},
+                                {"disabled", "true"}
                             }
                         }
                     }
@@ -312,7 +313,8 @@ namespace dashhaorch_ut
                             SET_COMMAND,
                             {
                                 {"version", "1"},
-                                {"ha_role", role}
+                                {"ha_role", role},
+                                {"disabled", "false"}
                             }
                         }
                     }
@@ -715,11 +717,13 @@ namespace dashhaorch_ut
         CreateHaScope();
 
         EXPECT_EQ(to_sai(m_dashHaOrch->getHaScopeEntries().find("HA_SET_1")->second.metadata.ha_role()), SAI_DASH_HA_ROLE_DEAD);
+        EXPECT_TRUE(m_dashHaOrch->getHaScopeEntries().find("HA_SET_1")->second.metadata.disabled());
 
         SetHaScopeHaRole();
         HaScopeEvent(SAI_HA_SCOPE_EVENT_STATE_CHANGED,
                     SAI_DASH_HA_ROLE_ACTIVE, SAI_DASH_HA_STATE_ACTIVE);
         EXPECT_EQ(to_sai(m_dashHaOrch->getHaScopeEntries().find("HA_SET_1")->second.metadata.ha_role()), SAI_DASH_HA_ROLE_ACTIVE);
+        EXPECT_FALSE(m_dashHaOrch->getHaScopeEntries().find("HA_SET_1")->second.metadata.disabled());
 
         SetHaScopeHaRole("");
         HaScopeEvent(SAI_HA_SCOPE_EVENT_STATE_CHANGED,
@@ -788,8 +792,7 @@ namespace dashhaorch_ut
         EXPECT_EQ(to_sai(m_dashHaOrch->getHaScopeEntries().find("HA_SET_1")->second.metadata.ha_role()), SAI_DASH_HA_ROLE_SWITCHING_TO_ACTIVE);
 
         EXPECT_CALL(*mock_sai_dash_ha_api, set_ha_scope_attribute)
-        .Times(2)       // Set ha_role and activate_role_requested
-        .WillRepeatedly(Return(SAI_STATUS_SUCCESS));
+        .Times(2);       // Set ha_role and activate_role_requested
 
         SetHaScopeActivateRoleRequest();
 
@@ -810,11 +813,14 @@ namespace dashhaorch_ut
         HaScopeEvent(SAI_HA_SCOPE_EVENT_FLOW_RECONCILE_NEEDED,
             SAI_DASH_HA_ROLE_ACTIVE, SAI_DASH_HA_STATE_ACTIVE);
 
+        EXPECT_TRUE(m_dashHaOrch->getHaScopeEntries().find("HA_SET_1")->second.metadata.disabled());
+
         EXPECT_CALL(*mock_sai_dash_ha_api, set_ha_scope_attribute)
-        .Times(1)
-        .WillOnce(Return(SAI_STATUS_SUCCESS));
+        .Times(1);
 
         SetHaScopeFlowReconcileRequest();
+
+        EXPECT_TRUE(m_dashHaOrch->getHaScopeEntries().find("HA_SET_1")->second.metadata.disabled());
 
         RemoveHaScope();
         RemoveHaSet();

--- a/tests/mock_tests/dashhaorch_ut.cpp
+++ b/tests/mock_tests/dashhaorch_ut.cpp
@@ -138,6 +138,42 @@ namespace dashhaorch_ut
             static_cast<Orch *>(m_dashHaOrch)->doTask(*consumer.get());
         }
 
+        void InvalidField()
+        {
+            auto consumer = unique_ptr<Consumer>(new Consumer(
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1, 1),
+                m_dashHaOrch, APP_DASH_HA_SET_TABLE_NAME));
+
+            consumer->addToSync(
+                deque<KeyOpFieldsValuesTuple>(
+                    {
+                        {
+                            "HA_SET_1",
+                            SET_COMMAND,
+                            {
+                                {"version", "1"},
+                                {"vip_v4", "10.0.0.1"},
+                                {"vip_v6", "3:2::1:0"},
+                                {"owner", "dpu"},
+                                {"scope", "dpu"},
+                                {"local_npu_ip", "192.168.1.10"},
+                                {"local_ip", "192.168.2.1"},
+                                {"peer_ip", "192.168.2.2"},
+                                {"cp_data_channel_port", "4789"},
+                                {"dp_channel_dst_port", "4790"},
+                                {"dp_channel_src_port_min", "5000"},
+                                {"dp_channel_src_port_max", "6000"},
+                                {"dp_channel_probe_interval_ms", "1000"},
+                                {"dp_channel_probe_fail_threshold", "3"},
+                                {"invalid_field", "invalid_value"}
+                            }
+                        }
+                    }
+                )
+            );
+            static_cast<Orch *>(m_dashHaOrch)->doTask(*consumer.get());
+        }
+
         void CreateEniScopeHaSet()
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
@@ -207,7 +243,33 @@ namespace dashhaorch_ut
                             SET_COMMAND,
                             {
                                 {"version", "1"},
-                                {"ha_role", "dead"}
+                                {"ha_role", "dead"},
+                                {"ha_set_id", "HA_SET_1"},
+                                {"vip_v4", "10.0.0.1"},
+                                {"vip_v6", "3:2::1:0"}
+                            }
+                        }
+                    }
+                )
+            );
+            static_cast<Orch *>(m_dashHaOrch)->doTask(*consumer.get());
+        }
+
+        void CreateHaScopeLessFields()
+        {
+            auto consumer = unique_ptr<Consumer>(new Consumer(
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1, 1),
+                m_dashHaOrch, APP_DASH_HA_SCOPE_TABLE_NAME));
+
+            consumer->addToSync(
+                deque<KeyOpFieldsValuesTuple>(
+                    {
+                        {
+                            "HA_SET_1",
+                            SET_COMMAND,
+                            {
+                                {"version", "1"},
+                                {"ha_role", "dead"},
                             }
                         }
                     }
@@ -523,10 +585,18 @@ namespace dashhaorch_ut
 
     TEST_F(DashHaOrchTest, InvalidIpAddresses)
     {
-        InvalidIpAddresses();
-
         EXPECT_CALL(*mock_sai_dash_ha_api, create_ha_set)
         .Times(0);
+
+        InvalidIpAddresses();
+    }
+
+    TEST_F(DashHaOrchTest, InvalidField)
+    {
+        EXPECT_CALL(*mock_sai_dash_ha_api, create_ha_set)
+        .Times(1);
+        
+        InvalidField();
     }
 
     TEST_F(DashHaOrchTest, HaSetAlreadyExists)
@@ -574,6 +644,35 @@ namespace dashhaorch_ut
 
         EXPECT_TRUE(m_dashHaOrch->getHaScopeEntries().size() == 0);
     }
+
+    TEST_F(DashHaOrchTest, AddRemoveHaScopeLessFields)
+    {
+        CreateHaSet();
+
+        EXPECT_CALL(*mock_sai_dash_ha_api, create_ha_scope)
+        .Times(1);
+
+        CreateHaScopeLessFields();
+
+        EXPECT_TRUE(m_dashHaOrch->getHaScopeEntries().size() == 1);
+        EXPECT_TRUE(m_dashHaOrch->getHaScopeEntries().find("HA_SET_1") != m_dashHaOrch->getHaScopeEntries().end());
+
+        // HA Scope already exists
+        EXPECT_CALL(*mock_sai_dash_ha_api, create_ha_scope)
+        .Times(0);
+        CreateHaScope();
+
+        EXPECT_TRUE(m_dashHaOrch->getHaScopeEntries().size() == 1);
+        EXPECT_TRUE(m_dashHaOrch->getHaScopeEntries().find("HA_SET_1") != m_dashHaOrch->getHaScopeEntries().end());
+
+        EXPECT_CALL(*mock_sai_dash_ha_api, remove_ha_scope)
+        .Times(1);
+
+        RemoveHaScope();
+
+        EXPECT_TRUE(m_dashHaOrch->getHaScopeEntries().size() == 0);
+    }
+
 
     TEST_F(DashHaOrchTest, AddRemoveEniHaScope)
     {

--- a/tests/mock_tests/dashhaorch_ut.cpp
+++ b/tests/mock_tests/dashhaorch_ut.cpp
@@ -174,42 +174,6 @@ namespace dashhaorch_ut
             static_cast<Orch *>(m_dashHaOrch)->doTask(*consumer.get());
         }
 
-        void InvalidField()
-        {
-            auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1, 1),
-                m_dashHaOrch, APP_DASH_HA_SET_TABLE_NAME));
-
-            consumer->addToSync(
-                deque<KeyOpFieldsValuesTuple>(
-                    {
-                        {
-                            "HA_SET_1",
-                            SET_COMMAND,
-                            {
-                                {"version", "1"},
-                                {"vip_v4", "10.0.0.1"},
-                                {"vip_v6", "3:2::1:0"},
-                                {"owner", "dpu"},
-                                {"scope", "dpu"},
-                                {"local_npu_ip", "192.168.1.10"},
-                                {"local_ip", "192.168.2.1"},
-                                {"peer_ip", "192.168.2.2"},
-                                {"cp_data_channel_port", "4789"},
-                                {"dp_channel_dst_port", "4790"},
-                                {"dp_channel_src_port_min", "5000"},
-                                {"dp_channel_src_port_max", "6000"},
-                                {"dp_channel_probe_interval_ms", "1000"},
-                                {"dp_channel_probe_fail_threshold", "3"},
-                                {"invalid_field", "invalid_value"}
-                            }
-                        }
-                    }
-                )
-            );
-            static_cast<Orch *>(m_dashHaOrch)->doTask(*consumer.get());
-        }
-
         void CreateEniScopeHaSet()
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
@@ -635,16 +599,6 @@ namespace dashhaorch_ut
         .Times(1);
         
         InvalidField();
-
-        InvalidIpAddresses();
-    }
-
-    TEST_F(DashHaOrchTest, InvalidField)
-    {
-        EXPECT_CALL(*mock_sai_dash_ha_api, create_ha_set)
-        .Times(1);
-        
-        InvalidField();
     }
 
     TEST_F(DashHaOrchTest, HaSetAlreadyExists)
@@ -692,35 +646,6 @@ namespace dashhaorch_ut
 
         EXPECT_TRUE(m_dashHaOrch->getHaScopeEntries().size() == 0);
     }
-
-    TEST_F(DashHaOrchTest, AddRemoveHaScopeLessFields)
-    {
-        CreateHaSet();
-
-        EXPECT_CALL(*mock_sai_dash_ha_api, create_ha_scope)
-        .Times(1);
-
-        CreateHaScopeLessFields();
-
-        EXPECT_TRUE(m_dashHaOrch->getHaScopeEntries().size() == 1);
-        EXPECT_TRUE(m_dashHaOrch->getHaScopeEntries().find("HA_SET_1") != m_dashHaOrch->getHaScopeEntries().end());
-
-        // HA Scope already exists
-        EXPECT_CALL(*mock_sai_dash_ha_api, create_ha_scope)
-        .Times(0);
-        CreateHaScope();
-
-        EXPECT_TRUE(m_dashHaOrch->getHaScopeEntries().size() == 1);
-        EXPECT_TRUE(m_dashHaOrch->getHaScopeEntries().find("HA_SET_1") != m_dashHaOrch->getHaScopeEntries().end());
-
-        EXPECT_CALL(*mock_sai_dash_ha_api, remove_ha_scope)
-        .Times(1);
-
-        RemoveHaScope();
-
-        EXPECT_TRUE(m_dashHaOrch->getHaScopeEntries().size() == 0);
-    }
-
 
     TEST_F(DashHaOrchTest, AddRemoveHaScopeLessFields)
     {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Take disabled field from HA_SCOPE_TABLE and set ha scope sai attribute `SAI_HA_SCOPE_ATTR_ADMIN_STATE` accordingly. 
https://github.com/opencomputeproject/SAI/blob/b925fc0f0fc8c620eea7d9dead7fc99e33b7b44e/experimental/saiexperimentaldashha.h#L310

sign-off: Jing Zhang zhangjing@microsoft.com 

**Why I did it**

If admin state is not set to true, the state machine won't be activated in ASIC for DPU scope HA. 

**How I verified it**
- UTs. 
- Integrated tests on DPU. 

**Details if related**
