### PR TITLE
Migrate agent pool from sonicbld-1es to sonicso1ES-amd64 for branch 202505

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -10,9 +10,9 @@ parameters:
 - name: pool
   type: string
   values:
-  - sonicbld-1es
-  - sonicbld-armhf
-  - sonicbld-arm64
+  - sonicso1ES-amd64
+  - sonicso1ES-armhf
+  - sonicso1ES-arm64
   - default
   default: default
 

--- a/.azure-pipelines/gcov.yml
+++ b/.azure-pipelines/gcov.yml
@@ -8,7 +8,7 @@ parameters:
 - name: pool
   type: string
   values:
-  - sonicbld-1es
+  - sonicso1ES-amd64
   - default
   default: default
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ stages:
   - template: .azure-pipelines/build-template.yml
     parameters:
       arch: amd64
-      pool: sonicbld-1es
+      pool: sonicso1ES-amd64
       sonic_slave: sonic-slave-${{ parameters.debian_version }}
       common_lib_artifact_name: common-lib
       swss_common_artifact_name: sonic-swss-common-${{ parameters.debian_version }}
@@ -61,7 +61,7 @@ stages:
   - template: .azure-pipelines/build-template.yml
     parameters:
       arch: amd64
-      pool: sonicbld-1es
+      pool: sonicso1ES-amd64
       sonic_slave: sonic-slave-${{ parameters.debian_version }}
       common_lib_artifact_name: common-lib
       swss_common_artifact_name: sonic-swss-common-${{ parameters.debian_version }}
@@ -77,7 +77,7 @@ stages:
     parameters:
       arch: armhf
       timeout: 240
-      pool: sonicbld-armhf
+      pool: sonicso1ES-armhf
       sonic_slave: sonic-slave-${{ parameters.debian_version }}-armhf
       common_lib_artifact_name: common-lib.armhf
       swss_common_artifact_name: sonic-swss-common-${{ parameters.debian_version }}.armhf
@@ -89,7 +89,7 @@ stages:
     parameters:
       arch: arm64
       timeout: 240
-      pool: sonicbld-arm64
+      pool: sonicso1ES-arm64
       sonic_slave: sonic-slave-${{ parameters.debian_version }}-arm64
       common_lib_artifact_name: common-lib.arm64
       swss_common_artifact_name: sonic-swss-common-${{ parameters.debian_version }}.arm64


### PR DESCRIPTION
What I did
Migrate pipeline agent pool to latest.
Old agent pool are deprecated
Why I did it

How I verified it

Details if related