### PR TITLE
[P4Orch] Make room for new 'no_action' in the L3MulticastManager

### DIFF
--- a/orchagent/p4orch/l3_multicast_manager.cpp
+++ b/orchagent/p4orch/l3_multicast_manager.cpp
@@ -432,7 +432,9 @@ L3MulticastManager::deserializeMulticastRouterInterfaceEntry(
     const auto& field = fvField(it);
     const auto& value = fvValue(it);
     if (field == p4orch::kAction) {
-      if (value != p4orch::kSetMulticastSrcMac) {
+      if (value == p4orch::kSetMulticastSrcMac || value == p4orch::kNoAction) {
+        router_interface_entry.action = value;
+      } else {
         return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
                << "Unexpected action " << QuotedVar(value) << " in "
                << APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME;
@@ -808,50 +810,120 @@ ReturnCode L3MulticastManager::validateDelMulticastGroupEntry(
   return ReturnCode();
 }
 
+ReturnCode L3MulticastManager::validateL3SetMulticastRouterInterfaceEntry(
+    const P4MulticastRouterInterfaceEntry& multicast_router_interface_entry,
+    const P4MulticastRouterInterfaceEntry* router_interface_entry_ptr) {
+  // Confirm RIF had SAI object ID.
+  if (router_interface_entry_ptr->router_interface_oid ==
+      SAI_OBJECT_TYPE_NULL) {
+    return ReturnCode(StatusCode::SWSS_RC_NOT_FOUND)
+           << "RIF was not assigned before updating multicast router "
+              "interface "
+              "entry with keys "
+           << QuotedVar(
+                  multicast_router_interface_entry.multicast_replica_port)
+           << " and "
+           << QuotedVar(multicast_router_interface_entry
+                            .multicast_replica_instance);
+  }
+
+  // Confirm we have a reference to the RIF object ID.
+  if (m_rifOidToRouterInterfaceEntries.find(
+          router_interface_entry_ptr->router_interface_oid) ==
+      m_rifOidToRouterInterfaceEntries.end()) {
+    return ReturnCode(StatusCode::SWSS_RC_NOT_FOUND)
+           << "Expected RIF OID is missing from map: "
+           << router_interface_entry_ptr->router_interface_oid;
+  }
+
+  // Confirm the RIF object ID exists in central mapper.
+  std::string rif_key = KeyGenerator::generateMulticastRouterInterfaceRifKey(
+      router_interface_entry_ptr->multicast_replica_port,
+      router_interface_entry_ptr->src_mac);
+  bool exist_in_mapper =
+      m_p4OidMapper->existsOID(SAI_OBJECT_TYPE_ROUTER_INTERFACE, rif_key);
+  if (!exist_in_mapper) {
+    return ReturnCode(StatusCode::SWSS_RC_NOT_FOUND)
+           << "Multicast router interface entry exists in manager but RIF "
+              "does "
+              "not exist in the centralized map";
+  }
+  return ReturnCode();
+}
+
+ReturnCode L3MulticastManager::validateL2SetMulticastRouterInterfaceEntry(
+    const P4MulticastRouterInterfaceEntry& multicast_router_interface_entry,
+    const P4MulticastRouterInterfaceEntry* router_interface_entry_ptr) {
+  // TODO: This needs to be implemented.
+  return ReturnCode(StatusCode::SWSS_RC_UNIMPLEMENTED);
+}
+
 ReturnCode L3MulticastManager::validateSetMulticastRouterInterfaceEntry(
     const P4MulticastRouterInterfaceEntry& multicast_router_interface_entry) {
   auto* router_interface_entry_ptr = getMulticastRouterInterfaceEntry(
       multicast_router_interface_entry.multicast_router_interface_entry_key);
 
+  // Confirm action is populated.
+  if (multicast_router_interface_entry.action.empty()) {
+    return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
+           << "Multicast router interface entry did not specify an action.";
+  }
+
   bool is_update_operation = router_interface_entry_ptr != nullptr;
   if (is_update_operation) {
-    // Confirm RIF had SAI object ID.
-    if (router_interface_entry_ptr->router_interface_oid ==
-        SAI_OBJECT_TYPE_NULL) {
-      return ReturnCode(StatusCode::SWSS_RC_NOT_FOUND)
-             << "RIF was not assigned before updating multicast router "
-                "interface "
-                "entry with keys "
-             << QuotedVar(
-                    multicast_router_interface_entry.multicast_replica_port)
-             << " and "
-             << QuotedVar(multicast_router_interface_entry
-                              .multicast_replica_instance);
+    // Confirm action did not change.
+    if (multicast_router_interface_entry.action !=
+        router_interface_entry_ptr->action) {
+      return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
+             << "Multicast router interface entry with key "
+             << QuotedVar(multicast_router_interface_entry.multicast_router_interface_entry_key)
+             << " cannot change action from "
+             << QuotedVar(router_interface_entry_ptr->action)
+             << " to " << QuotedVar(multicast_router_interface_entry.action);
     }
 
-    // Confirm we have a reference to the RIF object ID.
-    if (m_rifOidToRouterInterfaceEntries.find(
-            router_interface_entry_ptr->router_interface_oid) ==
-        m_rifOidToRouterInterfaceEntries.end()) {
-      return ReturnCode(StatusCode::SWSS_RC_NOT_FOUND)
-             << "Expected RIF OID is missing from map: "
-             << router_interface_entry_ptr->router_interface_oid;
-    }
-
-    // Confirm the RIF object ID exists in central mapper.
-    std::string rif_key = KeyGenerator::generateMulticastRouterInterfaceRifKey(
-        router_interface_entry_ptr->multicast_replica_port,
-        router_interface_entry_ptr->src_mac);
-    bool exist_in_mapper =
-        m_p4OidMapper->existsOID(SAI_OBJECT_TYPE_ROUTER_INTERFACE, rif_key);
-    if (!exist_in_mapper) {
-      return ReturnCode(StatusCode::SWSS_RC_NOT_FOUND)
-             << "Multicast router interface entry exists in manager but RIF "
-                "does "
-                "not exist in the centralized map";
+    if (multicast_router_interface_entry.action == p4orch::kSetMulticastSrcMac) {
+      return validateL3SetMulticastRouterInterfaceEntry(
+          multicast_router_interface_entry, router_interface_entry_ptr);
+    } else {
+      return validateL2SetMulticastRouterInterfaceEntry(
+          multicast_router_interface_entry, router_interface_entry_ptr);
     }
   }
   // No additional validation required for add operation.
+  return ReturnCode();
+}
+
+ReturnCode L3MulticastManager::validateL2DelMulticastRouterInterfaceEntry(
+    const P4MulticastRouterInterfaceEntry& multicast_router_interface_entry,
+    const P4MulticastRouterInterfaceEntry* router_interface_entry_ptr) {
+  // TODO: This needs to be implemented.
+  return ReturnCode(StatusCode::SWSS_RC_UNIMPLEMENTED);
+}
+
+ReturnCode L3MulticastManager::validateL3DelMulticastRouterInterfaceEntry(
+    const P4MulticastRouterInterfaceEntry& multicast_router_interface_entry,
+    const P4MulticastRouterInterfaceEntry* router_interface_entry_ptr) {
+
+  // Confirm we have a reference to the RIF object ID.
+  if (m_rifOidToRouterInterfaceEntries.find(
+          router_interface_entry_ptr->router_interface_oid) ==
+      m_rifOidToRouterInterfaceEntries.end()) {
+    return ReturnCode(StatusCode::SWSS_RC_NOT_FOUND)
+           << "Expected RIF OID is missing from map: "
+           << router_interface_entry_ptr->router_interface_oid;
+  }
+
+  // Confirm the RIF object ID exists in central mapper.
+  std::string rif_key = KeyGenerator::generateMulticastRouterInterfaceRifKey(
+      multicast_router_interface_entry.multicast_replica_port,
+      router_interface_entry_ptr
+          ->src_mac);  // No attributes provided on delete.
+  if (!m_p4OidMapper->existsOID(SAI_OBJECT_TYPE_ROUTER_INTERFACE, rif_key)) {
+    RETURN_INTERNAL_ERROR_AND_RAISE_CRITICAL(
+        "Multicast router interface entry does not exist in the central map");
+  }
+
   return ReturnCode();
 }
 
@@ -866,23 +938,14 @@ ReturnCode L3MulticastManager::validateDelMulticastRouterInterfaceEntry(
            << "Multicast router interface entry exists does not exist";
   }
 
-  // Confirm we have a reference to the RIF object ID.
-  if (m_rifOidToRouterInterfaceEntries.find(
-          router_interface_entry_ptr->router_interface_oid) ==
-      m_rifOidToRouterInterfaceEntries.end()) {
-    return ReturnCode(StatusCode::SWSS_RC_NOT_FOUND)
-           << "Expected RIF OID is missing from map: "
-           << router_interface_entry_ptr->router_interface_oid;
+  if (router_interface_entry_ptr->action == p4orch::kSetMulticastSrcMac) {
+    return validateL3DelMulticastRouterInterfaceEntry(
+        multicast_router_interface_entry, router_interface_entry_ptr);
+  } else {
+    return validateL2DelMulticastRouterInterfaceEntry(
+        multicast_router_interface_entry, router_interface_entry_ptr);
   }
 
-  // Confirm the RIF object ID exists in central mapper.
-  std::string rif_key = KeyGenerator::generateMulticastRouterInterfaceRifKey(
-      multicast_router_interface_entry.multicast_replica_port,
-      router_interface_entry_ptr->src_mac);  // No attributes provided on delete.
-  if (!m_p4OidMapper->existsOID(SAI_OBJECT_TYPE_ROUTER_INTERFACE, rif_key)) {
-    RETURN_INTERNAL_ERROR_AND_RAISE_CRITICAL(
-        "Multicast router interface entry does not exist in the central map");
-  }
   return ReturnCode();
 }
 
@@ -1936,6 +1999,8 @@ std::string L3MulticastManager::verifyMulticastRouterInterfaceStateCache(
         << " in l3 multicast manager.";
     return msg.str();
   }
+  // Note: action is checked for differences in the
+  // validateMulticastRouterInterfaceEntry function.
   if (multicast_router_interface_entry->src_mac.to_string() !=
       app_db_entry.src_mac.to_string()) {
     std::stringstream msg;
@@ -1954,15 +2019,31 @@ std::string L3MulticastManager::verifyMulticastRouterInterfaceStateCache(
         << " in l3 multicast manager.";
     return msg.str();
   }
-  std::string rif_key = KeyGenerator::generateMulticastRouterInterfaceRifKey(
-      multicast_router_interface_entry->multicast_replica_port,
-      multicast_router_interface_entry->src_mac);
-  return m_p4OidMapper->verifyOIDMapping(
-      SAI_OBJECT_TYPE_ROUTER_INTERFACE, rif_key,
-      multicast_router_interface_entry->router_interface_oid);
+
+  if (multicast_router_interface_entry->action == p4orch::kSetMulticastSrcMac) {
+    std::string rif_key = KeyGenerator::generateMulticastRouterInterfaceRifKey(
+        multicast_router_interface_entry->multicast_replica_port,
+        multicast_router_interface_entry->src_mac);
+    return m_p4OidMapper->verifyOIDMapping(
+        SAI_OBJECT_TYPE_ROUTER_INTERFACE, rif_key,
+        multicast_router_interface_entry->router_interface_oid);
+  } else {
+    return "SWSS_RC_UNIMPLEMENTED";
+  }
 }
 
 std::string L3MulticastManager::verifyMulticastRouterInterfaceStateAsicDb(
+    const P4MulticastRouterInterfaceEntry* multicast_router_interface_entry) {
+  if (multicast_router_interface_entry->action == p4orch::kSetMulticastSrcMac) {
+    return verifyL3MulticastRouterInterfaceStateAsicDb(
+        multicast_router_interface_entry);
+  } else {
+    return verifyL2MulticastRouterInterfaceStateAsicDb(
+        multicast_router_interface_entry);
+  }
+}
+
+std::string L3MulticastManager::verifyL3MulticastRouterInterfaceStateAsicDb(
     const P4MulticastRouterInterfaceEntry* multicast_router_interface_entry) {
   auto attrs_or = prepareRifSaiAttrs(*multicast_router_interface_entry);
   if (!attrs_or.ok()) {
@@ -1990,10 +2071,15 @@ std::string L3MulticastManager::verifyMulticastRouterInterfaceStateAsicDb(
                      /*allow_unknown=*/false);
 }
 
+std::string L3MulticastManager::verifyL2MulticastRouterInterfaceStateAsicDb(
+    const P4MulticastRouterInterfaceEntry* multicast_router_interface_entry) {
+  // TODO: This needs to be implemented.
+  return "SWSS_RC_UNIMPLEMENTED";
+}
+
 std::string L3MulticastManager::verifyMulticastGroupStateCache(
     const P4MulticastGroupEntry& app_db_entry,
     const P4MulticastGroupEntry* multicast_group_entry) {
-
   ReturnCode status = validateMulticastGroupEntry(app_db_entry,
                                                   SET_COMMAND);
   if (!status.ok()) {

--- a/orchagent/p4orch/l3_multicast_manager.h
+++ b/orchagent/p4orch/l3_multicast_manager.h
@@ -27,6 +27,7 @@ struct P4MulticastRouterInterfaceEntry {
   std::string multicast_replica_port;
   std::string multicast_replica_instance;
   swss::MacAddress src_mac;
+  std::string action;
   std::string multicast_metadata;
   sai_object_id_t router_interface_oid = SAI_OBJECT_TYPE_NULL;
 
@@ -34,10 +35,12 @@ struct P4MulticastRouterInterfaceEntry {
   P4MulticastRouterInterfaceEntry(const std::string& port,
                                   const std::string& instance,
                                   const swss::MacAddress& mac,
+                                  const std::string& action,
                                   const std::string& metadata)
       : multicast_replica_port(port),
         multicast_replica_instance(instance),
         src_mac(mac),
+        action(action),
         multicast_metadata(metadata) {}
 };
 
@@ -48,10 +51,10 @@ struct P4Replica {
   std::string key;
 
   P4Replica() = default;
-  P4Replica(const std::string& group_id,
-            const std::string& port_name,
+  P4Replica(const std::string& group_id, const std::string& port_name,
             const std::string& instance_number)
-      : multicast_group_id(group_id), port(port_name),
+      : multicast_group_id(group_id),
+        port(port_name),
         instance(instance_number) {
     key = group_id + ":" + port_name + ":" + instance_number;
   }
@@ -79,7 +82,7 @@ typedef std::unordered_map<std::string, P4MulticastRouterInterfaceEntry>
 
 // P4MulticastGroupTable: multicast group ID, P4MulticastGroupEntry
 typedef std::unordered_map<std::string, P4MulticastGroupEntry>
-P4MulticastGroupTable;
+    P4MulticastGroupTable;
 
 // The L3MulticastManager handles updates to two P4 tables:
 // * The "fixed" table multicast_router_interface_table, which defines a single
@@ -125,8 +128,7 @@ class L3MulticastManager : public ObjectManagerInterface {
       const std::vector<swss::FieldValueTuple>& attributes);
 
   // Converts db table entry into P4MulticastGroupEntry.
-  ReturnCodeOr<P4MulticastGroupEntry>
-  deserializeMulticastGroupEntry(
+  ReturnCodeOr<P4MulticastGroupEntry> deserializeMulticastGroupEntry(
       const std::string& key,
       const std::vector<swss::FieldValueTuple>& attributes);
 
@@ -142,6 +144,19 @@ class L3MulticastManager : public ObjectManagerInterface {
   // Performs multicast router interface entry validation for DEL command.
   ReturnCode validateDelMulticastRouterInterfaceEntry(
       const P4MulticastRouterInterfaceEntry& multicast_router_interface_entry);
+
+  ReturnCode validateL3SetMulticastRouterInterfaceEntry(
+      const P4MulticastRouterInterfaceEntry& multicast_router_interface_entry,
+      const P4MulticastRouterInterfaceEntry* router_interface_entry_ptr);
+  ReturnCode validateL2SetMulticastRouterInterfaceEntry(
+      const P4MulticastRouterInterfaceEntry& multicast_router_interface_entry,
+      const P4MulticastRouterInterfaceEntry* router_interface_entry_ptr);
+  ReturnCode validateL3DelMulticastRouterInterfaceEntry(
+      const P4MulticastRouterInterfaceEntry& multicast_router_interface_entry,
+      const P4MulticastRouterInterfaceEntry* router_interface_entry_ptr);
+  ReturnCode validateL2DelMulticastRouterInterfaceEntry(
+      const P4MulticastRouterInterfaceEntry& multicast_router_interface_entry,
+      const P4MulticastRouterInterfaceEntry* router_interface_entry_ptr);
 
   // Performs multicast group entry validation.
   ReturnCode validateMulticastGroupEntry(
@@ -220,11 +235,9 @@ class L3MulticastManager : public ObjectManagerInterface {
       const std::vector<P4MulticastGroupEntry>& entries);
 
   std::string verifyMulticastRouterInterfaceState(
-      const std::string& key,
-      const std::vector<swss::FieldValueTuple>& tuple);
+      const std::string& key, const std::vector<swss::FieldValueTuple>& tuple);
   std::string verifyMulticastGroupState(
-      const std::string& key,
-      const std::vector<swss::FieldValueTuple>& tuple);
+      const std::string& key, const std::vector<swss::FieldValueTuple>& tuple);
 
   // Verifies internal cache for a multicast router interface entry.
   std::string verifyMulticastRouterInterfaceStateCache(
@@ -237,6 +250,10 @@ class L3MulticastManager : public ObjectManagerInterface {
 
   // Verifies ASIC DB for a multicast router interface entry.
   std::string verifyMulticastRouterInterfaceStateAsicDb(
+      const P4MulticastRouterInterfaceEntry* multicast_router_interface_entry);
+  std::string verifyL3MulticastRouterInterfaceStateAsicDb(
+      const P4MulticastRouterInterfaceEntry* multicast_router_interface_entry);
+  std::string verifyL2MulticastRouterInterfaceStateAsicDb(
       const P4MulticastRouterInterfaceEntry* multicast_router_interface_entry);
   // Verifies ASIC DB for a multicast group entry.
   std::string verifyMulticastGroupStateAsicDb(

--- a/orchagent/p4orch/p4orch_util.h
+++ b/orchagent/p4orch/p4orch_util.h
@@ -60,6 +60,7 @@ constexpr char *kSetIpNexthop = "set_ip_nexthop";
 constexpr char* kSetIpNexthopAndDisableRewrites =
     "set_ip_nexthop_and_disable_rewrites";
 constexpr char *kSetTunnelNexthop = "set_p2p_tunnel_encap_nexthop";
+constexpr char* kNoAction = "no_action";
 constexpr char *kDrop = "drop";
 constexpr char *kTrap = "trap";
 constexpr char *kStage = "stage";

--- a/orchagent/p4orch/tests/l3_multicast_manager_test.cpp
+++ b/orchagent/p4orch/tests/l3_multicast_manager_test.cpp
@@ -107,11 +107,13 @@ class L3MulticastManagerTest : public ::testing::Test {
       const std::string& multicast_replica_port,
       const std::string& multicast_replica_instance,
       const swss::MacAddress src_mac,
-      const std::string& multicast_metadata = "") {
+      const std::string& multicast_metadata = "",
+      const std::string& action = p4orch::kSetMulticastSrcMac) {
     P4MulticastRouterInterfaceEntry router_interface_entry = {};
     router_interface_entry.multicast_replica_port = multicast_replica_port;
     router_interface_entry.multicast_replica_instance =
         multicast_replica_instance;
+    router_interface_entry.action = action;
     router_interface_entry.src_mac = src_mac;
     router_interface_entry.multicast_metadata = multicast_metadata;
     router_interface_entry.multicast_router_interface_entry_key =
@@ -299,6 +301,18 @@ class L3MulticastManagerTest : public ::testing::Test {
         app_db_entry, multicast_router_interface_entry);
   }
 
+  std::string VerifyMulticastRouterInterfaceStateAsicDb(
+      const P4MulticastRouterInterfaceEntry* multicast_router_interface_entry) {
+    return l3_multicast_manager_.verifyMulticastRouterInterfaceStateAsicDb(
+        multicast_router_interface_entry);
+  }
+
+  std::string VerifyL2MulticastRouterInterfaceStateAsicDb(
+      const P4MulticastRouterInterfaceEntry* multicast_router_interface_entry) {
+    return l3_multicast_manager_.verifyL2MulticastRouterInterfaceStateAsicDb(
+        multicast_router_interface_entry);
+  }
+
   std::string VerifyMulticastGroupStateCache(
       const P4MulticastGroupEntry& app_db_entry,
       const P4MulticastGroupEntry* multicast_group_entry) {
@@ -332,6 +346,20 @@ class L3MulticastManagerTest : public ::testing::Test {
       const std::string& operation) {
     return l3_multicast_manager_.validateMulticastRouterInterfaceEntry(
         multicast_router_interface_entry, operation);
+  }
+
+  ReturnCode ValidateL2SetMulticastRouterInterfaceEntry(
+      const P4MulticastRouterInterfaceEntry& multicast_router_interface_entry,
+      const P4MulticastRouterInterfaceEntry* router_interface_entry_ptr) {
+    return l3_multicast_manager_.validateL2SetMulticastRouterInterfaceEntry(
+        multicast_router_interface_entry, router_interface_entry_ptr);
+  }
+
+  ReturnCode ValidateL2DelMulticastRouterInterfaceEntry(
+      const P4MulticastRouterInterfaceEntry& multicast_router_interface_entry,
+      const P4MulticastRouterInterfaceEntry* router_interface_entry_ptr) {
+    return l3_multicast_manager_.validateL2DelMulticastRouterInterfaceEntry(
+        multicast_router_interface_entry, router_interface_entry_ptr);
   }
 
   ReturnCode ValidateMulticastGroupEntry(
@@ -1701,7 +1729,7 @@ TEST_F(L3MulticastManagerTest, DrainFirstEntryFailurePublishesCorrectNumber) {
 
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(appl_db_key, SET_COMMAND, attributes));
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key, SET_COMMAND,
                                        group_attributes));
 
@@ -1725,6 +1753,51 @@ TEST_F(L3MulticastManagerTest, ValidateSetMulticastRouterInterfaceEntryTest) {
   EXPECT_TRUE(status.ok());
 }
 
+TEST_F(L3MulticastManagerTest, ValidateL2SetMulticastRouterInterfaceEntryTest) {
+  auto entry = GenerateP4MulticastRouterInterfaceEntry(
+      "Ethernet2", "0x0", swss::MacAddress(kSrcMac1),
+      /*multicast_metadata=*/"", p4orch::kNoAction);
+  ReturnCode status = ValidateL2SetMulticastRouterInterfaceEntry(
+      entry, &entry);
+  EXPECT_EQ(StatusCode::SWSS_RC_UNIMPLEMENTED, status);
+}
+
+TEST_F(L3MulticastManagerTest,
+       VerifyMulticastRouterInterfaceStateAsicDbNoActionTest) {
+  auto entry = GenerateP4MulticastRouterInterfaceEntry(
+      "Ethernet2", "0x0", swss::MacAddress(kSrcMac1),
+      /*multicast_metadata=*/"", p4orch::kNoAction);
+  EXPECT_EQ("SWSS_RC_UNIMPLEMENTED",
+            VerifyMulticastRouterInterfaceStateAsicDb(&entry));
+}
+
+TEST_F(L3MulticastManagerTest,
+       VerifyL2MulticastRouterInterfaceStateAsicDbTest) {
+  auto entry = GenerateP4MulticastRouterInterfaceEntry(
+      "Ethernet2", "0x0", swss::MacAddress(kSrcMac1),
+      /*multicast_metadata=*/"", p4orch::kNoAction);
+  EXPECT_EQ("SWSS_RC_UNIMPLEMENTED",
+            VerifyL2MulticastRouterInterfaceStateAsicDb(&entry));
+}
+
+TEST_F(L3MulticastManagerTest,
+       verifyMulticastRouterInterfaceStateCacheForNoAction) {
+  auto entry = GenerateP4MulticastRouterInterfaceEntry(
+      "Ethernet2", "0x0", swss::MacAddress(kSrcMac1),
+      /*multicast_metadata=*/"", p4orch::kNoAction);
+  EXPECT_EQ("SWSS_RC_UNIMPLEMENTED",
+            VerifyMulticastRouterInterfaceStateCache(entry, &entry));
+}
+
+TEST_F(L3MulticastManagerTest, ValidateL2DelMulticastRouterInterfaceEntryTest) {
+  auto entry = GenerateP4MulticastRouterInterfaceEntry(
+      "Ethernet2", "0x0", swss::MacAddress(kSrcMac1),
+      /*multicast_metadata=*/"", p4orch::kNoAction);
+  ReturnCode status = ValidateL2DelMulticastRouterInterfaceEntry(
+      entry, &entry);
+  EXPECT_EQ(StatusCode::SWSS_RC_UNIMPLEMENTED, status);
+}
+
 TEST_F(L3MulticastManagerTest, ValidateDelMulticastRouterInterfaceEntryNoOid) {
   auto entry = SetupP4MulticastRouterInterfaceEntry(
       "Ethernet2", "0x0", swss::MacAddress(kSrcMac1), kRifOid1);
@@ -1746,6 +1819,24 @@ TEST_F(L3MulticastManagerTest,
        ValidateSetMulticastRouterInterfaceEntryEmptyInstanceTest) {
   auto entry = GenerateP4MulticastRouterInterfaceEntry(
       "Ethernet2", "", swss::MacAddress(kSrcMac1));
+  ReturnCode status = ValidateMulticastRouterInterfaceEntry(entry, SET_COMMAND);
+  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, status);
+}
+
+TEST_F(L3MulticastManagerTest,
+       ValidateSetMulticastRouterInterfaceEntryEmptyActionTest) {
+  auto entry = GenerateP4MulticastRouterInterfaceEntry(
+      "Ethernet2", "0x0", swss::MacAddress(kSrcMac1));
+  entry.action = "";
+  ReturnCode status = ValidateMulticastRouterInterfaceEntry(entry, SET_COMMAND);
+  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, status);
+}
+
+TEST_F(L3MulticastManagerTest,
+       ValidateSetMulticastRouterInterfaceEntryActionChangeFails) {
+  auto entry = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet1", "0x0", swss::MacAddress(kSrcMac1), kRifOid1);
+  entry.action = p4orch::kNoAction;
   ReturnCode status = ValidateMulticastRouterInterfaceEntry(entry, SET_COMMAND);
   EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, status);
 }
@@ -3431,7 +3522,7 @@ TEST_F(L3MulticastManagerTest, DrainMulticastGroupEntryAddSuccessTest) {
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(mac_appl_db_key, SET_COMMAND,
                                        mac_attributes));
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key, SET_COMMAND,
                                        group_attributes));
 
@@ -3513,10 +3604,10 @@ TEST_F(L3MulticastManagerTest, DrainMulticastGroupEntryAddInvalidEntryTest) {
   good_group_attributes.push_back(
       swss::FieldValueTuple{"replicas", json_array_good});
   // Enqueue entry for create operation.
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
 	  swss::KeyOpFieldsValuesTuple(good_appl_db_key, SET_COMMAND,
                                        bad_group_attributes));
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
 	  swss::KeyOpFieldsValuesTuple(good_appl_db_key, SET_COMMAND,
                                        good_group_attributes));
 
@@ -3550,10 +3641,10 @@ TEST_F(L3MulticastManagerTest,
       swss::FieldValueTuple{"replicas", json_array});
 
   // Enqueue entry for create operation.
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
   	  swss::KeyOpFieldsValuesTuple(good_appl_db_key1, SET_COMMAND,
                                        good_group_attributes));
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(good_appl_db_key2, SET_COMMAND,
                                        good_group_attributes));
 
@@ -3608,7 +3699,7 @@ TEST_F(L3MulticastManagerTest,
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(mac_appl_db_key2, SET_COMMAND,
                                        mac_attributes));
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key, SET_COMMAND,
                                        group_attributes));
 
@@ -3643,7 +3734,7 @@ TEST_F(L3MulticastManagerTest,
   group_attributes2.push_back(
       swss::FieldValueTuple{"replicas", json_array2});
 
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key, SET_COMMAND,
                                        group_attributes2));
 
@@ -3682,7 +3773,7 @@ TEST_F(L3MulticastManagerTest,
 
   // Then delete the group.
   std::vector<swss::FieldValueTuple> group_attributes_del = {};
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key, DEL_COMMAND,
                                        group_attributes_del));
   EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group_member(kGroupMemberOid2))
@@ -3770,10 +3861,10 @@ TEST_F(L3MulticastManagerTest,
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(mac_appl_db_key4, SET_COMMAND,
                                        mac_attributes));
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key1, SET_COMMAND,
                                        group_attributes1));
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key2, SET_COMMAND,
                                        group_attributes2));
 
