### PR TITLE
[countersyncd]: Modify the exit behavior of the main function

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -236,10 +236,10 @@ jobs:
          export ENABLE_ASAN=y
       fi
       ./autogen.sh
-      dpkg-buildpackage -us -uc -b -j$(nproc) && cp ../*.deb .
+      RUSTFLAGS=-Dwarnings dpkg-buildpackage -us -uc -b -j$(nproc) && cp ../*.deb .
     displayName: "Compile sonic swss"
   - script: |
-      cargo test
+      RUSTFLAGS=-Dwarnings cargo test
     displayName: "Test countersyncd"
   - publish: $(System.DefaultWorkingDirectory)/
     artifact: ${{ parameters.artifact_name }}

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["-Dwarnings"]


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
The main function exits as soon as any actor terminates.

**Why I did it**
Otel actor may terminate due to failed to connect the otel collector. In the previous behavior, the main function will not exit because it's waiting for all actor terminating.

**How I verified it**
Check it locally:
```
[2026-02-04 11:16:01.248] [crates/countersyncd/src/actor/otel.rs:340] [WARN] Export attempt 29 failed: status: Unavailable, message: "tcp connect error", details: [], metadata: MetadataMap { headers: {} }
[2026-02-04 11:16:11.253] [crates/countersyncd/src/actor/otel.rs:340] [WARN] Export attempt 30 failed: status: Unavailable, message: "tcp connect error", details: [], metadata: MetadataMap { headers: {} }
[2026-02-04 11:16:21.255] [crates/countersyncd/src/actor/otel.rs:405] [ERROR] Failed to export buffered metrics (consecutive failures 30): OtelActorExportError("Max export retries exceeded")
[2026-02-04 11:16:21.256] [crates/countersyncd/src/actor/otel.rs:431] [INFO] Shutting down OtelActor...
[2026-02-04 11:16:22.257] [crates/countersyncd/src/actor/otel.rs:439] [INFO] OtelActor shutdown complete. 2339 messages, 0 exports, 1 failures
[2026-02-04 11:16:22.257] [crates/countersyncd/src/main.rs:421] [INFO] OpenTelemetry actor terminated
[2026-02-04 11:16:22.257] [crates/countersyncd/src/main.rs:464] [ERROR] OpenTelemetry actor failed: OtelActorExportError("Max export retries exceeded")

```

**Details if related**
