### PR TITLE
[Generic-P4Orch] Improve watchport operation for large number of group update.

### DIFF
--- a/orchagent/eventexecutor.h
+++ b/orchagent/eventexecutor.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <sstream>
+
+#include "selectable.h"
+#include "selectableevent.h"
+#include "orch.h"
+#include "logger.h"
+
+namespace swss {
+
+class EventExecutor : public Executor
+{
+public:
+    EventExecutor(swss::SelectableEvent *event, Orch *orch, const std::string &name)
+        : Executor(event, orch, name)
+    {
+        assert(event != nullptr);
+    }
+
+    swss::SelectableEvent *getSelectableEvent()
+    {
+        return static_cast<swss::SelectableEvent *>(getSelectable());
+    }
+
+    void execute() override
+    {
+        /*
+         * Note: Unlike ExecutableTimer or Notifier, this executor explicitly catches
+         * exceptions. This is intentional for critical events (such as watchport)
+         * where doTask() may throw std::runtime_error to signal unrecoverable state
+         * inconsistencies. Catching them here allows the agent to notify the system
+         * via SWSS_RAISE_CRITICAL_STATE, enabling a managed recovery (e.g., warm
+         * reboot) rather than an unmanaged process crash.
+         */
+        try
+        {
+            m_orch->doTask(*getSelectableEvent());
+        }
+        catch (const std::runtime_error &e)
+        {
+            std::stringstream msg;
+            msg << "Received runtime_error exception: " << e.what();
+            SWSS_RAISE_CRITICAL_STATE(msg.str());
+        }
+    }
+
+    void drain() override
+    {
+        execute();
+    }
+};
+
+}

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -22,6 +22,7 @@ extern "C" {
 #include "zmqconsumerstatetable.h"
 #include "zmqserver.h"
 #include "notificationconsumer.h"
+#include "selectableevent.h"
 #include "selectabletimer.h"
 #include "macaddress.h"
 #include "response_publisher.h"
@@ -338,6 +339,7 @@ public:
     virtual void doTask(Consumer &consumer) { };
     virtual void doTask(swss::NotificationConsumer &consumer) { }
     virtual void doTask(swss::SelectableTimer &timer) { }
+    virtual void doTask(swss::SelectableEvent &event) { }
 
     /*
      * Called once after APPLY_VIEW in warm/fast boot scenario.

--- a/orchagent/p4orch/p4orch.cpp
+++ b/orchagent/p4orch/p4orch.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "copporch.h"
+#include "eventexecutor.h"
 #include "logger.h"
 #include "namelabelmapper.h"
 #include "orch.h"
@@ -47,6 +48,14 @@ P4Orch::P4Orch(swss::DBConnector* db, std::vector<std::string> tableNames,
 
     setOrderedQueueForAllConsumers(/*orderedQueue=*/true);
 
+    // Add watchport event handling support
+    // This is a low priority event that shouldn't block other high priority
+    // requests
+    m_watchportEvent = new swss::SelectableEvent(/*pri=*/-1);
+    auto watchportEventExecutor =
+        new EventExecutor(m_watchportEvent, this, "WATCHPORT_EVENT");
+    Orch::addExecutor(watchportEventExecutor);
+
     m_tablesDefnManager = std::make_unique<TablesDefnManager>(&m_p4OidMapper, &m_publisher);
     m_routerIntfManager = std::make_unique<RouterInterfaceManager>(&m_p4OidMapper, &m_publisher);
     m_neighborManager = std::make_unique<NeighborManager>(&m_p4OidMapper, &m_publisher);
@@ -60,7 +69,8 @@ P4Orch::P4Orch(swss::DBConnector* db, std::vector<std::string> tableNames,
     m_mirrorSessionManager = std::make_unique<p4orch::MirrorSessionManager>(&m_p4OidMapper, &m_publisher);
     m_aclTableManager = std::make_unique<p4orch::AclTableManager>(&m_p4OidMapper, &m_publisher);
     m_aclRuleManager = std::make_unique<p4orch::AclRuleManager>(&m_p4OidMapper, vrfOrch, coppOrch, &m_publisher);
-    m_wcmpManager = std::make_unique<p4orch::WcmpManager>(&m_p4OidMapper, &m_publisher);
+    m_wcmpManager = std::make_unique<p4orch::WcmpManager>(
+        &m_p4OidMapper, &m_publisher, m_watchportEvent);
     m_l3AdmitManager = std::make_unique<L3AdmitManager>(&m_p4OidMapper, &m_publisher);
     m_tunnelDecapGroupManager =
         std::make_unique<TunnelDecapGroupManager>(&m_p4OidMapper, &m_publisher);
@@ -338,6 +348,18 @@ void P4Orch::doTask(NotificationConsumer &consumer)
     if (&consumer == m_portStatusNotificationConsumer) {
         handlePortStatusChangeNotification(op, data);
     }
+}
+
+void P4Orch::doTask(swss::SelectableEvent& event) {
+  SWSS_LOG_ENTER();
+
+  if (!gPortsOrch->allPortsReady()) {
+    return;
+  }
+
+  if (&event == m_watchportEvent) {
+    m_wcmpManager->processWatchPortEvent();
+  }
 }
 
 bool P4Orch::addAclTableToManagerMapping(const std::string &acl_table_name)

--- a/orchagent/p4orch/p4orch.h
+++ b/orchagent/p4orch/p4orch.h
@@ -29,6 +29,7 @@
 #include "p4orch/wcmp_manager.h"
 #include "response_publisher.h"
 #include "return_code.h"
+#include "selectableevent.h"
 #include "vrforch.h"
 #include "zmqorch.h"
 
@@ -71,6 +72,7 @@ class P4Orch : public ZmqOrch
     void doTask(swss::NotificationConsumer &consumer);
     ObjectManagerInterface* findManager(const std::string key,
                                         std::string& table_name);
+    void doTask(swss::SelectableEvent& event);
     void enqueue(const swss::KeyOpFieldsValuesTuple& entry);
     ReturnCode drain();
     void handlePortStatusChangeNotification(const std::string &op, const std::string &data);
@@ -80,6 +82,7 @@ class P4Orch : public ZmqOrch
 
     swss::SelectableTimer *m_aclCounterStatsTimer;
     swss::SelectableTimer *m_extCounterStatsTimer;
+    swss::SelectableEvent* m_watchportEvent;
     P4OidMapper m_p4OidMapper;
     std::unique_ptr<TablesDefnManager> m_tablesDefnManager;
     std::unique_ptr<RouterInterfaceManager> m_routerIntfManager;

--- a/orchagent/p4orch/tests/wcmp_manager_test.cpp
+++ b/orchagent/p4orch/tests/wcmp_manager_test.cpp
@@ -260,14 +260,22 @@ class WcmpManagerTest : public ::testing::Test
         gP4Orch->handlePortStatusChangeNotification(op, data);
     }
 
+    void UpdateWatchPort(const std::string& port, bool prune) {
+      wcmp_group_manager_->updateWatchPort(port, prune);
+    }
+
+    void ProcessWatchPortEvent() { wcmp_group_manager_->processWatchPortEvent(); }
+
     void PruneNextHops(const std::string &port)
     {
       wcmp_group_manager_->updateWatchPort(port, true);
+      wcmp_group_manager_->processWatchPortEvent();
     }
 
     void RestorePrunedNextHops(const std::string &port)
     {
       wcmp_group_manager_->updateWatchPort(port, false);
+      wcmp_group_manager_->processWatchPortEvent();
     }
 
     bool VerifyWcmpGroupMemberInPortMap(std::shared_ptr<P4WcmpGroupMemberEntry> gm, bool expected_member_present,
@@ -303,7 +311,9 @@ class WcmpManagerTest : public ::testing::Test
     // dependencies of the WCMP group entry.
     // Returns a valid pointer to WCMP group entry on success.
     P4WcmpGroupEntry AddWcmpGroupEntry1();
-    P4WcmpGroupEntry AddWcmpGroupEntryWithWatchport(const std::string &port, const bool oper_up = false);
+    P4WcmpGroupEntry AddWcmpGroupEntryWithWatchport(
+        const std::string& port, const bool oper_up = false,
+        const std::string& group_id = kWcmpGroupId1);
     P4WcmpGroupEntry getDefaultWcmpGroupEntryForTest();
     std::shared_ptr<P4WcmpGroupMemberEntry> createWcmpGroupMemberEntry(
         const std::string& next_hop_id, const int weight, sai_object_id_t oid);
@@ -342,15 +352,15 @@ P4WcmpGroupEntry WcmpManagerTest::getDefaultWcmpGroupEntryForTest()
     return app_db_entry;
 }
 
