### PR TITLE
Replay VxLAN port settings from device metadata

### DIFF
--- a/cfgmgr/vxlanmgrd.cpp
+++ b/cfgmgr/vxlanmgrd.cpp
@@ -74,6 +74,33 @@ int main(int argc, char **argv)
         }
         gMacAddress = MacAddress(it->second);
 
+        /*
+         * Replay VXLAN port settings from DEVICE_METADATA to APP_DB SWITCH_TABLE
+         * so that orchagent/SAI picks them up on restart/reload.
+         * These fields (vxlan_port, vxlan_sport, vxlan_mask) are persisted in
+         * DEVICE_METADATA by the CLI but orchagent only subscribes to APP_DB
+         * SWITCH_TABLE, so we bridge the gap here at startup.
+         */
+        const vector<string> vxlan_fields = {"vxlan_port", "vxlan_sport", "vxlan_mask"};
+        vector<FieldValueTuple> switchFvs;
+        for (const auto &field : vxlan_fields)
+        {
+            auto fit = std::find_if(ovalues.begin(), ovalues.end(),
+                [&field](const FieldValueTuple& t){ return t.first == field; });
+            if (fit != ovalues.end())
+            {
+                switchFvs.emplace_back(fit->first, fit->second);
+                SWSS_LOG_NOTICE("Replaying DEVICE_METADATA field %s=%s to APP_DB SWITCH_TABLE",
+                                fit->first.c_str(), fit->second.c_str());
+            }
+        }
+        if (!switchFvs.empty())
+        {
+            ProducerStateTable appSwitchTable(&appDb, APP_SWITCH_TABLE_NAME);
+            appSwitchTable.set("switch", switchFvs);
+            SWSS_LOG_NOTICE("Replayed %zu VXLAN port field(s) to APP_DB SWITCH_TABLE", switchFvs.size());
+        }
+
         auto in_recon = true;
         vxlanmgr.beginReconcile(true);
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
As part of Sonic CLI support for VxLAN port configuration:
https://github.com/sonic-net/sonic-utilities/pull/4467

Added support to replay VxLAN port settings from DEVICE_METADATA to APP_DB. Whenever Vxlanmgrd comes up, it will read the configured port values from DEVICE_METADATA and replay it to SWITCH_TABLE in APP_DB.

**Why I did it**
Currently there is no way for the VxLAN port setting to persist across config reload or reboot. This change makes it persistence.

**How I verified it**
Tested manually.
[vxlan_test.txt](https://github.com/user-attachments/files/26809525/vxlan_test.txt)


**Details if related**
