### PR TITLE
[muxorch] Fix FDB-after-neighbor conversion for host-route mode

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1854,7 +1854,7 @@ void MuxOrch::updateFdb(const FdbUpdate& update)
 
     // Handle case where neighbor exists but is not yet a MUX neighbor
     // This can happen when FDB entry is learned after neighbor is added
-    if (!found_existing_mux_neighbor && isMuxCablePrefixBased(update.entry.port_name))
+    if (!found_existing_mux_neighbor && isMuxExists(update.entry.port_name))
     {
         // Check if there's an existing neighbor with this MAC on any VLAN interface
         // that could be converted to a MUX neighbor
@@ -1871,7 +1871,14 @@ void MuxOrch::updateFdb(const FdbUpdate& update)
                 const NeighborEntry& neighbor_entry = neighbor_pair.first;
                 const auto& neighbor_data = neighbor_pair.second;
 
-                // Skip if this neighbor is already a MUX neighbor
+                // Skip neighbors already tracked as MUX neighbors
+                NextHopKey nh_key = { neighbor_entry.ip_address, neighbor_entry.alias };
+                if (mux_nexthop_tb_.find(nh_key) != mux_nexthop_tb_.end())
+                {
+                    continue;
+                }
+
+                // Skip prefix_route neighbors that are not skip neighbors
                 // soc neighbors will get added with prefix_route but
                 // they may not be yet qualified as mux neighbor
                 if (neighbor_data.prefix_route && !isSkipNeighbor(neighbor_entry.ip_address))
@@ -1917,6 +1924,7 @@ bool MuxOrch::convertNeighborToMux(const NeighborEntry& neighbor_entry, const st
     }
 
     // Convert to MUX neighbor for prefix based nbr handler before adding the nbr entry to mux port
+    // If neighbor is host-route based, convertToPrefixBasedNbr will not be called (short-circuit)
     if (ptr->getNbrHandlerType() == MuxNbrHandlerType::NBR_HANDLER_HOST_ROUTE ||
             neigh_orch_->convertToPrefixBasedNbr(neighbor_entry, tunnel_nh_id))
     {

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1924,7 +1924,7 @@ bool MuxOrch::convertNeighborToMux(const NeighborEntry& neighbor_entry, const st
     }
 
     // Convert to MUX neighbor for prefix based nbr handler before adding the nbr entry to mux port
-    // If neighbor is host-route based, convertToPrefixBasedNbr will not be called (short-circuit)
+    // If the mux port uses the host-route nbr handler, convertToPrefixBasedNbr will not be called (short-circuit)
     if (ptr->getNbrHandlerType() == MuxNbrHandlerType::NBR_HANDLER_HOST_ROUTE ||
             neigh_orch_->convertToPrefixBasedNbr(neighbor_entry, tunnel_nh_id))
     {

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1871,13 +1871,6 @@ void MuxOrch::updateFdb(const FdbUpdate& update)
                 const NeighborEntry& neighbor_entry = neighbor_pair.first;
                 const auto& neighbor_data = neighbor_pair.second;
 
-                // Skip neighbors already tracked as MUX neighbors
-                NextHopKey nh_key = { neighbor_entry.ip_address, neighbor_entry.alias };
-                if (mux_nexthop_tb_.find(nh_key) != mux_nexthop_tb_.end())
-                {
-                    continue;
-                }
-
                 // Skip prefix_route neighbors that are not skip neighbors
                 // soc neighbors will get added with prefix_route but
                 // they may not be yet qualified as mux neighbor

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -1993,6 +1993,131 @@ class TestMuxTunnel(TestMuxTunnelBase):
             ]
         )
 
+    def test_fdb_after_neighbor_on_standby_mux(
+        self, dvs, dvs_route, setup, setup_vlan, setup_mux_cable, setup_tunnel,
+        setup_peer_switch, testlog
+    ):
+        """Test neighbor conversion to MUX neighbor when FDB is learned after neighbor (host-route mode).
+
+        When a new neighbor is learned on a standby mux port and the FDB entry
+        for that MAC has not yet been learned, MuxOrch::updateNeighbor fails to
+        associate the neighbor with the mux port (FDB lookup fails). The neighbor
+        is never added to mux_nexthop_tb_ and disableNeighbor is never called.
+
+        This test verifies that when the FDB entry is later learned on the mux port,
+        the neighbor gets properly converted to a MUX neighbor and disabled (standby).
+
+        Steps:
+        1. Set mux port to standby
+        2. Add neighbor (without prior FDB entry)
+        3. Verify neighbor is initially in ASIC as a regular neighbor (not yet mux-managed)
+        4. Simulate FDB learn on the mux port
+        5. Verify neighbor gets disabled (removed from ASIC neigh table, tunnel route installed)
+        6. Toggle to active and verify neighbor is re-enabled
+        """
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        test_ip = "192.168.0.200"
+        test_mac = "00:00:00:00:aa:bb"
+        test_mac_dash = "00-00-00-00-aa-bb"
+        cable_name = "Ethernet0"
+
+        try:
+            # Step 1: Set mux to standby
+            self.set_mux_state(appdb, cable_name, "standby")
+
+            # Step 2: Add neighbor WITHOUT prior FDB entry
+            # MuxOrch::updateNeighbor will fail to find FDB -> neighbor not mux-managed
+            self.add_neighbor(dvs, test_ip, test_mac)
+            time.sleep(1)
+
+            # Step 3: Neighbor should be in ASIC as a regular neighbor
+            # (not yet mux-managed, so no tunnel route yet)
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+
+            # Step 4: Simulate FDB learn on mux port
+            # This should trigger convertNeighborToMux -> disableNeighbor (standby)
+            self.add_fdb(dvs, cable_name, test_mac_dash)
+            time.sleep(2)
+
+            # Step 5: Verify neighbor is now mux-managed on standby:
+            # - Neighbor removed from ASIC (disabled)
+            # - Tunnel route installed
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=True)
+
+            # Step 6: Toggle to active -> neighbor should be re-enabled
+            self.set_mux_state(appdb, cable_name, "active")
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=False)
+
+            # Toggle back to standby -> verify it disables again
+            self.set_mux_state(appdb, cable_name, "standby")
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=True)
+
+        finally:
+            self.del_neighbor(dvs, test_ip)
+            self.del_fdb(dvs, test_mac_dash)
+            self.set_mux_state(appdb, cable_name, "active")
+            time.sleep(1)
+
+    def test_fdb_after_neighbor_on_active_mux(
+        self, dvs, dvs_route, setup, setup_vlan, setup_mux_cable, setup_tunnel,
+        setup_peer_switch, testlog
+    ):
+        """Test neighbor conversion to MUX neighbor when FDB is learned after neighbor on active mux.
+
+        Same scenario as standby test but with active mux port. The neighbor should
+        be registered as a MUX neighbor and remain enabled (active).
+        """
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        test_ip = "192.168.0.201"
+        test_mac = "00:00:00:00:aa:cc"
+        test_mac_dash = "00-00-00-00-aa-cc"
+        cable_name = "Ethernet0"
+
+        try:
+            # Step 1: Set mux to active
+            self.set_mux_state(appdb, cable_name, "active")
+
+            # Step 2: Add neighbor WITHOUT prior FDB entry
+            self.add_neighbor(dvs, test_ip, test_mac)
+            time.sleep(1)
+
+            # Step 3: Neighbor should be in ASIC as a regular neighbor
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+
+            # Step 4: Simulate FDB learn on mux port
+            self.add_fdb(dvs, cable_name, test_mac_dash)
+            time.sleep(2)
+
+            # Step 5: Verify neighbor is mux-managed on active:
+            # - Neighbor stays in ASIC (enabled)
+            # - No tunnel route
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=False)
+
+            # Step 6: Toggle to standby -> neighbor should be disabled
+            self.set_mux_state(appdb, cable_name, "standby")
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=True)
+
+            # Toggle back to active -> re-enabled
+            self.set_mux_state(appdb, cable_name, "active")
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=False)
+
+        finally:
+            self.del_neighbor(dvs, test_ip)
+            self.del_fdb(dvs, test_mac_dash)
+            self.set_mux_state(appdb, cable_name, "active")
+            time.sleep(1)
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():


