### PR TITLE
[P4Orch]Migrate to use new database schema format for update/process/drain/verifystate MulticastGroupEntries.

### DIFF
--- a/orchagent/p4orch/l3_multicast_manager.cpp
+++ b/orchagent/p4orch/l3_multicast_manager.cpp
@@ -188,9 +188,9 @@ ReturnCode L3MulticastManager::drain() {
       if (prev_table == APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME) {
         // This drain function will drain unexecuted entries upon failure.
         status = drainMulticastRouterInterfaceEntries(tuple_list);
-      } else if (prev_table == APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) {
+      } else if (prev_table == APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) {
         // This drain function will drain unexecuted entries upon failure.
-        status = drainMulticastReplicationEntries(tuple_list);
+	status = drainMulticastGroupEntries(tuple_list);
       } else {
         status = ReturnCode(StatusCode::SWSS_RC_NOT_EXECUTED)
                  << "Unexpected table " << QuotedVar(prev_table);
@@ -216,8 +216,8 @@ ReturnCode L3MulticastManager::drain() {
   if (status.ok() && !tuple_list.empty()) {
     if (prev_table == APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME) {
       status = drainMulticastRouterInterfaceEntries(tuple_list);
-    } else if (prev_table == APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) {
-      status = drainMulticastReplicationEntries(tuple_list);
+    } else if (prev_table == APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) {
+      status = drainMulticastGroupEntries(tuple_list);
     } else {
       status = ReturnCode(StatusCode::SWSS_RC_NOT_EXECUTED)
                << "Unexpected table " << QuotedVar(prev_table);
@@ -329,19 +329,19 @@ ReturnCode L3MulticastManager::drainMulticastRouterInterfaceEntries(
 
 // Drain entries associated with the multicast replication table, and those
 // only.
-ReturnCode L3MulticastManager::drainMulticastReplicationEntries(
-    std::deque<swss::KeyOpFieldsValuesTuple>& replication_tuples) {
+ReturnCode L3MulticastManager::drainMulticastGroupEntries(
+    std::deque<swss::KeyOpFieldsValuesTuple>& group_entry_tuples) {
   SWSS_LOG_ENTER();
   ReturnCode status;
-  std::vector<P4MulticastReplicationEntry> multicast_replication_entry_list;
+  std::vector<P4MulticastGroupEntry> multicast_group_entry_list;
   std::deque<swss::KeyOpFieldsValuesTuple> tuple_list;
 
   std::string prev_op;
   bool prev_update = false;
 
-  while (!replication_tuples.empty()) {
-    auto key_op_fvs_tuple = replication_tuples.front();
-    replication_tuples.pop_front();
+  while (!group_entry_tuples.empty()) {
+    auto key_op_fvs_tuple = group_entry_tuples.front();
+    group_entry_tuples.pop_front();
     std::string table_name;
     std::string key;
     parseP4RTKey(kfvKey(key_op_fvs_tuple), &table_name, &key);
@@ -349,11 +349,11 @@ ReturnCode L3MulticastManager::drainMulticastReplicationEntries(
         kfvFieldsValues(key_op_fvs_tuple);
 
     // Form entry object
-    auto replication_entry_or =
-        deserializeMulticastReplicationEntry(key, attributes);
+    auto group_entry_or = deserializeMulticastGroupEntry(
+        key, attributes);
 
-    if (!replication_entry_or.ok()) {
-      status = replication_entry_or.status();
+    if (!group_entry_or.ok()) {
+      status = group_entry_or.status();
       SWSS_LOG_ERROR("Unable to deserialize APP DB entry with key %s: %s",
                      QuotedVar(table_name + ":" + key).c_str(),
                      status.message().c_str());
@@ -362,14 +362,14 @@ ReturnCode L3MulticastManager::drainMulticastReplicationEntries(
                            /*replace=*/true);
       break;
     }
-    auto& replication_entry = *replication_entry_or;
+    auto& group_entry = *group_entry_or;
 
     // Validate entry
     const std::string& operation = kfvOp(key_op_fvs_tuple);
-    status = validateMulticastReplicationEntry(replication_entry, operation);
+    status = validateMulticastGroupEntry(group_entry, operation);
     if (!status.ok()) {
       SWSS_LOG_ERROR(
-          "Validation failed for replication APP DB entry with key  %s: %s",
+	  "Validation failed for APP DB group entry with key  %s: %s",
           QuotedVar(table_name + ":" + key).c_str(), status.message().c_str());
       m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple),
                            kfvFieldsValues(key_op_fvs_tuple), status,
@@ -378,9 +378,9 @@ ReturnCode L3MulticastManager::drainMulticastReplicationEntries(
     }
 
     // Now, start processing batch of entries.
-    auto* replication_entry_ptr = getMulticastReplicationEntry(
-        replication_entry.multicast_replication_key);
-    bool update = replication_entry_ptr != nullptr;
+    auto* group_entry_ptr = getMulticastGroupEntry(
+      group_entry.multicast_group_id);
+    bool update = group_entry_ptr != nullptr;
 
     if (prev_op == "") {
       prev_op = operation;
@@ -388,9 +388,9 @@ ReturnCode L3MulticastManager::drainMulticastReplicationEntries(
     }
     // Process the entries if the operation type changes.
     if (operation != prev_op || update != prev_update) {
-      status = processMulticastReplicationEntries(
-          multicast_replication_entry_list, tuple_list, prev_op, prev_update);
-      multicast_replication_entry_list.clear();
+      status = processMulticastGroupEntries(
+          multicast_group_entry_list, tuple_list, prev_op, prev_update);
+      multicast_group_entry_list.clear();
       tuple_list.clear();
       prev_op = operation;
       prev_update = update;
@@ -404,21 +404,21 @@ ReturnCode L3MulticastManager::drainMulticastReplicationEntries(
                            /*replace=*/true);
       break;
     } else {
-      multicast_replication_entry_list.push_back(replication_entry);
+      multicast_group_entry_list.push_back(group_entry);
       tuple_list.push_back(key_op_fvs_tuple);
     }
   }  // while
 
   // Process any pending entries.
-  if (!multicast_replication_entry_list.empty()) {
-    auto rc = processMulticastReplicationEntries(
-        multicast_replication_entry_list, tuple_list, prev_op, prev_update);
+  if (!multicast_group_entry_list.empty()) {
+    auto rc = processMulticastGroupEntries(
+        multicast_group_entry_list, tuple_list, prev_op, prev_update);
     if (!rc.ok()) {
       status = rc;
     }
   }
 
-  drainMgmtWithNotExecuted(replication_tuples, m_publisher);
+  drainMgmtWithNotExecuted(group_entry_tuples, m_publisher);
   return status;
 }
 
@@ -449,7 +449,7 @@ L3MulticastManager::deserializeMulticastRouterInterfaceEntry(
     const auto& field = fvField(it);
     const auto& value = fvValue(it);
     if (field == p4orch::kAction) {
-      if (value != p4orch::kSetSrcMac) {
+      if (value != p4orch::kSetMulticastSrcMac) {
         return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
                << "Unexpected action " << QuotedVar(value) << " in "
                << APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME;
@@ -502,7 +502,7 @@ L3MulticastManager::deserializeMulticastReplicationEntry(
     } else if (field != p4orch::kControllerMetadata) {
       return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
              << "Unexpected field " << QuotedVar(field) << " in "
-             << APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME;
+             << APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME;
     }
   }
   return replication_entry;
@@ -605,7 +605,7 @@ L3MulticastManager::deserializeMulticastGroupEntry(
     } else {
       return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
              << "Unexpected field " << QuotedVar(field) << " in "
-             << APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME;
+             << APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME;
     }
 
   }
@@ -634,8 +634,8 @@ std::string L3MulticastManager::verifyState(
   parseP4RTKey(p4rt_key, &table_name, &key_content);
   if (table_name == APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME) {
     return verifyMulticastRouterInterfaceState(key_content, tuple);
-  } else if (table_name == APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) {
-    return verifyMulticastReplicationState(key_content, tuple);
+  } else if (table_name == APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) {
+    return verifyMulticastGroupState(key_content, tuple);
   } else {
     return std::string("Invalid key, unexpected table name: ") + key;
   }
@@ -680,10 +680,11 @@ std::string L3MulticastManager::verifyMulticastRouterInterfaceState(
   return cache_result + "; " + asic_db_result;
 }
 
-std::string L3MulticastManager::verifyMulticastReplicationState(
+std::string L3MulticastManager::verifyMulticastGroupState(
     const std::string& key,
     const std::vector<swss::FieldValueTuple>& tuple) {
-  auto app_db_entry_or = deserializeMulticastReplicationEntry(key, tuple);
+  auto app_db_entry_or = deserializeMulticastGroupEntry(
+      key, tuple);
   if (!app_db_entry_or.ok()) {
     ReturnCode status = app_db_entry_or.status();
     std::stringstream msg;
@@ -693,22 +694,18 @@ std::string L3MulticastManager::verifyMulticastReplicationState(
   }
   auto& app_db_entry = *app_db_entry_or;
 
-  const std::string replication_entry_key =
-      KeyGenerator::generateMulticastReplicationKey(
-          app_db_entry.multicast_group_id, app_db_entry.multicast_replica_port,
-          app_db_entry.multicast_replica_instance);
-  auto* replication_entry_ptr =
-      getMulticastReplicationEntry(replication_entry_key);
-  if (replication_entry_ptr == nullptr) {
+  auto* group_entry_ptr = getMulticastGroupEntry(
+      app_db_entry.multicast_group_id);
+  if (group_entry_ptr == nullptr) {
     std::stringstream msg;
     msg << "No entry found with key " << QuotedVar(key);
     return msg.str();
   }
 
-  std::string cache_result =
-      verifyMulticastReplicationStateCache(app_db_entry, replication_entry_ptr);
-  std::string asic_db_result =
-      verifyMulticastReplicationStateAsicDb(replication_entry_ptr);
+  std::string cache_result = verifyMulticastGroupStateCache(
+      app_db_entry, group_entry_ptr);
+  std::string asic_db_result = verifyMulticastGroupStateAsicDb(
+      group_entry_ptr);
   if (cache_result.empty()) {
     return asic_db_result;
   }
@@ -1102,7 +1099,7 @@ ReturnCode L3MulticastManager::validateDelMulticastRouterInterfaceEntry(
   // Confirm the RIF object ID exists in central mapper.
   std::string rif_key = KeyGenerator::generateMulticastRouterInterfaceRifKey(
       multicast_router_interface_entry.multicast_replica_port,
-      multicast_router_interface_entry.src_mac);
+      router_interface_entry_ptr->src_mac);  // No attributes provided on delete.
   if (!m_p4OidMapper->existsOID(SAI_OBJECT_TYPE_ROUTER_INTERFACE, rif_key)) {
     RETURN_INTERNAL_ERROR_AND_RAISE_CRITICAL(
         "Multicast router interface entry does not exist in the central map");
@@ -1140,8 +1137,8 @@ ReturnCode L3MulticastManager::processMulticastRouterInterfaceEntries(
   return status;
 }
 
-ReturnCode L3MulticastManager::processMulticastReplicationEntries(
-    std::vector<P4MulticastReplicationEntry>& entries,
+ReturnCode L3MulticastManager::processMulticastGroupEntries(
+    std::vector<P4MulticastGroupEntry>& entries,
     const std::deque<swss::KeyOpFieldsValuesTuple>& tuple_list,
     const std::string& op, bool update) {
   SWSS_LOG_ENTER();
@@ -1151,12 +1148,12 @@ ReturnCode L3MulticastManager::processMulticastReplicationEntries(
   // In syncd, bulk SAI calls use mode SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR.
   if (op == SET_COMMAND) {
     if (!update) {
-      statuses = addMulticastReplicationEntries(entries);
+      statuses = addMulticastGroupEntries(entries);
     } else {
-      statuses = updateMulticastReplicationEntries(entries);
+      statuses = updateMulticastGroupEntries(entries);
     }
   } else {
-    statuses = deleteMulticastReplicationEntries(entries);
+    statuses = deleteMulticastGroupEntries(entries);
   }
   // Check status of each entry.
   for (size_t i = 0; i < entries.size(); ++i) {
@@ -1416,9 +1413,12 @@ L3MulticastManager::updateMulticastRouterInterfaceEntries(
     auto* old_entry_ptr = getMulticastRouterInterfaceEntry(
         entry.multicast_router_interface_entry_key);
     if (old_entry_ptr == nullptr) {
-      statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL)
-                    << "Multicast router interface entry is missing "
+      std::stringstream err_msg;
+            err_msg << "Multicast router interface entry is missing "
                     << QuotedVar(entry.multicast_router_interface_entry_key);
+	    SWSS_LOG_ERROR("%s", err_msg.str().c_str());
+	    SWSS_RAISE_CRITICAL_STATE(err_msg.str());
+	    statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL) << err_msg.str();
       break;
     }
 
@@ -1437,20 +1437,24 @@ L3MulticastManager::updateMulticastRouterInterfaceEntries(
         KeyGenerator::generateMulticastRouterInterfaceRifKey(
             old_entry_ptr->multicast_replica_port, old_entry_ptr->src_mac);
     if (old_rif_oid == SAI_NULL_OBJECT_ID) {
-      statuses[i] =
-          ReturnCode(StatusCode::SWSS_RC_INTERNAL)
-          << "Multicast router interface entry is missing a RIF oid "
-          << QuotedVar(old_entry_ptr->multicast_router_interface_entry_key);
+      std::stringstream err_msg;
+      err_msg << "Multicast router interface entry is missing a RIF oid "
+              << QuotedVar(old_entry_ptr->multicast_router_interface_entry_key);
+      SWSS_LOG_ERROR("%s", err_msg.str().c_str());
+      SWSS_RAISE_CRITICAL_STATE(err_msg.str());
+      statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL) << err_msg.str();
       break;
     }
 
     // Fetch the vector P4MulticastRouterInterfaceEntry associated with the RIF.
     if (m_rifOidToRouterInterfaceEntries.find(old_rif_oid) ==
         m_rifOidToRouterInterfaceEntries.end()) {
-      statuses[i] =
-          ReturnCode(StatusCode::SWSS_RC_INTERNAL)
-          << "RIF oid " << old_rif_oid << " missing from map for "
-          << QuotedVar(old_entry_ptr->multicast_router_interface_entry_key);
+      std::stringstream err_msg;
+      err_msg << "RIF oid " << old_rif_oid << " missing from map for "
+              << QuotedVar(old_entry_ptr->multicast_router_interface_entry_key);
+      SWSS_LOG_ERROR("%s", err_msg.str().c_str());
+      SWSS_RAISE_CRITICAL_STATE(err_msg.str());
+      statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL) << err_msg.str();
       break;
     }
     auto& old_entries_for_rif = m_rifOidToRouterInterfaceEntries[old_rif_oid];
@@ -1464,11 +1468,13 @@ L3MulticastManager::updateMulticastRouterInterfaceEntries(
         (m_multicastRouterInterfaceTable.find(
              old_entry_ptr->multicast_router_interface_entry_key) ==
          m_multicastRouterInterfaceTable.end())) {
-      statuses[i] =
-          ReturnCode(StatusCode::SWSS_RC_INTERNAL)
-          << "Unable to find entry "
-          << QuotedVar(old_entry_ptr->multicast_router_interface_entry_key)
-          << " in map";
+      std::stringstream err_msg;
+      err_msg << "Unable to find entry "
+              << QuotedVar(old_entry_ptr->multicast_router_interface_entry_key)
+              << " in map";
+      SWSS_LOG_ERROR("%s", err_msg.str().c_str());
+      SWSS_RAISE_CRITICAL_STATE(err_msg.str());
+      statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL) << err_msg.str();
       break;
     }
 
@@ -1569,9 +1575,10 @@ L3MulticastManager::deleteMulticastRouterInterfaceEntries(
   //    case, only remove the current entry from being associated with the RIF.
   for (size_t i = 0; i < entries.size(); ++i) {
     auto& entry = entries[i];
-    if (m_multicastRouterInterfaceTable.find(
-            entry.multicast_router_interface_entry_key) ==
-        m_multicastRouterInterfaceTable.end()) {
+    // Cannot assume that the src mac will be set on delete operation.
+    auto* old_entry_ptr = getMulticastRouterInterfaceEntry(
+        entry.multicast_router_interface_entry_key);
+    if (old_entry_ptr == nullptr) {
       statuses[i] = ReturnCode(StatusCode::SWSS_RC_UNKNOWN)
                     << "Multicast router interface entry is not known "
                     << QuotedVar(entry.multicast_router_interface_entry_key);
@@ -1579,11 +1586,14 @@ L3MulticastManager::deleteMulticastRouterInterfaceEntries(
     }
 
     // Confirm RIF OID was assigned.
-    sai_object_id_t rif_oid = getRifOid(&entry);
+    sai_object_id_t rif_oid = getRifOid(old_entry_ptr);
     if (rif_oid == SAI_NULL_OBJECT_ID) {
-      statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL)
-                    << "Multicast router interface entry is missing a RIF oid "
-                    << QuotedVar(entry.multicast_router_interface_entry_key);
+      std::stringstream err_msg;
+      err_msg << "Multicast router interface entry is missing a RIF oid "
+              << QuotedVar(entry.multicast_router_interface_entry_key);
+      SWSS_LOG_ERROR("%s", err_msg.str().c_str());
+      SWSS_RAISE_CRITICAL_STATE(err_msg.str());
+      statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL) << err_msg.str();
       break;
     }
 
@@ -1602,9 +1612,12 @@ L3MulticastManager::deleteMulticastRouterInterfaceEntries(
     // with the RIF.
     if (m_rifOidToRouterInterfaceEntries.find(rif_oid) ==
         m_rifOidToRouterInterfaceEntries.end()) {
-      statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL)
-                    << "RIF oid " << rif_oid << " missing from map for "
-                    << QuotedVar(entry.multicast_router_interface_entry_key);
+      std::stringstream err_msg;
+      err_msg << "RIF oid " << rif_oid << " missing from map for "
+              << QuotedVar(entry.multicast_router_interface_entry_key);
+      SWSS_LOG_ERROR("%s", err_msg.str().c_str());
+      SWSS_RAISE_CRITICAL_STATE(err_msg.str());
+      statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL) << err_msg.str();
       break;
     }
     auto& entries_for_rif = m_rifOidToRouterInterfaceEntries[rif_oid];
@@ -1618,14 +1631,17 @@ L3MulticastManager::deleteMulticastRouterInterfaceEntries(
         (m_multicastRouterInterfaceTable.find(
              entry.multicast_router_interface_entry_key) ==
          m_multicastRouterInterfaceTable.end())) {
-      statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL)
-                    << "Unable to find entry "
-                    << QuotedVar(entry.multicast_router_interface_entry_key)
-                    << " in map";
+      std::stringstream err_msg;
+      err_msg << "Unable to find entry "
+              << QuotedVar(entry.multicast_router_interface_entry_key)
+              << " in map";
+      SWSS_LOG_ERROR("%s", err_msg.str().c_str());
+      SWSS_RAISE_CRITICAL_STATE(err_msg.str());
+      statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL) << err_msg.str();
       break;
     }
     std::string rif_key = KeyGenerator::generateMulticastRouterInterfaceRifKey(
-        entry.multicast_replica_port, entry.src_mac);
+        old_entry_ptr->multicast_replica_port, old_entry_ptr->src_mac);
 
     // If this is the last entry, delete the RIF.
     // Attempt to delete RIF at SAI layer before adjusting internal maps, in
@@ -1896,6 +1912,209 @@ std::vector<ReturnCode> L3MulticastManager::updateMulticastReplicationEntries(
   return statuses;
 }
 
+std::vector<ReturnCode> L3MulticastManager::updateMulticastGroupEntries(
+    std::vector<P4MulticastGroupEntry>& entries) {
+  // An update operation has to figure out what replicas associated with the
+  // multicast group have been added, deleted, or left unchanged.
+  // Replicas will be deleted before new ones are added, to avoid the
+  // possibility of resource exhaustion.
+
+  SWSS_LOG_ENTER();
+  std::vector<ReturnCode> statuses(entries.size());
+  fillStatusArrayWithNotExecuted(statuses, 0);
+
+  for (size_t i = 0; i < entries.size(); ++i) {
+    auto& entry = entries[i];
+
+    // Confirm old entry exists.
+    auto *old_entry_ptr = getMulticastGroupEntry(entry.multicast_group_id);
+    if (old_entry_ptr == nullptr) {
+      statuses[i] = ReturnCode(StatusCode::SWSS_RC_UNKNOWN)
+                    << "Multicast group entry is not known "
+                    << QuotedVar(entry.multicast_group_id);
+      break;
+    }
+
+    // Fetch the group OID.
+    sai_object_id_t old_group_oid = SAI_NULL_OBJECT_ID;
+    if (!m_p4OidMapper->getOID(SAI_OBJECT_TYPE_IPMC_GROUP,
+                               old_entry_ptr->multicast_group_id,
+                               &old_group_oid)) {
+      std::stringstream err_msg;
+      err_msg << "Unable to fetch multicast group oid for group "
+              << old_entry_ptr->multicast_group_id;
+      SWSS_LOG_ERROR("%s", err_msg.str().c_str());
+      SWSS_RAISE_CRITICAL_STATE(err_msg.str());
+      statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL)
+                    << err_msg.str();
+      break;
+    }
+
+    std::vector<P4Replica> replicas_to_add;
+    for (auto& replica : entry.replicas) {
+      // New replica is not part of existing replicas.
+      if (old_entry_ptr->member_oids.find(replica.key) ==
+          old_entry_ptr->member_oids.end()) {
+        replicas_to_add.push_back(replica);
+      }
+    }
+
+    std::vector<P4Replica> replicas_to_delete;
+    for (auto& replica : old_entry_ptr->replicas) {
+      // Existing replica is not part of new replicas.
+      if (entry.member_oids.find(replica.key) == entry.member_oids.end()) {
+        replicas_to_delete.push_back(replica);
+      }
+    }
+
+    // Replicas in both old and new entries can be left untouched (no-op).
+
+    // First, delete replicas.
+    std::vector<P4Replica> deleted_replicas;
+    std::unordered_map<std::string, sai_object_id_t> replica_rif_map;
+
+    for (auto& replica : replicas_to_delete) {
+      // Fetch the RIF used by the member.
+      sai_object_id_t old_rif_oid = getRifOid(replica);
+      if (old_rif_oid == SAI_NULL_OBJECT_ID) {
+        std::stringstream err_msg;
+        err_msg << "Cannot find RIF oid associated with group member to delete "
+                << QuotedVar(replica.key);
+        SWSS_LOG_ERROR("%s", err_msg.str().c_str());
+        SWSS_RAISE_CRITICAL_STATE(err_msg.str());
+        statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL) << err_msg.str();
+        return statuses;
+      }
+      replica_rif_map[replica.key] = old_rif_oid;
+
+      // Fetch the member OID.
+      if (old_entry_ptr->member_oids.find(replica.key) ==
+          old_entry_ptr->member_oids.end()) {
+        std::stringstream err_msg;
+        err_msg << "Cannot find oid associated with group member to delete "
+                << QuotedVar(replica.key);
+        SWSS_LOG_ERROR("%s", err_msg.str().c_str());
+        SWSS_RAISE_CRITICAL_STATE(err_msg.str());
+        statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL) << err_msg.str();
+        return statuses;
+      }
+      sai_object_id_t old_group_member_oid =
+          old_entry_ptr->member_oids.at(replica.key);
+
+      // Delete group member
+      sai_status_t member_delete_status =
+          sai_ipmc_group_api->remove_ipmc_group_member(old_group_member_oid);
+      if (member_delete_status != SAI_STATUS_SUCCESS) {
+        statuses[i] = member_delete_status;
+
+        // Attempt to re-add deleted group members.
+        ReturnCode restore_status = restoreDeletedGroupMembers(deleted_replicas,
+                                                               replica_rif_map,
+                                                               old_group_oid,
+                                                               replica.key,
+                                                               old_entry_ptr);
+        if (!restore_status.ok()) {
+          SWSS_LOG_ERROR("%s", restore_status.message().c_str());
+          SWSS_RAISE_CRITICAL_STATE(restore_status.message());
+        }
+        // We still return the original failure when we successfully back
+        // out changes.
+        return statuses;
+      }
+      // Update internal state to reflect successful delete.
+      m_p4OidMapper->eraseOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                              replica.key);
+      old_entry_ptr->member_oids.erase(replica.key);
+      m_rifOidToMulticastGroupMembers[old_rif_oid].erase(replica.key);
+      deleted_replicas.push_back(replica);
+    }  // for replica (to delete)
+
+    // Second add new replicas.
+    std::vector<P4Replica> added_replicas;
+
+    for (auto& replica : replicas_to_add) {
+      // Fetch the RIF used by the member.
+      sai_object_id_t new_rif_oid = getRifOid(replica);
+      if (new_rif_oid == SAI_NULL_OBJECT_ID) {
+        std::stringstream err_msg;
+        err_msg << "Cannot find RIF oid associated with group member to add "
+                << QuotedVar(replica.key);
+        SWSS_LOG_ERROR("%s", err_msg.str().c_str());
+        SWSS_RAISE_CRITICAL_STATE(err_msg.str());
+        statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL) << err_msg.str();
+        return statuses;
+      }
+      replica_rif_map[replica.key] = new_rif_oid;
+
+      // Create the group member.
+      sai_object_id_t mcast_group_member_oid;
+      ReturnCode create_member_status = createMulticastGroupMember(
+          replica, old_group_oid, new_rif_oid, &mcast_group_member_oid);
+
+      if (!create_member_status.ok()) {
+        statuses[i] = create_member_status;
+
+        // Backout members added.
+        for (auto& added_replica : added_replicas) {
+          sai_status_t member_delete_status =
+              sai_ipmc_group_api->remove_ipmc_group_member(
+                  old_entry_ptr->member_oids[added_replica.key]);
+          if (member_delete_status != SAI_STATUS_SUCCESS) {
+            // All kinds of bad
+            std::stringstream err_msg;
+            err_msg << "Cannot revert to previous state, because added replica "
+                    << QuotedVar(added_replica.key)
+                    << " cannot be deleted";
+            SWSS_LOG_ERROR("%s", err_msg.str().c_str());
+            SWSS_RAISE_CRITICAL_STATE(err_msg.str());
+            return statuses;
+          }
+          // Update state based on successful removal.
+          m_p4OidMapper->eraseOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                  added_replica.key);
+          old_entry_ptr->member_oids.erase(added_replica.key);
+          m_rifOidToMulticastGroupMembers[
+              replica_rif_map.at(added_replica.key)].erase(added_replica.key);
+        }
+
+        // Attempt to re-add deleted group members.
+        ReturnCode restore_status = restoreDeletedGroupMembers(deleted_replicas,
+                                                               replica_rif_map,
+                                                               old_group_oid,
+                                                               replica.key,
+                                                               old_entry_ptr);
+        if (!restore_status.ok()) {
+          SWSS_LOG_ERROR("%s", restore_status.message().c_str());
+          SWSS_RAISE_CRITICAL_STATE(restore_status.message());
+        }
+        // We still return the original failure when we successfully back
+        // out changes.
+        return statuses;
+      }
+
+      // Update internal state to reflect successful add.
+      m_p4OidMapper->setOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                            replica.key, mcast_group_member_oid);
+      old_entry_ptr->member_oids[replica.key] = mcast_group_member_oid;
+      m_rifOidToMulticastGroupMembers[new_rif_oid].insert(replica.key);
+      added_replicas.push_back(replica);
+
+    }  // for replica (to add)
+
+    // Final bookkeeping.
+    // Since we updated the original entry in place, we need to replace the
+    // replicas and metadata with the new state.
+    old_entry_ptr->replicas.clear();
+    old_entry_ptr->replicas.insert(old_entry_ptr->replicas.end(),
+                                   entry.replicas.begin(),
+                                   entry.replicas.end());
+    old_entry_ptr->controller_metadata = entry.controller_metadata;
+    old_entry_ptr->multicast_metadata = entry.multicast_metadata;
+    statuses[i] = ReturnCode();
+  } // for i
+  return statuses;
+}
+
 std::vector<ReturnCode> L3MulticastManager::deleteMulticastReplicationEntries(
     const std::vector<P4MulticastReplicationEntry>& entries) {
   // There are two cases for removal:
@@ -1925,10 +2144,12 @@ std::vector<ReturnCode> L3MulticastManager::deleteMulticastReplicationEntries(
     // Fetch the RIF the member is associated with.
     sai_object_id_t old_rif_oid = getRifOid(old_entry_ptr);
     if (old_rif_oid == SAI_NULL_OBJECT_ID) {
-      statuses[i] =
-          ReturnCode(StatusCode::SWSS_RC_INTERNAL)
-          << "Cannot find RIF oid associated with group member to delete "
+      std::stringstream err_msg;
+      err_msg << "Cannot find RIF oid associated with group member to delete "
           << QuotedVar(old_entry_ptr->multicast_replication_key);
+      SWSS_LOG_ERROR("%s", err_msg.str().c_str());
+      SWSS_RAISE_CRITICAL_STATE(err_msg.str());
+      statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL) << err_msg.str();
       break;
     }
 
@@ -1942,19 +2163,25 @@ std::vector<ReturnCode> L3MulticastManager::deleteMulticastReplicationEntries(
                           &old_group_member_oid);
     if (old_group_oid == SAI_NULL_OBJECT_ID ||
         old_group_member_oid == SAI_NULL_OBJECT_ID) {
-      statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL)
-                    << "Multicast replication entry is missing a multicast "
-                    << "group OID or a multicast group member OID "
-                    << QuotedVar(entry.multicast_replication_key);
+      std::stringstream err_msg;
+      err_msg << "Multicast replication entry is missing a multicast "
+              << "group OID or a multicast group member OID "
+              << QuotedVar(entry.multicast_replication_key);
+      SWSS_LOG_ERROR("%s", err_msg.str().c_str());
+      SWSS_RAISE_CRITICAL_STATE(err_msg.str());
+      statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL) << err_msg.str();
       break;
     }
 
     // Fetch group members associated with multicast group
     if (m_multicastGroupMembers.find(old_entry_ptr->multicast_group_id) ==
         m_multicastGroupMembers.end()) {
-      statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL)
-                    << "Cannot find members associated with multicast group "
-                    << " id " << old_entry_ptr->multicast_group_id;
+      std::stringstream err_msg;
+      err_msg << "Cannot find members associated with multicast group id "
+              << old_entry_ptr->multicast_group_id;
+      SWSS_LOG_ERROR("%s", err_msg.str().c_str());
+      SWSS_RAISE_CRITICAL_STATE(err_msg.str());
+      statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL) << err_msg.str();
       break;
     }
     auto& group_members_set =
@@ -1962,10 +2189,13 @@ std::vector<ReturnCode> L3MulticastManager::deleteMulticastReplicationEntries(
     auto member_cnt = group_members_set.size();
     if (group_members_set.count(old_entry_ptr->multicast_replication_key) !=
         1) {
-      statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL)
-                    << "Member " << old_entry_ptr->multicast_replication_key
-                    << " was not associated with multicast group id "
-                    << old_entry_ptr->multicast_group_id;
+      std::stringstream err_msg;
+      err_msg << "Member " << old_entry_ptr->multicast_replication_key
+              << " was not associated with multicast group id "
+              << old_entry_ptr->multicast_group_id;
+      SWSS_LOG_ERROR("%s", err_msg.str().c_str());
+      SWSS_RAISE_CRITICAL_STATE(err_msg.str());
+      statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL) << err_msg.str();
       break;
     }
 
@@ -1978,10 +2208,14 @@ std::vector<ReturnCode> L3MulticastManager::deleteMulticastReplicationEntries(
       if (!m_p4OidMapper->getRefCount(SAI_OBJECT_TYPE_IPMC_GROUP,
                                       old_entry_ptr->multicast_group_id,
                                       &route_entry_ref_count)) {
-        statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL)
-                      << "Unable to fetch reference count for multicast "
-                      << "group " << old_entry_ptr->multicast_group_id;
-        break;
+	std::stringstream err_msg;
+          err_msg << "Unable to fetch reference count for multicast group "
+                  << old_entry_ptr->multicast_group_id;
+          SWSS_LOG_ERROR("%s", err_msg.str().c_str());
+          SWSS_RAISE_CRITICAL_STATE(err_msg.str());
+          statuses[i] = ReturnCode(StatusCode::SWSS_RC_INTERNAL)
+                        << err_msg.str();
+	  break;
       }
 
       if (route_entry_ref_count != 0) {
@@ -2331,105 +2565,115 @@ std::string L3MulticastManager::verifyMulticastRouterInterfaceStateAsicDb(
                      /*allow_unknown=*/false);
 }
 
-std::string L3MulticastManager::verifyMulticastReplicationStateCache(
-    const P4MulticastReplicationEntry& app_db_entry,
-    const P4MulticastReplicationEntry* multicast_replication_entry) {
-  const std::string replication_entry_key =
-      KeyGenerator::generateMulticastReplicationKey(
-          app_db_entry.multicast_group_id, app_db_entry.multicast_replica_port,
-          app_db_entry.multicast_replica_instance);
+std::string L3MulticastManager::verifyMulticastGroupStateCache(
+    const P4MulticastGroupEntry& app_db_entry,
+    const P4MulticastGroupEntry* multicast_group_entry) {
 
-  ReturnCode status =
-      validateMulticastReplicationEntry(app_db_entry, SET_COMMAND);
+  ReturnCode status = validateMulticastGroupEntry(app_db_entry,
+                                                  SET_COMMAND);
   if (!status.ok()) {
     std::stringstream msg;
-    msg << "Validation failed for multicast replication DB entry with key "
-        << QuotedVar(replication_entry_key) << ": " << status.message();
+    msg << "Validation failed for multicast group DB entry with key "
+        << QuotedVar(app_db_entry.multicast_group_id) << ": "
+        << status.message();
     return msg.str();
   }
-  if (multicast_replication_entry->multicast_replication_key !=
-      app_db_entry.multicast_replication_key) {
-    std::stringstream msg;
-    msg << "Multicast replication entry key "
-        << QuotedVar(app_db_entry.multicast_replication_key)
-        << " does not match internal cache "
-        << QuotedVar(multicast_replication_entry->multicast_replication_key)
-        << " in l3 multicast manager for replication entry.";
-    return msg.str();
-  }
-  if (multicast_replication_entry->multicast_group_id !=
+  if (multicast_group_entry->multicast_group_id !=
       app_db_entry.multicast_group_id) {
     std::stringstream msg;
     msg << "Multicast group ID " << QuotedVar(app_db_entry.multicast_group_id)
         << " does not match internal cache "
-        << QuotedVar(multicast_replication_entry->multicast_group_id)
-        << " in l3 multicast manager for replication entry.";
+        << QuotedVar(multicast_group_entry->multicast_group_id)
+        << " in l3 multicast manager for group entry.";
     return msg.str();
   }
-  if (multicast_replication_entry->multicast_replica_port !=
-      app_db_entry.multicast_replica_port) {
+
+  // Check replicas
+  if (app_db_entry.replicas.size() != multicast_group_entry->replicas.size()) {
     std::stringstream msg;
-    msg << "Output port name " << QuotedVar(app_db_entry.multicast_replica_port)
-        << " does not match internal cache "
-        << QuotedVar(multicast_replication_entry->multicast_replica_port)
-        << " in l3 multicast manager for replication entry.";
+    msg << "Multicast group ID " << QuotedVar(app_db_entry.multicast_group_id)
+        << " has a different number of replicas than internal cache.";
     return msg.str();
   }
-  if (multicast_replication_entry->multicast_replica_instance !=
-      app_db_entry.multicast_replica_instance) {
-    std::stringstream msg;
-    msg << "Egress instance "
-        << QuotedVar(app_db_entry.multicast_replica_instance)
-        << " does not match internal cache "
-        << QuotedVar(multicast_replication_entry->multicast_replica_instance)
-        << " in l3 multicast manager for replication entry.";
-    return msg.str();
+  std::unordered_set<std::string> replica_keys;
+  for (auto& replica : multicast_group_entry->replicas) {
+    replica_keys.insert(replica.key);
   }
-  if (multicast_replication_entry->multicast_metadata !=
+  for (auto& replica : app_db_entry.replicas) {
+    // Check we have the P4Replica object.
+    if (replica_keys.find(replica.key) == replica_keys.end()) {
+      std::stringstream msg;
+      msg << "Replica " << QuotedVar(replica.key)
+          << " is missing from internal cache for multicast group "
+          << QuotedVar(multicast_group_entry->multicast_group_id)
+          << " in l3 multicast manager for group entry.";
+      return msg.str();
+    }
+    // Check we have the replica in the member_oids map.
+    if (multicast_group_entry->member_oids.find(replica.key) ==
+        multicast_group_entry->member_oids.end()) {
+      std::stringstream msg;
+      msg << "Replica " << QuotedVar(replica.key)
+          << " is missing from internal member oid map for multicast group "
+          << QuotedVar(multicast_group_entry->multicast_group_id)
+          << " in l3 multicast manager for group entry.";
+      return msg.str();
+    }
+  }
+
+  if (multicast_group_entry->multicast_metadata !=
       app_db_entry.multicast_metadata) {
     std::stringstream msg;
     msg << "Multicast metadata " << QuotedVar(app_db_entry.multicast_metadata)
         << " does not match internal cache "
-        << QuotedVar(multicast_replication_entry->multicast_metadata)
-        << " in l3 multicast manager for replication entry.";
+        << QuotedVar(multicast_group_entry->multicast_metadata)
+        << " in l3 multicast manager for group entry.";
     return msg.str();
   }
+  if (multicast_group_entry->controller_metadata !=
+      app_db_entry.controller_metadata) {
+    std::stringstream msg;
+    msg << "Controller metadata " << QuotedVar(app_db_entry.controller_metadata)
+        << " does not match internal cache "
+        << QuotedVar(multicast_group_entry->controller_metadata)
+        << " in l3 multicast manager for group entry.";
+    return msg.str();
+  }
+
   std::string group_msg = m_p4OidMapper->verifyOIDMapping(
       SAI_OBJECT_TYPE_IPMC_GROUP,
-      multicast_replication_entry->multicast_group_id,
-      multicast_replication_entry->multicast_group_oid);
+      multicast_group_entry->multicast_group_id,
+      multicast_group_entry->multicast_group_oid);
   if (!group_msg.empty()) {
     return group_msg;
   }
-  return m_p4OidMapper->verifyOIDMapping(
-      SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
-      multicast_replication_entry->multicast_replication_key,
-      multicast_replication_entry->multicast_group_member_oid);
+
+  // Check group member OIDs for replicas.
+  for (auto& kv : multicast_group_entry->member_oids) {
+    std::string group_member_msg = m_p4OidMapper->verifyOIDMapping(
+        SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER, kv.first, kv.second);
+    if (!group_member_msg.empty()) {
+      return group_member_msg;
+    }
+  }
+  return "";
 }
 
-std::string L3MulticastManager::verifyMulticastReplicationStateAsicDb(
-    const P4MulticastReplicationEntry* multicast_replication_entry) {
-  // Confirm have RIF.
-  sai_object_id_t rif_oid = getRifOid(multicast_replication_entry);
-  if (rif_oid == SAI_NULL_OBJECT_ID) {
-    std::stringstream msg;
-    msg << "Unable to find RIF associated with multicast entry "
-        << QuotedVar(multicast_replication_entry->multicast_replication_key);
-    return msg.str();
-  }
+std::string L3MulticastManager::verifyMulticastGroupStateAsicDb(
+    const P4MulticastGroupEntry* multicast_group_entry) {
 
   // Confirm group settings.
   std::vector<sai_attribute_t> group_attrs;  // no required attributes
   std::vector<swss::FieldValueTuple> exp =
       saimeta::SaiAttributeList::serialize_attr_list(
-          SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER, (uint32_t)group_attrs.size(),
+	  SAI_OBJECT_TYPE_IPMC_GROUP, (uint32_t)group_attrs.size(),
           group_attrs.data(), /*countOnly=*/false);
 
   swss::DBConnector db("ASIC_DB", 0);
   swss::Table table(&db, "ASIC_STATE");
   std::string key =
       sai_serialize_object_type(SAI_OBJECT_TYPE_IPMC_GROUP) + ":" +
-      sai_serialize_object_id(multicast_replication_entry->multicast_group_oid);
+      sai_serialize_object_id(multicast_group_entry->multicast_group_oid);
   std::vector<swss::FieldValueTuple> values;
   if (!table.get(key, values)) {
     return std::string("ASIC DB key not found ") + key;
@@ -2442,20 +2686,43 @@ std::string L3MulticastManager::verifyMulticastReplicationStateAsicDb(
   }
 
   // Confirm group member settings.
-  auto member_attrs = prepareMulticastGroupMemberSaiAttrs(
-      *multicast_replication_entry, rif_oid);
-  exp = saimeta::SaiAttributeList::serialize_attr_list(
-      SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER, (uint32_t)member_attrs.size(),
-      member_attrs.data(), /*countOnly=*/false);
-  key = sai_serialize_object_type(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER) + ":" +
-        sai_serialize_object_id(
-            multicast_replication_entry->multicast_group_member_oid);
-  values.clear();
-  if (!table.get(key, values)) {
-    return std::string("ASIC DB key not found ") + key;
+  for (auto& replica : multicast_group_entry->replicas) {
+    // Confirm have RIF for each replica.
+    sai_object_id_t rif_oid = getRifOid(replica);
+    if (rif_oid == SAI_NULL_OBJECT_ID) {
+      std::stringstream msg;
+      msg << "Unable to find RIF associated with replica "
+          << QuotedVar(replica.key)
+          << " for multicast group "
+          << QuotedVar(multicast_group_entry->multicast_group_id);
+      return msg.str();
+    }
+
+    sai_object_id_t group_member_oid = SAI_NULL_OBJECT_ID;
+    if (multicast_group_entry->member_oids.find(replica.key) !=
+        multicast_group_entry->member_oids.end()) {
+      group_member_oid = multicast_group_entry->member_oids.at(replica.key);
+    }
+
+    auto member_attrs = prepareMulticastGroupMemberSaiAttrs(
+        multicast_group_entry->multicast_group_oid, rif_oid);
+    exp = saimeta::SaiAttributeList::serialize_attr_list(
+              SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER, (uint32_t)member_attrs.size(),
+              member_attrs.data(), /*countOnly=*/false);
+    key = sai_serialize_object_type(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER) + ":" +
+          sai_serialize_object_id(group_member_oid);
+    values.clear();
+    if (!table.get(key, values)) {
+      return std::string("ASIC DB key not found ") + key;
+    }
+    std::string group_member_msg = verifyAttrs(
+        values, exp, std::vector<swss::FieldValueTuple>{},
+        /*allow_unknown=*/false);
+    if (!group_member_msg.empty()) {
+      return group_member_msg;
+    }
   }
-  return verifyAttrs(values, exp, std::vector<swss::FieldValueTuple>{},
-                     /*allow_unknown=*/false);
+  return "";
 }
 
 P4MulticastRouterInterfaceEntry*
@@ -2503,12 +2770,14 @@ sai_object_id_t L3MulticastManager::getRifOid(
 }
 
 // A RIF is associated with an egress port and Ethernet src mac value.
-sai_object_id_t L3MulticastManager::getRifOid(const P4Replica& replica) {
+  sai_object_id_t L3MulticastManager::getRifOid(
+    const P4MulticastReplicationEntry* multicast_replication_entry) {
 
   // Get router interface entry for out port and egress instance.
   const std::string router_interface_key =
       KeyGenerator::generateMulticastRouterInterfaceKey(
-          replica.port, replica.instance);
+          multicast_replication_entry->multicast_replica_port,
+          multicast_replication_entry->multicast_replica_instance);
   auto* router_interface_entry_ptr =
       getMulticastRouterInterfaceEntry(router_interface_key);
   if (router_interface_entry_ptr == nullptr) {
@@ -2525,13 +2794,12 @@ sai_object_id_t L3MulticastManager::getRifOid(const P4Replica& replica) {
 }
 
 // A RIF is associated with an egress port and Ethernet src mac value.
-sai_object_id_t L3MulticastManager::getRifOid(
-    const P4MulticastReplicationEntry* multicast_replication_entry) {
+sai_object_id_t L3MulticastManager::getRifOid(const P4Replica& replica) {
+
   // Get router interface entry for out port and egress instance.
   const std::string router_interface_key =
       KeyGenerator::generateMulticastRouterInterfaceKey(
-          multicast_replication_entry->multicast_replica_port,
-          multicast_replication_entry->multicast_replica_instance);
+          replica.port, replica.instance);
   auto* router_interface_entry_ptr =
       getMulticastRouterInterfaceEntry(router_interface_key);
   if (router_interface_entry_ptr == nullptr) {

--- a/orchagent/p4orch/l3_multicast_manager.h
+++ b/orchagent/p4orch/l3_multicast_manager.h
@@ -108,9 +108,9 @@ P4MulticastGroupTable;
 
 // The L3MulticastManager handles updates to two P4 tables:
 // * The "fixed" table multicast_router_interface_table, which defines a single
-//   action set_src_mac to map output port and egress instance ID to a Ethernet
-//   source MAC address to use for replicated packets.  Entries in this table
-//   create router interface (RIF) objects in the ASIC.
+//   action set_multicast_src_mac to map output port and egress instance ID to
+//   an Ethernet source MAC address to use for replicated packets.  Entries in
+//   this table create router interface (RIF) objects in the ASIC.
 // * The new "packet replication" table replication_multicast_table, which
 //   is modeled as an action-less table, where the table key of
 //   multicast group ID, egress instance, and output port will create entries
@@ -139,9 +139,9 @@ class L3MulticastManager : public ObjectManagerInterface {
   ReturnCode drainMulticastRouterInterfaceEntries(
       std::deque<swss::KeyOpFieldsValuesTuple>& router_interface_tuples);
 
-  // Drains entries associated with the multicast replication table.
-  ReturnCode drainMulticastReplicationEntries(
-      std::deque<swss::KeyOpFieldsValuesTuple>& replication_tuples);
+  // Drains entries associated with the multicast group table.
+  ReturnCode drainMulticastGroupEntries(
+      std::deque<swss::KeyOpFieldsValuesTuple>& group_entry_tuples);
 
   // Converts db table entry into P4MulticastRouterInterfaceEntry.
   ReturnCodeOr<P4MulticastRouterInterfaceEntry>
@@ -213,12 +213,12 @@ class L3MulticastManager : public ObjectManagerInterface {
       const std::deque<swss::KeyOpFieldsValuesTuple>& tuple_list,
       const std::string& op, bool update);
 
-  // Processes a list of entries of the same operation type for the replication
-  // multicast table.
+  // Processes a list of entries of the same operation type for the multicast
+  // group table.
   // Returns an overall status code.
   // This method also sends the response to the application.
-  ReturnCode processMulticastReplicationEntries(
-      std::vector<P4MulticastReplicationEntry>& entries,
+  ReturnCode processMulticastGroupEntries(
+      std::vector<P4MulticastGroupEntry>& entries,
       const std::deque<swss::KeyOpFieldsValuesTuple>& tuple_list,
       const std::string& op, bool update);
 
@@ -274,7 +274,9 @@ class L3MulticastManager : public ObjectManagerInterface {
   // Add new multicast group table entries.
   std::vector<ReturnCode> addMulticastGroupEntries(
       std::vector<P4MulticastGroupEntry>& entries);
-
+  // Update existing multicast group table entries.
+  std::vector<ReturnCode> updateMulticastGroupEntries(
+      std::vector<P4MulticastGroupEntry>& entries);
   // Used during failure scenarios where we try to revert to the previous state.
   ReturnCode restoreDeletedGroupMembers(
       const std::vector<P4Replica>& deleted_replicas,
@@ -288,7 +290,7 @@ class L3MulticastManager : public ObjectManagerInterface {
   std::string verifyMulticastRouterInterfaceState(
       const std::string& key,
       const std::vector<swss::FieldValueTuple>& tuple);
-  std::string verifyMulticastReplicationState(
+  std::string verifyMulticastGroupState(
       const std::string& key,
       const std::vector<swss::FieldValueTuple>& tuple);
 
@@ -297,16 +299,16 @@ class L3MulticastManager : public ObjectManagerInterface {
       const P4MulticastRouterInterfaceEntry& app_db_entry,
       const P4MulticastRouterInterfaceEntry* multicast_router_interface_entry);
   // Verifies internal cache for a multicast replication entry.
-  std::string verifyMulticastReplicationStateCache(
-      const P4MulticastReplicationEntry& app_db_entry,
-      const P4MulticastReplicationEntry* multicast_replication_entry);
+  std::string verifyMulticastGroupStateCache(
+      const P4MulticastGroupEntry& app_db_entry,
+      const P4MulticastGroupEntry* multicast_group_entry);
 
   // Verifies ASIC DB for a multicast router interface entry.
   std::string verifyMulticastRouterInterfaceStateAsicDb(
       const P4MulticastRouterInterfaceEntry* multicast_router_interface_entry);
   // Verifies ASIC DB for a multicast replication entry.
-  std::string verifyMulticastReplicationStateAsicDb(
-      const P4MulticastReplicationEntry* multicast_replication_entry);
+  std::string verifyMulticastGroupStateAsicDb(
+      const P4MulticastGroupEntry* multicast_group_entry);
 
   // Gets the internal cached multicast router interface entry.
   // Return nullptr if corresponding multicast router interface entry is not

--- a/orchagent/p4orch/p4orch_util.h
+++ b/orchagent/p4orch/p4orch_util.h
@@ -51,6 +51,7 @@ constexpr char *kSetNexthopId = "set_nexthop_id";
 constexpr char *kSetWcmpGroupId = "set_wcmp_group_id";
 constexpr char* kSetMulticastGroupId = "set_multicast_group_id";
 constexpr char* kSetSrcMac = "set_src_mac";
+constexpr char* kSetMulticastSrcMac = "set_multicast_src_mac";
 constexpr char *kSetNexthopIdAndMetadata = "set_nexthop_id_and_metadata";
 constexpr char *kSetWcmpGroupIdAndMetadata = "set_wcmp_group_id_and_metadata";
 constexpr char *kSetMetadataAndDrop = "set_metadata_and_drop";

--- a/orchagent/p4orch/tests/l3_multicast_manager_test.cpp
+++ b/orchagent/p4orch/tests/l3_multicast_manager_test.cpp
@@ -57,6 +57,7 @@ constexpr char* kSrcMac5 = "10:20:30:40:50:60";
 constexpr sai_object_id_t kRifOid1 = 0x123456;
 constexpr sai_object_id_t kRifOid2 = 0x22789a;
 constexpr sai_object_id_t kRifOid3 = 0x33feed;
+constexpr sai_object_id_t kRifOid4 = 0x44cafe;
 constexpr sai_object_id_t kRifOid5 = 0x55abcd;
 
 constexpr sai_object_id_t kGroupOid1 = 0x1;
@@ -66,6 +67,7 @@ constexpr sai_object_id_t kGroupOid3 = 0x3;
 constexpr sai_object_id_t kGroupMemberOid1 = 0x11;
 constexpr sai_object_id_t kGroupMemberOid2 = 0x12;
 constexpr sai_object_id_t kGroupMemberOid3 = 0x13;
+constexpr sai_object_id_t kGroupMemberOid4 = 0x14;
 
 // Matches two SAI attributes.
 bool MatchSaiAttribute(const sai_attribute_t& attr,
@@ -361,17 +363,17 @@ class L3MulticastManagerTest : public ::testing::Test {
         app_db_entry, multicast_router_interface_entry);
   }
 
-  std::string VerifyMulticastReplicationStateCache(
-      const P4MulticastReplicationEntry& app_db_entry,
-      const P4MulticastReplicationEntry* multicast_replication_entry) {
-    return l3_multicast_manager_.verifyMulticastReplicationStateCache(
-        app_db_entry, multicast_replication_entry);
+  std::string VerifyMulticastGroupStateCache(
+      const P4MulticastGroupEntry& app_db_entry,
+      const P4MulticastGroupEntry* multicast_group_entry) {
+    return l3_multicast_manager_.verifyMulticastGroupStateCache(
+        app_db_entry, multicast_group_entry);
   }
 
-  std::string VerifyMulticastReplicationStateAsicDb(
-      const P4MulticastReplicationEntry* multicast_replication_entry) {
-    return l3_multicast_manager_.verifyMulticastReplicationStateAsicDb(
-        multicast_replication_entry);
+  std::string VerifyMulticastGroupStateAsicDb(
+      const P4MulticastGroupEntry* multicast_group_entry) {
+    return l3_multicast_manager_.verifyMulticastGroupStateAsicDb(
+        multicast_group_entry);
   }
 
   ReturnCodeOr<P4MulticastRouterInterfaceEntry>
@@ -498,6 +500,11 @@ class L3MulticastManagerTest : public ::testing::Test {
     return l3_multicast_manager_.updateMulticastReplicationEntries(entries);
   }
 
+  std::vector<ReturnCode> UpdateMulticastGroupEntries(
+      std::vector<P4MulticastGroupEntry>& entries) {
+    return l3_multicast_manager_.updateMulticastGroupEntries(entries);
+  }
+
   P4MulticastRouterInterfaceEntry* GetMulticastRouterInterfaceEntry(
       const std::string& multicast_router_interface_entry_key) {
     return l3_multicast_manager_.getMulticastRouterInterfaceEntry(
@@ -556,7 +563,7 @@ TEST_F(L3MulticastManagerTest, DeserializeMulticastRouterInterfaceEntryTest) {
                     R"("match/multicast_replica_instance":"0x0"})";
   std::vector<swss::FieldValueTuple> attributes;
   attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
   attributes.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kSrcMac), kSrcMac1});
   attributes.push_back(swss::FieldValueTuple{
@@ -611,7 +618,7 @@ TEST_F(L3MulticastManagerTest,
                     R"("match/multicast_replica_instance":"0x0"})";
   std::vector<swss::FieldValueTuple> attributes;
   attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
   attributes.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kSrcMac), kSrcMac1});
   attributes.push_back(swss::FieldValueTuple{"extra_attr", "extra_attr_val"});
@@ -1403,7 +1410,7 @@ TEST_F(L3MulticastManagerTest, DrainMulticastRouterInterfaceEntryAdd) {
 
   std::vector<swss::FieldValueTuple> attributes;
   attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
   attributes.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kSrcMac), kSrcMac2});
   attributes.push_back(
@@ -1453,7 +1460,7 @@ TEST_F(L3MulticastManagerTest,
 
   std::vector<swss::FieldValueTuple> attributes;
   attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
   attributes.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kSrcMac), kSrcMac1});
   attributes.push_back(
@@ -1522,7 +1529,7 @@ TEST_F(L3MulticastManagerTest,
 
   std::vector<swss::FieldValueTuple> attributes1;
   attributes1.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
   attributes1.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kSrcMac), kSrcMac1});
   attributes1.push_back(
@@ -1530,7 +1537,7 @@ TEST_F(L3MulticastManagerTest,
 
   std::vector<swss::FieldValueTuple> attributes2;
   attributes2.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
   attributes2.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kSrcMac), kSrcMac2});
   attributes2.push_back(
@@ -1585,7 +1592,7 @@ TEST_F(L3MulticastManagerTest, DrainMulticastRouterInterfaceEntryInvalidAdd) {
 
   std::vector<swss::FieldValueTuple> attributes;
   attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
 
   attributes.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kSrcMac), kSrcMac2});
@@ -1620,7 +1627,7 @@ TEST_F(L3MulticastManagerTest,
 
   std::vector<swss::FieldValueTuple> attributes;
   attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
   attributes.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kSrcMac), kSrcMac2});
   attributes.push_back(
@@ -1654,7 +1661,7 @@ TEST_F(L3MulticastManagerTest,
 
   std::vector<swss::FieldValueTuple> attributes;
   attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
   attributes.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kSrcMac), kSrcMac2});
   attributes.push_back(
@@ -1701,7 +1708,7 @@ TEST_F(L3MulticastManagerTest,
   // Enqueue entry for create operation.
   std::vector<swss::FieldValueTuple> attributes;
   attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
   attributes.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kSrcMac), kSrcMac2});
   attributes.push_back(
@@ -1726,7 +1733,7 @@ TEST_F(L3MulticastManagerTest,
 
   std::vector<swss::FieldValueTuple> attributes2;
   attributes2.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
   attributes2.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kSrcMac), kSrcMac3});
   attributes2.push_back(
@@ -1764,7 +1771,7 @@ TEST_F(L3MulticastManagerTest,
 
   std::vector<swss::FieldValueTuple> attributes;
   attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
 
   attributes.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kSrcMac), kSrcMac1});
@@ -1791,7 +1798,7 @@ TEST_F(L3MulticastManagerTest, DrainFirstEntryFailurePublishesCorrectNumber) {
 
   std::vector<swss::FieldValueTuple> attributes;
   attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
   attributes.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kSrcMac), kSrcMac2});
   attributes.push_back(
@@ -1802,7 +1809,7 @@ TEST_F(L3MulticastManagerTest, DrainFirstEntryFailurePublishesCorrectNumber) {
       R"("match/multicast_replica_port":"Ethernet1",)"
       R"("match/multicast_replica_instance":"0x1"})";
   const std::string group_appl_db_key =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
+      std::string(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) +
       kTableKeyDelimiter + group_match_key;
   std::vector<swss::FieldValueTuple> group_attributes;
   group_attributes.push_back(
@@ -1968,7 +1975,7 @@ TEST_F(L3MulticastManagerTest, VerifyStateMulticastRouterInterfaceTestSuccess) {
                            kTableKeyDelimiter + appl_db_key;
   std::vector<swss::FieldValueTuple> attributes;
   attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
   attributes.push_back(swss::FieldValueTuple{
       prependParamField(p4orch::kSrcMac), kSrcMac1});
   attributes.push_back(
@@ -1995,6 +2002,7 @@ TEST_F(L3MulticastManagerTest, VerifyStateMulticastRouterInterfaceTestSuccess) {
 
   // Verification should succeed with vaild key and value.
   EXPECT_EQ(VerifyState(db_key, attributes), "");
+  table.del("SAI_OBJECT_TYPE_ROUTER_INTERFACE:oid:0x123456");
 }
 
 TEST_F(L3MulticastManagerTest,
@@ -2013,7 +2021,7 @@ TEST_F(L3MulticastManagerTest,
 
   std::vector<swss::FieldValueTuple> attributes;
   attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
   // Use wrong source mac so state cache fails.
   attributes.push_back(swss::FieldValueTuple{
       prependParamField(p4orch::kSrcMac), kSrcMac2});
@@ -2094,7 +2102,7 @@ TEST_F(L3MulticastManagerTest,
                            kTableKeyDelimiter + appl_db_key;
   std::vector<swss::FieldValueTuple> attributes;
   attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
   attributes.push_back(swss::FieldValueTuple{
       prependParamField(p4orch::kSrcMac), kSrcMac1});
   attributes.push_back(
@@ -2755,14 +2763,602 @@ TEST_F(L3MulticastManagerTest,
                                        replica2.key));  // since remove failed
 }
 
-TEST_F(L3MulticastManagerTest, UpdateMulticastReplicationEntriesTestSuccess) {
-  auto entry1 = GenerateP4MulticastReplicationEntry("0x1", "Ethernet1", "0x1");
-  auto entry2 = GenerateP4MulticastReplicationEntry("0x2", "Ethernet1", "0x1");
-  std::vector<P4MulticastReplicationEntry> entries = {entry1, entry2};
-  auto statuses = UpdateMulticastReplicationEntries(entries);
-  EXPECT_EQ(statuses.size(), 2);
+TEST_F(L3MulticastManagerTest, UpdateMulticastGroupEntriesTestSuccess) {
+  auto rif_entry1 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet1", "0x0", swss::MacAddress(kSrcMac1), kRifOid1);
+  auto rif_entry2 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet2", "0x0", swss::MacAddress(kSrcMac2), kRifOid2);
+  auto rif_entry3 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet3", "0x0", swss::MacAddress(kSrcMac3), kRifOid3);
+
+  P4Replica replica1 = P4Replica("0x1", "Ethernet1", "0x0");
+  P4Replica replica2 = P4Replica("0x1", "Ethernet2", "0x0");
+  P4Replica replica3 = P4Replica("0x1", "Ethernet3", "0x0");
+
+  auto group_entry1 = SetupP4MulticastGroupEntry(
+      "0x1", {replica1, replica2},
+      kGroupOid1, {kGroupMemberOid1, kGroupMemberOid2});
+
+  // Should leave replica1 untouched, delete replica2, and add replica3.
+  auto group_entry3 = GenerateP4MulticastGroupEntry(
+      "0x1", {replica1, replica3});
+
+  EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group_member(kGroupMemberOid2))
+      .WillOnce(Return(SAI_STATUS_SUCCESS));
+
+  std::vector<sai_attribute_t> exp_member_attrs;
+  sai_attribute_t attr;
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_GROUP_ID;
+  attr.value.oid = kGroupOid1;
+  exp_member_attrs.push_back(attr);
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_OUTPUT_ID;
+  attr.value.oid = kRifOid3;
+  exp_member_attrs.push_back(attr);
+  EXPECT_CALL(mock_sai_ipmc_group_,
+              create_ipmc_group_member(_, _, 2, AttrArrayEq(exp_member_attrs)))
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupMemberOid3),
+                Return(SAI_STATUS_SUCCESS)));
+
+  std::vector<P4MulticastGroupEntry> entries = {group_entry3};
+  auto statuses = UpdateMulticastGroupEntries(entries);
+
+  EXPECT_EQ(statuses.size(), 1);
   EXPECT_EQ(statuses[0], StatusCode::SWSS_RC_SUCCESS);
-  EXPECT_EQ(statuses[1], StatusCode::SWSS_RC_SUCCESS);
+
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP, "0x1"));
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                       replica1.key));
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                        replica2.key));
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                       replica3.key));
+
+  auto* group_entry_ptr = GetMulticastGroupEntry("0x1");
+  ASSERT_NE(group_entry_ptr, nullptr);
+  auto expect_entry = GenerateP4MulticastGroupEntry(
+    "0x1", {replica1, replica3});
+  expect_entry.multicast_group_oid = kGroupOid1;
+  expect_entry.member_oids[replica1.key] = kGroupMemberOid1;
+  expect_entry.member_oids[replica3.key] = kGroupMemberOid3;
+  VerifyP4MulticastGroupEntryEqual(expect_entry, *group_entry_ptr);
+}
+
+TEST_F(L3MulticastManagerTest, UpdateMulticastGroupEntriesNoEntryFound) {
+  auto rif_entry1 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet1", "0x0", swss::MacAddress(kSrcMac1), kRifOid1);
+
+  P4Replica replica1 = P4Replica("0x1", "Ethernet1", "0x0");
+  P4Replica replica2 = P4Replica("0x2", "Ethernet1", "0x0");
+  auto group_entry1 = GenerateP4MulticastGroupEntry(
+      "0x1", {replica1});
+  auto group_entry2 = GenerateP4MulticastGroupEntry(
+      "0x2", {replica2});
+
+  std::vector<P4MulticastGroupEntry> entries = {group_entry1, group_entry2};
+  auto statuses = UpdateMulticastGroupEntries(entries);
+  EXPECT_EQ(statuses.size(), 2);
+  EXPECT_EQ(statuses[0], StatusCode::SWSS_RC_UNKNOWN);
+  EXPECT_EQ(statuses[1], StatusCode::SWSS_RC_NOT_EXECUTED);
+}
+
+TEST_F(L3MulticastManagerTest, UpdateMulticastGroupEntriesMissingGroupOid) {
+  auto rif_entry1 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet1", "0x0", swss::MacAddress(kSrcMac1), kRifOid1);
+  auto rif_entry2 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet2", "0x0", swss::MacAddress(kSrcMac2), kRifOid2);
+  auto rif_entry3 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet3", "0x0", swss::MacAddress(kSrcMac3), kRifOid3);
+
+  P4Replica replica1 = P4Replica("0x1", "Ethernet1", "0x0");
+  P4Replica replica2 = P4Replica("0x1", "Ethernet2", "0x0");
+  P4Replica replica3 = P4Replica("0x1", "Ethernet3", "0x0");
+
+  auto group_entry1 = SetupP4MulticastGroupEntry(
+      "0x1", {replica1, replica2},
+      kGroupOid1, {kGroupMemberOid1, kGroupMemberOid2});
+
+  // Unnaturally delete multicast group OID to cause an error.
+  p4_oid_mapper_.eraseOID(SAI_OBJECT_TYPE_IPMC_GROUP, "0x1");
+
+  // Want to leave replica1 untouched, delete replica2, and add replica3.
+  auto group_entry3 = GenerateP4MulticastGroupEntry(
+      "0x1", {replica1, replica3});
+
+  std::vector<P4MulticastGroupEntry> entries = {group_entry3, group_entry1};
+  auto statuses = UpdateMulticastGroupEntries(entries);
+  EXPECT_EQ(statuses.size(), 2);
+  EXPECT_EQ(statuses[0], StatusCode::SWSS_RC_INTERNAL);
+  EXPECT_EQ(statuses[1], StatusCode::SWSS_RC_NOT_EXECUTED);
+}
+
+TEST_F(L3MulticastManagerTest,
+       UpdateMulticastGroupEntriesUpdateNoDiffMakesNoSaiCalls) {
+  auto rif_entry1 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet1", "0x0", swss::MacAddress(kSrcMac1), kRifOid1);
+  auto rif_entry2 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet2", "0x0", swss::MacAddress(kSrcMac2), kRifOid2);
+
+  P4Replica replica1 = P4Replica("0x1", "Ethernet1", "0x0");
+  P4Replica replica2 = P4Replica("0x1", "Ethernet2", "0x0");
+
+  auto group_entry1 = SetupP4MulticastGroupEntry(
+      "0x1", {replica1, replica2},
+      kGroupOid1, {kGroupMemberOid1, kGroupMemberOid2});
+
+  std::vector<P4MulticastGroupEntry> entries = {group_entry1};
+  auto statuses = UpdateMulticastGroupEntries(entries);
+  EXPECT_EQ(statuses.size(), 1);
+  EXPECT_EQ(statuses[0], StatusCode::SWSS_RC_SUCCESS);
+}
+
+TEST_F(L3MulticastManagerTest, UpdateMulticastGroupEntriesMissingRifError) {
+  auto rif_entry1 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet1", "0x0", swss::MacAddress(kSrcMac1), kRifOid1);
+  auto rif_entry2 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet2", "0x0", swss::MacAddress(kSrcMac2), kRifOid2);
+  auto rif_entry3 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet3", "0x0", swss::MacAddress(kSrcMac3), kRifOid3);
+
+  P4Replica replica1 = P4Replica("0x1", "Ethernet1", "0x0");
+  P4Replica replica2 = P4Replica("0x1", "Ethernet2", "0x0");
+  P4Replica replica3 = P4Replica("0x1", "Ethernet3", "0x0");
+
+  auto group_entry1 = SetupP4MulticastGroupEntry(
+      "0x1", {replica1, replica2},
+      kGroupOid1, {kGroupMemberOid1, kGroupMemberOid2});
+
+  // Unnaturally force RIF for replica2 to disappear.
+  std::string rif_key = KeyGenerator::generateMulticastRouterInterfaceRifKey(
+    "Ethernet2", swss::MacAddress(kSrcMac2));
+  ForceRemoveRifKey(rif_key);
+
+  // Want to leave replica1 untouched, delete replica2, and add replica3.
+  auto group_entry2 = GenerateP4MulticastGroupEntry(
+      "0x1", {replica1, replica3});
+
+  std::vector<P4MulticastGroupEntry> entries = {group_entry2};
+  auto statuses = UpdateMulticastGroupEntries(entries);
+  EXPECT_EQ(statuses.size(), 1);
+  EXPECT_EQ(statuses[0], StatusCode::SWSS_RC_INTERNAL);
+
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP, "0x1"));
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                       replica1.key));
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                       replica2.key));
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                        replica3.key));
+}
+
+TEST_F(L3MulticastManagerTest,
+       UpdateMulticastGroupEntriesMemberDeleteFailsRestoreSucceeds) {
+  auto rif_entry1 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet1", "0x0", swss::MacAddress(kSrcMac1), kRifOid1);
+  auto rif_entry2 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet2", "0x0", swss::MacAddress(kSrcMac2), kRifOid2);
+  auto rif_entry3 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet3", "0x0", swss::MacAddress(kSrcMac3), kRifOid3);
+
+  P4Replica replica1 = P4Replica("0x1", "Ethernet1", "0x0");
+  P4Replica replica2 = P4Replica("0x1", "Ethernet2", "0x0");
+  P4Replica replica3 = P4Replica("0x1", "Ethernet3", "0x0");
+
+  auto group_entry1 = SetupP4MulticastGroupEntry(
+      "0x1", {replica1, replica2},
+      kGroupOid1, {kGroupMemberOid1, kGroupMemberOid2});
+
+  // Want to delete replicas 1 and 2, and add replica3.
+  auto group_entry2 = GenerateP4MulticastGroupEntry("0x1", {replica3});
+
+  EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group_member(kGroupMemberOid1))
+      .WillOnce(Return(SAI_STATUS_SUCCESS));
+  EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group_member(kGroupMemberOid2))
+      .WillOnce(Return(SAI_STATUS_FAILURE));
+
+  std::vector<sai_attribute_t> exp_member_attrs;
+  sai_attribute_t attr;
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_GROUP_ID;
+  attr.value.oid = kGroupOid1;
+  exp_member_attrs.push_back(attr);
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_OUTPUT_ID;
+  attr.value.oid = kRifOid1;
+  exp_member_attrs.push_back(attr);
+  EXPECT_CALL(mock_sai_ipmc_group_,
+              create_ipmc_group_member(_, _, 2, AttrArrayEq(exp_member_attrs)))
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupMemberOid1),
+                Return(SAI_STATUS_SUCCESS)));
+
+  std::vector<P4MulticastGroupEntry> entries = {group_entry2};
+  auto statuses = UpdateMulticastGroupEntries(entries);
+  EXPECT_EQ(statuses.size(), 1);
+  EXPECT_EQ(statuses[0], StatusCode::SWSS_RC_UNKNOWN);
+
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP, "0x1"));
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                       replica1.key));
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                       replica2.key));
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                        replica3.key));
+
+  auto* group_entry_ptr = GetMulticastGroupEntry("0x1");
+  ASSERT_NE(group_entry_ptr, nullptr);
+  auto expect_entry = GenerateP4MulticastGroupEntry(
+    "0x1", {replica1, replica2});
+  expect_entry.multicast_group_oid = kGroupOid1;
+  expect_entry.member_oids[replica1.key] = kGroupMemberOid1;
+  expect_entry.member_oids[replica2.key] = kGroupMemberOid2;
+  VerifyP4MulticastGroupEntryEqual(expect_entry, *group_entry_ptr);
+}
+
+TEST_F(L3MulticastManagerTest,
+       UpdateMulticastGroupEntriesMemberDeleteFailsRestoreFails) {
+  auto rif_entry1 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet1", "0x0", swss::MacAddress(kSrcMac1), kRifOid1);
+  auto rif_entry2 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet2", "0x0", swss::MacAddress(kSrcMac2), kRifOid2);
+  auto rif_entry3 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet3", "0x0", swss::MacAddress(kSrcMac3), kRifOid3);
+
+  P4Replica replica1 = P4Replica("0x1", "Ethernet1", "0x0");
+  P4Replica replica2 = P4Replica("0x1", "Ethernet2", "0x0");
+  P4Replica replica3 = P4Replica("0x1", "Ethernet3", "0x0");
+
+  auto group_entry1 = SetupP4MulticastGroupEntry(
+      "0x1", {replica1, replica2},
+      kGroupOid1, {kGroupMemberOid1, kGroupMemberOid2});
+
+  // Want to delete replicas 1 and 2, and add replica3.
+  auto group_entry2 = GenerateP4MulticastGroupEntry("0x1", {replica3});
+
+  EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group_member(kGroupMemberOid1))
+      .WillOnce(Return(SAI_STATUS_SUCCESS));
+  EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group_member(kGroupMemberOid2))
+      .WillOnce(Return(SAI_STATUS_FAILURE));
+
+  std::vector<sai_attribute_t> exp_member_attrs;
+  sai_attribute_t attr;
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_GROUP_ID;
+  attr.value.oid = kGroupOid1;
+  exp_member_attrs.push_back(attr);
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_OUTPUT_ID;
+  attr.value.oid = kRifOid1;
+  exp_member_attrs.push_back(attr);
+  EXPECT_CALL(mock_sai_ipmc_group_,
+              create_ipmc_group_member(_, _, 2, AttrArrayEq(exp_member_attrs)))
+      .WillOnce(Return(SAI_STATUS_FAILURE));
+
+  std::vector<P4MulticastGroupEntry> entries = {group_entry2};
+  auto statuses = UpdateMulticastGroupEntries(entries);
+  EXPECT_EQ(statuses.size(), 1);
+  EXPECT_EQ(statuses[0], StatusCode::SWSS_RC_UNKNOWN);
+
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP, "0x1"));
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                        replica1.key));
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                       replica2.key));
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                        replica3.key));
+}
+
+TEST_F(L3MulticastManagerTest,
+       UpdateMulticastGroupEntriesMemberAddCannotFindRif) {
+  auto rif_entry1 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet1", "0x0", swss::MacAddress(kSrcMac1), kRifOid1);
+  auto rif_entry2 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet2", "0x0", swss::MacAddress(kSrcMac2), kRifOid2);
+  auto rif_entry3 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet3", "0x0", swss::MacAddress(kSrcMac3), kRifOid3);
+
+  P4Replica replica1 = P4Replica("0x1", "Ethernet1", "0x0");
+  P4Replica replica2 = P4Replica("0x1", "Ethernet2", "0x0");
+  P4Replica replica3 = P4Replica("0x1", "Ethernet3", "0x0");
+
+  auto group_entry1 = SetupP4MulticastGroupEntry(
+      "0x1", {replica1, replica2},
+      kGroupOid1, {kGroupMemberOid1, kGroupMemberOid2});
+
+  // Want to add replica3.
+  auto group_entry2 = GenerateP4MulticastGroupEntry(
+      "0x1", {replica1, replica2, replica3});
+
+  // Unnaturally force RIFs to disappear.
+  std::string rif_key = KeyGenerator::generateMulticastRouterInterfaceRifKey(
+    "Ethernet3", swss::MacAddress(kSrcMac3));
+  ForceRemoveRifKey(rif_key);
+
+  std::vector<P4MulticastGroupEntry> entries = {group_entry2};
+  auto statuses = UpdateMulticastGroupEntries(entries);
+  EXPECT_EQ(statuses.size(), 1);
+  EXPECT_EQ(statuses[0], StatusCode::SWSS_RC_INTERNAL);
+
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP, "0x1"));
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                       replica1.key));
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                       replica2.key));
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                        replica3.key));
+}
+
+TEST_F(L3MulticastManagerTest,
+       UpdateMulticastGroupEntriesMemberAddMemberFailsBackoutSucceeds) {
+  auto rif_entry1 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet1", "0x0", swss::MacAddress(kSrcMac1), kRifOid1);
+  auto rif_entry2 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet2", "0x0", swss::MacAddress(kSrcMac2), kRifOid2);
+  auto rif_entry3 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet3", "0x0", swss::MacAddress(kSrcMac3), kRifOid3);
+  auto rif_entry4 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet4", "0x0", swss::MacAddress(kSrcMac4), kRifOid4);
+
+  P4Replica replica1 = P4Replica("0x1", "Ethernet1", "0x0");
+  P4Replica replica2 = P4Replica("0x1", "Ethernet2", "0x0");
+  P4Replica replica3 = P4Replica("0x1", "Ethernet3", "0x0");
+  P4Replica replica4 = P4Replica("0x1", "Ethernet4", "0x0");
+
+  auto group_entry1 = SetupP4MulticastGroupEntry(
+      "0x1", {replica1, replica2},
+      kGroupOid1, {kGroupMemberOid1, kGroupMemberOid2});
+
+  // Want to delete replica1 and replica2.  Want to add replica3 and replica4.
+  auto group_entry2 = GenerateP4MulticastGroupEntry(
+      "0x1", {replica3, replica4});
+
+  // Remove replica1 and replica2.
+  EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group_member(kGroupMemberOid1))
+      .WillOnce(Return(SAI_STATUS_SUCCESS));
+  EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group_member(kGroupMemberOid2))
+      .WillOnce(Return(SAI_STATUS_SUCCESS));
+
+  // Add replica3.
+  std::vector<sai_attribute_t> exp_member_attrs;
+  sai_attribute_t attr;
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_GROUP_ID;
+  attr.value.oid = kGroupOid1;
+  exp_member_attrs.push_back(attr);
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_OUTPUT_ID;
+  attr.value.oid = kRifOid3;
+  exp_member_attrs.push_back(attr);
+  EXPECT_CALL(mock_sai_ipmc_group_,
+              create_ipmc_group_member(_, _, 2, AttrArrayEq(exp_member_attrs)))
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupMemberOid3),
+                Return(SAI_STATUS_SUCCESS)));
+  // Try to add replica4, but it fails.
+  std::vector<sai_attribute_t> exp_member_attrs2;
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_GROUP_ID;
+  attr.value.oid = kGroupOid1;
+  exp_member_attrs2.push_back(attr);
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_OUTPUT_ID;
+  attr.value.oid = kRifOid4;
+  exp_member_attrs2.push_back(attr);
+  EXPECT_CALL(mock_sai_ipmc_group_,
+              create_ipmc_group_member(_, _, 2, AttrArrayEq(exp_member_attrs2)))
+      .WillOnce(Return(SAI_STATUS_FAILURE));
+  // Remove replica3.
+  EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group_member(kGroupMemberOid3))
+      .WillOnce(Return(SAI_STATUS_SUCCESS));
+  // Add replica1 and replica2 back.
+  std::vector<sai_attribute_t> exp_member_attrs3;
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_GROUP_ID;
+  attr.value.oid = kGroupOid1;
+  exp_member_attrs3.push_back(attr);
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_OUTPUT_ID;
+  attr.value.oid = kRifOid1;
+  exp_member_attrs3.push_back(attr);
+  EXPECT_CALL(mock_sai_ipmc_group_,
+              create_ipmc_group_member(_, _, 2, AttrArrayEq(exp_member_attrs3)))
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupMemberOid1),
+                Return(SAI_STATUS_SUCCESS)));
+  std::vector<sai_attribute_t> exp_member_attrs4;
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_GROUP_ID;
+  attr.value.oid = kGroupOid1;
+  exp_member_attrs4.push_back(attr);
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_OUTPUT_ID;
+  attr.value.oid = kRifOid2;
+  exp_member_attrs4.push_back(attr);
+  EXPECT_CALL(mock_sai_ipmc_group_,
+              create_ipmc_group_member(_, _, 2, AttrArrayEq(exp_member_attrs4)))
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupMemberOid2),
+                Return(SAI_STATUS_SUCCESS)));
+
+  std::vector<P4MulticastGroupEntry> entries = {group_entry2};
+  auto statuses = UpdateMulticastGroupEntries(entries);
+  EXPECT_EQ(statuses.size(), 1);
+  EXPECT_EQ(statuses[0], StatusCode::SWSS_RC_UNKNOWN);
+
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP, "0x1"));
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                       replica1.key));
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                       replica2.key));
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                        replica3.key));
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                        replica4.key));
+
+  auto* group_entry_ptr = GetMulticastGroupEntry("0x1");
+  ASSERT_NE(group_entry_ptr, nullptr);
+  auto expect_entry = GenerateP4MulticastGroupEntry(
+    "0x1", {replica1, replica2});
+  expect_entry.multicast_group_oid = kGroupOid1;
+  expect_entry.member_oids[replica1.key] = kGroupMemberOid1;
+  expect_entry.member_oids[replica2.key] = kGroupMemberOid2;
+  VerifyP4MulticastGroupEntryEqual(expect_entry, *group_entry_ptr);
+}
+
+TEST_F(L3MulticastManagerTest,
+       UpdateMulticastGroupEntriesMemberAddMemberFailsBackoutDeleteFails) {
+  auto rif_entry1 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet1", "0x0", swss::MacAddress(kSrcMac1), kRifOid1);
+  auto rif_entry2 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet2", "0x0", swss::MacAddress(kSrcMac2), kRifOid2);
+  auto rif_entry3 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet3", "0x0", swss::MacAddress(kSrcMac3), kRifOid3);
+  auto rif_entry4 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet4", "0x0", swss::MacAddress(kSrcMac4), kRifOid4);
+
+  P4Replica replica1 = P4Replica("0x1", "Ethernet1", "0x0");
+  P4Replica replica2 = P4Replica("0x1", "Ethernet2", "0x0");
+  P4Replica replica3 = P4Replica("0x1", "Ethernet3", "0x0");
+  P4Replica replica4 = P4Replica("0x1", "Ethernet4", "0x0");
+
+  auto group_entry1 = SetupP4MulticastGroupEntry(
+      "0x1", {replica1, replica2},
+      kGroupOid1, {kGroupMemberOid1, kGroupMemberOid2});
+
+  // Want to delete replica1 and replica2.  Want to add replica3 and replica4.
+  auto group_entry2 = GenerateP4MulticastGroupEntry(
+      "0x1", {replica3, replica4});
+
+  // Remove replica1 and replica2.
+  EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group_member(kGroupMemberOid1))
+      .WillOnce(Return(SAI_STATUS_SUCCESS));
+  EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group_member(kGroupMemberOid2))
+      .WillOnce(Return(SAI_STATUS_SUCCESS));
+
+  // Add replica3.
+  std::vector<sai_attribute_t> exp_member_attrs;
+  sai_attribute_t attr;
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_GROUP_ID;
+  attr.value.oid = kGroupOid1;
+  exp_member_attrs.push_back(attr);
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_OUTPUT_ID;
+  attr.value.oid = kRifOid3;
+  exp_member_attrs.push_back(attr);
+  EXPECT_CALL(mock_sai_ipmc_group_,
+              create_ipmc_group_member(_, _, 2, AttrArrayEq(exp_member_attrs)))
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupMemberOid3),
+                Return(SAI_STATUS_SUCCESS)));
+  // Try to add replica4, but it fails.
+  std::vector<sai_attribute_t> exp_member_attrs2;
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_GROUP_ID;
+  attr.value.oid = kGroupOid1;
+  exp_member_attrs2.push_back(attr);
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_OUTPUT_ID;
+  attr.value.oid = kRifOid4;
+  exp_member_attrs2.push_back(attr);
+  EXPECT_CALL(mock_sai_ipmc_group_,
+              create_ipmc_group_member(_, _, 2, AttrArrayEq(exp_member_attrs2)))
+      .WillOnce(Return(SAI_STATUS_FAILURE));
+  // Remove replica3, but it fails.
+  EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group_member(kGroupMemberOid3))
+      .WillOnce(Return(SAI_STATUS_FAILURE));
+
+  std::vector<P4MulticastGroupEntry> entries = {group_entry2};
+  auto statuses = UpdateMulticastGroupEntries(entries);
+  EXPECT_EQ(statuses.size(), 1);
+  EXPECT_EQ(statuses[0], StatusCode::SWSS_RC_UNKNOWN);
+
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP, "0x1"));
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                        replica1.key));
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                        replica2.key));
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                       replica3.key));
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                        replica4.key));
+}
+
+TEST_F(L3MulticastManagerTest,
+       UpdateMulticastGroupEntriesMemberAddMemberFailsBackoutAddFails) {
+  auto rif_entry1 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet1", "0x0", swss::MacAddress(kSrcMac1), kRifOid1);
+  auto rif_entry2 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet2", "0x0", swss::MacAddress(kSrcMac2), kRifOid2);
+  auto rif_entry3 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet3", "0x0", swss::MacAddress(kSrcMac3), kRifOid3);
+  auto rif_entry4 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet4", "0x0", swss::MacAddress(kSrcMac4), kRifOid4);
+
+  P4Replica replica1 = P4Replica("0x1", "Ethernet1", "0x0");
+  P4Replica replica2 = P4Replica("0x1", "Ethernet2", "0x0");
+  P4Replica replica3 = P4Replica("0x1", "Ethernet3", "0x0");
+  P4Replica replica4 = P4Replica("0x1", "Ethernet4", "0x0");
+
+  auto group_entry1 = SetupP4MulticastGroupEntry(
+      "0x1", {replica1, replica2},
+      kGroupOid1, {kGroupMemberOid1, kGroupMemberOid2});
+
+  // Want to delete replica1 and replica2.  Want to add replica3 and replica4.
+  auto group_entry2 = GenerateP4MulticastGroupEntry(
+      "0x1", {replica3, replica4});
+
+  // Remove replica1 and replica2.
+  EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group_member(kGroupMemberOid1))
+      .WillOnce(Return(SAI_STATUS_SUCCESS));
+  EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group_member(kGroupMemberOid2))
+      .WillOnce(Return(SAI_STATUS_SUCCESS));
+
+  // Add replica3.
+  std::vector<sai_attribute_t> exp_member_attrs;
+  sai_attribute_t attr;
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_GROUP_ID;
+  attr.value.oid = kGroupOid1;
+  exp_member_attrs.push_back(attr);
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_OUTPUT_ID;
+  attr.value.oid = kRifOid3;
+  exp_member_attrs.push_back(attr);
+  EXPECT_CALL(mock_sai_ipmc_group_,
+              create_ipmc_group_member(_, _, 2, AttrArrayEq(exp_member_attrs)))
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupMemberOid3),
+                Return(SAI_STATUS_SUCCESS)));
+  // Try to add replica4, but it fails.
+  std::vector<sai_attribute_t> exp_member_attrs2;
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_GROUP_ID;
+  attr.value.oid = kGroupOid1;
+  exp_member_attrs2.push_back(attr);
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_OUTPUT_ID;
+  attr.value.oid = kRifOid4;
+  exp_member_attrs2.push_back(attr);
+  EXPECT_CALL(mock_sai_ipmc_group_,
+              create_ipmc_group_member(_, _, 2, AttrArrayEq(exp_member_attrs2)))
+      .WillOnce(Return(SAI_STATUS_FAILURE));
+  // Remove replica3.
+  EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group_member(kGroupMemberOid3))
+      .WillOnce(Return(SAI_STATUS_SUCCESS));
+
+  // Try to add replica1 back.
+  std::vector<sai_attribute_t> exp_member_attrs3;
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_GROUP_ID;
+  attr.value.oid = kGroupOid1;
+  exp_member_attrs3.push_back(attr);
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_OUTPUT_ID;
+  attr.value.oid = kRifOid1;
+  exp_member_attrs3.push_back(attr);
+  EXPECT_CALL(mock_sai_ipmc_group_,
+              create_ipmc_group_member(_, _, 2, AttrArrayEq(exp_member_attrs3)))
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupMemberOid1),
+                Return(SAI_STATUS_SUCCESS)));
+
+  // Try to add replica2 back, but it fails.
+  std::vector<sai_attribute_t> exp_member_attrs4;
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_GROUP_ID;
+  attr.value.oid = kGroupOid1;
+  exp_member_attrs4.push_back(attr);
+  attr.id = SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_OUTPUT_ID;
+  attr.value.oid = kRifOid2;
+  exp_member_attrs4.push_back(attr);
+  EXPECT_CALL(mock_sai_ipmc_group_,
+              create_ipmc_group_member(_, _, 2, AttrArrayEq(exp_member_attrs4)))
+      .WillOnce(Return(SAI_STATUS_FAILURE));
+
+  std::vector<P4MulticastGroupEntry> entries = {group_entry2};
+  auto statuses = UpdateMulticastGroupEntries(entries);
+  EXPECT_EQ(statuses.size(), 1);
+  EXPECT_EQ(statuses[0], StatusCode::SWSS_RC_UNKNOWN);
+
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP, "0x1"));
+  EXPECT_TRUE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                       replica1.key));
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                        replica2.key));
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                        replica3.key));
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                        replica4.key));
 }
 
 TEST_F(L3MulticastManagerTest,
@@ -2945,7 +3541,7 @@ TEST_F(L3MulticastManagerTest,
   EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, status);
 }
 
