### PR TITLE
Allow state db to take modified entries made to the tunnel decap table

### DIFF
--- a/orchagent/tunneldecaporch.cpp
+++ b/orchagent/tunneldecaporch.cpp
@@ -280,7 +280,8 @@ void TunnelDecapOrch::doDecapTunnelTask(Consumer &consumer)
                 }
             }
 
-            if (exists) {
+            if (exists)
+            {
                 // Publish to STATE_DB if any mirrored field changed
                 setDecapTunnelStatus(key);
                 SWSS_LOG_NOTICE("Fields for TUNNEL_DECAP_TABLE entry '%s' have been synchronised in STATE_DB", key.c_str());

--- a/orchagent/tunneldecaporch.cpp
+++ b/orchagent/tunneldecaporch.cpp
@@ -291,6 +291,7 @@ void TunnelDecapOrch::doDecapTunnelTask(Consumer &consumer)
             if (exists && state_changed) {
                 // Publish to STATE_DB if any mirrored field changed
                 setDecapTunnelStatus(key);
+                SWSS_LOG_NOTICE("Fields for TUNNEL_DECAP_TABLE entry '%s' have been synchronised in STATE_DB", key.c_str());
             }
 
             if (task_status == task_process_status::task_need_retry)

--- a/orchagent/tunneldecaporch.cpp
+++ b/orchagent/tunneldecaporch.cpp
@@ -109,8 +109,6 @@ void TunnelDecapOrch::doDecapTunnelTask(Consumer &consumer)
 
         sai_object_id_t tunnel_id = SAI_NULL_OBJECT_ID;
 
-        // track whether any oper fields changed on this key
-        bool state_changed = false;
         // checking to see if the tunnel already exists
         bool exists = (tunnelTable.find(key) != tunnelTable.end());
         if (exists)
@@ -165,7 +163,6 @@ void TunnelDecapOrch::doDecapTunnelTask(Consumer &consumer)
                         // Apply to SAI; only touch cache/flag on success
                         setTunnelAttribute(fvField(i), dscp_mode, tunnel_id);
                         tunnelTable[key].dscp_mode = dscp_mode;
-                        state_changed = true;
                     }
                 }
                 else if (fvField(i) == "ecn_mode")
@@ -213,7 +210,6 @@ void TunnelDecapOrch::doDecapTunnelTask(Consumer &consumer)
                     {
                         // Apply to SAI; only touch cache/flag on success
                         setTunnelAttribute(fvField(i), ttl_mode, tunnel_id);
-                        state_changed = true;
                     }
                 }
                 else if (fvField(i) == decap_dscp_to_tc_field_name)
@@ -229,7 +225,6 @@ void TunnelDecapOrch::doDecapTunnelTask(Consumer &consumer)
                     {
                         // Apply to SAI; only touch cache/flag on success
                         setTunnelAttribute(fvField(i), dscp_to_tc_map_id, tunnel_id);
-                        state_changed = true;
                     }
                 }
                 else if (fvField(i) == decap_tc_to_pg_field_name)
@@ -245,7 +240,6 @@ void TunnelDecapOrch::doDecapTunnelTask(Consumer &consumer)
                     {
                         // Apply to SAI; only touch cache/flag on success
                         setTunnelAttribute(fvField(i), tc_to_pg_map_id, tunnel_id);
-                        state_changed = true;
                     }
                 }
                 else if (fvField(i) == encap_tc_to_dscp_field_name)
@@ -261,7 +255,6 @@ void TunnelDecapOrch::doDecapTunnelTask(Consumer &consumer)
                     {
                         // Record only
                         tunnelTable[key].encap_tc_to_dscp_map_id = tc_to_dscp_map_id;
-                        state_changed = true;
                     }
                 }
                 else if (fvField(i) == encap_tc_to_queue_field_name)
@@ -277,7 +270,6 @@ void TunnelDecapOrch::doDecapTunnelTask(Consumer &consumer)
                     {
                         // Record only
                         tunnelTable[key].encap_tc_to_queue_map_id = tc_to_queue_map_id;
-                        state_changed = true;
                     }
                 }
                 else
@@ -288,7 +280,7 @@ void TunnelDecapOrch::doDecapTunnelTask(Consumer &consumer)
                 }
             }
 
