### PR TITLE
[P4Orch] Enhance ACL Functionality: Support for Multicast Redirection, Metadata Actions, and  P4 ACL Policer default mode to STORM_CONTROL.

### DIFF
--- a/orchagent/p4orch/acl_rule_manager.cpp
+++ b/orchagent/p4orch/acl_rule_manager.cpp
@@ -1995,8 +1995,8 @@ ReturnCode AclRuleManager::processDeleteRuleRequest(const std::string &acl_table
     return status;
 }
 
-ReturnCode AclRuleManager::processUpdateRuleRequest(const P4AclRuleAppDbEntry &app_db_entry,
-                                                    const P4AclRule &old_acl_rule)
+ReturnCode AclRuleManager::processUpdateRuleRequest(
+    const P4AclRuleAppDbEntry& app_db_entry, P4AclRule &old_acl_rule)
 {
     SWSS_LOG_ENTER();
 

--- a/orchagent/p4orch/acl_rule_manager.cpp
+++ b/orchagent/p4orch/acl_rule_manager.cpp
@@ -1144,6 +1144,20 @@ ReturnCode AclRuleManager::getRedirectActionL3MulticastGroupOid(
     return ReturnCode();
 }
 
+ReturnCode AclRuleManager::getRedirectActionL2MulticastGroupOid(
+    const std::string& target, sai_object_id_t* redirect_oid) {
+    const auto& l2_multicast_group_key =
+        KeyGenerator::generateL2MulticastGroupKey(target);
+    if (!m_p4OidMapper->getOID(SAI_OBJECT_TYPE_L2MC_GROUP, l2_multicast_group_key,
+                               redirect_oid)) {
+        LOG_ERROR_AND_RETURN(ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
+                             << "ACL Redirect action target L2 multicast group ID: "
+                             << QuotedVar(target)
+                             << " doesn't exist on the switch");
+    }
+    return ReturnCode();
+}
+
 ReturnCode AclRuleManager::setAllMatchFieldValues(const P4AclRuleAppDbEntry &app_db_entry,
                                                   const P4AclTableDefinition *acl_table, P4AclRule &acl_rule)
 {
@@ -1316,6 +1330,13 @@ ReturnCode AclRuleManager::setActionValue(const sai_acl_entry_attr_t attr_name,
           value->aclaction.parameter.oid = redirect_oid;
           acl_rule->action_redirect_l3_multicast_group_key =
               KeyGenerator::generateL3MulticastGroupKey(attr_value);
+          break;
+        } else if (attr_type == SAI_OBJECT_TYPE_L2MC_GROUP) {
+          RETURN_IF_ERROR(
+              getRedirectActionL2MulticastGroupOid(attr_value, &redirect_oid));
+          value->aclaction.parameter.oid = redirect_oid;
+          acl_rule->action_redirect_l2_multicast_group_key =
+              KeyGenerator::generateL2MulticastGroupKey(attr_value);
           break;
         } else if (attr_type == SAI_OBJECT_TYPE_PORT) {
           auto port_status = getRedirectActionPortOid(attr_value, &redirect_oid);
@@ -1791,6 +1812,16 @@ ReturnCode AclRuleManager::updateAclRule(const P4AclRule &acl_rule, const P4AclR
           SAI_OBJECT_TYPE_IPMC_GROUP,
           acl_rule.action_redirect_l3_multicast_group_key);
     }
+    if (!old_acl_rule.action_redirect_l2_multicast_group_key.empty()) {
+        m_p4OidMapper->decreaseRefCount(
+          SAI_OBJECT_TYPE_L2MC_GROUP,
+          old_acl_rule.action_redirect_l2_multicast_group_key);
+    }
+    if (!acl_rule.action_redirect_l2_multicast_group_key.empty()) {
+        m_p4OidMapper->increaseRefCount(
+          SAI_OBJECT_TYPE_L2MC_GROUP,
+          acl_rule.action_redirect_l2_multicast_group_key);
+    }
     for (const auto &mirror_session : old_acl_rule.action_mirror_sessions)
     {
         m_p4OidMapper->decreaseRefCount(SAI_OBJECT_TYPE_MIRROR_SESSION, fvValue(mirror_session).key);
@@ -1911,6 +1942,11 @@ ReturnCode AclRuleManager::removeAclRule(const std::string &acl_table_name, cons
           SAI_OBJECT_TYPE_IPMC_GROUP,
           acl_rule->action_redirect_l3_multicast_group_key);
     }
+    if (!acl_rule->action_redirect_l2_multicast_group_key.empty()) {
+        m_p4OidMapper->decreaseRefCount(
+          SAI_OBJECT_TYPE_L2MC_GROUP,
+          acl_rule->action_redirect_l2_multicast_group_key);
+    }
     for (const auto &mirror_session : acl_rule->action_mirror_sessions)
     {
         m_p4OidMapper->decreaseRefCount(SAI_OBJECT_TYPE_MIRROR_SESSION, fvValue(mirror_session).key);
@@ -2005,6 +2041,11 @@ ReturnCode AclRuleManager::processAddRuleRequest(const std::string &acl_rule_key
         m_p4OidMapper->increaseRefCount(
           SAI_OBJECT_TYPE_IPMC_GROUP,
           acl_rule.action_redirect_l3_multicast_group_key);
+    }
+    if (!acl_rule.action_redirect_l2_multicast_group_key.empty()) {
+        m_p4OidMapper->increaseRefCount(
+          SAI_OBJECT_TYPE_L2MC_GROUP,
+          acl_rule.action_redirect_l2_multicast_group_key);
     }
     for (const auto &mirror_session : acl_rule.action_mirror_sessions)
     {
@@ -2471,6 +2512,17 @@ std::string AclRuleManager::verifyStateCache(const P4AclRuleAppDbEntry &app_db_e
           << QuotedVar(acl_rule_entry.action_redirect_l3_multicast_group_key)
           << " mismatch with internal cache "
           << QuotedVar(acl_rule->action_redirect_l3_multicast_group_key)
+          << " in ACl rule manager.";
+      return msg.str();
+    }
+    if (acl_rule->action_redirect_l2_multicast_group_key !=
+        acl_rule_entry.action_redirect_l2_multicast_group_key) {
+      std::stringstream msg;
+      msg << "ACL rule " << QuotedVar(acl_rule_key)
+          << " with redirect L2 multicast group key "
+          << QuotedVar(acl_rule_entry.action_redirect_l2_multicast_group_key)
+          << " mismatch with internal cache "
+          << QuotedVar(acl_rule->action_redirect_l2_multicast_group_key)
           << " in ACl rule manager.";
       return msg.str();
     }

--- a/orchagent/p4orch/acl_rule_manager.cpp
+++ b/orchagent/p4orch/acl_rule_manager.cpp
@@ -157,6 +157,16 @@ std::vector<sai_attribute_t> getMeterSaiAttrs(const P4AclMeter &p4_acl_meter)
             meter_attr.value.u64 = p4_acl_meter.pburst;
             meter_attrs.push_back(meter_attr);
         }
+
+        /* TBD
+        if (gLabelMapper->isLabelValid(p4_acl_meter.policer_label)) {
+          meter_attr.id = SAI_POLICER_ATTR_LABEL;
+          auto size = sizeof(meter_attr.value.chardata);
+          snprintf(meter_attr.value.chardata, size, "%s",
+                   p4_acl_meter.policer_label.c_str());
+          meter_attrs.push_back(meter_attr);
+        }
+       */
     }
 
     for (const auto &packet_color_action : p4_acl_meter.packet_color_actions)
@@ -697,7 +707,7 @@ ReturnCode AclRuleManager::validateAclRuleAppDbEntry(const P4AclRuleAppDbEntry &
           app_db_entry.meter.cburst != app_db_entry.meter.pburst))) {
       return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
              << "ACL policer for " << QuotedVar(app_db_entry.db_key)
-             << " in default storm mode has invalid cir:pir/cburst:pburst pairs, "
+             << " in default single_rate_two_color mode has invalid cir:pir/cburst:pburst pairs, "
                 "expected cir==pir, cburst==pburst.";
     }
     return ReturnCode();
@@ -2193,6 +2203,7 @@ ReturnCode AclRuleManager::processUpdateRuleRequest(
         }
         updated_meter = true;
         acl_rule.meter.meter_oid = old_acl_rule.meter.meter_oid;
+        acl_rule.meter.policer_label = old_acl_rule.meter.policer_label;
     }
 
     auto status = updateAclRule(acl_rule, old_acl_rule, acl_entry_attrs, rollback_attrs);

--- a/orchagent/p4orch/acl_rule_manager.cpp
+++ b/orchagent/p4orch/acl_rule_manager.cpp
@@ -144,13 +144,19 @@ std::vector<sai_attribute_t> getMeterSaiAttrs(const P4AclMeter &p4_acl_meter)
         meter_attr.value.u64 = p4_acl_meter.cir;
         meter_attrs.push_back(meter_attr);
 
-        meter_attr.id = SAI_POLICER_ATTR_PIR;
-        meter_attr.value.u64 = p4_acl_meter.pir;
-        meter_attrs.push_back(meter_attr);
+        if (p4_acl_meter.mode == SAI_POLICER_MODE_SR_TCM) {
+            meter_attr.id = SAI_POLICER_ATTR_PBS;
+            meter_attr.value.u64 = p4_acl_meter.pburst;
+            meter_attrs.push_back(meter_attr);
+        } else if (p4_acl_meter.mode == SAI_POLICER_MODE_TR_TCM) {
+            meter_attr.id = SAI_POLICER_ATTR_PIR;
+            meter_attr.value.u64 = p4_acl_meter.pir;
+            meter_attrs.push_back(meter_attr);
 
-        meter_attr.id = SAI_POLICER_ATTR_PBS;
-        meter_attr.value.u64 = p4_acl_meter.pburst;
-        meter_attrs.push_back(meter_attr);
+            meter_attr.id = SAI_POLICER_ATTR_PBS;
+            meter_attr.value.u64 = p4_acl_meter.pburst;
+            meter_attrs.push_back(meter_attr);
+        }
     }
 
     for (const auto &packet_color_action : p4_acl_meter.packet_color_actions)
