### PR TITLE
[cfgmgr]: Add kernel interface and route for VNET_ROUTE_TUNNEL

### DIFF
--- a/.azure-pipelines/docker-sonic-vs/start.sh
+++ b/.azure-pipelines/docker-sonic-vs/start.sh
@@ -183,6 +183,8 @@ supervisorctl start nbrmgrd
 
 supervisorctl start vxlanmgrd
 
+supervisorctl start vnetmgrd
+
 supervisorctl start sflowmgrd
 
 supervisorctl start natmgrd

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ cfgmgr/teammgrd
 cfgmgr/vlanmgrd
 cfgmgr/vrfmgrd
 cfgmgr/vxlanmgrd
+cfgmgr/vnetmgrd
 cfgmgr/natmgrd
 cfgmgr/sflowmgrd
 cfgmgr/macsecmgrd

--- a/cfgmgr/Makefile.am
+++ b/cfgmgr/Makefile.am
@@ -5,7 +5,7 @@ LIBNL_LIBS = -lnl-genl-3 -lnl-route-3 -lnl-3
 SAIMETA_LIBS = -lsaimeta -lsaimetadata -lzmq
 COMMON_LIBS = -lswsscommon -lpthread
 
-bin_PROGRAMS = vlanmgrd teammgrd portmgrd intfmgrd buffermgrd vrfmgrd nbrmgrd vxlanmgrd sflowmgrd natmgrd coppmgrd tunnelmgrd macsecmgrd fabricmgrd stpmgrd
+bin_PROGRAMS = vlanmgrd teammgrd portmgrd intfmgrd buffermgrd vrfmgrd nbrmgrd vxlanmgrd vnetmgrd sflowmgrd natmgrd coppmgrd tunnelmgrd macsecmgrd fabricmgrd stpmgrd
 
 cfgmgrdir = $(datadir)/swss
 
@@ -71,6 +71,11 @@ nbrmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(LIBNL
 nbrmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(LIBNL_CPPFLAGS) $(CFLAGS_ASAN)
 nbrmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS) $(LIBNL_LIBS)
 
+vnetmgrd_SOURCES = vnetmgrd.cpp vnetmgr.cpp $(COMMON_ORCH_SOURCE) shellcmd.h
+vnetmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+vnetmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+vnetmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
+
 vxlanmgrd_SOURCES = vxlanmgrd.cpp vxlanmgr.cpp $(COMMON_ORCH_SOURCE) shellcmd.h
 vxlanmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
 vxlanmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
@@ -117,6 +122,7 @@ buffermgrd_SOURCES += ../gcovpreload/gcovpreload.cpp
 vrfmgrd_SOURCES += ../gcovpreload/gcovpreload.cpp
 nbrmgrd_SOURCES += ../gcovpreload/gcovpreload.cpp
 vxlanmgrd_SOURCES +=  ../gcovpreload/gcovpreload.cpp
+vnetmgrd_SOURCES += ../gcovpreload/gcovpreload.cpp
 sflowmgrd_SOURCES +=  ../gcovpreload/gcovpreload.cpp
 natmgrd_SOURCES += ../gcovpreload/gcovpreload.cpp
 coppmgrd_SOURCES += ../gcovpreload/gcovpreload.cpp
@@ -134,6 +140,7 @@ buffermgrd_SOURCES += $(top_srcdir)/lib/asan.cpp
 vrfmgrd_SOURCES += $(top_srcdir)/lib/asan.cpp
 nbrmgrd_SOURCES += $(top_srcdir)/lib/asan.cpp
 vxlanmgrd_SOURCES += $(top_srcdir)/lib/asan.cpp
+vnetmgrd_SOURCES += $(top_srcdir)/lib/asan.cpp
 sflowmgrd_SOURCES += $(top_srcdir)/lib/asan.cpp
 natmgrd_SOURCES += $(top_srcdir)/lib/asan.cpp
 coppmgrd_SOURCES += $(top_srcdir)/lib/asan.cpp

