### PR TITLE
[vs]: Fix trimming test cases: avoid NULL OID polling

### DIFF
--- a/tests/dvslib/dvs_queue.py
+++ b/tests/dvslib/dvs_queue.py
@@ -17,6 +17,8 @@ class DVSQueue:
     COUNTERS_COUNTERS = "COUNTERS"
     COUNTERS_QUEUE_NAME_MAP = "COUNTERS_QUEUE_NAME_MAP"
 
+    OID_NULL = "oid:0x0"
+
     def __init__(self, asic_db, config_db, counters_db):
         """Create a new DVS queue manager."""
         self.asic_db = asic_db
@@ -47,6 +49,12 @@ class DVSQueue:
         sai_queue_id = self.get_queue_id(port_name, queue_index)
         attr_list = [ field ]
         fvs = self.asic_db.wait_for_fields(self.ASIC_QUEUE, sai_queue_id, attr_list)
+
+        if fvs[field] == self.OID_NULL:
+            attr_dict = {
+                field: self.OID_NULL
+            }
+            fvs = self.asic_db.wait_for_field_negative_match(self.ASIC_QUEUE, sai_queue_id, attr_dict)
 
         return fvs[field]
 


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

Sporadic validation errors are caused by a long initialization time required by dynamic buffer model after `buffermgrd` restart.
The issue is observed on a test frameworks with a high workload (running a several instances of docker VS testbeds).

After `buffermfrd` restart in dynamic mode, the buffer profiles associated with the port queues will be removed and nulled.
The records in ASIC DB will be updated only after injecting MMU global configuration into the STATE DB.

In order to avoid fetching `NULL` OIDs, an additional validation must be applied.

**Community infra result**

