### PR TITLE
[P4Orch] Update acl binding init.

### DIFF
--- a/orchagent/p4orch/acl_table_manager.cpp
+++ b/orchagent/p4orch/acl_table_manager.cpp
@@ -438,12 +438,6 @@ ReturnCode AclTableManager::processAddTableRequest(const P4AclTableDefinitionApp
                              << "ACL table stage " << QuotedVar(app_db_entry.stage) << " is invalid");
     }
 
-    if (gSwitchOrch->getAclGroupsBindingToSwitch().empty())
-    {
-        // Create default ACL groups binding to switch
-        gSwitchOrch->initAclGroupsBindToSwitch();
-    }
-
     P4AclTableDefinition acl_table_definition(app_db_entry.acl_table_name, stage, app_db_entry.priority,
                                               app_db_entry.size, app_db_entry.meter_unit, app_db_entry.counter_unit);
 

--- a/orchagent/p4orch/tests/acl_manager_test.cpp
+++ b/orchagent/p4orch/tests/acl_manager_test.cpp
@@ -867,17 +867,17 @@ class AclManagerTest : public ::testing::Test
         setUpCoppOrch();
         setUpSwitchOrch();
         setUpP4Orch();
-        // const auto& acl_groups = gSwitchOrch->getAclGroupsBindingToSwitch();
-        // EXPECT_EQ(3, acl_groups.size());
-        // EXPECT_NE(acl_groups.end(), acl_groups.find(SAI_ACL_STAGE_INGRESS));
-        // EXPECT_EQ(kAclGroupIngressOid,
-        //           acl_groups.at(SAI_ACL_STAGE_INGRESS).m_saiObjectId);
-        // EXPECT_NE(acl_groups.end(), acl_groups.find(SAI_ACL_STAGE_EGRESS));
-        // EXPECT_EQ(kAclGroupEgressOid,
-        //           acl_groups.at(SAI_ACL_STAGE_EGRESS).m_saiObjectId);
-        // EXPECT_NE(acl_groups.end(), acl_groups.find(SAI_ACL_STAGE_PRE_INGRESS));
-        // EXPECT_EQ(kAclGroupLookupOid,
-        //           acl_groups.at(SAI_ACL_STAGE_PRE_INGRESS).m_saiObjectId);
+        const auto& acl_groups = gSwitchOrch->getAclGroupsBindingToSwitch();
+        EXPECT_EQ(3, acl_groups.size());
+        EXPECT_NE(acl_groups.end(), acl_groups.find(SAI_ACL_STAGE_INGRESS));
+        EXPECT_EQ(kAclGroupIngressOid,
+                  acl_groups.at(SAI_ACL_STAGE_INGRESS).m_saiObjectId);
+        EXPECT_NE(acl_groups.end(), acl_groups.find(SAI_ACL_STAGE_EGRESS));
+        EXPECT_EQ(kAclGroupEgressOid,
+                  acl_groups.at(SAI_ACL_STAGE_EGRESS).m_saiObjectId);
+        EXPECT_NE(acl_groups.end(), acl_groups.find(SAI_ACL_STAGE_PRE_INGRESS));
+        EXPECT_EQ(kAclGroupLookupOid,
+                  acl_groups.at(SAI_ACL_STAGE_PRE_INGRESS).m_saiObjectId);
         p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_MIRROR_SESSION, KeyGenerator::generateMirrorSessionKey(gMirrorSession1),
                                kMirrorSessionOid1);
         p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_MIRROR_SESSION, KeyGenerator::generateMirrorSessionKey(gMirrorSession2),
