### PR TITLE
Cascade PortChannel admin shutdown to member ports

### DIFF
--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -212,6 +212,8 @@ public:
     sai_object_id_t     m_hif_id = 0;
     sai_object_id_t     m_lag_id = 0;
     sai_object_id_t     m_lag_member_id = 0;
+    /* PHY port admin state is overriden by parent LAG admin-down */
+    bool                m_lag_forced_admin_down = false;
     sai_object_id_t     m_tunnel_id = 0;
     sai_object_id_t     m_ingress_acl_table_group_id = 0;
     sai_object_id_t     m_egress_acl_table_group_id = 0;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -5515,6 +5515,15 @@ void PortsOrch::doPortTask(Consumer &consumer)
                     pCfg.admin_status.value = admin_status;
                 }
 
+                /* This is a guard to suppress admin-up of port if parent LAG is admin-down */
+                if (pCfg.admin_status.is_set && pCfg.admin_status.value && p.m_lag_forced_admin_down)
+                {
+                    SWSS_LOG_NOTICE("Port %s: suppressing admin-up from APP_DB "
+                                    "(forced admin-down by parent LAG)",
+                                    p.m_alias.c_str());
+                    pCfg.admin_status.is_set = false;
+                }
+
                 /* Last step set port admin status */
                 if (pCfg.admin_status.is_set)
                 {
@@ -6076,6 +6085,7 @@ void PortsOrch::doLagTask(Consumer &consumer)
             int32_t switch_id = -1;
             string tpid_string;
             uint16_t tpid = 0;
+            string admin_status_str;
 
             for (auto i : kfvFieldsValues(t))
             {
@@ -6123,6 +6133,10 @@ void PortsOrch::doLagTask(Consumer &consumer)
                     tpid = (uint16_t)stoi(tpid_string, 0, 16);
                     SWSS_LOG_DEBUG("reading TPID string:%s to uint16: 0x%x", tpid_string.c_str(), tpid);
                  }
+                else if (fvField(i) == "admin_status")
+                {
+                    admin_status_str = fvValue(i);
+                }
             }
 
             if (table_name == CHASSIS_APP_LAG_TABLE_NAME)
@@ -6220,6 +6234,22 @@ void PortsOrch::doLagTask(Consumer &consumer)
                         SWSS_LOG_NOTICE("Saved to set port %s learn mode %s", alias.c_str(), learn_mode_str.c_str());
                     }
                 }
+
+                /* Detect admin status transition and propagate to members */
+                if (!admin_status_str.empty())
+                {
+                    bool newAdminUp = (admin_status_str == "up");
+
+                    if (l.m_admin_state_up != newAdminUp)
+                    {
+                        SWSS_LOG_NOTICE("LAG %s admin status changed to %s",
+                                        alias.c_str(),
+                                        newAdminUp ? "up" : "down");
+                        l.m_admin_state_up = newAdminUp;
+                        cascadeLagAdminStatusToMembers(l, newAdminUp);
+                        m_portList[alias] = l;
+                    }
+                }
             }
 
             it = consumer.m_toSync.erase(it);
@@ -6234,6 +6264,12 @@ void PortsOrch::doLagTask(Consumer &consumer)
                 continue;
             }
 
+            /* If LAG is admin-down, restore member states before deleting the LAG */
+            if (!lag.m_admin_state_up)
+            {
+                cascadeLagAdminStatusToMembers(lag, true);
+            }
+
             if (removeLag(lag))
                 it = consumer.m_toSync.erase(it);
             else
