### PR TITLE
[fdborch] Clear stale FDB entries on unresolvable bridge port ID

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -306,8 +306,17 @@ void FdbOrch::update(sai_fdb_event_t        type,
             SWSS_LOG_INFO("Flush event: Failed to get port by bridge port ID 0x%" PRIx64 ".",
                         bridge_port_id);
         } else {
-            SWSS_LOG_ERROR("Failed to get port by bridge port ID 0x%" PRIx64 ".",
+            SWSS_LOG_ERROR("Failed to get port by bridge port ID 0x%" PRIx64 ". "
+                        "Removing stale FDB entries referencing this bridge port.",
                         bridge_port_id);
+            for (auto itr = m_entries.begin(); itr != m_entries.end();)
+            {
+                auto curr = itr++;
+                if (curr->second.bridge_port_id == bridge_port_id)
+                {
+                    clearFdbEntry(curr->first);
+                }
+            }
             return;
         }
     }


### PR DESCRIPTION
Fixes: sonic-net/sonic-buildimage#26531

**What I did**

When orchagent gets an FDB event for a bridge port ID it can't resolve, instead
of silently dropping it, clear all `m_entries` referencing that stale bridge port.

**Why I did it**

During a LAG member transition, the SAI can invalidate a bridge port below
orchagent without going through `removeBridgePort()`. The silent drop left stale
entries in `m_entries`, causing the FDB cache to diverge from the ASIC — in
production this caused a 75-minute traffic blackhole recoverable only by
`config reload`.

Fixes: sonic-net/sonic-buildimage#26531

**How I verified it**

Triggered a LAG member remove/re-add with a large FDB table, confirmed stale
entries are cleaned up and the error no longer repeats 1000+ times in syslog.

