### PR TITLE
[icmporch] use query attribute capability for stats mode and set explicitly supported value

### DIFF
--- a/orchagent/icmporch.cpp
+++ b/orchagent/icmporch.cpp
@@ -13,6 +13,7 @@
 #include "notifications.h"
 #include "icmporch.h"
 #include "switchorch.h"
+#include <algorithm>
 #include <string>
 
 using namespace std;
@@ -50,6 +51,11 @@ IcmpOrch::IcmpOrch(DBConnector *db, string tableName, TableConnector stateDbIcmp
         return;
     }
 
+    if (!resolve_stats_count_mode())
+    {
+        SWSS_LOG_WARN("ICMP stats count mode resolution failed, will try to create ICMP session without explicit stats count mode");
+    }
+
     DBConnector *notificationsDb = new DBConnector("ASIC_DB", 0);
     m_icmpStateNotificationConsumer = new swss::NotificationConsumer(notificationsDb, "NOTIFICATIONS");
 
@@ -71,6 +77,58 @@ IcmpOrch::~IcmpOrch(void)
 {
     // do nothing, just log
     SWSS_LOG_ENTER();
+}
+
+bool IcmpOrch::resolve_stats_count_mode()
+{
+    m_stats_count_mode_initialized = false;
+
+    const auto *meta = sai_metadata_get_attr_metadata(
+        SAI_OBJECT_TYPE_ICMP_ECHO_SESSION,
+        SAI_ICMP_ECHO_SESSION_ATTR_STATS_COUNT_MODE);
+    if (!meta || !meta->isenum)
+    {
+        SWSS_LOG_WARN("sai_metadata_get_attr_metadata for SAI_ICMP_ECHO_SESSION_ATTR_STATS_COUNT_MODE failed");
+        return false;
+    }
+
+    std::vector<int32_t> values_list(meta->enummetadata->valuescount);
+    sai_s32_list_t values;
+    values.count = static_cast<uint32_t>(values_list.size());
+    values.list = values_list.data();
+
+    auto status = sai_query_attribute_enum_values_capability(
+        gSwitchId,
+        SAI_OBJECT_TYPE_ICMP_ECHO_SESSION,
+        SAI_ICMP_ECHO_SESSION_ATTR_STATS_COUNT_MODE,
+        &values);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_WARN("sai_query_attribute_enum_values_capability for SAI_ICMP_ECHO_SESSION_ATTR_STATS_COUNT_MODE failed");
+        return false;
+    }
+
+    auto *end = values.list + values.count;
+
+    static const sai_stats_count_mode_t preferred_modes[] = {
+        SAI_STATS_COUNT_MODE_PACKET_AND_BYTE,
+        SAI_STATS_COUNT_MODE_PACKET,
+        SAI_STATS_COUNT_MODE_BYTE,
+        SAI_STATS_COUNT_MODE_NONE,
+    };
+
+    for (auto mode : preferred_modes)
+    {
+        if (std::find(values.list, end, static_cast<int32_t>(mode)) != end)
+        {
+            m_stats_count_mode = mode;
+            m_stats_count_mode_initialized = true;
+            return true;
+        }
+    }
+
+    SWSS_LOG_WARN("No supported stats count mode found");
+    return false;
 }
 
 void IcmpOrch::doTask(Consumer &consumer)
@@ -331,7 +389,6 @@ const std::string IcmpSaiSessionHandler::m_hw_lookup_fname          = "hw_lookup
 const std::string IcmpSaiSessionHandler::m_nexthop_switchover_fname = "nexthop_switchover";
 const std::string IcmpSaiSessionHandler::m_session_type_normal      = "NORMAL";
 const std::string IcmpSaiSessionHandler::m_session_type_rx          = "RX";
-const std::string IcmpSaiSessionHandler::m_stats_count_mode_fname   = "stats_count_mode";
 
 const uint32_t IcmpSaiSessionHandler::m_max_tx_interval_usec = 1200000;
 const uint32_t IcmpSaiSessionHandler::m_min_tx_interval_usec = 3000;
@@ -560,64 +617,16 @@ SaiOffloadHandlerStatus IcmpSaiSessionHandler::do_create()
         m_fv_map[m_tx_interval_fname] = "0";
     }
 
