### PR TITLE
Flex Counter Phase 2 - Port Serdes Attributes

### DIFF
--- a/orchagent/flex_counter/flex_counter_manager.cpp
+++ b/orchagent/flex_counter/flex_counter_manager.cpp
@@ -38,6 +38,7 @@ const unordered_map<CounterType, string> FlexCounterManager::counter_id_field_lo
 {
     { CounterType::PORT_DEBUG,          PORT_DEBUG_COUNTER_ID_LIST },
     { CounterType::PORT_PHY_ATTR,       PORT_PHY_ATTR_ID_LIST },
+    { CounterType::PORT_PHY_SERDES_ATTR,PORT_PHY_SERDES_ATTR_ID_LIST },
     { CounterType::SWITCH_DEBUG,        SWITCH_DEBUG_COUNTER_ID_LIST },
     { CounterType::PORT,                PORT_COUNTER_ID_LIST },
     { CounterType::QUEUE,               QUEUE_COUNTER_ID_LIST },

--- a/orchagent/flex_counter/flex_counter_manager.h
+++ b/orchagent/flex_counter/flex_counter_manager.h
@@ -28,6 +28,7 @@ enum class CounterType
 {
     PORT,
     PORT_PHY_ATTR,
+    PORT_PHY_SERDES_ATTR,
     QUEUE,
     QUEUE_ATTR,
     PRIORITY_GROUP,

--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -45,6 +45,7 @@ int gFlexCounterDelaySec;
 #define BUFFER_POOL_WATERMARK_KEY   "BUFFER_POOL_WATERMARK"
 #define PORT_KEY                    "PORT"
 #define PORT_PHY_ATTR_KEY           "PORT_PHY_ATTR"
+#define PORT_PHY_SERDES_ATTR_KEY    "PORT_PHY_SERDES_ATTR"
 #define PORT_BUFFER_DROP_KEY        "PORT_BUFFER_DROP"
 #define QUEUE_KEY                   "QUEUE"
 #define QUEUE_WATERMARK             "QUEUE_WATERMARK"
@@ -66,6 +67,7 @@ unordered_map<string, string> flexCounterGroupMap =
 {
     {"PORT", PORT_STAT_COUNTER_FLEX_COUNTER_GROUP},
     {"PORT_PHY_ATTR", PORT_PHY_ATTR_FLEX_COUNTER_GROUP},
+    {"PORT_PHY_SERDES_ATTR", PORT_PHY_SERDES_ATTR_FLEX_COUNTER_GROUP},
     {"PORT_RATES", PORT_RATE_COUNTER_FLEX_COUNTER_GROUP},
     {"DEBUG_MONITOR_COUNTER", DEBUG_DROP_MONITOR_FLEX_COUNTER_GROUP},
     {"PORT_BUFFER_DROP", PORT_BUFFER_DROP_STAT_FLEX_COUNTER_GROUP},
@@ -203,6 +205,11 @@ void FlexCounterOrch::doTask(Consumer &consumer)
                             setFlexCounterGroupPollInterval(flexCounterGroupMap[key], value, true);
                         }
                     }
+                    // PORT_PHY_ATTR_KEY and PORT_PHY_SERDES_ATTR_KEY share the 'counterpoll phy' knob
+                    if (key == PORT_PHY_ATTR_KEY)
+                    {
+                        setFlexCounterGroupPollInterval(flexCounterGroupMap[PORT_PHY_SERDES_ATTR_KEY], value);
+                    }
                 }
                 else if (field == BULK_CHUNK_SIZE_FIELD)
                 {
@@ -326,15 +333,31 @@ void FlexCounterOrch::doTask(Consumer &consumer)
                     }
                     if (gPortsOrch && (key == PORT_PHY_ATTR_KEY))
                     {
-                        if(value == "enable" && !m_port_phy_attr_enabled)
+                        if(value == "enable")
                         {
-                            m_port_phy_attr_enabled = true;
-                            gPortsOrch->generatePortPhyAttrCounterMap();
+                            if (!m_port_phy_attr_enabled)
+                            {
+                                m_port_phy_attr_enabled = true;
+                                gPortsOrch->generatePortPhyAttrCounterMap();
+                            }
+                            if (!m_port_phy_serdes_attr_enabled)
+                            {
+                                m_port_phy_serdes_attr_enabled = true;
+                                gPortsOrch->generatePortPhySerdesAttrCounterMap();
+                            }
                         }
-                        if (value == "disable" && m_port_phy_attr_enabled)
+                        if (value == "disable")
                         {
-                            gPortsOrch->clearPortPhyAttrCounterMap();
-                            m_port_phy_attr_enabled = false;
+                            if (m_port_phy_attr_enabled)
+                            {
+                                gPortsOrch->clearPortPhyAttrCounterMap();
+                                m_port_phy_attr_enabled = false;
+                            }
+                            if (m_port_phy_serdes_attr_enabled)
+                            {
+                                gPortsOrch->clearPortPhySerdesAttrCounterMap();
+                                m_port_phy_serdes_attr_enabled = false;
+                            }
                         }
                     }
                     if (gSwitchOrch && (key == SWITCH_KEY) && (value == "enable"))
@@ -355,6 +378,11 @@ void FlexCounterOrch::doTask(Consumer &consumer)
                         {
                             setFlexCounterGroupOperation(flexCounterGroupMap[key], value, true);
                         }
+                    }
+                    // PORT_PHY_ATTR_KEY and PORT_PHY_SERDES_ATTR_KEY share the 'counterpoll phy' knob
+                    if (key == PORT_PHY_ATTR_KEY)
+                    {
+                        setFlexCounterGroupOperation(flexCounterGroupMap[PORT_PHY_SERDES_ATTR_KEY], value);
                     }
                 }
                 else
@@ -403,6 +431,11 @@ bool FlexCounterOrch::getPortCountersState() const
 bool FlexCounterOrch::getPortPhyAttrCounterState() const
 {
     return m_port_phy_attr_enabled;
+}
+
+bool FlexCounterOrch::getPortPhySerdesAttrCountersState() const
+{
+    return m_port_phy_serdes_attr_enabled;
 }
 
 bool FlexCounterOrch::getPortBufferDropCountersState() const

--- a/orchagent/flexcounterorch.h
+++ b/orchagent/flexcounterorch.h
@@ -58,6 +58,7 @@ public:
     virtual ~FlexCounterOrch(void);
     bool getPortCountersState() const;
     bool getPortPhyAttrCounterState() const;
+    bool getPortPhySerdesAttrCountersState() const;
     bool getPortBufferDropCountersState() const;
     bool getQueueCountersState() const;
     bool getQueueWatermarkCountersState() const;
@@ -76,6 +77,7 @@ private:
     void handleDeviceMetadataTable(Consumer &consumer);
     bool m_port_counter_enabled = false;
     bool m_port_phy_attr_enabled = false;
+    bool m_port_phy_serdes_attr_enabled = false;
     bool m_port_buffer_drop_counter_enabled = false;
     bool m_queue_enabled = false;
     bool m_queue_watermark_enabled = false;

--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -26,6 +26,7 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
       port_stat_manager(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ,
                         PORT_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS, true),
       port_phy_attr_manager(PORT_PHY_ATTR_FLEX_COUNTER_GROUP, StatsMode::READ, PORT_PHY_ATTR_FLEX_COUNTER_POLLING_INTERVAL_MS, false),
+      port_phy_serdes_attr_manager(PORT_PHY_SERDES_ATTR_FLEX_COUNTER_GROUP, StatsMode::READ, PORT_PHY_ATTR_FLEX_COUNTER_POLLING_INTERVAL_MS, false),
       port_buffer_drop_stat_manager(PORT_BUFFER_DROP_STAT_FLEX_COUNTER_GROUP, StatsMode::READ,
                                     PORT_BUFFER_DROP_STAT_POLLING_INTERVAL_MS, true),
       queue_stat_manager(QUEUE_STAT_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ, QUEUE_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS, false),

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4081,23 +4081,22 @@ void PortsOrch::registerPort(Port &p)
 
     /* Get Port Serdes Id of this port*/
     sai_object_id_t port_serdes_id = SAI_NULL_OBJECT_ID;
-    port_serdes_id = getPortSerdesIdFromPortId(p.m_port_id);
+    if (p.m_type == Port::Type::PHY) {
+        port_serdes_id = getPortSerdesIdFromPortId(p.m_port_id);
+    }
 
     /* Add port serdes to port mapping */
-    if (p.m_type == Port::Type::PHY)
+    if (port_serdes_id != SAI_NULL_OBJECT_ID)
     {
-        if (port_serdes_id != SAI_NULL_OBJECT_ID)
-        {
-            // Store in memory map
-            m_portIdToSerdesId[p.m_port_id] = port_serdes_id;
+        // Store in memory map
+        m_portIdToSerdesId[p.m_port_id] = port_serdes_id;
 
-            // Store in COUNTERS_DB
-            FieldValueTuple serdes_tuple(sai_serialize_object_id(port_serdes_id),
-                sai_serialize_object_id(p.m_port_id));
-            vector<FieldValueTuple> serdes_fields;
-            serdes_fields.push_back(serdes_tuple);
-            m_portSerdesIdToPortIdTable->set("", serdes_fields);
-        }
+        // Store in COUNTERS_DB
+        FieldValueTuple serdes_tuple(sai_serialize_object_id(port_serdes_id),
+            sai_serialize_object_id(p.m_port_id));
+        vector<FieldValueTuple> serdes_fields;
+        serdes_fields.push_back(serdes_tuple);
+        m_portSerdesIdToPortIdTable->set("", serdes_fields);
     }
 
     // Install a flex counter for this port to track stats

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -231,6 +231,12 @@ const vector<sai_port_attr_t> port_phy_attr_ids =
     SAI_PORT_ATTR_RX_SNR                // Receive Signal-to-Noise Ratio per lane
 };
 
