### PR TITLE
[202511] Add explicitly ECN mode attributes for Dual-ToR IPinIP tunnel

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -205,7 +205,9 @@ static sai_object_id_t create_tunnel(
     const IpAddress* p_src_ip,
     sai_object_id_t tc_to_dscp_map_id,
     sai_object_id_t tc_to_queue_map_id,
-    string dscp_mode_name)
+    string dscp_mode_name,
+    const string& ecn_mode_name,
+    const string& encap_ecn_mode_name)
 {
     sai_status_t status;
 
@@ -271,6 +273,35 @@ static sai_object_id_t create_tunnel(
         attr.id = SAI_TUNNEL_ATTR_DECAP_DSCP_MODE;
         attr.value.s32 = dscp_mode;
         tunnel_attrs.push_back(attr);
+    }
+
+    /* ECN: same semantics as TunnelDecapOrch::addDecapTunnel (CONFIG TUNNEL / APP TUNNEL_DECAP_TABLE) */
+    if (ecn_mode_name == "copy_from_outer")
+    {
+        attr.id = SAI_TUNNEL_ATTR_DECAP_ECN_MODE;
+        attr.value.s32 = SAI_TUNNEL_DECAP_ECN_MODE_COPY_FROM_OUTER;
+        tunnel_attrs.push_back(attr);
+    }
+    else if (ecn_mode_name == "standard")
+    {
+        attr.id = SAI_TUNNEL_ATTR_DECAP_ECN_MODE;
+        attr.value.s32 = SAI_TUNNEL_DECAP_ECN_MODE_STANDARD;
+        tunnel_attrs.push_back(attr);
+    }
+    else if (!ecn_mode_name.empty())
+    {
+        SWSS_LOG_ERROR("Invalid mux tunnel ecn_mode '%s'", ecn_mode_name.c_str());
+    }
+
+    if (encap_ecn_mode_name == "standard")
+    {
+        attr.id = SAI_TUNNEL_ATTR_ENCAP_ECN_MODE;
+        attr.value.s32 = SAI_TUNNEL_ENCAP_ECN_MODE_STANDARD;
+        tunnel_attrs.push_back(attr);
+    }
+    else if (!encap_ecn_mode_name.empty())
+    {
+        SWSS_LOG_ERROR("Unsupported mux tunnel encap_ecn_mode '%s'", encap_ecn_mode_name.c_str());
     }
 
     attr.id = SAI_TUNNEL_ATTR_LOOPBACK_PACKET_ACTION;
@@ -1841,6 +1872,18 @@ bool MuxOrch::handlePeerSwitch(const Request& request)
             SWSS_LOG_NOTICE("dscp_mode for tunnel %s is not available. Will not be applied", MUX_TUNNEL);
         }
 
+        string ecn_mode_name = decap_orch_->getEcnMode(MUX_TUNNEL);
+        if (ecn_mode_name == "")
+        {
+            SWSS_LOG_NOTICE("ecn_mode for tunnel %s is not available. ECN SAI attrs will not be set", MUX_TUNNEL);
+        }
+
+        string encap_ecn_mode_name = decap_orch_->getEncapEcnMode(MUX_TUNNEL);
+        if (encap_ecn_mode_name == "")
+        {
+            SWSS_LOG_NOTICE("encap_ecn_mode for tunnel %s is not available. Encap ECN will not be set", MUX_TUNNEL);
+        }
+
         // Read tc_to_dscp_map_id of MuxTunnel0 from decap_orch
         sai_object_id_t tc_to_dscp_map_id = SAI_NULL_OBJECT_ID;
         decap_orch_->getQosMapId(MUX_TUNNEL, encap_tc_to_dscp_field_name, tc_to_dscp_map_id);
@@ -1856,7 +1899,8 @@ bool MuxOrch::handlePeerSwitch(const Request& request)
             SWSS_LOG_NOTICE("tc_to_queue_map_id for tunnel %s is not available. Will not be applied", MUX_TUNNEL);
         }
 
-        mux_tunnel_id_ = create_tunnel(&peer_ip, &dst_ip, tc_to_dscp_map_id, tc_to_queue_map_id, dscp_mode_name);
+        mux_tunnel_id_ = create_tunnel(&peer_ip, &dst_ip, tc_to_dscp_map_id, tc_to_queue_map_id, dscp_mode_name,
+                                       ecn_mode_name, encap_ecn_mode_name);
         mux_peer_switch_ = peer_ip;
         SWSS_LOG_NOTICE("Mux peer ip '%s' was added, peer name '%s'",
                          peer_ip.to_string().c_str(), peer_name.c_str());

