### PR TITLE
[acl] Support arbitrary IP masks for ACL match fields

### DIFF
--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -661,14 +661,31 @@ Stores rules associated with a specific ACL table on the switch.
     src_ip        = ipv4_prefix                ; options of the source ipv4
                                                ; address (and mask) field
 
+    src_ip_mask   = ipv4_address               ; optional non-contiguous IPv4 mask for src_ip.
+                                               ; Used when the mask cannot be expressed as a
+                                               ; CIDR prefix length (e.g. "255.0.255.0").
+                                               ; Requires src_ip to be a plain host address
+                                               ; (no "/" prefix notation).
+
     dst_ip        = ipv4_prefix                ; options of the destination ipv4
                                                ; address (and mask) field
+
+    dst_ip_mask   = ipv4_address               ; optional non-contiguous IPv4 mask for dst_ip.
+                                               ; See src_ip_mask for usage.
 
     src_ipv6      = ipv6_prefix                ; options of the source ipv6
                                                ; address (and mask) field
 
+    src_ipv6_mask = ipv6_address               ; optional non-contiguous IPv6 mask for src_ipv6.
+                                               ; Used when the mask cannot be expressed as a
+                                               ; CIDR prefix length (e.g. "ffff::ffff").
+                                               ; Requires src_ipv6 to be a plain host address.
+
     dst_ipv6      = ipv6_prefix                ; options of the destination ipv6
                                                ; address (and mask) field
+
+    dst_ipv6_mask = ipv6_address               ; optional non-contiguous IPv6 mask for dst_ipv6.
+                                               ; See src_ipv6_mask for usage.
 
     l4_src_port   = port_num                   ; source L4 port or the
     l4_dst_port   = port_num                   ; destination L4 port
@@ -700,6 +717,8 @@ Stores rules associated with a specific ACL table on the switch.
     h16         = 1*4HEXDIG
     ls32        = ( h16 ":" h16 ) / IPv4address
     ipv4_prefix = dec-octet "." dec-octet "." dec-octet "." dec-octet “/” %d1-32
+    ipv4_address = dec-octet "." dec-octet "." dec-octet "." dec-octet
+    ipv6_address = ipv6 host address without prefix-length (e.g. "ffff::ffff")
     dec-octet   = DIGIT                     ; 0-9
                     / %x31-39 DIGIT         ; 10-99
                     / "1" 2DIGIT            ; 100-199

--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -658,8 +658,8 @@ Stores rules associated with a specific ACL table on the switch.
 
     ip_protocol   = h8                         ; options of the l3_protocol_type field
 
-    src_ip        = ipv4_prefix                ; options of the source ipv4
-                                               ; address (and mask) field
+    src_ip        = ipv4_prefix / ipv4_address ; source IPv4 match: CIDR prefix (e.g. "10.0.0.0/8")
+                                               ; or plain host address when paired with src_ip_mask
 
     src_ip_mask   = ipv4_address               ; optional non-contiguous IPv4 mask for src_ip.
                                                ; Used when the mask cannot be expressed as a
@@ -667,22 +667,22 @@ Stores rules associated with a specific ACL table on the switch.
                                                ; Requires src_ip to be a plain host address
                                                ; (no "/" prefix notation).
 
-    dst_ip        = ipv4_prefix                ; options of the destination ipv4
-                                               ; address (and mask) field
+    dst_ip        = ipv4_prefix / ipv4_address ; destination IPv4 match: CIDR prefix or plain
+                                               ; host address when paired with dst_ip_mask
 
     dst_ip_mask   = ipv4_address               ; optional non-contiguous IPv4 mask for dst_ip.
                                                ; See src_ip_mask for usage.
 
-    src_ipv6      = ipv6_prefix                ; options of the source ipv6
-                                               ; address (and mask) field
+    src_ipv6      = ipv6_prefix / ipv6_address ; source IPv6 match: prefix (e.g. "2001:db8::/32")
+                                               ; or plain host address when paired with src_ipv6_mask
 
     src_ipv6_mask = ipv6_address               ; optional non-contiguous IPv6 mask for src_ipv6.
                                                ; Used when the mask cannot be expressed as a
-                                               ; CIDR prefix length (e.g. "ffff::ffff").
+                                               ; prefix length (e.g. "ffff::ffff").
                                                ; Requires src_ipv6 to be a plain host address.
 
-    dst_ipv6      = ipv6_prefix                ; options of the destination ipv6
-                                               ; address (and mask) field
+    dst_ipv6      = ipv6_prefix / ipv6_address ; destination IPv6 match: prefix or plain host
+                                               ; address when paired with dst_ipv6_mask
 
     dst_ipv6_mask = ipv6_address               ; optional non-contiguous IPv6 mask for dst_ipv6.
                                                ; See src_ipv6_mask for usage.

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -61,8 +61,12 @@ acl_rule_attr_lookup_t aclMatchLookup =
     { MATCH_OUT_PORTS,         SAI_ACL_ENTRY_ATTR_FIELD_OUT_PORTS },
     { MATCH_SRC_IP,            SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP },
     { MATCH_DST_IP,            SAI_ACL_ENTRY_ATTR_FIELD_DST_IP },
+    { MATCH_SRC_IP_MASK,       SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP },
+    { MATCH_DST_IP_MASK,       SAI_ACL_ENTRY_ATTR_FIELD_DST_IP },
     { MATCH_SRC_IPV6,          SAI_ACL_ENTRY_ATTR_FIELD_SRC_IPV6 },
     { MATCH_DST_IPV6,          SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6 },
+    { MATCH_SRC_IPV6_MASK,     SAI_ACL_ENTRY_ATTR_FIELD_SRC_IPV6 },
+    { MATCH_DST_IPV6_MASK,     SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6 },
     { MATCH_L4_SRC_PORT,       SAI_ACL_ENTRY_ATTR_FIELD_L4_SRC_PORT },
     { MATCH_L4_DST_PORT,       SAI_ACL_ENTRY_ATTR_FIELD_L4_DST_PORT },
     { MATCH_ETHER_TYPE,        SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE },
@@ -470,13 +474,15 @@ static acl_table_match_field_lookup_t stageMandatoryMatchFields =
             {
                 ACL_STAGE_INGRESS,
                 {
-                    SAI_ACL_TABLE_ATTR_FIELD_ACL_RANGE_TYPE
+                    SAI_ACL_TABLE_ATTR_FIELD_ACL_RANGE_TYPE,
+                    SAI_ACL_TABLE_ATTR_FIELD_IN_PORTS
                 }
             },
             {
                 ACL_STAGE_EGRESS,
                 {
-                    SAI_ACL_TABLE_ATTR_FIELD_ACL_RANGE_TYPE
+                    SAI_ACL_TABLE_ATTR_FIELD_ACL_RANGE_TYPE,
+                    SAI_ACL_TABLE_ATTR_FIELD_OUT_PORTS
                 }
             }
         }