+const vector<sai_port_serdes_attr_t> port_phy_serdes_attr_ids =
+{
+   SAI_PORT_SERDES_ATTR_RX_VGA,          // RX VGA setting values per lane
+   SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST // TX FIR tap values per lane
+};
+
 const vector<sai_port_stat_t> port_stat_ids =
 {
     SAI_PORT_STAT_IF_IN_OCTETS,
@@ -718,6 +724,7 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
         m_portOpErrTable(stateDb, STATE_PORT_OPER_ERR_TABLE_NAME),
         port_stat_manager(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ, PORT_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS, false),
         port_phy_attr_manager(PORT_PHY_ATTR_FLEX_COUNTER_GROUP, StatsMode::READ, PORT_PHY_ATTR_FLEX_COUNTER_POLLING_INTERVAL_MS, false),
+        port_phy_serdes_attr_manager(PORT_PHY_SERDES_ATTR_FLEX_COUNTER_GROUP, StatsMode::READ, PORT_PHY_ATTR_FLEX_COUNTER_POLLING_INTERVAL_MS, false),
         gb_port_stat_manager(true,
                 PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ,
                 PORT_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS, false),
@@ -731,6 +738,7 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
         counter_managers({
                 ref(port_stat_manager),
                 ref(port_phy_attr_manager),
+                ref(port_phy_serdes_attr_manager),
                 ref(port_buffer_drop_stat_manager),
                 ref(queue_stat_manager),
                 ref(queue_watermark_manager),
@@ -750,6 +758,7 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
     m_counterSysPortTable = unique_ptr<Table>(
                     new Table(m_counter_db.get(), COUNTERS_SYSTEM_PORT_NAME_MAP));
     m_counterLagTable = unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_LAG_NAME_MAP));
+    m_portSerdesIdToPortIdTable = unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_PORT_SERDES_ID_TO_PORT_ID_MAP));
     FieldValueTuple tuple("", "");
     vector<FieldValueTuple> defaultLagFv;
     defaultLagFv.push_back(tuple);
@@ -1082,6 +1091,9 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
 
     /* Query PORT_PHY_ATTR capabilities */
     queryPortPhyAttrCapabilities();
+
+    /* Query PORT_PHY_SERDES_ATTR capabilities */
+    queryPortPhySerdesAttrCapabilities();
 
     /* Initialize the stats capability in STATE_DB */
     initCounterCapabilities(gSwitchId);
@@ -4067,6 +4079,27 @@ void PortsOrch::registerPort(Port &p)
     fields.push_back(tuple);
     m_counterNameMapUpdater->setCounterNameMap(p.m_alias, p.m_port_id);
 
+    /* Get Port Serdes Id of this port*/
+    sai_object_id_t port_serdes_id = SAI_NULL_OBJECT_ID;
+    port_serdes_id = getPortSerdesIdFromPortId(p.m_port_id);
+
+    /* Add port serdes to port mapping */
+    if (p.m_type == Port::Type::PHY)
+    {
+        if (port_serdes_id != SAI_NULL_OBJECT_ID)
+        {
+            // Store in memory map
+            m_portIdToSerdesId[p.m_port_id] = port_serdes_id;
+
+            // Store in COUNTERS_DB
+            FieldValueTuple serdes_tuple(sai_serialize_object_id(port_serdes_id),
+                sai_serialize_object_id(p.m_port_id));
+            vector<FieldValueTuple> serdes_fields;
+            serdes_fields.push_back(serdes_tuple);
+            m_portSerdesIdToPortIdTable->set("", serdes_fields);
+        }
+    }
+
     // Install a flex counter for this port to track stats
     auto flex_counters_orch = gDirectory.get<FlexCounterOrch*>();
     /* Delay installing the counters if they are yet enabled
@@ -4096,6 +4129,19 @@ void PortsOrch::registerPort(Port &p)
             }
         }
     }
+
+    if (flex_counters_orch->getPortPhySerdesAttrCountersState())
+    {
+        if (!m_supported_phy_serdes_attrs.empty() &&
+            p.m_type == Port::Type::PHY &&
+            port_serdes_id != SAI_NULL_OBJECT_ID &&
+            supportsPortPhySerdesAttr(port_serdes_id, p.m_alias.c_str()))
+        {
+            auto port_attr_serdes_stats = generateCounterStats(m_supported_phy_serdes_attrs, sai_serialize_port_serdes_attr);
+            port_phy_serdes_attr_manager.setCounterIdList(port_serdes_id, CounterType::PORT_PHY_SERDES_ATTR, port_attr_serdes_stats);
+        }
+    }
+
     if (flex_counters_orch->getPortBufferDropCountersState())
     {
         auto port_buffer_drop_stats = generateCounterStats(port_buffer_drop_stat_ids, sai_serialize_port_stat);
@@ -4207,6 +4253,22 @@ void PortsOrch::deInitPort(string alias, sai_object_id_t port_id)
         {
             port_phy_attr_manager.clearCounterIdList(p.m_port_id);
         }
+    }
+
+    /* Get port serdes id for this port from local cached map */
+    sai_object_id_t port_serdes_id = SAI_NULL_OBJECT_ID;
+    auto it = m_portIdToSerdesId.find(p.m_port_id);
+    if (it != m_portIdToSerdesId.end())
+    {
+        port_serdes_id = it->second;
+    }
+
+    if (!m_supported_phy_serdes_attrs.empty() &&
+        p.m_type == Port::Type::PHY &&
+        port_serdes_id != SAI_NULL_OBJECT_ID &&
+        supportsPortPhySerdesAttr(port_serdes_id, p.m_alias.c_str()))
+    {
+        port_phy_serdes_attr_manager.clearCounterIdList(port_serdes_id);
     }
 
     /* remove port name map from counter table */
@@ -9142,6 +9204,163 @@ const std::vector<sai_port_attr_t>& PortsOrch::getPortPhyAttrIds() const
     return port_phy_attr_ids;
 }
 
