### PR TITLE
[202511] Revert "[FC] Set FC delay in command line parameters (#3814)"

### DIFF
--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -39,7 +39,7 @@ extern Srv6Orch *gSrv6Orch;
 extern SwitchOrch *gSwitchOrch;
 extern sai_object_id_t gSwitchId;
 
-int gFlexCounterDelaySec;
+#define FLEX_COUNTER_DELAY_SEC 60
 
 #define BUFFER_POOL_WATERMARK_KEY   "BUFFER_POOL_WATERMARK"
 #define PORT_KEY                    "PORT"
@@ -120,12 +120,11 @@ FlexCounterOrch::FlexCounterOrch(DBConnector *db, vector<string> &tableNames):
         SWSS_LOG_ERROR("System error reading create_only_config_db_buffers: %s", e.what());
     }
 
-    SWSS_LOG_NOTICE("Counter delay is %d seconds", gFlexCounterDelaySec);
-    if (gFlexCounterDelaySec > 0)
+    m_delayTimer = std::make_unique<SelectableTimer>(timespec{.tv_sec = FLEX_COUNTER_DELAY_SEC, .tv_nsec = 0});
+    if (WarmStart::isWarmStart())
     {
-        m_delayTimer = new SelectableTimer(timespec{.tv_sec = static_cast<time_t>(gFlexCounterDelaySec), .tv_nsec = 0});
-        auto delayExecutor = new ExecutableTimer(m_delayTimer, this, "FLEX_COUNTER_DELAY");
-        Orch::addExecutor(delayExecutor);
+        m_delayExecutor = std::make_unique<ExecutableTimer>(m_delayTimer.get(), this, "FLEX_COUNTER_DELAY");
+        Orch::addExecutor(m_delayExecutor.get());
         m_delayTimer->start();
     }
     else

--- a/orchagent/flexcounterorch.h
+++ b/orchagent/flexcounterorch.h
@@ -11,18 +11,6 @@ extern "C" {
 #include "sai.h"
 }
 
-// Delay in seconds before flex counter processing begins after orchagent startup.
-// 
-// This delay improves boot time by prioritizing data plane configuration over
-// counter initialization. Systems with many ports, priority groups (PGs), and
-// queues require significant time to generate counter maps, which is not
-// immediately necessary during boot.
-// Value of 0 will process flex counters immediately.
-// 
-// Configured via orchagent command line argument: -D <delay_sec>
-// 
-extern int gFlexCounterDelaySec;
-
 const std::string createAllAvailableBuffersStr = "create_all_available_buffers";
 
 class FlexCounterQueueStates
@@ -91,7 +79,8 @@ private:
     Table m_bufferQueueConfigTable;
     Table m_bufferPgConfigTable;
     Table m_deviceMetadataConfigTable;
-    SelectableTimer* m_delayTimer;
+    std::unique_ptr<SelectableTimer> m_delayTimer;
+    std::unique_ptr<Executor> m_delayExecutor;
     std::unordered_set<std::string> m_groupsWithBulkChunkSize;
 
     bool m_createOnlyConfigDbBuffers = false;

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -115,7 +115,6 @@ void usage()
     cout << "    -I heart_beat_interval: Heart beat interval in millisecond (default 10)" << endl;
     cout << "    -R enable the ring thread feature" << endl;
     cout << "    -M enable SAI MACSec POST" << endl;
-    cout << "    -D Delay in seconds before flex counter processing begins after orchagent startup (default 0)" << endl;
 }
 
 void sighup_handler(int signo)
@@ -397,7 +396,7 @@ int main(int argc, char **argv)
     // Disable SAI MACSec POST by default. Use option -M to enable it.
     bool macsec_post_enabled = false;
 
-    while ((opt = getopt(argc, argv, "b:m:r:f:j:d:i:hsz:k:q:c:t:v:I:R:D:M")) != -1)
+    while ((opt = getopt(argc, argv, "b:m:r:f:j:d:i:hsz:k:q:c:t:v:I:R:M")) != -1)
     {
         switch (opt)
         {
@@ -518,7 +517,6 @@ int main(int argc, char **argv)
          case 'M':
             macsec_post_enabled = true;
             break;
-        case 'D': { gFlexCounterDelaySec = swss::to_int<int>(optarg); } break;
         default: /* '?' */
             exit(EXIT_FAILURE);
         }

--- a/tests/mock_tests/flexcounter_ut.cpp
+++ b/tests/mock_tests/flexcounter_ut.cpp
@@ -274,7 +274,13 @@ namespace flexcounter_test
         sai_switch_api = pold_sai_switch_api;
     }
 
