### PR TITLE
Avoid notifying counter polling for duplicated priority groups or queues

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -1103,18 +1103,21 @@ task_process_status BufferOrch::processQueuePost(const QueueTask& task)
                 else if (gMySwitchType != "voq")
                 {
                     auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
-                    auto queues = tokens[1];
-                    if (!queueContext.counter_was_added && queueContext.counter_needs_to_add &&
-                        (flexCounterOrch->getQueueCountersState() || flexCounterOrch->getQueueWatermarkCountersState()))
+                    if (flexCounterOrch->isCreateOnlyConfigDbBuffers())
                     {
-                        SWSS_LOG_INFO("Creating counters for %s %zd", port_name.c_str(), ind);
-                        gPortsOrch->createPortBufferQueueCounters(port, queues);
-                    }
-                    else if (queueContext.counter_was_added && !queueContext.counter_needs_to_add &&
-                                (flexCounterOrch->getQueueCountersState() || flexCounterOrch->getQueueWatermarkCountersState()))
-                    {
-                        SWSS_LOG_INFO("Removing counters for %s %zd", port_name.c_str(), ind);
-                        gPortsOrch->removePortBufferQueueCounters(port, queues);
+                        auto queues = tokens[1];
+                        if (!queueContext.counter_was_added && queueContext.counter_needs_to_add &&
+                            (flexCounterOrch->getQueueCountersState() || flexCounterOrch->getQueueWatermarkCountersState()))
+                        {
+                            SWSS_LOG_INFO("Creating counters for %s %zd", port_name.c_str(), ind);
+                            gPortsOrch->createPortBufferQueueCounters(port, queues);
+                        }
+                        else if (queueContext.counter_was_added && !queueContext.counter_needs_to_add &&
+                                    (flexCounterOrch->getQueueCountersState() || flexCounterOrch->getQueueWatermarkCountersState()))
+                        {
+                            SWSS_LOG_INFO("Removing counters for %s %zd", port_name.c_str(), ind);
+                            gPortsOrch->removePortBufferQueueCounters(port, queues);
+                        }
                     }
                 }
             }
@@ -1471,18 +1474,21 @@ task_process_status BufferOrch::processPriorityGroupPost(const PriorityGroupTask
                 else
                 {
                     auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
-                    auto pgs = tokens[1];
-                    if (!pg.counter_was_added && pg.counter_needs_to_add &&
-                        (flexCounterOrch->getPgCountersState() || flexCounterOrch->getPgWatermarkCountersState()))
+                    if (flexCounterOrch->isCreateOnlyConfigDbBuffers())
                     {
-                        SWSS_LOG_INFO("Creating counters for priority group %s %zd", port_name.c_str(), ind);
-                        gPortsOrch->createPortBufferPgCounters(port, pgs);
-                    }
-                    else if (pg.counter_was_added && !pg.counter_needs_to_add &&
-                                (flexCounterOrch->getPgCountersState() || flexCounterOrch->getPgWatermarkCountersState()))
-                    {
-                        SWSS_LOG_INFO("Removing counters for priority group %s %zd", port_name.c_str(), ind);
-                        gPortsOrch->removePortBufferPgCounters(port, pgs);
+                        auto pgs = tokens[1];
+                        if (!pg.counter_was_added && pg.counter_needs_to_add &&
+                            (flexCounterOrch->getPgCountersState() || flexCounterOrch->getPgWatermarkCountersState()))
+                        {
+                            SWSS_LOG_INFO("Creating counters for priority group %s %zd", port_name.c_str(), ind);
+                            gPortsOrch->createPortBufferPgCounters(port, pgs);
+                        }
+                        else if (pg.counter_was_added && !pg.counter_needs_to_add &&
+                                    (flexCounterOrch->getPgCountersState() || flexCounterOrch->getPgWatermarkCountersState()))
+                        {
+                            SWSS_LOG_INFO("Removing counters for priority group %s %zd", port_name.c_str(), ind);
+                            gPortsOrch->removePortBufferPgCounters(port, pgs);
+                        }
                     }
                 }
             }

--- a/orchagent/flexcounterorch.h
+++ b/orchagent/flexcounterorch.h
@@ -56,6 +56,7 @@ public:
     bool getRouteFlowCountersState() const {return m_route_flow_counter_enabled;}
     bool getWredQueueCountersState() const;
     bool getWredPortCountersState() const;