+sai_object_id_t PortsOrch::getPortSerdesIdFromPortId(sai_object_id_t port_id)
+{
+    sai_attribute_t port_attr;
+
+    port_attr.id = SAI_PORT_ATTR_PORT_SERDES_ID;
+    sai_status_t status = sai_port_api->get_port_attribute(port_id, 1, &port_attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to get port serdes ID for port 0x%" PRIx64 " (status=%d)", port_id, status);
+        return SAI_NULL_OBJECT_ID;
+    }
+
+    return port_attr.value.oid;
+}
+
+void PortsOrch::queryPortPhySerdesAttrCapabilities()
+{
+    for (const auto& attr_id : port_phy_serdes_attr_ids)
+    {
+        sai_attr_capability_t capability;
+
+        sai_status_t status = sai_query_attribute_capability(
+            gSwitchId,
+            SAI_OBJECT_TYPE_PORT_SERDES,
+            attr_id,
+            &capability
+        );
+
+        auto meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_PORT_SERDES, attr_id);
+        std::string attr_id_str = std::to_string(attr_id);
+        const char* attr_name = meta ? meta->attridname : attr_id_str.c_str();
+
+        if (status == SAI_STATUS_SUCCESS && capability.get_implemented)
+        {
+            m_supported_phy_serdes_attrs.push_back(attr_id);
+            SWSS_LOG_NOTICE("PORT_PHY_SERDES_ATTR: Attribute %s is SUPPORTED for GET",
+                            attr_name);
+        }
+        else
+        {
+            SWSS_LOG_NOTICE("PORT_PHY_SERDES_ATTR: Attribute %s is NOT supported (status=%d, get_implemented=%d)",
+                            attr_name, status, capability.get_implemented);
+        }
+    }
+}
+
+bool PortsOrch::supportsPortPhySerdesAttr(sai_object_id_t port_serdes_id, const char* port_name)
+{
+    sai_status_t status;
+    sai_attribute_t test_attr;
+
+    // Check SAI_PORT_SERDES_ATTR_RX_VGA
+    test_attr.id = SAI_PORT_SERDES_ATTR_RX_VGA;
+    test_attr.value.u32list.count = 0;
+    test_attr.value.u32list.list = nullptr;
+
+    status = sai_port_api->get_port_serdes_attribute(port_serdes_id, 1, &test_attr);
+    if (status != SAI_STATUS_BUFFER_OVERFLOW)
+    {
+        SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Port %s does not support SAI_PORT_SERDES_ATTR_RX_VGA attribute (status=%d)",
+            port_name, status);
+        return false; 
+    }
+
+    // Check SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST
+    test_attr.id = SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST;
+    test_attr.value.portserdestaps.count = 0;
+    test_attr.value.portserdestaps.list = nullptr;
+
+    status = sai_port_api->get_port_serdes_attribute(port_serdes_id, 1, &test_attr);
+    if (status != SAI_STATUS_BUFFER_OVERFLOW)
+    {
+        SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Port %s does not support SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST attribute (status=%d)",
+            port_name, status);
+        return false;
+    }
+
+    return true;
+  }
+
+void PortsOrch::generatePortPhySerdesAttrCounterMap()
+{
+    if (m_supported_phy_serdes_attrs.empty())
+    {
+        SWSS_LOG_WARN("PORT_PHY_SERDES_ATTR: No PORT SERDES attributes supported on this platform");
+        return;
+    }
+
+    auto port_serdes_attr_stats = generateCounterStats(m_supported_phy_serdes_attrs, sai_serialize_port_serdes_attr);
+
+    for (const auto& it: m_portList)
+    {
+        if (it.second.m_type == Port::Type::PHY)
+        {
+            const char *port_name = it.second.m_alias.c_str();
+            sai_object_id_t port_id = it.second.m_port_id;
+            sai_object_id_t port_serdes_id = SAI_NULL_OBJECT_ID;
+
+            // Get the port_serdes_id from local map.
+            auto iter = m_portIdToSerdesId.find(port_id);
+            if (iter != m_portIdToSerdesId.end())
+            {
+               port_serdes_id = iter->second;
+            }
+
+            if (port_serdes_id == SAI_NULL_OBJECT_ID)
+            {
+                SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Port %s has no serdes object", port_name);
+                continue;
+            }
+
+            if (supportsPortPhySerdesAttr(port_serdes_id, port_name))
+            {
+                SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Setting counter ID list for port %s", port_name);
+                port_phy_serdes_attr_manager.setCounterIdList(port_serdes_id,
+                    CounterType::PORT_PHY_SERDES_ATTR, port_serdes_attr_stats);
+            }
+         }
+    }
+}
+
+void PortsOrch::clearPortPhySerdesAttrCounterMap()
+{
+    for (const auto& it: m_portList)
+    {
+        // Clear counter stats only for PHY ports that were previously configured
+        if (it.second.m_type != Port::Type::PHY)
+        {
+            continue;
+        }
+
+        sai_object_id_t port_id = it.second.m_port_id;
+        sai_object_id_t port_serdes_id = SAI_NULL_OBJECT_ID;
+
+        // Get the port_serdes_id from local map.
+        auto iter = m_portIdToSerdesId.find(port_id);
+        if (iter != m_portIdToSerdesId.end())
+        {
+            port_serdes_id = iter->second;
+        }
+
+        if (port_serdes_id == SAI_NULL_OBJECT_ID)
+        {
+            SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Port %s has no serdes object", it.second.m_alias.c_str());
+            continue;
+        }
+
+        SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Clearing counter ID list for port %s", it.second.m_alias.c_str());
+        port_phy_serdes_attr_manager.clearCounterIdList(port_serdes_id);
+    }
+}
+
+const std::vector<sai_port_serdes_attr_t>& PortsOrch::getPortPhySerdesAttrIds() const
+{
+    return port_phy_serdes_attr_ids;
+}
+
 /****
 *  Func Name  : generateWredPortCounterMap
 *  Parameters : None
@@ -9805,6 +10024,7 @@ bool PortsOrch::setPortSerdesAttribute(sai_object_id_t port_id, sai_object_id_t 
     sai_attribute_t port_serdes_attr;
     sai_status_t status;
     sai_object_id_t port_serdes_id = SAI_NULL_OBJECT_ID;
+    auto flex_counters_orch = gDirectory.get<FlexCounterOrch*>();
 
     port_attr.id = SAI_PORT_ATTR_PORT_SERDES_ID;
     status = sai_port_api->get_port_attribute(port_id, 1, &port_attr);
@@ -9830,6 +10050,24 @@ bool PortsOrch::setPortSerdesAttribute(sai_object_id_t port_id, sai_object_id_t 
             if (handle_status != task_success)
             {
                 return parseHandleSaiStatusFailure(handle_status);
+            }
+        }
+        else
+        {
+            // Remove old mapping from memory map
+            m_portIdToSerdesId.erase(port_id);
+
+            // Remove old mapping from COUNTERS_DB
+            m_portSerdesIdToPortIdTable->hdel("", sai_serialize_object_id(port_attr.value.oid));
+            SWSS_LOG_INFO("Removed old COUNTERS_PORT_SERDES_ID_TO_PORT_ID_MAP entry: serdes_id:0x%" PRIx64,
+                         port_attr.value.oid);
+
+            //clear the phy port serdes countersIDList
+            Port p;
+            if (getPort(port_id, p) && p.m_type == Port::Type::PHY &&
+                flex_counters_orch->getPortPhySerdesAttrCountersState())
+            {
+                port_phy_serdes_attr_manager.clearCounterIdList(port_attr.value.oid);
             }
         }
     }
@@ -9865,6 +10103,28 @@ bool PortsOrch::setPortSerdesAttribute(sai_object_id_t port_id, sai_object_id_t 
         }
     }
     SWSS_LOG_NOTICE("Created port serdes object 0x%" PRIx64 " for port 0x%" PRIx64, port_serdes_id, port_id);
+
+    // Add new mapping to memory map
+    m_portIdToSerdesId[port_id] = port_serdes_id;
+
+    // Add new mapping to COUNTERS_DB
+    FieldValueTuple serdes_tuple(sai_serialize_object_id(port_serdes_id), sai_serialize_object_id(port_id));
+    vector<FieldValueTuple> serdes_fields;
+    serdes_fields.push_back(serdes_tuple);
+    m_portSerdesIdToPortIdTable->set("", serdes_fields);
+    SWSS_LOG_DEBUG("Added COUNTERS_PORT_SERDES_ID_TO_PORT_ID_MAP: serdes_id:0x%" PRIx64 " -> port_id:0x%" PRIx64, port_serdes_id, port_id);
+
+    // update port-serdes-id counterIdList if applicable.
+    Port p;
+    if (flex_counters_orch->getPortPhySerdesAttrCountersState() &&
+        !m_supported_phy_serdes_attrs.empty() &&
+        getPort(port_id, p) && p.m_type == Port::Type::PHY &&
+        supportsPortPhySerdesAttr(port_serdes_id, p.m_alias.c_str()))
+    {
+            auto port_attr_serdes_stats = generateCounterStats(m_supported_phy_serdes_attrs, sai_serialize_port_serdes_attr);
+            port_phy_serdes_attr_manager.setCounterIdList(port_serdes_id,
+                    CounterType::PORT_PHY_SERDES_ATTR, port_attr_serdes_stats);
+    }
 
     return true;
 }
@@ -9926,6 +10186,12 @@ void PortsOrch::removePortSerdesAttribute(sai_object_id_t port_id)
             handleSaiRemoveStatus(SAI_API_PORT, status);
             return;
         }
+        // Remove mapping from memory map
+        m_portIdToSerdesId.erase(port_id);
+        // Remove mapping from COUNTERS_DB
+        m_portSerdesIdToPortIdTable->hdel("", sai_serialize_object_id(port_attr.value.oid));
+        SWSS_LOG_INFO("Removed COUNTERS_PORT_SERDES_ID_TO_PORT_ID_MAP entry: serdes_id:0x%" PRIx64 " -> port_id:0x%" PRIx64,
+                     port_attr.value.oid, port_id);
     }
     SWSS_LOG_NOTICE("Removed port serdes object 0x%" PRIx64 " for port 0x%" PRIx64, port_serdes_id, port_id);
 }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4119,11 +4119,12 @@ void PortsOrch::registerPort(Port &p)
     }
     if (flex_counters_orch->getPortPhyAttrCounterState())
     {
-        if (!m_supported_phy_attrs.empty())
+        if (!m_supported_phy_attrs.empty() && p.m_type == Port::Type::PHY)
         {
-            if (p.m_type == Port::Type::PHY && verifyPortSupportsAllPhyAttr(p.m_port_id, p.m_alias.c_str()))
+            auto supported_attrs = getPortPhySupportedAttrs(p.m_port_id, p.m_alias.c_str());
+            if (!supported_attrs.empty())
             {
-                auto port_phy_attr_stats = generateCounterStats(m_supported_phy_attrs, sai_serialize_port_attr);
+                auto port_phy_attr_stats = generateCounterStats(supported_attrs, sai_serialize_port_attr);
                 port_phy_attr_manager.setCounterIdList(p.m_port_id,
                         CounterType::PORT_PHY_ATTR, port_phy_attr_stats);
             }
@@ -4134,11 +4135,14 @@ void PortsOrch::registerPort(Port &p)
     {
         if (!m_supported_phy_serdes_attrs.empty() &&
             p.m_type == Port::Type::PHY &&
-            port_serdes_id != SAI_NULL_OBJECT_ID &&
-            supportsPortPhySerdesAttr(port_serdes_id, p.m_alias.c_str()))
+            port_serdes_id != SAI_NULL_OBJECT_ID)
         {
-            auto port_attr_serdes_stats = generateCounterStats(m_supported_phy_serdes_attrs, sai_serialize_port_serdes_attr);
-            port_phy_serdes_attr_manager.setCounterIdList(port_serdes_id, CounterType::PORT_PHY_SERDES_ATTR, port_attr_serdes_stats);
+            auto supported_attrs = getPortPhySerdesSupportedAttrs(port_serdes_id, p.m_alias.c_str());
+            if (!supported_attrs.empty())
+            {
+                auto port_attr_serdes_stats = generateCounterStats(supported_attrs, sai_serialize_port_serdes_attr);
+                port_phy_serdes_attr_manager.setCounterIdList(port_serdes_id, CounterType::PORT_PHY_SERDES_ATTR, port_attr_serdes_stats);
+            }
         }
     }
 
@@ -4247,12 +4251,9 @@ void PortsOrch::deInitPort(string alias, sai_object_id_t port_id)
     {
         wred_port_stat_manager.clearCounterIdList(p.m_port_id);
     }
-    if (!m_supported_phy_attrs.empty())
+    if (!m_supported_phy_attrs.empty() && p.m_type == Port::Type::PHY)
     {
-        if (p.m_type == Port::Type::PHY && verifyPortSupportsAllPhyAttr(p.m_port_id, p.m_alias.c_str()))
-        {
-            port_phy_attr_manager.clearCounterIdList(p.m_port_id);
-        }
+        port_phy_attr_manager.clearCounterIdList(p.m_port_id);
     }
 
     /* Get port serdes id for this port from local cached map */
