### PR TITLE
[fdborch] Fix VLAN FDB flush failure caused by missing VLAN prefix

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -15,6 +15,8 @@
 #include "vxlanorch.h"
 #include "directory.h"
 
+#define VLAN_PREFIX         "Vlan"
+
 extern sai_fdb_api_t    *sai_fdb_api;
 
 extern sai_object_id_t  gSwitchId;
@@ -988,7 +990,7 @@ void FdbOrch::doTask(NotificationConsumer& consumer)
         }
         else if (op == "VLAN")
         {
-            vlan = data;
+            vlan = VLAN_PREFIX + data;
             if (vlan.empty())
             {
                 SWSS_LOG_ERROR("Receive wrong vlan to flush fdb!");
@@ -1013,7 +1015,7 @@ void FdbOrch::doTask(NotificationConsumer& consumer)
             if (found != string::npos)
             {
                 alias = data.substr(0, found);
-                vlan = data.substr(found+1);
+                vlan = VLAN_PREFIX + data.substr(found+1);
             }
             if (alias.empty() || vlan.empty())
             {

--- a/tests/mock_tests/fdborch/flush_syncd_notif_ut.cpp
+++ b/tests/mock_tests/fdborch/flush_syncd_notif_ut.cpp
@@ -1,6 +1,8 @@
+#include "json.h"
 #include "../ut_helper.h"
 #include "../mock_orchagent_main.h"
 #include "../mock_table.h"
+#include "notifier.h"
 #include "port.h"
 #define private public // Need to modify internal cache
 #include "portsorch.h"
@@ -23,6 +25,7 @@ namespace fdb_syncd_flush_test
 
     sai_fdb_api_t ut_sai_fdb_api;
     sai_fdb_api_t *pold_sai_fdb_api;
+    static int g_sai_flush_call_count = 0;
 
     sai_status_t _ut_stub_sai_create_fdb_entry (
         _In_ const sai_fdb_entry_t *fdb_entry,
@@ -31,11 +34,22 @@ namespace fdb_syncd_flush_test
     {
         return SAI_STATUS_SUCCESS;
     }
+
+    sai_status_t _ut_stub_sai_flush_fdb_entries(
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list)
+    {
+        g_sai_flush_call_count++;
+        return SAI_STATUS_SUCCESS;
+    }
+
     void _hook_sai_fdb_api()
     {
         ut_sai_fdb_api = *sai_fdb_api;
         pold_sai_fdb_api = sai_fdb_api;
         ut_sai_fdb_api.create_fdb_entry = _ut_stub_sai_create_fdb_entry;
+        ut_sai_fdb_api.flush_fdb_entries = _ut_stub_sai_flush_fdb_entries;
         sai_fdb_api = &ut_sai_fdb_api;
     }
     void _unhook_sai_fdb_api()
@@ -213,6 +227,108 @@ namespace fdb_syncd_flush_test
 
 namespace fdb_syncd_flush_test
 {
+    /* Test Vlan Flush Request from Top to Bottom */
+    TEST_F(FdbOrchTest, FlushVlanFdbRequest)
+    {   
+        _hook_sai_fdb_api();
+
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        portTable.set("PortInitDone", { { "lanes", "0" } });
+        m_portsOrch->addExistingData(&portTable);
+
+        /* Set all ports to ready */
+        static_cast<Orch *>(m_portsOrch.get())->doTask();
+
+        ASSERT_NE(m_portsOrch, nullptr);
+        setUpVlan(m_portsOrch.get());
+        setUpPort(m_portsOrch.get());
+        ASSERT_NE(m_portsOrch->m_portList.find(VLAN40), m_portsOrch->m_portList.end());
+        ASSERT_NE(m_portsOrch->m_portList.find(ETH0), m_portsOrch->m_portList.end());
+        setUpVlanMember(m_portsOrch.get());
+        g_sai_flush_call_count = 0;
+
+        /* Generate a FDB Flush request for VLAN */
+        auto exec = static_cast<Notifier *>(m_fdborch->getExecutor("FLUSHFDBREQUEST"));
+        auto consumer = exec->getNotificationConsumer();
+    
+        /* Construct JSON payload in format: [["VLAN", "40"]] */
+        std::vector<FieldValueTuple> notifyValues;
+        FieldValueTuple opdata("VLAN", "40");
+        notifyValues.push_back(opdata); 
+        std::string msg = swss::JSon::buildJson(notifyValues);
+        
+        mockReply = (redisReply *)calloc(1, sizeof(redisReply));
+        mockReply->type = REDIS_REPLY_ARRAY;
+        mockReply->elements = 3;
+        mockReply->element = (redisReply **)calloc(mockReply->elements, sizeof(redisReply *));
+        
+        mockReply->element[2] = (redisReply *)calloc(1, sizeof(redisReply));
+        mockReply->element[2]->type = REDIS_REPLY_STRING;
+        mockReply->element[2]->str = (char *)calloc(1, msg.length() + 1);
+        memcpy(mockReply->element[2]->str, msg.c_str(), msg.length());
+        mockReply->element[2]->len = (int)msg.length();
+
+        /* Trigger data reading and execute the task */
+        consumer->readData(); 
+        m_fdborch->doTask(*consumer);
+        mockReply = nullptr;
+
+        /* Final verification */
+        ASSERT_EQ(g_sai_flush_call_count, 1);
+        _unhook_sai_fdb_api();
+    }
+
+    /* Test Port Vlan Flush Request from Top to Bottom */
+    TEST_F(FdbOrchTest, FlushPortVlanFdbRequest)
+    {
+        _hook_sai_fdb_api();
+        
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        portTable.set("PortInitDone", { { "lanes", "0" } });
+        m_portsOrch->addExistingData(&portTable);
+
+        /* Set all ports to ready */
+        static_cast<Orch *>(m_portsOrch.get())->doTask();
+
+        ASSERT_NE(m_portsOrch, nullptr);
+        setUpVlan(m_portsOrch.get());
+        setUpPort(m_portsOrch.get());
+        ASSERT_NE(m_portsOrch->m_portList.find(VLAN40), m_portsOrch->m_portList.end());
+        ASSERT_NE(m_portsOrch->m_portList.find(ETH0), m_portsOrch->m_portList.end());
+        setUpVlanMember(m_portsOrch.get());
+        g_sai_flush_call_count = 0;
+
+        /* Generate a FDB Flush request for PORT + VLAN */
+        auto exec = static_cast<Notifier *>(m_fdborch->getExecutor("FLUSHFDBREQUEST"));
+        auto consumer = exec->getNotificationConsumer();
+
+        /* Input format: port_alias|vlanId */
+        std::vector<FieldValueTuple> notifyValues;
+        FieldValueTuple opdata("PORTVLAN", "Ethernet0|40");
+        notifyValues.push_back(opdata); 
+        std::string msg = swss::JSon::buildJson(notifyValues);
+
+        mockReply = (redisReply *)calloc(1, sizeof(redisReply));
+        mockReply->type = REDIS_REPLY_ARRAY;
+        mockReply->elements = 3; 
+        mockReply->element = (redisReply **)calloc(mockReply->elements, sizeof(redisReply *));
+    
+        mockReply->element[2] = (redisReply *)calloc(1, sizeof(redisReply));
+        mockReply->element[2]->type = REDIS_REPLY_STRING;
+        mockReply->element[2]->str = (char *)calloc(1, msg.length() + 1);
+        memcpy(mockReply->element[2]->str, msg.c_str(), msg.length());
+        mockReply->element[2]->len = (int)msg.length();
+
+        /* Trigger processing */
+        consumer->readData(); 
+        m_fdborch->doTask(*consumer);
+        mockReply = nullptr;
+
+        /* Final verification */
+        ASSERT_EQ(g_sai_flush_call_count, 1);
+        _unhook_sai_fdb_api();
+    }
+
     /* Test Consolidated Flush Per Vlan and Per Port */
     TEST_F(FdbOrchTest, ConsolidatedFlushVlanandPort)
     {   


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

Fixes #4428

**What I did**
Fix VLAN-based FDB flush in `fdborch`.
For VLAN flush requests, `data` contains the VLAN ID only (for example, `1000`), but `getPort()` expects the VLAN interface name format (`Vlan1000`).  
This change prepends `Vlan` to the VLAN ID before calling `getPort()` in the VLAN FDB flush path.

**Why I did it**
Before this change, running `fdbclear -v <vid>` could report success on CLI, but the dynamic MAC entry was not removed.  
Meanwhile, `orchagent` logged an error like:
```text
doTask: Get Port from vlan(1000) failed!
```

**How I verified it**
- Learned a dynamic MAC entry in VLAN 1000
- Ran `fdbclear -v 1000`
- Verified that before the fix the entry remained and `orchagent` logged `Get Port from vlan(1000) failed!`
- Verified that after the fix the entry was removed successfully and no such error was logged

**Details if related**