### PR TITLE
Temporarily disable bulk init requests for PORT counters

### DIFF
--- a/orchagent/flex_counter/flex_counter_manager.h
+++ b/orchagent/flex_counter/flex_counter_manager.h
@@ -181,8 +181,8 @@ struct CachedObjects
         auto counter_type_it = FlexCounterManager::counter_id_field_lookup.find(pending_counter_type);
 
         // Temporary fix for SNMP PFC counter issue: disable bulk init requests for PORT counters
-        // This forces each port to be processed individually, avoiding capability mismatches
-        // for differnt ports in bulk requests
+        // This forces each port to be processed individually, avoiding capability mismatch
+        // for different ports in bulk requests
         if (pending_counter_type == CounterType::PORT)
         {
             for (const auto& oid: pending_sai_objects)

--- a/orchagent/flex_counter/flex_counter_manager.h
+++ b/orchagent/flex_counter/flex_counter_manager.h
@@ -180,9 +180,9 @@ struct CachedObjects
         auto counter_ids = FlexCounterManager::serializeCounterStats(pending_counter_stats);
         auto counter_type_it = FlexCounterManager::counter_id_field_lookup.find(pending_counter_type);
 
-        // Temporary fix for SNMP PFC counter issue: disable bulk requests for PORT counters
+        // Temporary fix for SNMP PFC counter issue: disable bulk init requests for PORT counters
         // This forces each port to be processed individually, avoiding capability mismatches
-        // between SFP ports and regular ports in bulk requests
+        // for differnt ports in bulk requests
         if (pending_counter_type == CounterType::PORT)
         {
             for (const auto& oid: pending_sai_objects)

--- a/tests/mock_tests/flexcounter_ut.cpp
+++ b/tests/mock_tests/flexcounter_ut.cpp
@@ -1065,7 +1065,7 @@ namespace flexcounter_test
 
         /* SAIREDIS channel should have been called thrice, once for port1&port2,port3,port4 */
         // ASSERT_EQ(mockFlexCounterOperationCallCount, 3);
-        // Temporary fix for SNMP PFC counter issue: disabled bulk requests for PORT counters
+        // Temporary fix for SNMP PFC counter issue: disabled bulk init requests for PORT counters
         ASSERT_EQ(mockFlexCounterOperationCallCount, 4);
 
         ASSERT_TRUE(checkFlexCounter(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, port1_oid,

--- a/tests/mock_tests/flexcounter_ut.cpp
+++ b/tests/mock_tests/flexcounter_ut.cpp
@@ -1064,7 +1064,9 @@ namespace flexcounter_test
         port_stat_manager.flush();
 
         /* SAIREDIS channel should have been called thrice, once for port1&port2,port3,port4 */
-        ASSERT_EQ(mockFlexCounterOperationCallCount, 3);
+        // ASSERT_EQ(mockFlexCounterOperationCallCount, 3);
+        // Temporary fix for SNMP PFC counter issue: disabled bulk requests for PORT counters
+        ASSERT_EQ(mockFlexCounterOperationCallCount, 4);
 
         ASSERT_TRUE(checkFlexCounter(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, port1_oid,
                                      {


### PR DESCRIPTION
Add temporary fix for https://github.com/aristanetworks/sonic-qual.msft/issues/655

This forces each port to be processed individually, avoiding capability mismatch between different ports in bulk requests

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Temporarily disable bulk init requests for PORT counters.

**Why I did it**
When swss requests bulk initialization of PORT counters, corresponding component in sonic-sairedis assumes all the requested ports support same attributes, which is not the case for SFP/mgmt ports of Arista switches and was causing these ports to be completely skipped. This is supposed to be fixed by [Azure/sonic-sairedis.msft#73](https://github.com/Azure/sonic-sairedis.msft/pull/73) but it needs a re-work as its breaking non-Broadcom platform.

So, we're temporarily disabling this flow.

**How I verified it**
Verified countersDB is now having all the supported counters for SFP ports.

**Details if related**
relevant threads: [#558](https://github.com/aristanetworks/sonic-qual.msft/issues/558), [#629](https://github.com/aristanetworks/sonic-qual.msft/issues/629), [655](https://github.com/aristanetworks/sonic-qual.msft/issues/655)
