### PR TITLE
cherry-pick-202511: Disable bulk requests for PORT counters

### DIFF
--- a/tests/mock_tests/flexcounter_ut.cpp
+++ b/tests/mock_tests/flexcounter_ut.cpp
@@ -1083,7 +1083,9 @@ namespace flexcounter_test
         port_stat_manager.flush();
 
         /* SAIREDIS channel should have been called thrice, once for port1&port2&port5, port3&port4 and port6*/
-        ASSERT_EQ(mockFlexCounterOperationCallCount, 3);
+        // ASSERT_EQ(mockFlexCounterOperationCallCount, 3);
+        // Temporary fix for SNMP PFC counter issue: disabled bulk init requests for PORT counters
+        ASSERT_EQ(mockFlexCounterOperationCallCount, 6);
 
         ASSERT_TRUE(checkFlexCounter(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, port6_oid,
                                      {


### PR DESCRIPTION
Add temporary fix for https://github.com/aristanetworks/sonic-qual.msft/issues/655, https://github.com/aristanetworks/sonic-qual.msft/issues/1031

This forces each port to be processed individually, avoiding capability mismatch between different ports in bulk requests
This is cherry-pick of https://github.com/sonic-net/sonic-swss/pull/3843 to 202511

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