@@ -979,46 +979,48 @@ class AclManagerTest : public ::testing::Test
     void setUpSwitchOrch()
     {
         EXPECT_CALL(mock_sai_serialize_, sai_serialize_object_id(_)).WillRepeatedly(Return(EMPTY_STRING));
-        TableConnector stateDbSwitchTable(gStateDb, "SWITCH_CAPABILITY");
-        TableConnector app_switch_table(gAppDb, APP_SWITCH_TABLE_NAME);
-        TableConnector conf_asic_sensors(gConfigDb, CFG_ASIC_SENSORS_TABLE_NAME);
-        std::vector<TableConnector> switch_tables = {conf_asic_sensors, app_switch_table};
-        gSwitchOrch = new SwitchOrch(gAppDb, switch_tables, stateDbSwitchTable);
-    }
-
-    void setUpP4Orch()
-    {
-        EXPECT_CALL(mock_sai_serialize_, sai_serialize_object_id(_)).WillRepeatedly(Return(EMPTY_STRING));
         EXPECT_CALL(mock_sai_acl_,
                     create_acl_table_group(
                         _, Eq(gSwitchId), Eq(3),
                         Truly(std::bind(MatchSaiAttributeAclGroupStage, SAI_ACL_STAGE_INGRESS, std::placeholders::_1))))
-            .WillRepeatedly(DoAll(SetArgPointee<0>(kAclGroupIngressOid), Return(SAI_STATUS_SUCCESS)));
+            .WillOnce(DoAll(SetArgPointee<0>(kAclGroupIngressOid),
+                            Return(SAI_STATUS_SUCCESS)));
         EXPECT_CALL(mock_sai_acl_,
                     create_acl_table_group(
                         _, Eq(gSwitchId), Eq(3),
                         Truly(std::bind(MatchSaiAttributeAclGroupStage, SAI_ACL_STAGE_EGRESS, std::placeholders::_1))))
-            .WillRepeatedly(DoAll(SetArgPointee<0>(kAclGroupEgressOid), Return(SAI_STATUS_SUCCESS)));
+            .WillOnce(DoAll(SetArgPointee<0>(kAclGroupEgressOid),
+                            Return(SAI_STATUS_SUCCESS)));
         EXPECT_CALL(mock_sai_acl_,
                     create_acl_table_group(_, Eq(gSwitchId), Eq(3),
                                            Truly(std::bind(MatchSaiAttributeAclGroupStage, SAI_ACL_STAGE_PRE_INGRESS,
                                                            std::placeholders::_1))))
-            .WillRepeatedly(DoAll(SetArgPointee<0>(kAclGroupLookupOid), Return(SAI_STATUS_SUCCESS)));
+            .WillOnce(DoAll(SetArgPointee<0>(kAclGroupLookupOid),
+                            Return(SAI_STATUS_SUCCESS)));
         EXPECT_CALL(mock_sai_switch_,
                     set_switch_attribute(Eq(gSwitchId),
                                          Truly(std::bind(MatchSaiSwitchAttrByAclStage, SAI_SWITCH_ATTR_INGRESS_ACL,
                                                          kAclGroupIngressOid, std::placeholders::_1))))
-            .WillRepeatedly(Return(SAI_STATUS_SUCCESS));
+            .WillOnce(Return(SAI_STATUS_SUCCESS));
         EXPECT_CALL(mock_sai_switch_,
                     set_switch_attribute(Eq(gSwitchId),
                                          Truly(std::bind(MatchSaiSwitchAttrByAclStage, SAI_SWITCH_ATTR_EGRESS_ACL,
                                                          kAclGroupEgressOid, std::placeholders::_1))))
-            .WillRepeatedly(Return(SAI_STATUS_SUCCESS));
+            .WillOnce(Return(SAI_STATUS_SUCCESS));
         EXPECT_CALL(mock_sai_switch_,
                     set_switch_attribute(Eq(gSwitchId),
                                          Truly(std::bind(MatchSaiSwitchAttrByAclStage, SAI_SWITCH_ATTR_PRE_INGRESS_ACL,
                                                          kAclGroupLookupOid, std::placeholders::_1))))
-            .WillRepeatedly(Return(SAI_STATUS_SUCCESS));
+            .WillOnce(Return(SAI_STATUS_SUCCESS));
+    TableConnector stateDbSwitchTable(gStateDb, "SWITCH_CAPABILITY");
+    TableConnector app_switch_table(gAppDb, APP_SWITCH_TABLE_NAME);
+    TableConnector conf_asic_sensors(gConfigDb, CFG_ASIC_SENSORS_TABLE_NAME);
+    std::vector<TableConnector> switch_tables = {conf_asic_sensors,
+                                                 app_switch_table};
+    gSwitchOrch = new SwitchOrch(gAppDb, switch_tables, stateDbSwitchTable);
+  }
+
+  void setUpP4Orch() {
         std::vector<std::string> p4_tables;
         gP4Orch = new P4Orch(gAppDb, p4_tables, nullptr, gVrfOrch, copp_orch_);
         acl_table_manager_ = gP4Orch->getAclTableManager();
@@ -1485,7 +1487,8 @@ TEST_F(AclManagerTest, CreatePuntTableFailsWhenUserTrapsSaiCallFails)
     EXPECT_EQ(StatusCode::SWSS_RC_FULL, ProcessAddTableRequest(app_db_entry));
 }
 
-TEST_F(AclManagerTest, DISABLED_CreatePuntTableFailsWhenUserTrapGroupOrHostifNotFound)
+
+TEST_F(AclManagerTest, CreatePuntTableFailsWhenUserTrapGroupOrHostifNotFound)
 {
     auto app_db_entry = getDefaultAclTableDefAppDbEntry();
     const auto skip_cpu_queue = 1;
@@ -5329,7 +5332,8 @@ TEST_F(AclManagerTest, DoAclCounterStatsTaskFailsWhenSaiCallFails)
     EXPECT_EQ(nullptr, GetAclRule(kAclIngressTableName, acl_rule_key));
 }
 
-TEST_F(AclManagerTest, DISABLED_InitCreateGroupFails)
+
+TEST_F(AclManagerTest, InitCreateGroupFails)
 {
     // Failed to create ACL groups
     EXPECT_CALL(mock_sai_serialize_, sai_serialize_object_id(_)).WillRepeatedly(Return(EMPTY_STRING));
@@ -5342,7 +5346,7 @@ TEST_F(AclManagerTest, DISABLED_InitCreateGroupFails)
     EXPECT_THROW(new SwitchOrch(gAppDb, switch_tables, stateDbSwitchTable), std::runtime_error);
 }
 
