### PR TITLE
Decrease log severity from ERR to WARN for non-existing ICMP session

### DIFF
--- a/orchagent/icmporch.cpp
+++ b/orchagent/icmporch.cpp
@@ -277,7 +277,7 @@ bool IcmpOrch::remove_icmp_session(const string& key)
 {
     if (m_icmp_session_map.find(key) == m_icmp_session_map.end())
     {
-        SWSS_LOG_ERROR("Request to remove non-existing ICMP session for %s", key.c_str());
+        SWSS_LOG_WARN("Request to remove non-existing ICMP session for %s", key.c_str());
         return true;
     }
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Decrease log severity from ERR to WARN for non-existing ICMP session

**Why I did it**
ERR log in ICMP offload scenario during 'config reload' is expected but loganalyzer report errors

**How I verified it**

**Details if related**
