### PR TITLE
[dualtor] Remove checks for subnet IP from muxorch logic

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -615,18 +615,6 @@ bool MuxCable::aclHandler(sai_object_id_t port, string alias, bool add)
     return true;
 }
 
-bool MuxCable::isIpInSubnet(IpAddress ip)
-{
-    if (ip.isV4())
-    {
-        return (srv_ip4_.isAddressInSubnet(ip));
-    }
-    else
-    {
-        return (srv_ip6_.isAddressInSubnet(ip));
-    }
-}
-
 bool MuxCable::nbrHandler(bool enable, bool update_rt)
 {
     bool ret;
@@ -1369,11 +1357,8 @@ MuxCable* MuxOrch::findMuxCableInSubnet(IpAddress ip)
 {
     for (auto it = mux_cable_tb_.begin(); it != mux_cable_tb_.end(); it++)
     {
-       MuxCable* ptr = it->second.get();
-       if (ptr->isIpInSubnet(ip))
-       {
-           return ptr;
-       }
+        MuxCable* ptr = it->second.get();
+        return ptr;
     }
 
     return nullptr;
@@ -1472,10 +1457,6 @@ void MuxOrch::updateFdb(const FdbUpdate& update)
             if (!nh->second.empty() && isMuxExists(nh->second))
             {
                 ptr = getMuxCable(nh->second);
-                if (ptr->isIpInSubnet(nh->first.ip_address))
-                {
-                    continue;
-                }
                 nh->second = update.entry.port_name;
                 ptr->updateNeighbor(nh->first, false);
             }
@@ -1530,11 +1511,8 @@ void MuxOrch::updateNeighbor(const NeighborUpdate& update)
     for (auto it = mux_cable_tb_.begin(); it != mux_cable_tb_.end(); it++)
     {
         MuxCable* ptr = it->second.get();
-        if (ptr->isIpInSubnet(update.entry.ip_address))
-        {
-            ptr->updateNeighbor(update.entry, update.add);
-            return;
-        }
+        ptr->updateNeighbor(update.entry, update.add);
+        return;
     }
 
     string port, old_port;


### PR DESCRIPTION
Today we allow neighbor IPs which are outside a mux cable's subnet to be learned on any mux port. However, internal logic prevents successful processing of these IPs in certain scenarios. This removes the check that compares the ip to the Vlan subnet so that it will be processed as a regular mux neighbor.

**What I did**
Removed subnet checks from muxorch logic and created unit tests to validate the functionality when a neighbor is moving between 2 vlan subnets

**Why I did it**
mac move between vlan subnets causes dualtor_neighbor_check inconsistency

**How I verified it**
created a unit test to check functionality

**Details if related**
ADO: #35945298
