### PR TITLE
[ci] Install redis from Debian

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -119,7 +119,7 @@ jobs:
   - script: |
       set -ex
       # install packages for vs test
-      sudo pip3 install flaky exabgp docker lcov_cobertura
+      sudo pip3 install pytest flaky exabgp docker lcov_cobertura
 
       # install other dependencies
       sudo apt-get -o DPkg::Lock::Timeout=600 install -y net-tools \
@@ -129,7 +129,6 @@ jobs:
           libzmq5 \
           libhiredis0.14 \
           libpcre3-dev \
-          python3-pytest \
           python3-redis
 
       sudo .azure-pipelines/build_and_install_module.sh


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

For the CI runner, install the python3 redis packages from the Ubuntu repos instead of via pip. This has the advantage of the version being fixed for the Debian version the test runner is using.

Also remove some development package installations, which shouldn't be needed for running these tests.

**Why I did it**

This works around the regression for Unix sockets introduced in redis 7.2.0 (see also redis/redis-py#3957 and redis/redis-py#3957).

**How I verified it**

**Details if related**
