### PR TITLE
[orchagent] Add host_tx_ready_count to track state transitions

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2165,9 +2165,12 @@ void PortsOrch::initHostTxReadyState(Port &port)
 
     if (hostTxReady.empty())
     {
-        setHostTxReady(port, "false");
-        SWSS_LOG_NOTICE("initialize host_tx_ready as false for port %s",
-                        port.m_alias.c_str());
+        /* Initialize host_tx_ready to false and count to 0 */
+        vector<FieldValueTuple> fvs;
+        fvs.emplace_back("host_tx_ready", "false");
+        fvs.emplace_back("host_tx_ready_count", "0");
+        m_portStateTable.set(port.m_alias, fvs);
+        SWSS_LOG_NOTICE("initialize host_tx_ready as false for port %s", port.m_alias.c_str());
     }
 }
 
@@ -2232,12 +2235,47 @@ void PortsOrch::setHostTxReady(Port port, const std::string &status)
     vector<FieldValueTuple> tuples;
     bool exist;
 
-    /* If the port is revmoed, don't need to update StateDB*/
+    /* If the port is removed, don't need to update StateDB*/
     exist = m_portStateTable.get(port.m_alias, tuples);
     if (exist)
     {
-        SWSS_LOG_NOTICE("Setting host_tx_ready status = %s, alias = %s, port_id = 0x%" PRIx64, status.c_str(), port.m_alias.c_str(), port.m_port_id);
-        m_portStateTable.hset(port.m_alias, "host_tx_ready", status);
+        /* Read current state and count from STATE_DB */
+        string currentStatus;
+        uint64_t currentCount = 0;
+
+        for (auto &tuple : tuples)
+        {
+            if (fvField(tuple) == "host_tx_ready")
+            {
+                currentStatus = fvValue(tuple);
+            }
+            else if (fvField(tuple) == "host_tx_ready_count")
+            {
+                try
+                {
+                    currentCount = stoull(fvValue(tuple));
+                }
+                catch (const std::exception &e)
+                {
+                    SWSS_LOG_ERROR("Failed to parse host_tx_ready_count for port %s: %s",
+                                  port.m_alias.c_str(), e.what());
+                }
+            }
+        }
+
+        /* Check if state changed, increment counter if so */
+        if (currentStatus != status)
+        {
+            currentCount++;
+            SWSS_LOG_NOTICE("Setting host_tx_ready status = %s, count = %" PRIu64 ", alias = %s, port_id = 0x%" PRIx64,
+                            status.c_str(), currentCount, port.m_alias.c_str(), port.m_port_id);
+
+            /* Write both status and count to STATE_DB*/
+            vector<FieldValueTuple> fvs;
+            fvs.emplace_back("host_tx_ready", status);
+            fvs.emplace_back("host_tx_ready_count", std::to_string(currentCount));
+            m_portStateTable.set(port.m_alias, fvs);
+        }
     }
 }
 

--- a/tests/test_admin_status.py
+++ b/tests/test_admin_status.py
@@ -77,6 +77,15 @@ class TestAdminStatus(object):
             if fv[0] == "host_tx_ready":
                 assert fv[1] == "true" if admin_status == "up" else "false"
 
+    def get_host_tx_ready_count(self, dvs, port):
+        ptbl = swsscommon.Table(self.sdb, "PORT_TABLE")
+        (status, fvs) = ptbl.get(port)
+        assert status == True
+        for fv in fvs:
+            if fv[0] == "host_tx_ready_count":
+                return int(fv[1])
+        return 0
+
     def test_PortChannelMemberAdminStatus(self, dvs, testlog):
         self.setup_db(dvs)
 
@@ -130,6 +139,41 @@ class TestAdminStatus(object):
         self.check_host_tx_ready_status(dvs, "Ethernet0", "up")
         self.check_host_tx_ready_status(dvs, "Ethernet4", "down")
         self.check_host_tx_ready_status(dvs, "Ethernet8", "up")
