### PR TITLE
[aclorch] ACL rule priority based programming

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -5819,10 +5819,19 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
             continue;
         }
 
+        bool ruleExisted = (getAclRule(table_id, rule_id) != nullptr);
         if (removeAclRule(table_id, rule_id))
         {
             removeAclRuleStatus(table_id, rule_id);
             consumer.m_toSync.erase(it);
+
+            /* Notify retry cache that resources may have been freed for this table,
+             * but only if the rule actually existed (i.e., ASIC resources were freed).
+             * This lets rules parked on SAI resource exhaustion be retried. */
+            if (ruleExisted)
+            {
+                notifyRetry(this, consumer.getTableName(), make_constraint(RETRY_CST_SAI_RESOURCE, table_id));
+            }
         }
         else
         {

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -5688,7 +5688,7 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
         string rule_id;
         string op;
         uint32_t priority;
-        KeyOpFieldsValuesTuple tuple;
+        const KeyOpFieldsValuesTuple* tuple;
     };
 
     // Collect all rules and extract their priorities
@@ -5698,12 +5698,12 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
     {
-        KeyOpFieldsValuesTuple t = it->second;
-        string key = kfvKey(t);
+        const KeyOpFieldsValuesTuple* data_ptr = &(it->second);
+        string key = kfvKey(*data_ptr);
         size_t found = key.find(consumer.getConsumerTable()->getTableNameSeparator().c_str());
         string table_id = key.substr(0, found);
         string rule_id = key.substr(found + 1);
-        string op = kfvOp(t);
+        string op = kfvOp(*data_ptr);
 
         RuleEntry entry;
         entry.iter = it;
@@ -5711,32 +5711,48 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
         entry.table_id = table_id;
         entry.rule_id = rule_id;
         entry.op = op;
-        entry.tuple = t;
+        entry.tuple = data_ptr;
         entry.priority = 0;
 
-        // Extract priority for both SET and DEL operations
-        for (const auto& fv : kfvFieldsValues(t))
-        {
-            string attr_name = to_upper(fvField(fv));
-            if (attr_name == "PRIORITY")
-            {
-                entry.priority = (uint32_t)stoul(fvValue(fv));
-                break;
-            }
-        }
-
+        // Extract priority based on operation type
         if (op == SET_COMMAND)
         {
+            // For SET operations, extract priority from field values
+            for (const auto& fv : kfvFieldsValues(*data_ptr))
+            {
+                string attr_name = to_upper(fvField(fv));
+                if (attr_name == "PRIORITY")
+                {
+                    entry.priority = (uint32_t)stoul(fvValue(fv));
+                    break;
+                }
+            }
             setRules.push_back(entry);
+        }
+        else if (op == DEL_COMMAND)
+        {
+            // Redis DEL operations do not carry field values, only the key is present.
+            // Look up priority from existing in-memory rule map
+            auto existingRule = getAclRule(table_id, rule_id);
+            if (existingRule)
+            {
+                entry.priority = existingRule->getPriority();
+            }
+            delRules.push_back(entry);
         }
         else
         {
-            delRules.push_back(entry);
+            SWSS_LOG_ERROR("Unknown operation type %s for ACL rule %s", op.c_str(), key.c_str());
+            it = consumer.m_toSync.erase(it);
+            continue;
         }
-
         it++;
     }
 
+    // Optimization: Sort rules by priority to minimize hardware TCAM shifting.
+    // This priority-based sorting is specifically optimized for bulk-update scenarios.
+    // In low-load scenarios with few entries, the shifting overhead is minimal, but in high-scale
+    // updates, this reduces programming time by ensuring rules are sent to SAI in priority order.
     // Sort SET rules by priority (higher priority value = higher priority, so descending order)
     sort(setRules.begin(), setRules.end(), [](const RuleEntry& a, const RuleEntry& b) {
         return a.priority > b.priority;
@@ -5747,6 +5763,8 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
         return a.priority < b.priority;
     });
 
