### PR TITLE
orchagent/portsorch: fix Query ingress priority groups lists

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -6546,6 +6546,11 @@ void PortsOrch::initializePriorityGroupsBulk(std::vector<Port>& ports)
             const auto status = bulker.statuses[idx];
             idx++;
 
+            if (port.m_priority_group_ids.size() == 0)
+            {
+                continue;
+            }
+
             if (status != SAI_STATUS_SUCCESS)
             {
                 SWSS_LOG_ERROR("Fail to get priority group list for port %s rv:%d", port.m_alias.c_str(), status);


### PR DESCRIPTION
**What I did**
Fix "Query ingress priority groups lists" for ASIC having "ingress priority groups"=0
in the orchagent/portsorchcpp:: initializePriorityGroupsBulk()
The case is on Board Nokia-7215(armhf) with ASIC Marvell-prestera AC3X 

**Why I did it**
Nokia-7215 SWITCH creation failed by the ERROR:
<<sonic ERR swss#orchagent: :- initializePriorityGroupsBulk: Fail to get priority group list for port Ethernet0 rv:-23>>

**How I verified it**
Start Nokia-7215 board. SWSS and SYNCD containers are going Up-and-Down. Switch does not work.

**Details if related**
6441: SWSS_LOG_INFO("Get %d priority groups for port %s", attr.value.u32, port.m_alias.c_str());
--------------> attr.value.u32 = 0
6454:   if (port.m_priority_group_ids.size() == 0)
                continue;
           no any   bulker.add(port.m_port_id, attr);
portCount = 1

FAILURE is 
        for (size_t idx = 0; idx < portCount; idx++)
            if (status != SAI_STATUS_SUCCESS)
            {
                SWSS_LOG_ERROR("Fail to get priority group list for port %s rv:%d", port.m_alias.c_str(), status);
                handleSaiGetStatus(SAI_API_PORT, status);
                throw runtime_error("PortsOrch initialization failure.");
            }