pytest:
```
2025-10-14T22:44:44.4088604Z =================================== FAILURES ===================================
2025-10-14T22:44:44.4089223Z _ TestTrimmingDynamicBufferModel.test_TrimDynamicBufferProfileConfiguration[drop-packet] _
2025-10-14T22:44:44.4089344Z 
2025-10-14T22:44:44.4089598Z self = <test_trimming.TestTrimmingDynamicBufferModel object at 0x77977902ad10>
2025-10-14T22:44:44.4089971Z bufferData = {'id': 'oid:0x0', 'name': 'egress_lossy_profile'}, action = 'drop'
2025-10-14T22:44:44.4090133Z 
2025-10-14T22:44:44.4090291Z     @pytest.mark.parametrize(
2025-10-14T22:44:44.4090535Z         "action", [
2025-10-14T22:44:44.4090762Z             pytest.param("drop", id="drop-packet"),
2025-10-14T22:44:44.4091051Z             pytest.param("trim", id="trim-packet")
2025-10-14T22:44:44.4091294Z         ]
2025-10-14T22:44:44.4091498Z     )
2025-10-14T22:44:44.4091769Z     def test_TrimDynamicBufferProfileConfiguration(self, bufferData, action):
2025-10-14T22:44:44.4092044Z >       self.verifyBufferProfileConfiguration(bufferData, action)
2025-10-14T22:44:44.4092297Z 
2025-10-14T22:44:44.4092538Z test_trimming.py:811: 
2025-10-14T22:44:44.4092861Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2025-10-14T22:44:44.4093221Z test_trimming.py:785: in verifyBufferProfileConfiguration
2025-10-14T22:44:44.4093603Z     self.dvs_buffer.verify_buffer_profile(
2025-10-14T22:44:44.4093955Z dvslib/dvs_buffer.py:153: in verify_buffer_profile
2025-10-14T22:44:44.4094373Z     self.asic_db.wait_for_field_match(self.ASIC_BUFFER_PROFILE, sai_buffer_profile_id, sai_qualifiers)
2025-10-14T22:44:44.4094644Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2025-10-14T22:44:44.4094788Z 
2025-10-14T22:44:44.4095005Z self = <dvslib.dvs_database.DVSDatabase object at 0x779778ec47f0>
2025-10-14T22:44:44.4095208Z table_name = 'ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_PROFILE', key = 'oid:0x0'
2025-10-14T22:44:44.4095502Z expected_fields = {'SAI_BUFFER_PROFILE_ATTR_PACKET_ADMISSION_FAIL_ACTION': 'SAI_BUFFER_PROFILE_PACKET_ADMISSION_FAIL_ACTION_DROP'}
2025-10-14T22:44:44.4095803Z polling_config = PollingConfig(polling_interval=0.01, timeout=20.0, strict=True)
2025-10-14T22:44:44.4095989Z comparator = None, failure_message = None
2025-10-14T22:44:44.4096054Z 
2025-10-14T22:44:44.4096374Z     def wait_for_field_match(
2025-10-14T22:44:44.4096541Z         self,
2025-10-14T22:44:44.4096663Z         table_name: str,
2025-10-14T22:44:44.4096792Z         key: str,
2025-10-14T22:44:44.4096929Z         expected_fields: Dict[str, str],
2025-10-14T22:44:44.4097126Z         polling_config: PollingConfig = PollingConfig(),
2025-10-14T22:44:44.4097348Z         comparator: Callable[[], bool] = None,
2025-10-14T22:44:44.4097530Z         failure_message: str = None,
2025-10-14T22:44:44.4097667Z     ) -> Dict[str, str]:
2025-10-14T22:44:44.4097843Z         """Wait for the entry stored at `key` to have the specified field/values and retrieve it.
2025-10-14T22:44:44.4098101Z     
2025-10-14T22:44:44.4098269Z         This method is useful if you only care about the contents of a subset of the fields stored
2025-10-14T22:44:44.4098447Z         in the specified entry.
2025-10-14T22:44:44.4098562Z     
2025-10-14T22:44:44.4098677Z         Args:
2025-10-14T22:44:44.4098926Z             table_name: The name of the table where the entry is stored.
2025-10-14T22:44:44.4099105Z             key: The key that maps to the entry being checked.
2025-10-14T22:44:44.4099286Z             expected_fields: The fields and their values we expect to see in the entry.
2025-10-14T22:44:44.4099470Z             polling_config: The parameters to use to poll the db.
2025-10-14T22:44:44.4099881Z             failure_message: The message to print if the call times out. This will only take effect
2025-10-14T22:44:44.4100070Z                 if the PollingConfig is set to strict.
2025-10-14T22:44:44.4100201Z     
2025-10-14T22:44:44.4100323Z         Returns:
2025-10-14T22:44:44.4100582Z             The entry stored at `key`. If no entry is found, then an empty Dict is returned.
2025-10-14T22:44:44.4100817Z         """
2025-10-14T22:44:44.4100921Z     
2025-10-14T22:44:44.4101051Z         def access_function():
2025-10-14T22:44:44.4101254Z             fv_pairs = self.get_entry(table_name, key)
2025-10-14T22:44:44.4101437Z     
2025-10-14T22:44:44.4101566Z             if comparator is not None:
2025-10-14T22:44:44.4101744Z                 result = all(comparator(k, fv_pairs.get(k, None), v) for k, v in expected_fields.items())
2025-10-14T22:44:44.4101922Z                 return (result, fv_pairs)
2025-10-14T22:44:44.4102254Z     
2025-10-14T22:44:44.4102415Z             return (
2025-10-14T22:44:44.4102575Z                 all(fv_pairs.get(k) == v for k, v in expected_fields.items()),
2025-10-14T22:44:44.4102734Z                 fv_pairs,
2025-10-14T22:44:44.4102893Z             )
2025-10-14T22:44:44.4103053Z     
2025-10-14T22:44:44.4103187Z         status, result = wait_for_result(
2025-10-14T22:44:44.4103362Z             access_function, self._disable_strict_polling(polling_config)
2025-10-14T22:44:44.4103515Z         )
2025-10-14T22:44:44.4103637Z     
2025-10-14T22:44:44.4103845Z         if not status:
2025-10-14T22:44:44.4103984Z             message = failure_message or (
2025-10-14T22:44:44.4104155Z                 f"Expected field/value pairs not found: expected={expected_fields}, "
2025-10-14T22:44:44.4104342Z                 f'received={result}, key="{key}", table="{table_name}"'
2025-10-14T22:44:44.4104501Z             )
2025-10-14T22:44:44.4104705Z >           assert not polling_config.strict, message
2025-10-14T22:44:44.4105024Z E           AssertionError: Expected field/value pairs not found: expected={'SAI_BUFFER_PROFILE_ATTR_PACKET_ADMISSION_FAIL_ACTION': 'SAI_BUFFER_PROFILE_PACKET_ADMISSION_FAIL_ACTION_DROP'}, received={}, key="oid:0x0", table="ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_PROFILE"
2025-10-14T22:44:44.4105283Z 
2025-10-14T22:44:44.4105515Z dvslib/dvs_database.py:261: AssertionError
2025-10-14T22:44:44.4105705Z _ TestTrimmingDynamicBufferModel.test_TrimDynamicBufferProfileConfiguration[trim-packet] _
2025-10-14T22:44:44.4105813Z 
2025-10-14T22:44:44.4105971Z self = <test_trimming.TestTrimmingDynamicBufferModel object at 0x77977902add0>
2025-10-14T22:44:44.4106237Z bufferData = {'id': 'oid:0x0', 'name': 'egress_lossy_profile'}, action = 'trim'
2025-10-14T22:44:44.4106371Z 
2025-10-14T22:44:44.4106502Z     @pytest.mark.parametrize(
2025-10-14T22:44:44.4106631Z         "action", [
2025-10-14T22:44:44.4106774Z             pytest.param("drop", id="drop-packet"),
2025-10-14T22:44:44.4106940Z             pytest.param("trim", id="trim-packet")
2025-10-14T22:44:44.4107162Z         ]
2025-10-14T22:44:44.4107273Z     )
2025-10-14T22:44:44.4107424Z     def test_TrimDynamicBufferProfileConfiguration(self, bufferData, action):
2025-10-14T22:44:44.4107617Z >       self.verifyBufferProfileConfiguration(bufferData, action)
2025-10-14T22:44:44.4107705Z 
2025-10-14T22:44:44.4107910Z test_trimming.py:811: 
2025-10-14T22:44:44.4108079Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2025-10-14T22:44:44.4108261Z test_trimming.py:785: in verifyBufferProfileConfiguration
2025-10-14T22:44:44.4108437Z     self.dvs_buffer.verify_buffer_profile(
2025-10-14T22:44:44.4108653Z dvslib/dvs_buffer.py:153: in verify_buffer_profile
2025-10-14T22:44:44.4108966Z     self.asic_db.wait_for_field_match(self.ASIC_BUFFER_PROFILE, sai_buffer_profile_id, sai_qualifiers)
2025-10-14T22:44:44.4109315Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2025-10-14T22:44:44.4109428Z 
2025-10-14T22:44:44.4109746Z self = <dvslib.dvs_database.DVSDatabase object at 0x779778ec47f0>
2025-10-14T22:44:44.4110025Z table_name = 'ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_PROFILE', key = 'oid:0x0'
2025-10-14T22:44:44.4110283Z expected_fields = {'SAI_BUFFER_PROFILE_ATTR_PACKET_ADMISSION_FAIL_ACTION': 'SAI_BUFFER_PROFILE_PACKET_ADMISSION_FAIL_ACTION_DROP_AND_TRIM'}
2025-10-14T22:44:44.4110535Z polling_config = PollingConfig(polling_interval=0.01, timeout=20.0, strict=True)
2025-10-14T22:44:44.4110722Z comparator = None, failure_message = None
2025-10-14T22:44:44.4110854Z 
2025-10-14T22:44:44.4110983Z     def wait_for_field_match(
2025-10-14T22:44:44.4111112Z         self,
2025-10-14T22:44:44.4111242Z         table_name: str,
2025-10-14T22:44:44.4111373Z         key: str,
2025-10-14T22:44:44.4111500Z         expected_fields: Dict[str, str],
2025-10-14T22:44:44.4111712Z         polling_config: PollingConfig = PollingConfig(),
2025-10-14T22:44:44.4111927Z         comparator: Callable[[], bool] = None,
2025-10-14T22:44:44.4112082Z         failure_message: str = None,
2025-10-14T22:44:44.4112446Z     ) -> Dict[str, str]:
2025-10-14T22:44:44.4112622Z         """Wait for the entry stored at `key` to have the specified field/values and retrieve it.
2025-10-14T22:44:44.4112775Z     
2025-10-14T22:44:44.4113042Z         This method is useful if you only care about the contents of a subset of the fields stored
2025-10-14T22:44:44.4113333Z         in the specified entry.
2025-10-14T22:44:44.4113529Z     
2025-10-14T22:44:44.4113715Z         Args:
2025-10-14T22:44:44.4113973Z             table_name: The name of the table where the entry is stored.
2025-10-14T22:44:44.4114142Z             key: The key that maps to the entry being checked.
2025-10-14T22:44:44.4114332Z             expected_fields: The fields and their values we expect to see in the entry.
2025-10-14T22:44:44.4114521Z             polling_config: The parameters to use to poll the db.
2025-10-14T22:44:44.4114710Z             failure_message: The message to print if the call times out. This will only take effect
2025-10-14T22:44:44.4114894Z                 if the PollingConfig is set to strict.
2025-10-14T22:44:44.4115025Z     
2025-10-14T22:44:44.4115136Z         Returns:
2025-10-14T22:44:44.4115296Z             The entry stored at `key`. If no entry is found, then an empty Dict is returned.
2025-10-14T22:44:44.4115449Z         """
2025-10-14T22:44:44.4115560Z     
2025-10-14T22:44:44.4115689Z         def access_function():
2025-10-14T22:44:44.4115833Z             fv_pairs = self.get_entry(table_name, key)
2025-10-14T22:44:44.4115968Z     
2025-10-14T22:44:44.4116101Z             if comparator is not None:
2025-10-14T22:44:44.4116286Z                 result = all(comparator(k, fv_pairs.get(k, None), v) for k, v in expected_fields.items())
2025-10-14T22:44:44.4116469Z                 return (result, fv_pairs)
2025-10-14T22:44:44.4116592Z     
2025-10-14T22:44:44.4116700Z             return (
2025-10-14T22:44:44.4116861Z                 all(fv_pairs.get(k) == v for k, v in expected_fields.items()),
2025-10-14T22:44:44.4117024Z                 fv_pairs,
2025-10-14T22:44:44.4117144Z             )
2025-10-14T22:44:44.4117259Z     
2025-10-14T22:44:44.4117387Z         status, result = wait_for_result(
2025-10-14T22:44:44.4117552Z             access_function, self._disable_strict_polling(polling_config)
2025-10-14T22:44:44.4117706Z         )
2025-10-14T22:44:44.4117816Z     
2025-10-14T22:44:44.4117936Z         if not status:
2025-10-14T22:44:44.4118072Z             message = failure_message or (
2025-10-14T22:44:44.4118238Z                 f"Expected field/value pairs not found: expected={expected_fields}, "
2025-10-14T22:44:44.4118421Z                 f'received={result}, key="{key}", table="{table_name}"'
2025-10-14T22:44:44.4118563Z             )
2025-10-14T22:44:44.4118703Z >           assert not polling_config.strict, message
2025-10-14T22:44:44.4119029Z E           AssertionError: Expected field/value pairs not found: expected={'SAI_BUFFER_PROFILE_ATTR_PACKET_ADMISSION_FAIL_ACTION': 'SAI_BUFFER_PROFILE_PACKET_ADMISSION_FAIL_ACTION_DROP_AND_TRIM'}, received={}, key="oid:0x0", table="ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_PROFILE"
2025-10-14T22:44:44.4119349Z 
2025-10-14T22:44:44.4119492Z dvslib/dvs_database.py:261: AssertionError
```

