### PR TITLE
[watermarkorch] Record LAST_RESET_TIME for USER watermark clears

### DIFF
--- a/orchagent/watermarkorch.cpp
+++ b/orchagent/watermarkorch.cpp
@@ -5,19 +5,23 @@
 #include "converter.h"
 #include "bufferorch.h"
 #include <inttypes.h>
-#include <chrono>
+#include <time.h>
 
 #define DEFAULT_TELEMETRY_INTERVAL 120
 #define LAST_RESET_TIME_FIELD "LAST_RESET_TIME"
 
 /*
- * Get system uptime in milliseconds using steady_clock (monotonic time).
+ * Get system uptime in centiseconds using CLOCK_BOOTTIME.
+ * Returns a 32-bit value that wraps at 2^32 per SNMP TimeTicks (RFC 2578).
+ * CLOCK_BOOTTIME includes time spent in suspend, unlike CLOCK_MONOTONIC.
  */
-static uint64_t getSysUptimeMilliseconds()
+static uint32_t getSysUptimeCentiseconds()
 {
-    using namespace std::chrono;
-    auto now = steady_clock::now();
-    return duration_cast<milliseconds>(now.time_since_epoch()).count();
+    struct timespec ts;
+    clock_gettime(CLOCK_BOOTTIME, &ts);
+    // Convert to centiseconds (1/100 sec) and wrap at 2^32
+    uint64_t centiseconds = (uint64_t)ts.tv_sec * 100 + ts.tv_nsec / 10000000;
+    return (uint32_t)(centiseconds & 0xFFFFFFFF);
 }
 
 #define CLEAR_PG_HEADROOM_REQUEST "PG_HEADROOM"
@@ -344,12 +348,12 @@ void WatermarkOrch::clearSingleWm(Table *table, string wm_name, vector<sai_objec
     vector<FieldValueTuple> vfvt = {{wm_name, "0"}};
 
     // Record the reset timestamp for user-initiated clears (for SNMP oracleXgsQueueWatermarkLastResetTime)
-    // SNMP TimeTicks uses centiseconds (1/100 sec), so divide milliseconds by 10
+    // SNMP TimeTicks uses centiseconds (1/100 sec), 32-bit value wrapping at 2^32
     if (recordResetTime)
     {
-        uint64_t uptimeCentiseconds = getSysUptimeMilliseconds() / 10;
+        uint32_t uptimeCentiseconds = getSysUptimeCentiseconds();
         vfvt.emplace_back(LAST_RESET_TIME_FIELD, to_string(uptimeCentiseconds));
-        SWSS_LOG_INFO("Recording watermark reset time: %" PRIu64 " centiseconds", uptimeCentiseconds);
+        SWSS_LOG_DEBUG("Recording watermark reset time: %" PRIu32 " centiseconds", uptimeCentiseconds);
     }
 
     for (sai_object_id_t id: obj_ids)
@@ -366,12 +370,12 @@ void WatermarkOrch::clearSingleWm(Table *table, string wm_name, const object_ref
     vector<FieldValueTuple> fvTuples = {{wm_name, "0"}};
 
     // Record the reset timestamp for user-initiated clears (for SNMP oracleXgsQueueWatermarkLastResetTime)
-    // SNMP TimeTicks uses centiseconds (1/100 sec), so divide milliseconds by 10
+    // SNMP TimeTicks uses centiseconds (1/100 sec), 32-bit value wrapping at 2^32
     if (recordResetTime)
     {
-        uint64_t uptimeCentiseconds = getSysUptimeMilliseconds() / 10;
+        uint32_t uptimeCentiseconds = getSysUptimeCentiseconds();
         fvTuples.emplace_back(LAST_RESET_TIME_FIELD, to_string(uptimeCentiseconds));
-        SWSS_LOG_INFO("Recording watermark reset time: %" PRIu64 " centiseconds", uptimeCentiseconds);
+        SWSS_LOG_DEBUG("Recording watermark reset time: %" PRIu32 " centiseconds", uptimeCentiseconds);
     }
 
     for (const auto &it : nameOidMap)

--- a/orchagent/watermarkorch.cpp
+++ b/orchagent/watermarkorch.cpp
@@ -277,25 +277,32 @@ void WatermarkOrch::doTask(SelectableTimer &timer)
 
         clearSingleWm(m_periodicWatermarkTable.get(),
                       "SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_BYTES",
-                      m_pg_ids);
+                      m_pg_ids,
+                      true);
         clearSingleWm(m_periodicWatermarkTable.get(),
                       "SAI_INGRESS_PRIORITY_GROUP_STAT_SHARED_WATERMARK_BYTES",
-                      m_pg_ids);
+                      m_pg_ids,
+                      true);
         clearSingleWm(m_periodicWatermarkTable.get(),
                       "SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES",
-                      m_unicast_queue_ids);
+                      m_unicast_queue_ids,
+                      true);
         clearSingleWm(m_periodicWatermarkTable.get(),
                       "SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES",
-                      m_multicast_queue_ids);
+                      m_multicast_queue_ids,
+                      true);
         clearSingleWm(m_periodicWatermarkTable.get(),
                       "SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES",
-                      m_all_queue_ids);
+                      m_all_queue_ids,
+                      true);
         clearSingleWm(m_periodicWatermarkTable.get(),
                       "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES",
-                      gBufferOrch->getBufferPoolNameOidMap());
+                      gBufferOrch->getBufferPoolNameOidMap(),
+                      true);
         clearSingleWm(m_periodicWatermarkTable.get(),
                       "SAI_BUFFER_POOL_STAT_XOFF_ROOM_WATERMARK_BYTES",
-                      gBufferOrch->getBufferPoolNameOidMap());
+                      gBufferOrch->getBufferPoolNameOidMap(),
+                      true);
         SWSS_LOG_DEBUG("Periodic watermark cleared by timer!");
     }
 }