-    // Query capability for stats count mode and set a supported value explicitly
+    if (m_orch.m_stats_count_mode_initialized)
     {
-        const auto* meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_ICMP_ECHO_SESSION,
-                                                          SAI_ICMP_ECHO_SESSION_ATTR_STATS_COUNT_MODE);
-        if (!meta || !meta->isenum)
-        {
-            SWSS_LOG_ERROR("sai_metadata_get_attr_metadata for SAI_ICMP_ECHO_SESSION_ATTR_STATS_COUNT_MODE failed ");
-            return SaiOffloadHandlerStatus::FAILED_VALID_ENTRY;;
-        }
-
-        std::vector<int32_t> values_list(meta->enummetadata->valuescount);
-        sai_s32_list_t values;
-        values.count = static_cast<uint32_t>(values_list.size());
-        values.list = values_list.data();
-
-        auto status = sai_query_attribute_enum_values_capability(
-            gSwitchId,
-            SAI_OBJECT_TYPE_ICMP_ECHO_SESSION,
-            SAI_ICMP_ECHO_SESSION_ATTR_STATS_COUNT_MODE,
-            &values);
-
-        if (status != SAI_STATUS_SUCCESS)
-        {
-            SWSS_LOG_ERROR("sai_query_attribute_enum_values_capability for SAI_ICMP_ECHO_SESSION_ATTR_STATS_COUNT_MODE failed ");
-            return SaiOffloadHandlerStatus::FAILED_VALID_ENTRY;
-        }
-
-        sai_attribute_value_t val{};
-        bool set = false;
-
-        for (size_t i = 0; i < values.count; i++)
-        {
-            // PACKET_AND_BYTE is the preferred mode, else - use PACKET only
-            if (values.list[i] == SAI_STATS_COUNT_MODE_PACKET_AND_BYTE)
-            {
-                val.s32 = SAI_STATS_COUNT_MODE_PACKET_AND_BYTE;
-                set = true;
-                break;
-            }
-            else if (values.list[i] == SAI_STATS_COUNT_MODE_PACKET)
-            {
-                val.s32 = SAI_STATS_COUNT_MODE_PACKET;
-                set = true;
-            }
-        }
-
-        if (set)
-        {
-            m_attr_val_map[SAI_ICMP_ECHO_SESSION_ATTR_STATS_COUNT_MODE] = val;
-            m_fv_vector.push_back({m_stats_count_mode_fname, "PACKET"});
-        }
-        else
-        {
-            SWSS_LOG_ERROR("No supported stats count mode found");
-            return SaiOffloadHandlerStatus::FAILED_VALID_ENTRY;
-        }
+        sai_attribute_value_t statsCountModeAttr{};
+        statsCountModeAttr.s32 = m_orch.m_stats_count_mode;
+        m_attr_val_map[SAI_ICMP_ECHO_SESSION_ATTR_STATS_COUNT_MODE] = statsCountModeAttr;
     }
-
+    else
+    {
+        SWSS_LOG_WARN("%s, Stats count mode capability unresolved", m_name.c_str());
+    }
 
     // update the hw_lookup parameter in fv_vector
     auto& hw_lookup_attr_val = m_attr_val_map[SAI_ICMP_ECHO_SESSION_ATTR_HW_LOOKUP_VALID];

--- a/orchagent/icmporch.h
+++ b/orchagent/icmporch.h
@@ -335,6 +335,7 @@ struct IcmpSaiSessionHandler : public SaiOffloadSessionHandler<IcmpSaiSessionHan
     static const std::string m_nexthop_switchover_fname;
     static const std::string m_session_type_normal;
     static const std::string m_session_type_rx;
+    static const std::string m_stats_count_mode_fname;
 
     static const uint32_t m_max_tx_interval_usec;
     static const uint32_t m_min_tx_interval_usec;

--- a/orchagent/icmporch.h
+++ b/orchagent/icmporch.h
@@ -108,6 +108,17 @@ public:
     }
 
 private:
