### PR TITLE
[fpmsyncd]: add libnexthopgroup in Makefile.am to support rib/fib

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -150,6 +150,17 @@ jobs:
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
+      project: ${{ parameters.buildimage_artifact_project }}
+      pipeline: Azure.sonic-buildimage.common_libs
+      artifact: common-lib
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/${{ parameters.buildimage_artifact_branch }}'
+      path: $(Build.ArtifactStagingDirectory)/download
+      patterns: '**/target/debs/${{ parameters.debian_version }}/libnexthopgroup_*.deb'
+    displayName: "Download sonic-buildimage libnexthopgroup package"
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: specific
       project: build
       pipeline: sonic-net.sonic-platform-vpp
       artifact: vpp
@@ -168,6 +179,7 @@ jobs:
       mkdir -p .azure-pipelines/docker-sonic-vs/debs
 
       find $(Build.ArtifactStagingDirectory)/download/sairedis -name '*.deb' -exec cp "{}" .azure-pipelines/docker-sonic-vs/debs \;
+      find $(Build.ArtifactStagingDirectory)/download -name 'libnexthopgroup_*.deb' -exec cp "{}" .azure-pipelines/docker-sonic-vs/debs \;
       cp -v $(Build.ArtifactStagingDirectory)/download/*.deb .azure-pipelines/docker-sonic-vs/debs
       if [ -f $(Build.ArtifactStagingDirectory)/download/coverage.info ]; then
         cp -v $(Build.ArtifactStagingDirectory)/download/coverage.info $(Build.ArtifactStagingDirectory)/

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -172,6 +172,8 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libnl-nf-3-200_*.deb
         target/debs/${{ parameters.debian_version }}/libnl-nf-3-dev_*.deb
         target/debs/${{ parameters.debian_version }}/libyang_*.deb
+        target/debs/${{ parameters.debian_version }}/libnexthopgroup_*.deb
+        target/debs/${{ parameters.debian_version }}/libnexthopgroup-dev_*.deb
     displayName: "Download common libs"
   - task: DownloadPipelineArtifact@2
     inputs:

--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -13,7 +13,7 @@ COPY ["debs", "/debs"]
 # same, even though contents have changed) are checked between the previous and current layer.
 RUN dpkg --remove --force-all libswsscommon
 RUN apt --fix-broken install -y
-RUN dpkg --purge python3-swsscommon sonic-db-cli libsaimetadata libsairedis libsaivs syncd-vs swss sonic-eventd libdashapi framework
+RUN dpkg --purge python3-swsscommon sonic-db-cli libsaimetadata libsairedis libsaivs syncd-vs swss sonic-eventd libdashapi framework libnexthopgroup
 
 RUN apt-get update
 
@@ -43,7 +43,8 @@ RUN apt install -y /debs/libdashapi_1.0.0_amd64.deb \
             /debs/libsairedis_1.0.0_amd64.deb \
             /debs/libsaivs_1.0.0_amd64.deb \
             /debs/syncd-vs_1.0.0_amd64.deb \
-            /debs/swss_1.0.0_amd64.deb
+            /debs/swss_1.0.0_amd64.deb \
+            /debs/libnexthopgroup_1.0.0_amd64.deb
 
 RUN if [ "$need_dbg" = "y" ] ; then dpkg -i /debs/swss-dbg_1.0.0_amd64.deb ; fi
 

--- a/fpmsyncd/Makefile.am
+++ b/fpmsyncd/Makefile.am
@@ -13,7 +13,7 @@ fpmsyncd_SOURCES = fpmsyncd.cpp fpmlink.cpp routesync.cpp $(top_srcdir)/warmrest
 
 fpmsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
 fpmsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
-fpmsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon
+fpmsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon -lnexthopgroup
 
 if GCOV_ENABLED
 fpmsyncd_SOURCES += ../gcovpreload/gcovpreload.cpp


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Add libnexthopgroup in fpmsyncd Makefile.am to support RIB/FIB

**Why I did it**

In the RIB/FIB design, we need the libnexthopgroup  compiled from sonic-fib to communicate with Zebra.
More details please refer the documents following:

RIB/FIB HLD: https://github.com/sonic-net/SONiC/pull/2060
nhg mgr LLD: https://github.com/sonic-net/SONiC/pull/2270
sonic-fib PR:  https://github.com/sonic-net/SONiC/pull/2270
RIB/FIB nhg mgr code: https://github.com/sonic-net/sonic-swss/pull/4395 

**How I verified it**

1. Unit tests for libnexthopgroup.
2. Unit tests for nhg mgr.
3. Daily vsonic tests.

**Details if related**