--- a/orchagent/watermarkorch.cpp
+++ b/orchagent/watermarkorch.cpp
@@ -5,8 +5,20 @@
 #include "converter.h"
 #include "bufferorch.h"
 #include <inttypes.h>
+#include <chrono>
 
 #define DEFAULT_TELEMETRY_INTERVAL 120
+#define LAST_RESET_TIME_FIELD "LAST_RESET_TIME"
+
+/*
+ * Get system uptime in milliseconds using steady_clock (monotonic time).
+ */
+static uint64_t getSysUptimeMilliseconds()
+{
+    using namespace std::chrono;
+    auto now = steady_clock::now();
+    return duration_cast<milliseconds>(now.time_since_epoch()).count();
+}
 
 #define CLEAR_PG_HEADROOM_REQUEST "PG_HEADROOM"
 #define CLEAR_PG_SHARED_REQUEST "PG_SHARED"
@@ -197,19 +209,22 @@ void WatermarkOrch::doTask(NotificationConsumer &consumer)
     {
         clearSingleWm(table,
                       "SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES",
-                      m_unicast_queue_ids);
+                      m_unicast_queue_ids,
+                      op == "USER");
     }
     else if (data == CLEAR_QUEUE_SHARED_MULTI_REQUEST)
     {
         clearSingleWm(table,
                       "SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES",
-                      m_multicast_queue_ids);
+                      m_multicast_queue_ids,
+                      op == "USER");
     }
     else if (data == CLEAR_QUEUE_SHARED_ALL_REQUEST)
     {
         clearSingleWm(table,
                       "SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES",
-                      m_all_queue_ids);
+                      m_all_queue_ids,
+                      op == "USER");
     }
     else if (data == CLEAR_BUFFER_POOL_REQUEST)
     {
@@ -320,13 +335,22 @@ void WatermarkOrch::init_queue_ids()
     }
 }
 
