### PR TITLE
[fpmsyncd]: Support fpmsyncd to use APP_STATE DB

### DIFF
--- a/fpmsyncd/fpmsyncd.cpp
+++ b/fpmsyncd/fpmsyncd.cpp
@@ -85,7 +85,8 @@ int main(int argc, char **argv)
     std::unique_ptr<NotificationConsumer> routeResponseChannel;
 
     RedisPipeline pipeline(&db, ROUTE_SYNC_PPL_SIZE);
-    RouteSync sync(&pipeline);
+    RedisPipeline app_state_pipeline(&applStateDb);
+    RouteSync sync(&pipeline, &app_state_pipeline);
 
     DBConnector stateDb("STATE_DB", 0);
     Table bgpStateTable(&stateDb, STATE_BGP_TABLE_NAME);

--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -150,7 +150,7 @@ static decltype(auto) makeNlAddr(const T& ip)
 }
 
 
-RouteSync::RouteSync(RedisPipeline *pipeline) :
+RouteSync::RouteSync(RedisPipeline *pipeline, RedisPipeline *app_state_pipeline) :
     // When the feature ORCH_NORTHBOND_ROUTE_ZMQ_ENABLED is enabled, route events must be sent to orchagent via the ZMQ channel.
     m_zmqClient(create_local_zmq_client(ORCH_NORTHBOND_ROUTE_ZMQ_ENABLED, false)),
     m_routeTable(createProducerStateTable(pipeline, APP_ROUTE_TABLE_NAME, true, m_zmqClient)),
@@ -162,7 +162,9 @@ RouteSync::RouteSync(RedisPipeline *pipeline) :
     m_warmStartHelper(pipeline, m_routeTable.get(), APP_ROUTE_TABLE_NAME, "bgp", "bgp"),
     m_srv6MySidTable(pipeline, APP_SRV6_MY_SID_TABLE_NAME, true),
     m_srv6SidListTable(pipeline, APP_SRV6_SID_LIST_TABLE_NAME, true),