@@ -3839,13 +3930,13 @@ TEST_F(L3MulticastManagerTest,
       swss::FieldValueTuple{"replicas", json_array4});
   std::vector<swss::FieldValueTuple> group_attributes_del = {};
 
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key3, SET_COMMAND,
                                        group_attributes3));
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key1, SET_COMMAND,
                                        group_attributes4));
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key2, DEL_COMMAND,
                                        group_attributes_del));
 
@@ -3988,10 +4079,10 @@ TEST_F(L3MulticastManagerTest,
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(mac_appl_db_key3, SET_COMMAND,
                                        mac_attributes));
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key1, SET_COMMAND,
                                        group_attributes1));
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key2, SET_COMMAND,
                                        group_attributes2));
 
@@ -4044,14 +4135,14 @@ TEST_F(L3MulticastManagerTest,
       swss::FieldValueTuple{"replicas", json_array1b});
   std::vector<swss::FieldValueTuple> group_attributes_del = {};
 
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key1, SET_COMMAND,
                                        group_attributes1b));
   // SAI delete failure
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key2, DEL_COMMAND,
                                        group_attributes_del));
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key1, SET_COMMAND,
                                        group_attributes1b));
 
@@ -4133,10 +4224,10 @@ TEST_F(L3MulticastManagerTest,
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(mac_appl_db_key3, SET_COMMAND,
                                        mac_attributes));
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key1, SET_COMMAND,
                                        group_attributes1));
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key2, SET_COMMAND,
                                        group_attributes2));
 
