### PR TITLE
PFCWD ACL recovery: Override getHwCounters to query acl counters

### DIFF
--- a/orchagent/pfcactionhandler.h
+++ b/orchagent/pfcactionhandler.h
@@ -100,6 +100,7 @@ class PfcWdAclHandler: public PfcWdLossyHandler
         PfcWdAclHandler(sai_object_id_t port, sai_object_id_t queue,
                 uint8_t queueId, shared_ptr<Table> countersTable);
         virtual ~PfcWdAclHandler(void);
+        virtual bool getHwCounters(PfcWdHwStats& counters) override;
 
         // class shared cleanup
         static void clear();


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
The current counters query queue stats which don't work for all the chips like Q3D, TH5. Since, acls are used to take action, acl counters should be queried to show pfcwd stats.

**Why I did it**
The current implementation doesn't work for all the broadcom chips. 

**How I verified it**
Ran the test test_pfcwd_cli.py successfully on TH5, Q3d, Trident3. 

**Details if related**
