### PR TITLE
portsorch: treat autoneg=off as no-op when AN is not supported

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4816,44 +4816,52 @@ void PortsOrch::doPortTask(Consumer &consumer)
                         }
                         if (p.m_cap_an < 1)
                         {
-                            SWSS_LOG_ERROR("%s: autoneg is not supported (cap=%d)", p.m_alias.c_str(), p.m_cap_an);
-                            // autoneg is not supported, don't retry
-                            it = taskMap.erase(it);
-                            continue;
-                        }
-                        if (p.m_admin_state_up)
-                        {
-                            /* Bring port down before applying speed */
-                            if (!setPortAdminStatus(p, false))
+                            if (pCfg.autoneg.value)
                             {
-                                SWSS_LOG_ERROR(
-                                    "Failed to set port %s admin status DOWN to set port autoneg mode",
-                                    p.m_alias.c_str()
-                                );
-                                it++;
+                                SWSS_LOG_ERROR("%s: autoneg is not supported (cap=%d)", p.m_alias.c_str(), p.m_cap_an);
+                                // autoneg is not supported, don't retry
+                                it = taskMap.erase(it);
                                 continue;
                             }
-
-                            p.m_admin_state_up = false;
-                            m_portList[p.m_alias] = p;
+                            /* autoneg as off is a no op when autoneg is not supported. Do not error out and delete remaining config */
+                            SWSS_LOG_INFO("%s: autoneg not supported; disable is no-op", p.m_alias.c_str());
                         }
