### PR TITLE
fpmsyncd crashes during execution of sonic-mgmt script vxlan/test_vnet_bgp_route_precedence.py

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -2992,7 +2992,7 @@ bool RouteOrch::removeRoutePrefix(const IpPrefix& prefix)
 {
     // This function removes the route if it exists.
 
-    string key = "ROUTE_TABLE:" + prefix.to_string();
+    string key = prefix.to_string();
     RouteBulkContext context(key, false);
     context.ip_prefix = prefix;
     context.vrf_id = gVirtualRouterId;


### PR DESCRIPTION
This is a revise of PR #3871 

Problem:

Orchagent sends incorrectly formatted info via APPL_DB_ROUTE_TABLE_RESPONSE_CHANNEL to fpmsyncd process and fpmsyncd crashes.

Root cause:

The function RouteOrch::removeRoutePrefix() is called from vnetorch.cpp when a vnet route is added and we want to delete the corresponding bgp route from hardware (as vnet has higher precedence than bgp).

The function creates a fake RouteBulkContext entry to satisfy the API signature.

The issue is that it wrongly adds the table name at the beginning of the key field. This causes an issue when fib suppression is enabled as it uses the key field.

See the stacktrace below:

RouteOrch::publishRouteState()
RouteOrch::removeRoutePost()
RouteOrch::removeRoutePrefix()
VNetRouteOrch::doRouteTask()
VNetRouteOrch::handleTunnel()
VNetRouteOrch::addOperation()

What I did

Set the RouteBulkContext key to just the prefix, instead of the original "ROUTE_TABLE:" + prefix.

Why I did it

it was set wrongly.

How I verified it

Re-run vxlan/test_vnet_bgp_route_precedence.py script and it passed.

Details if related

The issue is seen when running the
sonic-mgmt vxlan/test_vnet_bgp_route_precedence.py script on a testbed with "suppress-fib-pending": "enabled"

Here is an example of a bad entry from redis MONITOR

1757021230.758233 [14 unix:/var/run/redis/redis.sock] "PUBLISH" "APPL_DB_ROUTE_TABLE_RESPONSE_CHANNEL" "["SWSS_RC_SUCCESS","ROUTE_TABLE:20.1.0.0/24","err_str","SWSS_RC_SUCCESS"]"

Here is a good one:

1757021219.090477 [14 unix:/var/run/redis/redis.sock] "PUBLISH" "APPL_DB_ROUTE_TABLE_RESPONSE_CHANNEL" "["SWSS_RC_SUCCESS","22.1.0.0/24","err_str","SWSS_RC_SUCCESS"]"