### PR TITLE
[countersyncd]: align multi-message netlink parsing

### DIFF
--- a/crates/countersyncd/src/actor/data_netlink.rs
+++ b/crates/countersyncd/src/actor/data_netlink.rs
@@ -76,6 +76,7 @@ impl NetlinkMessageParser {
         }
     }
 
+    /// Mirrors `NLMSG_ALIGN` from `linux/netlink.h` by rounding lengths up to the next 4-byte boundary.
     fn nlmsg_align(len: usize) -> usize {
         (len + 3) & !3
     }


### PR DESCRIPTION
## What I did
- advance to the next netlink message using 4-byte alignment instead of raw `nlmsg_len`
- keep payload extraction bounded by the original message length (exclude padding)
- add a unit test that covers multiple messages in one recv buffer where the first message requires netlink padding

## Why
Linux netlink messages are 4-byte aligned, and the canonical `NLMSG_NEXT()` macro advances by `NLMSG_ALIGN(nlmsg_len)`. Advancing by raw `nlmsg_len` can misread the next header when a recv buffer contains multiple messages and one message length is not already aligned.

## Validation
Ran in CI-like `sonic-slave-bookworm` container with Azure Pipelines deb artifacts installed:
- `cargo test --locked --manifest-path crates/countersyncd/Cargo.toml test_multiple_aligned_messages_in_buffer -- --nocapture`
- `cargo test --locked --manifest-path crates/countersyncd/Cargo.toml test_multiple_messages_in_buffer -- --nocapture`
- `cargo test --locked --manifest-path crates/countersyncd/Cargo.toml test_fragmented_message -- --nocapture`
