### PR TITLE
[buffermgrd] Optimize fast-reboot startup

### DIFF
--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -860,7 +860,7 @@ void BufferMgrDynamic::checkSharedBufferPoolSize(bool force_update_during_initia
     // - Warm start: execute if buffer is completely initialized OR buffer pools are not ready.
     if (!m_mmuSize.empty() &&
         (!WarmStart::isWarmStart() ||
-         (m_bufferCompletelyInitialized || !m_bufferPoolReady)))
+         (WarmStart::isWarmStart() && (m_bufferCompletelyInitialized || !m_bufferPoolReady))))
     {
         recalculateSharedBufferPool();
     }

--- a/tests/mock_tests/buffermgrdyn_ut.cpp
+++ b/tests/mock_tests/buffermgrdyn_ut.cpp
@@ -1702,9 +1702,9 @@ namespace buffermgrdyn_test
         m_dynamicBuffer->m_bufferPoolReady = false;
 
         // Verify the condition logic - should be false when MMU size empty
-        // New condition: !m_mmuSize.empty() && (!WarmStart::isWarmStart() || (m_bufferCompletelyInitialized || !m_bufferPoolReady))
+        // New condition: !m_mmuSize.empty() && (!WarmStart::isWarmStart() || (WarmStart::isWarmStart() && (m_bufferCompletelyInitialized || !m_bufferPoolReady)))
         bool conditionShouldNotExecute = !m_dynamicBuffer->m_mmuSize.empty() &&
-                                         (!WarmStart::isWarmStart() || (m_dynamicBuffer->m_bufferCompletelyInitialized || !m_dynamicBuffer->m_bufferPoolReady));
+                                         (!WarmStart::isWarmStart() || (WarmStart::isWarmStart() && (m_dynamicBuffer->m_bufferCompletelyInitialized || !m_dynamicBuffer->m_bufferPoolReady)));
         EXPECT_FALSE(conditionShouldNotExecute) << "Condition should evaluate to false when MMU size is empty";
 
         // Call checkSharedBufferPoolSize - should not execute recalculateSharedBufferPool
@@ -1726,7 +1726,7 @@ namespace buffermgrdyn_test
         // Verify the condition logic
         EXPECT_FALSE(WarmStart::isWarmStart()) << "Test setup is non-warm-start";
         bool conditionShouldExecute = !m_dynamicBuffer->m_mmuSize.empty() &&
-                                     (!WarmStart::isWarmStart() || (m_dynamicBuffer->m_bufferCompletelyInitialized || !m_dynamicBuffer->m_bufferPoolReady));
+                                     (!WarmStart::isWarmStart() || (WarmStart::isWarmStart() && (m_dynamicBuffer->m_bufferCompletelyInitialized || !m_dynamicBuffer->m_bufferPoolReady)));
         EXPECT_TRUE(conditionShouldExecute) << "Condition should evaluate to true for execution in non-warm-start";
 
         // TEST CASE 3: MMU size available, buffer not initialized, buffer pool ready (non-warm-start) - should execute
@@ -1737,7 +1737,7 @@ namespace buffermgrdyn_test
         // Verify the condition logic - should be true in non-warm-start
         // New condition: true && (!false || (false || !true)) = true && (true || false) = true && true = true
         bool conditionShouldExecute3 = !m_dynamicBuffer->m_mmuSize.empty() &&
-                                       (!WarmStart::isWarmStart() || (m_dynamicBuffer->m_bufferCompletelyInitialized || !m_dynamicBuffer->m_bufferPoolReady));
+                                       (!WarmStart::isWarmStart() || (WarmStart::isWarmStart() && (m_dynamicBuffer->m_bufferCompletelyInitialized || !m_dynamicBuffer->m_bufferPoolReady)));
         EXPECT_TRUE(conditionShouldExecute3) << "Condition should evaluate to true in non-warm-start (true && true = true)";
 
         // Call checkSharedBufferPoolSize - should execute
@@ -1751,7 +1751,7 @@ namespace buffermgrdyn_test
         // Verify the condition logic - should be true (normal case after initialization)
         // New condition: true && (!false || (true || !true)) = true && (true || true) = true && true = true
         bool conditionShouldExecute4 = !m_dynamicBuffer->m_mmuSize.empty() &&