-TEST_F(AclManagerTest, DISABLED_InitBindGroupToSwitchFails)
+TEST_F(AclManagerTest, InitBindGroupToSwitchFails)
 {
     EXPECT_CALL(mock_sai_serialize_, sai_serialize_object_id(_)).WillRepeatedly(Return(EMPTY_STRING));
     // Failed to bind ACL group to switch attribute.

--- a/orchagent/p4orch/tests/test_main.cpp
+++ b/orchagent/p4orch/tests/test_main.cpp
@@ -15,6 +15,11 @@ extern "C"
 #include "flowcounterrouteorch.h"
 #include "gtest/gtest.h"
 #include "mock_sai_virtual_router.h"
+#include "mock_sai_hostif.h"
+#include "mock_sai_switch.h"
+#include "mock_sai_route.h"
+#include "mock_sai_router_interface.h"
+#include "mock_sai_acl.h"
 #include "p4orch.h"
 #include "portsorch.h"
 #include "sai_serialize.h"
@@ -22,7 +27,8 @@ extern "C"
 #include "vrforch.h"
 
 using ::testing::StrictMock;
-
+using ::testing::NiceMock;
+ 
 /* Global variables */
 sai_object_id_t gVirtualRouterId = SAI_NULL_OBJECT_ID;
 sai_object_id_t gSwitchId = SAI_NULL_OBJECT_ID;
@@ -54,13 +60,13 @@ bool gIsNatSupported = false;
 bool gTraditionalFlexCounter = false;
 sai_redis_communication_mode_t gRedisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC;
 
-AclOrch* gAclOrch;
-PortsOrch *gPortsOrch;
-CrmOrch *gCrmOrch;
-P4Orch *gP4Orch;
-VRFOrch *gVrfOrch;
-FlowCounterRouteOrch *gFlowCounterRouteOrch;
-SwitchOrch *gSwitchOrch;
+AclOrch* gAclOrch = NULL;
+PortsOrch *gPortsOrch = NULL;
+CrmOrch *gCrmOrch = NULL;
+P4Orch *gP4Orch = NULL;
+VRFOrch *gVrfOrch =NULL;
+FlowCounterRouteOrch *gFlowCounterRouteOrch = NULL;
+SwitchOrch *gSwitchOrch = NULL;
 Directory<Orch *> gDirectory;
 swss::DBConnector *gAppDb;
 swss::DBConnector *gStateDb;
@@ -91,6 +97,12 @@ sai_l2mc_api_t* sai_l2mc_api;
 sai_l2mc_group_api_t* sai_l2mc_group_api;
 sai_bridge_api_t* sai_bridge_api;
 sai_generic_programmable_api_t *sai_generic_programmable_api;
+
+NiceMock<MockSaiSwitch> mock_sai_switch_;
+NiceMock<MockSaiHostif> mock_sai_hostif_;
+NiceMock<MockSaiRouterInterface> mock_sai_router_intf_;
+NiceMock<MockSaiRoute> mock_sai_route_;
+NiceMock<MockSaiAcl> mock_sai_acl_;
 
 task_process_status handleSaiCreateStatus(sai_api_t api, sai_status_t status, void *context)
 {
@@ -196,6 +208,73 @@ void AddVrf()
     static_cast<Orch *>(gVrfOrch)->doTask();
 }
 
+void initSaiAclApi()
+{
+    mock_sai_acl = &mock_sai_acl_;
+    sai_acl_api->create_acl_table = create_acl_table;
+    sai_acl_api->remove_acl_table = remove_acl_table;
+    sai_acl_api->create_acl_table_group = create_acl_table_group;
+    sai_acl_api->remove_acl_table_group = remove_acl_table_group;
+    sai_acl_api->create_acl_table_group_member = create_acl_table_group_member;
+    sai_acl_api->remove_acl_table_group_member = remove_acl_table_group_member;
+    sai_acl_api->get_acl_counter_attribute = get_acl_counter_attribute;
+    sai_acl_api->create_acl_entry = create_acl_entry;
+    sai_acl_api->remove_acl_entry = remove_acl_entry;
+    sai_acl_api->set_acl_entry_attribute = set_acl_entry_attribute;
+    sai_acl_api->create_acl_counter = create_acl_counter;
+    sai_acl_api->remove_acl_counter = remove_acl_counter;
+}
+
+void initHostIfApi()
+{
+  mock_sai_hostif = &mock_sai_hostif_;
+  sai_hostif_api->create_hostif_trap = mock_create_hostif_trap;
+  sai_hostif_api->create_hostif_table_entry = mock_create_hostif_table_entry;
+
+  sai_hostif_api->create_hostif_trap = mock_create_hostif_trap;
+  sai_hostif_api->create_hostif_table_entry = mock_create_hostif_table_entry;
+  sai_hostif_api->remove_hostif_table_entry = mock_remove_hostif_table_entry;
+  sai_hostif_api->create_hostif_trap_group = mock_create_hostif_trap_group;
+  sai_hostif_api->create_hostif = mock_create_hostif;
+  sai_hostif_api->remove_hostif = mock_remove_hostif;
+  sai_hostif_api->create_hostif_user_defined_trap = mock_create_hostif_user_defined_trap;
+  sai_hostif_api->remove_hostif_user_defined_trap = mock_remove_hostif_user_defined_trap;
+}
+
+void initRouterIntfApi()
+{
+  mock_sai_router_intf = &mock_sai_router_intf_;
+  sai_router_intfs_api->create_router_interface =
+        mock_create_router_interface;
+  sai_router_intfs_api->remove_router_interface =
+        mock_remove_router_interface;
+  sai_router_intfs_api->set_router_interface_attribute =
+        mock_set_router_interface_attribute;
+  sai_router_intfs_api->remove_router_interface =
+        mock_remove_router_interface;
+}
+
+void initRouteApi()
+{
+  mock_sai_route = &mock_sai_route_;
+  sai_route_api->create_route_entry = create_route_entry;
+  sai_route_api->remove_route_entry = remove_route_entry;
+  sai_route_api->set_route_entry_attribute = set_route_entry_attribute;
+  sai_route_api->get_route_entry_attribute = get_route_entry_attribute;
+  sai_route_api->create_route_entries = create_route_entries;
+  sai_route_api->remove_route_entries = remove_route_entries;
+  sai_route_api->set_route_entries_attribute = set_route_entries_attribute;
+  sai_route_api->get_route_entries_attribute = get_route_entries_attribute;
+}
+
+void initSwitchApi()
+{
+
+	mock_sai_switch = &mock_sai_switch_;
+	sai_switch_api->get_switch_attribute = mock_get_switch_attribute;
+	sai_switch_api->set_switch_attribute = mock_set_switch_attribute;
+}
+
 } // namespace
 
 int main(int argc, char *argv[])