--- a/cfgmgr/vnetmgr.cpp
+++ b/cfgmgr/vnetmgr.cpp
@@ -1,0 +1,673 @@
+#include <unistd.h>
+#include <algorithm>
+#include <regex>
+#include <sstream>
+#include <string>
+#include <net/if.h>
+
+#include "logger.h"
+#include "producerstatetable.h"
+#include "macaddress.h"
+#include "vnetmgr.h"
+#include "exec.h"
+#include "tokenize.h"
+#include "shellcmd.h"
+#include "warm_restart.h"
+#include <swss/logger.h>
+
+using namespace std;
+using namespace swss;
+
+// Fields name
+#define VXLAN_TUNNEL "vxlan_tunnel"
+#define SOURCE_IP "src_ip"
+#define SOURCE_MAC "src_mac"
+#define MAC_ADDRESS "mac_address"
+#define ENDPOINT "endpoint"
+#define INSTALL_ON_KERNEL "install_on_kernel"
+#define VNI "vni"
+#define VNET "vnet"
+#define VXLAN "vxlan"
+#define VXLAN_NAME_PREFIX "Vxlan"
+#define VXLAN_SRC_PORT "vxlan_sport"
+#define SWITCH "switch"
+
+#define RET_SUCCESS 0
+
+// Commands
+
+static int cmdCreateVxlan(const swss::VNetMgr::VxlanKernelRouteInfo & info, std::string & res)
+{
+    // ip link add {{VXLAN}} [address {{SOURCE MAC}}] type vxlan id {{VNI}} [local {{SOURCE IP}}] [remote {{DEST IP}}] dstport 4789
+    ostringstream cmd;
+    cmd << IP_CMD " link add "
+        << shellquote(info.m_vxlanDevName);
+
+    if (!info.m_srcMac.empty())
+    {
+        cmd << " address " << shellquote(info.m_srcMac);
+    }
+
+    cmd << " type vxlan id "
+        << shellquote(info.m_vni);
+
+    if (!info.m_srcIp.empty())
+    {
+        cmd << " local " << shellquote(info.m_srcIp);
+    }
+
+    if (!info.m_dstIp.empty())
+    {
+        cmd << " remote " << shellquote(info.m_dstIp);
+    }
+    cmd << " dstport " << shellquote(info.m_vxlanSrcUdpPort);
+    return swss::exec(cmd.str(), res);
+}
+
+static int cmdDeleteVxlan(const swss::VNetMgr::VxlanKernelRouteInfo & info, std::string & res)
+{
+    // ip link del {{VXLAN}}
+    ostringstream cmd;
+    cmd << IP_CMD " link del "
+        << shellquote(info.m_vxlanDevName);
+    return swss::exec(cmd.str(), res);
+}
+
+static int cmdUpVxlan(const swss::VNetMgr::VxlanKernelRouteInfo & info, std::string & res)
+{
+    // ip link set dev {{VXLAN}} up
+    ostringstream cmd;
+    cmd << IP_CMD " link set dev "
+        << shellquote(info.m_vxlanDevName)
+        << " up";
+    return swss::exec(cmd.str(), res);
+}
+
+static int cmdAttachVxlanIfToVnet(const swss::VNetMgr::VxlanKernelRouteInfo & info, std::string & res)
+{
+    // ip link set dev {{VXLAN_IF}} vrf {{VNET}}
+    ostringstream cmd;
+    cmd << IP_CMD " link set dev "
+        << shellquote(info.m_vxlanDevName)
+        << " vrf "
+        << shellquote(info.m_vnet);
+    return swss::exec(cmd.str(), res);
+}
+
+static int cmdCreateKernelRoute(const swss::VNetMgr::VxlanKernelRouteInfo & info, std::string & res)
+{
+    // ip route add {{PREFIX}} dev {{VXLAN_IF}} vrf {{VNET}}
+    ostringstream cmd;
+    cmd << IP_CMD " route add "
+        << shellquote(info.m_prefix)
+        << " dev "
+        << shellquote(info.m_vxlanDevName)
+        << " vrf "
+        << shellquote(info.m_vnet);
+    return swss::exec(cmd.str(), res);
+}
+
+static bool shouldAddStaticMacEntry(const std::string prefix, std::string &address) {
+    size_t slashPos = prefix.find('/');
+    if (slashPos == std::string::npos) {
+        return false;
+    }
+    
+    address = prefix.substr(0, slashPos);
+    int prefixLen = std::stoi(prefix.substr(slashPos + 1));
+
+    // Add a static MAC entry only for /32 IPv4 or /128 IPv6 prefix
+    if (prefix.find('.') != std::string::npos) {
+        return prefixLen == 32;
+    }
+    else if (prefix.find(':') != std::string::npos) {
+        return prefixLen == 128;
+    }
+
+    return false;
+}
+
+static int cmdCreateStaticMacEntry(const swss::VNetMgr::VxlanKernelRouteInfo & info, std::string & res)
+{
+    std::string address;
+    if (!shouldAddStaticMacEntry(info.m_prefix, address)) {
+        return RET_SUCCESS;
+    }
+
+    // ip neigh add {{PREFIX}} lladdr {{DEST MAC}} dev {{VXLAN_IF}}
+    ostringstream cmd;
+    cmd << IP_CMD " neigh add "
+        << shellquote(address)
+        << " lladdr "
+        << shellquote(info.m_dstMac)
+        << " dev "
+        << shellquote(info.m_vxlanDevName);
+    return swss::exec(cmd.str(), res);
+}
+
+VNetMgr::VNetMgr(DBConnector *cfgDb, DBConnector *appDb, const std::vector<std::string> &tables) :
+        m_app_db(appDb),
+        Orch(cfgDb, tables),
+        m_appVnetRouteTable(appDb, APP_VNET_RT_TABLE_NAME),
+        m_appVnetRouteTunnelTable(appDb, APP_VNET_RT_TUNNEL_TABLE_NAME),
+        m_appSwitchTable(appDb, APP_SWITCH_TABLE_NAME)
+{
+    getAllVxlanNetDevices();
+}
+
+std::vector<std::string> VNetMgr::parseNetDev(const std::string& stdout){
+    std::vector<std::string> netdevs;
+    std::regex device_name_pattern("^\\d+:\\s+([^:]+)");
+    std::smatch match_result;
+    auto lines = tokenize(stdout, '\n');
+    for (const std::string & line : lines)
+    {
+        SWSS_LOG_NOTICE("line : %s\n",line.c_str());
+        if (!std::regex_search(line, match_result, device_name_pattern))
+        {
+            continue;
+        }
+        std::string dev_name = match_result[1];
+        netdevs.push_back(dev_name);
+    }
+    return netdevs;
+}
+
+void VNetMgr::getAllVxlanNetDevices()
+{
+    std::string stdout;
+
+    // Get VxLan Netdev Interfaces
+    std::string cmd = std::string("") + IP_CMD + " link show type vxlan";
+    int ret = swss::exec(cmd, stdout);
+    if (ret != 0)
+    {
+        SWSS_LOG_ERROR("Cannot get vxlan devices by command : %s", cmd.c_str());
+        stdout.clear();
+    }
+    std::vector<std::string> netdevs = parseNetDev(stdout);
+    for (auto netdev : netdevs)
+    {
+        SWSS_LOG_NOTICE("Found vxlan device: %s", netdev.c_str());
+        m_vxlanNetDevices[netdev] = VXLAN;
+    }
+
+    return;
+}
+
+std::string VNetMgr::getVxlanSourcePort()
+{
+    std::vector<FieldValueTuple> temp;
+
+    if (m_appSwitchTable.get(SWITCH, temp))
+    {
+        auto itr = std::find_if(
+            temp.begin(),
+            temp.end(),
+            [](const FieldValueTuple &fvt) { return fvt.first == VXLAN_SRC_PORT; });
+        if (itr != temp.end() && !(itr->second.empty()))
+        {
+            SWSS_LOG_DEBUG("Using Vxlan source port %s", itr->second.c_str());
+            return itr->second;
+        }
+    }
+    
+    SWSS_LOG_DEBUG("Using default Vxlan source port: 4789");
+    return "4789"; // default port
+}
+
+void VNetMgr::doTask(Consumer &consumer)
+{
+    SWSS_LOG_ENTER();
+
+    const string & table_name = consumer.getTableName();
+    auto it = consumer.m_toSync.begin();
+    while (it != consumer.m_toSync.end())
+    {
+        bool task_result = false;
+        auto t = it->second;
+        const std::string & op = kfvOp(t);
+
+        if (op == SET_COMMAND)
+        {
+            if (table_name == CFG_VNET_TABLE_NAME)
+            {
+                task_result = doVnetCreateTask(t);
+            }
+            else if (table_name == CFG_VXLAN_TUNNEL_TABLE_NAME)
+            {
+                task_result = doVxlanTunnelCreateTask(t);
+            }
+            else if (table_name == CFG_VNET_RT_TUNNEL_TABLE_NAME)
+            {
+                task_result = doVnetRouteTunnelCreateTask(t);
+            }
+            else if (table_name == CFG_VNET_RT_TABLE_NAME)
+            {
+                task_result = doVnetRouteTask(t, op);
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Unknown table : %s", table_name.c_str());
+            }
+        }
+        else if (op == DEL_COMMAND)
+        {
+            if (table_name == CFG_VNET_TABLE_NAME)
+            {
+                task_result = doVnetDeleteTask(t);
+            }
+            else if (table_name == CFG_VXLAN_TUNNEL_TABLE_NAME)
+            {
+                task_result = doVxlanTunnelDeleteTask(t);
+            }
+            else if (table_name == CFG_VNET_RT_TUNNEL_TABLE_NAME)
+            {
+                task_result = doVnetRouteTunnelDeleteTask(t);
+            }
+            else if (table_name == CFG_VNET_RT_TABLE_NAME)
+            {
+                task_result = doVnetRouteTask(t, op);
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Unknown table : %s", table_name.c_str());
+            }
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Unknown command : %s", op.c_str());
+        }
+
+        if (task_result == true)
+        {
+            it = consumer.m_toSync.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+}
+
+bool VNetMgr::doVnetCreateTask(const KeyOpFieldsValuesTuple & t)
+{
+    SWSS_LOG_ENTER();
+
+    VnetInfo info;
+    info.m_vnet = kfvKey(t);
+    for (auto i : kfvFieldsValues(t))
+    {
+        const std::string & field = fvField(i);
+        const std::string & value = fvValue(i);
+        if (field == VXLAN_TUNNEL)
+        {
+            info.m_vxlanTunnel = value;
+        }
+        else if (field == VNI)
+        {
+            info.m_vni = value;
+        }
+        else if (field == SOURCE_MAC)
+        {
+            info.m_macAddress = value;
+        }
+    }
+
+    // If all information of vnet has been set
+    if (info.m_vxlanTunnel.empty() 
+     || info.m_vni.empty())
+    {
+        SWSS_LOG_DEBUG("Vnet %s information is incomplete", info.m_vnet.c_str());
+        // if the information is incomplete, just ignore this message
+        // because all information will be sent if the information was
+        // completely set.
+        return true;
+    }
+
+    // If the vxlan tunnel has been created
+    auto it = m_vxlanTunnelCache.find(info.m_vxlanTunnel);
+    if (it == m_vxlanTunnelCache.end())
+    {
+        SWSS_LOG_DEBUG("Vxlan tunnel %s has not been created", info.m_vxlanTunnel.c_str());
+        // Suspend this message until the vxlan tunnel is created
+        return false;
+    }
+
+    info.m_sourceIp = it->second.m_sourceIp;
+    m_vnetCache[info.m_vnet] = info;
+
+    std::string vxlan_dev_name = VXLAN_NAME_PREFIX + info.m_vni;
+    m_vxlanNetDevices[vxlan_dev_name] = VXLAN;
+
+    SWSS_LOG_NOTICE("Create VNET %s, vni: %s, src_ip: %s, src_mac: %s", info.m_vnet.c_str(), info.m_vni.c_str(), info.m_sourceIp.c_str(), info.m_macAddress.c_str());
+
+    return true;
+}
+
+bool VNetMgr::doVnetDeleteTask(const KeyOpFieldsValuesTuple & t)
+{
+    SWSS_LOG_ENTER();
+
+    const std::string & vnetName = kfvKey(t);
+
+    auto it = m_vnetCache.find(vnetName);
+    if (it == m_vnetCache.end())
+    {
+        SWSS_LOG_WARN("Vxlan(Vnet %s) hasn't been created ", vnetName.c_str());
+        return true;
+    }
+
+    std::string vxlan_dev_name = VXLAN_NAME_PREFIX + it->second.m_vni;
+    auto dev = m_vxlanNetDevices.find(vxlan_dev_name);
+    if (dev != m_vxlanNetDevices.end())
+    {
+        m_vxlanNetDevices.erase(dev);
+    }
+
+    m_vnetCache.erase(it);
+
+    SWSS_LOG_INFO("Delete vxlan %s", vnetName.c_str());
+
+    return true;
+}
+
+bool VNetMgr::doVxlanTunnelCreateTask(const KeyOpFieldsValuesTuple & t)
+{
+    SWSS_LOG_ENTER();
+
+    const std::string & vxlanTunnelName = kfvKey(t);
+    
+    // Update vxlan tunnel cache
+    TunCache tuncache;
+
+    tuncache.fvt = kfvFieldsValues(t);
+    tuncache.m_sourceIp = "NULL";
+
+    for (auto i : kfvFieldsValues(t))
+    {
+        const std::string & field = fvField(i);
+        const std::string & value = fvValue(i);
+        if (field == SOURCE_IP)
+        {
+            tuncache.m_sourceIp = value;
+        }
+    }
+
+    m_vxlanTunnelCache[vxlanTunnelName] = tuncache;
+
+    SWSS_LOG_NOTICE("Create vxlan tunnel %s, src_ip: %s", vxlanTunnelName.c_str(), tuncache.m_sourceIp.c_str());
+    return true;
+}
+
+bool VNetMgr::doVxlanTunnelDeleteTask(const KeyOpFieldsValuesTuple & t)
+{
+    SWSS_LOG_ENTER();
+
+    const std::string & vxlanTunnelName = kfvKey(t);
+
+    auto it = m_vxlanTunnelCache.find(vxlanTunnelName);
+    if (it == m_vxlanTunnelCache.end())
+    {
+        SWSS_LOG_WARN("Vxlan tunnel %s hasn't been created ", vxlanTunnelName.c_str());
+        return true;
+    }
+
+    m_vxlanTunnelCache.erase(it);
+
+    SWSS_LOG_INFO("Delete vxlan tunnel %s", vxlanTunnelName.c_str());
+
+    return true;
+}
+
+bool VNetMgr::doVnetRouteTask(const KeyOpFieldsValuesTuple & t, const string & op)
+{
+    SWSS_LOG_ENTER();
+
+    string vnetRouteName = kfvKey(t);
+    replace(vnetRouteName.begin(), vnetRouteName.end(), config_db_key_delimiter, delimiter);
+    if (op == SET_COMMAND)
+    {
+        m_appVnetRouteTable.set(vnetRouteName, kfvFieldsValues(t));
+        SWSS_LOG_INFO("Create vnet route %s", vnetRouteName.c_str());
+    }
+    else if (op == DEL_COMMAND)
+    {
+        m_appVnetRouteTable.del(vnetRouteName);
+        SWSS_LOG_INFO("Delete vnet route %s", vnetRouteName.c_str());
+    }
+    else
+    {
+        SWSS_LOG_ERROR("Unknown command : %s", op.c_str());
+        return false;
+    }
+
+    return true;
+}
+
+bool VNetMgr::doVnetRouteTunnelCreateTask(const KeyOpFieldsValuesTuple & t)
+{
+    SWSS_LOG_ENTER();
+
+    const std::string & vnet_route_name = kfvKey(t);
+    
+    VxlanRouteTunnelInfo routeInfo;
+
+    routeInfo.m_endpoint = "NULL";
+    routeInfo.m_macAddress = "NULL";
+    routeInfo.m_vni = "NULL";
+    routeInfo.m_installOnKernel = false;
+
+    size_t delimiter_pos;
+    delimiter_pos = vnet_route_name.find_first_of(config_db_key_delimiter);
+    routeInfo.m_vnet = vnet_route_name.substr(0, delimiter_pos);
+    routeInfo.m_prefix = vnet_route_name.substr(delimiter_pos + 1);
+
+    for (auto i : kfvFieldsValues(t))
+    {
+        const std::string & field = fvField(i);
+        const std::string & value = fvValue(i);
+        if (field == ENDPOINT)
+        {
+            routeInfo.m_endpoint = value;
+        }
+        else if (field == MAC_ADDRESS)
+        {
+            routeInfo.m_macAddress = value;
+        }
+        else if (field == VNI)
+        {
+            routeInfo.m_vni = value;
+        }
+        else if (field == INSTALL_ON_KERNEL)
+        {
+            routeInfo.m_installOnKernel = (value == "true");
+        }
+    }
+
+    SWSS_LOG_NOTICE("Create vxlan tunnel route for vnet %s and prefix %s, dst_ip: %s, dst_mac: %s, vni: %s", routeInfo.m_vnet.c_str(), routeInfo.m_prefix.c_str(), routeInfo.m_endpoint.c_str(), routeInfo.m_macAddress.c_str(), routeInfo.m_vni.c_str());
+
+    routeInfo.m_routeName = vnet_route_name;
+    m_vnetRouteTunnelCache[vnet_route_name] = routeInfo;
+
+    if (routeInfo.m_installOnKernel)
+    {
+        if (!createKernelRoute(routeInfo))
+        {
+            SWSS_LOG_ERROR("Failed to create kernel route for vxlan route %s", vnet_route_name.c_str());
+            return false;
+        }
+    }
+    else
+    {
+        // Remove any existing kernel route if present
+        SWSS_LOG_NOTICE("Install on kernel is false. Deleting kernel interface for route %s", vnet_route_name.c_str());
+        deleteKernelRoute(routeInfo);
+    }
+
+    string vnetRouteTunnelName = kfvKey(t);
+    replace(vnetRouteTunnelName.begin(), vnetRouteTunnelName.end(), config_db_key_delimiter, delimiter);
+    
+    std::vector<swss::FieldValueTuple> values = const_cast<std::vector<swss::FieldValueTuple>&>(kfvFieldsValues(t));
+    
+    // if values contains INSTALL_ON_KERNEL, remove only this value
+    values.erase(std::remove_if(values.begin(), values.end(),
+                [](const swss::FieldValueTuple & fv) {
+                    return fv.first == INSTALL_ON_KERNEL;
+                }), values.end());
+
+    m_appVnetRouteTunnelTable.set(vnetRouteTunnelName, values);
+
+    SWSS_LOG_NOTICE("Create vxlan tunnel route %s", vnetRouteTunnelName.c_str());
+    return true;
+}
+
+bool VNetMgr::doVnetRouteTunnelDeleteTask(const KeyOpFieldsValuesTuple & t)
+{
+    SWSS_LOG_ENTER();
+
+    const std::string & vnet_route_name = kfvKey(t);
+
+    auto it = m_vnetRouteTunnelCache.find(vnet_route_name);
+    if (it == m_vnetRouteTunnelCache.end())
+    {
+        SWSS_LOG_WARN("Vxlan route tunnel %s hasn't been created ", vnet_route_name.c_str());
+        return true;
+    }
+
+    deleteKernelRoute(it->second);
+
+    m_vnetRouteTunnelCache.erase(it);
+    m_appVnetRouteTunnelTable.del(vnet_route_name);
+
+    SWSS_LOG_INFO("Delete vxlan route tunnel %s", vnet_route_name.c_str());
+
+    return true;
+}
+
+bool VNetMgr::createKernelRoute(const VxlanRouteTunnelInfo & vxlanRouteInfo)
+{
+    SWSS_LOG_ENTER();
+
+    if (m_vnetCache.find(vxlanRouteInfo.m_vnet) == m_vnetCache.end())
+    {
+        SWSS_LOG_WARN("Vnet %s hasn't been created ", vxlanRouteInfo.m_vnet.c_str());
+        return false;
+    }
+
+    VnetInfo vnetInfo = m_vnetCache[vxlanRouteInfo.m_vnet];
+
+    if (vnetInfo.m_vni == vxlanRouteInfo.m_vni)
+    {
+        SWSS_LOG_DEBUG("Skipping kernel routes since Vnet %s VNI %s match route VNI %s", 
+                        vxlanRouteInfo.m_vnet.c_str(),
+                        vnetInfo.m_vni.c_str(),
+                        vxlanRouteInfo.m_vni.c_str());
+
+        return false;
+    }
+
+    std::string vxlanDevName = VXLAN_NAME_PREFIX + vxlanRouteInfo.m_vni;
+
+    auto it = m_vxlanNetDevices.find(vxlanDevName);
+    if (it != m_vxlanNetDevices.end())
+    {
+        SWSS_LOG_INFO("Vxlan device %s already present", it->first.c_str());
+        //return false;
+    }
+
+    VxlanKernelRouteInfo vxlanKernelRouteInfo;
+    vxlanKernelRouteInfo.m_routeName = vxlanRouteInfo.m_routeName;
+    vxlanKernelRouteInfo.m_dstMac = vxlanRouteInfo.m_macAddress;
+    vxlanKernelRouteInfo.m_dstIp = vxlanRouteInfo.m_endpoint;
+    vxlanKernelRouteInfo.m_vni = vxlanRouteInfo.m_vni;
+    vxlanKernelRouteInfo.m_vnet = vxlanRouteInfo.m_vnet;
+    vxlanKernelRouteInfo.m_prefix = vxlanRouteInfo.m_prefix;
+    vxlanKernelRouteInfo.m_srcIp = vnetInfo.m_sourceIp;
+    vxlanKernelRouteInfo.m_srcMac = vnetInfo.m_macAddress;
+    vxlanKernelRouteInfo.m_vxlanDevName = vxlanDevName;
+    vxlanKernelRouteInfo.m_vxlanSrcUdpPort = getVxlanSourcePort();
+
+    // Create Vxlan Device
+    std::string res;
+    int ret = cmdCreateVxlan(vxlanKernelRouteInfo, res);
+    if (ret != RET_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Vxlan device %s creation failed: %s", 
+                        vxlanDevName.c_str(), res.c_str());
+        return false;
+    }
+
+    // Attach Vxlan Device to Vnet
+    ret = cmdAttachVxlanIfToVnet(vxlanKernelRouteInfo, res);
+    if (ret != RET_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Vxlan device %s failed to attach to vnet: %s", 
+                        vxlanDevName.c_str(), res.c_str());
+        return false;
+    }
+
+    // Bring up Vxlan Device
+    ret = cmdUpVxlan(vxlanKernelRouteInfo, res);
+    if (ret != RET_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Vxlan device %s up failed: %s", 
+                        vxlanDevName.c_str(), res.c_str());
+        return false;
+    }
+
+    // Create Kernel Route
+    ret = cmdCreateKernelRoute(vxlanKernelRouteInfo, res);
+    if (ret != RET_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Kernel route %s creation failed: %s", 
+                        vxlanKernelRouteInfo.m_routeName.c_str(), res.c_str());
+        return false;
+    }
+
+    // Create Static MAC Entry
+    ret = cmdCreateStaticMacEntry(vxlanKernelRouteInfo, res);
+    if (ret != RET_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Static MAC entry for route %s creation failed: %s", 
+                        vxlanKernelRouteInfo.m_routeName.c_str(), res.c_str());
+        return false;
+    }
+
+    m_kernelRouteTunnelCache[vxlanRouteInfo.m_routeName] = vxlanKernelRouteInfo;
+    m_vxlanNetDevices[vxlanDevName] = VXLAN;
+
+    SWSS_LOG_NOTICE("Create kernel route %s", vxlanRouteInfo.m_routeName.c_str());
+    return true;
+}
+
+bool VNetMgr::deleteKernelRoute(const VxlanRouteTunnelInfo & vxlanRouteInfo)
+{
+    SWSS_LOG_ENTER();
+    auto it = m_kernelRouteTunnelCache.find(vxlanRouteInfo.m_routeName);
+    if (it == m_kernelRouteTunnelCache.end())
+    {
+        SWSS_LOG_INFO("Vxlan route %s does not exists", vxlanRouteInfo.m_routeName.c_str());
+        return true;
+    }
+    
+    std::string vxlanDevName = VXLAN_NAME_PREFIX + vxlanRouteInfo.m_vni;
+    std::string res;
+    int ret = cmdDeleteVxlan(it->second, res);
+    if (ret != RET_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Vxlan device %s deletion failed: %s", 
+                        vxlanDevName.c_str(), res.c_str());
+        return false;
+    }
+
+    m_kernelRouteTunnelCache.erase(it);
+
+    auto dev = m_vxlanNetDevices.find(vxlanDevName);
+    if (dev != m_vxlanNetDevices.end())
+    {
+        m_vxlanNetDevices.erase(dev);
+    }
+
+    return true;
+}