-
-                        auto status = setPortAutoNeg(p, pCfg.autoneg.value);
-                        if (status != task_success)
+                        else
                         {
-                            SWSS_LOG_ERROR(
-                                "Failed to set port %s AN from %d to %d",
-                                p.m_alias.c_str(), p.m_autoneg, pCfg.autoneg.value
-                            );
-                            if (status == task_need_retry)
+                            if (p.m_admin_state_up)
                             {
-                                it++;
+                                /* Bring port down before applying speed */
+                                if (!setPortAdminStatus(p, false))
+                                {
+                                    SWSS_LOG_ERROR(
+                                        "Failed to set port %s admin status DOWN to set port autoneg mode",
+                                        p.m_alias.c_str()
+                                    );
+                                    it++;
+                                    continue;
+                                }
+
+                                p.m_admin_state_up = false;
+                                m_portList[p.m_alias] = p;
                             }
-                            else
+
+                            auto status = setPortAutoNeg(p, pCfg.autoneg.value);
+                            if (status != task_success)
                             {
-                                it = taskMap.erase(it);
+                                SWSS_LOG_ERROR(
+                                    "Failed to set port %s AN from %d to %d",
+                                    p.m_alias.c_str(), p.m_autoneg, pCfg.autoneg.value
+                                );
+                                if (status == task_need_retry)
+                                {
+                                    it++;
+                                }
+                                else
+                                {
+                                    it = taskMap.erase(it);
+                                }
+                                continue;
                             }
-                            continue;
                         }
 
                         p.m_autoneg = pCfg.autoneg.value;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4818,7 +4818,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                         {
                             if (pCfg.autoneg.value)
                             {
-                                SWSS_LOG_WARNING("%s: autoneg is not supported (cap=%d)", p.m_alias.c_str(), p.m_cap_an);
+                                SWSS_LOG_WARN("%s: autoneg is not supported (cap=%d)", p.m_alias.c_str(), p.m_cap_an);
                                 // autoneg is not supported, don't retry
                                 it = taskMap.erase(it);
                                 continue;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4818,7 +4818,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                         {
                             if (pCfg.autoneg.value)
                             {
-                                SWSS_LOG_ERROR("%s: autoneg is not supported (cap=%d)", p.m_alias.c_str(), p.m_cap_an);
+                                SWSS_LOG_WARNING("%s: autoneg is not supported (cap=%d)", p.m_alias.c_str(), p.m_cap_an);
                                 // autoneg is not supported, don't retry
                                 it = taskMap.erase(it);
                                 continue;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4816,15 +4816,10 @@ void PortsOrch::doPortTask(Consumer &consumer)
                         }
                         if (p.m_cap_an < 1)
                         {
-                            if (pCfg.autoneg.value)
-                            {
-                                SWSS_LOG_WARN("%s: autoneg is not supported (cap=%d)", p.m_alias.c_str(), p.m_cap_an);
-                                // autoneg is not supported, don't retry
-                                it = taskMap.erase(it);
-                                continue;
-                            }
-                            /* autoneg as off is a no op when autoneg is not supported. Do not error out and delete remaining config */
-                            SWSS_LOG_INFO("%s: autoneg not supported; disable is no-op", p.m_alias.c_str());
+                            /* autoneg not supported: log and continue applying remaining config (disable is a no-op; enable cannot be honored) */
+                            SWSS_LOG_WARN("%s: autoneg is not supported (cap=%d), requested=%s",
+                                          p.m_alias.c_str(), p.m_cap_an,
+                                          pCfg.autoneg.value ? "on" : "off");
                         }
                         else
                         {

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4825,7 +4825,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                         {
                             if (p.m_admin_state_up)
                             {
-                                /* Bring port down before applying speed */
+                                /* Bring port down before changing autoneg mode */
                                 if (!setPortAdminStatus(p, false))
                                 {
                                     SWSS_LOG_ERROR(

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -58,6 +58,7 @@ namespace portsorch_test
     uint32_t _sai_set_port_fec_count;
     uint32_t _sai_set_port_auto_neg_count;
     bool mock_autoneg_cap_supported = true;
+    bool set_autoneg_need_retry = false;
     uint32_t _sai_set_port_tpid_count;
     int32_t _sai_port_fec_mode;
     vector<sai_port_fec_mode_t> mock_port_fec_modes = {SAI_PORT_FEC_MODE_RS, SAI_PORT_FEC_MODE_FC};
@@ -168,6 +169,10 @@ namespace portsorch_test
         else if (attr[0].id == SAI_PORT_ATTR_AUTO_NEG_MODE)
         {
             _sai_set_port_auto_neg_count++;
+            if (set_autoneg_need_retry)
+            {
+                return SAI_STATUS_INSUFFICIENT_RESOURCES;
+            }
             /* Simulating failure case */
             return SAI_STATUS_FAILURE;
         }
@@ -3686,6 +3691,93 @@ namespace portsorch_test
         EXPECT_TRUE(ts.empty());
 
         mock_autoneg_cap_supported = true;
+        _unhook_sai_port_api();
+    }
+
+    TEST_F(PortsOrchTest, AutonegAdminDownFailure)
+    {
+        // When autoneg is configured on a port that is admin UP and bringing the
+        // port DOWN fails, the task must be retried (it++, not erased).
+        _hook_sai_port_api();
+
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        auto ports = ut_helper::getInitialSaiPorts();
+
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+        gPortsOrch->addExistingData(&portTable);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        // Force Ethernet0 into admin UP state
+        Port p;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", p));
+        p.m_admin_state_up = true;
+        gPortsOrch->m_portList["Ethernet0"] = p;
+
+        set_admin_status_fail = true;
+
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({"Ethernet0", SET_COMMAND,
+                           {
+                               { "autoneg", "on" }
+                           }});
+        auto consumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_PORT_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        EXPECT_EQ(set_admin_status_failures, 1);
+
+        // Task should remain queued for retry
+        vector<string> ts;
+        gPortsOrch->dumpPendingTasks(ts);
+        EXPECT_FALSE(ts.empty());
+
+        set_admin_status_fail = false;
+        set_admin_status_failures = 0;
+        _unhook_sai_port_api();
+    }
+
+    TEST_F(PortsOrchTest, AutonegSetNeedsRetry)
+    {
+        // When setPortAutoNeg returns task_need_retry (SAI_STATUS_INSUFFICIENT_RESOURCES),
+        // the task must stay queued (it++) rather than being dropped.
+        _hook_sai_port_api();
+        set_autoneg_need_retry = true;
+
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        auto ports = ut_helper::getInitialSaiPorts();
+
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+        gPortsOrch->addExistingData(&portTable);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        const auto an_call_count = _sai_set_port_auto_neg_count;
+
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({"Ethernet0", SET_COMMAND,
+                           {
+                               { "autoneg", "on" }
+                           }});
+        auto consumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_PORT_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        // SAI set was attempted
+        EXPECT_GT(_sai_set_port_auto_neg_count, an_call_count);
+
+        // Task should remain queued for retry
+        vector<string> ts;
+        gPortsOrch->dumpPendingTasks(ts);
+        EXPECT_FALSE(ts.empty());
+
+        set_autoneg_need_retry = false;
         _unhook_sai_port_api();
     }
 

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -57,6 +57,7 @@ namespace portsorch_test
     bool not_support_fetching_fec;
     uint32_t _sai_set_port_fec_count;
     uint32_t _sai_set_port_auto_neg_count;
+    bool mock_autoneg_cap_supported = true;
     uint32_t _sai_set_port_tpid_count;
     int32_t _sai_port_fec_mode;
     vector<sai_port_fec_mode_t> mock_port_fec_modes = {SAI_PORT_FEC_MODE_RS, SAI_PORT_FEC_MODE_FC};
@@ -114,6 +115,11 @@ namespace portsorch_test
             } else {
                 attr_list[0].value.oid = SAI_NULL_OBJECT_ID;
             }
+            status = SAI_STATUS_SUCCESS;
+        }
+        else if (attr_count == 1 && attr_list[0].id == SAI_PORT_ATTR_SUPPORTED_AUTO_NEG_MODE)
+        {
+            attr_list[0].value.booldata = mock_autoneg_cap_supported;
             status = SAI_STATUS_SUCCESS;
         }
         else
@@ -3588,6 +3594,99 @@ namespace portsorch_test
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
         _unhook_sai_port_api();
         _unhook_sai_switch_api();
+    }
+
+    TEST_F(PortsOrchTest, AutonegDisableNoopOnUnsupportedPort)
+    {
+        // Configuring autoneg=off on a port that doesn't support autoneg must be a
+        // no-op: no ASIC call, no error, port marked configured so we don't retry.
+        _hook_sai_port_api();
+        mock_autoneg_cap_supported = false;
+
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        auto ports = ut_helper::getInitialSaiPorts();
+
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+        gPortsOrch->addExistingData(&portTable);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        const auto an_call_count = _sai_set_port_auto_neg_count;
+
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({"Ethernet0", SET_COMMAND,
+                           {
+                               { "autoneg", "off" }
+                           }});
+        auto consumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_PORT_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        // No SAI set call should have been made
+        EXPECT_EQ(_sai_set_port_auto_neg_count, an_call_count);
+
+        // Port should be marked configured with autoneg disabled
+        Port p;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", p));
+        EXPECT_FALSE(p.m_autoneg);
+        EXPECT_TRUE(p.m_an_cfg);
+
+        // Task should have been consumed without error
+        vector<string> ts;
+        gPortsOrch->dumpPendingTasks(ts);
+        EXPECT_TRUE(ts.empty());
+
+        mock_autoneg_cap_supported = true;
+        _unhook_sai_port_api();
+    }
+
+    TEST_F(PortsOrchTest, AutonegEnableErrorOnUnsupportedPort)
+    {
+        // Configuring autoneg=on on a port that doesn't support autoneg must drop
+        // the task without an ASIC call and leave the port unconfigured.
+        _hook_sai_port_api();
+        mock_autoneg_cap_supported = false;
+
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        auto ports = ut_helper::getInitialSaiPorts();
+
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+        gPortsOrch->addExistingData(&portTable);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        const auto an_call_count = _sai_set_port_auto_neg_count;
+
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({"Ethernet0", SET_COMMAND,
+                           {
+                               { "autoneg", "on" }
+                           }});
+        auto consumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_PORT_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        // No SAI set call should have been made
+        EXPECT_EQ(_sai_set_port_auto_neg_count, an_call_count);
+
+        // Port should remain unconfigured
+        Port p;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", p));
+        EXPECT_FALSE(p.m_an_cfg);
+
+        // Task should have been dropped (no retry)
+        vector<string> ts;
+        gPortsOrch->dumpPendingTasks(ts);
+        EXPECT_TRUE(ts.empty());
+
+        mock_autoneg_cap_supported = true;
+        _unhook_sai_port_api();
     }
 
     TEST_F(PortsOrchTest, PortReadinessColdBoot)

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -3601,10 +3601,12 @@ namespace portsorch_test
         _unhook_sai_switch_api();
     }
 
-    TEST_F(PortsOrchTest, AutonegDisableNoopOnUnsupportedPort)
+    TEST_F(PortsOrchTest, AutonegOnUnsupportedPort)
     {
-        // Configuring autoneg=off on a port that doesn't support autoneg must be a
-        // no-op: no ASIC call, no error, port marked configured so we don't retry.
+        // Configuring autoneg on a port that doesn't support it (either on or off)
+        // must skip the ASIC call, mark the port configured so we don't retry, and
+        // not drop the rest of the task's config. The requested value is mirrored
+        // in cache.
         _hook_sai_port_api();
         mock_autoneg_cap_supported = false;
 
@@ -3619,76 +3621,37 @@ namespace portsorch_test
         gPortsOrch->addExistingData(&portTable);
         static_cast<Orch *>(gPortsOrch)->doTask();
 
-        const auto an_call_count = _sai_set_port_auto_neg_count;
-
-        std::deque<KeyOpFieldsValuesTuple> entries;
-        entries.push_back({"Ethernet0", SET_COMMAND,
-                           {
-                               { "autoneg", "off" }
-                           }});
         auto consumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_PORT_TABLE_NAME));
-        consumer->addToSync(entries);
-        static_cast<Orch *>(gPortsOrch)->doTask();
 
-        // No SAI set call should have been made
-        EXPECT_EQ(_sai_set_port_auto_neg_count, an_call_count);
-
-        // Port should be marked configured with autoneg disabled
-        Port p;
-        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", p));
-        EXPECT_FALSE(p.m_autoneg);
-        EXPECT_TRUE(p.m_an_cfg);
-
-        // Task should have been consumed without error
-        vector<string> ts;
-        gPortsOrch->dumpPendingTasks(ts);
-        EXPECT_TRUE(ts.empty());
-
-        mock_autoneg_cap_supported = true;
-        _unhook_sai_port_api();
-    }
-
-    TEST_F(PortsOrchTest, AutonegEnableErrorOnUnsupportedPort)
-    {
-        // Configuring autoneg=on on a port that doesn't support autoneg must drop
-        // the task without an ASIC call and leave the port unconfigured.
-        _hook_sai_port_api();
-        mock_autoneg_cap_supported = false;
-
-        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
-        auto ports = ut_helper::getInitialSaiPorts();
-
-        for (const auto &it : ports)
+        for (const auto &requested : {std::string("off"), std::string("on")})
         {
-            portTable.set(it.first, it.second);
+            const auto an_call_count = _sai_set_port_auto_neg_count;
+
+            // Reset the port's AN-configured flag so each iteration re-enters the AN block
+            Port pre;
+            ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", pre));
+            pre.m_an_cfg = false;
+            gPortsOrch->m_portList["Ethernet0"] = pre;
+
+            std::deque<KeyOpFieldsValuesTuple> entries;
+            entries.push_back({"Ethernet0", SET_COMMAND, { { "autoneg", requested } }});
+            consumer->addToSync(entries);
+            static_cast<Orch *>(gPortsOrch)->doTask();
+
+            // No SAI set call should have been made
+            EXPECT_EQ(_sai_set_port_auto_neg_count, an_call_count) << "requested=" << requested;
+
+            // Port marked configured; requested value reflected in cache
+            Port p;
+            ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", p));
+            EXPECT_TRUE(p.m_an_cfg) << "requested=" << requested;
+            EXPECT_EQ(p.m_autoneg, requested == "on") << "requested=" << requested;
+
+            // Task consumed (no pending) — sibling config in the same task is no longer dropped
+            vector<string> ts;
+            gPortsOrch->dumpPendingTasks(ts);
+            EXPECT_TRUE(ts.empty()) << "requested=" << requested;
         }
-        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
-        gPortsOrch->addExistingData(&portTable);
-        static_cast<Orch *>(gPortsOrch)->doTask();
-
-        const auto an_call_count = _sai_set_port_auto_neg_count;
-
-        std::deque<KeyOpFieldsValuesTuple> entries;
-        entries.push_back({"Ethernet0", SET_COMMAND,
-                           {
-                               { "autoneg", "on" }
-                           }});
-        auto consumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_PORT_TABLE_NAME));
-        consumer->addToSync(entries);
-        static_cast<Orch *>(gPortsOrch)->doTask();
-
-        // No SAI set call should have been made
-        EXPECT_EQ(_sai_set_port_auto_neg_count, an_call_count);
-
-        // Port should remain unconfigured
-        Port p;
-        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", p));
-        EXPECT_FALSE(p.m_an_cfg);
-
-        // Task should have been dropped (no retry)
-        vector<string> ts;
-        gPortsOrch->dumpPendingTasks(ts);
-        EXPECT_TRUE(ts.empty());
 
         mock_autoneg_cap_supported = true;
         _unhook_sai_port_api();