+
+    /**
+     *@method resolve_stats_count_mode
+     *
+     *@brief resolves supported stats count mode for ICMP sessions once
+     *
+     *@return true on success, false on failure
+     */
+    bool resolve_stats_count_mode();
+
+
     /**
      *@method create_icmp_session
      *
@@ -163,6 +174,11 @@ private:
 
     // keeps track of number of sessions
     uint32_t m_num_sessions = 0;
+
+    // resolved ICMP stats count mode reused across session creates
+    sai_stats_count_mode_t m_stats_count_mode = SAI_STATS_COUNT_MODE_PACKET;
+    // set to true only if ICMP stats count mode is resolved
+    bool m_stats_count_mode_initialized = false;
 
     // max number of sessions
     static const uint32_t m_max_sessions;
@@ -335,7 +351,6 @@ struct IcmpSaiSessionHandler : public SaiOffloadSessionHandler<IcmpSaiSessionHan
     static const std::string m_nexthop_switchover_fname;
     static const std::string m_session_type_normal;
     static const std::string m_session_type_rx;
-    static const std::string m_stats_count_mode_fname;
 
     static const uint32_t m_max_tx_interval_usec;
     static const uint32_t m_min_tx_interval_usec;

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -91,6 +91,8 @@ tests_SOURCES = aclorch_ut.cpp \
                 mirrororch_ut.cpp \
                 hftelorch_ut.cpp \
                 hftelorch_is_supported_sai_wrap.cpp \
+                icmporch_ut.cpp \
+                icmporch_sai_wrap.cpp \
                 $(top_srcdir)/warmrestart/warmRestartHelper.cpp \
                 $(top_srcdir)/lib/gearboxutils.cpp \
                 $(top_srcdir)/lib/subintf.cpp \
@@ -215,7 +217,8 @@ tests_SOURCES += $(P4_ORCH_DIR)/p4orch.cpp \
 
 tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
 tests_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_INCLUDES)
-tests_LDFLAGS = -Wl,--wrap=sai_query_stats_st_capability -Wl,--wrap=sai_query_attribute_capability
+tests_LDFLAGS = -Wl,--wrap=sai_query_stats_st_capability -Wl,--wrap=sai_query_attribute_capability \
+                -Wl,--wrap=sai_query_attribute_enum_values_capability -Wl,--wrap=sai_metadata_get_attr_metadata
 tests_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis -lpthread \
         -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lgmock -lgmock_main -lprotobuf -ldashapi
 

--- a/tests/mock_tests/icmporch_sai_wrap.cpp
+++ b/tests/mock_tests/icmporch_sai_wrap.cpp
@@ -1,0 +1,155 @@
+/*
+ * GNU ld --wrap for SAI calls on the ICMP echo session stats count mode path
+ * (orchagent/icmporch.cpp, IcmpSaiSessionHandler::do_create).
+ */
+
+#include "icmporch_sai_wrap.h"
+
+#include "saiobject.h"
+#include "saiicmpecho.h"
+#include "saimetadatautils.h"
+#include "saistatus.h"
+#include "saitypes.h"
+
+#include <cstddef>
+
+namespace
+{
+    enum class Hook : int
+    {
+        None = 0,
+        MetadataNull,
+        MetadataNotEnum,
+        QueryEnumFail,
+        QueryEnumByteOnly,
+        QueryEnumPacketOnly
+    };
+
+    static thread_local Hook g_hook = Hook::None;
+}
+
+static const sai_attr_metadata_t g_nonEnumMetadataTest{};
+
+extern "C"
+{
+    const sai_attr_metadata_t* __real_sai_metadata_get_attr_metadata(
+            _In_ sai_object_type_t object_type,
+            _In_ sai_attr_id_t attr_id);
+
+    sai_status_t __real_sai_query_attribute_enum_values_capability(
+            _In_ sai_object_id_t switch_id,
+            _In_ sai_object_type_t object_type,
+            _In_ sai_attr_id_t attr_id,
+            _Inout_ sai_s32_list_t* enum_values_capability);
+
+    const sai_attr_metadata_t* __wrap_sai_metadata_get_attr_metadata(
+            _In_ sai_object_type_t object_type,
+            _In_ sai_attr_id_t attr_id)
+    {
+        const bool is_icmp_stats_mode = (object_type == SAI_OBJECT_TYPE_ICMP_ECHO_SESSION)
+                && (attr_id == SAI_ICMP_ECHO_SESSION_ATTR_STATS_COUNT_MODE);
+
+        if (g_hook == Hook::MetadataNull && is_icmp_stats_mode)
+        {
+            return nullptr;
+        }
+        if (g_hook == Hook::MetadataNotEnum && is_icmp_stats_mode)
+        {
+            return &g_nonEnumMetadataTest;
+        }
+        return __real_sai_metadata_get_attr_metadata(object_type, attr_id);
+    }
+
+    sai_status_t __wrap_sai_query_attribute_enum_values_capability(
+            _In_ sai_object_id_t switch_id,
+            _In_ sai_object_type_t object_type,
+            _In_ sai_attr_id_t attr_id,
+            _Inout_ sai_s32_list_t* enum_values_capability)
+    {
+        const bool is_icmp_stats_mode = (object_type == SAI_OBJECT_TYPE_ICMP_ECHO_SESSION)
+                && (attr_id == SAI_ICMP_ECHO_SESSION_ATTR_STATS_COUNT_MODE);
+
+        if (g_hook == Hook::QueryEnumFail && is_icmp_stats_mode)
+        {
+            return SAI_STATUS_NOT_SUPPORTED;
+        }
+
+        if (is_icmp_stats_mode && (g_hook == Hook::QueryEnumByteOnly))
+        {
+            if (!enum_values_capability || !enum_values_capability->list
+                    || enum_values_capability->count < 1)
+            {
+                if (enum_values_capability)
+                {
+                    enum_values_capability->count = 0;
+                }
+                return SAI_STATUS_BUFFER_OVERFLOW;
+            }
+            enum_values_capability->count = 1;
+            enum_values_capability->list[0] = SAI_STATS_COUNT_MODE_BYTE;
+            return SAI_STATUS_SUCCESS;
+        }
+
+        if (is_icmp_stats_mode && (g_hook == Hook::QueryEnumPacketOnly))
+        {
+            if (!enum_values_capability || !enum_values_capability->list
+                    || enum_values_capability->count < 1)
+            {
+                if (enum_values_capability)
+                {
+                    enum_values_capability->count = 0;
+                }
+                return SAI_STATUS_BUFFER_OVERFLOW;
+            }
+            enum_values_capability->count = 1;
+            enum_values_capability->list[0] = SAI_STATS_COUNT_MODE_PACKET;
+            return SAI_STATUS_SUCCESS;
+        }
+
+        return __real_sai_query_attribute_enum_values_capability(
+                switch_id, object_type, attr_id, enum_values_capability);
+    }
+}
+
+namespace icmporch_sai_wrap_ut
+{
+    void setIcmpSaiHookNone()
+    {
+        g_hook = Hook::None;
+    }
+
+    void setIcmpSaiHookMetadataNull()
+    {
+        g_hook = Hook::MetadataNull;
+    }
+
+    void setIcmpSaiHookMetadataNotEnum()
+    {
+        g_hook = Hook::MetadataNotEnum;
+    }
+
+    void setIcmpSaiHookQueryEnumFail()
+    {
+        g_hook = Hook::QueryEnumFail;
+    }
+
+    void setIcmpSaiHookQueryEnumByteOnlyNoPacketModes()
+    {
+        g_hook = Hook::QueryEnumByteOnly;
+    }
+
+    void setIcmpSaiHookQueryEnumPacketOnly()
+    {
+        g_hook = Hook::QueryEnumPacketOnly;
+    }
+
+    IcmpSaiHookGuard::IcmpSaiHookGuard(void (*apply)())
+    {
+        apply();
+    }
+
+    IcmpSaiHookGuard::~IcmpSaiHookGuard()
+    {
+        setIcmpSaiHookNone();
+    }
+}

