### PR TITLE
[LPO] Added support for serdes Tx/Rx polarity settings

### DIFF
--- a/orchagent/port/portcnt.h
+++ b/orchagent/port/portcnt.h
@@ -196,6 +196,16 @@ public:
         } unreliable_los; // Port unreliable_los
 
         struct {
+            std::vector<std::uint32_t> value;
+            bool is_set = false;
+        } txpolarity; // Port serdes TX polarity
+
+        struct {
+            std::vector<std::uint32_t> value;
+            bool is_set = false;
+        } rxpolarity; // Port serdes RX polarity
+
+        struct {
             std::string value;
             bool is_set = false;
         } custom_collection; // Port serdes custom_collection

--- a/orchagent/port/porthlpr.cpp
+++ b/orchagent/port/porthlpr.cpp
@@ -764,6 +764,8 @@ template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::obplev) &serdes
 template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::obnlev) &serdes, const std::string &field, const std::string &value) const;
 template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::regn_bfm1p) &serdes, const std::string &field, const std::string &value) const;
 template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::regn_bfm1n) &serdes, const std::string &field, const std::string &value) const;
+template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::txpolarity) &serdes, const std::string &field, const std::string &value) const;
+template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::rxpolarity) &serdes, const std::string &field, const std::string &value) const;
 template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::custom_collection) &serdes, const std::string &field, const std::string &value) const;
 
 
@@ -1207,6 +1209,20 @@ bool PortHelper::parsePortConfig(PortConfig &port) const
         else if (field == PORT_REGN_BFM1P)
         {
             if (!this->parsePortSerdes(port.serdes.regn_bfm1p, field, value))
+            {
+                return false;
+            }
+        }
+        else if (field == PORT_TX_POLARITY)
+        {
+            if (!this->parsePortSerdes(port.serdes.txpolarity, field, value))
+            {
+                return false;
+            }
+        }
+        else if (field == PORT_RX_POLARITY)
+        {
+            if (!this->parsePortSerdes(port.serdes.rxpolarity, field, value))
             {
                 return false;
             }

--- a/orchagent/port/portschema.h
+++ b/orchagent/port/portschema.h
@@ -89,6 +89,8 @@
 #define PORT_OBNLEV                "obnlev"
 #define PORT_REGN_BFM1P            "regn_bfm1p"
 #define PORT_REGN_BFM1N            "regn_bfm1n"
+#define PORT_TX_POLARITY            "txpolarity"
+#define PORT_RX_POLARITY            "rxpolarity"
 #define PORT_CUSTOM_SERDES_ATTRS   "custom_serdes_attrs"
 #define PORT_ROLE                  "role"
 #define PORT_ADMIN_STATUS          "admin_status"

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -525,6 +525,15 @@ static void getPortSerdesAttr(PortSerdesAttrMap_t &map, const PortConfig &port)
         map[SAI_PORT_SERDES_ATTR_CUSTOM_COLLECTION] = SerdesValue(port.serdes.custom_collection.value);
     }
 
+    if (port.serdes.txpolarity.is_set)
+    {
+        map[SAI_PORT_SERDES_ATTR_TX_POLARITY] = SerdesValue(port.serdes.txpolarity.value);
+    }
+
+    if (port.serdes.rxpolarity.is_set)
+    {
+        map[SAI_PORT_SERDES_ATTR_RX_POLARITY] = SerdesValue(port.serdes.rxpolarity.value);
+    }
 }
 
 static bool isPathTracingSupported()


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
[LPO] Added support for serdes Tx/Rx polarity settings

**Why I did it**
To set the polarity for Tx and Rx serdes lanes as needed for LPO optics

**How I verified it**

Sample media_settings.json
```
root@sonic:/# cat media_settings.json
{
    "PORT_MEDIA_SETTINGS": {
        "1": {
            "OPTICAL100": {
                "pre3": {
                    "lane0": "0x0",
                    "lane1": "0x0",
                    "lane2": "0x0",
                    "lane3": "0x0",
                    "lane4": "0x0",
                    "lane5": "0x0",
                    "lane6": "0x0",
                    "lane7": "0x0"
                },
                "pre2": {
                    "lane0": "0x6",
                    "lane1": "0x6",
                    "lane2": "0x6",
                    "lane3": "0x6",
                    "lane4": "0x6",
                    "lane5": "0x6",
                    "lane6": "0x6",
                    "lane7": "0x6"
                },
                "pre1": {
                    "lane0": "0xffffffe8",
                    "lane1": "0xffffffe8",
                    "lane2": "0xffffffe8",
                    "lane3": "0xffffffe8",
                    "lane4": "0xffffffe8",
                    "lane5": "0xffffffe8",
                    "lane6": "0xffffffe8",
                    "lane7": "0xffffffe8"
                },
                "main": {
                    "lane0": "0x78",
                    "lane1": "0x78",
                    "lane2": "0x78",
                    "lane3": "0x78",
                    "lane4": "0x78",
                    "lane5": "0x78",
                    "lane6": "0x78",
                    "lane7": "0x78"
                },
                "post1": {
                    "lane0": "0xffffffec",
                    "lane1": "0xffffffec",
                    "lane2": "0xffffffec",
                    "lane3": "0xffffffec",
                    "lane4": "0xffffffec",
                    "lane5": "0xffffffec",
                    "lane6": "0xffffffec",
                    "lane7": "0xffffffec"
                },
                "post2": {
                    "lane0": "0x0",
                    "lane1": "0x0",
                    "lane2": "0x0",
                    "lane3": "0x0",
                    "lane4": "0x0",
                    "lane5": "0x0",
                    "lane6": "0x0",
                    "lane7": "0x0"
                },
                "rxpolarity": {
                    "lane0": "0x0",
                    "lane1": "0x1",
                    "lane2": "0x0",
                    "lane3": "0x1",
                    "lane4": "0x0",
                    "lane5": "0x1",
                    "lane6": "0x0",
                    "lane7": "0x1"
                }
            }
        }
    }
}
```

Ensured in sairedis record that the serdes object gets created with specified polarity in the media_settings.json

<img width="3522" height="572" alt="image" src="https://github.com/user-attachments/assets/9d5f35b1-ef58-44aa-bda8-a3ba7465eb05" />

**Details if related**