-P4WcmpGroupEntry WcmpManagerTest::AddWcmpGroupEntryWithWatchport(const std::string &port, const bool oper_up)
-{
+P4WcmpGroupEntry WcmpManagerTest::AddWcmpGroupEntryWithWatchport(
+    const std::string& port, const bool oper_up, const std::string& group_id) {
     P4WcmpGroupEntry app_db_entry;
-    app_db_entry.wcmp_group_id = kWcmpGroupId1;
+    app_db_entry.wcmp_group_id = group_id;
     std::shared_ptr<P4WcmpGroupMemberEntry> gm1 = std::make_shared<P4WcmpGroupMemberEntry>();
     gm1->next_hop_id = kNexthopId1;
     gm1->weight = 2;
     gm1->watch_port = port;
-    gm1->wcmp_group_id = kWcmpGroupId1;
+    gm1->wcmp_group_id = group_id;
     gm1->next_hop_oid = kNexthopOid1;
     if (!oper_up) {
       gm1->pruned = true;
@@ -393,7 +403,7 @@ P4WcmpGroupEntry WcmpManagerTest::AddWcmpGroupEntryWithWatchport(const std::stri
     std::vector<P4WcmpGroupEntry> entries{app_db_entry};
     EXPECT_THAT(CreateWcmpGroups(entries),
                 ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
-    EXPECT_NE(nullptr, GetWcmpGroupEntry(kWcmpGroupId1));
+    EXPECT_NE(nullptr, GetWcmpGroupEntry(group_id));
     return app_db_entry;
 }
 
@@ -1077,33 +1087,9 @@ TEST_F(WcmpManagerTest, WcmpGroupCreateAndUpdateInDrainSucceeds)
     EXPECT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, &ref_cnt));
     EXPECT_EQ(1, ref_cnt);
 
-    // Update WCMP group with exact same members.
+    // Update WCMP group with exact same members. No SAI call is made.
     Enqueue(swss::KeyOpFieldsValuesTuple(kKeyPrefix + j.dump(), SET_COMMAND, attributes));
 
-    std::vector<sai_object_id_t> member_oids_1{kNexthopOid1};
-    std::vector<uint32_t> member_weights_1{1};
-    std::vector<sai_attribute_t> attrs_1;
-    sai_attribute_t attr;
-    attr.id = SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_LIST;
-    attr.value.objlist.count = static_cast<uint32_t>(member_oids_1.size());
-    attr.value.objlist.list = member_oids_1.data();
-    attrs_1.push_back(attr);
-    attr.id = SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST;
-    attr.value.u32list.count = static_cast<uint32_t>(member_weights_1.size());
-    attr.value.u32list.list = member_weights_1.data();
-    attrs_1.push_back(attr);
-
-    std::vector<sai_status_t> exp_status_1{SAI_STATUS_SUCCESS,
-                                           SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                set_next_hop_groups_attribute(
-                    Eq(2),
-                    ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1,
-                                                         kWcmpGroupOid1}),
-                    AttrArrayEq(attrs_1), _, _))
-                .WillOnce(
-                    DoAll(SetArrayArgument<4>(exp_status_1.begin(), exp_status_1.end()),
-                          Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(
         *gMockResponsePublisher,
         publish(Eq(APP_P4RT_TABLE_NAME), Eq(kKeyPrefix + j.dump()),
@@ -1136,6 +1122,7 @@ TEST_F(WcmpManagerTest, WcmpGroupCreateAndUpdateInDrainSucceeds)
     std::vector<sai_object_id_t> member_oids_2{kNexthopOid2};
     std::vector<uint32_t> member_weights_2{1};
     std::vector<sai_attribute_t> attrs_2;
+    sai_attribute_t attr;
     attr.id = SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_LIST;
     attr.value.objlist.count = static_cast<uint32_t>(member_oids_2.size());
     attr.value.objlist.list = member_oids_2.data();
@@ -1145,6 +1132,8 @@ TEST_F(WcmpManagerTest, WcmpGroupCreateAndUpdateInDrainSucceeds)
     attr.value.u32list.list = member_weights_2.data();
     attrs_2.push_back(attr);
 
+    std::vector<sai_status_t> exp_status_1{SAI_STATUS_SUCCESS,
+                                           SAI_STATUS_SUCCESS};
     EXPECT_CALL(
         mock_sai_next_hop_group_,
         set_next_hop_groups_attribute(
@@ -1405,9 +1394,6 @@ TEST_F(WcmpManagerTest, PruneNextHopSucceeds)
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
     EXPECT_FALSE(app_db_entry.wcmp_group_members[0]->pruned);
 
-    bool pruned = app_db_entry.wcmp_group_members[0]->pruned;
-    app_db_entry.wcmp_group_members[0]->pruned = true;
-
     std::vector<sai_object_id_t> member_oids{};
     std::vector<uint32_t> member_weights{};
     std::vector<sai_attribute_t> attrs;
@@ -1432,7 +1418,6 @@ TEST_F(WcmpManagerTest, PruneNextHopSucceeds)
         .WillOnce(
             DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
                   Return(SAI_STATUS_SUCCESS)));
-    app_db_entry.wcmp_group_members[0]->pruned = pruned;
 
     // Prune next hops associated with port
     PruneNextHops(port_name);
@@ -1448,9 +1433,6 @@ TEST_F(WcmpManagerTest, PruneNextHopFails) {
   EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0],
                                              true, 1));
   EXPECT_FALSE(app_db_entry.wcmp_group_members[0]->pruned);
-
-  bool pruned = app_db_entry.wcmp_group_members[0]->pruned;
-  app_db_entry.wcmp_group_members[0]->pruned = true;
 
   std::vector<sai_object_id_t> member_oids{};
   std::vector<uint32_t> member_weights{};
@@ -1474,14 +1456,13 @@ TEST_F(WcmpManagerTest, PruneNextHopFails) {
           AttrArrayEq(attrs), _, _))
       .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
                       Return(SAI_STATUS_FAILURE)));
-  app_db_entry.wcmp_group_members[0]->pruned = pruned;
 
   // TODO: Expect critical state.
   // Prune next hops associated with port (fails)
   PruneNextHops(port_name);
   EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0],
                                              true, 1));
-  EXPECT_FALSE(app_db_entry.wcmp_group_members[0]->pruned);
+  EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
 }
 
 TEST_F(WcmpManagerTest, RestorePrunedNextHopSucceeds)
@@ -1493,9 +1474,6 @@ TEST_F(WcmpManagerTest, RestorePrunedNextHopSucceeds)
     P4WcmpGroupEntry app_db_entry = AddWcmpGroupEntryWithWatchport(port_name);
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
     EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
-
-    bool pruned = app_db_entry.wcmp_group_members[0]->pruned;
-    app_db_entry.wcmp_group_members[0]->pruned = false;
 
     std::vector<sai_object_id_t> member_oids{kNexthopOid1};
     std::vector<uint32_t> member_weights{2};
@@ -1521,7 +1499,6 @@ TEST_F(WcmpManagerTest, RestorePrunedNextHopSucceeds)
         .WillOnce(
             DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
                   Return(SAI_STATUS_SUCCESS)));
-    app_db_entry.wcmp_group_members[0]->pruned = pruned;
 
     // Restore next hops associated with port
     RestorePrunedNextHops(port_name);
@@ -1538,9 +1515,6 @@ TEST_F(WcmpManagerTest, RestorePrunedNextHopFails) {
   EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0],
                                              true, 1));
   EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
-
-  bool pruned = app_db_entry.wcmp_group_members[0]->pruned;
-  app_db_entry.wcmp_group_members[0]->pruned = false;
 
   std::vector<sai_object_id_t> member_oids{kNexthopOid1};
   std::vector<uint32_t> member_weights{2};
@@ -1565,13 +1539,12 @@ TEST_F(WcmpManagerTest, RestorePrunedNextHopFails) {
           AttrArrayEq(attrs), _, _))
       .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
                       Return(SAI_STATUS_FAILURE)));
-  app_db_entry.wcmp_group_members[0]->pruned = pruned;
 
   // TODO: Expect critical state.
   RestorePrunedNextHops(port_name);
   EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0],
                                              true, 1));