--- a/cfgmgr/vnetmgr.h
+++ b/cfgmgr/vnetmgr.h
@@ -1,0 +1,94 @@
+
+#ifndef __VNETMGRMGR__
+#define __VNETMGRMGR__
+
+#include "dbconnector.h"
+#include "producerstatetable.h"
+#include "orch.h"
+
+#include <map>
+#include <vector>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace swss {
+
+class VNetMgr : public Orch
+{
+public:
+    VNetMgr(DBConnector *cfgDb, DBConnector *appDb, const std::vector<std::string> &tables);
+    using Orch::doTask;
+
+    typedef struct VnetInfo
+    {
+        std::string m_vxlanTunnel;
+        std::string m_sourceIp;
+        std::string m_vnet;
+        std::string m_vni;
+        std::string m_macAddress;
+    } VnetInfo;
+
+    typedef struct TunCache
+    {
+        std::vector<FieldValueTuple> fvt;
+        std::string m_sourceIp;
+    } TunCache;
+
+    typedef struct VxlanRouteTunnelInfo
+    {
+        std::string m_routeName;
+        std::string m_macAddress;
+        std::string m_endpoint;
+        std::string m_vni;
+        std::string m_vnet;
+        std::string m_prefix;
+        bool m_installOnKernel;
+    } VxlanRouteTunnelInfo;
+
+    typedef struct VxlanKernelRouteInfo
+    {
+        std::string m_routeName;
+        std::string m_dstMac;
+        std::string m_dstIp;
+        std::string m_srcIp;
+        std::string m_srcMac;
+        std::string m_vni;
+        std::string m_vnet;
+        std::string m_prefix;
+        std::string m_vxlanDevName;
+        std::string m_vxlanSrcUdpPort;
+    } VxlanKernelRouteInfo;
+
+private:
+    void doTask(Consumer &consumer);
+    std::vector<std::string> parseNetDev(const std::string& stdout);
+    void getAllVxlanNetDevices();
+    bool doVnetCreateTask(const KeyOpFieldsValuesTuple & t);
+    bool doVnetDeleteTask(const KeyOpFieldsValuesTuple & t);
+    bool doVxlanTunnelCreateTask(const KeyOpFieldsValuesTuple & t);
+    bool doVxlanTunnelDeleteTask(const KeyOpFieldsValuesTuple & t);
+    bool doVnetRouteTask(const KeyOpFieldsValuesTuple & t, const std::string & op);
+    bool doVnetRouteTunnelCreateTask(const KeyOpFieldsValuesTuple & t);
+    bool doVnetRouteTunnelDeleteTask(const KeyOpFieldsValuesTuple & t);
+
+    bool createKernelRoute(const VxlanRouteTunnelInfo & vxlanRouteInfo);
+    bool deleteKernelRoute(const VxlanRouteTunnelInfo & vxlanRouteInfo);
+    std::string getVxlanSourcePort();
+
+
+    Table m_appSwitchTable;
+    ProducerStateTable m_appVnetRouteTunnelTable, m_appVnetRouteTable;
+
+    DBConnector *m_app_db;
+
+    std::map<std::string, std::string> m_vxlanNetDevices;
+    std::map<std::string, TunCache > m_vxlanTunnelCache;
+    std::map<std::string, VnetInfo> m_vnetCache;
+    std::map<std::string, VxlanRouteTunnelInfo> m_vnetRouteTunnelCache;
+    std::map<std::string, VxlanKernelRouteInfo> m_kernelRouteTunnelCache;
+};
+
+} // namespace swss
+
+#endif

