### PR TITLE
orchagent: Add missing end() check in VNetRouteOrch custom monitor lookup

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1186,9 +1186,12 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         std::map<NextHopKey, swss::IpAddress> origin_secondary_monitors;
         if (custom_monitor_ep_updated)
         {
-            auto it_route =  syncd_tunnel_routes_[vnet].find(ipPrefix);
-            getCustomMonitors(vnet, ipPrefix, it_route->second.primary, origin_primary_monitors);
-            getCustomMonitors(vnet, ipPrefix, it_route->second.secondary, origin_secondary_monitors);
+            auto it_route = syncd_tunnel_routes_[vnet].find(ipPrefix);
+            if (it_route != syncd_tunnel_routes_[vnet].end())
+            {
+                getCustomMonitors(vnet, ipPrefix, it_route->second.primary, origin_primary_monitors);
+                getCustomMonitors(vnet, ipPrefix, it_route->second.secondary, origin_secondary_monitors);
+            }
         }
 
         sai_object_id_t nh_id = SAI_NULL_OBJECT_ID;


### PR DESCRIPTION
**What I did**

Added a missing `end()` check before dereferencing a `find()` result in `VNetRouteOrch::doRouteTask()`.

**Why I did it**

`syncd_tunnel_routes_[vnet].find(ipPrefix)` is used without checking the iterator against `end()`. If the route is absent from `syncd_tunnel_routes_` while `custom_monitor_ep_updated` is true (e.g. due to a race between route deletion and monitor update), the unguarded dereference of `it_route->second` causes undefined behavior and can crash orchagent.

**How I verified it**

Code inspection. The fix wraps the two `getCustomMonitors()` calls in an `end()` check — no change to normal-path behavior when the route exists.

Signed-off-by: Uma Ramanathan <uramanathan@upscaleai.com>