### PR TITLE
[Generic-P4Orch] Initialize ZMQ server conditionally based on P4RT feature state.

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -888,7 +888,37 @@ bool OrchDaemon::init()
     m_orchList.push_back(&CounterCheckOrch::getInstance(m_configDb));
 
     vector<string> p4rt_tables = {APP_P4RT_TABLE_NAME};
-    m_p4OrchZmqServer = new swss::ZmqServer(m_p4OrchZmqServerEp, "", false, true);
+
+    // Check if P4RT is enabled in CONFIG_DB using standard macro table name
+    Table featureTable(m_configDb, CFG_FEATURE_TABLE_NAME);
+    std::vector<FieldValueTuple> values;
+    bool isP4Enabled = false;
+
+    // Safely fetch "p4rt" key from FEATURE table
+    if (featureTable.get("p4rt", values))
+    {
+        for (const auto& v : values)
+        {
+            // Fully aligns with CoppMgr's feature evaluation logic
+            if (fvField(v) == "state" && (fvValue(v) == "enabled" || fvValue(v) == "always_enabled"))
+            {
+                isP4Enabled = true;
+                break;
+            }
+        }
+    }
+
+    if (isP4Enabled)
+    {
+        SWSS_LOG_NOTICE("P4RT is enabled. Initializing ZMQ server and P4Orch.");
+        m_p4OrchZmqServer = new swss::ZmqServer(m_p4OrchZmqServerEp, "", false, true);
+    }
+    else
+    {
+        SWSS_LOG_NOTICE("P4RT is disabled. Skipping ZMQ server initialization to save memory.");
+        m_p4OrchZmqServer = nullptr;
+    }
+
     gP4Orch = new P4Orch(m_applDb, p4rt_tables, m_p4OrchZmqServer, vrf_orch, gCoppOrch);
     m_orchList.push_back(gP4Orch);
 

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -889,7 +889,37 @@ bool OrchDaemon::init()
     m_orchList.push_back(&CounterCheckOrch::getInstance(m_configDb));
 
     vector<string> p4rt_tables = {APP_P4RT_TABLE_NAME};
-    m_p4OrchZmqServer = new swss::ZmqServer(m_p4OrchZmqServerEp, "", false, true);
+
+    // Check if P4RT is enabled in CONFIG_DB using standard macro table name
+    Table featureTable(m_configDb, CFG_FEATURE_TABLE_NAME);
+    std::vector<FieldValueTuple> values;
+    bool isP4Enabled = false;
+
+    // Safely fetch "p4rt" key from FEATURE table
+    if (featureTable.get("p4rt", values))
+    {
+        for (const auto& v : values)
+        {
+            // Fully aligns with CoppMgr's feature evaluation logic
+            if (fvField(v) == "state" && (fvValue(v) == "enabled" || fvValue(v) == "always_enabled"))
+            {
+                isP4Enabled = true;
+                break;
+            }
+        }
+    }
+
+    if (isP4Enabled)
+    {
+        SWSS_LOG_NOTICE("P4RT is enabled. Initializing ZMQ server and P4Orch.");
+        m_p4OrchZmqServer = new swss::ZmqServer(m_p4OrchZmqServerEp, "", false, true);
+    }
+    else
+    {
+        SWSS_LOG_NOTICE("P4RT is disabled. Skipping ZMQ server initialization to save memory.");
+        m_p4OrchZmqServer = nullptr;
+    }
+
     gP4Orch = new P4Orch(m_applDb, p4rt_tables, m_p4OrchZmqServer, vrf_orch, gCoppOrch);
     m_orchList.push_back(gP4Orch);
 

