### PR TITLE
Skip flush if ring buffer is not empty or thread is not in idle

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -864,9 +864,22 @@ void OrchDaemon::flush()
         handleSaiFailure(SAI_API_SWITCH, "set", status);
     }
 
-    for (auto* orch: m_orchList)
+    /*
+     * Don't flush if ringbuffer is enable and it is not empty or Idle. Ring buffer thread
+     * could trigger notification update.
+     *
+     * Flush would be triggered later after SELECT_TIMEOUT in main thread again
+     * for avoiding race condition.
+     */
+    if (gRingBuffer &&(!gRingBuffer->IsEmpty() || !gRingBuffer->IsIdle()))
     {
-        orch->flushResponses();
+        gRingBuffer->notify();
+        SWSS_LOG_WARN("Skip Flush waiting for RingBuffer empty");
+    } else {
+        for (auto* orch: m_orchList)
+        {
+            orch->flushResponses();
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Skip flush in main thread if ring buffer is not empty or ring buffer thread is not in idle state. 
This would avoid m_publisher to be triggered from both main thread and ring thread to cause race condition. 

**Why I did it**
For fixing https://github.com/sonic-net/sonic-buildimage/issues/24065

**How I verified it**
Enable Ring Buffer and run SRv6 test suite. 

**Details if related**
