### PR TITLE
[muxorch] Fix FDB-after-neighbor conversion for host-route mode

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1459,6 +1459,7 @@ void MuxOrch::updateFdb(const FdbUpdate& update)
     NeighborEntry neigh;
     MacAddress mac;
     MuxCable* ptr;
+    bool found_existing_mux_neighbor = false;
     for (auto nh = mux_nexthop_tb_.begin(); nh != mux_nexthop_tb_.end(); ++nh)
     {
         auto res = neigh_orch_->getNeighborEntry(nh->first, neigh, mac);
@@ -1466,6 +1467,8 @@ void MuxOrch::updateFdb(const FdbUpdate& update)
         {
             continue;
         }
+
+        found_existing_mux_neighbor = true;
 
         if (nh->second != update.entry.port_name)
         {
@@ -1487,6 +1490,64 @@ void MuxOrch::updateFdb(const FdbUpdate& update)
             }
         }
     }
+
+    // Handle case where neighbor exists but is not yet a MUX neighbor.
+    // This can happen when FDB entry is learned after neighbor is added.
+    if (!found_existing_mux_neighbor && isMuxExists(update.entry.port_name))
+    {
+        auto vlan_ports = gPortsOrch->getAllVlans();
+        SWSS_LOG_INFO("FDB update without mux neighbor on mux port %s, mac %s",
+                      update.entry.port_name.c_str(),
+                      update.entry.mac.to_string().c_str());
+
+        for (auto vlan_alias : vlan_ports)
+        {
+            auto neighbors = neigh_orch_->getNeighborTable();
+            for (const auto& neighbor_pair : neighbors)
+            {
+                const NeighborEntry& neighbor_entry = neighbor_pair.first;
+                const auto& neighbor_data = neighbor_pair.second;
+
+                if (neighbor_data.mac == update.entry.mac && neighbor_entry.alias == vlan_alias)
+                {
+                    string port_name;
+                    if (getMuxPort(update.entry.mac, vlan_alias, port_name) &&
+                        !port_name.empty() && port_name == update.entry.port_name)
+                    {
+                        SWSS_LOG_INFO("Converting existing neighbor %s on %s to MUX neighbor due to FDB update",
+                                      neighbor_entry.ip_address.to_string().c_str(), vlan_alias.c_str());
+
+                        convertNeighborToMux(neighbor_entry, port_name);
+                    }
+                }
+            }
+        }
+    }
+}
+
+void MuxOrch::convertNeighborToMux(const NeighborEntry& neighbor_entry, const string& port_name)
+{
+    MuxCable* ptr = getMuxCable(port_name);
+    if (!ptr)
+    {
+        SWSS_LOG_WARN("MUX cable for port %s not found, skipping neighbor conversion", port_name.c_str());
+        return;
+    }
+
+    NextHopKey nh_key = { neighbor_entry.ip_address, neighbor_entry.alias };
+    if (containsNextHop(nh_key))
+    {
+        SWSS_LOG_INFO("Neighbor %s already tracked as MUX neighbor, skipping conversion",
+                       neighbor_entry.ip_address.to_string().c_str());
+        return;
+    }
+
+    mux_nexthop_tb_[nh_key] = port_name;
+    ptr->updateNeighbor(nh_key, true);
+
+    SWSS_LOG_NOTICE("Converted neighbor %s on %s to MUX neighbor on port %s",
+                     neighbor_entry.ip_address.to_string().c_str(),
+                     neighbor_entry.alias.c_str(), port_name.c_str());
 }
 
 void MuxOrch::updateNeighbor(const NeighborUpdate& update)

--- a/orchagent/muxorch.h
+++ b/orchagent/muxorch.h
@@ -261,6 +261,7 @@ private:
 
     void updateNeighbor(const NeighborUpdate&);
     void updateFdb(const FdbUpdate&);
