### PR TITLE
[build] Disable debian helper auto install for cargo project.

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -235,8 +235,11 @@ jobs:
       if [ '${{ parameters.asan }}' == True ]; then
          export ENABLE_ASAN=y
       fi
+      git ls-files --others debian
       ./autogen.sh
       RUSTFLAGS=-Dwarnings dpkg-buildpackage -us -uc -b -j$(nproc) && cp ../*.deb .
+      git ls-files --others debian
+      exit 1
     displayName: "Compile sonic swss"
   - script: |
       RUSTFLAGS=-Dwarnings cargo test


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Disable dh_auto_install
**Why I did it**
Rust and Go project build out binary files.
We don't need install step. Just copy binary to /bin/bash.
'cargo install' will download latest dependency versions. Dependency change may break build.
Disable debian package helper's default behaviour.
**How I verified it**

**Details if related**
