### PR TITLE
Increase Vrf pool to 4k

### DIFF
--- a/cfgmgr/vrfmgr.cpp
+++ b/cfgmgr/vrfmgr.cpp
@@ -10,9 +10,9 @@
 #include "warm_restart.h"
 
 #define VRF_TABLE_START 1001
-#define VRF_TABLE_END 2000
+#define VRF_TABLE_END 5097
 #define TABLE_LOCAL_PREF 1001 // after l3mdev-table
-#define MGMT_VRF_TABLE_ID 5000
+#define MGMT_VRF_TABLE_ID 6000
 #define MGMT_VRF          "mgmt"
 
 using namespace swss;

--- a/tests/test_inband_intf_mgmt_vrf.py
+++ b/tests/test_inband_intf_mgmt_vrf.py
@@ -14,7 +14,7 @@ class TestInbandInterface(object):
 
     def add_mgmt_vrf(self, dvs):
         initial_entries = set(self.asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_VIRTUAL_ROUTER")) 
-        dvs.runcmd("ip link add mgmt type vrf table 5000")
+        dvs.runcmd("ip link add mgmt type vrf table 6000")
         dvs.runcmd("ifconfig mgmt up")
         time.sleep(2)
 

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -254,7 +254,7 @@ class TestVrf(object):
 
         initial_entries_cnt = self.how_many_entries_exist(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_VIRTUAL_ROUTER")
 
-        maximum_vrf_cnt = 999
+        maximum_vrf_cnt = 4096
 
         def create_entry(self, tbl, key, pairs):
             fvs = swsscommon.FieldValuePairs(pairs)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Increase VRF pool size from 999 to 4096 to support hardware platforms with higher VRF scale capabilities.

**Why I did it**

Current VRF pool is limited to 999 instances (VRF_TABLE_END=2000, VRF_TABLE_START=1001) which artificially restricts VRF scale even on hardware platforms that support more VRFs.

**How I verified it**

**Details if related**