syslog:
```
Oct 14 22:38:01.232972 f3176e226da6 NOTICE #buffermgrd: :- handlePortTable: Admin-down port Ethernet0 is not handled for now because buffer pools are not configured yet
Oct 14 22:38:01.237697 f3176e226da6 NOTICE #orchagent: :- processPriorityGroup: Remove buffer PG Ethernet0:0
Oct 14 22:38:01.256068 f3176e226da6 NOTICE #buffermgrd: :- handleSingleBufferQueueEntry: Queue Ethernet0:0-2 has been configured on the system, referencing profile egress_lossy_profile
Oct 14 22:38:01.256258 f3176e226da6 NOTICE #buffermgrd: :- handleSingleBufferQueueEntry: Queue Ethernet0:3-4 has been configured on the system, referencing profile egress_lossless_profile
Oct 14 22:38:01.256473 f3176e226da6 NOTICE #buffermgrd: :- handleSingleBufferQueueEntry: Queue Ethernet0:5-6 has been configured on the system, referencing profile egress_lossy_profile
Oct 14 22:38:01.258833 f3176e226da6 NOTICE #orchagent: :- processQueue: Remove buffer queue Ethernet0:0-2
Oct 14 22:38:01.258932 f3176e226da6 NOTICE #orchagent: :- processQueue: Remove buffer queue Ethernet0:3-4
Oct 14 22:38:01.259000 f3176e226da6 NOTICE #orchagent: :- processQueue: Remove buffer queue Ethernet0:5-6
Oct 14 22:38:22.259268 f3176e226da6 NOTICE #buffermgrd: :- applyNormalBufferObjectsOnPort: Profile egress_lossy_profile has been applied on queue Ethernet0:0-2
Oct 14 22:38:22.259279 f3176e226da6 NOTICE #buffermgrd: :- updateBufferObjectToDb: Buffer pools are not ready when configuring buffer queue Ethernet0:0-2, pending
Oct 14 22:38:22.259285 f3176e226da6 NOTICE #buffermgrd: :- applyNormalBufferObjectsOnPort: Profile egress_lossless_profile has been applied on queue Ethernet0:3-4
Oct 14 22:38:22.259289 f3176e226da6 NOTICE #buffermgrd: :- updateBufferObjectToDb: Buffer pools are not ready when configuring buffer queue Ethernet0:3-4, pending
Oct 14 22:38:22.259293 f3176e226da6 NOTICE #buffermgrd: :- applyNormalBufferObjectsOnPort: Profile egress_lossy_profile has been applied on queue Ethernet0:5-6
Oct 14 22:38:22.259297 f3176e226da6 NOTICE #buffermgrd: :- updateBufferObjectToDb: Buffer pools are not ready when configuring buffer queue Ethernet0:5-6, pending
Oct 14 22:38:31.306880 f3176e226da6 NOTICE #pytest: === start test test_trimming.py::TestTrimmingDynamicBufferModel::test_TrimDynamicBufferProfileConfiguration[drop-packet] ===
Oct 14 22:38:31.307908 f3176e226da6 NOTICE #orchagent: :- processPriorityGroupBulk: Set 2 ingress priority groups buffer profile took 0.001043 sec
Oct 14 22:38:31.311672 f3176e226da6 NOTICE #buffermgrd: :- handleBufferProfileTable: BUFFER_PROFILE egress_lossy_profile has been inserted into APPL_DB directly
Oct 14 22:38:41.233922 f3176e226da6 NOTICE #buffermgrd: :- handlePendingBufferObjects: Additional zero profiles will be appied after 20 seconds
Oct 14 22:38:51.233885 f3176e226da6 NOTICE #buffermgrd: :- handlePendingBufferObjects: Additional zero profiles will be appied after 10 seconds
Oct 14 22:38:52.695386 f3176e226da6 NOTICE #pytest: === finish test test_trimming.py::TestTrimmingDynamicBufferModel::test_TrimDynamicBufferProfileConfiguration[drop-packet] ===
Oct 14 22:38:52.769920 f3176e226da6 NOTICE #pytest: === start test test_trimming.py::TestTrimmingDynamicBufferModel::test_TrimDynamicBufferProfileConfiguration[drop-packet] ===
```