--- a/cfgmgr/vnetmgrd.cpp
+++ b/cfgmgr/vnetmgrd.cpp
@@ -1,0 +1,87 @@
+#include <unistd.h>
+#include <vector>
+#include <sstream>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <algorithm>
+#include "dbconnector.h"
+#include "select.h"
+#include "exec.h"
+#include "schema.h"
+#include "macaddress.h"
+#include "producerstatetable.h"
+#include "vnetmgr.h"
+#include "shellcmd.h"
+#include "warm_restart.h"
+
+using namespace std;
+using namespace swss;
+
+/* select() function timeout retry time, in millisecond */
+#define SELECT_TIMEOUT 1000
+
+int main(int argc, char **argv)
+{
+    swss::Logger::linkToDbNative("vnetmgrd");
+
+    SWSS_LOG_NOTICE("--- Starting vnetmgrd ---");
+
+    try
+    {
+
+        DBConnector cfgDb("CONFIG_DB", 0);
+        DBConnector appDb("APPL_DB", 0);
+
+        WarmStart::initialize("vnetmgrd", "swss");
+        WarmStart::checkWarmStart("vnetmgrd", "swss");
+        if (WarmStart::isWarmStart())
+        {
+            WarmStart::setWarmStartState("vnetmgrd", WarmStart::INITIALIZED);
+        }
+
+        vector<std::string> cfg_vnet_tables = {
+            CFG_VNET_TABLE_NAME,
+            CFG_VXLAN_TUNNEL_TABLE_NAME,
+            CFG_VNET_RT_TUNNEL_TABLE_NAME,
+            CFG_VNET_RT_TABLE_NAME
+        };
+
+        VNetMgr vnetmgr(&cfgDb, &appDb, cfg_vnet_tables);
+
+        std::vector<Orch *> cfgOrchList = {&vnetmgr};
+
+        swss::Select s;
+        for (Orch *o : cfgOrchList)
+        {
+            s.addSelectables(o->getSelectables());
+        }
+
+        SWSS_LOG_NOTICE("starting main loop");
+        while (true)
+        {
+            Selectable *sel;
+            int ret;
+
+            ret = s.select(&sel, SELECT_TIMEOUT);
+            if (ret == Select::ERROR)
+            {
+                SWSS_LOG_NOTICE("Error: %s!", strerror(errno));
+                continue;
+            }
+            if (ret == Select::TIMEOUT)
+            {
+                vnetmgr.doTask();
+                continue;
+            }
+
+            auto *c = (Executor *)sel;
+            c->execute();
+        }
+    }
+    catch(const std::exception &e)
+    {
+        SWSS_LOG_ERROR("Runtime error: %s", e.what());
+    }
+    return -1;
+}