@@ -4265,8 +4266,7 @@ void PortsOrch::deInitPort(string alias, sai_object_id_t port_id)
 
     if (!m_supported_phy_serdes_attrs.empty() &&
         p.m_type == Port::Type::PHY &&
-        port_serdes_id != SAI_NULL_OBJECT_ID &&
-        supportsPortPhySerdesAttr(port_serdes_id, p.m_alias.c_str()))
+        port_serdes_id != SAI_NULL_OBJECT_ID)
     {
         port_phy_serdes_attr_manager.clearCounterIdList(port_serdes_id);
     }
@@ -9107,57 +9107,67 @@ void PortsOrch::queryPortPhyAttrCapabilities()
     }
 }
 
-bool PortsOrch::verifyPortSupportsAllPhyAttr(sai_object_id_t port_id, const char* port_name)
+std::vector<sai_port_attr_t> PortsOrch::getPortPhySupportedAttrs(sai_object_id_t port_id, const char* port_name)
 {
-    // Verify port supports ALL SERDES attributes
-    // Query with count=0 to check if attribute is supported (expect BUFFER_OVERFLOW)
+    std::vector<sai_port_attr_t> supported_attrs;
 
-    // Check RX_SIGNAL_DETECT
-    sai_attribute_t port_attr;
-    port_attr.id = SAI_PORT_ATTR_RX_SIGNAL_DETECT;
-    port_attr.value.portlanelatchstatuslist.count = 0;
-    port_attr.value.portlanelatchstatuslist.list = nullptr;
+    // Lambda function to check attribute support and handle logging
+    auto checkPortPhyAttrSupport = [&](sai_attribute_t& port_attr, const char* attr_name) {
+        sai_status_t status = sai_port_api->get_port_attribute(port_id, 1, &port_attr);
+        if (status == SAI_STATUS_BUFFER_OVERFLOW)
+        {
+            supported_attrs.push_back(static_cast<sai_port_attr_t>(port_attr.id));
+            SWSS_LOG_DEBUG("PORT_PHY_ATTR: Port %s supports %s attribute",
+                           port_name, attr_name);
+        }
+        else
+        {
+            SWSS_LOG_NOTICE("PORT_PHY_ATTR: Port %s does not support %s attribute (status=%d)",
+                          port_name, attr_name, status);
+        }
+    };
 
-    sai_status_t status = sai_port_api->get_port_attribute(port_id, 1, &port_attr);
-    if (status != SAI_STATUS_BUFFER_OVERFLOW)
+    // Iterate through platform-supported attributes and check if this port supports them
+    for (const auto& attr_id : m_supported_phy_attrs)
     {
-        SWSS_LOG_NOTICE("PORT_PHY_ATTR: Port %s does not support RX_SIGNAL_DETECT attribute (status=%d)",
-                      port_name, status);
-        return false;
+        sai_attribute_t port_attr;
+        switch (attr_id)
+        {
+            case SAI_PORT_ATTR_RX_SIGNAL_DETECT:
+            {
+                port_attr.id = SAI_PORT_ATTR_RX_SIGNAL_DETECT;
+                port_attr.value.portlanelatchstatuslist.count = 0;
+                port_attr.value.portlanelatchstatuslist.list = nullptr;
+                checkPortPhyAttrSupport(port_attr, "SAI_PORT_ATTR_RX_SIGNAL_DETECT");
+                break;
+            }
+
+            case SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK:
+            {
+                port_attr.id = SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK;
+                port_attr.value.portlanelatchstatuslist.count = 0;
+                port_attr.value.portlanelatchstatuslist.list = nullptr;
+                checkPortPhyAttrSupport(port_attr, "SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK");
+                break;
+            }
+
+            case SAI_PORT_ATTR_RX_SNR:
+            {
+                port_attr.id = SAI_PORT_ATTR_RX_SNR;
+                port_attr.value.portsnrlist.count = 0;
+                port_attr.value.portsnrlist.list = nullptr;
+                checkPortPhyAttrSupport(port_attr, "SAI_PORT_ATTR_RX_SNR");
+                break;
+            }
+
+            default:
+                SWSS_LOG_WARN("PORT_PHY_ATTR: Unknown attribute %d in m_supported_phy_attrs for port %s",
+                    attr_id, port_name);
+                break;
+        }
     }
-    SWSS_LOG_DEBUG("PORT_PHY_ATTR: Port %s supports RX_SIGNAL_DETECT attribute (count=%d)",
-                   port_name, port_attr.value.portlanelatchstatuslist.count);
 
-    // Check FEC_ALIGNMENT_LOCK
-    port_attr.id = SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK;
-    port_attr.value.portlanelatchstatuslist.count = 0;
-    port_attr.value.portlanelatchstatuslist.list = nullptr;
-
-    status = sai_port_api->get_port_attribute(port_id, 1, &port_attr);
-    if (status != SAI_STATUS_BUFFER_OVERFLOW)
-    {
-        SWSS_LOG_NOTICE("PORT_PHY_ATTR: Port %s does not support FEC_ALIGNMENT_LOCK attribute (status=%d)",
-                      port_name, status);
-        return false;
-    }
-    SWSS_LOG_DEBUG("PORT_PHY_ATTR: Port %s supports FEC_ALIGNMENT_LOCK attribute (count=%d)",
-                   port_name, port_attr.value.portlanelatchstatuslist.count);
-
-    // Check RX_SNR
-    port_attr.id = SAI_PORT_ATTR_RX_SNR;
-    port_attr.value.portsnrlist.count = 0;
-    port_attr.value.portsnrlist.list = nullptr;
-
-    status = sai_port_api->get_port_attribute(port_id, 1, &port_attr);
-    if (status != SAI_STATUS_BUFFER_OVERFLOW)
-    {
-        SWSS_LOG_NOTICE("PORT_PHY_ATTR: Port %s does not support RX_SNR attribute (status=%d)",
-                      port_name, status);
-        return false;
-    }
-    SWSS_LOG_DEBUG("PORT_PHY_ATTR: Port %s supports RX_SNR attribute (count=%d)",
-                   port_name, port_attr.value.portsnrlist.count);
-    return true;
+    return supported_attrs;
 }
 
 void PortsOrch::generatePortPhyAttrCounterMap()
@@ -9168,17 +9178,20 @@ void PortsOrch::generatePortPhyAttrCounterMap()
         return;
     }
 
-    auto port_phy_attr_stats = generateCounterStats(m_supported_phy_attrs, sai_serialize_port_attr);
-
     for (const auto& it: m_portList)
     {
-        if (it.second.m_type == Port::Type::PHY && verifyPortSupportsAllPhyAttr(it.second.m_port_id, it.second.m_alias.c_str()))
+        if (it.second.m_type == Port::Type::PHY)
         {
-            SWSS_LOG_DEBUG("PORT_PHY_ATTR: Setting counter ID list for port %s",
-                          it.second.m_alias.c_str());
+            auto supported_attrs = getPortPhySupportedAttrs(it.second.m_port_id, it.second.m_alias.c_str());
+            if (!supported_attrs.empty())
+            {
+                auto port_phy_attr_stats = generateCounterStats(supported_attrs, sai_serialize_port_attr);
+                SWSS_LOG_DEBUG("PORT_PHY_ATTR: Setting counter ID list for port %s",
+                              it.second.m_alias.c_str());
 
-            port_phy_attr_manager.setCounterIdList(it.second.m_port_id,
-                    CounterType::PORT_PHY_ATTR, port_phy_attr_stats);
+                port_phy_attr_manager.setCounterIdList(it.second.m_port_id,
+                        CounterType::PORT_PHY_ATTR, port_phy_attr_stats);
+            }
         }
     }
 }
@@ -9250,38 +9263,58 @@ void PortsOrch::queryPortPhySerdesAttrCapabilities()
     }
 }
 
-bool PortsOrch::supportsPortPhySerdesAttr(sai_object_id_t port_serdes_id, const char* port_name)
+std::vector<sai_port_serdes_attr_t> PortsOrch::getPortPhySerdesSupportedAttrs(sai_object_id_t port_serdes_id, const char* port_name)
 {
-    sai_status_t status;
-    sai_attribute_t test_attr;
+    std::vector<sai_port_serdes_attr_t> supported_attrs;
 
-    // Check SAI_PORT_SERDES_ATTR_RX_VGA
-    test_attr.id = SAI_PORT_SERDES_ATTR_RX_VGA;
-    test_attr.value.u32list.count = 0;
-    test_attr.value.u32list.list = nullptr;
+    // Lambda function to check attribute support and handle logging
+    auto checkPortPhySerdesAttrSupport = [&](sai_attribute_t& test_attr, const char* attr_name) {
+        sai_status_t status = sai_port_api->get_port_serdes_attribute(port_serdes_id, 1, &test_attr);
+        if (status == SAI_STATUS_BUFFER_OVERFLOW)
+        {
+            supported_attrs.push_back(static_cast<sai_port_serdes_attr_t>(test_attr.id));
+            SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Port %s supports %s attribute",
+                port_name, attr_name);
+        }
+        else
+        {
+            SWSS_LOG_NOTICE("PORT_PHY_SERDES_ATTR: Port %s does not support %s attribute (status=%d)",
+                port_name, attr_name, status);
+        }
+    };
 
