### PR TITLE
[vnet/vxlan] Dualstack vxlan support on vnet

### DIFF
--- a/cfgmgr/vxlanmgr.cpp
+++ b/cfgmgr/vxlanmgr.cpp
@@ -21,6 +21,7 @@ extern MacAddress gMacAddress;
 
 // Fields name
 #define VXLAN_TUNNEL "vxlan_tunnel"
+#define VXLAN_TUNNEL_LIST "vxlan_tunnel_list"
 #define SOURCE_IP "src_ip"
 #define VNI "vni"
 #define VNET "vnet"
@@ -289,6 +290,7 @@ bool VxlanMgr::doVxlanCreateTask(const KeyOpFieldsValuesTuple & t)
     SWSS_LOG_ENTER();
 
     VxlanInfo info;
+    bool multiple_vxlan_tunnels = false;
     info.m_vnet = kfvKey(t);
     for (auto i : kfvFieldsValues(t))
     {
@@ -302,11 +304,22 @@ bool VxlanMgr::doVxlanCreateTask(const KeyOpFieldsValuesTuple & t)
         {
             info.m_vni = value;
         }
+        else if (field == VXLAN_TUNNEL_LIST)
+        {
+            multiple_vxlan_tunnels = true;
+        }
+    }
+
+    if (multiple_vxlan_tunnels)
+    {
+        SWSS_LOG_ERROR("Vnet %s has multiple vxlan tunnels, skipping vxlan creation",
+                       info.m_vnet.c_str());
+        return true;
     }
 
     // If all information of vnet has been set
     if (info.m_vxlanTunnel.empty() 
-     || info.m_vni.empty())
+    || info.m_vni.empty())
     {
         SWSS_LOG_DEBUG("Vnet %s information is incomplete", info.m_vnet.c_str());
         // if the information is incomplete, just ignore this message

--- a/cfgmgr/vxlanmgr.cpp
+++ b/cfgmgr/vxlanmgr.cpp
@@ -290,7 +290,6 @@ bool VxlanMgr::doVxlanCreateTask(const KeyOpFieldsValuesTuple & t)
     SWSS_LOG_ENTER();
 
     VxlanInfo info;
-    bool multiple_vxlan_tunnels = false;
     info.m_vnet = kfvKey(t);
     for (auto i : kfvFieldsValues(t))
     {
@@ -304,17 +303,6 @@ bool VxlanMgr::doVxlanCreateTask(const KeyOpFieldsValuesTuple & t)
         {
             info.m_vni = value;
         }
-        else if (field == VXLAN_TUNNEL_LIST)
-        {
-            multiple_vxlan_tunnels = true;
-        }
-    }
-
-    if (multiple_vxlan_tunnels)
-    {
-        SWSS_LOG_ERROR("Vnet %s has multiple vxlan tunnels, skipping vxlan creation",
-                       info.m_vnet.c_str());
-        return true;
     }
 
     // If all information of vnet has been set

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -538,33 +538,33 @@ bool VNetOrch::addOperation(const Request& request)
     {
         VNetObject_T obj;
         auto it = vnet_table_.find(vnet_name);
+        set<string> tunnels;
         if (isVnetExecVrf())
         {
             VxlanTunnelOrch* vxlan_orch = gDirectory.get<VxlanTunnelOrch*>();
 
-            if (!tunnel_list.empty())
-            {
-                for (const auto& tunnel_name : tunnel_list)
-                {
-                    if (!vxlan_orch->isTunnelExists(tunnel_name))
-                    {
-                        SWSS_LOG_WARN("Vxlan tunnel '%s' doesn't exist", tunnel_name.c_str());
-                        return false;
-                    }
-                }
-            }
-            else if(!tunnel.empty())
-            {
-                if (!vxlan_orch->isTunnelExists(tunnel))
-                {
-                    SWSS_LOG_WARN("Vxlan tunnel '%s' doesn't exist", tunnel.c_str());
-                    return false;
-                }
-            }
-            else
+            if (tunnel_list.empty() && tunnel.empty())
             {
                 SWSS_LOG_ERROR("Vxlan tunnel or tunnel list must be specified for VNET '%s'", vnet_name.c_str());
                 return false;
+            }
+
+            if (!tunnel_list.empty())
+            {
+                tunnels = tunnel_list;
+            }
+            else
+            {
+                tunnels.insert(tunnel);
+            }
+
+            for (const auto& tun_name : tunnels)
+            {
+                if (!vxlan_orch->isTunnelExists(tun_name))
+                {
+                    SWSS_LOG_WARN("Vxlan tunnel '%s' doesn't exist", tun_name.c_str());
+                    return false;
+                }
             }
 
             if (it == std::end(vnet_table_))
@@ -573,30 +573,21 @@ bool VNetOrch::addOperation(const Request& request)
                 {
                     VNetInfoMultiTunnel vnet_info = { tunnel_list, vni, peer_list, scope, advertise_prefix, overlay_dmac };
                     obj = createObject<VNetVrfObject>(vnet_name, vnet_info, attrs);
-
-                    VNetVrfObject *vrf_obj = dynamic_cast<VNetVrfObject*>(obj.get());
-                    for (const auto& tun_name : tunnel_list)
-                    {
-                        if (!vxlan_orch->createVxlanTunnelMap(tun_name, TUNNEL_MAP_T_VIRTUAL_ROUTER, vni,
-                                                        vrf_obj->getEncapMapId(), vrf_obj->getDecapMapId(), VXLAN_ENCAP_TTL))
-                        {
-                            SWSS_LOG_ERROR("VNET '%s', tunnel '%s', map create failed",
-                                        vnet_name.c_str(), tun_name.c_str());
-                            return false;
-                        }
-                    }
                 }
                 else
                 {
                     VNetInfo vnet_info = { tunnel, vni, peer_list, scope, advertise_prefix, overlay_dmac };
                     obj = createObject<VNetVrfObject>(vnet_name, vnet_info, attrs);
+                }
 
-                    VNetVrfObject *vrf_obj = dynamic_cast<VNetVrfObject*>(obj.get());
-                    if (!vxlan_orch->createVxlanTunnelMap(tunnel, TUNNEL_MAP_T_VIRTUAL_ROUTER, vni,
-                                                        vrf_obj->getEncapMapId(), vrf_obj->getDecapMapId(), VXLAN_ENCAP_TTL))
+                VNetVrfObject *vrf_obj = dynamic_cast<VNetVrfObject*>(obj.get());
+                for (const auto& tun_name : tunnels)
+                {
+                    if (!vxlan_orch->createVxlanTunnelMap(tun_name, TUNNEL_MAP_T_VIRTUAL_ROUTER, vni,
+                                                    vrf_obj->getEncapMapId(), vrf_obj->getDecapMapId(), VXLAN_ENCAP_TTL))
                     {
                         SWSS_LOG_ERROR("VNET '%s', tunnel '%s', map create failed",
-                                    vnet_name.c_str(), tunnel.c_str());
+                                    vnet_name.c_str(), tun_name.c_str());
                         return false;
                     }
                 }

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -542,15 +542,7 @@ bool VNetOrch::addOperation(const Request& request)
         {
             VxlanTunnelOrch* vxlan_orch = gDirectory.get<VxlanTunnelOrch*>();
 
-            if(!tunnel.empty())
-            {
-                if (!vxlan_orch->isTunnelExists(tunnel))
-                {
-                    SWSS_LOG_WARN("Vxlan tunnel '%s' doesn't exist", tunnel.c_str());
-                    return false;
-                }
-            }
-            else if (!tunnel_list.empty())
+            if (!tunnel_list.empty())
             {
                 for (const auto& tunnel_name : tunnel_list)
                 {
@@ -561,6 +553,14 @@ bool VNetOrch::addOperation(const Request& request)
                     }
                 }
             }
+            else if(!tunnel.empty())
+            {
+                if (!vxlan_orch->isTunnelExists(tunnel))
+                {
+                    SWSS_LOG_WARN("Vxlan tunnel '%s' doesn't exist", tunnel.c_str());
+                    return false;
+                }
+            }
             else
             {
                 SWSS_LOG_ERROR("Vxlan tunnel or tunnel list must be specified for VNET '%s'", vnet_name.c_str());
@@ -569,30 +569,38 @@ bool VNetOrch::addOperation(const Request& request)
 
             if (it == std::end(vnet_table_))
             {
-                if (!tunnel.empty())
-                {
-                    VNetInfo vnet_info = { tunnel, vni, peer_list, scope, advertise_prefix, overlay_dmac };
-                    obj = createObject<VNetVrfObject>(vnet_name, vnet_info, attrs);
-                }
-                else
+                if (!tunnel_list.empty())
                 {
                     VNetInfoMultiTunnel vnet_info = { tunnel_list, vni, peer_list, scope, advertise_prefix, overlay_dmac };
                     obj = createObject<VNetVrfObject>(vnet_name, vnet_info, attrs);
-                }
-                create = true;
 
-                VNetVrfObject *vrf_obj = dynamic_cast<VNetVrfObject*>(obj.get());
-                for (const auto& tunnel : tunnel_list)
+                    VNetVrfObject *vrf_obj = dynamic_cast<VNetVrfObject*>(obj.get());
+                    for (const auto& tun_name : tunnel_list)
+                    {
+                        if (!vxlan_orch->createVxlanTunnelMap(tun_name, TUNNEL_MAP_T_VIRTUAL_ROUTER, vni,
+                                                        vrf_obj->getEncapMapId(), vrf_obj->getDecapMapId(), VXLAN_ENCAP_TTL))
+                        {
+                            SWSS_LOG_ERROR("VNET '%s', tunnel '%s', map create failed",
+                                        vnet_name.c_str(), tun_name.c_str());
+                            return false;
+                        }
+                    }
+                }
+                else
                 {
+                    VNetInfo vnet_info = { tunnel, vni, peer_list, scope, advertise_prefix, overlay_dmac };
+                    obj = createObject<VNetVrfObject>(vnet_name, vnet_info, attrs);
+
+                    VNetVrfObject *vrf_obj = dynamic_cast<VNetVrfObject*>(obj.get());
                     if (!vxlan_orch->createVxlanTunnelMap(tunnel, TUNNEL_MAP_T_VIRTUAL_ROUTER, vni,
                                                         vrf_obj->getEncapMapId(), vrf_obj->getDecapMapId(), VXLAN_ENCAP_TTL))
                     {
                         SWSS_LOG_ERROR("VNET '%s', tunnel '%s', map create failed",
-                                        vnet_name.c_str(), tunnel.c_str());
+                                    vnet_name.c_str(), tunnel.c_str());
                         return false;
                     }
                 }
-
+                create = true;
                 SWSS_LOG_NOTICE("VNET '%s' was added ", vnet_name.c_str());
             }
             else

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -58,6 +58,13 @@ VNetVrfObject::VNetVrfObject(const std::string& vnet, const VNetInfo& vnetInfo,
     createObj(attrs);
 }
 
+VNetVrfObject::VNetVrfObject(const std::string& vnet, const VNetInfoMultiTunnel& vnetInfo,
+                             vector<sai_attribute_t>& attrs) : VNetObject(vnetInfo)
+{
+    vnet_name_ = vnet;
+    createObj(attrs);
+}
+
 sai_object_id_t VNetVrfObject::getVRidIngress() const
 {
     if (vr_ids_.find(VR_TYPE::ING_VR_VALID) != vr_ids_.end())
@@ -308,7 +315,7 @@ bool VNetVrfObject::getRouteNextHop(IpPrefix& ipPrefix, nextHop& nh)
 sai_object_id_t VNetVrfObject::getTunnelNextHop(NextHopKey& nh)
 {
     sai_object_id_t nh_id = SAI_NULL_OBJECT_ID;
-    auto tun_name = getTunnelName();
+    auto tun_name = getTunnelNameForNextHop(nh);
 
     VxlanTunnelOrch* vxlan_orch = gDirectory.get<VxlanTunnelOrch*>();
 
@@ -328,7 +335,7 @@ sai_object_id_t VNetVrfObject::getTunnelNextHop(NextHopKey& nh)
 
 bool VNetVrfObject::removeTunnelNextHop(NextHopKey& nh)
 {
-    auto tun_name = getTunnelName();
+    auto tun_name = getTunnelNameForNextHop(nh);
 
     VxlanTunnelOrch* vxlan_orch = gDirectory.get<VxlanTunnelOrch*>();
 
@@ -340,6 +347,32 @@ bool VNetVrfObject::removeTunnelNextHop(NextHopKey& nh)
     }
 
     return true;
+}
+
+string VNetVrfObject::getTunnelNameForNextHop(const NextHopKey& nh)
+{
+    if (!IsMultiTunnelVnet())
+    {
+        return getTunnelName();
+    }
+
+    auto nh_ip_family = nh.ip_address.isV4() ? AF_INET : AF_INET6;
+    auto tunnel_list = getTunnelList();
+    VxlanTunnelOrch* vxlan_orch = gDirectory.get<VxlanTunnelOrch*>();
+
+    for (string tunnel_name : tunnel_list)
+    {
+        auto tun_obj = vxlan_orch->getVxlanTunnel(tunnel_name);
+        auto tun_ip_family = tun_obj->getSrcIP().isV4() ? AF_INET : AF_INET6;
+
+        if (nh_ip_family == tun_ip_family)
+        {
+            return tunnel_name;
+        }
+    }
+
+    throw std::runtime_error("NH Tunnel get name failed for " + vnet_name_ +
+                                 " no matching tunnel found");
 }
 
 VNetVrfObject::~VNetVrfObject()
@@ -368,6 +401,14 @@ VNetVrfObject::~VNetVrfObject()
 
 template <class T>
 std::unique_ptr<T> VNetOrch::createObject(const string& vnet_name, const VNetInfo& vnet_info,
+                                          vector<sai_attribute_t>& attrs)
+{
+    std::unique_ptr<T> vnet_obj(new T(vnet_name, vnet_info, attrs));
+    return vnet_obj;
+}
+
+template <class T>
+std::unique_ptr<T> VNetOrch::createObject(const string& vnet_name, const VNetInfoMultiTunnel& vnet_info,
                                           vector<sai_attribute_t>& attrs)
 {
     std::unique_ptr<T> vnet_obj(new T(vnet_name, vnet_info, attrs));
@@ -441,6 +482,7 @@ bool VNetOrch::addOperation(const Request& request)
     bool peer = false, create = false, advertise_prefix = false;
     uint32_t vni=0;
     string tunnel;
+    set<string> tunnel_list = {};
     string scope;
     swss::MacAddress overlay_dmac;
 
@@ -465,6 +507,10 @@ bool VNetOrch::addOperation(const Request& request)
         else if (name == "vxlan_tunnel")
         {
             tunnel = request.getAttrString("vxlan_tunnel");
+        }
+        else if (name == "vxlan_tunnel_list")
+        {
+            tunnel_list = request.getAttrSet("vxlan_tunnel_list");
         }
         else if (name == "scope")
         {
@@ -496,25 +542,55 @@ bool VNetOrch::addOperation(const Request& request)
         {
             VxlanTunnelOrch* vxlan_orch = gDirectory.get<VxlanTunnelOrch*>();
 
-            if (!vxlan_orch->isTunnelExists(tunnel))
+            if(!tunnel.empty())
             {
-                SWSS_LOG_WARN("Vxlan tunnel '%s' doesn't exist", tunnel.c_str());
+                if (!vxlan_orch->isTunnelExists(tunnel))
+                {
+                    SWSS_LOG_WARN("Vxlan tunnel '%s' doesn't exist", tunnel.c_str());
+                    return false;
+                }
+            }
+            else if (!tunnel_list.empty())
+            {
+                for (const auto& tunnel_name : tunnel_list)
+                {
+                    if (!vxlan_orch->isTunnelExists(tunnel_name))
+                    {
+                        SWSS_LOG_WARN("Vxlan tunnel '%s' doesn't exist", tunnel_name.c_str());
+                        return false;
+                    }
+                }
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Vxlan tunnel or tunnel list must be specified for VNET '%s'", vnet_name.c_str());
                 return false;
             }
 
             if (it == std::end(vnet_table_))
             {
-                VNetInfo vnet_info = { tunnel, vni, peer_list, scope, advertise_prefix, overlay_dmac };
-                obj = createObject<VNetVrfObject>(vnet_name, vnet_info, attrs);
+                if (!tunnel.empty())
+                {
+                    VNetInfo vnet_info = { tunnel, vni, peer_list, scope, advertise_prefix, overlay_dmac };
+                    obj = createObject<VNetVrfObject>(vnet_name, vnet_info, attrs);
+                }
+                else
+                {
+                    VNetInfoMultiTunnel vnet_info = { tunnel_list, vni, peer_list, scope, advertise_prefix, overlay_dmac };
+                    obj = createObject<VNetVrfObject>(vnet_name, vnet_info, attrs);
+                }
                 create = true;
 
                 VNetVrfObject *vrf_obj = dynamic_cast<VNetVrfObject*>(obj.get());
-                if (!vxlan_orch->createVxlanTunnelMap(tunnel, TUNNEL_MAP_T_VIRTUAL_ROUTER, vni,
-                                                      vrf_obj->getEncapMapId(), vrf_obj->getDecapMapId(), VXLAN_ENCAP_TTL))
+                for (const auto& tunnel : tunnel_list)
                 {
-                    SWSS_LOG_ERROR("VNET '%s', tunnel '%s', map create failed",
-                                    vnet_name.c_str(), tunnel.c_str());
-                    return false;
+                    if (!vxlan_orch->createVxlanTunnelMap(tunnel, TUNNEL_MAP_T_VIRTUAL_ROUTER, vni,
+                                                        vrf_obj->getEncapMapId(), vrf_obj->getDecapMapId(), VXLAN_ENCAP_TTL))
+                    {
+                        SWSS_LOG_ERROR("VNET '%s', tunnel '%s', map create failed",
+                                        vnet_name.c_str(), tunnel.c_str());
+                        return false;
+                    }
                 }
 
                 SWSS_LOG_NOTICE("VNET '%s' was added ", vnet_name.c_str());
@@ -585,10 +661,14 @@ bool VNetOrch::delOperation(const Request& request)
                 return false;
             }
 
-            if (!vxlan_orch->removeVxlanTunnelMap(vrf_obj->getTunnelName(), vrf_obj->getVni()))
+            set<string> tunnel_list = vrf_obj->getTunnelList();
+            for (const auto& tunnel : tunnel_list)
             {
-                SWSS_LOG_ERROR("VNET '%s' map delete failed", vnet_name.c_str());
-                return false;
+                if (!vxlan_orch->removeVxlanTunnelMap(tunnel, vrf_obj->getVni()))
+                {
+                    SWSS_LOG_ERROR("VNET '%s' map delete failed", vnet_name.c_str());
+                    return false;
+                }
             }
         }
     }
@@ -2014,7 +2094,7 @@ void VNetRouteOrch::createBfdSession(const string& vnet, const NextHopKey& endpo
         vector<FieldValueTuple>    data;
         string key = "default:default:" + monitor_addr.to_string();
 
-        auto tun_name = vnet_orch_->getTunnelName(vnet);
+        auto tun_name = vnet_orch_->getTunnelNameForNextHop(vnet, endpoint);
         VxlanTunnelOrch* vxlan_orch = gDirectory.get<VxlanTunnelOrch*>();
         auto tunnel_obj = vxlan_orch->getVxlanTunnel(tun_name);
         /*

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -46,6 +46,12 @@ extern MacAddress gVxlanMacAddress;
 extern BfdOrch *gBfdOrch;
 extern SwitchOrch *gSwitchOrch;
 extern TunnelDecapOrch *gTunneldecapOrch;
+
+#define VXLAN_NAME_PREFIX              "Vxlan"
+#define MAX_VXLAN_TUNNELS              2
+#define MAX_IPv4_VXLAN_TUNNELS         1
+#define MAX_IPv6_VXLAN_TUNNELS         1
+
 /*
  * VRF Modeling and VNetVrf class definitions
  */
@@ -357,10 +363,10 @@ string VNetVrfObject::getTunnelNameForNextHop(const NextHopKey& nh)
     }
 
     auto nh_ip_family = nh.ip_address.isV4() ? AF_INET : AF_INET6;
-    auto tunnel_list = getTunnelList();
+    auto tunnels = getTunnelNames();
     VxlanTunnelOrch* vxlan_orch = gDirectory.get<VxlanTunnelOrch*>();
 
-    for (string tunnel_name : tunnel_list)
+    for (string tunnel_name : tunnels)
     {
         auto tun_obj = vxlan_orch->getVxlanTunnel(tunnel_name);
         auto tun_ip_family = tun_obj->getSrcIP().isV4() ? AF_INET : AF_INET6;
@@ -558,6 +564,8 @@ bool VNetOrch::addOperation(const Request& request)
                 tunnels.insert(tunnel);
             }
 
+            auto ipv4_tun_count = 0;
+            auto ipv6_tun_count = 0;
             for (const auto& tun_name : tunnels)
             {
                 if (!vxlan_orch->isTunnelExists(tun_name))
@@ -565,6 +573,22 @@ bool VNetOrch::addOperation(const Request& request)
                     SWSS_LOG_WARN("Vxlan tunnel '%s' doesn't exist", tun_name.c_str());
                     return false;
                 }
+
+                if (vxlan_orch->getVxlanTunnel(tun_name)->getSrcIP().isV4())
+                {
+                    ipv4_tun_count++;
+                }
+                else
+                {
+                    ipv6_tun_count++;
+                }
+            }
+
+            if (ipv4_tun_count > MAX_IPv4_VXLAN_TUNNELS || ipv6_tun_count > MAX_IPv6_VXLAN_TUNNELS
+                || tunnels.size() > MAX_VXLAN_TUNNELS)
+            {
+                SWSS_LOG_ERROR("Too many vxlan tunnels for VNET '%s'", vnet_name.c_str());
+                return false;
             }
 
             if (it == std::end(vnet_table_))
@@ -660,8 +684,8 @@ bool VNetOrch::delOperation(const Request& request)
                 return false;
             }
 
-            set<string> tunnel_list = vrf_obj->getTunnelList();
-            for (const auto& tunnel : tunnel_list)
+            set<string> tunnels = vrf_obj->getTunnelNames();
+            for (const auto& tunnel : tunnels)
             {
                 if (!vxlan_orch->removeVxlanTunnelMap(tunnel, vrf_obj->getVni()))
                 {

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -40,14 +40,15 @@ typedef enum
 const request_description_t vnet_request_description = {
     { REQ_T_STRING },
     {
-        { "src_mac",            REQ_T_MAC_ADDRESS },
-        { "vxlan_tunnel",       REQ_T_SET },
-        { "vni",                REQ_T_UINT },
-        { "peer_list",          REQ_T_SET },
-        { "guid",               REQ_T_STRING },
-        { "scope",              REQ_T_STRING },
-        { "advertise_prefix",   REQ_T_BOOL},
-        { "overlay_dmac",       REQ_T_MAC_ADDRESS},
+        { "src_mac",                 REQ_T_MAC_ADDRESS },
+        { "vxlan_tunnel",            REQ_T_STRING },
+        { "vxlan_tunnel_list",       REQ_T_SET },
+        { "vni",                     REQ_T_UINT },
+        { "peer_list",               REQ_T_SET },
+        { "guid",                    REQ_T_STRING },
+        { "scope",                   REQ_T_STRING },
+        { "advertise_prefix",        REQ_T_BOOL},
+        { "overlay_dmac",            REQ_T_MAC_ADDRESS},
 
     },
     { "vxlan_tunnel", "vni" } // mandatory attributes

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -143,11 +143,11 @@ public:
         return tunnel_;
     }
 
-    set<string>& getTunnelNames() const
+    set<string> getTunnelNames() const
     {
         if (!tunnel_.empty())
         {
-            return set<string>{tunnel_};
+            return { tunnel_ };
         }
 
         return tunnel_list_;
@@ -308,7 +308,7 @@ public:
         return vnet_table_.at(name)->getTunnelName();
     }
 
-    const set<string>& getTunnelNames(const std::string& name) const
+    set<string> getTunnelNames(const std::string& name) const
     {
         return vnet_table_.at(name)->getTunnelNames();
     }

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -51,7 +51,7 @@ const request_description_t vnet_request_description = {
         { "overlay_dmac",            REQ_T_MAC_ADDRESS},
 
     },
-    { "vxlan_tunnel", "vni" } // mandatory attributes
+    { "vni" } // mandatory attributes
 };
 
 enum class VNET_EXEC
@@ -143,8 +143,13 @@ public:
         return tunnel_;
     }
 
-    const set<string>& getTunnelList() const
+    set<string>& getTunnelNames() const
     {
+        if (!tunnel_.empty())
+        {
+            return set<string>{tunnel_};
+        }
+
         return tunnel_list_;
     }
 
@@ -303,9 +308,9 @@ public:
         return vnet_table_.at(name)->getTunnelName();
     }
 