-TEST_F(L3MulticastManagerTest, DrainMulticastReplicationEntryAddSuccestTest) {
+TEST_F(L3MulticastManagerTest, DrainMulticastGroupEntryAddSuccessTest) {
   const std::string mac_match_key =
       R"({"match/multicast_replica_port":"Ethernet1",)"
       R"("match/multicast_replica_instance":"0x1"})";
@@ -2954,22 +3550,26 @@ TEST_F(L3MulticastManagerTest, DrainMulticastReplicationEntryAddSuccestTest) {
       kTableKeyDelimiter + mac_match_key;
   std::vector<swss::FieldValueTuple> mac_attributes;
   mac_attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
   mac_attributes.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kSrcMac), kSrcMac1});
   mac_attributes.push_back(
       swss::FieldValueTuple{p4orch::kControllerMetadata, "so_meta"});
 
-  const std::string group_match_key =
-      R"({"match/multicast_group_id":"0x1",)"
-      R"("match/multicast_replica_port":"Ethernet1",)"
-      R"("match/multicast_replica_instance":"0x1"})";
+  const std::string group_match_key = "0x1";
   const std::string group_appl_db_key =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
+      std::string(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) +
       kTableKeyDelimiter + group_match_key;
   std::vector<swss::FieldValueTuple> group_attributes;
