### PR TITLE
[agent][stpmgrd] Fix file descriptor leak in debug reload check

### DIFF
--- a/cfgmgr/stpmgrd.cpp
+++ b/cfgmgr/stpmgrd.cpp
@@ -23,9 +23,11 @@ int main(int argc, char **argv)
 
     SWSS_LOG_NOTICE("--- Starting stpmgrd ---");
 
-    if (fopen("/stpmgrd_dbg_reload", "r"))
+    FILE *dbg_file = fopen("/stpmgrd_dbg_reload", "r");
+    if (dbg_file)
     {
         Logger::setMinPrio(Logger::SWSS_DEBUG);
+        fclose(dbg_file);
     }
 
     try


### PR DESCRIPTION
#### What I did
Fix FILE* leak in stpmgrd debug reload check.

#### How I did it
Store `fopen()` result in a local variable and `fclose()` after use.

#### How to verify it
Run stpmgrd under valgrind — no more leaked file descriptors from the debug reload check.

#### Which release branch to backport
master

#### Description for the changelog
Fix file descriptor leak in stpmgrd debug reload file check.

Fixes: #4391