@@ -264,11 +343,27 @@ int main(int argc, char *argv[])
     gConfigDb = &config_db;
     gCountersDb = &counters_db;
     std::vector<table_name_with_pri_t> ports_tables;
+
+    CrmOrch crm_orch(gConfigDb, CFG_CRM_TABLE_NAME);
+    gCrmOrch = &crm_orch;
+
+    initSaiAclApi();
+    initHostIfApi();
+    initRouterIntfApi();
+    initRouteApi();
+
+    initSwitchApi();
+    TableConnector stateDbSwitchTable(gStateDb, "SWITCH_CAPABILITY");
+    TableConnector app_switch_table(gAppDb, APP_SWITCH_TABLE_NAME);
+    TableConnector conf_asic_sensors(gConfigDb, CFG_ASIC_SENSORS_TABLE_NAME);
+    std::vector<TableConnector> switch_tables = {conf_asic_sensors,
+                                                 app_switch_table};
+    SwitchOrch switch_orch(gAppDb, switch_tables, stateDbSwitchTable);
+    gSwitchOrch = &switch_orch;
+
     PortsOrch ports_orch(gAppDb, gStateDb, ports_tables, gAppDb);
     gPortsOrch = &ports_orch;
-    CrmOrch crm_orch(gConfigDb, CFG_CRM_TABLE_NAME);
 
-    gCrmOrch = &crm_orch;
     VRFOrch vrf_orch(gAppDb, APP_VRF_TABLE_NAME, gStateDb, STATE_VRF_OBJECT_TABLE_NAME);
     gVrfOrch = &vrf_orch;
     gDirectory.set(static_cast<VRFOrch *>(&vrf_orch));

--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -5,6 +5,7 @@
 
 #include "switchorch.h"
 #include "crmorch.h"
+#include "p4orch/p4orch.h"
 #include "converter.h"
 #include "notifier.h"
 #include "notificationproducer.h"
@@ -24,6 +25,7 @@ extern sai_acl_api_t *sai_acl_api;
 extern sai_hash_api_t *sai_hash_api;
 extern MacAddress gVxlanMacAddress;
 extern CrmOrch *gCrmOrch;
+extern P4Orch *gP4Orch;
 extern event_handle_t g_events_handle;
 extern string gMyAsicName;
 
@@ -172,6 +174,10 @@ SwitchOrch::SwitchOrch(DBConnector *db, vector<TableConnector>& connectors, Tabl
 
     auto executorT = new ExecutableTimer(m_sensorsPollerTimer, this, "ASIC_SENSORS_POLL_TIMER");
     Orch::addExecutor(executorT);
+    if (gP4Orch)
+    {
+        initAclGroupsBindToSwitch();
+    }
 }
 
 void SwitchOrch::generateSwitchCounterNameMap() const