@@ -4200,14 +4291,14 @@ TEST_F(L3MulticastManagerTest,
 
   std::vector<swss::FieldValueTuple> group_attributes_del = {};
  
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key1, SET_COMMAND,
                                        group_attributes1b));
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key3, SET_COMMAND,
                                        group_attributes3));
   // SAI delete failure
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key2, DEL_COMMAND,
                                        group_attributes_del));
 
@@ -4251,7 +4342,7 @@ TEST_F(L3MulticastManagerTest, DrainUnknownTable) {
   attributes.push_back(
       swss::FieldValueTuple{p4orch::kControllerMetadata, "so_meta"});
 
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_TUNNEL_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(appl_db_key, SET_COMMAND, attributes));
   EXPECT_CALL(publisher_,
               publish(Eq(APP_P4RT_TABLE_NAME), Eq(appl_db_key), Eq(attributes),
@@ -4277,7 +4368,7 @@ TEST_F(L3MulticastManagerTest, DrainUnknownFirstTable) {
   attributes.push_back(
       swss::FieldValueTuple{p4orch::kControllerMetadata, "so_meta"});
 
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+  Enqueue(APP_P4RT_TUNNEL_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(appl_db_key_unknown, SET_COMMAND,
                                        attributes));
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,


### PR DESCRIPTION
**What I did**
Make room for new 'no_action' in the L3MulticastManager

**Why I did it**
The use of 'no_action' is to bring in support for L2 multicast groups. The action no_action will signal that a bridge port object is going to be created to be used by a L2 multicast group.

**How I verified it**
Verified with UT cases.

**Details if related**