### PR TITLE
[teamsyncd] Filter out spurious millisecond LAG member status flaps

### DIFF
--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -23,6 +23,8 @@ using namespace swss;
 /* Taken from drivers/net/team/team.c */
 #define TEAM_DRV_NAME "team"
 
+static const timespec LAG_MEMBER_DISABLE_DEBOUNCE = {0, 10 * 1000 * 1000};
+
 TeamSync::TeamSync(DBConnector *db, DBConnector *stateDb, Select *select) :
     m_select(select),
     m_lagTable(db, APP_LAG_TABLE_NAME),
@@ -59,6 +61,36 @@ void TeamSync::periodic()
     }
 
     doSelectableTask();
+}
+
+bool TeamSync::processTimerSelectable(Selectable *selectable)
+{
+    auto timerIt = m_timerToMember.find(selectable);
+    if (timerIt == m_timerToMember.end())
+    {
+        SWSS_LOG_WARN("Detect untracked debounce timer selectable %p!",
+                selectable);
+        return false;
+    }
+
+    auto lag = timerIt->second.first;
+    auto memberName = timerIt->second.second;
+    auto stateIt = lag->m_memberDebounceStates.find(memberName);
+    if (stateIt == lag->m_memberDebounceStates.end() || !stateIt->second.pendingDisable)
+    {
+        return true;
+    }
+
+    auto timer = stateIt->second.timer;
+
+    timer->stop();
+    stateIt->second.pendingDisable = false;
+
+    applyLagMemberStatus(lag, memberName, false);
+    SWSS_LOG_NOTICE("Debounce timeout expired for LAG %s member %s, apply disabled",
+            lag->getLagName().c_str(), memberName.c_str());
+
+    return true;
 }
 
 void TeamSync::doSelectableTask()
@@ -186,9 +218,117 @@ void TeamSync::addLag(const string &lagName, int ifindex, bool admin_state,
     if (lag_update)
     {
         /* Create the team instance */
-        auto sync = make_shared<TeamPortSync>(lagName, ifindex, &m_lagMemberTable);
+        auto sync = make_shared<TeamPortSync>(this, lagName, ifindex, &m_lagMemberTable);
         m_teamSelectables[lagName] = sync;
         m_selectablesToAdd.insert(lagName);
+    }
+}
+
+void TeamSync::applyLagMemberStatus(TeamPortSync *lag, const string &memberName, bool enabled)
+{
+    string key = lag->getLagName() + ":" + memberName;
+    vector<FieldValueTuple> v;
+    FieldValueTuple l("status", enabled ? "enabled" : "disabled");
+    v.push_back(l);
+    m_lagMemberTable.set(key, v);
+    lag->m_lagMembers[memberName] = enabled;
+
+    SWSS_LOG_NOTICE("Set LAG %s member %s with status %s",
+            lag->getLagName().c_str(), memberName.c_str(), enabled ? "enabled" : "disabled");
+}
+
+void TeamSync::ensureMemberTimer(TeamPortSync *lag, const string &memberName)
+{
+    if (lag->m_memberDebounceStates.find(memberName) != lag->m_memberDebounceStates.end())
+    {
+        return;
+    }
+
+    TeamSync::TeamPortSync::MemberDebounceState state;
+    state.timer = make_shared<SelectableTimer>(LAG_MEMBER_DISABLE_DEBOUNCE);
+
+    lag->m_memberDebounceStates[memberName] = state;
+    m_timerToMember[state.timer.get()] = make_pair(lag, memberName);
+    m_select->addSelectable(state.timer.get());
+}
+
+void TeamSync::startPendingDisable(TeamPortSync *lag, const string &memberName)
+{
+    ensureMemberTimer(lag, memberName);
+    auto &state = lag->m_memberDebounceStates[memberName];
+    if (state.pendingDisable)
+    {
+        return;
+    }
+
+    state.pendingDisable = true;
+    state.timer->start();
+
+    SWSS_LOG_NOTICE("Start pending disable debounce for LAG %s member %s",
+            lag->getLagName().c_str(), memberName.c_str());
+}
+
+void TeamSync::cancelPendingDisable(TeamPortSync *lag, const string &memberName)
+{
+    auto stateIt = lag->m_memberDebounceStates.find(memberName);
+    if (stateIt == lag->m_memberDebounceStates.end() || !stateIt->second.pendingDisable)
+    {
+        return;
+    }
+
+    stateIt->second.timer->stop();
+    stateIt->second.pendingDisable = false;
+
+    SWSS_LOG_NOTICE("Cancel pending disable debounce for LAG %s member %s",
+            lag->getLagName().c_str(), memberName.c_str());
+}
+
+void TeamSync::clearPendingDisablesForLag(TeamPortSync *lag)
+{
+    vector<string> members;
+    for (const auto &it : lag->m_memberDebounceStates)
+    {
+        if (it.second.pendingDisable)
+        {
+            members.push_back(it.first);
+        }
+    }
+
+    for (const auto &memberName : members)
+    {
+        cancelPendingDisable(lag, memberName);
+    }
+}
+
+void TeamSync::handleLagMemberStatus(TeamPortSync *lag, const string &memberName, bool observedEnabled)
+{
+    auto it = lag->m_lagMembers.find(memberName);
+    bool appliedEnabled = (it != lag->m_lagMembers.end()) && it->second;
+
+    auto debounceIt = lag->m_memberDebounceStates.find(memberName);
+    bool hasPendingDisable = (debounceIt != lag->m_memberDebounceStates.end()) &&
+                             debounceIt->second.pendingDisable;
+
+    if (observedEnabled)
+    {
+        if (hasPendingDisable)
+        {
+            cancelPendingDisable(lag, memberName);
+        }
+        else if (!appliedEnabled)
+        {
+            applyLagMemberStatus(lag, memberName, true);
+        }
+        return;
+    }
+
+    if (it == lag->m_lagMembers.end())
+    {
+        applyLagMemberStatus(lag, memberName, false);
+    }
+    else if (appliedEnabled && !hasPendingDisable)
+    {
+        startPendingDisable(lag, memberName);
     }
 }
 
