### PR TITLE
[aclorch] Disable combined mirror V6 table for Tomahawk6 platforms

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3470,6 +3470,33 @@ bool AclRange::remove()
     return true;
 }
 
+static bool isSeparateMirrorV6TablePlatform()
+{
+    static const vector<string> separateMirrorV6Platforms = {
+        "nokia_ixr7220_h6",   // Tomahawk6
+    };
+
+    DBConnector cfgDb("CONFIG_DB", 0);
+    Table cfgDeviceMetaDataTable(&cfgDb, CFG_DEVICE_METADATA_TABLE_NAME);
+    string specific_platform;
+
+    if (!cfgDeviceMetaDataTable.hget("localhost", "platform", specific_platform))
+    {
+        return false;
+    }
+
+    for (const auto& p : separateMirrorV6Platforms)
+    {
+        if (specific_platform.find(p) != string::npos)
+        {
+            SWSS_LOG_NOTICE("Platform %s requires separate mirror V6 table", specific_platform.c_str());
+            return true;
+        }
+    }
+
+    return false;
+}
+
 void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, MirrorOrch *mirrorOrch, NeighOrch *neighOrch, RouteOrch *routeOrch)
 {
     SWSS_LOG_ENTER();
@@ -3548,7 +3575,8 @@ void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, Mirr
         platform == MRVL_PRST_PLATFORM_SUBSTRING ||
         platform == XS_PLATFORM_SUBSTRING ||
         platform == CLX_PLATFORM_SUBSTRING ||
-        (platform == BRCM_PLATFORM_SUBSTRING && sub_platform == BRCM_DNX_PLATFORM_SUBSTRING))
+        (platform == BRCM_PLATFORM_SUBSTRING && sub_platform == BRCM_DNX_PLATFORM_SUBSTRING) ||
+        isSeparateMirrorV6TablePlatform())
     {
         m_isCombinedMirrorV6Table = false;
     }


### PR DESCRIPTION
Add isSeparateMirrorV6TablePlatform() to check the device platform name from CONFIG_DB DEVICE_METADATA and disable the combined mirror V6 table for platforms that require separate V4/V6 mirror ACL tables. Currently this applies to Nokia IXR7220-H6 (Tomahawk6) platforms.

**Why I did it**

Currently, combined everflow IPv4/IPv6 table creation fails on TH6 platform. This is due to the qualifier set being too large for TH6 field processor. There is currently an open Broadcom CSP (Case CS00012433094) to address this. For now, to pass everflow tests, tell orchagent to create seperate IPv4 and IPv6 mirror tables similar to broadcom DNX platform.

**How I verified it**

Validate that everflow tests now pass.

**Details if related**