+    // Note: All DEL operations are processed before SET operations
+    // to facilitate priority-based sorting and ensure correct rule re-programming.
     // Process DEL rules first (in ascending priority order)
     for (auto& entry : delRules)
     {
@@ -5782,7 +5800,7 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
     for (auto& entry : setRules)
     {
         it = entry.iter;
-        KeyOpFieldsValuesTuple t = entry.tuple;
+        const KeyOpFieldsValuesTuple& t = *(entry.tuple);
         string key = entry.key;
         string table_id = entry.table_id;
         string rule_id = entry.rule_id;

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -5717,15 +5717,43 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
         // Extract priority based on operation type
         if (op == SET_COMMAND)
         {
+            bool invalidPriority = false;
             // For SET operations, extract priority from field values
             for (const auto& fv : kfvFieldsValues(*data_ptr))
             {
                 string attr_name = to_upper(fvField(fv));
                 if (attr_name == "PRIORITY")
                 {
-                    entry.priority = (uint32_t)stoul(fvValue(fv));
+                    const string &prioStr = fvValue(fv);
+                    try
+                    {
+                        size_t idx = 0;
+                        unsigned long prio = stoul(prioStr, &idx, 10);
+                        if (idx != prioStr.length() || prio > UINT32_MAX)
+                        {
+                            SWSS_LOG_ERROR("Invalid ACL rule priority '%s' for rule %s in table %s",
+                                         prioStr.c_str(), rule_id.c_str(), table_id.c_str());
+                            invalidPriority = true;
+                        }
+                        else
+                        {
+                            entry.priority = static_cast<uint32_t>(prio);
+                        }
+                    }
+                    catch (const std::exception &e)
+                    {
+                        SWSS_LOG_ERROR("Exception parsing ACL rule priority '%s' for rule %s in table %s: %s",
+                                     prioStr.c_str(), rule_id.c_str(), table_id.c_str(), e.what());
+                        invalidPriority = true;
+                    }
                     break;
                 }
+            }
+            if (invalidPriority)
+            {
+                // Treat invalid priority as invalid entry: log and skip processing this rule
+                it++;
+                continue;
             }
             setRules.push_back(entry);
         }

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -1940,6 +1940,11 @@ bool AclRule::getCreateCounter() const
     return m_createCounter;
 }
 
+uint32_t AclRule::getPriority() const
+{
+    return m_priority;
+}
+
 shared_ptr<AclRule> AclRule::makeShared(AclOrch *acl, MirrorOrch *mirror, DTelOrch *dtel, const string& rule, const string& table, const KeyOpFieldsValuesTuple& data, MetaDataMgr * m_metadataMgr)
 {
     shared_ptr<AclRule> aclRule;
@@ -5675,6 +5680,21 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
 
+    // Structure to hold rule information with priority for sorting
+    struct RuleEntry {
+        SyncMap::iterator iter;
+        string key;
+        string table_id;
+        string rule_id;
+        string op;
+        uint32_t priority;
+        KeyOpFieldsValuesTuple tuple;
+    };
+
+    // Collect all rules and extract their priorities
+    vector<RuleEntry> setRules;
+    vector<RuleEntry> delRules;
+
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
     {
@@ -5685,7 +5705,91 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
         string rule_id = key.substr(found + 1);
         string op = kfvOp(t);
 
-        SWSS_LOG_INFO("OP: %s, TABLE_ID: %s, RULE_ID: %s", op.c_str(), table_id.c_str(), rule_id.c_str());
+        RuleEntry entry;
+        entry.iter = it;
+        entry.key = key;
+        entry.table_id = table_id;
+        entry.rule_id = rule_id;
+        entry.op = op;
+        entry.tuple = t;
+        entry.priority = 0;
+
+        // Extract priority for both SET and DEL operations
+        for (const auto& fv : kfvFieldsValues(t))
+        {
+            string attr_name = to_upper(fvField(fv));
+            if (attr_name == "PRIORITY")
+            {
+                entry.priority = (uint32_t)stoul(fvValue(fv));
+                break;
+            }
+        }
+
+        if (op == SET_COMMAND)
+        {
+            setRules.push_back(entry);
+        }
+        else
+        {
+            delRules.push_back(entry);
+        }
+
+        it++;
+    }
+
+    // Sort SET rules by priority (higher priority value = higher priority, so descending order)
+    sort(setRules.begin(), setRules.end(), [](const RuleEntry& a, const RuleEntry& b) {
+        return a.priority > b.priority;
+    });
+
+    // Sort DEL rules by priority (lower priority values deleted first, so ascending order)
+    sort(delRules.begin(), delRules.end(), [](const RuleEntry& a, const RuleEntry& b) {
+        return a.priority < b.priority;
+    });
+
+    // Process DEL rules first (in ascending priority order)
+    for (auto& entry : delRules)
+    {
+        it = entry.iter;
+        string key = entry.key;
+        string table_id = entry.table_id;
+        string rule_id = entry.rule_id;
+        string op = entry.op;
+
+        SWSS_LOG_INFO("OP: %s, TABLE_ID: %s, RULE_ID: %s, PRIORITY: %u (processing DEL in ascending priority order)",
+                      op.c_str(), table_id.c_str(), rule_id.c_str(), entry.priority);
+
+        if (table_id.empty())
+        {
+            SWSS_LOG_WARN("ACL rule with RULE_ID: %s is not valid as TABLE_ID is empty", rule_id.c_str());
+            consumer.m_toSync.erase(it);
+            continue;
+        }
+
+        if (removeAclRule(table_id, rule_id))
+        {
+            removeAclRuleStatus(table_id, rule_id);
+            consumer.m_toSync.erase(it);
+        }
+        else
+        {
+            // Mark pending removal status if removeAclRule returns error
+            setAclRuleStatus(table_id, rule_id, AclObjectStatus::PENDING_REMOVAL);
+        }
+    }
+
+    // Process SET rules in priority order
+    for (auto& entry : setRules)
+    {
+        it = entry.iter;
+        KeyOpFieldsValuesTuple t = entry.tuple;
+        string key = entry.key;
+        string table_id = entry.table_id;
+        string rule_id = entry.rule_id;
+        string op = entry.op;
+
+        SWSS_LOG_INFO("OP: %s, TABLE_ID: %s, RULE_ID: %s, PRIORITY: %u (processing SET in descending priority order)",
+                      op.c_str(), table_id.c_str(), rule_id.c_str(), entry.priority);
 
         if (table_id.empty())
         {
@@ -5858,33 +5962,6 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
                 setAclRuleStatus(table_id, rule_id, AclObjectStatus::INACTIVE);
                 SWSS_LOG_ERROR("Failed to create ACL rule. Rule configuration is invalid");
             }
-        }
-        else if (op == DEL_COMMAND)
-        {
-            bool ruleExisted = (getAclRule(table_id, rule_id) != nullptr);
-            if (removeAclRule(table_id, rule_id))
-            {
-                removeAclRuleStatus(table_id, rule_id);
-                it = consumer.m_toSync.erase(it);
-
-                /* Notify retry cache that resources may have been freed for this table,
-                 * but only if the rule actually existed (i.e., ASIC resources were freed). */
-                if (ruleExisted)
-                {
-                    notifyRetry(this, consumer.getTableName(), make_constraint(RETRY_CST_SAI_RESOURCE, table_id));
-                }
-            }
-            else
-            {
-                // Mark pending removal status if removeAclRule returns error
-                setAclRuleStatus(table_id, rule_id, AclObjectStatus::PENDING_REMOVAL);
-                it++;
-            }
-        }
-        else
-        {
-            it = consumer.m_toSync.erase(it);
-            SWSS_LOG_ERROR("Unknown operation type %s", op.c_str());
         }
     }
 }

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -5742,7 +5742,7 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
                     }
                     catch (const std::exception &e)
                     {
-                        SWSS_LOG_ERROR("Exception parsing ACL rule priority '%s' for rule %s in table %s: %s",
+                        SWSS_LOG_ERROR("Invalid ACL rule priority '%s' for rule %s in table %s: %s",
                                      prioStr.c_str(), rule_id.c_str(), table_id.c_str(), e.what());
                         invalidPriority = true;
                     }
@@ -5751,8 +5751,8 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
             }
             if (invalidPriority)
             {
-                // Treat invalid priority as invalid entry: log and skip processing this rule
-                it++;
+                // Treat invalid priority as invalid entry: skip processing this rule
+                it = consumer.m_toSync.erase(it);
                 continue;
             }
             setRules.push_back(entry);
@@ -5793,7 +5793,14 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
 
     // Note: All DEL operations are processed before SET operations
     // to facilitate priority-based sorting and ensure correct rule re-programming.