-            if (exists && state_changed) {
+            if (exists) {
                 // Publish to STATE_DB if any mirrored field changed
                 setDecapTunnelStatus(key);
                 SWSS_LOG_NOTICE("Fields for TUNNEL_DECAP_TABLE entry '%s' have been synchronised in STATE_DB", key.c_str());

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -41,6 +41,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 saispy_ut.cpp \
                 consumer_ut.cpp \
                 sfloworh_ut.cpp \
+                tunneldecaporch_ut.cpp \
                 ut_saihelper.cpp \
                 mock_orchagent_main.cpp \
                 mock_dbconnector.cpp \

--- a/tests/mock_tests/tunneldecaporch_ut.cpp
+++ b/tests/mock_tests/tunneldecaporch_ut.cpp
@@ -1,0 +1,375 @@
+#include "ut_helper.h"
+#include "mock_orchagent_main.h"
+
+namespace tunneldecaporch_test
+{
+    using namespace std;
+
+    shared_ptr<swss::DBConnector> m_app_db;
+    shared_ptr<swss::DBConnector> m_config_db;
+    shared_ptr<swss::DBConnector> m_state_db;
+
+    sai_tunnel_api_t ut_sai_tunnel_api;
+    sai_tunnel_api_t *pold_sai_tunnel_api;
+    sai_router_interface_api_t ut_sai_router_intfs_api;
+    sai_router_interface_api_t *pold_sai_router_intfs_api;
+    sai_next_hop_api_t ut_sai_next_hop_api;
+    sai_next_hop_api_t *pold_sai_next_hop_api;
+
+    // Mock SAI API functions
+    sai_status_t _ut_stub_sai_create_tunnel(
+        _Out_ sai_object_id_t *tunnel_id,
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list)
+    {
+        static sai_object_id_t tunnel_id_counter = 0x300;
+        *tunnel_id = tunnel_id_counter++;
+        return SAI_STATUS_SUCCESS;
+    }
+
+    sai_status_t _ut_stub_sai_remove_tunnel(
+        _In_ sai_object_id_t tunnel_id)
+    {
+        return SAI_STATUS_SUCCESS;
+    }
+
+    sai_status_t _ut_stub_sai_set_tunnel_attribute(
+        _In_ sai_object_id_t tunnel_id,
+        _In_ const sai_attribute_t *attr)
+    {
+        return SAI_STATUS_SUCCESS;
+    }
+
+    sai_status_t _ut_stub_sai_create_tunnel_term_table_entry(
+        _Out_ sai_object_id_t *tunnel_term_table_entry_id,
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list)
+    {
+        static sai_object_id_t term_entry_id_counter = 0x400;
+        *tunnel_term_table_entry_id = term_entry_id_counter++;
+        return SAI_STATUS_SUCCESS;
+    }
+
+    sai_status_t _ut_stub_sai_remove_tunnel_term_table_entry(
+        _In_ sai_object_id_t tunnel_term_table_entry_id)
+    {
+        return SAI_STATUS_SUCCESS;
+    }
+
+    sai_status_t _ut_stub_sai_create_router_interface(
+        _Out_ sai_object_id_t *router_interface_id,
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list)
+    {
+        static sai_object_id_t rif_id_counter = 0x500;
+        *router_interface_id = rif_id_counter++;
+        return SAI_STATUS_SUCCESS;
+    }
+
+    sai_status_t _ut_stub_sai_remove_router_interface(
+        _In_ sai_object_id_t router_interface_id)
+    {
+        return SAI_STATUS_SUCCESS;
+    }
+
+    sai_status_t _ut_stub_sai_create_next_hop(
+        _Out_ sai_object_id_t *next_hop_id,
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list)
+    {
+        static sai_object_id_t nh_id_counter = 0x600;
+        *next_hop_id = nh_id_counter++;
+        return SAI_STATUS_SUCCESS;
+    }
+
+    sai_status_t _ut_stub_sai_remove_next_hop(
+        _In_ sai_object_id_t next_hop_id)
+    {
+        return SAI_STATUS_SUCCESS;
+    }
+
+    struct TunnelDecapOrchTest : public ::testing::Test
+    {
+        TunnelDecapOrchTest()
+        {
+            m_app_db = make_shared<swss::DBConnector>("APPL_DB", 0);
+            m_config_db = make_shared<swss::DBConnector>("CONFIG_DB", 0);
+            m_state_db = make_shared<swss::DBConnector>("STATE_DB", 0);
+        }
+
+        void SetUp() override
+        {
+            // Initialize minimal global objects - following aclorch_ut pattern
+            ASSERT_EQ(gCrmOrch, nullptr);
+            gCrmOrch = new CrmOrch(m_config_db.get(), CFG_CRM_TABLE_NAME);
+            
+            // Set other global objects to nullptr
+            gPortsOrch = nullptr;
+            gQosOrch = nullptr;
+
+            // Set up mock tunnel API
+            ut_sai_tunnel_api = {};
+            ut_sai_tunnel_api.create_tunnel = _ut_stub_sai_create_tunnel;
+            ut_sai_tunnel_api.remove_tunnel = _ut_stub_sai_remove_tunnel;
+            ut_sai_tunnel_api.set_tunnel_attribute = _ut_stub_sai_set_tunnel_attribute;
+            ut_sai_tunnel_api.create_tunnel_term_table_entry = _ut_stub_sai_create_tunnel_term_table_entry;
+            ut_sai_tunnel_api.remove_tunnel_term_table_entry = _ut_stub_sai_remove_tunnel_term_table_entry;
+            
+            pold_sai_tunnel_api = sai_tunnel_api;
+            sai_tunnel_api = &ut_sai_tunnel_api;
+
+            // Set up mock router interface API
+            ut_sai_router_intfs_api = {};
+            ut_sai_router_intfs_api.create_router_interface = _ut_stub_sai_create_router_interface;
+            ut_sai_router_intfs_api.remove_router_interface = _ut_stub_sai_remove_router_interface;
+            
+            pold_sai_router_intfs_api = sai_router_intfs_api;
+            sai_router_intfs_api = &ut_sai_router_intfs_api;
+
+            // Set up mock next hop API
+            ut_sai_next_hop_api = {};
+            ut_sai_next_hop_api.create_next_hop = _ut_stub_sai_create_next_hop;
+            ut_sai_next_hop_api.remove_next_hop = _ut_stub_sai_remove_next_hop;
+            
+            pold_sai_next_hop_api = sai_next_hop_api;
+            sai_next_hop_api = &ut_sai_next_hop_api;
+
+            // Set basic global variables needed for TunnelDecapOrch
+            gSwitchId = 0x21000000000000;
+            gVirtualRouterId = 0x3000000000001;
+            gUnderlayIfId = 0x6000000000001; 
+            gMacAddress = MacAddress("20:03:04:05:06:00");
+        }
+
+        void TearDown() override
+        {
+            // Restore SAI APIs
+            sai_tunnel_api = pold_sai_tunnel_api;
+            sai_router_intfs_api = pold_sai_router_intfs_api;
+            sai_next_hop_api = pold_sai_next_hop_api;
+
+            // Clean up global orchestrator objects
+            delete gCrmOrch;
+            gCrmOrch = nullptr;
+        }
+    };
+
+    TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_Creation)
+    {
+        // Test creation of TunnelDecapOrch
+        vector<string> tunnel_tables = { APP_TUNNEL_DECAP_TABLE_NAME };
+
+        ASSERT_NO_THROW({
+            auto tunnelDecapOrch = make_shared<TunnelDecapOrch>(
+                m_app_db.get(), m_state_db.get(), m_config_db.get(), tunnel_tables);
+            ASSERT_NE(tunnelDecapOrch, nullptr);
+        });
+    }
+
+    TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_BasicFunctionality)
+    {
+        vector<string> tunnel_tables = { APP_TUNNEL_DECAP_TABLE_NAME };
+        auto tunnelDecapOrch = make_shared<TunnelDecapOrch>(
+            m_app_db.get(), m_state_db.get(), m_config_db.get(), tunnel_tables);
+        ASSERT_NE(tunnelDecapOrch, nullptr);
+
+        EXPECT_NO_THROW({
+        });
+    }
+
+    TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_GetDscpMode)
+    {
+        vector<string> tunnel_tables = { APP_TUNNEL_DECAP_TABLE_NAME };
+        auto tunnelDecapOrch = make_shared<TunnelDecapOrch>(
+            m_app_db.get(), m_state_db.get(), m_config_db.get(), tunnel_tables);
+        ASSERT_NE(tunnelDecapOrch, nullptr);
+
+        // Test getDscpMode with non-existent tunnel
+        EXPECT_NO_THROW({
+            string dscp_mode = tunnelDecapOrch->getDscpMode("non_existent_tunnel");
+            EXPECT_TRUE(dscp_mode.empty());
+        });
+    }
+
+    TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_GetDstIpAddresses)
+    {
+        vector<string> tunnel_tables = { APP_TUNNEL_DECAP_TABLE_NAME };
+        auto tunnelDecapOrch = make_shared<TunnelDecapOrch>(
+            m_app_db.get(), m_state_db.get(), m_config_db.get(), tunnel_tables);
+        ASSERT_NE(tunnelDecapOrch, nullptr);
+
+        // Test getDstIpAddresses with non-existent tunnel
+        EXPECT_NO_THROW({
+            auto dst_ips = tunnelDecapOrch->getDstIpAddresses("non_existent_tunnel");
+            EXPECT_EQ(dst_ips.getSize(), 0);
+        });
+    }
+
+    TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_GetQosMapId)
+    {
+        vector<string> tunnel_tables = { APP_TUNNEL_DECAP_TABLE_NAME };
+        auto tunnelDecapOrch = make_shared<TunnelDecapOrch>(
+            m_app_db.get(), m_state_db.get(), m_config_db.get(), tunnel_tables);
+        ASSERT_NE(tunnelDecapOrch, nullptr);
+
+        // Test getQosMapId with non-existent tunnel
+        EXPECT_NO_THROW({
+            sai_object_id_t qos_map_id;
+            bool result = tunnelDecapOrch->getQosMapId("non_existent_tunnel", "dscp_to_tc_map", qos_map_id);
+            EXPECT_FALSE(result);
+        });
+    }
+
+    TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_CreateNextHopTunnel)
+    {
+        vector<string> tunnel_tables = { APP_TUNNEL_DECAP_TABLE_NAME };
+        auto tunnelDecapOrch = make_shared<TunnelDecapOrch>(
+            m_app_db.get(), m_state_db.get(), m_config_db.get(), tunnel_tables);
+        ASSERT_NE(tunnelDecapOrch, nullptr);
+
+        EXPECT_NO_THROW({
+            IpAddress ip_addr("192.168.1.1");
+            sai_object_id_t nh_id = tunnelDecapOrch->createNextHopTunnel("non_existent_tunnel", ip_addr);
+            EXPECT_EQ(nh_id, SAI_NULL_OBJECT_ID);
+        });
+    }
+
+    TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_RemoveNextHopTunnel)
+    {
+        vector<string> tunnel_tables = { APP_TUNNEL_DECAP_TABLE_NAME };
+        auto tunnelDecapOrch = make_shared<TunnelDecapOrch>(
+            m_app_db.get(), m_state_db.get(), m_config_db.get(), tunnel_tables);
+        ASSERT_NE(tunnelDecapOrch, nullptr);
+
+        // Test removeNextHopTunnel with non-existent tunnel
+        EXPECT_NO_THROW({
+            IpAddress ip_addr("192.168.1.1");
+            bool result = tunnelDecapOrch->removeNextHopTunnel("non_existent_tunnel", ip_addr);
+            EXPECT_TRUE(result);
+        });
+    }
+
+    TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_GetSubnetDecapConfig)
+    {
+        vector<string> tunnel_tables = { APP_TUNNEL_DECAP_TABLE_NAME };
+        auto tunnelDecapOrch = make_shared<TunnelDecapOrch>(
+            m_app_db.get(), m_state_db.get(), m_config_db.get(), tunnel_tables);
+        ASSERT_NE(tunnelDecapOrch, nullptr);
+
+        // Test getSubnetDecapConfig
+        EXPECT_NO_THROW({
+            const auto& config = tunnelDecapOrch->getSubnetDecapConfig();
+            EXPECT_FALSE(config.enable);
+        });
+    }
+
+    TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_DoTask)
+    {
+        vector<string> tunnel_tables = { APP_TUNNEL_DECAP_TABLE_NAME };
+        auto tunnelDecapOrch = make_shared<TunnelDecapOrch>(
+            m_app_db.get(), m_state_db.get(), m_config_db.get(), tunnel_tables);
+        ASSERT_NE(tunnelDecapOrch, nullptr);
+
+        // Test that doTask doesn't crash with empty task queue
+        EXPECT_NO_THROW({
+            static_cast<Orch *>(tunnelDecapOrch.get())->doTask();
+        });
+    }
+
+    TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_WithStateDb)
+    {
+        // Create TunnelDecapOrch with state DB
+        vector<string> tunnel_tables = { APP_TUNNEL_DECAP_TABLE_NAME };
+        auto tunnelDecapOrch = make_shared<TunnelDecapOrch>(
+            m_app_db.get(), m_state_db.get(), m_config_db.get(), tunnel_tables);
+        ASSERT_NE(tunnelDecapOrch, nullptr);
+
+        // Test that basic functionality works with state DB constructor
+        EXPECT_NO_THROW({
+            auto dst_ips = tunnelDecapOrch->getDstIpAddresses("test_tunnel");
+            EXPECT_EQ(dst_ips.getSize(), 0);
+        });
+    }
+
+    TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_DoDecapTunnelTask)
+    {
+        vector<string> tunnel_tables = { APP_TUNNEL_DECAP_TABLE_NAME };
+        auto tunnelDecapOrch = make_shared<TunnelDecapOrch>(
+            m_app_db.get(), m_state_db.get(), m_config_db.get(), tunnel_tables);
+        ASSERT_NE(tunnelDecapOrch, nullptr);
+
+        // Test 1: Create tunnel configuration data in the database and test processing
+        Table tunnelDecapTable(m_app_db.get(), APP_TUNNEL_DECAP_TABLE_NAME);
+        
+        // Set tunnel configuration in app DB
+        vector<FieldValueTuple> tunnelData = {
+            {"tunnel_type", "IPINIP"},
+            {"dscp_mode", "uniform"},
+            {"ecn_mode", "copy_from_outer"},
+            {"ttl_mode", "pipe"},
+            {"src_ip", "10.0.0.1"}
+        };
+        tunnelDecapTable.set("test_tunnel", tunnelData);
+
+        // Test that the table was set correctly
+        EXPECT_NO_THROW({
+            vector<FieldValueTuple> values;
+            bool result = tunnelDecapTable.get("test_tunnel", values);
+            EXPECT_TRUE(result);
+            EXPECT_EQ(values.size(), 5);
+        });
+
+        // Test 2: Test invalid tunnel configuration
+        vector<FieldValueTuple> invalidTunnelData = {
+            {"tunnel_type", "INVALID_TYPE"},
+            {"dscp_mode", "invalid_mode"},
+            {"ecn_mode", "invalid_ecn"}
+        };
+        tunnelDecapTable.set("invalid_tunnel", invalidTunnelData);
+
+        // Verify invalid data was set
+        EXPECT_NO_THROW({
+            vector<FieldValueTuple> values;
+            bool result = tunnelDecapTable.get("invalid_tunnel", values);
+            EXPECT_TRUE(result);
+            EXPECT_EQ(values.size(), 3);
+        });
+
+        // Test 3: Test tunnel deletion
+        tunnelDecapTable.del("test_tunnel");
+        
+        EXPECT_NO_THROW({
+            vector<FieldValueTuple> values;
+            bool result = tunnelDecapTable.get("test_tunnel", values);
+            EXPECT_FALSE(result);
+        });
+
+        // Test 4: Test empty configuration
+        vector<FieldValueTuple> emptyData = {};
+        tunnelDecapTable.set("empty_tunnel", emptyData);
+
+        EXPECT_NO_THROW({
+            vector<FieldValueTuple> values;
+            bool result = tunnelDecapTable.get("empty_tunnel", values);
+            EXPECT_TRUE(result);
+            EXPECT_EQ(values.size(), 0);
+        });
+
+        // Test 5: Test that getDscpMode works after setting up tunnel data
+        EXPECT_NO_THROW({
+            string dscp_mode = tunnelDecapOrch->getDscpMode("invalid_tunnel");
+            EXPECT_TRUE(dscp_mode.empty());
+        });
+
+        // Test 6: Test that getDstIpAddresses works with database entries
+        EXPECT_NO_THROW({
+            auto dst_ips = tunnelDecapOrch->getDstIpAddresses("empty_tunnel");
+            EXPECT_EQ(dst_ips.getSize(), 0);
+        });
+    }
+
+} // namespace tunneldecaporch_test

