### PR TITLE
[portsorch] Fix port flap during warm-reboot when FEC is configured

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -5085,6 +5085,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
                         p.m_fec_mode = pCfg.fec.value;
                         p.m_override_fec = pCfg.fec.override_fec;
+                        p.m_fec_cfg = true;
                         m_portList[p.m_alias] = p;
 
                         SWSS_LOG_NOTICE(


### PR DESCRIPTION
To resolve https://github.com/sonic-net/sonic-buildimage/issues/24969

**What I did**
Restored the missing `p.m_fec_cfg = true` assignment in `PortsOrch::doPortTask` when handling FEC configuration updates.

**Why I did it**
To prevent port flapping and packet loss during warm-reboot recovery. Previously, without this flag set, the system failed to correctly recognize the existing FEC configuration during the restore phase, causing the port to go down briefly.

**How I verified it**
 unit tests
 run warm-reboot test

**Details if related**

