### PR TITLE
[routeorch] Asynchronous route state publish  in db update thread.

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -274,6 +274,35 @@ void getCfgSwitchType(DBConnector *cfgDb, string &switch_type, string &switch_su
 
 }
 
+/*
+ * DEVICE_METADATA|localhost route_state_async_publish: if value is "disabled", turn off async route state publish.
+ * Otherwise keep default gRouteStateAsyncPublish == true. Must run before OrchDaemon::init() constructs RouteOrch.
+ */
+void getCfgRouteStateAsyncPublish(DBConnector *cfgDb)
+{
+    Table cfgDeviceMetaDataTable(cfgDb, CFG_DEVICE_METADATA_TABLE_NAME);
+    string val;
+
+    try
+    {
+        if (!cfgDeviceMetaDataTable.hget("localhost", "route_state_async_publish", val))
+        {
+            return;
+        }
+    }
+    catch (const std::system_error &e)
+    {
+        SWSS_LOG_WARN("Could not read route_state_async_publish from CONFIG_DB: %s; default enabled", e.what());
+        return;
+    }
+
+    if (val == "disabled")
+    {
+        gRouteStateAsyncPublish = false;
+        SWSS_LOG_NOTICE("route_state_async_publish is disabled in DEVICE_METADATA|localhost; synchronous route state publish");
+    }
+}
+
 bool isChassisAppDbPresent()
 {
     std::ifstream file(SonicDBConfig::DEFAULT_SONIC_DB_CONFIG_FILE);
@@ -1016,6 +1045,8 @@ int main(int argc, char **argv)
         /* Initialize the ring before OrchDaemon initializing Orchs */
         orchDaemon->enableRingBuffer();
     }
+
+    getCfgRouteStateAsyncPublish(&config_db);
 
     if (!orchDaemon->init())
     {

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -275,31 +275,31 @@ void getCfgSwitchType(DBConnector *cfgDb, string &switch_type, string &switch_su
 }
 
 /*
- * DEVICE_METADATA|localhost route_state_async_publish: if value is "disabled", turn off async route state publish.
+ * SYSTEM_DEFAULTS|async_rec status: if value is "disabled", turn off async route state publish.
  * Otherwise keep default gRouteStateAsyncPublish == true. Must run before OrchDaemon::init() constructs RouteOrch.
  */
 void getCfgRouteStateAsyncPublish(DBConnector *cfgDb)
 {
-    Table cfgDeviceMetaDataTable(cfgDb, CFG_DEVICE_METADATA_TABLE_NAME);
+    Table cfgSystemDefaultsTable(cfgDb, CFG_SYSTEM_DEFAULTS_TABLE_NAME);
     string val;
 
     try
     {
-        if (!cfgDeviceMetaDataTable.hget("localhost", "route_state_async_publish", val))
+        if (!cfgSystemDefaultsTable.hget("async_rec", "status", val))
         {
             return;
         }
     }
     catch (const std::system_error &e)
     {
-        SWSS_LOG_WARN("Could not read route_state_async_publish from CONFIG_DB: %s; default enabled", e.what());
+        SWSS_LOG_WARN("Could not read SYSTEM_DEFAULTS|async_rec status from CONFIG_DB: %s; default enabled", e.what());
         return;
     }
 
     if (val == "disabled")
     {
         gRouteStateAsyncPublish = false;
-        SWSS_LOG_NOTICE("route_state_async_publish is disabled in DEVICE_METADATA|localhost; synchronous route state publish");
+        SWSS_LOG_NOTICE("SYSTEM_DEFAULTS|async_rec status is disabled; synchronous route state publish");
     }
 }
 

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -80,6 +80,7 @@ uint32_t gCfgSystemPorts = 0;
 string gMyHostName = "";
 string gMyAsicName = "";
 bool gTraditionalFlexCounter = false;
+bool gRouteStateAsyncPublish = true;
 uint32_t create_switch_timeout = 0;
 bool gMultiAsicVoq = false;
 

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -80,7 +80,7 @@ uint32_t gCfgSystemPorts = 0;
 string gMyHostName = "";
 string gMyAsicName = "";
 bool gTraditionalFlexCounter = false;
-bool gRouteStateAsyncPublish = true;
+bool gRouteStateAsyncPublish = false;
 uint32_t create_switch_timeout = 0;
 bool gMultiAsicVoq = false;
 
@@ -104,7 +104,7 @@ void usage()
     cout << "    -b batch_size: set consumer table pop operation batch size (default 128)" << endl;
     cout << "    -m MAC: set switch MAC address" << endl;
     cout << "    -i INST_ID: set the ASIC instance_id in multi-asic platform" << endl;
-    cout << "    -A: enable async swss.rec recording path" << endl;
+    cout << "    -A: enable async swss.rec recording and async route state publish path" << endl;
     cout << "    -s enable synchronous mode (deprecated, use -z)" << endl;
     cout << "    -z redis communication mode (redis_async|redis_sync|zmq_sync), default: redis_async" << endl;
     cout << "    -f swss_rec_filename: swss record log filename(default 'swss.rec')" << endl;
@@ -272,35 +272,6 @@ void getCfgSwitchType(DBConnector *cfgDb, string &switch_type, string &switch_su
         SWSS_LOG_ERROR("System error in parsing switch subtype: %s", e.what());
     }
 
-}
-
-/*
- * SYSTEM_DEFAULTS|async_rec status: if value is "disabled", turn off async route state publish.
- * Otherwise keep default gRouteStateAsyncPublish == true. Must run before OrchDaemon::init() constructs RouteOrch.
- */
-void getCfgRouteStateAsyncPublish(DBConnector *cfgDb)
-{
-    Table cfgSystemDefaultsTable(cfgDb, CFG_SYSTEM_DEFAULTS_TABLE_NAME);
-    string val;
-
-    try
-    {
-        if (!cfgSystemDefaultsTable.hget("async_rec", "status", val))
-        {
-            return;
-        }
-    }
-    catch (const std::system_error &e)
-    {
-        SWSS_LOG_WARN("Could not read SYSTEM_DEFAULTS|async_rec status from CONFIG_DB: %s; default enabled", e.what());
-        return;
-    }
-
-    if (val == "disabled")
-    {
-        gRouteStateAsyncPublish = false;
-        SWSS_LOG_NOTICE("SYSTEM_DEFAULTS|async_rec status is disabled; synchronous route state publish");
-    }
 }
 
 bool isChassisAppDbPresent()
@@ -532,7 +503,8 @@ int main(int argc, char **argv)
             break;
         case 'A':
             Recorder::Instance().swss.setAsync(true);
-            SWSS_LOG_NOTICE("Async swss recorder enabled");
+            gRouteStateAsyncPublish = true;
+            SWSS_LOG_NOTICE("Async swss recorder and async route state publish enabled");
             break;
         case 'd':
             record_location = optarg;
@@ -1045,8 +1017,6 @@ int main(int argc, char **argv)
         /* Initialize the ring before OrchDaemon initializing Orchs */
         orchDaemon->enableRingBuffer();
     }
-
-    getCfgRouteStateAsyncPublish(&config_db);
 
     if (!orchDaemon->init())
     {

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -360,7 +360,7 @@ public:
     /**
      * @brief Flush pending responses
      */
-    void flushResponses();
+    virtual void flushResponses();
 protected:
     ConsumerMap m_consumerMap;
     RetryCacheMap m_retryCaches;

--- a/orchagent/response_publisher.cpp
+++ b/orchagent/response_publisher.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include "timestamp.h"
 
 namespace
 {
@@ -29,7 +30,7 @@ std::string PrependedComponent(const ReturnCode &status)
 }
 
 void RecordDBWrite(const std::string &table, const std::string &key, const std::vector<swss::FieldValueTuple> &attrs,
-                   const std::string &op)
+                   const std::string &op, const std::string *record_ts = nullptr)
 {
     if (!swss::Recorder::Instance().respub.isRecord())
     {
@@ -42,11 +43,19 @@ void RecordDBWrite(const std::string &table, const std::string &key, const std::
         s += "|" + fvField(attr) + ":" + fvValue(attr);
     }
 
-    swss::Recorder::Instance().respub.record(s);
+    if (record_ts != nullptr && !record_ts->empty())
+    {
+        swss::Recorder::Instance().respub.record(*record_ts, s);
+    }
+    else
+    {
+        swss::Recorder::Instance().respub.record(s);
+    }
 }
 
 void RecordResponse(const std::string &response_channel, const std::string &key,
-                    const std::vector<swss::FieldValueTuple> &attrs, const std::string &status)
+                    const std::vector<swss::FieldValueTuple> &attrs, const std::string &status,
+                    const std::string *record_ts = nullptr)
 {
     if (!swss::Recorder::Instance().respub.isRecord())
     {
@@ -59,7 +68,14 @@ void RecordResponse(const std::string &response_channel, const std::string &key,
         s += "|" + fvField(attr) + ":" + fvValue(attr);
     }
 
-    swss::Recorder::Instance().respub.record(s);
+    if (record_ts != nullptr && !record_ts->empty())
+    {
+        swss::Recorder::Instance().respub.record(*record_ts, s);
+    }
+    else
+    {
+        swss::Recorder::Instance().respub.record(s);
+    }
 }
 
 } // namespace
@@ -149,6 +165,61 @@ void ResponsePublisher::publish(const std::string &table, const std::string &key
     publish(table, key, intent_attrs, status, state_attrs, replace);
 }
 
