### PR TITLE
[Fixbug]: state db of hft miss-matched

### DIFF
--- a/orchagent/high_frequency_telemetry/hftelorch.cpp
+++ b/orchagent/high_frequency_telemetry/hftelorch.cpp
@@ -316,7 +316,7 @@ task_process_status HFTelOrch::groupTableDel(const std::string &profile_name, co
 
     profile->clearGroup(group_name);
     m_type_profile_mapping[type].erase(profile);
-    m_state_telemetry_session.del(profile_name + "|" + group_name);
+    m_state_telemetry_session.del(profile_name + "|" + HFTelUtils::sai_type_to_group_name(type));
 
     SWSS_LOG_NOTICE("The high frequency telemetry group %s with profile %s is deleted", group_name.c_str(), profile_name.c_str());
 


### PR DESCRIPTION
**What I did**
This pull request makes a minor update to the group deletion logic in the high frequency telemetry orchestration code. The change improves the consistency of key generation when deleting telemetry session state.

**Why I did it**
If the group name of hft uses the lowercases, we could not delete it due to the name miss-matched in the state db. Because the uppercases was used in the state db set.

**How I verified it**
Check it locally.

**Details if related**