@@ -379,6 +385,61 @@ ReturnCode SwitchOrch::bindAclGroupToSwitch(const sai_acl_stage_t &group_stage, 
     {
         LOG_ERROR_AND_RETURN(ReturnCode(sai_status) << "[SAI] Failed to set_switch_attribute with attribute.id="
                                                     << attr.id << " and acl group oid=" << acl_grp.m_saiObjectId);
+    }
+    return ReturnCode();
+}
+
+ReturnCode SwitchOrch::unbindAclGroupToSwitch(
+    const sai_acl_stage_t& group_stage)
+{
+    SWSS_LOG_ENTER();
+
+    referenced_object acl_grp = {};
+    acl_grp.m_saiObjectId = SAI_NULL_OBJECT_ID;
+    return bindAclGroupToSwitch(group_stage, acl_grp);
+}
+
+ReturnCode SwitchOrch::removeAclGroup(const sai_acl_stage_t& group_stage)
+{
+    SWSS_LOG_ENTER();
+
+    auto group_it = m_aclGroups.find(group_stage);
+    if (group_it == m_aclGroups.end())
+    {
+        LOG_ERROR_AND_RETURN(
+                ReturnCode(SAI_STATUS_INVALID_PARAMETER)
+                << "Failed to find ACL group by stage '" << group_stage << "'");
+    }
+    CHECK_ERROR_AND_LOG_AND_RETURN(
+        sai_acl_api->remove_acl_table_group(group_it->second.m_saiObjectId),
+        "Failed to create ACL group for stage " << group_stage);
+    if (group_stage == SAI_ACL_STAGE_INGRESS ||
+        group_stage == SAI_ACL_STAGE_PRE_INGRESS ||
+        group_stage == SAI_ACL_STAGE_EGRESS)
+    {
+        gCrmOrch->decCrmAclUsedCounter(CrmResourceType::CRM_ACL_GROUP,
+                                        (sai_acl_stage_t)group_stage,
+                                        SAI_ACL_BIND_POINT_TYPE_SWITCH,
+                                        group_it->second.m_saiObjectId);
+    }
+    m_aclGroups.erase(group_stage);
+    SWSS_LOG_NOTICE("Suceeded to remove ACL group %s in stage %d ",
+                    sai_serialize_object_id(group_it->second.m_saiObjectId).c_str(),
+                    group_stage);
+    return ReturnCode();
+}
+
+ReturnCode SwitchOrch::removeAllAclGroups()
+{
+    SWSS_LOG_ENTER();
+
+    for (auto stage_it : aclStageLookup)
+    {
+        if (m_aclGroups.find(fvValue(stage_it)) != m_aclGroups.end())
+        {
+            LOG_AND_RETURN_IF_ERROR(unbindAclGroupToSwitch(fvValue(stage_it)));
+            LOG_AND_RETURN_IF_ERROR(removeAclGroup(fvValue(stage_it)));
+        }
     }
     return ReturnCode();
 }

--- a/orchagent/switchorch.h
+++ b/orchagent/switchorch.h
@@ -62,8 +62,6 @@ public:
     // Return reference to ACL group created for each stage and the bind point is
     // the switch
     std::map<sai_acl_stage_t, referenced_object> &getAclGroupsBindingToSwitch();
-    // Initialize the ACL groups bind to Switch
-    void initAclGroupsBindToSwitch();
 
     bool checkOrderedEcmpEnable() { return m_orderedEcmpEnable; }
 
@@ -147,7 +145,8 @@ private:
     sai_status_t setSwitchTunnelVxlanParams(swss::FieldValueTuple &val);
     void setSwitchNonSaiAttributes(swss::FieldValueTuple &val);
 
-
+    // Initialize the ACL groups bind to Switch
+    void initAclGroupsBindToSwitch();
     // Create the default ACL group for the given stage, bind point is
     // SAI_ACL_BIND_POINT_TYPE_SWITCH and group type is
     // SAI_ACL_TABLE_GROUP_TYPE_PARALLEL.
@@ -156,6 +155,16 @@ private:
     // Bind the ACL group to switch for the given stage.
     // Set the SAI_SWITCH_ATTR_{STAGE}_ACL with the group oid.
     ReturnCode bindAclGroupToSwitch(const sai_acl_stage_t &group_stage, const referenced_object &acl_grp);
+
+    // Unbind the ACL group to switch for the given stage.
+    // Set the SAI_SWITCH_ATTR_{STAGE}_ACL to SAI_NULL_OBJECT_ID
+    ReturnCode unbindAclGroupToSwitch(const sai_acl_stage_t& group_stage);
+
+    // Remove the ACL group on given stage if reference count is zero.
+    ReturnCode removeAclGroup(const sai_acl_stage_t& group_stage);
+
+    // Remove all ACL groups on all stages.
+    ReturnCode removeAllAclGroups();
 
     swss::NotificationConsumer* m_restartCheckNotificationConsumer;
     void doTask(swss::NotificationConsumer& consumer);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,6 +176,7 @@ class AsicDbValidator(DVSDatabase):
 
         self.default_acl_tables = self.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE")
         self.default_acl_entries = self.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
+        self.default_acl_groups = self.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP")
 
         self.default_hash_keys = self.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_HASH")
 
@@ -1508,6 +1509,7 @@ class DockerVirtualSwitch:
             db = DVSDatabase(self.ASIC_DB_ID, self.redis_sock)
             db.default_acl_tables = self.asicdb.default_acl_tables
             db.default_acl_entries = self.asicdb.default_acl_entries
+            db.default_acl_groups = self.asicdb.default_acl_groups
             db.default_hash_keys = self.asicdb.default_hash_keys
             db.default_switch_keys = self.asicdb.default_switch_keys
             db.default_copp_policers = self.asicdb.default_copp_policers