+void ResponsePublisher::setAsyncFullPublish(bool enable)
+{
+    m_async_full_publish = enable;
+}
+
+void ResponsePublisher::publishAsync(const std::string &table, const std::string &key,
+                                     const std::vector<swss::FieldValueTuple> &intent_attrs, const ReturnCode &status,
+                                     bool replace)
+{
+    if (m_update_thread == nullptr)
+    {
+        publish(table, key, intent_attrs, status, replace);
+        return;
+    }
+    {
+        std::lock_guard<std::mutex> lock(m_lock);
+        std::string ts = swss::getTimestamp();
+        entry e(table, key, std::vector<swss::FieldValueTuple>{}, "", replace, /*flush=*/false, /*shutdown=*/false);
+        e.fullPublish = true;
+        e.intent_attrs = intent_attrs;
+        e.status = status;
+        e.record_ts = std::move(ts);
+        m_queue.push(std::move(e));
+    }
+    m_signal.notify_one();
+}
+
+void ResponsePublisher::publishFullFromThread(const std::string &table, const std::string &key,
+                                              const std::vector<swss::FieldValueTuple> &intent_attrs,
+                                              const ReturnCode &status, bool replace, const std::string &record_ts)
+{
+    std::vector<swss::FieldValueTuple> state_attrs;
+    if (status.ok())
+    {
+        state_attrs = intent_attrs;
+    }
+    std::string response_channel = "APPL_DB_" + table + "_RESPONSE_CHANNEL";
+    swss::NotificationProducer notificationProducer{m_ntf_pipe.get(), response_channel, m_buffered};
+
+    auto intent_attrs_copy = intent_attrs;
+    swss::FieldValueTuple err_str("err_str", PrependedComponent(status) + status.message());
+    intent_attrs_copy.insert(intent_attrs_copy.begin(), err_str);
+    notificationProducer.send(status.codeStr(), key, intent_attrs_copy);
+    // Same enqueue-time stamp for both lines (parity with sync publish recorder timing).
+    const std::string *ts_ptr = record_ts.empty() ? nullptr : &record_ts;
+    RecordResponse(response_channel, key, intent_attrs_copy, status.codeStr(), ts_ptr);
+
+    if ((intent_attrs.size() && state_attrs.size()) || (status.ok() && !intent_attrs.size()))
+    {
+        std::string op = intent_attrs.size() ? SET_COMMAND : DEL_COMMAND;
+        writeToDBInternal(table, key, state_attrs, op, replace);
+        RecordDBWrite(table, key, state_attrs, op, ts_ptr);
+    }
+}
+
 void ResponsePublisher::writeToDB(const std::string &table, const std::string &key,
                                   const std::vector<swss::FieldValueTuple> &values, const std::string &op, bool replace)
 {
@@ -229,19 +300,24 @@ void ResponsePublisher::flush() {
   } else {
     m_ntf_pipe->flush();
   }
-  if (m_update_thread != nullptr)
-  {
-      {
-          std::lock_guard<std::mutex> lock(m_lock);
-          m_queue.emplace(/*table=*/"", /*key=*/"", /*values =*/std::vector<swss::FieldValueTuple>{}, /*op=*/"",
-                          /*replace=*/false, /*flush=*/true, /*shutdown=*/false);
-      }
-      m_signal.notify_one();
-  }
-  else
-  {
-      m_db_pipe->flush();
-  }
+    if (m_update_thread != nullptr)
+    {
+        if (!m_async_full_publish)
+        {
+            m_ntf_pipe->flush();
+        }
+        {
+            std::lock_guard<std::mutex> lock(m_lock);
+            m_queue.emplace(/*table=*/"", /*key=*/"", /*values =*/std::vector<swss::FieldValueTuple>{}, /*op=*/"",
+                            /*replace=*/false, /*flush=*/true, /*shutdown=*/false);
+        }
+        m_signal.notify_one();
+    }
+    else
+    {
+        m_ntf_pipe->flush();
+        m_db_pipe->flush();
+    }
 }
 
 void ResponsePublisher::setBuffered(bool buffered)
@@ -249,6 +325,7 @@ void ResponsePublisher::setBuffered(bool buffered)
     m_buffered = buffered;
 }
 
+// Runs on m_update_thread (response publisher db update thread).
 void ResponsePublisher::dbUpdateThread()
 {
     while (true)
@@ -270,7 +347,15 @@ void ResponsePublisher::dbUpdateThread()
         }
         if (e.flush)
         {
+            if (m_async_full_publish)
+            {
+                m_ntf_pipe->flush();
+            }
             m_db_pipe->flush();
+        }
+        else if (e.fullPublish)
+        {
+            publishFullFromThread(e.table, e.key, e.intent_attrs, e.status, e.replace, e.record_ts);
         }
         else
         {

--- a/orchagent/response_publisher.cpp
+++ b/orchagent/response_publisher.cpp
@@ -298,10 +298,10 @@ void ResponsePublisher::flush() {
     }
     responses.clear();
   } else {
-    m_ntf_pipe->flush();
-  }
     if (m_update_thread != nullptr)
     {
+        // When m_async_full_publish, only the worker may use m_ntf_pipe (publishFullFromThread);
+        // flushing it here would race with the worker and can drop state/notification Redis ops.
         if (!m_async_full_publish)
         {
             m_ntf_pipe->flush();
@@ -318,6 +318,7 @@ void ResponsePublisher::flush() {
         m_ntf_pipe->flush();
         m_db_pipe->flush();
     }
+  }
 }
 
 void ResponsePublisher::setBuffered(bool buffered)

--- a/orchagent/response_publisher.cpp
+++ b/orchagent/response_publisher.cpp
@@ -3,7 +3,9 @@
 #include <fstream>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
+#include "logger.h"
 #include "timestamp.h"
 
 namespace