-    // Process DEL rules first (in ascending priority order)
+    //
+    // Safety invariant: the RuleEntry objects below hold iterators (entry.iter) into
+    // consumer.m_toSync that were captured during the collection loop above. This is
+    // safe because m_toSync is a std::map: erasing one element only invalidates the
+    // iterator to that element, leaving all other captured iterators valid. m_toSync
+    // is also keyed by rule key and holds a single op per key, so no two RuleEntry
+    // objects ever reference the same map node. Erasing one entry here therefore never
+    // invalidates the iterator of any other entry we still have to process.
     for (auto& entry : delRules)
     {
         it = entry.iter;

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -345,6 +345,7 @@ public:
     bool hasCounter() const;
     vector<sai_object_id_t> getInPorts() const;
     bool getCreateCounter() const;
+    uint32_t getPriority() const;
 
     const vector<AclRangeConfig>& getRangeConfig() const;
 

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -909,6 +909,134 @@ class TestAcl:
 
         assert not match_range_qualifier
 
+    def test_AclRulePriorityOrderProcessing(self, dvs_acl, l3_acl_table):
+        """
+        Test that ACL rules are processed in descending priority order (higher priority value first).
+        """
+        # Create rules with non-sequential priorities to test sorting
+        rule_priorities = ["100", "50", "200", "10", "150"]
+
+        config_qualifiers = {
+            "100": {"SRC_IP": "10.0.0.100/32"},
+            "50": {"SRC_IP": "10.0.0.50/32"},
+            "200": {"SRC_IP": "10.0.0.200/32"},
+            "10": {"SRC_IP": "10.0.0.10/32"},
+            "150": {"SRC_IP": "10.0.0.150/32"},
+        }
+
+        config_actions = {
+            "100": "DROP",
+            "50": "DROP",
+            "200": "DROP",
+            "10": "DROP",
+            "150": "DROP",
+        }
+
+        expected_sai_qualifiers = {
+            "100": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": dvs_acl.get_simple_qualifier_comparator("10.0.0.100&mask:255.255.255.255")},
+            "50": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": dvs_acl.get_simple_qualifier_comparator("10.0.0.50&mask:255.255.255.255")},
+            "200": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": dvs_acl.get_simple_qualifier_comparator("10.0.0.200&mask:255.255.255.255")},
+            "10": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": dvs_acl.get_simple_qualifier_comparator("10.0.0.10&mask:255.255.255.255")},
+            "150": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": dvs_acl.get_simple_qualifier_comparator("10.0.0.150&mask:255.255.255.255")},
+        }
+
+        # Create rules in random order
+        for priority in rule_priorities:
+            dvs_acl.create_acl_rule(L3_TABLE_NAME,
+                                    f"PRIORITY_ORDER_TEST_RULE_{priority}",
+                                    config_qualifiers[priority],
+                                    action=config_actions[priority],
+                                    priority=priority)
+            dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"PRIORITY_ORDER_TEST_RULE_{priority}", "Active")
+
+        # Verify all rules are created with correct priorities
+        dvs_acl.verify_acl_rule_set(rule_priorities, config_actions, expected_sai_qualifiers)
+
+        # Clean up
+        for priority in rule_priorities:
+            dvs_acl.remove_acl_rule(L3_TABLE_NAME, f"PRIORITY_ORDER_TEST_RULE_{priority}")
+            dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"PRIORITY_ORDER_TEST_RULE_{priority}", None)
+        dvs_acl.verify_no_acl_rules()
+
+    def test_AclRuleDeletionPriorityOrder(self, dvs_acl, l3_acl_table):
+        """
+        Test that ACL rules are deleted in ascending priority order (lower priority value first).
+        """
+        # Create rules with different priorities
+        rule_priorities = ["100", "50", "200", "10", "150"]
+
+        config_qualifiers = {
+            "100": {"DST_IP": "192.168.0.100/32"},
+            "50": {"DST_IP": "192.168.0.50/32"},
+            "200": {"DST_IP": "192.168.0.200/32"},
+            "10": {"DST_IP": "192.168.0.10/32"},
+            "150": {"DST_IP": "192.168.0.150/32"},
+        }
+
+        # Create all rules
+        for priority in rule_priorities:
+            dvs_acl.create_acl_rule(L3_TABLE_NAME,
+                                    f"DELETE_ORDER_TEST_RULE_{priority}",
+                                    config_qualifiers[priority],
+                                    action="FORWARD",
+                                    priority=priority)
+            dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"DELETE_ORDER_TEST_RULE_{priority}", "Active")
+
+        # Delete all rules at once (they should be deleted in ascending priority order)
+        for priority in rule_priorities:
+            dvs_acl.remove_acl_rule(L3_TABLE_NAME, f"DELETE_ORDER_TEST_RULE_{priority}")
+
+        # Verify all rules are deleted
+        for priority in rule_priorities:
+            dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"DELETE_ORDER_TEST_RULE_{priority}", None)
+        dvs_acl.verify_no_acl_rules()
+
+    def test_AclRuleMixedPriorityOperations(self, dvs_acl, l3_acl_table):
+        """
+        Test mixed SET and DEL operations with different priorities.
+        Verifies that DEL operations (ascending order) are processed before SET operations (descending order).
+        """
+        # First, create initial set of rules
+        initial_priorities = ["100", "50", "150"]
+
+        for priority in initial_priorities:
+            dvs_acl.create_acl_rule(L3_TABLE_NAME,
+                                    f"MIXED_OP_RULE_{priority}",
+                                    {"SRC_IP": f"10.0.{priority}.0/32"},
+                                    action="DROP",
+                                    priority=priority)
+            dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"MIXED_OP_RULE_{priority}", "Active")
+
+        # Now delete some and add new ones
+        # Delete rules with priority 50 and 150
+        dvs_acl.remove_acl_rule(L3_TABLE_NAME, "MIXED_OP_RULE_50")
+        dvs_acl.remove_acl_rule(L3_TABLE_NAME, "MIXED_OP_RULE_150")
+
+        # Add new rules with different priorities
+        new_priorities = ["200", "25", "75"]
+        for priority in new_priorities:
+            dvs_acl.create_acl_rule(L3_TABLE_NAME,
+                                    f"MIXED_OP_RULE_{priority}",
+                                    {"SRC_IP": f"10.0.{priority}.0/32"},
+                                    action="FORWARD",
+                                    priority=priority)
+            dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"MIXED_OP_RULE_{priority}", "Active")
+
+        # Verify final state: should have rules with priorities 100, 200, 25, 75
+        remaining_priorities = ["100", "200", "25", "75"]
+        for priority in remaining_priorities:
+            dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"MIXED_OP_RULE_{priority}", "Active")
+
+        # Verify deleted rules are gone
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, "MIXED_OP_RULE_50", None)
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, "MIXED_OP_RULE_150", None)
+
+        # Clean up
+        for priority in remaining_priorities:
+            dvs_acl.remove_acl_rule(L3_TABLE_NAME, f"MIXED_OP_RULE_{priority}")
+            dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"MIXED_OP_RULE_{priority}", None)
+        dvs_acl.verify_no_acl_rules()
+
 class TestAclCrmUtilization:
     @pytest.fixture(scope="class", autouse=True)
     def configure_crm_polling_interval_for_test(self, dvs):

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -940,37 +940,56 @@ class TestAcl:
             "150": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": dvs_acl.get_simple_qualifier_comparator("10.0.0.150&mask:255.255.255.255")},
         }
 
-        # Add log marker before creating rules
-        marker = dvs.add_log_marker()
+        # Create all rules in CONFIG_DB atomically using redis transaction
+        # This ensures all rules are batched together when they reach aclorch
+        redis_cmds = []
+        redis_cmds.append("MULTI")
 