-    const set<string>& getTunnelList(const std::string& name) const
+    const set<string>& getTunnelNames(const std::string& name) const
     {
-        return vnet_table_.at(name)->getTunnelList();
+        return vnet_table_.at(name)->getTunnelNames();
     }
 
     string getTunnelNameForNextHop(const std::string& vnet_name, const NextHopKey& nh) const


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, assignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
This PR adds support for multiple vxlan tunnels on vnets. The tunnels can have either an IPv4 underlay or IPv6 underlay and so it enables vxlan tunnel routes over IPv4 and IPv6 underlay simultaneously

- Added a new parameter `Vxlan_tunnel_list` under Vnet configuration that takes a list of vxlan tunnel names
- Enhanced VnetOrch/VnetRouteOrch to handle tunnel next hop creation based on the destination type (IPv4/IPv6) provided in `VNET_ROUTE_TUNNEL` configurations
 
**Why I did it**

Currently, VNet supports only one vxlan tunnel and it can be either on IPv4 underlay or IPv6 underlay.  As a result, in a single vnet, only IPv4 traffic or IPv6 traffic is supported over Vxlan and not both. 

**How I verified it**
Verified on virtual switch and cisco hardware

**Details if related**

HLD: https://github.com/sonic-net/SONiC/pull/2093