@@ -196,8 +336,19 @@ void TeamSync::removeLag(const string &lagName)
 {
     /* Delete all members */
     auto selectable = m_teamSelectables[lagName];
+
+    clearPendingDisablesForLag(selectable.get());
+
     for (auto it : selectable->m_lagMembers)
     {
+        auto stateIt = selectable->m_memberDebounceStates.find(it.first);
+        if (stateIt != selectable->m_memberDebounceStates.end())
+        {
+            m_timerToMember.erase(stateIt->second.timer.get());
+            m_select->removeSelectable(stateIt->second.timer.get());
+            selectable->m_memberDebounceStates.erase(stateIt);
+        }
+
         m_lagMemberTable.del(lagName + ":" + it.first);
 
         SWSS_LOG_INFO("Remove member %s before removing LAG %s",
@@ -243,8 +394,9 @@ const struct team_change_handler TeamSync::TeamPortSync::gPortChangeHandler = {
     .type_mask  = TEAM_PORT_CHANGE | TEAM_OPTION_CHANGE
 };
 
-TeamSync::TeamPortSync::TeamPortSync(const string &lagName, int ifindex,
+TeamSync::TeamPortSync::TeamPortSync(TeamSync *parent, const string &lagName, int ifindex,
                                      ProducerStateTable *lagMemberTable) :
+    m_parent(parent),
     m_lagMemberTable(lagMemberTable),
     m_lagName(lagName),
     m_ifindex(ifindex)
@@ -349,6 +501,12 @@ int TeamSync::TeamPortSync::onChange()
     struct team_port *port;
     map<string, bool> tmp_lag_members;
 
+    if (!m_parent)
+    {
+        SWSS_LOG_ERROR("TeamSync pointer is NULL!");
+        return -1;
+    }
+
     /* Check each port  */
     team_for_each_port(port, m_team)
     {
@@ -378,33 +536,39 @@ int TeamSync::TeamPortSync::onChange()
     /* Compare old and new LAG members and set/del accordingly */
     for (auto it : tmp_lag_members)
     {
-        if (m_lagMembers.find(it.first) == m_lagMembers.end() || it.second != m_lagMembers[it.first])
-        {
-            string key = m_lagName + ":" + it.first;
-            vector<FieldValueTuple> v;
-            FieldValueTuple l("status", it.second ? "enabled" : "disabled");
-            v.push_back(l);
-            m_lagMemberTable->set(key, v);
-
-            SWSS_LOG_INFO("Set LAG %s member %s with status %s",
-                    m_lagName.c_str(), it.first.c_str(), it.second ? "enabled" : "disabled");
-        }
+        m_parent->handleLagMemberStatus(this, it.first, it.second);
     }
 
+    vector<string> removedMembers;
     for (auto it : m_lagMembers)
     {
         if (tmp_lag_members.find(it.first) == tmp_lag_members.end())
         {
-            string key = m_lagName + ":" + it.first;
-            m_lagMemberTable->del(key);
-
-            SWSS_LOG_INFO("Remove member %s from LAG %s",
-                    it.first.c_str(), m_lagName.c_str());
+            removedMembers.push_back(it.first);
         }
     }
 
-    /* Replace the old LAG members with the new ones */
-    m_lagMembers = tmp_lag_members;
+    for (const auto &memberName : removedMembers)
+    {
+        string key = m_lagName + ":" + memberName;
+
+        m_parent->cancelPendingDisable(this, memberName);
+
+        auto stateIt = m_memberDebounceStates.find(memberName);
+        if (stateIt != m_memberDebounceStates.end())
+        {
+            m_parent->m_timerToMember.erase(stateIt->second.timer.get());
+            m_parent->m_select->removeSelectable(stateIt->second.timer.get());
+            m_memberDebounceStates.erase(stateIt);
+        }
+
+        m_lagMemberTable->del(key);
+        m_lagMembers.erase(memberName);
+
+        SWSS_LOG_INFO("Remove member %s from LAG %s",
+                memberName.c_str(), m_lagName.c_str());
+    }
+
     return 0;
 }
 

--- a/teamsyncd/teamsync.h
+++ b/teamsyncd/teamsync.h
@@ -2,12 +2,15 @@
 #define __TEAMSYNC__
 
 #include <map>
+#include <set>
 #include <string>
 #include <memory>
+#include <unordered_map>
 #include "dbconnector.h"
 #include "producerstatetable.h"
 #include "selectable.h"
 #include "select.h"
+#include "selectabletimer.h"
 #include "netmsg.h"
 #include <team.h>
 
@@ -21,11 +24,13 @@ namespace swss {
 
 class TeamSync : public NetMsg
 {
+    friend class TeamPortSync;
 public:
     TeamSync(DBConnector *db, DBConnector *stateDb, Select *select);
 
     void periodic();
     void cleanTeamSync();
+    bool processTimerSelectable(Selectable *selectable);
 
     /* Listen to RTM_NEWLINK, RTM_DELLINK to track team devices */
     virtual void onMsg(int nlmsg_type, struct nl_object *obj);
@@ -34,15 +39,28 @@ public:
     {
     public:
         enum { MAX_IFNAME = 64 };
-        TeamPortSync(const std::string &lagName, int ifindex,
+        TeamPortSync(TeamSync *parent, const std::string &lagName, int ifindex,
                      ProducerStateTable *lagMemberTable);
         ~TeamPortSync();
+
+        const std::string &getLagName() const
+        {
+            return m_lagName;
+        }
 
         int getFd() override;
         uint64_t readData() override;
 
         /* member_name -> enabled|disabled */
         std::map<std::string, bool> m_lagMembers;
+
+        struct MemberDebounceState
+        {
+            std::shared_ptr<SelectableTimer> timer;
+            bool pendingDisable = false;
+        };
+
+        std::map<std::string, MemberDebounceState> m_memberDebounceStates;
         bool admin_state;
         bool oper_state;
         unsigned int mtu;
@@ -52,6 +70,7 @@ public:
                                 team_change_type_mask_t type_mask);
         static const struct team_change_handler gPortChangeHandler;
     private:
+        TeamSync *m_parent;
         ProducerStateTable *m_lagMemberTable;
         struct team_handle *m_team;
         std::string m_lagName;
@@ -62,6 +81,13 @@ protected:
     void addLag(const std::string &lagName, int ifindex, bool admin_state,
                 bool oper_state, unsigned int mtu);
     void removeLag(const std::string &lagName);
+
+    void handleLagMemberStatus(TeamPortSync *lag, const std::string &memberName, bool observedEnabled);
+    void applyLagMemberStatus(TeamPortSync *lag, const std::string &memberName, bool enabled);
+    void ensureMemberTimer(TeamPortSync *lag, const std::string &memberName);
+    void startPendingDisable(TeamPortSync *lag, const std::string &memberName);
+    void cancelPendingDisable(TeamPortSync *lag, const std::string &memberName);
+    void clearPendingDisablesForLag(TeamPortSync *lag);
 
     /* valid only in WR mode */
     void applyState();
@@ -83,7 +109,10 @@ private:
     /* Store selectables needed to be updated in doSelectableTask function */
     std::set<std::string> m_selectablesToAdd;
     std::set<std::string> m_selectablesToRemove;
+
     std::map<std::string, std::shared_ptr<TeamPortSync> > m_teamSelectables;
+
+    std::map<Selectable *, std::pair<TeamPortSync *, std::string>> m_timerToMember;
 };
 
 }

--- a/teamsyncd/teamsyncd.cpp
+++ b/teamsyncd/teamsyncd.cpp
@@ -55,8 +55,19 @@ int main(int argc, char **argv)
         s.addSelectable(&netlink);
         while (!received_sigterm)
         {
-            Selectable *temps;
-            s.select(&temps, 1000); // block for a second
+            Selectable *temps = nullptr;
+
+            int ret = s.select(&temps, 1000); // block for a second
+
+            if (ret == Select::OBJECT && temps != nullptr)
+            {
+                swss::SelectableTimer* timer = dynamic_cast<swss::SelectableTimer*>(temps);
+                if (timer) 
+                {
+                    sync.processTimerSelectable(timer); 
+                }
+            }
+
             sync.periodic();
         }
         sync.cleanTeamSync();

--- a/tests/mock_tests/teamsync_ut.cpp
+++ b/tests/mock_tests/teamsync_ut.cpp
@@ -144,7 +144,7 @@ namespace teamportsync_test
     TEST_F(TeamPortSyncTest, TestInvalidIfIndex)
     {
         try {
-            swss::TeamSync::TeamPortSync("testLag", 0, NULL);
+            swss::TeamSync::TeamPortSync(NULL, "testLag", 0, NULL);
             FAIL();
         } catch (std::runtime_error &exception) {
             EXPECT_THAT(exception.what(), testing::HasSubstr("Unable to initialize team socket"));
@@ -154,7 +154,7 @@ namespace teamportsync_test
     TEST_F(TeamPortSyncTest, NoLagPresent)
     {
         try {
-            swss::TeamSync::TeamPortSync("testLag", 4, NULL);
+            swss::TeamSync::TeamPortSync(NULL, "testLag", 4, NULL);
             FAIL();
         } catch (std::runtime_error &exception) {
             EXPECT_THAT(exception.what(), testing::HasSubstr("Unable to initialize team socket"));
@@ -167,7 +167,7 @@ namespace teamportsync_test
         callback_team_change_handler = cb_team_change_handler;
         callback_teamdctl_connect = cb_teamdctl_connect;
         try {
-            swss::TeamSync::TeamPortSync("testLag", 4, NULL);
+            swss::TeamSync::TeamPortSync(NULL, "testLag", 4, NULL);
             FAIL();
         } catch (std::runtime_error &exception) {
             EXPECT_THAT(exception.what(), testing::HasSubstr("Unable to get config from teamd"));
@@ -180,6 +180,6 @@ namespace teamportsync_test
         callback_team_change_handler = cb_team_change_handler;
         callback_teamdctl_connect = cb_teamdctl_connect;
         callback_teamdctl_config_get_raw_direct = cb_teamdctl_config_get_raw_direct_success;
-        swss::TeamSync::TeamPortSync("testLag", 4, NULL);
+        swss::TeamSync::TeamPortSync(NULL, "testLag", 4, NULL);
     }
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
Fixes https://github.com/sonic-net/sonic-buildimage/issues/26531.

**What I did**
Introduces a debounce timer in teamsyncd to delay the state transition of LAG members from enabled to disabled.
- Implemented a 10ms delay window that triggers only when a member transitions from enabled to disabled.
- Spurious flaps occurring within this window are suppressed before reaching APP_DB, ensuring downstream components (like orchagent and SAI) only process stabilized state changes.

**Why I did it**
Rapid LACP renegotiation during remote LAG member re-addition can induce millisecond status jitter, which is a spurious artifact that should not occur in stable protocol operations.
<img width="1105" height="201" alt="img_v3_0210j_ed39a4e8-ae4d-47ab-b694-f8b1ca412b6g" src="https://github.com/user-attachments/assets/5386f642-350f-47a9-a51b-1a433cf57169" />

Source-side suppression: Filtering these flaps at the source prevents unnecessary and wasteful state propagation from teamsyncd to APPL_DB and the SAI layer.
Mitigate cascading failures: It specifically prevents cascading effects such as unexpected MAC move storms(as reported in #26531).

**How I verified it**
  1. monitored APP_DB to confirm ms flaps no longer trigger redundant writes.
  2. verified that persistent link-down events are still correctly propagated after the 10ms delay.
  3. confirmed traffic forwarding remains stable during LAG member transitions with ~800 MACs.

**Details if related**