-        # Create rules in random order
         for priority in rule_priorities:
-            dvs_acl.create_acl_rule(L3_TABLE_NAME,
-                                    f"PRIORITY_ORDER_TEST_RULE_{priority}",
-                                    config_qualifiers[priority],
-                                    action=config_actions[priority],
-                                    priority=priority)
+            rule_name = f"PRIORITY_ORDER_TEST_RULE_{priority}"
+            key = f"{L3_TABLE_NAME}|{rule_name}"
+
+            redis_cmds.append(f"HSET \"ACL_RULE|{key}\" \"priority\" \"{priority}\"")
+            redis_cmds.append(f"HSET \"ACL_RULE|{key}\" \"PACKET_ACTION\" \"DROP\"")
+            redis_cmds.append(f"HSET \"ACL_RULE|{key}\" \"SRC_IP\" \"10.0.0.{priority}/32\"")
+
+        redis_cmds.append("EXEC")
+        dvs.runcmd(['sh', '-c', f"redis-cli -n 4 <<EOF\n" + "\n".join(redis_cmds) + "\nEOF"])
+
+        # Give time for config to propagate through the system
+        time.sleep(3)
+
+        # Verify all rules are created
+        for priority in rule_priorities:
             dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"PRIORITY_ORDER_TEST_RULE_{priority}", "Active")
 
         # Verify all rules are created with correct priorities
         dvs_acl.verify_acl_rule_set(rule_priorities, config_actions, expected_sai_qualifiers)
 
-        # Verify the order of SET operations in syslog (should be descending: 200, 150, 100, 50, 10)
-        expected_order = ["200", "150", "100", "50", "10"]
-        (exitcode, log_output) = dvs.runcmd(
-            ['sh', '-c', f"awk '/{marker}/,ENDFILE {{print;}}' /var/log/syslog | grep 'processing SET in descending priority order'"])
+        # Verify the order of SAI create operations from sairedis.rec
+        exitcode, rec_output = dvs.runcmd('sh -c "tail -n 1000 /var/log/swss/sairedis.rec | grep \'c|SAI_OBJECT_TYPE_ACL_ENTRY\'"')
 
-        # Extract priorities from log lines in order
-        log_lines = log_output.strip().split('\n') if log_output.strip() else []
-        actual_order = []
-        for line in log_lines:
-            for priority in expected_order:
-                if f"PRIORITY_ORDER_TEST_RULE_{priority}" in line and f"PRIORITY: {priority}" in line:
-                    actual_order.append(priority)
-                    break
+        # Parse the create operations and extract priorities
+        created_priorities = []
+        if exitcode == 0 and rec_output:
+            for line in rec_output.strip().split('\n'):
+                if '|c|SAI_OBJECT_TYPE_ACL_ENTRY' in line and 'SAI_ACL_ENTRY_ATTR_PRIORITY' in line:
+                    for part in line.split('|'):
+                        if 'SAI_ACL_ENTRY_ATTR_PRIORITY=' in part:
+                            priority = part.split('=')[1].strip()
+                            # Check if this is one of our test rules by looking for the SRC_IP
+                            if any(f'10.0.0.{priority}' in line for priority in rule_priorities):
+                                created_priorities.append(priority)
+                            break
 
-        # Verify the rules were processed in descending priority order
-        assert actual_order == expected_order, f"Expected order {expected_order}, but got {actual_order}"
+        # Verify that the creates happened in descending priority order
+        expected_order = sorted([int(p) for p in rule_priorities], reverse=True)
+        expected_order_str = [str(p) for p in expected_order]
+
+        # The created_priorities should match expected_order (last 5 entries)
+        actual_order = created_priorities[-5:]
+        assert actual_order == expected_order_str, \
+            f"ACL rules not created in priority order. Expected {expected_order_str}, got {actual_order}"
 
         # Clean up
         for priority in rule_priorities:
@@ -982,7 +1001,7 @@ class TestAcl:
         """
         Test that ACL rules are deleted in ascending priority order (lower priority value first).
         """
-        # Create rules with different priorities
+        # Create rules with different priorities in random order
         rule_priorities = ["100", "50", "200", "10", "150"]
 
         config_qualifiers = {
@@ -993,6 +1012,8 @@ class TestAcl:
             "150": {"DST_IP": "192.168.0.150/32"},
         }
 
+        # Map to store OID for each priority (for SAI recording verification)
+        priority_to_oid = {}
         # Create all rules
         for priority in rule_priorities:
             dvs_acl.create_acl_rule(L3_TABLE_NAME,
@@ -1002,34 +1023,71 @@ class TestAcl:
                                     priority=priority)
             dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"DELETE_ORDER_TEST_RULE_{priority}", "Active")
 
-        # Add log marker before deleting rules
-        marker = dvs.add_log_marker()
+            # Get the OID for this rule from ASIC_DB for later verification
+            keys = dvs_acl.asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
+            for key in keys:
+                if key not in dvs_acl.asic_db.default_acl_entries:
+                    entry = dvs_acl.asic_db.get_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", key)
+                    entry_priority = entry.get("SAI_ACL_ENTRY_ATTR_PRIORITY")
+                    # Check if this is our rule by matching priority and DST_IP
+                    expected_dst_ip = config_qualifiers[priority]["DST_IP"].split("/")[0]
+                    entry_dst_ip = entry.get("SAI_ACL_ENTRY_ATTR_FIELD_DST_IP", "")
+                    if entry_priority == priority and expected_dst_ip in entry_dst_ip:
+                        # Extract OID from key (format is "oid:0x...")
+                        priority_to_oid[priority] = key.split(":")[1]
+                        break
 
-        # Delete all rules at once (they should be deleted in ascending priority order)
+        # Get initial count of ACL entries in ASIC_DB
+        initial_count = len(dvs_acl.asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY"))
+
+        # Delete all rules atomically using Redis transaction in CONFIG_DB
+        # This ensures all deletions are batched together and processed in one doTask call
+        redis_cmds = []
+        redis_cmds.append("MULTI")
+
         for priority in rule_priorities:
-            dvs_acl.remove_acl_rule(L3_TABLE_NAME, f"DELETE_ORDER_TEST_RULE_{priority}")
+            rule_name = f"DELETE_ORDER_TEST_RULE_{priority}"
+            key = f"{L3_TABLE_NAME}|{rule_name}"
+            redis_cmds.append(f"DEL \"ACL_RULE|{key}\"")
 
-        # Verify all rules are deleted
+        redis_cmds.append("EXEC")
+
+        # Execute as a single atomic transaction in CONFIG_DB (database 4)
+        dvs.runcmd(['sh', '-c', f"redis-cli -n 4 <<EOF\n" + "\n".join(redis_cmds) + "\nEOF"])
+
+        # Wait for all rules to be deleted from ASIC_DB
+        expected_final_count = initial_count - len(rule_priorities)
+        dvs_acl.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", expected_final_count)
+
+        # Verify all rules are deleted from CONFIG_DB and STATE_DB
         for priority in rule_priorities:
             dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"DELETE_ORDER_TEST_RULE_{priority}", None)
         dvs_acl.verify_no_acl_rules()
 
