### PR TITLE
[portsorch] [PHY/Gearbox] Fixed FEC config management issue as per Gearbox design in doPortTask #4000

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -5376,10 +5376,6 @@ void PortsOrch::doPortTask(Consumer &consumer)
                             p.m_alias.c_str(), m_portHlpr.getFecStr(pCfg).c_str()
                         );
                     }
-                    else
-                    {
-                        setGearboxPortsAttr(p, SAI_PORT_ATTR_FEC_MODE, &pCfg.fec.value, pCfg.fec.override_fec);
-                    }
                 }
 
                 if (pCfg.learn_mode.is_set)


### PR DESCRIPTION
Fixed FEC config management issue as per Gearbox design in doPortTask #4000. Since FEC was applied at the PHY level, MAC-PHY bringup sequence of Equalization and Link training impacted and hence ports went to oper-down.

Gearbox FEC configurations have to be configured using Forwarding ASIC faceplate index that would eventually apply Gearbox/PHY system/line side FEC as per finite state machine required for its application.

**What I did**
Fix the issue reported in #4000 

**How I verified it**
1) Tested on a platform with gearbox PHY (Broadcom-based) / BCM81356 (MillenioB) / BCM81724 (Millenio) in Gearbox mode. Gearbox mode used is 53Gx2 PAM to 100G (4x25G NRZ). Clause 91 FEC of RS544 at the system side and RS528 at the line side.
2) OC testsuite ran using T0 topology and verified link flap, FEC re-application, config reload/load_minigraph/reset, etc

**Details if related**
Nokia platforms used to validate: x86_64-nokia_ixr7220_d4-r0, x86_64-nokia_ixr7250_x1b-r0