--- a/tests/dvslib/dvs_acl.py
+++ b/tests/dvslib/dvs_acl.py
@@ -201,7 +201,12 @@ class DVSAcl:
         Returns:
             The list of ACL group IDs in ASIC DB.
         """
-        acl_table_groups = self.asic_db.wait_for_n_keys(self.ADB_ACL_GROUP_TABLE_NAME, expected)
+        num_keys = len(self.asic_db.default_acl_groups) + expected
+        keys = self.asic_db.wait_for_n_keys(self.ADB_ACL_GROUP_TABLE_NAME, num_keys)
+        for k in self.asic_db.default_acl_groups:
+            assert k in keys
+
+        acl_table_groups = [k for k in keys if k not in self.asic_db.default_acl_groups]
         return acl_table_groups
 
     # FIXME: This method currently assumes only ingress xor egress tables exist.
@@ -265,7 +270,7 @@ class DVSAcl:
             num_tables: The total number of ACL tables in ASIC DB.
             stage: The stage of the ACL table that was created.
         """
-        acl_table_group_ids = self.asic_db.wait_for_n_keys(self.ADB_ACL_GROUP_TABLE_NAME, len(bind_portchannels))
+        acl_table_group_ids = self.get_acl_table_group_ids(len(bind_portchannels))
 
         portchannel_groups = []
         for portchannel in bind_portchannels:
