### PR TITLE
Fine Grained ECMP for Vnet Tunnel Routes

### DIFF
--- a/orchagent/fgnhgorch.cpp
+++ b/orchagent/fgnhgorch.cpp
@@ -6,6 +6,8 @@
 #include "logger.h"
 #include "swssnet.h"
 #include "crmorch.h"
+#include "directory.h"
+#include "vnetorch.h"
 #include <array>
 #include <algorithm>
 
@@ -15,9 +17,11 @@
 extern sai_object_id_t gVirtualRouterId;
 extern sai_object_id_t gSwitchId;
 
+extern sai_switch_api_t*            sai_switch_api;
 extern sai_next_hop_group_api_t*    sai_next_hop_group_api;
 extern sai_route_api_t*             sai_route_api;
 
+extern Directory<Orch*> gDirectory;
 extern RouteOrch *gRouteOrch;
 extern CrmOrch *gCrmOrch;
 extern PortsOrch *gPortsOrch;
@@ -213,22 +217,30 @@ void FgNhgOrch::calculateBankHashBucketStartIndices(FgNhgEntry *fgNhgEntry)
 }
 
 
-void FgNhgOrch::setStateDbRouteEntry(const IpPrefix &ipPrefix, uint32_t index, NextHopKey nextHop)
+string FgNhgOrch::getWarmRebootStateDbKey(const string &vnet, const IpPrefix &ipPrefix)
+{
+    if (vnet.empty())
+    {
+        return ipPrefix.to_string();
+    }
+    return vnet + state_db_key_delimiter + ipPrefix.to_string();
+}
+
+void FgNhgOrch::setStateDbRouteEntry(const string &key, uint32_t index, NextHopKey nextHop)
 {
     SWSS_LOG_ENTER();
 
-    string key = ipPrefix.to_string();
     string field = std::to_string(index);
     string value = nextHop.to_string();
 
     m_stateWarmRestartRouteTable.hset(key, field, value);
 
-    SWSS_LOG_INFO("Set state db entry for ip prefix %s next hop %s with index %d",
+    SWSS_LOG_INFO("Set state db entry for key %s next hop %s with index %d",
                   key.c_str(), value.c_str(), index);
 }
 
 bool FgNhgOrch::writeHashBucketChange(FGNextHopGroupEntry *syncd_fg_route_entry, HashBucketIdx index, sai_object_id_t nh_oid,
-        const IpPrefix &ipPrefix, NextHopKey nextHop)
+        const string &key, NextHopKey nextHop)
 {
     SWSS_LOG_ENTER();
 
@@ -249,7 +261,59 @@ bool FgNhgOrch::writeHashBucketChange(FGNextHopGroupEntry *syncd_fg_route_entry,
         }
     }
 
-    setStateDbRouteEntry(ipPrefix, index, nextHop);
+    setStateDbRouteEntry(key, index, nextHop);
+    return true;
+}
+
+bool FgNhgOrch::getMaxEcmpMemberCount(uint32_t &maxEcmpMembers)
+{
+    SWSS_LOG_ENTER();
+
+    sai_attribute_t switch_attr;
+    switch_attr.id = SAI_SWITCH_ATTR_MAX_ECMP_MEMBER_COUNT;
+    switch_attr.value.u32 = 0;
+
+    sai_status_t status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &switch_attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_WARN("Failed to query SAI_SWITCH_ATTR_MAX_ECMP_MEMBER_COUNT, rv:%d", status);
+        return false;
+    }
+
+    maxEcmpMembers = switch_attr.value.u32;
+    return true;
+}
+
+bool FgNhgOrch::getEffectiveFgNhgMemberCapacity(uint32_t configuredBucketSize, uint32_t &memberCapacity)
+{
+    SWSS_LOG_ENTER();
+
+    memberCapacity = configuredBucketSize;
+
+    uint32_t hw_max_ecmp_members = 0;
+    if (!getMaxEcmpMemberCount(hw_max_ecmp_members))
+    {
+        return false;
+    }
+
+    memberCapacity = min(memberCapacity, hw_max_ecmp_members);
+    return true;
+}
+
+bool FgNhgOrch::validateFgNhgMemberCount(size_t memberCount, uint32_t configuredBucketSize, const string &logKey)
+{
+    SWSS_LOG_ENTER();
+
+    uint32_t member_capacity = 0;
+    getEffectiveFgNhgMemberCapacity(configuredBucketSize, member_capacity);
+
+    if (memberCount > member_capacity)
+    {
+        SWSS_LOG_ERROR("Number of next-hops %zu exceeds effective FG NHG member capacity %u for %s",
+                       memberCount, member_capacity, logKey.c_str());
+        return false;
+    }
+
     return true;
 }
 
@@ -261,6 +325,30 @@ bool FgNhgOrch::createFineGrainedNextHopGroup(FGNextHopGroupEntry &syncd_fg_rout
     string platform = getenv("platform") ? getenv("platform") : "";
     sai_attribute_t nhg_attr;
     vector<sai_attribute_t> nhg_attrs;
+
+    /* Query hardware maximum ECMP member count */
+    uint32_t effective_member_capacity = 0;
+    bool hw_limit_available = getEffectiveFgNhgMemberCapacity(fgNhgEntry->configured_bucket_size,
+                                                              effective_member_capacity);
+    
+    if (!hw_limit_available)
+    {
+        SWSS_LOG_WARN("Unable to verify hardware ECMP member limit. Proceeding with configured bucket size %d",
+                      fgNhgEntry->configured_bucket_size);
+    }
+    else
+    {
+        SWSS_LOG_INFO("Effective FG NHG member capacity: %d, Configured bucket size: %d",
+                      effective_member_capacity, fgNhgEntry->configured_bucket_size);
+        
+        /* If configured bucket size exceeds hardware maximum, adjust it */
+        if (fgNhgEntry->configured_bucket_size > effective_member_capacity)
+        {
+            SWSS_LOG_WARN("Configured bucket size %d exceeds effective FG NHG member capacity %d. Adjusting bucket size.",
+                          fgNhgEntry->configured_bucket_size, effective_member_capacity);
+            fgNhgEntry->configured_bucket_size = effective_member_capacity;
+        }
+    }
 
     nhg_attr.id = SAI_NEXT_HOP_GROUP_ATTR_TYPE;
     nhg_attr.value.s32 = SAI_NEXT_HOP_GROUP_TYPE_FINE_GRAIN_ECMP;
@@ -440,6 +528,10 @@ bool FgNhgOrch::validNextHopInNextHopGroup(const NextHopKey& nexthop)
                     nhs_to_add.push_back(nexthop);
             nhopgroup_members_set[nexthop] = m_neighOrch->getNextHopId(nexthop);
 
+            string vnet;
+            getVnetNameByVrfId(route_tables.first, vnet);
+            string key = getWarmRebootStateDbKey(vnet, route_table.first);
+
             if (syncd_fg_route_entry->points_to_rif)
             {
                 // RIF route is now neigh resolved: create Fine Grained ECMP
@@ -448,7 +540,7 @@ bool FgNhgOrch::validNextHopInNextHopGroup(const NextHopKey& nexthop)
                     return false;
                 }
 
-                if (!setNewNhgMembers(*syncd_fg_route_entry, fgNhgEntry, bank_member_changes, nhopgroup_members_set, route_table.first))
+                if (!setNewNhgMembers(*syncd_fg_route_entry, fgNhgEntry, bank_member_changes, nhopgroup_members_set, key))
                 {
                     return false;
                 }
@@ -468,7 +560,7 @@ bool FgNhgOrch::validNextHopInNextHopGroup(const NextHopKey& nexthop)
                 }
 
                 if (!computeAndSetHashBucketChanges(syncd_fg_route_entry, fgNhgEntry,
-                        bank_member_changes, nhopgroup_members_set, route_table.first))
+                        bank_member_changes, nhopgroup_members_set, key, route_table.first))
                 {
                     SWSS_LOG_ERROR("Failed to set fine grained next hop %s",
                         nexthop.to_string().c_str());
@@ -546,8 +638,12 @@ bool FgNhgOrch::invalidNextHopInNextHopGroup(const NextHopKey& nexthop)
             bank_member_changes[fgNhgEntry->next_hops[nexthop.ip_address].bank].
                     nhs_to_del.push_back(nexthop);
 
+            string vnet;
+            getVnetNameByVrfId(route_tables.first, vnet);
+            string key = getWarmRebootStateDbKey(vnet, route_table.first);
+
             if (!computeAndSetHashBucketChanges(syncd_fg_route_entry, fgNhgEntry,
-                    bank_member_changes, nhopgroup_members_set, route_table.first))
+                    bank_member_changes, nhopgroup_members_set, key, route_table.first))
             {
                 SWSS_LOG_ERROR("Failed to set fine grained next hop %s",
                     nexthop.to_string().c_str());
@@ -577,7 +673,7 @@ bool FgNhgOrch::invalidNextHopInNextHopGroup(const NextHopKey& nexthop)
  */
 bool FgNhgOrch::setActiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
         uint32_t syncd_bank, BankMemberChanges bank_member_change,
-        std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const IpPrefix &ipPrefix)
+        std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const string &key)
 {
     SWSS_LOG_ENTER();
 
@@ -595,7 +691,7 @@ bool FgNhgOrch::setActiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_rou
         {
             if (!writeHashBucketChange(syncd_fg_route_entry, hash_buckets->at(i),
                         nhopgroup_members_set[bank_member_change.nhs_to_add[add_idx]],
-                        ipPrefix, bank_member_change.nhs_to_add[add_idx]))
+                        key, bank_member_change.nhs_to_add[add_idx]))
             {
                 return false;
             }
@@ -643,7 +739,7 @@ bool FgNhgOrch::setActiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_rou
                     {
                         // this can neven happen
                         SWSS_LOG_ERROR("%s Unexpected no more active NHs before adding the %zu buckets, exp_bucket_size(%d)",
-                                       ipPrefix.to_string().c_str(),
+                                       key.c_str(),
                                        hash_buckets->size(), exp_bucket_size);
                         return false;
                     }
@@ -654,7 +750,19 @@ bool FgNhgOrch::setActiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_rou
                  * other available nhs, but for cases where # hash buckets is not
                  * divisible by # of nhs, simple round robin can make the hash bucket
                  * distribution non-ideal, thereby nhs can attract unequal traffic */
-                if (bank_fgnhg_map->at(*it).size() == exp_bucket_size)
+                if (bank_fgnhg_map->at(*it).size() > exp_bucket_size)
+                {
+                    // NH already has more than its fair share from a prior redistribution 
+                    if (num_nhs_with_one_more > 0)
+                    {
+                        num_nhs_with_one_more--;
+                    }
+                    SWSS_LOG_INFO("%s already has %zu buckets (> %d), skip assigning more, bkt_idx(%d)",
+                                  (*it).to_string().c_str(), bank_fgnhg_map->at(*it).size(),
+                                  exp_bucket_size, bkt_idx);
+                    remove_nh = true;
+                }
+                else if (bank_fgnhg_map->at(*it).size() == exp_bucket_size)
                 {
                     if (num_nhs_with_one_more == 0)
                     {
@@ -682,7 +790,7 @@ bool FgNhgOrch::setActiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_rou
                 if (move_bkt)
                 {
                     if (!writeHashBucketChange(syncd_fg_route_entry, hash_buckets->at(bkt_idx),
-                                               nhopgroup_members_set[*it], ipPrefix, *it))
+                                               nhopgroup_members_set[*it], key, *it))
                     {
                         return false;
                     }
@@ -794,7 +902,7 @@ bool FgNhgOrch::setActiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_rou
                     HashBucketIdx last_elem = map_entry->at((*map_entry).size() - 1);
                     if (!writeHashBucketChange(syncd_fg_route_entry, last_elem,
                                                nhopgroup_members_set[bank_member_change.nhs_to_add[add_idx]],
-                                               ipPrefix, bank_member_change.nhs_to_add[add_idx]))
+                                               key, bank_member_change.nhs_to_add[add_idx]))
                     {
                         return false;
                     }
@@ -822,7 +930,7 @@ bool FgNhgOrch::setActiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_rou
 
 bool FgNhgOrch::setInactiveBankToNextAvailableActiveBank(FGNextHopGroupEntry *syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
         uint32_t bank, std::vector<BankMemberChanges> bank_member_changes,
-        std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const IpPrefix &ipPrefix)
+        std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const string &key, const IpPrefix &ipPrefix)
 {
     SWSS_LOG_ENTER();
 
@@ -848,7 +956,7 @@ bool FgNhgOrch::setInactiveBankToNextAvailableActiveBank(FGNextHopGroupEntry *sy
                          active_nhs[i % bank_member_changes[new_bank_idx].active_nhs.size()];
 
                 if (!writeHashBucketChange(syncd_fg_route_entry, i,
-                    nhopgroup_members_set[bank_nh_memb],ipPrefix, bank_nh_memb ))
+                    nhopgroup_members_set[bank_nh_memb], key, bank_nh_memb ))
                 {
                     return false;
                 }
@@ -894,7 +1002,7 @@ bool FgNhgOrch::setInactiveBankToNextAvailableActiveBank(FGNextHopGroupEntry *sy
             syncd_fg_route_entry->next_hop_group_id = rif_next_hop_id;
 
             // remove state_db entry
-            m_stateWarmRestartRouteTable.del(ipPrefix.to_string());
+            m_stateWarmRestartRouteTable.del(key);
             // Clear data structures
             syncd_fg_route_entry->syncd_fgnhg_map.clear();
             syncd_fg_route_entry->active_nexthops.clear();
@@ -920,7 +1028,7 @@ bool FgNhgOrch::setInactiveBankToNextAvailableActiveBank(FGNextHopGroupEntry *sy
  */
 bool FgNhgOrch::setInactiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
         uint32_t bank,std::vector<BankMemberChanges> &bank_member_changes,
-        std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const IpPrefix &ipPrefix)
+        std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const string &key, const IpPrefix &ipPrefix)
 {
     SWSS_LOG_ENTER();
 
@@ -936,7 +1044,7 @@ bool FgNhgOrch::setInactiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_r
                 nhs_to_add[i % bank_member_changes[bank].nhs_to_add.size()];
 
             if (!writeHashBucketChange(syncd_fg_route_entry, i,
-                  nhopgroup_members_set[bank_nh_memb], ipPrefix, bank_nh_memb))
+                  nhopgroup_members_set[bank_nh_memb], key, bank_nh_memb))
             {
                 return false;
             }
@@ -954,7 +1062,7 @@ bool FgNhgOrch::setInactiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_r
         /* Previously active bank now transitions to inactive */
         SWSS_LOG_INFO("Previously active bank now transitions to inactive bank %u", bank);
         if (!setInactiveBankToNextAvailableActiveBank(syncd_fg_route_entry, fgNhgEntry,
-                    bank, bank_member_changes, nhopgroup_members_set, ipPrefix))
+                    bank, bank_member_changes, nhopgroup_members_set, key, ipPrefix))
         {
             SWSS_LOG_INFO("Failed to map to active_bank and set nh in SAI");
             return false;
@@ -976,7 +1084,7 @@ bool FgNhgOrch::setInactiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_r
         if (bank_member_changes[active_bank].active_nhs.size() == 0)
         {
             if (!setInactiveBankToNextAvailableActiveBank(syncd_fg_route_entry, fgNhgEntry,
-                        bank, bank_member_changes, nhopgroup_members_set, ipPrefix))
+                        bank, bank_member_changes, nhopgroup_members_set, key, ipPrefix))
             {
                 return false;
             }
@@ -984,7 +1092,7 @@ bool FgNhgOrch::setInactiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_r
         else
         {
             if (!setActiveBankHashBucketChanges(syncd_fg_route_entry, fgNhgEntry,
-                bank, bank_member_changes[active_bank], nhopgroup_members_set, ipPrefix))
+                bank, bank_member_changes[active_bank], nhopgroup_members_set, key))
             {
                 return false;
             }
@@ -997,7 +1105,7 @@ bool FgNhgOrch::setInactiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_r
 bool FgNhgOrch::computeAndSetHashBucketChanges(FGNextHopGroupEntry *syncd_fg_route_entry,
         FgNhgEntry *fgNhgEntry, std::vector<BankMemberChanges> &bank_member_changes,
         std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set,
-        const IpPrefix &ipPrefix)
+        const string &key, const IpPrefix &ipPrefix)
 {
     SWSS_LOG_ENTER();
 
@@ -1014,7 +1122,7 @@ bool FgNhgOrch::computeAndSetHashBucketChanges(FGNextHopGroupEntry *syncd_fg_rou
              * Route this to fn which deals with active banks
              */
             if (!setActiveBankHashBucketChanges(syncd_fg_route_entry, fgNhgEntry,
-                        bank_idx, bank_member_changes[bank_idx], nhopgroup_members_set, ipPrefix))
+                        bank_idx, bank_member_changes[bank_idx], nhopgroup_members_set, key))
             {
                 return false;
             }
@@ -1022,7 +1130,7 @@ bool FgNhgOrch::computeAndSetHashBucketChanges(FGNextHopGroupEntry *syncd_fg_rou
         else
         {
             if (!setInactiveBankHashBucketChanges(syncd_fg_route_entry, fgNhgEntry,
-                        bank_idx, bank_member_changes, nhopgroup_members_set, ipPrefix))
+                        bank_idx, bank_member_changes, nhopgroup_members_set, key, ipPrefix))
             {
                 return false;
             }
@@ -1035,7 +1143,7 @@ bool FgNhgOrch::computeAndSetHashBucketChanges(FGNextHopGroupEntry *syncd_fg_rou
 
 bool FgNhgOrch::setNewNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
         std::vector<BankMemberChanges> &bank_member_changes, std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set,
-        const IpPrefix &ipPrefix)
+        const string &key)
 {
     SWSS_LOG_ENTER();
 
@@ -1074,7 +1182,7 @@ bool FgNhgOrch::setNewNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, FgNh
     for (auto active_bank : active_banks)
     {
         syncd_fg_route_entry.inactive_to_active_map[active_bank] = active_bank;
-        if (!sprayBankNhgMembers(syncd_fg_route_entry, ipPrefix,
+        if (!sprayBankNhgMembers(syncd_fg_route_entry, key,
                 fgNhgEntry->hash_bucket_indices[active_bank], fgNhgEntry,
                 active_bank, bank_member_changes[active_bank],
                 nhopgroup_members_set))
@@ -1089,18 +1197,18 @@ bool FgNhgOrch::setNewNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, FgNh
         auto active_bank = active_banks[i % active_banks.size()];
         syncd_fg_route_entry.inactive_to_active_map[inactive_banks[i]] =
             active_bank;
-        if(!sprayBankNhgMembers(syncd_fg_route_entry, ipPrefix,
+        if(!sprayBankNhgMembers(syncd_fg_route_entry, key,
                 fgNhgEntry->hash_bucket_indices[inactive_banks[i]], fgNhgEntry,
                 inactive_banks[i], bank_member_changes[active_bank],
                 nhopgroup_members_set))
         {
             return false;
         }
-        SWSS_LOG_NOTICE("Bank# %d of FG next-hops is down for prefix %s",
-                inactive_banks[i], ipPrefix.to_string().c_str());
+        SWSS_LOG_NOTICE("Bank# %d of FG next-hops is down for key %s",
+                inactive_banks[i], key.c_str());
     }
 
-    auto nexthopsMap = m_recoveryMap.find(ipPrefix.to_string());
+    auto nexthopsMap = m_recoveryMap.find(key);
     if (nexthopsMap != m_recoveryMap.end()) {
         m_recoveryMap.erase(nexthopsMap);
     }
@@ -1110,14 +1218,13 @@ bool FgNhgOrch::setNewNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, FgNh
     return true;
 }
 
-bool FgNhgOrch::sprayBankNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, const IpPrefix &ipPrefix,
-        BankIndexRange hash_idx_range, FgNhgEntry *fgNhgEntry,
+bool FgNhgOrch::sprayBankNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, const string &key, BankIndexRange hash_idx_range, FgNhgEntry *fgNhgEntry,
         uint32_t bank, BankMemberChanges &bank_member_change,
         std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set)
 {
     sai_status_t status;
     bool isWarmReboot = false;
-    auto nexthopsMap = m_recoveryMap.find(ipPrefix.to_string());
+    auto nexthopsMap = m_recoveryMap.find(key);
 
     SWSS_LOG_ENTER();
 
@@ -1139,9 +1246,10 @@ bool FgNhgOrch::sprayBankNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, c
             nh_memb_key = nexthopsMap->second[bucket_idx];
             SWSS_LOG_INFO("Recovering nexthop %s with bucket_idx %d", nh_memb_key.ip_address.to_string().c_str(), bucket_idx);
             // case nhps in bank are all down
-            if (fgNhgEntry->next_hops[nh_memb_key.ip_address].bank != bank)
+            auto ip_bank = fgNhgEntry->match_mode == FGMatchMode::PREFIX_BASED ? 0 : fgNhgEntry->next_hops[nh_memb_key.ip_address].bank;
+            if (ip_bank != bank)
             {
-                syncd_fg_route_entry.inactive_to_active_map[bank] = fgNhgEntry->next_hops[nh_memb_key.ip_address].bank;
+                syncd_fg_route_entry.inactive_to_active_map[bank] = ip_bank;
             }
         }
         else
@@ -1187,7 +1295,7 @@ bool FgNhgOrch::sprayBankNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, c
             }
         }
 
-        setStateDbRouteEntry(ipPrefix, bucket_idx, nh_memb_key);
+        setStateDbRouteEntry(key, bucket_idx, nh_memb_key);
         syncd_fg_route_entry.syncd_fgnhg_map[bank][nh_memb_key].push_back(bucket_idx);
         syncd_fg_route_entry.active_nexthops.insert(nh_memb_key);
         syncd_fg_route_entry.nhopgroup_members[bucket_idx] = next_hop_group_member_id;
@@ -1204,8 +1312,8 @@ bool FgNhgOrch::isRouteFineGrained(sai_object_id_t vrf_id, const IpPrefix &ipPre
 
     if (!isFineGrainedConfigured || (vrf_id != gVirtualRouterId))
     {
-        SWSS_LOG_DEBUG("Route %s:%s vrf %" PRIx64 " default_vrf %" PRIx64 " NOT fine grained ECMP",
-                        ipPrefix.to_string().c_str(), nextHops.to_string().c_str(), vrf_id, gVirtualRouterId);
+        SWSS_LOG_DEBUG("Route %s:%s vrf %" PRIx64 " NOT fine grained ECMP",
+                        ipPrefix.to_string().c_str(), nextHops.to_string().c_str(), vrf_id);
         return false;
     }
 
@@ -1253,7 +1361,7 @@ bool FgNhgOrch::isRouteFineGrained(sai_object_id_t vrf_id, const IpPrefix &ipPre
 
 bool FgNhgOrch::syncdContainsFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix)
 {
-    if (!isFineGrainedConfigured || (vrf_id != gVirtualRouterId))
+    if (!isFineGrainedConfigured)
     {
         return false;
     }
@@ -1460,6 +1568,17 @@ bool FgNhgOrch::setFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix, const
         nhopgroup_members_set[nhk] = nhid;
     }
 
+    std::string vnet;
+    getVnetNameByVrfId(vrf_id, vnet);
+    string key = getWarmRebootStateDbKey(vnet, ipPrefix);
+
+    /* Defensive sanity check before SAI programming. Invalid config should be rejected earlier. */
+    if (!validateFgNhgMemberCount(nhopgroup_members_set.size(), fgNhgEntry->configured_bucket_size,
+                                  ipPrefix.to_string()))
+    {
+        return false;
+    }
+
     if (syncd_fg_route_entry_it != m_syncdFGRouteTables.at(vrf_id).end())
     {
         /* Route exists and nh was associated in the past */
@@ -1475,7 +1594,7 @@ bool FgNhgOrch::setFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix, const
                     return false;
                 }
 
-                if (!setNewNhgMembers(*syncd_fg_route_entry, fgNhgEntry, bank_member_changes, nhopgroup_members_set, ipPrefix))
+                if (!setNewNhgMembers(*syncd_fg_route_entry, fgNhgEntry, bank_member_changes, nhopgroup_members_set, key))
                 {
                     return false;
                 }
@@ -1499,7 +1618,7 @@ bool FgNhgOrch::setFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix, const
             }
 
             if (!computeAndSetHashBucketChanges(syncd_fg_route_entry, fgNhgEntry, bank_member_changes,
-                    nhopgroup_members_set, ipPrefix))
+                    nhopgroup_members_set, key, ipPrefix))
             {
                 return false;
             }
@@ -1517,7 +1636,7 @@ bool FgNhgOrch::setFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix, const
                 return false;
             }
 
-            if (!setNewNhgMembers(syncd_fg_route_entry, fgNhgEntry, bank_member_changes, nhopgroup_members_set, ipPrefix))
+            if (!setNewNhgMembers(syncd_fg_route_entry, fgNhgEntry, bank_member_changes, nhopgroup_members_set, key))
             {
                 return false;
             }
@@ -1561,6 +1680,143 @@ bool FgNhgOrch::setFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix, const
     return true;
 }
 
+bool FgNhgOrch::setFgNhgTunnel(sai_object_id_t vrf_id, const IpPrefix &ipPrefix,
+                        map<NextHopKey, sai_object_id_t>& nhopgroup_members_set, NextHopGroupKey& nextHops, uint16_t consistent_hashing_buckets,
+                        sai_object_id_t &next_hop_id, bool &isNextHopIdChanged)
+{
+    SWSS_LOG_ENTER();
+
+    /* default isNextHopIdChanged to false so that sai route is unaffected
+     * when we return early with success */
+    isNextHopIdChanged = false;
+
+    FGMatchMode match_mode = FGMatchMode::PREFIX_BASED;
+    uint32_t max_next_hops = consistent_hashing_buckets;
+    uint32_t bucket_size = consistent_hashing_buckets;
+    std::string fg_nhg_name = "FG_NHG_" + std::to_string(vrf_id) + "_" + ipPrefix.to_string();
+
+    std::string vnet;
+    getVnetNameByVrfId(vrf_id, vnet);
+    string key = getWarmRebootStateDbKey(vnet, ipPrefix);
+
+    if (bucket_size < 1)
+    {
+        SWSS_LOG_ERROR("Received bucket_size which is < 1 for key %s",
+                fg_nhg_name.c_str());
+        return true;
+    }
+
+    if (!validateFgNhgMemberCount(nhopgroup_members_set.size(), bucket_size, fg_nhg_name))
+    {
+        return false;
+    }
+
+    FgNhgEntry fgNhgEntry;
+    fgNhgEntry.configured_bucket_size = bucket_size;
+    fgNhgEntry.fg_nhg_name = fg_nhg_name;
+    fgNhgEntry.match_mode = match_mode;
+    fgNhgEntry.max_next_hops = max_next_hops;
+    SWSS_LOG_NOTICE("Added new FG_NHG entry %s with bucket_size %d, match_mode: %'" PRIu8,
+            fg_nhg_name.c_str(), bucket_size, match_mode);
+    isFineGrainedConfigured = true;
+    
+    if (m_FgNhgs.find(fg_nhg_name) == m_FgNhgs.end())
+    {
+        m_FgNhgs[fg_nhg_name] = fgNhgEntry;
+        m_FgNhgs[fg_nhg_name].prefixes.push_back(ipPrefix);
+    }
+
+    if (m_syncdFGRouteTables.find(vrf_id) != m_syncdFGRouteTables.end() &&
+        m_syncdFGRouteTables.at(vrf_id).find(ipPrefix) != m_syncdFGRouteTables.at(vrf_id).end() &&
+        m_syncdFGRouteTables.at(vrf_id).at(ipPrefix).nhg_key == nextHops)
+    {
+        return true;
+    }
+
+    if (m_syncdFGRouteTables.find(vrf_id) == m_syncdFGRouteTables.end())
+    {
+        m_syncdFGRouteTables.emplace(vrf_id, FGRouteTable());
+        m_vrfOrch->increaseVrfRefCount(vrf_id);
+    }
+
+    auto syncd_fg_route_entry_it = m_syncdFGRouteTables.at(vrf_id).find(ipPrefix);
+    bool next_hop_to_add = false;
+
+    /* Default init with # of banks */
+    std::vector<BankMemberChanges> bank_member_changes(1, BankMemberChanges()); // prefix_based match_mode supports single bank
+
+    /* initialize m_FgNhgs[fg_nhg_name].next_hops with the list of IP addresses in nextHops
+    and add the corresponding next_hop_id to next_hop_ids. */
+    for (const auto& member : nhopgroup_members_set)
+    {
+        const NextHopKey& nhk = member.first;
+
+        if (syncd_fg_route_entry_it == m_syncdFGRouteTables.at(vrf_id).end())
+        {
+            bank_member_changes[0].nhs_to_add.push_back(nhk);
+            next_hop_to_add = true;
+        }
+        else
+        {
+            FGNextHopGroupEntry *syncd_fg_route_entry = &(syncd_fg_route_entry_it->second);
+            if (syncd_fg_route_entry->active_nexthops.find(nhk) ==
+                syncd_fg_route_entry->active_nexthops.end())
+            {
+                bank_member_changes[0].nhs_to_add.push_back(nhk);
+                next_hop_to_add = true;
+            }
+        }
+    }
+
+    if (syncd_fg_route_entry_it != m_syncdFGRouteTables.at(vrf_id).end())
+    {
+        /* Route exists and nh was associated in the past */
+        FGNextHopGroupEntry *syncd_fg_route_entry = &(syncd_fg_route_entry_it->second);
+
+        /* Update FG ECMP group in SAI */
+        for (auto nhk : syncd_fg_route_entry->active_nexthops)
+        {
+            if (nhopgroup_members_set.find(nhk) == nhopgroup_members_set.end())
+            {
+                bank_member_changes[0].nhs_to_del.push_back(nhk);
+            }
+            else
+            {
+                bank_member_changes[0].active_nhs.push_back(nhk);
+            }
+        }
+
+        if (!computeAndSetHashBucketChanges(syncd_fg_route_entry, &m_FgNhgs[fg_nhg_name], bank_member_changes,
+                nhopgroup_members_set, key, ipPrefix))
+        {
+            return false;
+        }
+    }
+    else
+    {
+        /* New route + nhg addition */
+        isNextHopIdChanged = true;
+        FGNextHopGroupEntry syncd_fg_route_entry;
+        if (next_hop_to_add)
+        {
+            if (!createFineGrainedNextHopGroup(syncd_fg_route_entry, &m_FgNhgs[fg_nhg_name], nextHops))
+            {
+                return false;
+            }
+
+            if (!setNewNhgMembers(syncd_fg_route_entry, &m_FgNhgs[fg_nhg_name], bank_member_changes, nhopgroup_members_set, key))
+            {
+                return false;
+            }
+        }
+        m_syncdFGRouteTables[vrf_id][ipPrefix] = syncd_fg_route_entry;
+    }
+
+    m_syncdFGRouteTables[vrf_id][ipPrefix].nhg_key = nextHops;
+    next_hop_id =  m_syncdFGRouteTables[vrf_id][ipPrefix].next_hop_group_id;
+
+    return true;
+}
 
 bool FgNhgOrch::removeFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix)
 {
@@ -1602,7 +1858,10 @@ bool FgNhgOrch::removeFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix)
         }
 
         // remove state_db entry
