### PR TITLE
fpmsyncd crashes during execution of sonic-mgmt script vxlan/test_vnet_bgp_route_precedence.py

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -2998,7 +2998,7 @@ bool RouteOrch::removeRoutePrefix(const IpPrefix& prefix)
     context.vrf_id = gVirtualRouterId;
     if (removeRoute(context))
     {
-        SWSS_LOG_INFO("Could not find the route with prefix %s", prefix.to_string().c_str());
+        SWSS_LOG_INFO("Could not find the route  with prefix %s", prefix.to_string().c_str());
         return true;
     }
     gRouteBulker.flush();


### PR DESCRIPTION
Problem:

Orchagent sends incorrectly formatted info via APPL_DB_ROUTE_TABLE_RESPONSE_CHANNEL to fpmsyncd process and fpmsyncd crashes.

Root cause:

The function RouteOrch::removeRoutePrefix() is called from vnetorch.cpp when a vnet route is added and we want to delete the corresponding bgp route from hardware (as vnet has higher precedence than bgp).

The function creates a fake RouteBulkContext entry to satisfy the API signature.

The issue is that it wrongly adds the table name at the beginning of the key field. This causes an issue when fib suppression is enabled as it uses the key field.

See the stacktrace below:

RouteOrch::publishRouteState()
RouteOrch::removeRoutePost()
RouteOrch::removeRoutePrefix()
VNetRouteOrch::doRouteTask()
VNetRouteOrch::handleTunnel()
VNetRouteOrch::addOperation()

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Set the RouteBulkContext key to just the prefix, instead of the original "ROUTE_TABLE:" + prefix.

**Why I did it**

it was set wrongly.

**How I verified it**

Re-run vxlan/test_vnet_bgp_route_precedence.py script and it passed.

**Details if related**

The issue is seen when running the
sonic-mgmt vxlan/test_vnet_bgp_route_precedence.py script on a testbed with "suppress-fib-pending": "enabled"

#### Which release branch to backport (provide reason below if selected)

- [x] 202505
- [ ] 202411
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### A picture of a cute animal (not mandatory but encouraged)

Here is an example of a bad entry from redis MONITOR

1757021230.758233 [14 unix:/var/run/redis/redis.sock] "PUBLISH" "APPL_DB_ROUTE_TABLE_RESPONSE_CHANNEL" "[\"SWSS_RC_SUCCESS\",\"ROUTE_TABLE:20.1.0.0/24\",\"err_str\",\"SWSS_RC_SUCCESS\"]"

Here is a good  one:

1757021219.090477 [14 unix:/var/run/redis/redis.sock] "PUBLISH" "APPL_DB_ROUTE_TABLE_RESPONSE_CHANNEL" "[\"SWSS_RC_SUCCESS\",\"22.1.0.0/24\",\"err_str\",\"SWSS_RC_SUCCESS\"]"