--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -22,6 +22,7 @@ using namespace std;
 using namespace swss;
 
 #define VXLAN_IF_NAME_PREFIX    "Brvxlan"
+#define VXLAN_NAME_PREFIX       "Vxlan"
 #define VNET_PREFIX             "Vnet"
 #define VRF_PREFIX              "Vrf"
 #define MGMT_VRF_PREFIX         "mgmt"
@@ -2695,6 +2696,14 @@ void RouteSync::onVnetRouteMsg(int nlmsg_type, struct nl_object *obj, string vne
     /* Regular VNET route */
     else
     {
+        // Vxlan interface and route is created by vnetmgr for vxlan tunnel routes. If kernel sends the same route, ignore it since
+        // it is already processed by vnetmgr.
+        if ((nexthops.empty() || nexthops == "0.0.0.0" || nexthops == "::") && ifnames.find(VXLAN_NAME_PREFIX) == 0)
+        {
+            SWSS_LOG_INFO("Nexthop list is empty for VXLAN tunnel route %s, NH= %s", vnet_dip.c_str(), nexthops.c_str());
+            return;
+        }
+
         VnetRouteTableFieldValueTupleWrapper fvw{vnet_dip};
         fvw.ifname = ifnames;
 

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -255,8 +255,6 @@ bool OrchDaemon::init()
     vnet_orch = new VNetOrch(m_applDb, APP_VNET_TABLE_NAME);
 
     gDirectory.set(vnet_orch);
-    VNetCfgRouteOrch *cfg_vnet_rt_orch = new VNetCfgRouteOrch(m_configDb, m_applDb, cfg_vnet_tables);
-    gDirectory.set(cfg_vnet_rt_orch);
     VNetRouteOrch *vnet_rt_orch = new VNetRouteOrch(m_applDb, vnet_tables, vnet_orch);
     gDirectory.set(vnet_rt_orch);
     VRFOrch *vrf_orch = new VRFOrch(m_applDb, APP_VRF_TABLE_NAME, m_stateDb, STATE_VRF_OBJECT_TABLE_NAME);
@@ -567,7 +565,6 @@ bool OrchDaemon::init()
     }
 
     m_orchList.push_back(vxlan_vrf_orch);
-    m_orchList.push_back(cfg_vnet_rt_orch);
     m_orchList.push_back(vnet_orch);
     m_orchList.push_back(vnet_rt_orch);
     m_orchList.push_back(gNatOrch);

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -46,6 +46,9 @@ extern MacAddress gVxlanMacAddress;
 extern BfdOrch *gBfdOrch;
 extern SwitchOrch *gSwitchOrch;
 extern TunnelDecapOrch *gTunneldecapOrch;
+
+#define VXLAN_NAME_PREFIX       "Vxlan"
+
 /*
  * VRF Modeling and VNetVrf class definitions
  */
@@ -1791,6 +1794,17 @@ bool VNetRouteOrch::handleRoutes(const Request& request)
     SWSS_LOG_INFO("VNET-RT '%s' op '%s' for ip %s", vnet_name.c_str(),
                    op.c_str(), ip_pfx.to_string().c_str());
 
+    auto nextHops = ip_addresses.getIpAddresses();
+    auto nextHop = nextHops.begin()->to_string();
+    auto it_route = syncd_tunnel_routes_[vnet_name].find(nextHop);
+    if (ifname.find(VXLAN_NAME_PREFIX) == 0 && it_route != syncd_tunnel_routes_[vnet_name].end())
+    {
+        auto tunnelRoute = it_route->second;
+        map<NextHopKey, IpAddress> monitors;
+        string empty = "";
+        return doRouteTask<VNetVrfObject>(vnet_name, ip_pfx, tunnelRoute.primary, op, empty, empty, tunnelRoute.secondary, ip_pfx, monitors);
+    }
+
     if (op == SET_COMMAND)
     {
         addRoute(vnet_name, ip_pfx, nh);
@@ -3322,100 +3336,6 @@ bool VNetRouteOrch::isPartiallyLocal(const std::vector<swss::IpAddress>& ip_list
         });
 
     return !(all_true || all_false);
-}
-
-
-VNetCfgRouteOrch::VNetCfgRouteOrch(DBConnector *db, DBConnector *appDb, vector<string> &tableNames)
-                                  : Orch(db, tableNames),
-                                  m_appVnetRouteTable(appDb, APP_VNET_RT_TABLE_NAME),
-                                  m_appVnetRouteTunnelTable(appDb, APP_VNET_RT_TUNNEL_TABLE_NAME)
-{
-}
-
-void VNetCfgRouteOrch::doTask(Consumer &consumer)
-{
-    SWSS_LOG_ENTER();
-
-    const string & table_name = consumer.getTableName();
-    auto it = consumer.m_toSync.begin();
-
-    while (it != consumer.m_toSync.end())
-    {
-        bool task_result = false;
-        auto t = it->second;
-        const string & op = kfvOp(t);
-        if (table_name == CFG_VNET_RT_TABLE_NAME)
-        {
-            task_result = doVnetRouteTask(t, op);
-        }
-        else if (table_name == CFG_VNET_RT_TUNNEL_TABLE_NAME)
-        {
-            task_result = doVnetTunnelRouteTask(t, op);
-        }
-        else
-        {
-            SWSS_LOG_ERROR("Unknown table : %s", table_name.c_str());
-        }
-
-        if (task_result == true)
-        {
-            it = consumer.m_toSync.erase(it);
-        }
-        else
-        {
-            ++it;
-        }
-    }
-}
-
-bool VNetCfgRouteOrch::doVnetTunnelRouteTask(const KeyOpFieldsValuesTuple & t, const string & op)
-{
-    SWSS_LOG_ENTER();
-
-    string vnetRouteTunnelName = kfvKey(t);
-    replace(vnetRouteTunnelName.begin(), vnetRouteTunnelName.end(), config_db_key_delimiter, delimiter);
-    if (op == SET_COMMAND)
-    {
-        m_appVnetRouteTunnelTable.set(vnetRouteTunnelName, kfvFieldsValues(t));
-        SWSS_LOG_INFO("Create vnet route tunnel %s", vnetRouteTunnelName.c_str());
-    }
-    else if (op == DEL_COMMAND)
-    {
-        m_appVnetRouteTunnelTable.del(vnetRouteTunnelName);
-        SWSS_LOG_INFO("Delete vnet route tunnel %s", vnetRouteTunnelName.c_str());
-    }
-    else
-    {
-        SWSS_LOG_ERROR("Unknown command : %s", op.c_str());
-        return false;
-    }
-
-    return true;
-}
-
-bool VNetCfgRouteOrch::doVnetRouteTask(const KeyOpFieldsValuesTuple & t, const string & op)
-{
-    SWSS_LOG_ENTER();
-
-    string vnetRouteName = kfvKey(t);
-    replace(vnetRouteName.begin(), vnetRouteName.end(), config_db_key_delimiter, delimiter);
-    if (op == SET_COMMAND)
-    {
-        m_appVnetRouteTable.set(vnetRouteName, kfvFieldsValues(t));
-        SWSS_LOG_INFO("Create vnet route %s", vnetRouteName.c_str());
-    }
-    else if (op == DEL_COMMAND)
-    {
-        m_appVnetRouteTable.del(vnetRouteName);
-        SWSS_LOG_INFO("Delete vnet route %s", vnetRouteName.c_str());
-    }
-    else
-    {
-        SWSS_LOG_ERROR("Unknown command : %s", op.c_str());
-        return false;
-    }
-
-    return true;
 }
 
 MonitorOrch::MonitorOrch(DBConnector *db, string tableName):

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -593,19 +593,4 @@ private:
     shared_ptr<VNetTunnelTermAcl> vnet_tunnel_term_acl_;
 };
 
