### PR TITLE
Opportunistically use a matching kernel version for building the modules

### DIFF
--- a/.azure-pipelines/build_and_install_module.sh
+++ b/.azure-pipelines/build_and_install_module.sh
@@ -49,12 +49,15 @@ build_and_install_kmodule()
     KERNEL_PACKAGE_VERSION=$(trim $(apt-cache show linux-image-unsigned-${KERNEL_RELEASE} | grep ^Version: | cut -d':' -f 2))
     SOURCE_PACKAGE_VERSION=$(apt-cache showsrc "${KERNEL_PACKAGE_SOURCE}" | grep ^Version: | cut -d':' -f 2 | tr '\n' ' ')
     if ! echo "${SOURCE_PACKAGE_VERSION}" | grep "\b${KERNEL_PACKAGE_VERSION}\b"; then
-        echo "WARN: the running kernel version (${KERNEL_PACKAGE_VERSION}) doesn't match any of the available source " \
+        echo "WARNING: the running kernel version (${KERNEL_PACKAGE_VERSION}) doesn't match any of the available source " \
             "package versions (${SOURCE_PACKAGE_VERSION}) being downloaded. There's no guarantee any of the available " \
             "source packages can be loaded into the kernel or function correctly. Please update your kernel and reboot " \
             "your system so that it's running a matching kernel version." >&2
+        echo "Continuing with the build anyways" >&2
+        apt-get source "linux-image-unsigned-${KERNEL_RELEASE}"
+    else
+        apt-get source "linux-image-unsigned-${KERNEL_RELEASE}=${KERNEL_PACKAGE_VERSION}"
     fi
-    apt-get source "linux-image-unsigned-${KERNEL_RELEASE}"
 
     # Recover the original apt sources list
     cp /etc/apt/sources.list.bk /etc/apt/sources.list


### PR DESCRIPTION


<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

When building the team kernel module (and others), if a matching source kernel version exists, then make sure we use that exact version. This avoids the case where we end up pulling the sources for a newer kernel version when a matching one exists.

**Why I did it**

**How I verified it**

**Details if related**