+  const std::string json_array =
+      R"([{"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet1"}])";
   group_attributes.push_back(
-      swss::FieldValueTuple{p4orch::kControllerMetadata, "so_meta"});
+      swss::FieldValueTuple{"replicas", json_array});
+  group_attributes.push_back(
+      swss::FieldValueTuple{p4orch::kControllerMetadata, "controller_meta"});
+  group_attributes.push_back(
+      swss::FieldValueTuple{p4orch::kMulticastMetadata, "multicast_meta"});
 
   // Enqueue RIF creation and group member creation.
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
@@ -3008,10 +3608,11 @@ TEST_F(L3MulticastManagerTest, DrainMulticastReplicationEntryAddSuccestTest) {
   auto expect_mac_entry = GenerateP4MulticastRouterInterfaceEntry(
       "Ethernet1", "0x1", swss::MacAddress(kSrcMac1));
   expect_mac_entry.router_interface_oid = kRifOid1;
-  auto expect_group_entry =
-      GenerateP4MulticastReplicationEntry("0x1", "Ethernet1", "0x1");
+  P4Replica replica1 = P4Replica("0x1", "Ethernet1", "0x1");
+  auto expect_group_entry = GenerateP4MulticastGroupEntry(
+      "0x1", {replica1}, "multicast_meta", "controller_meta");
   expect_group_entry.multicast_group_oid = kGroupOid1;
-  expect_group_entry.multicast_group_member_oid = kGroupMemberOid1;
+  expect_group_entry.member_oids[replica1.key] = kGroupMemberOid1;
 
   auto* actual_mac_entry = GetMulticastRouterInterfaceEntry(
       expect_mac_entry.multicast_router_interface_entry_key);
@@ -3021,108 +3622,98 @@ TEST_F(L3MulticastManagerTest, DrainMulticastReplicationEntryAddSuccestTest) {
   auto end_rifOid = GetRifOid(actual_mac_entry);
   EXPECT_EQ(end_rifOid, kRifOid1);
 
-  auto* actual_group_entry = GetMulticastReplicationEntry(
-      expect_group_entry.multicast_replication_key);
+  auto* actual_group_entry = GetMulticastGroupEntry(
+      expect_group_entry.multicast_group_id);
   ASSERT_NE(nullptr, actual_group_entry);
-  VerifyP4MulticastReplicationEntryEqual(expect_group_entry,
-                                         *actual_group_entry);
+  VerifyP4MulticastGroupEntryEqual(expect_group_entry, *actual_group_entry);
 
   sai_object_id_t end_groupOid = SAI_NULL_OBJECT_ID;
   p4_oid_mapper_.getOID(SAI_OBJECT_TYPE_IPMC_GROUP,
                         actual_group_entry->multicast_group_id, &end_groupOid);
   sai_object_id_t end_groupMemberOid = SAI_NULL_OBJECT_ID;
   p4_oid_mapper_.getOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
-                        actual_group_entry->multicast_replication_key,
+			replica1.key,
                         &end_groupMemberOid);
   EXPECT_EQ(end_groupOid, kGroupOid1);
   EXPECT_EQ(end_groupMemberOid, kGroupMemberOid1);
 }
 