--- a/tests/mock_tests/icmporch_sai_wrap.cpp
+++ b/tests/mock_tests/icmporch_sai_wrap.cpp
@@ -1,6 +1,6 @@
 /*
  * GNU ld --wrap for SAI calls on the ICMP echo session stats count mode path
- * (orchagent/icmporch.cpp, IcmpSaiSessionHandler::do_create).
+ * (orchagent/icmporch.cpp, IcmpOrch::resolve_stats_count_mode).
  */
 
 #include "icmporch_sai_wrap.h"
@@ -21,8 +21,8 @@ namespace
         MetadataNull,
         MetadataNotEnum,
         QueryEnumFail,
-        QueryEnumByteOnly,
-        QueryEnumPacketOnly
+        QueryEnumEmptyList,
+        QueryEnumPacketAndByteOnly,
     };
 
     static thread_local Hook g_hook = Hook::None;
@@ -74,23 +74,16 @@ extern "C"
             return SAI_STATUS_NOT_SUPPORTED;
         }
 
-        if (is_icmp_stats_mode && (g_hook == Hook::QueryEnumByteOnly))
+        if (g_hook == Hook::QueryEnumEmptyList && is_icmp_stats_mode)
         {
-            if (!enum_values_capability || !enum_values_capability->list
-                    || enum_values_capability->count < 1)
+            if (enum_values_capability && enum_values_capability->list)
             {
-                if (enum_values_capability)
-                {
-                    enum_values_capability->count = 0;
-                }
-                return SAI_STATUS_BUFFER_OVERFLOW;
+                enum_values_capability->count = 0;
             }
-            enum_values_capability->count = 1;
-            enum_values_capability->list[0] = SAI_STATS_COUNT_MODE_BYTE;
             return SAI_STATUS_SUCCESS;
         }
 
-        if (is_icmp_stats_mode && (g_hook == Hook::QueryEnumPacketOnly))
+        if (is_icmp_stats_mode && (g_hook == Hook::QueryEnumPacketAndByteOnly))
         {
             if (!enum_values_capability || !enum_values_capability->list
                     || enum_values_capability->count < 1)
@@ -102,7 +95,7 @@ extern "C"
                 return SAI_STATUS_BUFFER_OVERFLOW;
             }
             enum_values_capability->count = 1;
-            enum_values_capability->list[0] = SAI_STATS_COUNT_MODE_PACKET;
+            enum_values_capability->list[0] = SAI_STATS_COUNT_MODE_PACKET_AND_BYTE;
             return SAI_STATUS_SUCCESS;
         }
 
@@ -133,14 +126,14 @@ namespace icmporch_sai_wrap_ut
         g_hook = Hook::QueryEnumFail;
     }
 
-    void setIcmpSaiHookQueryEnumByteOnlyNoPacketModes()
+    void setIcmpSaiHookQueryEnumEmptyList()
     {
-        g_hook = Hook::QueryEnumByteOnly;
+        g_hook = Hook::QueryEnumEmptyList;
     }
 
-    void setIcmpSaiHookQueryEnumPacketOnly()
+    void setIcmpSaiHookQueryEnumPacketAndByteOnly()
     {
-        g_hook = Hook::QueryEnumPacketOnly;
+        g_hook = Hook::QueryEnumPacketAndByteOnly;
     }
 
     IcmpSaiHookGuard::IcmpSaiHookGuard(void (*apply)())

--- a/tests/mock_tests/icmporch_sai_wrap.h
+++ b/tests/mock_tests/icmporch_sai_wrap.h
@@ -1,0 +1,32 @@
+#pragma once
+
+/**
+ * Test hooks for GNU ld --wrap of
+ *   sai_query_attribute_enum_values_capability
+ *   sai_metadata_get_attr_metadata
+ * used in IcmpSaiSessionHandler::do_create (orchagent/icmporch.cpp) stats
+ * count mode selection.
+ */
+namespace icmporch_sai_wrap_ut
+{
+    void setIcmpSaiHookNone();
+
+    void setIcmpSaiHookMetadataNull();
+
+    void setIcmpSaiHookMetadataNotEnum();
+
+    void setIcmpSaiHookQueryEnumFail();
+
+    void setIcmpSaiHookQueryEnumByteOnlyNoPacketModes();
+
+    void setIcmpSaiHookQueryEnumPacketOnly();
+
+    struct IcmpSaiHookGuard
+    {
+        explicit IcmpSaiHookGuard(void (*apply)());
+        ~IcmpSaiHookGuard();
+
+        IcmpSaiHookGuard(const IcmpSaiHookGuard&) = delete;
+        IcmpSaiHookGuard& operator=(const IcmpSaiHookGuard&) = delete;
+    };
+}

