### PR TITLE
[orchagent][log] Change port serdes ID null return log level to WARN 

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -9289,7 +9289,7 @@ sai_object_id_t PortsOrch::getPortSerdesIdFromPortId(sai_object_id_t port_id)
     sai_status_t status = sai_port_api->get_port_attribute(port_id, 1, &port_attr);
     if (status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR("Failed to get port serdes ID for port 0x%" PRIx64 " (status=%d)", port_id, status);
+        SWSS_LOG_INFO("Failed to get port serdes ID for port 0x%" PRIx64 " (status=%d)", port_id, status);
         return SAI_NULL_OBJECT_ID;
     }
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -9289,7 +9289,7 @@ sai_object_id_t PortsOrch::getPortSerdesIdFromPortId(sai_object_id_t port_id)
     sai_status_t status = sai_port_api->get_port_attribute(port_id, 1, &port_attr);
     if (status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_INFO("Failed to get port serdes ID for port 0x%" PRIx64 " (status=%d)", port_id, status);
+        SWSS_LOG_WARN("Failed to get port serdes ID for port 0x%" PRIx64 " (status=%d)", port_id, status);
         return SAI_NULL_OBJECT_ID;
     }
 


### PR DESCRIPTION
### What I did
In [`getPortSerdesIdFromPortId()`](https://github.com/sonic-net/sonic-swss/blob/master/orchagent/portsorch.cpp#L9284), changed the log level from `SWSS_LOG_ERROR` to `SWSS_LOG_INFO` when SAI returns null. 

### Why I did it
on platform does not support/implement serdes, and swss will log err as below
```
ERR swss#orchagent: :- getPortSerdesIdFromPortId: Failed to get port serdes ID for port 0x1000000000001 (status=-196608)
```

The status `-196608` is [`SAI_STATUS_ATTR_NOT_IMPLEMENTED_0`](https://github.com/opencomputeproject/SAI/blob/master/inc/saistatus.h#L223), meaning `SAI_PORT_ATTR_PORT_SERDES_ID` is not implemented on the platform. However, [`registerPort()`](https://github.com/sonic-net/sonic-swss/blob/master/orchagent/portsorch.cpp#L4119) unconditionally queries this attribute for all PHY ports, and the failure was logged at ERROR level.

**Why this is safe:** The calling code in [`registerPort()`](https://github.com/sonic-net/sonic-swss/blob/master/orchagent/portsorch.cpp#L4123-L4135) already handles a null SerDes ID gracefully — it simply skips the optional serdes-to-port counter mapping. Port functionality is unaffected; only SerDes PHY telemetry counters are unavailable.

### How I verified it

### Details if related
