### PR TITLE
[Buffer orch] Avoid setting buffer profile attribute twice

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -780,7 +780,7 @@ task_process_status BufferOrch::processBufferProfile(KeyOpFieldsValuesTuple &tup
                 }
             }
 
-            for (auto &attribute : attribs)
+            for (auto &attribute : attribs_to_retry)
             {
                 sai_status = sai_buffer_api->set_buffer_profile_attribute(sai_object, &attribute);
                 if (SAI_STATUS_SUCCESS != sai_status)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Avoid setting buffer profile attribute twice

**Why I did it**

**How I verified it**

**Details if related**