+    bool isCreateOnlyConfigDbBuffers() const;
     bool bake() override;
 
 private:
@@ -76,6 +77,8 @@ private:
     std::unique_ptr<SelectableTimer> m_delayTimer;
     std::unique_ptr<Executor> m_delayExecutor;
     std::unordered_set<std::string> m_groupsWithBulkChunkSize;
+
+    bool m_createOnlyConfigDbBuffers = false;
 };
 
 #endif

--- a/orchagent/flexcounterorch.h
+++ b/orchagent/flexcounterorch.h
@@ -60,6 +60,7 @@ public:
     bool bake() override;
 
 private:
+    void handleDeviceMetadataTable(Consumer &consumer);
     bool m_port_counter_enabled = false;
     bool m_port_buffer_drop_counter_enabled = false;
     bool m_queue_enabled = false;

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -591,7 +591,8 @@ bool OrchDaemon::init()
     }
 
     vector<string> flex_counter_tables = {
-        CFG_FLEX_COUNTER_TABLE_NAME
+        CFG_FLEX_COUNTER_TABLE_NAME,
+        CFG_DEVICE_METADATA_TABLE_NAME
     };
 
     auto* flexCounterOrch = new FlexCounterOrch(m_configDb, flex_counter_tables);

--- a/tests/mock_tests/bufferorch_ut.cpp
+++ b/tests/mock_tests/bufferorch_ut.cpp
@@ -307,6 +307,12 @@ namespace bufferorch_test
             auto* flexCounterOrch = new FlexCounterOrch(m_config_db.get(), flex_counter_tables);
             gDirectory.set(flexCounterOrch);
 
+            const vector<string> stel_tables = {
+                CFG_HIGH_FREQUENCY_TELEMETRY_PROFILE_TABLE_NAME,
+                CFG_HIGH_FREQUENCY_TELEMETRY_GROUP_TABLE_NAME
+            };
+            gHFTOrch = new HFTelOrch(m_config_db.get(), m_state_db.get(), stel_tables);
+
             ASSERT_EQ(gPortsOrch, nullptr);
             gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
 
@@ -421,6 +427,13 @@ namespace bufferorch_test
                 i.second->clear();
             }
 
+            // Clean up FlexCounterOrch
+            auto* flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
+            if (flexCounterOrch)
+            {
+                delete flexCounterOrch;
+            }
+
             gDirectory.m_values.clear();
 
             delete gCrmOrch;
@@ -449,13 +462,6 @@ namespace bufferorch_test
 
             delete gQosOrch;
             gQosOrch = nullptr;
-
-            // Clean up FlexCounterOrch
-            auto* flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
-            if (flexCounterOrch)
-            {
-                delete flexCounterOrch;
-            }
 
             ut_helper::uninitSaiApi();
         }

--- a/tests/mock_tests/bufferorch_ut.cpp
+++ b/tests/mock_tests/bufferorch_ut.cpp
@@ -29,6 +29,7 @@ namespace bufferorch_test
     shared_ptr<swss::DBConnector> m_config_db;
     shared_ptr<swss::DBConnector> m_state_db;
     shared_ptr<swss::DBConnector> m_chassis_app_db;
+    shared_ptr<swss::DBConnector> m_counters_db;
 
     uint32_t _ut_stub_expected_profile_count;
     uint32_t _ut_stub_port_profile_list_add_count;
@@ -244,6 +245,7 @@ namespace bufferorch_test
             m_config_db = make_shared<swss::DBConnector>("CONFIG_DB", 0);
             m_state_db = make_shared<swss::DBConnector>("STATE_DB", 0);
             m_app_state_db = make_shared<swss::DBConnector>("APPL_STATE_DB", 0);
+            m_counters_db = make_shared<swss::DBConnector>("COUNTERS_DB", 0);
             if(gMySwitchType == "voq")
                 m_chassis_app_db = make_shared<swss::DBConnector>("CHASSIS_APP_DB", 0);
 