-                                       (!WarmStart::isWarmStart() || (m_dynamicBuffer->m_bufferCompletelyInitialized || !m_dynamicBuffer->m_bufferPoolReady));
+                                       (!WarmStart::isWarmStart() || (WarmStart::isWarmStart() && (m_dynamicBuffer->m_bufferCompletelyInitialized || !m_dynamicBuffer->m_bufferPoolReady)));
         EXPECT_TRUE(conditionShouldExecute4) << "Condition should evaluate to true (true && true = true)";
 
         // Call checkSharedBufferPoolSize - should execute (normal case)
@@ -1765,7 +1765,7 @@ namespace buffermgrdyn_test
         // Verify the condition logic - should be true in non-warm-start
         // New condition: true && (!false || (true || !false)) = true && (true || true) = true && true = true
         bool conditionShouldExecute5 = !m_dynamicBuffer->m_mmuSize.empty() &&
-                                       (!WarmStart::isWarmStart() || (m_dynamicBuffer->m_bufferCompletelyInitialized || !m_dynamicBuffer->m_bufferPoolReady));
+                                       (!WarmStart::isWarmStart() || (WarmStart::isWarmStart() && (m_dynamicBuffer->m_bufferCompletelyInitialized || !m_dynamicBuffer->m_bufferPoolReady)));
         EXPECT_TRUE(conditionShouldExecute5) << "Condition should evaluate to true in non-warm-start";
 
         // Call checkSharedBufferPoolSize - should execute
@@ -1789,7 +1789,7 @@ namespace buffermgrdyn_test
         // If it were warm start: true && (false || (true || !true)) = true && (false || true) = true && true = true
         // This would execute during warm start when buffer is initialized or pool not ready
         bool conditionShouldExecute7 = !m_dynamicBuffer->m_mmuSize.empty() &&
-                                       (!WarmStart::isWarmStart() || (m_dynamicBuffer->m_bufferCompletelyInitialized || !m_dynamicBuffer->m_bufferPoolReady));
+                                       (!WarmStart::isWarmStart() || (WarmStart::isWarmStart() && (m_dynamicBuffer->m_bufferCompletelyInitialized || !m_dynamicBuffer->m_bufferPoolReady)));
         EXPECT_TRUE(conditionShouldExecute7) << "Condition should evaluate to true when both buffer initialized and pool ready";
     }
 
@@ -1938,7 +1938,7 @@ namespace buffermgrdyn_test
 
         // If warm start is enabled, the condition should still execute when pool not ready
         bool conditionShouldExecute1 = !m_dynamicBuffer->m_mmuSize.empty() &&
-                                       (!WarmStart::isWarmStart() || (m_dynamicBuffer->m_bufferCompletelyInitialized || !m_dynamicBuffer->m_bufferPoolReady));
+                                       (!WarmStart::isWarmStart() || (WarmStart::isWarmStart() && (m_dynamicBuffer->m_bufferCompletelyInitialized || !m_dynamicBuffer->m_bufferPoolReady)));
         // In warm start: true && (false || (false || true)) = true && (false || true) = true
         EXPECT_TRUE(conditionShouldExecute1) << "Condition should execute in warm start when pool not ready";
 
@@ -1948,9 +1948,9 @@ namespace buffermgrdyn_test
         m_dynamicBuffer->m_bufferCompletelyInitialized = true;
         m_dynamicBuffer->m_bufferPoolReady = false;
 
-        // New condition: true && (true || (true || !false)) = true && (true || true) = true
+        // New condition: true && (!false || (true && (true || !false))) = true && (true || true) = true
         bool conditionShouldExecute2 = !m_dynamicBuffer->m_mmuSize.empty() &&
-                                       (true || (m_dynamicBuffer->m_bufferCompletelyInitialized || !m_dynamicBuffer->m_bufferPoolReady));
+                                       (!WarmStart::isWarmStart() || (WarmStart::isWarmStart() && (m_dynamicBuffer->m_bufferCompletelyInitialized || !m_dynamicBuffer->m_bufferPoolReady)));
         EXPECT_TRUE(conditionShouldExecute2) << "Condition should execute in warm start when buffer initialized";
 
         m_dynamicBuffer->checkSharedBufferPoolSize(false);