-class VNetCfgRouteOrch : public Orch
-{
-public:
-    VNetCfgRouteOrch(DBConnector *db, DBConnector *appDb, vector<string> &tableNames);
-    using Orch::doTask;
-
-private:
-    void doTask(Consumer &consumer);
-
-    bool doVnetTunnelRouteTask(const KeyOpFieldsValuesTuple & t, const std::string & op);
-    bool doVnetRouteTask(const KeyOpFieldsValuesTuple & t, const std::string & op);
-
-    ProducerStateTable m_appVnetRouteTable, m_appVnetRouteTunnelTable;
-};
-
 #endif // __VNETORCH_H

--- a/tests/mock_tests/flowcounterrouteorch_ut.cpp
+++ b/tests/mock_tests/flowcounterrouteorch_ut.cpp
@@ -149,8 +149,6 @@ namespace flowcounterrouteorch_test
 
             auto* vnet_orch = new VNetOrch(m_app_db.get(), APP_VNET_TABLE_NAME);
             gDirectory.set(vnet_orch);
-            auto* cfg_vnet_rt_orch = new VNetCfgRouteOrch(m_config_db.get(), m_app_db.get(), cfg_vnet_tables);
-            gDirectory.set(cfg_vnet_rt_orch);
             auto* vnet_rt_orch = new VNetRouteOrch(m_app_db.get(), vnet_tables, vnet_orch);
             gDirectory.set(vnet_rt_orch);
             ASSERT_EQ(gVrfOrch, nullptr);

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -140,8 +140,6 @@ namespace intfsorch_test
 
             auto* vnet_orch = new VNetOrch(m_app_db.get(), APP_VNET_TABLE_NAME);
             gDirectory.set(vnet_orch);
