### PR TITLE
Runtime knob for Southbound ZMQ

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -62,6 +62,9 @@ bool gRingMode = false;
 bool gSyncMode = false;
 sai_redis_communication_mode_t gRedisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC;
 string gAsicInstance;
+// Context guid used to select a specific context from context_config.json
+// Set via -g command line flag. UINT32_MAX means "not set" and applies to all contexts
+uint32_t gContextGuid = UINT32_MAX;
 
 extern bool gIsNatSupported;
 
@@ -113,6 +116,7 @@ void usage()
     cout << "    -c counter mode (traditional|asic_db), default: asic_db" << endl;
     cout << "    -t Override create switch timeout, in sec" << endl;
     cout << "    -v vrf: VRF name (default empty)" << endl;
+    cout << "    -g guid: context guid (default: all contexts)" << endl;
     cout << "    -I heart_beat_interval: Heart beat interval in millisecond (default 10)" << endl;
     cout << "    -R enable the ring thread feature" << endl;
     cout << "    -M enable SAI MACSec POST" << endl;
@@ -400,7 +404,7 @@ int main(int argc, char **argv)
     // Disable SAI MACSec POST by default. Use option -M to enable it.
     bool macsec_post_enabled = false;
 
-    while ((opt = getopt(argc, argv, "b:m:r:f:j:d:i:hsz:k:q:c:t:v:I:RD:M")) != -1)
+    while ((opt = getopt(argc, argv, "b:m:r:f:j:d:i:hsz:k:q:c:t:v:g:I:RD:M")) != -1)
     {
         switch (opt)
         {
@@ -522,6 +526,10 @@ int main(int argc, char **argv)
             macsec_post_enabled = true;
             break;
         case 'D': { gFlexCounterDelaySec = swss::to_int<int>(optarg); } break;
+        case 'g':
+            gContextGuid = (uint32_t)std::stoul(optarg);
+            SWSS_LOG_NOTICE("Context guid set to: %u", gContextGuid);
+            break;
         default: /* '?' */
             exit(EXIT_FAILURE);
         }

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -106,6 +106,7 @@ extern sai_object_id_t gSwitchId;
 extern bool gTraditionalFlexCounter;
 extern bool gSyncMode;
 extern sai_redis_communication_mode_t gRedisCommunicationMode;
+extern uint32_t gContextGuid;
 extern event_handle_t g_events_handle;
 extern bool gOrchUnhealthy;
 extern string gSaiErrorString;
@@ -348,6 +349,21 @@ void initSaiRedis()
 
     sai_attribute_t attr;
     sai_status_t status;
+    // Set ZMQ enabled guid if ZMQ mode and a specific guid is requested
+    if (gContextGuid != UINT32_MAX &&
+        gRedisCommunicationMode == SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC)
+    {
+        attr.id = SAI_REDIS_SWITCH_ATTR_ZMQ_ENABLED_GUID;
+        attr.value.u32 = gContextGuid;
+
+        status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to set ZMQ enabled guid: rv:%d", status);
+            return handleSaiFailure(SAI_API_SWITCH, "set", status, true);
+        }
+        SWSS_LOG_NOTICE("ZMQ enabled guid set successfully to %u", gContextGuid);
+    }
 
     attr.id = SAI_REDIS_SWITCH_ATTR_REDIS_COMMUNICATION_MODE;
     attr.value.s32 = gRedisCommunicationMode;

--- a/tests/mock_tests/mock_orchagent_main.cpp
+++ b/tests/mock_tests/mock_orchagent_main.cpp
@@ -4,6 +4,7 @@ extern "C" {
 }
 
 #include "orchdaemon.h"
+#include <cstdint>
 
 /* Global variables */
 sai_object_id_t gVirtualRouterId;
@@ -20,6 +21,7 @@ string gMyAsicName = "Asic0";
 bool gTraditionalFlexCounter = false;
 bool gSyncMode = false;
 sai_redis_communication_mode_t gRedisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC;
+uint32_t gContextGuid = UINT32_MAX;
 bool gOrchUnhealthy = false;
 string gSaiErrorString;
 


### PR DESCRIPTION
#### Why I did it
Enable ZMQ communication between orchagent and syncd (southbound).

#### How I did it
Added -g flag to orchagent to specify the context GUID `gContextGuid`. This tells orchagent which context should use ZMQ for communication with syncd.

Updated saihelper.cpp to set `SAI_REDIS_SWITCH_ATTR_ZMQ_ENABLED_GUID` when both ZMQ mode (-z flag) and a specific GUID (-g flag) are provided. This configures the SAI Redis layer to use ZMQ for the specified context.

#### How to verify it
Ran route benchmark test with both configurations to confirm:

- Default behavior (knob disabled) remains unchanged
- ZMQ mode activates correctly when knob is enabled
- Routes program successfully through the full pipeline in both modes


#### Related PRs:

https://github.com/sonic-net/sonic-sairedis/pull/1835
https://github.com/sonic-net/sonic-buildimage/pull/26638
