### PR TITLE
Handle ACL resource constraints with event based retry

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -13,6 +13,7 @@
 #include "crmorch.h"
 #include "sai_serialize.h"
 #include "directory.h"
+#include "saihelper.h"
 
 using namespace std;
 using namespace swss;
@@ -1339,6 +1340,7 @@ bool AclRule::createRule()
     }
 
     status = sai_acl_api->create_acl_entry(&m_ruleOid, gSwitchId, (uint32_t)rule_attrs.size(), rule_attrs.data());
+    m_lastSaiStatus = status;
     if (status != SAI_STATUS_SUCCESS)
     {
         if (status == SAI_STATUS_ITEM_ALREADY_EXISTS)
@@ -4212,6 +4214,11 @@ AclOrch::AclOrch(vector<TableConnector>& connectors, DBConnector* stateDb, Switc
 
     init(connectors, portOrch, mirrorOrch, neighOrch, routeOrch);
 
+    /* Initialize retry caches for rule consumers so that resource-exhaustion
+     * failures can be parked and retried only when resources are freed. */
+    createRetryCache(CFG_ACL_RULE_TABLE_NAME);
+    createRetryCache(APP_ACL_RULE_TABLE_NAME);
+
     if (m_dTelOrch)
     {
         m_dTelOrch->attach(this);
@@ -5512,6 +5519,9 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
 
+    /* Move resolved retry-cache tasks back into the consumer sync queue */
+    retryToSync(consumer.getTableName());
+
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
     {
@@ -5661,6 +5671,18 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
                     setAclRuleStatus(table_id, rule_id, AclObjectStatus::ACTIVE);
                     it = consumer.m_toSync.erase(it);
                 }
+                else if (isSaiStatusResourceFull(newRule->getLastSaiStatus()))
+                {
+                    /* Park resource-exhaustion failures in the retry cache.
+                     * They will be re-queued when resources are freed (i.e.,
+                     * when an ACL rule is successfully removed from this table). */
+                    SWSS_LOG_WARN("ACL rule %s in table %s failed due to resource exhaustion, parking for retry",
+                            rule_id.c_str(), table_id.c_str());
+                    auto cst = make_constraint(RETRY_CST_SAI_RESOURCE, table_id);
+                    consumer.addToRetry(it->second, cst);
+                    setAclRuleStatus(table_id, rule_id, AclObjectStatus::INACTIVE);
+                    it = consumer.m_toSync.erase(it);
+                }
                 else
                 {
                     setAclRuleStatus(table_id, rule_id, AclObjectStatus::PENDING_CREATION);
@@ -5681,6 +5703,13 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
             {
                 removeAclRuleStatus(table_id, rule_id);
                 it = consumer.m_toSync.erase(it);
+
+                /* Notify retry cache that resources may have been freed for this table */
+                auto retryCache = getRetryCache(consumer.getTableName());
+                if (retryCache)
+                {
+                    retryCache->mark_resolved(make_constraint(RETRY_CST_SAI_RESOURCE, table_id));
+                }
             }
             else
             {

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -5521,9 +5521,6 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
 
-    /* Move resolved retry-cache tasks back into the consumer sync queue */
-    retryToSync(consumer.getTableName());
-
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
     {
@@ -5681,9 +5678,18 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
                     SWSS_LOG_WARN("ACL rule %s in table %s failed due to resource exhaustion, parking for retry",
                             rule_id.c_str(), table_id.c_str());
                     auto cst = make_constraint(RETRY_CST_SAI_RESOURCE, table_id);
-                    consumer.addToRetry(it->second, cst);
-                    setAclRuleStatus(table_id, rule_id, AclObjectStatus::INACTIVE);
-                    it = consumer.m_toSync.erase(it);
+                    if (consumer.addToRetry(it->second, cst))
+                    {
+                        setAclRuleStatus(table_id, rule_id, AclObjectStatus::PENDING_CREATION);
+                        it = consumer.m_toSync.erase(it);
+                    }
+                    else
+                    {
+                        SWSS_LOG_ERROR("Failed to park ACL rule %s in table %s in retry cache",
+                                rule_id.c_str(), table_id.c_str());
+                        setAclRuleStatus(table_id, rule_id, AclObjectStatus::PENDING_CREATION);
+                        it++;
+                    }
                 }
                 else
                 {
@@ -5701,13 +5707,18 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
         }
         else if (op == DEL_COMMAND)
         {
+            bool ruleExisted = (getAclRule(table_id, rule_id) != nullptr);
             if (removeAclRule(table_id, rule_id))
             {
                 removeAclRuleStatus(table_id, rule_id);
                 it = consumer.m_toSync.erase(it);
 
-                /* Notify retry cache that resources may have been freed for this table */
-                notifyRetry(this, consumer.getTableName(), make_constraint(RETRY_CST_SAI_RESOURCE, table_id));
+                /* Notify retry cache that resources may have been freed for this table,
+                 * but only if the rule actually existed (i.e., ASIC resources were freed). */
+                if (ruleExisted)
+                {
+                    notifyRetry(this, consumer.getTableName(), make_constraint(RETRY_CST_SAI_RESOURCE, table_id));
+                }
             }
             else
             {

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -5707,11 +5707,7 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
                 it = consumer.m_toSync.erase(it);
 
                 /* Notify retry cache that resources may have been freed for this table */
-                auto retryCache = getRetryCache(consumer.getTableName());
-                if (retryCache)
-                {
-                    retryCache->mark_resolved(make_constraint(RETRY_CST_SAI_RESOURCE, table_id));
-                }
+                notifyRetry(this, consumer.getTableName(), make_constraint(RETRY_CST_SAI_RESOURCE, table_id));
             }
             else
             {

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -331,6 +331,8 @@ public:
     virtual bool enableCounter();
     virtual bool disableCounter();
 
+    sai_status_t getLastSaiStatus() const { return m_lastSaiStatus; }
+
     string getId() const;
     string getTableId() const;
     sai_object_id_t getOid() const;
@@ -387,6 +389,7 @@ protected:
 
     vector<AclRangeConfig> m_rangeConfig;
     vector<AclRange*> m_ranges;
+    sai_status_t m_lastSaiStatus = SAI_STATUS_SUCCESS;
 
 private:
     bool m_createCounter;

--- a/orchagent/retrycache.h
+++ b/orchagent/retrycache.h
@@ -10,15 +10,17 @@ using namespace swss;
 enum ConstraintType
 {
     RETRY_CST_DUMMY,
-    RETRY_CST_PIC,          // context doesn't exist
-    RETRY_CST_PIC_REF      // context refcnt nonzero
+    RETRY_CST_PIC,              // context doesn't exist
+    RETRY_CST_PIC_REF,          // context refcnt nonzero
+    RETRY_CST_SAI_RESOURCE      // SAI resource exhaustion (INSUFFICIENT_RESOURCES, TABLE_FULL, etc.)
 };
 
 static inline std::ostream& operator<<(std::ostream& os, ConstraintType t) {
     switch(t) {
-        case ConstraintType::RETRY_CST_DUMMY:   return os << "RETRY_CST_DUMMY";
-        case ConstraintType::RETRY_CST_PIC: return os << "RETRY_CST_PIC";
-        case ConstraintType::RETRY_CST_PIC_REF:  return os << "RETRY_CST_PIC_REF";
+        case ConstraintType::RETRY_CST_DUMMY:        return os << "RETRY_CST_DUMMY";
+        case ConstraintType::RETRY_CST_PIC:          return os << "RETRY_CST_PIC";
+        case ConstraintType::RETRY_CST_PIC_REF:      return os << "RETRY_CST_PIC_REF";
+        case ConstraintType::RETRY_CST_SAI_RESOURCE: return os << "RETRY_CST_SAI_RESOURCE";
         default:           return os << "UNKNOWN";
     }
 }

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -759,6 +759,14 @@ bool parseHandleSaiStatusFailure(task_process_status status)
     return true;
 }
 
+bool isSaiStatusResourceFull(sai_status_t status)
+{
+    return status == SAI_STATUS_INSUFFICIENT_RESOURCES ||
+           status == SAI_STATUS_TABLE_FULL ||
+           status == SAI_STATUS_NO_MEMORY ||
+           status == SAI_STATUS_NV_STORAGE_FULL;
+}
+
 /* Handling SAI failure. Request redis to invoke SAI failure dump */
 void handleSaiFailure(sai_api_t api, string oper, sai_status_t status, bool abort_on_failure)
 {

--- a/orchagent/saihelper.h
+++ b/orchagent/saihelper.h
@@ -21,6 +21,7 @@ task_process_status handleSaiSetStatus(sai_api_t api, sai_status_t status, void 
 task_process_status handleSaiRemoveStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
 task_process_status handleSaiGetStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
 bool parseHandleSaiStatusFailure(task_process_status status);
+bool isSaiStatusResourceFull(sai_status_t status);
 void handleSaiFailure(sai_api_t api, std::string oper, sai_status_t status, bool abort_on_failure);
 
 void setFlexCounterGroupParameter(const std::string &group,

--- a/tests/mock_tests/aclorch_rule_ut.cpp
+++ b/tests/mock_tests/aclorch_rule_ut.cpp
@@ -3,6 +3,7 @@
 #include "mock_sai_api.h"
 #include "mock_orch_test.h"
 #include "check.h"
+#include "saihelper.h"
 
 EXTERN_MOCK_FNS
 
@@ -300,5 +301,209 @@ namespace aclorch_rule_test
         EXPECT_CALL(*mock_sai_acl_api, create_acl_entry).Times(0);
         addTunnelNhRule(mock_invalid_nh_ip_str, mock_tunnel_name, "");
         ASSERT_FALSE(gAclOrch->getAclRule(acl_table, acl_rule));
+    }
+
+    /*
+     * Test fixture for ACL rule resource exhaustion and retry cache integration.
+     * Validates that when SAI returns SAI_STATUS_INSUFFICIENT_RESOURCES (or similar),
+     * the failed rule is parked in the retry cache and re-queued when resources are freed.
+     */
+    struct AclResourceExhaustionTest : public AclOrchRuleTest
+    {
+        string acl_table_type = "L3_TEST_TYPE";
+        string acl_table = "L3_TEST_TABLE";
+        string acl_rule_1 = "RULE_1";
+        string acl_rule_2 = "RULE_2";
+        sai_object_id_t acl_entry_oid = 0x500000000001;
+
+        void PostSetUp() override
+        {
+            AclOrchRuleTest::PostSetUp();
+            populateL3Table();
+        }
+
+        void populateL3Table()
+        {
+            doAclTableTypeTask({
+                {
+                    acl_table_type,
+                    SET_COMMAND,
+                    {
+                        { ACL_TABLE_TYPE_MATCHES, string(MATCH_SRC_IP) },
+                        { ACL_TABLE_TYPE_ACTIONS, ACTION_PACKET_ACTION },
+                    }
+                }
+            });
+            doAclTableTask({
+                {
+                    acl_table,
+                    SET_COMMAND,
+                    {
+                        { ACL_TABLE_TYPE, acl_table_type },
+                        { ACL_TABLE_STAGE, STAGE_INGRESS },
+                    }
+                }
+            });
+        }
+
+        void addDropRule(const string& rule_id, const string& src_ip)
+        {
+            doAclRuleTask({
+                {
+                    acl_table + "|" + rule_id,
+                    SET_COMMAND,
+                    {
+                        { RULE_PRIORITY, "9999" },
+                        { MATCH_SRC_IP, src_ip },
+                        { ACTION_PACKET_ACTION, PACKET_ACTION_DROP }
+                    }
+                }
+            });
+        }
+
+        void delRule(const string& rule_id)
+        {
+            doAclRuleTask({
+                {
+                    acl_table + "|" + rule_id,
+                    DEL_COMMAND,
+                    { }
+                }
+            });
+        }
+
+        RetryCache* getRuleRetryCache()
+        {
+            return gAclOrch->getRetryCache(CFG_ACL_RULE_TABLE_NAME);
+        }
+    };
+
+    /* When create_acl_entry returns SAI_STATUS_INSUFFICIENT_RESOURCES,
+     * the rule should NOT be in the ACL table but should be parked in the retry cache. */
+    TEST_F(AclResourceExhaustionTest, RuleParkedOnResourceExhaustion)
+    {
+        auto *cache = getRuleRetryCache();
+        ASSERT_NE(cache, nullptr);
+        ASSERT_TRUE(cache->getRetryMap().empty());
+
+        /* Mock SAI to return INSUFFICIENT_RESOURCES on create */
+        EXPECT_CALL(*mock_sai_acl_api, create_acl_entry)
+            .WillOnce(Return(SAI_STATUS_INSUFFICIENT_RESOURCES));
+
+        addDropRule(acl_rule_1, "10.0.0.1/32");
+
+        /* Rule should NOT be created in orchagent */
+        ASSERT_FALSE(gAclOrch->getAclRule(acl_table, acl_rule_1));
+
+        /* Rule should be parked in the retry cache */
+        ASSERT_FALSE(cache->getRetryMap().empty());
+
+        auto constraint = make_constraint(RETRY_CST_SAI_RESOURCE, acl_table);
+        auto &retryKeys = cache->m_retryKeys;
+        ASSERT_NE(retryKeys.find(constraint), retryKeys.end());
+    }
+
+    /* When create_acl_entry returns SAI_STATUS_TABLE_FULL,
+     * the rule should also be parked in the retry cache (same as INSUFFICIENT_RESOURCES). */
+    TEST_F(AclResourceExhaustionTest, RuleParkedOnTableFull)
+    {
+        auto *cache = getRuleRetryCache();
+        ASSERT_NE(cache, nullptr);
+
+        EXPECT_CALL(*mock_sai_acl_api, create_acl_entry)
+            .WillOnce(Return(SAI_STATUS_TABLE_FULL));
+
+        addDropRule(acl_rule_1, "10.0.0.1/32");
+
+        ASSERT_FALSE(gAclOrch->getAclRule(acl_table, acl_rule_1));
+        ASSERT_FALSE(cache->getRetryMap().empty());
+    }
+
+    /* Non-resource failures (e.g., SAI_STATUS_FAILURE) should NOT park in retry cache;
+     * they should remain in m_toSync for normal retry. */
+    TEST_F(AclResourceExhaustionTest, NonResourceFailureNotParked)
+    {
+        auto *cache = getRuleRetryCache();
+        ASSERT_NE(cache, nullptr);
+
+        EXPECT_CALL(*mock_sai_acl_api, create_acl_entry)
+            .WillOnce(Return(SAI_STATUS_FAILURE));
+
+        addDropRule(acl_rule_1, "10.0.0.1/32");
+
+        /* Rule should NOT be created */
+        ASSERT_FALSE(gAclOrch->getAclRule(acl_table, acl_rule_1));
+
+        /* Retry cache should be empty — the rule stays in m_toSync for normal retry */
+        ASSERT_TRUE(cache->getRetryMap().empty());
+    }
+
+    /* After a rule is parked due to resource exhaustion, removing another rule from the same
+     * table should mark the constraint as resolved, allowing the parked rule to be retried. */
+    TEST_F(AclResourceExhaustionTest, RuleRetriedAfterResourceFreed)
+    {
+        auto *cache = getRuleRetryCache();
+        ASSERT_NE(cache, nullptr);
+
+        /* First, successfully create rule_1 */
+        EXPECT_CALL(*mock_sai_acl_api, create_acl_entry)
+            .WillOnce(DoAll(SetArgPointee<0>(acl_entry_oid), Return(SAI_STATUS_SUCCESS)));
+        addDropRule(acl_rule_1, "10.0.0.1/32");
+        ASSERT_TRUE(gAclOrch->getAclRule(acl_table, acl_rule_1));
+
+        /* Now try to create rule_2, but SAI returns INSUFFICIENT_RESOURCES */
+        EXPECT_CALL(*mock_sai_acl_api, create_acl_entry)
+            .WillOnce(Return(SAI_STATUS_INSUFFICIENT_RESOURCES));
+        addDropRule(acl_rule_2, "10.0.0.2/32");
+        ASSERT_FALSE(gAclOrch->getAclRule(acl_table, acl_rule_2));
+        ASSERT_FALSE(cache->getRetryMap().empty());
+
+        /* Remove rule_1 to free resources — this should mark the constraint as resolved */
+        EXPECT_CALL(*mock_sai_acl_api, remove_acl_entry)
+            .WillOnce(Return(SAI_STATUS_SUCCESS));
+        delRule(acl_rule_1);
+        ASSERT_FALSE(gAclOrch->getAclRule(acl_table, acl_rule_1));
+
+        /* The constraint should now be resolved */
+        auto constraint = make_constraint(RETRY_CST_SAI_RESOURCE, acl_table);
+        auto &resolvedConstraints = cache->getResolvedConstraints();
+        ASSERT_NE(resolvedConstraints.find(constraint), resolvedConstraints.end());
+
+        /* Now when doAclRuleTask is called again (e.g. via retryToSync),
+         * the parked task should be moved back to the consumer's m_toSync.
+         * Simulate this by calling retryToSync and then checking the real consumer. */
+        size_t moved = gAclOrch->retryToSync(CFG_ACL_RULE_TABLE_NAME);
+        ASSERT_GT(moved, 0u);
+
+        /* The retry cache should now be empty */
+        ASSERT_TRUE(cache->getRetryMap().empty());
+        ASSERT_TRUE(resolvedConstraints.empty());
+
+        /* The task should now be in the actual consumer's m_toSync */
+        auto *consumerBase = gAclOrch->getConsumerBase(CFG_ACL_RULE_TABLE_NAME);
+        ASSERT_NE(consumerBase, nullptr);
+        auto *consumer = dynamic_cast<Consumer *>(consumerBase);
+        ASSERT_NE(consumer, nullptr);
+        ASSERT_FALSE(consumer->m_toSync.empty());
+
+        /* Process the retried rule — now SAI succeeds */
+        EXPECT_CALL(*mock_sai_acl_api, create_acl_entry)
+            .WillOnce(DoAll(SetArgPointee<0>(acl_entry_oid + 1), Return(SAI_STATUS_SUCCESS)));
+        static_cast<Orch *>(gAclOrch)->doTask(*consumer);
+
+        /* Rule should now be created */
+        ASSERT_TRUE(gAclOrch->getAclRule(acl_table, acl_rule_2));
+    }
+
+    /* Verify isSaiStatusResourceFull correctly identifies resource exhaustion statuses */
+    TEST_F(AclResourceExhaustionTest, IsSaiStatusResourceFullHelper)
+    {
+        ASSERT_TRUE(isSaiStatusResourceFull(SAI_STATUS_INSUFFICIENT_RESOURCES));
+        ASSERT_TRUE(isSaiStatusResourceFull(SAI_STATUS_TABLE_FULL));
+        ASSERT_TRUE(isSaiStatusResourceFull(SAI_STATUS_NO_MEMORY));
+        ASSERT_TRUE(isSaiStatusResourceFull(SAI_STATUS_NV_STORAGE_FULL));
+        ASSERT_FALSE(isSaiStatusResourceFull(SAI_STATUS_SUCCESS));
+        ASSERT_FALSE(isSaiStatusResourceFull(SAI_STATUS_FAILURE));
+        ASSERT_FALSE(isSaiStatusResourceFull(SAI_STATUS_NOT_SUPPORTED));
     }
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
Handle ACL resource constraints with event based retry. Fixes #4406 

**What I did**

Use an event-based retry using RetryCache to handle ACL resource availability constraints.

**Why I did it**

Blind retries are not helpful when resources (ACL in this case) are not available. This can cause new events including route updates to be throttled even when retries are not guaranteed to help.

**How I verified it**
* By using mock tests to test the behavior.
* Also verified by the originator of issue 4406 that the problem reported is resolved.
  
**Details if related**

Uses the RetryCache mechanism that has already been used for some orchs like routeorch and srv6orch.

**Retry Behavior**

**How frequently does retry happen?**

 Retry is event-driven, not periodic. Parked tasks are retried only when resources are actually freed — specifically, when an ACL rule is successfully removed from the same table. The flow is:

 * Rule creation fails with SAI_STATUS_INSUFFICIENT_RESOURCES (or TABLE_FULL, NO_MEMORY, NV_STORAGE_FULL)
 * The task is parked in the RetryCache under a (RETRY_CST_SAI_RESOURCE, table_id) constraint
 * No retry occurs until a DEL operation successfully removes a rule from the same ACL table
 * The successful removal calls notifyRetry(), which marks the constraint as resolved
 * On the next Orch::doTask() cycle, retryToSync() moves resolved tasks back to m_toSync (subject to the per-iteration quota in Orch::doTask)
 * The task is then processed normally by doAclRuleTask()

 There is no timer or polling — no CPU is spent retrying until the resolving event occurs.

 **When is an entry removed from retry?**

 * On success: If the retried SAI create call succeeds, the rule is created normally and the entry is fully consumed (no longer in retry or m_toSync).
 * On repeated resource exhaustion: If the retry fails again with a resource-full status, the task is re-parked in the retry cache under the same constraint, awaiting the next resource-freeing event.
 * On non-resource failure: If the retry fails with a different error (e.g., SAI_STATUS_FAILURE), the task remains in m_toSync for normal retry handling (not re-parked).