+
+    def test_PortHostTxReadyCount(self, dvs, testlog):
+        dvs.setup_db()
+        self.setup_db(dvs)
+
+        #Find switch_id
+        switch_id = dvs.getSwitchOid()
+
+        # configure admin status to interface
+        self.set_admin_status("Ethernet0", "up")
+        time.sleep(1)
+
+        # Trigger host_tx_ready transitions and verify count increments
+        self.update_host_tx_ready_status(dvs, self.get_port_id(dvs, "Ethernet0"), switch_id, "up")
+        time.sleep(1)
+        count1 = self.get_host_tx_ready_count(dvs, "Ethernet0")
+        assert count1 == 1, f"Expected count 1, got {count1}"
+
+        # Transition to down
+        self.update_host_tx_ready_status(dvs, self.get_port_id(dvs, "Ethernet0"), switch_id, "down")
+        time.sleep(1)
+        count2 = self.get_host_tx_ready_count(dvs, "Ethernet0")
+        assert count2 == 2, f"Expected count 2, got {count2}"
+
+        # Transition back to up
+        self.update_host_tx_ready_status(dvs, self.get_port_id(dvs, "Ethernet0"), switch_id, "up")
+        time.sleep(1)
+        count3 = self.get_host_tx_ready_count(dvs, "Ethernet0")
+        assert count3 == 3, f"Expected count 3, got {count3}"
+
+        # Send same status (up->up), count should not increment
+        self.update_host_tx_ready_status(dvs, self.get_port_id(dvs, "Ethernet0"), switch_id, "up")
+        time.sleep(1)
+        count4 = self.get_host_tx_ready_count(dvs, "Ethernet0")
+        assert count4 == 3, f"Expected count 3 (no change), got {count4}"
 
 
 # Add Dummy always-pass test at end as workaroud


### PR DESCRIPTION
### Summary

Safer fix in 202511 for https://github.com/sonic-net/sonic-swss/pull/4497

Add persistent counter in STATE_DB PORT_TABLE that increments on every host_tx_ready state transition. Uses stateless read-before-write pattern with STATE_DB as single source of truth. Enables xcvrd to detect state changes even when boolean status remains unchanged across restarts.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

#### Why I did it

When a port transitions through host_tx_ready states (e.g., false->true->false->true),
downstream consumers like xcvrd may miss transitions if they only monitor the boolean
status value. Specifically, if a port goes down and comes back up while xcvrd is
processing other events, the final state appears unchanged (true->true), causing xcvrd
to skip necessary re-initialization of the transceiver.

This is problematic for CMIS and SFF transceivers that need to re-run initialization
sequences whenever the host interface is reset, regardless of whether the final state
looks the same.

#### How I did it

- Added `host_tx_ready_count` field to PORT_TABLE in STATE_DB
- Modified `initHostTxReadyState()` to initialize the counter to 0 if not present
- Implemented stateless logic in `setHostTxReady()`:
  - Read current status and count from STATE_DB (single source of truth)
  - Compare current status with new status
  - If different, increment counter and write both fields atomically
  - If same, skip write (no state change)
- Coalesced writes of both host_tx_ready and host_tx_ready_count in single set()

The counter increments on every true state transition:
- false->true: count++
- true->false: count++
- true->true (same): count unchanged

#### How to verify it

Check state db for count, after interface create on a config reload, we apply serdes settings, which sets it to false and then true.
```
2026 Mar 27 21:33:21.634547 humm212 NOTICE swss#orchagent: :- initHostTxReadyState: initialize host_tx_ready as false for port Ethernet0
2026 Mar 27 21:33:21.673139 humm212 NOTICE swss#orchagent: :- setHostTxReady: Setting host_tx_ready status = true, count = 1, alias = Ethernet0, port_id = 0x1000000000001
2026 Mar 27 21:33:21.673259 humm212 NOTICE swss#orchagent: :- setPortAdminStatus: Set admin status UP host_tx_ready to true for port Ethernet0
2026 Mar 27 21:33:23.248422 humm212 NOTICE swss#orchagent: :- setHostTxReady: Setting host_tx_ready status = false, count = 2, alias = Ethernet0, port_id = 0x1000000000001
2026 Mar 27 21:33:23.248495 humm212 NOTICE swss#orchagent: :- setPortAdminStatus: Set admin status DOWN host_tx_ready to false for port Ethernet0
2026 Mar 27 21:33:23.358714 humm212 NOTICE swss#orchagent: :- setHostTxReady: Setting host_tx_ready status = true, count = 3, alias = Ethernet0, port_id = 0x1000000000001
2026 Mar 27 21:33:23.358826 humm212 NOTICE swss#orchagent: :- setPortAdminStatus: Set admin status UP host_tx_ready to true for port Ethernet0

  "PORT_TABLE|Ethernet0": {
    "expireat": 1774653533.1311154,
    "ttl": -0.001,
    "type": "hash",
    "value": {
      "NPU_SI_SETTINGS_SYNC_STATUS": "NPU_SI_SETTINGS_NOTIFIED",
      "admin_status": "up",
      "fec": "rs",
      "host_tx_ready": "true",
      "host_tx_ready_count": "3",
      "mtu": "9100",
      "netdev_oper_status": "up",
      "speed": "400000",
      "state": "ok",
      "supported_fecs": "rs",
      "supported_speeds": "100000,200000,400000"
    }
  },
```
