### PR TITLE
[intfmgrd]: Replay IPv6 link-local address on interface admin up

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -1236,6 +1236,11 @@ void IntfMgr::doPortTableTask(const string& key, vector<FieldValueTuple> data, s
             {
                 SWSS_LOG_INFO("Port %s Admin %s", key.c_str(), value.c_str());
                 updateSubIntfAdminStatus(key, value);
+
+                if (value == "up")
+                {
+                    replayLLIntfAddresses(key);
+                }
             }
             else if (field == "mtu")
             {
@@ -1254,4 +1259,40 @@ bool IntfMgr::enableIpv6Flag(const string &alias)
     int ret = swss::exec(cmd.str(), temp_res);
     SWSS_LOG_INFO("disable_ipv6 flag is set to 0 for iface: %s, cmd: %s, ret: %d", alias.c_str(), cmd.str().c_str(), ret);
     return (ret == 0) ? true : false;
+}
+
+void IntfMgr::replayLLIntfAddresses(const string &alias)
+{
+    // Determine which CONFIG_DB table to use based on interface type
+    Table *cfgTable;
+    if (!alias.compare(0, strlen(VLAN_PREFIX), VLAN_PREFIX))
+    {
+        cfgTable = &m_cfgVlanIntfTable;
+    }
+    else if (!alias.compare(0, strlen(LAG_PREFIX), LAG_PREFIX))
+    {
+        cfgTable = &m_cfgLagIntfTable;
+    }
+    else
+    {
+        cfgTable = &m_cfgIntfTable;
+    }
+
+    vector<string> keys;
+    cfgTable->getKeys(keys);
+
+    for (const auto &key : keys)
+    {
+        auto tokens = tokenize(key, config_db_key_delimiter);
+        if (tokens.size() == 2 && tokens[0] == alias)
+        {
+            IpPrefix ipPrefix(tokens[1]);
+            if (!ipPrefix.isV4() && ipPrefix.getIp().getAddrScope() == IpAddress::AddrScope::LINK_SCOPE)
+            {
+                setIntfIp(alias, "add", ipPrefix);
+                SWSS_LOG_INFO("Replayed IPv6 link-local address %s on interface %s after admin up",
+                    tokens[1].c_str(), alias.c_str());
+            }
+        }
+    }
 }

--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -1120,6 +1120,11 @@ bool IntfMgr::doIntfAddrTask(const vector<string>& keys,
 
         setIntfIp(alias, "add", ip_prefix);
 
+        if (!ip_prefix.isV4() && ip_prefix.getIp().getAddrScope() == IpAddress::AddrScope::LINK_SCOPE)
+        {
+            m_intfLLAddresses[alias].insert(ip_prefix.to_string());
+        }
+
         std::vector<FieldValueTuple> fvVector;
         FieldValueTuple f("family", ip_prefix.isV4() ? IPV4_NAME : IPV6_NAME);
 
@@ -1136,6 +1141,19 @@ bool IntfMgr::doIntfAddrTask(const vector<string>& keys,
     else if (op == DEL_COMMAND)
     {
         setIntfIp(alias, "del", ip_prefix);
+
+        if (!ip_prefix.isV4() && ip_prefix.getIp().getAddrScope() == IpAddress::AddrScope::LINK_SCOPE)
+        {
+            auto it = m_intfLLAddresses.find(alias);
+            if (it != m_intfLLAddresses.end())
+            {
+                it->second.erase(ip_prefix.to_string());
+                if (it->second.empty())
+                {
+                    m_intfLLAddresses.erase(it);
+                }
+            }
+        }
 
         // Don't send ipv4 link local config to AppDB and Orchagent
         if ((ip_prefix.isV4() == false) || (ip_prefix.getIp().getAddrScope() != IpAddress::AddrScope::LINK_SCOPE))
@@ -1237,7 +1255,7 @@ void IntfMgr::doPortTableTask(const string& key, vector<FieldValueTuple> data, s
                 SWSS_LOG_INFO("Port %s Admin %s", key.c_str(), value.c_str());
                 updateSubIntfAdminStatus(key, value);
 
-                if (value == "up")
+                if (value == "up" && m_intfLLAddresses.count(key) > 0)
                 {
                     replayLLIntfAddresses(key);
                 }
@@ -1263,36 +1281,17 @@ bool IntfMgr::enableIpv6Flag(const string &alias)
 
 void IntfMgr::replayLLIntfAddresses(const string &alias)
 {
-    // Determine which CONFIG_DB table to use based on interface type
-    Table *cfgTable;
-    if (!alias.compare(0, strlen(VLAN_PREFIX), VLAN_PREFIX))
+    auto it = m_intfLLAddresses.find(alias);
+    if (it == m_intfLLAddresses.end())
     {
-        cfgTable = &m_cfgVlanIntfTable;
-    }
-    else if (!alias.compare(0, strlen(LAG_PREFIX), LAG_PREFIX))
-    {
-        cfgTable = &m_cfgLagIntfTable;
-    }
-    else
-    {
-        cfgTable = &m_cfgIntfTable;
+        return;
     }
 
-    vector<string> keys;
-    cfgTable->getKeys(keys);
-
-    for (const auto &key : keys)
+    for (const auto &addr : it->second)
     {
-        auto tokens = tokenize(key, config_db_key_delimiter);
-        if (tokens.size() == 2 && tokens[0] == alias)
-        {
-            IpPrefix ipPrefix(tokens[1]);
-            if (!ipPrefix.isV4() && ipPrefix.getIp().getAddrScope() == IpAddress::AddrScope::LINK_SCOPE)
-            {
-                setIntfIp(alias, "add", ipPrefix);
-                SWSS_LOG_INFO("Replayed IPv6 link-local address %s on interface %s after admin up",
-                    tokens[1].c_str(), alias.c_str());
-            }
-        }
+        IpPrefix ipPrefix(addr);
+        setIntfIp(alias, "add", ipPrefix);
+        SWSS_LOG_INFO("Replayed IPv6 link-local address %s on interface %s after admin up",
+            addr.c_str(), alias.c_str());
     }
 }

--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -77,6 +77,7 @@ private:
     void updateSubIntfAdminStatus(const std::string &alias, const std::string &admin);
     void updateSubIntfMtu(const std::string &alias, const std::string &mtu);
     bool enableIpv6Flag(const std::string&);
+    void replayLLIntfAddresses(const std::string &alias);
 
     bool m_replayDone {false};
 };

--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -37,6 +37,7 @@ private:
     std::set<std::string> m_loopbackIntfList;
     std::set<std::string> m_pendingReplayIntfList;
     std::set<std::string> m_ipv6LinkLocalModeList;
+    std::map<std::string, std::set<std::string>> m_intfLLAddresses;
     std::string mySwitchType;
 
     void setIntfIp(const std::string &alias, const std::string &opCmd, const IpPrefix &ipPrefix);

--- a/tests/mock_tests/intfmgrd/intfmgr_ut.cpp
+++ b/tests/mock_tests/intfmgrd/intfmgr_ut.cpp
@@ -127,4 +127,84 @@ namespace intfmgr_ut
         intfmgr.m_statePortTable.set("Ethernet64.10", values, "SET", "");
         EXPECT_THROW(intfmgr.setHostSubIntfAdminStatus("Ethernet64.10", "up", "up"), std::runtime_error);
     }
+
+    TEST_F(IntfMgrTest, testReplayLLIpv6AddressOnAdminUp){
+        Ethernet0IPv6Set = true;
+        swss::IntfMgr intfmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_intf_tables);
+
+        /* Add an IPv6 link-local address entry in CONFIG_DB INTERFACE table */
+        std::vector<swss::FieldValueTuple> values;
+        values.emplace_back("family", "IPv6");
+        intfmgr.m_cfgIntfTable.set("Ethernet0|fe80::1/64", values, "SET", "");
+
+        /* Also add a global IPv6 address — this should NOT be replayed */
+        values.clear();
+        values.emplace_back("family", "IPv6");
+        intfmgr.m_cfgIntfTable.set("Ethernet0|2001::8/64", values, "SET", "");
+
+        /* Also add an IPv4 address — this should NOT be replayed */
+        values.clear();
+        values.emplace_back("family", "IPv4");
+        intfmgr.m_cfgIntfTable.set("Ethernet0|10.0.0.1/31", values, "SET", "");
+
+        mockCallArgs.clear();
+
+        /* Simulate admin up by calling doPortTableTask */
+        std::vector<swss::FieldValueTuple> portData;
+        portData.emplace_back("admin_status", "up");
+        intfmgr.doPortTableTask("Ethernet0", portData, "SET");
+
+        /* Verify that only IPv6 link-local address add was called */
+        int ipv6_ll_add_called = 0;
+        int ipv6_global_add_called = 0;
+        int ipv4_add_called = 0;
+        for (const auto &cmd : mockCallArgs)
+        {
+            if (cmd.find("/sbin/ip -6 address \"add\"") != std::string::npos &&
+                cmd.find("fe80::1/64") != std::string::npos)
+            {
+                ipv6_ll_add_called++;
+            }
+            if (cmd.find("/sbin/ip -6 address \"add\"") != std::string::npos &&
+                cmd.find("2001::8/64") != std::string::npos)
+            {
+                ipv6_global_add_called++;
+            }
+            if (cmd.find("/sbin/ip address \"add\"") != std::string::npos &&
+                cmd.find("10.0.0.1/31") != std::string::npos)
+            {
+                ipv4_add_called++;
+            }
+        }
+        ASSERT_EQ(ipv6_ll_add_called, 1);
+        ASSERT_EQ(ipv6_global_add_called, 0);
+        ASSERT_EQ(ipv4_add_called, 0);
+    }
+
+    TEST_F(IntfMgrTest, testNoReplayLLOnAdminDown){
+        Ethernet0IPv6Set = true;
+        swss::IntfMgr intfmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_intf_tables);
+
+        /* Add an IPv6 link-local address entry in CONFIG_DB INTERFACE table */
+        std::vector<swss::FieldValueTuple> values;
+        values.emplace_back("family", "IPv6");
+        intfmgr.m_cfgIntfTable.set("Ethernet0|fe80::1/64", values, "SET", "");
+
+        mockCallArgs.clear();
+
+        /* Simulate admin down — should NOT trigger replay */
+        std::vector<swss::FieldValueTuple> portData;
+        portData.emplace_back("admin_status", "down");
+        intfmgr.doPortTableTask("Ethernet0", portData, "SET");
+
+        int ipv6_add_called = 0;
+        for (const auto &cmd : mockCallArgs)
+        {
+            if (cmd.find("/sbin/ip -6 address \"add\"") != std::string::npos)
+            {
+                ipv6_add_called++;
+            }
+        }
+        ASSERT_EQ(ipv6_add_called, 0);
+    }
 }