--- a/tests/mock_tests/icmporch_sai_wrap.h
+++ b/tests/mock_tests/icmporch_sai_wrap.h
@@ -4,7 +4,7 @@
  * Test hooks for GNU ld --wrap of
  *   sai_query_attribute_enum_values_capability
  *   sai_metadata_get_attr_metadata
- * used in IcmpSaiSessionHandler::do_create (orchagent/icmporch.cpp) stats
+ * (orchagent/icmporch.cpp, IcmpOrch::resolve_stats_count_mode).
  * count mode selection.
  */
 namespace icmporch_sai_wrap_ut
@@ -17,9 +17,9 @@ namespace icmporch_sai_wrap_ut
 
     void setIcmpSaiHookQueryEnumFail();
 
-    void setIcmpSaiHookQueryEnumByteOnlyNoPacketModes();
+    void setIcmpSaiHookQueryEnumEmptyList();
 
-    void setIcmpSaiHookQueryEnumPacketOnly();
+    void setIcmpSaiHookQueryEnumPacketAndByteOnly();
 
     struct IcmpSaiHookGuard
     {

--- a/tests/mock_tests/icmporch_ut.cpp
+++ b/tests/mock_tests/icmporch_ut.cpp
@@ -1,0 +1,102 @@
+#include "icmporch_sai_wrap.h"
+#include "mock_orch_test.h"
+#include "schema.h"
+#include "icmporch.h"
+
+#include <gtest/gtest.h>
+#include <vector>
+
+namespace icmporch_test
+{
+    using namespace std;
+    using namespace swss;
+
+    class IcmpOrchStatsCountModeTest : public mock_orch_test::MockOrchTest
+    {
+    protected:
+        void TearDown() override
+        {
+            icmporch_sai_wrap_ut::setIcmpSaiHookNone();
+            MockOrchTest::TearDown();
+        }
+    };
+
+    static vector<FieldValueTuple> makeMinimalIcmpSessionFvs()
+    {
+        return {
+            {"session_cookie", "12345"},
+            {"src_ip", "10.0.0.1"},
+            {"dst_ip", "10.0.0.2"},
+            {"tx_interval", "10"},
+            {"rx_interval", "10"},
+        };
+    }
+
+    /**
+     * icmporch.cpp (IcmpSaiSessionHandler::do_create, stats count mode block):
+     *   if (!meta) { SWSS_LOG_ERROR("sai_metadata_get_attr_metadata ..."); return FAILED_VALID_ENTRY; }
+     */
+    TEST_F(IcmpOrchStatsCountModeTest, DoCreate_failsWhenStatsCountModeMetadataNull)
+    {
+        icmporch_sai_wrap_ut::IcmpSaiHookGuard g(icmporch_sai_wrap_ut::setIcmpSaiHookMetadataNull);
+        IcmpOrch icmpOrch(m_app_db.get(), APP_ICMP_ECHO_SESSION_TABLE_NAME,
+                TableConnector(m_state_db.get(), STATE_ICMP_ECHO_SESSION_TABLE_NAME));
+        IcmpSaiSessionHandler h(icmpOrch);
+        ASSERT_EQ(h.init(sai_icmp_echo_api, "default:default:5000:NORMAL"), SaiOffloadHandlerStatus::SUCCESS_VALID_ENTRY);
+        EXPECT_EQ(h.create(makeMinimalIcmpSessionFvs()), SaiOffloadHandlerStatus::FAILED_VALID_ENTRY);
+    }
+
+    /**
+     * Same block: if (!meta->isenum) { SWSS_LOG_ERROR("sai_metadata_get_attr_metadata ..."); return FAILED_VALID_ENTRY; }
+     */
+    TEST_F(IcmpOrchStatsCountModeTest, DoCreate_failsWhenStatsCountModeMetadataNotEnum)
+    {
+        icmporch_sai_wrap_ut::IcmpSaiHookGuard g(icmporch_sai_wrap_ut::setIcmpSaiHookMetadataNotEnum);
+        IcmpOrch icmpOrch(m_app_db.get(), APP_ICMP_ECHO_SESSION_TABLE_NAME,
+                TableConnector(m_state_db.get(), STATE_ICMP_ECHO_SESSION_TABLE_NAME));
+        IcmpSaiSessionHandler h(icmpOrch);
+        ASSERT_EQ(h.init(sai_icmp_echo_api, "default:default:5000:NORMAL"), SaiOffloadHandlerStatus::SUCCESS_VALID_ENTRY);
+        EXPECT_EQ(h.create(makeMinimalIcmpSessionFvs()), SaiOffloadHandlerStatus::FAILED_VALID_ENTRY);
+    }
+
+    /**
+     *   if (status != SAI_STATUS_SUCCESS) { SWSS_LOG_ERROR("sai_query_attribute_enum_values_capability ..."); }
+     */
+    TEST_F(IcmpOrchStatsCountModeTest, DoCreate_failsWhenQueryAttributeEnumValuesCapabilityFails)
+    {
+        icmporch_sai_wrap_ut::IcmpSaiHookGuard g(icmporch_sai_wrap_ut::setIcmpSaiHookQueryEnumFail);
+        IcmpOrch icmpOrch(m_app_db.get(), APP_ICMP_ECHO_SESSION_TABLE_NAME,
+                TableConnector(m_state_db.get(), STATE_ICMP_ECHO_SESSION_TABLE_NAME));
+        IcmpSaiSessionHandler h(icmpOrch);
+        ASSERT_EQ(h.init(sai_icmp_echo_api, "default:default:5000:NORMAL"), SaiOffloadHandlerStatus::SUCCESS_VALID_ENTRY);
+        EXPECT_EQ(h.create(makeMinimalIcmpSessionFvs()), SaiOffloadHandlerStatus::FAILED_VALID_ENTRY);
+    }
+
+    /**
+     *   else { SWSS_LOG_ERROR("No supported stats count mode found"); return FAILED_VALID_ENTRY; }
+     * when SAI reports a mode that is neither PACKET_AND_BYTE nor PACKET (e.g. BYTE only).
+     */
+    TEST_F(IcmpOrchStatsCountModeTest, DoCreate_failsWhenNoPacketStatsCountModeSupported)
+    {
+        icmporch_sai_wrap_ut::IcmpSaiHookGuard g(icmporch_sai_wrap_ut::setIcmpSaiHookQueryEnumByteOnlyNoPacketModes);
+        IcmpOrch icmpOrch(m_app_db.get(), APP_ICMP_ECHO_SESSION_TABLE_NAME,
+                TableConnector(m_state_db.get(), STATE_ICMP_ECHO_SESSION_TABLE_NAME));
+        IcmpSaiSessionHandler h(icmpOrch);
+        ASSERT_EQ(h.init(sai_icmp_echo_api, "default:default:5000:NORMAL"), SaiOffloadHandlerStatus::SUCCESS_VALID_ENTRY);
+        EXPECT_EQ(h.create(makeMinimalIcmpSessionFvs()), SaiOffloadHandlerStatus::FAILED_VALID_ENTRY);
+    }
+
+    /**
+     *   else if (values.list[i] == SAI_STATS_COUNT_MODE_PACKET) { val.s32 = SAI_STATS_COUNT_MODE_PACKET; ... }
+     * PACKET is supported but not PACKET_AND_BYTE; do_create should still succeed and session creation may proceed.
+     */
+    TEST_F(IcmpOrchStatsCountModeTest, DoCreate_acceptsPacketOnlyWhenPacketAndByteNotReported)
+    {
+        icmporch_sai_wrap_ut::IcmpSaiHookGuard g(icmporch_sai_wrap_ut::setIcmpSaiHookQueryEnumPacketOnly);
+        IcmpOrch icmpOrch(m_app_db.get(), APP_ICMP_ECHO_SESSION_TABLE_NAME,
+                TableConnector(m_state_db.get(), STATE_ICMP_ECHO_SESSION_TABLE_NAME));
+        IcmpSaiSessionHandler h(icmpOrch);
+        ASSERT_EQ(h.init(sai_icmp_echo_api, "default:default:5000:NORMAL"), SaiOffloadHandlerStatus::SUCCESS_VALID_ENTRY);
+        EXPECT_EQ(h.create(makeMinimalIcmpSessionFvs()), SaiOffloadHandlerStatus::SUCCESS_VALID_ENTRY);
+    }
+} // namespace icmporch_test

--- a/tests/mock_tests/icmporch_ut.cpp
+++ b/tests/mock_tests/icmporch_ut.cpp
@@ -33,70 +33,69 @@ namespace icmporch_test
     }
 
     /**
-     * icmporch.cpp (IcmpSaiSessionHandler::do_create, stats count mode block):
-     *   if (!meta) { SWSS_LOG_ERROR("sai_metadata_get_attr_metadata ..."); return FAILED_VALID_ENTRY; }
+     * IcmpOrch::resolve_stats_count_mode() (constructor): metadata unavailable.
      */
