### PR TITLE
[202505] Fix orchagent error logging when unrecoverable SAI API failures occur

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -46,6 +46,8 @@ sai_object_id_t gUnderlayIfId;
 sai_object_id_t gSwitchId = SAI_NULL_OBJECT_ID;
 MacAddress gMacAddress;
 MacAddress gVxlanMacAddress;
+bool gOrchUnhealthy = false;
+string gSaiErrorString;
 
 extern size_t gMaxBulkSize;
 
@@ -345,6 +347,7 @@ int main(int argc, char **argv)
 
     SWSS_LOG_ENTER();
 
+    gOrchUnhealthy = false;
     WarmStart::initialize("orchagent", "swss");
     WarmStart::checkWarmStart("orchagent", "swss");
 

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -27,6 +27,8 @@ extern sai_switch_api_t*           sai_switch_api;
 extern sai_object_id_t             gSwitchId;
 extern string                      gMySwitchType;
 extern string                      gMySwitchSubType;
+extern bool                        gOrchUnhealthy;
+extern string                      gSaiErrorString;
 
 extern void syncd_apply_view();
 /*
@@ -882,6 +884,15 @@ void OrchDaemon::start(long heartBeatInterval)
         int ret;
 
         ret = m_select->select(&s, SELECT_TIMEOUT);
+
+        /*
+         * Log an error message periodically if a previous SAI API call failed with
+         * an unrecoverable error.
+         */
+        if (gOrchUnhealthy)
+        {
+            SWSS_LOG_ERROR("%s", gSaiErrorString.c_str());
+        }
 
         auto tend = std::chrono::high_resolution_clock::now();
         heartBeat(tend, heartBeatInterval);

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -97,6 +97,8 @@ extern bool gTraditionalFlexCounter;
 extern bool gSyncMode;
 extern sai_redis_communication_mode_t gRedisCommunicationMode;
 extern event_handle_t g_events_handle;
+extern bool gOrchUnhealthy;
+extern string gSaiErrorString;
 
 vector<sai_object_id_t> gGearboxOids;
 
