### PR TITLE
[swss]:Skip APPL_STATE_DB and pub/sub writes when FIB suppression is disabled

### DIFF
--- a/fpmsyncd/fpmsyncd.cpp
+++ b/fpmsyncd/fpmsyncd.cpp
@@ -8,7 +8,6 @@
 #include "netdispatcher.h"
 #include "netlink.h"
 #include "notificationconsumer.h"
-#include "subscriberstatetable.h"
 #include "warmRestartHelper.h"
 #include "fpmsyncd/fpmlink.h"
 #include "fpmsyncd/fpmsyncd.h"
@@ -79,7 +78,6 @@ int main(int argc, char **argv)
 
     DBConnector db("APPL_DB", 0);
     DBConnector cfgDb("CONFIG_DB", 0);
-    SubscriberStateTable deviceMetadataTableSubscriber(&cfgDb, CFG_DEVICE_METADATA_TABLE_NAME);
     Table deviceMetadataTable(&cfgDb, CFG_DEVICE_METADATA_TABLE_NAME);
     DBConnector applStateDb("APPL_STATE_DB", 0);
     std::unique_ptr<NotificationConsumer> routeResponseChannel;
@@ -118,6 +116,7 @@ int main(int argc, char **argv)
         routeResponseChannel = std::make_unique<NotificationConsumer>(&applStateDb, routeResponseChannelName);
         sync.setSuppressionEnabled(true);
     }
