### PR TITLE
[voq] Fixed the ParsePortConfig and processQueue Warning messages

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -1222,9 +1222,14 @@ task_process_status BufferOrch::processQueuePost(const QueueTask& task)
             }
             else
             {
-                if (gPortsOrch->isPortAdminUp(port_name))
+                /* In the Voq Switch, the admin status is set to True when the system port is added to the m_portList map
+                   and always True for remote System Port, so no need to check for remote system port*/
+                if (!((gMySwitchType == "voq") && (tokens.size() == 4)))
                 {
-                    SWSS_LOG_WARN("Queue profile '%s' applied after port %s is up", key.c_str(), port_name.c_str());
+                    if (gPortsOrch->isPortAdminUp(port_name))
+                    {
+                        SWSS_LOG_WARN("Queue profile '%s' applied after port %s is up", key.c_str(), port_name.c_str());
+                    }
                 }
             }
         }

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -1224,7 +1224,7 @@ task_process_status BufferOrch::processQueuePost(const QueueTask& task)
             {
                 /* In the Voq Switch, the admin status is set to True when the system port is added to the m_portList map
                    and always True for remote System Port, so no need to check for remote system port*/
-                if (!((gMySwitchType == "voq") && (tokens.size() == 4)))
+                if (gMySwitchType != "voq")
                 {
                     if (gPortsOrch->isPortAdminUp(port_name))
                     {

--- a/orchagent/port/porthlpr.cpp
+++ b/orchagent/port/porthlpr.cpp
@@ -1404,6 +1404,18 @@ bool PortHelper::parsePortConfig(PortConfig &port) const
                 return false;
             }
         }
+        else if (field == PORT_MACSEC)
+        {
+            /* Placeholder to prevent warning. Parsed by macsecorch.*/
+        }
+        else if (field == PORT_ASIC_PORT_NAME)
+        {
+            /* Placeholder to prevent warning. Not used by orchagent.*/
+        }
+        else if ((field == PORT_CORE_ID) || (field == PORT_CORE_PORT_ID) || (field == PORT_NUM_VOQ))
+        {
+            /* Placeholder to prevent warning. These fields are taken from SYSTEM_PORT*/
+        }
         else
         {
             SWSS_LOG_WARN("Unknown field(%s): skipping ...", field.c_str());

--- a/orchagent/port/porthlpr.cpp
+++ b/orchagent/port/porthlpr.cpp
@@ -1407,14 +1407,17 @@ bool PortHelper::parsePortConfig(PortConfig &port) const
         else if (field == PORT_MACSEC)
         {
             /* Placeholder to prevent warning. Parsed by macsecorch.*/
+            SWSS_LOG_INFO("Parsing %s", field.c_str());
         }
         else if (field == PORT_ASIC_PORT_NAME)
         {
             /* Placeholder to prevent warning. Not used by orchagent.*/
+            SWSS_LOG_INFO("Parsing %s", field.c_str());
         }
         else if ((field == PORT_CORE_ID) || (field == PORT_CORE_PORT_ID) || (field == PORT_NUM_VOQ))
         {
             /* Placeholder to prevent warning. These fields are taken from SYSTEM_PORT*/
+            SWSS_LOG_INFO("Parsing %s", field.c_str());
         }
         else
         {

--- a/orchagent/port/portschema.h
+++ b/orchagent/port/portschema.h
@@ -110,3 +110,8 @@
 #define PORT_UNRELIABLE_LOS        "unreliable_los"
 #define PORT_MEDIA_TYPE            "media_type"
 #define PORT_FAST_LINKUP           "fast_linkup"
+#define PORT_MACSEC                "macsec"
+#define PORT_ASIC_PORT_NAME        "asic_port_name"
+#define PORT_CORE_ID               "core_id"
+#define PORT_CORE_PORT_ID          "core_port_id"
+#define PORT_NUM_VOQ               "num_voq"

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -1364,7 +1364,9 @@ namespace portsorch_test
                 { "tpid",                "0x9100"            },
                 { "pfc_asym",            "on"                },
                 { "link_training",       "on"                },
-                { "admin_status",        "up"                }
+                { "admin_status",        "up"                },
+                { "macsec",              "basic-profile"     },
+                { "num_voq",             "8"                 }
             }
         }};
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixed the ParsePortConfig and processQueue Warning messages reported in https://github.com/sonic-net/sonic-buildimage/issues/25469 & https://github.com/sonic-net/sonic-buildimage/issues/19902

**Why I did it**
When the Voq system is rebooted, lot of Warning messages are printed in the syslog when the config is loaded. This PR fixes parsePortConfig and processQueue  warnings.
**How I verified it**
Verified that the config is loaded correctly and functioning with these messages in the syslog
**Details if related**