-void WatermarkOrch::clearSingleWm(Table *table, string wm_name, vector<sai_object_id_t> &obj_ids)
+void WatermarkOrch::clearSingleWm(Table *table, string wm_name, vector<sai_object_id_t> &obj_ids, bool recordResetTime)
 {
     /* Zero-out some WM in some table for some vector of object ids*/
     SWSS_LOG_ENTER();
-    SWSS_LOG_DEBUG("clear WM %s, for %zu obj ids", wm_name.c_str(), obj_ids.size());
+    SWSS_LOG_DEBUG("clear WM %s, for %zu obj ids, recordResetTime=%d", wm_name.c_str(), obj_ids.size(), recordResetTime);
 
     vector<FieldValueTuple> vfvt = {{wm_name, "0"}};
+
+    // Record the reset timestamp for user-initiated clears (for SNMP oracleXgsQueueWatermarkLastResetTime)
+    // SNMP TimeTicks uses centiseconds (1/100 sec), so divide milliseconds by 10
+    if (recordResetTime)
+    {
+        uint64_t uptimeCentiseconds = getSysUptimeMilliseconds() / 10;
+        vfvt.emplace_back(LAST_RESET_TIME_FIELD, to_string(uptimeCentiseconds));
+        SWSS_LOG_INFO("Recording watermark reset time: %" PRIu64 " centiseconds", uptimeCentiseconds);
+    }
 
     for (sai_object_id_t id: obj_ids)
     {
@@ -334,12 +358,21 @@ void WatermarkOrch::clearSingleWm(Table *table, string wm_name, vector<sai_objec
     }
 }
 
-void WatermarkOrch::clearSingleWm(Table *table, string wm_name, const object_reference_map &nameOidMap)
+void WatermarkOrch::clearSingleWm(Table *table, string wm_name, const object_reference_map &nameOidMap, bool recordResetTime)
 {
     SWSS_LOG_ENTER();
-    SWSS_LOG_DEBUG("clear WM %s, for %zu obj ids", wm_name.c_str(), nameOidMap.size());
+    SWSS_LOG_DEBUG("clear WM %s, for %zu obj ids, recordResetTime=%d", wm_name.c_str(), nameOidMap.size(), recordResetTime);
 
     vector<FieldValueTuple> fvTuples = {{wm_name, "0"}};
+
+    // Record the reset timestamp for user-initiated clears (for SNMP oracleXgsQueueWatermarkLastResetTime)
+    // SNMP TimeTicks uses centiseconds (1/100 sec), so divide milliseconds by 10
+    if (recordResetTime)
+    {
+        uint64_t uptimeCentiseconds = getSysUptimeMilliseconds() / 10;
+        fvTuples.emplace_back(LAST_RESET_TIME_FIELD, to_string(uptimeCentiseconds));
+        SWSS_LOG_INFO("Recording watermark reset time: %" PRIu64 " centiseconds", uptimeCentiseconds);
+    }
 
     for (const auto &it : nameOidMap)
     {

--- a/orchagent/watermarkorch.h
+++ b/orchagent/watermarkorch.h
@@ -34,8 +34,8 @@ public:
     void handleWmConfigUpdate(const std::string &key, const std::vector<swss::FieldValueTuple> &fvt);
     void handleFcConfigUpdate(const std::string &key, const std::vector<swss::FieldValueTuple> &fvt);
 
-    void clearSingleWm(swss::Table *table, std::string wm_name, std::vector<sai_object_id_t> &obj_ids);
-    void clearSingleWm(swss::Table *table, std::string wm_name, const object_reference_map &nameOidMap);
+    void clearSingleWm(swss::Table *table, std::string wm_name, std::vector<sai_object_id_t> &obj_ids, bool recordResetTime = false);
+    void clearSingleWm(swss::Table *table, std::string wm_name, const object_reference_map &nameOidMap, bool recordResetTime = false);
 
     std::shared_ptr<swss::Table> getCountersTable(void)
     {

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -315,7 +315,8 @@ class TestWatermark(object):
             keyvalues = dict(ret[1])
             assert "LAST_RESET_TIME" in keyvalues, f"LAST_RESET_TIME not found for {obj_id}"
             reset_time = int(keyvalues["LAST_RESET_TIME"])
-            assert reset_time > 0, f"LAST_RESET_TIME should be positive, got {reset_time}"
+            assert 0 <= reset_time <= 0xFFFFFFFF, \
+                f"LAST_RESET_TIME should be a non-negative 32-bit value, got {reset_time}"
 
     def verify_last_reset_time_not_set(self, dvs, obj_ids, table_name):
         """Verify LAST_RESET_TIME field does NOT exist (for persistent watermarks)"""

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -303,6 +303,74 @@ class TestWatermark(object):
 
         self.enable_unittests(dvs, "false")
 
+    def verify_last_reset_time_set(self, dvs, obj_ids, table_name):
+        """Verify LAST_RESET_TIME field exists and contains a valid numeric value"""
+        counters_db = swsscommon.DBConnector(swsscommon.COUNTERS_DB, dvs.redis_sock, 0)
+        table = swsscommon.Table(counters_db, table_name)
+
+        for obj_id in obj_ids:
+            ret = table.get(obj_id)
+            status = ret[0]
+            assert status, f"Entry {obj_id} not found in {table_name}"
+            keyvalues = dict(ret[1])
+            assert "LAST_RESET_TIME" in keyvalues, f"LAST_RESET_TIME not found for {obj_id}"
+            reset_time = int(keyvalues["LAST_RESET_TIME"])
+            assert reset_time > 0, f"LAST_RESET_TIME should be positive, got {reset_time}"
+
+    def verify_last_reset_time_not_set(self, dvs, obj_ids, table_name):
+        """Verify LAST_RESET_TIME field does NOT exist (for persistent watermarks)"""
+        counters_db = swsscommon.DBConnector(swsscommon.COUNTERS_DB, dvs.redis_sock, 0)
+        table = swsscommon.Table(counters_db, table_name)
+
+        for obj_id in obj_ids:
+            ret = table.get(obj_id)
+            if ret[0]:  # entry exists
+                keyvalues = dict(ret[1])
+                assert "LAST_RESET_TIME" not in keyvalues, \
+                    f"LAST_RESET_TIME should not be set for {table_name}"
+
+    def test_clear_user_watermark_sets_last_reset_time(self, dvs):
+        """
+        Test that clearing USER queue watermarks sets LAST_RESET_TIME field.
+        This timestamp is used by SNMP oracleXgsQueueWatermarkLastResetTime.
+        LAST_RESET_TIME should only be set for USER watermarks on queue clears,
+        not for PERSISTENT watermarks or PG/buffer pool clears.
+        """
+        self.setup_dbs(dvs)
+        self.set_up(dvs)
+        self.enable_unittests(dvs, "true")
+
+        try:
+            self.populate_asic_all(dvs, "100")
+
+            # Clear USER unicast queue watermark - should set LAST_RESET_TIME
+            self.clear_watermark(dvs, ["USER", "Q_SHARED_UNI"])
+            self.verify_value(dvs, self.uc_q, WmTables.user, SaiWmStats.queue_shared, "0")
+            self.verify_last_reset_time_set(dvs, self.uc_q, WmTables.user)
+
+            # Clear USER multicast queue watermark - should set LAST_RESET_TIME
+            self.clear_watermark(dvs, ["USER", "Q_SHARED_MULTI"])
+            self.verify_value(dvs, self.mc_q, WmTables.user, SaiWmStats.queue_shared, "0")
+            self.verify_last_reset_time_set(dvs, self.mc_q, WmTables.user)
+
+            # Clear USER all queue watermark - should set LAST_RESET_TIME
+            self.clear_watermark(dvs, ["USER", "Q_SHARED_ALL"])
+            self.verify_value(dvs, self.all_q, WmTables.user, SaiWmStats.queue_shared, "0")
+            self.verify_last_reset_time_set(dvs, self.all_q, WmTables.user)
+
+            # Clear PERSISTENT unicast queue watermark - should NOT set LAST_RESET_TIME
+            self.clear_watermark(dvs, ["PERSISTENT", "Q_SHARED_UNI"])
+            self.verify_value(dvs, self.uc_q, WmTables.persistent, SaiWmStats.queue_shared, "0")
+            self.verify_last_reset_time_not_set(dvs, self.uc_q, WmTables.persistent)
+
+            # Clear USER PG watermark - should NOT set LAST_RESET_TIME (only queue clears)
+            self.clear_watermark(dvs, ["USER", "PG_SHARED"])
+            self.verify_value(dvs, self.pgs, WmTables.user, SaiWmStats.pg_shared, "0")
+            self.verify_last_reset_time_not_set(dvs, self.pgs, WmTables.user)
+
+        finally:
+            self.enable_unittests(dvs, "false")
+
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying


### PR DESCRIPTION
### Description
Record the last reset time when watermarks are cleared, enabling SNMP to expose `oracleXgsQueueWatermarkLastResetTime` (TimeTicks since boot).

**Why is this change required?**
The ORACLE-XGS-MIB defines `oracleXgsQueueWatermarkLastResetTime` which reports when a queue's watermark was last cleared. Currently sonic-swss does not record this timestamp, so SNMP cannot report accurate reset times.

**How did you verify it?**
- Added unit test `test_clear_user_watermark_sets_last_reset_time` in `tests/test_watermark.py`
- Verified logic with standalone C++ test

### Implementation
- Added `getSysUptimeCentiseconds()` using `clock_gettime(CLOCK_BOOTTIME)` to get monotonic system uptime
- Extended `clearSingleWm()` with `recordResetTime` parameter (default false)
- Records `LAST_RESET_TIME` field for both:
  - **USER watermark clears** (user-initiated via CLI)
  - **PERIODIC watermark clears** (automatic timer-based refresh)
- Value is stored as centiseconds (1/100 sec) per SNMP TimeTicks (RFC 2578), wrapped at 2^32
- PERSISTENT watermark clears do NOT record timestamp

### Database Schema Change
- **Database:** COUNTERS_DB
- **Tables:** USER_WATERMARKS, PERIODIC_WATERMARKS
- **New Field:** `LAST_RESET_TIME` (string representation of uint32 centiseconds since boot)

### Related Issue
MIGSOFTWAR-35432 (internal to Cisco)

### Files Changed
- `orchagent/watermarkorch.cpp`: Added timestamp recording logic
- `orchagent/watermarkorch.h`: Updated function signatures
- `tests/test_watermark.py`: Added unit test