### PR DESCRIPTION
#### Why I did it

Implements the fix for https://github.com/sonic-net/sonic-mgmt/issues/24066

When autoneg is configured as 'off' on a platform whose ASIC does not support autoneg, the previous code logged an error and dropped the entire port config task (speed, admin_state etc). 

#### How I did it
Disabling autoneg on such a platform is a no-op — so there is no reason to error out. Skipping allows us to apply the other configs. Changes introduced another else case to handle this scenario gracefully


#### How to verify it

Before the changes: Links do not come up since the admin_state config is dropped

```
2026 Apr 21 04:55:49.058252 humm119 ERR swss#orchagent: :- doPortTask: Ethernet0: autoneg is not supported (cap=0)
2026 Apr 21 04:55:49.613104 humm119 ERR swss#orchagent: :- doPortTask: Ethernet244: autoneg is not supported (cap=0)
```

After the changes: Links come up 
```
2026 Apr 21 05:07:05.364331 humm119 INFO swss#orchagent: :- operator(): FIELD: autoneg, VALUE: off
2026 Apr 21 05:07:05.364666 humm119 INFO swss#orchagent: :- doPortTask: Ethernet0: autoneg not supported; disable is no-op
2026 Apr 21 05:07:05.364693 humm119 NOTICE swss#orchagent: :- doPortTask: Set port Ethernet0 autoneg to off
2026 Apr 21 05:07:05.963385 humm119 INFO swss#orchagent: :- operator(): FIELD: autoneg, VALUE: off
2026 Apr 21 05:07:05.963823 humm119 INFO swss#orchagent: :- doPortTask: Ethernet244: autoneg not supported; disable is no-op
2026 Apr 21 05:07:05.963852 humm119 NOTICE swss#orchagent: :- doPortTask: Set port Ethernet244 autoneg to off
```
```
Ethernet0  96,97,98,99     400G   9100     rs     etp1  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
Ethernet244  236,237,238,239     400G   9100     rs    etp62  routed      up       up  QSFP+ or later with CMIS         N/A
```

**Details if related**

#### Which release branch to port

- [ ] master
- [x] 202511
- [ ] 202505