-    status = sai_port_api->get_port_serdes_attribute(port_serdes_id, 1, &test_attr);
-    if (status != SAI_STATUS_BUFFER_OVERFLOW)
+    // Iterate through platform-supported attributes and check if this port supports them
+    for (const auto& attr_id : m_supported_phy_serdes_attrs)
     {
-        SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Port %s does not support SAI_PORT_SERDES_ATTR_RX_VGA attribute (status=%d)",
-            port_name, status);
-        return false; 
+        sai_attribute_t test_attr;
+        switch (attr_id)
+        {
+            case SAI_PORT_SERDES_ATTR_RX_VGA:
+            {
+                test_attr.id = SAI_PORT_SERDES_ATTR_RX_VGA;
+                test_attr.value.u32list.count = 0;
+                test_attr.value.u32list.list = nullptr;
+                checkPortPhySerdesAttrSupport(test_attr, "SAI_PORT_SERDES_ATTR_RX_VGA");
+                break;
+            }
+
+            case SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST:
+            {
+                test_attr.id = SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST;
+                test_attr.value.portserdestaps.count = 0;
+                test_attr.value.portserdestaps.list = nullptr;
+                checkPortPhySerdesAttrSupport(test_attr, "SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST");
+                break;
+            }
+
+            default:
+                SWSS_LOG_WARN("PORT_PHY_SERDES_ATTR: Unknown attribute %d in m_supported_phy_serdes_attrs for port %s",
+                    attr_id, port_name);
+                break;
+        }
     }
 
-    // Check SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST
-    test_attr.id = SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST;
-    test_attr.value.portserdestaps.count = 0;
-    test_attr.value.portserdestaps.list = nullptr;
-
-    status = sai_port_api->get_port_serdes_attribute(port_serdes_id, 1, &test_attr);
-    if (status != SAI_STATUS_BUFFER_OVERFLOW)
-    {
-        SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Port %s does not support SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST attribute (status=%d)",
-            port_name, status);
-        return false;
-    }
-
-    return true;
+    return supported_attrs;
   }
 
 void PortsOrch::generatePortPhySerdesAttrCounterMap()
@@ -9291,8 +9324,6 @@ void PortsOrch::generatePortPhySerdesAttrCounterMap()
         SWSS_LOG_WARN("PORT_PHY_SERDES_ATTR: No PORT SERDES attributes supported on this platform");
         return;
     }
-
-    auto port_serdes_attr_stats = generateCounterStats(m_supported_phy_serdes_attrs, sai_serialize_port_serdes_attr);
 
     for (const auto& it: m_portList)
     {
@@ -9315,8 +9346,10 @@ void PortsOrch::generatePortPhySerdesAttrCounterMap()
                 continue;
             }
 
-            if (supportsPortPhySerdesAttr(port_serdes_id, port_name))
+            auto supported_attrs = getPortPhySerdesSupportedAttrs(port_serdes_id, port_name);
+            if (!supported_attrs.empty())
             {
+                auto port_serdes_attr_stats = generateCounterStats(supported_attrs, sai_serialize_port_serdes_attr);
                 SWSS_LOG_DEBUG("PORT_PHY_SERDES_ATTR: Setting counter ID list for port %s", port_name);
                 port_phy_serdes_attr_manager.setCounterIdList(port_serdes_id,
                     CounterType::PORT_PHY_SERDES_ATTR, port_serdes_attr_stats);
@@ -10118,12 +10151,15 @@ bool PortsOrch::setPortSerdesAttribute(sai_object_id_t port_id, sai_object_id_t 
     Port p;
     if (flex_counters_orch->getPortPhySerdesAttrCountersState() &&
         !m_supported_phy_serdes_attrs.empty() &&
-        getPort(port_id, p) && p.m_type == Port::Type::PHY &&
-        supportsPortPhySerdesAttr(port_serdes_id, p.m_alias.c_str()))
+        getPort(port_id, p) && p.m_type == Port::Type::PHY)
     {
-            auto port_attr_serdes_stats = generateCounterStats(m_supported_phy_serdes_attrs, sai_serialize_port_serdes_attr);
+        auto supported_attrs = getPortPhySerdesSupportedAttrs(port_serdes_id, p.m_alias.c_str());
+        if (!supported_attrs.empty())
+        {
+            auto port_attr_serdes_stats = generateCounterStats(supported_attrs, sai_serialize_port_serdes_attr);
             port_phy_serdes_attr_manager.setCounterIdList(port_serdes_id,
                     CounterType::PORT_PHY_SERDES_ATTR, port_attr_serdes_stats);
+        }
     }
 
     return true;

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -236,14 +236,14 @@ public:
     void clearPortPhyAttrCounterMap();
     const std::vector<sai_port_attr_t>& getPortPhyAttrIds() const;
     void queryPortPhyAttrCapabilities();
-    bool verifyPortSupportsAllPhyAttr(sai_object_id_t port_id, const char* port_name);
+    std::vector<sai_port_attr_t> getPortPhySupportedAttrs(sai_object_id_t port_id, const char* port_name);
 
     sai_object_id_t getPortSerdesIdFromPortId(sai_object_id_t port_id);
     void generatePortPhySerdesAttrCounterMap();
     void clearPortPhySerdesAttrCounterMap();
     const std::vector<sai_port_serdes_attr_t>& getPortPhySerdesAttrIds() const;
     void queryPortPhySerdesAttrCapabilities();
-    bool supportsPortPhySerdesAttr(sai_object_id_t port_serdes_id, const char* port_name);
+    std::vector<sai_port_serdes_attr_t> getPortPhySerdesSupportedAttrs(sai_object_id_t port_serdes_id, const char* port_name);
 
     void generateWredPortCounterMap();
     void generateWredQueueCounterMap();

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -30,6 +30,7 @@
 #define PORT_RATE_COUNTER_FLEX_COUNTER_GROUP "PORT_RATE_COUNTER"
 #define PORT_BUFFER_DROP_STAT_FLEX_COUNTER_GROUP "PORT_BUFFER_DROP_STAT"
 #define PORT_PHY_ATTR_FLEX_COUNTER_GROUP "PORT_PHY_ATTR"
+#define PORT_PHY_SERDES_ATTR_FLEX_COUNTER_GROUP "PORT_PHY_SERDES_ATTR"
 #define QUEUE_STAT_COUNTER_FLEX_COUNTER_GROUP "QUEUE_STAT_COUNTER"
 #define QUEUE_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP "QUEUE_WATERMARK_STAT_COUNTER"
 #define PG_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP "PG_WATERMARK_STAT_COUNTER"
@@ -142,6 +143,11 @@ namespace portphyattr_test
 class PortAttrTest;
 } // namespace portphyattr_test
 
+namespace portphyserdesattr_test
+{
+class PortSerdesAttrTest;
+} // namespace portphyserdesattr_test
+
 class PortsOrch : public Orch, public Subject
 {
 public:
@@ -232,6 +238,13 @@ public:
     void queryPortPhyAttrCapabilities();
     bool verifyPortSupportsAllPhyAttr(sai_object_id_t port_id, const char* port_name);
 
+    sai_object_id_t getPortSerdesIdFromPortId(sai_object_id_t port_id);
+    void generatePortPhySerdesAttrCounterMap();
+    void clearPortPhySerdesAttrCounterMap();
+    const std::vector<sai_port_serdes_attr_t>& getPortPhySerdesAttrIds() const;
+    void queryPortPhySerdesAttrCapabilities();
+    bool supportsPortPhySerdesAttr(sai_object_id_t port_serdes_id, const char* port_name);
+
     void generateWredPortCounterMap();
     void generateWredQueueCounterMap();
 
@@ -288,6 +301,7 @@ private:
     unique_ptr<CounterNameMapUpdater> m_counterNameMapUpdater;
     unique_ptr<Table> m_counterSysPortTable;
     unique_ptr<Table> m_counterLagTable;
+    unique_ptr<Table> m_portSerdesIdToPortIdTable;
     unique_ptr<Table> m_portTable;
     unique_ptr<Table> m_sendToIngressPortTable;
     unique_ptr<Table> m_systemPortTable;
@@ -316,6 +330,7 @@ private:
 
     FlexCounterTaggedCachedManager<void> port_stat_manager;
     FlexCounterTaggedCachedManager<void> port_phy_attr_manager;
+    FlexCounterTaggedCachedManager<void> port_phy_serdes_attr_manager;
     FlexCounterTaggedCachedManager<void> port_buffer_drop_stat_manager;
     FlexCounterTaggedCachedManager<sai_queue_type_t> queue_stat_manager;
     FlexCounterTaggedCachedManager<sai_queue_type_t> queue_watermark_manager;
@@ -334,6 +349,9 @@ private:
     std::map<sai_object_id_t, PortSupportedSpeeds> m_portSupportedSpeeds;
     // Supported FEC modes on the system side.
     std::map<sai_object_id_t, PortFecModeCapability_t> m_portSupportedFecModes;
+
+    // Port ID to Port Serdes ID mapping
+    std::map<sai_object_id_t, sai_object_id_t> m_portIdToSerdesId;
 
     bool m_initDone = false;
     bool m_isSendToIngressPortConfigured = false;
@@ -523,6 +541,8 @@ private:
 
     std::vector<sai_port_attr_t> m_supported_phy_attrs;
 
+    std::vector<sai_port_serdes_attr_t> m_supported_phy_serdes_attrs;
+
     bool isAutoNegEnabled(sai_object_id_t id);
     task_process_status setPortAutoNeg(Port &port, bool autoneg);
     task_process_status setPortUnreliableLOS(Port &port, bool enabled);
@@ -637,5 +657,6 @@ private:
 
     // Friend declaration for unit tests
     friend class portphyattr_test::PortAttrTest;
+    friend class portphyserdesattr_test::PortSerdesAttrTest;
 };
 #endif /* SWSS_PORTSORCH_H */

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -77,6 +77,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 stporch_ut.cpp \
                 flexcounter_ut.cpp \
                 portphyattr_ut.cpp \
