### PR TITLE
[202511] Fix FDB race for secondary neighbors on mux ports

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1540,6 +1540,10 @@ void MuxOrch::updateNeighbor(const NeighborUpdate& update)
     string port, old_port;
     if (update.add && !getMuxPort(update.mac, update.entry.alias, port))
     {
+        SWSS_LOG_INFO("Mux FDB not found for neighbor %s mac %s, adding nexthop placeholder",
+                      update.entry.ip_address.to_string().c_str(),
+                      update.mac.to_string().c_str());
+        addNexthop(update.entry);
         return;
     }
     else if (update.add)

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -1978,6 +1978,131 @@ class TestMuxTunnel(TestMuxTunnelBase):
             ]
         )
 
+    def test_fdb_after_neighbor_on_standby_mux(
+        self, dvs, dvs_route, setup, setup_vlan, setup_mux_cable, setup_tunnel,
+        setup_peer_switch, testlog
+    ):
+        """Test neighbor conversion to MUX neighbor when FDB is learned after neighbor (host-route mode).
+
+        When a new neighbor is learned on a standby mux port and the FDB entry
+        for that MAC has not yet been learned, MuxOrch::updateNeighbor fails to
+        associate the neighbor with the mux port (FDB lookup fails). The neighbor
+        is never added to mux_nexthop_tb_ and disableNeighbor is never called.
+
+        This test verifies that when the FDB entry is later learned on the mux port,
+        the neighbor gets properly converted to a MUX neighbor and disabled (standby).
+
+        Steps:
+        1. Set mux port to standby
+        2. Add neighbor (without prior FDB entry)
+        3. Verify neighbor is initially in ASIC as a regular neighbor (not yet mux-managed)
+        4. Simulate FDB learn on the mux port
+        5. Verify neighbor gets disabled (removed from ASIC neigh table, tunnel route installed)
+        6. Toggle to active and verify neighbor is re-enabled
+        """
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        test_ip = "192.168.0.200"
+        test_mac = "00:00:00:00:aa:bb"
+        test_mac_dash = "00-00-00-00-aa-bb"
+        cable_name = "Ethernet0"
+
+        try:
+            # Step 1: Set mux to standby
+            self.set_mux_state(appdb, cable_name, "standby")
+
+            # Step 2: Add neighbor WITHOUT prior FDB entry
+            # MuxOrch::updateNeighbor will fail to find FDB -> neighbor not mux-managed
+            self.add_neighbor(dvs, test_ip, test_mac)
+            time.sleep(1)
+
+            # Step 3: Neighbor should be in ASIC as a regular neighbor
+            # (not yet mux-managed, so no tunnel route yet)
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+
+            # Step 4: Simulate FDB learn on mux port
+            # This should trigger updateFdb -> disableNeighbor (standby)
+            self.add_fdb(dvs, cable_name, test_mac_dash)
+            time.sleep(2)
+
+            # Step 5: Verify neighbor is now mux-managed on standby:
+            # - Neighbor removed from ASIC (disabled)
+            # - Tunnel route installed
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=True)
+
+            # Step 6: Toggle to active -> neighbor should be re-enabled
+            self.set_mux_state(appdb, cable_name, "active")
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=False)
+
+            # Toggle back to standby -> verify it disables again
+            self.set_mux_state(appdb, cable_name, "standby")
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=True)
+
+        finally:
+            self.del_neighbor(dvs, test_ip)
+            self.del_fdb(dvs, test_mac_dash)
+            self.set_mux_state(appdb, cable_name, "active")
+            time.sleep(1)
+
+    def test_fdb_after_neighbor_on_active_mux(
+        self, dvs, dvs_route, setup, setup_vlan, setup_mux_cable, setup_tunnel,
+        setup_peer_switch, testlog
+    ):
+        """Test neighbor conversion to MUX neighbor when FDB is learned after neighbor on active mux.
+
+        Same scenario as standby test but with active mux port. The neighbor should
+        be registered as a MUX neighbor and remain enabled (active).
+        """
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        test_ip = "192.168.0.201"
+        test_mac = "00:00:00:00:aa:cc"
+        test_mac_dash = "00-00-00-00-aa-cc"
+        cable_name = "Ethernet0"
+
+        try:
+            # Step 1: Set mux to active
+            self.set_mux_state(appdb, cable_name, "active")
+
+            # Step 2: Add neighbor WITHOUT prior FDB entry
+            self.add_neighbor(dvs, test_ip, test_mac)
+            time.sleep(1)
+
+            # Step 3: Neighbor should be in ASIC as a regular neighbor
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+
+            # Step 4: Simulate FDB learn on mux port
+            self.add_fdb(dvs, cable_name, test_mac_dash)
+            time.sleep(2)
+
+            # Step 5: Verify neighbor is mux-managed on active:
+            # - Neighbor stays in ASIC (enabled)
+            # - No tunnel route
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=False)
+
+            # Step 6: Toggle to standby -> neighbor should be disabled
+            self.set_mux_state(appdb, cable_name, "standby")
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=True)
+
+            # Toggle back to active -> re-enabled
+            self.set_mux_state(appdb, cable_name, "active")
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=False)
+
+        finally:
+            self.del_neighbor(dvs, test_ip)
+            self.del_fdb(dvs, test_mac_dash)
+            self.set_mux_state(appdb, cable_name, "active")
+            time.sleep(1)
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():


### PR DESCRIPTION
## What I did
Fix MuxOrch to properly convert neighbors to MUX neighbors when FDB is learned after the neighbor on host-route mode mux ports (202511 backport).

## How I did it
When a secondary neighbor (IP not in the mux cable configured subnet) is learned before its FDB entry is available, `updateNeighbor()` cannot determine which mux port the neighbor belongs to. Previously, a placeholder entry with an empty port was added to `mux_nexthop_tb_`, which pollutes the table with entries that may not map to a mux port.

This fix uses the cleaner conversion approach from master (PR #4459):

1. **`updateNeighbor()`**: When FDB is not yet learned (empty port from `getMuxPort`), skip processing instead of adding a placeholder. The neighbor will be converted when FDB arrives.

2. **`updateFdb()`**: After processing existing mux neighbors, check if there are any neighbors with matching MAC that are not yet tracked as mux neighbors. If found, scan the NeighOrch neighbor table and convert matching neighbors via the new `convertNeighborToMux()` helper.

3. **`convertNeighborToMux()`**: New helper that adds a neighbor to `mux_nexthop_tb_` and calls `MuxCable::updateNeighbor()` to enable/disable the neighbor based on mux state.

4. **`NeighOrch::getNeighborTable()`**: New const accessor to expose the synced neighbor table for scanning in `updateFdb()`.

## How to verify it
Two new VS tests exercise the FDB-after-neighbor race:
- `test_fdb_after_neighbor_on_standby_mux`: Verifies neighbor gets tunnel route after FDB arrives on standby
- `test_fdb_after_neighbor_on_active_mux`: Verifies neighbor stays direct on active mux

These tests add a neighbor with IP outside the mux subnet before FDB is learned, then add the FDB entry and verify proper mux neighbor management.

## Which release branch to backport
N/A (this is the 202511 backport of the master fix in #4459)

## Related PRs
- Master fix: https://github.com/sonic-net/sonic-swss/pull/4459