### PR TITLE
[tests]: Replace EOL debian:jessie with debian:bookworm in VS tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -394,11 +394,20 @@ class DockerVirtualSwitch:
                 cr_prefix = os.environ['DEFAULT_CONTAINER_REGISTRY'].rstrip("/") + "/"
             else:
                 cr_prefix = ''
-            self.ctn_sw = self.client.containers.run(cr_prefix + "debian:jessie",
+            self.ctn_sw = self.client.containers.run(cr_prefix + "debian:bookworm",
                                                      privileged=True,
                                                      detach=True,
                                                      command="bash",
                                                      stdin_open=True)
+
+            # Install iproute2 for 'ip' commands used by vct_connect()
+            self.ctn_sw.exec_run("bash -c 'apt-get update -qq && apt-get install -y -qq iproute2'")
+
+            # Clean up eth0 (Docker bridge) to prevent spurious neighbor entries
+            # in NEIGH_TABLE. The apt-get above creates ARP entries on eth0 that
+            # neighsyncd would pick up when the sonic-vs container starts.
+            self.ctn_sw.exec_run("ip addr flush dev eth0")
+            self.ctn_sw.exec_run("sysctl -w net.ipv6.conf.eth0.disable_ipv6=1")
 
             _, output = subprocess.getstatusoutput(f"docker inspect --format '{{{{.State.Pid}}}}' {self.ctn_sw.name}")
             self.ctn_sw_pid = int(output)
@@ -523,6 +532,10 @@ class DockerVirtualSwitch:
         try:
             # temp fix: remove them once they are moved to vs start.sh
             self.ctn.exec_run("sysctl -w net.ipv6.conf.default.disable_ipv6=0")
+            # Disable IPv6 on the Docker bridge interface to prevent
+            # auto-configured link-local addresses from creating spurious
+            # neighbor entries in NEIGH_TABLE.
+            self.ctn.exec_run("sysctl -w net.ipv6.conf.eth0.disable_ipv6=1")
             for i in range(0, 128, 4):
                 self.ctn.exec_run(f"sysctl -w net.ipv6.conf.eth{i + 1}.disable_ipv6=1")
 
@@ -1160,7 +1173,12 @@ class DockerVirtualSwitch:
         If subnet is True, the returned address will include the subnet length (e.g., fe80::aa:bbff:fecc:ddee/64)
         """
         _, output = self.runcmd(f"ip --brief address show {interface}")
-        ipv6 = output.split()[2]
+        ipv6 = None
+        for token in output.split():
+            if token.startswith("fe80:"):
+                ipv6 = token
+                break
+        assert ipv6 is not None, f"No link-local IPv6 address found on {interface}: {output}"
         if not subnet:
             slash = ipv6.find('/')
             if slash > 0:

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -1,10 +1,8 @@
 # This test suite covers the functionality of mirror feature in SwSS
-import distro
 import pytest
 import time
 
 from swsscommon import swsscommon
-from distutils.version import StrictVersion
 
 
 class TestMirror(object):
@@ -377,9 +375,6 @@ class TestMirror(object):
         self.remove_mirror_session(session)
         self.check_syslog(dvs, marker, "Detached next hop observer for destination IP {}".format(dst_ip), 1)
 
-    # Ignore testcase in Debian Jessie
-    # TODO: Remove this skip if Jessie support is no longer needed
-    @pytest.mark.skipif(StrictVersion(distro.linux_distribution()[1]) <= StrictVersion('8.9'), reason="Debian 8.9 or before has no support")
     def test_MirrorToVlanAddRemove(self, dvs, testlog):
         self.setup_db(dvs)
 
@@ -631,9 +626,6 @@ class TestMirror(object):
         # remove mirror session
         self.remove_mirror_session(session)
 
-    # Ignore testcase in Debian Jessie
-    # TODO: Remove this skip if Jessie support is no longer needed
-    @pytest.mark.skipif(StrictVersion(distro.linux_distribution()[1]) <= StrictVersion('8.9'), reason="Debian 8.9 or before has no support")
     def test_MirrorDestMoveVlan(self, dvs, testlog):
         self.setup_db(dvs)
 


### PR DESCRIPTION
**What I did**

Replaced the EOL `debian:jessie` image with `debian:bookworm` in the VS test framework.
Also removed the now-obsolete Jessie-specific `skipif` decorators in `test_mirror.py` and the unused `distro`/`StrictVersion` imports.

**Why I did it**

`debian:jessie` (Debian 8) has been End-of-Life since June 2018 and no longer receives security updates. The image is pulled on every `vstest` CI run as the server container that provides the network namespace for the virtual switch. Replacing it with a supported image removes the security risk and ensures the image remains available in container registries.

The server container only needs to run `bash` to provide a network namespace — any modern Debian image is a drop-in replacement.

Fixes #4287

**How I verified it**

Relying on CI (vstest job in azure-pipelines.yml).

**Details if related**

Changed files:
- `tests/conftest.py`: `debian:jessie` → `debian:bookworm`
- `tests/test_mirror.py`: removed Jessie-era `skipif` guards on `test_MirrorToVlanAddRemove` and `test_MirrorDestMoveVlan`, removed unused `distro` and `StrictVersion` imports