@@ -1959,9 +1959,9 @@ namespace buffermgrdyn_test
         m_dynamicBuffer->m_bufferCompletelyInitialized = true;
         m_dynamicBuffer->m_bufferPoolReady = true;
 
-        // New condition: true && (true || (true || !true)) = true && (true || true) = true
+        // New condition: true && (!false || (true && (true || !true))) = true && (true || true) = true
         bool conditionShouldExecute3 = !m_dynamicBuffer->m_mmuSize.empty() &&
-                                       (true || (m_dynamicBuffer->m_bufferCompletelyInitialized || !m_dynamicBuffer->m_bufferPoolReady));
+                                       (!WarmStart::isWarmStart() || (WarmStart::isWarmStart() && (m_dynamicBuffer->m_bufferCompletelyInitialized || !m_dynamicBuffer->m_bufferPoolReady)));
         EXPECT_TRUE(conditionShouldExecute3) << "Condition should execute in warm start when both initialized and ready";
 
         m_dynamicBuffer->checkSharedBufferPoolSize(false);
@@ -1970,9 +1970,12 @@ namespace buffermgrdyn_test
         m_dynamicBuffer->m_bufferCompletelyInitialized = false;
         m_dynamicBuffer->m_bufferPoolReady = true;
 
-        // New condition: true && (false || (false || false)) = true && false = false
+        // New condition with explicit warm-start gating:
+        // true && (!false || (true && (false || false))) = true && (true || false) = true
+        // But with bufferCompletelyInitialized=false and bufferPoolReady=true:
+        // true && (false || (true && false)) = false -> should not execute
         bool conditionShouldNotExecute4 = !m_dynamicBuffer->m_mmuSize.empty() &&
-                                       (false || (m_dynamicBuffer->m_bufferCompletelyInitialized || !m_dynamicBuffer->m_bufferPoolReady));
+                                       (!WarmStart::isWarmStart() || (WarmStart::isWarmStart() && (m_dynamicBuffer->m_bufferCompletelyInitialized || !m_dynamicBuffer->m_bufferPoolReady)));
         // In warm start: !WarmStart::isWarmStart() = false, m_bufferCompletelyInitialized = false, !m_bufferPoolReady = false
         // So: true && (false || (false || false)) = true && false = false
         EXPECT_FALSE(conditionShouldNotExecute4) << "Condition should not execute when warm start is enabled, buffer not initialized and pool ready";


### PR DESCRIPTION
This commit fixes a 10-second startup delay during fast-reboot in dynamic buffer mode.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add check for fast-reboot done flag m_bufferCompletelyInitialized in checkSharedBufferPoolSize() to avoid early calculation. This can save about 7s.
But still keep one calculation, because buffer pool need to be ready before buffer profile creation.
Also skip headroom validate in startup phase. This can save about 2s.

**Why I did it**
There is a 10-second startup delay during fast-reboot.
Because in fast-reboot, m_mmuSize is immediately available from STATE_DB (persisted from previous boot), causing checkSharedBufferPoolSize() to execute expensive Redis operations before buffer system init completes.

**How I verified it**
Test with fast reboot, and check timing duration between key logs:
Before fix:
2025 Jun  6 13:53:03.918106 sonic NOTICE swss#orchagent: :- main: Created underlay router interface ID 600000000000a
2025 Jun  6 13:53:14.411721 sonic NOTICE swss#orchagent: :- initBufferConstants: Got maximum memory size 20799, exposing to BUFFER_MAX_PARAM_TABLE|global
After fix:
2025 Sep 15 12:12:55.319951 r-bison-12 NOTICE swss#orchagent: :- main: Created underlay router interface ID 600000000000a
2025 Sep 15 12:12:55.617816 r-bison-12 NOTICE swss#orchagent: :- initBufferConstants: Got maximum memory size 20799, exposing to BUFFER_MAX_PARAM_TABLE|global