@@ -628,6 +634,10 @@ ReturnCodeOr<P4AclRuleAppDbEntry> AclRuleManager::deserializeAclRuleAppDbEntry(
         else if (prefix == kMeterPrefix)
         {
             const auto &meter_attr_name = tokenized_field[1];
+            if (meter_attr_name == kMeterMode) {
+                app_db_entry.meter.mode = value;
+                continue;
+            }
             try {
                 auto value_node = nlohmann::json::parse(value);
                 if (!value_node.is_number_unsigned()) {
@@ -668,6 +678,27 @@ ReturnCode AclRuleManager::validateAclRuleAppDbEntry(const P4AclRuleAppDbEntry &
     {
         return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
                << "ACL rule in table " << QuotedVar(app_db_entry.acl_table_name) << " is missing priority";
+    }
+    if (app_db_entry.meter.enabled && !app_db_entry.meter.mode.empty() &&
+        policerModeLookup.find(app_db_entry.meter.mode) ==
+            policerModeLookup.end()) {
+      return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
+             << "ACL rule " << QuotedVar(app_db_entry.db_key)
+             << " has invalid policer mode:"
+             << QuotedVar(app_db_entry.meter.mode);
+    }
+    // If meter/mode is empty, then OA will use storm mode by default.
+    // If meter/pir and meter/pburst present, they should be equal to meter/cir
+    // and meter/cburst.
+    if (app_db_entry.meter.enabled && app_db_entry.meter.mode.empty() &&
+        ((app_db_entry.meter.pir != 0 &&
+          app_db_entry.meter.cir != app_db_entry.meter.pir) ||
+         (app_db_entry.meter.pburst != 0 &&
+          app_db_entry.meter.cburst != app_db_entry.meter.pburst))) {
+      return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
+             << "ACL policer for " << QuotedVar(app_db_entry.db_key)
+             << " in default storm mode has invalid cir:pir/cburst:pburst pairs, "
+                "expected cir==pir, cburst==pburst.";
     }
     return ReturnCode();
 }
@@ -1485,11 +1516,18 @@ ReturnCode AclRuleManager::setMeterValue(const P4AclTableDefinition *acl_table, 
 {
     if (app_db_entry.meter.enabled)
     {
+        auto policer_mode_it = policerModeLookup.find(app_db_entry.meter.mode);
+        if (policer_mode_it != policerModeLookup.end()) {
+            acl_meter.mode = policer_mode_it->second;
+        }
         acl_meter.cir = app_db_entry.meter.cir;
         acl_meter.cburst = app_db_entry.meter.cburst;
-        acl_meter.pir = app_db_entry.meter.pir;
-        acl_meter.pburst = app_db_entry.meter.pburst;
-        acl_meter.mode = SAI_POLICER_MODE_TR_TCM;
+        if (acl_meter.mode == SAI_POLICER_MODE_SR_TCM) {
+            acl_meter.pburst = app_db_entry.meter.pburst;
+        } else if (acl_meter.mode == SAI_POLICER_MODE_TR_TCM) {
+            acl_meter.pir = app_db_entry.meter.pir;
+            acl_meter.pburst = app_db_entry.meter.pburst;
+        }
         if (acl_table->meter_unit == P4_METER_UNIT_PACKETS)
         {
             acl_meter.type = SAI_METER_TYPE_PACKETS;
@@ -1512,17 +1550,22 @@ ReturnCode AclRuleManager::setMeterValue(const P4AclTableDefinition *acl_table, 
         acl_meter.packet_color_actions = action_color_it->second;
     }
 
-    // SAI_POLICER_MODE_TR_TCM mode is used by default.
+    if (acl_meter.mode == SAI_POLICER_MODE_STORM_CONTROL &&
+        acl_meter.packet_color_actions.find(
+            SAI_POLICER_ATTR_YELLOW_PACKET_ACTION) !=
+            acl_meter.packet_color_actions.end()) {
+    acl_meter.packet_color_actions.erase(SAI_POLICER_ATTR_YELLOW_PACKET_ACTION);
+    }
+
+    // SAI_POLICER_MODE_STORM_CONTROL mode is used by default.
     // Meter rate limit config is not present for the ACL rule
     // Mark the packet as GREEN by setting rate limit to max.
     if (!acl_meter.packet_color_actions.empty() && !acl_meter.enabled)
     {
         acl_meter.enabled = true;
-        acl_meter.type = SAI_METER_TYPE_PACKETS;
-        acl_meter.cburst = 0x7fffffff;
+        acl_meter.type = SAI_METER_TYPE_BYTES;
+        acl_meter.cburst = 0x1000021;
         acl_meter.cir = 0x7fffffff;
-        acl_meter.pir = 0x7fffffff;
-        acl_meter.pburst = 0x7fffffff;
     }
 
     return ReturnCode();
@@ -2026,6 +2069,14 @@ ReturnCode AclRuleManager::processUpdateRuleRequest(const P4AclRuleAppDbEntry &a
     else if (old_acl_rule.meter.meter_oid != SAI_NULL_OBJECT_ID)
     {
         // Update meter attributes
+        if (acl_rule.meter.mode != old_acl_rule.meter.mode) {
+        // TODO: SAI_POLICER_ATTR_MODE is CREATE_ONLY
+        LOG_ERROR_AND_RETURN(
+            ReturnCode(StatusCode::SWSS_RC_UNIMPLEMENTED)
+            << "Updating ACL rule meter mode is not supported for ACL entry: "
+            << QuotedVar(acl_rule.acl_rule_key) << " in table "
+            << QuotedVar(acl_rule.acl_table_name));
+        }
         auto status = updateAclMeter(acl_rule.meter, old_acl_rule.meter);
         if (!status.ok())
         {

--- a/orchagent/p4orch/acl_rule_manager.cpp
+++ b/orchagent/p4orch/acl_rule_manager.cpp
@@ -1091,7 +1091,7 @@ ReturnCode AclRuleManager::setMatchValue(const sai_acl_entry_attr_t attr_name,
   return ReturnCode();
 }
 
-ReturnCode AclRuleManager::getRedirectActionPortOid(const std::string &target, sai_object_id_t *rediect_oid)
+ReturnCode AclRuleManager::getRedirectActionPortOid(const std::string& target, sai_object_id_t* redirect_oid)
 {
     // Try to parse physical port and LAG first
     Port port;
@@ -1099,12 +1099,12 @@ ReturnCode AclRuleManager::getRedirectActionPortOid(const std::string &target, s
     {
         if (port.m_type == Port::PHY)
         {
-            *rediect_oid = port.m_port_id;
+            *redirect_oid = port.m_port_id;
             return ReturnCode();
         }
         else if (port.m_type == Port::LAG)
         {
-            *rediect_oid = port.m_lag_id;
+            *redirect_oid = port.m_lag_id;
             return ReturnCode();
         }
         else
@@ -1117,14 +1117,28 @@ ReturnCode AclRuleManager::getRedirectActionPortOid(const std::string &target, s
     return ReturnCode(StatusCode::SWSS_RC_NOT_FOUND) << "Port " << QuotedVar(target) << " not found.";
 }
 
-ReturnCode AclRuleManager::getRedirectActionNextHopOid(const std::string &target, sai_object_id_t *rediect_oid)
+ReturnCode AclRuleManager::getRedirectActionNextHopOid(const std::string& target, sai_object_id_t* redirect_oid)
 {
     // Try to get nexthop object id
     const auto &next_hop_key = KeyGenerator::generateNextHopKey(target);
-    if (!m_p4OidMapper->getOID(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_key, rediect_oid))
+    if (!m_p4OidMapper->getOID(SAI_OBJECT_TYPE_NEXT_HOP, next_hop_key, redirect_oid))
     {
         LOG_ERROR_AND_RETURN(ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
                              << "ACL Redirect action target next hop ip: " << QuotedVar(target)
+                             << " doesn't exist on the switch");
+    }
+    return ReturnCode();
+}
+
+ReturnCode AclRuleManager::getRedirectActionL3MulticastGroupOid(
+    const std::string& target, sai_object_id_t* redirect_oid) {
+    const auto& multicast_group_key =
+        KeyGenerator::generateL3MulticastGroupKey(target);
+    if (!m_p4OidMapper->getOID(SAI_OBJECT_TYPE_IPMC_GROUP, multicast_group_key,
+                               redirect_oid)) {
+        LOG_ERROR_AND_RETURN(ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
+                             << "ACL Redirect action target multicast group ID: "
+                             << QuotedVar(target)
                              << " doesn't exist on the switch");
     }
     return ReturnCode();
@@ -1246,6 +1260,7 @@ ReturnCode AclRuleManager::setAllActionFieldValues(const P4AclRuleAppDbEntry &ap
         sai_action_param.action = action_param.action;
         sai_action_param.param_name = action_param.param_name;
         sai_action_param.param_value = action_param.param_value;
+        sai_action_param.object_type = action_param.object_type;
         if (!action_param.param_name.empty())
         {
             const auto &param_value_it = app_db_entry.action_param_fvs.find(action_param.param_name);
@@ -1261,6 +1276,7 @@ ReturnCode AclRuleManager::setAllActionFieldValues(const P4AclRuleAppDbEntry &ap
             }
         }
         auto set_action_rc = setActionValue(sai_action_param.action, sai_action_param.param_value,
+                                            sai_action_param.object_type,
                                             &acl_rule.action_fvs[sai_action_param.action], &acl_rule);
         if (!set_action_rc.ok())
         {
@@ -1272,6 +1288,7 @@ ReturnCode AclRuleManager::setAllActionFieldValues(const P4AclRuleAppDbEntry &ap
 
 ReturnCode AclRuleManager::setActionValue(const sai_acl_entry_attr_t attr_name,
                                           const std::string& attr_value,
+                                          const sai_object_id_t attr_type,
                                           sai_attribute_value_t* value,
                                           P4AclRule* acl_rule) {
   switch (attr_name) {
@@ -1291,6 +1308,36 @@ ReturnCode AclRuleManager::setActionValue(const sai_acl_entry_attr_t attr_name,
     }
     case SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT: {
         sai_object_id_t redirect_oid;
+
+        // Use the attr_type to disambiguate what we are redirecting to.
+        if (attr_type == SAI_OBJECT_TYPE_IPMC_GROUP) {
+          RETURN_IF_ERROR(
+              getRedirectActionL3MulticastGroupOid(attr_value, &redirect_oid));
+          value->aclaction.parameter.oid = redirect_oid;
+          acl_rule->action_redirect_l3_multicast_group_key =
+              KeyGenerator::generateL3MulticastGroupKey(attr_value);
+          break;
+        } else if (attr_type == SAI_OBJECT_TYPE_PORT) {
+          auto port_status = getRedirectActionPortOid(attr_value, &redirect_oid);
+          if (port_status.ok()) {
+            value->aclaction.parameter.oid = redirect_oid;
+            break;
+          } else if (port_status.code() == StatusCode::SWSS_RC_IN_USE) {
+            return ReturnCode(StatusCode::SWSS_RC_NOT_FOUND)
+                   << port_status.message();
+          } else {
+            return port_status;
+          }
+          break;
+        } else if (attr_type == SAI_OBJECT_TYPE_NEXT_HOP) {
+          RETURN_IF_ERROR(getRedirectActionNextHopOid(attr_value, &redirect_oid));
+          value->aclaction.parameter.oid = redirect_oid;
+          acl_rule->action_redirect_nexthop_key =
+              KeyGenerator::generateNextHopKey(attr_value);
+          break;
+        }
+
+        // If object type was not set, use original fall-through chain for now.
         if (getRedirectActionPortOid(attr_value, &redirect_oid).ok())
         {
             value->aclaction.parameter.oid = redirect_oid;
@@ -1734,6 +1781,16 @@ ReturnCode AclRuleManager::updateAclRule(const P4AclRule &acl_rule, const P4AclR
     {
         m_p4OidMapper->increaseRefCount(SAI_OBJECT_TYPE_NEXT_HOP, acl_rule.action_redirect_nexthop_key);
     }
+    if (!old_acl_rule.action_redirect_l3_multicast_group_key.empty()) {
+        m_p4OidMapper->decreaseRefCount(
+          SAI_OBJECT_TYPE_IPMC_GROUP,
+          old_acl_rule.action_redirect_l3_multicast_group_key);
+    }
+    if (!acl_rule.action_redirect_l3_multicast_group_key.empty()) {
+        m_p4OidMapper->increaseRefCount(
+          SAI_OBJECT_TYPE_IPMC_GROUP,
+          acl_rule.action_redirect_l3_multicast_group_key);
+    }
     for (const auto &mirror_session : old_acl_rule.action_mirror_sessions)
     {
         m_p4OidMapper->decreaseRefCount(SAI_OBJECT_TYPE_MIRROR_SESSION, fvValue(mirror_session).key);
@@ -1849,6 +1906,11 @@ ReturnCode AclRuleManager::removeAclRule(const std::string &acl_table_name, cons
     {
         m_p4OidMapper->decreaseRefCount(SAI_OBJECT_TYPE_NEXT_HOP, acl_rule->action_redirect_nexthop_key);
     }
+    if (!acl_rule->action_redirect_l3_multicast_group_key.empty()) {
+        m_p4OidMapper->decreaseRefCount(
+          SAI_OBJECT_TYPE_IPMC_GROUP,
+          acl_rule->action_redirect_l3_multicast_group_key);
+    }
     for (const auto &mirror_session : acl_rule->action_mirror_sessions)
     {
         m_p4OidMapper->decreaseRefCount(SAI_OBJECT_TYPE_MIRROR_SESSION, fvValue(mirror_session).key);
@@ -1938,6 +2000,11 @@ ReturnCode AclRuleManager::processAddRuleRequest(const std::string &acl_rule_key
     if (!acl_rule.action_redirect_nexthop_key.empty())
     {
         m_p4OidMapper->increaseRefCount(SAI_OBJECT_TYPE_NEXT_HOP, acl_rule.action_redirect_nexthop_key);
+    }
+    if (!acl_rule.action_redirect_l3_multicast_group_key.empty()) {
+        m_p4OidMapper->increaseRefCount(
+          SAI_OBJECT_TYPE_IPMC_GROUP,
+          acl_rule.action_redirect_l3_multicast_group_key);
     }
     for (const auto &mirror_session : acl_rule.action_mirror_sessions)
     {
@@ -2395,6 +2462,17 @@ std::string AclRuleManager::verifyStateCache(const P4AclRuleAppDbEntry &app_db_e
             << QuotedVar(acl_rule_entry.action_redirect_nexthop_key) << " mismatch with internal cache "
             << QuotedVar(acl_rule->action_redirect_nexthop_key) << " in ACl rule manager.";
         return msg.str();
+    }
+    if (acl_rule->action_redirect_l3_multicast_group_key !=
+        acl_rule_entry.action_redirect_l3_multicast_group_key) {
+      std::stringstream msg;
+      msg << "ACL rule " << QuotedVar(acl_rule_key)
+          << " with redirect L3 multicast group key "
+          << QuotedVar(acl_rule_entry.action_redirect_l3_multicast_group_key)
+          << " mismatch with internal cache "
+          << QuotedVar(acl_rule->action_redirect_l3_multicast_group_key)
+          << " in ACl rule manager.";
+      return msg.str();
     }
     if (acl_rule->action_mirror_sessions != acl_rule_entry.action_mirror_sessions)
     {

--- a/orchagent/p4orch/acl_rule_manager.h
+++ b/orchagent/p4orch/acl_rule_manager.h
@@ -124,14 +124,19 @@ class AclRuleManager : public ObjectManagerInterface
     // Validate and set an action attribute in an ACL rule.
     ReturnCode setActionValue(const sai_acl_entry_attr_t attr_name,
                               const std::string& attr_value,
+                              const sai_object_id_t attr_type,
                               sai_attribute_value_t* value,
                               P4AclRule* acl_rule);
 
     // Get port object id by name for redirect action.
-    ReturnCode getRedirectActionPortOid(const std::string &target, sai_object_id_t *rediect_oid);
+    ReturnCode getRedirectActionPortOid(const std::string &target, sai_object_id_t* redirect_oid);
 
     // Get next hop object id by name for redirect action.
-    ReturnCode getRedirectActionNextHopOid(const std::string &target, sai_object_id_t *rediect_oid);
+    ReturnCode getRedirectActionNextHopOid(const std::string &target, sai_object_id_t* redirect_oid);
+
+    // Get multicast group oid by name for redirection action.
+    ReturnCode getRedirectActionL3MulticastGroupOid(
+        const std::string& target, sai_object_id_t* redirect_oid);
 
     // Create user defined trap for each cpu queue/trap group and program user
     // defined traps in hostif. Save the user defined trap oids in m_p4OidMapper

--- a/orchagent/p4orch/acl_rule_manager.h
+++ b/orchagent/p4orch/acl_rule_manager.h
@@ -134,6 +134,10 @@ class AclRuleManager : public ObjectManagerInterface
     // Get next hop object id by name for redirect action.
     ReturnCode getRedirectActionNextHopOid(const std::string &target, sai_object_id_t* redirect_oid);
 
+    // Get L2 multicast group oid by name for redirection action.
+    ReturnCode getRedirectActionL2MulticastGroupOid(
+        const std::string& target, sai_object_id_t* redirect_oid);
+
     // Get multicast group oid by name for redirection action.
     ReturnCode getRedirectActionL3MulticastGroupOid(
         const std::string& target, sai_object_id_t* redirect_oid);

--- a/orchagent/p4orch/acl_rule_manager.h
+++ b/orchagent/p4orch/acl_rule_manager.h
@@ -71,7 +71,7 @@ class AclRuleManager : public ObjectManagerInterface
     ReturnCode processDeleteRuleRequest(const std::string &acl_table_name, const std::string &acl_rule_key);
 
     // Processes update operation for an ACL rule.
-    ReturnCode processUpdateRuleRequest(const P4AclRuleAppDbEntry &app_db_entry, const P4AclRule &old_acl_rule);
+    ReturnCode processUpdateRuleRequest(const P4AclRuleAppDbEntry &app_db_entry, P4AclRule &old_acl_rule);
 
     // Set counters stats for an ACL rule in COUNTERS_DB.
     ReturnCode setAclRuleCounterStats(const P4AclRule &acl_rule);

--- a/orchagent/p4orch/acl_util.cpp
+++ b/orchagent/p4orch/acl_util.cpp
@@ -52,6 +52,21 @@ bool parseAclTableAppDbActionField(const std::string &aggr_actions_str, std::vec
                 {
                     action_with_param.p4_param_name = action_param_it.value();
                 }
+                auto object_type_it = action_item.find(kObjectType);
+                if (object_type_it != action_item.end() &&
+                    !object_type_it.value().is_null()) {
+                if (aclObjectTypeLookup.find(object_type_it.value()) ==
+                    aclObjectTypeLookup.end()) {
+                  std::string ot = object_type_it.value();
+                  SWSS_LOG_ERROR(
+                      "Invalid ACL table definition action %s, unknown object type "
+                      "'%s'\n",
+                      aggr_actions_str.c_str(), ot.c_str());
+                  return false;
+                } else {
+                  action_with_param.sai_object_type = object_type_it.value();
+                }
+            }
                 action_list->push_back(action_with_param);
             }
             else
@@ -552,6 +567,17 @@ ReturnCode buildAclTableDefinitionActionFieldValues(
       }
       action_with_param.action = rule_action_it->second;
       action_with_param.param_name = single_action.p4_param_name;
+      if (!single_action.sai_object_type.empty()) {
+        auto object_type_it =
+            aclObjectTypeLookup.find(single_action.sai_object_type);
+        if (object_type_it == aclObjectTypeLookup.end()) {
+          return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
+                 << "ACL table action " << single_action.sai_action
+                 << " specifies an unknown sai object type "
+                 << single_action.sai_object_type;
+        }
+        action_with_param.object_type = object_type_it->second;
+      }
       aggr_sai_actions.push_back(action_with_param);
       acl_action_type_set->insert(
           AclEntryActionToAclAction(rule_action_it->second));

--- a/orchagent/p4orch/acl_util.cpp
+++ b/orchagent/p4orch/acl_util.cpp
@@ -871,6 +871,9 @@ bool isDiffActionFieldValue(const sai_acl_entry_attr_t attr_name,
     case SAI_ACL_ENTRY_ATTR_ACTION_SET_USER_TRAP_ID: {
         return value.aclaction.parameter.oid != old_value.aclaction.parameter.oid;
     }
+    case SAI_ACL_ENTRY_ATTR_ACTION_SET_ACL_META_DATA: {
+        return value.aclaction.parameter.u8 != old_value.aclaction.parameter.u8;
+    }
     case SAI_ACL_ENTRY_ATTR_ACTION_FLOOD:
     case SAI_ACL_ENTRY_ATTR_ACTION_DECREMENT_TTL:
     case SAI_ACL_ENTRY_ATTR_ACTION_SET_DO_NOT_LEARN: {

--- a/orchagent/p4orch/acl_util.h
+++ b/orchagent/p4orch/acl_util.h
@@ -142,6 +142,7 @@ struct P4AclRule
 
     sai_uint32_t action_qos_queue_num;
     std::string action_redirect_nexthop_key;
+    std::string action_redirect_l3_multicast_group_key;
     // SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_INGRESS and
     // SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_EGRESS are allowed as key
     std::map<sai_acl_entry_attr_t, P4AclMirrorSession> action_mirror_sessions;
@@ -159,10 +160,11 @@ struct SaiActionWithParam
   sai_acl_entry_attr_t action;
   std::string param_name;
   std::string param_value;
+  sai_object_id_t object_type = SAI_NULL_OBJECT_ID;
 
   bool operator==(const SaiActionWithParam& entry) const {
     return action == entry.action && param_name == entry.param_name &&
-           param_value == entry.param_value;
+           param_value == entry.param_value && object_type == entry.object_type;
   }
 
     bool operator!=(const SaiActionWithParam &entry) const
@@ -255,6 +257,7 @@ using acl_rule_attr_lookup_t = std::map<std::string, sai_acl_entry_attr_t>;
 using acl_table_attr_lookup_t = std::map<std::string, sai_acl_table_attr_t>;
 using acl_table_attr_format_lookup_t = std::map<sai_acl_table_attr_t, Format>;
 using acl_packet_action_lookup_t = std::map<std::string, sai_packet_action_t>;
+using acl_object_type_lookup_t = std::map<std::string, sai_object_id_t>;
 using acl_packet_color_lookup_t = std::map<std::string, sai_packet_color_t>;
 using acl_packet_color_policer_attr_lookup_t = std::map<std::string, sai_policer_attr_t>;
 using acl_ip_type_lookup_t = std::map<std::string, sai_acl_ip_type_t>;
@@ -386,6 +389,16 @@ using P4AclRuleTables = std::map<std::string, std::map<std::string, P4AclRule>>;
 #define P4_COUNTER_UNIT_PACKETS "PACKETS"
 #define P4_COUNTER_UNIT_BYTES "BYTES"
 #define P4_COUNTER_UNIT_BOTH "BOTH"
+
+// SAI_OBJECT_TYPES supported by SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT
+#define P4_OBJECT_TYPE_PORT "SAI_OBJECT_TYPE_PORT"
+#define P4_OBJECT_TYPE_SYSTEM_PORT "SAI_OBJECT_TYPE_SYSTEM_PORT"
+#define P4_OBJECT_TYPE_LAG "SAI_OBJECT_TYPE_LAG"
+#define P4_OBJECT_TYPE_NEXT_HOP "SAI_OBJECT_TYPE_NEXT_HOP"
+#define P4_OBJECT_TYPE_NEXT_HOP_GROUP "SAI_OBJECT_TYPE_NEXT_HOP_GROUP"
+#define P4_OBJECT_TYPE_BRIDGE_PORT "SAI_OBJECT_TYPE_BRIDGE_PORT"
+#define P4_OBJECT_TYPE_L2MC_GROUP "SAI_OBJECT_TYPE_L2MC_GROUP"
+#define P4_OBJECT_TYPE_IPMC_GROUP "SAI_OBJECT_TYPE_IPMC_GROUP"
 
 // IP_TYPE encode in p4. go/p4-ip-type
 #define P4_IP_TYPE_BIT_IP "IP"
@@ -646,6 +659,17 @@ static const acl_packet_action_lookup_t aclPacketActionLookup = {
     {P4_PACKET_ACTION_LOG, SAI_PACKET_ACTION_LOG},
     {P4_PACKET_ACTION_COPY_CANCEL, SAI_PACKET_ACTION_COPY_CANCEL},
     {P4_PACKET_ACTION_DENY, SAI_PACKET_ACTION_DENY},
+};
+
+static const acl_object_type_lookup_t aclObjectTypeLookup = {
+    {P4_OBJECT_TYPE_PORT, SAI_OBJECT_TYPE_PORT},
+    {P4_OBJECT_TYPE_SYSTEM_PORT, SAI_OBJECT_TYPE_SYSTEM_PORT},
+    {P4_OBJECT_TYPE_LAG, SAI_OBJECT_TYPE_LAG},
+    {P4_OBJECT_TYPE_NEXT_HOP, SAI_OBJECT_TYPE_NEXT_HOP},
+    {P4_OBJECT_TYPE_NEXT_HOP_GROUP, SAI_OBJECT_TYPE_NEXT_HOP_GROUP},
+    {P4_OBJECT_TYPE_BRIDGE_PORT, SAI_OBJECT_TYPE_BRIDGE_PORT},
+    {P4_OBJECT_TYPE_L2MC_GROUP, SAI_OBJECT_TYPE_L2MC_GROUP},
+    {P4_OBJECT_TYPE_IPMC_GROUP, SAI_OBJECT_TYPE_IPMC_GROUP},
 };
 
 static const acl_rule_attr_lookup_t aclActionLookup = {

--- a/orchagent/p4orch/acl_util.h
+++ b/orchagent/p4orch/acl_util.h
@@ -142,6 +142,7 @@ struct P4AclRule
 
     sai_uint32_t action_qos_queue_num;
     std::string action_redirect_nexthop_key;
+    std::string action_redirect_l2_multicast_group_key;
     std::string action_redirect_l3_multicast_group_key;
     // SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_INGRESS and
     // SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_EGRESS are allowed as key

--- a/orchagent/p4orch/acl_util.h
+++ b/orchagent/p4orch/acl_util.h
@@ -75,7 +75,7 @@ struct P4AclMeter
 
     P4AclMeter()
         : enabled(false), meter_oid(SAI_NULL_OBJECT_ID), cir(0), cburst(0), pir(0), pburst(0),
-          type(SAI_METER_TYPE_PACKETS), mode(SAI_POLICER_MODE_TR_TCM)
+          type(SAI_METER_TYPE_PACKETS), mode(SAI_POLICER_MODE_STORM_CONTROL)
     {
     }
 
@@ -432,6 +432,10 @@ using P4AclRuleTables = std::map<std::string, std::map<std::string, P4AclRule>>;
 #define P4_COUNTER_STATS_RED_PACKETS "red_packets"
 #define P4_COUNTER_STATS_RED_BYTES "red_bytes"
 
+#define P4_POLICER_MODE_SR_TCM "sr_tcm"
+#define P4_POLICER_MODE_TR_TCM "tr_tcm"
+#define P4_POLICER_MODE_STORM "storm"
+
 #define P4_UDF_BASE_L2 "SAI_UDF_BASE_L2"
 #define P4_UDF_BASE_L3 "SAI_UDF_BASE_L3"
 #define P4_UDF_BASE_L4 "SAI_UDF_BASE_L4"
@@ -750,6 +754,12 @@ static const std::map<sai_acl_stage_t, acl_stage_type_t>
         {SAI_ACL_STAGE_INGRESS, ACL_STAGE_INGRESS},
         {SAI_ACL_STAGE_EGRESS, ACL_STAGE_EGRESS},
         {SAI_ACL_STAGE_PRE_INGRESS, ACL_STAGE_PRE_INGRESS},
+};
+
+static std::map<std::string, sai_policer_mode_t> policerModeLookup = {
+    {P4_POLICER_MODE_SR_TCM, SAI_POLICER_MODE_SR_TCM},
+    {P4_POLICER_MODE_TR_TCM, SAI_POLICER_MODE_TR_TCM},
+    {P4_POLICER_MODE_STORM, SAI_POLICER_MODE_STORM_CONTROL}
 };
 
 // Parse ACL table definition APP DB entry action field to P4ActionParamName

--- a/orchagent/p4orch/acl_util.h
+++ b/orchagent/p4orch/acl_util.h
@@ -70,7 +70,6 @@ struct P4AclMeter
     sai_uint64_t pir;
     sai_uint64_t pburst;
     std::string policer_label;
-
     std::map<sai_policer_attr_t, sai_packet_action_t> packet_color_actions;
 
     P4AclMeter()
@@ -446,9 +445,9 @@ using P4AclRuleTables = std::map<std::string, std::map<std::string, P4AclRule>>;
 #define P4_COUNTER_STATS_RED_PACKETS "red_packets"
 #define P4_COUNTER_STATS_RED_BYTES "red_bytes"
 
-#define P4_POLICER_MODE_SR_TCM "sr_tcm"
-#define P4_POLICER_MODE_TR_TCM "tr_tcm"
-#define P4_POLICER_MODE_STORM "storm"
+#define P4_POLICER_MODE_SINGLE_RATE_THREE_COLOR "single_rate_three_color"
+#define P4_POLICER_MODE_TWO_RATE_THREE_COLOR "two_rate_three_color"
+#define P4_POLICER_MODE_SINGLE_RATE_TWO_COLOR "single_rate_two_color"
 
 #define P4_UDF_BASE_L2 "SAI_UDF_BASE_L2"
 #define P4_UDF_BASE_L3 "SAI_UDF_BASE_L3"
@@ -782,9 +781,9 @@ static const std::map<sai_acl_stage_t, acl_stage_type_t>
 };
 
 static std::map<std::string, sai_policer_mode_t> policerModeLookup = {
-    {P4_POLICER_MODE_SR_TCM, SAI_POLICER_MODE_SR_TCM},
-    {P4_POLICER_MODE_TR_TCM, SAI_POLICER_MODE_TR_TCM},
-    {P4_POLICER_MODE_STORM, SAI_POLICER_MODE_STORM_CONTROL}
+    {P4_POLICER_MODE_SINGLE_RATE_THREE_COLOR, SAI_POLICER_MODE_SR_TCM},
+    {P4_POLICER_MODE_TWO_RATE_THREE_COLOR, SAI_POLICER_MODE_TR_TCM},
+    {P4_POLICER_MODE_SINGLE_RATE_TWO_COLOR, SAI_POLICER_MODE_STORM_CONTROL}
 };
 
 // Parse ACL table definition APP DB entry action field to P4ActionParamName

--- a/orchagent/p4orch/p4orch_util.cpp
+++ b/orchagent/p4orch/p4orch_util.cpp
@@ -256,6 +256,12 @@ std::string KeyGenerator::generateL3MulticastGroupKey(
     return ss.str();
 }
 
+std::string KeyGenerator::generateL2MulticastGroupKey(
+    const std::string& l2_multicast_group_id) {
+    // L2 multicast group IDs are formatted just like L3 multicast group IDs.
+    return generateL3MulticastGroupKey(l2_multicast_group_id);
+}
+
 std::string KeyGenerator::generateIpMulticastKey(
     const std::string& vrf_id, const swss::IpAddress& ip_dst) {
   std::map<std::string, std::string> fv_map = {

--- a/orchagent/p4orch/p4orch_util.cpp
+++ b/orchagent/p4orch/p4orch_util.cpp
@@ -1,5 +1,9 @@
 #include "p4orch/p4orch_util.h"
 
+#include <iomanip>
+#include <sstream>
+#include <string>
+
 #include "p4orch/p4orch.h"
 #include "schema.h"
 
@@ -229,6 +233,27 @@ std::string KeyGenerator::generateMulticastRouterInterfaceRifKey(
                      p4orch::kFieldDelimiter + p4orch::kSrcMac,
                  src_mac.to_string());
   return generateKey(fv_map);
+}
+
+std::string KeyGenerator::generateL3MulticastGroupKey(
+    const std::string& multicast_group_id) {
+    // L3 multicast groups use the group ID directly as the key.  However,
+    // this is expected to be formatted as a 16-bit hex string, e.g. 0x0001.
+    int group_id = 0;
+    try {
+      if (multicast_group_id.rfind("0x") == 0 ||
+          multicast_group_id.rfind("0X") == 0) {
+        size_t processed = 0;
+        group_id = std::stoi(multicast_group_id, &processed, 16);
+      } else {
+        group_id = std::stoi(multicast_group_id);
+      }
+    } catch (std::exception& e) {
+      group_id = 0;  // invalid group ID
+    }
+    std::stringstream ss;
+    ss << "0x" << std::setfill('0') << std::setw(4) << std::hex << group_id;
+    return ss.str();
 }
 
 std::string KeyGenerator::generateIpMulticastKey(

--- a/orchagent/p4orch/p4orch_util.h
+++ b/orchagent/p4orch/p4orch_util.h
@@ -74,6 +74,7 @@ constexpr char *kStage = "stage";
 constexpr char *kSize = "size";
 constexpr char *kPriority = "priority";
 constexpr char *kPacketColor = "packet_color";
+constexpr char *kObjectType = "object_type";
 constexpr char *kMeterUnit = "meter/unit";
 constexpr char *kCounterUnit = "counter/unit";
 constexpr char kFieldDelimiter = '/';
@@ -281,6 +282,7 @@ struct P4ActionParamName
 {
     std::string sai_action;
     std::string p4_param_name;
+    std::string sai_object_type;  // optionally included for some sai_actions.
 };
 
 struct P4PacketActionWithColor
@@ -419,6 +421,9 @@ class KeyGenerator
     static std::string generateMulticastRouterInterfaceRifKey(
         const std::string& multicast_replica_port,
         const swss::MacAddress& src_mac);
+
+    static std::string generateL3MulticastGroupKey(
+        const std::string& multicast_group_id);
 
     static std::string generateIpMulticastKey(const std::string& vrf_id,
                                               const swss::IpAddress& ip_dst);

--- a/orchagent/p4orch/p4orch_util.h
+++ b/orchagent/p4orch/p4orch_util.h
@@ -83,6 +83,7 @@ constexpr char kPortsDelimiter = ',';
 constexpr char *kMatchPrefix = "match";
 constexpr char *kActionParamPrefix = "param";
 constexpr char *kMeterPrefix = "meter";
+constexpr char *kMeterMode = "mode";
 constexpr char *kMeterCir = "cir";
 constexpr char *kMeterCburst = "cburst";
 constexpr char *kMeterPir = "pir";
@@ -310,8 +311,10 @@ struct P4AclMeterAppDb
     uint64_t cburst;
     uint64_t pir;
     uint64_t pburst;
+    std::string mode;
 
-    P4AclMeterAppDb() : enabled(false)
+    //P4AclMeterAppDb() : enabled(false)
+    P4AclMeterAppDb() : enabled(false), cir(0), cburst(0), pir(0), pburst(0)
     {
     }
 };

--- a/orchagent/p4orch/p4orch_util.h
+++ b/orchagent/p4orch/p4orch_util.h
@@ -422,6 +422,8 @@ class KeyGenerator
         const std::string& multicast_replica_port,
         const swss::MacAddress& src_mac);
 
+    static std::string generateL2MulticastGroupKey(
+        const std::string& l2_multicast_group_id);
     static std::string generateL3MulticastGroupKey(
         const std::string& multicast_group_id);
 

--- a/orchagent/p4orch/tests/acl_manager_test.cpp
+++ b/orchagent/p4orch/tests/acl_manager_test.cpp
@@ -650,11 +650,14 @@ P4AclTableDefinitionAppDbEntry getDefaultAclTableDefAppDbEntry()
         BuildMatchFieldJsonStrKindSaiField(P4_MATCH_OUTER_TPID);
     // Action field mapping, from P4 action to SAI action
     app_db_entry.action_field_lookup["set_packet_action"].push_back(
-        {.sai_action = P4_ACTION_PACKET_ACTION, .p4_param_name = "packet_action"});
+        {.sai_action = P4_ACTION_PACKET_ACTION, .p4_param_name = "packet_action",
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["copy_and_set_tc"].push_back(
-        {.sai_action = P4_ACTION_SET_TRAFFIC_CLASS, .p4_param_name = "traffic_class"});
+        {.sai_action = P4_ACTION_SET_TRAFFIC_CLASS, .p4_param_name = "traffic_class",
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["punt_and_set_tc"].push_back(
-        {.sai_action = P4_ACTION_SET_TRAFFIC_CLASS, .p4_param_name = "traffic_class"});
+        {.sai_action = P4_ACTION_SET_TRAFFIC_CLASS, .p4_param_name = "traffic_class",
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.packet_action_color_lookup["copy_and_set_tc"].push_back(
         {.packet_action = P4_PACKET_ACTION_COPY, .packet_color = P4_PACKET_COLOR_GREEN});
     app_db_entry.packet_action_color_lookup["punt_and_set_tc"].push_back(
@@ -662,54 +665,111 @@ P4AclTableDefinitionAppDbEntry getDefaultAclTableDefAppDbEntry()
     app_db_entry.packet_action_color_lookup["punt_non_green_pk"].push_back(
         {.packet_action = P4_PACKET_ACTION_PUNT, .packet_color = P4_PACKET_COLOR_RED});
     app_db_entry.action_field_lookup["redirect"].push_back(
-        {.sai_action = P4_ACTION_REDIRECT, .p4_param_name = "target"});
+        {.sai_action = P4_ACTION_REDIRECT,
+         .p4_param_name = "target",
+         .sai_object_type = EMPTY_STRING});
+    app_db_entry.action_field_lookup["redirect_ipmc"].push_back(
+        {.sai_action = P4_ACTION_REDIRECT,
+         .p4_param_name = "target",
+         .sai_object_type = "SAI_OBJECT_TYPE_IPMC_GROUP"});
+    app_db_entry.action_field_lookup["redirect_port"].push_back(
+        {.sai_action = P4_ACTION_REDIRECT,
+         .p4_param_name = "target",
+         .sai_object_type = "SAI_OBJECT_TYPE_PORT"});
+    app_db_entry.action_field_lookup["redirect_next_hop"].push_back(
+        {.sai_action = P4_ACTION_REDIRECT,
+         .p4_param_name = "target",
+         .sai_object_type = "SAI_OBJECT_TYPE_NEXT_HOP"});
     app_db_entry.action_field_lookup["endpoint_ip"].push_back(
-        {.sai_action = P4_ACTION_ENDPOINT_IP, .p4_param_name = "ip_address"});
+        {.sai_action = P4_ACTION_ENDPOINT_IP,
+         .p4_param_name = "ip_address",
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["mirror_ingress"].push_back(
-        {.sai_action = P4_ACTION_MIRROR_INGRESS, .p4_param_name = "target"});
+        {.sai_action = P4_ACTION_MIRROR_INGRESS,
+         .p4_param_name = "target",
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["mirror_egress"].push_back(
-        {.sai_action = P4_ACTION_MIRROR_EGRESS, .p4_param_name = "target"});
+        {.sai_action = P4_ACTION_MIRROR_EGRESS,
+         .p4_param_name = "target",
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["set_packet_color"].push_back(
-        {.sai_action = P4_ACTION_SET_PACKET_COLOR, .p4_param_name = "packet_color"});
+        {.sai_action = P4_ACTION_SET_PACKET_COLOR, .p4_param_name = "packet_color",
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["set_src_mac"].push_back(
-        {.sai_action = P4_ACTION_SET_SRC_MAC, .p4_param_name = "mac_address"});
+        {.sai_action = P4_ACTION_SET_SRC_MAC,
+         .p4_param_name = "mac_address",
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["set_dst_mac"].push_back(
-        {.sai_action = P4_ACTION_SET_DST_MAC, .p4_param_name = "mac_address"});
+        {.sai_action = P4_ACTION_SET_DST_MAC,
+         .p4_param_name = "mac_address",
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["set_src_ip"].push_back(
-        {.sai_action = P4_ACTION_SET_SRC_IP, .p4_param_name = "ip_address"});
+        {.sai_action = P4_ACTION_SET_SRC_IP,
+         .p4_param_name = "ip_address",
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["set_dst_ip"].push_back(
-        {.sai_action = P4_ACTION_SET_DST_IP, .p4_param_name = "ip_address"});
+        {.sai_action = P4_ACTION_SET_DST_IP,
+         .p4_param_name = "ip_address",
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["set_src_ipv6"].push_back(
-        {.sai_action = P4_ACTION_SET_SRC_IPV6, .p4_param_name = "ip_address"});
+        {.sai_action = P4_ACTION_SET_SRC_IPV6,
+         .p4_param_name = "ip_address",
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["set_dst_ipv6"].push_back(
-        {.sai_action = P4_ACTION_SET_DST_IPV6, .p4_param_name = "ip_address"});
+        {.sai_action = P4_ACTION_SET_DST_IPV6,
+         .p4_param_name = "ip_address",
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["set_dscp_and_ecn"].push_back(
-        {.sai_action = P4_ACTION_SET_DSCP, .p4_param_name = "dscp"});
+        {.sai_action = P4_ACTION_SET_DSCP,
+         .p4_param_name = "dscp",
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["set_dscp_and_ecn"].push_back(
-        {.sai_action = P4_ACTION_SET_ECN, .p4_param_name = "ecn"});
+        {.sai_action = P4_ACTION_SET_ECN,
+         .p4_param_name = "ecn",
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["set_inner_vlan"].push_back(
-        {.sai_action = P4_ACTION_SET_INNER_VLAN_PRIORITY, .p4_param_name = "vlan_pri"});
+        {.sai_action = P4_ACTION_SET_INNER_VLAN_PRIORITY, .p4_param_name = "vlan_pri",
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["set_inner_vlan"].push_back(
-        {.sai_action = P4_ACTION_SET_INNER_VLAN_ID, .p4_param_name = "vlan_id"});
+        {.sai_action = P4_ACTION_SET_INNER_VLAN_ID,
+         .p4_param_name = "vlan_id",
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["set_outer_vlan"].push_back(
-        {.sai_action = P4_ACTION_SET_OUTER_VLAN_PRIORITY, .p4_param_name = "vlan_pri"});
+        {.sai_action = P4_ACTION_SET_OUTER_VLAN_PRIORITY, .p4_param_name = "vlan_pri",
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["set_outer_vlan"].push_back(
-        {.sai_action = P4_ACTION_SET_OUTER_VLAN_ID, .p4_param_name = "vlan_id"});
+        {.sai_action = P4_ACTION_SET_OUTER_VLAN_ID,
+         .p4_param_name = "vlan_id",
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["set_l4_src_port"].push_back(
-        {.sai_action = P4_ACTION_SET_L4_SRC_PORT, .p4_param_name = "port"});
+        {.sai_action = P4_ACTION_SET_L4_SRC_PORT,
+         .p4_param_name = "port",
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["set_l4_dst_port"].push_back(
-        {.sai_action = P4_ACTION_SET_L4_DST_PORT, .p4_param_name = "port"});
-    app_db_entry.action_field_lookup["flood"].push_back({.sai_action = P4_ACTION_FLOOD, .p4_param_name = EMPTY_STRING});
+        {.sai_action = P4_ACTION_SET_L4_DST_PORT,
+         .p4_param_name = "port",
+         .sai_object_type = EMPTY_STRING});
+    app_db_entry.action_field_lookup["flood"].push_back({.sai_action = P4_ACTION_FLOOD,
+         .p4_param_name = EMPTY_STRING,
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["decrement_ttl"].push_back(
-        {.sai_action = P4_ACTION_DECREMENT_TTL, .p4_param_name = EMPTY_STRING});
+        {.sai_action = P4_ACTION_DECREMENT_TTL,
+         .p4_param_name = EMPTY_STRING,
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["do_not_learn"].push_back(
-        {.sai_action = P4_ACTION_SET_DO_NOT_LEARN, .p4_param_name = EMPTY_STRING});
-    app_db_entry.action_field_lookup["set_vrf"].push_back({.sai_action = P4_ACTION_SET_VRF, .p4_param_name = "vrf"});
+        {.sai_action = P4_ACTION_SET_DO_NOT_LEARN, .p4_param_name = EMPTY_STRING,
+         .sai_object_type = EMPTY_STRING});
+    app_db_entry.action_field_lookup["set_vrf"].push_back({.sai_action = P4_ACTION_SET_VRF,
+         .p4_param_name = "vrf",
+         .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["set_metadata"].push_back(
       {.sai_action = P4_ACTION_SET_ACL_META_DATA,
-       .p4_param_name = "acl_metadata"});
+       .p4_param_name = "acl_metadata",
+       .sai_object_type = EMPTY_STRING});
     app_db_entry.action_field_lookup["qos_queue"].push_back(
-        {.sai_action = P4_ACTION_SET_QOS_QUEUE, .p4_param_name = "cpu_queue"});
+        {.sai_action = P4_ACTION_SET_QOS_QUEUE,
+         .p4_param_name = "cpu_queue",
+         .sai_object_type = EMPTY_STRING});
 
 
     // action/acl_rate_limit_copy = [
@@ -725,7 +785,9 @@ P4AclTableDefinitionAppDbEntry getDefaultAclTableDefAppDbEntry()
       {.packet_action = P4_PACKET_ACTION_COPY_CANCEL,
        .packet_color = P4_PACKET_COLOR_RED});
   app_db_entry.action_field_lookup["acl_rate_limit_copy"].push_back(
-      {.sai_action = P4_ACTION_SET_QOS_QUEUE, .p4_param_name = "qos_queue"});
+      {.sai_action = P4_ACTION_SET_QOS_QUEUE,
+       .p4_param_name = "qos_queue",
+       .sai_object_type = EMPTY_STRING});
 
 
     
@@ -737,8 +799,10 @@ P4AclTableDefinitionAppDbEntry getDefaultAclTableDefAppDbEntry()
     //     {"action": "QOS_QUEUE", "param": "queue"}
     //   ]
     app_db_entry.action_field_lookup["acl_trap"].push_back(
-        {.sai_action = P4_ACTION_SET_QOS_QUEUE, .p4_param_name = "queue"});
-    app_db_entry.packet_action_color_lookup["acl_trap"].push_back(
+        {.sai_action = P4_ACTION_SET_QOS_QUEUE,
+         .p4_param_name = "queue",
+         .sai_object_type = EMPTY_STRING});
+  app_db_entry.packet_action_color_lookup["acl_trap"].push_back(
         {.packet_action = P4_PACKET_ACTION_PUNT, .packet_color = P4_PACKET_COLOR_GREEN});
     app_db_entry.packet_action_color_lookup["acl_trap"].push_back(
         {.packet_action = P4_PACKET_ACTION_DROP, .packet_color = P4_PACKET_COLOR_RED});
@@ -1173,6 +1237,60 @@ TEST_F(AclManagerTest, UpdateAclRuleWithAclMetadataChange)
     app_db_entry.action_param_fvs["acl_metadata"] = "2";
 }
 
+TEST_F(AclManagerTest, UpdateAclRuleWithL3MulticastActionChange) {
+    ASSERT_NO_FATAL_FAILURE(AddDefaultIngressTable());
+    auto app_db_entry = getDefaultAclRuleAppDbEntryWithoutAction();
+    const auto& acl_rule_key =
+        KeyGenerator::generateAclRuleKey(app_db_entry.match_fvs, "100");
+    // Set up an L3 multicast group mapping
+    const std::string multicast_group_id = "0x1";
+    const auto& l3_multicast_group_key =
+        KeyGenerator::generateL3MulticastGroupKey(multicast_group_id);
+    p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_IPMC_GROUP, l3_multicast_group_key,
+                           /*ipmc_group_oid=*/7);
+    app_db_entry.action = "redirect_ipmc";
+    app_db_entry.action_param_fvs["target"] = multicast_group_id;
+
+    // Install rule
+    EXPECT_CALL(mock_sai_acl_, create_acl_entry(_, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<0>(kAclIngressRuleOid1),
+                        Return(SAI_STATUS_SUCCESS)));
+    EXPECT_CALL(mock_sai_acl_, create_acl_counter(_, _, _, _))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_policer_, create_policer(_, _, _, _))
+        .WillOnce(
+            DoAll(SetArgPointee<0>(kAclMeterOid1), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
+              ProcessAddRuleRequest(acl_rule_key, app_db_entry));
+    auto* acl_rule = GetAclRule(kAclIngressTableName, acl_rule_key);
+    ASSERT_NE(nullptr, acl_rule);
+    // Check action field value
+    EXPECT_EQ(/*ipmc_group_oid=*/7,
+              acl_rule->action_fvs[SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT]
+                  .aclaction.parameter.oid);
+
+    // Update rule
+    const std::string multicast_group_id2 = "0x2";
+    const auto& l3_multicast_group_key2 =
+        KeyGenerator::generateL3MulticastGroupKey(multicast_group_id2);
+    p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_IPMC_GROUP, l3_multicast_group_key2,
+                           /*ipmc_group_oid=*/8);
+    app_db_entry.action_param_fvs["target"] = multicast_group_id2;
+
+    EXPECT_CALL(mock_sai_acl_,
+                set_acl_entry_attribute(Eq(kAclIngressRuleOid1), _))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
+              ProcessUpdateRuleRequest(app_db_entry, *acl_rule));
+    acl_rule = GetAclRule(kAclIngressTableName, acl_rule_key);
+    ASSERT_NE(nullptr, acl_rule);
+    // Check action field value
+    EXPECT_EQ(1, acl_rule->action_fvs.size());
+    EXPECT_EQ(/*ipmc_group_oid=*/8,
+              acl_rule->action_fvs[SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT]
+                  .aclaction.parameter.oid);
+}
+
 TEST_F(AclManagerTest, DrainTableTuplesToProcessUpdateRequestExpectFails)
 {
     const auto &p4rtAclTableName =
@@ -1416,6 +1534,16 @@ TEST_F(AclManagerTest, CreateIngressPuntTableFailsWhenCapabilityExceeds)
     EXPECT_CALL(mock_sai_udf_, remove_udf_group(Eq(kUdfGroupOid1))).Times(3).WillRepeatedly(Return(SAI_STATUS_SUCCESS));
     EXPECT_CALL(mock_sai_udf_, remove_udf(_)).Times(3).WillRepeatedly(Return(SAI_STATUS_SUCCESS));
     EXPECT_EQ(StatusCode::SWSS_RC_FULL, ProcessAddTableRequest(app_db_entry));
+}
+
+TEST_F(AclManagerTest, CreateIngressTableFailsWhenRedirectObjectTypeUnknown) {
+    auto app_db_entry = getDefaultAclTableDefAppDbEntry();
+    app_db_entry.action_field_lookup["redirect_ipmc_error"].push_back(
+        {.sai_action = P4_ACTION_REDIRECT,
+         .p4_param_name = "target",
+         .sai_object_type = "SAI_OBJECT_TYPE_UNKNOWN"});
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+              ProcessAddTableRequest(app_db_entry));
 }
 
 TEST_F(AclManagerTest, CreateIngressPuntTableFailsWhenFailedToCreateTableGroupMember)
@@ -1888,7 +2016,9 @@ TEST_F(AclManagerTest, CreatePuntTableWithInvalidActionFieldFails)
 
     // Invalid action field
     app_db_entry.action_field_lookup["random_action"].push_back(
-        {.sai_action = "RANDOM_ACTION", .p4_param_name = "DUMMY"});
+        {.sai_action = "RANDOM_ACTION",
+         .p4_param_name = "DUMMY",
+         .sai_object_type = EMPTY_STRING});
 
     EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ProcessAddTableRequest(app_db_entry));
     EXPECT_EQ(nullptr, GetAclTable(app_db_entry.acl_table_name));
@@ -1930,8 +2060,14 @@ TEST_F(AclManagerTest, CreateAclGroupMemberFailsWhenAclGroupWasNotFound)
 
 TEST_F(AclManagerTest, DeserializeValidAclTableDefAppDbSucceeds)
 {
+    auto attrs = getDefaultTableDefFieldValueTuples();
+    attrs.push_back(swss::FieldValueTuple{
+        "action/redirect_to_ipmc",
+        "[{\"action\":\"SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT\","
+        "\"param\":\"multicast_group_id\",\"object_type\":"
+        "\"SAI_OBJECT_TYPE_IPMC_GROUP\"}]"});
     auto app_db_entry_or =
-        DeserializeAclTableDefinitionAppDbEntry(kAclIngressTableName, getDefaultTableDefFieldValueTuples());
+        DeserializeAclTableDefinitionAppDbEntry(kAclIngressTableName, attrs);
     EXPECT_TRUE(app_db_entry_or.ok());
     auto &app_db_entry = *app_db_entry_or;
     EXPECT_EQ(kAclIngressTableName, app_db_entry.acl_table_name);
@@ -1966,6 +2102,10 @@ TEST_F(AclManagerTest, DeserializeValidAclTableDefAppDbSucceeds)
     EXPECT_EQ(P4_PACKET_ACTION_PUNT,
               app_db_entry.packet_action_color_lookup.find("punt_and_set_tc")->second[0].packet_action);
     EXPECT_EQ(EMPTY_STRING, app_db_entry.packet_action_color_lookup.find("punt_and_set_tc")->second[0].packet_color);
+    EXPECT_EQ("SAI_OBJECT_TYPE_IPMC_GROUP",
+              app_db_entry.action_field_lookup.find("redirect_to_ipmc")
+                  ->second[0]
+                  .sai_object_type);
 }
 
 TEST_F(AclManagerTest, DeserializeAclTableDefAppDbWithInvalidJsonFails)
@@ -1990,6 +2130,16 @@ TEST_F(AclManagerTest, DeserializeAclTableDefAppDbWithInvalidJsonFails)
     attributes.pop_back();
     attributes.push_back(swss::FieldValueTuple{"action/drop_and_set_tc", "[\"action\":\"SAI_PACKET_ACTION_COPY\"]"});
     EXPECT_FALSE(DeserializeAclTableDefinitionAppDbEntry(acl_table_name, attributes).ok());
+
+    // Invalid object type.
+    attributes.pop_back();
+    attributes.push_back(swss::FieldValueTuple{
+        "action/redirect_to_ipmc",
+        "[{\"action\":\"SAI_ACL_ENTRY_ATTR_ACTION_"
+        "REDIRECT\",\"param\":\"multicast_group_id\",\"object_type\":"
+        "\"SAI_OBJECT_TYPE_UNKNOWN\"}]"});
+    EXPECT_FALSE(
+        DeserializeAclTableDefinitionAppDbEntry(acl_table_name, attributes).ok());
 }
 
 TEST_F(AclManagerTest, DeserializeAclTableDefAppDbWithInvalidSizeFails)
@@ -3125,12 +3275,12 @@ TEST_F(AclManagerTest, AclRuleWithColorPacketActionsButNoRateLimit)
         .WillOnce(DoAll(SetArgPointee<0>(kAclIngressRuleOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_acl_, create_acl_counter(_, _, _, _)).WillOnce(Return(SAI_STATUS_SUCCESS));
     EXPECT_CALL(mock_sai_policer_,
-              create_policer(_, Eq(gSwitchId), Eq(6),
-                             Truly(std::bind(
-                                 MatchSaiPolicerAttributeInStormMode, 6,
-                                 SAI_METER_TYPE_BYTES, SAI_PACKET_ACTION_TRAP,
-                                 SAI_PACKET_ACTION_DROP, 0x7fffffff, 0x1000021,
-                                 std::placeholders::_1))))
+              create_policer(
+                  _, Eq(gSwitchId), Eq(6),
+                  Truly(std::bind(MatchSaiPolicerAttributeInStormMode, 6,
+                                  SAI_METER_TYPE_BYTES, SAI_PACKET_ACTION_TRAP,
+                                  SAI_PACKET_ACTION_DROP, 0x7fffffff, 0x1000021,
+                                  std::placeholders::_1))))
         .WillOnce(DoAll(SetArgPointee<0>(kAclMeterOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ProcessAddRuleRequest(acl_rule_key, app_db_entry));
     auto acl_rule = GetAclRule(kAclIngressTableName, acl_rule_key);
@@ -3307,6 +3457,37 @@ TEST_F(AclManagerTest, AclRuleWithValidAction)
     EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ProcessDeleteRuleRequest(kAclIngressTableName, acl_rule_key));
     EXPECT_EQ(nullptr, GetAclRule(kAclIngressTableName, acl_rule_key));
 
+    // Repeat, redirect to port, but specify an object type.
+    app_db_entry.action = "redirect_port";
+    app_db_entry.action_param_fvs["target"] = "Ethernet7";
+    // Install rule
+    EXPECT_CALL(mock_sai_acl_, create_acl_entry(_, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<0>(kAclIngressRuleOid1),
+                        Return(SAI_STATUS_SUCCESS)));
+    EXPECT_CALL(mock_sai_acl_, create_acl_counter(_, _, _, _))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_policer_, create_policer(_, _, _, _))
+        .WillOnce(
+            DoAll(SetArgPointee<0>(kAclMeterOid1), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
+              ProcessAddRuleRequest(acl_rule_key, app_db_entry));
+    acl_rule = GetAclRule(kAclIngressTableName, acl_rule_key);
+    ASSERT_NE(nullptr, acl_rule);
+    // Check action field value
+    EXPECT_EQ(/*port_oid=*/0x1234,
+              acl_rule->action_fvs[SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT]
+                  .aclaction.parameter.oid);
+    // Remove rule
+    EXPECT_CALL(mock_sai_acl_, remove_acl_entry(Eq(kAclIngressRuleOid1)))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_acl_, remove_acl_counter(_))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_policer_, remove_policer(Eq(kAclMeterOid1)))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
+              ProcessDeleteRuleRequest(kAclIngressTableName, acl_rule_key));
+    EXPECT_EQ(nullptr, GetAclRule(kAclIngressTableName, acl_rule_key));
+
     // Set up an next hop mapping
     const std::string next_hop_id = "ju1u32m1.atl11:qe-3/7";
     const auto &next_hop_key = KeyGenerator::generateNextHopKey(next_hop_id);
@@ -3330,6 +3511,73 @@ TEST_F(AclManagerTest, AclRuleWithValidAction)
     EXPECT_CALL(mock_sai_acl_, remove_acl_counter(_)).WillOnce(Return(SAI_STATUS_SUCCESS));
     EXPECT_CALL(mock_sai_policer_, remove_policer(Eq(kAclMeterOid1))).WillOnce(Return(SAI_STATUS_SUCCESS));
     EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ProcessDeleteRuleRequest(kAclIngressTableName, acl_rule_key));
+    EXPECT_EQ(nullptr, GetAclRule(kAclIngressTableName, acl_rule_key));
+
+    // Repeat next hop rule, but specify an object type.
+    app_db_entry.action = "redirect_next_hop";
+    app_db_entry.action_param_fvs["target"] = next_hop_id;
+    // Install rule
+    EXPECT_CALL(mock_sai_acl_, create_acl_entry(_, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<0>(kAclIngressRuleOid1),
+                        Return(SAI_STATUS_SUCCESS)));
+    EXPECT_CALL(mock_sai_acl_, create_acl_counter(_, _, _, _))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_policer_, create_policer(_, _, _, _))
+        .WillOnce(
+            DoAll(SetArgPointee<0>(kAclMeterOid1), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
+              ProcessAddRuleRequest(acl_rule_key, app_db_entry));
+    acl_rule = GetAclRule(kAclIngressTableName, acl_rule_key);
+    ASSERT_NE(nullptr, acl_rule);
+    // Check action field value
+    EXPECT_EQ(/*next_hop_oid=*/1,
+              acl_rule->action_fvs[SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT]
+                  .aclaction.parameter.oid);
+    // Remove rule
+    EXPECT_CALL(mock_sai_acl_, remove_acl_entry(Eq(kAclIngressRuleOid1)))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_acl_, remove_acl_counter(_))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_policer_, remove_policer(Eq(kAclMeterOid1)))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
+              ProcessDeleteRuleRequest(kAclIngressTableName, acl_rule_key));
+    EXPECT_EQ(nullptr, GetAclRule(kAclIngressTableName, acl_rule_key));
+
+    // Set up an L3 multicast group mapping
+    const std::string multicast_group_id = "0x1";
+    const auto& l3_multicast_group_key =
+        KeyGenerator::generateL3MulticastGroupKey(multicast_group_id);
+    p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_IPMC_GROUP, l3_multicast_group_key,
+                           /*ipmc_group_oid=*/7);
+    app_db_entry.action = "redirect_ipmc";
+    app_db_entry.action_param_fvs["target"] = multicast_group_id;
+    // Install rule
+    EXPECT_CALL(mock_sai_acl_, create_acl_entry(_, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<0>(kAclIngressRuleOid1),
+                        Return(SAI_STATUS_SUCCESS)));
+    EXPECT_CALL(mock_sai_acl_, create_acl_counter(_, _, _, _))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_policer_, create_policer(_, _, _, _))
+        .WillOnce(
+            DoAll(SetArgPointee<0>(kAclMeterOid1), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
+              ProcessAddRuleRequest(acl_rule_key, app_db_entry));
+    acl_rule = GetAclRule(kAclIngressTableName, acl_rule_key);
+    ASSERT_NE(nullptr, acl_rule);
+    // Check action field value
+    EXPECT_EQ(/*ipmc_group_oid=*/7,
+              acl_rule->action_fvs[SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT]
+                  .aclaction.parameter.oid);
+    // Remove rule
+    EXPECT_CALL(mock_sai_acl_, remove_acl_entry(Eq(kAclIngressRuleOid1)))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_acl_, remove_acl_counter(_))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_policer_, remove_policer(Eq(kAclMeterOid1)))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
+              ProcessDeleteRuleRequest(kAclIngressTableName, acl_rule_key));
     EXPECT_EQ(nullptr, GetAclRule(kAclIngressTableName, acl_rule_key));
 
     // Set endpoint Ip action
@@ -3639,6 +3887,22 @@ TEST_F(AclManagerTest, AclRuleWithVrfAction)
     EXPECT_CALL(mock_sai_policer_, remove_policer(Eq(kAclMeterOid1))).WillOnce(Return(SAI_STATUS_SUCCESS));
     EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ProcessDeleteRuleRequest(kAclIngressTableName, acl_rule_key));
     EXPECT_EQ(nullptr, GetAclRule(kAclIngressTableName, acl_rule_key));
+}
+
+TEST_F(AclManagerTest,
+       AclRuleWithL3MulticastRedirectActionFailsWhenMulticastGroupNotFound) {
+    ASSERT_NO_FATAL_FAILURE(AddDefaultIngressTable());
+    auto app_db_entry = getDefaultAclRuleAppDbEntryWithoutAction();
+    const auto& acl_rule_key =
+        KeyGenerator::generateAclRuleKey(app_db_entry.match_fvs, "100");
+    // Set up an L3 multicast group mapping, but leave out fake OID mapping.
+    const std::string multicast_group_id = "0x1";
+    const auto& l3_multicast_group_key =
+        KeyGenerator::generateL3MulticastGroupKey(multicast_group_id);
+    app_db_entry.action = "redirect_ipmc";
+    app_db_entry.action_param_fvs["target"] = multicast_group_id;
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+              ProcessAddRuleRequest(acl_rule_key, app_db_entry));
 }
 
 TEST_F(AclManagerTest, AclRuleWithIpTypeBitEncoding)
@@ -4526,7 +4790,20 @@ TEST_F(AclManagerTest, CreateAclRuleWithInvalidActionFails) {
     app_db_entry.action_param_fvs["target"] = next_hop_id;
     EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ProcessAddRuleRequest(acl_rule_key, app_db_entry));
     app_db_entry.action_param_fvs.erase("target");
+    // Similar check when the object type is specified.
+    app_db_entry.action = "redirect_next_hop";
+    app_db_entry.action_param_fvs["target"] = next_hop_id;
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+              ProcessAddRuleRequest(acl_rule_key, app_db_entry));
+    app_db_entry.action_param_fvs.erase("target");
     // ACL rule has redirect action with wrong port type
+    app_db_entry.action = "redirect";
+    app_db_entry.action_param_fvs["target"] = "Ethernet8";
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+              ProcessAddRuleRequest(acl_rule_key, app_db_entry));
+    app_db_entry.action_param_fvs.erase("target");
+    // Similar check when the object type is specified.
+    app_db_entry.action = "redirect_port";
     app_db_entry.action_param_fvs["target"] = "Ethernet8";
     EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ProcessAddRuleRequest(acl_rule_key, app_db_entry));
     app_db_entry.action_param_fvs.erase("target");
@@ -5685,6 +5962,15 @@ TEST_F(AclManagerTest, AclRuleVerifyStateTest)
     acl_rule->action_redirect_nexthop_key = 111;
     EXPECT_FALSE(VerifyRuleState(db_key, attributes).empty());
     acl_rule->action_redirect_nexthop_key = saved_action_redirect_nexthop_key;
+
+    // Verification should fail if action kRedirectToIpmcGroup L3 multicast group
+    // ID key mismatches.
+    auto saved_action_redirect_l3_multicast_group_key =
+        acl_rule->action_redirect_l3_multicast_group_key;
+    acl_rule->action_redirect_l3_multicast_group_key = "0x7777";
+    EXPECT_FALSE(VerifyRuleState(db_key, attributes).empty());
+    acl_rule->action_redirect_l3_multicast_group_key =
+        saved_action_redirect_l3_multicast_group_key;
 
     // Verification should fail if action mirror section mismatches.
     acl_rule->action_mirror_sessions[SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_EGRESS] = P4AclMirrorSession{};

--- a/orchagent/p4orch/tests/acl_manager_test.cpp
+++ b/orchagent/p4orch/tests/acl_manager_test.cpp
@@ -672,6 +672,10 @@ P4AclTableDefinitionAppDbEntry getDefaultAclTableDefAppDbEntry()
         {.sai_action = P4_ACTION_REDIRECT,
          .p4_param_name = "target",
          .sai_object_type = "SAI_OBJECT_TYPE_IPMC_GROUP"});
+    app_db_entry.action_field_lookup["redirect_l2mc"].push_back(
+        {.sai_action = P4_ACTION_REDIRECT,
+         .p4_param_name = "target",
+         .sai_object_type = "SAI_OBJECT_TYPE_L2MC_GROUP"});
     app_db_entry.action_field_lookup["redirect_port"].push_back(
         {.sai_action = P4_ACTION_REDIRECT,
          .p4_param_name = "target",
@@ -2066,6 +2070,11 @@ TEST_F(AclManagerTest, DeserializeValidAclTableDefAppDbSucceeds)
         "[{\"action\":\"SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT\","
         "\"param\":\"multicast_group_id\",\"object_type\":"
         "\"SAI_OBJECT_TYPE_IPMC_GROUP\"}]"});
+    attrs.push_back(swss::FieldValueTuple{
+        "action/redirect_to_l2mc",
+        "[{\"action\":\"SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT\","
+        "\"param\":\"multicast_group_id\",\"object_type\":"
+        "\"SAI_OBJECT_TYPE_L2MC_GROUP\"}]"});
     auto app_db_entry_or =
         DeserializeAclTableDefinitionAppDbEntry(kAclIngressTableName, attrs);
     EXPECT_TRUE(app_db_entry_or.ok());
@@ -2104,6 +2113,10 @@ TEST_F(AclManagerTest, DeserializeValidAclTableDefAppDbSucceeds)
     EXPECT_EQ(EMPTY_STRING, app_db_entry.packet_action_color_lookup.find("punt_and_set_tc")->second[0].packet_color);
     EXPECT_EQ("SAI_OBJECT_TYPE_IPMC_GROUP",
               app_db_entry.action_field_lookup.find("redirect_to_ipmc")
+                  ->second[0]
+                  .sai_object_type);
+    EXPECT_EQ("SAI_OBJECT_TYPE_L2MC_GROUP",
+              app_db_entry.action_field_lookup.find("redirect_to_l2mc")
                   ->second[0]
                   .sai_object_type);
 }
@@ -3580,6 +3593,42 @@ TEST_F(AclManagerTest, AclRuleWithValidAction)
               ProcessDeleteRuleRequest(kAclIngressTableName, acl_rule_key));
     EXPECT_EQ(nullptr, GetAclRule(kAclIngressTableName, acl_rule_key));
 
+    // Set up an L2 multicast group mapping
+    const std::string l2_multicast_group_id = "0x2";
+    const auto& l2_multicast_group_key =
+        KeyGenerator::generateL2MulticastGroupKey(l2_multicast_group_id);
+    p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_L2MC_GROUP, l2_multicast_group_key,
+                           /*l2mc_group_oid=*/9);
+    app_db_entry.action = "redirect_l2mc";
+    app_db_entry.action_param_fvs["target"] = l2_multicast_group_id;
+    // Install rule
+    EXPECT_CALL(mock_sai_acl_, create_acl_entry(_, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<0>(kAclIngressRuleOid1),
+                        Return(SAI_STATUS_SUCCESS)));
+    EXPECT_CALL(mock_sai_acl_, create_acl_counter(_, _, _, _))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_policer_, create_policer(_, _, _, _))
+        .WillOnce(
+            DoAll(SetArgPointee<0>(kAclMeterOid1), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
+              ProcessAddRuleRequest(acl_rule_key, app_db_entry));
+    acl_rule = GetAclRule(kAclIngressTableName, acl_rule_key);
+    ASSERT_NE(nullptr, acl_rule);
+    // Check action field value
+    EXPECT_EQ(/*l2mc_group_oid=*/9,
+              acl_rule->action_fvs[SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT]
+                  .aclaction.parameter.oid);
+    // Remove rule
+    EXPECT_CALL(mock_sai_acl_, remove_acl_entry(Eq(kAclIngressRuleOid1)))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_acl_, remove_acl_counter(_))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_policer_, remove_policer(Eq(kAclMeterOid1)))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
+              ProcessDeleteRuleRequest(kAclIngressTableName, acl_rule_key));
+    EXPECT_EQ(nullptr, GetAclRule(kAclIngressTableName, acl_rule_key));
+
     // Set endpoint Ip action
     app_db_entry.action = "endpoint_ip";
     app_db_entry.action_param_fvs["ip_address"] = "127.0.0.1";
@@ -3901,6 +3950,22 @@ TEST_F(AclManagerTest,
         KeyGenerator::generateL3MulticastGroupKey(multicast_group_id);
     app_db_entry.action = "redirect_ipmc";
     app_db_entry.action_param_fvs["target"] = multicast_group_id;
+    EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
+              ProcessAddRuleRequest(acl_rule_key, app_db_entry));
+}
+
+TEST_F(AclManagerTest,
+       AclRuleWithL2MulticastRedirectActionFailsWhenMulticastGroupNotFound) {
+    ASSERT_NO_FATAL_FAILURE(AddDefaultIngressTable());
+    auto app_db_entry = getDefaultAclRuleAppDbEntryWithoutAction();
+    const auto& acl_rule_key =
+        KeyGenerator::generateAclRuleKey(app_db_entry.match_fvs, "100");
+    // Set up an L2 multicast group mapping, but leave out fake OID mapping.
+    const std::string l2_multicast_group_id = "0x1";
+    const auto& l2_multicast_group_key =
+        KeyGenerator::generateL2MulticastGroupKey(l2_multicast_group_id);
+    app_db_entry.action = "redirect_l2mc";
+    app_db_entry.action_param_fvs["target"] = l2_multicast_group_id;
     EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM,
               ProcessAddRuleRequest(acl_rule_key, app_db_entry));
 }
@@ -4545,6 +4610,60 @@ TEST_F(AclManagerTest, UpdateAclRuleWithVrfActionChange)
     // Check action field value
     EXPECT_EQ(1, acl_rule->action_fvs.size());
     EXPECT_EQ(gVirtualRouterId, acl_rule->action_fvs[SAI_ACL_ENTRY_ATTR_ACTION_SET_VRF].aclaction.parameter.oid);
+}
+
+TEST_F(AclManagerTest, UpdateAclRuleWithL2MulticastActionChange) {
+    ASSERT_NO_FATAL_FAILURE(AddDefaultIngressTable());
+    auto app_db_entry = getDefaultAclRuleAppDbEntryWithoutAction();
+    const auto& acl_rule_key =
+        KeyGenerator::generateAclRuleKey(app_db_entry.match_fvs, "100");
+    // Set up an L2 multicast group mapping
+    const std::string l2_multicast_group_id = "0x5";
+    const auto& l2_multicast_group_key =
+        KeyGenerator::generateL2MulticastGroupKey(l2_multicast_group_id);
+    p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_L2MC_GROUP, l2_multicast_group_key,
+                           /*l2mc_group_oid=*/18);
+    app_db_entry.action = "redirect_l2mc";
+    app_db_entry.action_param_fvs["target"] = l2_multicast_group_id;
+
+    // Install rule
+    EXPECT_CALL(mock_sai_acl_, create_acl_entry(_, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<0>(kAclIngressRuleOid1),
+                        Return(SAI_STATUS_SUCCESS)));
+    EXPECT_CALL(mock_sai_acl_, create_acl_counter(_, _, _, _))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_policer_, create_policer(_, _, _, _))
+        .WillOnce(
+            DoAll(SetArgPointee<0>(kAclMeterOid1), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
+              ProcessAddRuleRequest(acl_rule_key, app_db_entry));
+    auto* acl_rule = GetAclRule(kAclIngressTableName, acl_rule_key);
+    ASSERT_NE(nullptr, acl_rule);
+    // Check action field value
+    EXPECT_EQ(/*l2mc_group_oid=*/18,
+              acl_rule->action_fvs[SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT]
+                  .aclaction.parameter.oid);
+
+    // Update rule
+    const std::string l2_multicast_group_id2 = "0x6";
+    const auto& l2_multicast_group_key2 =
+        KeyGenerator::generateL2MulticastGroupKey(l2_multicast_group_id2);
+    p4_oid_mapper_->setOID(SAI_OBJECT_TYPE_L2MC_GROUP, l2_multicast_group_key2,
+                           /*ipmc_group_oid=*/19);
+    app_db_entry.action_param_fvs["target"] = l2_multicast_group_id2;
+
+    EXPECT_CALL(mock_sai_acl_,
+                set_acl_entry_attribute(Eq(kAclIngressRuleOid1), _))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
+              ProcessUpdateRuleRequest(app_db_entry, *acl_rule));
+    acl_rule = GetAclRule(kAclIngressTableName, acl_rule_key);
+    ASSERT_NE(nullptr, acl_rule);
+    // Check action field value
+    EXPECT_EQ(1, acl_rule->action_fvs.size());
+    EXPECT_EQ(/*l2mc_group_oid=*/19,
+              acl_rule->action_fvs[SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT]
+                  .aclaction.parameter.oid);
 }
 
 TEST_F(AclManagerTest, UpdateAclRuleFailsWhenSaiCallFails)
@@ -5971,6 +6090,15 @@ TEST_F(AclManagerTest, AclRuleVerifyStateTest)
     EXPECT_FALSE(VerifyRuleState(db_key, attributes).empty());
     acl_rule->action_redirect_l3_multicast_group_key =
         saved_action_redirect_l3_multicast_group_key;
+
+    // Verification should fail if action kRedirectToIpmcGroup L2 multicast group
+    // ID key mismatches.
+    auto saved_action_redirect_l2_multicast_group_key =
+        acl_rule->action_redirect_l2_multicast_group_key;
+    acl_rule->action_redirect_l2_multicast_group_key = "0x9999";
+    EXPECT_FALSE(VerifyRuleState(db_key, attributes).empty());
+    acl_rule->action_redirect_l2_multicast_group_key =
+        saved_action_redirect_l2_multicast_group_key;
 
     // Verification should fail if action mirror section mismatches.
     acl_rule->action_mirror_sessions[SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_EGRESS] = P4AclMirrorSession{};

--- a/orchagent/p4orch/tests/acl_manager_test.cpp
+++ b/orchagent/p4orch/tests/acl_manager_test.cpp
@@ -89,12 +89,13 @@ constexpr sai_object_id_t kUdfOid1 = 6001;
 constexpr char *kAclIngressTableName = "ACL_PUNT_TABLE";
 
 // Matches the policer sai_attribute_t[] argument.
-bool MatchSaiPolicerAttribute(const int attrs_size, const sai_meter_type_t expected_type,
-                              const sai_packet_action_t expected_gpa, const sai_packet_action_t expected_ypa,
-                              const sai_packet_action_t expected_rpa, const sai_uint64_t expected_cir,
-                              const sai_uint64_t expected_pir, const sai_uint64_t expected_cbs,
-                              const sai_uint64_t expected_pbs, const sai_attribute_t *attr_list)
-{
+bool MatchSaiPolicerAttributeInStormMode(const int attrs_size,
+                                         const sai_meter_type_t expected_type,
+                                         const sai_packet_action_t expected_gpa,
+                                         const sai_packet_action_t expected_rpa,
+                                         const sai_uint64_t expected_cir,
+                                         const sai_uint64_t expected_cbs,
+                                         const sai_attribute_t* attr_list) {
     if (attr_list == nullptr)
     {
         return false;
@@ -109,32 +110,14 @@ bool MatchSaiPolicerAttribute(const int attrs_size, const sai_meter_type_t expec
                 return false;
             }
             break;
-        case SAI_POLICER_ATTR_PBS:
-            if (attr_list[i].value.u64 != expected_pbs)
-            {
-                return false;
-            }
-            break;
         case SAI_POLICER_ATTR_CIR:
             if (attr_list[i].value.u64 != expected_cir)
             {
                 return false;
             }
             break;
-        case SAI_POLICER_ATTR_PIR:
-            if (attr_list[i].value.u64 != expected_pir)
-            {
-                return false;
-            }
-            break;
         case SAI_POLICER_ATTR_GREEN_PACKET_ACTION:
             if (attr_list[i].value.s32 != expected_gpa)
-            {
-                return false;
-            }
-            break;
-        case SAI_POLICER_ATTR_YELLOW_PACKET_ACTION:
-            if (attr_list[i].value.s32 != expected_ypa)
             {
                 return false;
             }
@@ -146,8 +129,7 @@ bool MatchSaiPolicerAttribute(const int attrs_size, const sai_meter_type_t expec
             }
             break;
         case SAI_POLICER_ATTR_MODE:
-            if (attr_list[i].value.s32 != SAI_POLICER_MODE_TR_TCM)
-            {
+            if (attr_list[i].value.s32 != SAI_POLICER_MODE_STORM_CONTROL) {
                 return false;
             }
             break;
@@ -473,11 +455,9 @@ void IsExpectedAclRuleMapping(const P4AclRule *acl_rule, const P4AclRuleAppDbEnt
     if (!table_def.meter_unit.empty())
     {
         EXPECT_TRUE(acl_rule->meter.enabled);
-        EXPECT_EQ(SAI_POLICER_MODE_TR_TCM, acl_rule->meter.mode);
+        EXPECT_EQ(SAI_POLICER_MODE_STORM_CONTROL, acl_rule->meter.mode);
         EXPECT_EQ(app_db_entry.meter.cir, acl_rule->meter.cir);
         EXPECT_EQ(app_db_entry.meter.cburst, acl_rule->meter.cburst);
-        EXPECT_EQ(app_db_entry.meter.pir, acl_rule->meter.pir);
-        EXPECT_EQ(app_db_entry.meter.pburst, acl_rule->meter.pburst);
         if (table_def.meter_unit == P4_METER_UNIT_BYTES)
         {
             EXPECT_EQ(SAI_METER_TYPE_BYTES, acl_rule->meter.type);
@@ -680,8 +660,6 @@ P4AclTableDefinitionAppDbEntry getDefaultAclTableDefAppDbEntry()
     app_db_entry.packet_action_color_lookup["punt_and_set_tc"].push_back(
         {.packet_action = P4_PACKET_ACTION_PUNT, .packet_color = EMPTY_STRING});
     app_db_entry.packet_action_color_lookup["punt_non_green_pk"].push_back(
-        {.packet_action = P4_PACKET_ACTION_PUNT, .packet_color = P4_PACKET_COLOR_YELLOW});
-    app_db_entry.packet_action_color_lookup["punt_non_green_pk"].push_back(
         {.packet_action = P4_PACKET_ACTION_PUNT, .packet_color = P4_PACKET_COLOR_RED});
     app_db_entry.action_field_lookup["redirect"].push_back(
         {.sai_action = P4_ACTION_REDIRECT, .p4_param_name = "target"});
@@ -736,7 +714,6 @@ P4AclTableDefinitionAppDbEntry getDefaultAclTableDefAppDbEntry()
 
     // action/acl_rate_limit_copy = [
     //   {"action":"SAI_PACKET_ACTION_FORWARD","packet_color":"SAI_PACKET_COLOR_GREEN"},
-    //   {"action":"SAI_PACKET_ACTION_COPY_CANCEL","packet_color":"SAI_PACKET_COLOR_YELLOW"},
     //   {"action":"SAI_PACKET_ACTION_COPY_CANCEL","packet_color":"SAI_PACKET_COLOR_RED"},
     //   {"action":"QOS_QUEUE","param":"qos_queue"}
     // ]
@@ -744,9 +721,6 @@ P4AclTableDefinitionAppDbEntry getDefaultAclTableDefAppDbEntry()
     app_db_entry.packet_action_color_lookup["acl_rate_limit_copy"].push_back(
       {.packet_action = P4_PACKET_ACTION_FORWARD,
        .packet_color = P4_PACKET_COLOR_GREEN});
-  app_db_entry.packet_action_color_lookup["acl_rate_limit_copy"].push_back(
-      {.packet_action = P4_PACKET_ACTION_COPY_CANCEL,
-       .packet_color = P4_PACKET_COLOR_YELLOW});
   app_db_entry.packet_action_color_lookup["acl_rate_limit_copy"].push_back(
       {.packet_action = P4_PACKET_ACTION_COPY_CANCEL,
        .packet_color = P4_PACKET_COLOR_RED});
@@ -759,8 +733,6 @@ P4AclTableDefinitionAppDbEntry getDefaultAclTableDefAppDbEntry()
     //     {"action": "SAI_PACKET_ACTION_TRAP", "packet_color":
     //     "SAI_PACKET_COLOR_GREEN"},
     //     {"action": "SAI_PACKET_ACTION_DROP", "packet_color":
-    //     "SAI_PACKET_COLOR_YELLOW"},
-    //     {"action": "SAI_PACKET_ACTION_DROP", "packet_color":
     //     "SAI_PACKET_COLOR_RED"},
     //     {"action": "QOS_QUEUE", "param": "queue"}
     //   ]
@@ -768,8 +740,6 @@ P4AclTableDefinitionAppDbEntry getDefaultAclTableDefAppDbEntry()
         {.sai_action = P4_ACTION_SET_QOS_QUEUE, .p4_param_name = "queue"});
     app_db_entry.packet_action_color_lookup["acl_trap"].push_back(
         {.packet_action = P4_PACKET_ACTION_PUNT, .packet_color = P4_PACKET_COLOR_GREEN});
-    app_db_entry.packet_action_color_lookup["acl_trap"].push_back(
-        {.packet_action = P4_PACKET_ACTION_DROP, .packet_color = P4_PACKET_COLOR_YELLOW});
     app_db_entry.packet_action_color_lookup["acl_trap"].push_back(
         {.packet_action = P4_PACKET_ACTION_DROP, .packet_color = P4_PACKET_COLOR_RED});
     return app_db_entry;
@@ -782,8 +752,6 @@ std::vector<swss::FieldValueTuple> getDefaultRuleFieldValueTuples()
     attributes.push_back(swss::FieldValueTuple{"param/traffic_class", "0x20"});
     attributes.push_back(swss::FieldValueTuple{"meter/cir", "80"});
     attributes.push_back(swss::FieldValueTuple{"meter/cburst", "80"});
-    attributes.push_back(swss::FieldValueTuple{"meter/pir", "200"});
-    attributes.push_back(swss::FieldValueTuple{"meter/pburst", "200"});
     attributes.push_back(swss::FieldValueTuple{"controller_metadata", "..."});
     return attributes;
 }
@@ -812,8 +780,6 @@ P4AclRuleAppDbEntry getDefaultAclRuleAppDbEntryWithoutAction()
     app_db_entry.meter.enabled = true;
     app_db_entry.meter.cir = 80;
     app_db_entry.meter.cburst = 80;
-    app_db_entry.meter.pir = 200;
-    app_db_entry.meter.pburst = 200;
     return app_db_entry;
 }
 
@@ -2579,8 +2545,6 @@ TEST_F(AclManagerTest, DeserializeAclRuleAppDbWithInvalidMeterFieldFails)
     attributes.push_back(swss::FieldValueTuple{kAction, "copy_and_set_tc"});
     attributes.push_back(swss::FieldValueTuple{"param/traffic_class", "0x20"});
     attributes.push_back(swss::FieldValueTuple{"meter/cburst", "80"});
-    attributes.push_back(swss::FieldValueTuple{"meter/pir", "200"});
-    attributes.push_back(swss::FieldValueTuple{"meter/pburst", "200"});
     const auto &acl_rule_json_key = "{\"match/ether_type\":\"0x0800\",\"match/"
                                     "ipv6_dst\":\"fdf8:f53b:82e4::53 & "
                                     "fdf8:f53b:82e4::53\",\"priority\":15}";
@@ -3128,10 +3092,12 @@ TEST_F(AclManagerTest, AclRuleWithColorPacketActionsButNoRateLimit)
         .WillOnce(DoAll(SetArgPointee<0>(kAclIngressRuleOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_acl_, create_acl_counter(_, _, _, _)).WillOnce(Return(SAI_STATUS_SUCCESS));
     EXPECT_CALL(mock_sai_policer_,
-                create_policer(_, Eq(gSwitchId), Eq(9),
-                               Truly(std::bind(MatchSaiPolicerAttribute, 9, SAI_METER_TYPE_PACKETS,
-                                               SAI_PACKET_ACTION_TRAP, SAI_PACKET_ACTION_DROP, SAI_PACKET_ACTION_DROP,
-                                               0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff, std::placeholders::_1))))
+              create_policer(_, Eq(gSwitchId), Eq(6),
+                             Truly(std::bind(
+                                 MatchSaiPolicerAttributeInStormMode, 6,
+                                 SAI_METER_TYPE_BYTES, SAI_PACKET_ACTION_TRAP,
+                                 SAI_PACKET_ACTION_DROP, 0x7fffffff, 0x1000021,
+                                 std::placeholders::_1))))
         .WillOnce(DoAll(SetArgPointee<0>(kAclMeterOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ProcessAddRuleRequest(acl_rule_key, app_db_entry));
     auto acl_rule = GetAclRule(kAclIngressTableName, acl_rule_key);
@@ -3182,12 +3148,10 @@ TEST_F(AclManagerTest, AclRuleWithColorPacketActionsButWithRateLimit) {
   EXPECT_CALL(
       mock_sai_policer_,
       create_policer(
-	  _, Eq(gSwitchId), Eq(9),
-          Truly(std::bind(MatchSaiPolicerAttribute, 9, SAI_METER_TYPE_PACKETS,
-                          SAI_PACKET_ACTION_FORWARD,
-			  SAI_PACKET_ACTION_COPY_CANCEL,
-			  SAI_PACKET_ACTION_COPY_CANCEL,
-                          0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff,
+          _, Eq(gSwitchId), Eq(6),
+          Truly(std::bind(MatchSaiPolicerAttributeInStormMode, 6,
+                          SAI_METER_TYPE_BYTES, SAI_PACKET_ACTION_FORWARD,
+                          SAI_PACKET_ACTION_COPY_CANCEL, 0x7fffffff, 0x1000021,
                           std::placeholders::_1))))
       .WillOnce(
           DoAll(SetArgPointee<0>(kAclMeterOid1), Return(SAI_STATUS_SUCCESS)));
@@ -3884,11 +3848,9 @@ TEST_F(AclManagerTest, UpdateAclRuleWithActionMeterChange)
     app_db_entry.action_param_fvs["traffic_class"] = "2";
     app_db_entry.meter.cburst = 500;
     app_db_entry.meter.cir = 500;
-    app_db_entry.meter.pburst = 600;
-    app_db_entry.meter.pir = 600;
     // Update meter attribute for green packet action
     EXPECT_CALL(mock_sai_policer_, set_policer_attribute(Eq(kAclMeterOid1), _))
-        .Times(5)
+        .Times(3)
         .WillRepeatedly(Return(SAI_STATUS_SUCCESS));
     EXPECT_CALL(mock_sai_acl_, set_acl_entry_attribute(Eq(kAclIngressRuleOid1), _))
         .WillOnce(Return(SAI_STATUS_SUCCESS));
@@ -3905,8 +3867,6 @@ TEST_F(AclManagerTest, UpdateAclRuleWithActionMeterChange)
     EXPECT_EQ(SAI_PACKET_ACTION_COPY, acl_rule->meter.packet_color_actions[SAI_POLICER_ATTR_GREEN_PACKET_ACTION]);
     EXPECT_EQ(500, acl_rule->meter.cburst);
     EXPECT_EQ(500, acl_rule->meter.cir);
-    EXPECT_EQ(600, acl_rule->meter.pburst);
-    EXPECT_EQ(600, acl_rule->meter.pir);
     EXPECT_TRUE(p4_oid_mapper_->getOID(SAI_OBJECT_TYPE_POLICER, table_name_and_rule_key, &meter_oid));
     EXPECT_EQ(kAclMeterOid1, meter_oid);
     EXPECT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_POLICER, table_name_and_rule_key, &ref_cnt));
@@ -3916,7 +3876,7 @@ TEST_F(AclManagerTest, UpdateAclRuleWithActionMeterChange)
     app_db_entry.meter.enabled = false;
     // Update meter attribute for green packet action
     EXPECT_CALL(mock_sai_policer_, set_policer_attribute(Eq(kAclMeterOid1), _))
-        .Times(4)
+        .Times(2)
         .WillRepeatedly(Return(SAI_STATUS_SUCCESS));
     EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ProcessUpdateRuleRequest(app_db_entry, *acl_rule));
     acl_rule = GetAclRule(kAclIngressTableName, acl_rule_key);
@@ -3930,10 +3890,8 @@ TEST_F(AclManagerTest, UpdateAclRuleWithActionMeterChange)
     EXPECT_TRUE(acl_rule->action_fvs[SAI_ACL_ENTRY_ATTR_ACTION_SET_TC].aclaction.enable);
     EXPECT_TRUE(p4_oid_mapper_->getOID(SAI_OBJECT_TYPE_POLICER, table_name_and_rule_key, &meter_oid));
     EXPECT_TRUE(acl_rule->meter.enabled);
-    EXPECT_EQ(0x7fffffff, acl_rule->meter.cburst);
+    EXPECT_EQ(0x1000021, acl_rule->meter.cburst);
     EXPECT_EQ(0x7fffffff, acl_rule->meter.cir);
-    EXPECT_EQ(0x7fffffff, acl_rule->meter.pburst);
-    EXPECT_EQ(0x7fffffff, acl_rule->meter.pir);
 
     // Update meter: enable rate limiting and reset green packet action
     app_db_entry.action = "punt_and_set_tc";
@@ -3941,7 +3899,7 @@ TEST_F(AclManagerTest, UpdateAclRuleWithActionMeterChange)
     // Update meter and rule: reset color packet action and update entry
     // attribute
     EXPECT_CALL(mock_sai_policer_, set_policer_attribute(Eq(kAclMeterOid1), _))
-        .Times(5)
+        .Times(3)
         .WillRepeatedly(Return(SAI_STATUS_SUCCESS));
     EXPECT_CALL(mock_sai_acl_, set_acl_entry_attribute(Eq(kAclIngressRuleOid1), _))
         .WillOnce(Return(SAI_STATUS_SUCCESS));
@@ -3957,8 +3915,6 @@ TEST_F(AclManagerTest, UpdateAclRuleWithActionMeterChange)
     EXPECT_TRUE(acl_rule->meter.packet_color_actions.empty());
     EXPECT_EQ(500, acl_rule->meter.cburst);
     EXPECT_EQ(500, acl_rule->meter.cir);
-    EXPECT_EQ(600, acl_rule->meter.pburst);
-    EXPECT_EQ(600, acl_rule->meter.pir);
     EXPECT_TRUE(p4_oid_mapper_->getOID(SAI_OBJECT_TYPE_POLICER, table_name_and_rule_key, &meter_oid));
     EXPECT_EQ(kAclMeterOid1, meter_oid);
     EXPECT_TRUE(p4_oid_mapper_->getRefCount(SAI_OBJECT_TYPE_POLICER, table_name_and_rule_key, &ref_cnt));
@@ -3982,8 +3938,6 @@ TEST_F(AclManagerTest, UpdateAclRuleWithActionMeterChange)
     EXPECT_FALSE(p4_oid_mapper_->getOID(SAI_OBJECT_TYPE_POLICER, table_name_and_rule_key, &meter_oid));
     EXPECT_EQ(0, acl_rule->meter.cburst);
     EXPECT_EQ(0, acl_rule->meter.cir);
-    EXPECT_EQ(0, acl_rule->meter.pburst);
-    EXPECT_EQ(0, acl_rule->meter.pir);
     EXPECT_TRUE(acl_rule->meter.packet_color_actions.empty());
     EXPECT_FALSE(acl_rule->meter.enabled);
 
@@ -4345,8 +4299,6 @@ TEST_F(AclManagerTest, UpdateAclRuleFailsWhenSaiCallFails)
     app_db_entry.action_param_fvs["traffic_class"] = "2";
     app_db_entry.meter.cburst = 500;
     app_db_entry.meter.cir = 500;
-    app_db_entry.meter.pburst = 600;
-    app_db_entry.meter.pir = 600;
     // Update meter attribute for green packet action
     EXPECT_CALL(mock_sai_policer_, set_policer_attribute(Eq(kAclMeterOid1), _))
         .WillOnce(Return(SAI_STATUS_SUCCESS))
@@ -4374,8 +4326,6 @@ TEST_F(AclManagerTest, UpdateAclRuleFailsWhenSaiCallFails)
     app_db_entry.action_param_fvs.erase("traffic_class");
     app_db_entry.meter.cburst = 80;
     app_db_entry.meter.cir = 80;
-    app_db_entry.meter.pburst = 200;
-    app_db_entry.meter.pir = 200;
     // Update meter attribute for green packet action
     EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ProcessUpdateRuleRequest(app_db_entry, *acl_rule));
     acl_rule = GetAclRule(kAclIngressTableName, acl_rule_key);
@@ -4818,8 +4768,6 @@ TEST_F(AclManagerTest, DoAclCounterStatsTaskSucceeds)
     EXPECT_FALSE(counters_table->hget(counter_stats_key, P4_COUNTER_STATS_GREEN_BYTES, stats));
     EXPECT_FALSE(counters_table->hget(counter_stats_key, P4_COUNTER_STATS_RED_PACKETS, stats));
     EXPECT_FALSE(counters_table->hget(counter_stats_key, P4_COUNTER_STATS_RED_BYTES, stats));
-    EXPECT_FALSE(counters_table->hget(counter_stats_key, P4_COUNTER_STATS_YELLOW_PACKETS, stats));
-    EXPECT_FALSE(counters_table->hget(counter_stats_key, P4_COUNTER_STATS_YELLOW_BYTES, stats));
 
     // Remove rule
     EXPECT_CALL(mock_sai_acl_, remove_acl_entry(Eq(kAclIngressRuleOid1))).WillRepeatedly(Return(SAI_STATUS_SUCCESS));
@@ -4868,17 +4816,15 @@ TEST_F(AclManagerTest, DoAclCounterStatsTaskSucceeds)
     EXPECT_EQ(nullptr, GetAclRule(kAclIngressTableName, acl_rule_key));
     EXPECT_FALSE(counters_table->get(counter_stats_key, values));
 
-    // Install rule with packet color YELLOW and RED
+    // Install rule with packet color RED
     app_db_entry.action = "punt_non_green_pk";
     EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ProcessAddRuleRequest(acl_rule_key, app_db_entry));
     // Populate counter stats in COUNTERS_DB
     EXPECT_CALL(mock_sai_policer_, get_policer_stats(Eq(kAclMeterOid1), _, _, _))
         .WillOnce(DoAll(Invoke([](sai_object_id_t policer_id, uint32_t number_of_counters,
                                   const sai_stat_id_t *counter_ids, uint64_t *counters) {
-                            counters[0] = 20;  // yellow_packets
-                            counters[1] = 200; // yellow_bytes
-                            counters[2] = 30;  // red_packets
-                            counters[3] = 300; // red_bytes
+                            counters[0] = 30;   // red_packets
+                            counters[1] = 300;  // red_bytes
                         }),
                         Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_acl_, get_acl_counter_attribute(Eq(kAclCounterOid1), _, _))
@@ -4888,11 +4834,7 @@ TEST_F(AclManagerTest, DoAclCounterStatsTaskSucceeds)
                         }),
                         Return(SAI_STATUS_SUCCESS)));
     DoAclCounterStatsTask();
-    // Only yellow/red_packets and yellow/red_bytes are populated in COUNTERS_DB
-    EXPECT_TRUE(counters_table->hget(counter_stats_key, P4_COUNTER_STATS_YELLOW_PACKETS, stats));
-    EXPECT_EQ("20", stats);
-    EXPECT_TRUE(counters_table->hget(counter_stats_key, P4_COUNTER_STATS_YELLOW_BYTES, stats));
-    EXPECT_EQ("200", stats);
+    // Only red_packets and red_bytes are populated in COUNTERS_DB
     EXPECT_TRUE(counters_table->hget(counter_stats_key, P4_COUNTER_STATS_RED_PACKETS, stats));
     EXPECT_EQ("30", stats);
     EXPECT_TRUE(counters_table->hget(counter_stats_key, P4_COUNTER_STATS_RED_BYTES, stats));
@@ -5463,8 +5405,6 @@ TEST_F(AclManagerTest, AclRuleVerifyStateTest)
     attributes.push_back(swss::FieldValueTuple{"param/target", gMirrorSession1});
     attributes.push_back(swss::FieldValueTuple{"meter/cir", "80"});
     attributes.push_back(swss::FieldValueTuple{"meter/cburst", "80"});
-    attributes.push_back(swss::FieldValueTuple{"meter/pir", "200"});
-    attributes.push_back(swss::FieldValueTuple{"meter/pburst", "200"});
     attributes.push_back(swss::FieldValueTuple{"controller_metadata", "..."});
     const auto& acl_rule_json_key =
         "{\"match/ether_type\":\"0x0800\",\"match/"
@@ -5536,10 +5476,9 @@ TEST_F(AclManagerTest, AclRuleVerifyStateTest)
     table.set(
         "SAI_OBJECT_TYPE_POLICER:oid:0x7d1",
         std::vector<swss::FieldValueTuple>{
-            swss::FieldValueTuple{"SAI_POLICER_ATTR_MODE", "SAI_POLICER_MODE_TR_TCM"},
+            swss::FieldValueTuple{"SAI_POLICER_ATTR_MODE", "SAI_POLICER_MODE_STORM_CONTROL"},
             swss::FieldValueTuple{"SAI_POLICER_ATTR_METER_TYPE", "SAI_METER_TYPE_BYTES"},
             swss::FieldValueTuple{"SAI_POLICER_ATTR_CBS", "80"}, swss::FieldValueTuple{"SAI_POLICER_ATTR_CIR", "80"},
-            swss::FieldValueTuple{"SAI_POLICER_ATTR_PIR", "200"}, swss::FieldValueTuple{"SAI_POLICER_ATTR_PBS", "200"},
             swss::FieldValueTuple{"SAI_POLICER_ATTR_GREEN_PACKET_ACTION", "SAI_PACKET_ACTION_COPY"}});
 
     // Verification should succeed with vaild key and value.
@@ -6052,10 +5991,9 @@ TEST_F(AclManagerTest, AclRuleVerifyStateAsicDbTest)
     table.set(
         "SAI_OBJECT_TYPE_POLICER:oid:0x7d1",
         std::vector<swss::FieldValueTuple>{
-            swss::FieldValueTuple{"SAI_POLICER_ATTR_MODE", "SAI_POLICER_MODE_TR_TCM"},
+            swss::FieldValueTuple{"SAI_POLICER_ATTR_MODE", "SAI_POLICER_MODE_STORM_CONTROL"},
             swss::FieldValueTuple{"SAI_POLICER_ATTR_METER_TYPE", "SAI_METER_TYPE_BYTES"},
             swss::FieldValueTuple{"SAI_POLICER_ATTR_CBS", "80"}, swss::FieldValueTuple{"SAI_POLICER_ATTR_CIR", "80"},
-            swss::FieldValueTuple{"SAI_POLICER_ATTR_PIR", "200"}, swss::FieldValueTuple{"SAI_POLICER_ATTR_PBS", "200"},
             swss::FieldValueTuple{"SAI_POLICER_ATTR_GREEN_PACKET_ACTION", "SAI_PACKET_ACTION_COPY"}});
 
     // Verification should succeed with correct ASIC DB values.
@@ -6109,10 +6047,9 @@ TEST_F(AclManagerTest, AclRuleVerifyStateAsicDbTest)
     table.set(
         "SAI_OBJECT_TYPE_POLICER:oid:0x7d1",
         std::vector<swss::FieldValueTuple>{
-            swss::FieldValueTuple{"SAI_POLICER_ATTR_MODE", "SAI_POLICER_MODE_TR_TCM"},
+            swss::FieldValueTuple{"SAI_POLICER_ATTR_MODE", "SAI_POLICER_MODE_STORM_CONTROL"},
             swss::FieldValueTuple{"SAI_POLICER_ATTR_METER_TYPE", "SAI_METER_TYPE_BYTES"},
             swss::FieldValueTuple{"SAI_POLICER_ATTR_CBS", "80"}, swss::FieldValueTuple{"SAI_POLICER_ATTR_CIR", "80"},
-            swss::FieldValueTuple{"SAI_POLICER_ATTR_PIR", "200"}, swss::FieldValueTuple{"SAI_POLICER_ATTR_PBS", "200"},
             swss::FieldValueTuple{"SAI_POLICER_ATTR_GREEN_PACKET_ACTION", "SAI_PACKET_ACTION_COPY"}});
 }
 

--- a/orchagent/p4orch/tests/acl_manager_test.cpp
+++ b/orchagent/p4orch/tests/acl_manager_test.cpp
@@ -1063,7 +1063,7 @@ class AclManagerTest : public ::testing::Test
         return acl_rule_manager_->processAddRuleRequest(acl_rule_key, app_db_entry);
     }
 
-    ReturnCode ProcessUpdateRuleRequest(const P4AclRuleAppDbEntry &app_db_entry, const P4AclRule &old_acl_rule)
+    ReturnCode ProcessUpdateRuleRequest(const P4AclRuleAppDbEntry &app_db_entry, P4AclRule &old_acl_rule)
     {
         return acl_rule_manager_->processUpdateRuleRequest(app_db_entry, old_acl_rule);
     }
@@ -1138,6 +1138,39 @@ TEST_F(AclManagerTest, DrainTableTuplesToProcessSetDelRequestSucceeds)
     EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
               DrainTableTuples(/*failure_before=*/false));
     EXPECT_EQ(nullptr, GetAclTable(kAclIngressTableName));
+}
+
+TEST_F(AclManagerTest, UpdateAclRuleWithAclMetadataChange)
+{
+    ASSERT_NO_FATAL_FAILURE(AddDefaultIngressTable());
+
+    auto app_db_entry = getDefaultAclRuleAppDbEntryWithoutAction();
+    const auto &acl_rule_key = KeyGenerator::generateAclRuleKey(app_db_entry.match_fvs, "100");
+    const auto &table_name_and_rule_key = concatTableNameAndRuleKey(kAclIngressTableName, acl_rule_key);
+    app_db_entry.action = "set_metadata";
+    app_db_entry.action_param_fvs["acl_metadata"] = "1";
+    // Install rule
+    EXPECT_CALL(mock_sai_acl_, create_acl_entry(_, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<0>(kAclIngressRuleOid1), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_CALL(mock_sai_acl_, create_acl_counter(_, _, _, _)).WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_policer_, create_policer(_, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<0>(kAclMeterOid1), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ProcessAddRuleRequest(acl_rule_key, app_db_entry));
+    auto *acl_rule = GetAclRule(kAclIngressTableName, acl_rule_key);
+    ASSERT_NE(nullptr, acl_rule);
+
+    // Set new metadata
+    app_db_entry.action_param_fvs["acl_metadata"] = "2";
+    // Update rule
+    EXPECT_CALL(mock_sai_acl_, set_acl_entry_attribute(Eq(kAclIngressRuleOid1), _))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ProcessUpdateRuleRequest(app_db_entry, *acl_rule));
+    acl_rule = GetAclRule(kAclIngressTableName, acl_rule_key);
+    ASSERT_NE(nullptr, acl_rule);
+    // Check action field value
+    EXPECT_EQ(1, acl_rule->action_fvs.size());
+    EXPECT_EQ(2, acl_rule->action_fvs[SAI_ACL_ENTRY_ATTR_ACTION_SET_ACL_META_DATA].aclaction.parameter.u8);
+    app_db_entry.action_param_fvs["acl_metadata"] = "2";
 }
 
 TEST_F(AclManagerTest, DrainTableTuplesToProcessUpdateRequestExpectFails)

--- a/orchagent/p4orch/tests/p4orch_util_test.cpp
+++ b/orchagent/p4orch/tests/p4orch_util_test.cpp
@@ -30,6 +30,13 @@ TEST(P4OrchUtilTest, KeyGeneratorTest)
     ipv6_route_key = KeyGenerator::generateRouteKey("b4-traffic", swss::IpPrefix("::/0"));
     EXPECT_EQ("ipv6_dst=::/0:vrf_id=b4-traffic", ipv6_route_key);
 
+    // L3 multicast group keys.
+    EXPECT_EQ("0x0001", KeyGenerator::generateL3MulticastGroupKey("0x1"));
+    EXPECT_EQ("0x0002", KeyGenerator::generateL3MulticastGroupKey("0X02"));
+    EXPECT_EQ("0x0011", KeyGenerator::generateL3MulticastGroupKey("17"));
+    // Invalid, expected to return group ID 0.
+    EXPECT_EQ("0x0000", KeyGenerator::generateL3MulticastGroupKey("zzz"));
+
     std::string ipv4_multicast_key = KeyGenerator::generateIpMulticastKey(
         "b4-traffic", swss::IpAddress("127.0.0.1"));
     EXPECT_EQ("ipv4_dst=127.0.0.1:vrf_id=b4-traffic", ipv4_multicast_key);

--- a/orchagent/p4orch/tests/p4orch_util_test.cpp
+++ b/orchagent/p4orch/tests/p4orch_util_test.cpp
@@ -37,6 +37,13 @@ TEST(P4OrchUtilTest, KeyGeneratorTest)
     // Invalid, expected to return group ID 0.
     EXPECT_EQ("0x0000", KeyGenerator::generateL3MulticastGroupKey("zzz"));
 
+    // L2 multicast group keys.
+    EXPECT_EQ("0x0003", KeyGenerator::generateL2MulticastGroupKey("0x3"));
+    EXPECT_EQ("0x0009", KeyGenerator::generateL2MulticastGroupKey("0X09"));
+    EXPECT_EQ("0x0021", KeyGenerator::generateL2MulticastGroupKey("33"));
+    // Invalid, expected to return group ID 0.
+    EXPECT_EQ("0x0000", KeyGenerator::generateL2MulticastGroupKey("invalid"));
+
     std::string ipv4_multicast_key = KeyGenerator::generateIpMulticastKey(
         "b4-traffic", swss::IpAddress("127.0.0.1"));
     EXPECT_EQ("ipv4_dst=127.0.0.1:vrf_id=b4-traffic", ipv4_multicast_key);

--- a/tests/p4rt/acl.py
+++ b/tests/p4rt/acl.py
@@ -77,6 +77,7 @@ class P4RtAclRuleWrapper(util.DBInterface):
     METER_CBURST = "meter/cburst"
     METER_PIR = "meter/pir"
     METER_PBURST = "meter/pburst"
+    METER_MODE = "meter/mode"
 
 
 class P4RtAclCounterWrapper(util.DBInterface):

--- a/tests/p4rt/acl.py
+++ b/tests/p4rt/acl.py
@@ -44,6 +44,7 @@ class P4RtAclTableDefinitionWrapper(util.DBInterface):
     ACTION_PUNT_AND_SET_TC = "action/punt_and_set_tc"
     ACTION_SET_QOS_QUEUE = "action/qos_queue"
     ACTION_SET_ACL_RATE_LIMIT_COPY = "action/acl_rate_limit_copy"
+    ACTION_SET_ACL_METADATA = "action/set_acl_metadata"
     METER_UNIT = "meter/unit"
     COUNTER_UNIT = "counter/unit"
 
@@ -69,6 +70,7 @@ class P4RtAclRuleWrapper(util.DBInterface):
     SAI_ATTR_ACTION_PACKET_ACTION = "SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION"
     SAI_ATTR_ACTION_SET_TC = "SAI_ACL_ENTRY_ATTR_ACTION_SET_TC"
     SAI_ATTR_ACTION_SET_USER_TRAP_ID = "SAI_ACL_ENTRY_ATTR_ACTION_SET_USER_TRAP_ID"
+    SAI_ATTR_ACTION_SET_ACL_META_DATA = "SAI_ACL_ENTRY_ATTR_ACTION_SET_ACL_META_DATA"
 
     # table name in APP_DB and attribute fields
     APP_DB_TBL_NAME = swsscommon.APP_P4RT_TABLE_NAME

--- a/tests/p4rt/test_p4rt_acl.py
+++ b/tests/p4rt/test_p4rt_acl.py
@@ -4,6 +4,7 @@ from swsscommon import swsscommon
 import pytest
 import util
 import acl
+import time
 
 
 def get_exist_entry(dvs, table):
@@ -189,8 +190,8 @@ class TestP4RTAcl(object):
         punt_and_set_tc = '[{"action":"SAI_PACKET_ACTION_TRAP","packet_color":"SAI_PACKET_COLOR_RED"},{"action":"SAI_ACL_ENTRY_ATTR_ACTION_SET_TC","param":"traffic_class"}]'
         qos_queue = '[{"action":"SAI_PACKET_ACTION_TRAP"},{"action":"QOS_QUEUE","param":"cpu_queue"}]'
 
-        acl_rate_limit_copy = '[{"action":"SAI_PACKET_ACTION_FORWARD","packet_color":"SAI_PACKET_COLOR_GREEN"},{"action":"SAI_PACKET_ACTION_COPY_CANCEL","packet_color":"SAI_PACKET_COLOR_RED"},{"action":"QOS_QUEUE","param":"qos_queue"}]'
-        acl_rate_limit_tcm = '[{"action":"SAI_PACKET_ACTION_FORWARD","packet_color":"SAI_PACKET_COLOR_GREEN"},{"action":"SAI_PACKET_ACTION_COPY_CANCEL","packet_color":"SAI_PACKET_COLOR_YELLOW"},{"action":"SAI_PACKET_ACTION_COPY_CANCEL","packet_color":"SAI_PACKET_COLOR_RED"},{"action":"QOS_QUEUE","param":"qos_queue"}]'
+        acl_rate_limit_copy = '[{"action":"SAI_PACKET_ACTION_FORWARD","packet_color":"SAI_PACKET_COLOR_GREEN"},{"action":"SAI_PACKET_ACTION_COPY_CANCEL","packet_color":"SAI_PACKET_COLOR_YELLOW"},{"action":"SAI_PACKET_ACTION_COPY_CANCEL","packet_color":"SAI_PACKET_COLOR_RED"},{"action":"QOS_QUEUE","param":"qos_queue"}]'
+        acl_set_metadata = '[{"action":"SAI_PACKET_ACTION_FORWARD"},{"action":"SAI_ACL_ENTRY_ATTR_ACTION_SET_ACL_META_DATA","param":"acl_metadata"}]'
 
         attr_list = [
             (self._p4rt_acl_table_definition_obj.STAGE_FIELD, stage),
@@ -217,14 +218,8 @@ class TestP4RTAcl(object):
                 punt_and_set_tc,
             ),
             (self._p4rt_acl_table_definition_obj.ACTION_SET_QOS_QUEUE, qos_queue),
-	                (
-                self._p4rt_acl_table_definition_obj.ACTION_SET_ACL_RATE_LIMIT_COPY,
-                acl_rate_limit_copy,
-            ),
-            (
-                "action/acl_rate_limit_tcm",
-                acl_rate_limit_tcm,
-            ),  # 3 color mode for ACL policer config
+	    (self._p4rt_acl_table_definition_obj.ACTION_SET_ACL_RATE_LIMIT_COPY, acl_rate_limit_copy),
+            (self._p4rt_acl_table_definition_obj.ACTION_SET_ACL_METADATA, acl_set_metadata),
             (self._p4rt_acl_table_definition_obj.METER_UNIT, meter_unit),
             (self._p4rt_acl_table_definition_obj.COUNTER_UNIT, counter_unit),
         ]
@@ -1366,6 +1361,224 @@ class TestP4RTAcl(object):
         util.verify_response(
             self.response_consumer, table_name_with_rule_key4, [], "SWSS_RC_SUCCESS"
         )
+
+        # create new ACL rule 4 with ACL_METADATA action
+        rule_json_key4 = '{"match/is_ip":"0x1","match/ether_type":"0x0800 & 0xFFFF","match/ether_dst":"11:22:33:44:55:66 & FF:FF:FF:FF:FF:FF","priority":100}'
+        action = "set_acl_metadata"
+        table_name_with_rule_key4 = table_name + ":" + rule_json_key4
+
+        attr_list = [
+            (self._p4rt_acl_rule_obj.ACTION, action),
+            ("param/acl_metadata", "1"),
+        ]
+
+        self._p4rt_acl_rule_obj.set_app_db_entry(
+            table_name_with_rule_key4, attr_list)
+        util.verify_response(
+            self.response_consumer,
+            table_name_with_rule_key4,
+            attr_list,
+            "SWSS_RC_SUCCESS",
+        )
+
+        # query application database for ACL rules
+        acl_rules = util.get_keys(
+            self._p4rt_acl_rule_obj.appl_db,
+            self._p4rt_acl_rule_obj.APP_DB_TBL_NAME + ":" + table_name,
+        )
+        assert len(acl_rules) == len(original_appl_acl_rules) + 4
+
+        # query application database for newly created ACL rule
+        (status, fvs) = util.get_key(
+            self._p4rt_acl_rule_obj.appl_db,
+            self._p4rt_acl_table_definition_obj.APP_DB_TBL_NAME,
+            table_name_with_rule_key4,
+        )
+        assert status == True
+        util.verify_attr(fvs, attr_list)
+
+        # query ASIC database for ACL counters
+        acl_asic_counters = util.get_keys(
+            self._p4rt_acl_counter_obj.asic_db,
+            self._p4rt_acl_counter_obj.ASIC_DB_TBL_NAME,
+        )
+        assert len(acl_asic_counters) == len(original_asic_acl_counters) + 4
+
+        # query ASIC database for newly created ACL counter
+        counter_asic_db_keys = [
+            key for key in acl_asic_counters
+            if key not in original_asic_acl_counters
+            and key != counter_asic_db_key1
+            and key != counter_asic_db_key2
+            and key != counter_asic_db_key3
+        ]
+        assert len(counter_asic_db_keys) == 1
+        counter_asic_db_key4 = counter_asic_db_keys[0]
+
+        (status, fvs) = util.get_key(
+            self._p4rt_acl_counter_obj.asic_db,
+            self._p4rt_acl_counter_obj.ASIC_DB_TBL_NAME,
+            counter_asic_db_key4,
+        )
+        assert status == True
+        attr_list = [
+            (self._p4rt_acl_counter_obj.SAI_ATTR_ENABLE_PACKET_COUNT, "true"),
+            (self._p4rt_acl_counter_obj.SAI_ATTR_ENABLE_BYTE_COUNT, "true"),
+            (self._p4rt_acl_counter_obj.SAI_ATTR_TABLE_ID, table_asic_db_key),
+        ]
+        util.verify_attr(fvs, attr_list)
+
+        # query ASIC database for ACL rules
+        acl_asic_rules = util.get_keys(
+            self._p4rt_acl_rule_obj.asic_db, self._p4rt_acl_rule_obj.ASIC_DB_TBL_NAME
+        )
+        assert len(acl_asic_rules) == len(original_asic_acl_rules) + 4
+
+        # query ASIC database for newly created ACL rule
+        rule_asic_db_keys = [
+            key for key in acl_asic_rules
+            if key not in original_asic_acl_rules
+            and key != rule_asic_db_key1
+            and key != rule_asic_db_key2
+            and key != rule_asic_db_key3
+        ]
+        assert len(rule_asic_db_keys) == 1
+        rule_asic_db_key4 = rule_asic_db_keys[0]
+
+        (status, fvs) = util.get_key(
+            self._p4rt_acl_rule_obj.asic_db,
+            self._p4rt_acl_rule_obj.ASIC_DB_TBL_NAME,
+            rule_asic_db_key4,
+        )
+        assert status == True
+        attr_list = [
+            (self._p4rt_acl_rule_obj.SAI_ATTR_ACTION_SET_ACL_META_DATA, "1"),
+            (
+                self._p4rt_acl_rule_obj.SAI_ATTR_ACTION_PACKET_ACTION,
+                "SAI_PACKET_ACTION_FORWARD",
+            ),
+            (self._p4rt_acl_rule_obj.SAI_ATTR_MATCH_ETHER_TYPE, "2048&mask:0xffff"),
+            (
+                self._p4rt_acl_rule_obj.SAI_ATTR_MATCH_IP_TYPE,
+                "SAI_ACL_IP_TYPE_IP&mask:0xffffffffffffffff",
+            ),
+            (
+                self._p4rt_acl_rule_obj.SAI_ATTR_MATCH_DST_MAC,
+                "11:22:33:44:55:66&mask:FF:FF:FF:FF:FF:FF",
+            ),
+            (self._p4rt_acl_rule_obj.SAI_ATTR_TABLE_ID, table_asic_db_key),
+            (self._p4rt_acl_rule_obj.SAI_ATTR_COUNTER, counter_asic_db_key4),
+            (self._p4rt_acl_rule_obj.SAI_ATTR_ADMIN_STATE, "true"),
+            (self._p4rt_acl_rule_obj.SAI_ATTR_PRIORITY, "100"),
+        ]
+        util.verify_attr(fvs, attr_list)
+
+        # update new ACL rule 4 with different acl metadata
+        attr_list = [
+            (self._p4rt_acl_rule_obj.ACTION, action),
+            ("param/acl_metadata", "2"),
+        ]
+
+        self._p4rt_acl_rule_obj.set_app_db_entry(
+            table_name_with_rule_key4, attr_list)
+        util.verify_response(
+            self.response_consumer,
+            table_name_with_rule_key4,
+            attr_list,
+            "SWSS_RC_SUCCESS",
+        )
+
+        # query application database for ACL rules
+        acl_rules = util.get_keys(
+            self._p4rt_acl_rule_obj.appl_db,
+            self._p4rt_acl_rule_obj.APP_DB_TBL_NAME + ":" + table_name,
+        )
+        assert len(acl_rules) == len(original_appl_acl_rules) + 4
+
+        # query application database for updated ACL rule
+        (status, fvs) = util.get_key(
+            self._p4rt_acl_rule_obj.appl_db,
+            self._p4rt_acl_table_definition_obj.APP_DB_TBL_NAME,
+            table_name_with_rule_key4,
+        )
+        assert status == True
+        util.verify_attr(fvs, attr_list)
+
+        # query ASIC database for updated ACL rule
+        (status, fvs) = util.get_key(
+            self._p4rt_acl_rule_obj.asic_db,
+            self._p4rt_acl_rule_obj.ASIC_DB_TBL_NAME,
+            rule_asic_db_key4,
+        )
+        assert status == True
+        attr_list = [
+            (self._p4rt_acl_rule_obj.SAI_ATTR_ACTION_SET_ACL_META_DATA, "2"),
+            (
+                self._p4rt_acl_rule_obj.SAI_ATTR_ACTION_PACKET_ACTION,
+                "SAI_PACKET_ACTION_FORWARD",
+            ),
+            (self._p4rt_acl_rule_obj.SAI_ATTR_MATCH_ETHER_TYPE, "2048&mask:0xffff"),
+            (
+                self._p4rt_acl_rule_obj.SAI_ATTR_MATCH_IP_TYPE,
+                "SAI_ACL_IP_TYPE_IP&mask:0xffffffffffffffff",
+            ),
+            (
+                self._p4rt_acl_rule_obj.SAI_ATTR_MATCH_DST_MAC,
+                "11:22:33:44:55:66&mask:FF:FF:FF:FF:FF:FF",
+            ),
+            (self._p4rt_acl_rule_obj.SAI_ATTR_TABLE_ID, table_asic_db_key),
+            (self._p4rt_acl_rule_obj.SAI_ATTR_COUNTER, counter_asic_db_key4),
+            (self._p4rt_acl_rule_obj.SAI_ATTR_ADMIN_STATE, "true"),
+            (self._p4rt_acl_rule_obj.SAI_ATTR_PRIORITY, "100"),
+        ]
+        util.verify_attr(fvs, attr_list)
+
+        # Perform state verification
+        sv = StateVerification(dvs)
+        component = "swss:orchagent"
+        timestamp = "2024-01-01 00:00:00"
+        alarm = "false"
+        sv.set_state_verification_response(
+            dvs, "syncd:syncd", timestamp, "ready", "")
+        sv.trigger_state_verification(dvs, component, timestamp, alarm)
+        time.sleep(2)
+        sv.check_state_verification_status(
+            dvs, component, timestamp, "pass")
+
+        # remove ACL rule 4
+        self._p4rt_acl_rule_obj.remove_app_db_entry(table_name_with_rule_key4)
+        util.verify_response(
+            self.response_consumer, table_name_with_rule_key4, [], "SWSS_RC_SUCCESS"
+        )
+
+        # query application database for ACL rules
+        acl_rules = util.get_keys(
+            self._p4rt_acl_rule_obj.appl_db,
+            self._p4rt_acl_rule_obj.APP_DB_TBL_NAME + ":" + table_name,
+        )
+        assert len(acl_rules) == len(original_appl_acl_rules) + 3
+
+        # verify that the ACL rule no longer exists in application database
+        (status, fvs) = util.get_key(
+            self._p4rt_acl_rule_obj.appl_db,
+            self._p4rt_acl_rule_obj.APP_DB_TBL_NAME,
+            table_name_with_rule_key4,
+        )
+        assert status == False
+
+        # query ASIC database for ACL rules
+        acl_rules = util.get_keys(
+            self._p4rt_acl_rule_obj.asic_db, self._p4rt_acl_rule_obj.ASIC_DB_TBL_NAME
+        )
+        assert len(acl_rules) == len(original_asic_acl_rules) + 3
+
+        # verify that removed ACL rule no longer exists in ASIC database
+        (status, fvs) = util.get_key(
+            self._p4rt_acl_rule_obj.asic_db,
+            self._p4rt_acl_rule_obj.ASIC_DB_TBL_NAME,
+            rule_asic_db_key4,
+        )
+        assert status == False
 
         # remove ACL rule 3
         self._p4rt_acl_rule_obj.remove_app_db_entry(table_name_with_rule_key3)

--- a/tests/p4rt/test_p4rt_acl.py
+++ b/tests/p4rt/test_p4rt_acl.py
@@ -142,13 +142,16 @@ class TestP4RTAcl(object):
         )
 
         # Verify APP DB trap groups for QOS_QUEUE
-        genetlink_name = "genl_packet"
+        genetlink_name = "genl_packet_q{}"
         genetlink_mcgrp_name = "packets"
 
         for queue_num in range(1, 9):
             attr_list = [
                 (self._p4rt_trap_group_obj.QUEUE, str(queue_num)),
-                (self._p4rt_trap_group_obj.HOSTIF_NAME, genetlink_name),
+                (
+                    self._p4rt_trap_group_obj.HOSTIF_NAME,
+                    genetlink_name.format(str(queue_num)),
+                ),
                 (
                     self._p4rt_trap_group_obj.HOSTIF_GENETLINK_MCGRP_NAME,
                     genetlink_mcgrp_name,
@@ -457,7 +460,7 @@ class TestP4RTAcl(object):
             ("param/traffic_class", "1"),
             (self._p4rt_acl_rule_obj.METER_CIR, meter_cir),
             (self._p4rt_acl_rule_obj.METER_CBURST, meter_cbs),
-            (self._p4rt_acl_rule_obj.METER_MODE, "storm"),
+            (self._p4rt_acl_rule_obj.METER_MODE, "single_rate_two_color"),
         ]
 
         self._p4rt_acl_rule_obj.set_app_db_entry(
@@ -1213,7 +1216,7 @@ class TestP4RTAcl(object):
             '[OrchAgent] ACL rule \'ACL_PUNT_TABLE_RULE_TEST:{"match/is_ip":"0x1","match/ether_type":"0x0800 & 0xFFFF","match/ether_dst":"AA:BB:CC:DD:EE:11 & FF:FF:FF:FF:FF:FF","priority":100}\' has invalid policer mode:\'tcm\'',
         )
 
-        # Second attempt failed with since pir!=cir or pburst!=cburst in default storm mode
+        # Second attempt failed with since pir!=cir or pburst!=cburst in default single_rate_two_color mode
         attr_list = [
             (self._p4rt_acl_rule_obj.ACTION, action),
             ("param/qos_queue", "7"),
@@ -1229,7 +1232,7 @@ class TestP4RTAcl(object):
             table_name_with_rule_key4,
             attr_list,
             "SWSS_RC_INVALID_PARAM",
-            '[OrchAgent] ACL policer for \'ACL_PUNT_TABLE_RULE_TEST:{"match/is_ip":"0x1","match/ether_type":"0x0800 & 0xFFFF","match/ether_dst":"AA:BB:CC:DD:EE:11 & FF:FF:FF:FF:FF:FF","priority":100}\' in default storm mode has invalid cir:pir/cburst:pburst pairs, expected cir==pir, cburst==pburst.',
+            '[OrchAgent] ACL policer for \'ACL_PUNT_TABLE_RULE_TEST:{"match/is_ip":"0x1","match/ether_type":"0x0800 & 0xFFFF","match/ether_dst":"AA:BB:CC:DD:EE:11 & FF:FF:FF:FF:FF:FF","priority":100}\' in default single_rate_two_color mode has invalid cir:pir/cburst:pburst pairs, expected cir==pir, cburst==pburst.',
         )
 
         attr_list = [
@@ -1237,7 +1240,7 @@ class TestP4RTAcl(object):
             ("param/qos_queue", "7"),
             (
                 self._p4rt_acl_rule_obj.METER_MODE,
-                "tr_tcm",
+                "two_rate_three_color",
             ),  # Two Rate, Three Code Marker
             (self._p4rt_acl_rule_obj.METER_CIR, meter_cir),
             (self._p4rt_acl_rule_obj.METER_CBURST, meter_cbs),
@@ -1320,13 +1323,13 @@ class TestP4RTAcl(object):
         ]
         util.verify_attr(fvs, attr_list)
 
-        # Update ACL rule 4 to sr_tcm policer mode is not supported
+        # Update ACL rule 4 to single_rate_three_color policer mode is not supported
         attr_list = [
             (self._p4rt_acl_rule_obj.ACTION, action),
             ("param/qos_queue", "7"),
             (
                 self._p4rt_acl_rule_obj.METER_MODE,
-                "sr_tcm",
+                "single_rate_three_color",
             ),  # Single Rate, Three Code Marker
             (self._p4rt_acl_rule_obj.METER_CIR, meter_cir),
             (self._p4rt_acl_rule_obj.METER_CBURST, meter_cbs),

--- a/tests/p4rt/test_p4rt_acl.py
+++ b/tests/p4rt/test_p4rt_acl.py
@@ -24,9 +24,10 @@ def verify_selected_attr_vals(db, table, key, expected_attrs):
     fv_dict = dict(fvs)
 
     for attr_name, expected_val in expected_attrs:
-        assert attr_name in fv_dict, "Attribute %s not found in %s" % (
-            attr_name, key)
-        assert fv_dict[attr_name] == expected_val, "Wrong value %s for the attribute %s = %s" % (
+        assert attr_name in fv_dict, "Attribute %s not found in %s" % (attr_name, key)
+        assert (
+            fv_dict[attr_name] == expected_val
+        ), "Wrong value %s for the attribute %s = %s" % (
             fv_dict[attr_name],
             attr_name,
             expected_val,
@@ -132,9 +133,11 @@ class TestP4RTAcl(object):
             self._p4rt_acl_group_obj.asic_db,
             "ASIC_STATE:SAI_OBJECT_TYPE_SWITCH",
             switch_oid,
-            [("SAI_SWITCH_ATTR_PRE_INGRESS_ACL", pre_ingress_group_oids[0]),
-             ("SAI_SWITCH_ATTR_INGRESS_ACL", ingress_group_oids[0]),
-             ("SAI_SWITCH_ATTR_EGRESS_ACL", egress_group_oids[0])],
+            [
+                ("SAI_SWITCH_ATTR_PRE_INGRESS_ACL", pre_ingress_group_oids[0]),
+                ("SAI_SWITCH_ATTR_INGRESS_ACL", ingress_group_oids[0]),
+                ("SAI_SWITCH_ATTR_EGRESS_ACL", egress_group_oids[0]),
+            ],
         )
 
         # Verify APP DB trap groups for QOS_QUEUE
@@ -186,7 +189,8 @@ class TestP4RTAcl(object):
         punt_and_set_tc = '[{"action":"SAI_PACKET_ACTION_TRAP","packet_color":"SAI_PACKET_COLOR_RED"},{"action":"SAI_ACL_ENTRY_ATTR_ACTION_SET_TC","param":"traffic_class"}]'
         qos_queue = '[{"action":"SAI_PACKET_ACTION_TRAP"},{"action":"QOS_QUEUE","param":"cpu_queue"}]'
 
-        acl_rate_limit_copy = '[{"action":"SAI_PACKET_ACTION_FORWARD","packet_color":"SAI_PACKET_COLOR_GREEN"},{"action":"SAI_PACKET_ACTION_COPY_CANCEL","packet_color":"SAI_PACKET_COLOR_YELLOW"},{"action":"SAI_PACKET_ACTION_COPY_CANCEL","packet_color":"SAI_PACKET_COLOR_RED"},{"action":"QOS_QUEUE","param":"qos_queue"}]'
+        acl_rate_limit_copy = '[{"action":"SAI_PACKET_ACTION_FORWARD","packet_color":"SAI_PACKET_COLOR_GREEN"},{"action":"SAI_PACKET_ACTION_COPY_CANCEL","packet_color":"SAI_PACKET_COLOR_RED"},{"action":"QOS_QUEUE","param":"qos_queue"}]'
+        acl_rate_limit_tcm = '[{"action":"SAI_PACKET_ACTION_FORWARD","packet_color":"SAI_PACKET_COLOR_GREEN"},{"action":"SAI_PACKET_ACTION_COPY_CANCEL","packet_color":"SAI_PACKET_COLOR_YELLOW"},{"action":"SAI_PACKET_ACTION_COPY_CANCEL","packet_color":"SAI_PACKET_COLOR_RED"},{"action":"QOS_QUEUE","param":"qos_queue"}]'
 
         attr_list = [
             (self._p4rt_acl_table_definition_obj.STAGE_FIELD, stage),
@@ -213,7 +217,14 @@ class TestP4RTAcl(object):
                 punt_and_set_tc,
             ),
             (self._p4rt_acl_table_definition_obj.ACTION_SET_QOS_QUEUE, qos_queue),
-	    (self._p4rt_acl_table_definition_obj.ACTION_SET_ACL_RATE_LIMIT_COPY, acl_rate_limit_copy),
+	                (
+                self._p4rt_acl_table_definition_obj.ACTION_SET_ACL_RATE_LIMIT_COPY,
+                acl_rate_limit_copy,
+            ),
+            (
+                "action/acl_rate_limit_tcm",
+                acl_rate_limit_tcm,
+            ),  # 3 color mode for ACL policer config
             (self._p4rt_acl_table_definition_obj.METER_UNIT, meter_unit),
             (self._p4rt_acl_table_definition_obj.COUNTER_UNIT, counter_unit),
         ]
@@ -320,8 +331,7 @@ class TestP4RTAcl(object):
         assert len(udfs_asic) == len(original_asic_udfs) + 2
 
         # query ASIC database for newly created UDFs
-        udfs_asic_db_keys = [
-            key for key in udfs_asic if key not in original_asic_udfs]
+        udfs_asic_db_keys = [key for key in udfs_asic if key not in original_asic_udfs]
         assert len(udfs_asic_db_keys) == 2
         udfs_asic_db_keys.sort()
         udf_0_asic_db_key = udfs_asic_db_keys[0]
@@ -382,7 +392,10 @@ class TestP4RTAcl(object):
             ),
             (self._p4rt_acl_table_definition_obj.SAI_ACL_TABLE_ATTR_SIZE, size),
             (self._p4rt_acl_table_definition_obj.SAI_ATTR_MATCH_ETHER_TYPE, "true"),
-            (self._p4rt_acl_table_definition_obj.SAI_ATTR_MATCH_ROUTE_DST_USER_META, "true"),
+            (
+                self._p4rt_acl_table_definition_obj.SAI_ATTR_MATCH_ROUTE_DST_USER_META,
+                "true",
+            ),
             (self._p4rt_acl_table_definition_obj.SAI_ATTR_MATCH_IP_TYPE, "true"),
             (self._p4rt_acl_table_definition_obj.SAI_ATTR_MATCH_DST_MAC, "true"),
             (self._p4rt_acl_table_definition_obj.SAI_ATTR_MATCH_SRC_IPV6_WORD3, "true"),
@@ -424,8 +437,6 @@ class TestP4RTAcl(object):
         action = "copy_and_set_tc"
         meter_cir = "80"
         meter_cbs = "80"
-        meter_pir = "200"
-        meter_pbs = "200"
         table_name_with_rule_key1 = table_name + ":" + rule_json_key1
 
         # First attemp failed due to invalid meter
@@ -451,8 +462,7 @@ class TestP4RTAcl(object):
             ("param/traffic_class", "1"),
             (self._p4rt_acl_rule_obj.METER_CIR, meter_cir),
             (self._p4rt_acl_rule_obj.METER_CBURST, meter_cbs),
-            (self._p4rt_acl_rule_obj.METER_PIR, meter_pir),
-            (self._p4rt_acl_rule_obj.METER_PBURST, meter_pbs),
+            (self._p4rt_acl_rule_obj.METER_MODE, "storm"),
         ]
 
         self._p4rt_acl_rule_obj.set_app_db_entry(
@@ -527,11 +537,12 @@ class TestP4RTAcl(object):
         assert status == True
         attr_list = [
             (self._p4rt_acl_meter_obj.SAI_ATTR_METER_TYPE, "SAI_METER_TYPE_PACKETS"),
-            (self._p4rt_acl_meter_obj.SAI_ATTR_METER_MODE, "SAI_POLICER_MODE_TR_TCM"),
+            (
+                self._p4rt_acl_meter_obj.SAI_ATTR_METER_MODE,
+                "SAI_POLICER_MODE_STORM_CONTROL",
+            ),
             (self._p4rt_acl_meter_obj.SAI_ATTR_METER_CIR, meter_cir),
             (self._p4rt_acl_meter_obj.SAI_ATTR_METER_CBS, meter_cbs),
-            (self._p4rt_acl_meter_obj.SAI_ATTR_METER_PIR, meter_pir),
-            (self._p4rt_acl_meter_obj.SAI_ATTR_METER_PBS, meter_pbs),
         ]
         util.verify_attr(fvs, attr_list)
 
@@ -598,8 +609,6 @@ class TestP4RTAcl(object):
         action = "punt_and_set_tc"
         meter_cir = "100"
         meter_cbs = "100"
-        meter_pir = "400"
-        meter_pbs = "400"
         table_name_with_rule_key1 = table_name + ":" + rule_json_key1
 
         attr_list = [
@@ -607,8 +616,6 @@ class TestP4RTAcl(object):
             ("param/traffic_class", "2"),
             (self._p4rt_acl_rule_obj.METER_CIR, meter_cir),
             (self._p4rt_acl_rule_obj.METER_CBURST, meter_cbs),
-            (self._p4rt_acl_rule_obj.METER_PIR, meter_pir),
-            (self._p4rt_acl_rule_obj.METER_PBURST, meter_pbs),
         ]
 
         self._p4rt_acl_rule_obj.set_app_db_entry(
@@ -683,11 +690,12 @@ class TestP4RTAcl(object):
         assert status == True
         attr_list = [
             (self._p4rt_acl_meter_obj.SAI_ATTR_METER_TYPE, "SAI_METER_TYPE_PACKETS"),
-            (self._p4rt_acl_meter_obj.SAI_ATTR_METER_MODE, "SAI_POLICER_MODE_TR_TCM"),
+            (
+                self._p4rt_acl_meter_obj.SAI_ATTR_METER_MODE,
+                "SAI_POLICER_MODE_STORM_CONTROL",
+            ),
             (self._p4rt_acl_meter_obj.SAI_ATTR_METER_CIR, meter_cir),
             (self._p4rt_acl_meter_obj.SAI_ATTR_METER_CBS, meter_cbs),
-            (self._p4rt_acl_meter_obj.SAI_ATTR_METER_PIR, meter_pir),
-            (self._p4rt_acl_meter_obj.SAI_ATTR_METER_PBS, meter_pbs),
             (
                 self._p4rt_acl_meter_obj.SAI_ATTR_RED_PACKET_ACTION,
                 "SAI_PACKET_ACTION_TRAP",
@@ -755,8 +763,6 @@ class TestP4RTAcl(object):
         action = "qos_queue"
         meter_cir = "80"
         meter_cbs = "80"
-        meter_pir = "200"
-        meter_pbs = "200"
         table_name_with_rule_key2 = table_name + ":" + rule_json_key2
 
     # First attempt failed since no UserDefinedTrap is created for the CPU queue    
@@ -804,8 +810,6 @@ class TestP4RTAcl(object):
             ("param/cpu_queue", "5"),
             (self._p4rt_acl_rule_obj.METER_CIR, meter_cir),
             (self._p4rt_acl_rule_obj.METER_CBURST, meter_cbs),
-            (self._p4rt_acl_rule_obj.METER_PIR, meter_pir),
-            (self._p4rt_acl_rule_obj.METER_PBURST, meter_pbs),
         ]
 
         self._p4rt_acl_rule_obj.set_app_db_entry(
@@ -884,11 +888,12 @@ class TestP4RTAcl(object):
         assert status == True
         attr_list = [
             (self._p4rt_acl_meter_obj.SAI_ATTR_METER_TYPE, "SAI_METER_TYPE_PACKETS"),
-            (self._p4rt_acl_meter_obj.SAI_ATTR_METER_MODE, "SAI_POLICER_MODE_TR_TCM"),
+            (
+                self._p4rt_acl_meter_obj.SAI_ATTR_METER_MODE,
+                "SAI_POLICER_MODE_STORM_CONTROL",
+            ),
             (self._p4rt_acl_meter_obj.SAI_ATTR_METER_CIR, meter_cir),
             (self._p4rt_acl_meter_obj.SAI_ATTR_METER_CBS, meter_cbs),
-            (self._p4rt_acl_meter_obj.SAI_ATTR_METER_PIR, meter_pir),
-            (self._p4rt_acl_meter_obj.SAI_ATTR_METER_PBS, meter_pbs),
         ]
         util.verify_attr(fvs, attr_list)
 
@@ -980,7 +985,9 @@ class TestP4RTAcl(object):
         util.verify_attr(fvs, attr_list)
 
         # create ACL rule 3 with match field SAI_ACL_TABLE_ATTR_FIELD_ROUTE_DST_USER_META
-        rule_json_key3 = '{"match/ether_type":"0x0800","match/l3_class_id":"0x1", "priority":100}'
+        rule_json_key3 = (
+            '{"match/ether_type":"0x0800","match/l3_class_id":"0x1", "priority":100}'
+        )
         action = "copy_and_set_tc"
         table_name_with_rule_key3 = table_name + ":" + rule_json_key3
 
@@ -1022,7 +1029,8 @@ class TestP4RTAcl(object):
 
         # query ASIC database for newly created ACL counter
         counter_asic_db_keys = [
-            key for key in acl_asic_counters
+            key
+            for key in acl_asic_counters
             if key not in original_asic_acl_counters
             and key != counter_asic_db_key1
             and key != counter_asic_db_key2
@@ -1051,7 +1059,8 @@ class TestP4RTAcl(object):
 
         # query ASIC database for newly created ACL rule
         rule_asic_db_keys = [
-            key for key in acl_asic_rules
+            key
+            for key in acl_asic_rules
             if key not in original_asic_acl_rules
             and key != rule_asic_db_key1
             and key != rule_asic_db_key2
@@ -1087,7 +1096,6 @@ class TestP4RTAcl(object):
         ]
         util.verify_attr(fvs, attr_list)
 
-	
 	  # update ACL rule 2 with acl_rate_limit_copy action
         action = "acl_rate_limit_copy"
 
@@ -1096,8 +1104,6 @@ class TestP4RTAcl(object):
             ("param/qos_queue", "7"),
             (self._p4rt_acl_rule_obj.METER_CIR, meter_cir),
             (self._p4rt_acl_rule_obj.METER_CBURST, meter_cbs),
-            (self._p4rt_acl_rule_obj.METER_PIR, meter_pir),
-            (self._p4rt_acl_rule_obj.METER_PBURST, meter_pbs),
         ]
 
         self._p4rt_acl_rule_obj.set_app_db_entry(
@@ -1124,7 +1130,7 @@ class TestP4RTAcl(object):
         assert status == True
         util.verify_attr(fvs, attr_list)
 
-         # query ASIC database for updated ACL meter
+        # query ASIC database for updated ACL meter
         (status, fvs) = util.get_key(
             self._p4rt_acl_meter_obj.asic_db,
             self._p4rt_acl_meter_obj.ASIC_DB_TBL_NAME,
@@ -1137,19 +1143,16 @@ class TestP4RTAcl(object):
                 "SAI_PACKET_ACTION_FORWARD",
             ),
             (
-                self._p4rt_acl_meter_obj.SAI_ATTR_YELLOW_PACKET_ACTION,
-                "SAI_PACKET_ACTION_COPY_CANCEL",
-            ),
-            (
                 self._p4rt_acl_meter_obj.SAI_ATTR_RED_PACKET_ACTION,
                 "SAI_PACKET_ACTION_COPY_CANCEL",
             ),
             (self._p4rt_acl_meter_obj.SAI_ATTR_METER_TYPE, "SAI_METER_TYPE_PACKETS"),
-            (self._p4rt_acl_meter_obj.SAI_ATTR_METER_MODE, "SAI_POLICER_MODE_TR_TCM"),
+            (
+                self._p4rt_acl_meter_obj.SAI_ATTR_METER_MODE,
+                "SAI_POLICER_MODE_STORM_CONTROL",
+            ),
             (self._p4rt_acl_meter_obj.SAI_ATTR_METER_CIR, meter_cir),
             (self._p4rt_acl_meter_obj.SAI_ATTR_METER_CBS, meter_cbs),
-            (self._p4rt_acl_meter_obj.SAI_ATTR_METER_PIR, meter_pir),
-            (self._p4rt_acl_meter_obj.SAI_ATTR_METER_PBS, meter_pbs),
         ]
         util.verify_attr(fvs, attr_list)
 
@@ -1186,6 +1189,183 @@ class TestP4RTAcl(object):
         ]
         util.verify_attr(fvs, attr_list)
 
+        # create ACL rule 4 with tr_tcm policer mode
+        rule_json_key4 = '{"match/is_ip":"0x1","match/ether_type":"0x0800 & 0xFFFF","match/ether_dst":"AA:BB:CC:DD:EE:11 & FF:FF:FF:FF:FF:FF","priority":100}'
+        action = "acl_rate_limit_tcm"
+        meter_cir = "80"
+        meter_cbs = "400"
+        meter_pir = "800"
+        meter_pbs = "4000"
+        table_name_with_rule_key4 = table_name + ":" + rule_json_key4
+
+        # First attempt failed with invalid policer mode
+        attr_list = [
+            (self._p4rt_acl_rule_obj.ACTION, action),
+            ("param/qos_queue", "7"),
+            (self._p4rt_acl_rule_obj.METER_MODE, "tcm"),  # invalid policer mode
+            (self._p4rt_acl_rule_obj.METER_CIR, meter_cir),
+            (self._p4rt_acl_rule_obj.METER_CBURST, meter_cbs),
+            (self._p4rt_acl_rule_obj.METER_PIR, meter_pir),
+            (self._p4rt_acl_rule_obj.METER_PBURST, meter_pbs),
+        ]
+
+        self._p4rt_acl_rule_obj.set_app_db_entry(table_name_with_rule_key4, attr_list)
+        util.verify_response(
+            self.response_consumer,
+            table_name_with_rule_key4,
+            attr_list,
+            "SWSS_RC_INVALID_PARAM",
+            '[OrchAgent] ACL rule \'ACL_PUNT_TABLE_RULE_TEST:{"match/is_ip":"0x1","match/ether_type":"0x0800 & 0xFFFF","match/ether_dst":"AA:BB:CC:DD:EE:11 & FF:FF:FF:FF:FF:FF","priority":100}\' has invalid policer mode:\'tcm\'',
+        )
+
+        # Second attempt failed with since pir!=cir or pburst!=cburst in default storm mode
+        attr_list = [
+            (self._p4rt_acl_rule_obj.ACTION, action),
+            ("param/qos_queue", "7"),
+            (self._p4rt_acl_rule_obj.METER_CIR, meter_cir),
+            (self._p4rt_acl_rule_obj.METER_CBURST, meter_cbs),
+            (self._p4rt_acl_rule_obj.METER_PIR, meter_pir),
+            (self._p4rt_acl_rule_obj.METER_PBURST, meter_pbs),
+        ]
+
+        self._p4rt_acl_rule_obj.set_app_db_entry(table_name_with_rule_key4, attr_list)
+        util.verify_response(
+            self.response_consumer,
+            table_name_with_rule_key4,
+            attr_list,
+            "SWSS_RC_INVALID_PARAM",
+            '[OrchAgent] ACL policer for \'ACL_PUNT_TABLE_RULE_TEST:{"match/is_ip":"0x1","match/ether_type":"0x0800 & 0xFFFF","match/ether_dst":"AA:BB:CC:DD:EE:11 & FF:FF:FF:FF:FF:FF","priority":100}\' in default storm mode has invalid cir:pir/cburst:pburst pairs, expected cir==pir, cburst==pburst.',
+        )
+
+        attr_list = [
+            (self._p4rt_acl_rule_obj.ACTION, action),
+            ("param/qos_queue", "7"),
+            (
+                self._p4rt_acl_rule_obj.METER_MODE,
+                "tr_tcm",
+            ),  # Two Rate, Three Code Marker
+            (self._p4rt_acl_rule_obj.METER_CIR, meter_cir),
+            (self._p4rt_acl_rule_obj.METER_CBURST, meter_cbs),
+            (self._p4rt_acl_rule_obj.METER_PIR, meter_pir),
+            (self._p4rt_acl_rule_obj.METER_PBURST, meter_pbs),
+        ]
+        self._p4rt_acl_rule_obj.set_app_db_entry(table_name_with_rule_key4, attr_list)
+        util.verify_response(
+            self.response_consumer,
+            table_name_with_rule_key4,
+            attr_list,
+            "SWSS_RC_SUCCESS",
+        )
+
+        # query application database for ACL rules
+        acl_rules = util.get_keys(
+            self._p4rt_acl_rule_obj.appl_db,
+            self._p4rt_acl_rule_obj.APP_DB_TBL_NAME + ":" + table_name,
+        )
+        assert len(acl_rules) == len(original_appl_acl_rules) + 4
+
+        # query application database for newly created ACL rule
+        (status, fvs) = util.get_key(
+            self._p4rt_acl_rule_obj.appl_db,
+            self._p4rt_acl_table_definition_obj.APP_DB_TBL_NAME,
+            table_name_with_rule_key4,
+        )
+        assert status == True
+        util.verify_attr(fvs, attr_list)
+
+        # query ASIC database for ACL counters
+        acl_asic_counters = util.get_keys(
+            self._p4rt_acl_counter_obj.asic_db,
+            self._p4rt_acl_counter_obj.ASIC_DB_TBL_NAME,
+        )
+        assert len(acl_asic_counters) == len(original_asic_acl_counters) + 4
+
+        # query ASIC database for ACL meters
+        acl_asic_meters = util.get_keys(
+            self._p4rt_acl_meter_obj.asic_db, self._p4rt_acl_meter_obj.ASIC_DB_TBL_NAME
+        )
+        assert len(acl_asic_meters) == len(original_asic_acl_meters) + 3
+
+        # query ASIC database for newly created ACL meter
+        meter_asic_db_keys = [
+            key
+            for key in acl_asic_meters
+            if key not in original_asic_acl_meters
+            and key != meter_asic_db_key1
+            and key != meter_asic_db_key2
+        ]
+        assert len(meter_asic_db_keys) == 1
+        meter_asic_db_key4 = meter_asic_db_keys[0]
+
+        (status, fvs) = util.get_key(
+            self._p4rt_acl_meter_obj.asic_db,
+            self._p4rt_acl_meter_obj.ASIC_DB_TBL_NAME,
+            meter_asic_db_key4,
+        )
+        assert status == True
+        attr_list = [
+            (self._p4rt_acl_meter_obj.SAI_ATTR_METER_TYPE, "SAI_METER_TYPE_PACKETS"),
+            (self._p4rt_acl_meter_obj.SAI_ATTR_METER_MODE, "SAI_POLICER_MODE_TR_TCM"),
+            (self._p4rt_acl_meter_obj.SAI_ATTR_METER_CIR, meter_cir),
+            (self._p4rt_acl_meter_obj.SAI_ATTR_METER_CBS, meter_cbs),
+            (self._p4rt_acl_meter_obj.SAI_ATTR_METER_PIR, meter_pir),
+            (self._p4rt_acl_meter_obj.SAI_ATTR_METER_PBS, meter_pbs),
+            (
+                self._p4rt_acl_meter_obj.SAI_ATTR_GREEN_PACKET_ACTION,
+                "SAI_PACKET_ACTION_FORWARD",
+            ),
+            (
+                self._p4rt_acl_meter_obj.SAI_ATTR_YELLOW_PACKET_ACTION,
+                "SAI_PACKET_ACTION_COPY_CANCEL",
+            ),
+            (
+                self._p4rt_acl_meter_obj.SAI_ATTR_RED_PACKET_ACTION,
+                "SAI_PACKET_ACTION_COPY_CANCEL",
+            ),
+        ]
+        util.verify_attr(fvs, attr_list)
+
+        # Update ACL rule 4 to sr_tcm policer mode is not supported
+        attr_list = [
+            (self._p4rt_acl_rule_obj.ACTION, action),
+            ("param/qos_queue", "7"),
+            (
+                self._p4rt_acl_rule_obj.METER_MODE,
+                "sr_tcm",
+            ),  # Single Rate, Three Code Marker
+            (self._p4rt_acl_rule_obj.METER_CIR, meter_cir),
+            (self._p4rt_acl_rule_obj.METER_CBURST, meter_cbs),
+            (self._p4rt_acl_rule_obj.METER_PIR, meter_pir),
+            (self._p4rt_acl_rule_obj.METER_PBURST, meter_pbs),
+        ]
+        self._p4rt_acl_rule_obj.set_app_db_entry(table_name_with_rule_key4, attr_list)
+        util.verify_response(
+            self.response_consumer,
+            table_name_with_rule_key4,
+            attr_list,
+            "SWSS_RC_UNIMPLEMENTED",
+            "[OrchAgent] Updating ACL rule meter mode is not supported for ACL entry: 'match/ether_dst=AA:BB:CC:DD:EE:11 & FF:FF:FF:FF:FF:FF:match/ether_type=0x0800 & 0xFFFF:match/is_ip=0x1:priority=100' in table 'ACL_PUNT_TABLE_RULE_TEST'",
+        )
+
+        # remove ACL rule 4
+        self._p4rt_acl_rule_obj.remove_app_db_entry(table_name_with_rule_key4)
+        util.verify_response(
+            self.response_consumer, table_name_with_rule_key4, [], "SWSS_RC_SUCCESS"
+        )
+
+        # Re-create ACL rule 4 with sr_tcm policer mode
+        self._p4rt_acl_rule_obj.set_app_db_entry(table_name_with_rule_key4, attr_list)
+        util.verify_response(
+            self.response_consumer,
+            table_name_with_rule_key4,
+            attr_list,
+            "SWSS_RC_SUCCESS",
+        )
+        # remove ACL rule 4
+        self._p4rt_acl_rule_obj.remove_app_db_entry(table_name_with_rule_key4)
+        util.verify_response(
+            self.response_consumer, table_name_with_rule_key4, [], "SWSS_RC_SUCCESS"
+        )
 
         # remove ACL rule 3
         self._p4rt_acl_rule_obj.remove_app_db_entry(table_name_with_rule_key3)
@@ -1396,8 +1576,6 @@ class TestP4RTAcl(object):
         action = "copy_and_set_tc"
         meter_cir = "80"
         meter_cbs = "80"
-        meter_pir = "200"
-        meter_pbs = "200"
         table_name_with_rule_key = table_name + ":" + rule_json_key
 
         attr_list = [
@@ -1405,8 +1583,6 @@ class TestP4RTAcl(object):
             ("param/traffic_class", "1"),
             (self._p4rt_acl_rule_obj.METER_CIR, meter_cir),
             (self._p4rt_acl_rule_obj.METER_CBURST, meter_cbs),
-            (self._p4rt_acl_rule_obj.METER_PIR, meter_pir),
-            (self._p4rt_acl_rule_obj.METER_PBURST, meter_pbs),
         ]
 
         self._p4rt_acl_rule_obj.set_app_db_entry(


### PR DESCRIPTION
****What I did***
P4Orch Combined Pr for
1.Update P4 ACL Policer default mode to STORM_CONTROL(single rate two color markers)
2.Add SAI_ACL_ENTRY_ATTR_ACTION_SET_ACL_META_DATA into isDiffActionFieldValue.
3.Add support to redirect to a L3 multicast group.
4.Add ACL support to redirect to L2 multicast group.
5. Update ACL meter mode p4 names and Modify test_AclRulesAddUpdateDelPass to use newer genetlink_name format and unskip the test.

**Why I did it**

**How I verified it**
Verified with UT cases.

**Details if related**
