### PR TITLE
update FLEX_COUNTER_DB when add new buffer pool

### DIFF
--- a/orchagent/bufferorch.h
+++ b/orchagent/bufferorch.h
@@ -117,6 +117,7 @@ private:
     void doTask() override;
     virtual void doTask(Consumer& consumer);
     void clearBufferPoolWatermarkCounterIdList(const sai_object_id_t object_id);
+    void addBufferPoolWatermarkCounterIdList(const sai_object_id_t object_id);
     void initTableHandlers();
     void initBufferReadyLists(DBConnector *confDb, DBConnector *applDb);
     void initBufferReadyList(Table& table, bool isConfigDb);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
update FLEX_COUNTER_DB when add new buffer pool

**Why I did it**
watermarkstat -t buffer_pool shows N/A after config qos clear and config qos reload.
```
cisco@r2-lc2:~$ sudo config qos clear
cisco@r2-lc2:~$ sudo config qos reload
cisco@r2-lc2:~$ watermarkstat -t buffer_pool
Shared pool maximum occupancy: (Namespace asic0)
                 Pool    Bytes
---------------------  -------
    egress_lossy_pool      N/A
ingress_lossless_pool      N/A
Shared pool maximum occupancy: (Namespace asic1)
                 Pool    Bytes
---------------------  -------
    egress_lossy_pool      N/A
ingress_lossless_pool      N/A
```

**How I verified it**
Installed new swss debian in swss1, config qos clear, config qos reload, verified asic1 buffer pool watermark is good.
```
cisco@r2-lc2:~$ watermarkstat -t buffer_pool
Shared pool maximum occupancy: (Namespace asic0)   // This still has problem since old swss debian
                 Pool    Bytes
---------------------  -------
    egress_lossy_pool      N/A
ingress_lossless_pool      N/A
Shared pool maximum occupancy: (Namespace asic1) // This is good since new swss debian
                 Pool    Bytes
---------------------  -------
    egress_lossy_pool    16512
ingress_lossless_pool    16512
```

**Details if related**
