### PR TITLE
[202511] [orchagent]: Fix infinite loop and SIGSEGV in AclRange::remove

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3400,11 +3400,11 @@ bool AclRange::remove(sai_object_id_t *oids, int oidsCnt)
 {
     SWSS_LOG_ENTER();
 
-    for (int oidIdx = 0; oidIdx < oidsCnt; oidsCnt++)
+    for (int oidIdx = 0; oidIdx < oidsCnt; oidIdx++)
     {
         for (auto it : m_ranges)
         {
-            if (it.second->m_oid == oids[oidsCnt])
+            if (it.second->m_oid == oids[oidIdx])
             {
                 return it.second->remove();
             }


### PR DESCRIPTION
function AclRange::remove.

**What I did**
Fixed a critical logic error in AclRange::remove where the loop limit (oidsCnt) was being incremented instead of the loop index (oidIdx).

**Why I did it**
The original code contained an infinite loop: for (int oidIdx = 0; oidIdx < oidsCnt; oidsCnt++). This caused Memory Corruption/Crash: The loop would continue until oidsCnt accessed memory outside the bounds of the oids pointer, resulting in a SIGSEGV (Segmentation Fault).

**How I verified it**
After the fix, orchagent remains stable and correctly logs the SAI error (rv:-2) instead of terminating.

**Details if related**
The crash was specifically observed in Arista Gardena switches.

### Issues
Fixes: #4174 
Fixes: [sonic-qual.msft](https://github.com/aristanetworks/sonic-qual.msft/issues/1067)