@@ -91,7 +93,7 @@ ResponsePublisher::ResponsePublisher(const std::string& dbName, bool buffered,
 {
     if (db_write_thread)
     {
-        m_update_thread = std::unique_ptr<std::thread>(new std::thread(&ResponsePublisher::dbUpdateThread, this));
+        m_update_thread = std::unique_ptr<std::thread>(new std::thread(&ResponsePublisher::stateUpdateThread, this));
     }
 }
 
@@ -99,6 +101,12 @@ ResponsePublisher::~ResponsePublisher()
 {
     if (m_update_thread != nullptr)
     {
+        if (!m_async_publish_pending.empty())
+        {
+            SWSS_LOG_WARN("~ResponsePublisher: dropping %zu pending async batch entries",
+                          m_async_publish_pending.size());
+            m_async_publish_pending.clear();
+        }
         {
             std::lock_guard<std::mutex> lock(m_lock);
             m_queue.emplace(/*table=*/"", /*key=*/"", /*values =*/std::vector<swss::FieldValueTuple>{}, /*op=*/"",
@@ -170,6 +178,27 @@ void ResponsePublisher::setAsyncFullPublish(bool enable)
     m_async_full_publish = enable;
 }
 
+void ResponsePublisher::publishAsyncBatch()
+{
+    if (m_update_thread == nullptr)
+    {
+        return;
+    }
+    std::vector<asyncPublishItem> batch = std::move(m_async_publish_pending);
+    if (batch.empty())
+    {
+        return;
+    }
+    {
+        std::lock_guard<std::mutex> lock(m_lock);
+        entry e;
+        e.fullPublishBatch = true;
+        e.full_publish_batch = std::move(batch);
+        m_queue.push(std::move(e));
+    }
+    m_signal.notify_one();
+}
+
 void ResponsePublisher::publishAsync(const std::string &table, const std::string &key,
                                      const std::vector<swss::FieldValueTuple> &intent_attrs, const ReturnCode &status,
                                      bool replace)
@@ -179,44 +208,62 @@ void ResponsePublisher::publishAsync(const std::string &table, const std::string
         publish(table, key, intent_attrs, status, replace);
         return;
     }
-    {
-        std::lock_guard<std::mutex> lock(m_lock);
-        std::string ts = swss::getTimestamp();
-        entry e(table, key, std::vector<swss::FieldValueTuple>{}, "", replace, /*flush=*/false, /*shutdown=*/false);
-        e.fullPublish = true;
-        e.intent_attrs = intent_attrs;
-        e.status = status;
-        e.record_ts = std::move(ts);
-        m_queue.push(std::move(e));
-    }
-    m_signal.notify_one();
+    asyncPublishItem item;
+    item.table = table;
+    item.key = key;
+    item.intent_attrs = intent_attrs;
+    item.status = status;
+    item.replace = replace;
+    item.record_ts = swss::getTimestamp();
+    m_async_publish_pending.push_back(std::move(item));
 }
 
-void ResponsePublisher::publishFullFromThread(const std::string &table, const std::string &key,
-                                              const std::vector<swss::FieldValueTuple> &intent_attrs,
-                                              const ReturnCode &status, bool replace, const std::string &record_ts)
+void ResponsePublisher::publishFullBatchFromThread(std::vector<asyncPublishItem> &&items)
 {
-    std::vector<swss::FieldValueTuple> state_attrs;
-    if (status.ok())
+    if (items.empty())
     {
-        state_attrs = intent_attrs;
+        return;
     }
-    std::string response_channel = "APPL_DB_" + table + "_RESPONSE_CHANNEL";
-    swss::NotificationProducer notificationProducer{m_ntf_pipe.get(), response_channel, m_buffered};
 
-    auto intent_attrs_copy = intent_attrs;
-    swss::FieldValueTuple err_str("err_str", PrependedComponent(status) + status.message());
-    intent_attrs_copy.insert(intent_attrs_copy.begin(), err_str);
-    notificationProducer.send(status.codeStr(), key, intent_attrs_copy);
-    // Same enqueue-time stamp for both lines (parity with sync publish recorder timing).
-    const std::string *ts_ptr = record_ts.empty() ? nullptr : &record_ts;
-    RecordResponse(response_channel, key, intent_attrs_copy, status.codeStr(), ts_ptr);
-
-    if ((intent_attrs.size() && state_attrs.size()) || (status.ok() && !intent_attrs.size()))
+    // Per item, match publish(): ZMQ queues responses[table]; else Redis notification. Then RecordResponse,
+    // then APPL_STATE write (writeToDBInternal on worker). Pipelines / ZMQ send drain in flush().
+    for (const auto &it : items)
     {
-        std::string op = intent_attrs.size() ? SET_COMMAND : DEL_COMMAND;
-        writeToDBInternal(table, key, state_attrs, op, replace);
-        RecordDBWrite(table, key, state_attrs, op, ts_ptr);
+        auto intent_attrs_copy = it.intent_attrs;
+        swss::FieldValueTuple err_str("err_str", PrependedComponent(it.status) + it.status.message());
+        intent_attrs_copy.insert(intent_attrs_copy.begin(), err_str);
+
+        std::string response_channel = "APPL_DB_" + it.table + "_RESPONSE_CHANNEL";
+        const std::string *ts_ptr = it.record_ts.empty() ? nullptr : &it.record_ts;
+
+        if (m_zmqServer != nullptr)
+        {
+            auto intent_attrs_zmq_copy = it.intent_attrs;
+            swss::FieldValueTuple fvs(it.status.codeStr(),
+                                      PrependedComponent(it.status) + it.status.message());
+            intent_attrs_zmq_copy.insert(intent_attrs_zmq_copy.begin(), fvs);
+            responses[it.table].push_back(
+                swss::KeyOpFieldsValuesTuple{it.key, SET_COMMAND, intent_attrs_zmq_copy});
+        }
+        else
+        {
+            swss::NotificationProducer notificationProducer{m_ntf_pipe.get(), response_channel, m_buffered};
+            notificationProducer.send(it.status.codeStr(), it.key, intent_attrs_copy);
+        }
+
+        RecordResponse(response_channel, it.key, intent_attrs_copy, it.status.codeStr(), ts_ptr);
+
+        std::vector<swss::FieldValueTuple> state_attrs;
+        if (it.status.ok())
+        {
+            state_attrs = it.intent_attrs;
+        }
+        if ((it.intent_attrs.size() && state_attrs.size()) || (it.status.ok() && !it.intent_attrs.size()))
+        {
+            std::string op = it.intent_attrs.size() ? SET_COMMAND : DEL_COMMAND;
+            writeToDBInternal(it.table, it.key, state_attrs, op, it.replace);
+            RecordDBWrite(it.table, it.key, state_attrs, op, ts_ptr);
+        }
     }
 }
 
@@ -291,16 +338,11 @@ void ResponsePublisher::writeToDBInternal(const std::string &table, const std::s
     }
 }
 
-void ResponsePublisher::flush() {
-  if (m_zmqServer != nullptr) {
-    for (const auto& response : responses) {
-      m_zmqServer->sendMsg("APPL_DB", response.first, response.second);
-    }
-    responses.clear();
-  } else {
+void ResponsePublisher::flush()
+{
     if (m_update_thread != nullptr)
     {
-        // When m_async_full_publish, only the worker may use m_ntf_pipe (publishFullFromThread);
+        // When m_async_full_publish, only the worker may use m_ntf_pipe (batch publish);
         // flushing it here would race with the worker and can drop state/notification Redis ops.
         if (!m_async_full_publish)
         {
@@ -312,13 +354,24 @@ void ResponsePublisher::flush() {
                             /*replace=*/false, /*flush=*/true, /*shutdown=*/false);
         }
         m_signal.notify_one();
+        return;
+    }
+
+    // No worker: synchronous ZMQ send on caller thread, or Redis pipelines here.
+    if (m_zmqServer != nullptr)
+    {
+        for (const auto &response : responses)
+        {
+            m_zmqServer->sendMsg("APPL_DB", response.first, response.second);
+        }
+        responses.clear();
+        m_db_pipe->flush();
     }
     else
     {
         m_ntf_pipe->flush();
         m_db_pipe->flush();
     }
-  }
 }
 
 void ResponsePublisher::setBuffered(bool buffered)
@@ -326,8 +379,8 @@ void ResponsePublisher::setBuffered(bool buffered)
     m_buffered = buffered;
 }
 
-// Runs on m_update_thread (response publisher db update thread).
-void ResponsePublisher::dbUpdateThread()
+// Runs on m_update_thread (response publisher state update thread).
+void ResponsePublisher::stateUpdateThread()
 {
     while (true)
     {
@@ -348,15 +401,23 @@ void ResponsePublisher::dbUpdateThread()
         }
         if (e.flush)
         {
+            if (m_zmqServer != nullptr)
+            {
+                for (const auto &response : responses)
+                {
+                    m_zmqServer->sendMsg("APPL_DB", response.first, response.second);
+                }
+                responses.clear();
+            }
             if (m_async_full_publish)
             {
                 m_ntf_pipe->flush();
             }
             m_db_pipe->flush();
         }
-        else if (e.fullPublish)
+        else if (e.fullPublishBatch)
         {
-            publishFullFromThread(e.table, e.key, e.intent_attrs, e.status, e.replace, e.record_ts);
+            publishFullBatchFromThread(std::move(e.full_publish_batch));
         }
         else
         {

--- a/orchagent/response_publisher.cpp
+++ b/orchagent/response_publisher.cpp
@@ -121,6 +121,16 @@ void ResponsePublisher::publish(const std::string &table, const std::string &key
                                 const std::vector<swss::FieldValueTuple> &intent_attrs, const ReturnCode &status,
                                 const std::vector<swss::FieldValueTuple> &state_attrs, bool replace)
 {
+    publishWrite(table, key, intent_attrs, status, state_attrs, replace, /*record_ts=*/nullptr,
+                 /*sync_publish=*/false);
+}
+
+void ResponsePublisher::publishWrite(const std::string &table, const std::string &key,
+                                     const std::vector<swss::FieldValueTuple> &intent_attrs,
+                                     const ReturnCode &status,
+                                     const std::vector<swss::FieldValueTuple> &state_attrs,
+                                     bool replace, const std::string *record_ts, bool sync_publish)
+{
     auto intent_attrs_copy = intent_attrs;
     // Add error message as the first field-value-pair.
     swss::FieldValueTuple err_str("err_str", PrependedComponent(status) + status.message());
@@ -145,7 +155,7 @@ void ResponsePublisher::publish(const std::string &table, const std::string &key
       }
     }
 
-    RecordResponse(response_channel, key, intent_attrs_copy, status.codeStr());
+    RecordResponse(response_channel, key, intent_attrs_copy, status.codeStr(), record_ts);
 
     // Write to the DB only if: m_enable_db_write_and_notify is true and:
     // 1) A write operation is being performed and state attributes are specified.
@@ -153,7 +163,16 @@ void ResponsePublisher::publish(const std::string &table, const std::string &key
     if (m_enable_db_write_and_notify &&
          ((intent_attrs.size() && state_attrs.size()) ||
          (status.ok() && !intent_attrs.size()))) {
-            writeToDB(table, key, state_attrs, intent_attrs.size() ? SET_COMMAND : DEL_COMMAND, replace);
+            const auto op = intent_attrs.size() ? SET_COMMAND : DEL_COMMAND;
+            if (sync_publish)
+            {
+                writeToDBInternal(table, key, state_attrs, op, replace);
+                RecordDBWrite(table, key, state_attrs, op, record_ts);
+            }
+            else
+            {
+                writeToDB(table, key, state_attrs, op, replace);
+            }
     }
 }
 
@@ -225,45 +244,17 @@ void ResponsePublisher::publishFullBatchFromThread(std::vector<asyncPublishItem>
         return;
     }
 
-    // Per item, match publish(): ZMQ queues responses[table]; else Redis notification. Then RecordResponse,
-    // then APPL_STATE write (writeToDBInternal on worker). Pipelines / ZMQ send drain in flush().
+    // Per item, use the same core publish logic as synchronous publish().
     for (const auto &it : items)
     {
-        auto intent_attrs_copy = it.intent_attrs;
-        swss::FieldValueTuple err_str("err_str", PrependedComponent(it.status) + it.status.message());
-        intent_attrs_copy.insert(intent_attrs_copy.begin(), err_str);
-
-        std::string response_channel = "APPL_DB_" + it.table + "_RESPONSE_CHANNEL";
-        const std::string *ts_ptr = it.record_ts.empty() ? nullptr : &it.record_ts;
-
-        if (m_zmqServer != nullptr)
-        {
-            auto intent_attrs_zmq_copy = it.intent_attrs;
-            swss::FieldValueTuple fvs(it.status.codeStr(),
-                                      PrependedComponent(it.status) + it.status.message());
-            intent_attrs_zmq_copy.insert(intent_attrs_zmq_copy.begin(), fvs);
-            responses[it.table].push_back(
-                swss::KeyOpFieldsValuesTuple{it.key, SET_COMMAND, intent_attrs_zmq_copy});
-        }
-        else
-        {
-            swss::NotificationProducer notificationProducer{m_ntf_pipe.get(), response_channel, m_buffered};
-            notificationProducer.send(it.status.codeStr(), it.key, intent_attrs_copy);
-        }
-
-        RecordResponse(response_channel, it.key, intent_attrs_copy, it.status.codeStr(), ts_ptr);
-
         std::vector<swss::FieldValueTuple> state_attrs;
         if (it.status.ok())
         {
             state_attrs = it.intent_attrs;
         }
-        if ((it.intent_attrs.size() && state_attrs.size()) || (it.status.ok() && !it.intent_attrs.size()))
-        {
-            std::string op = it.intent_attrs.size() ? SET_COMMAND : DEL_COMMAND;
-            writeToDBInternal(it.table, it.key, state_attrs, op, it.replace);
-            RecordDBWrite(it.table, it.key, state_attrs, op, ts_ptr);
-        }
+        const std::string *ts_ptr = it.record_ts.empty() ? nullptr : &it.record_ts;
+        publishWrite(it.table, it.key, it.intent_attrs, it.status, state_attrs, it.replace, ts_ptr,
+                     /*sync_publish=*/true);
     }
 }
 

--- a/orchagent/response_publisher.cpp
+++ b/orchagent/response_publisher.cpp
@@ -93,6 +93,8 @@ ResponsePublisher::ResponsePublisher(const std::string& dbName, bool buffered,
 {
     if (db_write_thread)
     {
+        // With a db update thread, the worker thread owns notification publish/flush
+        // (m_ntf_pipe) and DB writes, to avoid cross-thread RedisPipeline access.
         m_update_thread = std::unique_ptr<std::thread>(new std::thread(&ResponsePublisher::stateUpdateThread, this));
     }
 }
@@ -190,11 +192,6 @@ void ResponsePublisher::publish(const std::string &table, const std::string &key
         state_attrs = intent_attrs;
     }
     publish(table, key, intent_attrs, status, state_attrs, replace);
-}
-
-void ResponsePublisher::setAsyncFullPublish(bool enable)
-{
-    m_async_full_publish = enable;
 }
 
 void ResponsePublisher::publishAsyncBatch()
@@ -333,12 +330,9 @@ void ResponsePublisher::flush()
 {
     if (m_update_thread != nullptr)
     {
-        // When m_async_full_publish, only the worker may use m_ntf_pipe (batch publish);
-        // flushing it here would race with the worker and can drop state/notification Redis ops.
-        if (!m_async_full_publish)
-        {
-            m_ntf_pipe->flush();
-        }
+        // The worker thread owns m_ntf_pipe; flushing it here would race with the
+        // worker and can drop state/notification Redis ops. Enqueue a flush marker
+        // so the worker flushes m_ntf_pipe and m_db_pipe in its own context.
         {
             std::lock_guard<std::mutex> lock(m_lock);
             m_queue.emplace(/*table=*/"", /*key=*/"", /*values =*/std::vector<swss::FieldValueTuple>{}, /*op=*/"",
@@ -400,10 +394,7 @@ void ResponsePublisher::stateUpdateThread()
                 }
                 responses.clear();
             }
-            if (m_async_full_publish)
-            {
-                m_ntf_pipe->flush();
-            }
+            m_ntf_pipe->flush();
             m_db_pipe->flush();
         }
         else if (e.fullPublishBatch)

--- a/orchagent/response_publisher.h
+++ b/orchagent/response_publisher.h
@@ -54,6 +54,19 @@ class ResponsePublisher : public ResponsePublisherInterface
 
     void setEnableDbWriteAndNotify(bool enable_db_write_and_notify) override;
 
+    // Enqueue full publish (notification + APPL_STATE_DB write + recorder) on the response publisher 
+    // db update thread. When constructed without a DB update thread (e.g. RouteOrch with orchagent -a 
+    // gRouteStateAsyncPublish false), calls the 5-arg publish() synchronously.
+    void publishAsync(const std::string &table, const std::string &key,
+                      const std::vector<swss::FieldValueTuple> &intent_attrs, const ReturnCode &status,
+                      bool replace = false);
+
+    // When true and the response publisher db update thread is used, all notifications for this publisher 
+    // are sent from that thread (publishAsync path). flush() then flushes the notification pipeline on the 
+    // response publisher db update thread as well, avoiding concurrent use of the notification RedisPipeline 
+    // from two threads.
+    void setAsyncFullPublish(bool enable);
+
     /**
      * @brief Flush pending responses
      */
@@ -81,19 +94,28 @@ class ResponsePublisher : public ResponsePublisherInterface
         bool replace;
         bool flush;
         bool shutdown;
+        bool fullPublish;
+        std::vector<swss::FieldValueTuple> intent_attrs;
+        ReturnCode status;
+        // When fullPublish: timestamp at enqueue; matches sync publish() recorder timing.
+        std::string record_ts;
 
-        entry()
+        entry() : replace(false), flush(false), shutdown(false), fullPublish(false)
         {
         }
 
         entry(const std::string &table, const std::string &key, const std::vector<swss::FieldValueTuple> &values,
               const std::string &op, bool replace, bool flush, bool shutdown)
-            : table(table), key(key), values(values), op(op), replace(replace), flush(flush), shutdown(shutdown)
+            : table(table), key(key), values(values), op(op), replace(replace), flush(flush), shutdown(shutdown),
+              fullPublish(false)
         {
         }
     };
 
     void dbUpdateThread();
+    void publishFullFromThread(const std::string &table, const std::string &key,
+                               const std::vector<swss::FieldValueTuple> &intent_attrs, const ReturnCode &status,
+                               bool replace, const std::string &record_ts);
     void writeToDBInternal(const std::string &table, const std::string &key,
                            const std::vector<swss::FieldValueTuple> &values, const std::string &op, bool replace);
 
@@ -106,6 +128,9 @@ class ResponsePublisher : public ResponsePublisherInterface
   std::unordered_map<std::string, std::vector<swss::KeyOpFieldsValuesTuple>>
       responses;  // Cache the responses to send them together in flush(). Only
                   // used when ZMQ is enabled.
+    // When true with m_update_thread, full publish (incl. notifications) runs on the response publisher 
+    // db update thread; flush() coordinates m_ntf_pipe flush there.
+    bool m_async_full_publish{false};
     // Thread to write to DB.
     std::unique_ptr<std::thread> m_update_thread;
     std::queue<entry, std::list<entry>> m_queue;

--- a/orchagent/response_publisher.h
+++ b/orchagent/response_publisher.h
@@ -54,16 +54,19 @@ class ResponsePublisher : public ResponsePublisherInterface
 
     void setEnableDbWriteAndNotify(bool enable_db_write_and_notify) override;
 
-    // Enqueue full publish (notification + APPL_STATE_DB write + recorder) on the response publisher 
-    // db update thread. When constructed without a DB update thread (e.g. RouteOrch with orchagent -a 
-    // gRouteStateAsyncPublish false), calls the 5-arg publish() synchronously.
+    // With a state update thread: append to m_async_publish_pending; caller must call
+    // publishAsyncBatch() then flush() to enqueue work (batch + flush marker).
+    // Without a state update thread: synchronous publish().
     void publishAsync(const std::string &table, const std::string &key,
                       const std::vector<swss::FieldValueTuple> &intent_attrs, const ReturnCode &status,
                       bool replace = false);
 
-    // When true and the response publisher db update thread is used, all notifications for this publisher 
+    // Enqueue the current async batch as one queue item. No-op if empty or if no state update thread.
+    void publishAsyncBatch();
+
+    // When true and the response publisher state update thread is used, all notifications for this publisher 
     // are sent from that thread (publishAsync path). flush() then flushes the notification pipeline on the 
-    // response publisher db update thread as well, avoiding concurrent use of the notification RedisPipeline 
+    // response publisher state update thread as well, avoiding concurrent use of the notification RedisPipeline 
     // from two threads.
     void setAsyncFullPublish(bool enable);
 
@@ -85,6 +88,16 @@ class ResponsePublisher : public ResponsePublisherInterface
     bool m_directDbWrite = false;
 
   private:
+    struct asyncPublishItem
+    {
+        std::string table;
+        std::string key;
+        std::vector<swss::FieldValueTuple> intent_attrs;
+        ReturnCode status;
+        bool replace;
+        std::string record_ts;
+    };
+
     struct entry
     {
         std::string table;
@@ -94,28 +107,23 @@ class ResponsePublisher : public ResponsePublisherInterface
         bool replace;
         bool flush;
         bool shutdown;
-        bool fullPublish;
-        std::vector<swss::FieldValueTuple> intent_attrs;
-        ReturnCode status;
-        // When fullPublish: timestamp at enqueue; matches sync publish() recorder timing.
-        std::string record_ts;
+        bool fullPublishBatch;
+        std::vector<asyncPublishItem> full_publish_batch;
 
-        entry() : replace(false), flush(false), shutdown(false), fullPublish(false)
+        entry() : replace(false), flush(false), shutdown(false), fullPublishBatch(false)
         {
         }
 
         entry(const std::string &table, const std::string &key, const std::vector<swss::FieldValueTuple> &values,
               const std::string &op, bool replace, bool flush, bool shutdown)
             : table(table), key(key), values(values), op(op), replace(replace), flush(flush), shutdown(shutdown),
-              fullPublish(false)
+              fullPublishBatch(false)
         {
         }
     };
 
-    void dbUpdateThread();
-    void publishFullFromThread(const std::string &table, const std::string &key,
-                               const std::vector<swss::FieldValueTuple> &intent_attrs, const ReturnCode &status,
-                               bool replace, const std::string &record_ts);
+    void stateUpdateThread();
+    void publishFullBatchFromThread(std::vector<asyncPublishItem> &&items);
     void writeToDBInternal(const std::string &table, const std::string &key,
                            const std::vector<swss::FieldValueTuple> &values, const std::string &op, bool replace);
 
@@ -129,9 +137,10 @@ class ResponsePublisher : public ResponsePublisherInterface
       responses;  // Cache the responses to send them together in flush(). Only
                   // used when ZMQ is enabled.
     // When true with m_update_thread, full publish (incl. notifications) runs on the response publisher 
-    // db update thread; flush() coordinates m_ntf_pipe flush there.
+    // state update thread; flush() coordinates m_ntf_pipe flush there.
     bool m_async_full_publish{false};
-    // Thread to write to DB.
+    std::vector<asyncPublishItem> m_async_publish_pending;
+    // Thread to write to DB, notify and record.
     std::unique_ptr<std::thread> m_update_thread;
     std::queue<entry, std::list<entry>> m_queue;
     mutable std::mutex m_lock;

--- a/orchagent/response_publisher.h
+++ b/orchagent/response_publisher.h
@@ -64,12 +64,6 @@ class ResponsePublisher : public ResponsePublisherInterface
     // Enqueue the current async batch as one queue item. No-op if empty or if no state update thread.
     void publishAsyncBatch();
 
-    // When true and the response publisher state update thread is used, all notifications for this publisher 
-    // are sent from that thread (publishAsync path). flush() then flushes the notification pipeline on the 
-    // response publisher state update thread as well, avoiding concurrent use of the notification RedisPipeline 
-    // from two threads.
-    void setAsyncFullPublish(bool enable);
-
     /**
      * @brief Flush pending responses
      */
@@ -140,9 +134,8 @@ class ResponsePublisher : public ResponsePublisherInterface
   std::unordered_map<std::string, std::vector<swss::KeyOpFieldsValuesTuple>>
       responses;  // Cache the responses to send them together in flush(). Only
                   // used when ZMQ is enabled.
-    // When true with m_update_thread, full publish (incl. notifications) runs on the response publisher 
-    // state update thread; flush() coordinates m_ntf_pipe flush there.
-    bool m_async_full_publish{false};
+                  // When m_update_thread exists, responses is owned by the
+                  // update thread context only.
     std::vector<asyncPublishItem> m_async_publish_pending;
     // Thread to write to DB, notify and record.
     std::unique_ptr<std::thread> m_update_thread;

--- a/orchagent/response_publisher.h
+++ b/orchagent/response_publisher.h
@@ -124,6 +124,10 @@ class ResponsePublisher : public ResponsePublisherInterface
 
     void stateUpdateThread();
     void publishFullBatchFromThread(std::vector<asyncPublishItem> &&items);
+    void publishWrite(const std::string &table, const std::string &key,
+                      const std::vector<swss::FieldValueTuple> &intent_attrs, const ReturnCode &status,
+                      const std::vector<swss::FieldValueTuple> &state_attrs, bool replace,
+                      const std::string *record_ts, bool sync_publish);
     void writeToDBInternal(const std::string &table, const std::string &key,
                            const std::vector<swss::FieldValueTuple> &values, const std::string &op, bool replace);
 

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -58,7 +58,6 @@ RouteOrch::RouteOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames,
 
     m_routeStatePublisher.setBuffered(true);
     m_routeStatePublisher.m_directDbWrite = true;
-    m_routeStatePublisher.setAsyncFullPublish(true);
 
     sai_attribute_t attr;
     attr.id = SAI_SWITCH_ATTR_NUMBER_OF_ECMP_GROUPS;

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -56,9 +56,9 @@ RouteOrch::RouteOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames,
 {
     SWSS_LOG_ENTER();
 
-    m_publisher.setBuffered(true);
-    m_publisher.m_directDbWrite = true;
-    m_publisher.setAsyncFullPublish(true);
+    m_routeStatePublisher.setBuffered(true);
+    m_routeStatePublisher.m_directDbWrite = true;
+    m_routeStatePublisher.setAsyncFullPublish(true);
 
     sai_attribute_t attr;
     attr.id = SAI_SWITCH_ATTR_NUMBER_OF_ECMP_GROUPS;
@@ -1261,8 +1261,8 @@ void RouteOrch::doTask(ConsumerBase& consumer)
         // One async batch + flush per gRouteBulker.flush(): drain batched publishAsync work to the worker,
         // then enqueue the flush marker so fpmsyncd sees responses without waiting for OrchDaemon periodic 
         // flush.
-        m_publisher.publishAsyncBatch();
-        m_publisher.flush();
+        m_routeStatePublisher.publishAsyncBatch();
+        m_routeStatePublisher.flush();
 
         /* No Update to Default Route so we can return */
         if (!(v4_default_nhg_key.getSize()) && !(v6_default_nhg_key.getSize()))
@@ -3069,8 +3069,8 @@ bool RouteOrch::removeRoutePrefix(const IpPrefix& prefix)
     }
     gRouteBulker.flush();
     bool ret = removeRoutePost(context);
-    m_publisher.publishAsyncBatch();
-    m_publisher.flush();
+    m_routeStatePublisher.publishAsyncBatch();
+    m_routeStatePublisher.flush();
     return ret;
 }
 
@@ -3230,7 +3230,7 @@ void RouteOrch::publishRouteState(const RouteBulkContext& ctx, const ReturnCode&
 
     const bool replace = false;
 
-    m_publisher.publishAsync(APP_ROUTE_TABLE_NAME, ctx.key, fvs, status, replace);
+    m_routeStatePublisher.publishAsync(APP_ROUTE_TABLE_NAME, ctx.key, fvs, status, replace);
 }
 
 inline bool RouteOrch::isVipRoute(const IpPrefix &ipPrefix, const NextHopGroupKey &nextHops)
@@ -3284,6 +3284,7 @@ inline void RouteOrch::removeVipRouteSubnetDecapTerm(const IpPrefix &ipPrefix)
 
 void RouteOrch::flushResponses()
 {
-    m_publisher.flush();
+    m_routeStatePublisher.publishAsyncBatch();
+    m_routeStatePublisher.flush();
     Orch::flushResponses();
 }

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -33,6 +33,7 @@ extern TunnelDecapOrch *gTunneldecapOrch;
 
 extern size_t gMaxBulkSize;
 extern string gMySwitchType;
+extern bool gRouteStateAsyncPublish;
 
 /* Default maximum number of next hop groups */
 #define DEFAULT_NUMBER_OF_ECMP_GROUPS   128
@@ -57,6 +58,7 @@ RouteOrch::RouteOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames,
 
     m_publisher.setBuffered(true);
     m_publisher.m_directDbWrite = true;
+    m_publisher.setAsyncFullPublish(true);
 
     sai_attribute_t attr;
     attr.id = SAI_SWITCH_ATTR_NUMBER_OF_ECMP_GROUPS;
@@ -3216,7 +3218,7 @@ void RouteOrch::publishRouteState(const RouteBulkContext& ctx, const ReturnCode&
     std::vector<FieldValueTuple> fvs;
 
     /* Leave the fvs empty if the operation type is "DEL".
-     * An empty fvs makes ResponsePublisher::publish() remove the state entry from APPL_STATE_DB
+     * An empty fvs makes ResponsePublisher remove the state entry from APPL_STATE_DB
      */
     if (ctx.is_set)
     {
@@ -3225,7 +3227,7 @@ void RouteOrch::publishRouteState(const RouteBulkContext& ctx, const ReturnCode&
 
     const bool replace = false;
 
-    m_publisher.publish(APP_ROUTE_TABLE_NAME, ctx.key, fvs, status, replace);
+    m_publisher.publishAsync(APP_ROUTE_TABLE_NAME, ctx.key, fvs, status, replace);
 }
 
 inline bool RouteOrch::isVipRoute(const IpPrefix &ipPrefix, const NextHopGroupKey &nextHops)
@@ -3275,4 +3277,10 @@ inline void RouteOrch::removeVipRouteSubnetDecapTerm(const IpPrefix &ipPrefix)
     string key = tunnel_name + ":" + ipPrefix.to_string();
     m_appTunnelDecapTermProducer.del(key);
     m_SubnetDecapTermsCreated.erase(it);
+}
+
+void RouteOrch::flushResponses()
+{
+    m_publisher.flush();
+    Orch::flushResponses();
 }

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1238,12 +1238,6 @@ void RouteOrch::doTask(ConsumerBase& consumer)
             }
         }
 
-        /* Flush response publisher so route notifications reach fpmsyncd every batch.
-         * Without this, notifications stay buffered in the Redis pipeline until the
-         * next OrchDaemon periodic flush (up to 1s), delaying the offload reply to
-         * zebra and causing BGP advertisement delay when supress fib pending is ON */
-        m_publisher.flush();
-
         /* Remove next hop group if the reference count decreases to zero */
         for (auto& it_nhg : m_bulkNhgReducedRefCnt)
         {
@@ -1263,6 +1257,13 @@ void RouteOrch::doTask(ConsumerBase& consumer)
         {
             m_srv6Orch->removeSrv6Nexthops(m_bulkSrv6NhgReducedVec);
         }
+
+        // One async batch + flush per gRouteBulker.flush(): drain batched publishAsync work to the worker,
+        // then enqueue the flush marker so fpmsyncd sees responses without waiting for OrchDaemon periodic 
+        // flush.
+        m_publisher.publishAsyncBatch();
+        m_publisher.flush();
+
         /* No Update to Default Route so we can return */
         if (!(v4_default_nhg_key.getSize()) && !(v6_default_nhg_key.getSize()))
         {
@@ -3067,8 +3068,10 @@ bool RouteOrch::removeRoutePrefix(const IpPrefix& prefix)
         return true;
     }
     gRouteBulker.flush();
-    return removeRoutePost(context);
-
+    bool ret = removeRoutePost(context);
+    m_publisher.publishAsyncBatch();
+    m_publisher.flush();
+    return ret;
 }
 
 bool RouteOrch::createRemoteVtep(sai_object_id_t vrf_id, const NextHopKey &nextHop)

--- a/orchagent/routeorch.h
+++ b/orchagent/routeorch.h
@@ -318,8 +318,9 @@ private:
     EntityBulker<sai_mpls_api_t>            gLabelRouteBulker;
     ObjectBulker<sai_next_hop_group_api_t>  gNextHopGroupMemberBulker;
 
-    // Shadows Orch::m_publisher: APPL_STATE_DB + optional async thread for route state publish (publishAsync).
-    ResponsePublisher m_publisher{"APPL_STATE_DB", /*buffered=*/false, gRouteStateAsyncPublish};
+    // Dedicated APPL_STATE_DB publisher for route state (publishAsync path).
+    // Keep this distinct from Orch::m_publisher to avoid shadowing confusion.
+    ResponsePublisher m_routeStatePublisher{"APPL_STATE_DB", /*buffered=*/false, gRouteStateAsyncPublish};
 
     void addTempRoute(RouteBulkContext& ctx, const NextHopGroupKey&);
 

--- a/orchagent/routeorch.h
+++ b/orchagent/routeorch.h
@@ -20,6 +20,8 @@
 #include "zmqserver.h"
 #include <unordered_map>
 
+extern bool gRouteStateAsyncPublish;
+
 /* Maximum next hop group number */
 #define NHGRP_MAX_SIZE 128
 /* Length of the Interface Id value in EUI64 format */
@@ -279,6 +281,8 @@ public:
     bool checkNextHopGroupCount();
     const RouteTables& getSyncdRoutes() const { return m_syncdRoutes; }
 
+    void flushResponses() override;
+
 private:
     SwitchOrch *m_switchOrch;
     NeighOrch *m_neighOrch;
@@ -313,6 +317,9 @@ private:
     EntityBulker<sai_route_api_t>           gRouteBulker;
     EntityBulker<sai_mpls_api_t>            gLabelRouteBulker;
     ObjectBulker<sai_next_hop_group_api_t>  gNextHopGroupMemberBulker;
+
+    // Shadows Orch::m_publisher: APPL_STATE_DB + optional async thread for route state publish (publishAsync).
+    ResponsePublisher m_publisher{"APPL_STATE_DB", /*buffered=*/false, gRouteStateAsyncPublish};
 
     void addTempRoute(RouteBulkContext& ctx, const NextHopGroupKey&);
 

--- a/tests/mock_tests/fake_response_publisher.cpp
+++ b/tests/mock_tests/fake_response_publisher.cpp
@@ -39,6 +39,19 @@ void ResponsePublisher::publish(
     }
 }
 