--- a/tests/mock_tests/intfmgrd/intfmgr_ut.cpp
+++ b/tests/mock_tests/intfmgrd/intfmgr_ut.cpp
@@ -132,20 +132,26 @@ namespace intfmgr_ut
         Ethernet0IPv6Set = true;
         swss::IntfMgr intfmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_intf_tables);
 
-        /* Add an IPv6 link-local address entry in CONFIG_DB INTERFACE table */
+        /* Set portStateTable and stateIntfTable so doIntfAddrTask proceeds */
         std::vector<swss::FieldValueTuple> values;
-        values.emplace_back("family", "IPv6");
-        intfmgr.m_cfgIntfTable.set("Ethernet0|fe80::1/64", values, "SET", "");
+        values.emplace_back("state", "ok");
+        intfmgr.m_statePortTable.set("Ethernet0", values, "SET", "");
+        values.clear();
+        values.emplace_back("vrf", "");
+        intfmgr.m_stateIntfTable.set("Ethernet0", values, "SET", "");
+
+        /* Add an IPv6 link-local address via doIntfAddrTask to populate the cache */
+        const std::vector<std::string> llKeys = {"Ethernet0", "fe80::1/64"};
+        const std::vector<swss::FieldValueTuple> emptyData;
+        intfmgr.doIntfAddrTask(llKeys, emptyData, "SET");
 
         /* Also add a global IPv6 address — this should NOT be replayed */
