### PR TITLE
Optimize memory usage in ResponsePublisher queue

### DIFF
--- a/orchagent/response_publisher.h
+++ b/orchagent/response_publisher.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <condition_variable>
+#include <list>
 #include <memory>
 #include <mutex>
 #include <queue>
@@ -98,7 +99,7 @@ class ResponsePublisher : public ResponsePublisherInterface
     bool m_buffered{false};
     // Thread to write to DB.
     std::unique_ptr<std::thread> m_update_thread;
-    std::queue<entry> m_queue;
+    std::queue<entry, std::list<entry>> m_queue;
     mutable std::mutex m_lock;
     std::condition_variable m_signal;
 };


### PR DESCRIPTION
**What I did**

Replaced `std::queue<entry>` with `std::queue<entry, std::list<entry>>` in `ResponsePublisher::m_queue`.

**Why I did it**

`ResponsePublisher` uses a threaded producer-consumer pattern: the main orchagent thread pushes entry objects (containing `std::string` members and `std::vector<FieldValueTuple>`), and a background `dbUpdateThread` pops and writes them to the DB.

`std::deque` allocates memory in fixed-size chunks and never releases them, even after all elements are popped. During bursts of state updates, the queue grows and this memory persists even after draining. Since orchagent is a long-running daemon on memory-constrained network switches, this accumulated memory is never reclaimed.

`std::list` frees memory incrementally as each entry is popped, keeping usage proportional to actual queue depth. The per-node overhead of `std::list` (~16 bytes) is negligible relative to the entry size (3 strings + 1 vector + 3 bools).

**How I verified it**

Pass all existing test cases. The container change is a drop-in replacement — `std::queue` API is identical regardless of underlying container.
