### PR TITLE
orchagent: Fix memory leak and UB in srv6orch sidlist handling

### DIFF
--- a/orchagent/srv6orch.cpp
+++ b/orchagent/srv6orch.cpp
@@ -2,6 +2,7 @@
 #include <sstream>
 #include <inttypes.h>
 #include <iterator>
+#include <memory>
 
 #include "routeorch.h"
 #include "logger.h"
@@ -1055,7 +1056,8 @@ bool Srv6Orch::createUpdateSidList(const string sid_name, const string sid_list,
         return true;
     }
     SWSS_LOG_INFO("Segment count %d", segment_list.count);
-    segment_list.list = new sai_ip6_t[segment_list.count];
+    auto segment_buf = std::make_unique<sai_ip6_t[]>(segment_list.count);
+    segment_list.list = segment_buf.get();
     uint32_t index = 0;
 
     for (string ip_str : sid_ips)
@@ -1112,7 +1114,6 @@ bool Srv6Orch::createUpdateSidList(const string sid_name, const string sid_list,
             return false;
         }
     }
-    delete segment_list.list;
     return true;
 }
 


### PR DESCRIPTION
**What I did**

Fixed a memory leak and undefined behavior in `Srv6Orch::createUpdateSidList()` by replacing raw `new[]`/`delete` with `std::unique_ptr`.

**Why I did it**

`segment_list.list` is allocated with `new sai_ip6_t[count]` but on two SAI error paths (`create_srv6_sidlist` and `set_srv6_sidlist_attribute` failures) the function returns `false` without freeing the allocation. Additionally, the success path uses plain `delete` instead of `delete[]` for an array allocation, which is undefined behavior per the C++ standard.

**How I fixed it**

Replaced the raw `new[]` allocation with `std::unique_ptr<sai_ip6_t[]>` (RAII). The buffer is now freed automatically on every exit path — no manual `delete` calls needed. This is leak-proof by construction, even if new error paths are added in the future.

**How I verified it**

Code inspection — the fix is mechanical. Pass all existing test cases. No behavioral change on the happy path.

Signed-off-by: Uma Ramanathan <uramanathan@upscaleai.com>