+		portphyserdesattr_ut.cpp \
                 counternameupdater_ut.cpp \
                 mock_orch_test.cpp \
                 mock_dash_orch_test.cpp \

--- a/tests/mock_tests/portphyserdesattr_ut.cpp
+++ b/tests/mock_tests/portphyserdesattr_ut.cpp
@@ -1,0 +1,416 @@
+/**
+ * @file portphyserdesattr_ut.cpp
+ * @brief Unit tests for PORT_SERDES_ATTR flex counter orchestration
+ *
+ * Tests the end-to-end integration of PHY SERDES attribute collection from
+ * FlexCounterOrch through PortsOrch to the FlexCounter infrastructure.
+ */
+
+#include "ut_helper.h"
+#include "mock_orchagent_main.h"
+#include "mock_orch_test.h"
+#include "mock_table.h"
+
+#include <memory>
+#include <string>
+
+extern SwitchOrch *gSwitchOrch;
+extern PortsOrch *gPortsOrch;
+extern BufferOrch *gBufferOrch;
+
+namespace portphyserdesattr_test
+{
+    using namespace std;
+
+    // Mock flex counter infrastructure
+    shared_ptr<swss::DBConnector> mockFlexCounterDb;
+    shared_ptr<swss::Table> mockFlexCounterTable;
+    sai_switch_api_t ut_sai_switch_api;
+    sai_switch_api_t *pold_sai_switch_api;
+    sai_port_api_t ut_sai_port_api;
+    sai_port_api_t *pold_sai_port_api;
+
+    // Mock SAI get_port_serdes_attribute to simulate SERDES capability checks
+    sai_status_t _ut_stub_sai_get_port_serdes_attribute(
+        _In_ sai_object_id_t port_serdes_id,
+        _In_ uint32_t attr_count,
+        _Inout_ sai_attribute_t *attr_list)
+    {
+        // Simulate successful capability check by returning SAI_STATUS_BUFFER_OVERFLOW
+        // This indicates the attribute is supported but we need to know the buffer size
+        if (attr_count > 0)
+        {
+            if (attr_list[0].id == SAI_PORT_SERDES_ATTR_RX_VGA)
+            {
+                // Simulate that RX_VGA is supported with 4 lanes
+                attr_list[0].value.u32list.count = 4;
+                return SAI_STATUS_BUFFER_OVERFLOW;
+            }
+            else if (attr_list[0].id == SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST)
+            {
+                // Simulate that TX_FIR_TAPS_LIST is supported with 4 lanes
+                attr_list[0].value.portserdestaps.count = 4;
+                return SAI_STATUS_BUFFER_OVERFLOW;
+            }
+        }
+
+        // Call original implementation for other attributes
+        return pold_sai_port_api->get_port_serdes_attribute(port_serdes_id, attr_count, attr_list);
+    }
+
+    // Mock SAI set_switch_attribute to intercept flex counter operations
+    sai_status_t mockFlexCounterOperation(sai_object_id_t objectId, const sai_attribute_t *attr)
+    {
+        if (objectId != gSwitchId)
+        {
+            return SAI_STATUS_FAILURE;
+        }
+
+        auto *param = reinterpret_cast<sai_redis_flex_counter_parameter_t*>(attr->value.ptr);
+        std::vector<swss::FieldValueTuple> entries;
+        std::string key((const char*)param->counter_key.list);
+
+        // Extract group name and OID(s) from key (format: "GROUP_NAME:oid1,oid2,...")
+        auto delimiter = key.find_first_of(":");
+        if (delimiter == std::string::npos)
+        {
+            return SAI_STATUS_FAILURE;
+        }
+
+        std::string groupName = key.substr(0, delimiter);
+        std::string strOids = key.substr(delimiter + 1);
+
+        // Split OIDs by comma (mimics syncd behavior in Syncd.cpp:3144)
+        std::vector<std::string> oidVector;
+        size_t start = 0;
+        size_t end = strOids.find(',');
+        while (end != std::string::npos)
+        {
+            oidVector.push_back(strOids.substr(start, end - start));
+            start = end + 1;
+            end = strOids.find(',', start);
+        }
+        oidVector.push_back(strOids.substr(start));
+
+        if (param->counter_ids.list != nullptr)
+        {
+            entries.push_back({(const char*)param->counter_field_name.list, (const char*)param->counter_ids.list});
+
+            if (param->stats_mode.list != nullptr)
+            {
+                entries.push_back({STATS_MODE_FIELD, (const char*)param->stats_mode.list});
+            }
+
+            // Create individual entries for each OID (mimics syncd behavior in Syncd.cpp:3174-3177)
+            for (const auto& oid : oidVector)
+            {
+                std::string singleKey = groupName + ":" + oid;
+                mockFlexCounterTable->set(singleKey, entries);
+            }
+        }
+        else
+        {
+            // Delete individual entries for each OID
+            for (const auto& oid : oidVector)
+            {
+                std::string singleKey = groupName + ":" + oid;
+                mockFlexCounterTable->del(singleKey);
+            }
+        }
+
+        return SAI_STATUS_SUCCESS;
+    }
+
+    sai_status_t _ut_stub_sai_set_switch_attribute(sai_object_id_t switch_id, const sai_attribute_t *attr)
+    {
+        if (attr[0].id == SAI_REDIS_SWITCH_ATTR_FLEX_COUNTER)
+        {
+            return mockFlexCounterOperation(switch_id, attr);
+        }
+        return pold_sai_switch_api->set_switch_attribute(switch_id, attr);
+    }
+
+    void _hook_sai_switch_api()
+    {
+        mockFlexCounterDb = make_shared<swss::DBConnector>("FLEX_COUNTER_DB", 0);
+        mockFlexCounterTable = make_shared<swss::Table>(mockFlexCounterDb.get(), "FLEX_COUNTER_TABLE");
+
+        // Hook switch API for flex counter operations
+        ut_sai_switch_api = *sai_switch_api;
+        pold_sai_switch_api = sai_switch_api;
+        ut_sai_switch_api.set_switch_attribute = _ut_stub_sai_set_switch_attribute;
+        sai_switch_api = &ut_sai_switch_api;
+
+        // Hook port API for port serdes attribute capability checks
+        ut_sai_port_api = *sai_port_api;
+        pold_sai_port_api = sai_port_api;
+        ut_sai_port_api.get_port_serdes_attribute = _ut_stub_sai_get_port_serdes_attribute;
+        sai_port_api = &ut_sai_port_api;
+    }
+
+    void _unhook_sai_switch_api()
+    {
+        sai_switch_api = pold_sai_switch_api;
+        sai_port_api = pold_sai_port_api;
+    }
+
+    struct PortSerdesAttrTest : public ::testing::Test
+    {
+        PortSerdesAttrTest() {}
+
+        void SetUp() override
+        {
+            ::testing_db::reset();
+
+            // Initialize database connections
+            m_app_db = make_shared<swss::DBConnector>("APPL_DB", 0);
+            m_config_db = make_shared<swss::DBConnector>("CONFIG_DB", 0);
+            m_state_db = make_shared<swss::DBConnector>("STATE_DB", 0);
+            m_chassis_app_db = make_shared<swss::DBConnector>("CHASSIS_APP_DB", 0);
+            m_counters_db = make_shared<swss::DBConnector>("COUNTERS_DB", 0);
+
+            // Create SwitchOrch dependencies
+            // Required for SAI switch initialization in the mock environment
+            TableConnector stateDbSwitchTable(m_state_db.get(), "SWITCH_CAPABILITY");
+            TableConnector app_switch_table(m_app_db.get(), APP_SWITCH_TABLE_NAME);
+            TableConnector conf_asic_sensors(m_config_db.get(), CFG_ASIC_SENSORS_TABLE_NAME);
+
+            vector<TableConnector> switch_tables = {
+                conf_asic_sensors,
+                app_switch_table
+            };
+
+            ASSERT_EQ(gSwitchOrch, nullptr);
+            gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
+
+            // Create PortsOrch with all required table dependencies
+            const int portsorch_base_pri = 40;
+            vector<table_name_with_pri_t> port_tables = {
+                { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },                // Physical port config (highest priority)
+                { APP_SEND_TO_INGRESS_PORT_TABLE_NAME, portsorch_base_pri + 5 }, // Ingress port forwarding
+                { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },                // VLAN configuration
+                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },             // VLAN membership (lowest priority)
+                { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },                 // Link aggregation groups
+                { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }               // LAG membership
+            };
+
+            ASSERT_EQ(gPortsOrch, nullptr);
+            gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), port_tables, m_chassis_app_db.get());
+
+            vector<string> flex_counter_tables = {CFG_FLEX_COUNTER_TABLE_NAME};
+            m_flexCounterOrch = new FlexCounterOrch(m_config_db.get(), flex_counter_tables);
+
+            // Register FlexCounterOrch in gDirectory for PortsOrch to access via gDirectory.get<FlexCounterOrch*>()
+            gDirectory.set(m_flexCounterOrch);
+
+            // Create BufferOrch - required by PortsOrch for port initialization
+            vector<string> buffer_tables = { APP_BUFFER_POOL_TABLE_NAME,
+                                             APP_BUFFER_PROFILE_TABLE_NAME,
+                                             APP_BUFFER_QUEUE_TABLE_NAME,
+                                             APP_BUFFER_PG_TABLE_NAME,
+                                             APP_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME,
+                                             APP_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME };
+            gBufferOrch = new BufferOrch(m_app_db.get(), m_config_db.get(), m_state_db.get(), buffer_tables);
+
+            // Initialize ports using SAI default ports
+            Table portTable(m_app_db.get(), APP_PORT_TABLE_NAME);
+            auto ports = ut_helper::getInitialSaiPorts();
+            for (const auto &it : ports)
+            {
+                portTable.set(it.first, it.second);
+            }
+
+            // Set PortConfigDone
+            portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+            gPortsOrch->addExistingData(&portTable);
+            static_cast<Orch *>(gPortsOrch)->doTask();
+
+            // Signal that port initialization is complete
+            portTable.set("PortInitDone", { { "lanes", "0" } });
+            gPortsOrch->addExistingData(&portTable);
+            static_cast<Orch *>(gPortsOrch)->doTask();
+        }
+
+        void TearDown() override
+        {
+            ::testing_db::reset();
+
+            gDirectory.m_values.clear();
+
+            delete m_flexCounterOrch;
+            m_flexCounterOrch = nullptr;
+
+            delete gBufferOrch;
+            gBufferOrch = nullptr;
+
+            delete gPortsOrch;
+            gPortsOrch = nullptr;
+
+            delete gSwitchOrch;
+            gSwitchOrch = nullptr;
+        }
+
+        static void SetUpTestCase()
+        {
+            // Initialize the SAI virtual switch environment for unit testing
+            map<string, string> profile = {
+                { "SAI_VS_SWITCH_TYPE", "SAI_VS_SWITCH_TYPE_BCM56850" },  // Simulate Broadcom switch
+                { "KV_DEVICE_MAC_ADDRESS", "20:03:04:05:06:00" }         // Test MAC address
+            };
+
+            // Initialize the SAI API with virtual switch support
+            auto status = ut_helper::initSaiApi(profile);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            sai_attribute_t attr;
+
+            // Create the virtual switch instance
+            attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+            attr.value.booldata = true;
+            status = sai_switch_api->create_switch(&gSwitchId, 1, &attr);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            // Hook SAI switch API to intercept flex counter operations
+            _hook_sai_switch_api();
+        }
+
+        static void TearDownTestCase()
+        {
+            _unhook_sai_switch_api();
+
+            auto status = sai_switch_api->remove_switch(gSwitchId);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+            gSwitchId = 0;
+
+            ut_helper::uninitSaiApi();
+        }
+
+
+        shared_ptr<swss::DBConnector> m_app_db;
+        shared_ptr<swss::DBConnector> m_config_db;
+        shared_ptr<swss::DBConnector> m_state_db;
+        shared_ptr<swss::DBConnector> m_chassis_app_db;
+        shared_ptr<swss::DBConnector> m_counters_db;
+        shared_ptr<swss::DBConnector> m_flex_counter_db;
+
+        FlexCounterOrch* m_flexCounterOrch = nullptr;
+    };
+
+    /**
+     * PORT_SERDES_ATTR flex counter enable/disable via doTask
+     */
+    TEST_F(PortSerdesAttrTest, EnablePortSerdesAttrFlexCounterDoTask)
+    {
+        ASSERT_NE(m_flexCounterOrch, nullptr);
+        ASSERT_NE(gPortsOrch, nullptr);
+
+        bool initialState = m_flexCounterOrch->getPortPhySerdesAttrCountersState();
+        EXPECT_FALSE(initialState);
+
+        auto consumer = dynamic_cast<Consumer *>(m_flexCounterOrch->getExecutor(CFG_FLEX_COUNTER_TABLE_NAME));
+        ASSERT_NE(consumer, nullptr);
+
+        Table flexCounterTable(m_config_db.get(), CFG_FLEX_COUNTER_TABLE_NAME);
+        vector<FieldValueTuple> fvs;
+        fvs.push_back(FieldValueTuple("FLEX_COUNTER_STATUS", "enable"));
+        fvs.push_back(FieldValueTuple("POLL_INTERVAL", "1000"));
+        flexCounterTable.set("PORT_PHY_ATTR", fvs);
+        std::cout << " CONFIG_DB configured: FLEX_COUNTER_STATUS=enable, POLL_INTERVAL=1000" << std::endl;
+
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({"PORT_PHY_ATTR", "SET", {
+            {"FLEX_COUNTER_STATUS", "enable"},
+            {"POLL_INTERVAL", "1000"}
+        }});
+
+        consumer->addToSync(entries);
+        static_cast<Orch *>(m_flexCounterOrch)->doTask(*consumer);
+
+        bool state = m_flexCounterOrch->getPortPhySerdesAttrCountersState();
+        EXPECT_TRUE(state);
+        std::cout << " PORT_PHY_SERDES_ATTR enablement verified: state = " << (state ? "ENABLED" : "DISABLED") << std::endl;
+
+        entries.clear();
+        entries.push_back({"PORT_PHY_ATTR", "SET", {{"FLEX_COUNTER_STATUS", "disable"}}});
+
+        consumer->addToSync(entries);
+        static_cast<Orch *>(m_flexCounterOrch)->doTask(*consumer);
+
+        bool disabledState = m_flexCounterOrch->getPortPhySerdesAttrCountersState();
+        EXPECT_FALSE(disabledState);
+        std::cout << " PORT_PHY_SERDES_ATTR disablement verified: state = " << (disabledState ? "ENABLED" : "DISABLED") << std::endl;
+    }
+
+    TEST_F(PortSerdesAttrTest, QueryPortSerdesAttrCapabilitiesWithMockedSAI)
+    {
+        ASSERT_NE(gPortsOrch, nullptr);
+
+	// queryPortPhySerdesAttrCapabilities() is called  in PortsOrch Contructor
+        ASSERT_FALSE(gPortsOrch->m_supported_phy_serdes_attrs.empty());
+
+        for (const auto& attr : gPortsOrch->m_supported_phy_serdes_attrs)
+        {
+            EXPECT_TRUE(attr == SAI_PORT_SERDES_ATTR_RX_VGA ||
+                       attr == SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST);
+        }
+    }
+
+    TEST_F(PortSerdesAttrTest, VerifyFlexCountersDBEntriesAfterGenerate)
+    {
+        ASSERT_NE(gPortsOrch, nullptr);
+
+        auto flexCounterDb = make_shared<swss::DBConnector>("FLEX_COUNTER_DB", 0);
+        auto flexCounterTable = make_shared<swss::Table>(flexCounterDb.get(), "FLEX_COUNTER_TABLE");
+
+        gPortsOrch->generatePortPhySerdesAttrCounterMap();
+
+        // Flush cached flex counters to trigger the mock SAI API which writes to FLEX_COUNTER_DB
+        gPortsOrch->flushCounters();
+
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+
+        sai_object_id_t port_serdes_id = gPortsOrch->getPortSerdesIdFromPortId(port.m_port_id);
+
+        if (port_serdes_id == SAI_NULL_OBJECT_ID)
+        {
+            SUCCEED() << "Port does not have a valid SERDES ID, skipping verification";
+            return;
+        }
+
+        if (!gPortsOrch->supportsPortPhySerdesAttr(port_serdes_id, port.m_alias.c_str()))
+        {
+            SUCCEED();
+            return;
+        }
+
+        std::string key = "PORT_PHY_SERDES_ATTR:" + sai_serialize_object_id(port_serdes_id);
+
+        std::vector<FieldValueTuple> fieldValues;
+        bool entryExists = flexCounterTable->get(key, fieldValues);
+
+	EXPECT_TRUE(entryExists);
+
+        if (entryExists)
+        {
+            bool foundCounterList = false;
+            for (const auto &fv : fieldValues)
+            {
+                if (fvField(fv) == "PORT_PHY_SERDES_ATTR_ID_LIST")
+                {
+                    foundCounterList = true;
+                    std::string counterList = fvValue(fv);
+                    EXPECT_TRUE(counterList.find("SAI_PORT_SERDES_ATTR_RX_VGA") != std::string::npos);
+                    EXPECT_TRUE(counterList.find("SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST") != std::string::npos);
+                }
+            }
+            EXPECT_TRUE(foundCounterList);
+        }
+
+        gPortsOrch->clearPortPhySerdesAttrCounterMap();
+        fieldValues.clear();
+        bool entryExistsAfterClear = flexCounterTable->get(key, fieldValues);
+        EXPECT_FALSE(entryExistsAfterClear);
+    }
+} // namespace portphyserdesattr_test
+