-    m_nl_sock(NULL), m_link_cache(NULL)
+    m_nl_sock(NULL), m_link_cache(NULL),
+    m_app_state_pipeline(app_state_pipeline),
+    m_nhgFullStateTable(app_state_pipeline, "NHG_FULL_STATE_TABLE", true)
 {
     m_nl_sock = nl_socket_alloc();
     nl_connect(m_nl_sock, NETLINK_ROUTE);

--- a/fpmsyncd/routesync.h
+++ b/fpmsyncd/routesync.h
@@ -219,7 +219,7 @@ class RouteSync : public NetMsg
 public:
     enum { MAX_ADDR_SIZE = 64 };
 
-    RouteSync(RedisPipeline *pipeline);
+    RouteSync(RedisPipeline *pipeline, RedisPipeline *app_state_pipeline);
 
     virtual void onMsg(int nlmsg_type, struct nl_object *obj);
 
@@ -293,6 +293,10 @@ private:
     map<uint32_t,NextHopGroup> m_nh_groups;
     /* SID list to refcount */
     map<string, uint32_t> m_srv6_sidlist_refcnt;
+
+    /* APPL_STATE_DB pipeline and NHG Full debug state table */
+    RedisPipeline *m_app_state_pipeline;
+    swss::Table m_nhgFullStateTable;
 
     bool                m_isSuppressionEnabled{false};
     FpmInterface*       m_fpmInterface {nullptr};

--- a/tests/mock_tests/fpmsyncd/receive_srv6_mysids_ut.cpp
+++ b/tests/mock_tests/fpmsyncd/receive_srv6_mysids_ut.cpp
@@ -26,6 +26,8 @@ namespace ut_fpmsyncd
     {
         std::shared_ptr<swss::DBConnector> m_app_db;
         std::shared_ptr<swss::RedisPipeline> pipeline;
+        std::shared_ptr<swss::DBConnector> m_appl_state_db;
+        std::shared_ptr<swss::RedisPipeline> app_state_pipeline;
         std::shared_ptr<RouteSync> m_routeSync;
         std::shared_ptr<FpmLink> m_fpmLink;
         std::shared_ptr<swss::Table> m_srv6MySidTable;
@@ -40,7 +42,9 @@ namespace ut_fpmsyncd
 
             /*  1) RouteSync */
             pipeline = std::make_shared<swss::RedisPipeline>(m_app_db.get());
-            m_routeSync = std::make_shared<RouteSync>(pipeline.get());
+            m_appl_state_db = std::make_shared<swss::DBConnector>("APPL_STATE_DB", 0);
+            app_state_pipeline = std::make_shared<swss::RedisPipeline>(m_appl_state_db.get());
+            m_routeSync = std::make_shared<RouteSync>(pipeline.get(), app_state_pipeline.get());
 
             /* 2) FpmLink */
             m_fpmLink = std::make_shared<FpmLink>(m_routeSync.get());

--- a/tests/mock_tests/fpmsyncd/receive_srv6_steer_routes_ut.cpp
+++ b/tests/mock_tests/fpmsyncd/receive_srv6_steer_routes_ut.cpp
@@ -25,6 +25,8 @@ namespace ut_fpmsyncd
     {
         std::shared_ptr<swss::DBConnector> m_app_db;
         std::shared_ptr<swss::RedisPipeline> pipeline;
+        std::shared_ptr<swss::DBConnector> m_appl_state_db;
+        std::shared_ptr<swss::RedisPipeline> app_state_pipeline;
         std::shared_ptr<RouteSync> m_routeSync;
         std::shared_ptr<FpmLink> m_fpmLink;
         std::shared_ptr<swss::Table> m_routeTable;
@@ -40,7 +42,9 @@ namespace ut_fpmsyncd
 
             /* 1) RouteSync */
             pipeline = std::make_shared<swss::RedisPipeline>(m_app_db.get());
-            m_routeSync = std::make_shared<RouteSync>(pipeline.get());
+            m_appl_state_db = std::make_shared<swss::DBConnector>("APPL_STATE_DB", 0);
+            app_state_pipeline = std::make_shared<swss::RedisPipeline>(m_appl_state_db.get());
+            m_routeSync = std::make_shared<RouteSync>(pipeline.get(), app_state_pipeline.get());
 
             /* 2) FpmLink */
             m_fpmLink = std::make_shared<FpmLink>(m_routeSync.get());

--- a/tests/mock_tests/fpmsyncd/test_fpmlink.cpp
+++ b/tests/mock_tests/fpmsyncd/test_fpmlink.cpp
@@ -32,7 +32,9 @@ public:
 
     DBConnector m_db{"APPL_DB", 0};
     RedisPipeline m_pipeline{&m_db, 1};
-    RouteSync m_routeSync{&m_pipeline};
+    DBConnector m_appl_state_db{"APPL_STATE_DB", 0};
+    RedisPipeline m_app_state_pipeline{&m_appl_state_db};
+    RouteSync m_routeSync{&m_pipeline, &m_app_state_pipeline};
     FpmLink m_fpm{&m_routeSync};
     MockMsgHandler m_mock;
 };

--- a/tests/mock_tests/fpmsyncd/test_routesync.cpp
+++ b/tests/mock_tests/fpmsyncd/test_routesync.cpp
@@ -37,7 +37,7 @@ bool nlmsg_alloc_ret = true;
 class MockRouteSync : public RouteSync
 {
 public:
-    MockRouteSync(RedisPipeline *m_pipeline) : RouteSync(m_pipeline)
+    MockRouteSync(RedisPipeline *m_pipeline, RedisPipeline *app_state_pipeline) : RouteSync(m_pipeline, app_state_pipeline)
     {
     }
 
@@ -98,9 +98,11 @@ public:
 
     shared_ptr<swss::DBConnector> m_db = make_shared<swss::DBConnector>("APPL_DB", 0);
     shared_ptr<RedisPipeline> m_pipeline = make_shared<RedisPipeline>(m_db.get());
-    RouteSync m_routeSync{m_pipeline.get()};
+    shared_ptr<swss::DBConnector> m_appl_state_db = make_shared<swss::DBConnector>("APPL_STATE_DB", 0);
+    shared_ptr<RedisPipeline> m_app_state_pipeline = make_shared<RedisPipeline>(m_appl_state_db.get());
+    RouteSync m_routeSync{m_pipeline.get(), m_app_state_pipeline.get()};
     MockFpm m_mockFpm{&m_routeSync};
-    MockRouteSync m_mockRouteSync{m_pipeline.get()};
+    MockRouteSync m_mockRouteSync{m_pipeline.get(), m_app_state_pipeline.get()};
 
     const char* test_gateway = "192.168.1.1";
     const char* test_gateway_ = "192.168.1.2";
@@ -1278,7 +1280,9 @@ public:
 
     shared_ptr<swss::DBConnector> m_db = make_shared<swss::DBConnector>("APPL_DB", 0);
     shared_ptr<RedisPipeline> m_pipeline = make_shared<RedisPipeline>(m_db.get());
-    RouteSync m_testRouteSync{m_pipeline.get()};
+    shared_ptr<swss::DBConnector> m_appl_state_db = make_shared<swss::DBConnector>("APPL_STATE_DB", 0);
+    shared_ptr<RedisPipeline> m_app_state_pipeline = make_shared<RedisPipeline>(m_appl_state_db.get());
+    RouteSync m_testRouteSync{m_pipeline.get(), m_app_state_pipeline.get()};
 };
 
 TEST_F(WarmRestartRouteSyncTest, TestRouteMessageHandlingWarmRestartNotInProgress)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
- Introduce an additional RedisPipeline for APPL_STATE_DB in fpmsyncd.
- Add a NHG_FULL_STATE_TABLE (state-only) backed by this pipeline.
- No behavioral change to existing route/NHG handling.

</br>

**Why I did it**
In the upcoming RIBFIB module, we will use it to store NHG information pushed down by FRR. 
Since there is no consumer for this data, APPL_STATE_DB is a more appropriate place than APPL_DB.

</br>

**How I verified it**
- PR sanity: Updated existing fpmsyncd mock tests
- Phoenixwing test
