### PR TITLE
Gracefully handle case when speed is not supported in setGearboxPortAttr

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3352,6 +3352,11 @@ bool PortsOrch::setGearboxPortAttr(const Port &port, dest_port_type_t port_type,
                         attr.id = SAI_PORT_ATTR_SPEED;
                         attr.value.u32 = speed;
                     }
+                    else
+                    {
+                        SWSS_LOG_NOTICE("BOX: Speed %d not supported for port %s", speed, port.m_alias.c_str());
+                        return false;
+                    }
                     SWSS_LOG_NOTICE("BOX: Set %s lane %s %d", port.m_alias.c_str(), speed_attr.c_str(), speed);
                     break;
                 case SAI_PORT_ATTR_MTU:


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
Fixes https://github.com/sonic-net/sonic-buildimage/issues/25311

**What I did**
Fixed a bug in setGearboxPortAttr() where an uninitialized sai_attribute_t attr variable could be passed to the SAI API when isSpeedSupported() returns false for SAI_PORT_ATTR_SPEED operations.

The fix adds an else block that logs the unsupported speed and returns false early, preventing the SAI call with uninitialized data

**Why I did it**
This causes the following error logs to be printed:
```
	 E               2026 Jan 17 21:41:16.925578 ctn102 ERR gbsyncd#syncd: :- processQuadEvent: attr: SAI_PORT_ATTR_SPEED: 400000
	 E
	 E               2026 Jan 17 21:41:16.925694 ctn102 ERR swss#orchagent: :- setGearboxPortAttr: BOX: Failed to set Ethernet72 port attribute 31
	 E
	 E               2026 Jan 17 21:41:16.925694 ctn102 ERR swss#orchagent: :- handleSaiFailure: Encountered failure in set operation, SAI API: SAI_API_PORT, status: SAI_STATUS_INVALID_ATTR_VALUE_0
	 E
	 E               2026 Jan 17 21:41:16.932105 ctn102 ERR swss#orchagent: :- meta_generic_validation_set: unable to find attribute metadata SAI_OBJECT_TYPE_PORT:378307824
```

**How I verified it**
Verified that the fix prevents the uninitialized variable from being used in a SAI call
