### PR TITLE
[azure-pipelines]: Pin redis Python client to 7.1.1

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -119,7 +119,8 @@ jobs:
   - script: |
       set -ex
       # install packages for vs test
-      sudo pip3 install pytest flaky exabgp docker redis lcov_cobertura
+      # Pin redis==7.1.1 due to OpenTelemetry bug in 7.2.0 breaking Unix sockets (sonic-net/sonic-buildimage#25555)
+      sudo pip3 install pytest flaky exabgp docker "redis==7.1.1" lcov_cobertura
 
       # install other dependencies
       sudo apt-get -o DPkg::Lock::Timeout=600 install -y net-tools \

--- a/tests/README.md
+++ b/tests/README.md
@@ -70,7 +70,7 @@ sudo apt-get install -y net-tools bridge-utils vlan libzmq3-dev libzmq5 \
 sudo apt install -y python3-pip net-tools bridge-utils ethtool vlan \
   libnl-nf-3-200 libnl-cli-3-200
 
-sudo pip3 install docker pytest flaky redis distro dataclasses fstring \
+sudo pip3 install docker pytest flaky "redis==7.1.1" distro dataclasses fstring \
   exabgp docker lcov_cobertura
 ```
 


### PR DESCRIPTION
#### Why I did it

Fix https://github.com/sonic-net/sonic-swss/issues/4247
For more details see [sonic-net/sonic-buildimage#25555](https://github.com/sonic-net/sonic-buildimage/issues/25555)

The redis-py 7.2.0 release (Feb 16, 2026) introduced an OpenTelemetry instrumentation bug that breaks Unix socket connections used in VS tests. The new version unconditionally accesses `conn.port` when recording metrics, but `UnixDomainSocketConnection` doesn't have this attribute, causing `AttributeError` and test failures.

This affects all PRs in sonic-swss (and other repos running VS tests).

#### How I did it

* Pinned the redis Python client to version 7.1.1 (last known working version) in the CI pipeline
* Updated the tests/README.md documentation to reflect the pinned version for manual setup

#### How to verify it

* VS tests should pass

#### Description for the changelog

Pin redis Python client to 7.1.1 to fix VS test failures caused by regression in redis-py