--- a/orchagent/tunneldecaporch.cpp
+++ b/orchagent/tunneldecaporch.cpp
@@ -1436,6 +1436,28 @@ std::string TunnelDecapOrch::getDscpMode(const std::string &tunnelKey) const
     return iter->second.dscp_mode;
 }
 
+std::string TunnelDecapOrch::getEcnMode(const std::string &tunnelKey) const
+{
+    auto iter = tunnelTable.find(tunnelKey);
+    if (iter == tunnelTable.end())
+    {
+        SWSS_LOG_INFO("Tunnel not found %s", tunnelKey.c_str());
+        return "";
+    }
+    return iter->second.ecn_mode;
+}
+
+std::string TunnelDecapOrch::getEncapEcnMode(const std::string &tunnelKey) const
+{
+    auto iter = tunnelTable.find(tunnelKey);
+    if (iter == tunnelTable.end())
+    {
+        SWSS_LOG_INFO("Tunnel not found %s", tunnelKey.c_str());
+        return "";
+    }
+    return iter->second.encap_ecn_mode;
+}
+
 bool TunnelDecapOrch::getQosMapId(const std::string &tunnelKey, const std::string &qos_table_type, sai_object_id_t &oid) const
 {
     auto iter = tunnelTable.find(tunnelKey);

--- a/orchagent/tunneldecaporch.h
+++ b/orchagent/tunneldecaporch.h
@@ -82,6 +82,8 @@ public:
     bool removeNextHopTunnel(std::string tunnelKey, swss::IpAddress& ipAddr);
     swss::IpAddresses getDstIpAddresses(std::string tunnelKey);
     std::string getDscpMode(const std::string &tunnelKey) const;
+    std::string getEcnMode(const std::string &tunnelKey) const;
+    std::string getEncapEcnMode(const std::string &tunnelKey) const;
     bool getQosMapId(const std::string &tunnelKey, const std::string &qos_table_type, sai_object_id_t &oid) const;
     const SubnetDecapConfig &getSubnetDecapConfig() const
     {

--- a/tests/mock_tests/mux_rollback_ut.cpp
+++ b/tests/mock_tests/mux_rollback_ut.cpp
@@ -14,6 +14,8 @@
 #include "mock_orch_test.h"
 #include "gtest/gtest.h"
 #include <string>
+#include <utility>
+#include <vector>
 
 EXTERN_MOCK_FNS
 
@@ -32,6 +34,156 @@ namespace mux_rollback_test
     using ::testing::SetArrayArgument;
 
     static const string TEST_INTERFACE = "Ethernet4";
+
+    static const std::vector<std::pair<std::string, std::string>> kMuxTunnelValidEcnFields = {
+        {"dscp_mode", "uniform"},
+        {"src_ip", "1.1.1.1"},
+        {"ecn_mode", "copy_from_outer"},
+        {"encap_ecn_mode", "standard"},
+        {"ttl_mode", "pipe"},
+        {"tunnel_type", "IPINIP"},
+    };
+
+    /**
+     * Base for ECN-focused mux tests: helper must be a member so MockOrchTest protected
+     * members (m_app_db, m_TunnelDecapOrch, …) are accessible.
+     */
+    class MuxEcnTopologyTestBase : public mock_orch_test::MockOrchTest
+    {
+    protected:
+        void applyMuxPeerSwitchTopologyForEcnTests(
+            const std::vector<std::pair<std::string, std::string>> &mux_tunnel_field_values,
+            bool patch_tunnel_cache,
+            const std::string &ecn_cache_override,
+            const std::string &encap_ecn_cache_override)
+        {
+            Table peer_switch_table = Table(m_config_db.get(), CFG_PEER_SWITCH_TABLE_NAME);
+            Table decap_tunnel_table = Table(m_app_db.get(), APP_TUNNEL_DECAP_TABLE_NAME);
+            Table decap_term_table = Table(m_app_db.get(), APP_TUNNEL_DECAP_TERM_TABLE_NAME);
+            Table mux_cable_table = Table(m_config_db.get(), CFG_MUX_CABLE_TABLE_NAME);
+            Table port_table = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+            Table vlan_table = Table(m_app_db.get(), APP_VLAN_TABLE_NAME);
+            Table vlan_member_table = Table(m_app_db.get(), APP_VLAN_MEMBER_TABLE_NAME);
+            Table neigh_table = Table(m_app_db.get(), APP_NEIGH_TABLE_NAME);
+            Table intf_table = Table(m_app_db.get(), APP_INTF_TABLE_NAME);
+
+            auto ports = ut_helper::getInitialSaiPorts();
+            port_table.set(TEST_INTERFACE, ports[TEST_INTERFACE]);
+            port_table.set("PortConfigDone", { { "count", to_string(1) } });
+            port_table.set("PortInitDone", { {} });
+
+            neigh_table.set(
+                VLAN_1000 + neigh_table.getTableNameSeparator() + SERVER_IP1, { { "neigh", "62:f9:65:10:2f:04" },
+                                                                               { "family", "IPv4" } });
+
+            vlan_table.set(VLAN_1000, { { "admin_status", "up" },
+                                        { "mtu", "9100" },
+                                        { "mac", "00:aa:bb:cc:dd:ee" } });
+            vlan_member_table.set(
+                VLAN_1000 + vlan_member_table.getTableNameSeparator() + TEST_INTERFACE,
+                { { "tagging_mode", "untagged" } });
+
+            intf_table.set(VLAN_1000, { { "grat_arp", "enabled" },
+                                        { "proxy_arp", "enabled" },
+                                        { "mac_addr", "00:00:00:00:00:00" } });
+            intf_table.set(
+                VLAN_1000 + neigh_table.getTableNameSeparator() + "192.168.0.1/21", {
+                                                                                        { "scope", "global" },
+                                                                                        { "family", "IPv4" },
+                                                                                    });
+
+            decap_term_table.set(
+                MUX_TUNNEL + neigh_table.getTableNameSeparator() + "2.2.2.2", { { "src_ip", "1.1.1.1" },
+                                                                                { "term_type", "P2P" } });
+
+            decap_tunnel_table.set(MUX_TUNNEL, mux_tunnel_field_values);
+
+            peer_switch_table.set(PEER_SWITCH_HOSTNAME, { { "address_ipv4", PEER_IPV4_ADDRESS } });
+
+            mux_cable_table.set(TEST_INTERFACE, { { "server_ipv4", SERVER_IP1 + "/32" },
+                                                  { "server_ipv6", "a::a/128" },
+                                                  { "state", "auto" } });
+
+            gPortsOrch->addExistingData(&port_table);
+            gPortsOrch->addExistingData(&vlan_table);
+            gPortsOrch->addExistingData(&vlan_member_table);
+            static_cast<Orch *>(gPortsOrch)->doTask();
+
+            gIntfsOrch->addExistingData(&intf_table);
+            static_cast<Orch *>(gIntfsOrch)->doTask();
+
+            m_TunnelDecapOrch->addExistingData(&decap_tunnel_table);
+            m_TunnelDecapOrch->addExistingData(&decap_term_table);
+            static_cast<Orch *>(m_TunnelDecapOrch)->doTask();
+
+            if (patch_tunnel_cache)
+            {
+                auto &tt = m_TunnelDecapOrch->tunnelTable;
+                ASSERT_NE(tt.find(MUX_TUNNEL), tt.end());
+                tt[MUX_TUNNEL].ecn_mode = ecn_cache_override;
+                tt[MUX_TUNNEL].encap_ecn_mode = encap_ecn_cache_override;
+            }
+
+            m_MuxOrch->addExistingData(&peer_switch_table);
+            static_cast<Orch *>(m_MuxOrch)->doTask();
+
+            m_MuxOrch->addExistingData(&mux_cable_table);
+            static_cast<Orch *>(m_MuxOrch)->doTask();
+
+            gNeighOrch->addExistingData(&neigh_table);
+            static_cast<Orch *>(gNeighOrch)->doTask();
+
+            m_MuxCable = m_MuxOrch->getMuxCable(TEST_INTERFACE);
+
+            EXPECT_EQ(STANDBY_STATE, m_MuxCable->getState());
+        }
+    };
+
+    class MuxPeerSwitchEcnNoticeTest : public MuxEcnTopologyTestBase
+    {
+    protected:
+        void ApplyInitialConfigs() override
+        {
+            applyMuxPeerSwitchTopologyForEcnTests(
+                {
+                    {"dscp_mode", "uniform"},
+                    {"src_ip", "1.1.1.1"},
+                    {"ttl_mode", "pipe"},
+                    {"tunnel_type", "IPINIP"},
+                },
+                false,
+                "",
+                "");
+        }
+    };
+
+    /* Exercises muxorch.cpp create_tunnel: SWSS_LOG_ERROR invalid mux tunnel ecn_mode (else-if !ecn empty) */
+    class MuxCreateTunnelInvalidDecapEcnTest : public MuxEcnTopologyTestBase
+    {
+    protected:
+        void ApplyInitialConfigs() override
+        {
+            applyMuxPeerSwitchTopologyForEcnTests(
+                kMuxTunnelValidEcnFields,
+                true,
+                "invalid_mux_ecn",
+                "");
+        }
+    };
+
+    /* Exercises muxorch.cpp create_tunnel: SWSS_LOG_ERROR unsupported encap_ecn_mode (else-if !encap empty) */
+    class MuxCreateTunnelInvalidEncapEcnTest : public MuxEcnTopologyTestBase
+    {
+    protected:
+        void ApplyInitialConfigs() override
+        {
+            applyMuxPeerSwitchTopologyForEcnTests(
+                kMuxTunnelValidEcnFields,
+                true,
+                "copy_from_outer",
+                "unsupported_encap");
+        }
+    };
 
     sai_bulk_create_neighbor_entry_fn old_create_neighbor_entries;
     sai_bulk_remove_neighbor_entry_fn old_remove_neighbor_entries;
@@ -298,6 +450,24 @@ namespace mux_rollback_test
         EXPECT_CALL(*mock_sai_next_hop_api, create_next_hops)
             .WillOnce(DoAll(SetArrayArgument<6>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_TABLE_FULL)));
         SetMuxStateFromAppDb(ACTIVE_STATE);
+        EXPECT_EQ(STANDBY_STATE, m_MuxCable->getState());
+    }
+
+    TEST_F(MuxPeerSwitchEcnNoticeTest, PeerSwitch_CompletesWhenEcnModesUnsetInApplDb)
+    {
+        ASSERT_NE(m_MuxCable, nullptr);
+        EXPECT_EQ(STANDBY_STATE, m_MuxCable->getState());
+    }
+
+    TEST_F(MuxCreateTunnelInvalidDecapEcnTest, CreateTunnel_LogsErrorForInvalidDecapEcnMode)
+    {
+        ASSERT_NE(m_MuxCable, nullptr);
+        EXPECT_EQ(STANDBY_STATE, m_MuxCable->getState());
+    }
+
+    TEST_F(MuxCreateTunnelInvalidEncapEcnTest, CreateTunnel_LogsErrorForUnsupportedEncapEcnMode)
+    {
+        ASSERT_NE(m_MuxCable, nullptr);
         EXPECT_EQ(STANDBY_STATE, m_MuxCable->getState());
     }
 }

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -1267,6 +1267,10 @@ class TestMuxTunnelBase():
                 assert value == "SAI_TUNNEL_DSCP_MODE_PIPE_MODEL"
             elif field == "SAI_TUNNEL_ATTR_DECAP_DSCP_MODE":
                 assert value == "SAI_TUNNEL_DSCP_MODE_PIPE_MODEL"
