### PR TITLE
Add flap count variable to BFD state

### DIFF
--- a/orchagent/bfdorch.cpp
+++ b/orchagent/bfdorch.cpp
@@ -249,14 +249,26 @@ void BfdOrch::doTask(NotificationConsumer &consumer)
             if (state != bfd_session_lookup[id].state)
             {
                 auto key = bfd_session_lookup[id].peer;
+                const sai_bfd_session_state_t old_state = bfd_session_lookup[id].state;
+                const bool count_flap =
+                    (old_state == SAI_BFD_SESSION_STATE_UP && state == SAI_BFD_SESSION_STATE_DOWN) ||
+                    (old_state == SAI_BFD_SESSION_STATE_DOWN && state == SAI_BFD_SESSION_STATE_UP);
+
+                if (count_flap)
+                {
+                    bfd_session_lookup[id].flap_cnt++;
+                    m_stateBfdSessionTable.hset(key, "flap_cnt", to_string(bfd_session_lookup[id].flap_cnt));
+                }
+
                 m_stateBfdSessionTable.hset(key, "state", session_state_lookup.at(state));
 
                 SWSS_LOG_NOTICE("BFD session state for %s changed from %s to %s", key.c_str(),
-                            session_state_lookup.at(bfd_session_lookup[id].state).c_str(), session_state_lookup.at(state).c_str());
+                            session_state_lookup.at(old_state).c_str(), session_state_lookup.at(state).c_str());
 
                 BfdUpdate update;
                 update.peer = key;
                 update.state = state;
+                update.flap_cnt = bfd_session_lookup[id].flap_cnt;
                 notify(SUBJECT_TYPE_BFD_SESSION_STATE_CHANGE, static_cast<void *>(&update));
 
                 bfd_session_lookup[id].state = state;
@@ -542,6 +554,7 @@ bool BfdOrch::create_bfd_session(const string& key, const vector<FieldValueTuple
     }
 
     fvVector.emplace_back("state", session_state_lookup.at(SAI_BFD_SESSION_STATE_DOWN));
+    fvVector.emplace_back("flap_cnt", "0");
 
     sai_object_id_t bfd_session_id = SAI_NULL_OBJECT_ID;
     sai_status_t status = sai_bfd_api->create_bfd_session(&bfd_session_id, gSwitchId, (uint32_t)attrs.size(), attrs.data());
@@ -569,6 +582,7 @@ bool BfdOrch::create_bfd_session(const string& key, const vector<FieldValueTuple
     BfdUpdate update;
     update.peer = state_db_key;
     update.state = SAI_BFD_SESSION_STATE_DOWN;
+    update.flap_cnt = 0;
     notify(SUBJECT_TYPE_BFD_SESSION_STATE_CHANGE, static_cast<void *>(&update));
 
     return true;

--- a/orchagent/bfdorch.cpp
+++ b/orchagent/bfdorch.cpp
@@ -262,12 +262,16 @@ void BfdOrch::doTask(NotificationConsumer &consumer)
 
                 m_stateBfdSessionTable.hset(key, "state", session_state_lookup.at(state));
 
-                SWSS_LOG_NOTICE("BFD session state for %s changed from %s to %s", key.c_str(),
-                            session_state_lookup.at(old_state).c_str(), session_state_lookup.at(state).c_str());
+                SWSS_LOG_NOTICE(
+                    "BFD session state for %s changed from %s to %s, %ld flaps seen so far ",
+                    key.c_str(),
+                    session_state_lookup.at(old_state).c_str(),
+                    session_state_lookup.at(state).c_str(),
+                    bfd_session_lookup[id].flap_cnt);
 
                 BfdUpdate update;
-                update.peer = key;
-                update.state = state;
+                update.peer     = key;
+                update.state    = state;
                 update.flap_cnt = bfd_session_lookup[id].flap_cnt;
                 notify(SUBJECT_TYPE_BFD_SESSION_STATE_CHANGE, static_cast<void *>(&update));
 

--- a/orchagent/bfdorch.h
+++ b/orchagent/bfdorch.h
@@ -1,6 +1,8 @@
 #ifndef SWSS_BFDORCH_H
 #define SWSS_BFDORCH_H
 
+#include <cstdint>
+
 #include "orch.h"
 #include "observer.h"
 
@@ -8,6 +10,7 @@ struct BfdUpdate
 {
     std::string peer;
     sai_bfd_session_state_t state;
+    uint64_t flap_cnt = 0;
 };
 
 class BfdOrch: public Orch, public Subject


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Added additional variable in per session BFD state database to keep count of the flaps seen for the session

**Why I did it**
There is need to know the  BFD flap count. If session state alone is monitored and it flaps rapidly, it will not be noticed. flap count provides us a quick way to number of session state changes 

**How I verified it**
Built a new sonic image with the changes. loaded the image and triggered multiple BFD session state changes and make sure BFD flap count is incremented

**Details if related**
