### PR TITLE
Ignore LAG member port enable message for down ports

### DIFF
--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -25,6 +25,7 @@ TeamSync::TeamSync(DBConnector *db, DBConnector *stateDb, Select *select) :
     m_select(select),
     m_lagTable(db, APP_LAG_TABLE_NAME),
     m_lagMemberTable(db, APP_LAG_MEMBER_TABLE_NAME),
+    m_portTable(db, APP_PORT_TABLE_NAME),
     m_stateLagTable(stateDb, STATE_LAG_TABLE_NAME)
 {
     WarmStart::initialize(TEAMSYNCD_APP_NAME, "teamd");
@@ -183,7 +184,7 @@ void TeamSync::addLag(const string &lagName, int ifindex, bool admin_state,
     if (lag_update)
     {
         /* Create the team instance */
-        auto sync = make_shared<TeamPortSync>(lagName, ifindex, &m_lagMemberTable);
+        auto sync = make_shared<TeamPortSync>(lagName, ifindex, &m_lagMemberTable, &m_portTable);
         m_teamSelectables[lagName] = sync;
         m_selectablesToAdd.insert(lagName);
     }
@@ -241,8 +242,9 @@ const struct team_change_handler TeamSync::TeamPortSync::gPortChangeHandler = {
 };
 
 TeamSync::TeamPortSync::TeamPortSync(const string &lagName, int ifindex,
-                                     ProducerStateTable *lagMemberTable) :
+                                     ProducerStateTable *lagMemberTable, Table *portMemberTable) :
     m_lagMemberTable(lagMemberTable),
+    m_portMemberTable(portMemberTable),
     m_lagName(lagName),
     m_ifindex(ifindex)
 {
@@ -345,14 +347,26 @@ int TeamSync::TeamPortSync::onChange()
     {
         if (m_lagMembers.find(it.first) == m_lagMembers.end() || it.second != m_lagMembers[it.first])
         {
-            string key = m_lagName + ":" + it.first;
-            vector<FieldValueTuple> v;
-            FieldValueTuple l("status", it.second ? "enabled" : "disabled");
-            v.push_back(l);
-            m_lagMemberTable->set(key, v);
+            string admin_state, oper_state;
+            m_portMemberTable->hget(it.first, "admin_status", admin_state);
+            m_portMemberTable->hget(it.first, "oper_status", oper_state);
+            SWSS_LOG_INFO("Oper and Admin status of LAG %s member %s: %s, %s",
+                    m_lagName.c_str(), it.first.c_str(), oper_state.c_str(), admin_state.c_str());
+            if (admin_state == "up" || !it.second)
+            {
+                string key = m_lagName + ":" + it.first;
+                vector<FieldValueTuple> v;
+                FieldValueTuple l("status", it.second ? "enabled" : "disabled");
+                v.push_back(l);
+                m_lagMemberTable->set(key, v);
 
-            SWSS_LOG_INFO("Set LAG %s member %s with status %s",
-                    m_lagName.c_str(), it.first.c_str(), it.second ? "enabled" : "disabled");
+                SWSS_LOG_INFO("Set LAG %s member %s with status %s",
+                        m_lagName.c_str(), it.first.c_str(), it.second ? "enabled" : "disabled");
+            }
+            else
+            {
+                SWSS_LOG_WARN("Refuse to receive the teamd state of port member when port is down");
+            }
         }
     }
 

--- a/teamsyncd/teamsync.h
+++ b/teamsyncd/teamsync.h
@@ -35,7 +35,7 @@ public:
     public:
         enum { MAX_IFNAME = 64 };
         TeamPortSync(const std::string &lagName, int ifindex,
-                     ProducerStateTable *lagMemberTable);
+                     ProducerStateTable *lagMemberTable, Table *portMemberTable);
         ~TeamPortSync();
 
         int getFd() override;
@@ -52,6 +52,7 @@ public:
         static const struct team_change_handler gPortChangeHandler;
     private:
         ProducerStateTable *m_lagMemberTable;
+        Table *m_portMemberTable;
         struct team_handle *m_team;
         std::string m_lagName;
         int m_ifindex;


### PR DESCRIPTION
    [teamsyncd] Ignore LAG member port 'enable' message for down ports
    
    What I did
     Added a check for the physical port's up/down state when teamd reports member port status. This ensures that the 'enable' message for a member port is ignored if the physical port is down.
    
    Why I did it
     On platforms using the Trident4 ASIC, there is a specific issue in the SAI (Switch Abstraction Interface). Processing an 'enable' message for a port that is physically down causes an SAI error during operations like port splitting or removing a port from a LAG. This fix prevents that error from happening.
    
    How I verified it
     Verified on a Trident4-based physical switch. I confirmed that removing a 'down' member port from a LAG no longer triggers the SAI error.