-        values.clear();
-        values.emplace_back("family", "IPv6");
-        intfmgr.m_cfgIntfTable.set("Ethernet0|2001::8/64", values, "SET", "");
+        const std::vector<std::string> globalKeys = {"Ethernet0", "2001::8/64"};
+        intfmgr.doIntfAddrTask(globalKeys, emptyData, "SET");
 
         /* Also add an IPv4 address — this should NOT be replayed */
-        values.clear();
-        values.emplace_back("family", "IPv4");
-        intfmgr.m_cfgIntfTable.set("Ethernet0|10.0.0.1/31", values, "SET", "");
+        const std::vector<std::string> ipv4Keys = {"Ethernet0", "10.0.0.1/31"};
+        intfmgr.doIntfAddrTask(ipv4Keys, emptyData, "SET");
 
         mockCallArgs.clear();
 
@@ -185,10 +191,18 @@ namespace intfmgr_ut
         Ethernet0IPv6Set = true;
         swss::IntfMgr intfmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_intf_tables);
 
-        /* Add an IPv6 link-local address entry in CONFIG_DB INTERFACE table */
+        /* Set portStateTable and stateIntfTable so doIntfAddrTask proceeds */
         std::vector<swss::FieldValueTuple> values;
-        values.emplace_back("family", "IPv6");
-        intfmgr.m_cfgIntfTable.set("Ethernet0|fe80::1/64", values, "SET", "");
+        values.emplace_back("state", "ok");
+        intfmgr.m_statePortTable.set("Ethernet0", values, "SET", "");
+        values.clear();
+        values.emplace_back("vrf", "");
+        intfmgr.m_stateIntfTable.set("Ethernet0", values, "SET", "");
+
+        /* Add an IPv6 link-local address via doIntfAddrTask to populate the cache */
+        const std::vector<std::string> llKeys = {"Ethernet0", "fe80::1/64"};
+        const std::vector<swss::FieldValueTuple> emptyData;
+        intfmgr.doIntfAddrTask(llKeys, emptyData, "SET");
 
         mockCallArgs.clear();
 

