### PR TITLE
[DashHaOrch] Fix HA_SET PA address not updating on live changes

### DIFF
--- a/orchagent/dash/dashhaorch.h
+++ b/orchagent/dash/dashhaorch.h
@@ -65,6 +65,7 @@ protected:
 
     bool addHaSetEntry(const std::string &key, const dash::ha_set::HaSet &entry);
     bool removeHaSetEntry(const std::string &key);
+    bool updateHaSetEntry(const std::string &key, const dash::ha_set::HaSet &entry);
     bool addHaScopeEntry(const std::string &key, const dash::ha_scope::HaScope &entry);
     bool removeHaScopeEntry(const std::string &key);
     bool setHaScopeHaRole(const std::string &key, const dash::ha_scope::HaScope &entry);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

Fix #3949

**What I did**
- Updated `DashHaOrch` to support live HA set updates.
- Added a unit test (`UpdateHaSetAttributes`) and a helper (`UpdateHaSet`) to the mock test harness.

`DashHaOrch` now detects repeat SET operations for existing HA sets, diffs the protobuf, calls `sai_dash_ha_api->set_ha_set_attribute` for changed PA parameters, and refreshes the cached metadata so `DashOrch`/`BfdOrch` see the new state.

**Why I did it**
During DPU repair, the controller updates the `HA_SET` entry to point at a new PA IP/port. Previously, `DashHaOrch` only handled the create path, so the ASIC and dependent components continued using stale values. Thus repairs are ineffective unless the operator manually deleted and recreated the HA set.

**How I verified it**
Covered the changes with the new `UpdateHaSetAttributes` mock test.

**Details if related**
I don't think this change would impact the behavior for HA scopes or ENI programming. They just read `DashHaOrch`’s cache, which now reflects live updates.

Fields like VIP/scope still require recreate semantics (unchanged from before); this patch strictly addresses PA endpoint updates.