-            auto* cfg_vnet_rt_orch = new VNetCfgRouteOrch(m_config_db.get(), m_app_db.get(), cfg_vnet_tables);
-            gDirectory.set(cfg_vnet_rt_orch);
             auto* vnet_rt_orch = new VNetRouteOrch(m_app_db.get(), vnet_tables, vnet_orch);
             gDirectory.set(vnet_rt_orch);
             ASSERT_EQ(gVrfOrch, nullptr);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
For Vxlan tunnel routes on a VNET (VNET_ROUTE_TUNNEL), the routes are programmed on NPU only and the kernel is not aware of the vxlan interface or the routes. Any CPU generated packets (like ping, bgp etc) to this VxLAN endpoint is dropped in the kernel. In this PR, a new flag called `install_on_kernel` is added on the VNET_ROUTE_TUNNEL object in CONFIG_DB. If this flag is set to true, the route and the vxlan interface are created on the kernel in addition to adding to the NPU.

**Why I did it**
Design reference: https://github.com/sonic-net/SONiC/pull/2092

For SONiC to establish BGP over VxLAN tunnel in a VNET, the kernel should be aware of the vxlan interface and routes. The routes added in VNET_ROUTE_TUNNEL should also be present in kernel for the CPU generated packets to be forwarded by the kernel. If these routes are not present, the kernel will drop any VxLAN packet to/from the CPU. 

Please refer the design PR for more information on the usecase.

**How I verified it**
Verified on Virtual Switch and Hardware device

**Details if related**