-    struct FlexCounterTest : public ::testing::TestWithParam<std::tuple<bool, bool, uint32_t>>
+    enum class StartType
+    {
+        Cold,
+        Warm,
+    };
+
+    struct FlexCounterTest : public ::testing::TestWithParam<std::tuple<bool, bool, StartType>>
     {
         shared_ptr<swss::DBConnector> m_app_db;
         shared_ptr<swss::DBConnector> m_config_db;
@@ -284,6 +290,7 @@ namespace flexcounter_test
         shared_ptr<swss::DBConnector> m_asic_db;
         shared_ptr<swss::DBConnector> m_flex_counter_db;
         bool create_only_config_db_buffers;
+        StartType m_start_type;
 
         FlexCounterTest()
         {
@@ -310,7 +317,7 @@ namespace flexcounter_test
 
             gTraditionalFlexCounter = get<0>(GetParam());
             create_only_config_db_buffers = get<1>(GetParam());
-            gFlexCounterDelaySec = get<2>(GetParam());
+            m_start_type = get<2>(GetParam());
 
             if (gTraditionalFlexCounter)
             {
@@ -357,7 +364,17 @@ namespace flexcounter_test
                 CFG_FLEX_COUNTER_TABLE_NAME
             };
 
+            if (m_start_type == StartType::Warm)
+            {
+                WarmStart::getInstance().m_enabled = true;
+            }
+
             auto* flexCounterOrch = new FlexCounterOrch(m_config_db.get(), flex_counter_tables);
+
+            if (m_start_type == StartType::Warm)
+            {
+                WarmStart::getInstance().m_enabled = false;
+            }
 
             gDirectory.set(flexCounterOrch);
 
@@ -424,9 +441,6 @@ namespace flexcounter_test
             gDirectory.m_values.clear();
 
             _unhook_sai_switch_api();
-
-            // reset flex counter delay sec
-            gFlexCounterDelaySec = 0;
         }
 
         static void SetUpTestCase()
@@ -628,7 +642,7 @@ namespace flexcounter_test
         flexCounterOrch->addExistingData(&flexCounterCfg);
         static_cast<Orch *>(flexCounterOrch)->doTask();
 
-        if (gFlexCounterDelaySec > 0)
+        if (m_start_type == StartType::Warm)
         {
             // Expire timer
             flexCounterOrch->doTask(*flexCounterOrch->m_delayTimer);
@@ -1033,16 +1047,14 @@ namespace flexcounter_test
         FlexCounterTests,
         FlexCounterTest,
         ::testing::Values(
-            // traditional_flex_counter, create_only_config_db_buffers, flex_counter_delay_sec
-            std::make_tuple(false, true, 0),
-            std::make_tuple(false, false, 0),
-            std::make_tuple(true, true, 0),
-            std::make_tuple(true, false, 0),
-            std::make_tuple(false, true, 120),
-            std::make_tuple(false, false, 120),
-            std::make_tuple(true, true, 120),
-            std::make_tuple(true, false, 120)
-        )
+            std::make_tuple(false, true, StartType::Cold),
+            std::make_tuple(false, false, StartType::Cold),
+            std::make_tuple(true, true, StartType::Cold),
+            std::make_tuple(true, false, StartType::Cold),
+            std::make_tuple(false, true, StartType::Warm),
+            std::make_tuple(false, false, StartType::Warm),
+            std::make_tuple(true, true, StartType::Warm),
+            std::make_tuple(true, false, StartType::Warm))
     );
 
     using namespace mock_orch_test;


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

This reverts commit 5de59222041bdf29c0be1c9805180333351a9be8.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
* Reverted FC delay configuration

**Why I did it**
* To enable counter polling via timeout for all types of reboot

**How I verified it**
1. Run UTs

**Details if related**
* Enables counter polling after `warm-reboot` on timeout
* Backport from `master`: https://github.com/sonic-net/sonic-swss/pull/4381

#### A picture of a cute animal (not mandatory but encouraged)
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```