--- a/tests/mock_tests/portphyserdesattr_ut.cpp
+++ b/tests/mock_tests/portphyserdesattr_ut.cpp
@@ -30,6 +30,9 @@ namespace portphyserdesattr_test
     sai_port_api_t ut_sai_port_api;
     sai_port_api_t *pold_sai_port_api;
 
+    // Test mode flag for partial attribute support testing
+    bool g_test_partial_support_mode = false;
+
     // Mock SAI get_port_serdes_attribute to simulate SERDES capability checks
     sai_status_t _ut_stub_sai_get_port_serdes_attribute(
         _In_ sai_object_id_t port_serdes_id,
@@ -48,6 +51,12 @@ namespace portphyserdesattr_test
             }
             else if (attr_list[0].id == SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST)
             {
+                // In partial support mode, simulate TX_FIR_TAPS_LIST as NOT supported
+                if (g_test_partial_support_mode)
+                {
+                    return SAI_STATUS_NOT_SUPPORTED;
+                }
+
                 // Simulate that TX_FIR_TAPS_LIST is supported with 4 lanes
                 attr_list[0].value.portserdestaps.count = 4;
                 return SAI_STATUS_BUFFER_OVERFLOW;
@@ -378,7 +387,8 @@ namespace portphyserdesattr_test
             return;
         }
 
