### PR TITLE
[Generic-P4Orch] Disable response path notification during warmboot.

### DIFF
--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -1183,3 +1183,14 @@ void Orch2::doTask(Consumer &consumer)
         }
     }
 }
+
+void Orch::setWarmbootStateOnFailure(const string& app_name, bool set_on_fail)
+{
+    m_publisher.setWarmbootStateOnFailure(app_name, set_on_fail);
+}
+
+void Orch::setEnableNotify(bool enable)
+{
+    m_publisher.setEnableNotify(enable);
+}
+

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -1320,4 +1320,13 @@ void Orch::setOrderedQueueForAllConsumers(bool orderedQueue)
         }
     }
 }
+void Orch::setWarmbootStateOnFailure(const string& app_name, bool set_on_fail)
+{
+    m_publisher.setWarmbootStateOnFailure(app_name, set_on_fail);
+}
+
+void Orch::setEnableNotify(bool enable)
+{
+    m_publisher.setEnableNotify(enable);
+}
 

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -306,6 +306,10 @@ public:
     virtual void doTask(swss::NotificationConsumer &consumer) { }
     virtual void doTask(swss::SelectableTimer &timer) { }
 
+    virtual void setWarmbootStateOnFailure(const std::string& app_name,
+                                            bool set_on_fail);
+    virtual void setEnableNotify(bool enable);
+
     /*
      * Called once after APPLY_VIEW in warm/fast boot scenario.
      * Orch can override this method to perform orch specific operations after boot is finished.

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -339,6 +339,10 @@ public:
     virtual void doTask(swss::NotificationConsumer &consumer) { }
     virtual void doTask(swss::SelectableTimer &timer) { }
 
+    virtual void setWarmbootStateOnFailure(const std::string& app_name,
+                                            bool set_on_fail);
+    virtual void setEnableNotify(bool enable);
+
     /*
      * Called once after APPLY_VIEW in warm/fast boot scenario.
      * Orch can override this method to perform orch specific operations after boot is finished.

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -344,6 +344,10 @@ public:
     virtual void doTask(swss::SelectableTimer &timer) { }
     virtual void doTask(swss::SelectableEvent &event) { }
 
+    virtual void setWarmbootStateOnFailure(const std::string& app_name,
+                                            bool set_on_fail);
+    virtual void setEnableNotify(bool enable);
+
     /*
      * Called once after APPLY_VIEW in warm/fast boot scenario.
      * Orch can override this method to perform orch specific operations after boot is finished.

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -1062,6 +1062,9 @@ bool OrchDaemon::warmRestoreAndSyncUp()
 
     WarmStart::setWarmStartState("orchagent", WarmStart::INITIALIZED);
 
+    // Configure response publisher before warm-boot starts.
+    configureResponsePublisherForWarmBoot(/*warm_boot_start=*/true);
+
     for (Orch *o : m_orchList)
     {
         o->bake();
@@ -1105,6 +1108,9 @@ bool OrchDaemon::warmRestoreAndSyncUp()
     // after the rest of the data has been processed.
     gMirrorOrch->doTask();
     gAclOrch->doTask();
+
+    // Configure response publisher after warm-boot completes.
+    configureResponsePublisherForWarmBoot(/*warm_boot_start=*/false);
 
     /*
      * At this point, all the pre-existing data should have been processed properly, and
@@ -1212,6 +1218,25 @@ void OrchDaemon::addOrchList(Orch *o)
 {
     m_orchList.push_back(o);
 }
+
+void OrchDaemon::configureResponsePublisherForWarmBoot(bool warm_boot_start)
+{
+     for (Orch *o : m_orchList)
+     {
+        /* During warmboot, we will enable setWarmbootStateOnFailure, so that
+         * failure during warmboot will update the warmboot state to FAILED
+         * indicating that the reconciliation process failed. */
+        o->setWarmbootStateOnFailure("orchagent", warm_boot_start);
+
+        /* During warmboot, we will disable setEnableNotify, so that no
+         * response notification will be generated when processing warmboot
+         * entries. The response notification is not needed during warmboot as
+         * there is no application client receiving the response during
+         * warmboot. */
+        o->setEnableNotify(!warm_boot_start);
+     }
+}
+
 
 void OrchDaemon::heartBeat(std::chrono::time_point<std::chrono::high_resolution_clock> tcurrent, long interval)
 {

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -1175,6 +1175,9 @@ bool OrchDaemon::warmRestoreAndSyncUp()
 
     WarmStart::setWarmStartState("orchagent", WarmStart::INITIALIZED);
 
+    // Configure response publisher before warm-boot starts.
+    configureResponsePublisherForWarmBoot(/*warm_boot_start=*/true);
+
     for (Orch *o : m_orchList)
     {
         o->bake();
@@ -1218,6 +1221,9 @@ bool OrchDaemon::warmRestoreAndSyncUp()
     // after the rest of the data has been processed.
     gMirrorOrch->doTask();
     gAclOrch->doTask();
+
+    // Configure response publisher after warm-boot completes.
+    configureResponsePublisherForWarmBoot(/*warm_boot_start=*/false);
 
     /*
      * At this point, all the pre-existing data should have been processed properly, and
@@ -1325,6 +1331,25 @@ void OrchDaemon::addOrchList(Orch *o)
 {
     m_orchList.push_back(o);
 }
+
+void OrchDaemon::configureResponsePublisherForWarmBoot(bool warm_boot_start)
+{
+     for (Orch *o : m_orchList)
+     {
+        /* During warmboot, we will enable setWarmbootStateOnFailure, so that
+         * failure during warmboot will update the warmboot state to FAILED
+         * indicating that the reconciliation process failed. */
+        o->setWarmbootStateOnFailure("orchagent", warm_boot_start);
+
+        /* During warmboot, we will disable setEnableNotify, so that no
+         * response notification will be generated when processing warmboot
+         * entries. The response notification is not needed during warmboot as
+         * there is no application client receiving the response during
+         * warmboot. */
+        o->setEnableNotify(!warm_boot_start);
+     }
+}
+
 
 void OrchDaemon::heartBeat(std::chrono::time_point<std::chrono::high_resolution_clock> tcurrent, long interval)
 {

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -1269,6 +1269,9 @@ bool OrchDaemon::warmRestoreAndSyncUp()
 
     WarmStart::setWarmStartState("orchagent", WarmStart::INITIALIZED);
 
+    // Configure response publisher before warm-boot starts.
+    configureResponsePublisherForWarmBoot(/*warm_boot_start=*/true);
+
     for (Orch *o : m_orchList)
     {
         o->bake();
@@ -1312,6 +1315,9 @@ bool OrchDaemon::warmRestoreAndSyncUp()
     // after the rest of the data has been processed.
     gMirrorOrch->doTask();
     gAclOrch->doTask();
+
+    // Configure response publisher after warm-boot completes.
+    configureResponsePublisherForWarmBoot(/*warm_boot_start=*/false);
 
     /*
      * At this point, all the pre-existing data should have been processed properly, and
@@ -1419,6 +1425,25 @@ void OrchDaemon::addOrchList(Orch *o)
 {
     m_orchList.push_back(o);
 }
+
+void OrchDaemon::configureResponsePublisherForWarmBoot(bool warm_boot_start)
+{
+     for (Orch *o : m_orchList)
+     {
+        /* During warmboot, we will enable setWarmbootStateOnFailure, so that
+         * failure during warmboot will update the warmboot state to FAILED
+         * indicating that the reconciliation process failed. */
+        o->setWarmbootStateOnFailure("orchagent", warm_boot_start);
+
+        /* During warmboot, we will disable setEnableNotify, so that no
+         * response notification will be generated when processing warmboot
+         * entries. The response notification is not needed during warmboot as
+         * there is no application client receiving the response during
+         * warmboot. */
+        o->setEnableNotify(!warm_boot_start);
+     }
+}
+
 
 void OrchDaemon::heartBeat(std::chrono::time_point<std::chrono::high_resolution_clock> tcurrent, long interval)
 {

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -76,7 +76,7 @@ public:
     bool warmRestoreValidation();
 
     bool warmRestartCheck();
-
+    void configureResponsePublisherForWarmBoot(bool warm_boot_start);
     void addOrchList(Orch* o);
     void setFabricEnabled(bool enabled)
     {

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -82,7 +82,7 @@ public:
     bool warmRestoreValidation();
 
     bool warmRestartCheck();
-
+    void configureResponsePublisherForWarmBoot(bool warm_boot_start);
     void addOrchList(Orch* o);
     void setFabricEnabled(bool enabled)
     {

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -383,7 +383,7 @@ public:
     bool warmRestoreValidation();
 
     bool warmRestartCheck();
-
+    void configureResponsePublisherForWarmBoot(bool warm_boot_start);
     void addOrchList(Orch* o);
     void setFabricEnabled(bool enabled)
     {

--- a/orchagent/p4orch/p4orch.cpp
+++ b/orchagent/p4orch/p4orch.cpp
@@ -142,14 +142,14 @@ void P4Orch::doTask(ConsumerBase &consumer)
     // Warmboot scenario.
     if (!consumer.m_toSync.empty()) {
         // Do not need to write same entries to DB during warmboot.
-        m_publisher.setEnableDbWriteAndNotify(/*enable_db_write_and_notify=*/false);
+        m_publisher.setEnableDbWrite(/*enable=*/false);
         auto it = consumer.m_toSync.begin();
         while (it != consumer.m_toSync.end()) {
            enqueue(it->second);
            it = consumer.m_toSync.erase(it);
         }
         drain();
-        m_publisher.setEnableDbWriteAndNotify(/*enable_db_write_and_notify=*/true);
+        m_publisher.setEnableDbWrite(/*enable=*/true);
     }   
 
     auto* zmq_consumer = dynamic_cast<ZmqConsumer*>(&consumer);
@@ -386,4 +386,8 @@ void P4Orch::refreshPortStatus() {
 
 void P4Orch::setRouterIntfsMtu(const std::string& port, uint32_t mtu) {
     m_routerIntfManager->setRouterIntfsMtu(port, mtu);
+}
+
+void P4Orch::setEnableNotify(bool enable) {
+  m_publisher.setEnableNotify(enable);
 }

--- a/orchagent/p4orch/p4orch.cpp
+++ b/orchagent/p4orch/p4orch.cpp
@@ -150,14 +150,14 @@ void P4Orch::doTask(ConsumerBase &consumer)
     // Warmboot scenario.
     if (!consumer.m_toSync.empty()) {
         // Do not need to write same entries to DB during warmboot.
-        m_publisher.setEnableDbWriteAndNotify(/*enable_db_write_and_notify=*/false);
+        m_publisher.setEnableDbWrite(/*enable=*/false);
         auto it = consumer.m_toSync.begin();
         while (it != consumer.m_toSync.end()) {
            enqueue(it->second);
            it = consumer.m_toSync.erase(it);
         }
         drain();
-        m_publisher.setEnableDbWriteAndNotify(/*enable_db_write_and_notify=*/true);
+        m_publisher.setEnableDbWrite(/*enable=*/true);
     }   
 
     auto* zmq_consumer = dynamic_cast<ZmqConsumer*>(&consumer);
@@ -433,4 +433,7 @@ bool P4Orch::bake()
     }
 
     return true;
+}
+void P4Orch::setEnableNotify(bool enable) {
+  m_publisher.setEnableNotify(enable);
 }

--- a/orchagent/p4orch/p4orch.cpp
+++ b/orchagent/p4orch/p4orch.cpp
@@ -151,14 +151,14 @@ void P4Orch::doTask(ConsumerBase &consumer)
     // Warmboot scenario.
     if (!consumer.m_toSync.empty()) {
         // Do not need to write same entries to DB during warmboot.
-        m_publisher.setEnableDbWriteAndNotify(/*enable_db_write_and_notify=*/false);
+        m_publisher.setEnableDbWrite(/*enable=*/false);
         auto it = consumer.m_toSync.begin();
         while (it != consumer.m_toSync.end()) {
            enqueue(it->second);
            it = consumer.m_toSync.erase(it);
         }
         drain();
-        m_publisher.setEnableDbWriteAndNotify(/*enable_db_write_and_notify=*/true);
+        m_publisher.setEnableDbWrite(/*enable=*/true);
     }   
 
     auto* zmq_consumer = dynamic_cast<ZmqConsumer*>(&consumer);
@@ -418,4 +418,7 @@ bool P4Orch::bake()
     }
 
     return true;
+}
+void P4Orch::setEnableNotify(bool enable) {
+  m_publisher.setEnableNotify(enable);
 }

--- a/orchagent/p4orch/p4orch.h
+++ b/orchagent/p4orch/p4orch.h
@@ -59,6 +59,7 @@ class P4Orch : public ZmqOrch
     TunnelDecapGroupManager* getTunnelDecapGroupManager();
     void refreshPortStatus();
     void setRouterIntfsMtu(const std::string& port, uint32_t mtu);
+    void setEnableNotify(bool enable) override;
     TablesInfo *tablesinfo = NULL;
 
     // m_p4TableToManagerMap: P4 APP DB table name, P4 Object Manager

--- a/orchagent/p4orch/p4orch.h
+++ b/orchagent/p4orch/p4orch.h
@@ -60,6 +60,7 @@ class P4Orch : public ZmqOrch
     void refreshPortStatus();
     void setRouterIntfsMtu(const std::string& port, uint32_t mtu);
     bool bake() override;
+    void setEnableNotify(bool enable) override;
     TablesInfo *tablesinfo = NULL;
 
     // m_p4TableToManagerMap: P4 APP DB table name, P4 Object Manager

--- a/orchagent/p4orch/p4orch.h
+++ b/orchagent/p4orch/p4orch.h
@@ -63,6 +63,7 @@ class P4Orch : public ZmqOrch
     bool bake() override;
     void handlePortStatusUpdate(const std::string& alias,
                                 const sai_port_oper_status_t& status);
+    void setEnableNotify(bool enable) override;
     TablesInfo *tablesinfo = NULL;
 
     // m_p4TableToManagerMap: P4 APP DB table name, P4 Object Manager

--- a/orchagent/p4orch/tests/mock_response_publisher.h
+++ b/orchagent/p4orch/tests/mock_response_publisher.h
@@ -16,5 +16,9 @@ class MockResponsePublisher : public ResponsePublisherInterface
     MOCK_METHOD5(writeToDB,
                  void(const std::string &table, const std::string &key,
                       const std::vector<swss::FieldValueTuple> &values, const std::string &op, bool replace));
-    MOCK_METHOD1(setEnableDbWriteAndNotify, void(bool enable_db_write_and_notify));
+    MOCK_METHOD2(setWarmbootStateOnFailure,
+                 void(const std::string& app_name, bool set_on_fail));
+    MOCK_METHOD1(setEnableDbWrite, void(bool enable));
+    MOCK_METHOD1(setEnableNotify, void(bool enable));
+
 };