@@ -6243,6 +6279,92 @@ void PortsOrch::doLagTask(Consumer &consumer)
         {
             SWSS_LOG_ERROR("Unknown operation type %s", op.c_str());
             it = consumer.m_toSync.erase(it);
+        }
+    }
+}
+
+void PortsOrch::cascadeLagAdminStatusToMembers(Port &lag, bool bringLagMembersUp)
+{
+    /* This cascades the status of the LAG being up/down to its individual members.
+     * If the LAG is up or down, members are brought up or down accordingly.
+     * Note: Before deleting a LAG, we bring the members up if they were down already.
+    */
+    SWSS_LOG_ENTER();
+
+    for (const auto &memberAlias : lag.m_members)
+    {
+        auto memberIt = m_portList.find(memberAlias);
+        if (memberIt == m_portList.end())
+        {
+            SWSS_LOG_WARN("LAG %s member %s not found in portList",
+                          lag.m_alias.c_str(), memberAlias.c_str());
+            continue;
+        }
+
+        Port &member = memberIt->second;
+
+        if (member.m_type == Port::SYSTEM)
+            continue;
+
+        if (!bringLagMembersUp)
+        {
+            /* LAG going admin-down: flag all members and force them down */
+            member.m_lag_forced_admin_down = true;
+            if (member.m_admin_state_up)
+            {
+                if (!setPortAdminStatus(member, false))
+                {
+                    SWSS_LOG_ERROR("LAG %s: failed to force member %s admin-down",
+                                   lag.m_alias.c_str(), memberAlias.c_str());
+                    member.m_lag_forced_admin_down = false;
+                    continue;
+                }
+                member.m_admin_state_up = false;
+                SWSS_LOG_NOTICE("LAG %s admin-down: forced member %s admin-down",
+                                lag.m_alias.c_str(), memberAlias.c_str());
+            }
+        }
+        else
+        {
+            /* LAG going admin-up: restore member states */
+            if (!member.m_lag_forced_admin_down)
+                continue;
+
+            member.m_lag_forced_admin_down = false;
+
+            /* Read the port's configured admin_status from APP_DB */
+            string cfgAdminStatus;
+            vector<FieldValueTuple> tuples;
+            if (m_portTable->get(memberAlias, tuples))
+            {
+                for (const auto &fv : tuples)
+                {
+                    if (fvField(fv) == "admin_status")
+                    {
+                        cfgAdminStatus = fvValue(fv);
+                        break;
+                    }
+                }
+            }
+
+            bool shouldBeUp = (cfgAdminStatus == "up");
+            if (shouldBeUp && !member.m_admin_state_up)
+            {
+                if (!setPortAdminStatus(member, true))
+                {
+                    SWSS_LOG_ERROR("LAG %s: failed to restore member %s admin-up",
+                                   lag.m_alias.c_str(), memberAlias.c_str());
+                    continue;
+                }
+                member.m_admin_state_up = true;
+                SWSS_LOG_NOTICE("LAG %s admin-up: restored member %s admin-up",
+                                lag.m_alias.c_str(), memberAlias.c_str());
+            }
+            else if (!shouldBeUp)
+            {
+                SWSS_LOG_NOTICE("LAG %s admin-up: member %s stays admin-down (configured down)",
+                                lag.m_alias.c_str(), memberAlias.c_str());
+            }
         }
     }
 }
@@ -6359,6 +6481,33 @@ void PortsOrch::doLagMemberTask(Consumer &consumer)
                     it++;
                     continue;
                 }
+
+                /* If the parent LAG is admin-down, force the new member down */
+                if (!lag.m_admin_state_up)
+                {
+                    Port updatedMember;
+                    if (getPort(port_alias, updatedMember) &&
+                        updatedMember.m_type != Port::SYSTEM)
+                    {
+                        updatedMember.m_lag_forced_admin_down = true;
+                        if (updatedMember.m_admin_state_up)
+                        {
+                            if (setPortAdminStatus(updatedMember, false))
+                            {
+                                updatedMember.m_admin_state_up = false;
+                                SWSS_LOG_NOTICE("LAG %s admin-down: forced new member %s admin-down",
+                                                lag_alias.c_str(), port_alias.c_str());
+                            }
+                            else
+                            {
+                                SWSS_LOG_ERROR("LAG %s: failed to force new member %s admin-down",
+                                               lag_alias.c_str(), port_alias.c_str());
+                                updatedMember.m_lag_forced_admin_down = false;
+                            }
+                        }
+                        m_portList[port_alias] = updatedMember;
+                    }
+                }
             }
 
             if (isChassisDbInUse() && (port.m_type != Port::SYSTEM))
@@ -6418,6 +6567,49 @@ void PortsOrch::doLagMemberTask(Consumer &consumer)
 
             if (removeLagMember(lag, port))
             {
+                /* Restore admin state if it was forced down by parent LAG.
+                 * Check configured admin-status to decide if port should
+                 * come up. */
+                {
+                    Port updatedMember;
+                    if (getPort(port_alias, updatedMember) &&
+                        updatedMember.m_lag_forced_admin_down)
+                    {
+                        updatedMember.m_lag_forced_admin_down = false;
+
+                        string cfgAdminStatus;
+                        vector<FieldValueTuple> tuples;
+                        if (m_portTable->get(port_alias, tuples))
+                        {
+                            for (const auto &fv : tuples)
+                            {
+                                if (fvField(fv) == "admin_status")
+                                {
+                                    cfgAdminStatus = fvValue(fv);
+                                    break;
+                                }
+                            }
+                        }
+
+                        bool shouldBeUp = (cfgAdminStatus == "up");
+                        if (shouldBeUp && !updatedMember.m_admin_state_up)
+                        {
+                            if (setPortAdminStatus(updatedMember, true))
+                            {
+                                updatedMember.m_admin_state_up = true;
+                                SWSS_LOG_NOTICE("Restored member %s admin-up after removal from LAG %s",
+                                                port_alias.c_str(), lag_alias.c_str());
+                            }
+                            else
+                            {
+                                SWSS_LOG_ERROR("Failed to restore member %s admin-up after removal from LAG %s",
+                                               port_alias.c_str(), lag_alias.c_str());
+                            }
+                        }
+                        m_portList[port_alias] = updatedMember;
+                    }
+                }
+
                 it = consumer.m_toSync.erase(it);
             }
             else

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -465,6 +465,9 @@ private:
     bool setCollectionOnLagMember(Port &lagMember, bool enableCollection);
     bool setDistributionOnLagMember(Port &lagMember, bool enableDistribution);
 
