### PR TITLE
[countersyncd]: Make it possible to configure the poll intervals

### DIFF
--- a/crates/countersyncd/src/actor/data_netlink.rs
+++ b/crates/countersyncd/src/actor/data_netlink.rs
@@ -348,8 +348,33 @@ impl DataNetlinkActor {
                 bytes,
                 std::io::Error::last_os_error()
             );
+            return;
+        }
+
+        // Read back the actual value — Linux may cap it at net.core.rmem_max and doubles it internally.
+        let mut actual: libc::c_int = 0;
+        let mut len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+        let ret = unsafe {
+            libc::getsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_RCVBUF,
+                &mut actual as *mut _ as *mut libc::c_void,
+                &mut len,
+            )
+        };
+        if ret != 0 {
+            warn!(
+                "Failed to read back SO_RCVBUF: {:?}",
+                std::io::Error::last_os_error()
+            );
         } else {
-            info!("Set netlink socket SO_RCVBUF to {} bytes", bytes);
+            info!(
+                "Netlink SO_RCVBUF: requested={} bytes, actual={} bytes{}",
+                bytes,
+                actual,
+                if (actual as usize) < bytes { " (capped by net.core.rmem_max — consider raising it)" } else { "" }
+            );
         }
     }
 

--- a/crates/countersyncd/src/actor/data_netlink.rs
+++ b/crates/countersyncd/src/actor/data_netlink.rs
@@ -56,8 +56,8 @@ const DEBUG_LOG_INTERVAL: u32 = 3000; // 3000 * 10ms = 30 seconds
 /// WouldBlock debug logging interval (in iterations) - log WouldBlock every minute
 const WOULDBLOCK_LOG_INTERVAL: u32 = 6000; // 6000 * 10ms = 1 minute
 
-/// Socket readiness check timeout in milliseconds
-const SOCKET_READINESS_TIMEOUT_MS: u64 = 10;
+/// Default socket readiness poll interval (ms) when not configured via CLI.
+const DEFAULT_SOCKET_READINESS_TIMEOUT_MS: u64 = 5;
 
 /// Maximum size for buffering incomplete messages (1MB)
 const MAX_INCOMPLETE_MESSAGE_SIZE: usize = 1024 * 1024;
