### PR TITLE
[P4Orch] Enable use of SAI L2 multicast and add p4orch mocks

### DIFF
--- a/orchagent/p4orch/tests/Makefile.am
+++ b/orchagent/p4orch/tests/Makefile.am
@@ -84,6 +84,8 @@ p4orch_tests_SOURCES = $(ORCHAGENT_DIR)/orch.cpp \
 		       mock_sai_hostif.cpp \
 		       mock_sai_ipmc.cpp \
 		       mock_sai_ipmc_group.cpp \
+		       mock_sai_l2mc.cpp \
+		       mock_sai_l2mc_group.cpp \
 		       mock_sai_serialize.cpp \
 		       mock_sai_router_interface.cpp \
 		       mock_sai_rpf_group.cpp \

--- a/orchagent/p4orch/tests/mock_sai_l2mc.cpp
+++ b/orchagent/p4orch/tests/mock_sai_l2mc.cpp
@@ -1,0 +1,25 @@
+#include "mock_sai_l2mc.h"
+MockSaiL2mc* mock_sai_l2mc;
+sai_status_t mock_create_l2mc_entry(
+    _In_ const sai_l2mc_entry_t* l2mc_entry,
+    _In_ uint32_t attr_count,
+    _In_ const sai_attribute_t* attr_list) {
+  return mock_sai_l2mc->create_l2mc_entry(
+      l2mc_entry, attr_count, attr_list);
+}
+sai_status_t mock_remove_l2mc_entry(
+   _In_ const sai_l2mc_entry_t* l2mc_entry) {
+  return mock_sai_l2mc->remove_l2mc_entry(l2mc_entry);
+}
+sai_status_t mock_set_l2mc_entry_attribute(
+    _In_ const sai_l2mc_entry_t* l2mc_entry,
+    _In_ const sai_attribute_t* attr) {
+  return mock_sai_l2mc->set_l2mc_entry_attribute(l2mc_entry, attr);
+}
+sai_status_t mock_get_l2mc_entry_attribute(
+    _In_ const sai_l2mc_entry_t* l2mc_entr,
+    _In_ uint32_t attr_count,
+    _Inout_ sai_attribute_t* attr_list) {
+  return mock_sai_l2mc->get_l2mc_entry_attribute(
+      l2mc_entr, attr_count, attr_list);
+}

--- a/orchagent/p4orch/tests/mock_sai_l2mc.h
+++ b/orchagent/p4orch/tests/mock_sai_l2mc.h
@@ -1,0 +1,36 @@
+#pragma once
+#include <gmock/gmock.h>
+extern "C" {
+#include "sai.h"
+}
+// Mock Class mapping methods to L2 multicast SAI APIs.
+class MockSaiL2mc {
+ public:
+  MOCK_METHOD3(create_l2mc_entry,
+               sai_status_t(_In_ const sai_l2mc_entry_t* l2mc_entry,
+                            _In_ uint32_t attr_count,
+                            _In_ const sai_attribute_t* attr_list));
+  MOCK_METHOD1(remove_l2mc_entry,
+               sai_status_t(_In_ const sai_l2mc_entry_t* l2mc_entry));
+  MOCK_METHOD2(set_l2mc_entry_attribute,
+               sai_status_t(_In_ const sai_l2mc_entry_t* l2mc_entry,
+                            _In_ const sai_attribute_t* attr));
+  MOCK_METHOD3(get_l2mc_entry_attribute,
+               sai_status_t(_In_ const sai_l2mc_entry_t* l2mc_entry,
+                            _In_ uint32_t attr_count,
+                            _Inout_ sai_attribute_t* attr_list));
+};
+extern MockSaiL2mc* mock_sai_l2mc;
+sai_status_t mock_create_l2mc_entry(
+    _In_ const sai_l2mc_entry_t* l2mc_entry,
+    _In_ uint32_t attr_count,
+    _In_ const sai_attribute_t* attr_list);
+sai_status_t mock_remove_l2mc_entry(
+   _In_ const sai_l2mc_entry_t* l2mc_entry);
+sai_status_t mock_set_l2mc_entry_attribute(
+    _In_ const sai_l2mc_entry_t* l2mc_entry,
+    _In_ const sai_attribute_t* attr);
+sai_status_t mock_get_l2mc_entry_attribute(
+    _In_ const sai_l2mc_entry_t* l2mc_entr,
+    _In_ uint32_t attr_count,
+    _Inout_ sai_attribute_t* attr_list);

