### PR TITLE
Set arp_accept and accept_untracked_na to 2 by default

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -579,7 +579,7 @@ bool IntfMgr::setIntfGratArp(const string &alias, const string &grat_arp)
 
     if (grat_arp == "enabled")
     {
-        garp_enabled = "1";
+        garp_enabled = "2";
     }
     else if (grat_arp == "disabled")
     {

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -507,7 +507,7 @@ class TestVlan(object):
     def test_VlanGratArp(self, dvs):
         def arp_accept_enabled():
             rc, res = dvs.runcmd("cat /proc/sys/net/ipv4/conf/Vlan{}/arp_accept".format(vlan))
-            return (res.strip("\n") == "1", res)
+            return (res.strip("\n") == "2", res)
 
         def arp_accept_disabled():
             rc, res = dvs.runcmd("cat /proc/sys/net/ipv4/conf/Vlan{}/arp_accept".format(vlan))


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Microsoft ADO: 37292328

When `grat_arp` is not enabled in config_db for an interface, intfmgr automatically sets kernel sysctl `arp_accept` for that interface to 0 as well as sets the sysctl `accept_untracked_na` for that interface to 0. 

When `grat_arp` is enabled in config_db, intfmgr sets the kernel sysctl `arp_accept` for that interface to 1 and also sets the sysctl `accept_untracked_na` for that interface to 1.

Starting kernel 5.19, this sysctl has been extended to take a value of 2 to restrict learning of neighbor IPs from GARPs or unsolicited NAs to only IPs that are in the same subnet as the IP configured on that interface. In SONiC, it is more meaningful to have the value 2 instead of 1 by default.

This patch changes the default value of `arp_accept` and `accept_untracked_na` to 2 when `grat_arp` is enabled in the config_db for any interface.

Related sonic-mgmt change: https://github.com/sonic-net/sonic-mgmt/pull/23320

**Why I did it**

        To ensure that new ARP and NDP entries are created only if the source IP address is in the same subnet as the address configured on the interface that received the GARP.

**How I verified it**

        By using scapy to send GARP and unsolicited NA packets and making sure out of subnet neighbors are not learned on sonic interfaces and also by running new sonic-mgmt tests. Related sonic-mgmt change is https://github.com/sonic-net/sonic-mgmt/pull/23320.

**Details if related**

```
Ref: https://docs.kernel.org/networking/ip-sysctl.html
https://lore.kernel.org/netdev/93cfe14597ec1205f61366b9902876287465f1cd.1657755189.git.jhpark1013@gmail.com/
https://lore.kernel.org/netdev/56d57be31141c12e9034cfa7570f2012528ca884.1657755189.git.jhpark1013@gmail.com/

arp_accept - INTEGER
Define behavior for accepting gratuitous ARP (garp) frames from devices that are not already present in the ARP table:

0 - don’t create new entries in the ARP table

1 - create new entries in the ARP table

2 - create new entries only if the source IP address is in the same subnet as an address configured on the interface that received the garp message.

Both replies and requests type gratuitous arp will trigger the ARP table to be updated, if this setting is on.

If the ARP table already contains the IP address of the gratuitous arp frame, the arp table will be updated regardless if this setting is on or off.

accept_untracked_na - INTEGER
Define behavior for accepting neighbor advertisements from devices that are absent in the neighbor cache:

0 - (default) Do not accept unsolicited and untracked neighbor advertisements.

1 - Add a new neighbor cache entry in STALE state for routers on receiving a neighbor advertisement (either solicited or unsolicited) with target link-layer address option specified if no neighbor entry is already present for the advertised IPv6 address. Without this knob, NAs received for untracked addresses (absent in neighbor cache) are silently ignored.

This is as per router-side behavior documented in RFC9131.

This has lower precedence than drop_unsolicited_na.

This will optimize the return path for the initial off-link communication that is initiated by a directly connected host, by ensuring that the first-hop router which turns on this setting doesn’t have to buffer the initial return packets to do neighbor-solicitation. The prerequisite is that the host is configured to send unsolicited neighbor advertisements on interface bringup. This setting should be used in conjunction with the ndisc_notify setting on the host to satisfy this prerequisite.

2 - Extend option (1) to add a new neighbor cache entry only if the source IP address is in the same subnet as an address configured on the interface that received the neighbor advertisement.

```
