### PR TITLE
[FlexCounter] Fix stale COUNTERS_DB and FlexCounter group entries aft…

### DIFF
--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -722,3 +722,15 @@ void FlexCounterPgStates::enablePgCounter(uint32_t pgIndex)
     SWSS_LOG_ENTER();
     m_pgStates[pgIndex] = true;
 }
+
+void FlexCounterOrch::removePortCounter(sai_object_id_t port_id)
+{
+    std::string port_oid = sai_serialize_object_id(port_id);
+
+    if (m_countersTable)
+    {
+        m_countersTable->del("PORT_STAT_COUNTER:" + port_oid);
+    }
+
+    SWSS_LOG_NOTICE("Removed counters for port %s", port_oid.c_str());
+}

--- a/orchagent/flexcounterorch.h
+++ b/orchagent/flexcounterorch.h
@@ -72,6 +72,7 @@ public:
     bool getWredPortCountersState() const;
     bool isCreateOnlyConfigDbBuffers() const;
     bool bake() override;
+    void removePortCounter(sai_object_id_t port_id);
 
 private:
     void handleDeviceMetadataTable(Consumer &consumer);

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -43,6 +43,8 @@
 
 #include "saitam.h"
 
+#include "flexcounterorch.h"
+
 extern sai_switch_api_t *sai_switch_api;
 extern sai_bridge_api_t *sai_bridge_api;
 extern sai_port_api_t *sai_port_api;
@@ -3942,11 +3944,11 @@ sai_status_t PortsOrch::removePort(sai_object_id_t port_id)
      */
     if (getPort(port_id, port))
     {
-        extern FlexCounterOrch *gFlexCounterOrch;
+        auto *flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
 
-        if (gFlexCounterOrch && port_id != SAI_NULL_OBJECT_ID)
+        if (flexCounterOrch && port_id != SAI_NULL_OBJECT_ID)
         {
-            gFlexCounterOrch->removePortCounter(port_id);
+            flexCounterOrch->removePortCounter(port_id);
         }
         port_stat_manager.clearCounterIdList(port_id);
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3942,6 +3942,14 @@ sai_status_t PortsOrch::removePort(sai_object_id_t port_id)
      */
     if (getPort(port_id, port))
     {
+        extern FlexCounterOrch *gFlexCounterOrch;
+
+        if (gFlexCounterOrch && port_id != SAI_NULL_OBJECT_ID)
+        {
+            gFlexCounterOrch->removePortCounter(port_id);
+        }
+        port_stat_manager.clearCounterIdList(port_id);
+
         /* Bring port down before removing port */
         if (!setPortAdminStatus(port, false))
         {


### PR DESCRIPTION
**What I did**

Fixed stale PORT_STAT_COUNTER entries in COUNTERS_DB when a port is removed.

- Added removePortCounter() in FlexCounterOrch to delete the corresponding entry from COUNTERS_DB.
- Updated PortsOrch::removePort() to:
  - invoke removePortCounter()
  - clear FlexCounter group entries using port_stat_manager.clearCounterIdList()

This ensures both database and FlexCounter group states are consistent after port removal.


**Why I did it**

After performing Dynamic Port Breakout (DPB) or disabling counterpoll, stale entries for removed ports remained in COUNTERS_DB.

This caused inconsistency between actual port state and FlexCounter data.

The fix ensures that when a port is removed, its associated counters are also properly cleaned up.


**How I verified it**

- Reviewed FlexCounter unit tests (flexcounter_ut.cpp) to ensure behavior matches expectations.
- Verified that:
  - PORT_STAT_COUNTER entries are removed from COUNTERS_DB
  - FlexCounter group entries are removed using clearCounterIdList()
- Ensured no changes to existing counter enable/disable logic.


**Details if related**

Fixes: sonic-net/sonic-buildimage#26940