-        m_stateWarmRestartRouteTable.del(ipPrefix.to_string());
+        string vnet;
+        getVnetNameByVrfId(vrf_id, vnet);
+        string key = getWarmRebootStateDbKey(vnet, ipPrefix);
+        m_stateWarmRestartRouteTable.del(key);
     }
 
     it_route_table->second.erase(it_route);
@@ -1617,6 +1876,59 @@ bool FgNhgOrch::removeFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix)
     return true;
 }
 
+bool FgNhgOrch::removeFgNhgTunnel(sai_object_id_t vrf_id, const IpPrefix &ipPrefix)
+{
+    SWSS_LOG_ENTER();
+
+    if (!isFineGrainedConfigured)
+    {
+        return true;
+    }
+
+    auto it_route_table = m_syncdFGRouteTables.find(vrf_id);
+    if (it_route_table == m_syncdFGRouteTables.end())
+    {
+        SWSS_LOG_INFO("No route table found for %s, vrf_id 0x%" PRIx64,
+                ipPrefix.to_string().c_str(), vrf_id);
+        return true;
+    }
+
+    auto it_route = it_route_table->second.find(ipPrefix);
+    if (it_route == it_route_table->second.end())
+    {
+        SWSS_LOG_INFO("Failed to find route entry, vrf_id 0x%" PRIx64 ", prefix %s", vrf_id,
+                ipPrefix.to_string().c_str());
+        return true;
+    }
+
+    FGNextHopGroupEntry *syncd_fg_route_entry = &(it_route->second);
+    if (!removeFineGrainedNextHopGroup(syncd_fg_route_entry))
+    {
+        SWSS_LOG_ERROR("Failed to clean-up fine grained ECMP SAI group");
+        return false;
+    }
+
+    // remove state_db entry
+    string vnet;
+    getVnetNameByVrfId(vrf_id, vnet);
+    string key = getWarmRebootStateDbKey(vnet, ipPrefix);
+    m_stateWarmRestartRouteTable.del(key);
+
+    // remove from m_FgNhgs
+    std::string fg_nhg_name = "FG_NHG_" + std::to_string(vrf_id) + "_" + ipPrefix.to_string();
+    m_FgNhgs.erase(fg_nhg_name);
+
+    it_route_table->second.erase(it_route);
+    if (it_route_table->second.size() == 0)
+    {
+        m_syncdFGRouteTables.erase(vrf_id);
+        m_vrfOrch->decreaseVrfRefCount(vrf_id);
+    }
+    SWSS_LOG_NOTICE("All banks of FG next-hops are down for vrf_id 0x%" PRIx64 ", prefix %s", vrf_id,
+            ipPrefix.to_string().c_str());
+
+    return true;
+}
 
 vector<FieldValueTuple> FgNhgOrch::generateRouteTableFromNhgKey(NextHopGroupKey nhg)
 {
@@ -2161,4 +2473,17 @@ void FgNhgOrch::doTask(Consumer& consumer)
         }
     }
     return;
+}
+
+bool FgNhgOrch::getVnetNameByVrfId(sai_object_id_t vrf_id, std::string& vnet_name)
+{
+    auto *vnet_orch = gDirectory.get<VNetOrch*>();
+    assert(vnet_orch); 
+
+    if (!vnet_orch->getVnetNameByVrfId(vrf_id, vnet_name) && vrf_id == gVirtualRouterId)
+    {
+        vnet_name = "";
+        return false;
+    }
+    return true;
 }

--- a/orchagent/fgnhgorch.h
+++ b/orchagent/fgnhgorch.h
@@ -112,7 +112,9 @@ public:
     bool validNextHopInNextHopGroup(const NextHopKey&);
     bool invalidNextHopInNextHopGroup(const NextHopKey&);
     bool setFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix, const NextHopGroupKey &nextHops, sai_object_id_t &next_hop_id, bool &isNextHopIdChanged);
+    bool setFgNhgTunnel(sai_object_id_t vrf_id, const IpPrefix &ipPrefix, map<NextHopKey, sai_object_id_t>& nhopgroup_members_set, NextHopGroupKey& nextHops, uint16_t consistent_hashing_buckets, sai_object_id_t &next_hop_id, bool &isNextHopIdChanged);
     bool removeFgNhg(sai_object_id_t vrf_id, const IpPrefix &ipPrefix);
+    bool removeFgNhgTunnel(sai_object_id_t vrf_id, const IpPrefix &ipPrefix);
 
     // warm reboot support
     bool bake() override;
@@ -142,28 +144,32 @@ private:
 
     bool setNewNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
                     std::vector<BankMemberChanges> &bank_member_changes,
-                    std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const IpPrefix&);
-    bool sprayBankNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, const IpPrefix &ipPrefix,
+                    std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const string &key);
+    bool sprayBankNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, const string &key,
                     BankIndexRange hash_idx_range, FgNhgEntry *fgNhgEntry,
                     uint32_t bank, BankMemberChanges &bank_member_change,
                     std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set);
 
     bool computeAndSetHashBucketChanges(FGNextHopGroupEntry *syncd_fg_route_entry,
                     FgNhgEntry *fgNhgEntry, std::vector<BankMemberChanges> &bank_member_changes,
-                    std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const IpPrefix&);
+                    std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const string &key, const IpPrefix&);
     bool setActiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
                     uint32_t syncd_bank, BankMemberChanges bank_member_changes,
-                    std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const IpPrefix&);
+                    std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const string &key);
     bool setInactiveBankHashBucketChanges(FGNextHopGroupEntry *syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
                     uint32_t bank,std::vector<BankMemberChanges> &bank_member_changes,
-                    std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const IpPrefix&);
+                    std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const string &key, const IpPrefix&);
     bool setInactiveBankToNextAvailableActiveBank(FGNextHopGroupEntry *syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
                     uint32_t bank, std::vector<BankMemberChanges> bank_member_changes,
-                    std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const IpPrefix&);
+                    std::map<NextHopKey,sai_object_id_t> &nhopgroup_members_set, const string &key, const IpPrefix&);
     void calculateBankHashBucketStartIndices(FgNhgEntry *fgNhgEntry);
-    void setStateDbRouteEntry(const IpPrefix&, uint32_t index, NextHopKey nextHop);
+    bool getMaxEcmpMemberCount(uint32_t &maxEcmpMembers);
+    bool getEffectiveFgNhgMemberCapacity(uint32_t configuredBucketSize, uint32_t &memberCapacity);
+    bool validateFgNhgMemberCount(size_t memberCount, uint32_t configuredBucketSize, const string &logKey);
+    string getWarmRebootStateDbKey(const string &vnet, const IpPrefix &ipPrefix);
+    void setStateDbRouteEntry(const string &key, uint32_t index, NextHopKey nextHop);
     bool writeHashBucketChange(FGNextHopGroupEntry *syncd_fg_route_entry, uint32_t index, sai_object_id_t nh_oid,
-                    const IpPrefix &ipPrefix, NextHopKey nextHop);
+                     const string &key, NextHopKey nextHop);
     bool modifyRoutesNextHopId(sai_object_id_t vrf_id, const IpPrefix &ipPrefix, sai_object_id_t next_hop_id);
     bool createFineGrainedNextHopGroup(FGNextHopGroupEntry &syncd_fg_route_entry, FgNhgEntry *fgNhgEntry,
                     const NextHopGroupKey &nextHops);
@@ -171,6 +177,7 @@ private:
     vector<FieldValueTuple> generateRouteTableFromNhgKey(NextHopGroupKey nhg);
     void cleanupIpInLinkToIpMap(const string &link, const IpAddress &ip, FgNhgEntry &fgNhg_entry);
 
+    bool getVnetNameByVrfId(sai_object_id_t vrf_id, std::string& vnet_name);
     bool doTaskFgNhg(const KeyOpFieldsValuesTuple&);
     bool doTaskFgNhgPrefix(const KeyOpFieldsValuesTuple&);
     bool doTaskFgNhgMember(const KeyOpFieldsValuesTuple&);

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1299,6 +1299,259 @@ bool VNetRouteOrch::selectFgNextHopGroup(const string& vnet,
     return true;
 }
 
+RouteTypeTransitionInfo VNetRouteOrch::detectRouteTypeTransition(
+    const string& vnet,
+    const IpPrefix& ipPrefix,
+    const NextHopGroupKey& nexthops,
+    VNetVrfObject* vrf_obj,
+    uint16_t consistent_hashing_buckets)
+{
+    RouteTypeTransitionInfo info;
+    info.is_fg_route = (consistent_hashing_buckets > 0);
+
+    auto it_route = syncd_tunnel_routes_[vnet].find(ipPrefix);
+    if (it_route != syncd_tunnel_routes_[vnet].end())
+    {
+        sai_object_id_t vr_id_check = vrf_obj->getVRidIngress();
+        info.was_fg = gFgNhgOrch->syncdContainsFgNhg(vr_id_check, ipPrefix);
+        info.old_nhg_key = it_route->second.nhg_key;
+        info.is_type_transition = (info.was_fg != info.is_fg_route);
+    }
+
+    info.collision = info.is_type_transition && hasNextHopGroup(vnet, nexthops);
+    if (info.collision)
+    {
+        info.saved_old_nhg_info = syncd_nexthop_groups_[vnet][info.old_nhg_key];
+        syncd_nexthop_groups_[vnet].erase(info.old_nhg_key);
+    }
+
+    return info;
+}
+
+void VNetRouteOrch::cleanupOldRouteNhg(
+    const string& vnet,
+    IpPrefix& ipPrefix,
+    NextHopGroupKey& nexthops,
+    NextHopGroupKey& nexthops_secondary,
+    const string& monitoring,
+    VNetVrfObject* vrf_obj,
+    const NextHopGroupKey& active_nhg,
+    RouteTypeTransitionInfo& transition_info,
+    bool custom_monitor_ep_updated,
+    const map<NextHopKey, IpAddress>& origin_primary_monitors,
+    const map<NextHopKey, IpAddress>& origin_secondary_monitors,
+    bool is_custom_monitor_pinned_state_updated,
+    bool& route_updated,
+    bool& priority_route_updated)
+{
+    auto it_route = syncd_tunnel_routes_[vnet].find(ipPrefix);
+    if (it_route == syncd_tunnel_routes_[vnet].end())
+    {
+        return;
+    }
+
+    if (transition_info.collision)
+    {
+        route_updated = true;
+        if (--transition_info.saved_old_nhg_info.ref_count == 0)
+        {
+            if (transition_info.was_fg)
+            {
+                gFgNhgOrch->removeFgNhgTunnel(vrf_obj->getVRidIngress(), ipPrefix);
+                for (auto nh : transition_info.old_nhg_key.getNextHops())
+                {
+                    vrf_obj->removeTunnelNextHop(nh);
+                }
+            }
+            else
+            {
+                removeNextHopGroupDirectly(vnet, transition_info.saved_old_nhg_info,
+                                           transition_info.old_nhg_key, vrf_obj);
+            }
+            if (!transition_info.was_fg)
+            {
+                delEndpointMonitor(vnet, transition_info.old_nhg_key, ipPrefix);
+            }
+        }
+        else
+        {
+            transition_info.saved_old_nhg_info.tunnel_routes.erase(ipPrefix);
+            syncd_nexthop_groups_[vnet][transition_info.old_nhg_key] = transition_info.saved_old_nhg_info;
+        }
+        vrf_obj->removeRoute(ipPrefix);
+        vrf_obj->removeProfile(ipPrefix);
+    }
+    else if (transition_info.is_type_transition && transition_info.old_nhg_key != active_nhg)
+    {
+        route_updated = true;
+        if (--syncd_nexthop_groups_[vnet][transition_info.old_nhg_key].ref_count == 0)
+        {
+            if (transition_info.was_fg)
+            {
+                removeFgNextHopGroup(vnet, transition_info.old_nhg_key, ipPrefix, vrf_obj);
+            }
+            else
+            {
+                if (transition_info.old_nhg_key.getSize() > 1)
+                {
+                    removeNextHopGroup(vnet, transition_info.old_nhg_key, vrf_obj);
+                }
+                else
+                {
+                    syncd_nexthop_groups_[vnet].erase(transition_info.old_nhg_key);
+                    if (transition_info.old_nhg_key.getSize() == 1)
+                    {
+                        NextHopKey nexthop = *transition_info.old_nhg_key.getNextHops().begin();
+                        if (!isLocalEndpoint(vnet, nexthop.ip_address))
+                        {
+                            vrf_obj->removeTunnelNextHop(nexthop);
+                        }
+                    }
+                }
+                delEndpointMonitor(vnet, transition_info.old_nhg_key, ipPrefix);
+            }
+        }
+        else
+        {
+            syncd_nexthop_groups_[vnet][transition_info.old_nhg_key].tunnel_routes.erase(ipPrefix);
+        }
+        vrf_obj->removeRoute(ipPrefix);
+        vrf_obj->removeProfile(ipPrefix);
+    }
+    else if (transition_info.is_fg_route && !transition_info.is_type_transition)
+    {
+        if (it_route->second.nhg_key != nexthops)
+        {
+            route_updated = true;
+            NextHopGroupKey nhg = it_route->second.nhg_key;
+            if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
+            {
+                for (auto nh : nhg.getNextHops())
+                {
+                    vrf_obj->removeTunnelNextHop(nh);
+                }
+                syncd_nexthop_groups_[vnet].erase(nhg);
+            }
+            else
+            {
+                syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
+            }
+            vrf_obj->removeRoute(ipPrefix);
+        }
+    }
+    else if (!transition_info.is_fg_route && !transition_info.is_type_transition)
+    {
+        if (custom_monitor_ep_updated)
+        {
+            route_updated = true;
+            delEndpointMonitor(vnet, origin_primary_monitors, ipPrefix);
+            delEndpointMonitor(vnet, origin_secondary_monitors, ipPrefix);
+        }
+        else if ((monitoring == "" && it_route->second.nhg_key != nexthops) ||
+            ((monitoring == VNET_MONITORING_TYPE_CUSTOM || monitoring == VNET_MONITORING_TYPE_CUSTOM_BFD) &&
+             (it_route->second.primary != nexthops || it_route->second.secondary != nexthops_secondary)))
+        {
+            route_updated = true;
+            NextHopGroupKey nhg = it_route->second.nhg_key;
+            if (monitoring == VNET_MONITORING_TYPE_CUSTOM || monitoring == VNET_MONITORING_TYPE_CUSTOM_BFD)
+            {
+                if (it_route->second.primary != nexthops)
+                {
+                    delEndpointMonitor(vnet, it_route->second.primary, ipPrefix);
+                }
+                if (it_route->second.secondary != nexthops_secondary)
+                {
+                    delEndpointMonitor(vnet, it_route->second.secondary, ipPrefix);
+                }
+                if (monitor_info_[vnet][ipPrefix].empty())
+                {
+                    monitor_info_[vnet].erase(ipPrefix);
+                }
+                priority_route_updated = true;
+            }
+            else
+            {
+                if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
+                {
+                    if (nhg.getSize() > 1)
+                    {
+                        removeNextHopGroup(vnet, nhg, vrf_obj);
+                    }
+                    else
+                    {
+                        syncd_nexthop_groups_[vnet].erase(nhg);
+                        if (nhg.getSize() == 1)
+                        {
+                            NextHopKey nexthop = *nhg.getNextHops().begin();
+                            if (!isLocalEndpoint(vnet, nexthop.ip_address))
+                            {
+                                vrf_obj->removeTunnelNextHop(nexthop);
+                            }
+                        }
+                    }
+                    if (monitoring != VNET_MONITORING_TYPE_CUSTOM && monitoring != VNET_MONITORING_TYPE_CUSTOM_BFD)
+                    {
+                        delEndpointMonitor(vnet, nhg, ipPrefix);
+                    }
+                }
+                else
+                {
+                    syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
+                }
+                vrf_obj->removeRoute(ipPrefix);
+                vrf_obj->removeProfile(ipPrefix);
+            }
+        }
+        else if (is_custom_monitor_pinned_state_updated)
+        {
+            route_updated = true;
+        }
+    }
+}
+
+void VNetRouteOrch::cleanupDeletedRouteNhg(
+    const string& vnet,
+    NextHopGroupKey& nhg,
+    IpPrefix& ipPrefix,
+    VNetVrfObject* vrf_obj,
+    bool route_is_fg)
+{
+    if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
+    {
+        if (route_is_fg)
+        {
+            removeFgNextHopGroup(vnet, nhg, ipPrefix, vrf_obj);
+        }
+        else
+        {
+            if (nhg.getSize() > 1)
+            {
+                removeNextHopGroup(vnet, nhg, vrf_obj);
+            }
+            else
+            {
+                syncd_nexthop_groups_[vnet].erase(nhg);
+                if (nhg.getSize() == 1)
+                {
+                    NextHopKey nexthop = *nhg.getNextHops().begin();
+                    if (!isLocalEndpoint(vnet, nexthop.ip_address))
+                    {
+                        vrf_obj->removeTunnelNextHop(nexthop);
+                    }
+                }
+            }
+            if (monitor_info_[vnet].find(ipPrefix) == monitor_info_[vnet].end())
+            {
+                delEndpointMonitor(vnet, nhg, ipPrefix);
+            }
+        }
+    }
+    else
+    {
+        syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
+    }
+}
+
 template<>
 bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipPrefix,
                                                NextHopGroupKey& nexthops, string& op, string& profile,
@@ -1344,35 +1597,11 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
     sai_ip_prefix_t pfx;
     copy(pfx, ipPrefix);
 