### PR DESCRIPTION
#### What I did
Fix MuxOrch to properly convert neighbors to MUX neighbors when FDB is learned after the neighbor on host-route mode mux ports.

#### How I did it
The existing fix in PR #4152 added FDB-after-neighbor conversion logic in `updateFdb()`, but gated it behind `isMuxCablePrefixBased()` — only prefix-route mode ports were handled. Host-route mode ports with the same race condition (FDB not yet learned when neighbor arrives) were silently skipped.

Changes:
- **Widen `updateFdb()` gate**: `isMuxCablePrefixBased` → `isMuxExists` so all mux ports (including host-route) get FDB-after-neighbor conversion
- **Fix `updateFdb()` comment**: Clarify the skip condition for prefix_route neighbors that are not skip neighbors
- **Add clarifying comment in `convertNeighborToMux`**: Document that the short-circuit depends on the mux port's handler type (host-route handler skips `convertToPrefixBasedNbr`), not a per-neighbor property

The previously added `mux_nexthop_tb_` guard was removed as redundant: `found_existing_mux_neighbor` already guarantees no neighbor with matching MAC exists in `mux_nexthop_tb_` when we reach that code path, and the downstream `update()` in both `MuxNbrHandler` and `MuxPrefixBasedNbrHandler` independently checks `neighbors_` and returns early for duplicates.

#### How to verify it
- New VS tests: `test_fdb_after_neighbor_on_standby_mux` and `test_fdb_after_neighbor_on_active_mux` in `test_mux.py`
- These tests verify that when FDB arrives after neighbor on a host-route mux port, the neighbor is properly converted and managed (disabled on standby, enabled on active)

#### Which release branch to backport
- [x] 202511 - bug fix

#### Description for the changelog
Fix host-route mode FDB-after-neighbor race condition where neighbors on standby mux ports were not properly disabled when FDB was learned after the neighbor.

#### Link to config_db schema for patch update
N/A