### PR TITLE
Enable Hw PFCwd recovery for TH5 

### DIFF
--- a/orchagent/pfcactionhandler.h
+++ b/orchagent/pfcactionhandler.h
@@ -118,12 +118,23 @@ class PfcWdAclHandler: public PfcWdLossyHandler
         void updatePfcAclRule(shared_ptr<AclRule> rule, uint8_t queueId, string strTable, vector<sai_object_id_t> port);
 };
 
+// Tracks port-level TX drops for hardware-based PFC deadlock recovery
 class PfcWdDlrHandler: public PfcWdLossyHandler
 {
     public:
         PfcWdDlrHandler(sai_object_id_t port, sai_object_id_t queue,
                 uint8_t queueId, shared_ptr<Table> countersTable);
         virtual ~PfcWdDlrHandler(void);
+        virtual bool getHwCounters(PfcWdHwStats& counters) override;
+
+    private:
+        bool getPortTxDrops(uint64_t& txDrops);
+        bool getPortTxPackets(uint64_t& txPackets);
+        uint64_t m_lastPortTxDrops;
+        uint64_t m_lastPortTxPackets;
+        uint64_t m_baselineTxDrops;
+        uint64_t m_baselineTxPackets;
+        bool m_baselineSet;
 };
 
 // PFC queue that implements drop action by draining queue with buffer of zero size


### PR DESCRIPTION
pfcwd drop action does not take place with the current orchagent code.

Root-cause: Even though h/w recovery is supported in swss (https://github.com/sonic-net/sonic-swss/pull/2316/files), for SAI_QUEUE_ATTR_PFC_DLR_INIT attribute to trigger h/w recovery on a queue experiencing pfc storm, SAI_QUEUE_ATTR_ENABLE_PFC_DLDR attribute needs to be programmed to enable h/w detection and recovery. Once hardware recovery happens on the queue, packets do not even reach the queue counters, we need to check the port drop counters to see the result of the pfcwd action. Therefore, add getHwCounters using port stats.

How I did it:
As soon as a queue is programmed with pfcwd config, enable detection and recovery on the queue using SAI_QUEUE_ATTR_ENABLE_PFC_DLDR. Also, program the detection and recovery timers which are not handled in the orchagent code today.

Note with timers:
Detection timer: There is a chip specific default granularity of the detection timer. e.g. 1 ms for th4/th5. This is not exposed as a sai attribute. The SAI_PORT_ATTR_PFC_TC_DLD_INTERVAL is used to program the configured value. however, for bcm allowed values are 1-15 ticks. ticks is determined by the granularity programmed on the chip. Recovery timer: This is programmed (1-10 ticks) and the granularity is fixed at 100ms. So, max 1 sec recovery timer can be programmed.

How to verify it:
Configure a queue with pfcwd cli:
sudo pfcwd start --action drop Ethernet0 400 --restoration-time 300 Dump the lt table and verify the timers are programmed correctly

   OPERATIONAL_STATE=VALID
    RECOVERY_MODE=TIMER_MODE
    MANUAL_RECOVERY_OPER=1
    MANUAL_RECOVERY=1
    RECOVERY_TIMER=3
    DETECTION_TIMER_GRANULARITY=TIME_1_MS
    DETECTION_TIMER=0xf(15)
    DEADLOCK_RECOVERY=1
    PFC_PRI=3
    PORT_ID=1

    OPERATIONAL_STATE=VALID
    RECOVERY_MODE=TIMER_MODE
    MANUAL_RECOVERY_OPER=1
    MANUAL_RECOVERY=1
    RECOVERY_TIMER=3
    DETECTION_TIMER_GRANULARITY=TIME_1_MS
    DETECTION_TIMER=0xf(15)
    DEADLOCK_RECOVERY=1
    PFC_PRI=4
    PORT_ID=1

Explanation: Recovery timer is 300 ms which gets programmed as 300/100 = 3. detection timer granularity is 1ms and max value can be 15ms for TH5, so 400 gets capped to 15.

Patches applied from commits:
- e76c5eddc105b78915bff4cc25b0e19683af715a
- ded6d28033f35bd38c71233a6cfcbaa3d8fd4cc6

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