-TEST_F(L3MulticastManagerTest,
-       DrainMulticastReplicationEntryAddInvalidEntryTest) {
-  // Missing multicast_replica_port.
-  const std::string invalid_match_key =
-      R"({"match/multicast_group_id":"0x1",)"
-      R"("match/multicast_replica_instance":"0x1"})";
-  const std::string invalid_appl_db_key =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
-      kTableKeyDelimiter + invalid_match_key;
+TEST_F(L3MulticastManagerTest, DrainMulticastGroupEntryAddInvalidEntryTest) {
 
-  const std::string good_match_key =
-      R"({"match/multicast_group_id":"0x1",)"
-      R"("match/multicast_replica_port":"Ethernet1",)"
-      R"("match/multicast_replica_instance":"0x1"})";
   const std::string good_appl_db_key =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
-      kTableKeyDelimiter + good_match_key;
+      std::string(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) +
+      kTableKeyDelimiter + "0x1";
 
-  std::vector<swss::FieldValueTuple> group_attributes;
-  group_attributes.push_back(
-      swss::FieldValueTuple{p4orch::kControllerMetadata, "so_meta"});
-
+  std::vector<swss::FieldValueTuple> bad_group_attributes;
+  // The port is missing.
+  const std::string json_array_bad =
+      R"([{"multicast_replica_instance":"0x1"}])";
+  bad_group_attributes.push_back(
+      swss::FieldValueTuple{"replicas", json_array_bad});
+  std::vector<swss::FieldValueTuple> good_group_attributes;
+  const std::string json_array_good =
+      R"([{"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet1"}])";
+  good_group_attributes.push_back(
+      swss::FieldValueTuple{"replicas", json_array_good});
   // Enqueue entry for create operation.
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
-          swss::KeyOpFieldsValuesTuple(invalid_appl_db_key, SET_COMMAND,
-                                       group_attributes));
+	  swss::KeyOpFieldsValuesTuple(good_appl_db_key, SET_COMMAND,
+                                       bad_group_attributes));
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
-          swss::KeyOpFieldsValuesTuple(good_appl_db_key, SET_COMMAND,
-                                       group_attributes));
+	  swss::KeyOpFieldsValuesTuple(good_appl_db_key, SET_COMMAND,
+                                       good_group_attributes));
 
   EXPECT_CALL(publisher_,
-              publish(Eq(APP_P4RT_TABLE_NAME), Eq(invalid_appl_db_key),
-                      Eq(group_attributes),
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(good_appl_db_key),
+                      Eq(bad_group_attributes),
                       Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)));
   EXPECT_CALL(publisher_,
-              publish(Eq(APP_P4RT_TABLE_NAME), Eq(good_appl_db_key),
-                      Eq(group_attributes),
-                      Eq(StatusCode::SWSS_RC_NOT_EXECUTED), Eq(true)));
+            publish(Eq(APP_P4RT_TABLE_NAME), Eq(good_appl_db_key),
+                    Eq(good_group_attributes),
+                    Eq(StatusCode::SWSS_RC_NOT_EXECUTED), Eq(true)));
   EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, Drain(/*failure_before=*/false));
 }
 
 TEST_F(L3MulticastManagerTest,
-       DrainMulticastReplicationEntryAddInvalidEntryEmptyFieldTest) {
-  // empty multicast_group_id
-  const std::string invalid_match_key =
-      R"({"match/multicast_group_id":"",)"
-      R"("match/multicast_replica_port":"Ethernet1",)"
-      R"("match/multicast_replica_instance":"0x1"})";
-  const std::string invalid_appl_db_key =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
-      kTableKeyDelimiter + invalid_match_key;
+       DrainMulticastGroupEntryBeforeRifAddedTest) {
+  // If we do not add a RIF before using, the entry will be rejected as invalid.
+  const std::string good_appl_db_key1 =
+      std::string(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) +
+      kTableKeyDelimiter + "0x1";
 
-  const std::string good_match_key =
-      R"({"match/multicast_group_id":"0x1",)"
-      R"("match/multicast_replica_port":"Ethernet1",)"
-      R"("match/multicast_replica_instance":"0x1"})";
-  const std::string good_appl_db_key =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
-      kTableKeyDelimiter + good_match_key;
+  const std::string good_appl_db_key2 =
+      std::string(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) +
+      kTableKeyDelimiter + "0x2";
 
-  std::vector<swss::FieldValueTuple> group_attributes;
-  group_attributes.push_back(
-      swss::FieldValueTuple{p4orch::kControllerMetadata, "so_meta"});
+  std::vector<swss::FieldValueTuple> good_group_attributes;
+  const std::string json_array =
+      R"([{"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet1"}])";
+  good_group_attributes.push_back(
+      swss::FieldValueTuple{"replicas", json_array});
 
   // Enqueue entry for create operation.
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
-          swss::KeyOpFieldsValuesTuple(invalid_appl_db_key, SET_COMMAND,
-                                       group_attributes));
+  	  swss::KeyOpFieldsValuesTuple(good_appl_db_key1, SET_COMMAND,
+                                       good_group_attributes));
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
-          swss::KeyOpFieldsValuesTuple(good_appl_db_key, SET_COMMAND,
-                                       group_attributes));
+          swss::KeyOpFieldsValuesTuple(good_appl_db_key2, SET_COMMAND,
+                                       good_group_attributes));
 
   EXPECT_CALL(publisher_,
-              publish(Eq(APP_P4RT_TABLE_NAME), Eq(invalid_appl_db_key),
-                      Eq(group_attributes),
-                      Eq(StatusCode::SWSS_RC_INVALID_PARAM), Eq(true)));
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(good_appl_db_key1),
+                      Eq(good_group_attributes),
+                      Eq(StatusCode::SWSS_RC_NOT_FOUND), Eq(true)));
   EXPECT_CALL(publisher_,
-              publish(Eq(APP_P4RT_TABLE_NAME), Eq(good_appl_db_key),
-                      Eq(group_attributes),
-                      Eq(StatusCode::SWSS_RC_NOT_EXECUTED), Eq(true)));
-  EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, Drain(/*failure_before=*/false));
+            publish(Eq(APP_P4RT_TABLE_NAME), Eq(good_appl_db_key2),
+                    Eq(good_group_attributes),
+                    Eq(StatusCode::SWSS_RC_NOT_EXECUTED), Eq(true)));
+  EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND, Drain(/*failure_before=*/false));
 }
 
 TEST_F(L3MulticastManagerTest,
-       DrainMulticastReplicationEntryAddAndDeleteSuccestTest) {
+       DrainMulticastGroupEntryAddAndUpdateAndDeleteSuccessTest) {
   const std::string mac_match_key =
       R"({"match/multicast_replica_port":"Ethernet1",)"
       R"("match/multicast_replica_instance":"0x1"})";
@@ -3137,22 +3728,22 @@ TEST_F(L3MulticastManagerTest,
       kTableKeyDelimiter + mac_match_key2;
   std::vector<swss::FieldValueTuple> mac_attributes;
   mac_attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
   mac_attributes.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kSrcMac), kSrcMac1});
   mac_attributes.push_back(
       swss::FieldValueTuple{p4orch::kControllerMetadata, "so_meta"});
 
-  const std::string group_match_key =
-      R"({"match/multicast_group_id":"0x1",)"
-      R"("match/multicast_replica_port":"Ethernet1",)"
-      R"("match/multicast_replica_instance":"0x1"})";
+  const std::string group_match_key = "0x1";
   const std::string group_appl_db_key =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
+      std::string(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) +
       kTableKeyDelimiter + group_match_key;
   std::vector<swss::FieldValueTuple> group_attributes;
+  const std::string json_array =
+      R"([{"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet1"}])";
   group_attributes.push_back(
-      swss::FieldValueTuple{p4orch::kControllerMetadata, "so_meta"});
+      swss::FieldValueTuple{"replicas", json_array});
 
   // Enqueue RIF creation and group member creation.
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
@@ -3168,83 +3759,96 @@ TEST_F(L3MulticastManagerTest,
   EXPECT_CALL(mock_sai_router_intf_, create_router_interface(_, _, _, _))
       .WillOnce(DoAll(SetArgPointee<0>(kRifOid1), Return(SAI_STATUS_SUCCESS)))
       .WillOnce(DoAll(SetArgPointee<0>(kRifOid2), Return(SAI_STATUS_SUCCESS)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key),
-                                  Eq(mac_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key2),
-                                  Eq(mac_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key),
+                      Eq(mac_attributes), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key2),
+                      Eq(mac_attributes), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
   EXPECT_CALL(mock_sai_ipmc_group_, create_ipmc_group(_, _, _, _))
-      .WillOnce(
-          DoAll(SetArgPointee<0>(kGroupOid1), Return(SAI_STATUS_SUCCESS)));
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupOid1),
+                Return(SAI_STATUS_SUCCESS)));
   EXPECT_CALL(mock_sai_ipmc_group_, create_ipmc_group_member(_, _, _, _))
       .WillOnce(DoAll(SetArgPointee<0>(kGroupMemberOid1),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME),
-                                  Eq(group_appl_db_key), Eq(group_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+                Return(SAI_STATUS_SUCCESS)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(group_appl_db_key),
+                      Eq(group_attributes), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
   EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, Drain(/*failure_before=*/false));
 
   // Add another multicast group member (same group) and delete the first one.
-  const std::string group_match_key2 =
-      R"({"match/multicast_group_id":"0x1",)"
-      R"("match/multicast_replica_port":"Ethernet2",)"
-      R"("match/multicast_replica_instance":"0x1"})";
-  const std::string group_appl_db_key2 =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
-      kTableKeyDelimiter + group_match_key2;
+  std::vector<swss::FieldValueTuple> group_attributes2;
+  const std::string json_array2 =
+      R"([{"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet2"}])";
+  group_attributes2.push_back(
+      swss::FieldValueTuple{"replicas", json_array2});
 
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
-          swss::KeyOpFieldsValuesTuple(group_appl_db_key2, SET_COMMAND,
-                                       group_attributes));
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
-          swss::KeyOpFieldsValuesTuple(group_appl_db_key, DEL_COMMAND,
-                                       group_attributes));
+          swss::KeyOpFieldsValuesTuple(group_appl_db_key, SET_COMMAND,
+                                       group_attributes2));
 
   EXPECT_CALL(mock_sai_ipmc_group_, create_ipmc_group_member(_, _, _, _))
       .WillOnce(DoAll(SetArgPointee<0>(kGroupMemberOid2),
-                      Return(SAI_STATUS_SUCCESS)));
+                Return(SAI_STATUS_SUCCESS)));
   EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group_member(kGroupMemberOid1))
       .WillOnce(Return(SAI_STATUS_SUCCESS));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME),
-                                  Eq(group_appl_db_key2), Eq(group_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME),
-                                  Eq(group_appl_db_key), Eq(group_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(group_appl_db_key),
+                      Eq(group_attributes2), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
   EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, Drain(/*failure_before=*/false));
 
-  auto expect_group_entry =
-      GenerateP4MulticastReplicationEntry("0x1", "Ethernet1", "0x1");
-  auto expect_group_entry2 =
-      GenerateP4MulticastReplicationEntry("0x1", "Ethernet2", "0x1");
-  expect_group_entry2.multicast_group_oid = kGroupOid1;  // same group used
-  expect_group_entry2.multicast_group_member_oid = kGroupMemberOid2;
+  P4Replica replica2 = P4Replica("0x1", "Ethernet2", "0x1");
+  auto expect_group_entry = GenerateP4MulticastGroupEntry(
+    "0x1", {replica2});
+  expect_group_entry.multicast_group_oid = kGroupOid1;  // same group used
+  expect_group_entry.member_oids[replica2.key] = kGroupMemberOid2;
 
-  auto* actual_group_entry = GetMulticastReplicationEntry(
-      expect_group_entry.multicast_replication_key);
-  ASSERT_EQ(nullptr, actual_group_entry);  // entry was deleted
-  auto* actual_group_entry2 = GetMulticastReplicationEntry(
-      expect_group_entry2.multicast_replication_key);
-  ASSERT_NE(nullptr, actual_group_entry2);
+  auto* actual_group_entry = GetMulticastGroupEntry("0x1");
+  ASSERT_NE(actual_group_entry, nullptr);
 
-  VerifyP4MulticastReplicationEntryEqual(expect_group_entry2,
-                                         *actual_group_entry2);
+  VerifyP4MulticastGroupEntryEqual(expect_group_entry, *actual_group_entry);
 
   sai_object_id_t end_groupOid2 = SAI_NULL_OBJECT_ID;
   p4_oid_mapper_.getOID(SAI_OBJECT_TYPE_IPMC_GROUP,
-                        actual_group_entry2->multicast_group_id,
+                        actual_group_entry->multicast_group_id,
                         &end_groupOid2);
   sai_object_id_t end_groupMemberOid2 = SAI_NULL_OBJECT_ID;
   p4_oid_mapper_.getOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
-                        actual_group_entry2->multicast_replication_key,
+                        replica2.key,
                         &end_groupMemberOid2);
   EXPECT_EQ(end_groupOid2, kGroupOid1);
   EXPECT_EQ(end_groupMemberOid2, kGroupMemberOid2);
+
+  // Then delete the group.
+  std::vector<swss::FieldValueTuple> group_attributes_del = {};
+  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+          swss::KeyOpFieldsValuesTuple(group_appl_db_key, DEL_COMMAND,
+                                       group_attributes_del));
+  EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group_member(kGroupMemberOid2))
+      .WillOnce(Return(SAI_STATUS_SUCCESS));
+  EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group(kGroupOid1))
+      .WillOnce(Return(SAI_STATUS_SUCCESS));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(group_appl_db_key),
+                      Eq(group_attributes_del), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
+
+  EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, Drain(/*failure_before=*/false));
+
+  auto* actual_group_entry2 = GetMulticastGroupEntry("0x1");
+  ASSERT_EQ(actual_group_entry2, nullptr);
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP, "0x1"));
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                        replica2.key));
 }
 
 TEST_F(L3MulticastManagerTest,
-       DrainMulticastReplicationEntryAllOpsSuccestTest) {
+       DrainMulticastGroupEntryAllOpsSuccessTest) {
   const std::string mac_match_key =
       R"({"match/multicast_replica_port":"Ethernet1",)"
       R"("match/multicast_replica_instance":"0x1"})";
@@ -3263,31 +3867,39 @@ TEST_F(L3MulticastManagerTest,
   const std::string mac_appl_db_key3 =
       std::string(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME) +
       kTableKeyDelimiter + mac_match_key3;
+  const std::string mac_match_key4 =
+      R"({"match/multicast_replica_port":"Ethernet4",)"
+      R"("match/multicast_replica_instance":"0x1"})";
+  const std::string mac_appl_db_key4 =
+      std::string(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME) +
+      kTableKeyDelimiter + mac_match_key4;
   std::vector<swss::FieldValueTuple> mac_attributes;
   mac_attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
   mac_attributes.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kSrcMac), kSrcMac1});
   mac_attributes.push_back(
       swss::FieldValueTuple{p4orch::kControllerMetadata, "so_meta"});
 
-  const std::string group_match_key =
-      R"({"match/multicast_group_id":"0x1",)"
-      R"("match/multicast_replica_port":"Ethernet1",)"
-      R"("match/multicast_replica_instance":"0x1"})";
-  const std::string group_appl_db_key =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
-      kTableKeyDelimiter + group_match_key;
-  const std::string group_match_key2 =
-      R"({"match/multicast_group_id":"0x1",)"
-      R"("match/multicast_replica_port":"Ethernet2",)"
-      R"("match/multicast_replica_instance":"0x1"})";
+  const std::string group_appl_db_key1 =
+      std::string(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) +
+      kTableKeyDelimiter + "0x1";
+  std::vector<swss::FieldValueTuple> group_attributes1;
+  const std::string json_array1 =
+      R"([{"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet1"}])";
+  group_attributes1.push_back(
+      swss::FieldValueTuple{"replicas", json_array1});
+
   const std::string group_appl_db_key2 =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
