### PR TITLE
[SWSS] Enhance the hash-setting code to account for SAI_SWITCH_ATTR_ECMP/LAG_HASH_IPV4/V6

### DIFF
--- a/orchagent/switch/switch_capabilities.cpp
+++ b/orchagent/switch/switch_capabilities.cpp
@@ -399,29 +399,57 @@ void SwitchCapabilities::querySwitchEcmpHashAttrCapabilities()
 {
     SWSS_LOG_ENTER();
 
-    sai_attr_capability_t attrCap;
-
-    auto status = queryAttrCapabilitiesSai(
-        attrCap, SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_ECMP_HASH
+    sai_attr_capability_t ecmpCap;
+    auto ecmpStatus = queryAttrCapabilitiesSai(
+        ecmpCap, SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_ECMP_HASH
     );
-    if (status != SAI_STATUS_SUCCESS)
+    if (ecmpStatus != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR(
+        SWSS_LOG_WARN(
             "Failed to get attribute(%s) capabilities",
             toStr(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_ECMP_HASH).c_str()
         );
+    }
+    else if (ecmpCap.get_implemented)
+    {
+        switchCapabilities.ecmpHash.isAttrSupported = true;
         return;
     }
 
-    if (!attrCap.get_implemented)
+    sai_attr_capability_t ecmpV4Cap;
+    auto ecmpV4Status = queryAttrCapabilitiesSai(
+        ecmpV4Cap, SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_ECMP_HASH_IPV4
+    );
+    if (ecmpV4Status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_WARN(
-            "Attribute(%s) GET is not implemented in SAI",
-            toStr(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_ECMP_HASH).c_str()
+        SWSS_LOG_ERROR(
+            "Failed to get attribute(%s) capabilities",
+            toStr(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_ECMP_HASH_IPV4).c_str()
         );
         return;
     }
 
+    sai_attr_capability_t ecmpV6Cap;
+    auto ecmpV6Status = queryAttrCapabilitiesSai(
+        ecmpV6Cap, SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_ECMP_HASH_IPV6
+    );
+    if (ecmpV6Status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR(
+            "Failed to get attribute(%s) capabilities",
+            toStr(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_ECMP_HASH_IPV6).c_str()
+        );
+        return;
+    }
+
+    if (!ecmpV4Cap.get_implemented || !ecmpV6Cap.get_implemented)
+    {
+        SWSS_LOG_ERROR(
+            "One or more of required ECMP capabilities not supported %d, %d",
+            ecmpV4Cap.get_implemented, ecmpV6Cap.get_implemented
+        );
+        return;
+    }
     switchCapabilities.ecmpHash.isAttrSupported = true;
 }
 
@@ -440,14 +468,44 @@ void SwitchCapabilities::querySwitchLagHashAttrCapabilities()
             "Failed to get attribute(%s) capabilities",
             toStr(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_LAG_HASH).c_str()
         );
+    }
+    else if (attrCap.get_implemented)
+    {
+        switchCapabilities.lagHash.isAttrSupported = true;
         return;
     }
 
-    if (!attrCap.get_implemented)
+    sai_attr_capability_t lagV4Cap;
+    auto lagV4Status = queryAttrCapabilitiesSai(
+        lagV4Cap, SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_LAG_HASH_IPV4
+    );
+    if (lagV4Status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_WARN(
-            "Attribute(%s) GET is not implemented in SAI",
-            toStr(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_LAG_HASH).c_str()
+        SWSS_LOG_ERROR(
+            "Failed to get attribute(%s) capabilities",
+            toStr(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_LAG_HASH_IPV4).c_str()
+        );
+        return;
+    }
+
+    sai_attr_capability_t lagV6Cap;
+    auto lagV6Status = queryAttrCapabilitiesSai(
+        lagV6Cap, SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_LAG_HASH_IPV6
+    );
+    if (lagV6Status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR(
+            "Failed to get attribute(%s) capabilities",
+            toStr(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_LAG_HASH_IPV6).c_str()
+        );
+        return;
+    }
+
+    if (!lagV4Cap.get_implemented || !lagV6Cap.get_implemented)
+    {
+        SWSS_LOG_ERROR(
+            "One or more of required LAG capabilities not supported %d, %d",
+            lagV4Cap.get_implemented, lagV6Cap.get_implemented
         );
         return;
     }

--- a/orchagent/switchorch.h
+++ b/orchagent/switchorch.h
@@ -101,11 +101,14 @@ private:
     void generateSwitchCounterNameMap() const;
 
     // Switch hash
-    bool setSwitchHashFieldListSai(const SwitchHash &hash, bool isEcmpHash) const;
+    sai_status_t setSwitchHashFieldListSai(const sai_object_id_t oid, const std::set<sai_native_hash_field_t> &hfSet) const;
+    sai_status_t createHashObjectSai(sai_object_id_t &oid, const std::set<sai_native_hash_field_t> &hfSet) const;
+    sai_status_t setSwitchHashAttributeSai(sai_attr_id_t attrType, sai_object_id_t oid) const;
+    bool setSwitchHashFieldList(const SwitchHash &hash, bool isEcmpHash);
     bool setSwitchHashAlgorithmSai(const SwitchHash &hash, bool isEcmpHash) const;
     bool setSwitchHash(const SwitchHash &hash);
 
-    bool getSwitchHashOidSai(sai_object_id_t &oid, bool isEcmpHash) const;
+    bool getSwitchHashOidSai(sai_object_id_t &oid, sai_attr_id_t attr_id) const;
     void querySwitchHashDefaults();
     void setSwitchIcmpOffloadCapability();
 
@@ -174,10 +177,17 @@ private:
     struct {
         struct {
             sai_object_id_t oid = SAI_NULL_OBJECT_ID;
+            sai_object_id_t v4Oid = SAI_NULL_OBJECT_ID;
+            sai_object_id_t v6Oid = SAI_NULL_OBJECT_ID;
+            bool platformSupportsOnlyV4V6 = false; // platform supports only V4/V6 attr type
         } ecmpHash;
         struct {
             sai_object_id_t oid = SAI_NULL_OBJECT_ID;
+            sai_object_id_t v4Oid = SAI_NULL_OBJECT_ID;
+            sai_object_id_t v6Oid = SAI_NULL_OBJECT_ID;
+            bool platformSupportsOnlyV4V6 = false; // platform supports only V4/V6 attr type
         } lagHash;
+
     } m_switchHashDefaults;
 
     // Statistics


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

Fixes : https://github.com/sonic-net/sonic-swss/issues/3986

**What I did**
1. While setting the capabilities check for SAI_SWITCH_ATTR_ECMP/LAG_HASH_IPV4/6 if SAI_SWITCH_ATTR_ECMP/LAG_HASH fails.
2. Introduced a new flag platformSupportsOnlyV4V6. It will be set if unable to get the oid for SAI_SWITCH_ATTR_ECMP/LAG_HASH.
3. When setting hash-fields for the first time (v4Oid or v6Oid == NULL), clear out the default field-list, create new object to get the oids and use them for subsequent hash-field settings.

**Why I did it**
For setting the global hash-fields, SONIC currently uses SAI_SWITCH_ATTR_ECMP/LAG_HASH.
However, Broadcom SAI only supports SAI_SWITCH_ATTR_ECMP/LAG_HASH_IPV4/6.
Hence, enhancing the hash-field support to include Broadcom SAI.

Also, Broadcom platform doesn't accept setting the fields with SAI_NULL_OBJECT_ID. 
It needs the SONIC to create hash objects (for v4 and v6) and use them to set the hash-fields.
Also, since Broadcom SAI would've set some default values, they need to be cleared before setting new field-list.

**How I verified it**
Since this can not be verified on VS, I ran the command on Broadcom platform and used bcm shell commands to verify that correct fields are set.
Before the change
```
admin@gold230:~$ show switch-hash capabilities
+--------+---------------------------------+
| Hash   | Capabilities                    |
+========+=================================+
| ECMP   | +---------------+-------------+ |
|        | | Hash Field    | Algorithm   | |
|        | |---------------+-------------| |
|        | | not supported | CRC         | |
|        | |               | XOR         | |
|        | |               | CRC_32LO    | |
|        | |               | CRC_32HI    | |
|        | |               | CRC_CCITT   | |
|        | |               | CRC_XOR     | |
|        | +---------------+-------------+ |
+--------+---------------------------------+
| LAG    | +---------------+-------------+ |
|        | | Hash Field    | Algorithm   | |
|        | |---------------+-------------| |
|        | | not supported | CRC         | |
|        | |               | XOR         | |
|        | |               | CRC_32LO    | |
|        | |               | CRC_32HI    | |
|        | |               | CRC_CCITT   | |
|        | |               | CRC_XOR     | |
|        | +---------------+-------------+ |
+--------+---------------------------------+
```

After the change
```
admin@gold230-dut:~$ show switch-hash capabilities 
+--------+-------------------------------------------------------------------+
| Hash   | Capabilities                                                      |
+========+===================================================================+
| ECMP   | +-----------------+-------------+---------------+---------------+ |
|        | | Hash Field      | Algorithm   | Seed          | Offset        | |
|        | |-----------------+-------------+---------------+---------------| |
|        | | SRC_IP          | CRC         | not supported | not supported | |
|        | | DST_IP          | XOR         |               |               | |
|        | | VLAN_ID         | CRC_32LO    |               |               | |
|        | | IP_PROTOCOL     | CRC_32HI    |               |               | |
|        | | ETHERTYPE       | CRC_CCITT   |               |               | |
|        | | L4_SRC_PORT     | CRC_XOR     |               |               | |
|        | | L4_DST_PORT     |             |               |               | |
|        | | SRC_MAC         |             |               |               | |
|        | | DST_MAC         |             |               |               | |
|        | | IN_PORT         |             |               |               | |
|        | | IPV6_FLOW_LABEL |             |               |               | |
|        | +-----------------+-------------+---------------+---------------+ |
+--------+-------------------------------------------------------------------+
| LAG    | +-----------------+-------------+---------------+---------------+ |
|        | | Hash Field      | Algorithm   | Seed          | Offset        | |
|        | |-----------------+-------------+---------------+---------------| |
|        | | SRC_IP          | CRC         | not supported | not supported | |
|        | | DST_IP          | XOR         |               |               | |
|        | | VLAN_ID         | CRC_32LO    |               |               | |
|        | | IP_PROTOCOL     | CRC_32HI    |               |               | |
|        | | ETHERTYPE       | CRC_CCITT   |               |               | |
|        | | L4_SRC_PORT     | CRC_XOR     |               |               | |
|        | | L4_DST_PORT     |             |               |               | |
|        | | SRC_MAC         |             |               |               | |
|        | | DST_MAC         |             |               |               | |
|        | | IN_PORT         |             |               |               | |
|        | | IPV6_FLOW_LABEL |             |               |               | |
|        | +-----------------+-------------+---------------+---------------+ |
+--------+-------------------------------------------------------------------+

admin@gold230-dut:~$ sudo config switch-hash global ecmp-hash DST_IP L4_SRC_PORT
admin@gold230-dut:~$ sudo config switch-hash global lag-hash SRC_IP L4_DST_PORT
admin@gold230-dut:~$ show switch-hash  global
+--------+----------------------------------------------------+
| Hash   | Configuration                                      |
+========+====================================================+
| ECMP   | +--------------+-------------+--------+----------+ |
|        | | Hash Field   | Algorithm   | Seed   | Offset   | |
|        | |--------------+-------------+--------+----------| |
|        | | DST_IP       | N/A         | N/A    | N/A      | |
|        | | L4_SRC_PORT  |             |        |          | |
|        | +--------------+-------------+--------+----------+ |
+--------+----------------------------------------------------+
| LAG    | +--------------+-------------+--------+----------+ |
|        | | Hash Field   | Algorithm   | Seed   | Offset   | |
|        | |--------------+-------------+--------+----------| |
|        | | SRC_IP       | N/A         | N/A    | N/A      | |
|        | | L4_DST_PORT  |             |        |          | |
|        | +--------------+-------------+--------+----------+ |
+--------+----------------------------------------------------+
```

**Details if related**