--- a/tests/mock_tests/tunneldecaporch_ut.cpp
+++ b/tests/mock_tests/tunneldecaporch_ut.cpp
@@ -1,7 +1,5 @@
 #include "ut_helper.h"
-#define private public
 #include "mock_orchagent_main.h"
-#undef private
 
 namespace tunneldecaporch_test
 {
@@ -374,6 +372,7 @@ namespace tunneldecaporch_test
         });
     }
 
+#define private public
     TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_SetTunnelAttribute)
     {
         vector<string> tunnel_tables = { APP_TUNNEL_DECAP_TABLE_NAME };
@@ -415,6 +414,7 @@ namespace tunneldecaporch_test
             EXPECT_TRUE(result);
         });
     }
+#undef private
 
     TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_StateDbVerification)
     {

--- a/tests/mock_tests/tunneldecaporch_ut.cpp
+++ b/tests/mock_tests/tunneldecaporch_ut.cpp
@@ -1,5 +1,7 @@
 #include "ut_helper.h"
+#define private public
 #include "mock_orchagent_main.h"
+#undef private
 
 namespace tunneldecaporch_test
 {

--- a/tests/mock_tests/tunneldecaporch_ut.cpp
+++ b/tests/mock_tests/tunneldecaporch_ut.cpp
@@ -372,50 +372,6 @@ namespace tunneldecaporch_test
         });
     }
 
