### PR TITLE
Temporarily moving the PORT_PHY_ATTR ERR messages to NOTICE level.

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -8993,7 +8993,7 @@ bool PortsOrch::verifyPortSupportsAllPhyAttr(sai_object_id_t port_id, const char
     sai_status_t status = sai_port_api->get_port_attribute(port_id, 1, &port_attr);
     if (status != SAI_STATUS_BUFFER_OVERFLOW)
     {
-        SWSS_LOG_ERROR("PORT_PHY_ATTR: Port %s does not support RX_SIGNAL_DETECT attribute (status=%d)",
+        SWSS_LOG_NOTICE("PORT_PHY_ATTR: Port %s does not support RX_SIGNAL_DETECT attribute (status=%d)",
                       port_name, status);
         return false;
     }
@@ -9008,7 +9008,7 @@ bool PortsOrch::verifyPortSupportsAllPhyAttr(sai_object_id_t port_id, const char
     status = sai_port_api->get_port_attribute(port_id, 1, &port_attr);
     if (status != SAI_STATUS_BUFFER_OVERFLOW)
     {
-        SWSS_LOG_ERROR("PORT_PHY_ATTR: Port %s does not support FEC_ALIGNMENT_LOCK attribute (status=%d)",
+        SWSS_LOG_NOTICE("PORT_PHY_ATTR: Port %s does not support FEC_ALIGNMENT_LOCK attribute (status=%d)",
                       port_name, status);
         return false;
     }
@@ -9023,7 +9023,7 @@ bool PortsOrch::verifyPortSupportsAllPhyAttr(sai_object_id_t port_id, const char
     status = sai_port_api->get_port_attribute(port_id, 1, &port_attr);
     if (status != SAI_STATUS_BUFFER_OVERFLOW)
     {
-        SWSS_LOG_ERROR("PORT_PHY_ATTR: Port %s does not support RX_SNR attribute (status=%d)",
+        SWSS_LOG_NOTICE("PORT_PHY_ATTR: Port %s does not support RX_SNR attribute (status=%d)",
                       port_name, status);
         return false;
     }


### PR DESCRIPTION
**What I did**
Suppressed the noisy ERR logs by moving them to NOTICE level logs.

**Why I did it**
For vendors who didn't implement the new attributes yet, the following log errors will be generated for all ports: ERR swss#orchagent: :- verifyPortSupportsAllPhyAttr: PORT_PHY_ATTR: Port Ethernet0 does not support RX_SIGNAL_DETECT attribute (status=-196608)

The ideal fix is to query only supported set of attributes in m_supported_phy_attrs. We are working on this , in the meantime to unblock others , we are moving this to NOTICE level log.

**How I verified it**

**Details if related**

Fixes: 
https://github.com/sonic-net/sonic-buildimage/issues/25619
https://github.com/sonic-net/sonic-swss/issues/4242