-      kTableKeyDelimiter + group_match_key2;
-  std::vector<swss::FieldValueTuple> group_attributes;
-  group_attributes.push_back(
-      swss::FieldValueTuple{p4orch::kControllerMetadata, "so_meta"});
+      std::string(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) +
+      kTableKeyDelimiter + "0x2";
+  std::vector<swss::FieldValueTuple> group_attributes2;
+  const std::string json_array2 =
+      R"([{"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet2"}])";
+  group_attributes2.push_back(
+      swss::FieldValueTuple{"replicas", json_array2});
 
   // Enqueue RIF creation and group member creation.
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
@@ -3300,127 +3912,170 @@ TEST_F(L3MulticastManagerTest,
           swss::KeyOpFieldsValuesTuple(mac_appl_db_key3, SET_COMMAND,
                                        mac_attributes));
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
-          swss::KeyOpFieldsValuesTuple(group_appl_db_key, SET_COMMAND,
-                                       group_attributes));
+          swss::KeyOpFieldsValuesTuple(mac_appl_db_key4, SET_COMMAND,
+                                       mac_attributes));
+  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+          swss::KeyOpFieldsValuesTuple(group_appl_db_key1, SET_COMMAND,
+                                       group_attributes1));
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key2, SET_COMMAND,
-                                       group_attributes));
+                                       group_attributes2));
 
   EXPECT_CALL(mock_sai_router_intf_, create_router_interface(_, _, _, _))
       .WillOnce(DoAll(SetArgPointee<0>(kRifOid1), Return(SAI_STATUS_SUCCESS)))
       .WillOnce(DoAll(SetArgPointee<0>(kRifOid2), Return(SAI_STATUS_SUCCESS)))
-      .WillOnce(DoAll(SetArgPointee<0>(kRifOid3), Return(SAI_STATUS_SUCCESS)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key),
-                                  Eq(mac_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key2),
-                                  Eq(mac_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key3),
-                                  Eq(mac_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+      .WillOnce(DoAll(SetArgPointee<0>(kRifOid3), Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArgPointee<0>(kRifOid4), Return(SAI_STATUS_SUCCESS)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key),
+                      Eq(mac_attributes), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key2),
+                      Eq(mac_attributes), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key3),
+                      Eq(mac_attributes), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key4),
+                      Eq(mac_attributes), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
   EXPECT_CALL(mock_sai_ipmc_group_, create_ipmc_group(_, _, _, _))
-      .WillOnce(
-          DoAll(SetArgPointee<0>(kGroupOid1), Return(SAI_STATUS_SUCCESS)));
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupOid1),
+                Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupOid2),
+                Return(SAI_STATUS_SUCCESS)));
   EXPECT_CALL(mock_sai_ipmc_group_, create_ipmc_group_member(_, _, _, _))
-      .WillOnce(
-          DoAll(SetArgPointee<0>(kGroupMemberOid1), Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupMemberOid1),
+                Return(SAI_STATUS_SUCCESS)))
       .WillOnce(DoAll(SetArgPointee<0>(kGroupMemberOid2),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME),
-                                  Eq(group_appl_db_key), Eq(group_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME),
-                                  Eq(group_appl_db_key2), Eq(group_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+                Return(SAI_STATUS_SUCCESS)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(group_appl_db_key1),
+                      Eq(group_attributes1), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(group_appl_db_key2),
+                      Eq(group_attributes2), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
   EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, Drain(/*failure_before=*/false));
 
-  // Add another multicast group member (same group), update the first one, and
-  // delete the second one.
-  const std::string group_match_key3 =
-      R"({"match/multicast_group_id":"0x1",)"
-      R"("match/multicast_replica_port":"Ethernet3",)"
-      R"("match/multicast_replica_instance":"0x1"})";
+  // Add another multicast group, update the first group, and
+  // delete the second group.
   const std::string group_appl_db_key3 =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
-      kTableKeyDelimiter + group_match_key3;
+      std::string(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) +
+      kTableKeyDelimiter + "0x3";
+  std::vector<swss::FieldValueTuple> group_attributes3;
+  const std::string json_array3 =
+      R"([{"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet3"}])";
+  group_attributes3.push_back(
+      swss::FieldValueTuple{"replicas", json_array3});
+
+  // This is expected to delete replica1, since it is no longer in the entry.
+  std::vector<swss::FieldValueTuple> group_attributes4;
+  const std::string json_array4 =
+      R"([{"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet4"}])";
+  group_attributes4.push_back(
+      swss::FieldValueTuple{"replicas", json_array4});
+  std::vector<swss::FieldValueTuple> group_attributes_del = {};
 
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key3, SET_COMMAND,
-                                       group_attributes));
+                                       group_attributes3));
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
-          swss::KeyOpFieldsValuesTuple(group_appl_db_key, SET_COMMAND,
-                                       group_attributes));
+          swss::KeyOpFieldsValuesTuple(group_appl_db_key1, SET_COMMAND,
+                                       group_attributes4));
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key2, DEL_COMMAND,
-                                       group_attributes));
+                                       group_attributes_del));
 
+  EXPECT_CALL(mock_sai_ipmc_group_, create_ipmc_group(_, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupOid3),
+                Return(SAI_STATUS_SUCCESS)));
   EXPECT_CALL(mock_sai_ipmc_group_, create_ipmc_group_member(_, _, _, _))
       .WillOnce(DoAll(SetArgPointee<0>(kGroupMemberOid3),
-                      Return(SAI_STATUS_SUCCESS)));
+                Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupMemberOid4),
+                Return(SAI_STATUS_SUCCESS)));
+  EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group_member(kGroupMemberOid1))
+      .WillOnce(Return(SAI_STATUS_SUCCESS));
   EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group_member(kGroupMemberOid2))
       .WillOnce(Return(SAI_STATUS_SUCCESS));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME),
-                                  Eq(group_appl_db_key3), Eq(group_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME),
-                                  Eq(group_appl_db_key), Eq(group_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME),
-                                  Eq(group_appl_db_key2), Eq(group_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+  EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group(kGroupOid2))
+      .WillOnce(Return(SAI_STATUS_SUCCESS));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(group_appl_db_key3),
+                      Eq(group_attributes3), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(group_appl_db_key1),
+                      Eq(group_attributes4), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(group_appl_db_key2),
+                      Eq(group_attributes_del), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
   EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, Drain(/*failure_before=*/false));
 
-  auto expect_group_entry =
-      GenerateP4MulticastReplicationEntry("0x1", "Ethernet1", "0x1");
-  expect_group_entry.multicast_group_oid = kGroupOid1;  // same group used
-  expect_group_entry.multicast_group_member_oid = kGroupMemberOid1;
-  auto expect_group_entry2 =
-      GenerateP4MulticastReplicationEntry("0x1", "Ethernet2", "0x1");
-  auto expect_group_entry3 =
-      GenerateP4MulticastReplicationEntry("0x1", "Ethernet3", "0x1");
-  expect_group_entry3.multicast_group_oid = kGroupOid1;  // same group used
-  expect_group_entry3.multicast_group_member_oid = kGroupMemberOid3;
+  P4Replica replica1 = P4Replica("0x1", "Ethernet1", "0x1");
+  P4Replica replica2 = P4Replica("0x2", "Ethernet2", "0x1");
+  P4Replica replica3 = P4Replica("0x3", "Ethernet3", "0x1");
+  P4Replica replica4 = P4Replica("0x1", "Ethernet4", "0x1");
 
-  auto* actual_group_entry = GetMulticastReplicationEntry(
-      expect_group_entry.multicast_replication_key);
-  ASSERT_NE(nullptr, actual_group_entry);
-  auto* actual_group_entry2 = GetMulticastReplicationEntry(
-      expect_group_entry2.multicast_replication_key);
-  ASSERT_EQ(nullptr, actual_group_entry2);  // entry was deleted
-  auto* actual_group_entry3 = GetMulticastReplicationEntry(
-      expect_group_entry3.multicast_replication_key);
-  ASSERT_NE(nullptr, actual_group_entry3);
+  auto expect_group_entry1 = GenerateP4MulticastGroupEntry(
+    "0x1", {replica4});  // replica1 was deleted
+  expect_group_entry1.multicast_group_oid = kGroupOid1;
+  expect_group_entry1.member_oids[replica4.key] = kGroupMemberOid4;
 
-  VerifyP4MulticastReplicationEntryEqual(expect_group_entry,
-                                         *actual_group_entry);
-  VerifyP4MulticastReplicationEntryEqual(expect_group_entry3,
-                                         *actual_group_entry3);
+  // entry 2 was deleted
+
+  auto expect_group_entry3 = GenerateP4MulticastGroupEntry(
+    "0x3", {replica3});
+  expect_group_entry3.multicast_group_oid = kGroupOid3;
+  expect_group_entry3.member_oids[replica3.key] = kGroupMemberOid3;
+
+  auto* actual_group_entry1 = GetMulticastGroupEntry("0x1");
+  auto* actual_group_entry2 = GetMulticastGroupEntry("0x2");
+  auto* actual_group_entry3 = GetMulticastGroupEntry("0x3");
+  ASSERT_NE(actual_group_entry1, nullptr);
+  EXPECT_EQ(actual_group_entry2, nullptr);
+  ASSERT_NE(actual_group_entry3, nullptr);
+
+  VerifyP4MulticastGroupEntryEqual(expect_group_entry1, *actual_group_entry1);
+  VerifyP4MulticastGroupEntryEqual(expect_group_entry3, *actual_group_entry3);
 
   sai_object_id_t end_groupOid = SAI_NULL_OBJECT_ID;
   p4_oid_mapper_.getOID(SAI_OBJECT_TYPE_IPMC_GROUP,
-                        actual_group_entry->multicast_group_id, &end_groupOid);
+                        "0x1", &end_groupOid);
   sai_object_id_t end_groupMemberOid = SAI_NULL_OBJECT_ID;
   p4_oid_mapper_.getOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
-                        actual_group_entry->multicast_replication_key,
-                        &end_groupMemberOid);
+                        replica4.key, &end_groupMemberOid);
   EXPECT_EQ(end_groupOid, kGroupOid1);
-  EXPECT_EQ(end_groupMemberOid, kGroupMemberOid1);
+  EXPECT_EQ(end_groupMemberOid, kGroupMemberOid4);
+
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP, "0x2"));
 
   sai_object_id_t end_groupOid3 = SAI_NULL_OBJECT_ID;
   p4_oid_mapper_.getOID(SAI_OBJECT_TYPE_IPMC_GROUP,
-                        actual_group_entry3->multicast_group_id,
-                        &end_groupOid3);
+                       "0x3", &end_groupOid3);
   sai_object_id_t end_groupMemberOid3 = SAI_NULL_OBJECT_ID;
   p4_oid_mapper_.getOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
-                        actual_group_entry3->multicast_replication_key,
-                        &end_groupMemberOid3);
-  EXPECT_EQ(end_groupOid3, kGroupOid1);
+                        replica3.key, &end_groupMemberOid3);
+  EXPECT_EQ(end_groupOid3, kGroupOid3);
   EXPECT_EQ(end_groupMemberOid3, kGroupMemberOid3);
+
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                        replica1.key));
+  EXPECT_FALSE(p4_oid_mapper_.existsOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER,
+                                        replica2.key));
 }
 
 TEST_F(L3MulticastManagerTest,
-       DrainMulticastReplicationEntryDeleteFailureTest) {
+       DrainMulticastGroupEntryDeleteFailureTest) {
   const std::string mac_match_key =
       R"({"match/multicast_replica_port":"Ethernet1",)"
       R"("match/multicast_replica_instance":"0x1"})";
@@ -3441,29 +4096,31 @@ TEST_F(L3MulticastManagerTest,
       kTableKeyDelimiter + mac_match_key3;
   std::vector<swss::FieldValueTuple> mac_attributes;
   mac_attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
   mac_attributes.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kSrcMac), kSrcMac1});
   mac_attributes.push_back(
       swss::FieldValueTuple{p4orch::kControllerMetadata, "so_meta"});
 
-  const std::string group_match_key =
-      R"({"match/multicast_group_id":"0x1",)"
-      R"("match/multicast_replica_port":"Ethernet1",)"
-      R"("match/multicast_replica_instance":"0x1"})";
-  const std::string group_appl_db_key =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
-      kTableKeyDelimiter + group_match_key;
-  const std::string group_match_key2 =
-      R"({"match/multicast_group_id":"0x1",)"
-      R"("match/multicast_replica_port":"Ethernet2",)"
-      R"("match/multicast_replica_instance":"0x1"})";
+  const std::string group_appl_db_key1 =
+      std::string(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) +
+      kTableKeyDelimiter + "0x1";
+  std::vector<swss::FieldValueTuple> group_attributes1;
+  const std::string json_array1 =
+      R"([{"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet1"}])";
+  group_attributes1.push_back(
+      swss::FieldValueTuple{"replicas", json_array1});
+
   const std::string group_appl_db_key2 =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
-      kTableKeyDelimiter + group_match_key2;
-  std::vector<swss::FieldValueTuple> group_attributes;
-  group_attributes.push_back(
-      swss::FieldValueTuple{p4orch::kControllerMetadata, "so_meta"});
+      std::string(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) +
+      kTableKeyDelimiter + "0x2";
+  std::vector<swss::FieldValueTuple> group_attributes2;
+  const std::string json_array2 =
+      R"([{"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet2"}])";
+  group_attributes2.push_back(
+      swss::FieldValueTuple{"replicas", json_array1});
 
   // Enqueue RIF creation and group member creation.
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
@@ -3476,83 +4133,94 @@ TEST_F(L3MulticastManagerTest,
           swss::KeyOpFieldsValuesTuple(mac_appl_db_key3, SET_COMMAND,
                                        mac_attributes));
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
-          swss::KeyOpFieldsValuesTuple(group_appl_db_key, SET_COMMAND,
-                                       group_attributes));
+          swss::KeyOpFieldsValuesTuple(group_appl_db_key1, SET_COMMAND,
+                                       group_attributes1));
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key2, SET_COMMAND,
-                                       group_attributes));
+                                       group_attributes2));
 
   EXPECT_CALL(mock_sai_router_intf_, create_router_interface(_, _, _, _))
       .WillOnce(DoAll(SetArgPointee<0>(kRifOid1), Return(SAI_STATUS_SUCCESS)))
       .WillOnce(DoAll(SetArgPointee<0>(kRifOid2), Return(SAI_STATUS_SUCCESS)))
       .WillOnce(DoAll(SetArgPointee<0>(kRifOid3), Return(SAI_STATUS_SUCCESS)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key),
-                                  Eq(mac_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key2),
-                                  Eq(mac_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key3),
-                                  Eq(mac_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key),
+                      Eq(mac_attributes), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key2),
+                      Eq(mac_attributes), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key3),
+                      Eq(mac_attributes), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
   EXPECT_CALL(mock_sai_ipmc_group_, create_ipmc_group(_, _, _, _))
-      .WillOnce(
-          DoAll(SetArgPointee<0>(kGroupOid1), Return(SAI_STATUS_SUCCESS)));
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupOid1),
+                Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupOid2),
+                Return(SAI_STATUS_SUCCESS)));
   EXPECT_CALL(mock_sai_ipmc_group_, create_ipmc_group_member(_, _, _, _))
-      .WillOnce(
-          DoAll(SetArgPointee<0>(kGroupMemberOid1), Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupMemberOid1),
+                Return(SAI_STATUS_SUCCESS)))
       .WillOnce(DoAll(SetArgPointee<0>(kGroupMemberOid2),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME),
-                                  Eq(group_appl_db_key), Eq(group_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME),
-                                  Eq(group_appl_db_key2), Eq(group_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+                Return(SAI_STATUS_SUCCESS)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(group_appl_db_key1),
+                      Eq(group_attributes1), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(group_appl_db_key2),
+                      Eq(group_attributes2), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
   EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, Drain(/*failure_before=*/false));
 
-  // Request to delete unknown entry, should cause an error.
-  // Add another multicast group member (same group), attempt to delete an
-  // unknown entry, update the first entry, and delete the second one.
-  const std::string group_match_key3 =
-      R"({"match/multicast_group_id":"0x1",)"
-      R"("match/multicast_replica_port":"Ethernet3",)"
-      R"("match/multicast_replica_instance":"0x1"})";
-  const std::string group_appl_db_key3 =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
-      kTableKeyDelimiter + group_match_key3;
+  // Update group 1 to add a new member.
+  // Attempt to delete group 2 (has error).
+  // Set group 1 again (should be no-op, but not executed).
+  std::vector<swss::FieldValueTuple> group_attributes1b;
+  const std::string json_array1b =
+      R"([{"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet1"},)"
+      R"({"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet3"}])";
+  group_attributes1b.push_back(
+      swss::FieldValueTuple{"replicas", json_array1b});
+  std::vector<swss::FieldValueTuple> group_attributes_del = {};
 
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
-          swss::KeyOpFieldsValuesTuple(group_appl_db_key3, SET_COMMAND,
-                                       group_attributes));
+          swss::KeyOpFieldsValuesTuple(group_appl_db_key1, SET_COMMAND,
+                                       group_attributes1b));
   // SAI delete failure
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key2, DEL_COMMAND,
-                                       group_attributes));
+                                       group_attributes_del));
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
-          swss::KeyOpFieldsValuesTuple(group_appl_db_key, SET_COMMAND,
-                                       group_attributes));
+          swss::KeyOpFieldsValuesTuple(group_appl_db_key1, SET_COMMAND,
+                                       group_attributes1b));
 
   EXPECT_CALL(mock_sai_ipmc_group_, create_ipmc_group_member(_, _, _, _))
       .WillOnce(DoAll(SetArgPointee<0>(kGroupMemberOid3),
-                      Return(SAI_STATUS_SUCCESS)));
+                Return(SAI_STATUS_SUCCESS)));
   EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group_member(kGroupMemberOid2))
       .WillOnce(Return(SAI_STATUS_FAILURE));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME),
-                                  Eq(group_appl_db_key3), Eq(group_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME),
-                                  Eq(group_appl_db_key2), Eq(group_attributes),
-                                  Eq(StatusCode::SWSS_RC_UNKNOWN), Eq(true)));
   EXPECT_CALL(publisher_,
-              publish(Eq(APP_P4RT_TABLE_NAME), Eq(group_appl_db_key),
-                      Eq(group_attributes),
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(group_appl_db_key1),
+                      Eq(group_attributes1b), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(group_appl_db_key2),
+                      Eq(group_attributes_del), Eq(StatusCode::SWSS_RC_UNKNOWN),
+                      Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(group_appl_db_key1),
+                      Eq(group_attributes1b),
                       Eq(StatusCode::SWSS_RC_NOT_EXECUTED), Eq(true)));
   EXPECT_EQ(StatusCode::SWSS_RC_UNKNOWN, Drain(/*failure_before=*/false));
 }
 
 TEST_F(L3MulticastManagerTest,
-       DrainMulticastReplicationEntryDeleteFailureOnLastTest) {
+       DrainMulticastGroupEntryDeleteFailureOnLastTest) {
   const std::string mac_match_key =
       R"({"match/multicast_replica_port":"Ethernet1",)"
       R"("match/multicast_replica_instance":"0x1"})";
@@ -3573,29 +4241,31 @@ TEST_F(L3MulticastManagerTest,
       kTableKeyDelimiter + mac_match_key3;
   std::vector<swss::FieldValueTuple> mac_attributes;
   mac_attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
   mac_attributes.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kSrcMac), kSrcMac1});
   mac_attributes.push_back(
       swss::FieldValueTuple{p4orch::kControllerMetadata, "so_meta"});
 
-  const std::string group_match_key =
-      R"({"match/multicast_group_id":"0x1",)"
-      R"("match/multicast_replica_port":"Ethernet1",)"
-      R"("match/multicast_replica_instance":"0x1"})";
-  const std::string group_appl_db_key =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
-      kTableKeyDelimiter + group_match_key;
-  const std::string group_match_key2 =
-      R"({"match/multicast_group_id":"0x1",)"
-      R"("match/multicast_replica_port":"Ethernet2",)"
-      R"("match/multicast_replica_instance":"0x1"})";
+
+  const std::string group_appl_db_key1 =
+      std::string(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) +
+      kTableKeyDelimiter + "0x1";
+  std::vector<swss::FieldValueTuple> group_attributes1;
+  const std::string json_array1 =
+      R"([{"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet1"}])";
+  group_attributes1.push_back(
+      swss::FieldValueTuple{"replicas", json_array1});
   const std::string group_appl_db_key2 =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
-      kTableKeyDelimiter + group_match_key2;
-  std::vector<swss::FieldValueTuple> group_attributes;
-  group_attributes.push_back(
-      swss::FieldValueTuple{p4orch::kControllerMetadata, "so_meta"});
+      std::string(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) +
+      kTableKeyDelimiter + "0x2";
+  std::vector<swss::FieldValueTuple> group_attributes2;
+  const std::string json_array2 =
+      R"([{"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet2"}])";
+  group_attributes2.push_back(
+      swss::FieldValueTuple{"replicas", json_array1});
 
   // Enqueue RIF creation and group member creation.
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
@@ -3608,77 +4278,105 @@ TEST_F(L3MulticastManagerTest,
           swss::KeyOpFieldsValuesTuple(mac_appl_db_key3, SET_COMMAND,
                                        mac_attributes));
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
-          swss::KeyOpFieldsValuesTuple(group_appl_db_key, SET_COMMAND,
-                                       group_attributes));
+          swss::KeyOpFieldsValuesTuple(group_appl_db_key1, SET_COMMAND,
+                                       group_attributes1));
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key2, SET_COMMAND,
-                                       group_attributes));
+                                       group_attributes2));
 
   EXPECT_CALL(mock_sai_router_intf_, create_router_interface(_, _, _, _))
       .WillOnce(DoAll(SetArgPointee<0>(kRifOid1), Return(SAI_STATUS_SUCCESS)))
       .WillOnce(DoAll(SetArgPointee<0>(kRifOid2), Return(SAI_STATUS_SUCCESS)))
       .WillOnce(DoAll(SetArgPointee<0>(kRifOid3), Return(SAI_STATUS_SUCCESS)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key),
-                                  Eq(mac_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key2),
-                                  Eq(mac_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key3),
-                                  Eq(mac_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key),
+                      Eq(mac_attributes), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key2),
+                      Eq(mac_attributes), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(mac_appl_db_key3),
+                      Eq(mac_attributes), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
   EXPECT_CALL(mock_sai_ipmc_group_, create_ipmc_group(_, _, _, _))
-      .WillOnce(
-          DoAll(SetArgPointee<0>(kGroupOid1), Return(SAI_STATUS_SUCCESS)));
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupOid1),
+                Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupOid2),
+                Return(SAI_STATUS_SUCCESS)));
   EXPECT_CALL(mock_sai_ipmc_group_, create_ipmc_group_member(_, _, _, _))
-      .WillOnce(
-          DoAll(SetArgPointee<0>(kGroupMemberOid1), Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupMemberOid1),
+                Return(SAI_STATUS_SUCCESS)))
       .WillOnce(DoAll(SetArgPointee<0>(kGroupMemberOid2),
-                      Return(SAI_STATUS_SUCCESS)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME),
-                                  Eq(group_appl_db_key), Eq(group_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME),
-                                  Eq(group_appl_db_key2), Eq(group_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
+                Return(SAI_STATUS_SUCCESS)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(group_appl_db_key1),
+                      Eq(group_attributes1), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(group_appl_db_key2),
+                      Eq(group_attributes2), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
   EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, Drain(/*failure_before=*/false));
 
-  // Request to delete unknown entry, should cause an error.
-  // Add another multicast group member (same group), attempt to delete an
-  // unknown entry, update the first entry, and delete the second one.
-  const std::string group_match_key3 =
-      R"({"match/multicast_group_id":"0x1",)"
-      R"("match/multicast_replica_port":"Ethernet3",)"
-      R"("match/multicast_replica_instance":"0x1"})";
-  const std::string group_appl_db_key3 =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
-      kTableKeyDelimiter + group_match_key3;
+  // Add another multicast group member to group 1 (update).
+  // Add third group.
+  // Attempt to delete group 2, but force failure.
+  std::vector<swss::FieldValueTuple> group_attributes1b;
+  const std::string json_array1b =
+      R"([{"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet1"},)"
+      R"({"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet3"}])";
+  group_attributes1b.push_back(
+      swss::FieldValueTuple{"replicas", json_array1b});
 
+  const std::string group_appl_db_key3 =
+      std::string(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) +
+      kTableKeyDelimiter + "0x3";
+  std::vector<swss::FieldValueTuple> group_attributes3;
+  const std::string json_array3 =
+      R"([{"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet3"}])";
+  group_attributes3.push_back(
+      swss::FieldValueTuple{"replicas", json_array3});
+
+  std::vector<swss::FieldValueTuple> group_attributes_del = {};
+ 
+  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
+          swss::KeyOpFieldsValuesTuple(group_appl_db_key1, SET_COMMAND,
+                                       group_attributes1b));
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key3, SET_COMMAND,
-                                       group_attributes));
-  Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
-          swss::KeyOpFieldsValuesTuple(group_appl_db_key, SET_COMMAND,
-                                       group_attributes));
+                                       group_attributes3));
   // SAI delete failure
   Enqueue(APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME,
           swss::KeyOpFieldsValuesTuple(group_appl_db_key2, DEL_COMMAND,
-                                       group_attributes));
+                                       group_attributes_del));
 
   EXPECT_CALL(mock_sai_ipmc_group_, create_ipmc_group_member(_, _, _, _))
       .WillOnce(DoAll(SetArgPointee<0>(kGroupMemberOid3),
-                      Return(SAI_STATUS_SUCCESS)));
+                Return(SAI_STATUS_SUCCESS)))
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupMemberOid4),
+                Return(SAI_STATUS_SUCCESS)));
+  EXPECT_CALL(mock_sai_ipmc_group_, create_ipmc_group(_, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<0>(kGroupOid3),
+                Return(SAI_STATUS_SUCCESS)));
   EXPECT_CALL(mock_sai_ipmc_group_, remove_ipmc_group_member(kGroupMemberOid2))
       .WillOnce(Return(SAI_STATUS_FAILURE));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME),
-                                  Eq(group_appl_db_key3), Eq(group_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME),
-                                  Eq(group_appl_db_key), Eq(group_attributes),
-                                  Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
-  EXPECT_CALL(publisher_, publish(Eq(APP_P4RT_TABLE_NAME),
-                                  Eq(group_appl_db_key2), Eq(group_attributes),
-                                  Eq(StatusCode::SWSS_RC_UNKNOWN), Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(group_appl_db_key1),
+                      Eq(group_attributes1b), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(group_appl_db_key3),
+                      Eq(group_attributes3), Eq(StatusCode::SWSS_RC_SUCCESS),
+                      Eq(true)));
+  EXPECT_CALL(publisher_,
+              publish(Eq(APP_P4RT_TABLE_NAME), Eq(group_appl_db_key2),
+                      Eq(group_attributes_del), Eq(StatusCode::SWSS_RC_UNKNOWN),
+                      Eq(true)));
   EXPECT_EQ(StatusCode::SWSS_RC_UNKNOWN, Drain(/*failure_before=*/false));
 }
 