@@ -299,7 +301,8 @@ namespace bufferorch_test
             };
 
             vector<string> flex_counter_tables = {
-                CFG_FLEX_COUNTER_TABLE_NAME
+                CFG_FLEX_COUNTER_TABLE_NAME,
+                CFG_DEVICE_METADATA_TABLE_NAME
             };
             auto* flexCounterOrch = new FlexCounterOrch(m_config_db.get(), flex_counter_tables);
             gDirectory.set(flexCounterOrch);
@@ -446,6 +449,13 @@ namespace bufferorch_test
 
             delete gQosOrch;
             gQosOrch = nullptr;
+
+            // Clean up FlexCounterOrch
+            auto* flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
+            if (flexCounterOrch)
+            {
+                delete flexCounterOrch;
+            }
 
             ut_helper::uninitSaiApi();
         }
@@ -839,5 +849,120 @@ namespace bufferorch_test
 
         _ut_stub_buffer_profile_sanity_check = false;
         _unhook_sai_apis();
+    }
+
+    TEST_F(BufferOrchTest, BufferOrchTestCreateOnlyConfigDbBuffersDynamicUpdate)
+    {
+        // Get FlexCounterOrch from directory
+        auto* flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
+        ASSERT_NE(flexCounterOrch, nullptr);
+
+        // Test Phase 1: Initial State Verification
+        // Set up initial configuration with create_only_config_db_buffers = false and verify it
+        ASSERT_FALSE(flexCounterOrch->isCreateOnlyConfigDbBuffers());
+
+        // Test Phase 2: Enable Flex Counter and Verify All Counters Added
+        // Add configuration to enable flex counter for watermark
+        Table flexCounterTable = Table(m_config_db.get(), CFG_FLEX_COUNTER_TABLE_NAME);
+        flexCounterTable.set("PG_WATERMARK", {
+            {"FLEX_COUNTER_STATUS", "enable"},
+            {"POLL_INTERVAL", "1000"}
+        });
+        flexCounterTable.set("QUEUE_WATERMARK", {
+            {"FLEX_COUNTER_STATUS", "enable"},
+            {"POLL_INTERVAL", "1000"}
+        });
+        flexCounterOrch->addExistingData(&flexCounterTable);
+        static_cast<Orch *>(flexCounterOrch)->doTask();
+
+        // Verify all counters are added to counter database (because create_only_config_db_buffers = false)
+        Table countersPgTable = Table(m_counters_db.get(), COUNTERS_PG_NAME_MAP);
+        Table countersQueueTable = Table(m_counters_db.get(), COUNTERS_QUEUE_NAME_MAP);
+
+        // Check that counter database has entries for all PGs and queues
+        // These tables use empty string "" as key and store all entries as fields
+        std::vector<FieldValueTuple> pgFields;
+        std::vector<FieldValueTuple> queueFields;
+        countersPgTable.get("", pgFields);
+        countersQueueTable.get("", queueFields);
+        ASSERT_GT(pgFields.size(), 0);
+        ASSERT_GT(queueFields.size(), 0);
+
+        // Test Phase 3: Add Individual Buffer Configurations (Should NOT be added to map)
+        // Clear existing counter entries
+        countersPgTable.del("");
+        countersQueueTable.del("");
+
+        // Add buffer PG and buffer queue configuration
+        Table bufferPgTable = Table(m_app_db.get(), APP_BUFFER_PG_TABLE_NAME);
+        Table bufferQueueTable = Table(m_app_db.get(), APP_BUFFER_QUEUE_TABLE_NAME);
+
+        bufferPgTable.set("Ethernet0:0", {
+            {"profile", "ingress_lossy_profile"}
+        });
+        bufferQueueTable.set("Ethernet0:0", {
+            {"profile", "ingress_lossy_profile"}
+        });
+
+        gBufferOrch->addExistingData(&bufferPgTable);
+        gBufferOrch->addExistingData(&bufferQueueTable);
+        static_cast<Orch *>(gBufferOrch)->doTask();
+
+        // Verify they are NOT added to the counter database (because create_only_config_db_buffers = false)
+        // Individual buffer configurations should not create counter database entries again
+        pgFields.clear();
+        queueFields.clear();
+        countersPgTable.get("", pgFields);
+        countersQueueTable.get("", queueFields);
+        ASSERT_EQ(pgFields.size(), 0);
+        ASSERT_EQ(queueFields.size(), 0);
+
+        // Test Phase 4: Dynamic Configuration Update to true
+        // Update DEVICE_METADATA table
+        Table deviceMetadataTable = Table(m_config_db.get(), CFG_DEVICE_METADATA_TABLE_NAME);
+        deviceMetadataTable.set("localhost", {
+            {"create_only_config_db_buffers", "true"}
+        });
+        flexCounterOrch->addExistingData(&deviceMetadataTable);
+        static_cast<Orch *>(flexCounterOrch)->doTask();
+
+        // Verify configuration change
+        ASSERT_TRUE(flexCounterOrch->isCreateOnlyConfigDbBuffers());
+
+        // Test Phase 5: Add Individual Buffer Configurations (Should be added to map)
+        // Add buffer PG and buffer queue configuration for different objects
+        bufferPgTable.set("Ethernet0:1", {
+            {"profile", "ingress_lossy_profile"}
+        });
+        bufferQueueTable.set("Ethernet0:1", {
+            {"profile", "ingress_lossy_profile"}
+        });
+
+        gBufferOrch->addExistingData(&bufferPgTable);
+        gBufferOrch->addExistingData(&bufferQueueTable);
+        static_cast<Orch *>(gBufferOrch)->doTask();
+
+        // Verify they ARE added to the counter database (because create_only_config_db_buffers = true)
+        // Individual buffer configurations should create counter database entries
+        pgFields.clear();
+        queueFields.clear();
+        countersPgTable.get("", pgFields);
+        countersQueueTable.get("", queueFields);
+        ASSERT_EQ(pgFields.size(), 1);
+        ASSERT_EQ(queueFields.size(), 1);
+
+        // Verify the specific entries exist
+        {
+            std::string value;
+            bool found = countersPgTable.hget("", "Ethernet0:1", value);
+            ASSERT_TRUE(found);
+            ASSERT_FALSE(value.empty());
+        }
+        {
+            std::string value;
+            bool found = countersQueueTable.hget("", "Ethernet0:1", value);
+            ASSERT_TRUE(found);
+            ASSERT_FALSE(value.empty());
+        }
     }
 }