-    TEST_F(IcmpOrchStatsCountModeTest, DoCreate_failsWhenStatsCountModeMetadataNull)
+    TEST_F(IcmpOrchStatsCountModeTest, DoCreate_continuesWhenStatsCountModeMetadataNull)
     {
         icmporch_sai_wrap_ut::IcmpSaiHookGuard g(icmporch_sai_wrap_ut::setIcmpSaiHookMetadataNull);
         IcmpOrch icmpOrch(m_app_db.get(), APP_ICMP_ECHO_SESSION_TABLE_NAME,
                 TableConnector(m_state_db.get(), STATE_ICMP_ECHO_SESSION_TABLE_NAME));
         IcmpSaiSessionHandler h(icmpOrch);
         ASSERT_EQ(h.init(sai_icmp_echo_api, "default:default:5000:NORMAL"), SaiOffloadHandlerStatus::SUCCESS_VALID_ENTRY);
-        EXPECT_EQ(h.create(makeMinimalIcmpSessionFvs()), SaiOffloadHandlerStatus::FAILED_VALID_ENTRY);
+        EXPECT_EQ(h.create(makeMinimalIcmpSessionFvs()), SaiOffloadHandlerStatus::SUCCESS_VALID_ENTRY);
     }
 
     /**
-     * Same block: if (!meta->isenum) { SWSS_LOG_ERROR("sai_metadata_get_attr_metadata ..."); return FAILED_VALID_ENTRY; }
+     * resolve_stats_count_mode: metadata not marked enum false.
      */