-        # Verify the order of DEL operations in syslog (should be ascending: 10, 50, 100, 150, 200)
-        expected_order = ["10", "50", "100", "150", "200"]
-        (exitcode, log_output) = dvs.runcmd(
-            ['sh', '-c', f"awk '/{marker}/,ENDFILE {{print;}}' /var/log/syslog | grep 'processing DEL in ascending priority order'"])
+        # Verify the order of SAI remove operations from sairedis.rec
+        exitcode, rec_output = dvs.runcmd('sh -c "tail -n 1000 /var/log/swss/sairedis.rec | grep \'r|SAI_OBJECT_TYPE_ACL_ENTRY\'"')
 
-        # Extract priorities from log lines in order
-        log_lines = log_output.strip().split('\n') if log_output.strip() else []
-        actual_order = []
-        for line in log_lines:
-            for priority in expected_order:
-                if f"DELETE_ORDER_TEST_RULE_{priority}" in line and f"PRIORITY: {priority}" in line:
-                    actual_order.append(priority)
+        # Parse the remove operations and extract OIDs
+        removed_oids = []
+        if exitcode == 0 and rec_output:
+            for line in rec_output.strip().split('\n'):
+                if '|r|SAI_OBJECT_TYPE_ACL_ENTRY:oid:' in line:
+                    # Extract OID from line (format: timestamp|r|SAI_OBJECT_TYPE_ACL_ENTRY:oid:0x...)
+                    oid = line.split('SAI_OBJECT_TYPE_ACL_ENTRY:oid:')[1].strip()
+                    removed_oids.append(oid)
+
+        # Find the sequence of our test rule removals by matching OIDs
+        test_removal_sequence = []
+        for oid in removed_oids[-10:]:  # Look at last 10 removals
+            for priority, recorded_oid in priority_to_oid.items():
+                if oid == recorded_oid:
+                    test_removal_sequence.append(int(priority))
                     break
 
-        # Verify the rules were processed in ascending priority order
-        assert actual_order == expected_order, f"Expected DEL order {expected_order}, but got {actual_order}"
+        expected_order = sorted([int(p) for p in rule_priorities])
+
+        assert test_removal_sequence == expected_order, \
+            f"ACL rules not removed in priority order. Expected {expected_order}, got {test_removal_sequence}"
 
     def test_AclRuleMixedPriorityOperations(self, dvs, dvs_acl, l3_acl_table):
         """
@@ -1038,6 +1096,7 @@ class TestAcl:
         """
         # First, create initial set of rules
         initial_priorities = ["100", "50", "150"]
+        priority_to_oid = {}
 
         for priority in initial_priorities:
             dvs_acl.create_acl_rule(L3_TABLE_NAME,
@@ -1047,75 +1106,89 @@ class TestAcl:
                                     priority=priority)
             dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"MIXED_OP_RULE_{priority}", "Active")
 
-        # Add log marker before mixed operations
-        marker = dvs.add_log_marker()
+            # Get the OID for this rule from ASIC_DB for later verification
+            keys = dvs_acl.asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
+            for key in keys:
+                if key not in dvs_acl.asic_db.default_acl_entries:
+                    entry = dvs_acl.asic_db.get_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", key)
+                    entry_priority = entry.get("SAI_ACL_ENTRY_ATTR_PRIORITY")
+                    # Check if this is our rule by matching priority and SRC_IP
+                    expected_src_ip = f"10.0.{priority}.0"
+                    entry_src_ip = entry.get("SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP", "")
+                    if entry_priority == priority and expected_src_ip in entry_src_ip:
+                        priority_to_oid[priority] = key.split(":")[1]
+                        break
 
-        # Now delete some and add new ones
-        # Delete rules with priority 50 and 150
-        dvs_acl.remove_acl_rule(L3_TABLE_NAME, "MIXED_OP_RULE_50")
-        dvs_acl.remove_acl_rule(L3_TABLE_NAME, "MIXED_OP_RULE_150")
+        # Perform bulk deletion and creation using Redis transaction
+        redis_cmds = []
+        redis_cmds.append("MULTI")
 
-        # Add new rules with different priorities
-        new_priorities = ["200", "25", "75"]
+        delete_priorities = ["50", "150"]
+        for priority in delete_priorities:
+            rule_name = f"MIXED_OP_RULE_{priority}"
+            key = f"{L3_TABLE_NAME}|{rule_name}"
+            redis_cmds.append(f"DEL \"ACL_RULE|{key}\"")
+
+        new_priorities = ["200", "25"]
         for priority in new_priorities:
-            dvs_acl.create_acl_rule(L3_TABLE_NAME,
-                                    f"MIXED_OP_RULE_{priority}",
-                                    {"SRC_IP": f"10.0.{priority}.0/32"},
-                                    action="FORWARD",
-                                    priority=priority)
-            dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"MIXED_OP_RULE_{priority}", "Active")
+            rule_name = f"MIXED_OP_RULE_{priority}"
+            key = f"{L3_TABLE_NAME}|{rule_name}"
+            redis_cmds.append(f"HSET \"ACL_RULE|{key}\" \"priority\" \"{priority}\"")
+            redis_cmds.append(f"HSET \"ACL_RULE|{key}\" \"PACKET_ACTION\" \"DROP\"")
+            redis_cmds.append(f"HSET \"ACL_RULE|{key}\" \"SRC_IP\" \"10.0.{priority}.0/32\"")
 
-        # Verify final state: should have rules with priorities 100, 200, 25, 75
-        remaining_priorities = ["100", "200", "25", "75"]
-        for priority in remaining_priorities:
-            dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"MIXED_OP_RULE_{priority}", "Active")
+        redis_cmds.append("EXEC")
+        dvs.runcmd(['sh', '-c', f"redis-cli -n 4 <<EOF\n" + "\n".join(redis_cmds) + "\nEOF"])
 
-        # Verify deleted rules are gone
+        # Wait for operations to complete
+        time.sleep(2)
         dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, "MIXED_OP_RULE_50", None)
         dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, "MIXED_OP_RULE_150", None)
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, "MIXED_OP_RULE_100", "Active")
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, "MIXED_OP_RULE_200", "Active")
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, "MIXED_OP_RULE_25", "Active")
 
