### PR TITLE
Add explicitly ECN mode attributes for Dual-ToR IPinIP tunnel

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -219,7 +219,9 @@ static sai_object_id_t create_tunnel(
     const IpAddress* p_src_ip,
     sai_object_id_t tc_to_dscp_map_id,
     sai_object_id_t tc_to_queue_map_id,
-    string dscp_mode_name)
+    string dscp_mode_name,
+    const string& ecn_mode_name,
+    const string& encap_ecn_mode_name)
 {
     sai_status_t status;
 
@@ -285,6 +287,35 @@ static sai_object_id_t create_tunnel(
         attr.id = SAI_TUNNEL_ATTR_DECAP_DSCP_MODE;
         attr.value.s32 = dscp_mode;
         tunnel_attrs.push_back(attr);
+    }
+
+    /* ECN: same semantics as TunnelDecapOrch::addDecapTunnel (CONFIG TUNNEL / APP TUNNEL_DECAP_TABLE) */
+    if (ecn_mode_name == "copy_from_outer")
+    {
+        attr.id = SAI_TUNNEL_ATTR_DECAP_ECN_MODE;
+        attr.value.s32 = SAI_TUNNEL_DECAP_ECN_MODE_COPY_FROM_OUTER;
+        tunnel_attrs.push_back(attr);
+    }
+    else if (ecn_mode_name == "standard")
+    {
+        attr.id = SAI_TUNNEL_ATTR_DECAP_ECN_MODE;
+        attr.value.s32 = SAI_TUNNEL_DECAP_ECN_MODE_STANDARD;
+        tunnel_attrs.push_back(attr);
+    }
+    else if (!ecn_mode_name.empty())
+    {
+        SWSS_LOG_ERROR("Invalid mux tunnel ecn_mode '%s'", ecn_mode_name.c_str());
+    }
+
+    if (encap_ecn_mode_name == "standard")
+    {
+        attr.id = SAI_TUNNEL_ATTR_ENCAP_ECN_MODE;
+        attr.value.s32 = SAI_TUNNEL_ENCAP_ECN_MODE_STANDARD;
+        tunnel_attrs.push_back(attr);
+    }
+    else if (!encap_ecn_mode_name.empty())
+    {
+        SWSS_LOG_ERROR("Unsupported mux tunnel encap_ecn_mode '%s'", encap_ecn_mode_name.c_str());
     }
 
     attr.id = SAI_TUNNEL_ATTR_LOOPBACK_PACKET_ACTION;
@@ -2362,6 +2393,18 @@ bool MuxOrch::handlePeerSwitch(const Request& request)
             SWSS_LOG_NOTICE("dscp_mode for tunnel %s is not available. Will not be applied", MUX_TUNNEL);
         }
 
+        string ecn_mode_name = decap_orch_->getEcnMode(MUX_TUNNEL);
+        if (ecn_mode_name == "")
+        {
+            SWSS_LOG_NOTICE("ecn_mode for tunnel %s is not available. ECN SAI attrs will not be set", MUX_TUNNEL);
+        }
+
+        string encap_ecn_mode_name = decap_orch_->getEncapEcnMode(MUX_TUNNEL);
+        if (encap_ecn_mode_name == "")
+        {
+            SWSS_LOG_NOTICE("encap_ecn_mode for tunnel %s is not available. Encap ECN will not be set", MUX_TUNNEL);
+        }
+
         // Read tc_to_dscp_map_id of MuxTunnel0 from decap_orch
         sai_object_id_t tc_to_dscp_map_id = SAI_NULL_OBJECT_ID;
         decap_orch_->getQosMapId(MUX_TUNNEL, encap_tc_to_dscp_field_name, tc_to_dscp_map_id);
@@ -2377,7 +2420,8 @@ bool MuxOrch::handlePeerSwitch(const Request& request)
             SWSS_LOG_NOTICE("tc_to_queue_map_id for tunnel %s is not available. Will not be applied", MUX_TUNNEL);
         }
 
-        mux_tunnel_id_ = create_tunnel(&peer_ip, &dst_ip, tc_to_dscp_map_id, tc_to_queue_map_id, dscp_mode_name);
+        mux_tunnel_id_ = create_tunnel(&peer_ip, &dst_ip, tc_to_dscp_map_id, tc_to_queue_map_id, dscp_mode_name,
+                                       ecn_mode_name, encap_ecn_mode_name);
         mux_peer_switch_ = peer_ip;
         SWSS_LOG_NOTICE("Mux peer ip '%s' was added, peer name '%s'",
                          peer_ip.to_string().c_str(), peer_name.c_str());

--- a/orchagent/tunneldecaporch.cpp
+++ b/orchagent/tunneldecaporch.cpp
@@ -1447,6 +1447,28 @@ std::string TunnelDecapOrch::getDscpMode(const std::string &tunnelKey) const
     return iter->second.dscp_mode;
 }
 