@@ -251,6 +251,8 @@ pub struct DataNetlinkActor {
     message_parser: NetlinkMessageParser,
     /// Netlink socket receive buffer size in bytes (0 = OS default). Reduces ENOBUFS when set.
     netlink_rcvbuf_bytes: usize,
+    /// Socket readiness poll interval in milliseconds. Shorter than HFT interval reduces ENOBUFS.
+    socket_readiness_timeout_ms: u64,
 }
 
 impl DataNetlinkActor {
@@ -262,6 +264,7 @@ impl DataNetlinkActor {
     /// * `group` - The multicast group name
     /// * `command_recipient` - Channel for receiving control commands
     /// * `netlink_rcvbuf_bytes` - Socket SO_RCVBUF size in bytes (0 = OS default). Larger values reduce ENOBUFS under high HFT load.
+    /// * `socket_readiness_timeout_ms` - Poll interval in ms for socket readiness. Shorter than HFT interval (e.g. 10 ms) reduces ENOBUFS.
     ///
     /// # Returns
     ///
@@ -271,6 +274,7 @@ impl DataNetlinkActor {
         group: &str,
         command_recipient: Receiver<NetlinkCommand>,
         netlink_rcvbuf_bytes: usize,
+        socket_readiness_timeout_ms: u64,
     ) -> Self {
         let nl_resolver = Self::create_nl_resolver();
         let mut actor = DataNetlinkActor {
@@ -283,6 +287,7 @@ impl DataNetlinkActor {
             command_recipient,
             message_parser: NetlinkMessageParser::new(),
             netlink_rcvbuf_bytes,
+            socket_readiness_timeout_ms,
         };
 
         // Use instance method for initial connection
@@ -880,7 +885,7 @@ impl DataNetlinkActor {
             }
 
             // Check socket readiness with configurable timeout to allow periodic checks
-            match Self::check_socket_readiness(SOCKET_READINESS_TIMEOUT_MS).await {
+            match Self::check_socket_readiness(actor.socket_readiness_timeout_ms).await {
                 Ok(data_ready) => {
                     // Only try to receive data if we have a socket and data is ready
                     if actor.socket.is_some() && data_ready {
@@ -934,7 +939,10 @@ impl DataNetlinkActor {
                                 // Handle specific errors
                                 if let Some(os_error) = e.raw_os_error() {
                                     if os_error == ENOBUFS {
-                                        warn!("Netlink receive buffer full (ENOBUFS). Consider increasing buffer size or processing messages faster. Error: {:?}", e);
+                                        warn!(
+                                            "Netlink receive buffer full (ENOBUFS). poll_interval_ms={}. Consider reducing --socket-readiness-timeout-ms or increasing buffer. Error: {:?}",
+                                            actor.socket_readiness_timeout_ms, e
+                                        );
                                         // Don't disconnect on ENOBUFS, just continue
                                         continue;
                                     }
@@ -975,7 +983,7 @@ impl DataNetlinkActor {
                 Err(e) => {
                     warn!("Poll error: {:?}", e);
                     // Wait a bit before retrying to avoid busy loop on persistent poll errors
-                    sleep(Duration::from_millis(SOCKET_READINESS_TIMEOUT_MS));
+                    sleep(Duration::from_millis(actor.socket_readiness_timeout_ms));
                 }
             }
         }
@@ -1168,7 +1176,7 @@ pub mod test {
         let (command_sender, command_receiver) = channel(1);
         let (buffer_sender, mut buffer_receiver) = channel(1);
 
-        let mut actor = DataNetlinkActor::new("family", "group", command_receiver, 0);
+        let mut actor = DataNetlinkActor::new("family", "group", command_receiver, 0, DEFAULT_SOCKET_READINESS_TIMEOUT_MS);
         actor.add_recipient(buffer_sender);
 
         let task = spawn(DataNetlinkActor::run(actor));

--- a/crates/countersyncd/src/actor/data_netlink.rs
+++ b/crates/countersyncd/src/actor/data_netlink.rs
@@ -322,7 +322,17 @@ impl DataNetlinkActor {
             return;
         }
         let fd = socket.as_raw_fd();
-        let v: libc::c_int = bytes.try_into().unwrap_or(libc::c_int::MAX);
+        let v: libc::c_int = match bytes.try_into() {
+            Ok(v) => v,
+            Err(_) => {
+                warn!(
+                    "netlink_rcvbuf {} exceeds c_int::MAX, clamping to {}",
+                    bytes,
+                    libc::c_int::MAX
+                );
+                libc::c_int::MAX
+            }
+        };
         let ret = unsafe {
             libc::setsockopt(
                 fd,

--- a/crates/countersyncd/src/actor/data_netlink.rs
+++ b/crates/countersyncd/src/actor/data_netlink.rs
@@ -1462,6 +1462,22 @@ pub mod test {
             assert!(!group.is_empty());
         }
     }
+
+    #[test]
+    fn test_netlink_rcvbuf_stored_on_construction() {
+        let (_, command_receiver) = channel(1);
+        let actor = DataNetlinkActor::new("family", "group", command_receiver, 4194304, 5);
+        assert_eq!(actor.netlink_rcvbuf_bytes, 4194304);
+    }
+
+    #[test]
+    fn test_log_interval_cadence_at_default_poll_ms() {
+        const DEFAULT_POLL_MS: u64 = 5;
+        assert_eq!(HEARTBEAT_LOG_INTERVAL as u64 * DEFAULT_POLL_MS, 5 * 60 * 1000);  // 5 minutes
+        assert_eq!(DEBUG_LOG_INTERVAL as u64 * DEFAULT_POLL_MS, 30 * 1000);           // 30 seconds
+        assert_eq!(WOULDBLOCK_LOG_INTERVAL as u64 * DEFAULT_POLL_MS, 60 * 1000);      // 1 minute
+    }
+
 }
 
 /// Reads the Generic Netlink family and group names from the configuration file.

--- a/crates/countersyncd/src/actor/data_netlink.rs
+++ b/crates/countersyncd/src/actor/data_netlink.rs
@@ -249,6 +249,8 @@ pub struct DataNetlinkActor {
     command_recipient: Receiver<NetlinkCommand>,
     /// Message parser for handling multiple and fragmented netlink messages
     message_parser: NetlinkMessageParser,
+    /// Netlink socket receive buffer size in bytes (0 = OS default). Reduces ENOBUFS when set.
+    netlink_rcvbuf_bytes: usize,
 }
 
 impl DataNetlinkActor {
@@ -259,11 +261,17 @@ impl DataNetlinkActor {
     /// * `family` - The generic netlink family name
     /// * `group` - The multicast group name
     /// * `command_recipient` - Channel for receiving control commands
+    /// * `netlink_rcvbuf_bytes` - Socket SO_RCVBUF size in bytes (0 = OS default). Larger values reduce ENOBUFS under high HFT load.
     ///
     /// # Returns
     ///
     /// A new DataNetlinkActor instance with an initial connection attempt
-    pub fn new(family: &str, group: &str, command_recipient: Receiver<NetlinkCommand>) -> Self {
+    pub fn new(
+        family: &str,
+        group: &str,
+        command_recipient: Receiver<NetlinkCommand>,
+        netlink_rcvbuf_bytes: usize,
+    ) -> Self {
         let nl_resolver = Self::create_nl_resolver();
         let mut actor = DataNetlinkActor {
             family: family.to_string(),
@@ -274,6 +282,7 @@ impl DataNetlinkActor {
             buffer_recipients: LinkedList::new(),
             command_recipient,
             message_parser: NetlinkMessageParser::new(),
+            netlink_rcvbuf_bytes,
         };
 
         // Use instance method for initial connection
@@ -301,6 +310,34 @@ impl DataNetlinkActor {
     #[cfg(not(test))]
     fn create_nl_resolver() -> Option<Socket> {
         netlink_utils::create_nl_resolver()
+    }
+
+    /// Sets SO_RCVBUF on the netlink socket to reduce ENOBUFS under high HFT load.
+    #[cfg(not(test))]
+    fn set_socket_rcvbuf(socket: &mut Socket, bytes: usize) {
+        if bytes == 0 {
+            return;
+        }
+        let fd = socket.as_raw_fd();
+        let v: libc::c_int = bytes.try_into().unwrap_or(libc::c_int::MAX);
+        let ret = unsafe {
+            libc::setsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_RCVBUF,
+                &v as *const _ as *const libc::c_void,
+                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            )
+        };
+        if ret != 0 {
+            warn!(
+                "Failed to set netlink SO_RCVBUF to {}: {:?}",
+                bytes,
+                std::io::Error::last_os_error()
+            );
+        } else {
+            info!("Set netlink socket SO_RCVBUF to {} bytes", bytes);
+        }
     }
 
     /// Mock netlink resolver for testing.
@@ -362,7 +399,7 @@ impl DataNetlinkActor {
                         }
                     } else {
                         // Fallback to creating temporary socket
-                        return Self::connect_fallback(family, group);
+                        return Self::connect_fallback(family, group, self.netlink_rcvbuf_bytes);
                     }
                 }
             }
@@ -390,7 +427,7 @@ impl DataNetlinkActor {
                 }
             } else {
                 // Fallback to creating temporary socket
-                return Self::connect_fallback(family, group);
+                return Self::connect_fallback(family, group, self.netlink_rcvbuf_bytes);
             }
         };
 
@@ -432,6 +469,8 @@ impl DataNetlinkActor {
             return None;
         }
 
+        Self::set_socket_rcvbuf(&mut socket, self.netlink_rcvbuf_bytes);
+
         info!(
             "Successfully connected to family '{}', group '{}' with group_id: {}",
             family, group, group_id
@@ -457,7 +496,11 @@ impl DataNetlinkActor {
 
     /// Fallback connection method when shared router is not available.
     #[cfg(not(test))]
-    fn connect_fallback(family: &str, group: &str) -> Option<SocketType> {
+    fn connect_fallback(
+        family: &str,
+        group: &str,
+        netlink_rcvbuf_bytes: usize,
+    ) -> Option<SocketType> {
         debug!(
             "Using fallback connection for family '{}', group '{}'",
             family, group
@@ -540,6 +583,8 @@ impl DataNetlinkActor {
             warn!("Failed to set non-blocking mode: {:?}", e);
             return None;
         }
+
+        Self::set_socket_rcvbuf(&mut socket, netlink_rcvbuf_bytes);
 
         info!(
             "Successfully connected to family '{}', group '{}' with group_id: {}",
@@ -1123,7 +1168,7 @@ pub mod test {
         let (command_sender, command_receiver) = channel(1);
         let (buffer_sender, mut buffer_receiver) = channel(1);
 
-        let mut actor = DataNetlinkActor::new("family", "group", command_receiver);
+        let mut actor = DataNetlinkActor::new("family", "group", command_receiver, 0);
         actor.add_recipient(buffer_sender);
 
         let task = spawn(DataNetlinkActor::run(actor));

--- a/crates/countersyncd/src/actor/data_netlink.rs
+++ b/crates/countersyncd/src/actor/data_netlink.rs
@@ -47,14 +47,14 @@ const MAX_LOCAL_RECONNECT_ATTEMPTS: u32 = 3;
 /// Socket health check timeout - if no data received for this duration, socket is considered unhealthy
 const SOCKET_HEALTH_TIMEOUT_SECS: u64 = 60;
 
-/// Heartbeat logging interval (in iterations) - log every 5 minutes at 5ms per iteration
-const HEARTBEAT_LOG_INTERVAL: u32 = 60000; // 60000 * 5ms = 5 minutes
+/// Target duration for heartbeat log (5 minutes).
+const HEARTBEAT_TARGET_MS: u64 = 5 * 60 * 1000;
 
-/// Debug logging interval (in iterations) - log debug info every 30 seconds
-const DEBUG_LOG_INTERVAL: u32 = 6000; // 6000 * 5ms = 30 seconds
+/// Target duration for debug log (30 seconds).
+const DEBUG_TARGET_MS: u64 = 30 * 1000;
 
-/// WouldBlock debug logging interval (in iterations) - log WouldBlock every minute
-const WOULDBLOCK_LOG_INTERVAL: u32 = 12000; // 12000 * 5ms = 1 minute
+/// Target duration for WouldBlock log (1 minute).
+const WOULDBLOCK_TARGET_MS: u64 = 60 * 1000;
 
 
 /// Maximum size for buffering incomplete messages (1MB)
@@ -806,16 +806,20 @@ impl DataNetlinkActor {
         );
         let mut heartbeat_counter = 0u32;
         let mut consecutive_failures = 0u32;
+        let poll_ms = actor.socket_readiness_timeout_ms.max(1);
+        let heartbeat_interval = (HEARTBEAT_TARGET_MS / poll_ms).max(1) as u32;
+        let debug_interval = (DEBUG_TARGET_MS / poll_ms).max(1) as u32;
+        let wouldblock_interval = (WOULDBLOCK_TARGET_MS / poll_ms).max(1) as u32;
 
         loop {
             // Log heartbeat every 5 minutes to show the actor is running
             heartbeat_counter += 1;
-            if heartbeat_counter % HEARTBEAT_LOG_INTERVAL == 0 {
+            if heartbeat_counter % heartbeat_interval == 0 {
                 info!("DataNetlinkActor is running normally - waiting for data messages");
             }
 
             // More frequent debug info about socket status
-            if heartbeat_counter % DEBUG_LOG_INTERVAL == 0 {
+            if heartbeat_counter % debug_interval == 0 {
                 debug!(
                     "DataNetlinkActor heartbeat: socket={}, recipients={}, failures={}",
                     actor.socket.is_some(),
@@ -921,7 +925,7 @@ impl DataNetlinkActor {
                                 // Check if it's WouldBlock using standard ErrorKind
                                 if e.kind() == io::ErrorKind::WouldBlock {
                                     // No data available right now, continue normally
-                                    if heartbeat_counter % WOULDBLOCK_LOG_INTERVAL == 0 {
+                                    if heartbeat_counter % wouldblock_interval == 0 {
                                         debug!("No netlink data available (WouldBlock) - socket is connected but no messages from kernel");
                                     }
                                 } else {
@@ -945,7 +949,7 @@ impl DataNetlinkActor {
                         }
                     } else if actor.socket.is_none() {
                         // No socket available, log this periodically but don't spam
-                        if heartbeat_counter % DEBUG_LOG_INTERVAL == 0 {
+                        if heartbeat_counter % debug_interval == 0 {
                             debug!("No socket available - waiting for reconnect command from ControlNetlinkActor");
                         }
                     }
@@ -1408,11 +1412,16 @@ pub mod test {
     }
 
     #[test]
-    fn test_log_interval_cadence_at_default_poll_ms() {
-        const DEFAULT_POLL_MS: u64 = 5;
-        assert_eq!(HEARTBEAT_LOG_INTERVAL as u64 * DEFAULT_POLL_MS, 5 * 60 * 1000);  // 5 minutes
-        assert_eq!(DEBUG_LOG_INTERVAL as u64 * DEFAULT_POLL_MS, 30 * 1000);           // 30 seconds
-        assert_eq!(WOULDBLOCK_LOG_INTERVAL as u64 * DEFAULT_POLL_MS, 60 * 1000);      // 1 minute
+    fn test_log_interval_cadence() {
+        // Verify that computed intervals match target durations for various poll rates.
+        for poll_ms in [1u64, 5, 10, 50, 100] {
+            let heartbeat = (HEARTBEAT_TARGET_MS / poll_ms).max(1);
+            let debug = (DEBUG_TARGET_MS / poll_ms).max(1);
+            let wouldblock = (WOULDBLOCK_TARGET_MS / poll_ms).max(1);
+            assert_eq!(heartbeat * poll_ms, HEARTBEAT_TARGET_MS, "poll_ms={}", poll_ms);
+            assert_eq!(debug * poll_ms, DEBUG_TARGET_MS, "poll_ms={}", poll_ms);
+            assert_eq!(wouldblock * poll_ms, WOULDBLOCK_TARGET_MS, "poll_ms={}", poll_ms);
+        }
     }
 
 }

--- a/crates/countersyncd/src/actor/data_netlink.rs
+++ b/crates/countersyncd/src/actor/data_netlink.rs
@@ -315,69 +315,6 @@ impl DataNetlinkActor {
         netlink_utils::create_nl_resolver()
     }
 
-    /// Sets SO_RCVBUF on the netlink socket to reduce ENOBUFS under high HFT load.
-    #[cfg(not(test))]
-    fn set_socket_rcvbuf(socket: &mut Socket, bytes: usize) {
-        if bytes == 0 {
-            return;
-        }
-        let fd = socket.as_raw_fd();
-        let v: libc::c_int = match bytes.try_into() {
-            Ok(v) => v,
-            Err(_) => {
-                warn!(
-                    "netlink_rcvbuf {} exceeds c_int::MAX, clamping to {}",
-                    bytes,
-                    libc::c_int::MAX
-                );
-                libc::c_int::MAX
-            }
-        };
-        let ret = unsafe {
-            libc::setsockopt(
-                fd,
-                libc::SOL_SOCKET,
-                libc::SO_RCVBUF,
-                &v as *const _ as *const libc::c_void,
-                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
-            )
-        };
-        if ret != 0 {
-            warn!(
-                "Failed to set netlink SO_RCVBUF to {}: {:?}",
-                bytes,
-                std::io::Error::last_os_error()
-            );
-            return;
-        }
-
-        // Read back the actual value — Linux may cap it at net.core.rmem_max and doubles it internally.
-        let mut actual: libc::c_int = 0;
-        let mut len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
-        let ret = unsafe {
-            libc::getsockopt(
-                fd,
-                libc::SOL_SOCKET,
-                libc::SO_RCVBUF,
-                &mut actual as *mut _ as *mut libc::c_void,
-                &mut len,
-            )
-        };
-        if ret != 0 {
-            warn!(
-                "Failed to read back SO_RCVBUF: {:?}",
-                std::io::Error::last_os_error()
-            );
-        } else {
-            info!(
-                "Netlink SO_RCVBUF: requested={} bytes, actual={} bytes{}",
-                bytes,
-                actual,
-                if (actual as usize) < bytes { " (capped by net.core.rmem_max — consider raising it)" } else { "" }
-            );
-        }
-    }
-
     /// Mock netlink resolver for testing.
     #[cfg(test)]
     fn create_nl_resolver() -> Option<Socket> {
@@ -507,7 +444,7 @@ impl DataNetlinkActor {
             return None;
         }
 
-        Self::set_socket_rcvbuf(&mut socket, self.netlink_rcvbuf_bytes);
+        netlink_utils::set_socket_rcvbuf(&socket, self.netlink_rcvbuf_bytes);
 
         info!(
             "Successfully connected to family '{}', group '{}' with group_id: {}",
@@ -622,7 +559,7 @@ impl DataNetlinkActor {
             return None;
         }
 
-        Self::set_socket_rcvbuf(&mut socket, netlink_rcvbuf_bytes);
+        netlink_utils::set_socket_rcvbuf(&socket, netlink_rcvbuf_bytes);
 
         info!(
             "Successfully connected to family '{}', group '{}' with group_id: {}",

--- a/crates/countersyncd/src/actor/data_netlink.rs
+++ b/crates/countersyncd/src/actor/data_netlink.rs
@@ -56,8 +56,6 @@ const DEBUG_LOG_INTERVAL: u32 = 3000; // 3000 * 10ms = 30 seconds
 /// WouldBlock debug logging interval (in iterations) - log WouldBlock every minute
 const WOULDBLOCK_LOG_INTERVAL: u32 = 6000; // 6000 * 10ms = 1 minute
 
-/// Default socket readiness poll interval (ms) when not configured via CLI.
-const DEFAULT_SOCKET_READINESS_TIMEOUT_MS: u64 = 5;
 
 /// Maximum size for buffering incomplete messages (1MB)
 const MAX_INCOMPLETE_MESSAGE_SIZE: usize = 1024 * 1024;
@@ -1176,7 +1174,7 @@ pub mod test {
         let (command_sender, command_receiver) = channel(1);
         let (buffer_sender, mut buffer_receiver) = channel(1);
 
-        let mut actor = DataNetlinkActor::new("family", "group", command_receiver, 0, DEFAULT_SOCKET_READINESS_TIMEOUT_MS);
+        let mut actor = DataNetlinkActor::new("family", "group", command_receiver, 0, 5);
         actor.add_recipient(buffer_sender);
 
         let task = spawn(DataNetlinkActor::run(actor));

--- a/crates/countersyncd/src/actor/data_netlink.rs
+++ b/crates/countersyncd/src/actor/data_netlink.rs
@@ -47,14 +47,14 @@ const MAX_LOCAL_RECONNECT_ATTEMPTS: u32 = 3;
 /// Socket health check timeout - if no data received for this duration, socket is considered unhealthy
 const SOCKET_HEALTH_TIMEOUT_SECS: u64 = 60;
 
-/// Heartbeat logging interval (in iterations) - log every 5 minutes at 10ms per iteration
-const HEARTBEAT_LOG_INTERVAL: u32 = 30000; // 30000 * 10ms = 5 minutes
+/// Heartbeat logging interval (in iterations) - log every 5 minutes at 5ms per iteration
+const HEARTBEAT_LOG_INTERVAL: u32 = 60000; // 60000 * 5ms = 5 minutes
 
 /// Debug logging interval (in iterations) - log debug info every 30 seconds
-const DEBUG_LOG_INTERVAL: u32 = 3000; // 3000 * 10ms = 30 seconds
+const DEBUG_LOG_INTERVAL: u32 = 6000; // 6000 * 5ms = 30 seconds
 
 /// WouldBlock debug logging interval (in iterations) - log WouldBlock every minute
-const WOULDBLOCK_LOG_INTERVAL: u32 = 6000; // 6000 * 10ms = 1 minute
+const WOULDBLOCK_LOG_INTERVAL: u32 = 12000; // 12000 * 5ms = 1 minute
 
 
 /// Maximum size for buffering incomplete messages (1MB)

--- a/crates/countersyncd/src/actor/netlink_utils.rs
+++ b/crates/countersyncd/src/actor/netlink_utils.rs
@@ -11,7 +11,7 @@ use std::io;
 use std::os::fd::AsRawFd;
 
 #[cfg(not(test))]
-use log::{debug, warn};
+use log::{debug, info, warn};
 #[cfg(not(test))]
 use netlink_packet_core::{NetlinkMessage, NetlinkPayload, NLM_F_ACK, NLM_F_REQUEST};
 #[cfg(not(test))]
@@ -24,6 +24,41 @@ use netlink_packet_generic::{
 };
 #[cfg(not(test))]
 use netlink_sys::{protocols::NETLINK_GENERIC, SocketAddr};
+
+/// Sets SO_RCVBUF on a netlink socket to reduce ENOBUFS under high HFT load.
+///
+/// Logs the actual buffer size granted by the kernel after setting, since Linux
+/// may cap it at net.core.rmem_max and doubles it internally.
+#[cfg(not(test))]
+pub fn set_socket_rcvbuf(socket: &Socket, bytes: usize) {
+    if bytes == 0 {
+        return;
+    }
+    let v: libc::c_int = match bytes.try_into() {
+        Ok(v) => v,
+        Err(_) => {
+            warn!(
+                "netlink_rcvbuf {} exceeds c_int::MAX, clamping to {}",
+                bytes,
+                libc::c_int::MAX
+            );
+            libc::c_int::MAX
+        }
+    };
+    if let Err(e) = socket.set_rx_buf_sz(v) {
+        warn!("Failed to set netlink SO_RCVBUF to {}: {:?}", bytes, e);
+        return;
+    }
+    match socket.get_rx_buf_sz() {
+        Ok(actual) => info!(
+            "Netlink SO_RCVBUF: requested={} bytes, actual={} bytes{}",
+            bytes,
+            actual,
+            if actual < bytes { " (capped by net.core.rmem_max — consider raising it)" } else { "" }
+        ),
+        Err(e) => warn!("Failed to read back SO_RCVBUF: {:?}", e),
+    }
+}
 
 /// Creates a netlink socket for family/group resolution.
 ///

--- a/crates/countersyncd/src/main.rs
+++ b/crates/countersyncd/src/main.rs
@@ -179,6 +179,14 @@ struct Args {
     )]
     comm_stats_interval: u64,
 
+    /// Netlink socket receive buffer size in bytes (0 = OS default). Increase to reduce ENOBUFS under high HFT load.
+    #[arg(
+        long,
+        default_value = "4194304",
+        help = "Netlink SO_RCVBUF size in bytes (0 = default). Use 4MB or higher if you see 'Netlink receive buffer full (ENOBUFS)'"
+    )]
+    netlink_rcvbuf: usize,
+
     /// Channel capacity for data_netlink to ipfix communication (IPFIX records)
     #[arg(
         long,
@@ -302,7 +310,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Using netlink family: '{}', group: '{}'", family, group);
 
     // Initialize and configure actors
-    let mut data_netlink = DataNetlinkActor::new(family.as_str(), group.as_str(), command_receiver);
+    let mut data_netlink = DataNetlinkActor::new(
+        family.as_str(),
+        group.as_str(),
+        command_receiver,
+        args.netlink_rcvbuf,
+    );
     data_netlink.add_recipient(ipfix_record_sender);
 
     let control_netlink = ControlNetlinkActor::new(family.as_str(), command_sender);

--- a/crates/countersyncd/src/main.rs
+++ b/crates/countersyncd/src/main.rs
@@ -175,7 +175,8 @@ struct Args {
     #[arg(
         long,
         default_value = "600",
-        help = "Interval in seconds for logging comm stats (channel lengths). Use a shorter value (e.g. 60) when verifying HFT processing slowness"
+        value_parser = clap::value_parser!(u64).range(1..),
+        help = "Interval in seconds for logging comm stats (channel lengths). Use a shorter value (e.g. 60) when verifying HFT processing slowness. Minimum 1"
     )]
     comm_stats_interval: u64,
 
@@ -508,5 +509,55 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         res = async { otel_handle.as_mut().unwrap().await }, if otel_handle.is_some() => {
             exit_on_otel_join(res);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    fn parse(args: &[&str]) -> Result<Args, clap::Error> {
+        Args::try_parse_from(args)
+    }
+
+    #[test]
+    fn test_defaults() {
+        let args = parse(&["countersyncd"]).unwrap();
+        assert_eq!(args.socket_readiness_timeout_ms, 5);
+        assert_eq!(args.netlink_rcvbuf, 4194304);
+        assert_eq!(args.comm_stats_interval, 600);
+        assert_eq!(args.stats_interval, 10);
+        assert!(!args.enable_stats);
+        assert!(!args.enable_counter_db);
+        assert!(!args.enable_otel);
+    }
+
+    #[test]
+    fn test_socket_readiness_timeout_zero_rejected() {
+        assert!(parse(&["countersyncd", "--socket-readiness-timeout-ms", "0"]).is_err());
+    }
+
+    #[test]
+    fn test_socket_readiness_timeout_custom() {
+        let args = parse(&["countersyncd", "--socket-readiness-timeout-ms", "10"]).unwrap();
+        assert_eq!(args.socket_readiness_timeout_ms, 10);
+    }
+
+    #[test]
+    fn test_netlink_rcvbuf_zero_accepted() {
+        let args = parse(&["countersyncd", "--netlink-rcvbuf", "0"]).unwrap();
+        assert_eq!(args.netlink_rcvbuf, 0);
+    }
+
+    #[test]
+    fn test_comm_stats_interval_custom() {
+        let args = parse(&["countersyncd", "--comm-stats-interval", "60"]).unwrap();
+        assert_eq!(args.comm_stats_interval, 60);
+    }
+
+    #[test]
+    fn test_unknown_flag_rejected() {
+        assert!(parse(&["countersyncd", "--unknown-flag"]).is_err());
     }
 }

--- a/crates/countersyncd/src/main.rs
+++ b/crates/countersyncd/src/main.rs
@@ -24,7 +24,7 @@ use crate::actor::{
 
 // Internal exit codes
 use countersyncd::exit_codes::{EXIT_FAILURE, EXIT_OTEL_EXPORT_RETRIES_EXHAUSTED, EXIT_SUCCESS};
-use crate::utilities::{set_comm_capacity, ChannelLabel};
+use crate::utilities::{set_comm_capacity, set_comm_log_interval_secs, ChannelLabel};
 
 /// Initialize logging based on command line arguments
 fn init_logging(log_level: &str, log_format: &str) {
@@ -171,6 +171,14 @@ struct Args {
     )]
     log_format: String,
 
+    /// Interval (seconds) between periodic comm stats log lines (channel queue stats)
+    #[arg(
+        long,
+        default_value = "600",
+        help = "Interval in seconds for logging comm stats (channel lengths). Use a shorter value (e.g. 60) when verifying HFT processing slowness"
+    )]
+    comm_stats_interval: u64,
+
     /// Channel capacity for data_netlink to ipfix communication (IPFIX records)
     #[arg(
         long,
@@ -263,9 +271,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
     }
     info!(
+        "Comm stats log interval: {} seconds",
+        args.comm_stats_interval
+    );
+    info!(
         "Channel capacities - ipfix_records: {}, stats_reporter: {}, counter_db: {}, otel: {}",
         args.data_netlink_capacity, args.stats_reporter_capacity, args.counter_db_capacity, args.otel_capacity
     );
+
+    set_comm_log_interval_secs(args.comm_stats_interval);
 
     // Create communication channels between actors with configurable capacities
     let (command_sender, command_receiver) = channel(10); // Keep small buffer for commands

--- a/crates/countersyncd/src/main.rs
+++ b/crates/countersyncd/src/main.rs
@@ -187,6 +187,14 @@ struct Args {
     )]
     netlink_rcvbuf: usize,
 
+    /// Socket readiness poll interval in milliseconds. Shorter than HFT sample interval (e.g. 10 ms) reduces ENOBUFS.
+    #[arg(
+        long,
+        default_value = "5",
+        help = "Poll interval in ms for netlink socket readiness. Default 5"
+    )]
+    socket_readiness_timeout_ms: u64,
+
     /// Channel capacity for data_netlink to ipfix communication (IPFIX records)
     #[arg(
         long,
@@ -283,6 +291,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         args.comm_stats_interval
     );
     info!(
+        "Socket readiness poll interval: {} ms",
+        args.socket_readiness_timeout_ms
+    );
+    info!(
         "Channel capacities - ipfix_records: {}, stats_reporter: {}, counter_db: {}, otel: {}",
         args.data_netlink_capacity, args.stats_reporter_capacity, args.counter_db_capacity, args.otel_capacity
     );
@@ -315,6 +327,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         group.as_str(),
         command_receiver,
         args.netlink_rcvbuf,
+        args.socket_readiness_timeout_ms,
     );
     data_netlink.add_recipient(ipfix_record_sender);
 

--- a/crates/countersyncd/src/main.rs
+++ b/crates/countersyncd/src/main.rs
@@ -191,7 +191,8 @@ struct Args {
     #[arg(
         long,
         default_value = "5",
-        help = "Poll interval in ms for netlink socket readiness. Default 5"
+        value_parser = clap::value_parser!(u64).range(1..),
+        help = "Poll interval in ms for netlink socket readiness. Default 5, minimum 1"
     )]
     socket_readiness_timeout_ms: u64,
 

--- a/crates/countersyncd/src/utilities/mod.rs
+++ b/crates/countersyncd/src/utilities/mod.rs
@@ -1,6 +1,7 @@
 /// Utility helpers shared across countersyncd modules.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
@@ -30,8 +31,16 @@ pub fn format_hex_lines(buffer: &[u8]) -> String {
     lines.join("\n")
 }
 
-/// Log interval for communication stats.
-const COMM_LOG_INTERVAL: Duration = Duration::from_secs(600);
+/// Configurable log interval for communication stats (seconds).
+/// Set via set_comm_log_interval_secs() at startup (e.g. from CLI); default 600.
+static COMM_LOG_INTERVAL_SECS: AtomicU64 = AtomicU64::new(600);
+
+/// Sets the interval (in seconds) between periodic comm stats log lines.
+/// Call once at startup (e.g. from CLI). Shorter intervals (e.g. 60) help when
+/// verifying HFT processing slowness.
+pub fn set_comm_log_interval_secs(secs: u64) {
+    COMM_LOG_INTERVAL_SECS.store(secs, Ordering::Relaxed);
+}
 
 /// Channel labels for actor-to-actor communication.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -131,7 +140,8 @@ pub fn record_comm_stats(label: ChannelLabel, channel_len: usize) {
     }
 
     let now = Instant::now();
-    if now.duration_since(stats.last_log) >= COMM_LOG_INTERVAL {
+    let interval = Duration::from_secs(COMM_LOG_INTERVAL_SECS.load(Ordering::Relaxed));
+    if now.duration_since(stats.last_log) >= interval {
         let avg = stats.sum as f64 / stats.count as f64;
         let rms = (stats.sum_sq as f64 / stats.count as f64).sqrt();
         if stats.capacity > 0 {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
- Made the socket readiness poll interval configurable via --socket-readiness-timeout-ms (default 5 ms; was fixed at 10 ms). The data_netlink actor uses this value when waiting before checking the netlink socket.
- Made the netlink socket receive buffer configurable via --netlink-rcvbuf (default 4 MB; 0 = OS default). Set SO_RCVBUF on the data netlink socket at connect/reconnect and log requested vs actual size.
- Made the comm stats log interval configurable via --comm-stats-interval (default 600 s) so queue-depth stats can be emitted more often when debugging.

**Why I did it**
To make sure we can empty the buffer before the next samples of counters is received.
And to fix https://github.com/sonic-net/sonic-buildimage/issues/26246

**How I verified it**
Configure HFT with a large amount of counters and ports and verified the amount of messages received per second.
Use the test test_hft_full_queue_counters to validate such secnario.

**Details if related**