+    SWSS_LOG_NOTICE("FIB suppression state: %s", suppressionEnabledStr.c_str());
 
     while (true)
     {
@@ -144,8 +143,6 @@ int main(int argc, char **argv)
 
             s.addSelectable(&fpm);
             s.addSelectable(&netlink);
-            s.addSelectable(&deviceMetadataTableSubscriber);
-
             if (sync.isSuppressionEnabled())
             {
                 s.addSelectable(routeResponseChannel.get());
@@ -250,61 +247,6 @@ int main(int argc, char **argv)
                     {
                         s.removeSelectable(&eoiuCheckTimer);
                     }
-                }
-                else if (temps == &deviceMetadataTableSubscriber)
-                {
-                    std::deque<KeyOpFieldsValuesTuple> keyOpFvsQueue;
-                    deviceMetadataTableSubscriber.pops(keyOpFvsQueue);
-
-                    for (const auto& keyOpFvs: keyOpFvsQueue)
-                    {
-                        const auto& key = kfvKey(keyOpFvs);
-                        const auto& op = kfvOp(keyOpFvs);
-                        const auto& fvs = kfvFieldsValues(keyOpFvs);
-
-                        if (op != SET_COMMAND)
-                        {
-                            continue;
-                        }
-
-                        if (key != "localhost")
-                        {
-                            continue;
-                        }
-
-                        for (const auto& fv: fvs)
-                        {
-                            const auto& field = fvField(fv);
-                            const auto& value = fvValue(fv);
-
-                            if (field != "suppress-fib-pending")
-                            {
-                                continue;
-                            }
-
-                            bool shouldEnable = (value == "enabled");
-
-                            if (shouldEnable && !sync.isSuppressionEnabled())
-                            {
-                                routeResponseChannel = std::make_unique<NotificationConsumer>(&applStateDb, routeResponseChannelName);
-                                sync.setSuppressionEnabled(true);
-                                s.addSelectable(routeResponseChannel.get());
-                            }
-                            else if (!shouldEnable && sync.isSuppressionEnabled())
-                            {
-                                /* When disabling suppression we mark all existing routes offloaded in zebra
-                                 * as there could be some transient routes which are pending response from
-                                 * orchagent, thus such updates might be missing. Since we are disabling suppression
-                                 * we no longer care about real HW offload status and can mark all routes as offloaded
-                                 * to avoid routes stuck in suppressed state after transition. */
-                                sync.markRoutesOffloaded(db);
-
-                                sync.setSuppressionEnabled(false);
-                                s.removeSelectable(routeResponseChannel.get());
-                                routeResponseChannel.reset();
-                            }
-                        } // end for fvs
-                    } // end for keyOpFvsQueue
                 }
                 else if (routeResponseChannel && (temps == routeResponseChannel.get()))
                 {

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -59,6 +59,7 @@ extern int gBatchSize;
 
 bool gRingMode = false;
 bool gSyncMode = false;
+bool gEnableFibSuppress = false;
 sai_redis_communication_mode_t gRedisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC;
 string gAsicInstance;
 
@@ -91,7 +92,7 @@ bool isChassisDbInUse()
 
 void usage()
 {
-    cout << "usage: orchagent [-h] [-r record_type] [-A] [-d record_location] [-f swss_rec_filename] [-j sairedis_rec_filename] [-b batch_size] [-m MAC] [-i INST_ID] [-s] [-z mode] [-k bulk_size] [-q zmq_server_address] [-c mode] [-t create_switch_timeout] [-v VRF] [-I heart_beat_interval] [-R] [-M]" << endl;
+    cout << "usage: orchagent [-h] [-r record_type] [-A] [-d record_location] [-f swss_rec_filename] [-j sairedis_rec_filename] [-b batch_size] [-m MAC] [-i INST_ID] [-s] [-z mode] [-k bulk_size] [-q zmq_server_address] [-c mode] [-t create_switch_timeout] [-v VRF] [-I heart_beat_interval] [-R] [-M] [-F]" << endl;
     cout << "    -h: display this message" << endl;
     cout << "    -r record_type: record orchagent logs with type (default 3)" << endl;
     cout << "                    Bit 0: sairedis.rec, Bit 1: swss.rec, Bit 2: responsepublisher.rec. For example:" << endl;
@@ -117,6 +118,7 @@ void usage()
     cout << "    -I heart_beat_interval: Heart beat interval in millisecond (default 10)" << endl;
     cout << "    -R enable the ring thread feature" << endl;
     cout << "    -M enable SAI MACSec POST" << endl;
+    cout << "    -F enable BGP FIB suppression" << endl;
 }
 
 void sighup_handler(int signo)
@@ -468,7 +470,7 @@ int main(int argc, char **argv)
     // Disable SAI MACSec POST by default. Use option -M to enable it.
     bool macsec_post_enabled = false;
 
-    while ((opt = getopt(argc, argv, "b:m:r:Af:j:d:i:hsz:k:q:c:t:v:I:RM")) != -1)
+    while ((opt = getopt(argc, argv, "b:m:r:Af:j:d:i:hsz:k:q:c:t:v:I:RMF")) != -1)
     {
         switch (opt)
         {
@@ -594,6 +596,9 @@ int main(int argc, char **argv)
          case 'M':
             macsec_post_enabled = true;
             break;
+        case 'F': // LCOV_EXCL_LINE
+            gEnableFibSuppress = true; // LCOV_EXCL_LINE
+            break; // LCOV_EXCL_LINE
         default: /* '?' */
             exit(EXIT_FAILURE);
         }

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -34,6 +34,7 @@ extern TunnelDecapOrch *gTunneldecapOrch;
 extern size_t gMaxBulkSize;
 extern string gMySwitchType;
 extern bool gRouteStateAsyncPublish;
+extern bool gEnableFibSuppress;
 
 /* Default maximum number of next hop groups */
 #define DEFAULT_NUMBER_OF_ECMP_GROUPS   128
@@ -3201,6 +3202,11 @@ void RouteOrch::decNhgRefCount(const std::string &nhg_index, const std::string &
 void RouteOrch::publishRouteState(const RouteBulkContext& ctx, const ReturnCode& status)
 {
     SWSS_LOG_ENTER();
+
+    if (!gEnableFibSuppress)
+    {
+        return;
+    }
 
     std::vector<FieldValueTuple> fvs;
 

--- a/tests/mock_tests/mock_orchagent_main.cpp
+++ b/tests/mock_tests/mock_orchagent_main.cpp
@@ -21,6 +21,7 @@ string gMyAsicName = "Asic0";
 bool gTraditionalFlexCounter = false;
 bool gRouteStateAsyncPublish = false;
 bool gSyncMode = false;
+bool gEnableFibSuppress = false;
 sai_redis_communication_mode_t gRedisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC;
 
 VRFOrch *gVrfOrch;

--- a/tests/mock_tests/routeorch_ut.cpp
+++ b/tests/mock_tests/routeorch_ut.cpp
@@ -12,6 +12,7 @@
 #include "bulker.h"
 
 extern string gMySwitchType;
+extern bool gEnableFibSuppress;
 
 extern std::unique_ptr<MockResponsePublisher> gMockResponsePublisher;
 
@@ -411,6 +412,8 @@ namespace routeorch_test
 
         void TearDown() override
         {
+            gEnableFibSuppress = false;
+
             RestoreSaiApis();
             DEINIT_SAI_API_MOCK(route);
             DEINIT_SAI_API_MOCK(next_hop_group);
@@ -876,6 +879,7 @@ namespace routeorch_test
 
     TEST_F(RouteOrchTest, RouteOrchTestSetDelResponse)
     {
+        gEnableFibSuppress = true;
         gMockResponsePublisher = std::make_unique<MockResponsePublisher>();
 
         std::deque<KeyOpFieldsValuesTuple> entries;
@@ -912,6 +916,7 @@ namespace routeorch_test
 
     TEST_F(RouteOrchTest, RouteOrchSetFullMaskSubnetPrefix)
     {
+        gEnableFibSuppress = true;
         gMockResponsePublisher = std::make_unique<MockResponsePublisher>();
 
         std::deque<KeyOpFieldsValuesTuple> entries;
@@ -930,6 +935,7 @@ namespace routeorch_test
 
     TEST_F(RouteOrchTest, RouteOrchLoopbackRoute)
     {
+        gEnableFibSuppress = true;
         gMockResponsePublisher = std::make_unique<MockResponsePublisher>();
 
         std::deque<KeyOpFieldsValuesTuple> entries;

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -6,7 +6,7 @@ import pytest
 import ipaddress
 
 from swsscommon import swsscommon
-from dvslib.dvs_common import wait_for_result
+from dvslib.dvs_common import wait_for_result, PollingConfig
 
 class TestRouteBase(object):
     def setup_db(self, dvs):
@@ -1077,22 +1077,55 @@ class TestFpmSyncResponse(TestRouteBase):
         route_entry = json.loads(output)
         return bool(route_entry[route][0].get('offloaded'))
 
-    @pytest.mark.xfail(reason="BGP suppress FIB disabled on master/202405 - https://github.com/sonic-net/sonic-buildimage/issues/19092")
+    def wait_for_nexthop_reachable(self, dvs, nexthop):
+        # Poll until the interface IP is reprogrammed and the peer is reachable again.
+        def _nexthop_reachable():
+            rc, _ = dvs.runcmd(f"ping -c 1 -W 1 {nexthop}")
+            return (rc == 0, None)
+
+        wait_for_result(
+            _nexthop_reachable,
+            PollingConfig(polling_interval=1, timeout=60, strict=True),
+            failure_message=f"Nexthop {nexthop} not reachable after swss/fpmsyncd restart",
+        )
+
+    def configure_orchagent_fib_suppress(self, dvs, suppress_state):
+        # Until sonic-buildimage#26151 lands, the DVS image does not read
+        # suppress-fib-pending from CONFIG_DB and pass -F to orchagent at startup.
+        # Patch orchagent.sh here (same pattern as test_zmq.py flag coverage tests).
+        ORCHAGENT_SH_BACKUP = "/usr/bin/orchagent.sh_fib_suppress_ut_backup"
+        if suppress_state == "enabled":
+            rc, _ = dvs.runcmd(["sh", "-c", f"test -f {ORCHAGENT_SH_BACKUP} || cp /usr/bin/orchagent.sh {ORCHAGENT_SH_BACKUP}"])
+            assert rc == 0, "Failed to back up orchagent.sh"
+            rc, _ = dvs.runcmd("sed -i.bak 's|/usr/bin/orchagent |/usr/bin/orchagent -F |g' /usr/bin/orchagent.sh")
+            assert rc == 0, "Failed to patch orchagent.sh with -F flag"
+        else:
+            rc, _ = dvs.runcmd(["sh", "-c", f"test -f {ORCHAGENT_SH_BACKUP}"])
+            if rc == 0:
+                rc, _ = dvs.runcmd(f"cp {ORCHAGENT_SH_BACKUP} /usr/bin/orchagent.sh")
+                assert rc == 0, "Failed to restore orchagent.sh"
+
     @pytest.mark.parametrize("suppress_state", ["enabled", "disabled"])
     def test_offload(self, suppress_state, setup, dvs):
         route = "1.1.1.0/24"
 
-        # enable route suppression
-        rc, _ = dvs.runcmd(f"config suppress-fib-pending {suppress_state}")
-        assert rc == 0, "Failed to configure suppress-fib-pending"
-
-        time.sleep(5)
-
         try:
+            rc, _ = dvs.runcmd(f"config suppress-fib-pending {suppress_state}")
+            assert rc == 0, "Failed to configure suppress-fib-pending"
+
+            self.configure_orchagent_fib_suppress(dvs, suppress_state)
+
+            rc, _ = dvs.runcmd("config save -y")
+            assert rc == 0, "Failed to save config"
+
+            dvs.restart()
+
+            self.wait_for_nexthop_reachable(dvs, "10.0.0.1")
+
             rc, _ = dvs.runcmd("bash -c 'kill -SIGSTOP $(pidof orchagent)'")
             assert rc == 0, "Failed to suspend orchagent"
 
-            rc, _ = dvs.runcmd(f"ip route add {route} via 10.0.0.1 proto bgp")
+            rc, _ = dvs.runcmd(f'vtysh -c "configure terminal" -c "ip route {route} 10.0.0.1"')
             assert rc == 0, "Failed to configure route"
 
             time.sleep(5)
@@ -1112,10 +1145,17 @@ class TestFpmSyncResponse(TestRouteBase):
             wait_for_result(check_offloaded, failure_message=f"{route} is expected to be offloaded after orchagent resume")
         finally:
             dvs.runcmd("bash -c 'kill -SIGCONT $(pidof orchagent)'")
-            dvs.runcmd(f"ip route del {route}")
+            dvs.runcmd(f'vtysh -c "configure terminal" -c "no ip route {route} 10.0.0.1"')
 
-            # make sure route suppression is disabled
-            dvs.runcmd("config suppress-fib-pending disabled")
+            rc, _ = dvs.runcmd("config suppress-fib-pending disabled")
+            assert rc == 0, "Failed to disable suppress-fib-pending during cleanup"
+
+            self.configure_orchagent_fib_suppress(dvs, "disabled")
+
+            rc, _ = dvs.runcmd("config save -y")
+            assert rc == 0, "Failed to save config during cleanup"
+
+            dvs.restart()
 
 
 class TestSubnetDecapVipRoute(TestRouteBase):


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**Why I did it**

Route download speed degraded after BGP prefix suppression was introduced. RouteOrch::publishRouteState() unconditionally writes to APPL_STATE_DB and sends a pub/sub notification on every route add/remove, even when FIB suppression is disabled and no consumer needs the data.


**What I did**

Made publishRouteState() a no-op until FIB suppression is enabled.

Made "suppress-fib-pending" config changes take effect only after swss restart or config reload, 
not dynamically at runtime. This eliminates multi-process race conditions between orchagent, fpmsyncd, and FRR.

Detailed description:

The CLI (config suppress-fib-pending) writes to DEVICE_METADATA and prints a message telling the user to perform config save and config reload  for the change to take effect. This is in the sonic-utilities PR (#4361).

Detailed Changes in this PR:
- orchagent: add -F command-line flag (gEnableFibSuppress) to control FIB suppression at startup; guard publishRouteState() to return early when suppression is disabled
- fpmsyncd: read orchagent's FIB suppression state from CONFIG_DB at startup instead of using CONFIG_DB subscription; remove dynamic CONFIG_DB subscription.

**How I verified it**
UT and sonic-mgmt  script.

**Details if related**
This change needs to go together with 
https://github.com/sonic-net/sonic-buildimage/pull/26151
https://github.com/sonic-net/sonic-utilities/pull/4361
https://github.com/sonic-net/sonic-mgmt/pull/22916
https://github.com/sonic-net/SONiC/pull/2335