-    TEST_F(IcmpOrchStatsCountModeTest, DoCreate_failsWhenStatsCountModeMetadataNotEnum)
+    TEST_F(IcmpOrchStatsCountModeTest, DoCreate_continuesWhenStatsCountModeMetadataNotEnum)
     {
         icmporch_sai_wrap_ut::IcmpSaiHookGuard g(icmporch_sai_wrap_ut::setIcmpSaiHookMetadataNotEnum);
         IcmpOrch icmpOrch(m_app_db.get(), APP_ICMP_ECHO_SESSION_TABLE_NAME,
                 TableConnector(m_state_db.get(), STATE_ICMP_ECHO_SESSION_TABLE_NAME));
         IcmpSaiSessionHandler h(icmpOrch);
         ASSERT_EQ(h.init(sai_icmp_echo_api, "default:default:5000:NORMAL"), SaiOffloadHandlerStatus::SUCCESS_VALID_ENTRY);
-        EXPECT_EQ(h.create(makeMinimalIcmpSessionFvs()), SaiOffloadHandlerStatus::FAILED_VALID_ENTRY);
+        EXPECT_EQ(h.create(makeMinimalIcmpSessionFvs()), SaiOffloadHandlerStatus::SUCCESS_VALID_ENTRY);
     }
 
     /**
-     *   if (status != SAI_STATUS_SUCCESS) { SWSS_LOG_ERROR("sai_query_attribute_enum_values_capability ..."); }
+     * resolve_stats_count_mode: sai_query_attribute_enum_values_capability fails false;
      */
-    TEST_F(IcmpOrchStatsCountModeTest, DoCreate_failsWhenQueryAttributeEnumValuesCapabilityFails)
+    TEST_F(IcmpOrchStatsCountModeTest, DoCreate_continuesWhenQueryAttributeEnumValuesCapabilityFails)
     {
         icmporch_sai_wrap_ut::IcmpSaiHookGuard g(icmporch_sai_wrap_ut::setIcmpSaiHookQueryEnumFail);
         IcmpOrch icmpOrch(m_app_db.get(), APP_ICMP_ECHO_SESSION_TABLE_NAME,
                 TableConnector(m_state_db.get(), STATE_ICMP_ECHO_SESSION_TABLE_NAME));
         IcmpSaiSessionHandler h(icmpOrch);
         ASSERT_EQ(h.init(sai_icmp_echo_api, "default:default:5000:NORMAL"), SaiOffloadHandlerStatus::SUCCESS_VALID_ENTRY);
-        EXPECT_EQ(h.create(makeMinimalIcmpSessionFvs()), SaiOffloadHandlerStatus::FAILED_VALID_ENTRY);
+        EXPECT_EQ(h.create(makeMinimalIcmpSessionFvs()), SaiOffloadHandlerStatus::SUCCESS_VALID_ENTRY);
     }
 
     /**
-     *   else { SWSS_LOG_ERROR("No supported stats count mode found"); return FAILED_VALID_ENTRY; }
-     * when SAI reports a mode that is neither PACKET_AND_BYTE nor PACKET (e.g. BYTE only).
+     * resolve_stats_count_mode: sai_query_attribute_enum_values_capability success with an empty list.
      */
-    TEST_F(IcmpOrchStatsCountModeTest, DoCreate_failsWhenNoPacketStatsCountModeSupported)
+    TEST_F(IcmpOrchStatsCountModeTest, DoCreate_continuesWhenCapabilityEnumListEmpty)
     {
-        icmporch_sai_wrap_ut::IcmpSaiHookGuard g(icmporch_sai_wrap_ut::setIcmpSaiHookQueryEnumByteOnlyNoPacketModes);
+        icmporch_sai_wrap_ut::IcmpSaiHookGuard g(icmporch_sai_wrap_ut::setIcmpSaiHookQueryEnumEmptyList);
         IcmpOrch icmpOrch(m_app_db.get(), APP_ICMP_ECHO_SESSION_TABLE_NAME,
                 TableConnector(m_state_db.get(), STATE_ICMP_ECHO_SESSION_TABLE_NAME));
         IcmpSaiSessionHandler h(icmpOrch);
         ASSERT_EQ(h.init(sai_icmp_echo_api, "default:default:5000:NORMAL"), SaiOffloadHandlerStatus::SUCCESS_VALID_ENTRY);
-        EXPECT_EQ(h.create(makeMinimalIcmpSessionFvs()), SaiOffloadHandlerStatus::FAILED_VALID_ENTRY);
+        EXPECT_EQ(h.create(makeMinimalIcmpSessionFvs()), SaiOffloadHandlerStatus::SUCCESS_VALID_ENTRY);
     }
 
     /**
-     *   else if (values.list[i] == SAI_STATS_COUNT_MODE_PACKET) { val.s32 = SAI_STATS_COUNT_MODE_PACKET; ... }
-     * PACKET is supported but not PACKET_AND_BYTE; do_create should still succeed and session creation may proceed.
+     * resolve_stats_count_mode: capability includes PACKET_AND_BYTE (first entry in preferred modes) and create succeeds.
      */
