### PR TITLE
[202511] [portsorch] DOM config change causes interface link to flap (#4056)

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4739,11 +4739,6 @@ void PortsOrch::doPortTask(Consumer &consumer)
                             p.m_alias.c_str(), pCfg.speed.value
                         );
                     }
-                    else
-                    {
-                        /* Always update Gearbox speed on Gearbox ports */
-                        setGearboxPortsAttr(p, SAI_PORT_ATTR_SPEED, &pCfg.speed.value);
-                    }
                 }
 
                 if (pCfg.adv_speeds.is_set)
@@ -5031,6 +5026,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
                         p.m_fec_mode = pCfg.fec.value;
                         p.m_override_fec = pCfg.fec.override_fec;
+                        p.m_fec_cfg = true;
                         m_portList[p.m_alias] = p;
 
                         SWSS_LOG_NOTICE(


### PR DESCRIPTION
202511 Cherry-pick for https://github.com/sonic-net/sonic-swss/pull/4056/changes

This PR fixes a bug where DOM (transceiver) configuration changes cause unexpected interface link flaps due to unnecessary FEC reconfiguration. The issue was introduced in PR #3529 which refactored port configuration handling but inadvertently removed the logic to set the m_fec_cfg flag after applying FEC configuration at runtime in doPortTask(), while it was still being set during initial port creation in addPortBulk().

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