--- a/orchagent/p4orch/p4orch.cpp
+++ b/orchagent/p4orch/p4orch.cpp
@@ -135,6 +135,16 @@ void P4Orch::doTask(ConsumerBase &consumer)
 {
     SWSS_LOG_ENTER();
 
+    if (m_zmqServer == nullptr)
+    {
+        auto it = consumer.m_toSync.begin();
+        while (it != consumer.m_toSync.end())
+        {
+            it = consumer.m_toSync.erase(it);
+        }
+        return;
+    }
+
     if (!gPortsOrch->allPortsReady())
     {
         return;

--- a/orchagent/p4orch/p4orch.cpp
+++ b/orchagent/p4orch/p4orch.cpp
@@ -136,6 +136,16 @@ void P4Orch::doTask(ConsumerBase &consumer)
 {
     SWSS_LOG_ENTER();
 
+    if (m_zmqServer == nullptr)
+    {
+        auto it = consumer.m_toSync.begin();
+        while (it != consumer.m_toSync.end())
+        {
+            it = consumer.m_toSync.erase(it);
+        }
+        return;
+    }
+
     if (!gPortsOrch->allPortsReady())
     {
         return;

--- a/orchagent/p4orch/tests/p4orch_test.cpp
+++ b/orchagent/p4orch/tests/p4orch_test.cpp
@@ -198,6 +198,11 @@ TEST_F(P4OrchTest, ProcessInvalidEntry) {
   InSequence s;
   ZmqServer zmq_server("endpoint", "", false, true);
   DBConnector db("APPL_DB", 0);
+
+  std::vector<std::string> p4rt_tables = {APP_P4RT_TABLE_NAME};
+  delete gP4Orch;
+  gP4Orch = new P4Orch(&db, p4rt_tables, &zmq_server, gVrfOrch, copp_orch_);
+
   ZmqConsumerStateTable* table =
       new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
                                 TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,
@@ -222,6 +227,11 @@ TEST_F(P4OrchTest, ProcessP4Notification) {
   InSequence s;
   ZmqServer zmq_server("endpoint", "", false, true);
   DBConnector db("APPL_DB", 0);
+
+  std::vector<std::string> p4rt_tables = {APP_P4RT_TABLE_NAME};
+  delete gP4Orch;
+  gP4Orch = new P4Orch(&db, p4rt_tables, &zmq_server, gVrfOrch, copp_orch_);
+
   ZmqConsumerStateTable* table =
       new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
                                 TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,
@@ -321,6 +331,11 @@ TEST_F(P4OrchTest, ProcessP4NotificationInvalidKey) {
   InSequence s;
   ZmqServer zmq_server("endpoint");
   DBConnector db("APPL_DB", 0);
+
+  std::vector<std::string> p4rt_tables = {APP_P4RT_TABLE_NAME};
+  delete gP4Orch;
+  gP4Orch = new P4Orch(&db, p4rt_tables, &zmq_server, gVrfOrch, copp_orch_);
+
   ZmqConsumerStateTable* table =
       new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
                                 TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,
@@ -344,6 +359,11 @@ TEST_F(P4OrchTest, ProcessP4NotificationInOrder) {
   InSequence s;
   ZmqServer zmq_server("endpoint");
   DBConnector db("APPL_DB", 0);
+
+  std::vector<std::string> p4rt_tables = {APP_P4RT_TABLE_NAME};
+  delete gP4Orch;
+  gP4Orch = new P4Orch(&db, p4rt_tables, &zmq_server, gVrfOrch, copp_orch_);
+
   ZmqConsumerStateTable* table =
       new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
                                 TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,
@@ -402,6 +422,11 @@ TEST_F(P4OrchTest, ProcessP4NotificationWrongOrder) {
   InSequence s;
   ZmqServer zmq_server("endpoint");
   DBConnector db("APPL_DB", 0);
+
+  std::vector<std::string> p4rt_tables = {APP_P4RT_TABLE_NAME};
+  delete gP4Orch;
+  gP4Orch = new P4Orch(&db, p4rt_tables, &zmq_server, gVrfOrch, copp_orch_);
+
   ZmqConsumerStateTable* table =
       new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
                                 TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,
@@ -501,6 +526,11 @@ TEST_F(P4OrchTest, ProcessP4NotificationStopOnFirstFailure) {
   InSequence s;
   ZmqServer zmq_server("endpoint", "", false, true);
   DBConnector db("APPL_DB", 0);
+
+  std::vector<std::string> p4rt_tables = {APP_P4RT_TABLE_NAME};
+  delete gP4Orch;
+  gP4Orch = new P4Orch(&db, p4rt_tables, &zmq_server, gVrfOrch, copp_orch_);
+
   ZmqConsumerStateTable* table =
       new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
                                 TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,
@@ -604,6 +634,11 @@ TEST_F(P4OrchTest, ProcessP4NotificationStopOnFirstFailureDifferentTypes) {
   InSequence s;
   ZmqServer zmq_server("endpoint", "", false, true);
   DBConnector db("APPL_DB", 0);
+
+  std::vector<std::string> p4rt_tables = {APP_P4RT_TABLE_NAME};
+  delete gP4Orch;
+  gP4Orch = new P4Orch(&db, p4rt_tables, &zmq_server, gVrfOrch, copp_orch_);
+
   ZmqConsumerStateTable* table =
       new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
                                 TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2170,3 +2170,23 @@ def dpb_setup_fixture(dvs):
         dvs.vct.restart()
     yield
     remove_dpb_config_file(dvs)
+
+@pytest.fixture(scope="module", autouse=True)
+def enable_p4rt_feature(request, dvs):
+    """
+    Automatically enables P4RT in ConfigDB and restarts orchagent
+    to ensure ZMQ server is initialized.
+    """
+
+    if "tests/p4rt" not in str(request.fspath):
+        return
+
+    ec, out = dvs.runcmd("show feature status p4rt")
+    if out and "enabled" in out:
+        return
+
+    dvs.runcmd("python3 -c 'import json; f=\"/etc/sonic/config_db.json\"; data=json.load(open(f)); data.setdefault(\"FEATURE\", {}); data[\"FEATURE\"].setdefault(\"p4rt\", {}); data[\"FEATURE\"][\"p4rt\"][\"state\"]=\"enabled\"; json.dump(data, open(f,\"w\"), indent=4)'")
+
+    dvs.restart()
+    time.sleep(2)
+


### PR DESCRIPTION
**Summary**:
Raised this PR for the review comments shared in the PR #[4243](https://github.com/sonic-net/sonic-swss/pull/4243/changes).

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Made the initialization of the P4RT ZeroMQ server conditional based on the p4rt feature state in CONFIG_DB and added a graceful early return if the server is uninitialized.

**Why I did it**
To optimize memory by skipping ZeroMQ server creation when the P4RT feature is disabled.

**How I verified it**
Updated the P4OrchTest unit tests to handle the new initialization lifecycle and added an automated fixture in conftest.py to enable P4RT and restart orchagent for system test runs.

**Details if related**
This change introduces a runtime dependency on CONFIG_DB under FEATURE|p4rt before allocating P4RT orchestration resources.