@@ -3691,7 +4389,7 @@ TEST_F(L3MulticastManagerTest, DrainUnknownTable) {
       std::string(APP_P4RT_TUNNEL_TABLE_NAME) + kTableKeyDelimiter + match_key;
   std::vector<swss::FieldValueTuple> attributes;
   attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
   attributes.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kSrcMac), kSrcMac2});
   attributes.push_back(
@@ -3717,7 +4415,7 @@ TEST_F(L3MulticastManagerTest, DrainUnknownFirstTable) {
       kTableKeyDelimiter + match_key;
   std::vector<swss::FieldValueTuple> attributes;
   attributes.push_back(
-      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetSrcMac});
+      swss::FieldValueTuple{p4orch::kAction, p4orch::kSetMulticastSrcMac});
   attributes.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kSrcMac), kSrcMac2});
   attributes.push_back(
@@ -3739,25 +4437,25 @@ TEST_F(L3MulticastManagerTest, DrainUnknownFirstTable) {
   EXPECT_EQ(StatusCode::SWSS_RC_NOT_EXECUTED, Drain(/*failure_before=*/false));
 }
 
-TEST_F(L3MulticastManagerTest, VerifyStateMulticastReplicationTestSuccess) {
+TEST_F(L3MulticastManagerTest, VerifyStateMulticastGroupTestSuccess) {
   // Add router interface entry so have RIF.
   auto rif_entry = SetupP4MulticastRouterInterfaceEntry(
       "Ethernet1", "0x1", swss::MacAddress(kSrcMac1), kRifOid1);
-  // Add entries to then be deleted.
-  auto group_entry = SetupP4MulticastReplicationEntry(
-      "0x1", "Ethernet1", "0x1", kGroupOid1, kGroupMemberOid1);
-
-  const std::string match_key = R"({"match/multicast_group_id":"0x1",)"
-                                R"("match/multicast_replica_port":"Ethernet1",)"
-                                R"("match/multicast_replica_instance":"0x1"})";
+  // Add multicast group.
+  P4Replica replica1 = P4Replica("0x1", "Ethernet1", "0x1");
+  auto group_entry = SetupP4MulticastGroupEntry(
+      "0x1", {replica1}, kGroupOid1, {kGroupMemberOid1});
   const std::string appl_db_key =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
-      kTableKeyDelimiter + match_key;
+      std::string(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) +
+      kTableKeyDelimiter + "0x1";
   const std::string db_key =
       std::string(APP_P4RT_TABLE_NAME) + kTableKeyDelimiter + appl_db_key;
   std::vector<swss::FieldValueTuple> attributes;
+  const std::string json_array =
+      R"([{"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet1"}])";
   attributes.push_back(
-      swss::FieldValueTuple{p4orch::kControllerMetadata, "so_meta"});
+      swss::FieldValueTuple{"replicas", json_array});
 
   // Setup ASIC DB.
   swss::Table table(nullptr, "ASIC_STATE");
@@ -3773,118 +4471,154 @@ TEST_F(L3MulticastManagerTest, VerifyStateMulticastReplicationTestSuccess) {
 
   // Verification should succeed with vaild key and value.
   EXPECT_EQ(VerifyState(db_key, attributes), "");
+  table.del("SAI_OBJECT_TYPE_IPMC_GROUP:oid:0x1");
+  table.del("SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER:oid:0x11");
 }
 
-TEST_F(L3MulticastManagerTest, VerifyStateMulticastReplicationTestBadEntries) {
-  // no multicast_replica_port
-  const std::string bad_match_key =
-      R"({"match/multicast_group_id":"0x1",)"
-      R"("match/multicast_replica_instance":"0x1"})";
-  const std::string bad_appl_db_key =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
-      kTableKeyDelimiter + bad_match_key;
-  const std::string bad_db_key =
-      std::string(APP_P4RT_TABLE_NAME) + kTableKeyDelimiter + bad_appl_db_key;
-
-  const std::string match_key = R"({"match/multicast_group_id":"0x1",)"
-                                R"("match/multicast_replica_port":"Ethernet1",)"
-                                R"("match/multicast_replica_instance":"0x1"})";
+TEST_F(L3MulticastManagerTest, VerifyStateMulticastGroupTestBadEntries) {
   const std::string appl_db_key =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
-      kTableKeyDelimiter + match_key;
-  const std::string db_key =
-      std::string(APP_P4RT_TABLE_NAME) + kTableKeyDelimiter + appl_db_key;
+      std::string(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) +
+      kTableKeyDelimiter + "0x1";
+  const std::string db_key = std::string(APP_P4RT_TABLE_NAME) +
+                           kTableKeyDelimiter + appl_db_key;
 
-  std::vector<swss::FieldValueTuple> attributes;
-  attributes.push_back(
-      swss::FieldValueTuple{p4orch::kControllerMetadata, "so_meta"});
+  std::vector<swss::FieldValueTuple> bad_attributes;
+  const std::string json_array_bad =
+      R"([{"multicast_replica_instance":"0x1"])";
+  bad_attributes.push_back(
+      swss::FieldValueTuple{"replicas", json_array_bad});
 
-  EXPECT_FALSE(VerifyState(bad_db_key, attributes).empty());
+  std::vector<swss::FieldValueTuple> good_attributes;
+  const std::string json_array_good =
+      R"([{"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet1"}])";
+  good_attributes.push_back(
+      swss::FieldValueTuple{"replicas", json_array_good});
+
+  EXPECT_FALSE(VerifyState(db_key, bad_attributes).empty());
   // No entry found.
-  EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+  EXPECT_FALSE(VerifyState(db_key, good_attributes).empty());
 }
 
-TEST_F(L3MulticastManagerTest,
-       VerifyStateMulticastReplicationTestStateCacheFails) {
+TEST_F(L3MulticastManagerTest, VerifyStateMulticastGroupTestStateCacheFails) {
   // Need RIFs to be able to validate entries.
   auto rif_entry1 = SetupP4MulticastRouterInterfaceEntry(
-      "Ethernet1", "0x1", swss::MacAddress(kSrcMac1), kRifOid1);
+      "Ethernet1", "0x0", swss::MacAddress(kSrcMac1), kRifOid1);
   auto rif_entry2 = SetupP4MulticastRouterInterfaceEntry(
-      "Ethernet1", "0x2", swss::MacAddress(kSrcMac1), kRifOid1,
+      "Ethernet1", "0x1", swss::MacAddress(kSrcMac1), kRifOid1,
       /*expect_mock=*/false);
   auto rif_entry3 = SetupP4MulticastRouterInterfaceEntry(
-      "Ethernet2", "0x1", swss::MacAddress(kSrcMac1), kRifOid2);
+      "Ethernet2", "0x0", swss::MacAddress(kSrcMac1), kRifOid2);
 
-  P4MulticastReplicationEntry internal_entry =
-      GenerateP4MulticastReplicationEntry("0x1", "Ethernet1", "0x1");
+  P4Replica replica1 = P4Replica("0x1", "Ethernet1", "0x0");
+  P4Replica replica2 = P4Replica("0x1", "Ethernet2", "0x0");
+  P4Replica replica3 = P4Replica("0x1", "Ethernet1", "0x1");
+  P4MulticastGroupEntry internal_entry =
+      GenerateP4MulticastGroupEntry("0x1", {replica1, replica2}, "multi_meta",
+                                    "controller_meta");
   internal_entry.multicast_group_oid = kGroupOid1;
-  internal_entry.multicast_group_member_oid = kGroupMemberOid1;
+  internal_entry.member_oids[replica1.key] = kGroupMemberOid1;
+  internal_entry.member_oids[replica2.key] = kGroupMemberOid2;
+  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_IPMC_GROUP, "0x1", kGroupOid1);
+  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER, replica1.key,
+                        kGroupMemberOid1);
+  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER, replica2.key,
+                        kGroupMemberOid2);
 
-  // Bad app db entry.
-  P4MulticastReplicationEntry missing_multicast_replica_port =
-      GenerateP4MulticastReplicationEntry("0x1", "", "0x1", "meta1");
-  EXPECT_FALSE(VerifyMulticastReplicationStateCache(
-                   missing_multicast_replica_port, &internal_entry)
-                   .empty());
+  // Empty multicast group ID.
+  P4MulticastGroupEntry empty_group_id =
+      GenerateP4MulticastGroupEntry("", {replica1}, "multi_meta",
+                                    "controller_meta");
+  EXPECT_FALSE(VerifyMulticastGroupStateCache(
+                   empty_group_id, &internal_entry).empty());
+
+  // Missing replica.
+  P4MulticastGroupEntry missing_replica =
+      GenerateP4MulticastGroupEntry("0x1", {replica1}, "multi_meta",
+                                    "controller_meta");
+  EXPECT_FALSE(VerifyMulticastGroupStateCache(
+                   missing_replica, &internal_entry).empty());
+
+  P4MulticastGroupEntry missing_replica2 =
+      GenerateP4MulticastGroupEntry("0x1", {replica1, replica2, replica3},
+                                    "multi_meta", "controller_meta");
+  EXPECT_FALSE(VerifyMulticastGroupStateCache(
+                   missing_replica2, &internal_entry).empty());
+
+  P4MulticastGroupEntry missing_replica3 =
+      GenerateP4MulticastGroupEntry("0x1", {replica1, replica2}, "multi_meta",
+                                    "controller_meta");
+  // Remove from OID map (and then put back).
+  internal_entry.member_oids.erase(replica2.key);
+  EXPECT_FALSE(VerifyMulticastGroupStateCache(
+                   missing_replica3, &internal_entry).empty());
+  internal_entry.member_oids[replica2.key] = kGroupMemberOid2;
+  // Change internal OID map (and then put restore).
+  p4_oid_mapper_.eraseOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER, replica2.key);
+  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER, replica2.key,
+                        kGroupMemberOid3);
+  EXPECT_FALSE(VerifyMulticastGroupStateCache(
+                   missing_replica3, &internal_entry).empty());
+  p4_oid_mapper_.eraseOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER, replica2.key);
+  p4_oid_mapper_.setOID(SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER, replica2.key,
+                        kGroupMemberOid2);
+
+  // Different replicas.
+  P4MulticastGroupEntry different_replicas =
+      GenerateP4MulticastGroupEntry("0x1", {replica2, replica3},
+                                    "multi_meta", "controller_meta");
+  EXPECT_FALSE(VerifyMulticastGroupStateCache(
+                   different_replicas, &internal_entry).empty());
 
   // Mismatch on key.
-  P4MulticastReplicationEntry key_mismatch =
-      GenerateP4MulticastReplicationEntry("0x1", "Ethernet2", "0x1", "meta1");
-  EXPECT_FALSE(
-      VerifyMulticastReplicationStateCache(key_mismatch, &internal_entry)
-          .empty());
+  P4MulticastGroupEntry key_mismatch =
+      GenerateP4MulticastGroupEntry("0x2", {replica1, replica2}, "multi_meta",
+                                    "controller_meta");
+  EXPECT_FALSE(VerifyMulticastGroupStateCache(key_mismatch,
+                                              &internal_entry).empty());
 
   // Mismatch on multicast_group_id.
-  P4MulticastReplicationEntry group_id_mismatch =
-      GenerateP4MulticastReplicationEntry("0x1", "Ethernet1", "0x1", "meta1");
+  P4MulticastGroupEntry group_id_mismatch =
+      GenerateP4MulticastGroupEntry("0x1", {replica1, replica2}, "multi_meta",
+                                    "controller_meta");
   group_id_mismatch.multicast_group_id = "0x2";
-  EXPECT_FALSE(
-      VerifyMulticastReplicationStateCache(group_id_mismatch, &internal_entry)
-          .empty());
+  EXPECT_FALSE(VerifyMulticastGroupStateCache(group_id_mismatch,
+                                              &internal_entry).empty());
 
-  // Mismatch on multicast_replica_port.
-  P4MulticastReplicationEntry multicast_replica_port_mismatch =
-      GenerateP4MulticastReplicationEntry("0x1", "Ethernet1", "0x1", "meta1");
-  multicast_replica_port_mismatch.multicast_replica_port = "Ethernet2";
-  EXPECT_FALSE(VerifyMulticastReplicationStateCache(
-                   multicast_replica_port_mismatch, &internal_entry)
-                   .empty());
+  // Mismatch on multicast metadata.
+  P4MulticastGroupEntry multicast_metadata_mismatch =
+      GenerateP4MulticastGroupEntry("0x1", {replica1, replica2}, "mismatch",
+                                    "controller_meta");
+  EXPECT_FALSE(VerifyMulticastGroupStateCache(multicast_metadata_mismatch,
+                                              &internal_entry).empty());
 
-  // Mismatch on multicast_replica_instance.
-  P4MulticastReplicationEntry multicast_replica_instance_mismatch =
-      GenerateP4MulticastReplicationEntry("0x1", "Ethernet1", "0x1", "meta1");
-  multicast_replica_instance_mismatch.multicast_replica_instance = "0x2";
-  EXPECT_FALSE(VerifyMulticastReplicationStateCache(
-                   multicast_replica_instance_mismatch, &internal_entry)
-                   .empty());
-
-  // Mismatch on multicast_metadata.
-  P4MulticastReplicationEntry multicast_metadata_mismatch =
-      GenerateP4MulticastReplicationEntry("0x1", "Ethernet1", "0x1", "meta2");
-  EXPECT_FALSE(VerifyMulticastReplicationStateCache(multicast_metadata_mismatch,
-                                                    &internal_entry)
-                   .empty());
+  // Mismatch on controller metadata.
+  P4MulticastGroupEntry controller_metdata_mismatch =
+      GenerateP4MulticastGroupEntry("0x1", {replica1, replica2}, "multi_meta",
+                                    "mismatch");
+  EXPECT_FALSE(VerifyMulticastGroupStateCache(controller_metdata_mismatch,
+                                              &internal_entry).empty());
 }
 
-TEST_F(L3MulticastManagerTest, VerifyStateMulticastReplicationMissingAsicDb) {
+TEST_F(L3MulticastManagerTest, VerifyStateMulticastGroupMissingAsicDb) {
   // Need RIFs to be able to validate entries.
   auto rif_entry1 = SetupP4MulticastRouterInterfaceEntry(
       "Ethernet1", "0x1", swss::MacAddress(kSrcMac1), kRifOid1);
   // Add group entry.
-  auto group_entry1 = SetupP4MulticastReplicationEntry(
-      "0x1", "Ethernet1", "0x1", kGroupOid1, kGroupMemberOid1);
-
-  const std::string match_key = R"({"match/multicast_group_id":"0x1",)"
-                                R"("match/multicast_replica_port":"Ethernet1",)"
-                                R"("match/multicast_replica_instance":"0x1"})";
+  P4Replica replica1 = P4Replica("0x1", "Ethernet1", "0x1");
+  auto group_entry = SetupP4MulticastGroupEntry(
+      "0x1", {replica1}, kGroupOid1, {kGroupMemberOid1});
   const std::string appl_db_key =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
-      kTableKeyDelimiter + match_key;
+      std::string(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) +
+      kTableKeyDelimiter + "0x1";
   const std::string db_key =
       std::string(APP_P4RT_TABLE_NAME) + kTableKeyDelimiter + appl_db_key;
   std::vector<swss::FieldValueTuple> attributes;
+  const std::string json_array =
+      R"([{"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet1"}])";
   attributes.push_back(
-      swss::FieldValueTuple{p4orch::kControllerMetadata, "so_meta"});
+      swss::FieldValueTuple{"replicas", json_array});
 
   // Setup ASIC DB.
   swss::Table table(nullptr, "ASIC_STATE");
@@ -3924,36 +4658,54 @@ TEST_F(L3MulticastManagerTest, VerifyStateMulticastReplicationMissingAsicDb) {
           swss::FieldValueTuple{"SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_OUTPUT_ID",
                                 "oid:0x123456"}});
   EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+  table.del("SAI_OBJECT_TYPE_IPMC_GROUP:oid:0x1");
+  table.del("SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER:oid:0x11");
 }
 