-    bool is_fg_route = (consistent_hashing_buckets > 0);
+    auto transition = detectRouteTypeTransition(vnet, ipPrefix, nexthops, vrf_obj, consistent_hashing_buckets);
 
     if (op == SET_COMMAND)
     {
         auto it_route = syncd_tunnel_routes_[vnet].find(ipPrefix);
-
-        // Determine if the route was previously fine-grained
-        sai_object_id_t vr_id_check = vrf_obj->getVRidIngress();
-        bool was_fg = (it_route != syncd_tunnel_routes_[vnet].end())
-                      && gFgNhgOrch->syncdContainsFgNhg(vr_id_check, ipPrefix);
-
-        NextHopGroupKey old_nhg_key;
-        if (it_route != syncd_tunnel_routes_[vnet].end())
-        {
-            old_nhg_key = it_route->second.nhg_key;
-        }
-
-        bool is_type_transition = (it_route != syncd_tunnel_routes_[vnet].end())
-                                  && (was_fg != is_fg_route);
-
-        // If transitioning from regular -? fg or vice versa with same endpoints, collision will occur on same NHG key.
-        // save old NHG info and evict from map before creating new one.
-        NextHopGroupInfo saved_old_nhg_info;
-        bool collision = is_type_transition && hasNextHopGroup(vnet, nexthops);
-        if (collision)
-        {
-            saved_old_nhg_info = syncd_nexthop_groups_[vnet][old_nhg_key];
-            syncd_nexthop_groups_[vnet].erase(old_nhg_key);
-        }
 
         sai_object_id_t nh_id = SAI_NULL_OBJECT_ID;
         bool isNextHopIdChanged = false;
@@ -1383,14 +1612,15 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         std::map<NextHopKey, swss::IpAddress> origin_secondary_monitors;
         bool is_custom_monitor_pinned_state_updated = false;
 
-        if (is_fg_route)
+        if (transition.is_fg_route)
         {
             if (!selectFgNextHopGroup(vnet, nexthops, ipPrefix, vrf_obj,
                                       consistent_hashing_buckets, isNextHopIdChanged))
             {
-                if (collision)
+                if (transition.collision)
                 {
-                    syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
+                    syncd_nexthop_groups_[vnet][transition.old_nhg_key] = transition.saved_old_nhg_info;
+                    SWSS_LOG_INFO("Unable to transition from regular to fine-grained ECMP route for VNET %s, prefix %s", vnet.c_str(), ipPrefix.to_string().c_str());
                 }
                 return true;
             }
@@ -1399,7 +1629,6 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         }
         else
         {
-            // Regular ECMP path with monitoring/priority support
             custom_monitor_ep_updated = isCustomMonitorEndpointUpdated(vnet, ipPrefix, monitors);
             if (custom_monitor_ep_updated)
             {
@@ -1416,9 +1645,10 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                                     rx_monitor_timer, tx_monitor_timer, ipPrefix,
                                     vrf_obj, active_nhg, monitors, monitor_addr_to_pinned_state))
             {
-                if (collision)
+                if (transition.collision)
                 {
-                    syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
+                    syncd_nexthop_groups_[vnet][transition.old_nhg_key] = transition.saved_old_nhg_info;
+                    SWSS_LOG_INFO("Unable to transition from fine-grained to regular ECMP route for VNET %s, prefix %s", vnet.c_str(), ipPrefix.to_string().c_str());
                 }
                 return true;
             }
@@ -1428,15 +1658,15 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         sai_object_id_t old_nh_id = SAI_NULL_OBJECT_ID;
         if (it_route != syncd_tunnel_routes_[vnet].end())
         {
-            old_nh_id = collision ? saved_old_nhg_info.next_hop_group_id
-                                  : syncd_nexthop_groups_[vnet][old_nhg_key].next_hop_group_id;
+            old_nh_id = transition.collision ? transition.saved_old_nhg_info.next_hop_group_id
+                                             : syncd_nexthop_groups_[vnet][transition.old_nhg_key].next_hop_group_id;
         }
 
         for (auto vr_id : vr_set)
         {
             bool route_status = true;
 
-            if (is_fg_route)
+            if (transition.is_fg_route)
             {
                 if (it_route == syncd_tunnel_routes_[vnet].end())
                 {
@@ -1454,9 +1684,9 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                     if (it_route != syncd_tunnel_routes_[vnet].end())
                     {
                         NextHopGroupKey nhg = it_route->second.nhg_key;
-                        if (collision)
+                        if (transition.collision)
                         {
-                            if (!saved_old_nhg_info.active_members.empty())
+                            if (!transition.saved_old_nhg_info.active_members.empty())
                             {
                                 del_route(vr_id, pfx);
                             }
@@ -1480,9 +1710,9 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                         if (!gRouteOrch->removeRoutePrefix(prefixSubnet))
                         {
                             SWSS_LOG_ERROR("Could not remove existing bgp route for prefix: %s\n", prefixSubnet.to_string().c_str());
-                            if (collision)
+                            if (transition.collision)
                             {
-                                syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
+                                syncd_nexthop_groups_[vnet][transition.old_nhg_key] = transition.saved_old_nhg_info;
                             }
                             return false;
                         }
@@ -1495,7 +1725,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                     }
                     else if (nh_id != old_nh_id)
                     {
-                        if (collision || !syncd_nexthop_groups_[vnet][old_nhg_key].active_members.empty())
+                        if (transition.collision || !syncd_nexthop_groups_[vnet][transition.old_nhg_key].active_members.empty())
                         {
                             route_status = update_route(vr_id, pfx, nh_id);
                         }
@@ -1510,7 +1740,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
             if (!route_status)
             {
                 SWSS_LOG_ERROR("Route add/update failed for %s, vr_id '0x%" PRIx64, ipPrefix.to_string().c_str(), vr_id);
-                if (is_fg_route)
+                if (transition.is_fg_route)
                 {
                     removeFgNextHopGroup(vnet, nexthops, ipPrefix, vrf_obj);
                 }
@@ -1518,9 +1748,9 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                 {
                     removeNextHopGroup(vnet, active_nhg, vrf_obj);
                 }
-                if (collision)
+                if (transition.collision)
                 {
-                    syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
+                    syncd_nexthop_groups_[vnet][transition.old_nhg_key] = transition.saved_old_nhg_info;
                 }
                 return false;
             }
@@ -1530,168 +1760,13 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         bool priority_route_updated = false;
         if (it_route != syncd_tunnel_routes_[vnet].end())
         {
-            if (collision)
-            {
-                route_updated = true;
-                if (--saved_old_nhg_info.ref_count == 0)
-                {
-                    if (was_fg)
-                    {
-                        gFgNhgOrch->removeFgNhgTunnel(vrf_obj->getVRidIngress(), ipPrefix);
-                        for (auto nh : old_nhg_key.getNextHops())
-                        {
-                            vrf_obj->removeTunnelNextHop(nh);
-                        }
-                    }
-                    else
-                    {
-                        removeNextHopGroupDirectly(vnet, saved_old_nhg_info, old_nhg_key, vrf_obj);
-                    }
-                    if (!was_fg)
-                    {
-                        delEndpointMonitor(vnet, old_nhg_key, ipPrefix);
-                    }
-                }
-                else
-                {
-                    saved_old_nhg_info.tunnel_routes.erase(ipPrefix);
-                    syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
-                }
-                vrf_obj->removeRoute(ipPrefix);
-                vrf_obj->removeProfile(ipPrefix);
-            }
-            else if (is_type_transition && old_nhg_key != active_nhg)
-            {
-                // Type transition with different endpoints — no collision
-                route_updated = true;
-                if (--syncd_nexthop_groups_[vnet][old_nhg_key].ref_count == 0)
-                {
-                    if (was_fg)
-                    {
-                        removeFgNextHopGroup(vnet, old_nhg_key, ipPrefix, vrf_obj);
-                    }
-                    else
-                    {
-                        if (old_nhg_key.getSize() > 1)
-                        {
-                            removeNextHopGroup(vnet, old_nhg_key, vrf_obj);
-                        }
-                        else
-                        {
-                            syncd_nexthop_groups_[vnet].erase(old_nhg_key);
-                            if (old_nhg_key.getSize() == 1)
-                            {
-                                NextHopKey nexthop = *old_nhg_key.getNextHops().begin();
-                                if (!isLocalEndpoint(vnet, nexthop.ip_address))
-                                {
-                                    vrf_obj->removeTunnelNextHop(nexthop);
-                                }
-                            }
-                        }
-                        delEndpointMonitor(vnet, old_nhg_key, ipPrefix);
-                    }
-                }
-                else
-                {
-                    syncd_nexthop_groups_[vnet][old_nhg_key].tunnel_routes.erase(ipPrefix);
-                }
-                vrf_obj->removeRoute(ipPrefix);
-                vrf_obj->removeProfile(ipPrefix);
-            }
-            else if (is_fg_route && !is_type_transition)
-            {
-                // FG → FG update with different endpoints
-                if (it_route->second.nhg_key != nexthops)
-                {
-                    route_updated = true;
-                    NextHopGroupKey nhg = it_route->second.nhg_key;
-                    if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
-                    {
-                        for (auto nh : nhg.getNextHops())
-                        {
-                            vrf_obj->removeTunnelNextHop(nh);
-                        }
-                        syncd_nexthop_groups_[vnet].erase(nhg);
-                    }
-                    else
-                    {
-                        syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
-                    }
-                    vrf_obj->removeRoute(ipPrefix);
-                }
-            }
-            else if (!is_fg_route && !is_type_transition)
-            {
-                // Regular → Regular update (existing logic)
-                if (custom_monitor_ep_updated)
-                {
-                    route_updated = true;
-                    delEndpointMonitor(vnet, origin_primary_monitors, ipPrefix);
-                    delEndpointMonitor(vnet, origin_secondary_monitors, ipPrefix);
-                }
-                else if ((monitoring == "" && it_route->second.nhg_key != nexthops) ||
-                    ((monitoring == VNET_MONITORING_TYPE_CUSTOM || monitoring == VNET_MONITORING_TYPE_CUSTOM_BFD) &&
-                     (it_route->second.primary != nexthops || it_route->second.secondary != nexthops_secondary)))
-                {
-                    route_updated = true;
-                    NextHopGroupKey nhg = it_route->second.nhg_key;
-                    if (monitoring == VNET_MONITORING_TYPE_CUSTOM || monitoring == VNET_MONITORING_TYPE_CUSTOM_BFD)
-                    {
-                        if (it_route->second.primary != nexthops)
-                        {
-                            delEndpointMonitor(vnet, it_route->second.primary, ipPrefix);
-                        }
-                        if (it_route->second.secondary != nexthops_secondary)
-                        {
-                            delEndpointMonitor(vnet, it_route->second.secondary, ipPrefix);
-                        }
-                        if (monitor_info_[vnet][ipPrefix].empty())
-                        {
-                            monitor_info_[vnet].erase(ipPrefix);
-                        }
-                        priority_route_updated = true;
-                    }
-                    else
-                    {
-                        if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
-                        {
-                            if (nhg.getSize() > 1)
-                            {
-                                removeNextHopGroup(vnet, nhg, vrf_obj);
-                            }
-                            else
-                            {
-                                syncd_nexthop_groups_[vnet].erase(nhg);
-                                if (nhg.getSize() == 1)
-                                {
-                                    NextHopKey nexthop = *nhg.getNextHops().begin();
-                                    if (!isLocalEndpoint(vnet, nexthop.ip_address))
-                                    {
-                                        vrf_obj->removeTunnelNextHop(nexthop);
-                                    }
-                                }
-                            }
-                            if (monitoring != VNET_MONITORING_TYPE_CUSTOM && monitoring != VNET_MONITORING_TYPE_CUSTOM_BFD)
-                            {
-                                delEndpointMonitor(vnet, nhg, ipPrefix);
-                            }
-                        }
-                        else
-                        {
-                            syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
-                        }
-                        vrf_obj->removeRoute(ipPrefix);
-                        vrf_obj->removeProfile(ipPrefix);
-                    }
-                }
-                else if (is_custom_monitor_pinned_state_updated)
-                {
-                    route_updated = true;
-                }
-            }
+            cleanupOldRouteNhg(vnet, ipPrefix, nexthops, nexthops_secondary, monitoring,
+                               vrf_obj, active_nhg, transition,
+                               custom_monitor_ep_updated, origin_primary_monitors,
+                               origin_secondary_monitors, is_custom_monitor_pinned_state_updated,
+                               route_updated, priority_route_updated);
         }
 
-        // --- STEP 4: Update syncd_tunnel_routes_ ---
         if (!profile.empty())
         {
             vrf_obj->addProfile(ipPrefix, profile);
@@ -1707,7 +1782,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
             tunnel_route_entry.secondary = nexthops_secondary;
             syncd_tunnel_routes_[vnet][ipPrefix] = tunnel_route_entry;
 
-            if (!is_fg_route && (priority_route_updated || custom_monitor_ep_updated || is_custom_monitor_pinned_state_updated))
+            if (!transition.is_fg_route && (priority_route_updated || custom_monitor_ep_updated || is_custom_monitor_pinned_state_updated))
             {
                 MonitorUpdate update;
                 update.monitoring_type = monitoring;
@@ -1719,7 +1794,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                 return true;
             }
 
-            if (!is_fg_route && adv_prefix.to_string() != ipPrefix.to_string() && prefix_to_adv_prefix_.find(ipPrefix) == prefix_to_adv_prefix_.end())
+            if (!transition.is_fg_route && adv_prefix.to_string() != ipPrefix.to_string() && prefix_to_adv_prefix_.find(ipPrefix) == prefix_to_adv_prefix_.end())
             {
                 prefix_to_adv_prefix_[ipPrefix] = adv_prefix;
                 if (adv_prefix_refcount_.find(adv_prefix) == adv_prefix_refcount_.end())
@@ -1747,7 +1822,6 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         NextHopGroupKey nhg = it_route->second.nhg_key;
         auto last_nhg_size = nhg.getSize();
 
-        // Determine if route is currently fine-grained
         bool route_is_fg = gFgNhgOrch->syncdContainsFgNhg(vrf_obj->getVRidIngress(), ipPrefix);
 
         for (auto vr_id : vr_set)
@@ -1763,40 +1837,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
             }
         }
 
-        if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
-        {
-            if (route_is_fg)
-            {
-                removeFgNextHopGroup(vnet, nhg, ipPrefix, vrf_obj);
-            }
-            else
-            {
-                if (nhg.getSize() > 1)
-                {
-                    removeNextHopGroup(vnet, nhg, vrf_obj);
-                }
-                else
-                {
-                    syncd_nexthop_groups_[vnet].erase(nhg);
-                    if (nhg.getSize() == 1)
-                    {
-                        NextHopKey nexthop = *nhg.getNextHops().begin();
-                        if (!isLocalEndpoint(vnet, nexthop.ip_address))
-                        {
-                            vrf_obj->removeTunnelNextHop(nexthop);
-                        }
-                    }
-                }
-                if (monitor_info_[vnet].find(ipPrefix) == monitor_info_[vnet].end())
-                {
-                    delEndpointMonitor(vnet, nhg, ipPrefix);
-                }
-            }
-        }
-        else
-        {
-            syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
-        }
+        cleanupDeletedRouteNhg(vnet, nhg, ipPrefix, vrf_obj, route_is_fg);
 
         if (!route_is_fg && monitor_info_[vnet].find(ipPrefix) != monitor_info_[vnet].end())
         {

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -46,6 +46,7 @@ extern MacAddress gVxlanMacAddress;
 extern BfdOrch *gBfdOrch;
 extern SwitchOrch *gSwitchOrch;
 extern TunnelDecapOrch *gTunneldecapOrch;
+extern FgNhgOrch *gFgNhgOrch;
 /*
  * VRF Modeling and VNetVrf class definitions
  */
@@ -320,6 +321,23 @@ sai_object_id_t VNetVrfObject::getTunnelNextHop(NextHopKey& nh)
          * is already done in createNextHopTunnel()
          */
         SWSS_LOG_ERROR("NH Tunnel create failed for '%s' ip '%s'",
+                vnet_name_.c_str(), nh.ip_address.to_string().c_str());
+    }
+
+    return nh_id;
+}
+
+sai_object_id_t VNetVrfObject::getExistingTunnelNextHopId(NextHopKey& nh)
+{
+    auto tun_name = getTunnelName();
+
+    VxlanTunnelOrch* vxlan_orch = gDirectory.get<VxlanTunnelOrch*>();
+
+    auto *tunnel_obj = vxlan_orch->getVxlanTunnel(tun_name);
+    sai_object_id_t nh_id = tunnel_obj->getNextHop(nh.ip_address, nh.mac_address, nh.vni);
+    if (nh_id == SAI_NULL_OBJECT_ID)
+    {
+        SWSS_LOG_ERROR("NH Tunnel lookup failed for '%s' ip '%s'",
                 vnet_name_.c_str(), nh.ip_address.to_string().c_str());
     }
 
@@ -933,6 +951,73 @@ bool VNetRouteOrch::removeNextHopGroup(const string& vnet, const NextHopGroupKey
     return true;
 }
 
+bool VNetRouteOrch::removeNextHopGroupDirectly(const string& vnet, NextHopGroupInfo& nhg_info, const NextHopGroupKey &nexthops, VNetVrfObject *vrf_obj)
+{
+    SWSS_LOG_ENTER();
+
+    sai_object_id_t next_hop_group_id = nhg_info.next_hop_group_id;
+    sai_status_t status;
+
+    SWSS_LOG_NOTICE("Direct delete next hop group %s", nexthops.to_string().c_str());
+
+    for (auto nhop = nhg_info.active_members.begin();
+         nhop != nhg_info.active_members.end();)
+    {
+        NextHopKey nexthop = nhop->first;
+
+        status = sai_next_hop_group_api->remove_next_hop_group_member(nhop->second);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to remove next hop group member %" PRIx64 ", rv:%d",
+                           nhop->second, status);
+            return false;
+        }
+
+        if (!isLocalEndpoint(vnet, nexthop.ip_address))
+        {
+            vrf_obj->removeTunnelNextHop(nexthop);
+        }
+
+        gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
+        nhop = nhg_info.active_members.erase(nhop);
+    }
+
+    if (nexthops.getSize() > 1)
+    {
+        status = sai_next_hop_group_api->remove_next_hop_group(next_hop_group_id);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to remove next hop group %" PRIx64 ", rv:%d", next_hop_group_id, status);
+            return false;
+        }
+
+        gRouteOrch->decreaseNextHopGroupCount();
+        gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP);
+    }
+
+    return true;
+}
+
+bool VNetRouteOrch::removeFgNextHopGroup(const string& vnet, const NextHopGroupKey &nexthops, const IpPrefix& ipPrefix, VNetVrfObject *vrf_obj)
+{
+    SWSS_LOG_ENTER();
+
+    sai_object_id_t vr_id = vrf_obj->getVRidIngress();
+    if (!gFgNhgOrch->removeFgNhgTunnel(vr_id, ipPrefix))
+    {
+        SWSS_LOG_ERROR("Failed to remove fine grained next hop group for %s, vr_id '0x%" PRIx64, ipPrefix.to_string().c_str(), vr_id);
+        return false;
+    }
+
+    for (auto nhop : nexthops.getNextHops())
+    {
+        vrf_obj->removeTunnelNextHop(nhop);
+    }
+
+    syncd_nexthop_groups_[vnet].erase(nexthops);
+    return true;
+}
+
 bool VNetRouteOrch::createNextHopGroup(const string& vnet,
                                        NextHopGroupKey& nexthops,
                                        VNetVrfObject *vrf_obj,
@@ -1142,6 +1227,78 @@ bool VNetRouteOrch::selectNextHopGroup(const string& vnet,
     return true;
 }
 
+bool VNetRouteOrch::selectFgNextHopGroup(const string& vnet,
+                                       NextHopGroupKey& nexthops,
+                                       IpPrefix& ipPrefix,
+                                       VNetVrfObject *vrf_obj,
+                                       const uint16_t consistent_hashing_buckets,
+                                       bool& isNextHopIdChanged)
+{
+    // This function returns the next hop group which is to be used to in the hardware
+    // for fine grained ECMP tunnel routes.
+
+    bool nhg_exists = hasNextHopGroup(vnet, nexthops);
+    std::map<NextHopKey, sai_object_id_t> nhopgroup_members_set;
+
+    for (auto nh : nexthops.getNextHops())
+    {
+        sai_object_id_t next_hop_id;
+        if (nhg_exists)
+        {
+            // NHG already exists, look up existing tunnel NH IDs without incrementing refcount
+            next_hop_id = vrf_obj->getExistingTunnelNextHopId(nh);
+        }
+        else
+        {
+            // New NHG, create tunnel NHs (sets refcount to 1)
+            next_hop_id = vrf_obj->getTunnelNextHop(nh);
+        }
+        nhopgroup_members_set[nh] = next_hop_id;
+    }
+
+    sai_object_id_t nh_id = SAI_NULL_OBJECT_ID;
+
+    sai_object_id_t vrf_id;
+    vnet_orch_->getVrfIdByVnetName(vnet, vrf_id);
+    if (!gFgNhgOrch->setFgNhgTunnel(vrf_id, ipPrefix, nhopgroup_members_set, nexthops, consistent_hashing_buckets, nh_id, isNextHopIdChanged))
+    {
+        SWSS_LOG_ERROR("Failed to create fine grained next hop group for VNET %s", vnet.c_str());
+
+        if (!nhg_exists)
+        {
+            for (auto nh : nexthops.getNextHops())
+            {
+                vrf_obj->removeTunnelNextHop(nh);
+            }
+        }
+        return false;
+    }
+
+    if (!nhg_exists)
+    {
+        NextHopGroupInfo next_hop_group_entry;
+        next_hop_group_entry.next_hop_group_id = nh_id;
+
+        /*
+        * Initialize the next hop group structure with ref_count as 0. This
+        * count will increase once the route is successfully syncd.
+        */
+        next_hop_group_entry.ref_count = 0;
+        syncd_nexthop_groups_[vnet][nexthops] = next_hop_group_entry;
+
+        for (auto nh : nexthops.getNextHops())
+        {
+            syncd_nexthop_groups_[vnet][nexthops].active_members[nh] = SAI_NULL_OBJECT_ID;
+        }
+    }
+    if (isNextHopIdChanged)
+    {
+        syncd_nexthop_groups_[vnet][nexthops].next_hop_group_id = nh_id;
+    }
+
+    return true;
+}
+
 template<>
 bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipPrefix,
                                                NextHopGroupKey& nexthops, string& op, string& profile,
@@ -1151,7 +1308,8 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                                                NextHopGroupKey& nexthops_secondary,
                                                const IpPrefix& adv_prefix,
                                                const map<NextHopKey, IpAddress>& monitors,
-                                               const map<IpAddress, pinned_state_t>& monitor_addr_to_pinned_state)
+                                               const map<IpAddress, pinned_state_t>& monitor_addr_to_pinned_state,
+                                               const uint16_t consistent_hashing_buckets)
 {
     SWSS_LOG_ENTER();
 
@@ -1186,83 +1344,165 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
     sai_ip_prefix_t pfx;
     copy(pfx, ipPrefix);
 
+    bool is_fg_route = (consistent_hashing_buckets > 0);
+
     if (op == SET_COMMAND)
     {
-        bool custom_monitor_ep_updated = isCustomMonitorEndpointUpdated(vnet, ipPrefix, monitors);
-        std::map<NextHopKey, swss::IpAddress> origin_primary_monitors;
-        std::map<NextHopKey, swss::IpAddress> origin_secondary_monitors;
-        if (custom_monitor_ep_updated)
+        auto it_route = syncd_tunnel_routes_[vnet].find(ipPrefix);
+
+        // Determine if the route was previously fine-grained
+        sai_object_id_t vr_id_check = vrf_obj->getVRidIngress();
+        bool was_fg = (it_route != syncd_tunnel_routes_[vnet].end())
+                      && gFgNhgOrch->syncdContainsFgNhg(vr_id_check, ipPrefix);
+
+        NextHopGroupKey old_nhg_key;
+        if (it_route != syncd_tunnel_routes_[vnet].end())
         {
-            auto it_route = syncd_tunnel_routes_[vnet].find(ipPrefix);
-            if (it_route != syncd_tunnel_routes_[vnet].end())
-            {
-                getCustomMonitors(vnet, ipPrefix, it_route->second.primary, origin_primary_monitors);
-                getCustomMonitors(vnet, ipPrefix, it_route->second.secondary, origin_secondary_monitors);
-            }
+            old_nhg_key = it_route->second.nhg_key;
         }
 
-        bool is_custom_monitor_pinned_state_updated = isPinnedStateUpdated(vnet, ipPrefix, monitor_addr_to_pinned_state);
+        bool is_type_transition = (it_route != syncd_tunnel_routes_[vnet].end())
+                                  && (was_fg != is_fg_route);
+
+        // If transitioning from regular -? fg or vice versa with same endpoints, collision will occur on same NHG key.
+        // save old NHG info and evict from map before creating new one.
+        NextHopGroupInfo saved_old_nhg_info;
+        bool collision = is_type_transition && hasNextHopGroup(vnet, nexthops);
+        if (collision)
+        {
+            saved_old_nhg_info = syncd_nexthop_groups_[vnet][old_nhg_key];
+            syncd_nexthop_groups_[vnet].erase(old_nhg_key);
+        }
 
         sai_object_id_t nh_id = SAI_NULL_OBJECT_ID;
+        bool isNextHopIdChanged = false;
         NextHopGroupKey active_nhg("", true);
-        if (!selectNextHopGroup(vnet, nexthops, nexthops_secondary, monitoring, rx_monitor_timer, tx_monitor_timer, ipPrefix, vrf_obj, active_nhg, monitors, monitor_addr_to_pinned_state))
+
+        bool custom_monitor_ep_updated = false;
+        std::map<NextHopKey, swss::IpAddress> origin_primary_monitors;
+        std::map<NextHopKey, swss::IpAddress> origin_secondary_monitors;
+        bool is_custom_monitor_pinned_state_updated = false;
+
+        if (is_fg_route)
         {
-            return true;
+            if (!selectFgNextHopGroup(vnet, nexthops, ipPrefix, vrf_obj,
+                                      consistent_hashing_buckets, isNextHopIdChanged))
+            {
+                if (collision)
+                {
+                    syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
+                }
+                return true;
+            }
+            active_nhg = nexthops;
+            nh_id = syncd_nexthop_groups_[vnet][nexthops].next_hop_group_id;
+        }
+        else
+        {
+            // Regular ECMP path with monitoring/priority support
+            custom_monitor_ep_updated = isCustomMonitorEndpointUpdated(vnet, ipPrefix, monitors);
+            if (custom_monitor_ep_updated)
+            {
+                if (it_route != syncd_tunnel_routes_[vnet].end())
+                {
+                    getCustomMonitors(vnet, ipPrefix, it_route->second.primary, origin_primary_monitors);
+                    getCustomMonitors(vnet, ipPrefix, it_route->second.secondary, origin_secondary_monitors);
+                }
+            }
+
+            is_custom_monitor_pinned_state_updated = isPinnedStateUpdated(vnet, ipPrefix, monitor_addr_to_pinned_state);
+
+            if (!selectNextHopGroup(vnet, nexthops, nexthops_secondary, monitoring,
+                                    rx_monitor_timer, tx_monitor_timer, ipPrefix,
+                                    vrf_obj, active_nhg, monitors, monitor_addr_to_pinned_state))
+            {
+                if (collision)
+                {
+                    syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
+                }
+                return true;
+            }
+            nh_id = syncd_nexthop_groups_[vnet][active_nhg].next_hop_group_id;
         }
 
-        // note: nh_id can be SAI_NULL_OBJECT_ID when active_nhg is empty.
-        nh_id = syncd_nexthop_groups_[vnet][active_nhg].next_hop_group_id;
+        sai_object_id_t old_nh_id = SAI_NULL_OBJECT_ID;
+        if (it_route != syncd_tunnel_routes_[vnet].end())
+        {
+            old_nh_id = collision ? saved_old_nhg_info.next_hop_group_id
+                                  : syncd_nexthop_groups_[vnet][old_nhg_key].next_hop_group_id;
+        }
 
-        auto it_route = syncd_tunnel_routes_[vnet].find(ipPrefix);
         for (auto vr_id : vr_set)
         {
             bool route_status = true;
 
-            // Remove route if the nexthop group has no active endpoint
-            if (syncd_nexthop_groups_[vnet][active_nhg].active_members.empty())
+            if (is_fg_route)
             {
-                if (it_route != syncd_tunnel_routes_[vnet].end())
-                {
-                    NextHopGroupKey nhg = it_route->second.nhg_key;
-                    // Remove route when updating from a nhg with active member to another nhg without
-                    if (!syncd_nexthop_groups_[vnet][nhg].active_members.empty())
-                    {
-                        del_route(vr_id, pfx);
-                    }
-                }
-            }
-            else
-            {
-                auto prefixToRemove = ipPrefix;
-                if (adv_prefix.to_string() != ipPrefix.to_string())
-                {
-                    prefixToRemove = adv_prefix;
-                }
-                auto prefixSubnet = prefixToRemove.getSubnet();
-                if(gRouteOrch && gRouteOrch->isRouteExists(vr_id, prefixSubnet))
-                {
-                    if (!gRouteOrch->removeRoutePrefix(prefixSubnet))
-                    {
-                        SWSS_LOG_ERROR("Could not remove existing bgp route for prefix: %s\n", prefixSubnet.to_string().c_str());
-                        return false;
-                    }
-                    SWSS_LOG_INFO("Successfully removed existing bgp route for prefix: %s\n",
-                                  prefixSubnet.to_string().c_str());
-                }
                 if (it_route == syncd_tunnel_routes_[vnet].end())
                 {
                     route_status = add_route(vr_id, pfx, nh_id);
                 }
+                else if (nh_id != old_nh_id || isNextHopIdChanged)
+                {
+                    route_status = update_route(vr_id, pfx, nh_id);
+                }
+            }
+            else
+            {
+                if (syncd_nexthop_groups_[vnet][active_nhg].active_members.empty())
+                {
+                    if (it_route != syncd_tunnel_routes_[vnet].end())
+                    {
+                        NextHopGroupKey nhg = it_route->second.nhg_key;
+                        if (collision)
+                        {
+                            if (!saved_old_nhg_info.active_members.empty())
+                            {
+                                del_route(vr_id, pfx);
+                            }
+                        }
+                        else if (!syncd_nexthop_groups_[vnet][nhg].active_members.empty())
+                        {
+                            del_route(vr_id, pfx);
+                        }
+                    }
+                }
                 else
                 {
-                    NextHopGroupKey nhg = it_route->second.nhg_key;
-                    if (syncd_nexthop_groups_[vnet][nhg].active_members.empty())
+                    auto prefixToRemove = ipPrefix;
+                    if (adv_prefix.to_string() != ipPrefix.to_string())
+                    {
+                        prefixToRemove = adv_prefix;
+                    }
+                    auto prefixSubnet = prefixToRemove.getSubnet();
+                    if (gRouteOrch && gRouteOrch->isRouteExists(vr_id, prefixSubnet))
+                    {
+                        if (!gRouteOrch->removeRoutePrefix(prefixSubnet))
+                        {
+                            SWSS_LOG_ERROR("Could not remove existing bgp route for prefix: %s\n", prefixSubnet.to_string().c_str());
+                            if (collision)
+                            {
+                                syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
+                            }
+                            return false;
+                        }
+                        SWSS_LOG_INFO("Successfully removed existing bgp route for prefix: %s\n",
+                                      prefixSubnet.to_string().c_str());
+                    }
+                    if (it_route == syncd_tunnel_routes_[vnet].end())
                     {
                         route_status = add_route(vr_id, pfx, nh_id);
                     }
-                    else
+                    else if (nh_id != old_nh_id)
                     {
-                        route_status = update_route(vr_id, pfx, nh_id);
+                        if (collision || !syncd_nexthop_groups_[vnet][old_nhg_key].active_members.empty())
+                        {
+                            route_status = update_route(vr_id, pfx, nh_id);
+                        }
+                        else
+                        {
+                            route_status = add_route(vr_id, pfx, nh_id);
+                        }
                     }
                 }
             }
@@ -1270,88 +1510,188 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
             if (!route_status)
             {
                 SWSS_LOG_ERROR("Route add/update failed for %s, vr_id '0x%" PRIx64, ipPrefix.to_string().c_str(), vr_id);
-                /* Clean up the newly created next hop group entry */
-                if (active_nhg.getSize() > 1)
+                if (is_fg_route)
+                {
+                    removeFgNextHopGroup(vnet, nexthops, ipPrefix, vrf_obj);
+                }
+                else if (active_nhg.getSize() > 1)
                 {
                     removeNextHopGroup(vnet, active_nhg, vrf_obj);
+                }
+                if (collision)
+                {
+                    syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
                 }
                 return false;
             }
         }
+
         bool route_updated = false;
         bool priority_route_updated = false;
         if (it_route != syncd_tunnel_routes_[vnet].end())
         {
-            if (custom_monitor_ep_updated)
+            if (collision)
             {
                 route_updated = true;
-
-                delEndpointMonitor(vnet, origin_primary_monitors, ipPrefix);
-                delEndpointMonitor(vnet, origin_secondary_monitors, ipPrefix);
-            }
-            else if ((monitoring == "" && it_route->second.nhg_key != nexthops) ||
-                ((monitoring == VNET_MONITORING_TYPE_CUSTOM || monitoring == VNET_MONITORING_TYPE_CUSTOM_BFD) &&
-                 (it_route->second.primary != nexthops || it_route->second.secondary != nexthops_secondary)))
-            {
-                route_updated = true;
-                NextHopGroupKey nhg = it_route->second.nhg_key;
-                if (monitoring == VNET_MONITORING_TYPE_CUSTOM || monitoring == VNET_MONITORING_TYPE_CUSTOM_BFD)
+                if (--saved_old_nhg_info.ref_count == 0)
                 {
-                    // if the previously active NHG is same as the newly created active NHG.case of primary secondary swap or
-                    //when primary is active and secondary is changed or vice versa. In these cases we dont remove the NHG
-                    // but only remove the monitors for the set which has changed.
-                    if (it_route->second.primary != nexthops)
+                    if (was_fg)
                     {
-                        delEndpointMonitor(vnet, it_route->second.primary, ipPrefix);
+                        gFgNhgOrch->removeFgNhgTunnel(vrf_obj->getVRidIngress(), ipPrefix);
+                        for (auto nh : old_nhg_key.getNextHops())
+                        {
+                            vrf_obj->removeTunnelNextHop(nh);
+                        }
                     }
-                    if (it_route->second.secondary != nexthops_secondary)
+                    else
                     {
-                        delEndpointMonitor(vnet, it_route->second.secondary, ipPrefix);
+                        removeNextHopGroupDirectly(vnet, saved_old_nhg_info, old_nhg_key, vrf_obj);
                     }
-                    if (monitor_info_[vnet][ipPrefix].empty())
+                    if (!was_fg)
                     {
-                        monitor_info_[vnet].erase(ipPrefix);
+                        delEndpointMonitor(vnet, old_nhg_key, ipPrefix);
                     }
-                    priority_route_updated = true;
                 }
                 else
                 {
-                    // In case of updating an existing route, decrease the reference count for the previous nexthop group
-                    if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
+                    saved_old_nhg_info.tunnel_routes.erase(ipPrefix);
+                    syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
+                }
+                vrf_obj->removeRoute(ipPrefix);
+                vrf_obj->removeProfile(ipPrefix);
+            }
+            else if (is_type_transition && old_nhg_key != active_nhg)
+            {
+                // Type transition with different endpoints — no collision
+                route_updated = true;
+                if (--syncd_nexthop_groups_[vnet][old_nhg_key].ref_count == 0)
+                {
+                    if (was_fg)
                     {
-                        if (nhg.getSize() > 1)
+                        removeFgNextHopGroup(vnet, old_nhg_key, ipPrefix, vrf_obj);
+                    }
+                    else
+                    {
+                        if (old_nhg_key.getSize() > 1)
                         {
-                            removeNextHopGroup(vnet, nhg, vrf_obj);
+                            removeNextHopGroup(vnet, old_nhg_key, vrf_obj);
                         }
                         else
                         {
-                            syncd_nexthop_groups_[vnet].erase(nhg);
-                            if(nhg.getSize() == 1)
+                            syncd_nexthop_groups_[vnet].erase(old_nhg_key);
+                            if (old_nhg_key.getSize() == 1)
                             {
-                                NextHopKey nexthop = *nhg.getNextHops().begin();
+                                NextHopKey nexthop = *old_nhg_key.getNextHops().begin();
                                 if (!isLocalEndpoint(vnet, nexthop.ip_address))
                                 {
                                     vrf_obj->removeTunnelNextHop(nexthop);
                                 }
                             }
                         }
-                        if (monitoring != VNET_MONITORING_TYPE_CUSTOM && monitoring != VNET_MONITORING_TYPE_CUSTOM_BFD)
+                        delEndpointMonitor(vnet, old_nhg_key, ipPrefix);
+                    }
+                }
+                else
+                {
+                    syncd_nexthop_groups_[vnet][old_nhg_key].tunnel_routes.erase(ipPrefix);
+                }
+                vrf_obj->removeRoute(ipPrefix);
+                vrf_obj->removeProfile(ipPrefix);
+            }
+            else if (is_fg_route && !is_type_transition)
+            {
+                // FG → FG update with different endpoints
+                if (it_route->second.nhg_key != nexthops)
+                {
+                    route_updated = true;
+                    NextHopGroupKey nhg = it_route->second.nhg_key;
+                    if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
+                    {
+                        for (auto nh : nhg.getNextHops())
                         {
-                            delEndpointMonitor(vnet, nhg, ipPrefix);
+                            vrf_obj->removeTunnelNextHop(nh);
                         }
+                        syncd_nexthop_groups_[vnet].erase(nhg);
                     }
                     else
                     {
                         syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
                     }
                     vrf_obj->removeRoute(ipPrefix);
-                    vrf_obj->removeProfile(ipPrefix);
                 }
-            } else if (is_custom_monitor_pinned_state_updated)
+            }
+            else if (!is_fg_route && !is_type_transition)
             {
-                route_updated = true;
+                // Regular → Regular update (existing logic)
+                if (custom_monitor_ep_updated)
+                {
+                    route_updated = true;
+                    delEndpointMonitor(vnet, origin_primary_monitors, ipPrefix);
+                    delEndpointMonitor(vnet, origin_secondary_monitors, ipPrefix);
+                }
+                else if ((monitoring == "" && it_route->second.nhg_key != nexthops) ||
+                    ((monitoring == VNET_MONITORING_TYPE_CUSTOM || monitoring == VNET_MONITORING_TYPE_CUSTOM_BFD) &&
+                     (it_route->second.primary != nexthops || it_route->second.secondary != nexthops_secondary)))
+                {
+                    route_updated = true;
+                    NextHopGroupKey nhg = it_route->second.nhg_key;
+                    if (monitoring == VNET_MONITORING_TYPE_CUSTOM || monitoring == VNET_MONITORING_TYPE_CUSTOM_BFD)
+                    {
+                        if (it_route->second.primary != nexthops)
+                        {
+                            delEndpointMonitor(vnet, it_route->second.primary, ipPrefix);
+                        }
+                        if (it_route->second.secondary != nexthops_secondary)
+                        {
+                            delEndpointMonitor(vnet, it_route->second.secondary, ipPrefix);
+                        }
+                        if (monitor_info_[vnet][ipPrefix].empty())
+                        {
+                            monitor_info_[vnet].erase(ipPrefix);
+                        }
+                        priority_route_updated = true;
+                    }
+                    else
+                    {
+                        if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
+                        {
+                            if (nhg.getSize() > 1)
+                            {
+                                removeNextHopGroup(vnet, nhg, vrf_obj);
+                            }
+                            else
+                            {
+                                syncd_nexthop_groups_[vnet].erase(nhg);
+                                if (nhg.getSize() == 1)
+                                {
+                                    NextHopKey nexthop = *nhg.getNextHops().begin();
+                                    if (!isLocalEndpoint(vnet, nexthop.ip_address))
+                                    {
+                                        vrf_obj->removeTunnelNextHop(nexthop);
+                                    }
+                                }
+                            }
+                            if (monitoring != VNET_MONITORING_TYPE_CUSTOM && monitoring != VNET_MONITORING_TYPE_CUSTOM_BFD)
+                            {
+                                delEndpointMonitor(vnet, nhg, ipPrefix);
+                            }
+                        }
+                        else
+                        {
+                            syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
+                        }
+                        vrf_obj->removeRoute(ipPrefix);
+                        vrf_obj->removeProfile(ipPrefix);
+                    }
+                }
+                else if (is_custom_monitor_pinned_state_updated)
+                {
+                    route_updated = true;
+                }
             }
         }
+
+        // --- STEP 4: Update syncd_tunnel_routes_ ---
         if (!profile.empty())
         {
             vrf_obj->addProfile(ipPrefix, profile);
@@ -1359,14 +1699,15 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         if (it_route == syncd_tunnel_routes_[vnet].end() || route_updated)
         {
             syncd_nexthop_groups_[vnet][active_nhg].tunnel_routes.insert(ipPrefix);
+            syncd_nexthop_groups_[vnet][active_nhg].ref_count++;
+
             VNetTunnelRouteEntry tunnel_route_entry;
             tunnel_route_entry.nhg_key = active_nhg;
             tunnel_route_entry.primary = nexthops;
             tunnel_route_entry.secondary = nexthops_secondary;
             syncd_tunnel_routes_[vnet][ipPrefix] = tunnel_route_entry;
-            syncd_nexthop_groups_[vnet][active_nhg].ref_count++;
 
-            if (priority_route_updated || custom_monitor_ep_updated || is_custom_monitor_pinned_state_updated)
+            if (!is_fg_route && (priority_route_updated || custom_monitor_ep_updated || is_custom_monitor_pinned_state_updated))
             {
                 MonitorUpdate update;
                 update.monitoring_type = monitoring;
@@ -1378,14 +1719,14 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                 return true;
             }
 
-            if (adv_prefix.to_string() != ipPrefix.to_string() && prefix_to_adv_prefix_.find(ipPrefix) == prefix_to_adv_prefix_.end())
+            if (!is_fg_route && adv_prefix.to_string() != ipPrefix.to_string() && prefix_to_adv_prefix_.find(ipPrefix) == prefix_to_adv_prefix_.end())
             {
                 prefix_to_adv_prefix_[ipPrefix] = adv_prefix;
                 if (adv_prefix_refcount_.find(adv_prefix) == adv_prefix_refcount_.end())
                 {
                     adv_prefix_refcount_[adv_prefix] = 0;
                 }
-                if(active_nhg.getSize() > 0)
+                if (active_nhg.getSize() > 0)
                 {
                     adv_prefix_refcount_[adv_prefix] += 1;
                 }
@@ -1405,9 +1746,12 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         }
         NextHopGroupKey nhg = it_route->second.nhg_key;
         auto last_nhg_size = nhg.getSize();
+
+        // Determine if route is currently fine-grained
+        bool route_is_fg = gFgNhgOrch->syncdContainsFgNhg(vrf_obj->getVRidIngress(), ipPrefix);
+
         for (auto vr_id : vr_set)
         {
-            // If an nhg has no active member, the route should already be removed
             if (!syncd_nexthop_groups_[vnet][nhg].active_members.empty())
             {
                 if (!del_route(vr_id, pfx))
@@ -1416,40 +1760,45 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                     return false;
                 }
                 SWSS_LOG_INFO("Successfully deleted the route for prefix: %s", ipPrefix.to_string().c_str());
-
             }
         }
 
-        if(--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
+        if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
         {
-            if (nhg.getSize() > 1)
+            if (route_is_fg)
             {
-                removeNextHopGroup(vnet, nhg, vrf_obj);
+                removeFgNextHopGroup(vnet, nhg, ipPrefix, vrf_obj);
             }
             else
             {
-                syncd_nexthop_groups_[vnet].erase(nhg);
-                // We need to check specifically if there is only one next hop active.
-                // In case of Priority routes we can end up in a situation where the active NHG has 0 nexthops.
-                if(nhg.getSize() == 1)
+                if (nhg.getSize() > 1)
                 {
-                    NextHopKey nexthop = *nhg.getNextHops().begin();
-                    if (!isLocalEndpoint(vnet, nexthop.ip_address))
+                    removeNextHopGroup(vnet, nhg, vrf_obj);
+                }
+                else
+                {
+                    syncd_nexthop_groups_[vnet].erase(nhg);
+                    if (nhg.getSize() == 1)
                     {
-                        vrf_obj->removeTunnelNextHop(nexthop);
+                        NextHopKey nexthop = *nhg.getNextHops().begin();
+                        if (!isLocalEndpoint(vnet, nexthop.ip_address))
+                        {
+                            vrf_obj->removeTunnelNextHop(nexthop);
+                        }
                     }
                 }
-            }
-            if (monitor_info_[vnet].find(ipPrefix) == monitor_info_[vnet].end())
-            {
-                delEndpointMonitor(vnet, nhg, ipPrefix);
+                if (monitor_info_[vnet].find(ipPrefix) == monitor_info_[vnet].end())
+                {
+                    delEndpointMonitor(vnet, nhg, ipPrefix);
+                }
             }
         }
         else
         {
             syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
         }
-        if (monitor_info_[vnet].find(ipPrefix) != monitor_info_[vnet].end())
+
+        if (!route_is_fg && monitor_info_[vnet].find(ipPrefix) != monitor_info_[vnet].end())
         {
             delEndpointMonitor(vnet, it_route->second.primary, ipPrefix);
             delEndpointMonitor(vnet, it_route->second.secondary, ipPrefix);
@@ -1464,8 +1813,8 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
 
         vrf_obj->removeRoute(ipPrefix);
         vrf_obj->removeProfile(ipPrefix);
-
         removeRouteState(vnet, ipPrefix);
+
         if (prefix_to_adv_prefix_.find(ipPrefix) != prefix_to_adv_prefix_.end())
         {
             auto adv_pfx = prefix_to_adv_prefix_[ipPrefix];
@@ -3207,6 +3556,7 @@ bool VNetRouteOrch::handleTunnel(const Request& request)
     string monitoring;
     int32_t rx_monitor_timer = -1;
     int32_t tx_monitor_timer = -1;
+    uint16_t consistent_hashing_buckets = 0;
     swss::IpPrefix adv_prefix;
     bool has_priority_ep = false;
     bool has_adv_pfx = false;
@@ -3263,6 +3613,10 @@ bool VNetRouteOrch::handleTunnel(const Request& request)
         else if (name == "pinned_state")
         {
             pinned_state_list = request.getAttrStringList(name);
+        }
+        else if (name == "consistent_hashing_buckets")
+        {
+            consistent_hashing_buckets = static_cast<uint16_t>(request.getAttrUint(name));
         }
         else
         {
@@ -3424,7 +3778,11 @@ bool VNetRouteOrch::handleTunnel(const Request& request)
     }
     if (vnet_orch_->isVnetExecVrf())
     {
-        return doRouteTask<VNetVrfObject>(vnet_name, ip_pfx, (has_priority_ep == true) ? nhg_primary : nhg, op, profile, monitoring, rx_monitor_timer, tx_monitor_timer, nhg_secondary, adv_prefix, monitors, monitor_addr_to_pinned_state);
+        return doRouteTask<VNetVrfObject>(vnet_name, ip_pfx,
+            (has_priority_ep) ? nhg_primary : nhg, op, profile,
+            monitoring, rx_monitor_timer, tx_monitor_timer,
+            nhg_secondary, adv_prefix, monitors, monitor_addr_to_pinned_state,
+            consistent_hashing_buckets);
     }
 
     return true;

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1341,6 +1341,259 @@ bool VNetRouteOrch::selectFgNextHopGroup(const string& vnet,
     return true;
 }
 
+RouteTypeTransitionInfo VNetRouteOrch::detectRouteTypeTransition(
+    const string& vnet,
+    const IpPrefix& ipPrefix,
+    const NextHopGroupKey& nexthops,
+    VNetVrfObject* vrf_obj,
+    uint16_t consistent_hashing_buckets)
+{
+    RouteTypeTransitionInfo info;
+    info.is_fg_route = (consistent_hashing_buckets > 0);
+
+    auto it_route = syncd_tunnel_routes_[vnet].find(ipPrefix);
+    if (it_route != syncd_tunnel_routes_[vnet].end())
+    {
+        sai_object_id_t vr_id_check = vrf_obj->getVRidIngress();
+        info.was_fg = gFgNhgOrch->syncdContainsFgNhg(vr_id_check, ipPrefix);
+        info.old_nhg_key = it_route->second.nhg_key;
+        info.is_type_transition = (info.was_fg != info.is_fg_route);
+    }
+
+    info.collision = info.is_type_transition && hasNextHopGroup(vnet, nexthops);
+    if (info.collision)
+    {
+        info.saved_old_nhg_info = syncd_nexthop_groups_[vnet][info.old_nhg_key];
+        syncd_nexthop_groups_[vnet].erase(info.old_nhg_key);
+    }
+
+    return info;
+}
+
+void VNetRouteOrch::cleanupOldRouteNhg(
+    const string& vnet,
+    IpPrefix& ipPrefix,
+    NextHopGroupKey& nexthops,
+    NextHopGroupKey& nexthops_secondary,
+    const string& monitoring,
+    VNetVrfObject* vrf_obj,
+    const NextHopGroupKey& active_nhg,
+    RouteTypeTransitionInfo& transition_info,
+    bool custom_monitor_ep_updated,
+    const map<NextHopKey, IpAddress>& origin_primary_monitors,
+    const map<NextHopKey, IpAddress>& origin_secondary_monitors,
+    bool is_custom_monitor_pinned_state_updated,
+    bool& route_updated,
+    bool& priority_route_updated)
+{
+    auto it_route = syncd_tunnel_routes_[vnet].find(ipPrefix);
+    if (it_route == syncd_tunnel_routes_[vnet].end())
+    {
+        return;
+    }
+
+    if (transition_info.collision)
+    {
+        route_updated = true;
+        if (--transition_info.saved_old_nhg_info.ref_count == 0)
+        {
+            if (transition_info.was_fg)
+            {
+                gFgNhgOrch->removeFgNhgTunnel(vrf_obj->getVRidIngress(), ipPrefix);
+                for (auto nh : transition_info.old_nhg_key.getNextHops())
+                {
+                    vrf_obj->removeTunnelNextHop(nh);
+                }
+            }
+            else
+            {
+                removeNextHopGroupDirectly(vnet, transition_info.saved_old_nhg_info,
+                                           transition_info.old_nhg_key, vrf_obj);
+            }
+            if (!transition_info.was_fg)
+            {
+                delEndpointMonitor(vnet, transition_info.old_nhg_key, ipPrefix);
+            }
+        }
+        else
+        {
+            transition_info.saved_old_nhg_info.tunnel_routes.erase(ipPrefix);
+            syncd_nexthop_groups_[vnet][transition_info.old_nhg_key] = transition_info.saved_old_nhg_info;
+        }
+        vrf_obj->removeRoute(ipPrefix);
+        vrf_obj->removeProfile(ipPrefix);
+    }
+    else if (transition_info.is_type_transition && transition_info.old_nhg_key != active_nhg)
+    {
+        route_updated = true;
+        if (--syncd_nexthop_groups_[vnet][transition_info.old_nhg_key].ref_count == 0)
+        {
+            if (transition_info.was_fg)
+            {
+                removeFgNextHopGroup(vnet, transition_info.old_nhg_key, ipPrefix, vrf_obj);
+            }
+            else
+            {
+                if (transition_info.old_nhg_key.getSize() > 1)
+                {
+                    removeNextHopGroup(vnet, transition_info.old_nhg_key, vrf_obj);
+                }
+                else
+                {
+                    syncd_nexthop_groups_[vnet].erase(transition_info.old_nhg_key);
+                    if (transition_info.old_nhg_key.getSize() == 1)
+                    {
+                        NextHopKey nexthop = *transition_info.old_nhg_key.getNextHops().begin();
+                        if (!isLocalEndpoint(vnet, nexthop.ip_address))
+                        {
+                            vrf_obj->removeTunnelNextHop(nexthop);
+                        }
+                    }
+                }
+                delEndpointMonitor(vnet, transition_info.old_nhg_key, ipPrefix);
+            }
+        }
+        else
+        {
+            syncd_nexthop_groups_[vnet][transition_info.old_nhg_key].tunnel_routes.erase(ipPrefix);
+        }
+        vrf_obj->removeRoute(ipPrefix);
+        vrf_obj->removeProfile(ipPrefix);
+    }
+    else if (transition_info.is_fg_route && !transition_info.is_type_transition)
+    {
+        if (it_route->second.nhg_key != nexthops)
+        {
+            route_updated = true;
+            NextHopGroupKey nhg = it_route->second.nhg_key;
+            if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
+            {
+                for (auto nh : nhg.getNextHops())
+                {
+                    vrf_obj->removeTunnelNextHop(nh);
+                }
+                syncd_nexthop_groups_[vnet].erase(nhg);
+            }
+            else
+            {
+                syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
+            }
+            vrf_obj->removeRoute(ipPrefix);
+        }
+    }
+    else if (!transition_info.is_fg_route && !transition_info.is_type_transition)
+    {
+        if (custom_monitor_ep_updated)
+        {
+            route_updated = true;
+            delEndpointMonitor(vnet, origin_primary_monitors, ipPrefix);
+            delEndpointMonitor(vnet, origin_secondary_monitors, ipPrefix);
+        }
+        else if ((monitoring == "" && it_route->second.nhg_key != nexthops) ||
+            ((monitoring == VNET_MONITORING_TYPE_CUSTOM || monitoring == VNET_MONITORING_TYPE_CUSTOM_BFD) &&
+             (it_route->second.primary != nexthops || it_route->second.secondary != nexthops_secondary)))
+        {
+            route_updated = true;
+            NextHopGroupKey nhg = it_route->second.nhg_key;
+            if (monitoring == VNET_MONITORING_TYPE_CUSTOM || monitoring == VNET_MONITORING_TYPE_CUSTOM_BFD)
+            {
+                if (it_route->second.primary != nexthops)
+                {
+                    delEndpointMonitor(vnet, it_route->second.primary, ipPrefix);
+                }
+                if (it_route->second.secondary != nexthops_secondary)
+                {
+                    delEndpointMonitor(vnet, it_route->second.secondary, ipPrefix);
+                }
+                if (monitor_info_[vnet][ipPrefix].empty())
+                {
+                    monitor_info_[vnet].erase(ipPrefix);
+                }
+                priority_route_updated = true;
+            }
+            else
+            {
+                if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
+                {
+                    if (nhg.getSize() > 1)
+                    {
+                        removeNextHopGroup(vnet, nhg, vrf_obj);
+                    }
+                    else
+                    {
+                        syncd_nexthop_groups_[vnet].erase(nhg);
+                        if (nhg.getSize() == 1)
+                        {
+                            NextHopKey nexthop = *nhg.getNextHops().begin();
+                            if (!isLocalEndpoint(vnet, nexthop.ip_address))
+                            {
+                                vrf_obj->removeTunnelNextHop(nexthop);
+                            }
+                        }
+                    }
+                    if (monitoring != VNET_MONITORING_TYPE_CUSTOM && monitoring != VNET_MONITORING_TYPE_CUSTOM_BFD)
+                    {
+                        delEndpointMonitor(vnet, nhg, ipPrefix);
+                    }
+                }
+                else
+                {
+                    syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
+                }
+                vrf_obj->removeRoute(ipPrefix);
+                vrf_obj->removeProfile(ipPrefix);
+            }
+        }
+        else if (is_custom_monitor_pinned_state_updated)
+        {
+            route_updated = true;
+        }
+    }
+}
+
+void VNetRouteOrch::cleanupDeletedRouteNhg(
+    const string& vnet,
+    NextHopGroupKey& nhg,
+    IpPrefix& ipPrefix,
+    VNetVrfObject* vrf_obj,
+    bool route_is_fg)
+{
+    if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
+    {
+        if (route_is_fg)
+        {
+            removeFgNextHopGroup(vnet, nhg, ipPrefix, vrf_obj);
+        }
+        else
+        {
+            if (nhg.getSize() > 1)
+            {
+                removeNextHopGroup(vnet, nhg, vrf_obj);
+            }
+            else
+            {
+                syncd_nexthop_groups_[vnet].erase(nhg);
+                if (nhg.getSize() == 1)
+                {
+                    NextHopKey nexthop = *nhg.getNextHops().begin();
+                    if (!isLocalEndpoint(vnet, nexthop.ip_address))
+                    {
+                        vrf_obj->removeTunnelNextHop(nexthop);
+                    }
+                }
+            }
+            if (monitor_info_[vnet].find(ipPrefix) == monitor_info_[vnet].end())
+            {
+                delEndpointMonitor(vnet, nhg, ipPrefix);
+            }
+        }
+    }
+    else
+    {
+        syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
+    }
+}
+
 template<>
 bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipPrefix,
                                                NextHopGroupKey& nexthops, string& op, string& profile,
@@ -1386,35 +1639,11 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
     sai_ip_prefix_t pfx;
     copy(pfx, ipPrefix);
 
-    bool is_fg_route = (consistent_hashing_buckets > 0);
+    auto transition = detectRouteTypeTransition(vnet, ipPrefix, nexthops, vrf_obj, consistent_hashing_buckets);
 
     if (op == SET_COMMAND)
     {
         auto it_route = syncd_tunnel_routes_[vnet].find(ipPrefix);
-
-        // Determine if the route was previously fine-grained
-        sai_object_id_t vr_id_check = vrf_obj->getVRidIngress();
-        bool was_fg = (it_route != syncd_tunnel_routes_[vnet].end())
-                      && gFgNhgOrch->syncdContainsFgNhg(vr_id_check, ipPrefix);
-
-        NextHopGroupKey old_nhg_key;
-        if (it_route != syncd_tunnel_routes_[vnet].end())
-        {
-            old_nhg_key = it_route->second.nhg_key;
-        }
-
-        bool is_type_transition = (it_route != syncd_tunnel_routes_[vnet].end())
-                                  && (was_fg != is_fg_route);
-
-        // If transitioning from regular -? fg or vice versa with same endpoints, collision will occur on same NHG key.
-        // save old NHG info and evict from map before creating new one.
-        NextHopGroupInfo saved_old_nhg_info;
-        bool collision = is_type_transition && hasNextHopGroup(vnet, nexthops);
-        if (collision)
-        {
-            saved_old_nhg_info = syncd_nexthop_groups_[vnet][old_nhg_key];
-            syncd_nexthop_groups_[vnet].erase(old_nhg_key);
-        }
 
         sai_object_id_t nh_id = SAI_NULL_OBJECT_ID;
         bool isNextHopIdChanged = false;
@@ -1425,14 +1654,15 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         std::map<NextHopKey, swss::IpAddress> origin_secondary_monitors;
         bool is_custom_monitor_pinned_state_updated = false;
 
-        if (is_fg_route)
+        if (transition.is_fg_route)
         {
             if (!selectFgNextHopGroup(vnet, nexthops, ipPrefix, vrf_obj,
                                       consistent_hashing_buckets, isNextHopIdChanged))
             {
-                if (collision)
+                if (transition.collision)
                 {
-                    syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
+                    syncd_nexthop_groups_[vnet][transition.old_nhg_key] = transition.saved_old_nhg_info;
+                    SWSS_LOG_INFO("Unable to transition from regular to fine-grained ECMP route for VNET %s, prefix %s", vnet.c_str(), ipPrefix.to_string().c_str());
                 }
                 return true;
             }
@@ -1441,7 +1671,6 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         }
         else
         {
-            // Regular ECMP path with monitoring/priority support
             custom_monitor_ep_updated = isCustomMonitorEndpointUpdated(vnet, ipPrefix, monitors);
             if (custom_monitor_ep_updated)
             {
@@ -1458,9 +1687,10 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                                     rx_monitor_timer, tx_monitor_timer, ipPrefix,
                                     vrf_obj, active_nhg, monitors, monitor_addr_to_pinned_state))
             {
-                if (collision)
+                if (transition.collision)
                 {
-                    syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
+                    syncd_nexthop_groups_[vnet][transition.old_nhg_key] = transition.saved_old_nhg_info;
+                    SWSS_LOG_INFO("Unable to transition from fine-grained to regular ECMP route for VNET %s, prefix %s", vnet.c_str(), ipPrefix.to_string().c_str());
                 }
                 return true;
             }
@@ -1470,15 +1700,15 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         sai_object_id_t old_nh_id = SAI_NULL_OBJECT_ID;
         if (it_route != syncd_tunnel_routes_[vnet].end())
         {
-            old_nh_id = collision ? saved_old_nhg_info.next_hop_group_id
-                                  : syncd_nexthop_groups_[vnet][old_nhg_key].next_hop_group_id;
+            old_nh_id = transition.collision ? transition.saved_old_nhg_info.next_hop_group_id
+                                             : syncd_nexthop_groups_[vnet][transition.old_nhg_key].next_hop_group_id;
         }
 
         for (auto vr_id : vr_set)
         {
             bool route_status = true;
 
-            if (is_fg_route)
+            if (transition.is_fg_route)
             {
                 if (it_route == syncd_tunnel_routes_[vnet].end())
                 {
@@ -1496,9 +1726,9 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                     if (it_route != syncd_tunnel_routes_[vnet].end())
                     {
                         NextHopGroupKey nhg = it_route->second.nhg_key;
-                        if (collision)
+                        if (transition.collision)
                         {
-                            if (!saved_old_nhg_info.active_members.empty())
+                            if (!transition.saved_old_nhg_info.active_members.empty())
                             {
                                 del_route(vr_id, pfx);
                             }
@@ -1522,9 +1752,9 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                         if (!gRouteOrch->removeRoutePrefix(prefixSubnet))
                         {
                             SWSS_LOG_ERROR("Could not remove existing bgp route for prefix: %s\n", prefixSubnet.to_string().c_str());
-                            if (collision)
+                            if (transition.collision)
                             {
-                                syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
+                                syncd_nexthop_groups_[vnet][transition.old_nhg_key] = transition.saved_old_nhg_info;
                             }
                             return false;
                         }
@@ -1537,7 +1767,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                     }
                     else if (nh_id != old_nh_id)
                     {
-                        if (collision || !syncd_nexthop_groups_[vnet][old_nhg_key].active_members.empty())
+                        if (transition.collision || !syncd_nexthop_groups_[vnet][transition.old_nhg_key].active_members.empty())
                         {
                             route_status = update_route(vr_id, pfx, nh_id);
                         }
@@ -1552,7 +1782,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
             if (!route_status)
             {
                 SWSS_LOG_ERROR("Route add/update failed for %s, vr_id '0x%" PRIx64, ipPrefix.to_string().c_str(), vr_id);
-                if (is_fg_route)
+                if (transition.is_fg_route)
                 {
                     removeFgNextHopGroup(vnet, nexthops, ipPrefix, vrf_obj);
                 }
@@ -1560,9 +1790,9 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                 {
                     removeNextHopGroup(vnet, active_nhg, vrf_obj);
                 }
-                if (collision)
+                if (transition.collision)
                 {
-                    syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
+                    syncd_nexthop_groups_[vnet][transition.old_nhg_key] = transition.saved_old_nhg_info;
                 }
                 return false;
             }
@@ -1572,168 +1802,13 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         bool priority_route_updated = false;
         if (it_route != syncd_tunnel_routes_[vnet].end())
         {
-            if (collision)
-            {
-                route_updated = true;
-                if (--saved_old_nhg_info.ref_count == 0)
-                {
-                    if (was_fg)
-                    {
-                        gFgNhgOrch->removeFgNhgTunnel(vrf_obj->getVRidIngress(), ipPrefix);
-                        for (auto nh : old_nhg_key.getNextHops())
-                        {
-                            vrf_obj->removeTunnelNextHop(nh);
-                        }
-                    }
-                    else
-                    {
-                        removeNextHopGroupDirectly(vnet, saved_old_nhg_info, old_nhg_key, vrf_obj);
-                    }
-                    if (!was_fg)
-                    {
-                        delEndpointMonitor(vnet, old_nhg_key, ipPrefix);
-                    }
-                }
-                else
-                {
-                    saved_old_nhg_info.tunnel_routes.erase(ipPrefix);
-                    syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
-                }
-                vrf_obj->removeRoute(ipPrefix);
-                vrf_obj->removeProfile(ipPrefix);
-            }
-            else if (is_type_transition && old_nhg_key != active_nhg)
-            {
-                // Type transition with different endpoints — no collision
-                route_updated = true;
-                if (--syncd_nexthop_groups_[vnet][old_nhg_key].ref_count == 0)
-                {
-                    if (was_fg)
-                    {
-                        removeFgNextHopGroup(vnet, old_nhg_key, ipPrefix, vrf_obj);
-                    }
-                    else
-                    {
-                        if (old_nhg_key.getSize() > 1)
-                        {
-                            removeNextHopGroup(vnet, old_nhg_key, vrf_obj);
-                        }
-                        else
-                        {
-                            syncd_nexthop_groups_[vnet].erase(old_nhg_key);
-                            if (old_nhg_key.getSize() == 1)
-                            {
-                                NextHopKey nexthop = *old_nhg_key.getNextHops().begin();
-                                if (!isLocalEndpoint(vnet, nexthop.ip_address))
-                                {
-                                    vrf_obj->removeTunnelNextHop(nexthop);
-                                }
-                            }
-                        }
-                        delEndpointMonitor(vnet, old_nhg_key, ipPrefix);
-                    }
-                }
-                else
-                {
-                    syncd_nexthop_groups_[vnet][old_nhg_key].tunnel_routes.erase(ipPrefix);
-                }
-                vrf_obj->removeRoute(ipPrefix);
-                vrf_obj->removeProfile(ipPrefix);
-            }
-            else if (is_fg_route && !is_type_transition)
-            {
-                // FG → FG update with different endpoints
-                if (it_route->second.nhg_key != nexthops)
-                {
-                    route_updated = true;
-                    NextHopGroupKey nhg = it_route->second.nhg_key;
-                    if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
-                    {
-                        for (auto nh : nhg.getNextHops())
-                        {
-                            vrf_obj->removeTunnelNextHop(nh);
-                        }
-                        syncd_nexthop_groups_[vnet].erase(nhg);
-                    }
-                    else
-                    {
-                        syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
-                    }
-                    vrf_obj->removeRoute(ipPrefix);
-                }
-            }
-            else if (!is_fg_route && !is_type_transition)
-            {
-                // Regular → Regular update (existing logic)
-                if (custom_monitor_ep_updated)
-                {
-                    route_updated = true;
-                    delEndpointMonitor(vnet, origin_primary_monitors, ipPrefix);
-                    delEndpointMonitor(vnet, origin_secondary_monitors, ipPrefix);
-                }
-                else if ((monitoring == "" && it_route->second.nhg_key != nexthops) ||
-                    ((monitoring == VNET_MONITORING_TYPE_CUSTOM || monitoring == VNET_MONITORING_TYPE_CUSTOM_BFD) &&
-                     (it_route->second.primary != nexthops || it_route->second.secondary != nexthops_secondary)))
-                {
-                    route_updated = true;
-                    NextHopGroupKey nhg = it_route->second.nhg_key;
-                    if (monitoring == VNET_MONITORING_TYPE_CUSTOM || monitoring == VNET_MONITORING_TYPE_CUSTOM_BFD)
-                    {
-                        if (it_route->second.primary != nexthops)
-                        {
-                            delEndpointMonitor(vnet, it_route->second.primary, ipPrefix);
-                        }
-                        if (it_route->second.secondary != nexthops_secondary)
-                        {
-                            delEndpointMonitor(vnet, it_route->second.secondary, ipPrefix);
-                        }
-                        if (monitor_info_[vnet][ipPrefix].empty())
-                        {
-                            monitor_info_[vnet].erase(ipPrefix);
-                        }
-                        priority_route_updated = true;
-                    }
-                    else
-                    {
-                        if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
-                        {
-                            if (nhg.getSize() > 1)
-                            {
-                                removeNextHopGroup(vnet, nhg, vrf_obj);
-                            }
-                            else
-                            {
-                                syncd_nexthop_groups_[vnet].erase(nhg);
-                                if (nhg.getSize() == 1)
-                                {
-                                    NextHopKey nexthop = *nhg.getNextHops().begin();
-                                    if (!isLocalEndpoint(vnet, nexthop.ip_address))
-                                    {
-                                        vrf_obj->removeTunnelNextHop(nexthop);
-                                    }
-                                }
-                            }
-                            if (monitoring != VNET_MONITORING_TYPE_CUSTOM && monitoring != VNET_MONITORING_TYPE_CUSTOM_BFD)
-                            {
-                                delEndpointMonitor(vnet, nhg, ipPrefix);
-                            }
-                        }
-                        else
-                        {
-                            syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
-                        }
-                        vrf_obj->removeRoute(ipPrefix);
-                        vrf_obj->removeProfile(ipPrefix);
-                    }
-                }
-                else if (is_custom_monitor_pinned_state_updated)
-                {
-                    route_updated = true;
-                }
-            }
+            cleanupOldRouteNhg(vnet, ipPrefix, nexthops, nexthops_secondary, monitoring,
+                               vrf_obj, active_nhg, transition,
+                               custom_monitor_ep_updated, origin_primary_monitors,
+                               origin_secondary_monitors, is_custom_monitor_pinned_state_updated,
+                               route_updated, priority_route_updated);
         }
 
-        // --- STEP 4: Update syncd_tunnel_routes_ ---
         if (!profile.empty())
         {
             vrf_obj->addProfile(ipPrefix, profile);
@@ -1749,7 +1824,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
             tunnel_route_entry.secondary = nexthops_secondary;
             syncd_tunnel_routes_[vnet][ipPrefix] = tunnel_route_entry;
 
-            if (!is_fg_route && (priority_route_updated || custom_monitor_ep_updated || is_custom_monitor_pinned_state_updated))
+            if (!transition.is_fg_route && (priority_route_updated || custom_monitor_ep_updated || is_custom_monitor_pinned_state_updated))
             {
                 MonitorUpdate update;
                 update.monitoring_type = monitoring;
@@ -1761,7 +1836,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                 return true;
             }
 
-            if (!is_fg_route && adv_prefix.to_string() != ipPrefix.to_string() && prefix_to_adv_prefix_.find(ipPrefix) == prefix_to_adv_prefix_.end())
+            if (!transition.is_fg_route && adv_prefix.to_string() != ipPrefix.to_string() && prefix_to_adv_prefix_.find(ipPrefix) == prefix_to_adv_prefix_.end())
             {
                 prefix_to_adv_prefix_[ipPrefix] = adv_prefix;
                 if (adv_prefix_refcount_.find(adv_prefix) == adv_prefix_refcount_.end())
@@ -1789,7 +1864,6 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         NextHopGroupKey nhg = it_route->second.nhg_key;
         auto last_nhg_size = nhg.getSize();
 
-        // Determine if route is currently fine-grained
         bool route_is_fg = gFgNhgOrch->syncdContainsFgNhg(vrf_obj->getVRidIngress(), ipPrefix);
 
         for (auto vr_id : vr_set)
@@ -1805,40 +1879,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
             }
         }
 
-        if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
-        {
-            if (route_is_fg)
-            {
-                removeFgNextHopGroup(vnet, nhg, ipPrefix, vrf_obj);
-            }
-            else
-            {
-                if (nhg.getSize() > 1)
-                {
-                    removeNextHopGroup(vnet, nhg, vrf_obj);
-                }
-                else
-                {
-                    syncd_nexthop_groups_[vnet].erase(nhg);
-                    if (nhg.getSize() == 1)
-                    {
-                        NextHopKey nexthop = *nhg.getNextHops().begin();
-                        if (!isLocalEndpoint(vnet, nexthop.ip_address))
-                        {
-                            vrf_obj->removeTunnelNextHop(nexthop);
-                        }
-                    }
-                }
-                if (monitor_info_[vnet].find(ipPrefix) == monitor_info_[vnet].end())
-                {
-                    delEndpointMonitor(vnet, nhg, ipPrefix);
-                }
-            }
-        }
-        else
-        {
-            syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
-        }
+        cleanupDeletedRouteNhg(vnet, nhg, ipPrefix, vrf_obj, route_is_fg);
 
         if (!route_is_fg && monitor_info_[vnet].find(ipPrefix) != monitor_info_[vnet].end())
         {

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -792,6 +792,11 @@ sai_object_id_t VNetRouteOrch::getNextHopGroupId(const string& vnet, const NextH
     return syncd_nexthop_groups_[vnet][nexthops].next_hop_group_id;
 }
 
+bool VNetRouteOrch::hasFgNextHopGroup(const string& vnet, const IpPrefix& ipPrefix)
+{
+    return syncd_fg_nexthop_groups_[vnet].find(ipPrefix) != syncd_fg_nexthop_groups_[vnet].end();
+}
+
 bool VNetRouteOrch::addNextHopGroup(const string& vnet, const NextHopGroupKey &nexthops, VNetVrfObject *vrf_obj, const string& monitoring,  const bool isLocalEp)
 {
     SWSS_LOG_ENTER();
@@ -1035,12 +1040,28 @@ bool VNetRouteOrch::removeFgNextHopGroup(const string& vnet, const NextHopGroupK
         return false;
     }
 
-    for (auto nhop : nexthops.getNextHops())
+    auto it_fg = syncd_fg_nexthop_groups_[vnet].find(ipPrefix);
+    if (it_fg != syncd_fg_nexthop_groups_[vnet].end())
     {
-        vrf_obj->removeTunnelNextHop(nhop);
+        for (auto& member : it_fg->second.active_members)
+        {
+            NextHopKey nhop = member.first;
+            vrf_obj->removeTunnelNextHop(nhop);
+        }
+    }
+    else
+    {
+        for (auto nhop : nexthops.getNextHops())
+        {
+            vrf_obj->removeTunnelNextHop(nhop);
+        }
     }
 
-    syncd_nexthop_groups_[vnet].erase(nexthops);
+    syncd_fg_nexthop_groups_[vnet].erase(ipPrefix);
+    if (syncd_fg_nexthop_groups_[vnet].empty())
+    {
+        syncd_fg_nexthop_groups_.erase(vnet);
+    }
     return true;
 }
 
@@ -1274,25 +1295,36 @@ bool VNetRouteOrch::selectFgNextHopGroup(const string& vnet,
                                        IpPrefix& ipPrefix,
                                        VNetVrfObject *vrf_obj,
                                        const uint16_t consistent_hashing_buckets,
+                                       bool is_type_transition,
                                        bool& isNextHopIdChanged)
 {
     // This function returns the next hop group which is to be used to in the hardware
     // for fine grained ECMP tunnel routes.
 
-    bool nhg_exists = hasNextHopGroup(vnet, nexthops);
+    bool nhg_exists = hasFgNextHopGroup(vnet, ipPrefix);
+    std::set<NextHopKey> old_members;
+    if (nhg_exists && !is_type_transition)
+    {
+        auto it_route = syncd_tunnel_routes_[vnet].find(ipPrefix);
+        if (it_route != syncd_tunnel_routes_[vnet].end())
+        {
+            old_members = it_route->second.nhg_key.getNextHops();
+        }
+    }
+
     std::map<NextHopKey, sai_object_id_t> nhopgroup_members_set;
 
     for (auto nh : nexthops.getNextHops())
     {
         sai_object_id_t next_hop_id;
-        if (nhg_exists)
+        if (old_members.count(nh))
         {
-            // NHG already exists, look up existing tunnel NH IDs without incrementing refcount
+            // look up existing tunnel NH IDs without incrementing refcount
             next_hop_id = vrf_obj->getExistingTunnelNextHopId(nh);
         }
         else
         {
-            // New NHG, create tunnel NHs (sets refcount to 1)
+            // create tunnel NHs (bumps refcount)
             next_hop_id = vrf_obj->getTunnelNextHop(nh);
         }
         nhopgroup_members_set[nh] = next_hop_id;
@@ -1306,9 +1338,9 @@ bool VNetRouteOrch::selectFgNextHopGroup(const string& vnet,
     {
         SWSS_LOG_ERROR("Failed to create fine grained next hop group for VNET %s", vnet.c_str());
 
-        if (!nhg_exists)
+        for (auto nh : nexthops.getNextHops())
         {
-            for (auto nh : nexthops.getNextHops())
+            if (!old_members.count(nh))
             {
                 vrf_obj->removeTunnelNextHop(nh);
             }
@@ -1326,16 +1358,17 @@ bool VNetRouteOrch::selectFgNextHopGroup(const string& vnet,
         * count will increase once the route is successfully syncd.
         */
         next_hop_group_entry.ref_count = 0;
-        syncd_nexthop_groups_[vnet][nexthops] = next_hop_group_entry;
+        syncd_fg_nexthop_groups_[vnet][ipPrefix] = next_hop_group_entry;
+    }
 
-        for (auto nh : nexthops.getNextHops())
-        {
-            syncd_nexthop_groups_[vnet][nexthops].active_members[nh] = SAI_NULL_OBJECT_ID;
-        }
+    syncd_fg_nexthop_groups_[vnet][ipPrefix].active_members.clear();
+    for (auto nh : nexthops.getNextHops())
+    {
+        syncd_fg_nexthop_groups_[vnet][ipPrefix].active_members[nh] = SAI_NULL_OBJECT_ID;
     }
     if (isNextHopIdChanged)
     {
-        syncd_nexthop_groups_[vnet][nexthops].next_hop_group_id = nh_id;
+        syncd_fg_nexthop_groups_[vnet][ipPrefix].next_hop_group_id = nh_id;
     }
 
     return true;
@@ -1360,13 +1393,6 @@ RouteTypeTransitionInfo VNetRouteOrch::detectRouteTypeTransition(
         info.is_type_transition = (info.was_fg != info.is_fg_route);
     }
 
-    info.collision = info.is_type_transition && hasNextHopGroup(vnet, nexthops);
-    if (info.collision)
-    {
-        info.saved_old_nhg_info = syncd_nexthop_groups_[vnet][info.old_nhg_key];
-        syncd_nexthop_groups_[vnet].erase(info.old_nhg_key);
-    }
-
     return info;
 }
 
@@ -1377,7 +1403,6 @@ void VNetRouteOrch::cleanupOldRouteNhg(
     NextHopGroupKey& nexthops_secondary,
     const string& monitoring,
     VNetVrfObject* vrf_obj,
-    const NextHopGroupKey& active_nhg,
     RouteTypeTransitionInfo& transition_info,
     bool custom_monitor_ep_updated,
     const map<NextHopKey, IpAddress>& origin_primary_monitors,
@@ -1392,47 +1417,16 @@ void VNetRouteOrch::cleanupOldRouteNhg(
         return;
     }
 
-    if (transition_info.collision)
+    if (transition_info.is_type_transition)
     {
         route_updated = true;
-        if (--transition_info.saved_old_nhg_info.ref_count == 0)
+        if (transition_info.was_fg)
         {
-            if (transition_info.was_fg)
-            {
-                gFgNhgOrch->removeFgNhgTunnel(vrf_obj->getVRidIngress(), ipPrefix);
-                for (auto nh : transition_info.old_nhg_key.getNextHops())
-                {
-                    vrf_obj->removeTunnelNextHop(nh);
-                }
-            }
-            else
-            {
-                removeNextHopGroupDirectly(vnet, transition_info.saved_old_nhg_info,
-                                           transition_info.old_nhg_key, vrf_obj);
-            }
-            if (!transition_info.was_fg)
-            {
-                delEndpointMonitor(vnet, transition_info.old_nhg_key, ipPrefix);
-            }
+            removeFgNextHopGroup(vnet, transition_info.old_nhg_key, ipPrefix, vrf_obj);
         }
         else
         {
-            transition_info.saved_old_nhg_info.tunnel_routes.erase(ipPrefix);
-            syncd_nexthop_groups_[vnet][transition_info.old_nhg_key] = transition_info.saved_old_nhg_info;
-        }
-        vrf_obj->removeRoute(ipPrefix);
-        vrf_obj->removeProfile(ipPrefix);
-    }
-    else if (transition_info.is_type_transition && transition_info.old_nhg_key != active_nhg)
-    {
-        route_updated = true;
-        if (--syncd_nexthop_groups_[vnet][transition_info.old_nhg_key].ref_count == 0)
-        {
-            if (transition_info.was_fg)
-            {
-                removeFgNextHopGroup(vnet, transition_info.old_nhg_key, ipPrefix, vrf_obj);
-            }
-            else
+            if (--syncd_nexthop_groups_[vnet][transition_info.old_nhg_key].ref_count == 0)
             {
                 if (transition_info.old_nhg_key.getSize() > 1)
                 {
@@ -1452,10 +1446,10 @@ void VNetRouteOrch::cleanupOldRouteNhg(
                 }
                 delEndpointMonitor(vnet, transition_info.old_nhg_key, ipPrefix);
             }
-        }
-        else
-        {
-            syncd_nexthop_groups_[vnet][transition_info.old_nhg_key].tunnel_routes.erase(ipPrefix);
+            else
+            {
+                syncd_nexthop_groups_[vnet][transition_info.old_nhg_key].tunnel_routes.erase(ipPrefix);
+            }
         }
         vrf_obj->removeRoute(ipPrefix);
         vrf_obj->removeProfile(ipPrefix);
@@ -1465,18 +1459,13 @@ void VNetRouteOrch::cleanupOldRouteNhg(
         if (it_route->second.nhg_key != nexthops)
         {
             route_updated = true;
-            NextHopGroupKey nhg = it_route->second.nhg_key;
-            if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
+            std::set<NextHopKey> new_members = nexthops.getNextHops();
+            for (auto nh : it_route->second.nhg_key.getNextHops())
             {
-                for (auto nh : nhg.getNextHops())
+                if (new_members.find(nh) == new_members.end())
                 {
                     vrf_obj->removeTunnelNextHop(nh);
                 }
-                syncd_nexthop_groups_[vnet].erase(nhg);
-            }
-            else
-            {
-                syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
             }
             vrf_obj->removeRoute(ipPrefix);
         }
@@ -1558,34 +1547,33 @@ void VNetRouteOrch::cleanupDeletedRouteNhg(
     VNetVrfObject* vrf_obj,
     bool route_is_fg)
 {
+    if (route_is_fg)
+    {
+        removeFgNextHopGroup(vnet, nhg, ipPrefix, vrf_obj);
+        return;
+    }
+
     if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
     {
-        if (route_is_fg)
+        if (nhg.getSize() > 1)
         {
-            removeFgNextHopGroup(vnet, nhg, ipPrefix, vrf_obj);
+            removeNextHopGroup(vnet, nhg, vrf_obj);
         }
         else
         {
-            if (nhg.getSize() > 1)
+            syncd_nexthop_groups_[vnet].erase(nhg);
+            if (nhg.getSize() == 1)
             {
-                removeNextHopGroup(vnet, nhg, vrf_obj);
-            }
-            else
-            {
-                syncd_nexthop_groups_[vnet].erase(nhg);
-                if (nhg.getSize() == 1)
+                NextHopKey nexthop = *nhg.getNextHops().begin();
+                if (!isLocalEndpoint(vnet, nexthop.ip_address))
                 {
-                    NextHopKey nexthop = *nhg.getNextHops().begin();
-                    if (!isLocalEndpoint(vnet, nexthop.ip_address))
-                    {
-                        vrf_obj->removeTunnelNextHop(nexthop);
-                    }
+                    vrf_obj->removeTunnelNextHop(nexthop);
                 }
             }
-            if (monitor_info_[vnet].find(ipPrefix) == monitor_info_[vnet].end())
-            {
-                delEndpointMonitor(vnet, nhg, ipPrefix);
-            }
+        }
+        if (monitor_info_[vnet].find(ipPrefix) == monitor_info_[vnet].end())
+        {
+            delEndpointMonitor(vnet, nhg, ipPrefix);
         }
     }
     else
@@ -1657,17 +1645,16 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         if (transition.is_fg_route)
         {
             if (!selectFgNextHopGroup(vnet, nexthops, ipPrefix, vrf_obj,
-                                      consistent_hashing_buckets, isNextHopIdChanged))
+                                      consistent_hashing_buckets, transition.is_type_transition, isNextHopIdChanged))
             {
-                if (transition.collision)
+                if (transition.is_type_transition)
                 {
-                    syncd_nexthop_groups_[vnet][transition.old_nhg_key] = transition.saved_old_nhg_info;
                     SWSS_LOG_INFO("Unable to transition from regular to fine-grained ECMP route for VNET %s, prefix %s", vnet.c_str(), ipPrefix.to_string().c_str());
                 }
                 return true;
             }
             active_nhg = nexthops;
-            nh_id = syncd_nexthop_groups_[vnet][nexthops].next_hop_group_id;
+            nh_id = syncd_fg_nexthop_groups_[vnet][ipPrefix].next_hop_group_id;
         }
         else
         {
@@ -1687,9 +1674,8 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                                     rx_monitor_timer, tx_monitor_timer, ipPrefix,
                                     vrf_obj, active_nhg, monitors, monitor_addr_to_pinned_state))
             {
-                if (transition.collision)
+                if (transition.is_type_transition)
                 {
-                    syncd_nexthop_groups_[vnet][transition.old_nhg_key] = transition.saved_old_nhg_info;
                     SWSS_LOG_INFO("Unable to transition from fine-grained to regular ECMP route for VNET %s, prefix %s", vnet.c_str(), ipPrefix.to_string().c_str());
                 }
                 return true;
@@ -1698,10 +1684,19 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         }
 
         sai_object_id_t old_nh_id = SAI_NULL_OBJECT_ID;
+        bool old_group_has_active_members = false;
         if (it_route != syncd_tunnel_routes_[vnet].end())
         {
-            old_nh_id = transition.collision ? transition.saved_old_nhg_info.next_hop_group_id
-                                             : syncd_nexthop_groups_[vnet][transition.old_nhg_key].next_hop_group_id;
+            if (transition.was_fg)
+            {
+                old_nh_id = syncd_fg_nexthop_groups_[vnet][ipPrefix].next_hop_group_id;
+                old_group_has_active_members = !syncd_fg_nexthop_groups_[vnet][ipPrefix].active_members.empty();
+            }
+            else
+            {
+                old_nh_id = syncd_nexthop_groups_[vnet][transition.old_nhg_key].next_hop_group_id;
+                old_group_has_active_members = !syncd_nexthop_groups_[vnet][transition.old_nhg_key].active_members.empty();
+            }
         }
 
         for (auto vr_id : vr_set)
@@ -1714,7 +1709,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                 {
                     route_status = add_route(vr_id, pfx, nh_id);
                 }
-                else if (nh_id != old_nh_id || isNextHopIdChanged)
+                else if (isNextHopIdChanged)
                 {
                     route_status = update_route(vr_id, pfx, nh_id);
                 }
@@ -1725,15 +1720,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                 {
                     if (it_route != syncd_tunnel_routes_[vnet].end())
                     {
-                        NextHopGroupKey nhg = it_route->second.nhg_key;
-                        if (transition.collision)
-                        {
-                            if (!transition.saved_old_nhg_info.active_members.empty())
-                            {
-                                del_route(vr_id, pfx);
-                            }
-                        }
-                        else if (!syncd_nexthop_groups_[vnet][nhg].active_members.empty())
+                        if (old_group_has_active_members)
                         {
                             del_route(vr_id, pfx);
                         }
@@ -1752,10 +1739,6 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                         if (!gRouteOrch->removeRoutePrefix(prefixSubnet))
                         {
                             SWSS_LOG_ERROR("Could not remove existing bgp route for prefix: %s\n", prefixSubnet.to_string().c_str());
-                            if (transition.collision)
-                            {
-                                syncd_nexthop_groups_[vnet][transition.old_nhg_key] = transition.saved_old_nhg_info;
-                            }
                             return false;
                         }
                         SWSS_LOG_INFO("Successfully removed existing bgp route for prefix: %s\n",
@@ -1767,7 +1750,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                     }
                     else if (nh_id != old_nh_id)
                     {
-                        if (transition.collision || !syncd_nexthop_groups_[vnet][transition.old_nhg_key].active_members.empty())
+                        if (old_group_has_active_members)
                         {
                             route_status = update_route(vr_id, pfx, nh_id);
                         }
@@ -1790,10 +1773,6 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                 {
                     removeNextHopGroup(vnet, active_nhg, vrf_obj);
                 }
-                if (transition.collision)
-                {
-                    syncd_nexthop_groups_[vnet][transition.old_nhg_key] = transition.saved_old_nhg_info;
-                }
                 return false;
             }
         }
@@ -1803,7 +1782,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         if (it_route != syncd_tunnel_routes_[vnet].end())
         {
             cleanupOldRouteNhg(vnet, ipPrefix, nexthops, nexthops_secondary, monitoring,
-                               vrf_obj, active_nhg, transition,
+                               vrf_obj, transition,
                                custom_monitor_ep_updated, origin_primary_monitors,
                                origin_secondary_monitors, is_custom_monitor_pinned_state_updated,
                                route_updated, priority_route_updated);
@@ -1815,8 +1794,16 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         }
         if (it_route == syncd_tunnel_routes_[vnet].end() || route_updated)
         {
-            syncd_nexthop_groups_[vnet][active_nhg].tunnel_routes.insert(ipPrefix);
-            syncd_nexthop_groups_[vnet][active_nhg].ref_count++;
+            if (transition.is_fg_route)
+            {
+                syncd_fg_nexthop_groups_[vnet][ipPrefix].tunnel_routes.insert(ipPrefix);
+                syncd_fg_nexthop_groups_[vnet][ipPrefix].ref_count++;
+            }
+            else
+            {
+                syncd_nexthop_groups_[vnet][active_nhg].tunnel_routes.insert(ipPrefix);
+                syncd_nexthop_groups_[vnet][active_nhg].ref_count++;
+            }
 
             VNetTunnelRouteEntry tunnel_route_entry;
             tunnel_route_entry.nhg_key = active_nhg;
@@ -1850,7 +1837,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
             }
             vrf_obj->addRoute(ipPrefix, active_nhg);
         }
-        postRouteState(vnet, ipPrefix, active_nhg, profile);
+        postRouteState(vnet, ipPrefix, active_nhg, profile, transition.is_fg_route);
     }
     else if (op == DEL_COMMAND)
     {
@@ -1865,10 +1852,13 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         auto last_nhg_size = nhg.getSize();
 
         bool route_is_fg = gFgNhgOrch->syncdContainsFgNhg(vrf_obj->getVRidIngress(), ipPrefix);
+        bool nhg_has_active_members = route_is_fg
+            ? !syncd_fg_nexthop_groups_[vnet][ipPrefix].active_members.empty()
+            : !syncd_nexthop_groups_[vnet][nhg].active_members.empty();
 
         for (auto vr_id : vr_set)
         {
-            if (!syncd_nexthop_groups_[vnet][nhg].active_members.empty())
+            if (nhg_has_active_members)
             {
                 if (!del_route(vr_id, pfx))
                 {
@@ -2999,11 +2989,11 @@ void VNetRouteOrch::updateMonitorState(string& op, const IpPrefix& prefix, const
     }
 }
 
-void VNetRouteOrch::postRouteState(const string& vnet, IpPrefix& ipPrefix, NextHopGroupKey& nexthops, string& profile)
+void VNetRouteOrch::postRouteState(const string& vnet, IpPrefix& ipPrefix, NextHopGroupKey& nexthops, string& profile, bool is_fg)
 {
     const string state_db_key = vnet + state_db_key_delimiter + ipPrefix.to_string();
     vector<FieldValueTuple> fvVector;
-    NextHopGroupInfo& nhg_info = syncd_nexthop_groups_[vnet][nexthops];
+    NextHopGroupInfo& nhg_info = is_fg ? syncd_fg_nexthop_groups_[vnet][ipPrefix] : syncd_nexthop_groups_[vnet][nexthops];
     string route_state = nhg_info.active_members.empty() ? "inactive" : "active";
     string ep_str = "";
     int idx_ep = 0;

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -46,6 +46,7 @@ extern MacAddress gVxlanMacAddress;
 extern BfdOrch *gBfdOrch;
 extern SwitchOrch *gSwitchOrch;
 extern TunnelDecapOrch *gTunneldecapOrch;
+extern FgNhgOrch *gFgNhgOrch;
 /*
  * VRF Modeling and VNetVrf class definitions
  */
@@ -327,6 +328,23 @@ sai_object_id_t VNetVrfObject::getTunnelNextHop(NextHopKey& nh)
          * is already done in createNextHopTunnel()
          */
         SWSS_LOG_ERROR("NH Tunnel create failed for '%s' ip '%s'",
+                vnet_name_.c_str(), nh.ip_address.to_string().c_str());
+    }
+
+    return nh_id;
+}
+
+sai_object_id_t VNetVrfObject::getExistingTunnelNextHopId(NextHopKey& nh)
+{
+    auto tun_name = getTunnelName();
+
+    VxlanTunnelOrch* vxlan_orch = gDirectory.get<VxlanTunnelOrch*>();
+
+    auto *tunnel_obj = vxlan_orch->getVxlanTunnel(tun_name);
+    sai_object_id_t nh_id = tunnel_obj->getNextHop(nh.ip_address, nh.mac_address, nh.vni);
+    if (nh_id == SAI_NULL_OBJECT_ID)
+    {
+        SWSS_LOG_ERROR("NH Tunnel lookup failed for '%s' ip '%s'",
                 vnet_name_.c_str(), nh.ip_address.to_string().c_str());
     }
 
@@ -959,6 +977,73 @@ bool VNetRouteOrch::removeNextHopGroup(const string& vnet, const NextHopGroupKey
     return true;
 }
 
+bool VNetRouteOrch::removeNextHopGroupDirectly(const string& vnet, NextHopGroupInfo& nhg_info, const NextHopGroupKey &nexthops, VNetVrfObject *vrf_obj)
+{
+    SWSS_LOG_ENTER();
+
+    sai_object_id_t next_hop_group_id = nhg_info.next_hop_group_id;
+    sai_status_t status;
+
+    SWSS_LOG_NOTICE("Direct delete next hop group %s", nexthops.to_string().c_str());
+
+    for (auto nhop = nhg_info.active_members.begin();
+         nhop != nhg_info.active_members.end();)
+    {
+        NextHopKey nexthop = nhop->first;
+
+        status = sai_next_hop_group_api->remove_next_hop_group_member(nhop->second);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to remove next hop group member %" PRIx64 ", rv:%d",
+                           nhop->second, status);
+            return false;
+        }
+
+        if (!isLocalEndpoint(vnet, nexthop.ip_address))
+        {
+            vrf_obj->removeTunnelNextHop(nexthop);
+        }
+
+        gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
+        nhop = nhg_info.active_members.erase(nhop);
+    }
+
+    if (nexthops.getSize() > 1)
+    {
+        status = sai_next_hop_group_api->remove_next_hop_group(next_hop_group_id);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to remove next hop group %" PRIx64 ", rv:%d", next_hop_group_id, status);
+            return false;
+        }
+
+        gRouteOrch->decreaseNextHopGroupCount();
+        gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP);
+    }
+
+    return true;
+}
+
+bool VNetRouteOrch::removeFgNextHopGroup(const string& vnet, const NextHopGroupKey &nexthops, const IpPrefix& ipPrefix, VNetVrfObject *vrf_obj)
+{
+    SWSS_LOG_ENTER();
+
+    sai_object_id_t vr_id = vrf_obj->getVRidIngress();
+    if (!gFgNhgOrch->removeFgNhgTunnel(vr_id, ipPrefix))
+    {
+        SWSS_LOG_ERROR("Failed to remove fine grained next hop group for %s, vr_id '0x%" PRIx64, ipPrefix.to_string().c_str(), vr_id);
+        return false;
+    }
+
+    for (auto nhop : nexthops.getNextHops())
+    {
+        vrf_obj->removeTunnelNextHop(nhop);
+    }
+
+    syncd_nexthop_groups_[vnet].erase(nexthops);
+    return true;
+}
+
 bool VNetRouteOrch::createNextHopGroup(const string& vnet,
                                        NextHopGroupKey& nexthops,
                                        VNetVrfObject *vrf_obj,
@@ -1184,6 +1269,78 @@ bool VNetRouteOrch::selectNextHopGroup(const string& vnet,
     return true;
 }
 
+bool VNetRouteOrch::selectFgNextHopGroup(const string& vnet,
+                                       NextHopGroupKey& nexthops,
+                                       IpPrefix& ipPrefix,
+                                       VNetVrfObject *vrf_obj,
+                                       const uint16_t consistent_hashing_buckets,
+                                       bool& isNextHopIdChanged)
+{
+    // This function returns the next hop group which is to be used to in the hardware
+    // for fine grained ECMP tunnel routes.
+
+    bool nhg_exists = hasNextHopGroup(vnet, nexthops);
+    std::map<NextHopKey, sai_object_id_t> nhopgroup_members_set;
+
+    for (auto nh : nexthops.getNextHops())
+    {
+        sai_object_id_t next_hop_id;
+        if (nhg_exists)
+        {
+            // NHG already exists, look up existing tunnel NH IDs without incrementing refcount
+            next_hop_id = vrf_obj->getExistingTunnelNextHopId(nh);
+        }
+        else
+        {
+            // New NHG, create tunnel NHs (sets refcount to 1)
+            next_hop_id = vrf_obj->getTunnelNextHop(nh);
+        }
+        nhopgroup_members_set[nh] = next_hop_id;
+    }
+
+    sai_object_id_t nh_id = SAI_NULL_OBJECT_ID;
+
+    sai_object_id_t vrf_id;
+    vnet_orch_->getVrfIdByVnetName(vnet, vrf_id);
+    if (!gFgNhgOrch->setFgNhgTunnel(vrf_id, ipPrefix, nhopgroup_members_set, nexthops, consistent_hashing_buckets, nh_id, isNextHopIdChanged))
+    {
+        SWSS_LOG_ERROR("Failed to create fine grained next hop group for VNET %s", vnet.c_str());
+
+        if (!nhg_exists)
+        {
+            for (auto nh : nexthops.getNextHops())
+            {
+                vrf_obj->removeTunnelNextHop(nh);
+            }
+        }
+        return false;
+    }
+
+    if (!nhg_exists)
+    {
+        NextHopGroupInfo next_hop_group_entry;
+        next_hop_group_entry.next_hop_group_id = nh_id;
+
+        /*
+        * Initialize the next hop group structure with ref_count as 0. This
+        * count will increase once the route is successfully syncd.
+        */
+        next_hop_group_entry.ref_count = 0;
+        syncd_nexthop_groups_[vnet][nexthops] = next_hop_group_entry;
+
+        for (auto nh : nexthops.getNextHops())
+        {
+            syncd_nexthop_groups_[vnet][nexthops].active_members[nh] = SAI_NULL_OBJECT_ID;
+        }
+    }
+    if (isNextHopIdChanged)
+    {
+        syncd_nexthop_groups_[vnet][nexthops].next_hop_group_id = nh_id;
+    }
+
+    return true;
+}
+
 template<>
 bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipPrefix,
                                                NextHopGroupKey& nexthops, string& op, string& profile,
@@ -1193,7 +1350,8 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                                                NextHopGroupKey& nexthops_secondary,
                                                const IpPrefix& adv_prefix,
                                                const map<NextHopKey, IpAddress>& monitors,
-                                               const map<IpAddress, pinned_state_t>& monitor_addr_to_pinned_state)
+                                               const map<IpAddress, pinned_state_t>& monitor_addr_to_pinned_state,
+                                               const uint16_t consistent_hashing_buckets)
 {
     SWSS_LOG_ENTER();
 
@@ -1228,83 +1386,165 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
     sai_ip_prefix_t pfx;
     copy(pfx, ipPrefix);
 
+    bool is_fg_route = (consistent_hashing_buckets > 0);
+
     if (op == SET_COMMAND)
     {
-        bool custom_monitor_ep_updated = isCustomMonitorEndpointUpdated(vnet, ipPrefix, monitors);
-        std::map<NextHopKey, swss::IpAddress> origin_primary_monitors;
-        std::map<NextHopKey, swss::IpAddress> origin_secondary_monitors;
-        if (custom_monitor_ep_updated)
+        auto it_route = syncd_tunnel_routes_[vnet].find(ipPrefix);
+
+        // Determine if the route was previously fine-grained
+        sai_object_id_t vr_id_check = vrf_obj->getVRidIngress();
+        bool was_fg = (it_route != syncd_tunnel_routes_[vnet].end())
+                      && gFgNhgOrch->syncdContainsFgNhg(vr_id_check, ipPrefix);
+
+        NextHopGroupKey old_nhg_key;
+        if (it_route != syncd_tunnel_routes_[vnet].end())
         {
-            auto it_route = syncd_tunnel_routes_[vnet].find(ipPrefix);
-            if (it_route != syncd_tunnel_routes_[vnet].end())
-            {
-                getCustomMonitors(vnet, ipPrefix, it_route->second.primary, origin_primary_monitors);
-                getCustomMonitors(vnet, ipPrefix, it_route->second.secondary, origin_secondary_monitors);
-            }
+            old_nhg_key = it_route->second.nhg_key;
         }
 
-        bool is_custom_monitor_pinned_state_updated = isPinnedStateUpdated(vnet, ipPrefix, monitor_addr_to_pinned_state);
+        bool is_type_transition = (it_route != syncd_tunnel_routes_[vnet].end())
+                                  && (was_fg != is_fg_route);
+
+        // If transitioning from regular -? fg or vice versa with same endpoints, collision will occur on same NHG key.
+        // save old NHG info and evict from map before creating new one.
+        NextHopGroupInfo saved_old_nhg_info;
+        bool collision = is_type_transition && hasNextHopGroup(vnet, nexthops);
+        if (collision)
+        {
+            saved_old_nhg_info = syncd_nexthop_groups_[vnet][old_nhg_key];
+            syncd_nexthop_groups_[vnet].erase(old_nhg_key);
+        }
 
         sai_object_id_t nh_id = SAI_NULL_OBJECT_ID;
+        bool isNextHopIdChanged = false;
         NextHopGroupKey active_nhg("", true);
-        if (!selectNextHopGroup(vnet, nexthops, nexthops_secondary, monitoring, rx_monitor_timer, tx_monitor_timer, ipPrefix, vrf_obj, active_nhg, monitors, monitor_addr_to_pinned_state))
+
+        bool custom_monitor_ep_updated = false;
+        std::map<NextHopKey, swss::IpAddress> origin_primary_monitors;
+        std::map<NextHopKey, swss::IpAddress> origin_secondary_monitors;
+        bool is_custom_monitor_pinned_state_updated = false;
+
+        if (is_fg_route)
         {
-            return true;
+            if (!selectFgNextHopGroup(vnet, nexthops, ipPrefix, vrf_obj,
+                                      consistent_hashing_buckets, isNextHopIdChanged))
+            {
+                if (collision)
+                {
+                    syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
+                }
+                return true;
+            }
+            active_nhg = nexthops;
+            nh_id = syncd_nexthop_groups_[vnet][nexthops].next_hop_group_id;
+        }
+        else
+        {
+            // Regular ECMP path with monitoring/priority support
+            custom_monitor_ep_updated = isCustomMonitorEndpointUpdated(vnet, ipPrefix, monitors);
+            if (custom_monitor_ep_updated)
+            {
+                if (it_route != syncd_tunnel_routes_[vnet].end())
+                {
+                    getCustomMonitors(vnet, ipPrefix, it_route->second.primary, origin_primary_monitors);
+                    getCustomMonitors(vnet, ipPrefix, it_route->second.secondary, origin_secondary_monitors);
+                }
+            }
+
+            is_custom_monitor_pinned_state_updated = isPinnedStateUpdated(vnet, ipPrefix, monitor_addr_to_pinned_state);
+
+            if (!selectNextHopGroup(vnet, nexthops, nexthops_secondary, monitoring,
+                                    rx_monitor_timer, tx_monitor_timer, ipPrefix,
+                                    vrf_obj, active_nhg, monitors, monitor_addr_to_pinned_state))
+            {
+                if (collision)
+                {
+                    syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
+                }
+                return true;
+            }
+            nh_id = syncd_nexthop_groups_[vnet][active_nhg].next_hop_group_id;
         }
 
-        // note: nh_id can be SAI_NULL_OBJECT_ID when active_nhg is empty.
-        nh_id = syncd_nexthop_groups_[vnet][active_nhg].next_hop_group_id;
+        sai_object_id_t old_nh_id = SAI_NULL_OBJECT_ID;
+        if (it_route != syncd_tunnel_routes_[vnet].end())
+        {
+            old_nh_id = collision ? saved_old_nhg_info.next_hop_group_id
+                                  : syncd_nexthop_groups_[vnet][old_nhg_key].next_hop_group_id;
+        }
 
-        auto it_route = syncd_tunnel_routes_[vnet].find(ipPrefix);
         for (auto vr_id : vr_set)
         {
             bool route_status = true;
 
-            // Remove route if the nexthop group has no active endpoint
-            if (syncd_nexthop_groups_[vnet][active_nhg].active_members.empty())
+            if (is_fg_route)
             {
-                if (it_route != syncd_tunnel_routes_[vnet].end())
-                {
-                    NextHopGroupKey nhg = it_route->second.nhg_key;
-                    // Remove route when updating from a nhg with active member to another nhg without
-                    if (!syncd_nexthop_groups_[vnet][nhg].active_members.empty())
-                    {
-                        del_route(vr_id, pfx);
-                    }
-                }
-            }
-            else
-            {
-                auto prefixToRemove = ipPrefix;
-                if (adv_prefix.to_string() != ipPrefix.to_string())
-                {
-                    prefixToRemove = adv_prefix;
-                }
-                auto prefixSubnet = prefixToRemove.getSubnet();
-                if(gRouteOrch && gRouteOrch->isRouteExists(vr_id, prefixSubnet))
-                {
-                    if (!gRouteOrch->removeRoutePrefix(prefixSubnet))
-                    {
-                        SWSS_LOG_ERROR("Could not remove existing bgp route for prefix: %s\n", prefixSubnet.to_string().c_str());
-                        return false;
-                    }
-                    SWSS_LOG_INFO("Successfully removed existing bgp route for prefix: %s\n",
-                                  prefixSubnet.to_string().c_str());
-                }
                 if (it_route == syncd_tunnel_routes_[vnet].end())
                 {
                     route_status = add_route(vr_id, pfx, nh_id);
                 }
+                else if (nh_id != old_nh_id || isNextHopIdChanged)
+                {
+                    route_status = update_route(vr_id, pfx, nh_id);
+                }
+            }
+            else
+            {
+                if (syncd_nexthop_groups_[vnet][active_nhg].active_members.empty())
+                {
+                    if (it_route != syncd_tunnel_routes_[vnet].end())
+                    {
+                        NextHopGroupKey nhg = it_route->second.nhg_key;
+                        if (collision)
+                        {
+                            if (!saved_old_nhg_info.active_members.empty())
+                            {
+                                del_route(vr_id, pfx);
+                            }
+                        }
+                        else if (!syncd_nexthop_groups_[vnet][nhg].active_members.empty())
+                        {
+                            del_route(vr_id, pfx);
+                        }
+                    }
+                }
                 else
                 {
-                    NextHopGroupKey nhg = it_route->second.nhg_key;
-                    if (syncd_nexthop_groups_[vnet][nhg].active_members.empty())
+                    auto prefixToRemove = ipPrefix;
+                    if (adv_prefix.to_string() != ipPrefix.to_string())
+                    {
+                        prefixToRemove = adv_prefix;
+                    }
+                    auto prefixSubnet = prefixToRemove.getSubnet();
+                    if (gRouteOrch && gRouteOrch->isRouteExists(vr_id, prefixSubnet))
+                    {
+                        if (!gRouteOrch->removeRoutePrefix(prefixSubnet))
+                        {
+                            SWSS_LOG_ERROR("Could not remove existing bgp route for prefix: %s\n", prefixSubnet.to_string().c_str());
+                            if (collision)
+                            {
+                                syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
+                            }
+                            return false;
+                        }
+                        SWSS_LOG_INFO("Successfully removed existing bgp route for prefix: %s\n",
+                                      prefixSubnet.to_string().c_str());
+                    }
+                    if (it_route == syncd_tunnel_routes_[vnet].end())
                     {
                         route_status = add_route(vr_id, pfx, nh_id);
                     }
-                    else
+                    else if (nh_id != old_nh_id)
                     {
-                        route_status = update_route(vr_id, pfx, nh_id);
+                        if (collision || !syncd_nexthop_groups_[vnet][old_nhg_key].active_members.empty())
+                        {
+                            route_status = update_route(vr_id, pfx, nh_id);
+                        }
+                        else
+                        {
+                            route_status = add_route(vr_id, pfx, nh_id);
+                        }
                     }
                 }
             }
@@ -1312,88 +1552,188 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
             if (!route_status)
             {
                 SWSS_LOG_ERROR("Route add/update failed for %s, vr_id '0x%" PRIx64, ipPrefix.to_string().c_str(), vr_id);
-                /* Clean up the newly created next hop group entry */
-                if (active_nhg.getSize() > 1)
+                if (is_fg_route)
+                {
+                    removeFgNextHopGroup(vnet, nexthops, ipPrefix, vrf_obj);
+                }
+                else if (active_nhg.getSize() > 1)
                 {
                     removeNextHopGroup(vnet, active_nhg, vrf_obj);
+                }
+                if (collision)
+                {
+                    syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
                 }
                 return false;
             }
         }
+
         bool route_updated = false;
         bool priority_route_updated = false;
         if (it_route != syncd_tunnel_routes_[vnet].end())
         {
-            if (custom_monitor_ep_updated)
+            if (collision)
             {
                 route_updated = true;
-
-                delEndpointMonitor(vnet, origin_primary_monitors, ipPrefix);
-                delEndpointMonitor(vnet, origin_secondary_monitors, ipPrefix);
-            }
-            else if ((monitoring == "" && it_route->second.nhg_key != nexthops) ||
-                ((monitoring == VNET_MONITORING_TYPE_CUSTOM || monitoring == VNET_MONITORING_TYPE_CUSTOM_BFD) &&
-                 (it_route->second.primary != nexthops || it_route->second.secondary != nexthops_secondary)))
-            {
-                route_updated = true;
-                NextHopGroupKey nhg = it_route->second.nhg_key;
-                if (monitoring == VNET_MONITORING_TYPE_CUSTOM || monitoring == VNET_MONITORING_TYPE_CUSTOM_BFD)
+                if (--saved_old_nhg_info.ref_count == 0)
                 {
-                    // if the previously active NHG is same as the newly created active NHG.case of primary secondary swap or
-                    //when primary is active and secondary is changed or vice versa. In these cases we dont remove the NHG
-                    // but only remove the monitors for the set which has changed.
-                    if (it_route->second.primary != nexthops)
+                    if (was_fg)
                     {
-                        delEndpointMonitor(vnet, it_route->second.primary, ipPrefix);
+                        gFgNhgOrch->removeFgNhgTunnel(vrf_obj->getVRidIngress(), ipPrefix);
+                        for (auto nh : old_nhg_key.getNextHops())
+                        {
+                            vrf_obj->removeTunnelNextHop(nh);
+                        }
                     }
-                    if (it_route->second.secondary != nexthops_secondary)
+                    else
                     {
-                        delEndpointMonitor(vnet, it_route->second.secondary, ipPrefix);
+                        removeNextHopGroupDirectly(vnet, saved_old_nhg_info, old_nhg_key, vrf_obj);
                     }
-                    if (monitor_info_[vnet][ipPrefix].empty())
+                    if (!was_fg)
                     {
-                        monitor_info_[vnet].erase(ipPrefix);
+                        delEndpointMonitor(vnet, old_nhg_key, ipPrefix);
                     }
-                    priority_route_updated = true;
                 }
                 else
                 {
-                    // In case of updating an existing route, decrease the reference count for the previous nexthop group
-                    if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
+                    saved_old_nhg_info.tunnel_routes.erase(ipPrefix);
+                    syncd_nexthop_groups_[vnet][old_nhg_key] = saved_old_nhg_info;
+                }
+                vrf_obj->removeRoute(ipPrefix);
+                vrf_obj->removeProfile(ipPrefix);
+            }
+            else if (is_type_transition && old_nhg_key != active_nhg)
+            {
+                // Type transition with different endpoints — no collision
+                route_updated = true;
+                if (--syncd_nexthop_groups_[vnet][old_nhg_key].ref_count == 0)
+                {
+                    if (was_fg)
                     {
-                        if (nhg.getSize() > 1)
+                        removeFgNextHopGroup(vnet, old_nhg_key, ipPrefix, vrf_obj);
+                    }
+                    else
+                    {
+                        if (old_nhg_key.getSize() > 1)
                         {
-                            removeNextHopGroup(vnet, nhg, vrf_obj);
+                            removeNextHopGroup(vnet, old_nhg_key, vrf_obj);
                         }
                         else
                         {
-                            syncd_nexthop_groups_[vnet].erase(nhg);
-                            if(nhg.getSize() == 1)
+                            syncd_nexthop_groups_[vnet].erase(old_nhg_key);
+                            if (old_nhg_key.getSize() == 1)
                             {
-                                NextHopKey nexthop = *nhg.getNextHops().begin();
+                                NextHopKey nexthop = *old_nhg_key.getNextHops().begin();
                                 if (!isLocalEndpoint(vnet, nexthop.ip_address))
                                 {
                                     vrf_obj->removeTunnelNextHop(nexthop);
                                 }
                             }
                         }
-                        if (monitoring != VNET_MONITORING_TYPE_CUSTOM && monitoring != VNET_MONITORING_TYPE_CUSTOM_BFD)
+                        delEndpointMonitor(vnet, old_nhg_key, ipPrefix);
+                    }
+                }
+                else
+                {
+                    syncd_nexthop_groups_[vnet][old_nhg_key].tunnel_routes.erase(ipPrefix);
+                }
+                vrf_obj->removeRoute(ipPrefix);
+                vrf_obj->removeProfile(ipPrefix);
+            }
+            else if (is_fg_route && !is_type_transition)
+            {
+                // FG → FG update with different endpoints
+                if (it_route->second.nhg_key != nexthops)
+                {
+                    route_updated = true;
+                    NextHopGroupKey nhg = it_route->second.nhg_key;
+                    if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
+                    {
+                        for (auto nh : nhg.getNextHops())
                         {
-                            delEndpointMonitor(vnet, nhg, ipPrefix);
+                            vrf_obj->removeTunnelNextHop(nh);
                         }
+                        syncd_nexthop_groups_[vnet].erase(nhg);
                     }
                     else
                     {
                         syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
                     }
                     vrf_obj->removeRoute(ipPrefix);
-                    vrf_obj->removeProfile(ipPrefix);
                 }
-            } else if (is_custom_monitor_pinned_state_updated)
+            }
+            else if (!is_fg_route && !is_type_transition)
             {
-                route_updated = true;
+                // Regular → Regular update (existing logic)
+                if (custom_monitor_ep_updated)
+                {
+                    route_updated = true;
+                    delEndpointMonitor(vnet, origin_primary_monitors, ipPrefix);
+                    delEndpointMonitor(vnet, origin_secondary_monitors, ipPrefix);
+                }
+                else if ((monitoring == "" && it_route->second.nhg_key != nexthops) ||
+                    ((monitoring == VNET_MONITORING_TYPE_CUSTOM || monitoring == VNET_MONITORING_TYPE_CUSTOM_BFD) &&
+                     (it_route->second.primary != nexthops || it_route->second.secondary != nexthops_secondary)))
+                {
+                    route_updated = true;
+                    NextHopGroupKey nhg = it_route->second.nhg_key;
+                    if (monitoring == VNET_MONITORING_TYPE_CUSTOM || monitoring == VNET_MONITORING_TYPE_CUSTOM_BFD)
+                    {
+                        if (it_route->second.primary != nexthops)
+                        {
+                            delEndpointMonitor(vnet, it_route->second.primary, ipPrefix);
+                        }
+                        if (it_route->second.secondary != nexthops_secondary)
+                        {
+                            delEndpointMonitor(vnet, it_route->second.secondary, ipPrefix);
+                        }
+                        if (monitor_info_[vnet][ipPrefix].empty())
+                        {
+                            monitor_info_[vnet].erase(ipPrefix);
+                        }
+                        priority_route_updated = true;
+                    }
+                    else
+                    {
+                        if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
+                        {
+                            if (nhg.getSize() > 1)
+                            {
+                                removeNextHopGroup(vnet, nhg, vrf_obj);
+                            }
+                            else
+                            {
+                                syncd_nexthop_groups_[vnet].erase(nhg);
+                                if (nhg.getSize() == 1)
+                                {
+                                    NextHopKey nexthop = *nhg.getNextHops().begin();
+                                    if (!isLocalEndpoint(vnet, nexthop.ip_address))
+                                    {
+                                        vrf_obj->removeTunnelNextHop(nexthop);
+                                    }
+                                }
+                            }
+                            if (monitoring != VNET_MONITORING_TYPE_CUSTOM && monitoring != VNET_MONITORING_TYPE_CUSTOM_BFD)
+                            {
+                                delEndpointMonitor(vnet, nhg, ipPrefix);
+                            }
+                        }
+                        else
+                        {
+                            syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
+                        }
+                        vrf_obj->removeRoute(ipPrefix);
+                        vrf_obj->removeProfile(ipPrefix);
+                    }
+                }
+                else if (is_custom_monitor_pinned_state_updated)
+                {
+                    route_updated = true;
+                }
             }
         }
+
+        // --- STEP 4: Update syncd_tunnel_routes_ ---
         if (!profile.empty())
         {
             vrf_obj->addProfile(ipPrefix, profile);
@@ -1401,14 +1741,15 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         if (it_route == syncd_tunnel_routes_[vnet].end() || route_updated)
         {
             syncd_nexthop_groups_[vnet][active_nhg].tunnel_routes.insert(ipPrefix);
+            syncd_nexthop_groups_[vnet][active_nhg].ref_count++;
+
             VNetTunnelRouteEntry tunnel_route_entry;
             tunnel_route_entry.nhg_key = active_nhg;
             tunnel_route_entry.primary = nexthops;
             tunnel_route_entry.secondary = nexthops_secondary;
             syncd_tunnel_routes_[vnet][ipPrefix] = tunnel_route_entry;
-            syncd_nexthop_groups_[vnet][active_nhg].ref_count++;
 
-            if (priority_route_updated || custom_monitor_ep_updated || is_custom_monitor_pinned_state_updated)
+            if (!is_fg_route && (priority_route_updated || custom_monitor_ep_updated || is_custom_monitor_pinned_state_updated))
             {
                 MonitorUpdate update;
                 update.monitoring_type = monitoring;
@@ -1420,14 +1761,14 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                 return true;
             }
 
-            if (adv_prefix.to_string() != ipPrefix.to_string() && prefix_to_adv_prefix_.find(ipPrefix) == prefix_to_adv_prefix_.end())
+            if (!is_fg_route && adv_prefix.to_string() != ipPrefix.to_string() && prefix_to_adv_prefix_.find(ipPrefix) == prefix_to_adv_prefix_.end())
             {
                 prefix_to_adv_prefix_[ipPrefix] = adv_prefix;
                 if (adv_prefix_refcount_.find(adv_prefix) == adv_prefix_refcount_.end())
                 {
                     adv_prefix_refcount_[adv_prefix] = 0;
                 }
-                if(active_nhg.getSize() > 0)
+                if (active_nhg.getSize() > 0)
                 {
                     adv_prefix_refcount_[adv_prefix] += 1;
                 }
@@ -1447,9 +1788,12 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         }
         NextHopGroupKey nhg = it_route->second.nhg_key;
         auto last_nhg_size = nhg.getSize();
+
+        // Determine if route is currently fine-grained
+        bool route_is_fg = gFgNhgOrch->syncdContainsFgNhg(vrf_obj->getVRidIngress(), ipPrefix);
+
         for (auto vr_id : vr_set)
         {
-            // If an nhg has no active member, the route should already be removed
             if (!syncd_nexthop_groups_[vnet][nhg].active_members.empty())
             {
                 if (!del_route(vr_id, pfx))
@@ -1458,40 +1802,45 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                     return false;
                 }
                 SWSS_LOG_INFO("Successfully deleted the route for prefix: %s", ipPrefix.to_string().c_str());
-
             }
         }
 
-        if(--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
+        if (--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
         {
-            if (nhg.getSize() > 1)
+            if (route_is_fg)
             {
-                removeNextHopGroup(vnet, nhg, vrf_obj);
+                removeFgNextHopGroup(vnet, nhg, ipPrefix, vrf_obj);
             }
             else
             {
-                syncd_nexthop_groups_[vnet].erase(nhg);
-                // We need to check specifically if there is only one next hop active.
-                // In case of Priority routes we can end up in a situation where the active NHG has 0 nexthops.
-                if(nhg.getSize() == 1)
+                if (nhg.getSize() > 1)
                 {
-                    NextHopKey nexthop = *nhg.getNextHops().begin();
-                    if (!isLocalEndpoint(vnet, nexthop.ip_address))
+                    removeNextHopGroup(vnet, nhg, vrf_obj);
+                }
+                else
+                {
+                    syncd_nexthop_groups_[vnet].erase(nhg);
+                    if (nhg.getSize() == 1)
                     {
-                        vrf_obj->removeTunnelNextHop(nexthop);
+                        NextHopKey nexthop = *nhg.getNextHops().begin();
+                        if (!isLocalEndpoint(vnet, nexthop.ip_address))
+                        {
+                            vrf_obj->removeTunnelNextHop(nexthop);
+                        }
                     }
                 }
-            }
-            if (monitor_info_[vnet].find(ipPrefix) == monitor_info_[vnet].end())
-            {
-                delEndpointMonitor(vnet, nhg, ipPrefix);
+                if (monitor_info_[vnet].find(ipPrefix) == monitor_info_[vnet].end())
+                {
+                    delEndpointMonitor(vnet, nhg, ipPrefix);
+                }
             }
         }
         else
         {
             syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
         }
-        if (monitor_info_[vnet].find(ipPrefix) != monitor_info_[vnet].end())
+
+        if (!route_is_fg && monitor_info_[vnet].find(ipPrefix) != monitor_info_[vnet].end())
         {
             delEndpointMonitor(vnet, it_route->second.primary, ipPrefix);
             delEndpointMonitor(vnet, it_route->second.secondary, ipPrefix);
@@ -1506,8 +1855,8 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
 
         vrf_obj->removeRoute(ipPrefix);
         vrf_obj->removeProfile(ipPrefix);
-
         removeRouteState(vnet, ipPrefix);
+
         if (prefix_to_adv_prefix_.find(ipPrefix) != prefix_to_adv_prefix_.end())
         {
             auto adv_pfx = prefix_to_adv_prefix_[ipPrefix];
@@ -3266,6 +3615,7 @@ bool VNetRouteOrch::handleTunnel(const Request& request)
     string monitoring;
     int32_t rx_monitor_timer = -1;
     int32_t tx_monitor_timer = -1;
+    uint16_t consistent_hashing_buckets = 0;
     swss::IpPrefix adv_prefix;
     bool has_priority_ep = false;
     bool has_adv_pfx = false;
@@ -3322,6 +3672,10 @@ bool VNetRouteOrch::handleTunnel(const Request& request)
         else if (name == "pinned_state")
         {
             pinned_state_list = request.getAttrStringList(name);
+        }
+        else if (name == "consistent_hashing_buckets")
+        {
+            consistent_hashing_buckets = static_cast<uint16_t>(request.getAttrUint(name));
         }
         else
         {
@@ -3483,7 +3837,11 @@ bool VNetRouteOrch::handleTunnel(const Request& request)
     }
     if (vnet_orch_->isVnetExecVrf())
     {
-        return doRouteTask<VNetVrfObject>(vnet_name, ip_pfx, (has_priority_ep == true) ? nhg_primary : nhg, op, profile, monitoring, rx_monitor_timer, tx_monitor_timer, nhg_secondary, adv_prefix, monitors, monitor_addr_to_pinned_state);
+        return doRouteTask<VNetVrfObject>(vnet_name, ip_pfx,
+            (has_priority_ep) ? nhg_primary : nhg, op, profile,
+            monitoring, rx_monitor_timer, tx_monitor_timer,
+            nhg_secondary, adv_prefix, monitors, monitor_addr_to_pinned_state,
+            consistent_hashing_buckets);
     }
 
     return true;

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -226,6 +226,7 @@ public:
     bool hasRoute(IpPrefix& ipPrefix);
 
     sai_object_id_t getTunnelNextHop(NextHopKey& nh);
+    sai_object_id_t getExistingTunnelNextHopId(NextHopKey& nh);
     bool removeTunnelNextHop(NextHopKey& nh);
     void increaseNextHopRefCount(const nextHop&);
     void decreaseNextHopRefCount(const nextHop&);
@@ -324,7 +325,8 @@ const request_description_t vnet_route_description = {
         { "rx_monitor_timer",       REQ_T_UINT },
         { "tx_monitor_timer",       REQ_T_UINT },
         { "pinned_state",           REQ_T_STRING_LIST },
-        { "metric",                 REQ_T_UINT }
+        { "metric",                 REQ_T_UINT },
+        { "consistent_hashing_buckets", REQ_T_UINT },
     },
     { }
 };
@@ -532,6 +534,8 @@ private:
     bool addNextHopGroup(const string&, const NextHopGroupKey&, VNetVrfObject *vrf_obj,
                             const string& monitoring, const bool isLocalEp=false);
     bool removeNextHopGroup(const string&, const NextHopGroupKey&, VNetVrfObject *vrf_obj);
+    bool removeNextHopGroupDirectly(const string&, NextHopGroupInfo&, const NextHopGroupKey&, VNetVrfObject *vrf_obj);
+    bool removeFgNextHopGroup(const string&, const NextHopGroupKey&, const IpPrefix&, VNetVrfObject *vrf_obj);
     bool createNextHopGroup(const string&, NextHopGroupKey&, VNetVrfObject *vrf_obj,
                             const string& monitoring);
     NextHopGroupKey getActiveNHSet(const string&, NextHopGroupKey&, const IpPrefix& );
@@ -540,6 +544,7 @@ private:
                             VNetVrfObject *vrf_obj, NextHopGroupKey&,
                             const std::map<NextHopKey,IpAddress>& monitors=std::map<NextHopKey, IpAddress>(),
                             const std::map<IpAddress, pinned_state_t>& monitor_addr_to_pinned_state={});
+    bool selectFgNextHopGroup(const string&, NextHopGroupKey&, IpPrefix&, VNetVrfObject *vrf_obj, const uint16_t consistent_hashing_buckets, bool &isNextHopIdChanged);
 
     void createBfdSession(const string& vnet, const NextHopKey& endpoint, const IpAddress& ipAddr, const int32_t rx_monitor_timer, const int32_t tx_monitor_timer);
     void removeBfdSession(const string& vnet, const NextHopKey& endpoint, const IpAddress& ipAddr);
@@ -580,7 +585,8 @@ private:
                     const string& monitoring, const int32_t rx_monitor_timer, const int32_t tx_monitor_timer,
                     NextHopGroupKey& nexthops_secondary, const IpPrefix& adv_prefix,
                     const std::map<NextHopKey, IpAddress>& monitors=std::map<NextHopKey, IpAddress>(),
-                    const std::map<IpAddress, pinned_state_t>& monitor_addr_to_pinned_state = {});
+                    const std::map<IpAddress, pinned_state_t>& monitor_addr_to_pinned_state = {},
+                    const uint16_t consistent_hashing_buckets = 0);
 
     template<typename T>
     bool doRouteTask(const string& vnet, IpPrefix& ipPrefix, nextHop& nh, string& op);

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -101,6 +101,16 @@ struct NextHopGroupInfo
     std::set<IpPrefix>                      tunnel_routes;
 };
 
+struct RouteTypeTransitionInfo
+{
+    bool is_fg_route = false;
+    bool was_fg = false;
+    bool is_type_transition = false;
+    bool collision = false;
+    NextHopGroupKey old_nhg_key;
+    NextHopGroupInfo saved_old_nhg_info;
+};
+
 class VNetObject
 {
 public:
@@ -545,6 +555,26 @@ private:
                             const std::map<NextHopKey,IpAddress>& monitors=std::map<NextHopKey, IpAddress>(),
                             const std::map<IpAddress, pinned_state_t>& monitor_addr_to_pinned_state={});
     bool selectFgNextHopGroup(const string&, NextHopGroupKey&, IpPrefix&, VNetVrfObject *vrf_obj, const uint16_t consistent_hashing_buckets, bool &isNextHopIdChanged);
+
+    RouteTypeTransitionInfo detectRouteTypeTransition(const string& vnet, const IpPrefix& ipPrefix,
+                            const NextHopGroupKey& nexthops, VNetVrfObject* vrf_obj,
+                            uint16_t consistent_hashing_buckets);
+
+    void cleanupOldRouteNhg(const string& vnet, IpPrefix& ipPrefix,
+                            NextHopGroupKey& nexthops,
+                            NextHopGroupKey& nexthops_secondary,
+                            const string& monitoring, VNetVrfObject* vrf_obj,
+                            const NextHopGroupKey& active_nhg,
+                            RouteTypeTransitionInfo& transition_info,
+                            bool custom_monitor_ep_updated,
+                            const std::map<NextHopKey, IpAddress>& origin_primary_monitors,
+                            const std::map<NextHopKey, IpAddress>& origin_secondary_monitors,
+                            bool is_custom_monitor_pinned_state_updated,
+                            bool& route_updated, bool& priority_route_updated);
+
+    void cleanupDeletedRouteNhg(const string& vnet, NextHopGroupKey& nhg,
+                            IpPrefix& ipPrefix, VNetVrfObject* vrf_obj,
+                            bool route_is_fg);
 
     void createBfdSession(const string& vnet, const NextHopKey& endpoint, const IpAddress& ipAddr, const int32_t rx_monitor_timer, const int32_t tx_monitor_timer);
     void removeBfdSession(const string& vnet, const NextHopKey& endpoint, const IpAddress& ipAddr);

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -106,9 +106,7 @@ struct RouteTypeTransitionInfo
     bool is_fg_route = false;
     bool was_fg = false;
     bool is_type_transition = false;
-    bool collision = false;
     NextHopGroupKey old_nhg_key;
-    NextHopGroupInfo saved_old_nhg_info;
 };
 
 class VNetObject
@@ -484,6 +482,7 @@ struct VNetLocEpAclRule
 };
 
 typedef std::map<NextHopGroupKey, NextHopGroupInfo> VNetNextHopGroupInfoTable;
+typedef std::map<IpPrefix, NextHopGroupInfo> VNetFgNextHopGroupInfoTable;
 typedef std::map<IpPrefix, VNetTunnelRouteEntry> VNetTunnelRouteTable;
 typedef std::map<IpAddress, BfdSessionInfo> BfdSessionTable;
 typedef std::map<IpPrefix, std::map<IpAddress, MonitorSessionInfo>> MonitorSessionTable;
@@ -541,6 +540,7 @@ private:
 
     bool hasNextHopGroup(const string&, const NextHopGroupKey&);
     sai_object_id_t getNextHopGroupId(const string&, const NextHopGroupKey&);
+    bool hasFgNextHopGroup(const string&, const IpPrefix&);
     bool addNextHopGroup(const string&, const NextHopGroupKey&, VNetVrfObject *vrf_obj,
                             const string& monitoring, const bool isLocalEp=false);
     bool removeNextHopGroup(const string&, const NextHopGroupKey&, VNetVrfObject *vrf_obj);
@@ -554,7 +554,7 @@ private:
                             VNetVrfObject *vrf_obj, NextHopGroupKey&,
                             const std::map<NextHopKey,IpAddress>& monitors=std::map<NextHopKey, IpAddress>(),
                             const std::map<IpAddress, pinned_state_t>& monitor_addr_to_pinned_state={});
-    bool selectFgNextHopGroup(const string&, NextHopGroupKey&, IpPrefix&, VNetVrfObject *vrf_obj, const uint16_t consistent_hashing_buckets, bool &isNextHopIdChanged);
+    bool selectFgNextHopGroup(const string&, NextHopGroupKey&, IpPrefix&, VNetVrfObject *vrf_obj, const uint16_t consistent_hashing_buckets, bool is_type_transition, bool &isNextHopIdChanged);
 
     RouteTypeTransitionInfo detectRouteTypeTransition(const string& vnet, const IpPrefix& ipPrefix,
                             const NextHopGroupKey& nexthops, VNetVrfObject* vrf_obj,
@@ -564,7 +564,6 @@ private:
                             NextHopGroupKey& nexthops,
                             NextHopGroupKey& nexthops_secondary,
                             const string& monitoring, VNetVrfObject* vrf_obj,
-                            const NextHopGroupKey& active_nhg,
                             RouteTypeTransitionInfo& transition_info,
                             bool custom_monitor_ep_updated,
                             const std::map<NextHopKey, IpAddress>& origin_primary_monitors,
@@ -596,7 +595,7 @@ private:
                                   const std::map<NextHopKey, IpAddress>& monitors);
     void getCustomMonitors(const string& vnet, const IpPrefix& ipPrefix, const NextHopGroupKey& nexthops, std::map<NextHopKey, IpAddress>& monitors);
 
-    void postRouteState(const string& vnet, IpPrefix& ipPrefix, NextHopGroupKey& nexthops, string& profile);
+    void postRouteState(const string& vnet, IpPrefix& ipPrefix, NextHopGroupKey& nexthops, string& profile, bool is_fg = false);
     void removeRouteState(const string& vnet, IpPrefix& ipPrefix);
     void addRouteAdvertisement(IpPrefix& ipPrefix, string& profile);
     void removeRouteAdvertisement(IpPrefix& ipPrefix);
@@ -631,6 +630,7 @@ private:
     VNetRouteTable syncd_routes_;
     VNetNextHopObserverTable next_hop_observers_;
     std::map<std::string, VNetNextHopGroupInfoTable> syncd_nexthop_groups_;
+    std::map<std::string, VNetFgNextHopGroupInfoTable> syncd_fg_nexthop_groups_;
     std::map<std::string, VNetTunnelRouteTable> syncd_tunnel_routes_;
     std::map<std::string, bool> vnet_tunnel_route_check_directly_connected;
     BfdSessionTable bfd_sessions_;

--- a/tests/test_fgnhg.py
+++ b/tests/test_fgnhg.py
@@ -32,21 +32,22 @@ def remove_entry(db, table, key):
     db.delete_entry(table, key)
     db.wait_for_deleted_entry(table,key)
 
-def get_asic_route_key(asic_db, ipprefix):
+def get_asic_route_key(asic_db, ipprefix, vr=None):
     route_exists = False
     key = ''
     keys = asic_db.get_keys(ASIC_ROUTE_TB)
     for k in keys:
         rt_key = json.loads(k)
-
         if rt_key['dest'] == ipprefix:
-            route_exists = True
-            key = k
-            break
+            if vr is None or rt_key.get('vr') == vr:
+                route_exists = True
+                key = k
+                break
+        
     assert route_exists
     return key
 
-def validate_asic_nhg_fine_grained_ecmp(asic_db, ipprefix, size):
+def validate_asic_nhg_fine_grained_ecmp(asic_db, ipprefix, size, vr=None):
     def _access_function():
         false_ret = (False, '')
         keys = asic_db.get_keys(ASIC_ROUTE_TB)
@@ -55,8 +56,10 @@ def validate_asic_nhg_fine_grained_ecmp(asic_db, ipprefix, size):
         for k in keys:
             rt_key = json.loads(k)
             if rt_key['dest'] == ipprefix:
-                route_exists = True
-                key = k
+                if vr is None or rt_key.get('vr') == vr:
+                    route_exists = True
+                    key = k
+                    break
         if not route_exists:
             return false_ret
 
@@ -137,6 +140,12 @@ def validate_asic_nhg_regular_ecmp(asic_db, ipprefix):
         return (True, nhgid)
     _, result = wait_for_result(_access_function, failure_message="SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP not found")
     return result
+
+def get_expected_key(vnet_name, fg_nhg_prefix):
+    if vnet_name == "":
+        return fg_nhg_prefix
+    else:
+        return vnet_name + "|" + fg_nhg_prefix
 
 def get_nh_oid_map(asic_db):
     nh_oid_map = {}
@@ -230,12 +239,13 @@ def run_warm_reboot(dvs):
     dvs.runcmd(['sh', '-c', 'supervisorctl start neighsyncd'])
     dvs.runcmd(['sh', '-c', 'supervisorctl start restore_neighbors'])
 
-def verify_programmed_fg_state_db_entry(state_db, fg_nhg_prefix, nh_memb_exp_count):
+def verify_programmed_fg_state_db_entry(state_db, fg_nhg_prefix, nh_memb_exp_count, vnet_name=""):
     memb_dict = nh_memb_exp_count
     keys = state_db.get_keys("FG_ROUTE_TABLE")
     assert len(keys) !=  0
+    expected_key = get_expected_key(vnet_name, fg_nhg_prefix)
     for key in keys:
-        if key != fg_nhg_prefix:
+        if key != expected_key:
             continue
         fvs = state_db.get_entry("FG_ROUTE_TABLE", key)
         assert fvs != {}
@@ -246,15 +256,16 @@ def verify_programmed_fg_state_db_entry(state_db, fg_nhg_prefix, nh_memb_exp_cou
     for idx,memb in memb_dict.items():
         assert memb == 0
 
-def verify_fg_state_db_for_even_distribution(state_db, fg_nhg_prefix, bucket_size, nh_ip_count):
+def verify_fg_state_db_for_even_distribution(state_db, fg_nhg_prefix, bucket_size, nh_ip_count, vnet_name=""):
     def _access_function():
         false_ret = (False, '')
         ret = True
         keys = state_db.get_keys("FG_ROUTE_TABLE")
         if not keys:
             return false_ret
+        expected_key = get_expected_key(vnet_name, fg_nhg_prefix)
         for key in keys:
-            if key != fg_nhg_prefix:
+            if key != expected_key:
                 continue
             fvs = state_db.get_entry("FG_ROUTE_TABLE", key)
             if not fvs:
@@ -282,17 +293,17 @@ def verify_fg_state_db_for_even_distribution(state_db, fg_nhg_prefix, bucket_siz
     assert status, f"Member count distribution is uneven"
 
 def validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map, prev_memb_dict, num_exp_changes,
-                                fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size):
+                                fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name=""):
     state_db_entry_memb_exp_count = {}
 
     for ip, cnt in nh_memb_exp_count.items():
         state_db_entry_memb_exp_count[ip + '@' + ip_to_if_map[ip]] = cnt
     next_memb_dict = verify_programmed_fg_asic_db_entry(asic_db,prev_memb_dict,num_exp_changes,nh_memb_exp_count,nh_oid_map,nhgid,bucket_size)
-    verify_programmed_fg_state_db_entry(state_db, fg_nhg_prefix, state_db_entry_memb_exp_count)
+    verify_programmed_fg_state_db_entry(state_db, fg_nhg_prefix, state_db_entry_memb_exp_count, vnet_name)
     return next_memb_dict
 
 def program_route_and_validate_fine_grained_ecmp(app_db, asic_db, state_db, ip_to_if_map, prev_memb_dict, num_exp_changes,
-                            fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size):
+                            fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name=""):
     ips = ""
     ifs = ""
     for ip in nh_memb_exp_count:
@@ -307,10 +318,10 @@ def program_route_and_validate_fine_grained_ecmp(app_db, asic_db, state_db, ip_t
     fvs = swsscommon.FieldValuePairs([("nexthop", ips), ("ifname", ifs)])
     ps.set(fg_nhg_prefix, fvs)
     new_memb_dict = validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
-                        prev_memb_dict, num_exp_changes, fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size)
+                        prev_memb_dict, num_exp_changes, fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name)
     return new_memb_dict
 
-def program_route_and_validate_distribtution(app_db, state_db, ip_to_if_map, fg_nhg_prefix, nh_ips, bucket_size):
+def program_route_and_validate_distribtution(app_db, state_db, ip_to_if_map, fg_nhg_prefix, nh_ips, bucket_size, vnet_name=""):
     ips = ""
     ifs = ""
     for ip in nh_ips:
@@ -324,7 +335,7 @@ def program_route_and_validate_distribtution(app_db, state_db, ip_to_if_map, fg_
     ps = swsscommon.ProducerStateTable(app_db, ROUTE_TB)
     fvs = swsscommon.FieldValuePairs([("nexthop", ips), ("ifname", ifs)])
     ps.set(fg_nhg_prefix, fvs)
-    verify_fg_state_db_for_even_distribution(state_db, fg_nhg_prefix, bucket_size, len(nh_ips))
+    verify_fg_state_db_for_even_distribution(state_db, fg_nhg_prefix, bucket_size, len(nh_ips), vnet_name)
 
 def create_interface_n_fg_ecmp_config(dvs, nh_range_start, nh_range_end, fg_nhg_name):
     ip_to_if_map = {}
@@ -1605,7 +1616,6 @@ class TestFineGrainedNextHopGroup(object):
 
         # cleanup all entries
         remove_interface_n_fg_ecmp_config(dvs, 0, NUM_NHs+NUM_NHs_non_fgnhg, fg_nhg_name)
-
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying

--- a/tests/test_fgnhg.py
+++ b/tests/test_fgnhg.py
@@ -197,7 +197,7 @@ def verify_programmed_fg_asic_db_entry(asic_db,prev_memb_dict,num_exp_changes,nh
                 if nh_oid_map.get(nh_oid,"NULL") == "NULL":
                     print("nh_oid is null")
                 if nh_oid_map.get(nh_oid) not in nh_memb_exp_count:
-                    print("nh_memb_exp_count is " + str(nh_memb_exp_count) + " nh_oid_map val is " + nh_oid_map.get(nh_oid))
+                    print("nh_memb_exp_count is " + str(nh_memb_exp_count) + " nh_oid_map val is " + str(nh_oid_map.get(nh_oid)))
                 return false_ret
             memb_dict[index] = nh_oid_map.get(nh_oid)
         idxs = [0]*bucket_size
@@ -1345,6 +1345,41 @@ def fine_grained_ecmp_match_mode_prefix_even_distribution_test(dvs):
         dvs.servers[i].runcmd("ip link set down dev eth0") == 0
 
 
+def fine_grained_ecmp_member_count_exceeds_bucket_size_test(dvs):
+    app_db = dvs.get_app_db()
+    asic_db = dvs.get_asic_db()
+    config_db = dvs.get_config_db()
+    state_db = dvs.get_state_db()
+
+    fg_nhg_name = "fgnhg_oversized_v4"
+    fg_nhg_prefix = "4.4.4.0/24"
+    bucket_size = 2
+    NUM_NHs = 3
+
+    fvs = {"bucket_size": str(bucket_size)}
+    create_entry(config_db, FG_NHG, fg_nhg_name, fvs)
+
+    fvs = {"FG_NHG": fg_nhg_name}
+    create_entry(config_db, FG_NHG_PREFIX, fg_nhg_prefix, fvs)
+
+    create_interface_n_fg_ecmp_config(dvs, 0, NUM_NHs, fg_nhg_name)
+
+    # 3 FG next hops for a route while bucket_size only allows 2
+    ps = swsscommon.ProducerStateTable(app_db.db_connection, ROUTE_TB)
+    fvs = swsscommon.FieldValuePairs([("nexthop", "10.0.0.1,10.0.0.3,10.0.0.5"),
+        ("ifname", "Ethernet0,Ethernet4,Ethernet8")])
+    ps.set(fg_nhg_prefix, fvs)
+    time.sleep(2)
+
+    assert fg_nhg_prefix not in state_db.get_keys("FG_ROUTE_TABLE")
+
+    # cleanup
+    ps._del(fg_nhg_prefix)
+    time.sleep(1)
+    remove_interface_n_fg_ecmp_config(dvs, 0, NUM_NHs, fg_nhg_name)
+    remove_entry(config_db, FG_NHG_PREFIX, fg_nhg_prefix)
+
+
 class TestFineGrainedNextHopGroup(object):
     def test_fgnhg_matchmode_route(self, dvs, testlog):
         '''
@@ -1616,6 +1651,13 @@ class TestFineGrainedNextHopGroup(object):
 
         # cleanup all entries
         remove_interface_n_fg_ecmp_config(dvs, 0, NUM_NHs+NUM_NHs_non_fgnhg, fg_nhg_name)
+
+    def test_fgnhg_member_count_exceeds_bucket_size(self, dvs, testlog):
+        '''
+        Test that a route is rejected as fine grained ECMP when its next hop
+        count exceeds the configured bucket_size
+        '''
+        fine_grained_ecmp_member_count_exceeds_bucket_size_test(dvs)
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -9,6 +9,7 @@ from swsscommon import swsscommon
 from pprint import pprint
 from dvslib.dvs_common import wait_for_result
 from vnet_lib import *
+import test_fgnhg
 
 class TestVnetOrch(object):
 
@@ -3574,7 +3575,174 @@ class TestVnetOrch(object):
         self.remove_neighbor("Ethernet4", "9.1.0.1")
         self.remove_ip_address("Ethernet4", "9.1.0.1/32")
         self.set_admin_status("Ethernet4", "down")
+        
 
+    '''
+    Test 37 - Test for vnet tunnel routes with fine-grained ECMP using consistent_hashing_buckets
+    '''
+    def test_vnet_orch_37(self, dvs, testlog):
+        self.setup_db(dvs)
+        vnet_obj = self.get_vnet_obj()
+        asic_db = dvs.get_asic_db()
+        state_db = dvs.get_state_db()
+
+        tunnel_name = 'tunnel_37'
+        vnet_name = 'Vnet37'
+        fg_nhg_prefix = "100.100.37.0/24"
+        bucket_size = 60
+
+        vnet_obj.fetch_exist_entries(dvs)
+        initial_nhop_count = len(asic_db.get_keys(vnet_obj.ASIC_NEXT_HOP))
+
+        create_vxlan_tunnel(dvs, tunnel_name, '10.10.10.10')
+        create_vnet_entry(dvs, vnet_name, tunnel_name, '10037', "")
+
+        vnet_obj.check_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, vnet_name, '10037')
+        vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, '10.10.10.10')
+        
+        vnet_obj.fetch_exist_entries(dvs)
+        
+        vr_id = vnet_obj.vr_map[vnet_name]['ing']
+
+        # Create VNET route with consistent_hashing_buckets and 3 tunnel next hops for fine-grained ECMP
+        create_vnet_routes(dvs, fg_nhg_prefix, vnet_name, '37.0.0.1,37.0.0.2,37.0.0.3',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C', consistent_hashing_buckets=bucket_size)
+
+        asic_db.wait_for_n_keys(test_fgnhg.ASIC_NHG_MEMB, bucket_size)
+        nhgid = test_fgnhg.validate_asic_nhg_fine_grained_ecmp(asic_db, fg_nhg_prefix, bucket_size, vr_id)
+        
+        nh_oid_map = test_fgnhg.get_nh_oid_map(asic_db)
+        
+        ip_to_if_map = {
+            '37.0.0.1': '',
+            '37.0.0.2': '',
+            '37.0.0.3': '',
+            '37.0.0.4': '',
+            '37.0.0.5': '',
+            '37.0.0.6': '',
+            '37.0.0.7': '',
+            '37.0.0.8': '',
+            '38.0.0.1': '',
+            '38.0.0.2': '',
+            '38.0.0.3': ''
+        }
+        
+        check_state_db_routes(dvs, vnet_name, fg_nhg_prefix, ['37.0.0.1', '37.0.0.2', '37.0.0.3'])
+
+        num_exp_changes = 60
+        nh_memb_exp_count = {'37.0.0.1': 20, '37.0.0.2': 20, '37.0.0.3': 20}
+        prev_memb_dict = {}
+        memb_dict = test_fgnhg.validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
+                            prev_memb_dict, num_exp_changes, fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name)
+
+        vnet_obj.fetch_exist_entries(dvs)
+
+        # Add 3 more nexthops
+        create_vnet_routes(dvs, fg_nhg_prefix, vnet_name, '37.0.0.1,37.0.0.2,37.0.0.3,37.0.0.4,37.0.0.5,37.0.0.6',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C,00:12:34:56:78:9D,00:12:34:56:78:9E,00:12:34:56:78:9F', 
+                          consistent_hashing_buckets=bucket_size)
+        
+        time.sleep(2)
+
+        nh_oid_map = test_fgnhg.get_nh_oid_map(asic_db)
+        
+        check_state_db_routes(dvs, vnet_name, fg_nhg_prefix, ['37.0.0.1', '37.0.0.2', '37.0.0.3','37.0.0.4','37.0.0.5','37.0.0.6'])
+        
+        num_exp_changes = 30
+        nh_memb_exp_count = {'37.0.0.1': 10, '37.0.0.2': 10, '37.0.0.3': 10, '37.0.0.4': 10, '37.0.0.5': 10, '37.0.0.6': 10}
+        memb_dict = test_fgnhg.validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
+                            memb_dict, num_exp_changes, fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name)
+        
+        vnet_obj.fetch_exist_entries(dvs)
+
+        # Update route with different endpoints
+        create_vnet_routes(dvs, fg_nhg_prefix, vnet_name, '37.0.0.1,37.0.0.2,37.0.0.3,37.0.0.4,37.0.0.7,37.0.0.8',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C,00:12:34:56:78:9D,00:12:34:56:78:8E,00:12:34:56:78:8F', 
+                          consistent_hashing_buckets=bucket_size)
+        
+        time.sleep(2)
+
+        nh_oid_map = test_fgnhg.get_nh_oid_map(asic_db)
+        
+        check_state_db_routes(dvs, vnet_name, fg_nhg_prefix, ['37.0.0.1', '37.0.0.2', '37.0.0.3','37.0.0.4','37.0.0.7','37.0.0.8'])
+        
+        num_exp_changes = 20
+        nh_memb_exp_count = {'37.0.0.1': 10, '37.0.0.2': 10, '37.0.0.3': 10, '37.0.0.4': 10, '37.0.0.7': 10, '37.0.0.8': 10}
+        memb_dict = test_fgnhg.validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
+                            memb_dict, num_exp_changes, fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name)
+
+        vnet_obj.fetch_exist_entries(dvs)
+
+        # Remove one endpoint
+        create_vnet_routes(dvs, fg_nhg_prefix, vnet_name, '37.0.0.1,37.0.0.2,37.0.0.3,37.0.0.4,37.0.0.7',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C,00:12:34:56:78:9D,00:12:34:56:78:8E', 
+                          consistent_hashing_buckets=bucket_size)
+        
+        time.sleep(2)
+
+        nh_oid_map = test_fgnhg.get_nh_oid_map(asic_db)
+        
+        check_state_db_routes(dvs, vnet_name, fg_nhg_prefix, ['37.0.0.1', '37.0.0.2', '37.0.0.3','37.0.0.4','37.0.0.7'])
+        
+        num_exp_changes = 10
+        nh_memb_exp_count = {'37.0.0.1': 12, '37.0.0.2': 12, '37.0.0.3': 12, '37.0.0.4': 12, '37.0.0.7': 12}
+        memb_dict = test_fgnhg.validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
+                            memb_dict, 10, fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name)
+        
+        # create route for new vnet with same IP space
+        vnet_name_2 = 'Vnet38'
+        create_vnet_entry(dvs, vnet_name_2, tunnel_name, '10038', "")
+        
+        vnet_obj.check_vnet_entry(dvs, vnet_name_2)
+        
+        # Get VR ID for vnet_name_2
+        vr_id_2 = vnet_obj.vr_map[vnet_name_2]['ing']
+        
+        create_vnet_routes(dvs, fg_nhg_prefix, vnet_name_2, '38.0.0.1,38.0.0.2,38.0.0.3',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C', consistent_hashing_buckets=bucket_size)
+        
+        asic_db.wait_for_n_keys(test_fgnhg.ASIC_NHG_MEMB, 120)
+        nhgid = test_fgnhg.validate_asic_nhg_fine_grained_ecmp(asic_db, fg_nhg_prefix, bucket_size, vr_id_2)
+        
+        check_state_db_routes(dvs, vnet_name_2, fg_nhg_prefix, ['38.0.0.1', '38.0.0.2', '38.0.0.3'])
+
+        num_exp_changes = 60
+        nh_memb_exp_count = {'38.0.0.1': 20, '38.0.0.2': 20, '38.0.0.3': 20}
+        prev_memb_dict = {}
+        memb_dict = test_fgnhg.validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
+                            prev_memb_dict, num_exp_changes, fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name_2)
+
+        # Clean up
+        vnet_obj.fetch_exist_entries(dvs)
+        asic_rt_key_1 = test_fgnhg.get_asic_route_key(asic_db, fg_nhg_prefix, vr_id)
+        asic_rt_key_2 = test_fgnhg.get_asic_route_key(asic_db, fg_nhg_prefix, vr_id_2)
+        
+        delete_vnet_routes(dvs, fg_nhg_prefix, vnet_name)
+        delete_vnet_routes(dvs, fg_nhg_prefix, vnet_name_2)
+        
+        time.sleep(2)
+        
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name, [fg_nhg_prefix])
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name_2, [fg_nhg_prefix])
+        check_remove_state_db_routes(dvs, vnet_name, fg_nhg_prefix)
+        check_remove_state_db_routes(dvs, vnet_name_2, fg_nhg_prefix)
+
+        asic_db.wait_for_n_keys(test_fgnhg.ASIC_NHG_MEMB, 0)
+        asic_db.wait_for_n_keys(test_fgnhg.ASIC_NHG, 0)
+        asic_db.wait_for_n_keys(vnet_obj.ASIC_NEXT_HOP, initial_nhop_count)
+        
+        asic_db.wait_for_deleted_entry(test_fgnhg.ASIC_ROUTE_TB, asic_rt_key_1)
+        asic_db.wait_for_deleted_entry(test_fgnhg.ASIC_ROUTE_TB, asic_rt_key_2)
+        state_db.wait_for_n_keys("FG_ROUTE_TABLE", 0)
+
+        delete_vnet_entry(dvs, vnet_name)
+        delete_vnet_entry(dvs, vnet_name_2)
+        vnet_obj.check_del_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_del_vnet_entry(dvs, vnet_name_2)
+        
+        delete_vxlan_tunnel(dvs, tunnel_name)
+        vnet_obj.check_del_vxlan_tunnel(dvs)
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -3705,6 +3705,8 @@ class TestVnetOrch(object):
         asic_db.wait_for_n_keys(test_fgnhg.ASIC_NHG_MEMB, 120)
         nhgid = test_fgnhg.validate_asic_nhg_fine_grained_ecmp(asic_db, fg_nhg_prefix, bucket_size, vr_id_2)
         
+        nh_oid_map = test_fgnhg.get_nh_oid_map(asic_db)
+                
         check_state_db_routes(dvs, vnet_name_2, fg_nhg_prefix, ['38.0.0.1', '38.0.0.2', '38.0.0.3'])
 
         num_exp_changes = 60
@@ -3736,10 +3738,132 @@ class TestVnetOrch(object):
         asic_db.wait_for_deleted_entry(test_fgnhg.ASIC_ROUTE_TB, asic_rt_key_2)
         state_db.wait_for_n_keys("FG_ROUTE_TABLE", 0)
 
-        delete_vnet_entry(dvs, vnet_name)
         delete_vnet_entry(dvs, vnet_name_2)
-        vnet_obj.check_del_vnet_entry(dvs, vnet_name)
         vnet_obj.check_del_vnet_entry(dvs, vnet_name_2)
+
+        # Route Type Transitions (Regular ECMP <-> Fine-Grained ECMP)
+        transition_prefix = "100.100.37.1/32"
+
+        vnet_obj.fetch_exist_entries(dvs)
+
+        # Regular ECMP -> FG ECMP with same NHG key 
+        create_vnet_routes(dvs, transition_prefix, vnet_name, '37.0.0.1,37.0.0.2,37.0.0.3',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C')
+        route1, nhg1 = vnet_obj.check_vnet_ecmp_routes(dvs, vnet_name, ['37.0.0.1', '37.0.0.2', '37.0.0.3'], tunnel_name)
+        check_state_db_routes(dvs, vnet_name, transition_prefix, ['37.0.0.1', '37.0.0.2', '37.0.0.3'])
+
+        vnet_obj.fetch_exist_entries(dvs)
+
+        # Regular -> FG transition path 
+        create_vnet_routes(dvs, transition_prefix, vnet_name, '37.0.0.1,37.0.0.2,37.0.0.3',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C', consistent_hashing_buckets=bucket_size)
+
+        time.sleep(2)
+
+        # Verify FG NHG is created and route is updated
+        nhgid = test_fgnhg.validate_asic_nhg_fine_grained_ecmp(asic_db, transition_prefix, bucket_size, vr_id)
+        nh_oid_map = test_fgnhg.get_nh_oid_map(asic_db)
+        check_state_db_routes(dvs, vnet_name, transition_prefix, ['37.0.0.1', '37.0.0.2', '37.0.0.3'])
+
+        # Verify the old regular ECMP NHG was removed
+        vnet_obj.fetch_exist_entries(dvs)
+        assert nhg1 not in vnet_obj.nhgs
+
+        num_exp_changes = 60
+        nh_memb_exp_count = {'37.0.0.1': 20, '37.0.0.2': 20, '37.0.0.3': 20}
+        prev_memb_dict = {}
+        memb_dict = test_fgnhg.validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
+                            prev_memb_dict, num_exp_changes, transition_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name)
+
+        # Fine-Grained ECMP -> Regular ECMP transition
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vnet_routes(dvs, transition_prefix, vnet_name, '37.0.0.1,37.0.0.2,37.0.0.3',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C')
+
+        time.sleep(2)
+
+        # Verify FG NHG is removed and regular ECMP NHG is created
+        state_db.wait_for_n_keys("FG_ROUTE_TABLE", 0)
+        route1, nhg1 = vnet_obj.check_vnet_ecmp_routes(dvs, vnet_name, ['37.0.0.1', '37.0.0.2', '37.0.0.3'], tunnel_name, route_ids=route1)
+        check_state_db_routes(dvs, vnet_name, transition_prefix, ['37.0.0.1', '37.0.0.2', '37.0.0.3'])
+
+        # Regular ECMP -> FG with different endpoints 
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vnet_routes(dvs, transition_prefix, vnet_name, '37.0.0.4,37.0.0.5,37.0.0.6',
+                          '00:12:34:56:78:9D,00:12:34:56:78:9E,00:12:34:56:78:9F', consistent_hashing_buckets=bucket_size)
+
+        time.sleep(2)
+
+        # Verify FG NHG is created with new endpoints
+        nhgid = test_fgnhg.validate_asic_nhg_fine_grained_ecmp(asic_db, transition_prefix, bucket_size, vr_id)
+        nh_oid_map = test_fgnhg.get_nh_oid_map(asic_db)
+        check_state_db_routes(dvs, vnet_name, transition_prefix, ['37.0.0.4', '37.0.0.5', '37.0.0.6'])
+
+        # Verify old regular ECMP NHG was cleaned up
+        vnet_obj.fetch_exist_entries(dvs)
+        assert nhg1 not in vnet_obj.nhgs
+
+        num_exp_changes = 60
+        nh_memb_exp_count = {'37.0.0.4': 20, '37.0.0.5': 20, '37.0.0.6': 20}
+        prev_memb_dict = {}
+        memb_dict = test_fgnhg.validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
+                            prev_memb_dict, num_exp_changes, transition_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name)
+
+        # Regular with different endpoints
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vnet_routes(dvs, transition_prefix, vnet_name, '37.0.0.7,37.0.0.8',
+                          '00:12:34:56:78:8E,00:12:34:56:78:8F')
+
+        time.sleep(2)
+
+        # Verify FG NHG is removed and regular ECMP NHG is created with new endpoints
+        state_db.wait_for_n_keys("FG_ROUTE_TABLE", 0)
+        route1, nhg1 = vnet_obj.check_vnet_ecmp_routes(dvs, vnet_name, ['37.0.0.7', '37.0.0.8'], tunnel_name, route_ids=route1)
+        check_state_db_routes(dvs, vnet_name, transition_prefix, ['37.0.0.7', '37.0.0.8'])
+
+        # Clean up transition test route
+        delete_vnet_routes(dvs, transition_prefix, vnet_name)
+        time.sleep(2)
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name, [transition_prefix])
+        check_remove_state_db_routes(dvs, vnet_name, transition_prefix)
+
+        # FG route with more distinct next hops than configured buckets must be rejected
+        oversized_prefix = "100.100.37.20/32"
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vnet_routes(dvs, oversized_prefix, vnet_name, '37.0.0.1,37.0.0.2,37.0.0.3',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C', consistent_hashing_buckets=2)
+        time.sleep(2)
+        assert (vnet_name + '|' + oversized_prefix) not in state_db.get_keys("FG_ROUTE_TABLE")
+        delete_vnet_routes(dvs, oversized_prefix, vnet_name)
+        time.sleep(2)
+
+        # Re-applying an unchanged FG route (identical prefix/endpoints/buckets) is a no-op
+        idempotent_prefix = "100.100.37.21/32"
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vnet_routes(dvs, idempotent_prefix, vnet_name, '37.0.0.1,37.0.0.2,37.0.0.3',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C', consistent_hashing_buckets=bucket_size)
+        nhgid = test_fgnhg.validate_asic_nhg_fine_grained_ecmp(asic_db, idempotent_prefix, bucket_size, vr_id)
+        check_state_db_routes(dvs, vnet_name, idempotent_prefix, ['37.0.0.1', '37.0.0.2', '37.0.0.3'])
+
+        create_vnet_routes(dvs, idempotent_prefix, vnet_name, '37.0.0.1,37.0.0.2,37.0.0.3',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C', consistent_hashing_buckets=bucket_size)
+        time.sleep(2)
+        nhgid_unchanged = test_fgnhg.validate_asic_nhg_fine_grained_ecmp(asic_db, idempotent_prefix, bucket_size, vr_id)
+        assert nhgid == nhgid_unchanged
+        check_state_db_routes(dvs, vnet_name, idempotent_prefix, ['37.0.0.1', '37.0.0.2', '37.0.0.3'])
+
+        # Isolated deletion of a non-shared FG route drives full FG NHG teardown
+        vnet_obj.fetch_exist_entries(dvs)
+        asic_rt_key_iso = test_fgnhg.get_asic_route_key(asic_db, idempotent_prefix, vr_id)
+        delete_vnet_routes(dvs, idempotent_prefix, vnet_name)
+        time.sleep(2)
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name, [idempotent_prefix])
+        check_remove_state_db_routes(dvs, vnet_name, idempotent_prefix)
+        asic_db.wait_for_deleted_entry(test_fgnhg.ASIC_ROUTE_TB, asic_rt_key_iso)
+
+        # cleanup
+        delete_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_del_vnet_entry(dvs, vnet_name)
         
         delete_vxlan_tunnel(dvs, tunnel_name)
         vnet_obj.check_del_vxlan_tunnel(dvs)

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -4051,6 +4051,8 @@ class TestVnetOrch(object):
         asic_db.wait_for_n_keys(test_fgnhg.ASIC_NHG_MEMB, 120)
         nhgid = test_fgnhg.validate_asic_nhg_fine_grained_ecmp(asic_db, fg_nhg_prefix, bucket_size, vr_id_2)
         
+        nh_oid_map = test_fgnhg.get_nh_oid_map(asic_db)
+                
         check_state_db_routes(dvs, vnet_name_2, fg_nhg_prefix, ['38.0.0.1', '38.0.0.2', '38.0.0.3'])
 
         num_exp_changes = 60
@@ -4082,10 +4084,132 @@ class TestVnetOrch(object):
         asic_db.wait_for_deleted_entry(test_fgnhg.ASIC_ROUTE_TB, asic_rt_key_2)
         state_db.wait_for_n_keys("FG_ROUTE_TABLE", 0)
 
-        delete_vnet_entry(dvs, vnet_name)
         delete_vnet_entry(dvs, vnet_name_2)
-        vnet_obj.check_del_vnet_entry(dvs, vnet_name)
         vnet_obj.check_del_vnet_entry(dvs, vnet_name_2)
+
+        # Route Type Transitions (Regular ECMP <-> Fine-Grained ECMP)
+        transition_prefix = "100.100.37.1/32"
+
+        vnet_obj.fetch_exist_entries(dvs)
+
+        # Regular ECMP -> FG ECMP with same NHG key 
+        create_vnet_routes(dvs, transition_prefix, vnet_name, '37.0.0.1,37.0.0.2,37.0.0.3',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C')
+        route1, nhg1 = vnet_obj.check_vnet_ecmp_routes(dvs, vnet_name, ['37.0.0.1', '37.0.0.2', '37.0.0.3'], tunnel_name)
+        check_state_db_routes(dvs, vnet_name, transition_prefix, ['37.0.0.1', '37.0.0.2', '37.0.0.3'])
+
+        vnet_obj.fetch_exist_entries(dvs)
+
+        # Regular -> FG transition path 
+        create_vnet_routes(dvs, transition_prefix, vnet_name, '37.0.0.1,37.0.0.2,37.0.0.3',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C', consistent_hashing_buckets=bucket_size)
+
+        time.sleep(2)
+
+        # Verify FG NHG is created and route is updated
+        nhgid = test_fgnhg.validate_asic_nhg_fine_grained_ecmp(asic_db, transition_prefix, bucket_size, vr_id)
+        nh_oid_map = test_fgnhg.get_nh_oid_map(asic_db)
+        check_state_db_routes(dvs, vnet_name, transition_prefix, ['37.0.0.1', '37.0.0.2', '37.0.0.3'])
+
+        # Verify the old regular ECMP NHG was removed
+        vnet_obj.fetch_exist_entries(dvs)
+        assert nhg1 not in vnet_obj.nhgs
+
+        num_exp_changes = 60
+        nh_memb_exp_count = {'37.0.0.1': 20, '37.0.0.2': 20, '37.0.0.3': 20}
+        prev_memb_dict = {}
+        memb_dict = test_fgnhg.validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
+                            prev_memb_dict, num_exp_changes, transition_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name)
+
+        # Fine-Grained ECMP -> Regular ECMP transition
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vnet_routes(dvs, transition_prefix, vnet_name, '37.0.0.1,37.0.0.2,37.0.0.3',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C')
+
+        time.sleep(2)
+
+        # Verify FG NHG is removed and regular ECMP NHG is created
+        state_db.wait_for_n_keys("FG_ROUTE_TABLE", 0)
+        route1, nhg1 = vnet_obj.check_vnet_ecmp_routes(dvs, vnet_name, ['37.0.0.1', '37.0.0.2', '37.0.0.3'], tunnel_name, route_ids=route1)
+        check_state_db_routes(dvs, vnet_name, transition_prefix, ['37.0.0.1', '37.0.0.2', '37.0.0.3'])
+
+        # Regular ECMP -> FG with different endpoints 
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vnet_routes(dvs, transition_prefix, vnet_name, '37.0.0.4,37.0.0.5,37.0.0.6',
+                          '00:12:34:56:78:9D,00:12:34:56:78:9E,00:12:34:56:78:9F', consistent_hashing_buckets=bucket_size)
+
+        time.sleep(2)
+
+        # Verify FG NHG is created with new endpoints
+        nhgid = test_fgnhg.validate_asic_nhg_fine_grained_ecmp(asic_db, transition_prefix, bucket_size, vr_id)
+        nh_oid_map = test_fgnhg.get_nh_oid_map(asic_db)
+        check_state_db_routes(dvs, vnet_name, transition_prefix, ['37.0.0.4', '37.0.0.5', '37.0.0.6'])
+
+        # Verify old regular ECMP NHG was cleaned up
+        vnet_obj.fetch_exist_entries(dvs)
+        assert nhg1 not in vnet_obj.nhgs
+
+        num_exp_changes = 60
+        nh_memb_exp_count = {'37.0.0.4': 20, '37.0.0.5': 20, '37.0.0.6': 20}
+        prev_memb_dict = {}
+        memb_dict = test_fgnhg.validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
+                            prev_memb_dict, num_exp_changes, transition_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name)
+
+        # Regular with different endpoints
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vnet_routes(dvs, transition_prefix, vnet_name, '37.0.0.7,37.0.0.8',
+                          '00:12:34:56:78:8E,00:12:34:56:78:8F')
+
+        time.sleep(2)
+
+        # Verify FG NHG is removed and regular ECMP NHG is created with new endpoints
+        state_db.wait_for_n_keys("FG_ROUTE_TABLE", 0)
+        route1, nhg1 = vnet_obj.check_vnet_ecmp_routes(dvs, vnet_name, ['37.0.0.7', '37.0.0.8'], tunnel_name, route_ids=route1)
+        check_state_db_routes(dvs, vnet_name, transition_prefix, ['37.0.0.7', '37.0.0.8'])
+
+        # Clean up transition test route
+        delete_vnet_routes(dvs, transition_prefix, vnet_name)
+        time.sleep(2)
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name, [transition_prefix])
+        check_remove_state_db_routes(dvs, vnet_name, transition_prefix)
+
+        # FG route with more distinct next hops than configured buckets must be rejected
+        oversized_prefix = "100.100.37.20/32"
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vnet_routes(dvs, oversized_prefix, vnet_name, '37.0.0.1,37.0.0.2,37.0.0.3',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C', consistent_hashing_buckets=2)
+        time.sleep(2)
+        assert (vnet_name + '|' + oversized_prefix) not in state_db.get_keys("FG_ROUTE_TABLE")
+        delete_vnet_routes(dvs, oversized_prefix, vnet_name)
+        time.sleep(2)
+
+        # Re-applying an unchanged FG route (identical prefix/endpoints/buckets) is a no-op
+        idempotent_prefix = "100.100.37.21/32"
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vnet_routes(dvs, idempotent_prefix, vnet_name, '37.0.0.1,37.0.0.2,37.0.0.3',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C', consistent_hashing_buckets=bucket_size)
+        nhgid = test_fgnhg.validate_asic_nhg_fine_grained_ecmp(asic_db, idempotent_prefix, bucket_size, vr_id)
+        check_state_db_routes(dvs, vnet_name, idempotent_prefix, ['37.0.0.1', '37.0.0.2', '37.0.0.3'])
+
+        create_vnet_routes(dvs, idempotent_prefix, vnet_name, '37.0.0.1,37.0.0.2,37.0.0.3',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C', consistent_hashing_buckets=bucket_size)
+        time.sleep(2)
+        nhgid_unchanged = test_fgnhg.validate_asic_nhg_fine_grained_ecmp(asic_db, idempotent_prefix, bucket_size, vr_id)
+        assert nhgid == nhgid_unchanged
+        check_state_db_routes(dvs, vnet_name, idempotent_prefix, ['37.0.0.1', '37.0.0.2', '37.0.0.3'])
+
+        # Isolated deletion of a non-shared FG route drives full FG NHG teardown
+        vnet_obj.fetch_exist_entries(dvs)
+        asic_rt_key_iso = test_fgnhg.get_asic_route_key(asic_db, idempotent_prefix, vr_id)
+        delete_vnet_routes(dvs, idempotent_prefix, vnet_name)
+        time.sleep(2)
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name, [idempotent_prefix])
+        check_remove_state_db_routes(dvs, vnet_name, idempotent_prefix)
+        asic_db.wait_for_deleted_entry(test_fgnhg.ASIC_ROUTE_TB, asic_rt_key_iso)
+
+        # cleanup
+        delete_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_del_vnet_entry(dvs, vnet_name)
         
         delete_vxlan_tunnel(dvs, tunnel_name)
         vnet_obj.check_del_vxlan_tunnel(dvs)

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -4173,6 +4173,65 @@ class TestVnetOrch(object):
         vnet_obj.check_del_vnet_routes(dvs, vnet_name, [transition_prefix])
         check_remove_state_db_routes(dvs, vnet_name, transition_prefix)
 
+        # Regular -> FG transition for NHG shared by multiple prefixes (ref_count > 1)
+        shared_prefix_1 = "100.100.37.30/32"
+        shared_prefix_2 = "100.100.37.31/32"
+        shared_endpoints = ['37.0.0.1', '37.0.0.2', '37.0.0.3']
+        shared_endpoints_csv = '37.0.0.1,37.0.0.2,37.0.0.3'
+        shared_macs_csv = '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C'
+
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vnet_routes(dvs, shared_prefix_1, vnet_name, shared_endpoints_csv, shared_macs_csv)
+        route_shared_1, nhg_shared = vnet_obj.check_vnet_ecmp_routes(dvs, vnet_name, shared_endpoints, tunnel_name)
+        check_state_db_routes(dvs, vnet_name, shared_prefix_1, shared_endpoints)
+
+        create_vnet_routes(dvs, shared_prefix_2, vnet_name, shared_endpoints_csv, shared_macs_csv)
+        route_shared_2, nhg_shared_2 = vnet_obj.check_vnet_ecmp_routes(dvs, vnet_name, shared_endpoints, tunnel_name)
+        check_state_db_routes(dvs, vnet_name, shared_prefix_2, shared_endpoints)
+
+        # Both prefixes must share same NHG
+        assert nhg_shared == nhg_shared_2
+
+        # Transition shared_prefix_1 to FG
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vnet_routes(dvs, shared_prefix_1, vnet_name, shared_endpoints_csv, shared_macs_csv,
+                          consistent_hashing_buckets=bucket_size)
+        time.sleep(2)
+
+        nhgid_shared = test_fgnhg.validate_asic_nhg_fine_grained_ecmp(asic_db, shared_prefix_1, bucket_size, vr_id)
+        nh_oid_map = test_fgnhg.get_nh_oid_map(asic_db)
+        check_state_db_routes(dvs, vnet_name, shared_prefix_1, shared_endpoints)
+
+        num_exp_changes = 60
+        nh_memb_exp_count = {'37.0.0.1': 20, '37.0.0.2': 20, '37.0.0.3': 20}
+        prev_memb_dict = {}
+        memb_dict = test_fgnhg.validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
+                            prev_memb_dict, num_exp_changes, shared_prefix_1, nh_memb_exp_count, nh_oid_map, nhgid_shared, bucket_size, vnet_name)
+
+        # Regular prefix and NHG must remain intact
+        vnet_obj.fetch_exist_entries(dvs)
+        assert nhg_shared in vnet_obj.nhgs
+        route_shared_2_after, nhg_shared_2_after = vnet_obj.check_vnet_ecmp_routes(
+            dvs, vnet_name, shared_endpoints, tunnel_name, route_ids=route_shared_2, nhg=nhg_shared)
+        assert nhg_shared_2_after == nhg_shared
+        assert route_shared_2_after == route_shared_2
+        check_state_db_routes(dvs, vnet_name, shared_prefix_2, shared_endpoints)
+
+        vnet_obj.fetch_exist_entries(dvs)
+        delete_vnet_routes(dvs, shared_prefix_2, vnet_name)
+        time.sleep(2)
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name, [shared_prefix_2])
+        check_remove_state_db_routes(dvs, vnet_name, shared_prefix_2)
+        vnet_obj.fetch_exist_entries(dvs)
+        assert nhg_shared not in vnet_obj.nhgs
+
+        asic_rt_key_shared_1 = test_fgnhg.get_asic_route_key(asic_db, shared_prefix_1, vr_id)
+        delete_vnet_routes(dvs, shared_prefix_1, vnet_name)
+        time.sleep(2)
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name, [shared_prefix_1])
+        check_remove_state_db_routes(dvs, vnet_name, shared_prefix_1)
+        asic_db.wait_for_deleted_entry(test_fgnhg.ASIC_ROUTE_TB, asic_rt_key_shared_1)
+
         # FG route with more distinct next hops than configured buckets must be rejected
         oversized_prefix = "100.100.37.20/32"
         vnet_obj.fetch_exist_entries(dvs)

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -9,6 +9,7 @@ from swsscommon import swsscommon
 from pprint import pprint
 from dvslib.dvs_common import wait_for_result
 from vnet_lib import *
+import test_fgnhg
 
 class TestVnetOrch(object):
 
@@ -3921,6 +3922,173 @@ class TestVnetOrch(object):
             assert k not in final_routes, (
                 "Link-local trap route %s not cleaned up after VNET delete" % k
             )
+
+    '''
+    Test for vnet tunnel routes with fine-grained ECMP using consistent_hashing_buckets
+    '''
+    def test_vnet_fg_ecmp(self, dvs, testlog):
+        self.setup_db(dvs)
+        vnet_obj = self.get_vnet_obj()
+        asic_db = dvs.get_asic_db()
+        state_db = dvs.get_state_db()
+
+        tunnel_name = 'tunnel_37'
+        vnet_name = 'Vnet37'
+        fg_nhg_prefix = "100.100.37.0/24"
+        bucket_size = 60
+
+        vnet_obj.fetch_exist_entries(dvs)
+        initial_nhop_count = len(asic_db.get_keys(vnet_obj.ASIC_NEXT_HOP))
+
+        create_vxlan_tunnel(dvs, tunnel_name, '10.10.10.10')
+        create_vnet_entry(dvs, vnet_name, tunnel_name, '10037', "")
+
+        vnet_obj.check_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, vnet_name, '10037')
+        vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, '10.10.10.10')
+        
+        vnet_obj.fetch_exist_entries(dvs)
+        
+        vr_id = vnet_obj.vr_map[vnet_name]['ing']
+
+        # Create VNET route with consistent_hashing_buckets and 3 tunnel next hops for fine-grained ECMP
+        create_vnet_routes(dvs, fg_nhg_prefix, vnet_name, '37.0.0.1,37.0.0.2,37.0.0.3',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C', consistent_hashing_buckets=bucket_size)
+
+        asic_db.wait_for_n_keys(test_fgnhg.ASIC_NHG_MEMB, bucket_size)
+        nhgid = test_fgnhg.validate_asic_nhg_fine_grained_ecmp(asic_db, fg_nhg_prefix, bucket_size, vr_id)
+        
+        nh_oid_map = test_fgnhg.get_nh_oid_map(asic_db)
+        
+        ip_to_if_map = {
+            '37.0.0.1': '',
+            '37.0.0.2': '',
+            '37.0.0.3': '',
+            '37.0.0.4': '',
+            '37.0.0.5': '',
+            '37.0.0.6': '',
+            '37.0.0.7': '',
+            '37.0.0.8': '',
+            '38.0.0.1': '',
+            '38.0.0.2': '',
+            '38.0.0.3': ''
+        }
+        
+        check_state_db_routes(dvs, vnet_name, fg_nhg_prefix, ['37.0.0.1', '37.0.0.2', '37.0.0.3'])
+
+        num_exp_changes = 60
+        nh_memb_exp_count = {'37.0.0.1': 20, '37.0.0.2': 20, '37.0.0.3': 20}
+        prev_memb_dict = {}
+        memb_dict = test_fgnhg.validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
+                            prev_memb_dict, num_exp_changes, fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name)
+
+        vnet_obj.fetch_exist_entries(dvs)
+
+        # Add 3 more nexthops
+        create_vnet_routes(dvs, fg_nhg_prefix, vnet_name, '37.0.0.1,37.0.0.2,37.0.0.3,37.0.0.4,37.0.0.5,37.0.0.6',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C,00:12:34:56:78:9D,00:12:34:56:78:9E,00:12:34:56:78:9F', 
+                          consistent_hashing_buckets=bucket_size)
+        
+        time.sleep(2)
+
+        nh_oid_map = test_fgnhg.get_nh_oid_map(asic_db)
+        
+        check_state_db_routes(dvs, vnet_name, fg_nhg_prefix, ['37.0.0.1', '37.0.0.2', '37.0.0.3','37.0.0.4','37.0.0.5','37.0.0.6'])
+        
+        num_exp_changes = 30
+        nh_memb_exp_count = {'37.0.0.1': 10, '37.0.0.2': 10, '37.0.0.3': 10, '37.0.0.4': 10, '37.0.0.5': 10, '37.0.0.6': 10}
+        memb_dict = test_fgnhg.validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
+                            memb_dict, num_exp_changes, fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name)
+        
+        vnet_obj.fetch_exist_entries(dvs)
+
+        # Update route with different endpoints
+        create_vnet_routes(dvs, fg_nhg_prefix, vnet_name, '37.0.0.1,37.0.0.2,37.0.0.3,37.0.0.4,37.0.0.7,37.0.0.8',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C,00:12:34:56:78:9D,00:12:34:56:78:8E,00:12:34:56:78:8F', 
+                          consistent_hashing_buckets=bucket_size)
+        
+        time.sleep(2)
+
+        nh_oid_map = test_fgnhg.get_nh_oid_map(asic_db)
+        
+        check_state_db_routes(dvs, vnet_name, fg_nhg_prefix, ['37.0.0.1', '37.0.0.2', '37.0.0.3','37.0.0.4','37.0.0.7','37.0.0.8'])
+        
+        num_exp_changes = 20
+        nh_memb_exp_count = {'37.0.0.1': 10, '37.0.0.2': 10, '37.0.0.3': 10, '37.0.0.4': 10, '37.0.0.7': 10, '37.0.0.8': 10}
+        memb_dict = test_fgnhg.validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
+                            memb_dict, num_exp_changes, fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name)
+
+        vnet_obj.fetch_exist_entries(dvs)
+
+        # Remove one endpoint
+        create_vnet_routes(dvs, fg_nhg_prefix, vnet_name, '37.0.0.1,37.0.0.2,37.0.0.3,37.0.0.4,37.0.0.7',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C,00:12:34:56:78:9D,00:12:34:56:78:8E', 
+                          consistent_hashing_buckets=bucket_size)
+        
+        time.sleep(2)
+
+        nh_oid_map = test_fgnhg.get_nh_oid_map(asic_db)
+        
+        check_state_db_routes(dvs, vnet_name, fg_nhg_prefix, ['37.0.0.1', '37.0.0.2', '37.0.0.3','37.0.0.4','37.0.0.7'])
+        
+        num_exp_changes = 10
+        nh_memb_exp_count = {'37.0.0.1': 12, '37.0.0.2': 12, '37.0.0.3': 12, '37.0.0.4': 12, '37.0.0.7': 12}
+        memb_dict = test_fgnhg.validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
+                            memb_dict, 10, fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name)
+        
+        # create route for new vnet with same IP space
+        vnet_name_2 = 'Vnet38'
+        create_vnet_entry(dvs, vnet_name_2, tunnel_name, '10038', "")
+        
+        vnet_obj.check_vnet_entry(dvs, vnet_name_2)
+        
+        # Get VR ID for vnet_name_2
+        vr_id_2 = vnet_obj.vr_map[vnet_name_2]['ing']
+        
+        create_vnet_routes(dvs, fg_nhg_prefix, vnet_name_2, '38.0.0.1,38.0.0.2,38.0.0.3',
+                          '00:12:34:56:78:9A,00:12:34:56:78:9B,00:12:34:56:78:9C', consistent_hashing_buckets=bucket_size)
+        
+        asic_db.wait_for_n_keys(test_fgnhg.ASIC_NHG_MEMB, 120)
+        nhgid = test_fgnhg.validate_asic_nhg_fine_grained_ecmp(asic_db, fg_nhg_prefix, bucket_size, vr_id_2)
+        
+        check_state_db_routes(dvs, vnet_name_2, fg_nhg_prefix, ['38.0.0.1', '38.0.0.2', '38.0.0.3'])
+
+        num_exp_changes = 60
+        nh_memb_exp_count = {'38.0.0.1': 20, '38.0.0.2': 20, '38.0.0.3': 20}
+        prev_memb_dict = {}
+        memb_dict = test_fgnhg.validate_fine_grained_asic_n_state_db_entries(asic_db, state_db, ip_to_if_map,
+                            prev_memb_dict, num_exp_changes, fg_nhg_prefix, nh_memb_exp_count, nh_oid_map, nhgid, bucket_size, vnet_name_2)
+
+        # Clean up
+        vnet_obj.fetch_exist_entries(dvs)
+        asic_rt_key_1 = test_fgnhg.get_asic_route_key(asic_db, fg_nhg_prefix, vr_id)
+        asic_rt_key_2 = test_fgnhg.get_asic_route_key(asic_db, fg_nhg_prefix, vr_id_2)
+        
+        delete_vnet_routes(dvs, fg_nhg_prefix, vnet_name)
+        delete_vnet_routes(dvs, fg_nhg_prefix, vnet_name_2)
+        
+        time.sleep(2)
+        
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name, [fg_nhg_prefix])
+        vnet_obj.check_del_vnet_routes(dvs, vnet_name_2, [fg_nhg_prefix])
+        check_remove_state_db_routes(dvs, vnet_name, fg_nhg_prefix)
+        check_remove_state_db_routes(dvs, vnet_name_2, fg_nhg_prefix)
+
+        asic_db.wait_for_n_keys(test_fgnhg.ASIC_NHG_MEMB, 0)
+        asic_db.wait_for_n_keys(test_fgnhg.ASIC_NHG, 0)
+        asic_db.wait_for_n_keys(vnet_obj.ASIC_NEXT_HOP, initial_nhop_count)
+        
+        asic_db.wait_for_deleted_entry(test_fgnhg.ASIC_ROUTE_TB, asic_rt_key_1)
+        asic_db.wait_for_deleted_entry(test_fgnhg.ASIC_ROUTE_TB, asic_rt_key_2)
+        state_db.wait_for_n_keys("FG_ROUTE_TABLE", 0)
+
+        delete_vnet_entry(dvs, vnet_name)
+        delete_vnet_entry(dvs, vnet_name_2)
+        vnet_obj.check_del_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_del_vnet_entry(dvs, vnet_name_2)
+        
+        delete_vxlan_tunnel(dvs, tunnel_name)
+        vnet_obj.check_del_vxlan_tunnel(dvs)
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying

--- a/tests/vnet_lib.py
+++ b/tests/vnet_lib.py
@@ -192,7 +192,10 @@ def set_vnet_routes(dvs, prefix, vnet_name, endpoint, mac="", vni=0, ep_monitor=
 
     tbl = swsscommon.Table(conf_db, "VNET_ROUTE_TUNNEL")
     fvs = swsscommon.FieldValuePairs(attrs)
-    tbl.set("%s|%s" % (vnet_name, prefix), fvs)
+    key = "%s|%s" % (vnet_name, prefix)
+    if consistent_hashing_buckets <= 0:
+        tbl.hdel(key, 'consistent_hashing_buckets')
+    tbl.set(key, fvs)
 
     time.sleep(2)
 
@@ -1192,7 +1195,7 @@ class VnetVxlanVrfTunnel(object):
 
         if nhg:
             new_nhg = nhg
-        elif endpoint_str in self.nhg_ids:
+        elif endpoint_str in self.nhg_ids and self.nhg_ids[endpoint_str] in self.nhgs:
             new_nhg = self.nhg_ids[endpoint_str]
         else:
             new_nhg = get_created_entry(asic_db, self.ASIC_NEXT_HOP_GROUP, self.nhgs)

--- a/tests/vnet_lib.py
+++ b/tests/vnet_lib.py
@@ -140,11 +140,11 @@ def delete_vnet_local_routes(dvs, prefix, vnet_name):
     time.sleep(2)
 
 
-def create_vnet_routes(dvs, prefix, vnet_name, endpoint, mac="", vni=0, ep_monitor="", profile="", primary="", monitoring="", rx_monitor_timer=-1, tx_monitor_timer=-1, adv_prefix="", check_directly_connected=False, pinned_state="", metric=-1):
-    set_vnet_routes(dvs, prefix, vnet_name, endpoint, mac=mac, vni=vni, ep_monitor=ep_monitor, profile=profile, primary=primary, monitoring=monitoring, rx_monitor_timer=rx_monitor_timer, tx_monitor_timer=tx_monitor_timer, adv_prefix=adv_prefix, check_directly_connected=check_directly_connected, pinned_state=pinned_state, metric=metric)
+def create_vnet_routes(dvs, prefix, vnet_name, endpoint, mac="", vni=0, ep_monitor="", profile="", primary="", monitoring="", rx_monitor_timer=-1, tx_monitor_timer=-1, adv_prefix="", check_directly_connected=False, pinned_state="", metric=-1, consistent_hashing_buckets=0):
+    set_vnet_routes(dvs, prefix, vnet_name, endpoint, mac=mac, vni=vni, ep_monitor=ep_monitor, profile=profile, primary=primary, monitoring=monitoring, rx_monitor_timer=rx_monitor_timer, tx_monitor_timer=tx_monitor_timer, adv_prefix=adv_prefix, check_directly_connected=check_directly_connected, pinned_state=pinned_state, metric=metric, consistent_hashing_buckets=consistent_hashing_buckets)
 
 
-def set_vnet_routes(dvs, prefix, vnet_name, endpoint, mac="", vni=0, ep_monitor="", profile="", primary="", monitoring="", rx_monitor_timer=-1, tx_monitor_timer=-1, adv_prefix="", check_directly_connected=False, pinned_state="", metric=-1):
+def set_vnet_routes(dvs, prefix, vnet_name, endpoint, mac="", vni=0, ep_monitor="", profile="", primary="", monitoring="", rx_monitor_timer=-1, tx_monitor_timer=-1, adv_prefix="", check_directly_connected=False, pinned_state="", metric=-1, consistent_hashing_buckets=0):
     conf_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
 
     attrs = [
@@ -186,6 +186,9 @@ def set_vnet_routes(dvs, prefix, vnet_name, endpoint, mac="", vni=0, ep_monitor=
 
     if metric >= 0:
         attrs.append(('metric', str(metric)))
+
+    if consistent_hashing_buckets > 0:
+        attrs.append(('consistent_hashing_buckets', str(consistent_hashing_buckets)))
 
     tbl = swsscommon.Table(conf_db, "VNET_ROUTE_TUNNEL")
     fvs = swsscommon.FieldValuePairs(attrs)

--- a/tests/vnet_lib.py
+++ b/tests/vnet_lib.py
@@ -192,7 +192,10 @@ def set_vnet_routes(dvs, prefix, vnet_name, endpoint, mac="", vni=0, ep_monitor=
 
     tbl = swsscommon.Table(conf_db, "VNET_ROUTE_TUNNEL")
     fvs = swsscommon.FieldValuePairs(attrs)
-    tbl.set("%s|%s" % (vnet_name, prefix), fvs)
+    key = "%s|%s" % (vnet_name, prefix)
+    if consistent_hashing_buckets <= 0:
+        tbl.hdel(key, 'consistent_hashing_buckets')
+    tbl.set(key, fvs)
 
     time.sleep(2)
 
@@ -1197,7 +1200,7 @@ class VnetVxlanVrfTunnel(object):
 
         if nhg:
             new_nhg = nhg
-        elif endpoint_str in self.nhg_ids:
+        elif endpoint_str in self.nhg_ids and self.nhg_ids[endpoint_str] in self.nhgs:
             new_nhg = self.nhg_ids[endpoint_str]
         else:
             new_nhg = get_created_entry(asic_db, self.ASIC_NEXT_HOP_GROUP, self.nhgs)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
This PR adds support for fine-grained ECMP (FG-ECMP) for VNET tunnel routes using a new consistent_hashing_buckets attribute, wiring VNET route programming into the existing FG-NHG orchestration and extending tests accordingly.
Changed FG_ROUTE_TABLE schema to include Vnet name in the key. 

Changes:

Extend VNET route configuration to accept consistent_hashing_buckets and plumb it through to VNetRouteOrch::doRouteTask, which now invokes FgNhgOrch to create/update fine-grained ECMP next-hop groups for tunnel routes.
Enhance FgNhgOrch to support FG-ECMP for non-default VRFs (VNET VRFs), including per-VNET state-DB keys (vnet|prefix) and a new overload of setFgNhg that can work directly with tunnel next-hop IDs and consistent hashing bucket sizes.
Add and update unit tests in test_vnet.py, vnet_lib.py, and test_fgnhg.py to exercise FG-ECMP behavior for VNET routes and to validate new state-DB key formats.

**Why I did it**
To allow consistent ecmp for VXLAN tunnels according to HLD https://github.com/sonic-net/SONiC/pull/2099

**How I verified it**
Via unit tests and datapath testing

**Details if related**
