### PR TITLE
Skip usb0 in neighbor/route/interface orchagent

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -814,7 +814,7 @@ void IntfsOrch::doTask(Consumer &consumer)
             }
         }
 
-        if (alias == "eth0" || alias == "docker0")
+        if (alias == "eth0" || alias == "docker0" || alias == "usb0")
         {
             it = consumer.m_toSync.erase(it);
             continue;

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -908,7 +908,7 @@ void NeighOrch::doTask(Consumer &consumer)
 
         string alias = key.substr(0, found);
 
-        if (alias == "eth0" || alias == "lo" || alias == "docker0"
+        if (alias == "eth0" || alias == "lo" || alias == "docker0" || alias == "usb0"
             || ((op == SET_COMMAND) && m_intfsOrch->isInbandIntfInMgmtVrf(alias)))
         {
             it = consumer.m_toSync.erase(it);

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -901,7 +901,7 @@ void RouteOrch::doTask(ConsumerBase& consumer)
                         * way is to create loopback interface and then create
                         * route pointing to it, so that we can traps packets to
                         * CPU */
-                        if (alias == "eth0" || alias == "docker0" ||
+                        if (alias == "eth0" || alias == "docker0" || alias == "usb0" ||
                             alias == "lo" || !alias.compare(0, strlen(LOOPBACK_PREFIX), LOOPBACK_PREFIX))
                         {
                             excp_intfs_flag = true;

--- a/tests/mock_tests/neighorch_ut.cpp
+++ b/tests/mock_tests/neighorch_ut.cpp
@@ -268,4 +268,13 @@ namespace neighorch_test
         gPortsOrch->m_portList.erase(VLAN_2000);
         LearnNeighbor(VLAN_2000, TEST_IP, MAC2);
     }
+
+    TEST_F(NeighOrchTest, SkipHostInterfaceUsb0)
+    {
+        EXPECT_CALL(*mock_sai_neighbor_api, create_neighbor_entry).Times(0);
+        EXPECT_CALL(*mock_sai_neighbor_api, remove_neighbor_entry).Times(0);
+        LearnNeighbor("usb0", TEST_IP, MAC1);
+        /* Literal "usb0" can overload-resolve to NextHopKey(str, bool overlay) vs (str, str). */
+        ASSERT_EQ(gNeighOrch->m_syncdNeighbors.count(NeighborEntry(TEST_IP, std::string("usb0"))), 0);
+    }
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

- Treated the BMC **usb0** host interface like other non-ASIC host links (e.g. **eth0** / **docker0** / **lo**):
  - **neighorch**: drop **NEIGH** work for **usb0** before `getPort` so we do not log *"Port usb0 doesn't exist"* or retry on a non-routable port.
  - **neighsyncd**: do not publish **adds** for neighbors on **usb0** to **APPL_DB**; still process **deletes** and warm-restart housekeeping.
  - **intfsorch**: ignore **INTF** entries for **usb0**.
  - **routeorch**: skip routes whose outgoing interface is **usb0**.
- Added / adjusted **mock_tests**: **NeighOrchTest.SkipHostInterfaceUsb0** uses **`NeighborEntry(TEST_IP, std::string("usb0"))`** so **`NextHopKey`** resolves to the `(ip, interface)` overload (avoids **`Error converting … to NextHop`** from the **`(string, bool)`** overload).

**Why I did it**

On platforms where the BMC exposes **usb0**, kernel/neighbor events can generate SWSS/APPL_DB churn and noisy orchagent errors for an interface that is not a switch front-panel port. Filtering **usb0** consistently avoids pointless orchagent work and misleading logs without affecting dataplane routing on ASIC ports.

**How I verified it**

- Built **sonic-swss** mock tests in the slave docker environment (deps from **`/sonic/target/debs/bookworm`** as needed).
- Ran **`./tests --gtest_filter=NeighOrchTest.SkipHostInterfaceUsb0`** → **PASSED**.

**Details if related**

- Aligns behavior with documentation that treats **usb0** as a host-side skip alongside **eth0**/**docker0** where applicable.
- **gtest note**: when **`NeighborEntry`** aliases **`NextHopKey`**, passing a string literal as the second constructor argument can bind to **`(const std::string &, bool)`**; use **`std::string("usb0")`** (or equivalent) for explicit interface-name overload selection.