+            elif field == "SAI_TUNNEL_ATTR_DECAP_ECN_MODE":
+                assert value == "SAI_TUNNEL_DECAP_ECN_MODE_STANDARD"
+            elif field == "SAI_TUNNEL_ATTR_ENCAP_ECN_MODE":
+                assert value == "SAI_TUNNEL_ENCAP_ECN_MODE_STANDARD"
             else:
                 assert False, "Field %s is not tested" % field
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add SAI_TUNNEL_DECAP_ECN_MODE_COPY_FROM_OUTER for SAI_TUNNEL_ATTR_DECAP_ECN_MODE
add SAI_TUNNEL_ENCAP_ECN_MODE_STANDARD for SAI_TUNNEL_ATTR_ENCAP_ECN_MODE

**Why I did it**
In Dual-ToR scenario we create tunnel 2 times (in [tunneldecaporch](https://github.com/sonic-net/sonic-swss/blob/master/orchagent/tunneldecaporch.cpp#L849) and [muxorch](https://github.com/sonic-net/sonic-swss/blob/master/orchagent/muxorch.cpp#L325)
But in muxorch we do not set ECN-related param (copy_from_outer). And since it was not set then by [default ](https://github.com/opencomputeproject/SAI/blob/master/inc/saitunnel.h#L606)we are using "standard" ECN mode.
Need to specify explicitly ECN mode for decap and encap

**How I verified it**
run https://github.com/sonic-net/sonic-mgmt/blob/master/tests/decap/mellanox/test_ecn_mode.py
or
Send encapsulated packets to uplink, check that decaplusated packets has different ECN

**Details if related**