-  EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
+  EXPECT_FALSE(app_db_entry.wcmp_group_members[0]->pruned);
 }
 
 TEST_F(WcmpManagerTest, RemoveWcmpGroupAfterPruningSucceeds)
@@ -1581,9 +1554,6 @@ TEST_F(WcmpManagerTest, RemoveWcmpGroupAfterPruningSucceeds)
     P4WcmpGroupEntry app_db_entry = AddWcmpGroupEntryWithWatchport(port_name, true);
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
     EXPECT_FALSE(app_db_entry.wcmp_group_members[0]->pruned);
-
-    bool pruned = app_db_entry.wcmp_group_members[0]->pruned;
-    app_db_entry.wcmp_group_members[0]->pruned = true;
 
     std::vector<sai_object_id_t> member_oids{};
     std::vector<uint32_t> member_weights{};
@@ -1609,7 +1579,6 @@ TEST_F(WcmpManagerTest, RemoveWcmpGroupAfterPruningSucceeds)
         .WillOnce(
             DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
                   Return(SAI_STATUS_SUCCESS)));
-    app_db_entry.wcmp_group_members[0]->pruned = pruned;
 
     PruneNextHops(port_name);
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
@@ -1713,9 +1682,6 @@ TEST_F(WcmpManagerTest, RemoveNextHopWithRestoredPrunedMember)
     EXPECT_EQ(1, ref_cnt);
 
     // Restore member associated with port.
-    bool pruned = app_db_entry.wcmp_group_members[0]->pruned;
-    app_db_entry.wcmp_group_members[0]->pruned = false;
-
     std::vector<sai_object_id_t> member_oids{kNexthopOid1};
     std::vector<uint32_t> member_weights{2};
     std::vector<sai_attribute_t> attrs;
@@ -1740,7 +1706,6 @@ TEST_F(WcmpManagerTest, RemoveNextHopWithRestoredPrunedMember)
         .WillOnce(
             DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
                   Return(SAI_STATUS_SUCCESS)));
-    app_db_entry.wcmp_group_members[0]->pruned = pruned;
 
     RestorePrunedNextHops(port_name);
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
@@ -1786,9 +1751,6 @@ TEST_F(WcmpManagerTest, VerifyNextHopRefCountWhenMemberPruned)
     EXPECT_EQ(1, ref_cnt);
 
     // Prune member associated with port.
-    bool pruned = app_db_entry.wcmp_group_members[0]->pruned;
-    app_db_entry.wcmp_group_members[0]->pruned = true;
-
     std::vector<sai_object_id_t> member_oids{};
     std::vector<uint32_t> member_weights{};
     std::vector<sai_attribute_t> attrs;
@@ -1813,7 +1775,6 @@ TEST_F(WcmpManagerTest, VerifyNextHopRefCountWhenMemberPruned)
         .WillOnce(
             DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
                   Return(SAI_STATUS_SUCCESS)));
-    app_db_entry.wcmp_group_members[0]->pruned = pruned;
 
     PruneNextHops(port_name);
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
@@ -1885,38 +1846,13 @@ TEST_F(WcmpManagerTest, UpdateWcmpGroupWithOperationallyDownWatchportMemberSucce
     EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
 
     // Update WCMP group to remove kNexthopId1 and add kNexthopId2.
+    // Expect no SAI call is made.
     P4WcmpGroupEntry updated_app_db_entry;
     updated_app_db_entry.wcmp_group_id = kWcmpGroupId1;
     std::shared_ptr<P4WcmpGroupMemberEntry> updated_gm =
         createWcmpGroupMemberEntryWithWatchport(kNexthopId2, 1, port_name, kWcmpGroupId1, kNexthopOid2);
     updated_gm->pruned = true;
     updated_app_db_entry.wcmp_group_members.push_back(updated_gm);
-
-    std::vector<sai_object_id_t> member_oids{};
-    std::vector<uint32_t> member_weights{};
-    std::vector<sai_attribute_t> attrs;
-    sai_attribute_t attr;
-    attr.id = SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_LIST;
-    attr.value.objlist.count = static_cast<uint32_t>(member_oids.size());
-    attr.value.objlist.list = member_oids.data();
-    attrs.push_back(attr);
-    attr.id = SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST;
-    attr.value.u32list.count = static_cast<uint32_t>(member_weights.size());
-    attr.value.u32list.list = member_weights.data();
-    attrs.push_back(attr);
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS,
-                                         SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                set_next_hop_groups_attribute(
-                    Eq(2),
-                    ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1,
-                                                         kWcmpGroupOid1}),
-                    AttrArrayEq(attrs), _, _))
-        .WillOnce(
-            DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                  Return(SAI_STATUS_SUCCESS)));
-
     std::vector<P4WcmpGroupEntry> entries{updated_app_db_entry};
     EXPECT_THAT(UpdateWcmpGroups(entries),
                 ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
@@ -1972,9 +1908,6 @@ TEST_F(WcmpManagerTest, PruneAfterWcmpGroupUpdateSucceeds)
     EXPECT_FALSE(updated_app_db_entry.wcmp_group_members[0]->pruned);
 
     // Prune members associated with port.
-    bool pruned = updated_app_db_entry.wcmp_group_members[0]->pruned;
-    updated_app_db_entry.wcmp_group_members[0]->pruned = true;
-
     std::vector<sai_object_id_t> member_oids_2{};
     std::vector<uint32_t> member_weights_2{};
     std::vector<sai_attribute_t> attrs_2;
@@ -1996,7 +1929,6 @@ TEST_F(WcmpManagerTest, PruneAfterWcmpGroupUpdateSucceeds)
         .WillOnce(
             DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
                   Return(SAI_STATUS_SUCCESS)));
-    updated_app_db_entry.wcmp_group_members[0]->pruned = pruned;
 
     PruneNextHops(port_name);
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(updated_app_db_entry.wcmp_group_members[0], true, 1));
@@ -2035,37 +1967,13 @@ TEST_F(WcmpManagerTest, PrunedMemberUpdateOnRestoreSucceeds)
     EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
 
     // Update WCMP group to modify weight of kNexthopId1.
+    // Expect no SAI call is made.
     P4WcmpGroupEntry updated_app_db_entry;
     updated_app_db_entry.wcmp_group_id = kWcmpGroupId1;
     std::shared_ptr<P4WcmpGroupMemberEntry> updated_gm =
         createWcmpGroupMemberEntryWithWatchport(kNexthopId1, 10, port_name, kWcmpGroupId1, kNexthopOid1);
     updated_gm->pruned = true;
     updated_app_db_entry.wcmp_group_members.push_back(updated_gm);
-
-    std::vector<sai_object_id_t> member_oids_1{};
-    std::vector<uint32_t> member_weights_1{};
-    std::vector<sai_attribute_t> attrs_1;
-    sai_attribute_t attr;
-    attr.id = SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_LIST;
-    attr.value.objlist.count = static_cast<uint32_t>(member_oids_1.size());
-    attr.value.objlist.list = member_oids_1.data();
-    attrs_1.push_back(attr);
-    attr.id = SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST;
-    attr.value.u32list.count = static_cast<uint32_t>(member_weights_1.size());
-    attr.value.u32list.list = member_weights_1.data();
-    attrs_1.push_back(attr);
-
-    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS,
-                                         SAI_STATUS_SUCCESS};
-    EXPECT_CALL(mock_sai_next_hop_group_,
-                set_next_hop_groups_attribute(
-                    Eq(2),
-                    ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1,
-                                                         kWcmpGroupOid1}),
-                    AttrArrayEq(attrs_1), _, _))
-        .WillOnce(
-            DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
-                  Return(SAI_STATUS_SUCCESS)));
 
     std::vector<P4WcmpGroupEntry> entries{updated_app_db_entry};
     EXPECT_THAT(UpdateWcmpGroups(entries),
@@ -2078,6 +1986,7 @@ TEST_F(WcmpManagerTest, PrunedMemberUpdateOnRestoreSucceeds)
     std::vector<sai_object_id_t> member_oids_2{kNexthopOid1};
     std::vector<uint32_t> member_weights_2{10};
     std::vector<sai_attribute_t> attrs_2;
+    sai_attribute_t attr;
     attr.id = SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_LIST;
     attr.value.objlist.count = static_cast<uint32_t>(member_oids_2.size());
     attr.value.objlist.list = member_oids_2.data();
@@ -2087,6 +1996,7 @@ TEST_F(WcmpManagerTest, PrunedMemberUpdateOnRestoreSucceeds)
     attr.value.u32list.list = member_weights_2.data();
     attrs_2.push_back(attr);
 
+    std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
     EXPECT_CALL(mock_sai_next_hop_group_,
                 set_next_hop_groups_attribute(
                     Eq(2),
@@ -2142,6 +2052,7 @@ TEST_F(WcmpManagerTest, WatchportStateChangetoOperDownSucceeds)
                   Return(SAI_STATUS_SUCCESS)));
 
     HandlePortStatusChangeNotification(op, data);
+    ProcessWatchPortEvent();
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
     EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
 }