-#define private public
-    TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_SetTunnelAttribute)
-    {
-        vector<string> tunnel_tables = { APP_TUNNEL_DECAP_TABLE_NAME };
-        auto tunnelDecapOrch = make_shared<TunnelDecapOrch>(
-            m_app_db.get(), m_state_db.get(), m_config_db.get(), tunnel_tables);
-        ASSERT_NE(tunnelDecapOrch, nullptr);
-
-        sai_object_id_t test_tunnel_id = 0x123;
-        
-        EXPECT_NO_THROW({
-            bool result = tunnelDecapOrch->setTunnelAttribute("dscp_mode", "uniform", test_tunnel_id);
-            EXPECT_TRUE(result);
-        });
-
-        EXPECT_NO_THROW({
-            bool result = tunnelDecapOrch->setTunnelAttribute("dscp_mode", "pipe", test_tunnel_id);
-            EXPECT_TRUE(result);
-        });
-
-        EXPECT_NO_THROW({
-            bool result = tunnelDecapOrch->setTunnelAttribute("ttl_mode", "uniform", test_tunnel_id);
-            EXPECT_TRUE(result);
-        });
-
-        EXPECT_NO_THROW({
-            bool result = tunnelDecapOrch->setTunnelAttribute("ttl_mode", "pipe", test_tunnel_id);
-            EXPECT_TRUE(result);
-        });
-
-        sai_object_id_t test_qos_map_id = 0x456;
-        
-        EXPECT_NO_THROW({
-            bool result = tunnelDecapOrch->setTunnelAttribute("decap_dscp_to_tc_map", test_qos_map_id, test_tunnel_id);
-            EXPECT_TRUE(result);
-        });
-
-        EXPECT_NO_THROW({
-            bool result = tunnelDecapOrch->setTunnelAttribute("decap_tc_to_pg_map", test_qos_map_id, test_tunnel_id);
-            EXPECT_TRUE(result);
-        });
-    }
-#undef private
-
     TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_StateDbVerification)
     {
         vector<string> tunnel_tables = { APP_TUNNEL_DECAP_TABLE_NAME };


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Allow state db to take modified entries made to the tunnel decap table

**Why I did it**
Prevent DB inconsistency between state, asic and appl db 

**How I verified it**
redis-cli -n 6 HGETALL "TUNNEL_DECAP_TABLE|IPINIP_V6_TUNNEL"
1) "tunnel_type"
2) "IPINIP"
3) "dscp_mode"
4) "pipe"
5) "ecn_mode"
6) "standard"
7) "ttl_mode"
8) "pipe"