+void ResponsePublisher::setAsyncFullPublish(bool enable)
+{
+    (void)enable;
+}
+
+void ResponsePublisher::publishAsync(
+    const std::string& table, const std::string& key,
+    const std::vector<swss::FieldValueTuple>& intent_attrs, const ReturnCode& status, bool replace)
+{
+    // Fake has no db update thread; mirror real ResponsePublisher::publishAsync fallback.
+    publish(table, key, intent_attrs, status, replace);
+}
+
 void ResponsePublisher::writeToDB(
     const std::string& table, const std::string& key,
     const std::vector<swss::FieldValueTuple>& values, const std::string& op,

--- a/tests/mock_tests/fake_response_publisher.cpp
+++ b/tests/mock_tests/fake_response_publisher.cpp
@@ -48,8 +48,13 @@ void ResponsePublisher::publishAsync(
     const std::string& table, const std::string& key,
     const std::vector<swss::FieldValueTuple>& intent_attrs, const ReturnCode& status, bool replace)
 {
-    // Fake has no db update thread; mirror real ResponsePublisher::publishAsync fallback.
+    // Fake has no state update thread; mirror synchronous publish() path.
     publish(table, key, intent_attrs, status, replace);
+}
+
+void ResponsePublisher::publishAsyncBatch()
+{
+    // No pending batch: publishAsync already called publish() above.
 }
 
 void ResponsePublisher::writeToDB(

--- a/tests/mock_tests/fake_response_publisher.cpp
+++ b/tests/mock_tests/fake_response_publisher.cpp
@@ -39,11 +39,6 @@ void ResponsePublisher::publish(
     }
 }
 
-void ResponsePublisher::setAsyncFullPublish(bool enable)
-{
-    (void)enable;
-}
-
 void ResponsePublisher::publishAsync(
     const std::string& table, const std::string& key,
     const std::vector<swss::FieldValueTuple>& intent_attrs, const ReturnCode& status, bool replace)

--- a/tests/mock_tests/mock_orchagent_main.cpp
+++ b/tests/mock_tests/mock_orchagent_main.cpp
@@ -19,7 +19,7 @@ int32_t gVoqMySwitchId = 0;
 string gMyHostName = "Linecard1";
 string gMyAsicName = "Asic0";
 bool gTraditionalFlexCounter = false;
-bool gRouteStateAsyncPublish = true;
+bool gRouteStateAsyncPublish = false;
 bool gSyncMode = false;
 sai_redis_communication_mode_t gRedisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC;
 

--- a/tests/mock_tests/mock_orchagent_main.cpp
+++ b/tests/mock_tests/mock_orchagent_main.cpp
@@ -19,6 +19,7 @@ int32_t gVoqMySwitchId = 0;
 string gMyHostName = "Linecard1";
 string gMyAsicName = "Asic0";
 bool gTraditionalFlexCounter = false;
+bool gRouteStateAsyncPublish = true;
 bool gSyncMode = false;
 sai_redis_communication_mode_t gRedisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC;
 

--- a/tests/mock_tests/response_publisher/response_publisher_ut.cpp
+++ b/tests/mock_tests/response_publisher/response_publisher_ut.cpp
@@ -1,8 +1,35 @@
 #include "response_publisher.h"
 
+#include <chrono>
 #include <gtest/gtest.h>
+#include <string>
+#include <thread>
+
+#include "return_code.h"
 
 using namespace swss;
+
+namespace
+{
+/* ResponsePublisher::flush() returns after enqueueing work; the state thread
+ * applies DB writes asynchronously. Poll until hget succeeds or timeout. */
+bool pollHget(Table &t, const std::string &key, const std::string &field, std::string *out, int timeout_ms = 3000)
+{
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+        std::string v;
+        if (t.hget(key, field, v))
+        {
+            if (out)
+                *out = std::move(v);
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    return false;
+}
+} // namespace
 
 TEST(ResponsePublisher, TestPublish)
 {
@@ -56,5 +83,127 @@ TEST(ResponsePublisher, TestPublishEnableDbWrite)
     publisher.flush();
     ASSERT_TRUE(stateTable.hget("SOME_KEY", "field", value));
     ASSERT_EQ(value, "new-value");
+}
+
+/* RouteOrch-style async path: third ctor arg starts m_update_thread; RouteOrch
+ * uses publishAsync + publishAsyncBatch + flush after gRouteBulker.flush(). */
+TEST(ResponsePublisher, PublishAsyncNoThreadFallsBackToSyncPublish)
+{
+    DBConnector conn{"APPL_STATE_DB", 0};
+    Table stateTable{&conn, "ROUTE_TABLE"};
+    std::string value;
+
+    ResponsePublisher publisher{"APPL_STATE_DB", /*buffered=*/false, /*db_write_thread=*/false};
+    publisher.m_directDbWrite = true;
+
+    publisher.publishAsync("ROUTE_TABLE", "10.0.0.0/24", {{"protocol", "bgp"}, {"state", "ok"}},
+                           ReturnCode(SAI_STATUS_SUCCESS));
+    ASSERT_TRUE(pollHget(stateTable, "10.0.0.0/24", "state", &value));
+    ASSERT_EQ(value, "ok");
+}
+
+TEST(ResponsePublisher, PublishAsyncBatchWithWorkerWritesAllKeys)
+{
+    DBConnector conn{"APPL_STATE_DB", 0};
+    Table stateTable{&conn, "ROUTE_TABLE"};
+
+    ResponsePublisher publisher{"APPL_STATE_DB", /*buffered=*/false, /*db_write_thread=*/true};
+    publisher.m_directDbWrite = true;
+    publisher.setAsyncFullPublish(true);
+
+    publisher.publishAsync("ROUTE_TABLE", "10.1.0.0/24", {{"protocol", "bgp"}, {"state", "ok"}},
+                           ReturnCode(SAI_STATUS_SUCCESS));
+    publisher.publishAsync("ROUTE_TABLE", "10.2.0.0/24", {{"protocol", "bgp"}, {"state", "ok"}},
+                           ReturnCode(SAI_STATUS_SUCCESS));
+    publisher.publishAsync("ROUTE_TABLE", "10.3.0.0/24", {{"protocol", "bgp"}, {"state", "ok"}},
+                           ReturnCode(SAI_STATUS_SUCCESS));
+
+    publisher.publishAsyncBatch();
+    publisher.flush();
+
+    std::string v;
+    ASSERT_TRUE(pollHget(stateTable, "10.1.0.0/24", "state", &v));
+    ASSERT_EQ(v, "ok");
+    ASSERT_TRUE(pollHget(stateTable, "10.2.0.0/24", "state", &v));
+    ASSERT_EQ(v, "ok");
+    ASSERT_TRUE(pollHget(stateTable, "10.3.0.0/24", "state", &v));
+    ASSERT_EQ(v, "ok");
+}
+
+TEST(ResponsePublisher, PublishAsyncWithoutBatchThenFlushDoesNotWriteState)
+{
+    DBConnector conn{"APPL_STATE_DB", 0};
+    Table stateTable{&conn, "ROUTE_TABLE"};
+
+    {
+        ResponsePublisher publisher{"APPL_STATE_DB", false, true};
+        publisher.m_directDbWrite = true;
+        publisher.setAsyncFullPublish(true);
+
+        publisher.publishAsync("ROUTE_TABLE", "10.9.9.0/24", {{"protocol", "bgp"}, {"state", "ok"}},
+                               ReturnCode(SAI_STATUS_SUCCESS));
+        /* Missing publishAsyncBatch(): pending stays in m_async_publish_pending; flush only drains pipes. */
+        publisher.flush();
+
+        std::string dummy;
+        ASSERT_FALSE(pollHget(stateTable, "10.9.9.0/24", "state", &dummy, 200));
+    }
+
+    /* After destructor, key must still be absent (batch was never enqueued). */
+    std::string value;
+    ASSERT_FALSE(stateTable.hget("10.9.9.0/24", "state", value));
+}
+
+TEST(ResponsePublisher, PublishAsyncBatchEmptyIsNoOpThenFlush)
+{
+    DBConnector conn{"APPL_STATE_DB", 0};
+    ResponsePublisher publisher{"APPL_STATE_DB", false, true};
+    publisher.setAsyncFullPublish(true);
+
+    publisher.publishAsyncBatch();
+    publisher.flush();
+    /* No ASSERT on DB: should complete without deadlock/hang. */
+    SUCCEED();
+}
+
+TEST(ResponsePublisher, PublishAsyncErrorStatusSkipsApplStateWrite)
+{
+    DBConnector conn{"APPL_STATE_DB", 0};
+    Table stateTable{&conn, "ROUTE_TABLE"};
+
+    ResponsePublisher publisher{"APPL_STATE_DB", false, true};
+    publisher.m_directDbWrite = true;
+    publisher.setAsyncFullPublish(true);
+
+    publisher.publishAsync("ROUTE_TABLE", "10.8.0.0/24", {{"protocol", "bgp"}, {"state", "bad"}},
+                           ReturnCode(SAI_STATUS_INVALID_PARAMETER));
+    publisher.publishAsyncBatch();
+    publisher.flush();
+
+    std::string dummy;
+    ASSERT_FALSE(pollHget(stateTable, "10.8.0.0/24", "state", &dummy, 200));
+}
+
+TEST(ResponsePublisher, PublishAsyncTwoSequentialBatches)
+{
+    DBConnector conn{"APPL_STATE_DB", 0};
+    Table stateTable{&conn, "ROUTE_TABLE"};
+
+    ResponsePublisher publisher{"APPL_STATE_DB", false, true};
+    publisher.m_directDbWrite = true;
+    publisher.setAsyncFullPublish(true);
+
+    publisher.publishAsync("ROUTE_TABLE", "10.10.1.0/24", {{"state", "a"}}, ReturnCode(SAI_STATUS_SUCCESS));
+    publisher.publishAsyncBatch();
+    publisher.flush();
+    std::string v;
+    ASSERT_TRUE(pollHget(stateTable, "10.10.1.0/24", "state", &v));
+    ASSERT_EQ(v, "a");
+
+    publisher.publishAsync("ROUTE_TABLE", "10.10.2.0/24", {{"state", "b"}}, ReturnCode(SAI_STATUS_SUCCESS));
+    publisher.publishAsyncBatch();
+    publisher.flush();
+    ASSERT_TRUE(pollHget(stateTable, "10.10.2.0/24", "state", &v));
+    ASSERT_EQ(v, "b");
 }
 

--- a/tests/mock_tests/response_publisher/response_publisher_ut.cpp
+++ b/tests/mock_tests/response_publisher/response_publisher_ut.cpp
@@ -104,6 +104,27 @@ TEST(ResponsePublisher, PublishAsyncNoThreadFallsBackToSyncPublish)
     ASSERT_EQ(value, "ok");
 }
 
+TEST(ResponsePublisher, PublishAsyncNoThreadBatchFlushKeepsSyncDisableFlow)
+{
+    DBConnector conn{"APPL_STATE_DB", 0};
+    Table stateTable{&conn, "ROUTE_TABLE"};
+    std::string value;
+
+    // Simulates gRouteStateAsyncPublish=false path in RouteOrch:
+    // ResponsePublisher constructed without db update thread.
+    ResponsePublisher publisher{"APPL_STATE_DB", /*buffered=*/false, /*db_write_thread=*/false};
+    publisher.m_directDbWrite = true;
+
+    publisher.publishAsync("ROUTE_TABLE", "10.0.1.0/24", {{"protocol", "bgp"}, {"state", "ok"}},
+                           ReturnCode(SAI_STATUS_SUCCESS));
+    // No-op without db_write_thread; kept to mirror RouteOrch flow.
+    publisher.publishAsyncBatch();
+    publisher.flush();
+
+    ASSERT_TRUE(stateTable.hget("10.0.1.0/24", "state", value));
+    ASSERT_EQ(value, "ok");
+}
+
 TEST(ResponsePublisher, PublishAsyncBatchWithWorkerWritesAllKeys)
 {
     DBConnector conn{"APPL_STATE_DB", 0};
@@ -111,8 +132,6 @@ TEST(ResponsePublisher, PublishAsyncBatchWithWorkerWritesAllKeys)
 
     ResponsePublisher publisher{"APPL_STATE_DB", /*buffered=*/false, /*db_write_thread=*/true};
     publisher.m_directDbWrite = true;
-    publisher.setAsyncFullPublish(true);
-
     publisher.publishAsync("ROUTE_TABLE", "10.1.0.0/24", {{"protocol", "bgp"}, {"state", "ok"}},
                            ReturnCode(SAI_STATUS_SUCCESS));
     publisher.publishAsync("ROUTE_TABLE", "10.2.0.0/24", {{"protocol", "bgp"}, {"state", "ok"}},
@@ -132,6 +151,26 @@ TEST(ResponsePublisher, PublishAsyncBatchWithWorkerWritesAllKeys)
     ASSERT_EQ(v, "ok");
 }
 
+TEST(ResponsePublisher, PublishAsyncWorkerPublishesViaUpdateThread)
+{
+    DBConnector conn{"APPL_STATE_DB", 0};
+    Table stateTable{&conn, "ROUTE_TABLE"};
+
+    // With db_write_thread=true the worker thread owns notification/DB publish;
+    // no separate enable call is needed.
+    ResponsePublisher publisher{"APPL_STATE_DB", /*buffered=*/false, /*db_write_thread=*/true};
+    publisher.m_directDbWrite = true;
+
+    publisher.publishAsync("ROUTE_TABLE", "10.1.9.0/24", {{"protocol", "bgp"}, {"state", "ok"}},
+                           ReturnCode(SAI_STATUS_SUCCESS));
+    publisher.publishAsyncBatch();
+    publisher.flush();
+
+    std::string v;
+    ASSERT_TRUE(pollHget(stateTable, "10.1.9.0/24", "state", &v));
+    ASSERT_EQ(v, "ok");
+}
+
 TEST(ResponsePublisher, PublishAsyncWithoutBatchThenFlushDoesNotWriteState)
 {
     DBConnector conn{"APPL_STATE_DB", 0};
@@ -140,8 +179,6 @@ TEST(ResponsePublisher, PublishAsyncWithoutBatchThenFlushDoesNotWriteState)
     {
         ResponsePublisher publisher{"APPL_STATE_DB", false, true};
         publisher.m_directDbWrite = true;
-        publisher.setAsyncFullPublish(true);
-
         publisher.publishAsync("ROUTE_TABLE", "10.9.9.0/24", {{"protocol", "bgp"}, {"state", "ok"}},
                                ReturnCode(SAI_STATUS_SUCCESS));
         /* Missing publishAsyncBatch(): pending stays in m_async_publish_pending; flush only drains pipes. */
@@ -160,8 +197,6 @@ TEST(ResponsePublisher, PublishAsyncBatchEmptyIsNoOpThenFlush)
 {
     DBConnector conn{"APPL_STATE_DB", 0};
     ResponsePublisher publisher{"APPL_STATE_DB", false, true};
-    publisher.setAsyncFullPublish(true);
-
     publisher.publishAsyncBatch();
     publisher.flush();
     /* No ASSERT on DB: should complete without deadlock/hang. */
@@ -175,8 +210,6 @@ TEST(ResponsePublisher, PublishAsyncErrorStatusSkipsApplStateWrite)
 
     ResponsePublisher publisher{"APPL_STATE_DB", false, true};
     publisher.m_directDbWrite = true;
-    publisher.setAsyncFullPublish(true);
-
     publisher.publishAsync("ROUTE_TABLE", "10.8.0.0/24", {{"protocol", "bgp"}, {"state", "bad"}},
                            ReturnCode(SAI_STATUS_INVALID_PARAMETER));
     publisher.publishAsyncBatch();
@@ -193,7 +226,6 @@ TEST(ResponsePublisher, PublishAsyncRespectsEnableDbWriteAndNotifyToggle)
 
     ResponsePublisher publisher{"APPL_STATE_DB", false, true};
     publisher.m_directDbWrite = true;
-    publisher.setAsyncFullPublish(true);
     publisher.setEnableDbWriteAndNotify(false);
 
     publisher.publishAsync("ROUTE_TABLE", "10.8.1.0/24", {{"state", "off"}}, ReturnCode(SAI_STATUS_SUCCESS));
@@ -219,8 +251,6 @@ TEST(ResponsePublisher, PublishAsyncTwoSequentialBatches)
 
     ResponsePublisher publisher{"APPL_STATE_DB", false, true};
     publisher.m_directDbWrite = true;
-    publisher.setAsyncFullPublish(true);
-
     publisher.publishAsync("ROUTE_TABLE", "10.10.1.0/24", {{"state", "a"}}, ReturnCode(SAI_STATUS_SUCCESS));
     publisher.publishAsyncBatch();
     publisher.flush();
@@ -247,8 +277,6 @@ TEST(ResponsePublisher, PublishAsyncBatchWithRecorderUsesTimestampRecord)
     {
         ResponsePublisher publisher{"APPL_STATE_DB", false, true};
         publisher.m_directDbWrite = true;
-        publisher.setAsyncFullPublish(true);
-
         publisher.publishAsync("ROUTE_TABLE", "10.11.0.0/24", {{"state", "rec"}}, ReturnCode(SAI_STATUS_SUCCESS));
         publisher.publishAsyncBatch();
         publisher.flush();
@@ -285,8 +313,6 @@ TEST(ResponsePublisher, PublishAsyncBatchWithZmqWorkerQueuesResponses)
 
     ResponsePublisher publisher{"APPL_STATE_DB", false, true, &zmq};
     publisher.m_directDbWrite = true;
-    publisher.setAsyncFullPublish(true);
-
     publisher.publishAsync("ROUTE_TABLE", "10.20.0.0/24", {{"state", "z"}}, ReturnCode(SAI_STATUS_SUCCESS));
     publisher.publishAsyncBatch();
     publisher.flush();
@@ -296,24 +322,6 @@ TEST(ResponsePublisher, PublishAsyncBatchWithZmqWorkerQueuesResponses)
     ASSERT_EQ(v, "z");
 }
 
-TEST(ResponsePublisher, PublishAsyncBatchWorkerNotAsyncFullPublishFlushesNtfOnCaller)
-{
-    DBConnector conn{"APPL_STATE_DB", 0};
-    Table stateTable{&conn, "ROUTE_TABLE"};
-
-    ResponsePublisher publisher{"APPL_STATE_DB", false, true};
-    publisher.m_directDbWrite = true;
-    publisher.setAsyncFullPublish(false);
-
-    publisher.publishAsync("ROUTE_TABLE", "10.21.0.0/24", {{"state", "nf"}}, ReturnCode(SAI_STATUS_SUCCESS));
-    publisher.publishAsyncBatch();
-    publisher.flush();
-
-    std::string v;
-    ASSERT_TRUE(pollHget(stateTable, "10.21.0.0/24", "state", &v));
-    ASSERT_EQ(v, "nf");
-}
-
 TEST(ResponsePublisher, PublishAsyncBatchOkDeleteEmptyIntentWritesDel)
 {
     DBConnector conn{"APPL_STATE_DB", 0};
@@ -321,8 +329,6 @@ TEST(ResponsePublisher, PublishAsyncBatchOkDeleteEmptyIntentWritesDel)
 
     ResponsePublisher publisher{"APPL_STATE_DB", false, true};
     publisher.m_directDbWrite = true;
-    publisher.setAsyncFullPublish(true);
-
     publisher.publishAsync("ROUTE_TABLE", "10.22.0.0/24", {{"state", "before"}}, ReturnCode(SAI_STATUS_SUCCESS));
     publisher.publishAsyncBatch();
     publisher.flush();

--- a/tests/mock_tests/response_publisher/response_publisher_ut.cpp
+++ b/tests/mock_tests/response_publisher/response_publisher_ut.cpp
@@ -186,6 +186,32 @@ TEST(ResponsePublisher, PublishAsyncErrorStatusSkipsApplStateWrite)
     ASSERT_FALSE(pollHget(stateTable, "10.8.0.0/24", "state", &dummy, 200));
 }
 
+TEST(ResponsePublisher, PublishAsyncRespectsEnableDbWriteAndNotifyToggle)
+{
+    DBConnector conn{"APPL_STATE_DB", 0};
+    Table stateTable{&conn, "ROUTE_TABLE"};
+
+    ResponsePublisher publisher{"APPL_STATE_DB", false, true};
+    publisher.m_directDbWrite = true;
+    publisher.setAsyncFullPublish(true);
+    publisher.setEnableDbWriteAndNotify(false);
+
+    publisher.publishAsync("ROUTE_TABLE", "10.8.1.0/24", {{"state", "off"}}, ReturnCode(SAI_STATUS_SUCCESS));
+    publisher.publishAsyncBatch();
+    publisher.flush();
+
+    std::string v;
+    ASSERT_FALSE(pollHget(stateTable, "10.8.1.0/24", "state", &v, 200));
+
+    publisher.setEnableDbWriteAndNotify(true);
+    publisher.publishAsync("ROUTE_TABLE", "10.8.1.0/24", {{"state", "on"}}, ReturnCode(SAI_STATUS_SUCCESS));
+    publisher.publishAsyncBatch();
+    publisher.flush();
+
+    ASSERT_TRUE(pollHget(stateTable, "10.8.1.0/24", "state", &v));
+    ASSERT_EQ(v, "on");
+}
+
 TEST(ResponsePublisher, PublishAsyncTwoSequentialBatches)
 {
     DBConnector conn{"APPL_STATE_DB", 0};

--- a/tests/mock_tests/response_publisher/response_publisher_ut.cpp
+++ b/tests/mock_tests/response_publisher/response_publisher_ut.cpp
@@ -5,7 +5,9 @@
 #include <string>
 #include <thread>
 
+#include "recorder.h"
 #include "return_code.h"
+#include "zmqserver.h"
 
 using namespace swss;
 
@@ -205,5 +207,118 @@ TEST(ResponsePublisher, PublishAsyncTwoSequentialBatches)
     publisher.flush();
     ASSERT_TRUE(pollHget(stateTable, "10.10.2.0/24", "state", &v));
     ASSERT_EQ(v, "b");
+}
+
+TEST(ResponsePublisher, PublishAsyncBatchWithRecorderUsesTimestampRecord)
+{
+    DBConnector conn{"APPL_STATE_DB", 0};
+    Table stateTable{&conn, "ROUTE_TABLE"};
+
+    Recorder::Instance().respub.setRecord(true);
+    Recorder::Instance().respub.setLocation("/tmp");
+    Recorder::Instance().respub.startRec(false);
+
+    {
+        ResponsePublisher publisher{"APPL_STATE_DB", false, true};
+        publisher.m_directDbWrite = true;
+        publisher.setAsyncFullPublish(true);
+
+        publisher.publishAsync("ROUTE_TABLE", "10.11.0.0/24", {{"state", "rec"}}, ReturnCode(SAI_STATUS_SUCCESS));
+        publisher.publishAsyncBatch();
+        publisher.flush();
+
+        std::string v;
+        ASSERT_TRUE(pollHget(stateTable, "10.11.0.0/24", "state", &v));
+        ASSERT_EQ(v, "rec");
+    }
+
+    Recorder::Instance().respub.setRecord(false);
+}
+
+TEST(ResponsePublisher, PublishSyncWithZmqQueuesThenFlushDrains)
+{
+    ZmqServer zmq("inproc://rp_ut_zmq_sync", "", true);
+    DBConnector conn{"APPL_STATE_DB", 0};
+    Table stateTable{&conn, "ZMQT"};
+
+    ResponsePublisher publisher{"APPL_STATE_DB", false, false, &zmq};
+    publisher.m_directDbWrite = true;
+
+    publisher.publish("ZMQT", "k1", {{"a", "1"}}, ReturnCode(SAI_STATUS_SUCCESS));
+    publisher.flush();
+    std::string v;
+    ASSERT_TRUE(pollHget(stateTable, "k1", "a", &v));
+    ASSERT_EQ(v, "1");
+}
+
+TEST(ResponsePublisher, PublishAsyncBatchWithZmqWorkerQueuesResponses)
+{
+    ZmqServer zmq("inproc://rp_ut_zmq_async", "", true);
+    DBConnector conn{"APPL_STATE_DB", 0};
+    Table stateTable{&conn, "ROUTE_TABLE"};
+
+    ResponsePublisher publisher{"APPL_STATE_DB", false, true, &zmq};
+    publisher.m_directDbWrite = true;
+    publisher.setAsyncFullPublish(true);
+
+    publisher.publishAsync("ROUTE_TABLE", "10.20.0.0/24", {{"state", "z"}}, ReturnCode(SAI_STATUS_SUCCESS));
+    publisher.publishAsyncBatch();
+    publisher.flush();
+
+    std::string v;
+    ASSERT_TRUE(pollHget(stateTable, "10.20.0.0/24", "state", &v));
+    ASSERT_EQ(v, "z");
+}
+
+TEST(ResponsePublisher, PublishAsyncBatchWorkerNotAsyncFullPublishFlushesNtfOnCaller)
+{
+    DBConnector conn{"APPL_STATE_DB", 0};
+    Table stateTable{&conn, "ROUTE_TABLE"};
+
+    ResponsePublisher publisher{"APPL_STATE_DB", false, true};
+    publisher.m_directDbWrite = true;
+    publisher.setAsyncFullPublish(false);
+
+    publisher.publishAsync("ROUTE_TABLE", "10.21.0.0/24", {{"state", "nf"}}, ReturnCode(SAI_STATUS_SUCCESS));
+    publisher.publishAsyncBatch();
+    publisher.flush();
+
+    std::string v;
+    ASSERT_TRUE(pollHget(stateTable, "10.21.0.0/24", "state", &v));
+    ASSERT_EQ(v, "nf");
+}
+
+TEST(ResponsePublisher, PublishAsyncBatchOkDeleteEmptyIntentWritesDel)
+{
+    DBConnector conn{"APPL_STATE_DB", 0};
+    Table stateTable{&conn, "ROUTE_TABLE"};
+
+    ResponsePublisher publisher{"APPL_STATE_DB", false, true};
+    publisher.m_directDbWrite = true;
+    publisher.setAsyncFullPublish(true);
+
+    publisher.publishAsync("ROUTE_TABLE", "10.22.0.0/24", {{"state", "before"}}, ReturnCode(SAI_STATUS_SUCCESS));
+    publisher.publishAsyncBatch();
+    publisher.flush();
+    std::string v;
+    ASSERT_TRUE(pollHget(stateTable, "10.22.0.0/24", "state", &v));
+
+    publisher.publishAsync("ROUTE_TABLE", "10.22.0.0/24", {}, ReturnCode(SAI_STATUS_SUCCESS));
+    publisher.publishAsyncBatch();
+    publisher.flush();
+
+    /* flush() only queues work on the state thread; DEL may land shortly after.
+     * pollHget() returns true as soon as hget succeeds — do not use ASSERT_FALSE(pollHget)
+     * here or we fail while the old "before" value is still visible before DEL is applied. */
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+        if (!stateTable.hget("10.22.0.0/24", "state", v))
+        {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    ASSERT_FALSE(stateTable.hget("10.22.0.0/24", "state", v));
 }
 

--- a/tests/mock_tests/routeorch_ut.cpp
+++ b/tests/mock_tests/routeorch_ut.cpp
@@ -1718,4 +1718,19 @@ namespace routeorch_test
         // desired_nhg_key is empty: route now directly points to NHG (no longer a temp route)
         ASSERT_EQ(it->second.desired_nhg_key.getSize(), 0);
     }
+
+    TEST_F(RouteOrchTest, RouteOrch_RemoveRoutePrefixRunsAsyncPublisherFlush)
+    {
+        auto *routeConsumer = dynamic_cast<Consumer *>(gRouteOrch->getExecutor(APP_ROUTE_TABLE_NAME));
+        ASSERT_NE(routeConsumer, nullptr);
+
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({"7.7.7.0/24", "SET",
+                           {{"ifname", "Ethernet0"}, {"nexthop", "10.0.0.2"}}});
+        routeConsumer->addToSync(entries);
+        static_cast<Orch *>(gRouteOrch)->doTask();
+
+        (void)gRouteOrch->removeRoutePrefix(IpPrefix("7.7.7.0/24"));
+        ASSERT_TRUE(gRouteOrch->removeRoutePrefix(IpPrefix("7.7.7.0/24")));
+    }
 }


### PR DESCRIPTION


<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Implemented asynchoronous update of route state publication which includes APPL_STATE_DB update, notifications and recordings. 

Route state updates (APPL_STATE_DB notification, APPL_STATE_DB state, response recording and db write recording) can be queued on the ResponsePublisher DB update thread instead of running synchronously on the routeorch's route programming hot path.

- Add publishAsync() and publishAsyncBatch() so full publish (notification + state DB write + recorder) runs on m_update_thread and m_ntf_pipe flush on flush entries also done in the worker thread to avoid cross-thread notifications wrongly flushed.
- publishAsync() adds all the route states to the batch without taking lock. After completing gRouteBulker.flus(), all the batched states are queued as single item to the worker queue. The lock is taken only during this queuing. The assumption is the batching of route states is done only in the RouteOrch.
- RouteOrch uses a dedicated ResponsePublisher and publishAsync() from publishRouteState(); override flushResponses() to flush it before the base implementation.
- This async route state publish  is disabled by default. To enable, a knob gRouteStateAsyncPublish is used and this can be enabled by config db "SYSTEM_DEFAULTS|async_rec:status" set to "enabled". Setting this adds orchagent option -A which enables async route state publish (also enabling async swss.rec recording)
- For recording, to ensuare correct timestamp, the timestamp is passed while enqueuing the state and RecWrite::record() method is called with additional paramter of timestamp. (Depends on sonic-swss PR https://github.com/sonic-net/sonic-swss/pull/4400)
- Adjusted mock ResponsePublisher for unit tests.

Ref: HLD: https://github.com/sonic-net/SONiC/pull/2285

**Why I did it**

To improve route convergence. Solution for Issue: https://github.com/sonic-net/sonic-swss/issues/4436

**How I verified it**

Advertised 250k routes from a neighbor, measured the time required for FIB programming of all 250k routes. The convergence is measured as per RFC7747 rib-in-convergence methodology. 

With suppress-fib-pending enabled, with async route state published, the average rib-in-convergence improvement is 45%+ (when compared with sync hot path route state publish)

**Details if related**
