### PR TITLE
[routeorch] Remove updateRoute call to prevent set operations

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -2895,7 +2895,6 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
                         removeNextHopRoute(*nh, routekey);
                     }
                 }
-                mux_orch->updateRoute(ipPrefix);
             }
         }
         else if (ol_nextHops.is_overlay_nexthop())


### PR DESCRIPTION
This call to updateRoute is not needed because the route entry has already been removed. It is causing unneccesary route set operations and printing harmless (but verbose) error logs. Removing this call to prevent the side-effects.

**What I did**
Removed call to updateRoute from removeRoutePost path.

**Why I did it**
This call is not needed, and is causing error logs.

**How I verified it**
Small change, should be covered by current vstests and mgmt tests. Behavior will not change, just cause less ERR logs.

