### PR TITLE
[teamsyncd] remove m_stateLagTablePreserved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ tests/mock_tests/tests_fpmsyncd
 tests/mock_tests/tests_intfmgrd
 tests/mock_tests/tests_teammgrd
 tests/mock_tests/tests_portsyncd
+tests/mock_tests/tests_teamsyncd
 
 
 # Test Files #

--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -184,7 +184,7 @@ void TeamSync::addLag(const string &lagName, int ifindex, bool admin_state,
         try
         {
             auto sync = make_shared<TeamPortSync>(lagName, ifindex, &m_lagMemberTable);
-            m_stateLagTable.set(lagName, fvVector);	    
+            m_stateLagTable.set(lagName, fvVector);
             m_teamSelectables[lagName] = sync;
             m_selectablesToAdd.insert(lagName);
         }
@@ -197,7 +197,7 @@ void TeamSync::addLag(const string &lagName, int ifindex, bool admin_state,
     }
     else
     {
-        m_stateLagTable.set(lagName, fvVector);	    
+        m_stateLagTable.set(lagName, fvVector);
     }
 }
 

--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -87,15 +87,6 @@ void TeamSync::applyState()
 
     m_lagTable.apply_temp_view();
     m_lagMemberTable.apply_temp_view();
-
-    for(auto &it: m_stateLagTablePreserved)
-    {
-        const auto &lagName  = it.first;
-        const auto &fvVector = it.second;
-        m_stateLagTable.set(lagName, fvVector);
-    }
-
-    m_stateLagTablePreserved.clear();
 }
 
 void TeamSync::onMsg(int nlmsg_type, struct nl_object *obj)
