### PR TITLE
HFT: fix uninitialized m_sai_tam_obj

### DIFF
--- a/orchagent/high_frequency_telemetry/hftelorch.cpp
+++ b/orchagent/high_frequency_telemetry/hftelorch.cpp
@@ -70,7 +70,8 @@ HFTelOrch::HFTelOrch(
       m_sai_hostif_user_defined_trap_obj(SAI_NULL_OBJECT_ID),
       m_sai_hostif_table_entry_obj(SAI_NULL_OBJECT_ID),
       m_sai_tam_transport_obj(SAI_NULL_OBJECT_ID),
-      m_sai_tam_collector_obj(SAI_NULL_OBJECT_ID)
+      m_sai_tam_collector_obj(SAI_NULL_OBJECT_ID),
+      m_sai_tam_obj(SAI_NULL_OBJECT_ID)
 {
     SWSS_LOG_ENTER();
 


### PR DESCRIPTION
**What I did**
Added missing initialization for the m_sai_tam_obj variable.

**Why I did it**
To fix an issue with access to the uninitialized m_sai_tam_obj (in HFTelOrch::deleteTAM())

**How I verified it**
Manual test with ASAN build

**Details if related**