@@ -1097,26 +1103,53 @@ bool AclRule::validateAddMatch(string attr_name, string attr_value)
         }
         else if (attr_name == MATCH_SRC_IP || attr_name == MATCH_DST_IP || attr_name == MATCH_INNER_SRC_IP)
         {
-            IpPrefix ip(attr_value);
-
-            if (!ip.isV4())
+            if (attr_value.find('/') != string::npos)
             {
-                SWSS_LOG_ERROR("IP type is not v4 type");
-                return false;
+                IpPrefix ip(attr_value);
+                if (!ip.isV4())
+                {
+                    SWSS_LOG_ERROR("IP type is not v4 type");
+                    return false;
+                }
+                matchData.data.ip4 = ip.getIp().getV4Addr();
+                matchData.mask.ip4 = ip.getMask().getV4Addr();
             }
-            matchData.data.ip4 = ip.getIp().getV4Addr();
-            matchData.mask.ip4 = ip.getMask().getV4Addr();
+            else
+            {
+                m_pendingIpFields[attr_name] = attr_value;
+                return true;
+            }
+        }
+        else if (attr_name == MATCH_SRC_IP_MASK || attr_name == MATCH_DST_IP_MASK)
+        {
+            string ip_field = attr_name.substr(0, attr_name.length() - 5);
+            m_pendingIpMasks[ip_field] = attr_value;
+            return true;
         }
         else if (attr_name == MATCH_SRC_IPV6 || attr_name == MATCH_DST_IPV6)
         {
-            IpPrefix ip(attr_value);
-            if (ip.isV4())
+            if (attr_value.find('/') != string::npos)
             {
-                SWSS_LOG_ERROR("IP type is not v6 type");
-                return false;
+                IpPrefix ip(attr_value);
+                if (ip.isV4())
+                {
+                    SWSS_LOG_ERROR("IP type is not v6 type");
+                    return false;
+                }
+                memcpy(matchData.data.ip6, ip.getIp().getV6Addr(), 16);
+                memcpy(matchData.mask.ip6, ip.getMask().getV6Addr(), 16);
             }
-            memcpy(matchData.data.ip6, ip.getIp().getV6Addr(), 16);
-            memcpy(matchData.mask.ip6, ip.getMask().getV6Addr(), 16);
+            else
+            {
+                m_pendingIpFields[attr_name] = attr_value;
+                return true;
+            }
+        }
+        else if (attr_name == MATCH_SRC_IPV6_MASK || attr_name == MATCH_DST_IPV6_MASK)
+        {
+            string ip_field = attr_name.substr(0, attr_name.length() - 5);
+            m_pendingIpMasks[ip_field] = attr_value;
+            return true;
         }
         else if ((attr_name == MATCH_L4_SRC_PORT_RANGE) || (attr_name == MATCH_L4_DST_PORT_RANGE))
         {
@@ -1248,6 +1281,70 @@ bool AclRule::processIpType(string type, sai_uint32_t &ip_type)
 
     ip_type = it->second;
 
+    return true;
+}
+
+bool AclRule::processPendingIpFields()
+{
+    SWSS_LOG_ENTER();
+
+    for (const auto& entry : m_pendingIpFields)
+    {
+        const string& field = entry.first;
+        const string& addr  = entry.second;
+
+        sai_acl_field_data_t matchData{};
+        matchData.enable = true;
+
+        bool isV6 = (field == MATCH_SRC_IPV6 || field == MATCH_DST_IPV6);
+
+        try
+        {
+            auto maskIt = m_pendingIpMasks.find(field);
+
+            if (!isV6)
+            {
+                IpAddress ip(addr);
+                matchData.data.ip4 = ip.getV4Addr();
+                if (maskIt != m_pendingIpMasks.end())
+                {
+                    IpAddress mask(maskIt->second);
+                    matchData.mask.ip4 = mask.getV4Addr();
+                }
+                else
+                {
+                    matchData.mask.ip4 = 0xFFFFFFFF;
+                }
+            }
+            else
+            {
+                IpAddress ip(addr);
+                memcpy(matchData.data.ip6, ip.getV6Addr(), 16);
+                if (maskIt != m_pendingIpMasks.end())
+                {
+                    IpAddress mask(maskIt->second);
+                    memcpy(matchData.mask.ip6, mask.getV6Addr(), 16);
+                }
+                else
+                {
+                    memset(matchData.mask.ip6, 0xFF, 16);
+                }
+            }
+        }
+        catch (exception& e)
+        {
+            SWSS_LOG_ERROR("Failed to process IP field %s=%s: %s", field.c_str(), addr.c_str(), e.what());
+            return false;
+        }
+
+        if (!setMatch(aclMatchLookup[field], matchData))
+        {
+            return false;
+        }
+    }
+
+    m_pendingIpFields.clear();
+    m_pendingIpMasks.clear();
     return true;
 }
 