+    void convertNeighborToMux(const NeighborEntry&, const std::string&);
 
     /***
      * Methods for managing tunnel routes for neighbor IPs not associated

--- a/orchagent/neighorch.h
+++ b/orchagent/neighorch.h
@@ -88,6 +88,8 @@ public:
     bool getNeighborEntry(const NextHopKey&, NeighborEntry&, MacAddress&);
     bool getNeighborEntry(const IpAddress&, NeighborEntry&, MacAddress&);
 
+    const NeighborTable& getNeighborTable() const { return m_syncdNeighbors; }
+
     bool enableNeighbor(const NeighborEntry&);
     bool disableNeighbor(const NeighborEntry&);
     bool enableNeighbors(std::list<NeighborContext>&);

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -1978,6 +1978,131 @@ class TestMuxTunnel(TestMuxTunnelBase):
             ]
         )
 
+    def test_fdb_after_neighbor_on_standby_mux(
+        self, dvs, dvs_route, setup, setup_vlan, setup_mux_cable, setup_tunnel,
+        setup_peer_switch, testlog
+    ):
+        """Test neighbor conversion to MUX neighbor when FDB is learned after neighbor (host-route mode).
+
+        When a new neighbor is learned on a standby mux port and the FDB entry
+        for that MAC has not yet been learned, MuxOrch::updateNeighbor fails to
+        associate the neighbor with the mux port (FDB lookup fails). The neighbor
+        is never added to mux_nexthop_tb_ and disableNeighbor is never called.
+
+        This test verifies that when the FDB entry is later learned on the mux port,
+        the neighbor gets properly converted to a MUX neighbor and disabled (standby).
+
+        Steps:
+        1. Set mux port to standby
+        2. Add neighbor (without prior FDB entry)
+        3. Verify neighbor is initially in ASIC as a regular neighbor (not yet mux-managed)
+        4. Simulate FDB learn on the mux port
+        5. Verify neighbor gets disabled (removed from ASIC neigh table, tunnel route installed)
+        6. Toggle to active and verify neighbor is re-enabled
+        """
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        test_ip = "192.168.0.200"
+        test_mac = "00:00:00:00:aa:bb"
+        test_mac_dash = "00-00-00-00-aa-bb"
+        cable_name = "Ethernet0"
+
+        try:
+            # Step 1: Set mux to standby
+            self.set_mux_state(appdb, cable_name, "standby")
+
+            # Step 2: Add neighbor WITHOUT prior FDB entry
+            # MuxOrch::updateNeighbor will fail to find FDB -> neighbor not mux-managed
+            self.add_neighbor(dvs, test_ip, test_mac)
+            time.sleep(1)
+
+            # Step 3: Neighbor should be in ASIC as a regular neighbor
+            # (not yet mux-managed, so no tunnel route yet)
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+
+            # Step 4: Simulate FDB learn on mux port
+            # This should trigger updateFdb -> disableNeighbor (standby)
+            self.add_fdb(dvs, cable_name, test_mac_dash)
+            time.sleep(2)
+
+            # Step 5: Verify neighbor is now mux-managed on standby:
+            # - Neighbor removed from ASIC (disabled)
+            # - Tunnel route installed
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=True)
+
+            # Step 6: Toggle to active -> neighbor should be re-enabled
+            self.set_mux_state(appdb, cable_name, "active")
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=False)
+
+            # Toggle back to standby -> verify it disables again
+            self.set_mux_state(appdb, cable_name, "standby")
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=True)
+
+        finally:
+            self.del_neighbor(dvs, test_ip)
+            self.del_fdb(dvs, test_mac_dash)
+            self.set_mux_state(appdb, cable_name, "active")
+            time.sleep(1)
+
+    def test_fdb_after_neighbor_on_active_mux(
+        self, dvs, dvs_route, setup, setup_vlan, setup_mux_cable, setup_tunnel,
+        setup_peer_switch, testlog
+    ):
+        """Test neighbor conversion to MUX neighbor when FDB is learned after neighbor on active mux.
+
+        Same scenario as standby test but with active mux port. The neighbor should
+        be registered as a MUX neighbor and remain enabled (active).
+        """
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        test_ip = "192.168.0.201"
+        test_mac = "00:00:00:00:aa:cc"
+        test_mac_dash = "00-00-00-00-aa-cc"
+        cable_name = "Ethernet0"
+
+        try:
+            # Step 1: Set mux to active
+            self.set_mux_state(appdb, cable_name, "active")
+
+            # Step 2: Add neighbor WITHOUT prior FDB entry
+            self.add_neighbor(dvs, test_ip, test_mac)
+            time.sleep(1)
+
+            # Step 3: Neighbor should be in ASIC as a regular neighbor
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+
+            # Step 4: Simulate FDB learn on mux port
+            self.add_fdb(dvs, cable_name, test_mac_dash)
+            time.sleep(2)
+
+            # Step 5: Verify neighbor is mux-managed on active:
+            # - Neighbor stays in ASIC (enabled)
+            # - No tunnel route
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=False)
+
+            # Step 6: Toggle to standby -> neighbor should be disabled
+            self.set_mux_state(appdb, cable_name, "standby")
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=True)
+
+            # Toggle back to active -> re-enabled
+            self.set_mux_state(appdb, cable_name, "active")
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=False)
+
+        finally:
+            self.del_neighbor(dvs, test_ip)
+            self.del_fdb(dvs, test_mac_dash)
+            self.set_mux_state(appdb, cable_name, "active")
+            time.sleep(1)
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():


### PR DESCRIPTION
## What I did
Fix MuxOrch to properly convert neighbors to MUX neighbors when FDB is learned after the neighbor on host-route mode mux ports (202511 backport).

## How I did it
When a secondary neighbor (IP not in the mux cable configured subnet) is learned before its FDB entry is available, `updateNeighbor()` adds it to `mux_nexthop_tb_` with an empty port name. Later when the FDB entry arrives, `updateFdb()` finds the existing entry and processes it through the normal port-change path. However, if the neighbor was never added to `mux_nexthop_tb_` for any reason (e.g., `getNeighborEntry` resolves differently at FDB time), there is no fallback to discover and convert it.

This fix adds FDB-after-neighbor conversion logic to `updateFdb()`, matching the approach used on master (PR #4459):

1. **`updateFdb()`**: Track whether any existing mux neighbor matched the FDB MAC. If not, scan NeighOrch's neighbor table for neighbors with matching MAC and convert them to mux neighbors via `convertNeighborToMux()`.

2. **`convertNeighborToMux()`**: New helper that validates the mux cable, checks for duplicates via `containsNextHop()`, adds the neighbor to `mux_nexthop_tb_`, and calls `MuxCable::updateNeighbor()` to manage the neighbor based on mux state.

3. **`NeighOrch::getNeighborTable()`**: New const accessor exposing the synced neighbor table for scanning in `updateFdb()`.

## How to verify it
Two new VS tests exercise the FDB-after-neighbor race condition:
- `test_fdb_after_neighbor_on_standby_mux`: Verifies neighbor gets tunnel route after FDB arrives on standby
- `test_fdb_after_neighbor_on_active_mux`: Verifies neighbor stays direct on active mux

These tests add a neighbor with IP outside the mux subnet before FDB is learned, then add the FDB entry and verify proper mux neighbor management.

## Which release branch to backport
N/A (this is the 202511 backport of the master fix in #4459)

## Related PRs
- Master fix: https://github.com/sonic-net/sonic-swss/pull/4459