sairedis:
```
2025-10-14.22:37:55.582661|p|QUEUE_STAT_COUNTER|POLL_INTERVAL=10000
2025-10-14.22:37:55.583384|p|QUEUE_STAT_COUNTER|FLEX_COUNTER_STATUS=disable
2025-10-14.22:38:01.234497|s|SAI_OBJECT_TYPE_BUFFER_POOL:oid:0x180000000005f4|SAI_BUFFER_POOL_ATTR_SIZE=12766208
2025-10-14.22:38:01.235977|s|SAI_OBJECT_TYPE_BUFFER_POOL:oid:0x180000000005f5|SAI_BUFFER_POOL_ATTR_SIZE=7326924
2025-10-14.22:38:01.236643|s|SAI_OBJECT_TYPE_BUFFER_POOL:oid:0x180000000005f6|SAI_BUFFER_POOL_ATTR_SIZE=12766208
2025-10-14.22:38:01.238249|S|SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP||oid:0x1a000000000465|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a00000000052d|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a000000000535|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a00000000053d|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a000000000545|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a00000000054d|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0
2025-10-14.22:38:01.240976|S|SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP||oid:0x1a000000000555|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a00000000055d|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a00000000047d|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a000000000485|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a00000000048d|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a000000000495|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a00000000049d|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a0000000004a5|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0
2025-10-14.22:38:01.243263|S|SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP||oid:0x1a0000000004ad|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a0000000004b5|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a0000000004bd|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0
2025-10-14.22:38:01.245467|S|SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP||oid:0x1a0000000004c5|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a00000000046d|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a0000000004cd|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0
2025-10-14.22:38:01.247890|S|SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP||oid:0x1a0000000004d5|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a0000000004dd|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0
2025-10-14.22:38:01.250168|S|SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP||oid:0x1a0000000004e5|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a0000000004ed|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0
2025-10-14.22:38:01.252168|S|SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP||oid:0x1a0000000004f5|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a0000000004fd|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a000000000505|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0
2025-10-14.22:38:01.254250|S|SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP||oid:0x1a00000000050d|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a000000000515|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0
2025-10-14.22:38:01.256287|S|SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP||oid:0x1a000000000475|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a00000000051d|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0||oid:0x1a000000000525|SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE=oid:0x0
2025-10-14.22:38:01.259441|S|SAI_OBJECT_TYPE_QUEUE||oid:0x15000000000025|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000026|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000027|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000028|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000029|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000002a|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000002b|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000219|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000021a|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000021b|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000021c|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000021d|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000021e|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000021f|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000022d|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000022e|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000022f|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0
2025-10-14.22:38:01.262559|S|SAI_OBJECT_TYPE_QUEUE||oid:0x15000000000230|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000231|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000232|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000233|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000241|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000242|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000243|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000244|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000245|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000246|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000247|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000255|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000256|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000257|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000258|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000259|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000025a|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000025b|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000269|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000026a|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000026b|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000026c|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000026d|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0
2025-10-14.22:38:01.266595|S|SAI_OBJECT_TYPE_QUEUE||oid:0x1500000000026e|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000026f|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000027d|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000027e|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000027f|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000280|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000281|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000282|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000283|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000291|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000292|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000293|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000294|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000295|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000296|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000297|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000061|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000062|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000063|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000064|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000065|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000066|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000067|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000075|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000076|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000077|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000078|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000079|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0
2025-10-14.22:38:01.270434|S|SAI_OBJECT_TYPE_QUEUE||oid:0x1500000000007a|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000007b|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000089|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000008a|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000008b|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000008c|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000008d|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000008e|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000008f|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000009d|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000009e|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000009f|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000a0|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000a1|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000a2|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000a3|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000b1|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000b2|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000b3|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000b4|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000b5|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000b6|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000b7|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000c5|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000c6|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000c7|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000c8|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000c9|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000ca|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000cb|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0
2025-10-14.22:38:01.275008|S|SAI_OBJECT_TYPE_QUEUE||oid:0x150000000000d9|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000da|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000db|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000dc|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000dd|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000de|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000df|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000ed|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000ee|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000ef|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000f0|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000f1|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000f2|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000000f3|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000101|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000102|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000103|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000104|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000105|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000106|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000107|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000115|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000116|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000117|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000118|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000119|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000011a|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000011b|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000039|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000003a|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000003b|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0
2025-10-14.22:38:01.279613|S|SAI_OBJECT_TYPE_QUEUE||oid:0x1500000000003c|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000003d|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000003e|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000003f|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000129|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000012a|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000012b|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000012c|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000012d|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000012e|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000012f|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000013d|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000013e|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000013f|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000140|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000141|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000142|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000143|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000151|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000152|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000153|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000154|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000155|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000156|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000157|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000165|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000166|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000167|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000168|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000169|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0
2025-10-14.22:38:01.284590|S|SAI_OBJECT_TYPE_QUEUE||oid:0x1500000000016a|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000016b|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000179|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000017a|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000017b|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000017c|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000017d|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000017e|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000017f|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000018d|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000018e|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000018f|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000190|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000191|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000192|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000193|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001a1|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001a2|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001a3|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001a4|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001a5|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001a6|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001a7|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001b5|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001b6|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001b7|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001b8|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001b9|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001ba|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001bb|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001c9|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001ca|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001cb|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001cc|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001cd|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001ce|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001cf|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0
2025-10-14.22:38:01.288864|S|SAI_OBJECT_TYPE_QUEUE||oid:0x150000000001dd|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001de|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001df|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001e0|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001e1|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001e2|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001e3|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000004d|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000004e|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000004f|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000050|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000051|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000052|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000053|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001f1|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001f2|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001f3|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001f4|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001f5|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001f6|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x150000000001f7|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000205|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000206|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000207|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000208|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x15000000000209|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000020a|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0||oid:0x1500000000020b|SAI_QUEUE_ATTR_BUFFER_PROFILE_ID=oid:0x0
```

**What I did**
* Stabilized packet trimming VS test case suite

**Why I did it**
* To fix the issue related to sporadic validation errors

**How I verified it**
1. Run VS test

**Details if related**
* N/A

**A picture of a cute animal (not mandatory but encouraged)**
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```