@@ -744,8 +746,10 @@ void handleSaiFailure(sai_api_t api, string oper, sai_status_t status, bool abor
 
     string s_api = sai_serialize_api(api);
     string s_status = sai_serialize_status(status);
-    SWSS_LOG_ERROR("Encountered failure in %s operation, SAI API: %s, status: %s",
-                        oper.c_str(), s_api.c_str(), s_status.c_str());
+    gOrchUnhealthy = true;
+    gSaiErrorString = "Encountered failure in " + oper +
+                      " operation, SAI API: " + s_api + ", status: " + s_status;
+    SWSS_LOG_ERROR("%s", gSaiErrorString.c_str());
 
     // Publish a structured syslog event
     event_params_t params = {

--- a/tests/mock_tests/mock_orchagent_main.cpp
+++ b/tests/mock_tests/mock_orchagent_main.cpp
@@ -20,6 +20,8 @@ string gMyAsicName = "Asic0";
 bool gTraditionalFlexCounter = false;
 bool gSyncMode = false;
 sai_redis_communication_mode_t gRedisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC;
+bool gOrchUnhealthy = false;
+string gSaiErrorString;
 
 VRFOrch *gVrfOrch;
 


### PR DESCRIPTION
 * Currently, when an unrecoverable SAI error occurrs, orchagent logs and error once and then does no retry. To make the error obvious, log it repeatedly in the orchagent while loop periodically, so it can be detected quickly.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add a global variable and a global error log string that gets set when handleSaiFailure is called for unrecoverable SAI failures. This is read in orchdaemon::start() function which gets periodically polled to log the SAI failure error log periodically.

**Why I did it**
To alert on unhealthy orchagent repeatedly until orchagent restarts

**How I verified it**
Manually verified with an unrecoverable error and verified that the errors are logged repeatedly to syslog
**Details if related**
```
2025 Dec 17 05:12:12.789825 sonic ERR swss#orchagent: :- meta_sai_validate_route_entry: object key SAI_OBJECT_TYPE_ROUTE_ENTRY:{"dest":"10.1.0.32/32","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000002"} already exists
2025 Dec 17 05:12:12.790003 sonic ERR swss#orchagent: :- flush_creating_entries: EntityBulker.flush create entries failed, number of entries to create: 1, status: SAI_STATUS_ITEM_ALREADY_EXISTS
2025 Dec 17 05:12:12.790420 sonic ERR swss#orchagent: :- addRoutePost: Failed to create route 10.1.0.32/32 with next hop(s) 10.0.0.57@PortChannel101
2025 Dec 17 05:12:12.794823 sonic ERR swss#orchagent: :- handleSaiFailure: Encountered failure in create operation, SAI API: SAI_API_ROUTE, status: SAI_STATUS_NOT_EXECUTED
2025 Dec 17 05:12:12.795064 sonic NOTICE swss#orchagent: :- publish: EVENT_PUBLISHED: {"sonic-events-swss:sai-operation-failure":{"api":"SAI_API_ROUTE","operation":"create","status":"SAI_STATUS_NOT_EXECUTED","timestamp":"2025-12-17T05:12:12.789218Z"}}
2025 Dec 17 05:12:12.795256 sonic NOTICE swss#orchagent: :- notifySyncd: sending syncd: SYNCD_INVOKE_DUMP
2025 Dec 17 05:12:12.797830 sonic NOTICE syncd#SDK: :- processNotifySyncd: Invoking SAI failure dump
2025 Dec 17 05:12:12.924293 sonic INFO syncd#SDK: [LOG.INFO] Initializing SX log with user callback function.
2025 Dec 17 05:12:12.955115 sonic NOTICE syncd#SDK: [DBG_DUMP.NOTICE] The dump is generated using the API sx_api_dbg_generate_dump.
2025 Dec 17 05:12:12.955371 sonic NOTICE syncd#SDK: [DBG_DUMP.NOTICE] sx_api_dbg_generate_dump: The user set the path to /var/log/sai_failure_dump/sai_sdk_dump_12_17_2025_05_12_AM/sai_sdk_dump_12_17_2025_05_12_AM
2025 Dec 17 05:12:12.955371 sonic NOTICE syncd#SDK: [DBG_DUMP.NOTICE] sx_api_dbg_generate_dump: The TXT path is set to /var/log/sai_failure_dump/sai_sdk_dump_12_17_2025_05_12_AM/sai_sdk_dump_12_17_2025_05_12_AM 
2025 Dec 17 05:12:12.955389 sonic NOTICE syncd#SDK: [DBG_DUMP.NOTICE] sx_api_dbg_generate_dump: The JSON path is set to /var/log/sai_failure_dump/sai_sdk_dump_12_17_2025_05_12_AM/sai_sdk_dump_12_17_2025_05_12_AM.json 
2025 Dec 17 05:12:12.955407 sonic NOTICE syncd#SDK: [DBG_DUMP.NOTICE] Started DEBUG-DUMP
.                                                                               
.                                                                               
.                                                                               
.                                                                               
2025 Dec 17 05:18:20.017727 sonic ERR swss#orchagent: message repeated 21 times: [ :- start: Encountered failure in create operation, SAI API: SAI_API_ROUTE, status: SAI_STATUS_NOT_EXECUTED]
2025 Dec 17 05:18:20.018113 sonic INFO swss#supervisord: orchagent              
2025 Dec 17 05:18:20.322556 sonic ERR swss#orchagent: :- start: Encountered failure in create operation, SAI API: SAI_API_ROUTE, status: SAI_STATUS_NOT_EXECUTED
2025 Dec 17 05:18:30.322862 sonic ERR swss#orchagent: message repeated 22 times: [ :- start: Encountered failure in create operation, SAI API: SAI_API_ROUTE, status: SAI_STATUS_NOT_EXECUTED]
2025 Dec 17 05:18:30.322862 sonic INFO swss#supervisord: orchagent              
2025 Dec 17 05:18:31.017249 sonic ERR swss#orchagent: :- start: Encountered failure in create operation, SAI API: SAI_API_ROUTE, status: SAI_STATUS_NOT_EXECUTED
2025 Dec 17 05:18:37.357157 sonic INFO dhcp_relay#dhcpmon[47]: Start to write DB counter
2025 Dec 17 05:18:37.372278 sonic INFO dhcp_relay#dhcpmon[47]: Write DB counter done
2025 Dec 17 05:18:40.323144 sonic ERR swss#orchagent: message repeated 21 times: [ :- start: Encountered failure in create operation, SAI API: SAI_API_ROUTE, status: SAI_STATUS_NOT_EXECUTED]
2025 Dec 17 05:18:40.323456 sonic INFO swss#supervisord: orchagent              
2025 Dec 17 05:18:41.017166 sonic ERR swss#orchagent: :- start: Encountered failure in create operation, SAI API: SAI_API_ROUTE, status: SAI_STATUS_NOT_EXECUTED
2025 Dec 17 05:18:51.017449 sonic ERR swss#orchagent: message repeated 22 times: [ :- start: Encountered failure in create operation, SAI API: SAI_API_ROUTE, status: SAI_STATUS_NOT_EXECUTED]
2025 Dec 17 05:18:51.017449 sonic INFO swss#supervisord: orchagent              
2025 Dec 17 05:18:51.322586 sonic ERR swss#orchagent: :- start: Encountered failure in create operation, SAI API: SAI_API_ROUTE, status: SAI_STATUS_NOT_EXECUTED
2025 Dec 17 05:18:56.918027 sonic INFO systemd[1]: run-docker-runtime\x2drunc-moby-ed571c3e1cbd40ca9ee1bdd059915383df71f9f352866a59e2a455cd1031a801-runc.B9RNrV.mount: Deactivated successfully.
2025 Dec 17 05:18:57.354993 sonic INFO dhcp_relay#dhcpmon[47]: Start to write DB counter
2025 Dec 17 05:18:57.363156 sonic INFO dhcp_relay#dhcpmon[47]: Write DB counter done
2025 Dec 17 05:19:00.697077 sonic INFO systemd[1]: run-docker-runtime\x2drunc-moby-7485536568fd845bb88100b83e34c74443ecde420c137edee6468c5533256fa8-runc.akQUUV.mount: Deactivated successfully.
2025 Dec 17 05:19:01.323255 sonic ERR swss#orchagent: message repeated 22 times: [ :- start: Encountered failure in create operation, SAI API: SAI_API_ROUTE, status: SAI_STATUS_NOT_EXECUTED]
2025 Dec 17 05:19:01.323568 sonic INFO swss#supervisord: orchagent              
2025 Dec 17 05:19:01.931685 sonic INFO systemd[1]: run-docker-runtime\x2drunc-moby-d7953ff27d95b9d5ca9af71f235151373c8c7a7ede14d5fac61c98476757aa85-runc.MEOYgc.mount: Deactivated successfully.
2025 Dec 17 05:19:02.017489 sonic ERR swss#orchagent: :- start: Encountered failure in create operation, SAI API: SAI_API_ROUTE, status: SAI_STATUS_NOT_EXECUTED
2025 Dec 17 05:19:10.987949 sonic INFO memory_checker: [memory_checker] Exits without checking memory usage since container 'bmp' is not running! 
2025 Dec 17 05:19:11.324311 sonic ERR swss#orchagent: message repeated 22 times: [ :- start: Encountered failure in create operation, SAI API: SAI_API_ROUTE, status: SAI_STATUS_NOT_EXECUTED]
2025 Dec 17 05:19:11.324311 sonic INFO swss#supervisord: orchagent              
2025 Dec 17 05:19:11.340579 sonic INFO memory_checker: [memory_checker] Container ID of 'snmp' is: '7485536568fd845bb88100b83e34c74443ecde420c137edee6468c5533256fa8'.
2025 Dec 17 05:19:11.341726 sonic INFO memory_checker: [memory_checker] The memory usage of container 'snmp' is '69787648' Bytes!
2025 Dec 17 05:19:11.342042 sonic INFO memory_checker: [memory_checker] The cache usage of container 'snmp' is '24576' Bytes!
2025 Dec 17 05:19:11.342135 sonic INFO memory_checker: [memory_checker] Total memory usage of container 'snmp' is '69763072' Bytes!
2025 Dec 17 05:19:11.494282 sonic INFO memory_checker: [memory_checker] Container ID of 'telemetry' is: 'f86c4a80d18b9c1b9c50f69b0577d12fda6f8e726203fae41c2715260b062435'.
2025 Dec 17 05:19:11.494420 sonic INFO memory_checker: [memory_checker] The memory usage of container 'telemetry' is '75649024' Bytes!
2025 Dec 17 05:19:11.494497 sonic INFO memory_checker: [memory_checker] The cache usage of container 'telemetry' is '12288' Bytes!
2025 Dec 17 05:19:11.494564 sonic INFO memory_checker: [memory_checker] Total memory usage of container 'telemetry' is '75636736' Bytes!
2025 Dec 17 05:19:11.651908 sonic INFO memory_checker: [memory_checker] Container ID of 'gnmi' is: 'd7953ff27d95b9d5ca9af71f235151373c8c7a7ede14d5fac61c98476757aa85'.
2025 Dec 17 05:19:11.652952 sonic INFO memory_checker: [memory_checker] The memory usage of container 'gnmi' is '84307968' Bytes!
2025 Dec 17 05:19:11.653737 sonic INFO memory_checker: [memory_checker] The cache usage of container 'gnmi' is '12288' Bytes!
2025 Dec 17 05:19:11.654112 sonic INFO memory_checker: [memory_checker] Total memory usage of container 'gnmi' is '84295680' Bytes!
2025 Dec 17 05:19:12.017229 sonic ERR swss#orchagent: :- start: Encountered failure in create operation, SAI API: SAI_API_ROUTE, status: SAI_STATUS_NOT_EXECUTED
2025 Dec 17 05:19:17.341787 sonic INFO dhcp_relay#dhcpmon[47]: Start to write DB counter
2025 Dec 17 05:19:17.390195 sonic INFO dhcp_relay#dhcpmon[47]: Write DB counter done
2025 Dec 17 05:19:21.323669 sonic ERR swss#orchagent: message repeated 21 times: [ :- start: Encountered failure in create operation, SAI API: SAI_API_ROUTE, status: SAI_STATUS_NOT_EXECUTED]
2025 Dec 17 05:19:21.323980 sonic INFO swss#supervisord: orchagent              
2025 Dec 17 05:19:22.017262 sonic ERR swss#orchagent: :- start: Encountered failure in create operation, SAI API: SAI_API_ROUTE, status: SAI_STATUS_NOT_EXECUTED
2025 Dec 17 05:19:32.018347 sonic ERR swss#orchagent: message repeated 22 times: [ :- start: Encountered failure in create operation, SAI API: SAI_API_ROUTE, status: SAI_STATUS_NOT_EXECUTED]
2025 Dec 17 05:19:32.018792 sonic INFO swss#supervisord: orchagent              
2025 Dec 17 05:19:32.322518 sonic ERR swss#orchagent: :- start: Encountered failure in create operation, SAI API: SAI_API_ROUTE, status: SAI_STATUS_NOT_EXECUTED
```
