### PR TITLE
[master] [orchagent]: Fix infinite loop and SIGSEGV in AclRange::remove

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3424,11 +3424,11 @@ bool AclRange::remove(sai_object_id_t *oids, int oidsCnt)
 {
     SWSS_LOG_ENTER();
 
-    for (int oidIdx = 0; oidIdx < oidsCnt; oidsCnt++)
+    for (int oidIdx = 0; oidIdx < oidsCnt; oidIdx++)
     {
         for (auto it : m_ranges)
         {
-            if (it.second->m_oid == oids[oidsCnt])
+            if (it.second->m_oid == oids[oidIdx])
             {
                 return it.second->remove();
             }


### PR DESCRIPTION
This patch is to fix a major bug in the for loop of the function AclRange::remove.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixed a critical logic error in AclRange::remove where the loop limit (oidsCnt) was being incremented instead of the loop index (oidIdx).

**Why I did it**
The original code contained an infinite loop: for (int oidIdx = 0; oidIdx < oidsCnt; oidsCnt++). This caused Memory Corruption/Crash: The loop would continue until oidsCnt accessed memory outside the bounds of the oids pointer, resulting in a SIGSEGV (Segmentation Fault).

**How I verified it**
After the fix, orchagent remains stable and correctly logs the SAI error (rv:-2) instead of terminating.

**Details if related**
The crash was specifically observed in Arista Gardena switches.

### Issues
Fixes: https://github.com/sonic-net/sonic-swss/issues/4174
Fixes: [sonic-qual.msft](https://github.com/aristanetworks/sonic-qual.msft/issues/1067)

Already fixed in 202511: #4173 