-        # Verify the order of operations in syslog
-        # DEL operations should be processed first (in ascending order: 50, 150)
-        # Then SET operations (in descending order: 200, 75, 25)
-        (exitcode, log_output) = dvs.runcmd(
-            ['sh', '-c', f"awk '/{marker}/,ENDFILE {{print;}}' /var/log/syslog | grep -E 'processing (DEL|SET) in (ascending|descending) priority order'"])
+        # Verify the order of SAI operations from sairedis.rec
+        exitcode, rec_output = dvs.runcmd('sh -c "tail -n 1000 /var/log/swss/sairedis.rec | grep \'SAI_OBJECT_TYPE_ACL_ENTRY\'"')
 
-        log_lines = log_output.strip().split('\n') if log_output.strip() else []
-
-        # Extract operation type and priority from each log line
+        # Parse operations and extract sequence
         operations = []
-        for line in log_lines:
-            if "MIXED_OP_RULE_" in line:
-                if "processing DEL" in line:
-                    if "MIXED_OP_RULE_50" in line and "PRIORITY: 50" in line:
-                        operations.append(("DEL", "50"))
-                    elif "MIXED_OP_RULE_150" in line and "PRIORITY: 150" in line:
-                        operations.append(("DEL", "150"))
-                elif "processing SET" in line:
-                    if "MIXED_OP_RULE_200" in line and "PRIORITY: 200" in line:
-                        operations.append(("SET", "200"))
-                    elif "MIXED_OP_RULE_75" in line and "PRIORITY: 75" in line:
-                        operations.append(("SET", "75"))
-                    elif "MIXED_OP_RULE_25" in line and "PRIORITY: 25" in line:
-                        operations.append(("SET", "25"))
+        if exitcode == 0 and rec_output:
+            for line in rec_output.strip().split('\n'):
+                # Look for remove operations
+                if '|r|SAI_OBJECT_TYPE_ACL_ENTRY:oid:' in line:
+                    oid = line.split('SAI_OBJECT_TYPE_ACL_ENTRY:oid:')[1].strip()
+                    # Check if this is one of our deleted rules
+                    for priority in delete_priorities:
+                        if priority in priority_to_oid and oid == priority_to_oid[priority]:
+                            operations.append(('DEL', int(priority)))
+                            break
+                # Look for create operations
+                elif '|c|SAI_OBJECT_TYPE_ACL_ENTRY' in line and 'SAI_ACL_ENTRY_ATTR_PRIORITY' in line:
+                    for part in line.split('|'):
+                        if 'SAI_ACL_ENTRY_ATTR_PRIORITY=' in part:
+                            priority = part.split('=')[1].strip()
+                            # Check if this is one of our new rules
+                            if priority in new_priorities and f'10.0.{priority}.0' in line:
+                                operations.append(('SET', int(priority)))
+                            break
 
-        # Expected order: DEL operations first (ascending: 50, 150), then SET operations (descending: 200, 75, 25)
-        expected_operations = [
-            ("DEL", "50"),
-            ("DEL", "150"),
-            ("SET", "200"),
-            ("SET", "75"),
-            ("SET", "25")
-        ]
+        # Extract the last operations that match our test (2 DELs + 2 SETs = 4 operations)
+        test_operations = operations[-4:]
 
-        # Verify the operations were processed in the correct order
-        assert operations == expected_operations, f"Expected operation order {expected_operations}, but got {operations}"
+        # Verify the order: DELs should be in ascending order (50, 150), SETs in descending order (200, 25)
+        expected_operations = [('DEL', 50), ('DEL', 150), ('SET', 200), ('SET', 25)]
+
+        assert test_operations == expected_operations, \
+            f"Mixed operations not processed in correct order. Expected {expected_operations}, got {test_operations}"
 
         # Clean up
-        for priority in remaining_priorities:
-            dvs_acl.remove_acl_rule(L3_TABLE_NAME, f"MIXED_OP_RULE_{priority}")
-            dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"MIXED_OP_RULE_{priority}", None)
-        dvs_acl.verify_no_acl_rules()
+        dvs_acl.remove_acl_rule(L3_TABLE_NAME, "MIXED_OP_RULE_100")
+        dvs_acl.remove_acl_rule(L3_TABLE_NAME, "MIXED_OP_RULE_200")
+        dvs_acl.remove_acl_rule(L3_TABLE_NAME, "MIXED_OP_RULE_25")
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, "MIXED_OP_RULE_100", None)
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, "MIXED_OP_RULE_200", None)
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, "MIXED_OP_RULE_25", None)
 
 class TestAclCrmUtilization:
     @pytest.fixture(scope="class", autouse=True)

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -909,7 +909,7 @@ class TestAcl:
 
         assert not match_range_qualifier
 
-    def test_AclRulePriorityOrderProcessing(self, dvs_acl, l3_acl_table):
+    def test_AclRulePriorityOrderProcessing(self, dvs, dvs_acl, l3_acl_table):
         """
         Test that ACL rules are processed in descending priority order (higher priority value first).
         """
@@ -940,6 +940,9 @@ class TestAcl:
             "150": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": dvs_acl.get_simple_qualifier_comparator("10.0.0.150&mask:255.255.255.255")},
         }
 
+        # Add log marker before creating rules
+        marker = dvs.add_log_marker()
+
         # Create rules in random order
         for priority in rule_priorities:
             dvs_acl.create_acl_rule(L3_TABLE_NAME,
@@ -952,13 +955,30 @@ class TestAcl:
         # Verify all rules are created with correct priorities
         dvs_acl.verify_acl_rule_set(rule_priorities, config_actions, expected_sai_qualifiers)
 
+        # Verify the order of SET operations in syslog (should be descending: 200, 150, 100, 50, 10)
+        expected_order = ["200", "150", "100", "50", "10"]
+        (exitcode, log_output) = dvs.runcmd(
+            ['sh', '-c', f"awk '/{marker}/,ENDFILE {{print;}}' /var/log/syslog | grep 'processing SET in descending priority order'"])
+
+        # Extract priorities from log lines in order
+        log_lines = log_output.strip().split('\n') if log_output.strip() else []
+        actual_order = []
+        for line in log_lines:
+            for priority in expected_order:
+                if f"PRIORITY_ORDER_TEST_RULE_{priority}" in line and f"PRIORITY: {priority}" in line:
+                    actual_order.append(priority)
+                    break
+
+        # Verify the rules were processed in descending priority order
+        assert actual_order == expected_order, f"Expected order {expected_order}, but got {actual_order}"
+
         # Clean up
         for priority in rule_priorities:
             dvs_acl.remove_acl_rule(L3_TABLE_NAME, f"PRIORITY_ORDER_TEST_RULE_{priority}")
             dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"PRIORITY_ORDER_TEST_RULE_{priority}", None)
         dvs_acl.verify_no_acl_rules()
 