@@ -174,7 +165,6 @@ void TeamSync::addLag(const string &lagName, int ifindex, bool admin_state,
 
     FieldValueTuple s("state", "ok");
     fvVector.push_back(s);
-
     if (lag_update)
     {
         /* Create the team instance.
@@ -194,14 +184,7 @@ void TeamSync::addLag(const string &lagName, int ifindex, bool admin_state,
         try
         {
             auto sync = make_shared<TeamPortSync>(lagName, ifindex, &m_lagMemberTable);
-            if (m_warmstart)
-            {
-                m_stateLagTablePreserved[lagName] = fvVector;
-            }
-            else
-            {
-                m_stateLagTable.set(lagName, fvVector);
-            }
+            m_stateLagTable.set(lagName, fvVector);	    
             m_teamSelectables[lagName] = sync;
             m_selectablesToAdd.insert(lagName);
         }
@@ -214,14 +197,7 @@ void TeamSync::addLag(const string &lagName, int ifindex, bool admin_state,
     }
     else
     {
-        if (m_warmstart)
-        {
-            m_stateLagTablePreserved[lagName] = fvVector;
-        }
-        else
-        {
-            m_stateLagTable.set(lagName, fvVector);
-        }
+        m_stateLagTable.set(lagName, fvVector);	    
     }
 }
 
@@ -246,14 +222,7 @@ void TeamSync::removeLag(const string &lagName)
     if (m_teamSelectables.find(lagName) == m_teamSelectables.end())
         return;
 
-    if (m_warmstart)
-    {
-        m_stateLagTablePreserved.erase(lagName);
-    }
-    else
-    {
-        m_stateLagTable.del(lagName);
-    }
+    m_stateLagTable.del(lagName);
 
     m_selectablesToRemove.insert(lagName);
 }

--- a/teamsyncd/teamsync.h
+++ b/teamsyncd/teamsync.h
@@ -76,7 +76,6 @@ private:
     Table m_stateLagTable;
 
     bool m_warmstart;
-    std::unordered_map<std::string, std::vector<FieldValueTuple>> m_stateLagTablePreserved;
     steady_clock::time_point m_start_time;
     uint32_t m_pending_timeout;
 

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -237,25 +237,6 @@ tests_portsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GT
 tests_portsyncd_LDADD = $(LDADD_GTEST) -lnl-genl-3 -lhiredis -lhiredis \
         -lswsscommon -lswsscommon -lgtest -lgtest_main -lnl-3 -lnl-route-3 -lpthread
 
-## teamsyncd unit tests
-
-tests_teamsyncd_SOURCES = teamsyncd/teamsyncd_ut.cpp \
-                          teamsyncd/mock_libteam.cpp \
-                          $(top_srcdir)/lib/recorder.cpp \
-                          $(top_srcdir)/teamsyncd/teamsync.cpp \
-                          mock_dbconnector.cpp \
-                          common/mock_shell_command.cpp \
-                          mock_table.cpp \
-                          mock_hiredis.cpp \
-                          mock_redisreply.cpp
-
-tests_teamsyncd_INCLUDES = -I $(top_srcdir)/teamsyncd -I $(top_srcdir)/cfgmgr -I $(top_srcdir)/lib
-tests_teamsyncd_CXXFLAGS = -Wl,-wrap,if_nameindex -Wl,-wrap,if_freenameindex
-tests_teamsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST)
-tests_teamsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(tests_teamsyncd_INCLUDES)
-tests_teamsyncd_LDADD = $(LDADD_GTEST) -lnl-genl-3 -lhiredis -lhiredis \
-        -lswsscommon -lswsscommon -lgtest -lgtest_main -lnl-3 -lnl-route-3 -lpthread -lteam
-
 ## intfmgrd unit tests
 
 tests_intfmgrd_SOURCES = intfmgrd/intfmgr_ut.cpp \
@@ -368,13 +349,18 @@ tests_nbrmgrd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredi
 
 
 tests_teamsyncd_SOURCES = teamsync_ut.cpp \
+                          teamsyncd/teamsyncd_ut.cpp \
+                          teamsyncd/mock_libteam.cpp \
+                          $(top_srcdir)/lib/recorder.cpp \
                           $(top_srcdir)/teamsyncd/teamsync.cpp \
                           mock_dbconnector.cpp \
+                          common/mock_shell_command.cpp \
                           mock_table.cpp \
                           mock_hiredis.cpp \
                           mock_redisreply.cpp
 
-tests_teamsyncd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/teamsyncd
+tests_teamsyncd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/teamsyncd -I$(top_srcdir)/cfgmgr -I$(top_srcdir)/lib
+tests_teamsyncd_CXXFLAGS = -Wl,-wrap,if_nameindex -Wl,-wrap,if_freenameindex
 tests_teamsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
 tests_teamsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_teamsyncd_INCLUDES)
 tests_teamsyncd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 \

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -237,6 +237,25 @@ tests_portsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GT
 tests_portsyncd_LDADD = $(LDADD_GTEST) -lnl-genl-3 -lhiredis -lhiredis \
         -lswsscommon -lswsscommon -lgtest -lgtest_main -lnl-3 -lnl-route-3 -lpthread
 
+## teamsyncd unit tests
+
+tests_teamsyncd_SOURCES = teamsyncd/teamsyncd_ut.cpp \
+                          teamsyncd/mock_libteam.cpp \
+                          $(top_srcdir)/lib/recorder.cpp \
+                          $(top_srcdir)/teamsyncd/teamsync.cpp \
+                          mock_dbconnector.cpp \
+                          common/mock_shell_command.cpp \
+                          mock_table.cpp \
+                          mock_hiredis.cpp \
+                          mock_redisreply.cpp
+
+tests_teamsyncd_INCLUDES = -I $(top_srcdir)/teamsyncd -I $(top_srcdir)/cfgmgr -I $(top_srcdir)/lib
+tests_teamsyncd_CXXFLAGS = -Wl,-wrap,if_nameindex -Wl,-wrap,if_freenameindex
+tests_teamsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST)
+tests_teamsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(tests_teamsyncd_INCLUDES)
+tests_teamsyncd_LDADD = $(LDADD_GTEST) -lnl-genl-3 -lhiredis -lhiredis \
+        -lswsscommon -lswsscommon -lgtest -lgtest_main -lnl-3 -lnl-route-3 -lpthread -lteam
+
 ## intfmgrd unit tests
 
 tests_intfmgrd_SOURCES = intfmgrd/intfmgr_ut.cpp \

--- a/tests/mock_tests/teamsync_ut.cpp
+++ b/tests/mock_tests/teamsync_ut.cpp
@@ -187,6 +187,26 @@ namespace teamportsync_test
 
 namespace teamsync_test
 {
+    void resetTeamSyncMocks()
+    {
+        callback_sleep = NULL;
+        callback_team_init = NULL;
+        callback_team_change_handler = NULL;
+        callback_teamdctl_connect = NULL;
+        callback_teamdctl_config_get_raw_direct = NULL;
+        callback_teamdctl_disconnect = NULL;
+    }
+
+    void setTeamSyncSuccessMocks()
+    {
+        callback_sleep = cb_sleep;
+        callback_team_init = cb_team_init;
+        callback_team_change_handler = cb_team_change_handler;
+        callback_teamdctl_connect = cb_teamdctl_connect;
+        callback_teamdctl_config_get_raw_direct = cb_teamdctl_config_get_raw_direct_success;
+        callback_teamdctl_disconnect = cb_teamdctl_disconnect;
+    }
+
     /* Subclass to expose the protected addLag() for unit testing. */
     class TeamSyncUnderTest : public swss::TeamSync
     {

--- a/tests/mock_tests/teamsyncd/mock_libteam.cpp
+++ b/tests/mock_tests/teamsyncd/mock_libteam.cpp
@@ -1,0 +1,35 @@
+extern "C"
+{
+
+#include <cstddef>
+#include <team.h>
+
+team_handle* team_alloc()
+{
+    return reinterpret_cast<team_handle*>(1);
+}
+
+int team_init(team_handle*, uint32_t)
+{
+    return 0;
+}
+
+void team_free(team_handle*)
+{
+}
+
+int team_change_handler_register(team_handle*, const team_change_handler*, void*)
+{
+    return 0;
+}
+
+void team_change_handler_unregister(team_handle*, const team_change_handler*, void*)
+{
+}
+
+team_port* team_get_next_port(team_handle*, team_port*)
+{
+    return nullptr;
+}
+
+}

--- a/tests/mock_tests/teamsyncd/mock_libteam.cpp
+++ b/tests/mock_tests/teamsyncd/mock_libteam.cpp
@@ -4,20 +4,6 @@ extern "C"
 #include <cstddef>
 #include <team.h>
 
-team_handle* team_alloc()
-{
-    return reinterpret_cast<team_handle*>(1);
-}
-
-int team_init(team_handle*, uint32_t)
-{
-    return 0;
-}
-
-void team_free(team_handle*)
-{
-}
-
 int team_change_handler_register(team_handle*, const team_change_handler*, void*)
 {
     return 0;

--- a/tests/mock_tests/teamsyncd/teamsyncd_ut.cpp
+++ b/tests/mock_tests/teamsyncd/teamsyncd_ut.cpp
@@ -1,0 +1,47 @@
+#include "gtest/gtest.h"
+#define protected public
+#define private public
+#include "teamsync.h"
+#undef protected
+#undef private 
+#include "mock_table.h"
+
+namespace teamsyncd_ut
+{
+    struct TeamSyncdTest : public ::testing::Test
+    {
+        std::shared_ptr<swss::DBConnector> m_config_db;
+        std::shared_ptr<swss::DBConnector> m_app_db;
+        std::shared_ptr<swss::DBConnector> m_state_db;
+
+        std::shared_ptr<swss::Table> m_stateWarmRestartTable;
+
+        void SetUp() override
+        {
+            testing_db::reset();
+            m_config_db = std::make_shared<swss::DBConnector>("CONFIG_DB", 0);
+            m_app_db = std::make_shared<swss::DBConnector>("APPL_DB", 0);
+            m_state_db = std::make_shared<swss::DBConnector>("STATE_DB", 0);
+        }
+    };
+
+    TEST_F(TeamSyncdTest, testAddingLagOnWarmBootSetsStateDbFlag)
+    {
+        swss::TeamSync sync(m_config_db.get(), m_state_db.get(), nullptr);
+        swss::Table stateLagTable(m_state_db.get(), STATE_LAG_TABLE_NAME);
+
+        sync.m_warmstart = true;
+
+        const bool admin_state = true;
+        const bool oper_state = true;
+        const int if_index = 1;
+        const unsigned int mtu = 1500;
+        const char* lag_name = "PortChannel1";
+        sync.addLag(lag_name, if_index, admin_state, oper_state, mtu);
+
+        std::string okValue;
+        const bool found = stateLagTable.hget(lag_name, "state", okValue);
+        ASSERT_TRUE(found);
+        ASSERT_EQ(okValue, "ok");
+    }
+}

--- a/tests/mock_tests/teamsyncd/teamsyncd_ut.cpp
+++ b/tests/mock_tests/teamsyncd/teamsyncd_ut.cpp
@@ -1,10 +1,22 @@
+#include <chrono>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+
 #include "gtest/gtest.h"
 #define protected public
 #define private public
 #include "teamsync.h"
 #undef protected
-#undef private 
+#undef private
 #include "mock_table.h"
+
+namespace teamsync_test
+{
+    void setTeamSyncSuccessMocks();
+    void resetTeamSyncMocks();
+}
 
 namespace teamsyncd_ut
 {
@@ -19,15 +31,22 @@ namespace teamsyncd_ut
         void SetUp() override
         {
             testing_db::reset();
+            teamsync_test::setTeamSyncSuccessMocks();
             m_config_db = std::make_shared<swss::DBConnector>("CONFIG_DB", 0);
             m_app_db = std::make_shared<swss::DBConnector>("APPL_DB", 0);
             m_state_db = std::make_shared<swss::DBConnector>("STATE_DB", 0);
+        }
+
+        void TearDown() override
+        {
+            teamsync_test::resetTeamSyncMocks();
+            testing_db::reset();
         }
     };
 
     TEST_F(TeamSyncdTest, testAddingLagOnWarmBootSetsStateDbFlag)
     {
-        swss::TeamSync sync(m_config_db.get(), m_state_db.get(), nullptr);
+        swss::TeamSync sync(m_app_db.get(), m_state_db.get(), nullptr);
         swss::Table stateLagTable(m_state_db.get(), STATE_LAG_TABLE_NAME);
 
         sync.m_warmstart = true;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

This PR reopened this PR - [https://github.com/sonic-net/sonic-swss/pull/3782](https://github.com/sonic-net/sonic-swss/pull/3782)

Depends on - [https://github.com/sonic-net/sonic-buildimage/pull/25269](https://github.com/sonic-net/sonic-buildimage/pull/25269)

**What I did**
Remove m_stateLagTablePreserved.

**Why I did it**
Once LAG is created in the kernel set its state to STATE_DB immediately. STATE_DB flag triggers kernel LAG IP configuration, which does not need to be delayed.

Only LAG experience this behaviour, any other type of interface gets kernel IP configuration as soon as netdev is created.
To not delay kernel LAG IP configuration.

Before:

```
2025 Jul 22 11:49:57.368571 sonic NOTICE teamd#teamsyncd: :- checkWarmStart: teamsyncd doing warm start, restore count 1
2025 Jul 22 11:49:57.369866 sonic INFO teamd#teamsyncd: :- onMsg:  nlmsg type:16 key:PortChannel0001 admin:1 oper:1 ifindex:4 type:team
2025 Jul 22 11:51:07.531605 sonic DEBUG swss#intfmgrd: :- doIntfAddrTask: Interface is not ready, skipping PortChannel0001
2025 Jul 22 11:51:08.685359 sonic NOTICE teamd#teamsyncd: :- applyState: Applying state
2025 Jul 22 11:51:10.611619 sonic DEBUG swss#intfmgrd: :- exec: /sbin/ip address "add" "30.0.0.1/24" broadcast "30.0.0.255" dev "PortChannel0001" :  : Exited with rc=0
```

After:
```
2025 Jul 23 10:03:32.445081 sonic NOTICE teamd#teamsyncd: :- checkWarmStart: teamsyncd doing warm start, restore count 1
2025 Jul 23 10:03:32.445879 sonic INFO teamd#teamsyncd: :- onMsg:  nlmsg type:16 key:PortChannel0001 admin:1 oper:1 ifindex:4 type:team
2025 Jul 23 10:03:37.237107 sonic DEBUG swss#intfmgrd: :- exec: /sbin/ip address "add" "30.0.0.1/24" broadcast "30.0.0.255" dev "PortChannel0001" :  : Exited with rc=0
2025 Jul 23 10:04:44.369749 sonic NOTICE teamd#teamsyncd: :- applyState: Applying state
```

**How I verified it**
Ran following tests on Mellanox-SN4600C-C64 (master.0-e7331e3cb_Internal):

- warm-reboot
- warm-reboot-sad
- warm-reboot-multi-sad-lag
- warm-reboot-sad-lag-member
- fast-reboot

**Details if related**

#### Tested branch

- [x] master
- [x] 202605