+    /* Propagate LAG admin status changes to member ports */
+    void cascadeLagAdminStatusToMembers(Port &lag, bool adminUp);
+
     sai_status_t removePort(sai_object_id_t port_id);
     bool initExistingPort(const PortConfig &port);
     bool initPortsBulk(std::vector<Port>& ports);

--- a/tests/test_portchannel.py
+++ b/tests/test_portchannel.py
@@ -470,6 +470,146 @@ class TestPortchannel(object):
         # wait for port-channel deletion
         time.sleep(1)
 
+    def get_port_admin_state(self, dvs, port_name):
+        """Helper: return SAI_PORT_ATTR_ADMIN_STATE for a PHY port from ASIC_DB."""
+        adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
+        tbl = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_PORT")
+        (status, fvs) = tbl.get(dvs.asicdb.portnamemap[port_name])
+        assert status, "Port %s not found in ASIC_DB" % port_name
+        for fv in fvs:
+            if fv[0] == "SAI_PORT_ATTR_ADMIN_STATE":
+                return fv[1]
+        return None
+
+    def set_port_admin_status(self, dvs, port_name, admin_status):
+        """Helper: set admin_status for a PHY port via CONFIG_DB."""
+        cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+        tbl = swsscommon.Table(cdb, "PORT")
+        fvs = swsscommon.FieldValuePairs([("admin_status", admin_status)])
+        tbl.set(port_name, fvs)
+        time.sleep(1)
+
+    def test_lag_admin_down_cascades_to_members(self, dvs, testlog):
+        """Verify LAG admin-down cascades to member ports:
+        1. LAG admin-down forces all members admin-down
+        2. Manual admin-up of member is suppressed while LAG is down
+        3. Adding/removing members to admin-down LAG
+        4. LAG admin-up restores members to their configured state"""
+        cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+
+        # Setup: Ethernet0 up, Ethernet4 up, Ethernet8 up (for later add/remove)
+        self.set_port_admin_status(dvs, "Ethernet0", "up")
+        self.set_port_admin_status(dvs, "Ethernet4", "up")
+        self.set_port_admin_status(dvs, "Ethernet8", "up")
+
+        # Create LAG with admin-up via CONFIG_DB
+        tbl = swsscommon.Table(cdb, "PORTCHANNEL")
+        fvs = swsscommon.FieldValuePairs([("admin_status", "up"), ("mtu", "9100")])
+        tbl.set("PortChannel201", fvs)
+        time.sleep(1)
+
+        # Add Ethernet0 and Ethernet4 as members
+        tbl = swsscommon.Table(cdb, "PORTCHANNEL_MEMBER")
+        fvs = swsscommon.FieldValuePairs([("NULL", "NULL")])
+        tbl.set("PortChannel201|Ethernet0", fvs)
+        tbl.set("PortChannel201|Ethernet4", fvs)
+        time.sleep(1)
+
+        # Set Ethernet0 individually admin-down (before LAG goes down)
+        self.set_port_admin_status(dvs, "Ethernet0", "down")
+        assert self.get_port_admin_state(dvs, "Ethernet0") == "false"
+        assert self.get_port_admin_state(dvs, "Ethernet4") == "true"
+
+        # --- Case 1: LAG admin-down forces all members admin-down ---
+        tbl = swsscommon.Table(cdb, "PORTCHANNEL")
+        fvs = swsscommon.FieldValuePairs([("admin_status", "down"), ("mtu", "9100")])
+        tbl.set("PortChannel201", fvs)
+        time.sleep(1)
+
+        assert self.get_port_admin_state(dvs, "Ethernet0") == "false"
+        assert self.get_port_admin_state(dvs, "Ethernet4") == "false"
+
+        # --- Case 2: Manual admin-up of member suppressed while LAG is down ---
+        self.set_port_admin_status(dvs, "Ethernet4", "up")
+        assert self.get_port_admin_state(dvs, "Ethernet4") == "false"
+
+        # --- Case 3: Add member to admin-down LAG, then remove it ---
+        tbl = swsscommon.Table(cdb, "PORTCHANNEL_MEMBER")
+        fvs = swsscommon.FieldValuePairs([("NULL", "NULL")])
+        tbl.set("PortChannel201|Ethernet8", fvs)
+        time.sleep(1)
+
+        # New member should be forced admin-down
+        assert self.get_port_admin_state(dvs, "Ethernet8") == "false"
+
+        # Remove Ethernet8 — should restore its configured admin state (up)
+        tbl = swsscommon.Table(cdb, "PORTCHANNEL_MEMBER")
+        tbl._del("PortChannel201|Ethernet8")
+        time.sleep(1)
+
+        assert self.get_port_admin_state(dvs, "Ethernet8") == "true"
+
+        # --- Case 4: LAG admin-up restores members to configured state ---
+        # Ethernet0 was configured down before LAG went down — should stay down
+        # Ethernet4 was configured up — should be restored to up
+        tbl = swsscommon.Table(cdb, "PORTCHANNEL")
+        fvs = swsscommon.FieldValuePairs([("admin_status", "up"), ("mtu", "9100")])
+        tbl.set("PortChannel201", fvs)
+        time.sleep(1)
+
+        assert self.get_port_admin_state(dvs, "Ethernet0") == "false"
+        assert self.get_port_admin_state(dvs, "Ethernet4") == "true"
+
+        # Cleanup
+        tbl = swsscommon.Table(cdb, "PORTCHANNEL_MEMBER")
+        tbl._del("PortChannel201|Ethernet0")
+        tbl._del("PortChannel201|Ethernet4")
+        time.sleep(1)
+        tbl = swsscommon.Table(cdb, "PORTCHANNEL")
+        tbl._del("PortChannel201")
+        time.sleep(1)
+        self.set_port_admin_status(dvs, "Ethernet0", "up")
+
+    def test_lag_deletion_restores_member_admin_state(self, dvs, testlog):
+        """Deleting an admin-down LAG restores member ports to their
+        configured admin state."""
+        cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+
+        self.set_port_admin_status(dvs, "Ethernet0", "up")
+        self.set_port_admin_status(dvs, "Ethernet4", "up")
+
+        # Create LAG with two members via CONFIG_DB
+        tbl = swsscommon.Table(cdb, "PORTCHANNEL")
+        fvs = swsscommon.FieldValuePairs([("admin_status", "up"), ("mtu", "9100")])
+        tbl.set("PortChannel202", fvs)
+        time.sleep(1)
+
+        tbl = swsscommon.Table(cdb, "PORTCHANNEL_MEMBER")
+        fvs = swsscommon.FieldValuePairs([("NULL", "NULL")])
+        tbl.set("PortChannel202|Ethernet0", fvs)
+        tbl.set("PortChannel202|Ethernet4", fvs)
+        time.sleep(1)
+
+        assert self.get_port_admin_state(dvs, "Ethernet0") == "true"
+        assert self.get_port_admin_state(dvs, "Ethernet4") == "true"
+
+        # Set LAG admin-down
+        tbl = swsscommon.Table(cdb, "PORTCHANNEL")
+        fvs = swsscommon.FieldValuePairs([("admin_status", "down"), ("mtu", "9100")])
+        tbl.set("PortChannel202", fvs)
+        time.sleep(1)
+
+        assert self.get_port_admin_state(dvs, "Ethernet0") == "false"
+        assert self.get_port_admin_state(dvs, "Ethernet4") == "false"
+
+        # Delete the LAG — members should be restored
+        tbl = swsscommon.Table(cdb, "PORTCHANNEL")
+        tbl._del("PortChannel202")
+        time.sleep(1)
+
+        assert self.get_port_admin_state(dvs, "Ethernet0") == "true"
+        assert self.get_port_admin_state(dvs, "Ethernet4") == "true"
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():


### PR DESCRIPTION
When a PortChannel is admin-shut, force all member ports admin-down. This allows the peer device to immediately detect link-down instead of waiting for LACP timeout.
On PortChannel admin-up (or member removal/LAG deletion), restore each member to its configured admin state from APP_DB.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added `cascadeLagAdminStatusToMembers()` in `portsorch` which propagates LAG admin-down to member ports via `setPortAdminStatus()`.
Added a guard in `doPortTask()` to prevent APP_DB from overriding the forced state.
On LAG admin-up (or member removal/LAG deletion), each member's configured admin status is restored to the intended state.


**Why I did it**
When a PortChannel is admin-shut, its member links' transceivers remain physically active.
The peer device must rely on LACP timeout to detect the PortChannel is down, which introduces unnecessary delay (up to 90s with long timeout). 


**How I verified it**
- New DVS tests: `test_lag_admin_down_cascades_to_members`, `test_lag_deletion_restores_member_admin_state`
- On hardware: `config interface shutdown PortChannelXXXX` → verify member port LEDs go off and peer detects link-down immediately

**Details if related**
Fixes: https://github.com/sonic-net/sonic-buildimage/issues/26494

cc: @venkit-nexthop @kalash-nexthop