--- a/tests/mock_tests/mock_orchagent_main.h
+++ b/tests/mock_tests/mock_orchagent_main.h
@@ -32,6 +32,7 @@
 #include "copporch.h"
 #include "twamporch.h"
 #include "mlagorch.h"
+#include "high_frequency_telemetry/hftelorch.h"
 #define private public
 #include "stporch.h"
 #undef private 
@@ -72,6 +73,7 @@ extern PolicerOrch *gPolicerOrch;
 extern TunnelDecapOrch *gTunneldecapOrch;
 extern StpOrch *gStpOrch;
 extern MlagOrch *gMlagOrch;
+extern HFTelOrch *gHFTOrch;
 extern Directory<Orch*> gDirectory;
 
 extern sai_acl_api_t *sai_acl_api;

--- a/tests/mock_tests/mock_table.cpp
+++ b/tests/mock_tests/mock_table.cpp
@@ -100,6 +100,15 @@ namespace swss
         }
     }
 
+    void Table::hset(const std::string &key, const std::string &field, const std::string &value,
+                const std::string& op, const std::string& prefix)
+    {
+        FieldValueTuple fvp(field, value);
+        std::vector<FieldValueTuple> attrs = { fvp };
+
+        Table::set(key, attrs, op, prefix);
+    }
+
     void Table::getKeys(std::vector<std::string> &keys)
     {
         keys.clear();


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Avoid notifying counter polling for duplicated PG or queue when `create_only_config_db_buffers` is `False` in the flow:

1. Flex counter orchagent enables counter polling for PG or queue. It notifies counter polling for all PGs or queues since `create_only_config_db_buffers` is `False`
2. Particular items in BUFFER_PG or BUFFER_QUEUE is configured. It notifies counter polling for the items again.

In most cases, BUFFER_PG and BUFFER_QUEUE are handled ahead of counter polling (i.e., the order is 2, 1), and the issue won't occur. But in a rare scenario, it can be 1 and then 2.

**Why I did it**

**How I verified it**

Manual test, mock test

**Details if related**