-    TEST_F(IcmpOrchStatsCountModeTest, DoCreate_acceptsPacketOnlyWhenPacketAndByteNotReported)
+    TEST_F(IcmpOrchStatsCountModeTest, DoCreate_resolvesPacketAndByteWhenReported)
     {
-        icmporch_sai_wrap_ut::IcmpSaiHookGuard g(icmporch_sai_wrap_ut::setIcmpSaiHookQueryEnumPacketOnly);
+        icmporch_sai_wrap_ut::IcmpSaiHookGuard g(
+                icmporch_sai_wrap_ut::setIcmpSaiHookQueryEnumPacketAndByteOnly);
         IcmpOrch icmpOrch(m_app_db.get(), APP_ICMP_ECHO_SESSION_TABLE_NAME,
                 TableConnector(m_state_db.get(), STATE_ICMP_ECHO_SESSION_TABLE_NAME));
         IcmpSaiSessionHandler h(icmpOrch);
-        ASSERT_EQ(h.init(sai_icmp_echo_api, "default:default:5000:NORMAL"), SaiOffloadHandlerStatus::SUCCESS_VALID_ENTRY);
+        ASSERT_EQ(h.init(sai_icmp_echo_api, "default:default:5000:NORMAL"),
+                SaiOffloadHandlerStatus::SUCCESS_VALID_ENTRY);
         EXPECT_EQ(h.create(makeMinimalIcmpSessionFvs()), SaiOffloadHandlerStatus::SUCCESS_VALID_ENTRY);
     }
 } // namespace icmporch_test

--- a/tests/mock_tests/mock_orchagent_main.h
+++ b/tests/mock_tests/mock_orchagent_main.h
@@ -124,3 +124,4 @@ extern sai_dash_meter_api_t* sai_dash_meter_api;
 extern sai_dash_tunnel_api_t* sai_dash_tunnel_api;
 extern sai_dash_outbound_port_map_api_t* sai_dash_outbound_port_map_api;
 extern sai_dash_trusted_vni_api_t* sai_dash_trusted_vni_api;
+extern sai_icmp_echo_api_t* sai_icmp_echo_api;

--- a/tests/mock_tests/ut_saihelper.cpp
+++ b/tests/mock_tests/ut_saihelper.cpp
@@ -1,6 +1,10 @@
 #include "ut_helper.h"
 #include "mock_orchagent_main.h"
 
+#include <saiicmpecho.h>
+
+extern sai_icmp_echo_api_t* sai_icmp_echo_api;
+
 namespace ut_helper
 {
     map<string, string> gProfileMap;
@@ -90,6 +94,7 @@ namespace ut_helper
         sai_api_query(SAI_API_MPLS, (void**)&sai_mpls_api);
         sai_api_query(SAI_API_COUNTER, (void**)&sai_counter_api);
         sai_api_query(SAI_API_FDB, (void**)&sai_fdb_api);
+        sai_api_query(SAI_API_ICMP_ECHO, (void**)&sai_icmp_echo_api);
         sai_api_query(SAI_API_TWAMP, (void**)&sai_twamp_api);
         sai_api_query(SAI_API_TAM, (void**)&sai_tam_api);
         sai_api_query((sai_api_t)SAI_API_DASH_VIP, (void**)&sai_dash_vip_api);
@@ -137,6 +142,7 @@ namespace ut_helper
         sai_buffer_api = nullptr;
         sai_queue_api = nullptr;
         sai_counter_api = nullptr;
+        sai_icmp_echo_api = nullptr;
         sai_twamp_api = nullptr;
         sai_tam_api = nullptr;
         sai_dash_vip_api = nullptr;

--- a/tests/mock_tests/ut_saihelper.cpp
+++ b/tests/mock_tests/ut_saihelper.cpp
@@ -3,8 +3,6 @@
 
 #include <saiicmpecho.h>
 
-extern sai_icmp_echo_api_t* sai_icmp_echo_api;
-
 namespace ut_helper
 {
     map<string, string> gProfileMap;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
Depend on PR: https://github.com/sonic-net/sonic-sairedis/pull/1756 
It should fix PR failure

**What I did**
use query attribute capability for stats mode and set an explicitly supported value.
If stats mode is not set or not supported then log WARN messages and rely on internal SAI logic during session creation

**Why I did it**
need to check if some SAI capabilities are supported before using them.
Currently there are few possible stats count mode:
- SAI_STATS_COUNT_MODE_PACKET_AND_BYTE,
- SAI_STATS_COUNT_MODE_PACKET
- SAI_STATS_COUNT_MODE_BYTE
- SAI_STATS_COUNT_MODE_NONE

Preffered mode: 
1) PACKET_AND_BYTE,  2) PACKET only,  3)BYTE only,  4) none

**How I verified it**
UT test added 

**Details if related**