-TEST_F(L3MulticastManagerTest, VerifyStateMulticastReplicationAsicDbNoRif) {
-  P4MulticastReplicationEntry entry =
-      GenerateP4MulticastReplicationEntry("0x1", "Ethernet1", "0x1");
-  entry.multicast_group_oid = kGroupOid1;
-  entry.multicast_group_member_oid = kGroupMemberOid1;
+TEST_F(L3MulticastManagerTest, VerifyStateMulticastGroupAsicDbNoRif) {
+  // Need RIFs to setup multicast group.
+  auto rif_entry1 = SetupP4MulticastRouterInterfaceEntry(
+      "Ethernet1", "0x1", swss::MacAddress(kSrcMac1), kRifOid1);
+  P4Replica replica1 = P4Replica("0x1", "Ethernet1", "0x1");
+  auto entry = SetupP4MulticastGroupEntry(
+      "0x1", {replica1}, kGroupOid1, {kGroupMemberOid1});
 
-  EXPECT_FALSE(VerifyMulticastReplicationStateAsicDb(&entry).empty());
+  // Force-remove the OID.
+  std::string rif_key = KeyGenerator::generateMulticastRouterInterfaceRifKey(
+    rif_entry1.multicast_replica_port, rif_entry1.src_mac);
+  ForceRemoveRifKey(rif_key);
+
+  // Setup ASIC DB.
+  swss::Table table(nullptr, "ASIC_STATE");
+  table.set(
+      "SAI_OBJECT_TYPE_IPMC_GROUP:oid:0x1",
+      std::vector<swss::FieldValueTuple>{});
+
+  auto* group_entry_ptr = GetMulticastGroupEntry("0x1");
+  ASSERT_NE(group_entry_ptr, nullptr);
+  EXPECT_FALSE(VerifyMulticastGroupStateAsicDb(group_entry_ptr).empty());
+  table.del("SAI_OBJECT_TYPE_IPMC_GROUP:oid:0x1");
 }
 
-TEST_F(L3MulticastManagerTest, VerifyStateMulticastReplicationFailures) {
+TEST_F(L3MulticastManagerTest, VerifyStateMulticastGroupFailures) {
   // Need RIFs to be able to validate entries.
   auto rif_entry1 = SetupP4MulticastRouterInterfaceEntry(
       "Ethernet1", "0x1", swss::MacAddress(kSrcMac1), kRifOid1);
   // Add group entry.
-  auto group_entry1 = SetupP4MulticastReplicationEntry(
-      "0x1", "Ethernet1", "0x1", kGroupOid1, kGroupMemberOid1);
-
-  const std::string match_key = R"({"match/multicast_group_id":"0x1",)"
-                                R"("match/multicast_replica_port":"Ethernet1",)"
-                                R"("match/multicast_replica_instance":"0x1"})";
+  P4Replica replica1 = P4Replica("0x1", "Ethernet1", "0x1");
+  auto group_entry = SetupP4MulticastGroupEntry(
+      "0x1", {replica1}, kGroupOid1, {kGroupMemberOid1});
   const std::string appl_db_key =
-      std::string(APP_P4RT_REPLICATION_L2_MULTICAST_TABLE_NAME) +
-      kTableKeyDelimiter + match_key;
+      std::string(APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME) +
+      kTableKeyDelimiter + "0x1";
   const std::string db_key =
       std::string(APP_P4RT_TABLE_NAME) + kTableKeyDelimiter + appl_db_key;
   std::vector<swss::FieldValueTuple> attributes;
+  const std::string json_array =
+      R"([{"multicast_replica_instance":"0x1",)"
+      R"("multicast_replica_port":"Ethernet1"}])";
   attributes.push_back(
-      swss::FieldValueTuple{p4orch::kControllerMetadata, "so_meta"});
+      swss::FieldValueTuple{"replicas", json_array});
 
   // Setup ASIC DB.
   swss::Table table(nullptr, "ASIC_STATE");
@@ -3976,6 +4728,7 @@ TEST_F(L3MulticastManagerTest, VerifyStateMulticastReplicationFailures) {
   // Force ASIC DB to be bad also.
   table.del("SAI_OBJECT_TYPE_IPMC_GROUP:oid:0x1");
   EXPECT_FALSE(VerifyState(db_key, attributes).empty());
+  table.del("SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER:oid:0x11");
 }
 
 TEST_F(L3MulticastManagerTest,

--- a/tests/p4rt/l3_multicast.py
+++ b/tests/p4rt/l3_multicast.py
@@ -1,0 +1,168 @@
+from swsscommon import swsscommon
+
+import util
+import json
+
+
+class P4RtL3MulticastRouterInterfaceWrapper(util.DBInterface):
+  """Interface to interact with APP DB and ASIC DB tables for P4RT L3 multicast router interface object."""
+
+  # Database and SAI constants.
+  APP_DB_TBL_NAME = swsscommon.APP_P4RT_TABLE_NAME
+  TBL_NAME = swsscommon.APP_P4RT_MULTICAST_ROUTER_INTERFACE_TABLE_NAME
+
+  ASIC_DB_TBL_NAME = "ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE"
+  SAI_ATTR_VIRTUAL_ROUTER_ID = "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID"
+  SAI_ATTR_SRC_MAC = "SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS"
+  SAI_ATTR_TYPE = "SAI_ROUTER_INTERFACE_ATTR_TYPE"
+  SAI_ATTR_TYPE_PORT = "SAI_ROUTER_INTERFACE_TYPE_PORT"
+  SAI_ATTR_MTU = "SAI_ROUTER_INTERFACE_ATTR_MTU"
+  SAI_ATTR_PORT_ID = "SAI_ROUTER_INTERFACE_ATTR_PORT_ID"
+  SAI_ATTR_V4_MCAST_ENABLE = "SAI_ROUTER_INTERFACE_ATTR_V4_MCAST_ENABLE"
+  SAI_ATTR_V6_MCAST_ENABLE = "SAI_ROUTER_INTERFACE_ATTR_V6_MCAST_ENABLE"
+  SAI_ATTR_DEFAULT_MTU = "9100"
+
+  # Attribute fields for multicast router interface entry.
+  ACTION_FIELD = "action"
+  SRC_MAC_FIELD = "src_mac"
+
+  # Default router interface attribute values.
+  DEFAULT_PORT_ID = "Ethernet8"
+  DEFAULT_INSTANCE = "0x0"
+  DEFAULT_SRC_MAC = "00:11:22:33:44:55"
+  DEFAULT_ACTION = "set_multicast_src_mac"
+
+  def generate_app_db_key(self, multicast_replica_port,
+                          multicast_replica_instance):
+    d = {}
+    d[util.prepend_match_field("multicast_replica_port")] = (
+        multicast_replica_port)
+    d[util.prepend_match_field("multicast_replica_instance")] = (
+        multicast_replica_instance)
+    key = json.dumps(d, separators=(",", ":"))
+    return self.TBL_NAME + ":" + key
+
+  # Create default router interface.
+  def create_router_interface(self, port_id=None, instance=None,
+                              src_mac=None):
+    port_id = port_id or self.DEFAULT_PORT_ID
+    instance = instance or self.DEFAULT_INSTANCE
+    src_mac = src_mac or self.DEFAULT_SRC_MAC
+    action = self.DEFAULT_ACTION
+    attr_list = [
+        (util.prepend_param_field(self.SRC_MAC_FIELD), src_mac),
+        (self.ACTION_FIELD, action),
+    ]
+    mcast_router_intf_key = self.generate_app_db_key(port_id, instance)
+    self.set_app_db_entry(mcast_router_intf_key, attr_list)
+    return mcast_router_intf_key, attr_list
+
+
+class P4RtL3MulticastGroupWrapper(util.DBInterface):
+  """Interface to interact with APP DB and ASIC DB tables for P4RT L3 multicast group object."""
+
+  # Database and SAI constants.
+  APP_DB_TBL_NAME = swsscommon.APP_P4RT_TABLE_NAME
+  TBL_NAME = swsscommon.APP_P4RT_REPLICATION_IP_MULTICAST_TABLE_NAME
+
+  ASIC_DB_GROUP_TBL_NAME = "ASIC_STATE:SAI_OBJECT_TYPE_IPMC_GROUP"
+  ASIC_DB_GROUP_MEMBER_TBL_NAME = "ASIC_STATE:SAI_OBJECT_TYPE_IPMC_GROUP_MEMBER"
+  SAI_ATTR_IPMC_GROUP_ID = "SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_GROUP_ID"
+  SAI_ATTR_IPMC_OUTPUT_ID = "SAI_IPMC_GROUP_MEMBER_ATTR_IPMC_OUTPUT_ID"
+
+  # Default router interface attribute values.
+  DEFAULT_GROUP_ID = "0x1"
+  DEFAULT_REPLICAS = [("Ethernet8", "0x0")]
+
+  CONTROLLER_METADATA = "controller_metadata"
+  DEFAULT_METADATA = "my_metadata"
+
+  def generate_app_db_key(self, multicast_group_id):
+    return self.TBL_NAME + ":" + multicast_group_id
+
+  # Create default multicast group entry.
+  def create_multicast_group_entry(self, group_id=None, replicas=None):
+    group_id = group_id or self.DEFAULT_GROUP_ID
+    if replicas is None:
+      local_replicas = [x for x in self.DEFAULT_REPLICAS]
+    else:
+      local_replicas = replicas
+
+    replica_dicts = []
+    for port_name, instance in local_replicas:
+      replica_dicts.append(
+          "{\"multicast_replica_instance\":\"" + instance  + "\"" +
+          ",\"multicast_replica_port\":\"" + port_name + "\"}")
+    replica_json_array = "[" + ",".join(replica_dicts) + "]"
+    attr_list = [("replicas", replica_json_array)]
+
+    mcast_group_key = self.generate_app_db_key(group_id)
+    self.set_app_db_entry(mcast_group_key, attr_list)
+    return mcast_group_key, attr_list
+
+
+class P4RtL3MulticastRouteWrapper(util.DBInterface):
+  """Interface to interact with APP DB and ASIC DB tables for P4RT L3 multicast route object."""
+
+  # Database and SAI constants.
+  APP_DB_TBL_NAME = swsscommon.APP_P4RT_TABLE_NAME
+  TBL_NAME_IPV4 = swsscommon.APP_P4RT_IPV4_TABLE_NAME
+  TBL_NAME_IPV6 = swsscommon.APP_P4RT_IPV6_TABLE_NAME
+
+  ASIC_DB_TBL_NAME = "ASIC_STATE:SAI_OBJECT_TYPE_IPMC_ENTRY"
+  ASIC_DB_RPF_GROUP_TBL_NAME = "ASIC_STATE:SAI_OBJECT_TYPE_RPF_GROUP"
+  SAI_ATTR_PACKET_ACTION = "SAI_IPMC_ENTRY_ATTR_PACKET_ACTION"
+  SAI_ATTR_PACKET_ACTION_FORWARD = "SAI_PACKET_ACTION_FORWARD"
+  SAI_ATTR_OUTPUT_GROUP_ID = "SAI_IPMC_ENTRY_ATTR_OUTPUT_GROUP_ID"
+  SAI_ATTR_RPF_GROUP_ID = "SAI_IPMC_ENTRY_ATTR_RPF_GROUP_ID"
+
+  # Attribute fields for multicast route entry.
+  ACTION_FIELD = "action"
+  MULTICAST_GROUP_ID_FIELD = "multicast_group_id"
+  NEXT_HOP_ID_FIELD = "nexthop_id"
+
+  # Default router interface attribute values.
+  DEFAULT_ACTION = "set_multicast_group_id"
+  SET_NEXT_HOP_ID_ACTION = "set_nexthop_id"
+  DEFAULT_GROUP_ID = "0x1"
+  DEFAULT_VRF_ID = "b4-traffic"
+  DEFAULT_DST_V6 = "2001:db8:3:4:5:6:7:8"
+  DEFAULT_DST_V4 = "10.11.12.0"
+
+  def generate_app_db_key(self, vrf_id, ipv4_dst=None, ipv6_dst=None):
+    d = {}
+    d[util.prepend_match_field("vrf_id")] = vrf_id
+    if ipv4_dst is None:
+      d[util.prepend_match_field("ipv6_dst")] = ipv6_dst
+      tbl_name = self.TBL_NAME_IPV6
+    else:
+      d[util.prepend_match_field("ipv4_dst")] = ipv4_dst
+      tbl_name = self.TBL_NAME_IPV4
+    key = json.dumps(d, separators=(",", ":"))
+    return tbl_name + ":" + key
+
+  # Create default multicast route entry.
+  def create_multicast_route(self, group_id=None, dst_ip=None, is_v4=True,
+                             action=None, param="0"):
+    group_id = group_id or self.DEFAULT_GROUP_ID
+    if is_v4:
+      ipv4_dst = dst_ip or self.DEFAULT_DST_V4
+      ipv6_dst = None
+    else:
+      ipv4_dst = None
+      ipv6_dst = dst_ip or self.DEFAULT_DST_V6
+    vrf_id = self.DEFAULT_VRF_ID
+    action = action or self.DEFAULT_ACTION
+    if action == self.DEFAULT_ACTION:
+      attr_list = [
+          (util.prepend_param_field(self.MULTICAST_GROUP_ID_FIELD), group_id),
+          (self.ACTION_FIELD, action),
+      ]
+    else:
+      attr_list = [
+          (util.prepend_param_field(self.NEXT_HOP_ID_FIELD), param),
+          (self.ACTION_FIELD, action),
+      ]
+    mcast_route_key = self.generate_app_db_key(vrf_id, ipv4_dst, ipv6_dst)
+    self.set_app_db_entry(mcast_route_key, attr_list)
+    return mcast_route_key, attr_list

--- a/tests/p4rt/test_p4rt_l3_multicast.py
+++ b/tests/p4rt/test_p4rt_l3_multicast.py
@@ -1,0 +1,1174 @@
+# Lint as: python3
+from swsscommon import swsscommon
+
+import pytest
+import util
+import l3
+import l3_multicast
+import test_vrf
+APP_P4RT_CHANNEL_NAME="P4rt_Channel"
+
+
+class TestP4RTL3MulticastRouterInterface(object):
+  """Tests interacting with multicast router interface table"""
+
+  def _set_up(self, dvs):
+    self._p4rt_l3_multicast_router_intf = (
+        l3_multicast.P4RtL3MulticastRouterInterfaceWrapper())
+
+    self._p4rt_l3_multicast_router_intf.set_up_databases(dvs)
+
+    self.p4rt_notifier = swsscommon.NotificationProducer(
+      self._p4rt_l3_multicast_router_intf.appl_db,
+      APP_P4RT_CHANNEL_NAME)
+    self.response_consumer = swsscommon.NotificationConsumer(
+      self._p4rt_l3_multicast_router_intf.appl_db, "APPL_DB_" +
+      swsscommon.APP_P4RT_TABLE_NAME + "_RESPONSE_CHANNEL"
+    )
+    self.appl_db_table = (
+        self._p4rt_l3_multicast_router_intf.APP_DB_TBL_NAME + ":" +
+            self._p4rt_l3_multicast_router_intf.TBL_NAME)
+    self.asic_db_table = self._p4rt_l3_multicast_router_intf.ASIC_DB_TBL_NAME
+
+  def get_global_vrf_id(self):
+    virt_entries = util.get_keys(self._p4rt_l3_multicast_router_intf.asic_db,
+                                 "ASIC_STATE:SAI_OBJECT_TYPE_VIRTUAL_ROUTER")
+    for key in virt_entries:
+      return key
+    return "0"
+
+  def test_L3MulticastRouterInterfaceAddUpdateDelete(self, dvs, testlog):
+    """
+    This test attempts to add a multicast router interface entry, confirms the
+    databases are setup correctly, updates the entry to use a different MAC
+    address, confirms the databases are setup correctly, and then deletes the
+    entry.
+    """
+    # Initialize database connectors
+    self._set_up(dvs)
+
+    # Fetch database state after init.
+    original_app_db_entries = util.get_keys(
+        self._p4rt_l3_multicast_router_intf.appl_db, self.appl_db_table)
+    original_asic_db_entries = util.get_keys(
+        self._p4rt_l3_multicast_router_intf.asic_db, self.asic_db_table)
+
+    ####################################
+    # Add operation
+    ####################################
+    # Add one L3 multicast router interface entry.
+    mcast_router_intf_key, attr_list = (
+        self._p4rt_l3_multicast_router_intf.create_router_interface(
+            port_id=None, instance=None, src_mac=None))
+    util.verify_response(self.response_consumer, mcast_router_intf_key,
+                         attr_list, "SWSS_RC_SUCCESS")
+
+    # Check that APP DB has expected entry with expected values.
+    mcast_rif_entries = util.get_keys(
+        self._p4rt_l3_multicast_router_intf.appl_db, self.appl_db_table)
+    assert len(mcast_rif_entries) == (len(original_app_db_entries) + 1)
+
+    (status, fvs) = util.get_key(
+        self._p4rt_l3_multicast_router_intf.appl_db,
+        self._p4rt_l3_multicast_router_intf.APP_DB_TBL_NAME,
+        mcast_router_intf_key)
+    assert status == True
+    util.verify_attr(fvs, attr_list)
+
+    # Check that ASIC DB has expected values.
+    mcast_rif_asic_entries = util.get_keys(
+        self._p4rt_l3_multicast_router_intf.asic_db, self.asic_db_table)
+    assert len(mcast_rif_asic_entries) == (len(original_asic_db_entries) + 1)
+
+    asic_db_key = None
+    for key in mcast_rif_asic_entries:
+      if key not in original_asic_db_entries:
+        asic_db_key = key
+        break
+    assert asic_db_key is not None
+    (status, fvs) = util.get_key(
+        self._p4rt_l3_multicast_router_intf.asic_db,
+        self._p4rt_l3_multicast_router_intf.ASIC_DB_TBL_NAME,
+        asic_db_key)
+    assert status == True
+
+    global_vrf_id = self.get_global_vrf_id()
+    port_oid = util.get_port_oid_by_name(
+        dvs, self._p4rt_l3_multicast_router_intf.DEFAULT_PORT_ID)
+
+    attr_list = [
+        (self._p4rt_l3_multicast_router_intf.SAI_ATTR_VIRTUAL_ROUTER_ID,
+         global_vrf_id),
+        (self._p4rt_l3_multicast_router_intf.SAI_ATTR_SRC_MAC,
+         self._p4rt_l3_multicast_router_intf.DEFAULT_SRC_MAC),
+        (self._p4rt_l3_multicast_router_intf.SAI_ATTR_TYPE,
+         self._p4rt_l3_multicast_router_intf.SAI_ATTR_TYPE_PORT),
+        (self._p4rt_l3_multicast_router_intf.SAI_ATTR_MTU,
+         self._p4rt_l3_multicast_router_intf.SAI_ATTR_DEFAULT_MTU),
+        (self._p4rt_l3_multicast_router_intf.SAI_ATTR_PORT_ID, port_oid),
+        (self._p4rt_l3_multicast_router_intf.SAI_ATTR_V4_MCAST_ENABLE, "true"),
+        (self._p4rt_l3_multicast_router_intf.SAI_ATTR_V6_MCAST_ENABLE, "true"),
+    ]
+    util.verify_attr(fvs, attr_list)
+
+    ####################################
+    # Update operation
+    ####################################
+    # Update L3 multicast router interface entry to use a different MAC.
+    new_src_mac = "00:66:77:88:99:AA"
+    mcast_router_intf_key, attr_list = (
+        self._p4rt_l3_multicast_router_intf.create_router_interface(
+            port_id=None, instance=None, src_mac=new_src_mac))
+    util.verify_response(self.response_consumer, mcast_router_intf_key,
+                         attr_list, "SWSS_RC_SUCCESS")
+
+    # Check that APP DB has expected entry with expected values.
+    mcast_rif_entries = util.get_keys(
+        self._p4rt_l3_multicast_router_intf.appl_db, self.appl_db_table)
+    assert len(mcast_rif_entries) == (len(original_app_db_entries) + 1)
+
+    (status, fvs) = util.get_key(
+        self._p4rt_l3_multicast_router_intf.appl_db,
+        self._p4rt_l3_multicast_router_intf.APP_DB_TBL_NAME,
+        mcast_router_intf_key)
+    assert status == True
+    util.verify_attr(fvs, attr_list)
+
+    # Check that ASIC DB has expected values.
+    mcast_rif_asic_entries = util.get_keys(
+        self._p4rt_l3_multicast_router_intf.asic_db, self.asic_db_table)
+    assert len(mcast_rif_asic_entries) == (len(original_asic_db_entries) + 1)
+
+    asic_db_key = None
+    for key in mcast_rif_asic_entries:
+      if key not in original_asic_db_entries:
+        asic_db_key = key
+        break
+    assert asic_db_key is not None
+    (status, fvs) = util.get_key(
+        self._p4rt_l3_multicast_router_intf.asic_db,
+        self._p4rt_l3_multicast_router_intf.ASIC_DB_TBL_NAME,
+        asic_db_key)
+    assert status == True
+
+    attr_list = [
+        (self._p4rt_l3_multicast_router_intf.SAI_ATTR_VIRTUAL_ROUTER_ID,
+         global_vrf_id),
+        (self._p4rt_l3_multicast_router_intf.SAI_ATTR_SRC_MAC, new_src_mac),
+        (self._p4rt_l3_multicast_router_intf.SAI_ATTR_TYPE,
+         self._p4rt_l3_multicast_router_intf.SAI_ATTR_TYPE_PORT),
+        (self._p4rt_l3_multicast_router_intf.SAI_ATTR_MTU,
+         self._p4rt_l3_multicast_router_intf.SAI_ATTR_DEFAULT_MTU),
+        (self._p4rt_l3_multicast_router_intf.SAI_ATTR_PORT_ID, port_oid),
+        (self._p4rt_l3_multicast_router_intf.SAI_ATTR_V4_MCAST_ENABLE, "true"),
+        (self._p4rt_l3_multicast_router_intf.SAI_ATTR_V6_MCAST_ENABLE, "true"),
+    ]
+    util.verify_attr(fvs, attr_list)
+
+    ####################################
+    # Delete operation
+    ####################################
+    self._p4rt_l3_multicast_router_intf.remove_app_db_entry(
+        mcast_router_intf_key)
+    util.verify_response(self.response_consumer, mcast_router_intf_key, [],
+                         "SWSS_RC_SUCCESS")
+
+    # Check that entries are gone.
+    mcast_rif_entries = util.get_keys(
+        self._p4rt_l3_multicast_router_intf.appl_db, self.appl_db_table)
+    assert len(mcast_rif_entries) == len(original_app_db_entries)
+
+    # Check that ASIC DB has expected values.
+    mcast_rif_asic_entries = util.get_keys(
+        self._p4rt_l3_multicast_router_intf.asic_db, self.asic_db_table)
+    assert len(mcast_rif_asic_entries) == len(original_asic_db_entries)
+
+  def test_L3MulticastRouterInterfaceDeleteUnknown(self, dvs, testlog):
+    """
+    This test attempts to delete an unknown multicast router interface entry,
+    which should result in an error.
+    """
+    self._set_up(dvs)
+
+    # Fetch database state after init.
+    original_app_db_entries = util.get_keys(
+        self._p4rt_l3_multicast_router_intf.appl_db, self.appl_db_table)
+    original_asic_db_entries = util.get_keys(
+        self._p4rt_l3_multicast_router_intf.asic_db, self.asic_db_table)
+
+    ####################################
+    # Delete operation
+    ####################################
+    mcast_router_intf_key = (
+        self._p4rt_l3_multicast_router_intf.generate_app_db_key(
+            self._p4rt_l3_multicast_router_intf.DEFAULT_PORT_ID,
+            self._p4rt_l3_multicast_router_intf.DEFAULT_INSTANCE))
+
+    self._p4rt_l3_multicast_router_intf.remove_app_db_entry(
+        mcast_router_intf_key)
+    util.verify_response(
+        self.response_consumer, mcast_router_intf_key, [], "SWSS_RC_NOT_FOUND",
+        "[OrchAgent] Multicast router interface entry exists does not exist")
+
+    # Check that entries remain unchanged.
+    mcast_rif_entries = util.get_keys(
+        self._p4rt_l3_multicast_router_intf.appl_db, self.appl_db_table)
+    assert len(mcast_rif_entries) == len(original_app_db_entries)
+
+    mcast_rif_asic_entries = util.get_keys(
+        self._p4rt_l3_multicast_router_intf.asic_db, self.asic_db_table)
+    assert len(mcast_rif_asic_entries) == len(original_asic_db_entries)
+
+  def test_L3MulticastRouterInterfaceAddTwoDeleteOne(self, dvs, testlog):
+    """
+    This tests two entries that will end up sharing a RIF.  When we delete
+    one of the entries, we want to confirm that the RIF remains.
+    """
+    self._set_up(dvs)
+
+    # Fetch database state after init.
+    original_app_db_entries = util.get_keys(
+        self._p4rt_l3_multicast_router_intf.appl_db, self.appl_db_table)
+    original_asic_db_entries = util.get_keys(
+        self._p4rt_l3_multicast_router_intf.asic_db, self.asic_db_table)
+
+    ####################################
+    # Add operation
+    ####################################
+    # Add two L3 multicast router interface entries.
+    mcast_router_intf_key_0, attr_list_0 = (
+        self._p4rt_l3_multicast_router_intf.create_router_interface(
+            port_id=None, instance="0x0", src_mac=None))
+    util.verify_response(self.response_consumer, mcast_router_intf_key_0,
+                         attr_list_0, "SWSS_RC_SUCCESS")
+
+    mcast_router_intf_key_1, attr_list_1 = (
+        self._p4rt_l3_multicast_router_intf.create_router_interface(
+            port_id=None, instance="0x1", src_mac=None))
+    util.verify_response(self.response_consumer, mcast_router_intf_key_1,
+                         attr_list_1, "SWSS_RC_SUCCESS")
+
+    # Check that APP DB has expected entry with expected values.
+    mcast_rif_entries = util.get_keys(
+        self._p4rt_l3_multicast_router_intf.appl_db, self.appl_db_table)
+    assert len(mcast_rif_entries) == (len(original_app_db_entries) + 2)
+
+    (status_0, fvs_0) = util.get_key(
+        self._p4rt_l3_multicast_router_intf.appl_db,
+        self._p4rt_l3_multicast_router_intf.APP_DB_TBL_NAME,
+        mcast_router_intf_key_0)
+    assert status_0 == True
+    util.verify_attr(fvs_0, attr_list_0)
+
+    (status_1, fvs_1) = util.get_key(
+        self._p4rt_l3_multicast_router_intf.appl_db,
+        self._p4rt_l3_multicast_router_intf.APP_DB_TBL_NAME,
+        mcast_router_intf_key_1)
+    assert status_1 == True
+    util.verify_attr(fvs_1, attr_list_1)
+
+    # Check that ASIC DB has expected values.
+    # It's only one entry, because we share a RIF.
+    mcast_rif_asic_entries = util.get_keys(
+        self._p4rt_l3_multicast_router_intf.asic_db, self.asic_db_table)
+    assert len(mcast_rif_asic_entries) == (len(original_asic_db_entries) + 1)
+
+    asic_db_key = None
+    for key in mcast_rif_asic_entries:
+      if key not in original_asic_db_entries:
+        asic_db_key = key
+        break
+    assert asic_db_key is not None
+    (status_asic, fvs_asic) = util.get_key(
+        self._p4rt_l3_multicast_router_intf.asic_db,
+        self._p4rt_l3_multicast_router_intf.ASIC_DB_TBL_NAME,
+        asic_db_key)
+    assert status_asic == True
+
+    global_vrf_id = self.get_global_vrf_id()
+    port_oid = util.get_port_oid_by_name(
+        dvs, self._p4rt_l3_multicast_router_intf.DEFAULT_PORT_ID)
+
+    asic_attr_list = [
+        (self._p4rt_l3_multicast_router_intf.SAI_ATTR_VIRTUAL_ROUTER_ID,
+         global_vrf_id),
+        (self._p4rt_l3_multicast_router_intf.SAI_ATTR_SRC_MAC,
+         self._p4rt_l3_multicast_router_intf.DEFAULT_SRC_MAC),
+        (self._p4rt_l3_multicast_router_intf.SAI_ATTR_TYPE,
+         self._p4rt_l3_multicast_router_intf.SAI_ATTR_TYPE_PORT),
+        (self._p4rt_l3_multicast_router_intf.SAI_ATTR_MTU,
+         self._p4rt_l3_multicast_router_intf.SAI_ATTR_DEFAULT_MTU),
+        (self._p4rt_l3_multicast_router_intf.SAI_ATTR_PORT_ID, port_oid),
+        (self._p4rt_l3_multicast_router_intf.SAI_ATTR_V4_MCAST_ENABLE, "true"),
+        (self._p4rt_l3_multicast_router_intf.SAI_ATTR_V6_MCAST_ENABLE, "true"),
+    ]
+    util.verify_attr(fvs_asic, asic_attr_list)
+
+    ####################################
+    # Delete operation
+    ####################################
+    self._p4rt_l3_multicast_router_intf.remove_app_db_entry(
+        mcast_router_intf_key_0)
+    util.verify_response(self.response_consumer, mcast_router_intf_key_0, [],
+                         "SWSS_RC_SUCCESS")
+
+    # Check that one APP DB entry has been removed.
+    mcast_rif_entries = util.get_keys(
+        self._p4rt_l3_multicast_router_intf.appl_db, self.appl_db_table)
+    assert len(mcast_rif_entries) == (len(original_app_db_entries) + 1)
+
+    (status_0, fvs_0) = util.get_key(
+        self._p4rt_l3_multicast_router_intf.appl_db,
+        self._p4rt_l3_multicast_router_intf.APP_DB_TBL_NAME,
+        mcast_router_intf_key_0)
+    assert status_0 == False  # We removed the entry.
+
+    (status_1, fvs_1) = util.get_key(
+        self._p4rt_l3_multicast_router_intf.appl_db,
+        self._p4rt_l3_multicast_router_intf.APP_DB_TBL_NAME,
+        mcast_router_intf_key_1)
+    assert status_1 == True
+    util.verify_attr(fvs_1, attr_list_1)
+
+    # Check that ASIC DB has not been changed after adds.
+    mcast_rif_asic_entries = util.get_keys(
+        self._p4rt_l3_multicast_router_intf.asic_db, self.asic_db_table)
+    assert len(mcast_rif_asic_entries) == (len(original_asic_db_entries) + 1)
+
+    asic_db_key = None
+    for key in mcast_rif_asic_entries:
+      if key not in original_asic_db_entries:
+        asic_db_key = key
+        break
+    assert asic_db_key is not None
+    (status_asic, fvs_asic) = util.get_key(
+        self._p4rt_l3_multicast_router_intf.asic_db,
+        self._p4rt_l3_multicast_router_intf.ASIC_DB_TBL_NAME,
+        asic_db_key)
+    assert status_asic == True
+    # asic_attr_list should be unchanged from original adds.
+    util.verify_attr(fvs_asic, asic_attr_list)
+
+    ####################################
+    # Cleanup
+    ####################################
+    dvs.restart()
+
+
+class TestP4RTL3MulticastGroup(object):
+  """Tests interacting with replication multicast table"""
+  def _set_up(self, dvs):
+    self._p4rt_l3_multicast_router_intf = (
+        l3_multicast.P4RtL3MulticastRouterInterfaceWrapper())
+    self._p4rt_l3_multicast_router_intf.set_up_databases(dvs)
+
+    self._p4rt_l3_multicast_group_intf = (
+        l3_multicast.P4RtL3MulticastGroupWrapper())
+    self._p4rt_l3_multicast_group_intf.set_up_databases(dvs)
+
+    self.p4rt_notifier = swsscommon.NotificationProducer(
+      self._p4rt_l3_multicast_group_intf.appl_db,
+      APP_P4RT_CHANNEL_NAME)
+    self.response_consumer = swsscommon.NotificationConsumer(
+      self._p4rt_l3_multicast_group_intf.appl_db, "APPL_DB_" +
+      swsscommon.APP_P4RT_TABLE_NAME + "_RESPONSE_CHANNEL")
+
+    self.appl_db_table = (
+        self._p4rt_l3_multicast_group_intf.APP_DB_TBL_NAME + ":" +
+            self._p4rt_l3_multicast_group_intf.TBL_NAME)
+    self.asic_db_group_table = (
+        self._p4rt_l3_multicast_group_intf.ASIC_DB_GROUP_TBL_NAME)
+    self.asic_db_group_member_table = (
+        self._p4rt_l3_multicast_group_intf.ASIC_DB_GROUP_MEMBER_TBL_NAME)
+    self.asic_db_rif_table = (
+        self._p4rt_l3_multicast_router_intf.ASIC_DB_TBL_NAME)
+
+  def get_added_multicast_group_oid(self, original_entries):
+    """Returns OID key if single multicast group was added"""
+    group_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self._p4rt_l3_multicast_group_intf.ASIC_DB_GROUP_TBL_NAME)
+    for key in group_entries:
+      if key not in original_entries:
+        return key
+    return "0"
+
+  def get_added_multicast_group_member_oids(self, original_entries):
+    """Returns OID keys of multicast group members added"""
+    member_oids = []
+
+    group_member_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self._p4rt_l3_multicast_group_intf.ASIC_DB_GROUP_MEMBER_TBL_NAME)
+    for key in group_member_entries:
+      if key not in original_entries:
+        member_oids.append(key)
+    return member_oids
+
+  def get_added_rif_oid(self, original_entries):
+    """Returns OID key if single RIF was added"""
+    rif_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self._p4rt_l3_multicast_router_intf.ASIC_DB_TBL_NAME)
+
+    for key in rif_entries:
+      if key not in original_entries:
+        return key
+    return "0"
+
+  def add_rif(self, port_id=None, instance=None, src_mac=None):
+    """Adds a multicast router interface entry"""
+    start_asic_db_rif_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_rif_table)
+
+    mcast_router_intf_key, attr_list = (
+        self._p4rt_l3_multicast_router_intf.create_router_interface(
+            port_id, instance, src_mac))
+    util.verify_response(self.response_consumer, mcast_router_intf_key,
+                         attr_list, "SWSS_RC_SUCCESS")
+    rif_oid = self.get_added_rif_oid(start_asic_db_rif_entries)
+    return rif_oid
+
+  def add_and_verify_multicast_group(self, group_id=None, replicas=None,
+                                     rif_oids=None, new_replicas=None,
+                                     group_oid=None):
+    """Adds a multicast group entry and verifies APP DB and ASIC DB"""
+    start_app_db_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.appl_db, self.appl_db_table)
+    start_asic_db_group_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_group_table)
+    start_asic_db_group_member_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_group_member_table)
+    assert len(rif_oids) == len(new_replicas)
+
+    # Add the group member.
+    mcast_group_key, attr_list = (
+        self._p4rt_l3_multicast_group_intf.create_multicast_group_entry(
+            group_id=group_id, replicas=replicas))
+    util.verify_response(self.response_consumer, mcast_group_key,
+                         attr_list, "SWSS_RC_SUCCESS")
+
+    # Check that APP DB has expected entry with expected values.
+    mcast_group_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.appl_db, self.appl_db_table)
+    # If we provided a group_oid, we expected the entry to already exist.
+    if group_oid is not None:
+      assert len(mcast_group_entries) == len(start_app_db_entries)
+    else:
+      assert len(mcast_group_entries) == (len(start_app_db_entries) + 1)
+
+    (status, fvs) = util.get_key(
+        self._p4rt_l3_multicast_group_intf.appl_db,
+        self._p4rt_l3_multicast_group_intf.APP_DB_TBL_NAME,
+        mcast_group_key)
+    assert status == True
+    util.verify_attr(fvs, attr_list)
+
+    # Check that ASIC DB has expected value
+    mcast_group_asic_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_group_table)
+    if group_oid is not None:
+      # If we provided a group_oid, that means we expected the group OID to
+      # already exist.
+      assert len(mcast_group_asic_entries) == (
+          len(start_asic_db_group_entries))
+      group_oid_to_ret = group_oid
+    else:
+      # There are no attributes to check for the group.  We just need to check
+      # that there is a new entry.
+      assert len(mcast_group_asic_entries) == (
+          len(start_asic_db_group_entries) + 1)
+      group_oid_to_ret = self.get_added_multicast_group_oid(
+          start_asic_db_group_entries)
+
+    # Verify group member.
+    mcast_group_member_asic_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_group_member_table)
+    assert len(mcast_group_member_asic_entries) == (
+        len(start_asic_db_group_member_entries) + len(new_replicas))
+
+    new_group_member_oids = self.get_added_multicast_group_member_oids(
+        start_asic_db_group_member_entries)
+    assert len(new_group_member_oids) == len(new_replicas)
+
+    for idx, group_member_oid in enumerate(new_group_member_oids):
+      (status_asic_group_member, fvs_asic_group_member) = util.get_key(
+          self._p4rt_l3_multicast_group_intf.asic_db,
+          self._p4rt_l3_multicast_group_intf.ASIC_DB_GROUP_MEMBER_TBL_NAME,
+          group_member_oid)
+      assert status_asic_group_member == True
+
+      asic_group_member_attr_list = [
+          (self._p4rt_l3_multicast_group_intf.SAI_ATTR_IPMC_GROUP_ID,
+           group_oid_to_ret),
+          (self._p4rt_l3_multicast_group_intf.SAI_ATTR_IPMC_OUTPUT_ID,
+           rif_oids[idx]),
+      ]
+      util.verify_attr(fvs_asic_group_member, asic_group_member_attr_list)
+    return mcast_group_key, attr_list, group_oid_to_ret, new_group_member_oids
+
+  def test_L3MulticastGroupAddUpdateDelete(self, dvs, testlog):
+    """
+    This test adds a muliticast group member, confirms a group and a member
+    were created, confirms an update operation can add a new member, and then
+    deletes the group.
+    """
+    self._set_up(dvs)
+
+    # Fetch database state after init.
+    original_app_db_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.appl_db, self.appl_db_table)
+    original_asic_db_rif_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_rif_table)
+    original_asic_db_group_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_group_table)
+    original_asic_db_group_member_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_group_member_table)
+
+    # To be able to add multicast groups and members, we need the corresponding
+    # router interface to have been created.
+    rif_oid_0 = self.add_rif()
+    rif_oid_1 = self.add_rif(port_id="Ethernet4")
+
+    ####################################
+    # Add operation
+    ####################################
+    # Add one L3 multicast group entry (one group member).
+    mcast_group_key, attr_list, group_oid, group_member_oids = (
+        self.add_and_verify_multicast_group(replicas=[("Ethernet8", "0x0")],
+                                            rif_oids=[rif_oid_0],
+                                            new_replicas=[("Ethernet8", "0x0")]))
+
+    ####################################
+    # Update operation
+    ####################################
+    # We'll add a new replica to the same multicast group.
+    mcast_group_key_1, attr_list_1, group_oid_1, group_member_oids_1 = (
+        self.add_and_verify_multicast_group(replicas=[("Ethernet8", "0x0"),
+                                                      ("Ethernet4", "0x0")],
+                                            rif_oids=[rif_oid_1],
+                                            new_replicas=[("Ethernet4", "0x0")],
+                                            group_oid=group_oid))
+
+    ####################################
+    # Delete operation
+    ####################################
+    self._p4rt_l3_multicast_group_intf.remove_app_db_entry(mcast_group_key)
+    util.verify_response(self.response_consumer, mcast_group_key, [],
+                         "SWSS_RC_SUCCESS")
+
+    # Check that APP DB entry was removed.
+    mcast_group_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.appl_db, self.appl_db_table)
+    assert len(mcast_group_entries) == len(original_app_db_entries)
+
+    # Check that ASIC DB entries were removed (both group and member).
+    mcast_group_asic_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_group_table)
+    assert len(mcast_group_asic_entries) == len(original_asic_db_group_entries)
+    mcast_group_member_asic_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_group_member_table)
+    assert len(mcast_group_member_asic_entries) == (
+        len(original_asic_db_group_member_entries))
+
+    ####################################
+    # Cleanup
+    ####################################
+    dvs.restart()
+
+  def test_L3MulticastGroupAddTwoDeleteOne(self, dvs, testlog):
+    """
+    This test adds two muliticast group members, confirms the group members were
+    created, deletes one group member, and verifies the multicast group remains.
+    """
+    self._set_up(dvs)
+
+    # Fetch database state after init.
+    original_app_db_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.appl_db, self.appl_db_table)
+    original_asic_db_rif_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_rif_table)
+    original_asic_db_group_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_group_table)
+    original_asic_db_group_member_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_group_member_table)
+
+    # For this test, we need to setup two RIFs (for the two group members).
+    rif_oid_0 = self.add_rif()
+    rif_oid_1 = self.add_rif(port_id="Ethernet4")
+
+    ####################################
+    # Add operations
+    ####################################
+    # Add two group members to same multicast group.  We add one replica at a
+    # time to allow us to determine which group_member oid was assigned to each.
+    mcast_group_key_a, attr_list_a, group_oid_a, group_member_oids_a = (
+        self.add_and_verify_multicast_group(replicas=[("Ethernet8", "0x0")],
+                                            rif_oids=[rif_oid_0],
+                                            new_replicas=[("Ethernet8", "0x0")]))
+    mcast_group_key_b, attr_list_b, group_oid_b, group_member_oids_b = (
+        self.add_and_verify_multicast_group(replicas=[("Ethernet8", "0x0"),
+                                                      ("Ethernet4", "0x0")],
+                                            rif_oids=[rif_oid_1],
+                                            new_replicas=[("Ethernet4", "0x0")],
+                                            group_oid=group_oid_a))
+
+    ####################################
+    # Delete group member (via update operation)
+    ####################################
+    mcast_group_key_1, attr_list_1 = (
+        self._p4rt_l3_multicast_group_intf.create_multicast_group_entry(
+            replicas=[("Ethernet4", "0x0")]))
+    util.verify_response(self.response_consumer, mcast_group_key_1,
+                         attr_list_1, "SWSS_RC_SUCCESS")
+
+    # Check that APP DB entry is still there.
+    mcast_group_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.appl_db, self.appl_db_table)
+    assert len(mcast_group_entries) == (len(original_app_db_entries) + 1)
+
+    # Check that ASIC DB entries were removed (both group and member).
+    mcast_group_asic_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_group_table)
+    assert len(mcast_group_asic_entries) == (
+        len(original_asic_db_group_entries) + 1)
+    mcast_group_member_asic_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_group_member_table)
+    assert len(mcast_group_member_asic_entries) == (
+        len(original_asic_db_group_member_entries) + 1)
+
+    # Confirm that Ethernet4 replica is still there.
+    (status_asic_group_member, fvs_asic_group_member) = util.get_key(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self._p4rt_l3_multicast_group_intf.ASIC_DB_GROUP_MEMBER_TBL_NAME,
+        group_member_oids_b[0])
+    assert status_asic_group_member == True
+
+    asic_group_member_attr_list = [
+        (self._p4rt_l3_multicast_group_intf.SAI_ATTR_IPMC_GROUP_ID,
+         group_oid_a),
+        (self._p4rt_l3_multicast_group_intf.SAI_ATTR_IPMC_OUTPUT_ID,
+         rif_oid_1),
+    ]
+    util.verify_attr(fvs_asic_group_member, asic_group_member_attr_list)
+
+    ####################################
+    # Cleanup
+    ####################################
+    dvs.restart()
+
+  def test_L3MulticastGroupDeleteUnknown(self, dvs, testlog):
+    """
+    This test attempts to delete an unknown multicast group.
+    """
+    self._set_up(dvs)
+
+    # Fetch database state after init.
+    original_app_db_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.appl_db, self.appl_db_table)
+    original_asic_db_group_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_group_table)
+    original_asic_db_group_member_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_group_member_table)
+
+    ####################################
+    # Delete operation
+    ####################################
+    mcast_group_key = (
+        self._p4rt_l3_multicast_group_intf.generate_app_db_key(
+            self._p4rt_l3_multicast_group_intf.DEFAULT_GROUP_ID))
+
+    self._p4rt_l3_multicast_group_intf.remove_app_db_entry(mcast_group_key)
+    util.verify_response(
+        self.response_consumer, mcast_group_key, [], "SWSS_RC_NOT_FOUND",
+        "[OrchAgent] Multicast group entry does not exist for group 0x1")
+
+    # Check that entries remain unchanged.
+    mcast_app_db_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.appl_db, self.appl_db_table)
+    assert len(mcast_app_db_entries) == len(original_app_db_entries)
+
+    mcast_group_asic_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_group_table)
+    assert len(mcast_group_asic_entries) == len(original_asic_db_group_entries)
+    mcast_group_member_asic_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_group_member_table)
+    assert len(mcast_group_member_asic_entries) == (
+        len(original_asic_db_group_member_entries))
+
+  def test_L3MulticastGroupAddBeforeRif(self, dvs, testlog):
+    """
+    This test attempts to add a group member before a RIF was created.
+    """
+    self._set_up(dvs)
+
+    # Fetch database state after init.
+    original_asic_db_group_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_group_table)
+    original_asic_db_group_member_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_group_member_table)
+
+    ####################################
+    # Add operation
+    ####################################
+    # No RIF!
+    mcast_group_key, attr_list = (
+        self._p4rt_l3_multicast_group_intf.create_multicast_group_entry(
+            group_id=None, replicas=[("Ethernet8", "0x0")]))
+    util.verify_response(
+        self.response_consumer, mcast_group_key, attr_list,
+        "SWSS_RC_NOT_FOUND",
+        ("[OrchAgent] Multicast group member '0x1:Ethernet8:0x0' "
+         "does not have an associated RIF available yet"))
+
+    # Check that asic entries remain unchanged.
+    mcast_group_asic_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_group_table)
+    assert len(mcast_group_asic_entries) == len(original_asic_db_group_entries)
+    mcast_group_member_asic_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_group_member_table)
+    assert len(mcast_group_member_asic_entries) == (
+        len(original_asic_db_group_member_entries))
+
+
+class TestP4RTL3MulticastRoute(object):
+  """Tests for interacting with the route tables ipv4_table and ipv6_table"""
+  def _set_up(self, dvs):
+    self._p4rt_l3_multicast_router_intf = (
+        l3_multicast.P4RtL3MulticastRouterInterfaceWrapper())
+    self._p4rt_l3_multicast_router_intf.set_up_databases(dvs)
+
+    self._p4rt_l3_multicast_group_intf = (
+        l3_multicast.P4RtL3MulticastGroupWrapper())
+    self._p4rt_l3_multicast_group_intf.set_up_databases(dvs)
+
+    self._p4rt_l3_multicast_route = l3_multicast.P4RtL3MulticastRouteWrapper()
+    self._p4rt_l3_multicast_route.set_up_databases(dvs)
+
+    self.p4rt_notifier = swsscommon.NotificationProducer(
+      self._p4rt_l3_multicast_route.appl_db,
+      APP_P4RT_CHANNEL_NAME)
+    self.response_consumer = swsscommon.NotificationConsumer(
+      self._p4rt_l3_multicast_route.appl_db, "APPL_DB_" +
+      swsscommon.APP_P4RT_TABLE_NAME + "_RESPONSE_CHANNEL")
+
+    self._vrf_obj = test_vrf.TestVrf()
+
+    self.asic_db_group_table = (
+        self._p4rt_l3_multicast_group_intf.ASIC_DB_GROUP_TBL_NAME)
+    self.asic_db_rif_table = (
+        self._p4rt_l3_multicast_router_intf.ASIC_DB_TBL_NAME)
+
+    self.appl_db_table_ipv4 = (
+        self._p4rt_l3_multicast_route.APP_DB_TBL_NAME + ":" +
+            self._p4rt_l3_multicast_route.TBL_NAME_IPV4)
+    self.appl_db_table_ipv6 = (
+        self._p4rt_l3_multicast_route.APP_DB_TBL_NAME + ":" +
+            self._p4rt_l3_multicast_route.TBL_NAME_IPV6)
+    self.asic_db_route_table = self._p4rt_l3_multicast_route.ASIC_DB_TBL_NAME
+
+  def _set_vrf(self, dvs):
+    """Sets up a default VRF"""
+    self._vrf_obj.setup_db(dvs)
+    self.default_vrf_state = self._vrf_obj.vrf_create(
+        dvs, self._p4rt_l3_multicast_route.DEFAULT_VRF_ID, [], {})
+
+  def get_added_rif_oid(self, original_entries):
+    """Returns OID key if single RIF was added"""
+    rif_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self._p4rt_l3_multicast_router_intf.ASIC_DB_TBL_NAME)
+    for key in rif_entries:
+      if key not in original_entries:
+        return key
+    return "0"
+
+  def get_added_multicast_group_oid(self, original_entries):
+    """Returns OID key if single multicast group was added"""
+    group_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self._p4rt_l3_multicast_group_intf.ASIC_DB_GROUP_TBL_NAME)
+    for key in group_entries:
+      if key not in original_entries:
+        return key
+    return "0"
+
+  def add_rif(self, port_id=None, instance=None, src_mac=None):
+    """Adds a multicast router interface entry"""
+    start_asic_db_rif_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_rif_table)
+
+    mcast_router_intf_key, attr_list = (
+        self._p4rt_l3_multicast_router_intf.create_router_interface(
+            port_id, instance, src_mac))
+    util.verify_response(self.response_consumer, mcast_router_intf_key,
+                         attr_list, "SWSS_RC_SUCCESS")
+    rif_oid = self.get_added_rif_oid(start_asic_db_rif_entries)
+    return rif_oid
+
+  def add_multicast_group_entry(self, group_id):
+    """Adds a multicast group entry with one group member"""
+    start_asic_db_group_entries = util.get_keys(
+        self._p4rt_l3_multicast_group_intf.asic_db,
+        self.asic_db_group_table)
+    mcast_group_key, attr_list = (
+        self._p4rt_l3_multicast_group_intf.create_multicast_group_entry(
+            group_id=group_id))
+    util.verify_response(self.response_consumer, mcast_group_key,
+                         attr_list, "SWSS_RC_SUCCESS")
+    group_oid = self.get_added_multicast_group_oid(start_asic_db_group_entries)
+    return group_oid
+
+  def get_added_multicast_asic_route(self, original_entries):
+    """Returns asic key if single multicast route entry was added"""
+    route_entries = util.get_keys(
+        self._p4rt_l3_multicast_route.asic_db,
+        self._p4rt_l3_multicast_route.ASIC_DB_TBL_NAME)
+    for key in route_entries:
+      if key not in original_entries:
+        return key
+    return "0"
+
+  def get_added_rpf_oid(self):
+    """Returns the RPF OID key that was added."""
+    # RPF OID is added on the first IPMC entry add.
+    rpf_entries = util.get_keys(
+        self._p4rt_l3_multicast_route.asic_db,
+        self._p4rt_l3_multicast_route.ASIC_DB_RPF_GROUP_TBL_NAME)
+    assert len(rpf_entries) == 1
+    for key in rpf_entries:
+      return key
+    return "0"
+
+  def setup_multicast_group(self, group_id=None, add_rif=True):
+    """Sets up tables to be able to support a multicast group"""
+    if add_rif:
+      rif_oid = self.add_rif()
+    group_oid = self.add_multicast_group_entry(group_id)
+    return group_oid
+
+  def add_and_verify_multicast_route(self, group_id=None, vrf_id=None,
+                                     dst_ip=None, is_v4=True, group_oid="0",
+                                     rpf_oid=None, update=False,
+                                     route_asic_key="0"):
+    """Adds a new multicast route entry and verifies APP DB and ASIC DB"""
+    if is_v4:
+      appl_db_table = self.appl_db_table_ipv4
+    else:
+      appl_db_table = self.appl_db_table_ipv6
+
+    start_app_db_entries = util.get_keys(
+        self._p4rt_l3_multicast_route.appl_db, appl_db_table)
+    start_asic_db_entries = util.get_keys(
+        self._p4rt_l3_multicast_route.asic_db,
+        self.asic_db_route_table)
+
+    # Add the route entry.
+    mcast_route_key, attr_list = (
+        self._p4rt_l3_multicast_route.create_multicast_route(
+            group_id=group_id, dst_ip=dst_ip, is_v4=is_v4))
+    util.verify_response(self.response_consumer, mcast_route_key,
+                         attr_list, "SWSS_RC_SUCCESS")
+    if update:
+      new_entries = 0
+    else:
+      new_entries = 1
+
+    # Check that APP DB has expected entry with expected values.
+    mcast_route_entries = util.get_keys(
+        self._p4rt_l3_multicast_route.appl_db, appl_db_table)
+    assert len(mcast_route_entries) == (len(start_app_db_entries) + new_entries)
+
+    (status, fvs) = util.get_key(
+        self._p4rt_l3_multicast_route.appl_db,
+        self._p4rt_l3_multicast_route.APP_DB_TBL_NAME,
+        mcast_route_key)
+    assert status == True
+    util.verify_attr(fvs, attr_list)
+
+    # Check that ASIC DB has expected value
+    route_asic_db_entries = util.get_keys(
+        self._p4rt_l3_multicast_route.asic_db,
+        self.asic_db_route_table)
+    assert len(route_asic_db_entries) == (
+        len(start_asic_db_entries) + new_entries)
+
+    # If RPF OID is provided, we expect it to have already been created.
+    if rpf_oid is None:
+      rpf_oid_to_ret = self.get_added_rpf_oid()
+    else:
+      rpf_oid_to_ret = rpf_oid
+
+    if update:
+      route_asic_key_to_ret = route_asic_key
+    else:
+      route_asic_key_to_ret = (
+          self.get_added_multicast_asic_route(start_asic_db_entries))
+
+    (asic_status, asic_fvs) = util.get_key(
+        self._p4rt_l3_multicast_route.asic_db,
+        self._p4rt_l3_multicast_route.ASIC_DB_TBL_NAME,
+        route_asic_key_to_ret)
+    assert asic_status == True
+    asic_route_attr_list = [
+        (self._p4rt_l3_multicast_route.SAI_ATTR_PACKET_ACTION,
+         self._p4rt_l3_multicast_route.SAI_ATTR_PACKET_ACTION_FORWARD),
+        (self._p4rt_l3_multicast_route.SAI_ATTR_OUTPUT_GROUP_ID, group_oid),
+        (self._p4rt_l3_multicast_route.SAI_ATTR_RPF_GROUP_ID, rpf_oid_to_ret),
+    ]
+    util.verify_attr(asic_fvs, asic_route_attr_list)
+    return mcast_route_key, attr_list, rpf_oid_to_ret, route_asic_key_to_ret
+
+  def test_L3MulticastRouteAddUpdateDelete(self, dvs, testlog):
+    """
+    This test adds a route entry that assigns the packet to a multicast group,
+    confirms that ASIC db is setup, modifies the entry to point to another
+    multicast group, confirms ASIC db is setup, and then deletes the route
+    entry.
+    """
+    self._set_up(dvs)
+    self._set_vrf(dvs)
+
+    # Fetch database state after init.
+    original_app_db_entries_v4 = util.get_keys(
+        self._p4rt_l3_multicast_route.appl_db, self.appl_db_table_ipv4)
+    original_app_db_entries_v6 = util.get_keys(
+        self._p4rt_l3_multicast_route.appl_db, self.appl_db_table_ipv6)
+    original_asic_db_entries = util.get_keys(
+        self._p4rt_l3_multicast_route.asic_db, self.asic_db_route_table)
+
+    # Setup multicast groups.
+    group_oid_0 = self.setup_multicast_group()
+    group_oid_1 = self.setup_multicast_group(group_id="0x2", add_rif=False)
+
+    ####################################
+    # Add operation
+    ####################################
+    # Add two L3 multicast route entries (v4 and v6).
+    mcast_route_key_v4, attr_list_v4, rpf_oid, route_asic_key_v4 = (
+        self.add_and_verify_multicast_route(group_oid=group_oid_0,
+                                            rpf_oid=None))
+    mcast_route_key_v6, attr_list_v6, rpf_oid, route_asic_key_v6 = (
+        self.add_and_verify_multicast_route(
+            group_id="0x2", dst_ip=self._p4rt_l3_multicast_route.DEFAULT_DST_V6,
+            is_v4=False, group_oid=group_oid_1, rpf_oid=rpf_oid))
+
+    ####################################
+    # Update operation
+    ####################################
+    # Update v4 route to use multicast group 2 instead of 1.
+    mcast_route_key_v4, attr_list_v4, rpf_oid, route_asic_key_v4 = (
+        self.add_and_verify_multicast_route(group_id="0x2",
+                                            group_oid=group_oid_1,
+                                            rpf_oid=rpf_oid, update=True,
+                                            route_asic_key=route_asic_key_v4))
+
+    ####################################
+    # Delete operation
+    ####################################
+    self._p4rt_l3_multicast_route.remove_app_db_entry(mcast_route_key_v4)
+    util.verify_response(self.response_consumer, mcast_route_key_v4, [],
+                         "SWSS_RC_SUCCESS")
+    self._p4rt_l3_multicast_route.remove_app_db_entry(mcast_route_key_v6)
+    util.verify_response(self.response_consumer, mcast_route_key_v6, [],
+                         "SWSS_RC_SUCCESS")
+
+    # Check that APP DB entries were removed.
+    route_app_db_entries_v4 = util.get_keys(
+        self._p4rt_l3_multicast_route.appl_db, self.appl_db_table_ipv4)
+    assert len(route_app_db_entries_v4) == len(original_app_db_entries_v4)
+    route_app_db_entries_v6 = util.get_keys(
+        self._p4rt_l3_multicast_route.appl_db, self.appl_db_table_ipv6)
+    assert len(route_app_db_entries_v6) == len(original_app_db_entries_v6)
+
+    # Check that ASIC DB entries were removed.
+    route_asic_db_entries = util.get_keys(
+        self._p4rt_l3_multicast_route.asic_db, self.asic_db_route_table)
+    assert len(route_asic_db_entries) == len(original_asic_db_entries)
+
+    ####################################
+    # Cleanup
+    ####################################
+    dvs.restart()
+
+  def test_L3MulticastRouteUpdatePacketActionUnimplemented(self, dvs, testlog):
+    """
+    This test attempts to update a route entry from using the
+    set_multicast_group_id action to one of the other table actions.  This is
+    not supported and should result in an unimplemented error.
+    """
+    self._set_up(dvs)
+    self._set_vrf(dvs)
+
+    # We need these wrappers so we can properly setup a next hop ID.
+    self._p4rt_nexthop_obj = l3.P4RtNextHopWrapper()
+    self._p4rt_nexthop_obj.set_up_databases(dvs)
+    self._p4rt_router_intf_obj = l3.P4RtRouterInterfaceWrapper()
+    self._p4rt_router_intf_obj.set_up_databases(dvs)
+    self._p4rt_neighbor_obj = l3.P4RtNeighborWrapper()
+    self._p4rt_neighbor_obj.set_up_databases(dvs)
+
+    # Setup multicast groups.
+    group_oid_0 = self.setup_multicast_group()
+
+    # Add original route entry that assigns multicast.
+    mcast_route_key_v4, attr_list_v4, rpf_oid, route_asic_key_v4 = (
+        self.add_and_verify_multicast_route(group_oid=group_oid_0,
+                                            rpf_oid=None))
+
+    # Setup items needed for a properly formed next hop update request.
+    # Create default router interface for next hop.
+    router_interface_id, router_intf_key, attr_list = (
+        self._p4rt_router_intf_obj.create_router_interface())
+    util.verify_response(
+        self.response_consumer, router_intf_key, attr_list, "SWSS_RC_SUCCESS")
+    # Create neighbor.
+    neighbor_id, neighbor_key, attr_list = (
+        self._p4rt_neighbor_obj.create_neighbor())
+    util.verify_response(
+        self.response_consumer, neighbor_key, attr_list, "SWSS_RC_SUCCESS")
+    # Create next hop.
+    nexthop_id, nexthop_key, attr_list = (
+        self._p4rt_nexthop_obj.create_next_hop())
+    util.verify_response(
+        self.response_consumer, nexthop_key, attr_list, "SWSS_RC_SUCCESS")
+
+    # Now attempt to update.
+    mcast_route_key_v4_update, attr_list_update = (
+        self._p4rt_l3_multicast_route.create_multicast_route(
+            action=self._p4rt_l3_multicast_route.SET_NEXT_HOP_ID_ACTION,
+            param=nexthop_id))
+    util.verify_response(
+        self.response_consumer, mcast_route_key_v4_update, attr_list_update,
+        "SWSS_RC_NOT_FOUND",
+        "[OrchAgent] Route entry exists in manager but does not exist in the centralized map")
+
+    ####################################
+    # Cleanup
+    ####################################
+    dvs.restart()
+
+  def test_L3MulticastRouteUpdatePacketActionUnimplemented2(self, dvs, testlog):
+    """
+    This test attempts to update a route entry from using the
+    set_nexthop_id action to the set_multicast_group_id action.  This is not
+    supported and should result in an unimplemented error.
+    """
+    self._set_up(dvs)
+    self._set_vrf(dvs)
+
+    # We need these wrappers so we can properly setup a next hop ID.
+    self._p4rt_nexthop_obj = l3.P4RtNextHopWrapper()
+    self._p4rt_nexthop_obj.set_up_databases(dvs)
+    self._p4rt_router_intf_obj = l3.P4RtRouterInterfaceWrapper()
+    self._p4rt_router_intf_obj.set_up_databases(dvs)
+    self._p4rt_neighbor_obj = l3.P4RtNeighborWrapper()
+    self._p4rt_neighbor_obj.set_up_databases(dvs)
+
+    # Setup multicast groups.
+    group_oid_0 = self.setup_multicast_group()
+
+    # Setup items needed for a properly formed next hop update request.
+    # Create default router interface for next hop.
+    router_interface_id, router_intf_key, attr_list = (
+        self._p4rt_router_intf_obj.create_router_interface())
+    util.verify_response(
+        self.response_consumer, router_intf_key, attr_list, "SWSS_RC_SUCCESS")
+    # Create neighbor.
+    neighbor_id, neighbor_key, attr_list = (
+        self._p4rt_neighbor_obj.create_neighbor())
+    util.verify_response(
+        self.response_consumer, neighbor_key, attr_list, "SWSS_RC_SUCCESS")
+    # Create next hop.
+    nexthop_id, nexthop_key, attr_list = (
+        self._p4rt_nexthop_obj.create_next_hop())
+    util.verify_response(
+        self.response_consumer, nexthop_key, attr_list, "SWSS_RC_SUCCESS")
+
+    # Add original route entry that assigns the next hop.
+    mcast_route_key_v4_update, attr_list_update = (
+        self._p4rt_l3_multicast_route.create_multicast_route(
+            action=self._p4rt_l3_multicast_route.SET_NEXT_HOP_ID_ACTION,
+            param=nexthop_id))
+    util.verify_response(
+        self.response_consumer, mcast_route_key_v4_update, attr_list_update,
+        "SWSS_RC_SUCCESS")
+
+    # Now attempt to update.
+    mcast_route_key_v4_update, attr_list_update = (
+        self._p4rt_l3_multicast_route.create_multicast_route())
+    util.verify_response(
+    self.response_consumer, mcast_route_key_v4_update, attr_list_update,
+    "SWSS_RC_NOT_FOUND",
+    ("[OrchAgent] Route entry exists in manager but does not exist in the centralized map"))
+
+    ####################################
+    # Cleanup
+    ####################################
+    dvs.restart()
+
+  def test_L3MulticastRouteDeleteUnknown(self, dvs, testlog):
+    """
+    This test attempts to delete a multicast route entry that does not exist,
+    which should result in an error.
+    """
+    self._set_up(dvs)
+    self._set_vrf(dvs)
+
+    mcast_route_key = self._p4rt_l3_multicast_route.generate_app_db_key(
+        self._p4rt_l3_multicast_route.DEFAULT_VRF_ID,
+        self._p4rt_l3_multicast_route.DEFAULT_DST_V4, ipv6_dst=None)
+
+    self._p4rt_l3_multicast_route.remove_app_db_entry(mcast_route_key)
+    util.verify_response(
+        self.response_consumer, mcast_route_key, [], "SWSS_RC_NOT_FOUND",
+        "[OrchAgent] Route entry does not exist")
+
+    ####################################
+    # Cleanup
+    ####################################
+    dvs.restart()
+
+  def test_L3MulticastRouteAddBeforeGroup(self, dvs, testlog):
+    """
+    This test attempts to add a multicast route entry before its necessary
+    multicast group has been created, which should result in an error.
+    """
+    self._set_up(dvs)
+    self._set_vrf(dvs)
+
+    mcast_route_key_v4_update, attr_list_update = (
+        self._p4rt_l3_multicast_route.create_multicast_route())
+    util.verify_response(
+        self.response_consumer, mcast_route_key_v4_update, attr_list_update,
+        "SWSS_RC_NOT_FOUND",
+        "[OrchAgent] No multicast group ID found for '0x1'")
+
+    ####################################
+    # Cleanup
+    ####################################
+    dvs.restart()

--- a/tests/p4rt/util.py
+++ b/tests/p4rt/util.py
@@ -55,8 +55,8 @@ def verify_response(consumer, key, attr_list, status, err_message = "SWSS_RC_SUC
   if consumer.peek() <= 0:
     consumer.readData()
   (op, data, values) = consumer.pop()
-  assert data == key
-  assert op == status
+  assert data == key, "data '%s' does not match key '%s'" % (data, key)
+  assert op == status, "op '%s' does not match status '%s'" % (op, status)
   assert len(values) >= 1
   assert values[0][0] == "err_str", "Unexpected status '%s' received, expected '%s'" % \
                 (values[0][0], "err_str")


### PR DESCRIPTION
**What I did**
Migrate verifyState to new database schema format
Migrate to processMulticastGroupEntries and drainMulticastGroupEntries
Migrate to use updateMulticastGroupEntries

**Why I did it**
Migrate to use updateMulticastGroupEntries, verifyState to new database schema format, processMulticastGroupEntries and drainMulticastGroupEntries.

**How I verified it**
UT cases