--- a/orchagent/p4orch/tests/mock_sai_l2mc_group.cpp
+++ b/orchagent/p4orch/tests/mock_sai_l2mc_group.cpp
@@ -1,0 +1,51 @@
+#include "mock_sai_l2mc_group.h"
+MockSaiL2mcGroup* mock_sai_l2mc_group;
+sai_status_t mock_create_l2mc_group(
+    _Out_ sai_object_id_t* l2mc_group_id,
+    _In_ sai_object_id_t switch_id,
+    _In_ uint32_t attr_count,
+    _In_ const sai_attribute_t* attr_list) {
+  return mock_sai_l2mc_group->create_l2mc_group(
+      l2mc_group_id, switch_id, attr_count, attr_list);
+}
+sai_status_t mock_remove_l2mc_group(
+    _In_ sai_object_id_t l2mc_group_id) {
+  return mock_sai_l2mc_group->remove_l2mc_group(l2mc_group_id);
+}
+sai_status_t mock_set_l2mc_group_attribute(
+    _In_ sai_object_id_t l2mc_group_id,
+    _In_ const sai_attribute_t* attr) {
+  return mock_sai_l2mc_group->set_l2mc_group_attribute(l2mc_group_id, attr);
+}
+sai_status_t mock_get_l2mc_group_attribute(
+    _In_ sai_object_id_t l2mc_group_id,
+    _In_ uint32_t attr_count,
+    _Inout_ sai_attribute_t* attr_list) {
+  return mock_sai_l2mc_group->get_l2mc_group_attribute(
+      l2mc_group_id, attr_count, attr_list);
+}
+sai_status_t mock_create_l2mc_group_member(
+    _Out_ sai_object_id_t* l2mc_group_member_id,
+    _In_ sai_object_id_t switch_id,
+    _In_ uint32_t attr_count,
+    _In_ const sai_attribute_t* attr_list) {
+  return mock_sai_l2mc_group->create_l2mc_group_member(
+      l2mc_group_member_id, switch_id, attr_count, attr_list);
+}
+sai_status_t mock_remove_l2mc_group_member(
+    _In_ sai_object_id_t l2mc_group_member_id) {
+  return mock_sai_l2mc_group->remove_l2mc_group_member(l2mc_group_member_id);
+}
+sai_status_t mock_set_l2mc_group_member_attribute(
+    _In_ sai_object_id_t l2mc_group_member_id,
+    _In_ const sai_attribute_t* attr) {
+  return mock_sai_l2mc_group->set_l2mc_group_member_attribute(
+      l2mc_group_member_id, attr);
+}
+sai_status_t mock_get_l2mc_group_member_attribute(
+    _In_ sai_object_id_t l2mc_group_member_id,
+    _In_ uint32_t attr_count,
+    _Inout_ sai_attribute_t* attr_list) {
+  return mock_sai_l2mc_group->get_l2mc_group_member_attribute(
+      l2mc_group_member_id, attr_count, attr_list);
+}

--- a/orchagent/p4orch/tests/mock_sai_l2mc_group.h
+++ b/orchagent/p4orch/tests/mock_sai_l2mc_group.h
@@ -1,0 +1,66 @@
+#pragma once
+#include <gmock/gmock.h>
+extern "C" {
+#include "sai.h"
+}
+// Mock Class mapping methods to L2 multicast group SAI APIs.
+class MockSaiL2mcGroup {
+ public:
+  MOCK_METHOD4(create_l2mc_group,
+               sai_status_t(_Out_ sai_object_id_t* l2mc_group_id,
+                            _In_ sai_object_id_t switch_id,
+                            _In_ uint32_t attr_count,
+                            _In_ const sai_attribute_t* attr_list));
+  MOCK_METHOD1(remove_l2mc_group,
+               sai_status_t(_In_ sai_object_id_t l2mc_group_id));
+  MOCK_METHOD2(set_l2mc_group_attribute,
+               sai_status_t(_In_ sai_object_id_t l2mc_group_id,
+                            _In_ const sai_attribute_t* attr));
+  MOCK_METHOD3(get_l2mc_group_attribute,
+               sai_status_t(_In_ sai_object_id_t l2mc_group_id,
+                            _In_ uint32_t attr_count,
+                            _Inout_ sai_attribute_t* attr_list));
+  MOCK_METHOD4(create_l2mc_group_member,
+               sai_status_t(_Out_ sai_object_id_t* l2mc_group_member_id,
+                            _In_ sai_object_id_t switch_id,
+                            _In_ uint32_t attr_count,
+                            _In_ const sai_attribute_t* attr_list));
+  MOCK_METHOD1(remove_l2mc_group_member,
+               sai_status_t(_In_ sai_object_id_t l2mc_group_member_id));
+  MOCK_METHOD2(set_l2mc_group_member_attribute,
+               sai_status_t(_In_ sai_object_id_t l2mc_group_member_id,
+                            _In_ const sai_attribute_t* attr));
+  MOCK_METHOD3(get_l2mc_group_member_attribute,
+               sai_status_t(_In_ sai_object_id_t l2mc_group_member_id,
+                            _In_ uint32_t attr_count,
+                            _Inout_ sai_attribute_t* attr_list));
+};
+extern MockSaiL2mcGroup* mock_sai_l2mc_group;
+sai_status_t mock_create_l2mc_group(
+    _Out_ sai_object_id_t* l2mc_group_id,
+    _In_ sai_object_id_t switch_id,
+    _In_ uint32_t attr_count,
+    _In_ const sai_attribute_t* attr_list);
+sai_status_t mock_remove_l2mc_group(
+    _In_ sai_object_id_t l2mc_group_id);
+sai_status_t mock_set_l2mc_group_attribute(
+    _In_ sai_object_id_t l2mc_group_id,
+    _In_ const sai_attribute_t* attr);
+sai_status_t mock_get_l2mc_group_attribute(
+    _In_ sai_object_id_t l2mc_group_id,
+    _In_ uint32_t attr_count,
+    _Inout_ sai_attribute_t* attr_list);
+sai_status_t mock_create_l2mc_group_member(
+    _Out_ sai_object_id_t* l2mc_group_member_id,
+    _In_ sai_object_id_t switch_id,
+    _In_ uint32_t attr_count,
+    _In_ const sai_attribute_t* attr_list);
+sai_status_t mock_remove_l2mc_group_member(
+    _In_ sai_object_id_t l2mc_group_member_id);
+sai_status_t mock_set_l2mc_group_member_attribute(
+    _In_ sai_object_id_t l2mc_group_member_id,
+    _In_ const sai_attribute_t* attr);
+sai_status_t mock_get_l2mc_group_member_attribute(
+    _In_ sai_object_id_t l2mc_group_member_id,
+    _In_ uint32_t attr_count,
+    _Inout_ sai_attribute_t* attr_list);