+std::string TunnelDecapOrch::getEcnMode(const std::string &tunnelKey) const
+{
+    auto iter = tunnelTable.find(tunnelKey);
+    if (iter == tunnelTable.end())
+    {
+        SWSS_LOG_INFO("Tunnel not found %s", tunnelKey.c_str());
+        return "";
+    }
+    return iter->second.ecn_mode;
+}
+
+std::string TunnelDecapOrch::getEncapEcnMode(const std::string &tunnelKey) const
+{
+    auto iter = tunnelTable.find(tunnelKey);
+    if (iter == tunnelTable.end())
+    {
+        SWSS_LOG_INFO("Tunnel not found %s", tunnelKey.c_str());
+        return "";
+    }
+    return iter->second.encap_ecn_mode;
+}
+
 bool TunnelDecapOrch::getQosMapId(const std::string &tunnelKey, const std::string &qos_table_type, sai_object_id_t &oid) const
 {
     auto iter = tunnelTable.find(tunnelKey);

--- a/orchagent/tunneldecaporch.h
+++ b/orchagent/tunneldecaporch.h
@@ -82,6 +82,8 @@ public:
     bool removeNextHopTunnel(std::string tunnelKey, swss::IpAddress& ipAddr);
     swss::IpAddresses getDstIpAddresses(std::string tunnelKey);
     std::string getDscpMode(const std::string &tunnelKey) const;
+    std::string getEcnMode(const std::string &tunnelKey) const;
+    std::string getEncapEcnMode(const std::string &tunnelKey) const;
     bool getQosMapId(const std::string &tunnelKey, const std::string &qos_table_type, sai_object_id_t &oid) const;
     const SubnetDecapConfig &getSubnetDecapConfig() const
     {

--- a/tests/mock_tests/tunneldecaporch_ut.cpp
+++ b/tests/mock_tests/tunneldecaporch_ut.cpp
@@ -195,6 +195,32 @@ namespace tunneldecaporch_test
         });
     }
 
+    TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_GetEcnMode_NotFound)
+    {
+        vector<string> tunnel_tables = { APP_TUNNEL_DECAP_TABLE_NAME };
+        auto tunnelDecapOrch = make_shared<TunnelDecapOrch>(
+            m_app_db.get(), m_state_db.get(), m_config_db.get(), tunnel_tables);
+        ASSERT_NE(tunnelDecapOrch, nullptr);
+
+        EXPECT_NO_THROW({
+            string ecn_mode = tunnelDecapOrch->getEcnMode("non_existent_tunnel");
+            EXPECT_TRUE(ecn_mode.empty());
+        });
+    }
+
+    TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_GetEncapEcnMode_NotFound)
+    {
+        vector<string> tunnel_tables = { APP_TUNNEL_DECAP_TABLE_NAME };
+        auto tunnelDecapOrch = make_shared<TunnelDecapOrch>(
+            m_app_db.get(), m_state_db.get(), m_config_db.get(), tunnel_tables);
+        ASSERT_NE(tunnelDecapOrch, nullptr);
+
+        EXPECT_NO_THROW({
+            string encap_ecn = tunnelDecapOrch->getEncapEcnMode("non_existent_tunnel");
+            EXPECT_TRUE(encap_ecn.empty());
+        });
+    }
+
     TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_GetDstIpAddresses)
     {
         vector<string> tunnel_tables = { APP_TUNNEL_DECAP_TABLE_NAME };

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -1268,6 +1268,10 @@ class TestMuxTunnelBase():
                 assert value == "SAI_TUNNEL_DSCP_MODE_PIPE_MODEL"
             elif field == "SAI_TUNNEL_ATTR_DECAP_DSCP_MODE":
                 assert value == "SAI_TUNNEL_DSCP_MODE_PIPE_MODEL"
+            elif field == "SAI_TUNNEL_ATTR_DECAP_ECN_MODE":
+                assert value == "SAI_TUNNEL_DECAP_ECN_MODE_STANDARD"
+            elif field == "SAI_TUNNEL_ATTR_ENCAP_ECN_MODE":
+                assert value == "SAI_TUNNEL_ENCAP_ECN_MODE_STANDARD"
             else:
                 assert False, "Field %s is not tested" % field
 

--- a/tests/test_mux_prefixroute.py
+++ b/tests/test_mux_prefixroute.py
@@ -1399,6 +1399,10 @@ class TestMuxTunnelBase():
                 assert value == "SAI_TUNNEL_DSCP_MODE_PIPE_MODEL"
             elif field == "SAI_TUNNEL_ATTR_DECAP_DSCP_MODE":
                 assert value == "SAI_TUNNEL_DSCP_MODE_PIPE_MODEL"
+            elif field == "SAI_TUNNEL_ATTR_DECAP_ECN_MODE":
+                assert value == self.ecn_modes_map[self.DEFAULT_TUNNEL_PARAMS["ecn_mode"]]
+            elif field == "SAI_TUNNEL_ATTR_ENCAP_ECN_MODE":
+                assert value == "SAI_TUNNEL_ENCAP_ECN_MODE_STANDARD"
             else:
                 assert False, "Field %s is not tested" % field
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add SAI_TUNNEL_DECAP_ECN_MODE_COPY_FROM_OUTER for SAI_TUNNEL_ATTR_DECAP_ECN_MODE
add SAI_TUNNEL_ENCAP_ECN_MODE_STANDARD for SAI_TUNNEL_ATTR_ENCAP_ECN_MODE

**Why I did it**
In Dual-ToR scenario we create tunnel 2 times (in [tunneldecaporch](https://github.com/sonic-net/sonic-swss/blob/master/orchagent/tunneldecaporch.cpp#L849) and [muxorch](https://github.com/sonic-net/sonic-swss/blob/master/orchagent/muxorch.cpp#L325)
But in muxorch we do not set ECN-related param (copy_from_outer). And since it was not set then by [default ](https://github.com/opencomputeproject/SAI/blob/master/inc/saitunnel.h#L606)we are using "standard" ECN mode.
Need to specify explicitly ECN mode for decap and encap

**How I verified it**
run https://github.com/sonic-net/sonic-mgmt/blob/master/tests/decap/mellanox/test_ecn_mode.py
or
Send encapsulated packets to uplink, check that decaplusated packets has different ECN

**Details if related**