@@ -1709,6 +1806,7 @@ bool AclRule::setMatch(sai_acl_entry_attr_t matchId, sai_acl_field_data_t matchD
 
     if (!m_pTable->validateAclRuleMatch(matchId, *this))
     {
+        m_matches.erase(matchId);
         return false;
     }
 
@@ -2229,7 +2327,7 @@ AclRuleInnerSrcMacRewrite::AclRuleInnerSrcMacRewrite(AclOrch *aclOrch, string ru
  {
     SWSS_LOG_ENTER();
 
-    if ((m_rangeConfig.empty() && m_matches.empty()) || m_actions.size() != 1 )
+    if ((m_rangeConfig.empty() && m_matches.empty()) || m_actions.size() != 1)
     {
         return false;
     }
@@ -5171,6 +5269,11 @@ bool AclOrch::updateAclRule(shared_ptr<AclRule> updatedRule)
         return false;
     }
 
+    if (!updatedRule->processPendingIpFields())
+    {
+        return false;
+    }
+
     if (!m_AclTables[tableOid].updateRule(updatedRule))
     {
         return false;
@@ -5654,7 +5757,7 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
             }
 
             // validate and create ACL rule
-            if (bAllAttributesOk && newRule->validate())
+            if (bAllAttributesOk && newRule->processPendingIpFields() && newRule->validate())
             {
                 if (addAclRule(newRule, table_id))
                 {

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -1350,6 +1350,11 @@ bool AclRule::processPendingIpFields()
 
 bool AclRule::create()
 {
+    if (!processPendingIpFields())
+    {
+        return false;
+    }
+
     if (m_createCounter && !createCounter())
     {
         return false;

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -61,12 +61,8 @@ acl_rule_attr_lookup_t aclMatchLookup =
     { MATCH_OUT_PORTS,         SAI_ACL_ENTRY_ATTR_FIELD_OUT_PORTS },
     { MATCH_SRC_IP,            SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP },
     { MATCH_DST_IP,            SAI_ACL_ENTRY_ATTR_FIELD_DST_IP },
-    { MATCH_SRC_IP_MASK,       SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP },
-    { MATCH_DST_IP_MASK,       SAI_ACL_ENTRY_ATTR_FIELD_DST_IP },
     { MATCH_SRC_IPV6,          SAI_ACL_ENTRY_ATTR_FIELD_SRC_IPV6 },
     { MATCH_DST_IPV6,          SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6 },
-    { MATCH_SRC_IPV6_MASK,     SAI_ACL_ENTRY_ATTR_FIELD_SRC_IPV6 },
-    { MATCH_DST_IPV6_MASK,     SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6 },
     { MATCH_L4_SRC_PORT,       SAI_ACL_ENTRY_ATTR_FIELD_L4_SRC_PORT },
     { MATCH_L4_DST_PORT,       SAI_ACL_ENTRY_ATTR_FIELD_L4_DST_PORT },
     { MATCH_ETHER_TYPE,        SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE },
@@ -1118,12 +1114,17 @@ bool AclRule::validateAddMatch(string attr_name, string attr_value)
             }
             else
             {
+                // Intentional deferred validation: a plain IP address (no CIDR) may be paired
+                // with a separate *_MASK field. Both are stored here and combined in
+                // processPendingIpFields(). INNER_SRC_IP only supports CIDR notation and
+                // has no *_MASK counterpart.
                 m_pendingIpFields[attr_name] = attr_value;
                 return true;
             }
         }
         else if (attr_name == MATCH_SRC_IP_MASK || attr_name == MATCH_DST_IP_MASK)
         {
+            // Strip the "_MASK" suffix to get the companion IP field name (e.g. SRC_IP_MASK -> SRC_IP)
             string ip_field = attr_name.substr(0, attr_name.length() - 5);
             m_pendingIpMasks[ip_field] = attr_value;
             return true;
@@ -1143,6 +1144,7 @@ bool AclRule::validateAddMatch(string attr_name, string attr_value)
             }
             else
             {
+                // Intentional deferred validation: see comment above for IPv4 case.
                 m_pendingIpFields[attr_name] = attr_value;
                 return true;
             }
@@ -1346,12 +1348,24 @@ bool AclRule::processPendingIpFields()
     }
 
     m_pendingIpFields.clear();
+
+    // Warn about any mask fields that had no corresponding IP field
+    for (const auto& entry : m_pendingIpMasks)
+    {
+        SWSS_LOG_WARN("IP mask field %s_MASK specified without a corresponding %s address field; ignoring",
+            entry.first.c_str(), entry.first.c_str());
+    }
     m_pendingIpMasks.clear();
     return true;
 }
 
 bool AclRule::create()
 {
+    // processPendingIpFields() is also called in doAclRuleTask/updateAclRule before validate(),
+    // because validate() checks m_matches and IP fields must be moved there first.
+    // This call handles the addAclRule() code path which bypasses doAclRuleTask entirely
+    // (e.g. used by other orchs and unit tests). When coming via doAclRuleTask the maps
+    // are already cleared, so this is a no-op on that path.
     if (!processPendingIpFields())
     {
         return false;
@@ -2730,7 +2744,7 @@ bool AclTable::addStageMandatoryRangeFields()
 }
 
 
-bool AclTable::addStageMandatoryMatchFields()
+bool AclTable::addStageMandatoryMatchFields(bool l3v6InPortsEnabled, bool l3v6OutPortsEnabled)
 {
     SWSS_LOG_ENTER();
 
@@ -2749,6 +2763,21 @@ bool AclTable::addStageMandatoryMatchFields()
             {
                 if (match != SAI_ACL_TABLE_ATTR_FIELD_ACL_RANGE_TYPE)
                 {
+                    // IN_PORTS/OUT_PORTS for L3V6 are gated by SAI capability queries;
+                    // skip if the platform does not support the field.
+                    if (type.getName() == TABLE_TYPE_L3V6)
+                    {
+                        if (match == SAI_ACL_TABLE_ATTR_FIELD_IN_PORTS && !l3v6InPortsEnabled)
+                        {
+                            SWSS_LOG_INFO("Skipping IN_PORTS for L3V6 table: not supported by SAI");
+                            continue;
+                        }
+                        if (match == SAI_ACL_TABLE_ATTR_FIELD_OUT_PORTS && !l3v6OutPortsEnabled)
+                        {
+                            SWSS_LOG_INFO("Skipping OUT_PORTS for L3V6 table: not supported by SAI");
+                            continue;
+                        }
+                    }
                     type.addMatch(make_shared<AclTableMatch>(match));
                     SWSS_LOG_INFO("Added mandatory match field %s for table type %s stage %d",
                         sai_serialize_enum(match, &sai_metadata_enum_sai_acl_table_attr_t).c_str(),
@@ -3763,6 +3792,40 @@ void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, Mirr
         m_metaDataMgr.populateRange(metadataMin, metadataMax);
 
     }
+
+    // Query IN_PORTS and OUT_PORTS ACL table field capabilities independently —
+    // platforms may support one but not the other.
+    {
+        sai_attr_capability_t capability;
+        sai_status_t status = sai_query_attribute_capability(gSwitchId, SAI_OBJECT_TYPE_ACL_TABLE,
+            SAI_ACL_TABLE_ATTR_FIELD_IN_PORTS, &capability);
+        if (status == SAI_STATUS_SUCCESS)
+        {
+            m_l3v6InPortsCapability = capability.create_implemented;
+        }
+        else
+        {
+            SWSS_LOG_NOTICE("Could not query SAI_ACL_TABLE_ATTR_FIELD_IN_PORTS capability (%d), "
+                "disabling L3V6 IN_PORTS match", status);
+        }
+
+        status = sai_query_attribute_capability(gSwitchId, SAI_OBJECT_TYPE_ACL_TABLE,
+            SAI_ACL_TABLE_ATTR_FIELD_OUT_PORTS, &capability);
+        if (status == SAI_STATUS_SUCCESS)
+        {
+            m_l3v6OutPortsCapability = capability.create_implemented;
+        }
+        else
+        {
+            SWSS_LOG_NOTICE("Could not query SAI_ACL_TABLE_ATTR_FIELD_OUT_PORTS capability (%d), "
+                "disabling L3V6 OUT_PORTS match", status);
+        }
+
+        SWSS_LOG_NOTICE("    TABLE_TYPE_L3V6 IN_PORTS: %s, OUT_PORTS: %s",
+            m_l3v6InPortsCapability ? "yes" : "no",
+            m_l3v6OutPortsCapability ? "yes" : "no");
+    }
+
     // Store the capabilities in state database
     // TODO: Move this part of the code into syncd
     vector<FieldValueTuple> fvVector;
@@ -4851,7 +4914,7 @@ bool AclOrch::addAclTable(AclTable &newTable)
         }
     }
     // Update matching field according to ACL stage
-    newTable.addStageMandatoryMatchFields();
+    newTable.addStageMandatoryMatchFields(m_l3v6InPortsCapability, m_l3v6OutPortsCapability);
 
     // Add mandatory ACL action if not present
     // We need to call addMandatoryActions here because addAclTable is directly called in other orchs.

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -525,6 +525,11 @@ static map<AclObjectStatus, string> aclObjectStatusLookup =
     {AclObjectStatus::PENDING_REMOVAL, "Pending removal"}
 };
 
+static bool isSubnetNotation(const string& value)
+{
+    return value.find('/') != string::npos;
+}
+
 static bool parseIpv4Subnet(const string& value, sai_acl_field_data_t& matchData)
 {
     IpPrefix ip(value);
@@ -1136,7 +1141,7 @@ bool AclRule::validateAddMatch(string attr_name, string attr_value)
         }
         else if (attr_name == MATCH_SRC_IP || attr_name == MATCH_DST_IP || attr_name == MATCH_INNER_SRC_IP)
         {
-            if (attr_value.find('/') != string::npos)
+            if (isSubnetNotation(attr_value))
             {
                 if (!parseIpv4Subnet(attr_value, matchData))
                 {
@@ -1147,15 +1152,18 @@ bool AclRule::validateAddMatch(string attr_name, string attr_value)
             {
                 // Intentional deferred validation: a plain IP address (no CIDR) may be paired
                 // with a separate *_MASK field. Both are stored here and combined in
-                // processPendingIpFields(). INNER_SRC_IP only supports CIDR notation and
-                // has no *_MASK counterpart.
+                // processPendingIpFields(). If no *_MASK field is provided, processPendingIpFields()
+                // applies a host mask (all-ones), making it equivalent to an exact-host match.
+                // Note: INNER_SRC_IP has no *_MASK counterpart and does not support non-CIDR
+                // notation in practice, but a plain address is accepted here and treated as a
+                // host match (same as passing /32) for consistency.
                 m_pendingIpFields[attr_name] = attr_value;
                 return true;
             }
         }
         else if (attr_name == MATCH_SRC_IPV6 || attr_name == MATCH_DST_IPV6)
         {
-            if (attr_value.find('/') != string::npos)
+            if (isSubnetNotation(attr_value))
             {
                 if (!parseIpv6Subnet(attr_value, matchData))
                 {

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -472,15 +472,13 @@ static acl_table_match_field_lookup_t stageMandatoryMatchFields =
             {
                 ACL_STAGE_INGRESS,
                 {
-                    SAI_ACL_TABLE_ATTR_FIELD_ACL_RANGE_TYPE,
-                    SAI_ACL_TABLE_ATTR_FIELD_IN_PORTS
+                    SAI_ACL_TABLE_ATTR_FIELD_ACL_RANGE_TYPE
                 }
             },
             {
                 ACL_STAGE_EGRESS,
                 {
-                    SAI_ACL_TABLE_ATTR_FIELD_ACL_RANGE_TYPE,
-                    SAI_ACL_TABLE_ATTR_FIELD_OUT_PORTS
+                    SAI_ACL_TABLE_ATTR_FIELD_ACL_RANGE_TYPE
                 }
             }
         }
@@ -942,6 +940,17 @@ bool AclRule::validateAddMatch(string attr_name, string attr_value)
 
     matchData.enable = true;
 
+    // *_MASK fields have no direct SAI entry attribute mapping; they are stored
+    // here and combined with the companion IP field in processPendingIpFields().
+    // This check must come before the aclMatchLookup guard below.
+    if (attr_name == MATCH_SRC_IP_MASK || attr_name == MATCH_DST_IP_MASK ||
+        attr_name == MATCH_SRC_IPV6_MASK || attr_name == MATCH_DST_IPV6_MASK)
+    {
+        string ip_field = attr_name.substr(0, attr_name.length() - 5);
+        m_pendingIpMasks[ip_field] = attr_value;
+        return true;
+    }
+
     try
     {
         if (aclMatchLookup.find(attr_name) == aclMatchLookup.end())
@@ -1122,13 +1131,6 @@ bool AclRule::validateAddMatch(string attr_name, string attr_value)
                 return true;
             }
         }
-        else if (attr_name == MATCH_SRC_IP_MASK || attr_name == MATCH_DST_IP_MASK)
-        {
-            // Strip the "_MASK" suffix to get the companion IP field name (e.g. SRC_IP_MASK -> SRC_IP)
-            string ip_field = attr_name.substr(0, attr_name.length() - 5);
-            m_pendingIpMasks[ip_field] = attr_value;
-            return true;
-        }
         else if (attr_name == MATCH_SRC_IPV6 || attr_name == MATCH_DST_IPV6)
         {
             if (attr_value.find('/') != string::npos)
@@ -1148,12 +1150,6 @@ bool AclRule::validateAddMatch(string attr_name, string attr_value)
                 m_pendingIpFields[attr_name] = attr_value;
                 return true;
             }
-        }
-        else if (attr_name == MATCH_SRC_IPV6_MASK || attr_name == MATCH_DST_IPV6_MASK)
-        {
-            string ip_field = attr_name.substr(0, attr_name.length() - 5);
-            m_pendingIpMasks[ip_field] = attr_value;
-            return true;
         }
         else if ((attr_name == MATCH_L4_SRC_PORT_RANGE) || (attr_name == MATCH_L4_DST_PORT_RANGE))
         {
@@ -2744,7 +2740,7 @@ bool AclTable::addStageMandatoryRangeFields()
 }
 
 
-bool AclTable::addStageMandatoryMatchFields(bool l3v6InPortsEnabled, bool l3v6OutPortsEnabled)
+bool AclTable::addStageMandatoryMatchFields()
 {
     SWSS_LOG_ENTER();
 
@@ -2763,21 +2759,6 @@ bool AclTable::addStageMandatoryMatchFields(bool l3v6InPortsEnabled, bool l3v6Ou
             {
                 if (match != SAI_ACL_TABLE_ATTR_FIELD_ACL_RANGE_TYPE)
                 {
-                    // IN_PORTS/OUT_PORTS for L3V6 are gated by SAI capability queries;
-                    // skip if the platform does not support the field.
-                    if (type.getName() == TABLE_TYPE_L3V6)
-                    {
-                        if (match == SAI_ACL_TABLE_ATTR_FIELD_IN_PORTS && !l3v6InPortsEnabled)
-                        {
-                            SWSS_LOG_INFO("Skipping IN_PORTS for L3V6 table: not supported by SAI");
-                            continue;
-                        }
-                        if (match == SAI_ACL_TABLE_ATTR_FIELD_OUT_PORTS && !l3v6OutPortsEnabled)
-                        {
-                            SWSS_LOG_INFO("Skipping OUT_PORTS for L3V6 table: not supported by SAI");
-                            continue;
-                        }
-                    }
                     type.addMatch(make_shared<AclTableMatch>(match));
                     SWSS_LOG_INFO("Added mandatory match field %s for table type %s stage %d",
                         sai_serialize_enum(match, &sai_metadata_enum_sai_acl_table_attr_t).c_str(),
@@ -3791,39 +3772,6 @@ void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, Mirr
 
         m_metaDataMgr.populateRange(metadataMin, metadataMax);
 
-    }
-
-    // Query IN_PORTS and OUT_PORTS ACL table field capabilities independently —
-    // platforms may support one but not the other.
-    {
-        sai_attr_capability_t capability;
-        sai_status_t status = sai_query_attribute_capability(gSwitchId, SAI_OBJECT_TYPE_ACL_TABLE,
-            SAI_ACL_TABLE_ATTR_FIELD_IN_PORTS, &capability);
-        if (status == SAI_STATUS_SUCCESS)
-        {
-            m_l3v6InPortsCapability = capability.create_implemented;
-        }
-        else
-        {
-            SWSS_LOG_NOTICE("Could not query SAI_ACL_TABLE_ATTR_FIELD_IN_PORTS capability (%d), "
-                "disabling L3V6 IN_PORTS match", status);
-        }
-
-        status = sai_query_attribute_capability(gSwitchId, SAI_OBJECT_TYPE_ACL_TABLE,
-            SAI_ACL_TABLE_ATTR_FIELD_OUT_PORTS, &capability);
-        if (status == SAI_STATUS_SUCCESS)
-        {
-            m_l3v6OutPortsCapability = capability.create_implemented;
-        }
-        else
-        {
-            SWSS_LOG_NOTICE("Could not query SAI_ACL_TABLE_ATTR_FIELD_OUT_PORTS capability (%d), "
-                "disabling L3V6 OUT_PORTS match", status);
-        }
-
-        SWSS_LOG_NOTICE("    TABLE_TYPE_L3V6 IN_PORTS: %s, OUT_PORTS: %s",
-            m_l3v6InPortsCapability ? "yes" : "no",
-            m_l3v6OutPortsCapability ? "yes" : "no");
     }
 
     // Store the capabilities in state database
@@ -4914,7 +4862,7 @@ bool AclOrch::addAclTable(AclTable &newTable)
         }
     }
     // Update matching field according to ACL stage
-    newTable.addStageMandatoryMatchFields(m_l3v6InPortsCapability, m_l3v6OutPortsCapability);
+    newTable.addStageMandatoryMatchFields();
 
     // Add mandatory ACL action if not present
     // We need to call addMandatoryActions here because addAclTable is directly called in other orchs.

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -525,6 +525,32 @@ static map<AclObjectStatus, string> aclObjectStatusLookup =
     {AclObjectStatus::PENDING_REMOVAL, "Pending removal"}
 };
 
+static bool parseIpv4Subnet(const string& value, sai_acl_field_data_t& matchData)
+{
+    IpPrefix ip(value);
+    if (!ip.isV4())
+    {
+        SWSS_LOG_ERROR("IP type is not v4 type");
+        return false;
+    }
+    matchData.data.ip4 = ip.getIp().getV4Addr();
+    matchData.mask.ip4 = ip.getMask().getV4Addr();
+    return true;
+}
+
+static bool parseIpv6Subnet(const string& value, sai_acl_field_data_t& matchData)
+{
+    IpPrefix ip(value);
+    if (ip.isV4())
+    {
+        SWSS_LOG_ERROR("IP type is not v6 type");
+        return false;
+    }
+    memcpy(matchData.data.ip6, ip.getIp().getV6Addr(), 16);
+    memcpy(matchData.mask.ip6, ip.getMask().getV6Addr(), 16);
+    return true;
+}
+
 static sai_acl_table_attr_t AclEntryFieldToAclTableField(sai_acl_entry_attr_t attr)
 {
     if (!IS_ATTR_ID_IN_RANGE(attr, ACL_ENTRY, FIELD))
@@ -1112,14 +1138,10 @@ bool AclRule::validateAddMatch(string attr_name, string attr_value)
         {
             if (attr_value.find('/') != string::npos)
             {
-                IpPrefix ip(attr_value);
-                if (!ip.isV4())
+                if (!parseIpv4Subnet(attr_value, matchData))
                 {
-                    SWSS_LOG_ERROR("IP type is not v4 type");
                     return false;
                 }
-                matchData.data.ip4 = ip.getIp().getV4Addr();
-                matchData.mask.ip4 = ip.getMask().getV4Addr();
             }
             else
             {
@@ -1135,14 +1157,10 @@ bool AclRule::validateAddMatch(string attr_name, string attr_value)
         {
             if (attr_value.find('/') != string::npos)
             {
-                IpPrefix ip(attr_value);
-                if (ip.isV4())
+                if (!parseIpv6Subnet(attr_value, matchData))
                 {
-                    SWSS_LOG_ERROR("IP type is not v6 type");
                     return false;
                 }
-                memcpy(matchData.data.ip6, ip.getIp().getV6Addr(), 16);
-                memcpy(matchData.mask.ip6, ip.getMask().getV6Addr(), 16);
             }
             else
             {

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -1336,6 +1336,7 @@ bool AclRule::processPendingIpFields()
                 {
                     IpAddress mask(maskIt->second);
                     matchData.mask.ip4 = mask.getV4Addr();
+                    m_pendingIpMasks.erase(maskIt);
                 }
                 else
                 {
@@ -1350,6 +1351,7 @@ bool AclRule::processPendingIpFields()
                 {
                     IpAddress mask(maskIt->second);
                     memcpy(matchData.mask.ip6, mask.getV6Addr(), 16);
+                    m_pendingIpMasks.erase(maskIt);
                 }
                 else
                 {
@@ -1371,13 +1373,19 @@ bool AclRule::processPendingIpFields()
 
     m_pendingIpFields.clear();
 
-    // Warn about any mask fields that had no corresponding IP field
+    // Any masks still in the map were not consumed: either the paired IP field was absent,
+    // or it was given in CIDR notation (which bypasses m_pendingIpFields). Both are invalid
+    // because the resulting rule would silently match differently from what was configured.
     for (const auto& entry : m_pendingIpMasks)
     {
-        SWSS_LOG_WARN("IP mask field %s_MASK specified without a corresponding %s address field; ignoring",
+        SWSS_LOG_ERROR("IP mask field %s_MASK has no paired plain-address %s field; rule rejected",
             entry.first.c_str(), entry.first.c_str());
     }
-    m_pendingIpMasks.clear();
+    if (!m_pendingIpMasks.empty())
+    {
+        m_pendingIpMasks.clear();
+        return false;
+    }
     return true;
 }
 

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -345,8 +345,6 @@ public:
 
     const vector<AclRangeConfig>& getRangeConfig() const;
 
-    bool processPendingIpFields();
-
     static shared_ptr<AclRule> makeShared(AclOrch *acl,
                                         MirrorOrch *mirror,
                                         DTelOrch *dtel,
@@ -399,7 +397,9 @@ protected:
     std::map<std::string, std::string> m_pendingIpMasks;
 
 private:
+    friend class AclOrch;
     bool m_createCounter;
+    bool processPendingIpFields();
 };
 
 class AclRulePacket: public AclRule
@@ -509,7 +509,7 @@ public:
     bool addMandatoryActions();
 
     // Add stage mandatory matching fields to ACL table
-    bool addStageMandatoryMatchFields();
+    bool addStageMandatoryMatchFields(bool l3v6InPortsEnabled = false, bool l3v6OutPortsEnabled = false);
 
     // Add stage mandatory range fields to ACL table
     bool addStageMandatoryRangeFields();
@@ -638,6 +638,8 @@ public:
     bool m_isCombinedMirrorV6Table = true;
     map<string, bool> m_mirrorTableCapabilities;
     map<acl_stage_type_t, bool> m_L3V4V6Capability;
+    bool m_l3v6InPortsCapability = false;
+    bool m_l3v6OutPortsCapability = false;
     map<string, string> m_switchMetaDataCapabilities;
     
     void registerFlexCounter(const AclRule& rule);

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -28,8 +28,12 @@
 #define MATCH_OUT_PORTS         "OUT_PORTS"
 #define MATCH_SRC_IP            "SRC_IP"
 #define MATCH_DST_IP            "DST_IP"
+#define MATCH_SRC_IP_MASK       "SRC_IP_MASK"
+#define MATCH_DST_IP_MASK       "DST_IP_MASK"
 #define MATCH_SRC_IPV6          "SRC_IPV6"
 #define MATCH_DST_IPV6          "DST_IPV6"
+#define MATCH_SRC_IPV6_MASK     "SRC_IPV6_MASK"
+#define MATCH_DST_IPV6_MASK     "DST_IPV6_MASK"
 #define MATCH_L4_SRC_PORT       "L4_SRC_PORT"
 #define MATCH_L4_DST_PORT       "L4_DST_PORT"
 #define MATCH_ETHER_TYPE        "ETHER_TYPE"
@@ -340,6 +344,9 @@ public:
     bool getCreateCounter() const;
 
     const vector<AclRangeConfig>& getRangeConfig() const;
+
+    bool processPendingIpFields();
+
     static shared_ptr<AclRule> makeShared(AclOrch *acl,
                                         MirrorOrch *mirror,
                                         DTelOrch *dtel,
@@ -387,6 +394,9 @@ protected:
 
     vector<AclRangeConfig> m_rangeConfig;
     vector<AclRange*> m_ranges;
+
+    std::map<std::string, std::string> m_pendingIpFields;
+    std::map<std::string, std::string> m_pendingIpMasks;
 
 private:
     bool m_createCounter;

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -509,7 +509,7 @@ public:
     bool addMandatoryActions();
 
     // Add stage mandatory matching fields to ACL table
-    bool addStageMandatoryMatchFields(bool l3v6InPortsEnabled = false, bool l3v6OutPortsEnabled = false);
+    bool addStageMandatoryMatchFields();
 
     // Add stage mandatory range fields to ACL table
     bool addStageMandatoryRangeFields();
@@ -638,8 +638,6 @@ public:
     bool m_isCombinedMirrorV6Table = true;
     map<string, bool> m_mirrorTableCapabilities;
     map<acl_stage_type_t, bool> m_L3V4V6Capability;
-    bool m_l3v6InPortsCapability = false;
-    bool m_l3v6OutPortsCapability = false;
     map<string, string> m_switchMetaDataCapabilities;
     
     void registerFlexCounter(const AclRule& rule);

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -2559,6 +2559,8 @@ namespace aclorch_test
                 { { acl_table_id, DEL_COMMAND, {} } });
             orch->doAclTableTask(kvfDel);
         }
+    }
+
     sai_switch_api_t *old_sai_switch_api_mirror_egress;
 
     sai_status_t getSwitchAttributeMirrorEgress(_In_ sai_object_id_t switch_id, _In_ uint32_t attr_count,

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -2242,8 +2242,7 @@ namespace aclorch_test
         ASSERT_EQ(getAclRuleSaiAttribute(*rule, SAI_ACL_ENTRY_ATTR_PRIORITY), "900");
         ASSERT_EQ(getAclRuleSaiAttribute(*rule, SAI_ACL_ENTRY_ATTR_FIELD_TUNNEL_VNI), "1100&mask:0xffffffff");
 
-        // SRC IP SAI attribute is updated even though the match is not validated
-        ASSERT_EQ(getAclRuleSaiAttribute(*rule, SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP), "12.13.12.12&mask:255.255.255.0");
+        // SRC_IP match was rejected (not in table type) so it is not set in SAI
         ASSERT_EQ(getAclRuleSaiAttribute(*rule, SAI_ACL_ENTRY_ATTR_FIELD_INNER_SRC_IP), "2.3.2.2&mask:255.255.248.0");
         ASSERT_EQ(getAclRuleSaiAttribute(*rule, SAI_ACL_ENTRY_ATTR_ACTION_SET_INNER_SRC_MAC), "60:30:34:AB:CD:EF");
 
@@ -2363,5 +2362,202 @@ namespace aclorch_test
         });
         orch->doAclRuleTask(ruleKofvt);
         ASSERT_NE(orch->getAclRule(aclTableName, aclRuleName), nullptr);
+    }
+
+    // Verify that SRC_IP/DST_IP with a separate _MASK field creates the correct SAI
+    // attribute (arbitrary mask, not just prefix-length notation).
+    // Also verifies backward compatibility: CIDR notation (/prefix) still works.
+    TEST_F(AclOrchTest, AclRule_ArbitraryIpv4Mask)
+    {
+        const string acl_table_id = "acl_table_1";
+        const string acl_rule_id  = "acl_rule_1";
+
+        auto orch = createAclOrch();
+
+        auto kvfAclTable = deque<KeyOpFieldsValuesTuple>(
+            { { acl_table_id,
+                SET_COMMAND,
+                { { ACL_TABLE_DESCRIPTION, "TEST" },
+                  { ACL_TABLE_TYPE, TABLE_TYPE_L3 },
+                  { ACL_TABLE_STAGE, STAGE_INGRESS },
+                  { ACL_TABLE_PORTS, "1,2" } } } });
+        orch->doAclTableTask(kvfAclTable);
+
+        const auto &acl_tables = orch->getAclTables();
+        auto acl_table_oid = orch->getTableById(acl_table_id);
+        ASSERT_NE(acl_table_oid, SAI_NULL_OBJECT_ID);
+        const auto &acl_table = acl_tables.at(acl_table_oid);
+
+        auto addRule = [&](const vector<FieldValueTuple> &extra_fields)
+        {
+            auto kofvt = deque<KeyOpFieldsValuesTuple>(
+                { { acl_table_id + "|" + acl_rule_id,
+                    SET_COMMAND,
+                    [&]() {
+                        vector<FieldValueTuple> fvs = {
+                            { RULE_PRIORITY, "100" },
+                            { ACTION_PACKET_ACTION, PACKET_ACTION_DROP },
+                        };
+                        fvs.insert(fvs.end(), extra_fields.begin(), extra_fields.end());
+                        return fvs;
+                    }() } });
+            orch->doAclRuleTask(kofvt);
+        };
+
+        auto delRule = [&]()
+        {
+            auto kofvt = deque<KeyOpFieldsValuesTuple>(
+                { { acl_table_id + "|" + acl_rule_id, DEL_COMMAND, {} } });
+            orch->doAclRuleTask(kofvt);
+            ASSERT_EQ(acl_table.rules.find(acl_rule_id), acl_table.rules.end());
+        };
+
+        // SRC_IP plain address + SRC_IP_MASK
+        addRule({ { MATCH_SRC_IP, "192.168.1.1" }, { MATCH_SRC_IP_MASK, "255.255.255.0" } });
+        ASSERT_NE(acl_table.rules.find(acl_rule_id), acl_table.rules.end());
+        ASSERT_EQ(getAclRuleSaiAttribute(*acl_table.rules.at(acl_rule_id), SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP),
+                  "192.168.1.1&mask:255.255.255.0");
+        delRule();
+
+        // DST_IP plain address + DST_IP_MASK
+        addRule({ { MATCH_DST_IP, "10.0.0.1" }, { MATCH_DST_IP_MASK, "255.0.0.0" } });
+        ASSERT_NE(acl_table.rules.find(acl_rule_id), acl_table.rules.end());
+        ASSERT_EQ(getAclRuleSaiAttribute(*acl_table.rules.at(acl_rule_id), SAI_ACL_ENTRY_ATTR_FIELD_DST_IP),
+                  "10.0.0.1&mask:255.0.0.0");
+        delRule();
+
+        // Backward compat: CIDR notation still works
+        addRule({ { MATCH_SRC_IP, "192.168.0.0/16" } });
+        ASSERT_NE(acl_table.rules.find(acl_rule_id), acl_table.rules.end());
+        ASSERT_EQ(getAclRuleSaiAttribute(*acl_table.rules.at(acl_rule_id), SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP),
+                  "192.168.0.0&mask:255.255.0.0");
+        delRule();
+    }
+
+    // Verify that SRC_IPV6/DST_IPV6 with a separate _MASK field creates the correct SAI
+    // attribute with an arbitrary IPv6 mask.
+    TEST_F(AclOrchTest, AclRule_ArbitraryIpv6Mask)
+    {
+        const string acl_table_id = "acl_table_1";
+        const string acl_rule_id  = "acl_rule_1";
+
+        auto orch = createAclOrch();
+
+        auto kvfAclTable = deque<KeyOpFieldsValuesTuple>(
+            { { acl_table_id,
+                SET_COMMAND,
+                { { ACL_TABLE_DESCRIPTION, "TEST" },
+                  { ACL_TABLE_TYPE, TABLE_TYPE_L3V6 },
+                  { ACL_TABLE_STAGE, STAGE_INGRESS },
+                  { ACL_TABLE_PORTS, "1,2" } } } });
+        orch->doAclTableTask(kvfAclTable);
+
+        const auto &acl_tables = orch->getAclTables();
+        auto acl_table_oid = orch->getTableById(acl_table_id);
+        ASSERT_NE(acl_table_oid, SAI_NULL_OBJECT_ID);
+        const auto &acl_table = acl_tables.at(acl_table_oid);
+
+        auto addRule = [&](const vector<FieldValueTuple> &extra_fields)
+        {
+            auto kofvt = deque<KeyOpFieldsValuesTuple>(
+                { { acl_table_id + "|" + acl_rule_id,
+                    SET_COMMAND,
+                    [&]() {
+                        vector<FieldValueTuple> fvs = {
+                            { RULE_PRIORITY, "100" },
+                            { ACTION_PACKET_ACTION, PACKET_ACTION_DROP },
+                        };
+                        fvs.insert(fvs.end(), extra_fields.begin(), extra_fields.end());
+                        return fvs;
+                    }() } });
+            orch->doAclRuleTask(kofvt);
+        };
+
+        auto delRule = [&]()
+        {
+            auto kofvt = deque<KeyOpFieldsValuesTuple>(
+                { { acl_table_id + "|" + acl_rule_id, DEL_COMMAND, {} } });
+            orch->doAclRuleTask(kofvt);
+            ASSERT_EQ(acl_table.rules.find(acl_rule_id), acl_table.rules.end());
+        };
+
+        // SRC_IPV6 plain address + SRC_IPV6_MASK
+        addRule({ { MATCH_SRC_IPV6, "2001:db8::1" }, { MATCH_SRC_IPV6_MASK, "ffff:ffff::" } });
+        ASSERT_NE(acl_table.rules.find(acl_rule_id), acl_table.rules.end());
+        ASSERT_EQ(getAclRuleSaiAttribute(*acl_table.rules.at(acl_rule_id), SAI_ACL_ENTRY_ATTR_FIELD_SRC_IPV6),
+                  "2001:db8::1&mask:ffff:ffff::");
+        delRule();
+
+        // DST_IPV6 plain address + DST_IPV6_MASK
+        addRule({ { MATCH_DST_IPV6, "fe80::1" }, { MATCH_DST_IPV6_MASK, "ffff::" } });
+        ASSERT_NE(acl_table.rules.find(acl_rule_id), acl_table.rules.end());
+        ASSERT_EQ(getAclRuleSaiAttribute(*acl_table.rules.at(acl_rule_id), SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6),
+                  "fe80::1&mask:ffff::");
+        delRule();
+
+        // Backward compat: CIDR notation still works
+        addRule({ { MATCH_SRC_IPV6, "2001:db8::/32" } });
+        ASSERT_NE(acl_table.rules.find(acl_rule_id), acl_table.rules.end());
+        ASSERT_EQ(getAclRuleSaiAttribute(*acl_table.rules.at(acl_rule_id), SAI_ACL_ENTRY_ATTR_FIELD_SRC_IPV6),
+                  "2001:db8::&mask:ffff:ffff::");
+        delRule();
+    }
+
+    // Verify that L3V6 ACL tables automatically have IN_PORTS capability at ingress
+    // and OUT_PORTS capability at egress via stageMandatoryMatchFields.
+    // Rules are not required to use these fields; they are just enabled on the table.
+    TEST_F(AclOrchTest, L3V6Acl_StagePortMatchCapability)
+    {
+        auto orch = createAclOrch();
+
+        // Ingress L3V6 table: SAI table attributes must include FIELD_IN_PORTS.
+        {
+            const string acl_table_id = "l3v6_ingress_table";
+            auto kvfAclTable = deque<KeyOpFieldsValuesTuple>(
+                { { acl_table_id,
+                    SET_COMMAND,
+                    { { ACL_TABLE_DESCRIPTION, "L3V6 ingress" },
+                      { ACL_TABLE_TYPE, TABLE_TYPE_L3V6 },
+                      { ACL_TABLE_STAGE, STAGE_INGRESS },
+                      { ACL_TABLE_PORTS, "1,2" } } } });
+            orch->doAclTableTask(kvfAclTable);
+
+            auto acl_table_oid = orch->getTableById(acl_table_id);
+            ASSERT_NE(acl_table_oid, SAI_NULL_OBJECT_ID);
+
+            const auto &acl_table = orch->getAclTables().at(acl_table_oid);
+            const auto &matches = acl_table.type.getMatches();
+            ASSERT_NE(matches.find(SAI_ACL_TABLE_ATTR_FIELD_IN_PORTS), matches.end())
+                << "L3V6 ingress table must have FIELD_IN_PORTS as a mandatory match";
+
+            auto kvfDel = deque<KeyOpFieldsValuesTuple>(
+                { { acl_table_id, DEL_COMMAND, {} } });
+            orch->doAclTableTask(kvfDel);
+        }
+
+        // Egress L3V6 table: SAI table attributes must include FIELD_OUT_PORTS.
+        {
+            const string acl_table_id = "l3v6_egress_table";
+            auto kvfAclTable = deque<KeyOpFieldsValuesTuple>(
+                { { acl_table_id,
+                    SET_COMMAND,
+                    { { ACL_TABLE_DESCRIPTION, "L3V6 egress" },
+                      { ACL_TABLE_TYPE, TABLE_TYPE_L3V6 },
+                      { ACL_TABLE_STAGE, STAGE_EGRESS },
+                      { ACL_TABLE_PORTS, "1,2" } } } });
+            orch->doAclTableTask(kvfAclTable);
+
+            auto acl_table_oid = orch->getTableById(acl_table_id);
+            ASSERT_NE(acl_table_oid, SAI_NULL_OBJECT_ID);
+
+            const auto &acl_table = orch->getAclTables().at(acl_table_oid);
+            const auto &matches = acl_table.type.getMatches();
+            ASSERT_NE(matches.find(SAI_ACL_TABLE_ATTR_FIELD_OUT_PORTS), matches.end())
+                << "L3V6 egress table must have FIELD_OUT_PORTS as a mandatory match";
+
+            auto kvfDel = deque<KeyOpFieldsValuesTuple>(
+                { { acl_table_id, DEL_COMMAND, {} } });
+            orch->doAclTableTask(kvfDel);
+        }
     }
 } // namespace nsAclOrchTest

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -2412,18 +2412,18 @@ namespace aclorch_test
             ASSERT_EQ(acl_table.rules.find(acl_rule_id), acl_table.rules.end());
         };
 
-        // SRC_IP plain address + SRC_IP_MASK
-        addRule({ { MATCH_SRC_IP, "192.168.1.1" }, { MATCH_SRC_IP_MASK, "255.255.255.0" } });
+        // SRC_IP plain address + SRC_IP_MASK — non-contiguous mask (cannot be /prefix)
+        addRule({ { MATCH_SRC_IP, "192.168.1.1" }, { MATCH_SRC_IP_MASK, "255.0.255.0" } });
         ASSERT_NE(acl_table.rules.find(acl_rule_id), acl_table.rules.end());
         ASSERT_EQ(getAclRuleSaiAttribute(*acl_table.rules.at(acl_rule_id), SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP),
-                  "192.168.1.1&mask:255.255.255.0");
+                  "192.168.1.1&mask:255.0.255.0");
         delRule();
 
-        // DST_IP plain address + DST_IP_MASK
-        addRule({ { MATCH_DST_IP, "10.0.0.1" }, { MATCH_DST_IP_MASK, "255.0.0.0" } });
+        // DST_IP plain address + DST_IP_MASK — non-contiguous mask
+        addRule({ { MATCH_DST_IP, "10.1.0.1" }, { MATCH_DST_IP_MASK, "255.0.255.0" } });
         ASSERT_NE(acl_table.rules.find(acl_rule_id), acl_table.rules.end());
         ASSERT_EQ(getAclRuleSaiAttribute(*acl_table.rules.at(acl_rule_id), SAI_ACL_ENTRY_ATTR_FIELD_DST_IP),
-                  "10.0.0.1&mask:255.0.0.0");
+                  "10.1.0.1&mask:255.0.255.0");
         delRule();
 
         // Backward compat: CIDR notation still works
@@ -2481,18 +2481,18 @@ namespace aclorch_test
             ASSERT_EQ(acl_table.rules.find(acl_rule_id), acl_table.rules.end());
         };
 
-        // SRC_IPV6 plain address + SRC_IPV6_MASK
-        addRule({ { MATCH_SRC_IPV6, "2001:db8::1" }, { MATCH_SRC_IPV6_MASK, "ffff:ffff::" } });
+        // SRC_IPV6 plain address + SRC_IPV6_MASK — non-contiguous mask (cannot be /prefix)
+        addRule({ { MATCH_SRC_IPV6, "2001:db8::1" }, { MATCH_SRC_IPV6_MASK, "ffff::ffff" } });
         ASSERT_NE(acl_table.rules.find(acl_rule_id), acl_table.rules.end());
         ASSERT_EQ(getAclRuleSaiAttribute(*acl_table.rules.at(acl_rule_id), SAI_ACL_ENTRY_ATTR_FIELD_SRC_IPV6),
-                  "2001:db8::1&mask:ffff:ffff::");
+                  "2001:db8::1&mask:ffff::ffff");
         delRule();
 
-        // DST_IPV6 plain address + DST_IPV6_MASK
-        addRule({ { MATCH_DST_IPV6, "fe80::1" }, { MATCH_DST_IPV6_MASK, "ffff::" } });
+        // DST_IPV6 plain address + DST_IPV6_MASK — non-contiguous mask
+        addRule({ { MATCH_DST_IPV6, "fe80::1" }, { MATCH_DST_IPV6_MASK, "ffff::ffff" } });
         ASSERT_NE(acl_table.rules.find(acl_rule_id), acl_table.rules.end());
         ASSERT_EQ(getAclRuleSaiAttribute(*acl_table.rules.at(acl_rule_id), SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6),
-                  "fe80::1&mask:ffff::");
+                  "fe80::1&mask:ffff::ffff");
         delRule();
 
         // Backward compat: CIDR notation still works

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -2503,64 +2503,6 @@ namespace aclorch_test
         delRule();
     }
 
-    // Verify that L3V6 ACL tables automatically have IN_PORTS capability at ingress
-    // and OUT_PORTS capability at egress via stageMandatoryMatchFields.
-    // Rules are not required to use these fields; they are just enabled on the table.
-    TEST_F(AclOrchTest, L3V6Acl_StagePortMatchCapability)
-    {
-        auto orch = createAclOrch();
-
-        // Ingress L3V6 table: SAI table attributes must include FIELD_IN_PORTS.
-        {
-            const string acl_table_id = "l3v6_ingress_table";
-            auto kvfAclTable = deque<KeyOpFieldsValuesTuple>(
-                { { acl_table_id,
-                    SET_COMMAND,
-                    { { ACL_TABLE_DESCRIPTION, "L3V6 ingress" },
-                      { ACL_TABLE_TYPE, TABLE_TYPE_L3V6 },
-                      { ACL_TABLE_STAGE, STAGE_INGRESS },
-                      { ACL_TABLE_PORTS, "1,2" } } } });
-            orch->doAclTableTask(kvfAclTable);
-
-            auto acl_table_oid = orch->getTableById(acl_table_id);
-            ASSERT_NE(acl_table_oid, SAI_NULL_OBJECT_ID);
-
-            const auto &acl_table = orch->getAclTables().at(acl_table_oid);
-            const auto &matches = acl_table.type.getMatches();
-            ASSERT_NE(matches.find(SAI_ACL_TABLE_ATTR_FIELD_IN_PORTS), matches.end())
-                << "L3V6 ingress table must have FIELD_IN_PORTS as a mandatory match";
-
-            auto kvfDel = deque<KeyOpFieldsValuesTuple>(
-                { { acl_table_id, DEL_COMMAND, {} } });
-            orch->doAclTableTask(kvfDel);
-        }
-
-        // Egress L3V6 table: SAI table attributes must include FIELD_OUT_PORTS.
-        {
-            const string acl_table_id = "l3v6_egress_table";
-            auto kvfAclTable = deque<KeyOpFieldsValuesTuple>(
-                { { acl_table_id,
-                    SET_COMMAND,
-                    { { ACL_TABLE_DESCRIPTION, "L3V6 egress" },
-                      { ACL_TABLE_TYPE, TABLE_TYPE_L3V6 },
-                      { ACL_TABLE_STAGE, STAGE_EGRESS },
-                      { ACL_TABLE_PORTS, "1,2" } } } });
-            orch->doAclTableTask(kvfAclTable);
-
-            auto acl_table_oid = orch->getTableById(acl_table_id);
-            ASSERT_NE(acl_table_oid, SAI_NULL_OBJECT_ID);
-
-            const auto &acl_table = orch->getAclTables().at(acl_table_oid);
-            const auto &matches = acl_table.type.getMatches();
-            ASSERT_NE(matches.find(SAI_ACL_TABLE_ATTR_FIELD_OUT_PORTS), matches.end())
-                << "L3V6 egress table must have FIELD_OUT_PORTS as a mandatory match";
-
-            auto kvfDel = deque<KeyOpFieldsValuesTuple>(
-                { { acl_table_id, DEL_COMMAND, {} } });
-            orch->doAclTableTask(kvfDel);
-        }
-    }
-
     sai_switch_api_t *old_sai_switch_api_mirror_egress;
 
     sai_status_t getSwitchAttributeMirrorEgress(_In_ sai_object_id_t switch_id, _In_ uint32_t attr_count,

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -779,6 +779,80 @@ class TestAcl:
         else:
             assert not match_in_ports
 
+    def test_AclRuleArbitraryIpv4Mask(self, dvs_acl, l3_acl_table):
+        """Verify SRC_IP/DST_IP with a separate *_MASK field creates an ACL rule
+        with a non-contiguous IPv4 mask that cannot be expressed as a CIDR prefix.
+        """
+        # SRC_IP + SRC_IP_MASK — non-contiguous mask (cannot be expressed as /prefix)
+        config_qualifiers = {"SRC_IP": "192.168.1.1", "SRC_IP_MASK": "255.0.255.0"}
+        expected_sai_qualifiers = {
+            "SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": dvs_acl.get_simple_qualifier_comparator("192.168.1.1&mask:255.0.255.0")
+        }
+        dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, "Active")
+        dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
+
+        # DST_IP + DST_IP_MASK — non-contiguous mask
+        config_qualifiers = {"DST_IP": "10.1.0.1", "DST_IP_MASK": "255.0.255.0"}
+        expected_sai_qualifiers = {
+            "SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": dvs_acl.get_simple_qualifier_comparator("10.1.0.1&mask:255.0.255.0")
+        }
+        dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, "Active")
+        dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
+
+        # CIDR notation still works (backward compatibility)
+        config_qualifiers = {"SRC_IP": "192.168.0.0/16"}
+        expected_sai_qualifiers = {
+            "SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": dvs_acl.get_simple_qualifier_comparator("192.168.0.0&mask:255.255.0.0")
+        }
+        dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, "Active")
+        dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
+
+    def test_V6AclRuleArbitraryIpv6Mask(self, dvs_acl, l3v6_acl_table):
+        """Verify SRC_IPV6/DST_IPV6 with a separate *_MASK field creates an ACL rule
+        with a non-contiguous IPv6 mask that cannot be expressed as a CIDR prefix.
+        """
+        # SRC_IPV6 + SRC_IPV6_MASK — non-contiguous mask (cannot be expressed as /prefix)
+        config_qualifiers = {"SRC_IPV6": "2001:db8::1", "SRC_IPV6_MASK": "ffff::ffff"}
+        expected_sai_qualifiers = {
+            "SAI_ACL_ENTRY_ATTR_FIELD_SRC_IPV6": dvs_acl.get_simple_qualifier_comparator("2001:db8::1&mask:ffff::ffff")
+        }
+        dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, "Active")
+        dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
+
+        # DST_IPV6 + DST_IPV6_MASK — non-contiguous mask
+        config_qualifiers = {"DST_IPV6": "fe80::1", "DST_IPV6_MASK": "ffff::ffff"}
+        expected_sai_qualifiers = {
+            "SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6": dvs_acl.get_simple_qualifier_comparator("fe80::1&mask:ffff::ffff")
+        }
+        dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, "Active")
+        dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
+
+        # CIDR notation still works (backward compatibility)
+        config_qualifiers = {"SRC_IPV6": "2777::0/64"}
+        expected_sai_qualifiers = {
+            "SAI_ACL_ENTRY_ATTR_FIELD_SRC_IPV6": dvs_acl.get_simple_qualifier_comparator("2777::&mask:ffff:ffff:ffff:ffff::")
+        }
+        dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, "Active")
+        dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
+
     def test_AclTableMandatoryRangeFields(self, dvs, l3_acl_table):
         """
         The test case is to verify range qualifier is not applied for egress ACL

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -853,6 +853,49 @@ class TestAcl:
         dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
         dvs_acl.verify_no_acl_rules()
 
+    def test_AclRuleInvalidMaskCombinations(self, dvs_acl, l3_acl_table):
+        """Verify that invalid mask combinations are rejected (rule stays Inactive).
+
+        Two invalid cases per field:
+          - *_MASK without a paired plain-address field
+          - *_MASK combined with a CIDR-notation address (e.g. 10.0.0.0/8)
+        """
+        invalid_cases = [
+            # SRC_IP_MASK without SRC_IP
+            {"SRC_IP_MASK": "255.0.255.0"},
+            # SRC_IP_MASK with CIDR SRC_IP
+            {"SRC_IP": "10.0.0.0/8", "SRC_IP_MASK": "255.0.255.0"},
+            # DST_IP_MASK without DST_IP
+            {"DST_IP_MASK": "255.0.255.0"},
+            # DST_IP_MASK with CIDR DST_IP
+            {"DST_IP": "192.168.0.0/16", "DST_IP_MASK": "255.0.255.0"},
+        ]
+        for qualifiers in invalid_cases:
+            dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, qualifiers)
+            dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, "Inactive")
+            dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+            dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, None)
+            dvs_acl.verify_no_acl_rules()
+
+    def test_V6AclRuleInvalidMaskCombinations(self, dvs_acl, l3v6_acl_table):
+        """Verify that invalid IPv6 mask combinations are rejected (rule stays Inactive)."""
+        invalid_cases = [
+            # SRC_IPV6_MASK without SRC_IPV6
+            {"SRC_IPV6_MASK": "ffff::ffff"},
+            # SRC_IPV6_MASK with CIDR SRC_IPV6
+            {"SRC_IPV6": "2001:db8::/32", "SRC_IPV6_MASK": "ffff::ffff"},
+            # DST_IPV6_MASK without DST_IPV6
+            {"DST_IPV6_MASK": "ffff::ffff"},
+            # DST_IPV6_MASK with CIDR DST_IPV6
+            {"DST_IPV6": "2001:db8::/32", "DST_IPV6_MASK": "ffff::ffff"},
+        ]
+        for qualifiers in invalid_cases:
+            dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, qualifiers)
+            dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, "Inactive")
+            dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+            dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, None)
+            dvs_acl.verify_no_acl_rules()
+
     def test_AclTableMandatoryRangeFields(self, dvs, l3_acl_table):
         """
         The test case is to verify range qualifier is not applied for egress ACL


### PR DESCRIPTION
**What I did**

Added `SRC_IP_MASK`, `DST_IP_MASK`, `SRC_IPV6_MASK`, `DST_IPV6_MASK` match fields to support non-contiguous (arbitrary) IPv4/IPv6 masks that cannot be expressed in CIDR notation. CIDR notation continues to work unchanged.

**Why I did it**

Some network policies require matching on non-contiguous bit patterns (e.g. `255.0.255.0`) that are impossible to express as a prefix length. This adds the flexibility to specify the mask independently of the IP address.

**How I verified it**

- Unit tests: `AclRule_ArbitraryIpv4Mask`, `AclRule_ArbitraryIpv6Mask` in `aclorch_ut.cpp`
- DVS tests: `test_AclRuleArbitraryIpv4Mask`, `test_V6AclRuleArbitraryIpv6Mask` in `test_acl.py`

**Details if related**

Side-effect fix: `setMatch()` now correctly removes a rejected SAI attribute from `m_matches` on validation failure (pre-existing bug).

Yang Model PR: https://github.com/sonic-net/sonic-buildimage/pull/27046