--- a/orchagent/response_publisher.cpp
+++ b/orchagent/response_publisher.cpp
@@ -103,7 +103,7 @@ void ResponsePublisher::publish(const std::string &table, const std::string &key
     intent_attrs_copy.insert(intent_attrs_copy.begin(), err_str);
     std::string response_channel = "APPL_DB_" + table + "_RESPONSE_CHANNEL";
 
-    if (m_enable_db_write_and_notify) {
+    if (m_enable_notify) {
       if (m_zmqServer != nullptr) {
         auto intent_attrs_zmq_copy = intent_attrs;
         // Add status code and error message as the first field-value-pair.
@@ -111,8 +111,8 @@ void ResponsePublisher::publish(const std::string &table, const std::string &key
                                   PrependedComponent(status) + status.message());
         intent_attrs_zmq_copy.insert(intent_attrs_zmq_copy.begin(), fvs);
         // Queue the response.
-        responses[table].push_back(
-            swss::KeyOpFieldsValuesTuple{key, SET_COMMAND, intent_attrs_zmq_copy});
+        responses[table].push_back(swss::KeyOpFieldsValuesTuple{
+	    key, SET_COMMAND, intent_attrs_zmq_copy});
       } else {
         // Sends the response to the notification channel.
         swss::NotificationProducer notificationProducer{
@@ -123,13 +123,13 @@ void ResponsePublisher::publish(const std::string &table, const std::string &key
 
     RecordResponse(response_channel, key, intent_attrs_copy, status.codeStr());
 
-    // Write to the DB only if: m_enable_db_write_and_notify is true and:
+    // Write to the DB only if: m_enable_db_write is true and:
     // 1) A write operation is being performed and state attributes are specified.
     // 2) OR a successful delete operation.
-    if (m_enable_db_write_and_notify &&
-         ((intent_attrs.size() && state_attrs.size()) ||
-         (status.ok() && !intent_attrs.size()))) {
-            writeToDB(table, key, state_attrs, intent_attrs.size() ? SET_COMMAND : DEL_COMMAND, replace);
+    if (m_enable_db_write && ((intent_attrs.size() && state_attrs.size()) ||
+                            (status.ok() && !intent_attrs.size()))) {
+      writeToDB(table, key, state_attrs,
+		intent_attrs.size() ? SET_COMMAND : DEL_COMMAND, replace);
     }
 }
 
@@ -279,8 +279,17 @@ void ResponsePublisher::dbUpdateThread()
     }
 }
 
-void ResponsePublisher::setEnableDbWriteAndNotify(bool enable_db_write_and_notify)
-{
-    m_enable_db_write_and_notify = enable_db_write_and_notify;
+void ResponsePublisher::setWarmbootStateOnFailure(const std::string& app_name,
+                                                  bool set_on_fail) {
+  m_app_name = app_name;
+  m_set_warmboot_state_fail = set_on_fail;
+}
+
+void ResponsePublisher::setEnableDbWrite(bool enable) {
+  m_enable_db_write = enable;
+}
+
+void ResponsePublisher::setEnableNotify(bool enable) {
+  m_enable_notify = enable;
 }
 

--- a/orchagent/response_publisher.cpp
+++ b/orchagent/response_publisher.cpp
@@ -139,7 +139,7 @@ void ResponsePublisher::publishWrite(const std::string &table, const std::string
     intent_attrs_copy.insert(intent_attrs_copy.begin(), err_str);
     std::string response_channel = "APPL_DB_" + table + "_RESPONSE_CHANNEL";
 
-    if (m_enable_db_write_and_notify) {
+    if (m_enable_notify) {
       if (m_zmqServer != nullptr) {
         auto intent_attrs_zmq_copy = intent_attrs;
         // Add status code and error message as the first field-value-pair.
@@ -147,8 +147,8 @@ void ResponsePublisher::publishWrite(const std::string &table, const std::string
                                   PrependedComponent(status) + status.message());
         intent_attrs_zmq_copy.insert(intent_attrs_zmq_copy.begin(), fvs);
         // Queue the response.
-        responses[table].push_back(
-            swss::KeyOpFieldsValuesTuple{key, SET_COMMAND, intent_attrs_zmq_copy});
+        responses[table].push_back(swss::KeyOpFieldsValuesTuple{
+	    key, SET_COMMAND, intent_attrs_zmq_copy});
       } else {
         // Sends the response to the notification channel.
         swss::NotificationProducer notificationProducer{
@@ -159,22 +159,17 @@ void ResponsePublisher::publishWrite(const std::string &table, const std::string
 
     RecordResponse(response_channel, key, intent_attrs_copy, status.codeStr(), record_ts);
 
-    // Write to the DB only if: m_enable_db_write_and_notify is true and:
+    // Write to the DB only if: m_enable_db_write is true and:
     // 1) A write operation is being performed and state attributes are specified.
     // 2) OR a successful delete operation.
-    if (m_enable_db_write_and_notify &&
-         ((intent_attrs.size() && state_attrs.size()) ||
-         (status.ok() && !intent_attrs.size()))) {
-            const auto op = intent_attrs.size() ? SET_COMMAND : DEL_COMMAND;
-            if (sync_publish)
-            {
-                writeToDBInternal(table, key, state_attrs, op, replace);
-                RecordDBWrite(table, key, state_attrs, op, record_ts);
-            }
-            else
-            {
-                writeToDB(table, key, state_attrs, op, replace);
-            }
+    if (m_enable_db_write && ((intent_attrs.size() && state_attrs.size()) || (status.ok() && !intent_attrs.size()))) {
+        const auto op = intent_attrs.size() ? SET_COMMAND : DEL_COMMAND;
+        if (sync_publish) {
+            writeToDBInternal(table, key, state_attrs, op, replace);
+            RecordDBWrite(table, key, state_attrs, op, record_ts);
+        } else {
+            writeToDB(table, key, state_attrs, op, replace);
+        }
     }
 }
 
@@ -408,8 +403,17 @@ void ResponsePublisher::stateUpdateThread()
     }
 }
 
-void ResponsePublisher::setEnableDbWriteAndNotify(bool enable_db_write_and_notify)
-{
-    m_enable_db_write_and_notify = enable_db_write_and_notify;
+void ResponsePublisher::setWarmbootStateOnFailure(const std::string& app_name,
+                                                  bool set_on_fail) {
+  m_app_name = app_name;
+  m_set_warmboot_state_fail = set_on_fail;
+}
+
+void ResponsePublisher::setEnableDbWrite(bool enable) {
+  m_enable_db_write = enable;
+}
+
+void ResponsePublisher::setEnableNotify(bool enable) {
+  m_enable_notify = enable;
 }
 

--- a/orchagent/response_publisher.cpp
+++ b/orchagent/response_publisher.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include "logger.h"
 #include "timestamp.h"
+#include "warm_restart.h"
 
 namespace
 {
@@ -133,13 +134,25 @@ void ResponsePublisher::publishWrite(const std::string &table, const std::string
                                      const std::vector<swss::FieldValueTuple> &state_attrs,
                                      bool replace, const std::string *record_ts, bool sync_publish)
 {
+    if (m_set_warmboot_state_fail && !status.ok()) {
+        if (!m_app_name.empty()) {
+            SWSS_LOG_ERROR("Warmboot reconciliation failed for %s:%s. Status: %s. Setting warmboot state to WSDISABLED.",
+                           table.c_str(), key.c_str(), status.message().c_str());
+            swss::WarmStart::setWarmStartState(m_app_name, swss::WarmStart::WSDISABLED);
+        }
+        else
+        {
+            SWSS_LOG_WARN("Warmboot failure detected but m_app_name is empty. Cannot update warmboot state.");
+        }
+    }
+
     auto intent_attrs_copy = intent_attrs;
     // Add error message as the first field-value-pair.
     swss::FieldValueTuple err_str("err_str", PrependedComponent(status) + status.message());
     intent_attrs_copy.insert(intent_attrs_copy.begin(), err_str);
     std::string response_channel = "APPL_DB_" + table + "_RESPONSE_CHANNEL";
 
-    if (m_enable_db_write_and_notify) {
+    if (m_enable_notify) {
       if (m_zmqServer != nullptr) {
         auto intent_attrs_zmq_copy = intent_attrs;
         // Add status code and error message as the first field-value-pair.
@@ -147,8 +160,8 @@ void ResponsePublisher::publishWrite(const std::string &table, const std::string
                                   PrependedComponent(status) + status.message());
         intent_attrs_zmq_copy.insert(intent_attrs_zmq_copy.begin(), fvs);
         // Queue the response.
-        responses[table].push_back(
-            swss::KeyOpFieldsValuesTuple{key, SET_COMMAND, intent_attrs_zmq_copy});
+        responses[table].push_back(swss::KeyOpFieldsValuesTuple{
+	    key, SET_COMMAND, intent_attrs_zmq_copy});
       } else {
         // Sends the response to the notification channel.
         swss::NotificationProducer notificationProducer{
@@ -159,22 +172,17 @@ void ResponsePublisher::publishWrite(const std::string &table, const std::string
 
     RecordResponse(response_channel, key, intent_attrs_copy, status.codeStr(), record_ts);
 
-    // Write to the DB only if: m_enable_db_write_and_notify is true and:
+    // Write to the DB only if: m_enable_db_write is true and:
     // 1) A write operation is being performed and state attributes are specified.
     // 2) OR a successful delete operation.
-    if (m_enable_db_write_and_notify &&
-         ((intent_attrs.size() && state_attrs.size()) ||
-         (status.ok() && !intent_attrs.size()))) {
-            const auto op = intent_attrs.size() ? SET_COMMAND : DEL_COMMAND;
-            if (sync_publish)
-            {
-                writeToDBInternal(table, key, state_attrs, op, replace);
-                RecordDBWrite(table, key, state_attrs, op, record_ts);
-            }
-            else
-            {
-                writeToDB(table, key, state_attrs, op, replace);
-            }
+    if (m_enable_db_write && ((intent_attrs.size() && state_attrs.size()) || (status.ok() && !intent_attrs.size()))) {
+        const auto op = intent_attrs.size() ? SET_COMMAND : DEL_COMMAND;
+        if (sync_publish) {
+            writeToDBInternal(table, key, state_attrs, op, replace);
+            RecordDBWrite(table, key, state_attrs, op, record_ts);
+        } else {
+            writeToDB(table, key, state_attrs, op, replace);
+        }
     }
 }
 
@@ -408,8 +416,17 @@ void ResponsePublisher::stateUpdateThread()
     }
 }
 
-void ResponsePublisher::setEnableDbWriteAndNotify(bool enable_db_write_and_notify)
-{
-    m_enable_db_write_and_notify = enable_db_write_and_notify;
+void ResponsePublisher::setWarmbootStateOnFailure(const std::string& app_name,
+                                                  bool set_on_fail) {
+  m_app_name = app_name;
+  m_set_warmboot_state_fail = set_on_fail;
+}
+
+void ResponsePublisher::setEnableDbWrite(bool enable) {
+  m_enable_db_write = enable;
+}
+
+void ResponsePublisher::setEnableNotify(bool enable) {
+  m_enable_notify = enable;
 }
 

--- a/orchagent/response_publisher.h
+++ b/orchagent/response_publisher.h
@@ -52,7 +52,11 @@ class ResponsePublisher : public ResponsePublisherInterface
     void writeToDB(const std::string &table, const std::string &key, const std::vector<swss::FieldValueTuple> &values,
                    const std::string &op, bool replace = false) override;
 
-    void setEnableDbWriteAndNotify(bool enable_db_write_and_notify) override;
+    void setWarmbootStateOnFailure(const std::string& app_name, bool set_on_fail) override;
+
+    void setEnableDbWrite(bool enable) override;
+
+    void setEnableNotify(bool enable) override;
 
     /**
      * @brief Flush pending responses
@@ -111,5 +115,8 @@ class ResponsePublisher : public ResponsePublisherInterface
     std::queue<entry, std::list<entry>> m_queue;
     mutable std::mutex m_lock;
     std::condition_variable m_signal;
-    bool m_enable_db_write_and_notify{true};
+    std::string m_app_name;
+    bool m_set_warmboot_state_fail{false};
+    bool m_enable_db_write{true};
+    bool m_enable_notify{true};
 };

--- a/orchagent/response_publisher.h
+++ b/orchagent/response_publisher.h
@@ -52,7 +52,11 @@ class ResponsePublisher : public ResponsePublisherInterface
     void writeToDB(const std::string &table, const std::string &key, const std::vector<swss::FieldValueTuple> &values,
                    const std::string &op, bool replace = false) override;
 
-    void setEnableDbWriteAndNotify(bool enable_db_write_and_notify) override;
+    void setWarmbootStateOnFailure(const std::string& app_name, bool set_on_fail) override;
+
+    void setEnableDbWrite(bool enable) override;
+
+    void setEnableNotify(bool enable) override;
 
     // With a state update thread: append to m_async_publish_pending; caller must call
     // publishAsyncBatch() then flush() to enqueue work (batch + flush marker).
@@ -142,5 +146,8 @@ class ResponsePublisher : public ResponsePublisherInterface
     std::queue<entry, std::list<entry>> m_queue;
     mutable std::mutex m_lock;
     std::condition_variable m_signal;
-    bool m_enable_db_write_and_notify{true};
+    std::string m_app_name;
+    bool m_set_warmboot_state_fail{false};
+    bool m_enable_db_write{true};
+    bool m_enable_notify{true};
 };

--- a/orchagent/response_publisher_interface.h
+++ b/orchagent/response_publisher_interface.h
@@ -33,6 +33,11 @@ class ResponsePublisherInterface
                            const std::vector<swss::FieldValueTuple> &values, const std::string &op,
                            bool replace = false) = 0;
 
-    // Flag to enable/disable DB write and notification.
-    virtual void setEnableDbWriteAndNotify(bool enable_db_write_and_notify) = 0;
+    virtual void setWarmbootStateOnFailure(const std::string& app_name,
+                                           bool set_on_fail) = 0;
+    // Flag to enable/disable DB write.
+    virtual void setEnableDbWrite(bool enable) = 0;
+
+    // Flag to enable/disable notification.
+    virtual void setEnableNotify(bool enable) = 0;
 };

--- a/tests/dvslib/dvs_database.py
+++ b/tests/dvslib/dvs_database.py
@@ -500,6 +500,79 @@ class DVSDatabase:
 
         return result
 
+    def get_response_consumers_from_json(self, json_path: str, filter_table: List[str]) -> List[swsscommon.NotificationConsumer]:
+        """Parse json object from file and return the response consumers that
+            can be used to verify response messages.
+            Note that P4RT entries will not show up in APPL STATE DB.
+            The json file should be formatted in one of below schemas:
+            Option 1
+            {
+                "TABLE_NAME_A":{
+                    "KEY_1": {
+                        "FIELD_1" : "VALUE_1",
+                        "FIELD_2" : "VALUE_2"
+                    },
+                    "KEY_2": {
+                        "FIELD_1" : "VALUE_3",
+                        "FIELD_2" : "VALUE_4"
+                    }
+                },
+                "TABLE_NAME_B":{
+                    "KEY_3": {
+                        "FIELD_3" : "VALUE_5",
+                        "FIELD_4" : "VALUE_6"
+                    }
+                }
+            }
+            Option 2
+            {
+                "TABLE_NAME_A:KEY_1": {
+                    "FIELD_1" : "VALUE_1",
+                    "FIELD_2" : "VALUE_2"
+                },
+                "TABLE_NAME_A:KEY_2": {
+                    "FIELD_1" : "VALUE_3",
+                    "FIELD_2" : "VALUE_4"
+                },
+                "TABLE_NAME_B:KEY_3": {
+                    "FIELD_3" : "VALUE_5",
+                    "FIELD_4" : "VALUE_6"
+                }
+            }
+
+        Args:
+            json_path: relevant path to appl_state_db json file.
+
+        Returns:
+            A list of NotificationConsumer.
+        """
+        with open(json_path) as f:
+            json_obj = json.load(f)
+        if not json_obj:
+            return []
+        channel_name_set = set()
+        response_consumer_list = []
+        for key_str in json_obj:
+            if self.APPL_DB_KEY_DELIMITER in key_str:
+                # Parse and verify entries in concatenated table:key schema.
+                # E.g. "TABLE_NAME_A:KEY_1": {
+                #        "FIELD_1" : "VALUE_1"
+                #    }
+                table_name = key_str.split(self.APPL_DB_KEY_DELIMITER, 1)[0]
+            else:
+                # Verify entries in separated table key schema.
+                # E.g. "TABLE_NAME_A": {
+                #        ""KEY_1": {
+                #            "FIELD_1" : "VALUE_1"
+                #        }
+                table_name = key_str
+            channel_name = "APPL_DB_" + table_name + "_RESPONSE_CHANNEL"
+            if table_name not in filter_table and channel_name not in channel_name_set:
+                response_consumer_list.append(swsscommon.NotificationConsumer(
+                    self.db_connection, channel_name))
+                channel_name_set.add(channel_name)
+        return response_consumer_list
+
     @staticmethod
     def _disable_strict_polling(polling_config: PollingConfig) -> PollingConfig:
         disabled_config = PollingConfig(

--- a/tests/mock_tests/fake_response_publisher.cpp
+++ b/tests/mock_tests/fake_response_publisher.cpp
@@ -44,11 +44,29 @@ void ResponsePublisher::writeToDB(
     const std::vector<swss::FieldValueTuple>& values, const std::string& op,
     bool replace) {}
 
-void ResponsePublisher::setEnableDbWriteAndNotify(bool enable_db_write_and_notify)
+
+void ResponsePublisher::setWarmbootStateOnFailure(
+    const std::string& app_name, bool set_on_fail)
 {
     if (gMockResponsePublisher)
     {
-        gMockResponsePublisher->setEnableDbWriteAndNotify(enable_db_write_and_notify);
+        gMockResponsePublisher->setWarmbootStateOnFailure(app_name, set_on_fail);
+    }
+}
+
+void ResponsePublisher::setEnableDbWrite(bool enable)
+{
+    if (gMockResponsePublisher)
+    {
+        gMockResponsePublisher->setEnableDbWrite(enable);
+    }
+}
+
+void ResponsePublisher::setEnableNotify(bool enable)
+{
+    if (gMockResponsePublisher)
+    {
+        gMockResponsePublisher->setEnableNotify(enable);
     }
 }
 

--- a/tests/mock_tests/fake_response_publisher.cpp
+++ b/tests/mock_tests/fake_response_publisher.cpp
@@ -57,11 +57,29 @@ void ResponsePublisher::writeToDB(
     const std::vector<swss::FieldValueTuple>& values, const std::string& op,
     bool replace) {}
 
-void ResponsePublisher::setEnableDbWriteAndNotify(bool enable_db_write_and_notify)
+
+void ResponsePublisher::setWarmbootStateOnFailure(
+    const std::string& app_name, bool set_on_fail)
 {
     if (gMockResponsePublisher)
     {
-        gMockResponsePublisher->setEnableDbWriteAndNotify(enable_db_write_and_notify);
+        gMockResponsePublisher->setWarmbootStateOnFailure(app_name, set_on_fail);
+    }
+}
+
+void ResponsePublisher::setEnableDbWrite(bool enable)
+{
+    if (gMockResponsePublisher)
+    {
+        gMockResponsePublisher->setEnableDbWrite(enable);
+    }
+}
+
+void ResponsePublisher::setEnableNotify(bool enable)
+{
+    if (gMockResponsePublisher)
+    {
+        gMockResponsePublisher->setEnableNotify(enable);
     }
 }
 

--- a/tests/mock_tests/response_publisher/response_publisher_ut.cpp
+++ b/tests/mock_tests/response_publisher/response_publisher_ut.cpp
@@ -43,14 +43,14 @@ TEST(ResponsePublisher, TestPublishEnableDbWrite)
     ASSERT_TRUE(stateTable.hget("SOME_KEY", "field", value));
     ASSERT_EQ(value, "value");
 
-    publisher.setEnableDbWriteAndNotify(false);
+    publisher.setEnableDbWrite(false);
 
     publisher.publish("SOME_TABLE", "SOME_KEY", {{"field", "new-value"}}, ReturnCode(SAI_STATUS_SUCCESS));
     publisher.flush();
     ASSERT_TRUE(stateTable.hget("SOME_KEY", "field", value));
     ASSERT_EQ(value, "value");
 
-    publisher.setEnableDbWriteAndNotify(true);
+    publisher.setEnableDbWrite(true);
 
     publisher.publish("SOME_TABLE", "SOME_KEY", {{"field", "new-value"}}, ReturnCode(SAI_STATUS_SUCCESS));
     publisher.flush();

--- a/tests/mock_tests/response_publisher/response_publisher_ut.cpp
+++ b/tests/mock_tests/response_publisher/response_publisher_ut.cpp
@@ -72,14 +72,14 @@ TEST(ResponsePublisher, TestPublishEnableDbWrite)
     ASSERT_TRUE(stateTable.hget("SOME_KEY", "field", value));
     ASSERT_EQ(value, "value");
 
-    publisher.setEnableDbWriteAndNotify(false);
+    publisher.setEnableDbWrite(false);
 
     publisher.publish("SOME_TABLE", "SOME_KEY", {{"field", "new-value"}}, ReturnCode(SAI_STATUS_SUCCESS));
     publisher.flush();
     ASSERT_TRUE(stateTable.hget("SOME_KEY", "field", value));
     ASSERT_EQ(value, "value");
 
-    publisher.setEnableDbWriteAndNotify(true);
+    publisher.setEnableDbWrite(true);
 
     publisher.publish("SOME_TABLE", "SOME_KEY", {{"field", "new-value"}}, ReturnCode(SAI_STATUS_SUCCESS));
     publisher.flush();
@@ -226,7 +226,7 @@ TEST(ResponsePublisher, PublishAsyncRespectsEnableDbWriteAndNotifyToggle)
 
     ResponsePublisher publisher{"APPL_STATE_DB", false, true};
     publisher.m_directDbWrite = true;
-    publisher.setEnableDbWriteAndNotify(false);
+    publisher.setEnableDbWrite(false);
 
     publisher.publishAsync("ROUTE_TABLE", "10.8.1.0/24", {{"state", "off"}}, ReturnCode(SAI_STATUS_SUCCESS));
     publisher.publishAsyncBatch();
@@ -235,7 +235,7 @@ TEST(ResponsePublisher, PublishAsyncRespectsEnableDbWriteAndNotifyToggle)
     std::string v;
     ASSERT_FALSE(pollHget(stateTable, "10.8.1.0/24", "state", &v, 200));
 
-    publisher.setEnableDbWriteAndNotify(true);
+    publisher.setEnableDbWrite(true);
     publisher.publishAsync("ROUTE_TABLE", "10.8.1.0/24", {{"state", "on"}}, ReturnCode(SAI_STATUS_SUCCESS));
     publisher.publishAsyncBatch();
     publisher.flush();
@@ -354,3 +354,27 @@ TEST(ResponsePublisher, PublishAsyncBatchOkDeleteEmptyIntentWritesDel)
     ASSERT_FALSE(stateTable.hget("10.22.0.0/24", "state", v));
 }
 
+TEST(ResponsePublisher, TestWarmbootAndControlFlags)
+{
+    DBConnector conn{"APPL_STATE_DB", 0};
+    Table stateTable{&conn, "TABLE"};
+    std::string value;
+
+    ResponsePublisher publisher{"APPL_STATE_DB", false, false};
+
+    publisher.setEnableNotify(false);
+    publisher.publish("TABLE", "KEY_NOTIFY", {{"f", "v"}}, ReturnCode(SAI_STATUS_SUCCESS));
+    publisher.setEnableNotify(true);
+
+    publisher.setWarmbootStateOnFailure("orchagent", true);
+    publisher.publish("TABLE", "KEY_FAIL", {{"f", "v"}}, ReturnCode(SAI_STATUS_FAILURE));
+    publisher.setWarmbootStateOnFailure("orchagent", false);
+
+    publisher.setEnableDbWrite(false);
+    publisher.publish("TABLE", "KEY_NO_DB", {{"f", "v"}}, ReturnCode(SAI_STATUS_SUCCESS));
+    ASSERT_FALSE(stateTable.hget("KEY_NO_DB", "f", value));
+
+    publisher.setEnableDbWrite(true);
+    publisher.publish("TABLE", "KEY_WRITE", {{"f", "v"}}, ReturnCode(SAI_STATUS_SUCCESS));
+    ASSERT_TRUE(stateTable.hget("KEY_WRITE", "f", value));
+}

--- a/tests/mock_tests/response_publisher/response_publisher_ut.cpp
+++ b/tests/mock_tests/response_publisher/response_publisher_ut.cpp
@@ -8,6 +8,7 @@
 #include "recorder.h"
 #include "return_code.h"
 #include "zmqserver.h"
+#include "warm_restart.h"
 
 using namespace swss;
 
@@ -72,14 +73,14 @@ TEST(ResponsePublisher, TestPublishEnableDbWrite)
     ASSERT_TRUE(stateTable.hget("SOME_KEY", "field", value));
     ASSERT_EQ(value, "value");
 
-    publisher.setEnableDbWriteAndNotify(false);
+    publisher.setEnableDbWrite(false);
 
     publisher.publish("SOME_TABLE", "SOME_KEY", {{"field", "new-value"}}, ReturnCode(SAI_STATUS_SUCCESS));
     publisher.flush();
     ASSERT_TRUE(stateTable.hget("SOME_KEY", "field", value));
     ASSERT_EQ(value, "value");
 
-    publisher.setEnableDbWriteAndNotify(true);
+    publisher.setEnableDbWrite(true);
 
     publisher.publish("SOME_TABLE", "SOME_KEY", {{"field", "new-value"}}, ReturnCode(SAI_STATUS_SUCCESS));
     publisher.flush();
@@ -226,7 +227,7 @@ TEST(ResponsePublisher, PublishAsyncRespectsEnableDbWriteAndNotifyToggle)
 
     ResponsePublisher publisher{"APPL_STATE_DB", false, true};
     publisher.m_directDbWrite = true;
-    publisher.setEnableDbWriteAndNotify(false);
+    publisher.setEnableDbWrite(false);
 
     publisher.publishAsync("ROUTE_TABLE", "10.8.1.0/24", {{"state", "off"}}, ReturnCode(SAI_STATUS_SUCCESS));
     publisher.publishAsyncBatch();
@@ -235,7 +236,7 @@ TEST(ResponsePublisher, PublishAsyncRespectsEnableDbWriteAndNotifyToggle)
     std::string v;
     ASSERT_FALSE(pollHget(stateTable, "10.8.1.0/24", "state", &v, 200));
 
-    publisher.setEnableDbWriteAndNotify(true);
+    publisher.setEnableDbWrite(true);
     publisher.publishAsync("ROUTE_TABLE", "10.8.1.0/24", {{"state", "on"}}, ReturnCode(SAI_STATUS_SUCCESS));
     publisher.publishAsyncBatch();
     publisher.flush();
@@ -354,3 +355,42 @@ TEST(ResponsePublisher, PublishAsyncBatchOkDeleteEmptyIntentWritesDel)
     ASSERT_FALSE(stateTable.hget("10.22.0.0/24", "state", v));
 }
 
+TEST(ResponsePublisher, TestWarmbootAndControlFlags)
+{
+    DBConnector conn{"APPL_STATE_DB", 0};
+    Table stateTable{&conn, "TABLE"};
+    std::string value;
+
+    DBConnector stateDbConn{"STATE_DB", 0};
+    Table warmRestartTable{&stateDbConn, "WARM_RESTART_TABLE"};
+
+    ResponsePublisher publisher{"APPL_STATE_DB", false, false};
+
+    // 1. Verify disabling notify does not prevent DB writes
+    publisher.setEnableNotify(false);
+    publisher.publish("TABLE", "KEY_NOTIFY", {{"f", "v"}}, ReturnCode(SAI_STATUS_SUCCESS));
+    ASSERT_TRUE(stateTable.hget("KEY_NOTIFY", "f", value));
+    ASSERT_EQ(value, "v");
+    publisher.setEnableNotify(true);
+
+    // 2. Initialize WarmStart state table and test failure path
+    swss::WarmStart::initialize("orchagent", "orchagent");
+    warmRestartTable.hset("orchagent", "state", "initialized");
+    publisher.setWarmbootStateOnFailure("orchagent", true);
+    publisher.publish("TABLE", "KEY_FAIL", {{"f", "v"}}, ReturnCode(SAI_STATUS_FAILURE));
+    ASSERT_FALSE(stateTable.hget("KEY_FAIL", "f", value));
+
+    std::string warmState;
+    ASSERT_TRUE(warmRestartTable.hget("orchagent", "state", warmState));
+    ASSERT_EQ(warmState, "disabled");
+
+    publisher.setWarmbootStateOnFailure("orchagent", false);
+
+    publisher.setEnableDbWrite(false);
+    publisher.publish("TABLE", "KEY_NO_DB", {{"f", "v"}}, ReturnCode(SAI_STATUS_SUCCESS));
+    ASSERT_FALSE(stateTable.hget("KEY_NO_DB", "f", value));
+
+    publisher.setEnableDbWrite(true);
+    publisher.publish("TABLE", "KEY_WRITE", {{"f", "v"}}, ReturnCode(SAI_STATUS_SUCCESS));
+    ASSERT_TRUE(stateTable.hget("KEY_WRITE", "f", value));
+}


### PR DESCRIPTION
**What I did**
Refactored responsepublisher to decouple DB writes from notifications and introduced configureResponsePublisherForWarmBoot to toggle these flags during the warm-boot.

**Why I did it**
To prevent unnecessary response notifications to Northbound clients during warm-boot reconciliation (where no clients are listening) and to ensure the warm-boot state is correctly marked as failed if an error occurs during this process.

**How I verified it**
Performed local builds and confirmed that all relevant unit tests passed successfully.

**Details if related**