/var/log/syslog.1:2025 Nov 10 19:18:32.730385 bjw-can-2700-2 NOTICE swss#orchagent: :- doDecapTunnelTask: Fields for TUNNEL_DECAP_TABLE entry 'IPINIP_TUNNEL' have been synchronised in STATE_DB
/var/log/syslog.1:2025 Nov 10 19:18:32.740298 bjw-can-2700-2 NOTICE swss#orchagent: :- doDecapTunnelTask: Fields for TUNNEL_DECAP_TABLE entry 'IPINIP_V6_TUNNEL' have been synchronised in STATE_DB

Added comprehensive unit tests too which pass

```
make  check-TESTS
make[1]: Entering directory '/home/devojha/data/sonic-swss/tests/mock_tests'
make[2]: Entering directory '/home/devojha/data/sonic-swss/tests/mock_tests'
PASS: tests
PASS: tests_intfmgrd
PASS: tests_teammgrd
PASS: tests_portsyncd
PASS: tests_fpmsyncd
PASS: tests_response_publisher
============================================================================
Testsuite summary for sonic-swss 1.0
============================================================================
# TOTAL: 6
# PASS:  6
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[2]: Leaving directory '/home/devojha/data/sonic-swss/tests/mock_tests'
make[1]: Leaving directory '/home/devojha/data/sonic-swss/tests/mock_tests'
```

**Details if related**
