### PR TITLE
Add drop monitor attributes to supported debug counter attributes

### DIFF
--- a/orchagent/debug_counter/debug_counter.cpp
+++ b/orchagent/debug_counter/debug_counter.cpp
@@ -27,7 +27,12 @@ const unordered_set<string> DebugCounter::supported_debug_counter_attributes =
     COUNTER_ALIAS,
     COUNTER_TYPE,
     COUNTER_DESCRIPTION,
-    COUNTER_GROUP
+    COUNTER_GROUP,
+    // Drop counter specific attributes for drop monitor feature
+    DROP_MONITOR_STATUS,
+    DROP_MONITOR_DROP_COUNT_THRESHOLD,
+    DROP_MONITOR_INCIDENT_COUNT_THRESHOLD,
+    DROP_MONITOR_WINDOW
 };
 
 const std::unordered_map<std::string, sai_debug_counter_type_t> DebugCounter::debug_counter_type_lookup =

--- a/orchagent/debug_counter/debug_counter.h
+++ b/orchagent/debug_counter/debug_counter.h
@@ -17,6 +17,12 @@ extern "C" {
 #define COUNTER_DESCRIPTION "desc"
 #define COUNTER_GROUP       "group"
 
+// Drop counter specific attributes for drop monitor feature.
+#define DROP_MONITOR_STATUS                   "drop_monitor_status"
+#define DROP_MONITOR_DROP_COUNT_THRESHOLD     "drop_count_threshold"
+#define DROP_MONITOR_INCIDENT_COUNT_THRESHOLD "incident_count_threshold"
+#define DROP_MONITOR_WINDOW                   "window"
+
 // Supported debug counter types.
 #define PORT_INGRESS_DROPS   "PORT_INGRESS_DROPS"
 #define PORT_EGRESS_DROPS    "PORT_EGRESS_DROPS"


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add the missing drop monitor attribute definitions to debug_counter.h and include them in the supported attributes set in debug_counter.cpp.

**Why I did it**
The drop monitor feature introduced new CONFIG_DB fields drop_monitor_status, drop_count_threshold, incident_count_threshold and window for drop monitoring configuration. However, these attributes were not added to the supported_debug_counter_attributes set, causing error logs during debug counter installation: ```"Unknown debug counter attribute 'drop_monitor_status'"```
It can replicated by running the ```test_configurable_drop_counters.py``` testcase which will fail in teardown with this error.

**How I verified it**
Verified the fix by running test_configurable_drop_counters.py which was previously failing in teardown with the error "Unknown debug counter attribute 'drop_monitor_status'". After applying the fix, the test passes without generating any error logs

**Details if related**
