### PR TITLE
Replace EOL debian:jessie with debian:bookworm in VS tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -394,7 +394,7 @@ class DockerVirtualSwitch:
                 cr_prefix = os.environ['DEFAULT_CONTAINER_REGISTRY'].rstrip("/") + "/"
             else:
                 cr_prefix = ''
-            self.ctn_sw = self.client.containers.run(cr_prefix + "debian:jessie",
+            self.ctn_sw = self.client.containers.run(cr_prefix + "debian:bookworm",
                                                      privileged=True,
                                                      detach=True,
                                                      command="bash",


### PR DESCRIPTION
## What I changed
- Replaced \debian:jessie\ with \debian:bookworm\ in \	ests/conftest.py\ (line 397).

## Why
**Debian Jessie (Debian 8) has been End-of-Life since June 2018** and no longer receives security updates. The VS test framework uses this image to create minimal server containers for virtual switch testing. Any supported Debian image is compatible since the container only runs \ash\.

\debian:bookworm\ (Debian 12) is the current stable release with LTS support.

## Validation
- The change is a one-line image tag swap with no functional impact on test behavior.
- The container is started with \command=\"bash\"\, \privileged=True\, \stdin_open=True\ — no jessie-specific packages or features are used.

Fixes #4287