--- a/orchagent/p4orch/tests/p4orch_test.cpp
+++ b/orchagent/p4orch/tests/p4orch_test.cpp
@@ -10,6 +10,8 @@
 #include "mock_sai_hostif.h"
 #include "mock_sai_ipmc.h"
 #include "mock_sai_ipmc_group.h"
+#include "mock_sai_l2mc.h"
+#include "mock_sai_l2mc_group.h"
 #include "mock_sai_neighbor.h"
 #include "mock_sai_next_hop.h"
 #include "mock_sai_route.h"
@@ -28,6 +30,8 @@ extern sai_hostif_api_t* sai_hostif_api;
 extern sai_switch_api_t* sai_switch_api;
 extern sai_ipmc_api_t* sai_ipmc_api;
 extern sai_ipmc_group_api_t* sai_ipmc_group_api;
+extern sai_l2mc_api_t* sai_l2mc_api;
+extern sai_l2mc_group_api_t* sai_l2mc_group_api;
 extern sai_bridge_api_t* sai_bridge_api;
 extern sai_router_interface_api_t* sai_router_intfs_api;
 extern sai_neighbor_api_t* sai_neighbor_api;
@@ -117,6 +121,26 @@ class P4OrchTest : public ::testing::Test {
         mock_set_rpf_group_member_attribute;
     sai_rpf_group_api->get_rpf_group_member_attribute =
         mock_get_rpf_group_member_attribute;
+    mock_sai_l2mc = &mock_sai_l2mc_;
+    sai_l2mc_api->create_l2mc_entry = mock_create_l2mc_entry;
+    sai_l2mc_api->remove_l2mc_entry = mock_remove_l2mc_entry;
+    sai_l2mc_api->set_l2mc_entry_attribute = mock_set_l2mc_entry_attribute;
+    sai_l2mc_api->get_l2mc_entry_attribute = mock_get_l2mc_entry_attribute;
+    mock_sai_l2mc_group = &mock_sai_l2mc_group_;
+    sai_l2mc_group_api->create_l2mc_group = mock_create_l2mc_group;
+    sai_l2mc_group_api->remove_l2mc_group = mock_remove_l2mc_group;
+    sai_l2mc_group_api->set_l2mc_group_attribute =
+        mock_set_l2mc_group_attribute;
+    sai_l2mc_group_api->get_l2mc_group_attribute =
+        mock_get_l2mc_group_attribute;
+    sai_l2mc_group_api->create_l2mc_group_member =
+        mock_create_l2mc_group_member;
+    sai_l2mc_group_api->remove_l2mc_group_member =
+        mock_remove_l2mc_group_member;
+    sai_l2mc_group_api->set_l2mc_group_member_attribute =
+        mock_set_l2mc_group_member_attribute;
+    sai_l2mc_group_api->get_l2mc_group_member_attribute =
+        mock_get_l2mc_group_member_attribute;
     mock_sai_bridge = &mock_sai_bridge_;
     sai_bridge_api->create_bridge = mock_create_bridge;
     sai_bridge_api->remove_bridge = mock_remove_bridge;
@@ -160,6 +184,8 @@ class P4OrchTest : public ::testing::Test {
   NiceMock<MockSaiIpmc> mock_sai_ipmc_;
   NiceMock<MockSaiRpfGroup> mock_sai_rpf_group_;
   NiceMock<MockSaiBridge> mock_sai_bridge_;
+  NiceMock<MockSaiL2mc> mock_sai_l2mc_;
+  NiceMock<MockSaiL2mcGroup> mock_sai_l2mc_group_;
   CoppOrch* copp_orch_;
 };
 

--- a/orchagent/p4orch/tests/test_main.cpp
+++ b/orchagent/p4orch/tests/test_main.cpp
@@ -87,6 +87,8 @@ sai_counter_api_t *sai_counter_api;
 sai_ipmc_api_t* sai_ipmc_api;
 sai_ipmc_group_api_t* sai_ipmc_group_api;
 sai_rpf_group_api_t* sai_rpf_group_api;
+sai_l2mc_api_t* sai_l2mc_api;
+sai_l2mc_group_api_t* sai_l2mc_group_api;
 sai_bridge_api_t* sai_bridge_api;
 sai_generic_programmable_api_t *sai_generic_programmable_api;
 
@@ -216,6 +218,8 @@ int main(int argc, char *argv[])
     sai_ipmc_api_t ipmc_api;
     sai_ipmc_group_api_t ipmc_group_api;
     sai_rpf_group_api_t rpf_group_api;
+    sai_l2mc_api_t l2mc_api;
+    sai_l2mc_group_api_t l2mc_group_api;
     sai_bridge_api_t bridge_api;
     sai_generic_programmable_api_t generic_programmable_api;
     sai_router_intfs_api = &router_intfs_api;
@@ -237,6 +241,8 @@ int main(int argc, char *argv[])
     sai_ipmc_api = &ipmc_api;
     sai_ipmc_group_api = &ipmc_group_api;
     sai_rpf_group_api = &rpf_group_api;
+    sai_l2mc_api = &l2mc_api;
+    sai_l2mc_group_api = &l2mc_group_api;
     sai_bridge_api = &bridge_api;
     sai_generic_programmable_api = &generic_programmable_api;
 

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -69,6 +69,7 @@ sai_isolation_group_api_t*  sai_isolation_group_api;
 sai_system_port_api_t*      sai_system_port_api;
 sai_macsec_api_t*           sai_macsec_api;
 sai_srv6_api_t**            sai_srv6_api;;
+sai_l2mc_api_t*             sai_l2mc_api;
 sai_l2mc_group_api_t*       sai_l2mc_group_api;
 sai_counter_api_t*          sai_counter_api;
 sai_bfd_api_t*              sai_bfd_api;
@@ -232,6 +233,7 @@ void initSaiApi()
     sai_api_query(SAI_API_SYSTEM_PORT,          (void **)&sai_system_port_api);
     sai_api_query(SAI_API_MACSEC,               (void **)&sai_macsec_api);
     sai_api_query(SAI_API_SRV6,                 (void **)&sai_srv6_api);
+    sai_api_query(SAI_API_L2MC,                 (void **)&sai_l2mc_api);
     sai_api_query(SAI_API_L2MC_GROUP,           (void **)&sai_l2mc_group_api);
     sai_api_query(SAI_API_COUNTER,              (void **)&sai_counter_api);
     sai_api_query(SAI_API_BFD,                  (void **)&sai_bfd_api);
@@ -293,6 +295,7 @@ void initSaiApi()
     sai_log_set(SAI_API_SYSTEM_PORT,            SAI_LOG_LEVEL_NOTICE);
     sai_log_set(SAI_API_MACSEC,                 SAI_LOG_LEVEL_NOTICE);
     sai_log_set(SAI_API_SRV6,                   SAI_LOG_LEVEL_NOTICE);
+    sai_log_set(SAI_API_L2MC,                   SAI_LOG_LEVEL_NOTICE);
     sai_log_set(SAI_API_L2MC_GROUP,             SAI_LOG_LEVEL_NOTICE);
     sai_log_set(SAI_API_COUNTER,                SAI_LOG_LEVEL_NOTICE);
     sai_log_set(SAI_API_BFD,                    SAI_LOG_LEVEL_NOTICE);


### PR DESCRIPTION
**What I did**
Enable use of SAI L2 multicast and add p4orch mocks.
**Why I did it**
To Enable use of SAI L2 multicast and add p4orch mocks.
**How I verified it**
Verified with UT testcases.

**Details if related**
