### PR TITLE
[intfmgrd]: Replay IPv6 link-local address on interface admin up

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -1236,6 +1236,11 @@ void IntfMgr::doPortTableTask(const string& key, vector<FieldValueTuple> data, s
             {
                 SWSS_LOG_INFO("Port %s Admin %s", key.c_str(), value.c_str());
                 updateSubIntfAdminStatus(key, value);
+
+                if (value == "up")
+                {
+                    replayLLIntfAddresses(key);
+                }
             }
             else if (field == "mtu")
             {
@@ -1254,4 +1259,40 @@ bool IntfMgr::enableIpv6Flag(const string &alias)
     int ret = swss::exec(cmd.str(), temp_res);
     SWSS_LOG_INFO("disable_ipv6 flag is set to 0 for iface: %s, cmd: %s, ret: %d", alias.c_str(), cmd.str().c_str(), ret);
     return (ret == 0) ? true : false;
+}
+
+void IntfMgr::replayLLIntfAddresses(const string &alias)
+{
+    // Determine which CONFIG_DB table to use based on interface type
+    Table *cfgTable;
+    if (!alias.compare(0, strlen(VLAN_PREFIX), VLAN_PREFIX))
+    {
+        cfgTable = &m_cfgVlanIntfTable;
+    }
+    else if (!alias.compare(0, strlen(LAG_PREFIX), LAG_PREFIX))
+    {
+        cfgTable = &m_cfgLagIntfTable;
+    }
+    else
+    {
+        cfgTable = &m_cfgIntfTable;
+    }
+
+    vector<string> keys;
+    cfgTable->getKeys(keys);
+
+    for (const auto &key : keys)
+    {
+        auto tokens = tokenize(key, config_db_key_delimiter);
+        if (tokens.size() == 2 && tokens[0] == alias)
+        {
+            IpPrefix ipPrefix(tokens[1]);
+            if (!ipPrefix.isV4() && ipPrefix.getIp().getAddrScope() == IpAddress::AddrScope::LINK_SCOPE)
+            {
+                setIntfIp(alias, "add", ipPrefix);
+                SWSS_LOG_INFO("Replayed IPv6 link-local address %s on interface %s after admin up",
+                    tokens[1].c_str(), alias.c_str());
+            }
+        }
+    }
 }

--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -77,6 +77,7 @@ private:
     void updateSubIntfAdminStatus(const std::string &alias, const std::string &admin);
     void updateSubIntfMtu(const std::string &alias, const std::string &mtu);
     bool enableIpv6Flag(const std::string&);
+    void replayLLIntfAddresses(const std::string &alias);
 
     bool m_replayDone {false};
 };

--- a/tests/mock_tests/intfmgrd/intfmgr_ut.cpp
+++ b/tests/mock_tests/intfmgrd/intfmgr_ut.cpp
@@ -127,4 +127,84 @@ namespace intfmgr_ut
         intfmgr.m_statePortTable.set("Ethernet64.10", values, "SET", "");
         EXPECT_THROW(intfmgr.setHostSubIntfAdminStatus("Ethernet64.10", "up", "up"), std::runtime_error);
     }
