### PR TITLE
[fixbug]: Fix orchagent crashed issue due to empty counters or stats in HFTorch

### DIFF
--- a/orchagent/high_frequency_telemetry/hftelorch.cpp
+++ b/orchagent/high_frequency_telemetry/hftelorch.cpp
@@ -258,7 +258,7 @@ task_process_status HFTelOrch::groupTableSet(const std::string &profile_name, co
     }
 
     auto arg_object_names = fvsGetValue(values, "object_names", true);
-    if (arg_object_names)
+    if (arg_object_names && !arg_object_names->empty())
     {
         vector<string> buffer;
         boost::split(buffer, *arg_object_names, boost::is_any_of(","));
@@ -267,7 +267,7 @@ task_process_status HFTelOrch::groupTableSet(const std::string &profile_name, co
     }
 
     auto arg_object_counters = fvsGetValue(values, "object_counters", true);
-    if (arg_object_counters)
+    if (arg_object_counters && !arg_object_counters->empty())
     {
         vector<string> buffer;
         boost::split(buffer, *arg_object_counters, boost::is_any_of(","));

--- a/tests/test_hft.py
+++ b/tests/test_hft.py
@@ -411,6 +411,31 @@ class TestHFT(object):
         self.delete_hft_group(dvs)
         self.delete_hft_profile(dvs)
 
+    def test_hft_empty_fields_with_disabled_status(self, dvs, testlog):
+        """Test HFT with empty object_names and object_counters when profile is disabled."""
+        # Create HFT profile with disabled status
+        self.create_hft_profile(dvs, status="disabled")
+        
+        # Create HFT group with empty object_names and object_counters
+        self.create_hft_group(dvs,
+                              object_names="",
+                              object_counters="")
+
+        # Wait for processing
+        time.sleep(3)
+
+        # Verify that no counter subscriptions are created when 
+        # profile is disabled and fields are empty
+        asic_db = self.get_asic_db_objects(dvs)
+        
+        assert len(asic_db["tam_counter_subscription"]) == 0, \
+            "Expected no tam counter subscriptions when profile is disabled " \
+            "and object_names/object_counters are empty"
+
+        # Clean up
+        self.delete_hft_group(dvs)
+        self.delete_hft_profile(dvs)
+
 
     def test_hft_multiple_groups(self, dvs, testlog):
         """Test HFT with multiple groups and objects."""

--- a/tests/test_hft.py
+++ b/tests/test_hft.py
@@ -40,6 +40,16 @@ class TestHFT(object):
         ])
         tbl.set(key, fvs)
 
+    def create_hft_group_without_fields(self, dvs, profile_name="test", group_name="PORT"):
+        """Create HFT group in CONFIG_DB without object_names and object_counters fields."""
+        config_db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+        tbl = swsscommon.Table(config_db, "HIGH_FREQUENCY_TELEMETRY_GROUP")
+
+        key = f"{profile_name}|{group_name}"
+        # Create empty field-value pairs - no object_names or object_counters
+        fvs = swsscommon.FieldValuePairs([("NULL", "NULL")])
+        tbl.set(key, fvs)
+
     def delete_hft_profile(self, dvs, name="test"):
         """Delete HFT profile from CONFIG_DB."""
         config_db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
@@ -436,6 +446,28 @@ class TestHFT(object):
         self.delete_hft_group(dvs)
         self.delete_hft_profile(dvs)
 
+    def test_hft_missing_fields_with_disabled_status(self, dvs, testlog):
+        """Test HFT without object_names and object_counters fields when profile is disabled."""
+        # Create HFT profile with disabled status
+        self.create_hft_profile(dvs, status="disabled")
+        
+        # Create HFT group without object_names and object_counters fields
+        self.create_hft_group_without_fields(dvs)
+
+        # Wait for processing
+        time.sleep(3)
+
+        # Verify that no counter subscriptions are created when 
+        # profile is disabled and fields are missing entirely
+        asic_db = self.get_asic_db_objects(dvs)
+        
+        assert len(asic_db["tam_counter_subscription"]) == 0, \
+            "Expected no tam counter subscriptions when profile is disabled " \
+            "and object_names/object_counters fields are missing"
+
+        # Clean up
+        self.delete_hft_group(dvs)
+        self.delete_hft_profile(dvs)
 
     def test_hft_multiple_groups(self, dvs, testlog):
         """Test HFT with multiple groups and objects."""


### PR DESCRIPTION
**What I did**
This pull request improves the robustness of the high frequency telemetry (HFT) group creation logic and adds a new test to cover edge cases with empty fields. The main changes ensure that empty `object_names` and `object_counters` are handled correctly, and that the system behaves as expected when the profile is disabled.
Updated `HFTelOrch::groupTableSet` in `hftelorch.cpp` to only process `object_names` and `object_counters` if they are present and non-empty, preventing unnecessary splitting and processing of empty strings. 

**Why I did it**
If the counters or objects is empty, the orchagent will get crashed. Because the `boost::split` will still generate an empty item in the vector from the empty string.

**How I verified it**
Added a new test `test_hft_empty_fields_with_disabled_status` in `test_hft.py` to verify that no counter subscriptions are created when both `object_names` and `object_counters` are empty and the profile is disabled, ensuring correct behavior in edge cases.

**Details if related**