--- a/tests/mock_tests/intfmgrd/intfmgr_ut.cpp
+++ b/tests/mock_tests/intfmgrd/intfmgr_ut.cpp
@@ -185,6 +185,24 @@ namespace intfmgr_ut
         ASSERT_EQ(ipv6_ll_add_called, 1);
         ASSERT_EQ(ipv6_global_add_called, 0);
         ASSERT_EQ(ipv4_add_called, 0);
+
+        /* Now delete the link-local address and verify it is no longer replayed */
+        intfmgr.doIntfAddrTask(llKeys, emptyData, "DEL");
+        ASSERT_EQ(intfmgr.m_intfLLAddresses.count("Ethernet0"), 0u);
+
+        mockCallArgs.clear();
+        intfmgr.doPortTableTask("Ethernet0", portData, "SET");
+
+        ipv6_ll_add_called = 0;
+        for (const auto &cmd : mockCallArgs)
+        {
+            if (cmd.find("/sbin/ip -6 address \"add\"") != std::string::npos &&
+                cmd.find("fe80::1/64") != std::string::npos)
+            {
+                ipv6_ll_add_called++;
+            }
+        }
+        ASSERT_EQ(ipv6_ll_add_called, 0);
     }
 
     TEST_F(IntfMgrTest, testNoReplayLLOnAdminDown){
@@ -221,4 +239,5 @@ namespace intfmgr_ut
         }
         ASSERT_EQ(ipv6_add_called, 0);
     }
+
 }


### PR DESCRIPTION
## Description
When an interface is shut/no-shut, configured IPv6 link-local addresses are lost because the kernel removes them on admin-down but they are not replayed on admin-up.

This change:
1. Adds handling in `doPortTableTask` to detect admin-up events and replay IPv6 link-local addresses via `replayLLIntfAddresses()`
2. Tracks IPv6 link-local addresses in an in-memory cache (`m_intfLLAddresses`) populated during `doIntfAddrTask` add/del operations
3. On admin-up, replays cached link-local addresses

## Motivation
IPv6 link-local addresses configured via CONFIG_DB are removed by the kernel when the interface is administratively shut down. On admin-up, these addresses need to be re-applied.

## Changes
- **cfgmgr/intfmgr.cpp**: 
  - Track IPv6 link-local addresses in `m_intfLLAddresses` map during add/del
  - Conditionally call `replayLLIntfAddresses()` only when link-local addresses exist
  - Simplify `replayLLIntfAddresses()` to iterate the in-memory cache
- **cfgmgr/intfmgr.h**: Add `m_intfLLAddresses` member variable

Signed-off-by: Prince Sunny <prsunny@microsoft.com>