### PR TITLE
[P4Orch] Migrate to new schema format for REPLICATION_MULTICAST_TABLE and to use addMulticastGroupEntries and deleteMulticastGroupEntries.

### DIFF
--- a/orchagent/p4orch/p4orch_util.h
+++ b/orchagent/p4orch/p4orch_util.h
@@ -31,6 +31,7 @@ constexpr char *kPort = "port";
 constexpr char *kInPort = "in_port";
 constexpr char* kMulticastReplicaPort = "multicast_replica_port";
 constexpr char* kMulticastReplicaInstance = "multicast_replica_instance";
+constexpr char* kReplicas = "replicas";
 constexpr char *kSrcMac = "src_mac";
 constexpr char *kAction = "action";
 constexpr char *kActions = "actions";


### PR DESCRIPTION
**What I did**
Migrate to new schema format for REPLICATION_MULTICAST_TABLE
Migrate to use addMulticastGroupEntries
Migrate to use deleteMulticastGroupEntries

**Why I did it**
To add addMulticastGroupEntries & deleteMulticastGroupEntries in multicast group manager.

**How I verified it**
UT cases