-    def test_AclRuleDeletionPriorityOrder(self, dvs_acl, l3_acl_table):
+    def test_AclRuleDeletionPriorityOrder(self, dvs, dvs_acl, l3_acl_table):
         """
         Test that ACL rules are deleted in ascending priority order (lower priority value first).
         """
@@ -982,6 +1002,9 @@ class TestAcl:
                                     priority=priority)
             dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"DELETE_ORDER_TEST_RULE_{priority}", "Active")
 
+        # Add log marker before deleting rules
+        marker = dvs.add_log_marker()
+
         # Delete all rules at once (they should be deleted in ascending priority order)
         for priority in rule_priorities:
             dvs_acl.remove_acl_rule(L3_TABLE_NAME, f"DELETE_ORDER_TEST_RULE_{priority}")
@@ -991,7 +1014,24 @@ class TestAcl:
             dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"DELETE_ORDER_TEST_RULE_{priority}", None)
         dvs_acl.verify_no_acl_rules()
 
-    def test_AclRuleMixedPriorityOperations(self, dvs_acl, l3_acl_table):
+        # Verify the order of DEL operations in syslog (should be ascending: 10, 50, 100, 150, 200)
+        expected_order = ["10", "50", "100", "150", "200"]
+        (exitcode, log_output) = dvs.runcmd(
+            ['sh', '-c', f"awk '/{marker}/,ENDFILE {{print;}}' /var/log/syslog | grep 'processing DEL in ascending priority order'"])
+
+        # Extract priorities from log lines in order
+        log_lines = log_output.strip().split('\n') if log_output.strip() else []
+        actual_order = []
+        for line in log_lines:
+            for priority in expected_order:
+                if f"DELETE_ORDER_TEST_RULE_{priority}" in line and f"PRIORITY: {priority}" in line:
+                    actual_order.append(priority)
+                    break
+
+        # Verify the rules were processed in ascending priority order
+        assert actual_order == expected_order, f"Expected DEL order {expected_order}, but got {actual_order}"
+
+    def test_AclRuleMixedPriorityOperations(self, dvs, dvs_acl, l3_acl_table):
         """
         Test mixed SET and DEL operations with different priorities.
         Verifies that DEL operations (ascending order) are processed before SET operations (descending order).
@@ -1006,6 +1046,9 @@ class TestAcl:
                                     action="DROP",
                                     priority=priority)
             dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"MIXED_OP_RULE_{priority}", "Active")
+
+        # Add log marker before mixed operations
+        marker = dvs.add_log_marker()
 
         # Now delete some and add new ones
         # Delete rules with priority 50 and 150
@@ -1030,6 +1073,43 @@ class TestAcl:
         # Verify deleted rules are gone
         dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, "MIXED_OP_RULE_50", None)
         dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, "MIXED_OP_RULE_150", None)
+
+        # Verify the order of operations in syslog
+        # DEL operations should be processed first (in ascending order: 50, 150)
+        # Then SET operations (in descending order: 200, 75, 25)
+        (exitcode, log_output) = dvs.runcmd(
+            ['sh', '-c', f"awk '/{marker}/,ENDFILE {{print;}}' /var/log/syslog | grep -E 'processing (DEL|SET) in (ascending|descending) priority order'"])
+
+        log_lines = log_output.strip().split('\n') if log_output.strip() else []
+
+        # Extract operation type and priority from each log line
+        operations = []
+        for line in log_lines:
+            if "MIXED_OP_RULE_" in line:
+                if "processing DEL" in line:
+                    if "MIXED_OP_RULE_50" in line and "PRIORITY: 50" in line:
+                        operations.append(("DEL", "50"))
+                    elif "MIXED_OP_RULE_150" in line and "PRIORITY: 150" in line:
+                        operations.append(("DEL", "150"))
+                elif "processing SET" in line:
+                    if "MIXED_OP_RULE_200" in line and "PRIORITY: 200" in line:
+                        operations.append(("SET", "200"))
+                    elif "MIXED_OP_RULE_75" in line and "PRIORITY: 75" in line:
+                        operations.append(("SET", "75"))
+                    elif "MIXED_OP_RULE_25" in line and "PRIORITY: 25" in line:
+                        operations.append(("SET", "25"))
+
+        # Expected order: DEL operations first (ascending: 50, 150), then SET operations (descending: 200, 75, 25)
+        expected_operations = [
+            ("DEL", "50"),
+            ("DEL", "150"),
+            ("SET", "200"),
+            ("SET", "75"),
+            ("SET", "25")
+        ]
+
+        # Verify the operations were processed in the correct order
+        assert operations == expected_operations, f"Expected operation order {expected_operations}, but got {operations}"
 
         # Clean up
         for priority in remaining_priorities:

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -916,14 +916,6 @@ class TestAcl:
         # Create rules with non-sequential priorities to test sorting
         rule_priorities = ["100", "50", "200", "10", "150"]
 
-        config_qualifiers = {
-            "100": {"SRC_IP": "10.0.0.100/32"},
-            "50": {"SRC_IP": "10.0.0.50/32"},
-            "200": {"SRC_IP": "10.0.0.200/32"},
-            "10": {"SRC_IP": "10.0.0.10/32"},
-            "150": {"SRC_IP": "10.0.0.150/32"},
-        }
-
         config_actions = {
             "100": "DROP",
             "50": "DROP",
@@ -995,6 +987,85 @@ class TestAcl:
         for priority in rule_priorities:
             dvs_acl.remove_acl_rule(L3_TABLE_NAME, f"PRIORITY_ORDER_TEST_RULE_{priority}")
             dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, f"PRIORITY_ORDER_TEST_RULE_{priority}", None)
+        dvs_acl.verify_no_acl_rules()
+
+    def test_AclRuleInvalidPriorityHandling(self, dvs, dvs_acl, l3_acl_table):
+        """
+        Test that ACL rules with invalid priority values are properly rejected and logged,
+        while valid rules in the same batch are still processed correctly.
+        """
+        # Create a mix of valid and invalid priority rules
+        test_cases = [
+            ("100", True),           # Valid priority
+            ("abc", False),          # Invalid: non-numeric
+            ("50", True),            # Valid priority
+            ("99999999999", False),  # Invalid: exceeds UINT32_MAX
+            ("200", True),           # Valid priority
+            ("10.5", False),         # Invalid: decimal number
+            ("150", True),           # Valid priority
+        ]
+
+        valid_priorities = [tc[0] for tc in test_cases if tc[1]]
+        invalid_priorities = [tc[0] for tc in test_cases if not tc[1]]
+
+        config_actions = {p: "DROP" for p in valid_priorities}
+        expected_sai_qualifiers = {
+            p: {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": dvs_acl.get_simple_qualifier_comparator(f"10.0.0.{p}&mask:255.255.255.255")}
+            for p in valid_priorities
+        }
+
+        # Create all rules (valid and invalid) in CONFIG_DB atomically
+        redis_cmds = []
+        redis_cmds.append("MULTI")
+
+        for priority, is_valid in test_cases:
+            rule_name = f"INVALID_PRIO_TEST_RULE_{priority.replace('.', '_')}"
+            key = f"{L3_TABLE_NAME}|{rule_name}"
+
+            redis_cmds.append(f"HSET \"ACL_RULE|{key}\" \"priority\" \"{priority}\"")
+            redis_cmds.append(f"HSET \"ACL_RULE|{key}\" \"PACKET_ACTION\" \"DROP\"")
+            redis_cmds.append(f"HSET \"ACL_RULE|{key}\" \"SRC_IP\" \"10.0.0.{priority}/32\"")
+
+        redis_cmds.append("EXEC")
+        dvs.runcmd(['sh', '-c', f"redis-cli -n 4 <<EOF\n" + "\n".join(redis_cmds) + "\nEOF"])
+
+        # Give time for config to propagate
+        time.sleep(3)
+
+        # Verify that only valid priority rules are created
+        for priority in valid_priorities:
+            rule_name = f"INVALID_PRIO_TEST_RULE_{priority}"
+            dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, rule_name, "Active")
+
+        # Verify that invalid priority rules are NOT created (should be None or not exist)
+        for priority in invalid_priorities:
+            rule_name = f"INVALID_PRIO_TEST_RULE_{priority.replace('.', '_')}"
+            # The rule should not exist in ASIC_DB
+            dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, rule_name, None)
+
+        # Verify valid rules are created with correct attributes
+        dvs_acl.verify_acl_rule_set(valid_priorities, config_actions, expected_sai_qualifiers)
+
+        # Check syslog for error messages about invalid priorities
+        exitcode, log_output = dvs.runcmd('sh -c "grep -i \'Invalid ACL rule priority\' /var/log/syslog | tail -20"')
+
+        # We should see error logs for each invalid priority
+        if exitcode == 0 and log_output:
+            for invalid_prio in invalid_priorities:
+                assert invalid_prio in log_output, \
+                    f"Expected error log for invalid priority '{invalid_prio}' not found in syslog"
+
+        # Clean up valid rules
+        for priority in valid_priorities:
+            rule_name = f"INVALID_PRIO_TEST_RULE_{priority}"
+            dvs_acl.remove_acl_rule(L3_TABLE_NAME, rule_name)
+            dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, rule_name, None)
+
+        # Clean up invalid rules from CONFIG_DB (they should still be there)
+        for priority in invalid_priorities:
+            rule_name = f"INVALID_PRIO_TEST_RULE_{priority.replace('.', '_')}"
+            dvs_acl.remove_acl_rule(L3_TABLE_NAME, rule_name)
+
         dvs_acl.verify_no_acl_rules()
 
     def test_AclRuleDeletionPriorityOrder(self, dvs, dvs_acl, l3_acl_table):


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Updated the ACL rule processing logic in aclorch to explicitly sort rules by priority, ensuring rules are added/deleted in the correct priority order.

**Why I did it**
In aclorch, ACL rules were being inserted into std::multimap and processed in lexicographic (key) order rather than their intended priority order. Inserting rules out of priority sequence forces expensive TCAM reordering/shifting in hardware, leading to significant slowdowns during ACL programming.

**How I verified it**
Validated with test_acl.py test on 64 peer Q3D DUT. There are 2369 entries in field group and the total programming time reduced from 260sec to 44sec. Also sanity tested on TH5 DUT.

Without changes:

admin@humm209:~$ sudo tail -f /var/log/syslog | grep 'Successfully created ACL rule'
2026 Feb 6 23:11:24.731487 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule DEFAULT_RULE in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:11:26.005298 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_1 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:11:27.454700 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_10 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:11:28.688798 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_11 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:11:29.935848 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_12 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:11:31.222184 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_13 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:11:32.457372 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_14 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:11:33.705663 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_15 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:11:34.988975 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_16 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:11:36.282561 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_17 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:11:37.581924 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_18 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:11:38.898635 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_19 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:11:52.071344 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_2 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:11:53.427291 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_20 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:11:54.666869 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_21 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:11:55.925729 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_22 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:11:57.202169 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_23 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:11:58.481925 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_24 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:11:59.729990 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_25 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:12:00.959070 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_26 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:12:02.211914 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_27 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:12:03.491793 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_28 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:12:04.783488 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_29 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:12:31.144733 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_3 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:12:32.394530 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_30 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:12:33.628703 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_31 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:12:34.910732 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_32 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:12:36.502260 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_33 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:12:37.804475 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_34 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:13:09.172148 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_4 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:13:40.345228 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_5 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:14:11.290365 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_6 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:14:42.302303 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_7 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:15:13.420126 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_8 in table DATA_INGRESS_IPV4_TEST
2026 Feb 6 23:15:44.513512 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_9 in table DATA_INGRESS_IPV4_TEST

With changes:

admin@humm209:~$ sudo tail -f /var/log/syslog | grep 'Successfully created ACL rule'
2026 Feb 7 03:05:20.526846 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule DEFAULT_RULE in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:21.773153 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_1 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:22.999752 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_2 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:24.229544 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_3 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:25.474298 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_4 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:26.692653 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_5 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:27.920455 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_6 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:29.179956 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_7 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:30.653672 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_8 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:31.945321 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_9 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:33.229613 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_10 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:34.486685 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_11 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:35.754205 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_12 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:37.045517 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_13 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:38.573261 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_14 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:39.840866 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_15 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:41.092846 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_16 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:42.608053 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_17 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:43.879954 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_18 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:45.132939 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_19 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:46.378986 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_20 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:47.626227 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_21 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:48.887582 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_22 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:50.119566 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_23 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:51.367623 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_24 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:52.631811 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_25 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:53.860403 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_26 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:55.128167 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_27 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:56.535292 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_28 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:57.804326 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_29 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:05:59.238164 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_30 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:06:00.531409 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_31 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:06:01.925566 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_32 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:06:03.194505 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_33 in table DATA_INGRESS_IPV4_TEST
2026 Feb 7 03:06:04.449220 humm209 NOTICE swss#orchagent: :- add: Successfully created ACL rule RULE_34 in table DATA_INGRESS_IPV4_TEST


### Back port request
<!--
Only check a release or feature branch when the PR links a GitHub issue or ADO
work item above. The linked tracker should explain the failure in detail,
including whether it is a day-one issue or a regression, the affected
branch/image/platform/test, and why this branch needs the fix. Backport or
cherry-pick requests without a linked issue/work item may not be favored.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

### Tested branch
<!--
Select each branch where the change was tested. If you request a
backport/cherry-pick, select the base branch and the tested target release
branch(es).
-->
- [ ] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] N/A