@@ -296,7 +301,7 @@ class DVSAcl:
             num_tables: The total number of ACL tables in ASIC DB.
             stage: The stage of the ACL table that was created.
         """
-        acl_table_group_ids = self.asic_db.wait_for_n_keys(self.ADB_ACL_GROUP_TABLE_NAME, len(bind_ports))
+        acl_table_group_ids = self.get_acl_table_group_ids(len(bind_ports))
 
         port_groups = []
         for port in bind_ports:

--- a/tests/mock_tests/aclorch_rule_ut.cpp
+++ b/tests/mock_tests/aclorch_rule_ut.cpp
@@ -5,6 +5,7 @@
 #include "check.h"
 #include "saihelper.h"
 
+extern CrmOrch *gCrmOrch;
 EXTERN_MOCK_FNS
 
 /* 
@@ -242,6 +243,8 @@ namespace aclorch_rule_test
 
     TEST_F(AclRedirectActionTest, TunnelNH)
     {
+        shared_ptr<swss::DBConnector> config_db = make_shared<swss::DBConnector>("CONFIG_DB", 0);
+        gCrmOrch = new CrmOrch(config_db.get(), CFG_CRM_TABLE_NAME);
         EXPECT_CALL(*mock_sai_next_hop_api, create_next_hop).WillOnce(DoAll(SetArgPointee<0>(nh_oid),
                 Return(SAI_STATUS_SUCCESS)
         ));

--- a/tests/mock_tests/copporch_ut.cpp
+++ b/tests/mock_tests/copporch_ut.cpp
@@ -150,6 +150,7 @@ namespace copporch_test
                 switchTableAppDb
             };
 
+            gCrmOrch = new CrmOrch(this->configDb.get(), CFG_CRM_TABLE_NAME);
             gSwitchOrch = new SwitchOrch(this->appDb.get(), switchTableList, switchCapTableStateDb);
             gDirectory.set(gSwitchOrch);
             resourcesList.push_back(gSwitchOrch);
@@ -244,6 +245,7 @@ namespace copporch_test
                 delete it;
             }
 
+            gCrmOrch = nullptr;
             gSwitchOrch = nullptr;
             gPortsOrch = nullptr;
             gQosOrch = nullptr;

--- a/tests/mock_tests/fdborch/flush_syncd_notif_ut.cpp
+++ b/tests/mock_tests/fdborch/flush_syncd_notif_ut.cpp
@@ -79,7 +79,11 @@ namespace fdb_syncd_flush_test
             m_asic_db = std::make_shared<swss::DBConnector>("ASIC_DB", 0);
 
             // Construct dependencies
-            // 1) SwitchOrch
+            // 1) Crmorch
+            ASSERT_EQ(gCrmOrch, nullptr);
+            gCrmOrch = new CrmOrch(m_config_db.get(), CFG_CRM_TABLE_NAME);
+
+            // 2) SwitchOrch
             TableConnector stateDbSwitchTable(m_state_db.get(), "SWITCH_CAPABILITY");
             TableConnector app_switch_table(m_app_db.get(), APP_SWITCH_TABLE_NAME);
             TableConnector conf_asic_sensors(m_config_db.get(), CFG_ASIC_SENSORS_TABLE_NAME);
@@ -92,7 +96,7 @@ namespace fdb_syncd_flush_test
             ASSERT_EQ(gSwitchOrch, nullptr);
             gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
 
-            // 2) Portsorch
+            // 3) Portsorch
             const int portsorch_base_pri = 40;
 
             vector<table_name_with_pri_t> ports_tables = {
@@ -105,9 +109,6 @@ namespace fdb_syncd_flush_test
 
             m_portsOrch = std::make_shared<PortsOrch>(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
 
-            // 3) Crmorch
-            ASSERT_EQ(gCrmOrch, nullptr);
-            gCrmOrch = new CrmOrch(m_config_db.get(), CFG_CRM_TABLE_NAME);
             VxlanTunnelOrch *vxlan_tunnel_orch_1 = new VxlanTunnelOrch(m_state_db.get(), m_app_db.get(), APP_VXLAN_TUNNEL_TABLE_NAME);
             gDirectory.set(vxlan_tunnel_orch_1);
             

--- a/tests/mock_tests/flexcounter_ut.cpp
+++ b/tests/mock_tests/flexcounter_ut.cpp
@@ -342,6 +342,9 @@ namespace flexcounter_test
                 app_switch_table
             };
 
+            ASSERT_EQ(gCrmOrch, nullptr);
+            gCrmOrch = new CrmOrch(m_config_db.get(), CFG_CRM_TABLE_NAME);
+
             ASSERT_EQ(gSwitchOrch, nullptr);
             gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
 
@@ -434,6 +437,8 @@ namespace flexcounter_test
             gBufferOrch = nullptr;
             delete gQosOrch;
             gQosOrch = nullptr;
+            delete gCrmOrch;
+            gCrmOrch = nullptr;
             delete gSwitchOrch;
             gSwitchOrch = nullptr;
 

--- a/tests/mock_tests/mock_orch_test.cpp
+++ b/tests/mock_tests/mock_orch_test.cpp
@@ -1,5 +1,6 @@
 #include "mock_orch_test.h"
 
+extern CrmOrch *gCrmOrch;
 using namespace std;
 
 namespace mock_orch_test
@@ -117,6 +118,7 @@ void MockOrchTest::SetUp()
         app_switch_table
     };
 
+    gCrmOrch = new CrmOrch(m_config_db.get(), CFG_CRM_TABLE_NAME);
     gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
     gDirectory.set(gSwitchOrch);
     ut_orch_list.push_back((Orch **)&gSwitchOrch);

--- a/tests/mock_tests/mock_saihelper.cpp
+++ b/tests/mock_tests/mock_saihelper.cpp
@@ -168,6 +168,9 @@ namespace saihelper_test
                     app_switch_table
                 };
 
+                ASSERT_EQ(gCrmOrch, nullptr);
+                gCrmOrch = new CrmOrch(m_config_db.get(), CFG_CRM_TABLE_NAME);
+
                 ASSERT_EQ(gSwitchOrch, nullptr);
                 gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
             }
@@ -177,6 +180,9 @@ namespace saihelper_test
                 ::testing_db::reset();
 
                 gDirectory.m_values.clear();
+
+                delete gCrmOrch;
+                gCrmOrch = nullptr;
 
                 delete gSwitchOrch;
                 gSwitchOrch = nullptr;

--- a/tests/mock_tests/portphyattr_ut.cpp
+++ b/tests/mock_tests/portphyattr_ut.cpp
@@ -81,6 +81,9 @@ namespace portphyattr_test
                 app_switch_table
             };
 
+            ASSERT_EQ(gCrmOrch, nullptr);
+            gCrmOrch = new CrmOrch(m_config_db.get(), CFG_CRM_TABLE_NAME);
+
             ASSERT_EQ(gSwitchOrch, nullptr);
             gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
 
@@ -146,6 +149,9 @@ namespace portphyattr_test
 
             delete gPortsOrch;
             gPortsOrch = nullptr;
+
+            delete gCrmOrch;
+            gCrmOrch = nullptr;
 
             delete gSwitchOrch;
             gSwitchOrch = nullptr;

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -572,6 +572,8 @@ namespace portsorch_test
                 app_switch_table
             };
 
+            ASSERT_EQ(gCrmOrch, nullptr);
+            gCrmOrch = new CrmOrch(m_config_db.get(), CFG_CRM_TABLE_NAME);
             ASSERT_EQ(gSwitchOrch, nullptr);
             gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
 
@@ -726,8 +728,11 @@ namespace portsorch_test
             gQosOrch = nullptr;
             delete gSwitchOrch;
             gSwitchOrch = nullptr;
+            delete gCrmOrch;
+            gCrmOrch = nullptr;
             delete gMlagOrch;
             gMlagOrch = nullptr;
+
             // clear orchs saved in directory
             gDirectory.m_values.clear();
         }

--- a/tests/mock_tests/routeorch_ut.cpp
+++ b/tests/mock_tests/routeorch_ut.cpp
@@ -146,6 +146,12 @@ namespace routeorch_test
 
         void SetUp() override
         {
+            if (gCrmOrch)
+            {
+                delete gCrmOrch;
+                gCrmOrch = nullptr;
+            }
+
             ASSERT_EQ(sai_route_api, nullptr);
             map<string, string> profile = {
                 { "SAI_VS_SWITCH_TYPE", "SAI_VS_SWITCH_TYPE_BCM56850" },

--- a/tests/mock_tests/sfloworh_ut.cpp
+++ b/tests/mock_tests/sfloworh_ut.cpp
@@ -167,6 +167,7 @@ namespace sflow_test
                 switchTableAppDb
             };
 
+            gCrmOrch = new CrmOrch(this->configDb.get(), CFG_CRM_TABLE_NAME);
             gSwitchOrch = new SwitchOrch(this->appDb.get(), switchTableList, switchCapTableStateDb);
             gDirectory.set(gSwitchOrch);
             resourcesList.push_back(gSwitchOrch);
@@ -249,6 +250,7 @@ namespace sflow_test
                 delete it;
             }
 
+            gCrmOrch = nullptr;
             gSwitchOrch = nullptr;
             gPortsOrch = nullptr;
             gQosOrch = nullptr;

--- a/tests/mock_tests/switchorch_ut.cpp
+++ b/tests/mock_tests/switchorch_ut.cpp
@@ -141,6 +141,11 @@ namespace switchorch_test
             ASSERT_EQ(status, SAI_STATUS_SUCCESS);
         }
 
+        void initCrmOrch()
+        {
+            gCrmOrch = new CrmOrch(m_config_db.get(), CFG_CRM_TABLE_NAME);
+        }
+
         void initSwitchOrch()
         {
             TableConnector stateDbSwitchTable(m_state_db.get(), "SWITCH_CAPABILITY");
@@ -155,6 +160,7 @@ namespace switchorch_test
             };
 
             ASSERT_EQ(gSwitchOrch, nullptr);
+            initCrmOrch();
             gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
         }
 

--- a/tests/mock_tests/twamporch_ut.cpp
+++ b/tests/mock_tests/twamporch_ut.cpp
@@ -243,6 +243,14 @@ namespace twamporch_test
         void initOrch()
         {
             //
+            // CrmOrch
+            //
+            ASSERT_EQ(gCrmOrch, nullptr);
+            gCrmOrch = new CrmOrch(this->configDb.get(), CFG_CRM_TABLE_NAME);
+            gDirectory.set(gCrmOrch);
+            resourcesList.push_back(gCrmOrch);
+
+            //
             // SwitchOrch
             //
             TableConnector state_switch_table(this->stateDb.get(), "SWITCH_CAPABILITY");
@@ -310,14 +318,6 @@ namespace twamporch_test
             auto flexCounterOrch = new FlexCounterOrch(this->configDb.get(), flexCounterTableList);
             gDirectory.set(flexCounterOrch);
             resourcesList.push_back(flexCounterOrch);
-
-            //
-            // CrmOrch
-            //
-            ASSERT_EQ(gCrmOrch, nullptr);
-            gCrmOrch = new CrmOrch(this->configDb.get(), CFG_CRM_TABLE_NAME);
-            gDirectory.set(gCrmOrch);
-            resourcesList.push_back(gCrmOrch);
         }
 
         void deinitOrch()
@@ -328,11 +328,11 @@ namespace twamporch_test
                 delete it;
             }
 
+            gCrmOrch = nullptr;
             gSwitchOrch = nullptr;
             gPortsOrch = nullptr;
             gVrfOrch = nullptr;
             gBufferOrch = nullptr;
-            gCrmOrch = nullptr;
 
             Portal::DirectoryInternal::clear(gDirectory);
             EXPECT_TRUE(Portal::DirectoryInternal::empty(gDirectory));

--- a/tests/mock_tests/vxlanorch_ut.cpp
+++ b/tests/mock_tests/vxlanorch_ut.cpp
@@ -122,6 +122,11 @@ namespace vxlanorch_test
                 ASSERT_EQ(status, SAI_STATUS_SUCCESS);
             }
 
+            void initCrmOrch()
+            {
+                gCrmOrch = new CrmOrch(m_config_db.get(), CFG_CRM_TABLE_NAME);
+            }
+
             void initSwitchOrch()
             {
                 TableConnector stateDbSwitchTable(m_state_db.get(), "SWITCH_CAPABILITY");
@@ -136,6 +141,7 @@ namespace vxlanorch_test
                 };
 
                 ASSERT_EQ(gSwitchOrch, nullptr);
+                initCrmOrch();
                 gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
             }
 

--- a/tests/test_acl_mclag.py
+++ b/tests/test_acl_mclag.py
@@ -46,9 +46,9 @@ class TestMclagAcl(object):
         else:
             return None
 
-    def verify_acl_group_num(self, expt):
+    def verify_acl_group_num(self, dvs, expt):
         atbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP")
-        acl_table_groups = atbl.getKeys()
+        acl_table_groups = [k for k in atbl.getKeys() if k not in dvs.asicdb.default_acl_groups]
         assert len(acl_table_groups) == expt
 
         for k in acl_table_groups:
@@ -88,7 +88,7 @@ class TestMclagAcl(object):
 
     def verify_acl_port_binding(self, dvs, bind_ports):
         atbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP")
-        acl_table_groups = atbl.getKeys()
+        acl_table_groups = [k for k in atbl.getKeys() if k not in dvs.asicdb.default_acl_groups]
         assert len(acl_table_groups) == len(bind_ports)
 
         atbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_PORT")
@@ -126,11 +126,11 @@ class TestMclagAcl(object):
         assert acl_table_id is not None
 
         # check acl table group in asic db
-        self.verify_acl_group_num(2)
+        self.verify_acl_group_num(dvs, 2)
 
         # get acl table group ids and verify the id numbers
         atbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP")
-        acl_group_ids = atbl.getKeys()
+        acl_group_ids = [k for k in atbl.getKeys() if k not in dvs.asicdb.default_acl_groups]
         assert len(acl_group_ids) == 2
 
         # check acl table group member


### PR DESCRIPTION
What I did
Update acl binding init
The core of this PR involves shifting the responsibility of creating and managing default ACL Groups (Ingress, Egress, and Pre-ingress) from P4AclTableManager to SwitchOrch.


Why I did it
ACL Groups bound to the switch (Ingress/Egress/Pre-Ingress) are global switch resources. They should be managed by the SwitchOrch (which handles the SAI Switch Object) .

How I verified it
Verified with UT cases.

Details if related
