### PR TITLE
orchagent: Replace operator[] with find() in TunnelDecapOrch refcount helpers

### DIFF
--- a/orchagent/tunneldecaporch.h
+++ b/orchagent/tunneldecaporch.h
@@ -152,15 +152,18 @@ private:
     void RemoveTunnelIfNotReferenced(const std::string &tunnel_name);
     int getTunnelRefCount(const std::string &tunnel_name)
     {
-        return tunnelTable[tunnel_name].ref_count;
+        auto it = tunnelTable.find(tunnel_name);
+        return it == tunnelTable.end() ? 0 : it->second.ref_count;
     }
     void increaseTunnelRefCount(const std::string &tunnel_name)
     {
-        ++tunnelTable[tunnel_name].ref_count;
+        auto it = tunnelTable.find(tunnel_name);
+        if (it != tunnelTable.end()) ++it->second.ref_count;
     }
     void decreaseTunnelRefCount(const std::string &tunnel_name)
     {
-        --tunnelTable[tunnel_name].ref_count;
+        auto it = tunnelTable.find(tunnel_name);
+        if (it != tunnelTable.end()) --it->second.ref_count;
     }
 };
 #endif

--- a/orchagent/tunneldecaporch.h
+++ b/orchagent/tunneldecaporch.h
@@ -72,6 +72,8 @@ typedef std::map<std::string, Nexthop> TunnelNhs;
 /* unhandled decap term table */
 typedef std::map<std::string, std::map<swss::IpPrefix, TunnelTermEntry>> UnhandledDecapTermTable;
 
+namespace tunneldecaporch_test { class TunnelDecapOrchTest; }
+
 class TunnelDecapOrch : public Orch
 {
 public:
@@ -89,6 +91,8 @@ public:
     }
 
 private:
+    friend class tunneldecaporch_test::TunnelDecapOrchTest;
+
     TunnelTable tunnelTable;
     TunnelNhs   tunnelNhs;
     UnhandledDecapTermTable unhandledDecapTerms;

--- a/tests/mock_tests/tunneldecaporch_ut.cpp
+++ b/tests/mock_tests/tunneldecaporch_ut.cpp
@@ -518,4 +518,21 @@ namespace tunneldecaporch_test
         });
     }
 
+    TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_RefCountMissingTunnelDoesNotInsert)
+    {
+        vector<string> tunnel_tables = { APP_TUNNEL_DECAP_TABLE_NAME };
+        auto tunnelDecapOrch = make_shared<TunnelDecapOrch>(
+            m_app_db.get(), m_state_db.get(), m_config_db.get(), tunnel_tables);
+        ASSERT_NE(tunnelDecapOrch, nullptr);
+
+        // operator[] would insert a default entry; find() must not.
+        EXPECT_EQ(tunnelDecapOrch->getTunnelRefCount("missing_tunnel"), 0);
+        tunnelDecapOrch->increaseTunnelRefCount("missing_tunnel");
+        EXPECT_EQ(tunnelDecapOrch->getTunnelRefCount("missing_tunnel"), 0);
+        tunnelDecapOrch->decreaseTunnelRefCount("missing_tunnel");
+        EXPECT_EQ(tunnelDecapOrch->getTunnelRefCount("missing_tunnel"), 0);
+        EXPECT_EQ(tunnelDecapOrch->tunnelTable.find("missing_tunnel"),
+                  tunnelDecapOrch->tunnelTable.end());
+    }
+
 } // namespace tunneldecaporch_test

--- a/tests/mock_tests/tunneldecaporch_ut.cpp
+++ b/tests/mock_tests/tunneldecaporch_ut.cpp
@@ -156,6 +156,16 @@ namespace tunneldecaporch_test
             delete gCrmOrch;
             gCrmOrch = nullptr;
         }
+
+        void expectMissingTunnelRefCountUnchanged(TunnelDecapOrch &orch, const string &name)
+        {
+            EXPECT_EQ(orch.getTunnelRefCount(name), 0);
+            orch.increaseTunnelRefCount(name);
+            EXPECT_EQ(orch.getTunnelRefCount(name), 0);
+            orch.decreaseTunnelRefCount(name);
+            EXPECT_EQ(orch.getTunnelRefCount(name), 0);
+            EXPECT_EQ(orch.tunnelTable.find(name), orch.tunnelTable.end());
+        }
     };
 
     TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_Creation)
@@ -526,13 +536,7 @@ namespace tunneldecaporch_test
         ASSERT_NE(tunnelDecapOrch, nullptr);
 
         // operator[] would insert a default entry; find() must not.
-        EXPECT_EQ(tunnelDecapOrch->getTunnelRefCount("missing_tunnel"), 0);
-        tunnelDecapOrch->increaseTunnelRefCount("missing_tunnel");
-        EXPECT_EQ(tunnelDecapOrch->getTunnelRefCount("missing_tunnel"), 0);
-        tunnelDecapOrch->decreaseTunnelRefCount("missing_tunnel");
-        EXPECT_EQ(tunnelDecapOrch->getTunnelRefCount("missing_tunnel"), 0);
-        EXPECT_EQ(tunnelDecapOrch->tunnelTable.find("missing_tunnel"),
-                  tunnelDecapOrch->tunnelTable.end());
+        expectMissingTunnelRefCountUnchanged(*tunnelDecapOrch, "missing_tunnel");
     }
 
 } // namespace tunneldecaporch_test


### PR DESCRIPTION
**What I did**

Replaced `std::map::operator[]` with `find()` in the three tunnel refcount helper functions in `TunnelDecapOrch`: `getTunnelRefCount`, `increaseTunnelRefCount`, and `decreaseTunnelRefCount`.

**Why I did it**

`operator[]` silently default-constructs a `TunnelEntry` when the key is absent. This creates a phantom entry with uninitialized SAI OIDs and a zero refcount. Because `RemoveTunnelIfNotReferenced` checks `getTunnelRefCount() == 0`, a phantom entry satisfies that condition and can trigger `removeDecapTunnel` on an invalid tunnel object, leading to SAI errors or a crash.

Using `find()` makes lookups on non-existent tunnels harmless: `getTunnelRefCount` returns 0 without inserting, and `increase`/`decrease` become no-ops for unknown names.

**How I verified it**

Code inspection — the fix is mechanical. No behavioral change for tunnels that exist in the map. All existing tests pass.

Signed-off-by: Uma Ramanathan <uramanathan@upscaleai.com>