-        if (!gPortsOrch->supportsPortPhySerdesAttr(port_serdes_id, port.m_alias.c_str()))
+        auto supported_attrs = gPortsOrch->getPortPhySerdesSupportedAttrs(port_serdes_id, port.m_alias.c_str());
+        if (supported_attrs.empty())
         {
             SUCCEED();
             return;
@@ -411,6 +421,74 @@ namespace portphyserdesattr_test
         fieldValues.clear();
         bool entryExistsAfterClear = flexCounterTable->get(key, fieldValues);
         EXPECT_FALSE(entryExistsAfterClear);
+    }
+
+    TEST_F(PortSerdesAttrTest, PartialAttributeSupport_OnlyRxVgaSupported)
+    {
+        ASSERT_NE(gPortsOrch, nullptr);
+
+        // Enable partial support mode: only RX_VGA supported, TX_FIR_TAPS_LIST not supported
+        g_test_partial_support_mode = true;
+
+        auto flexCounterDb = make_shared<swss::DBConnector>("FLEX_COUNTER_DB", 0);
+        auto flexCounterTable = make_shared<swss::Table>(flexCounterDb.get(), "FLEX_COUNTER_TABLE");
+
+        // Generate counter map with partial support
+        gPortsOrch->generatePortPhySerdesAttrCounterMap();
+
+        // Flush cached flex counters to trigger the mock SAI API which writes to FLEX_COUNTER_DB
+        gPortsOrch->flushCounters();
+
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+
+        sai_object_id_t port_serdes_id = gPortsOrch->getPortSerdesIdFromPortId(port.m_port_id);
+
+        if (port_serdes_id == SAI_NULL_OBJECT_ID)
+        {
+            g_test_partial_support_mode = false;
+            SUCCEED() << "Port does not have a valid SERDES ID, skipping verification";
+            return;
+        }
+
+        // Verify that only RX_VGA is in the supported list
+        auto supported_attrs = gPortsOrch->getPortPhySerdesSupportedAttrs(port_serdes_id, port.m_alias.c_str());
+        EXPECT_FALSE(supported_attrs.empty());
+        EXPECT_EQ(supported_attrs.size(), 1);
+        EXPECT_EQ(supported_attrs[0], SAI_PORT_SERDES_ATTR_RX_VGA);
+
+        std::string key = "PORT_PHY_SERDES_ATTR:" + sai_serialize_object_id(port_serdes_id);
+
+        std::vector<FieldValueTuple> fieldValues;
+        bool entryExists = flexCounterTable->get(key, fieldValues);
+
+        EXPECT_TRUE(entryExists);
+
+        if (entryExists)
+        {
+            bool foundCounterList = false;
+            for (const auto &fv : fieldValues)
+            {
+                if (fvField(fv) == "PORT_PHY_SERDES_ATTR_ID_LIST")
+                {
+                    foundCounterList = true;
+                    std::string counterList = fvValue(fv);
+
+                    // Should contain RX_VGA
+                    EXPECT_TRUE(counterList.find("SAI_PORT_SERDES_ATTR_RX_VGA") != std::string::npos);
+
+                    // Should NOT contain TX_FIR_TAPS_LIST
+                    EXPECT_TRUE(counterList.find("SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST") == std::string::npos);
+
+                    std::cout << "Partial support verified: counter list = " << counterList << std::endl;
+                }
+            }
+            EXPECT_TRUE(foundCounterList);
+        }
+
+        // Cleanup
+        gPortsOrch->clearPortPhySerdesAttrCounterMap();
+        g_test_partial_support_mode = false;
     }
 } // namespace portphyserdesattr_test
 

--- a/tests/mock_tests/portphyserdesattr_ut.cpp
+++ b/tests/mock_tests/portphyserdesattr_ut.cpp
@@ -33,6 +33,20 @@ namespace portphyserdesattr_test
     // Test mode flag for partial attribute support testing
     bool g_test_partial_support_mode = false;
 
+    // RAII guard to ensure g_test_partial_support_mode is always restored
+    class PartialSupportModeGuard
+    {
+    public:
+        PartialSupportModeGuard()
+        {
+            g_test_partial_support_mode = true;
+        }
+        ~PartialSupportModeGuard()
+        {
+            g_test_partial_support_mode = false;
+        }
+    };
+
     // Mock SAI get_port_serdes_attribute to simulate SERDES capability checks
     sai_status_t _ut_stub_sai_get_port_serdes_attribute(
         _In_ sai_object_id_t port_serdes_id,
@@ -354,7 +368,7 @@ namespace portphyserdesattr_test
     {
         ASSERT_NE(gPortsOrch, nullptr);
 
-	// queryPortPhySerdesAttrCapabilities() is called  in PortsOrch Contructor
+	// queryPortPhySerdesAttrCapabilities() is called  in PortsOrch Constructor
         ASSERT_FALSE(gPortsOrch->m_supported_phy_serdes_attrs.empty());
 
         for (const auto& attr : gPortsOrch->m_supported_phy_serdes_attrs)
@@ -428,7 +442,7 @@ namespace portphyserdesattr_test
         ASSERT_NE(gPortsOrch, nullptr);
 
         // Enable partial support mode: only RX_VGA supported, TX_FIR_TAPS_LIST not supported
-        g_test_partial_support_mode = true;
+        PartialSupportModeGuard partialSupportGuard;
 
         auto flexCounterDb = make_shared<swss::DBConnector>("FLEX_COUNTER_DB", 0);
         auto flexCounterTable = make_shared<swss::Table>(flexCounterDb.get(), "FLEX_COUNTER_TABLE");
@@ -446,7 +460,6 @@ namespace portphyserdesattr_test
 
         if (port_serdes_id == SAI_NULL_OBJECT_ID)
         {
-            g_test_partial_support_mode = false;
             SUCCEED() << "Port does not have a valid SERDES ID, skipping verification";
             return;
         }
@@ -488,7 +501,6 @@ namespace portphyserdesattr_test
 
         // Cleanup
         gPortsOrch->clearPortPhySerdesAttrCounterMap();
-        g_test_partial_support_mode = false;
     }
 } // namespace portphyserdesattr_test
 


### PR DESCRIPTION
**What I did**
1 - Added logic to read "CONFIG_DB :: FLEX_COUNTER_TABLE|PORT_PHY_ATTR" changes in flexcounterorch dotask method. 
This is added so as to read the changes made by cli knob "counterpoll phy enable/disable/interval" It calls PortsOrch->generatePortSerdesAttributeCounterMap.

2 - Added logic to add Port Phy Serdes Attribute Counter Map for each port.
This implements the logic to add Port Phy Serdes Attributes per port in the FLEX_COUNTER_DB in the following format :
FLEX_COUNTER_DB :: FLEX_COUNTER_TABLE:PORT_PHY_SERDES_ATTR: -> {'PORT_SERDES_ATTR_ID_LIST':<attrs>''} 
(it is expected that syncd reads these changes later and enable counter polling for these attributes for each port) example:

ex:
`$ sudo sonic-db-cli FLEX_COUNTER_DB hgetall "FLEX_COUNTER_TABLE:PORT_PHY_SERDES_ATTR:oid:0x1000000000017" {'PORT_PHY_SERDES_ATTR_ID_LIST': 'SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST,SAI_PORT_SERDES_ATTR_RX_VGA'}`

3 - Added logic to keep a table map, COUNTERS_PORT_SERDES_ID_TO_PORT_ID, in COUNTERS_DB to keep a track of port_serdes_vid -> port_vid mapping.

4 - Added unit tests to test the above changes.

**Why I did it**
These changes are brought in sonic-swss to support the collection of following attributes: 
1 - SAI_PORT_SERDES_ATTR_RX_VGA (type : sai_u32_list_t) 
2 - SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST (type : sai_taps_list_t) (both under sai_port_serdes_attr_)

**How I verified it**
Manual testing - 
1) Enabled phy counterpolling :  `$counterpoll phy enable`
2) Verified FLEX_COUNTER_DB has FLEX_COUNTER_GROUP_TABLE:PORT_PHY_SERDES_ATTR with correct interval and details and status enabled, and has "FLEX_COUNTER_TABLE:PORT_PHY_SERDES_ATTR:oid:<PORT SERDES VID>" correctly poppulated with correct attr id list.
```
$ sudo sonic-db-cli FLEX_COUNTER_DB hgetall "FLEX_COUNTER_GROUP_TABLE:PORT_PHY_SERDES_ATTR"
{'POLL_INTERVAL': '10000', 'STATS_MODE': 'STATS_MODE_READ', 'FLEX_COUNTER_STATUS': 'enable'}

$ sudo sonic-db-cli FLEX_COUNTER_DB hgetall "FLEX_COUNTER_TABLE:PORT_PHY_SERDES_ATTR:oid:0x5700000000049a"
{'PORT_PHY_SERDES_ATTR_ID_LIST': 'SAI_PORT_SERDES_ATTR_TX_FIR_TAPS_LIST,SAI_PORT_SERDES_ATTR_RX_VGA'}
```
3) Verified COUNTERS_PORT_SERDES_ID_TO_PORT_ID_MAP is poppulated in COUNTERS_DB:
```
$ sudo sonic-db-cli COUNTERS_DB hgetall "COUNTERS_PORT_SERDES_ID_TO_PORT_ID_MAP"
{'oid:0x5700000000018f': 'oid:0x1000000000007', 'oid:0x570000000001b8': 'oid:0x1000000000008',  ... }
```
4) Verify DB is cleared when phy counterpoll is disabled.