@@ -2189,6 +2100,7 @@ TEST_F(WcmpManagerTest, WatchportStateChangeToOperUpSucceeds)
                   Return(SAI_STATUS_SUCCESS)));
 
     HandlePortStatusChangeNotification(op, data);
+    ProcessWatchPortEvent();
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0], true, 1));
     EXPECT_FALSE(app_db_entry.wcmp_group_members[0]->pruned);
 }
@@ -2212,9 +2124,282 @@ TEST_F(WcmpManagerTest,
         "[{\"port_id\":\"oid:0x56789abcfff\",\"port_state\":\"SAI_PORT_OPER_"
         "STATUS_DOWN\",\"port_error_status\":\"0\"}]";
     HandlePortStatusChangeNotification(op, data);
+    ProcessWatchPortEvent();
     EXPECT_TRUE(VerifyWcmpGroupMemberInPortMap(app_db_entry.wcmp_group_members[0],
                                                true, 1));
     EXPECT_TRUE(app_db_entry.wcmp_group_members[0]->pruned);
+}
+
+TEST_F(WcmpManagerTest, MultipleWatchportGroupsUpdate) {
+  P4WcmpGroupEntry app_db_entry_1 = AddWcmpGroupEntryWithWatchport(
+      "Ethernet1", /*oper_up=*/true, kWcmpGroupId1);
+  P4WcmpGroupEntry app_db_entry_2 = AddWcmpGroupEntryWithWatchport(
+      "Ethernet6", /*oper_up=*/true, kWcmpGroupId2);
+  UpdateWatchPort("Ethernet1", /*prune=*/true);
+  UpdateWatchPort("Ethernet6", /*prune=*/true);
+
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS,
+                                       SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
+  sai_attribute_t attr_1;
+  attr_1.id = SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_LIST;
+  attr_1.value.objlist.count = 0;
+  sai_attribute_t attr_2;
+  attr_2.id = SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST;
+  attr_2.value.u32list.count = 0;
+  EXPECT_CALL(
+      mock_sai_next_hop_group_,
+      set_next_hop_groups_attribute(
+          Eq(4),
+          ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1, kWcmpGroupOid1,
+                                               kWcmpGroupOid1, kWcmpGroupOid1}),
+          AttrArrayEq(
+              std::vector<sai_attribute_t>{attr_1, attr_2, attr_1, attr_2}),
+          _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  ProcessWatchPortEvent();
+}
+
+TEST_F(WcmpManagerTest, MultipleWatchportUpdateOnTheSameGroup) {
+  P4WcmpGroupEntry app_db_entry;
+  app_db_entry.wcmp_group_id = kWcmpGroupId1;
+  std::shared_ptr<P4WcmpGroupMemberEntry> gm1 =
+      std::make_shared<P4WcmpGroupMemberEntry>();
+  gm1->next_hop_id = kNexthopId1;
+  gm1->weight = 2;
+  gm1->watch_port = "Ethernet1";
+  gm1->wcmp_group_id = kWcmpGroupId1;
+  gm1->next_hop_oid = kNexthopOid1;
+  gm1->pruned = false;
+  app_db_entry.wcmp_group_members.push_back(gm1);
+  p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, kNexthopOid1);
+  std::shared_ptr<P4WcmpGroupMemberEntry> gm2 =
+      std::make_shared<P4WcmpGroupMemberEntry>();
+  gm2->next_hop_id = kNexthopId2;
+  gm2->weight = 2;
+  gm2->watch_port = "Ethernet6";
+  gm2->wcmp_group_id = kWcmpGroupId1;
+  gm2->next_hop_oid = kNexthopOid2;
+  gm2->pruned = false;
+  app_db_entry.wcmp_group_members.push_back(gm2);
+  p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, kNexthopOid2);
+
+  std::vector<sai_object_id_t> exp_oids{kWcmpGroupOid1};
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_next_hop_group_,
+              create_next_hop_groups(_, _, _, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_oids.begin(), exp_oids.end()),
+                      SetArrayArgument<6>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  std::vector<P4WcmpGroupEntry> entries{app_db_entry};
+  EXPECT_THAT(CreateWcmpGroups(entries),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+
+  UpdateWatchPort("Ethernet1", /*prune=*/true);
+  UpdateWatchPort("Ethernet6", /*prune=*/true);
+
+  std::vector<sai_status_t> exp_update_status{SAI_STATUS_SUCCESS,
+                                              SAI_STATUS_SUCCESS};
+  sai_attribute_t attr_1;
+  attr_1.id = SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_LIST;
+  attr_1.value.objlist.count = 0;
+  sai_attribute_t attr_2;
+  attr_2.id = SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST;
+  attr_2.value.u32list.count = 0;
+  EXPECT_CALL(
+      mock_sai_next_hop_group_,
+      set_next_hop_groups_attribute(
+          Eq(2),
+          ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1, kWcmpGroupOid1}),
+          AttrArrayEq(std::vector<sai_attribute_t>{attr_1, attr_2}), _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_update_status.begin(),
+                                          exp_update_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  ProcessWatchPortEvent();
+}
+
+TEST_F(WcmpManagerTest, WatchportGroupUpdateWithRequest) {
+  P4WcmpGroupEntry app_db_entry = AddWcmpGroupEntryWithWatchport(
+      "Ethernet1", /*oper_up=*/true, kWcmpGroupId1);
+  UpdateWatchPort("Ethernet1", /*prune=*/true);
+
+  // Process a request on the same group.
+  const std::string kKeyPrefix =
+      std::string(APP_P4RT_WCMP_GROUP_TABLE_NAME) + kTableKeyDelimiter;
+  p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, kNexthopOid2);
+  nlohmann::json j;
+  j[prependMatchField(p4orch::kWcmpGroupId)] = kWcmpGroupId1;
+  std::vector<swss::FieldValueTuple> attributes;
+  nlohmann::json actions;
+  nlohmann::json action;
+  action[p4orch::kAction] = p4orch::kSetNexthopId;
+  action[prependParamField(p4orch::kNexthopId)] = kNexthopId1;
+  action[p4orch::kWatchPort] = "Ethernet1";
+  actions.push_back(action);
+  action[prependParamField(p4orch::kNexthopId)] = kNexthopId2;
+  action[p4orch::kWatchPort] = "Ethernet6";
+  actions.push_back(action);
+  attributes.push_back(swss::FieldValueTuple{p4orch::kActions, actions.dump()});
+  Enqueue(swss::KeyOpFieldsValuesTuple(kKeyPrefix + j.dump(), SET_COMMAND,
+                                       attributes));
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS, SAI_STATUS_SUCCESS};
+  EXPECT_CALL(
+      mock_sai_next_hop_group_,
+      set_next_hop_groups_attribute(
+          Eq(2),
+          ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1, kWcmpGroupOid1}),
+          _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, Drain(/*failure_before=*/false));
+
+  // Expect no SAI call is made on the watchport event processing.
+  ProcessWatchPortEvent();
+}
+
+TEST_F(WcmpManagerTest, WatchportGroupUpdateWithRequestOnDifferentGroup) {
+  P4WcmpGroupEntry app_db_entry = AddWcmpGroupEntryWithWatchport(
+      "Ethernet1", /*oper_up=*/true, kWcmpGroupId1);
+  UpdateWatchPort("Ethernet1", /*prune=*/true);
+
+  // Process a request on the same group.
+  const std::string kKeyPrefix =
+      std::string(APP_P4RT_WCMP_GROUP_TABLE_NAME) + kTableKeyDelimiter;
+  p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, kNexthopOid2);
+  nlohmann::json j;
+  j[prependMatchField(p4orch::kWcmpGroupId)] = kWcmpGroupId2;
+  std::vector<swss::FieldValueTuple> attributes;
+  nlohmann::json actions;
+  nlohmann::json action;
+  action[p4orch::kAction] = p4orch::kSetNexthopId;
+  action[prependParamField(p4orch::kNexthopId)] = kNexthopId1;
+  action[p4orch::kWatchPort] = "Ethernet1";
+  actions.push_back(action);
+  action[prependParamField(p4orch::kNexthopId)] = kNexthopId2;
+  action[p4orch::kWatchPort] = "Ethernet6";
+  actions.push_back(action);
+  attributes.push_back(swss::FieldValueTuple{p4orch::kActions, actions.dump()});
+  Enqueue(swss::KeyOpFieldsValuesTuple(kKeyPrefix + j.dump(), SET_COMMAND,
+                                       attributes));
+  std::vector<sai_object_id_t> exp_oids{kWcmpGroupOid2};
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_next_hop_group_,
+              create_next_hop_groups(_, _, _, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_oids.begin(), exp_oids.end()),
+                      SetArrayArgument<6>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, Drain(/*failure_before=*/false));
+
+  // Expect SAI call is made on the watchport event processing.
+  std::vector<sai_status_t> exp_update_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(
+      mock_sai_next_hop_group_,
+      set_next_hop_groups_attribute(
+          Eq(2),
+          ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1, kWcmpGroupOid1}),
+          _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_update_status.begin(),
+                                          exp_update_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  ProcessWatchPortEvent();
+}
+
+TEST_F(WcmpManagerTest, PortFlapWithRequest) {
+  P4WcmpGroupEntry app_db_entry;
+  app_db_entry.wcmp_group_id = kWcmpGroupId1;
+  std::shared_ptr<P4WcmpGroupMemberEntry> gm1 =
+      std::make_shared<P4WcmpGroupMemberEntry>();
+  gm1->next_hop_id = kNexthopId1;
+  gm1->weight = 2;
+  gm1->watch_port = "Ethernet1";
+  gm1->wcmp_group_id = kWcmpGroupId1;
+  gm1->next_hop_oid = kNexthopOid1;
+  gm1->pruned = false;
+  app_db_entry.wcmp_group_members.push_back(gm1);
+  p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey1, kNexthopOid1);
+  std::shared_ptr<P4WcmpGroupMemberEntry> gm2 =
+      std::make_shared<P4WcmpGroupMemberEntry>();
+  gm2->next_hop_id = kNexthopId2;
+  gm2->weight = 2;
+  gm2->watch_port = "Ethernet6";
+  gm2->wcmp_group_id = kWcmpGroupId1;
+  gm2->next_hop_oid = kNexthopOid2;
+  gm2->pruned = false;
+  app_db_entry.wcmp_group_members.push_back(gm2);
+  p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_NEXT_HOP, kNexthopKey2, kNexthopOid2);
+
+  std::vector<sai_object_id_t> exp_oids{kWcmpGroupOid1};
+  std::vector<sai_status_t> exp_status{SAI_STATUS_SUCCESS};
+  EXPECT_CALL(mock_sai_next_hop_group_,
+              create_next_hop_groups(_, _, _, _, _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<5>(exp_oids.begin(), exp_oids.end()),
+                      SetArrayArgument<6>(exp_status.begin(), exp_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+
+  std::vector<P4WcmpGroupEntry> entries{app_db_entry};
+  EXPECT_THAT(CreateWcmpGroups(entries),
+              ArrayEq(std::vector<StatusCode>{StatusCode::SWSS_RC_SUCCESS}));
+
+  // Port down
+  UpdateWatchPort("Ethernet1", /*prune=*/true);
+  // Port up
+  UpdateWatchPort("Ethernet1", /*prune=*/false);
+
+  // Request to prune
+  const std::string kKeyPrefix =
+      std::string(APP_P4RT_WCMP_GROUP_TABLE_NAME) + kTableKeyDelimiter;
+  nlohmann::json j;
+  j[prependMatchField(p4orch::kWcmpGroupId)] = kWcmpGroupId1;
+  std::vector<swss::FieldValueTuple> attributes;
+  nlohmann::json actions;
+  nlohmann::json action;
+  action[p4orch::kAction] = p4orch::kSetNexthopId;
+  action[prependParamField(p4orch::kNexthopId)] = kNexthopId2;
+  action[p4orch::kWatchPort] = "Ethernet6";
+  actions.push_back(action);
+  attributes.push_back(swss::FieldValueTuple{p4orch::kActions, actions.dump()});
+  Enqueue(swss::KeyOpFieldsValuesTuple(kKeyPrefix + j.dump(), SET_COMMAND,
+                                       attributes));
+  std::vector<sai_status_t> exp_update_status{SAI_STATUS_SUCCESS,
+                                              SAI_STATUS_SUCCESS};
+  EXPECT_CALL(
+      mock_sai_next_hop_group_,
+      set_next_hop_groups_attribute(
+          Eq(2),
+          ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1, kWcmpGroupOid1}),
+          _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_update_status.begin(),
+                                          exp_update_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, Drain(/*failure_before=*/false));
+
+  // Expect no SAI call is made on the watchport event processing.
+  ProcessWatchPortEvent();
+
+  // Request to restore
+  action[p4orch::kAction] = p4orch::kSetNexthopId;
+  action[prependParamField(p4orch::kNexthopId)] = kNexthopId1;
+  action[p4orch::kWatchPort] = "Ethernet1";
+  actions.push_back(action);
+  attributes.push_back(swss::FieldValueTuple{p4orch::kActions, actions.dump()});
+  Enqueue(swss::KeyOpFieldsValuesTuple(kKeyPrefix + j.dump(), SET_COMMAND,
+                                       attributes));
+  EXPECT_CALL(
+      mock_sai_next_hop_group_,
+      set_next_hop_groups_attribute(
+          Eq(2),
+          ArrayEq(std::vector<sai_object_id_t>{kWcmpGroupOid1, kWcmpGroupOid1}),
+          _, _, _))
+      .WillOnce(DoAll(SetArrayArgument<4>(exp_update_status.begin(),
+                                          exp_update_status.end()),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, Drain(/*failure_before=*/false));
+
+  // Expect no SAI call is made on the watchport event processing.
+  ProcessWatchPortEvent();
 }
 
 TEST_F(WcmpManagerTest, WcmpGroupDrainStopOnFirstFailureDelete) {

--- a/orchagent/p4orch/wcmp_manager.cpp
+++ b/orchagent/p4orch/wcmp_manager.cpp
@@ -71,23 +71,6 @@ std::vector<sai_attribute_t> prepareSaiGroupAttrs(
   return attrs;
 }
 
-ReturnCode updateGroup(P4WcmpGroupEntry& wcmp_group) {
-  auto attrs = prepareSaiGroupAttrs(wcmp_group, /*update=*/true);
-  std::vector<sai_object_id_t> oids(attrs.size());
-  std::vector<sai_status_t> status(attrs.size());
-  for (size_t i = 0; i < attrs.size(); ++i) {
-    oids[i] = wcmp_group.wcmp_group_oid;
-  }
-  // This SAI operation is assumed to be atomic.
-  CHECK_ERROR_AND_LOG_AND_RETURN(
-      sai_next_hop_group_api->set_next_hop_groups_attribute(
-          uint32_t(attrs.size()), oids.data(), attrs.data(),
-          SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR, status.data()),
-      "Failed to update next hop group  "
-          << QuotedVar(wcmp_group.wcmp_group_id));
-  return ReturnCode();
-}
-
 }  // namespace
 
 ReturnCode WcmpManager::validateWcmpGroupEntry(
@@ -400,10 +383,10 @@ std::vector<ReturnCode> WcmpManager::removeWcmpGroups(
 }
 
 std::vector<ReturnCode> WcmpManager::updateWcmpGroups(
-    std::vector<P4WcmpGroupEntry>& entries) {
+    std::vector<P4WcmpGroupEntry>& entries, bool watchport) {
   SWSS_LOG_ENTER();
 
-  // Each group update will have two SAI attrs:
+  // Each group update will have exactly two SAI attrs:
   // SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_LIST and
   // SAI_NEXT_HOP_GROUP_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST.
   std::vector<P4WcmpGroupEntry*> old_entries(entries.size());
@@ -411,51 +394,76 @@ std::vector<ReturnCode> WcmpManager::updateWcmpGroups(
   std::vector<sai_object_id_t> oids(2 * entries.size());
   std::vector<sai_status_t> object_statuses(2 * entries.size());
   std::vector<ReturnCode> statuses(entries.size());
+  // Index that points to the entry that needs to make SAI calls.
+  // -1 indicates that the entry does not make any SAI call due to no change in
+  // any SAI attr.
+  std::vector<int> indice(entries.size());
+  int index = 0;
 
   for (size_t i = 0; i < entries.size(); ++i) {
     old_entries[i] = getWcmpGroupEntry(entries[i].wcmp_group_id);
     entries[i].wcmp_group_oid = old_entries[i]->wcmp_group_oid;
-    oids[2 * i] = old_entries[i]->wcmp_group_oid;
-    oids[2 * i + 1] = old_entries[i]->wcmp_group_oid;
     auto attrs = prepareSaiGroupAttrs(entries[i], /*update=*/true);
-    sai_attr[2 * i] = attrs[0];
-    sai_attr[2 * i + 1] = attrs[1];
+    // Only make the SAI call if SAI attributes change.
+    if (entries[i].nexthop_ids != old_entries[i]->nexthop_ids ||
+        entries[i].nexthop_weights != old_entries[i]->nexthop_weights) {
+      // Since each group update has exactly two SAI attrs, the SAI attr indice
+      // will be 2 * index and 2 * index + 1 from the entry index.
+      int sai_attr_index = 2 * index;
+      oids[sai_attr_index] = old_entries[i]->wcmp_group_oid;
+      oids[sai_attr_index + 1] = old_entries[i]->wcmp_group_oid;
+      sai_attr[sai_attr_index] = attrs[0];
+      sai_attr[sai_attr_index + 1] = attrs[1];
+      indice[i] = index++;
+    } else {
+      indice[i] = -1;
+    }
   }
-  // This SAI operation is assumed to be atomic.
-  sai_next_hop_group_api->set_next_hop_groups_attribute(
-      static_cast<uint32_t>(sai_attr.size()), oids.data(), sai_attr.data(),
-      SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR, object_statuses.data());
 
-  for (size_t i = 0; i < entries.size(); ++i) {
-    CHECK_ERROR_AND_LOG(object_statuses[2 * i + 1],
-                        "Failed to update WCMP group with id "
-                            << QuotedVar(entries[i].wcmp_group_id));
+  if (index > 0) {
+    // This SAI operation is assumed to be atomic.
+    sai_next_hop_group_api->set_next_hop_groups_attribute(
+        static_cast<uint32_t>(2 * index), oids.data(), sai_attr.data(),
+        SAI_BULK_OP_ERROR_MODE_STOP_ON_ERROR, object_statuses.data());
+  }
 
-    if (object_statuses[2 * i + 1] == SAI_STATUS_SUCCESS) {
-      for (auto& member : old_entries[i]->wcmp_group_members) {
-        const std::string& next_hop_key =
-            KeyGenerator::generateNextHopKey(member->next_hop_id);
-        gCrmOrch->decCrmResUsedCounter(
-            CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
-        m_p4OidMapper->decreaseRefCount(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_key);
-        if (!member->watch_port.empty()) {
-          removeMemberFromPortNameToWcmpGroupMemberMap(member);
+    for (size_t i = 0; i < entries.size(); ++i) {
+    int sai_entry_index = indice[i];
+    int sai_attr_index = 2 * sai_entry_index + 1;
+    if (sai_entry_index == -1 ||
+        object_statuses[sai_attr_index] == SAI_STATUS_SUCCESS) {
+      // Do not update reference for watchport update.
+      if (!watchport) {
+        for (auto& member : old_entries[i]->wcmp_group_members) {
+          const std::string& next_hop_key =
+              KeyGenerator::generateNextHopKey(member->next_hop_id);
+          gCrmOrch->decCrmResUsedCounter(
+              CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
+          m_p4OidMapper->decreaseRefCount(SAI_OBJECT_TYPE_NEXT_HOP,
+                                          next_hop_key);
+          if (!member->watch_port.empty()) {
+            removeMemberFromPortNameToWcmpGroupMemberMap(member);
+          }
         }
-      }
       for (auto& member : entries[i].wcmp_group_members) {
-        const std::string& next_hop_key =
-            KeyGenerator::generateNextHopKey(member->next_hop_id);
-        gCrmOrch->incCrmResUsedCounter(
-            CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
-        m_p4OidMapper->increaseRefCount(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_key);
-        if (!member->watch_port.empty()) {
-          insertMemberInPortNameToWcmpGroupMemberMap(member);
+          const std::string& next_hop_key =
+              KeyGenerator::generateNextHopKey(member->next_hop_id);
+          gCrmOrch->incCrmResUsedCounter(
+              CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
+          m_p4OidMapper->increaseRefCount(SAI_OBJECT_TYPE_NEXT_HOP,
+                                          next_hop_key);
+          if (!member->watch_port.empty()) {
+            insertMemberInPortNameToWcmpGroupMemberMap(member);
+          }
         }
       }
       m_wcmpGroupTable[entries[i].wcmp_group_id] = entries[i];
       statuses[i] = ReturnCode();
     } else {
-      statuses[i] = ReturnCode(object_statuses[2 * i + 1])
+      CHECK_ERROR_AND_LOG(object_statuses[sai_attr_index],
+                          "Failed to update WCMP group with id "
+                              << QuotedVar(entries[i].wcmp_group_id));
+      statuses[i] = ReturnCode(object_statuses[sai_attr_index])
                     << "Failed to update WCMP group with id "
                     << QuotedVar(entries[i].wcmp_group_id);
       }
@@ -487,8 +495,12 @@ ReturnCode WcmpManager::processEntries(
     m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(tuple_list[i]),
                          kfvFieldsValues(tuple_list[i]), statuses[i],
                          /*replace=*/true);
-    if (status.ok() && !statuses[i].ok()) {
-      status = statuses[i];
+    if (status.ok()) {
+      // Remove the queued watchport event if the group has been updated.
+      m_watchport_groups.erase(entries[i].wcmp_group_id);
+      if (!statuses[i].ok()) {
+        status = statuses[i];
+      }
       }
     }
 
@@ -512,21 +524,56 @@ void WcmpManager::updateWatchPort(const std::string& port, bool prune) {
         } else {
           const std::string update = prune ? "prune" : "restore";
           member->pruned = prune;
-          auto status = updateGroup(*wcmp_group);
-          if (!status.ok()) {
-            member->pruned = !member->pruned;
-            SWSS_RAISE_CRITICAL_STATE(
-                "Failed to " + update + " member in group " +
-                QuotedVar(member->wcmp_group_id) +
-                " in updateWatchPort: " + status.message());
-          } else {
-            SWSS_LOG_NOTICE("%s member %s from group %s", update.c_str(),
-                            member->next_hop_id.c_str(),
-                            member->wcmp_group_id.c_str());
-          }
+          m_watchport_groups.insert(member->wcmp_group_id);
+          SWSS_LOG_NOTICE("Queued watchport event: %s member %s from group %s",
+                          update.c_str(), member->next_hop_id.c_str(),
+                          member->wcmp_group_id.c_str());
         }
       }
     }
+  }
+  if (!m_watchport_groups.empty()) {
+    m_watchport_event->notify();
+  }
+}
+
+void WcmpManager::processWatchPortEvent() {
+  SWSS_LOG_ENTER();
+
+  uint count = 0;
+  std::vector<P4WcmpGroupEntry> entries;
+  auto it = m_watchport_groups.begin();
+  while (it != m_watchport_groups.end()) {
+    auto* wcmp_group_ptr = getWcmpGroupEntry(*it);
+
+    if (wcmp_group_ptr != nullptr) {
+      entries.push_back(*wcmp_group_ptr);
+    } else {
+      SWSS_LOG_NOTICE("WCMP group %s no longer exists, skipping watchport update.", it->c_str());
+    }
+
+    it = m_watchport_groups.erase(it);
+    if (++count >= kMaxWatchportGroupBulkSize) {
+      break;
+    }
+  }
+
+  if (!entries.empty()) {
+    auto status = updateWcmpGroups(entries, /*watchport=*/true);
+    for (size_t i = 0; i < entries.size(); ++i) {
+      if (!status[i].ok()) {
+        SWSS_RAISE_CRITICAL_STATE(
+            "Failed to process watchport event for group " +
+            QuotedVar(entries[i].wcmp_group_id));
+      } else {
+        SWSS_LOG_NOTICE("Watchport event processed for group %s",
+                        entries[i].wcmp_group_id.c_str());
+      }
+    }
+  }
+
+  if (!m_watchport_groups.empty()) {
+    m_watchport_event->notify();
   }
 }
 
@@ -849,8 +896,7 @@ void WcmpManager::refreshPortOperStatus() {
   for (const auto& it : port_oper_status_map) {
     Port port;
     if (!gPortsOrch->getPort(it.first, port)) {
-      SWSS_LOG_ERROR("Failed to get port object for port %s",
-                     it.first.c_str());
+      SWSS_LOG_ERROR("Failed to get port object for port %s", it.first.c_str());
       continue;
     }
     // Update oper-status in local cache.

--- a/orchagent/p4orch/wcmp_manager.h
+++ b/orchagent/p4orch/wcmp_manager.h
@@ -17,6 +17,7 @@ extern "C"
 {
 #include "sai.h"
 }
+#include "selectableevent.h"
 
 namespace p4orch
 {
@@ -24,6 +25,8 @@ namespace test
 {
 class WcmpManagerTest;
 } // namespace test
+
+constexpr uint32_t kMaxWatchportGroupBulkSize = 30;
 
 struct P4WcmpGroupMemberEntry
 {
@@ -69,8 +72,8 @@ struct P4WcmpGroupEntry
 class WcmpManager : public ObjectManagerInterface
 {
   public:
-   WcmpManager(P4OidMapper* p4oidMapper,
-               ResponsePublisherInterface* publisher)
+   WcmpManager(P4OidMapper* p4oidMapper, ResponsePublisherInterface* publisher,
+               swss::SelectableEvent* watchport_event)
        : m_asic_db("ASIC_DB", 0), m_asic_state_table(&m_asic_db, "ASIC_STATE") {
      SWSS_LOG_ENTER();
 
@@ -78,6 +81,8 @@ class WcmpManager : public ObjectManagerInterface
      m_p4OidMapper = p4oidMapper;
      assert(publisher != nullptr);
      m_publisher = publisher;
+     assert(watchport_event != nullptr);
+     m_watchport_event = watchport_event;
    }
 
     virtual ~WcmpManager() = default;
@@ -90,7 +95,13 @@ class WcmpManager : public ObjectManagerInterface
                             std::string &object_key) override;
 
     // Prunes or restores next hop members.
+    // This call only queues the group update event into m_watchport_groups.
+    // The real watchport update will happen in processWatchPortEvent().
     void updateWatchPort(const std::string& port, bool prune);
+
+    // Process group update in m_watchport_groups, maximum of
+    // kMaxWatchportGroupBulkSize groups per call.
+    void processWatchPortEvent();
 
     // Inserts into/updates port_oper_status_map
     void updatePortOperStatusMap(const std::string &port, const sai_port_oper_status_t &status);
@@ -129,7 +140,7 @@ class WcmpManager : public ObjectManagerInterface
 
     // Updates a list of WCMP groups in the WCMP group table.
     std::vector<ReturnCode> updateWcmpGroups(
-        std::vector<P4WcmpGroupEntry>& entries);
+        std::vector<P4WcmpGroupEntry>& entries, bool watchport = false);
 
     // Fetches oper-status of port using port_oper_status_map or SAI.
     ReturnCode fetchPortOperStatus(const std::string &port, sai_port_oper_status_t *oper_status);
@@ -169,6 +180,11 @@ class WcmpManager : public ObjectManagerInterface
     swss::DBConnector m_asic_db;
     swss::Table m_asic_state_table;
     ResponsePublisherInterface* m_publisher;
+    swss::SelectableEvent* m_watchport_event;
+
+    // A set that stores the groups that need to be updated due to watchport
+    // events.
+    std::unordered_set<std::string> m_watchport_groups;
 
     friend class p4orch::test::WcmpManagerTest;
 };

--- a/tests/p4rt/test_l3.py
+++ b/tests/p4rt/test_l3.py
@@ -7,7 +7,9 @@ import l3
 import test_vrf
 import time
 
+
 class TestP4RTL3(object):
+
     def _set_up(self, dvs):
         self._p4rt_router_intf_obj = l3.P4RtRouterInterfaceWrapper()
         self._p4rt_gre_tunnel_obj = l3.P4RtGreTunnelWrapper()
@@ -1906,6 +1908,304 @@ class TestP4RTL3(object):
         assert len(wcmp_group_entries) == (
             self._p4rt_wcmp_group_obj.get_original_asic_db_group_entries_count()
         )
+
+        # Delete next hop.
+        self._p4rt_nexthop_obj.remove_app_db_entry(nexthop_key)
+
+        # Delete neighbor.
+        self._p4rt_neighbor_obj.remove_app_db_entry(neighbor_key)
+
+        # Delete router interface.
+        self._p4rt_router_intf_obj.remove_app_db_entry(router_intf_key)
+
+        self._cleanup()
+
+    def test_LargeWatchportOperations(self, dvs, testlog):
+        # Initialize L3 objects and database connectors.
+        self._set_up(dvs)
+        cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+
+        # Maintain original WCMP group entries for ASIC DB.
+        original_wcmp_group_entries = util.get_keys(
+            self._p4rt_wcmp_group_obj.asic_db,
+            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_TBL_NAME,
+        )
+        db_list = (
+            (self._p4rt_nexthop_obj.asic_db,
+             self._p4rt_nexthop_obj.ASIC_DB_TBL_NAME),
+        )
+        self._p4rt_nexthop_obj.get_original_redis_entries(db_list)
+
+        # Bring up the port.
+        port_name = "Ethernet0"
+        if_name = "eth0"
+        util.initialize_interface(dvs, port_name, "10.0.0.0/31")
+        util.set_interface_status(dvs, if_name, "up")
+
+        # Create router interface.
+        (
+            router_interface_id,
+            router_intf_key,
+            attr_list,
+        ) = self._p4rt_router_intf_obj.create_router_interface()
+        self._p4rt_router_intf_obj.verify_response(
+            router_intf_key, attr_list, "SWSS_RC_SUCCESS"
+        )
+
+        # Create neighbor.
+        neighbor_id, neighbor_key, attr_list = self._p4rt_neighbor_obj.create_neighbor()
+        self._p4rt_neighbor_obj.verify_response(
+            neighbor_key, attr_list, "SWSS_RC_SUCCESS"
+        )
+
+        # Create nexthop.
+        nexthop_id, nexthop_key, attr_list = self._p4rt_nexthop_obj.create_next_hop()
+        self._p4rt_nexthop_obj.verify_response(
+            nexthop_key, attr_list, "SWSS_RC_SUCCESS"
+        )
+        # Get nexthop_oid of newly created nexthop.
+        nexthop_oid = self._p4rt_nexthop_obj.get_newly_created_nexthop_oid()
+        assert nexthop_oid is not None
+
+        # Create 40 wcmp groups with one member.
+        # Watchport operations will complete the 40 group update in two iterations.
+        wcmp_group_keys = []
+        for i in range(40):
+            wcmp_group_id = "group-" + str(i)
+            (
+                wcmp_group_id,
+                wcmp_group_key,
+                attr_list,
+            ) = self._p4rt_wcmp_group_obj.create_wcmp_group(wcmp_group_id=wcmp_group_id, watch_port=port_name)
+            self._p4rt_wcmp_group_obj.verify_response(
+                wcmp_group_key, attr_list, "SWSS_RC_SUCCESS"
+            )
+            wcmp_group_keys.append(wcmp_group_key)
+
+        # Query ASIC database for wcmp group entries.
+        wcmp_group_entries = util.get_keys(
+            self._p4rt_wcmp_group_obj.asic_db,
+            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_TBL_NAME,
+        )
+        assert len(wcmp_group_entries) == len(original_wcmp_group_entries) + 40
+
+        # Query ASIC database for newly created wcmp groups.
+        for group in wcmp_group_entries:
+            if group not in original_wcmp_group_entries:
+                (status, fvs) = util.get_key(
+                    self._p4rt_wcmp_group_obj.asic_db,
+                    self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_TBL_NAME,
+                    group,
+                )
+                assert status == True
+                asic_attr_list = [
+                    (
+                        self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_TYPE,
+                        (
+                            self._p4rt_wcmp_group_obj.SAI_NEXT_HOP_GROUP_TYPE_ECMP_WITH_MEMBERS
+                        ),
+                    ),
+                    (
+                        self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_LIST,
+                        "1:" + nexthop_oid,
+                    ),
+                    (
+                        self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST,
+                        "1:" + str(self._p4rt_wcmp_group_obj.DEFAULT_WEIGHT),
+                    )
+                ]
+                util.verify_attr(fvs, asic_attr_list)
+
+        # Bring down the port.
+        util.set_interface_status(dvs, if_name)
+        time.sleep(3)
+
+        # Expect 40 groups to be updated in ASIC DB.
+        for group in wcmp_group_entries:
+            if group not in original_wcmp_group_entries:
+                (status, fvs) = util.get_key(
+                    self._p4rt_wcmp_group_obj.asic_db,
+                    self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_TBL_NAME,
+                    group,
+                )
+                assert status == True
+                asic_attr_list = [
+                    (
+                        self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_TYPE,
+                        (
+                            self._p4rt_wcmp_group_obj.SAI_NEXT_HOP_GROUP_TYPE_ECMP_WITH_MEMBERS
+                        ),
+                    ),
+                    (
+                        self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_LIST,
+                        "0:null",
+                    ),
+                    (
+                        self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST,
+                        "0:null",
+                    )
+                ]
+                util.verify_attr(fvs, asic_attr_list)
+
+        # Delete the 40 wcmp groups
+        for wcmp_group_key in wcmp_group_keys:
+            self._p4rt_wcmp_group_obj.remove_app_db_entry(wcmp_group_key)
+
+        # Delete next hop.
+        self._p4rt_nexthop_obj.remove_app_db_entry(nexthop_key)
+
+        # Delete neighbor.
+        self._p4rt_neighbor_obj.remove_app_db_entry(neighbor_key)
+
+        # Delete router interface.
+        self._p4rt_router_intf_obj.remove_app_db_entry(router_intf_key)
+
+        self._cleanup()
+
+    def test_LargeWatchportOperationsWithRequests(self, dvs, testlog):
+        # Initialize L3 objects and database connectors.
+        self._set_up(dvs)
+        cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+
+        # Maintain original WCMP group entries for ASIC DB.
+        original_wcmp_group_entries = util.get_keys(
+            self._p4rt_wcmp_group_obj.asic_db,
+            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_TBL_NAME,
+        )
+        db_list = (
+            (self._p4rt_nexthop_obj.asic_db,
+             self._p4rt_nexthop_obj.ASIC_DB_TBL_NAME),
+        )
+        self._p4rt_nexthop_obj.get_original_redis_entries(db_list)
+
+        # Bring up the port.
+        port_name = "Ethernet0"
+        if_name = "eth0"
+        util.initialize_interface(dvs, port_name, "10.0.0.0/31")
+        util.set_interface_status(dvs, if_name, "up")
+
+        # Create router interface.
+        (
+            router_interface_id,
+            router_intf_key,
+            attr_list,
+        ) = self._p4rt_router_intf_obj.create_router_interface()
+        self._p4rt_router_intf_obj.verify_response(
+            router_intf_key, attr_list, "SWSS_RC_SUCCESS"
+        )
+
+        # Create neighbor.
+        neighbor_id, neighbor_key, attr_list = self._p4rt_neighbor_obj.create_neighbor()
+        self._p4rt_neighbor_obj.verify_response(
+            neighbor_key, attr_list, "SWSS_RC_SUCCESS"
+        )
+
+        # Create nexthop.
+        nexthop_id, nexthop_key, attr_list = self._p4rt_nexthop_obj.create_next_hop()
+        self._p4rt_nexthop_obj.verify_response(
+            nexthop_key, attr_list, "SWSS_RC_SUCCESS"
+        )
+        # Get nexthop_oid of newly created nexthop.
+        nexthop_oid = self._p4rt_nexthop_obj.get_newly_created_nexthop_oid()
+        assert nexthop_oid is not None
+
+        # Create 40 wcmp groups with one member.
+        # Watchport operations will complete the 40 group update in two iterations.
+        wcmp_group_keys = []
+        for i in range(40):
+            wcmp_group_id = "group-" + str(i)
+            (
+                wcmp_group_id,
+                wcmp_group_key,
+                attr_list,
+            ) = self._p4rt_wcmp_group_obj.create_wcmp_group(wcmp_group_id=wcmp_group_id, watch_port=port_name)
+            self._p4rt_wcmp_group_obj.verify_response(
+                wcmp_group_key, attr_list, "SWSS_RC_SUCCESS"
+            )
+            wcmp_group_keys.append(wcmp_group_key)
+
+        # Query ASIC database for wcmp group entries.
+        wcmp_group_entries = util.get_keys(
+            self._p4rt_wcmp_group_obj.asic_db,
+            self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_TBL_NAME,
+        )
+        assert len(wcmp_group_entries) == len(original_wcmp_group_entries) + 40
+
+        # Query ASIC database for newly created wcmp groups.
+        for group in wcmp_group_entries:
+            if group not in original_wcmp_group_entries:
+                (status, fvs) = util.get_key(
+                    self._p4rt_wcmp_group_obj.asic_db,
+                    self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_TBL_NAME,
+                    group,
+                )
+                assert status == True
+                asic_attr_list = [
+                    (
+                        self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_TYPE,
+                        (
+                            self._p4rt_wcmp_group_obj.SAI_NEXT_HOP_GROUP_TYPE_ECMP_WITH_MEMBERS
+                        ),
+                    ),
+                    (
+                        self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_LIST,
+                        "1:" + nexthop_oid,
+                    ),
+                    (
+                        self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST,
+                        "1:" + str(self._p4rt_wcmp_group_obj.DEFAULT_WEIGHT),
+                    )
+                ]
+                util.verify_attr(fvs, asic_attr_list)
+
+        # Bring down the port.
+        util.set_interface_status(dvs, if_name)
+
+        # Program 30 of the groups
+        for i in range(30):
+            wcmp_group_id = "group-" + str(i)
+            action = self._p4rt_wcmp_group_obj.DEFAULT_ACTION
+            action1 = {
+                self._p4rt_wcmp_group_obj.ACTION_FIELD: action,
+            }
+            actions = [action1]
+            attr_list = [
+                (self._p4rt_wcmp_group_obj.ACTIONS_FIELD, json.dumps(actions))]
+            wcmp_group_key = self._p4rt_wcmp_group_obj.generate_app_db_key(
+                wcmp_group_id)
+            self._p4rt_wcmp_group_obj.set_app_db_entry(
+                wcmp_group_key, attr_list)
+
+        # Expect 40 groups to be updated in ASIC DB.
+        for group in wcmp_group_entries:
+            if group not in original_wcmp_group_entries:
+                (status, fvs) = util.get_key(
+                    self._p4rt_wcmp_group_obj.asic_db,
+                    self._p4rt_wcmp_group_obj.ASIC_DB_GROUP_TBL_NAME,
+                    group,
+                )
+                assert status == True
+                asic_attr_list = [
+                    (
+                        self._p4rt_wcmp_group_obj.SAI_ATTR_GROUP_TYPE,
+                        (
+                            self._p4rt_wcmp_group_obj.SAI_NEXT_HOP_GROUP_TYPE_ECMP_WITH_MEMBERS
+                        ),
+                    ),
+                    (
+                        self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_LIST,
+                        "0:null",
+                    ),
+                    (
+                        self._p4rt_wcmp_group_obj.SAI_ATTR_NEXT_HOP_MEMBER_WEIGHT_LIST,
+                        "0:null",
+                    )
+                ]
+                util.verify_attr(fvs, asic_attr_list)
+
+        # Delete the 40 wcmp groups
+        for wcmp_group_key in wcmp_group_keys:
+            self._p4rt_wcmp_group_obj.remove_app_db_entry(wcmp_group_key)
 
         # Delete next hop.
         self._p4rt_nexthop_obj.remove_app_db_entry(nexthop_key)


### PR DESCRIPTION
**What I did**
Add Event based executor.
This PR introduces an asynchronous, event-driven mechanism for handling watchport status changes (port UP/DOWN) within the P4Orch and WcmpManager modules.

**Why I did it**
To Add functionality to improve watchport operation for large number of group update.
Previously, when a port state changed (e.g., a port flap), the WcmpManager would immediately attempt to update every WCMP group associated with that "watchport.
By moving to an event-based bulk processing model, we ensure the orchagent remains responsive and that hardware updates are handled efficiently.

**How I verified it**
Performed local builds and confirmed that all relevant unit tests passed successfully.

**Details if related**