+
+    TEST_F(IntfMgrTest, testReplayLLIpv6AddressOnAdminUp){
+        Ethernet0IPv6Set = true;
+        swss::IntfMgr intfmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_intf_tables);
+
+        /* Add an IPv6 link-local address entry in CONFIG_DB INTERFACE table */
+        std::vector<swss::FieldValueTuple> values;
+        values.emplace_back("family", "IPv6");
+        intfmgr.m_cfgIntfTable.set("Ethernet0|fe80::1/64", values, "SET", "");
+
+        /* Also add a global IPv6 address — this should NOT be replayed */
+        values.clear();
+        values.emplace_back("family", "IPv6");
+        intfmgr.m_cfgIntfTable.set("Ethernet0|2001::8/64", values, "SET", "");
+
+        /* Also add an IPv4 address — this should NOT be replayed */
+        values.clear();
+        values.emplace_back("family", "IPv4");
+        intfmgr.m_cfgIntfTable.set("Ethernet0|10.0.0.1/31", values, "SET", "");
+
+        mockCallArgs.clear();
+
+        /* Simulate admin up by calling doPortTableTask */
+        std::vector<swss::FieldValueTuple> portData;
+        portData.emplace_back("admin_status", "up");
+        intfmgr.doPortTableTask("Ethernet0", portData, "SET");
+
+        /* Verify that only IPv6 link-local address add was called */
+        int ipv6_ll_add_called = 0;
+        int ipv6_global_add_called = 0;
+        int ipv4_add_called = 0;
+        for (const auto &cmd : mockCallArgs)
+        {
+            if (cmd.find("/sbin/ip -6 address \"add\"") != std::string::npos &&
+                cmd.find("fe80::1/64") != std::string::npos)
+            {
+                ipv6_ll_add_called++;
+            }
+            if (cmd.find("/sbin/ip -6 address \"add\"") != std::string::npos &&
+                cmd.find("2001::8/64") != std::string::npos)
+            {
+                ipv6_global_add_called++;
+            }
+            if (cmd.find("/sbin/ip address \"add\"") != std::string::npos &&
+                cmd.find("10.0.0.1/31") != std::string::npos)
+            {
+                ipv4_add_called++;
+            }
+        }
+        ASSERT_EQ(ipv6_ll_add_called, 1);
+        ASSERT_EQ(ipv6_global_add_called, 0);
+        ASSERT_EQ(ipv4_add_called, 0);
+    }
+
+    TEST_F(IntfMgrTest, testNoReplayLLOnAdminDown){
+        Ethernet0IPv6Set = true;
+        swss::IntfMgr intfmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_intf_tables);
+
+        /* Add an IPv6 link-local address entry in CONFIG_DB INTERFACE table */
+        std::vector<swss::FieldValueTuple> values;
+        values.emplace_back("family", "IPv6");
+        intfmgr.m_cfgIntfTable.set("Ethernet0|fe80::1/64", values, "SET", "");
+
+        mockCallArgs.clear();
+
+        /* Simulate admin down — should NOT trigger replay */
+        std::vector<swss::FieldValueTuple> portData;
+        portData.emplace_back("admin_status", "down");
+        intfmgr.doPortTableTask("Ethernet0", portData, "SET");
+
+        int ipv6_add_called = 0;
+        for (const auto &cmd : mockCallArgs)
+        {
+            if (cmd.find("/sbin/ip -6 address \"add\"") != std::string::npos)
+            {
+                ipv6_add_called++;
+            }
+        }
+        ASSERT_EQ(ipv6_add_called, 0);
+    }
 }


### PR DESCRIPTION
## Description
When an interface has an explicitly configured IPv6 link-local address (fe80::/10) and the interface is shut then no-shut, the kernel removes the link-local address on admin down but nothing restores it on admin up.

### Root Cause
`intfmgrd` processes CONFIG_DB INTERFACE table entries and programs addresses into the kernel via `setIntfIp()`. However, `doPortTableTask()` only propagated admin status to sub-interfaces — it had no mechanism to replay configured addresses when a port came back up. The kernel auto-removes IPv6 link-local addresses on admin down, leaving the configured address missing after no-shut.

### Fix
Add `replayLLIntfAddresses()` to `IntfMgr` that is triggered in `doPortTableTask()` when admin status transitions to `up`. It:
1. Looks up the interface's CONFIG_DB table (INTERFACE / VLAN_INTERFACE / PORTCHANNEL_INTERFACE)
2. Finds configured IPv6 link-local addresses (fe80::/10 scope)
3. Re-programs them into the kernel via `setIntfIp()`

### Testing
- Added `testReplayLLIpv6AddressOnAdminUp` — verifies fe80 link-local addresses are replayed on admin up, while global IPv6 and IPv4 addresses are not
- Added `testNoReplayLLOnAdminDown` — verifies no replay occurs on admin down

Fixes #4323