### PR TITLE
fpmsyncd: fix parseEncap array bounds overflow

### DIFF
--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -246,7 +246,7 @@ void RouteSync::parseRtAttrNested(struct rtattr **tb, int max,
  */
 void RouteSync::parseEncap(struct rtattr *tb, uint32_t &encap_value, string &rmac)
 {
-    struct rtattr *tb_encap[3] = {0};
+    struct rtattr *tb_encap[VXLAN_RMAC + 1] = {0};
     char mac_buf[MAX_ADDR_SIZE+1];
     char mac_val[MAX_ADDR_SIZE+1];
 


### PR DESCRIPTION
#### Why I did it

`tb_encap` array in `parseEncap()` is sized `[3]` but `VXLAN_RMAC` is defined as `3`, so accessing `tb_encap[VXLAN_RMAC]` reads one past the end of the array.

#### How I did it

```diff
-    struct rtattr *tb_encap[3] = {0};
+    struct rtattr *tb_encap[VXLAN_RMAC + 1] = {0};
```

#### How to verify it

Any route with RMAC encap no longer triggers undefined behavior.

#### Which release branch to backport (provide reason below if selected)

- [x] 202411
- [x] 202505

Bug exists in all branches where `VXLAN_RMAC` is defined as 3.

#### Description for the changelog

Fix array bounds overflow in fpmsyncd parseEncap when processing VXLAN RMAC.