### PR TITLE
muxorch: fix shared-MAC neighbor recovery in updateFdb

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1,6 +1,7 @@
 #include <cassert>
 #include <string>
 #include <vector>
+#include <set>
 #include <unordered_map>
 #include <unordered_set>
 #include <stdexcept>
@@ -1818,7 +1819,7 @@ void MuxOrch::updateFdb(const FdbUpdate& update)
     NeighborEntry neigh;
     MacAddress mac;
     MuxCable* ptr;
-    bool found_existing_mux_neighbor = false;
+    std::set<NeighborEntry> handled;
 
     // Handle existing MUX neighbors that might be moving between ports
     for (auto nh = mux_nexthop_tb_.begin(); nh != mux_nexthop_tb_.end(); ++nh)
@@ -1829,7 +1830,7 @@ void MuxOrch::updateFdb(const FdbUpdate& update)
             continue;
         }
 
-        found_existing_mux_neighbor = true;
+        handled.insert(nh->first);
 
         if (nh->second != update.entry.port_name)
         {
@@ -1852,15 +1853,17 @@ void MuxOrch::updateFdb(const FdbUpdate& update)
         }
     }
 
-    // Handle case where neighbor exists but is not yet a MUX neighbor
-    // This can happen when FDB entry is learned after neighbor is added
-    if (!found_existing_mux_neighbor && isMuxExists(update.entry.port_name))
+    // Fallback: convert any NeighOrch entry that shares this MAC on the FDB's
+    // mux port but is not yet in mux_nexthop_tb_. Always runs when the FDB
+    // port is a mux; the `handled` set prevents re-processing neighbors that
+    // the loop above already re-bound.
+    if (isMuxExists(update.entry.port_name))
     {
         // Check if there's an existing neighbor with this MAC on any VLAN interface
         // that could be converted to a MUX neighbor
         auto vlan_ports = gPortsOrch->getAllVlans();
-        SWSS_LOG_INFO("FDB update without mux neighbor on mux port %s, mac %s", update.entry.port_name.c_str(),
-                update.entry.mac.to_string().c_str());
+        SWSS_LOG_INFO("FDB update on mux port %s, mac %s — scanning for stranded neighbors",
+                update.entry.port_name.c_str(), update.entry.mac.to_string().c_str());
 
         for (auto vlan_alias : vlan_ports)
         {
@@ -1870,6 +1873,12 @@ void MuxOrch::updateFdb(const FdbUpdate& update)
             {
                 const NeighborEntry& neighbor_entry = neighbor_pair.first;
                 const auto& neighbor_data = neighbor_pair.second;
+
+                // Already re-bound by the loop above — skip.
+                if (handled.count(neighbor_entry))
+                {
+                    continue;
+                }
 
                 // Skip prefix_route neighbors that are not skip neighbors
                 // soc neighbors will get added with prefix_route but

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1859,50 +1859,44 @@ void MuxOrch::updateFdb(const FdbUpdate& update)
     // the loop above already re-bound.
     if (isMuxExists(update.entry.port_name))
     {
-        // Check if there's an existing neighbor with this MAC on any VLAN interface
-        // that could be converted to a MUX neighbor
-        auto vlan_ports = gPortsOrch->getAllVlans();
         SWSS_LOG_INFO("FDB update on mux port %s, mac %s — scanning for stranded neighbors",
                 update.entry.port_name.c_str(), update.entry.mac.to_string().c_str());
 
-        for (auto vlan_alias : vlan_ports)
+        const auto& neighbors = neigh_orch_->getNeighborTable();
+        for (const auto& neighbor_pair : neighbors)
         {
-            // Check all existing neighbors on this VLAN interface
-            auto neighbors = neigh_orch_->getNeighborTable();
-            for (const auto& neighbor_pair : neighbors)
+            const NeighborEntry& neighbor_entry = neighbor_pair.first;
+            const auto& neighbor_data = neighbor_pair.second;
+
+            // Already re-bound by the loop above — skip.
+            if (handled.count(neighbor_entry))
             {
-                const NeighborEntry& neighbor_entry = neighbor_pair.first;
-                const auto& neighbor_data = neighbor_pair.second;
+                continue;
+            }
 
-                // Already re-bound by the loop above — skip.
-                if (handled.count(neighbor_entry))
-                {
-                    continue;
-                }
+            // MAC must match the FDB update.
+            if (neighbor_data.mac != update.entry.mac)
+            {
+                continue;
+            }
 
-                // Skip prefix_route neighbors that are not skip neighbors
-                // soc neighbors will get added with prefix_route but
-                // they may not be yet qualified as mux neighbor
-                if (neighbor_data.prefix_route && !isSkipNeighbor(neighbor_entry.ip_address))
-                {
-                    continue;
-                }
+            // Skip prefix_route neighbors that are not skip neighbors
+            // soc neighbors will get added with prefix_route but
+            // they may not be yet qualified as mux neighbor
+            if (neighbor_data.prefix_route && !isSkipNeighbor(neighbor_entry.ip_address))
+            {
+                continue;
+            }
 
-                // Check if MAC matches and it's on a VLAN interface
-                if (neighbor_data.mac == update.entry.mac && neighbor_entry.alias == vlan_alias)
-                {
-                    // Check if this neighbor should be a MUX neighbor based on the FDB update
-                    string port_name;
-                    if (getMuxPort(update.entry.mac, vlan_alias, port_name) && 
-                        !port_name.empty() && port_name == update.entry.port_name)
-                    {
-                        // Convert this neighbor to a MUX neighbor
-                        SWSS_LOG_INFO("Converting existing neighbor %s on %s to MUX neighbor due to FDB update",
-                                      neighbor_entry.ip_address.to_string().c_str(), vlan_alias.c_str());
+            // Check if this neighbor should be a MUX neighbor on the FDB's port.
+            string port_name;
+            if (getMuxPort(update.entry.mac, neighbor_entry.alias, port_name) &&
+                !port_name.empty() && port_name == update.entry.port_name)
+            {
+                SWSS_LOG_INFO("Converting existing neighbor %s on %s to MUX neighbor due to FDB update",
+                              neighbor_entry.ip_address.to_string().c_str(), neighbor_entry.alias.c_str());
 
-                        convertNeighborToMux(neighbor_entry, port_name, "due to FDB update");
-                    }
-                }
+                convertNeighborToMux(neighbor_entry, port_name, "due to FDB update");
             }
         }
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -501,7 +501,7 @@ class DockerVirtualSwitch:
                 self.runcmd('supervisorctl stop all')
 
             # Generate the converage info by lcov and copy to the host
-            cmd = f"docker exec {self.ctn.short_id} sh -c 'cd $BUILD_DIR; rm -rf **/.libs ./lib/libSaiRedis*; lcov -c --directory . --no-external --exclude tests --ignore-errors gcov,unused,source --output-file /tmp/coverage.info && lcov --add-tracefile /tmp/coverage.info -o /tmp/coverage.info; sed -i \"s#SF:$BUILD_DIR/#SF:#\" /tmp/coverage.info; lcov_cobertura /tmp/coverage.info -o /tmp/coverage.xml'"
+            cmd = f"docker exec {self.ctn.short_id} sh -c 'cd $BUILD_DIR; rm -rf **/.libs ./lib/libSaiRedis*; lcov -c --directory . --no-external --exclude tests --ignore-errors gcov,unused --output-file /tmp/coverage.info && lcov --add-tracefile /tmp/coverage.info -o /tmp/coverage.info; sed -i \"s#SF:$BUILD_DIR/#SF:#\" /tmp/coverage.info; lcov_cobertura /tmp/coverage.info -o /tmp/coverage.xml'"
             subprocess.getstatusoutput(cmd)
             cmd = f"docker exec {self.ctn.short_id} sh -c 'cd $BUILD_DIR; find . -name *.gcda -type f   -exec tar -rf /tmp/gcda.tar {{}} \\;'"
             subprocess.getstatusoutput(cmd)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -501,7 +501,7 @@ class DockerVirtualSwitch:
                 self.runcmd('supervisorctl stop all')
 
             # Generate the converage info by lcov and copy to the host
-            cmd = f"docker exec {self.ctn.short_id} sh -c 'cd $BUILD_DIR; rm -rf **/.libs ./lib/libSaiRedis*; lcov -c --directory . --no-external --exclude tests --ignore-errors gcov,unused --output-file /tmp/coverage.info && lcov --add-tracefile /tmp/coverage.info -o /tmp/coverage.info; sed -i \"s#SF:$BUILD_DIR/#SF:#\" /tmp/coverage.info; lcov_cobertura /tmp/coverage.info -o /tmp/coverage.xml'"
+            cmd = f"docker exec {self.ctn.short_id} sh -c 'cd $BUILD_DIR; rm -rf **/.libs ./lib/libSaiRedis*; lcov -c --directory . --no-external --exclude tests --ignore-errors gcov,unused,source --output-file /tmp/coverage.info && lcov --add-tracefile /tmp/coverage.info -o /tmp/coverage.info; sed -i \"s#SF:$BUILD_DIR/#SF:#\" /tmp/coverage.info; lcov_cobertura /tmp/coverage.info -o /tmp/coverage.xml'"
             subprocess.getstatusoutput(cmd)
             cmd = f"docker exec {self.ctn.short_id} sh -c 'cd $BUILD_DIR; find . -name *.gcda -type f   -exec tar -rf /tmp/gcda.tar {{}} \\;'"
             subprocess.getstatusoutput(cmd)

--- a/tests/mock_tests/mux_rollback_ut.cpp
+++ b/tests/mock_tests/mux_rollback_ut.cpp
@@ -9,6 +9,7 @@
 #define protected public
 #include "neighorch.h"
 #include "muxorch.h"
+#include "fdborch.h"
 #undef protected
 #undef private
 #include "mock_orchagent_main.h"
@@ -441,5 +442,101 @@ namespace mux_rollback_test
             // Without prefix-based neighbors, expect rollback to standby
             EXPECT_EQ(STANDBY_STATE, m_MuxCable->getState());
         }
+    }
+
+    // Covers MuxOrch::updateFdb shared-MAC fallback: when an FDB add on a
+    // mux port matches the MAC of a neighbor that bypassed mux registration
+    // (e.g. learned while the FDB was aged out), the fallback loop converts
+    // it. The negative-filter neighbors (different MAC, prefix_route) must
+    // be skipped so unrelated NeighOrch entries are not touched.
+    TEST_F(MuxRollbackTest, UpdateFdbConvertsStrandedSharedMacNeighbor)
+    {
+        if (IsPrefixBasedMuxNeighbor())
+        {
+            GTEST_SKIP() << "Fallback path is for host-route mux neighbors";
+        }
+
+        // Use a MAC distinct from the fixture's SERVER_IP1 (MAC4) so the
+        // first loop's port-move branch finds no match and leaves
+        // found_existing_mux_neighbor false, letting the fallback fire.
+        const MacAddress shared_mac("62:f9:65:10:2f:05");
+        const MacAddress other_mac("aa:bb:cc:dd:ee:ff");
+
+        // Stranded same-MAC neighbor that the fallback should convert.
+        IpAddress ip_stranded("192.168.0.3");
+        NeighborEntry stranded_entry(ip_stranded, VLAN_1000);
+        NextHopKey stranded_nh(ip_stranded, VLAN_1000);
+        gNeighOrch->m_syncdNeighbors[stranded_entry] =
+            { shared_mac, /*hw_configured*/ false, 0, /*prefix_route*/ false };
+
+        // Different-MAC neighbor — must hit the mac-mismatch continue.
+        IpAddress ip_other_mac("192.168.0.4");
+        NeighborEntry other_mac_entry(ip_other_mac, VLAN_1000);
+        NextHopKey other_mac_nh(ip_other_mac, VLAN_1000);
+        gNeighOrch->m_syncdNeighbors[other_mac_entry] =
+            { other_mac, false, 0, false };
+
+        // Prefix-route same-MAC neighbor — must hit the prefix_route continue.
+        IpAddress ip_prefix("192.168.0.5");
+        NeighborEntry prefix_entry(ip_prefix, VLAN_1000);
+        NextHopKey prefix_nh(ip_prefix, VLAN_1000);
+        gNeighOrch->m_syncdNeighbors[prefix_entry] =
+            { shared_mac, false, 0, /*prefix_route*/ true };
+
+        // Pre-populate the FDB cache so getMuxPort() resolves shared_mac to
+        // TEST_INTERFACE without going through SAI notifications.
+        Port vlan_port, eth_port;
+        ASSERT_TRUE(gPortsOrch->getVlanByVlanId(1000, vlan_port));
+        ASSERT_TRUE(gPortsOrch->getPort(TEST_INTERFACE, eth_port));
+        FdbEntry fdb_entry;
+        fdb_entry.mac = shared_mac;
+        fdb_entry.bv_id = vlan_port.m_vlan_info.vlan_oid;
+        fdb_entry.port_name = TEST_INTERFACE;
+        FdbData fdb_data{};
+        fdb_data.bridge_port_id = eth_port.m_bridge_port_id;
+        fdb_data.type = "dynamic";
+        fdb_data.origin = FDB_ORIGIN_LEARN;
+        gFdbOrch->m_entries[fdb_entry] = fdb_data;
+
+        ASSERT_EQ(m_MuxOrch->mux_nexthop_tb_.find(stranded_nh),
+                  m_MuxOrch->mux_nexthop_tb_.end());
+
+        FdbUpdate update;
+        update.entry = fdb_entry;
+        update.add = true;
+        update.type = "dynamic";
+        m_MuxOrch->updateFdb(update);
+
+        // The stranded neighbor must now be a mux nexthop on TEST_INTERFACE.
+        auto it = m_MuxOrch->mux_nexthop_tb_.find(stranded_nh);
+        ASSERT_NE(it, m_MuxOrch->mux_nexthop_tb_.end());
+        EXPECT_EQ(TEST_INTERFACE, it->second);
+
+        // Mac-mismatch and prefix-route neighbors must remain untouched.
+        EXPECT_EQ(m_MuxOrch->mux_nexthop_tb_.find(other_mac_nh),
+                  m_MuxOrch->mux_nexthop_tb_.end());
+        EXPECT_EQ(m_MuxOrch->mux_nexthop_tb_.find(prefix_nh),
+                  m_MuxOrch->mux_nexthop_tb_.end());
+
+        // Clean up the entries we injected so we don't bleed into other tests.
+        gNeighOrch->m_syncdNeighbors.erase(stranded_entry);
+        gNeighOrch->m_syncdNeighbors.erase(other_mac_entry);
+        gNeighOrch->m_syncdNeighbors.erase(prefix_entry);
+        m_MuxOrch->mux_nexthop_tb_.erase(stranded_nh);
+        gFdbOrch->m_entries.erase(fdb_entry);
+    }
+
+    // Delete FDB events must be a no-op for updateFdb so that mac aging does
+    // not tear down mux neighbor state out from under the cable.
+    TEST_F(MuxRollbackTest, UpdateFdbDeleteIsNoOp)
+    {
+        FdbUpdate update;
+        update.entry.mac = MacAddress("62:f9:65:10:2f:04");
+        update.entry.port_name = TEST_INTERFACE;
+        update.add = false;
+
+        size_t before = m_MuxOrch->mux_nexthop_tb_.size();
+        m_MuxOrch->updateFdb(update);
+        EXPECT_EQ(before, m_MuxOrch->mux_nexthop_tb_.size());
     }
 }

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -2117,6 +2117,113 @@ class TestMuxTunnel(TestMuxTunnelBase):
             self.set_mux_state(appdb, cable_name, "active")
             time.sleep(1)
 
+    def test_fdb_aging_after_neighbor_shared_mac(
+        self, dvs, dvs_route, setup, setup_vlan, setup_mux_cable, setup_tunnel,
+        setup_peer_switch, testlog
+    ):
+        """Reproduce shared-MAC neighbor recovery bug in MuxOrch::updateFdb().
+
+        Scenario (two neighbors sharing one MAC on a standby mux port, e.g.
+        IPv6 link-local + global on the same server NIC):
+
+        1. FDB for MAC X is present on Ethernet0 (standby).
+        2. Neighbor A (IP_A / MAC X) is learned -> fully converted to a MUX
+           neighbor, present in mux_nexthop_tb_.
+        3. FDB for MAC X ages out.
+        4. Neighbor B (IP_B / MAC X) is learned while FDB is absent.
+           On master (post-#4459) updateNeighbor returns early because
+           getMuxPort() fails with no FDB and the empty-port placeholder
+           was removed. B is NOT added to mux_nexthop_tb_.
+        5. FDB for MAC X is re-learned on Ethernet0 -> MuxOrch::updateFdb
+           fires. Loop over mux_nexthop_tb_ hits A (same MAC), sets
+           found_existing_mux_neighbor=true. The fallback block that is
+           supposed to convert any stranded same-MAC neighbor is gated
+           by !found_existing_mux_neighbor, so it is skipped for B.
+
+        Expected (fix): both A and B end up MUX-managed on standby
+        (removed from ASIC neighbor table, tunnel route installed).
+        Actual (current master): B stays as a regular ASIC neighbor with
+        no tunnel route -> unroutable toward peer ToR.
+
+        This test currently fails on master and is the canary for the
+        fix that replaces the function-scoped boolean with per-IP
+        tracking.
+        """
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        ip_a = "192.168.0.210"
+        ip_b = "192.168.0.211"
+        shared_mac = "00:00:00:00:aa:dd"
+        shared_mac_dash = "00-00-00-00-aa-dd"
+        cable_name = "Ethernet0"
+
+        try:
+            # Step 1: Standby mux, prime FDB for the shared MAC on Ethernet0
+            self.set_mux_state(appdb, cable_name, "standby")
+            self.add_fdb(dvs, cable_name, shared_mac_dash)
+            time.sleep(1)
+
+            # Step 2: Neighbor A with the shared MAC arrives while FDB is
+            # present -> should be fully converted to a MUX neighbor on
+            # standby (not in ASIC, tunnel route installed).
+            self.add_neighbor(dvs, ip_a, shared_mac)
+            time.sleep(2)
+            self.check_neigh_in_asic_db(asicdb, ip_a, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [ip_a + self.IPV4_MASK], expected=True)
+
+            # Step 3: FDB for the shared MAC ages out. MuxOrch::updateFdb
+            # ignores delete events, so A stays in mux_nexthop_tb_.
+            self.del_fdb(dvs, shared_mac_dash)
+            time.sleep(1)
+
+            # Step 4: Neighbor B (different IP, same MAC) arrives while
+            # FDB is absent. On master, updateNeighbor returns early and
+            # B is NOT added to mux_nexthop_tb_; it sits as a plain
+            # NeighOrch entry in the ASIC.
+            self.add_neighbor(dvs, ip_b, shared_mac)
+            time.sleep(1)
+            self.check_neigh_in_asic_db(asicdb, ip_b, expected=True)
+            self.check_tunnel_route_in_app_db(dvs, [ip_b + self.IPV4_MASK], expected=False)
+
+            # Step 5: FDB for the shared MAC is re-learned on Ethernet0.
+            # This fires MuxOrch::updateFdb. Loop (A) hits neighbor A and
+            # sets found_existing_mux_neighbor=true, which masks the
+            # fallback that would otherwise convert B.
+            self.add_fdb(dvs, cable_name, shared_mac_dash)
+            time.sleep(2)
+
+            # Step 6: Both neighbors should now be MUX-managed on standby.
+            # A stays converted (baseline); B should ALSO be disabled and
+            # have a tunnel route installed. This assertion is the
+            # canary: it FAILS on master until the flag is replaced with
+            # per-IP tracking.
+            self.check_neigh_in_asic_db(asicdb, ip_a, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [ip_a + self.IPV4_MASK], expected=True)
+
+            self.check_neigh_in_asic_db(
+                asicdb, ip_b, expected=False
+            )  # Bug: currently True on master (B stranded)
+            self.check_tunnel_route_in_app_db(
+                dvs, [ip_b + self.IPV4_MASK], expected=True
+            )  # Bug: currently missing on master
+
+            # Step 7: Toggle to active -> both should be re-enabled and
+            # tunnel routes withdrawn (fix-validation smoke check).
+            self.set_mux_state(appdb, cable_name, "active")
+            self.check_neigh_in_asic_db(asicdb, ip_a, expected=True)
+            self.check_neigh_in_asic_db(asicdb, ip_b, expected=True)
+            self.check_tunnel_route_in_app_db(
+                dvs, [ip_a + self.IPV4_MASK, ip_b + self.IPV4_MASK], expected=False
+            )
+
+        finally:
+            self.del_neighbor(dvs, ip_a)
+            self.del_neighbor(dvs, ip_b)
+            self.del_fdb(dvs, shared_mac_dash)
+            self.set_mux_state(appdb, cable_name, "active")
+            time.sleep(1)
+
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -1749,6 +1749,233 @@ class TestMuxTunnel(TestMuxTunnelBase):
 
         self.create_and_test_NH_routes(appdb, asicdb, dvs, dvs_route, mac)
 
+    def test_fdb_after_neighbor_on_standby_mux(
+        self, dvs, dvs_route, setup, setup_vlan, setup_mux_cable, setup_tunnel,
+        setup_peer_switch, testlog
+    ):
+        """Test neighbor conversion to MUX neighbor when FDB is learned after neighbor (host-route mode).
+
+        When a new neighbor is learned on a standby mux port and the FDB entry
+        for that MAC has not yet been learned, MuxOrch::updateNeighbor fails to
+        associate the neighbor with the mux port (FDB lookup fails). The neighbor
+        is never added to mux_nexthop_tb_ and disableNeighbor is never called.
+
+        This test verifies that when the FDB entry is later learned on the mux port,
+        the neighbor gets properly converted to a MUX neighbor and disabled (standby).
+
+        Steps:
+        1. Set mux port to standby
+        2. Add neighbor (without prior FDB entry)
+        3. Verify neighbor is initially in ASIC as a regular neighbor (not yet mux-managed)
+        4. Simulate FDB learn on the mux port
+        5. Verify neighbor gets disabled (removed from ASIC neigh table, tunnel route installed)
+        6. Toggle to active and verify neighbor is re-enabled
+        """
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        test_ip = "192.168.0.200"
+        test_mac = "00:00:00:00:aa:bb"
+        test_mac_dash = "00-00-00-00-aa-bb"
+        cable_name = "Ethernet0"
+
+        try:
+            # Step 1: Set mux to standby
+            self.set_mux_state(appdb, cable_name, "standby")
+
+            # Step 2: Add neighbor WITHOUT prior FDB entry
+            # MuxOrch::updateNeighbor will fail to find FDB -> neighbor not mux-managed
+            self.add_neighbor(dvs, test_ip, test_mac)
+            time.sleep(1)
+
+            # Step 3: Neighbor should be in ASIC as a regular neighbor
+            # (not yet mux-managed, so no tunnel route yet)
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+
+            # Step 4: Simulate FDB learn on mux port
+            # This should trigger convertNeighborToMux -> disableNeighbor (standby)
+            self.add_fdb(dvs, cable_name, test_mac_dash)
+            time.sleep(2)
+
+            # Step 5: Verify neighbor is now mux-managed on standby:
+            # - Neighbor removed from ASIC (disabled)
+            # - Tunnel route installed
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=True)
+
+            # Step 6: Toggle to active -> neighbor should be re-enabled
+            self.set_mux_state(appdb, cable_name, "active")
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=False)
+
+            # Toggle back to standby -> verify it disables again
+            self.set_mux_state(appdb, cable_name, "standby")
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=True)
+
+        finally:
+            self.del_neighbor(dvs, test_ip)
+            self.del_fdb(dvs, test_mac_dash)
+            self.set_mux_state(appdb, cable_name, "active")
+            time.sleep(1)
+
+    def test_fdb_after_neighbor_on_active_mux(
+        self, dvs, dvs_route, setup, setup_vlan, setup_mux_cable, setup_tunnel,
+        setup_peer_switch, testlog
+    ):
+        """Test neighbor conversion to MUX neighbor when FDB is learned after neighbor on active mux.
+
+        Same scenario as standby test but with active mux port. The neighbor should
+        be registered as a MUX neighbor and remain enabled (active).
+        """
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        test_ip = "192.168.0.201"
+        test_mac = "00:00:00:00:aa:cc"
+        test_mac_dash = "00-00-00-00-aa-cc"
+        cable_name = "Ethernet0"
+
+        try:
+            # Step 1: Set mux to active
+            self.set_mux_state(appdb, cable_name, "active")
+
+            # Step 2: Add neighbor WITHOUT prior FDB entry
+            self.add_neighbor(dvs, test_ip, test_mac)
+            time.sleep(1)
+
+            # Step 3: Neighbor should be in ASIC as a regular neighbor
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+
+            # Step 4: Simulate FDB learn on mux port
+            self.add_fdb(dvs, cable_name, test_mac_dash)
+            time.sleep(2)
+
+            # Step 5: Verify neighbor is mux-managed on active:
+            # - Neighbor stays in ASIC (enabled)
+            # - No tunnel route
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=False)
+
+            # Step 6: Toggle to standby -> neighbor should be disabled
+            self.set_mux_state(appdb, cable_name, "standby")
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=True)
+
+            # Toggle back to active -> re-enabled
+            self.set_mux_state(appdb, cable_name, "active")
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=False)
+
+        finally:
+            self.del_neighbor(dvs, test_ip)
+            self.del_fdb(dvs, test_mac_dash)
+            self.set_mux_state(appdb, cable_name, "active")
+            time.sleep(1)
+
+    def test_fdb_aging_after_neighbor_shared_mac(
+        self, dvs, dvs_route, setup, setup_vlan, setup_mux_cable, setup_tunnel,
+        setup_peer_switch, testlog
+    ):
+        """Reproduce shared-MAC neighbor recovery bug in MuxOrch::updateFdb().
+
+        Scenario (two neighbors sharing one MAC on a standby mux port, e.g.
+        IPv6 link-local + global on the same server NIC):
+
+        1. FDB for MAC X is present on Ethernet0 (standby).
+        2. Neighbor A (IP_A / MAC X) is learned -> fully converted to a MUX
+           neighbor, present in mux_nexthop_tb_.
+        3. FDB for MAC X ages out.
+        4. Neighbor B (IP_B / MAC X) is learned while FDB is absent.
+           On master (post-#4491) updateNeighbor returns early because
+           getMuxPort() fails with no FDB and the empty-port placeholder
+           was removed. B is NOT added to mux_nexthop_tb_.
+        5. FDB for MAC X is re-learned on Ethernet0 -> MuxOrch::updateFdb
+           fires. Loop over mux_nexthop_tb_ hits A (same MAC), sets
+           found_existing_mux_neighbor=true. The fallback block that is
+           supposed to convert any stranded same-MAC neighbor is gated
+           by !found_existing_mux_neighbor, so it is skipped for B.
+
+        Expected: both A and B end up MUX-managed on standby
+        (removed from ASIC neighbor table, tunnel route installed).
+        Actual (current master): B stays as a regular ASIC neighbor with
+        no tunnel route -> unroutable toward peer ToR.
+        """
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        ip_a = "192.168.0.210"
+        ip_b = "192.168.0.211"
+        shared_mac = "00:00:00:00:aa:dd"
+        shared_mac_dash = "00-00-00-00-aa-dd"
+        cable_name = "Ethernet0"
+
+        try:
+            # Step 1: Standby mux, prime FDB for the shared MAC on Ethernet0
+            self.set_mux_state(appdb, cable_name, "standby")
+            self.add_fdb(dvs, cable_name, shared_mac_dash)
+            time.sleep(1)
+
+            # Step 2: Neighbor A with the shared MAC arrives while FDB is
+            # present -> should be fully converted to a MUX neighbor on
+            # standby (not in ASIC, tunnel route installed).
+            self.add_neighbor(dvs, ip_a, shared_mac)
+            time.sleep(2)
+            self.check_neigh_in_asic_db(asicdb, ip_a, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [ip_a + self.IPV4_MASK], expected=True)
+
+            # Step 3: FDB for the shared MAC ages out. MuxOrch::updateFdb
+            # ignores delete events, so A stays in mux_nexthop_tb_.
+            self.del_fdb(dvs, shared_mac_dash)
+            time.sleep(1)
+
+            # Step 4: Neighbor B (different IP, same MAC) arrives while
+            # FDB is absent. On master, updateNeighbor returns early and
+            # B is NOT added to mux_nexthop_tb_; it sits as a plain
+            # NeighOrch entry in the ASIC.
+            self.add_neighbor(dvs, ip_b, shared_mac)
+            time.sleep(1)
+            self.check_neigh_in_asic_db(asicdb, ip_b, expected=True)
+            self.check_tunnel_route_in_app_db(dvs, [ip_b + self.IPV4_MASK], expected=False)
+
+            # Step 5: FDB for the shared MAC is re-learned on Ethernet0.
+            # This fires MuxOrch::updateFdb. Loop (A) hits neighbor A and
+            # sets found_existing_mux_neighbor=true, which masks the
+            # fallback that would otherwise convert B.
+            self.add_fdb(dvs, cable_name, shared_mac_dash)
+            time.sleep(2)
+
+            # Step 6: Both neighbors should now be MUX-managed on standby.
+            # A stays converted (baseline); B should ALSO be disabled and
+            # have a tunnel route installed. This assertion is the
+            # canary: it FAILS on master until the flag is replaced with
+            # per-IP tracking.
+            self.check_neigh_in_asic_db(asicdb, ip_a, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [ip_a + self.IPV4_MASK], expected=True)
+
+            self.check_neigh_in_asic_db(
+                asicdb, ip_b, expected=False
+            )  # Bug: currently True on master (B stranded)
+            self.check_tunnel_route_in_app_db(
+                dvs, [ip_b + self.IPV4_MASK], expected=True
+            )  # Bug: currently missing on master
+
+            # Step 7: Toggle to active -> both should be re-enabled and
+            # tunnel routes withdrawn (fix-validation smoke check).
+            self.set_mux_state(appdb, cable_name, "active")
+            self.check_neigh_in_asic_db(asicdb, ip_a, expected=True)
+            self.check_neigh_in_asic_db(asicdb, ip_b, expected=True)
+            self.check_tunnel_route_in_app_db(
+                dvs, [ip_a + self.IPV4_MASK, ip_b + self.IPV4_MASK], expected=False
+            )
+
+        finally:
+            self.del_neighbor(dvs, ip_a)
+            self.del_neighbor(dvs, ip_b)
+            self.del_fdb(dvs, shared_mac_dash)
+            self.set_mux_state(appdb, cable_name, "active")
+            time.sleep(1)
+
     def test_multi_nexthop(self, dvs, dvs_route, intf_fdb_map, neighbor_cleanup, testlog, setup):
         appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
         dvs.runcmd("swssloglevel -l INFO -c orchagent")
@@ -1992,233 +2219,6 @@ class TestMuxTunnel(TestMuxTunnelBase):
                 self.NEIGH3_IPV6 + self.IPV6_MASK
             ]
         )
-
-    def test_fdb_after_neighbor_on_standby_mux(
-        self, dvs, dvs_route, setup, setup_vlan, setup_mux_cable, setup_tunnel,
-        setup_peer_switch, testlog
-    ):
-        """Test neighbor conversion to MUX neighbor when FDB is learned after neighbor (host-route mode).
-
-        When a new neighbor is learned on a standby mux port and the FDB entry
-        for that MAC has not yet been learned, MuxOrch::updateNeighbor fails to
-        associate the neighbor with the mux port (FDB lookup fails). The neighbor
-        is never added to mux_nexthop_tb_ and disableNeighbor is never called.
-
-        This test verifies that when the FDB entry is later learned on the mux port,
-        the neighbor gets properly converted to a MUX neighbor and disabled (standby).
-
-        Steps:
-        1. Set mux port to standby
-        2. Add neighbor (without prior FDB entry)
-        3. Verify neighbor is initially in ASIC as a regular neighbor (not yet mux-managed)
-        4. Simulate FDB learn on the mux port
-        5. Verify neighbor gets disabled (removed from ASIC neigh table, tunnel route installed)
-        6. Toggle to active and verify neighbor is re-enabled
-        """
-        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
-        asicdb = dvs.get_asic_db()
-
-        test_ip = "192.168.0.200"
-        test_mac = "00:00:00:00:aa:bb"
-        test_mac_dash = "00-00-00-00-aa-bb"
-        cable_name = "Ethernet0"
-
-        try:
-            # Step 1: Set mux to standby
-            self.set_mux_state(appdb, cable_name, "standby")
-
-            # Step 2: Add neighbor WITHOUT prior FDB entry
-            # MuxOrch::updateNeighbor will fail to find FDB -> neighbor not mux-managed
-            self.add_neighbor(dvs, test_ip, test_mac)
-            time.sleep(1)
-
-            # Step 3: Neighbor should be in ASIC as a regular neighbor
-            # (not yet mux-managed, so no tunnel route yet)
-            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
-
-            # Step 4: Simulate FDB learn on mux port
-            # This should trigger convertNeighborToMux -> disableNeighbor (standby)
-            self.add_fdb(dvs, cable_name, test_mac_dash)
-            time.sleep(2)
-
-            # Step 5: Verify neighbor is now mux-managed on standby:
-            # - Neighbor removed from ASIC (disabled)
-            # - Tunnel route installed
-            self.check_neigh_in_asic_db(asicdb, test_ip, expected=False)
-            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=True)
-
-            # Step 6: Toggle to active -> neighbor should be re-enabled
-            self.set_mux_state(appdb, cable_name, "active")
-            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
-            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=False)
-
-            # Toggle back to standby -> verify it disables again
-            self.set_mux_state(appdb, cable_name, "standby")
-            self.check_neigh_in_asic_db(asicdb, test_ip, expected=False)
-            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=True)
-
-        finally:
-            self.del_neighbor(dvs, test_ip)
-            self.del_fdb(dvs, test_mac_dash)
-            self.set_mux_state(appdb, cable_name, "active")
-            time.sleep(1)
-
-    def test_fdb_after_neighbor_on_active_mux(
-        self, dvs, dvs_route, setup, setup_vlan, setup_mux_cable, setup_tunnel,
-        setup_peer_switch, testlog
-    ):
-        """Test neighbor conversion to MUX neighbor when FDB is learned after neighbor on active mux.
-
-        Same scenario as standby test but with active mux port. The neighbor should
-        be registered as a MUX neighbor and remain enabled (active).
-        """
-        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
-        asicdb = dvs.get_asic_db()
-
-        test_ip = "192.168.0.201"
-        test_mac = "00:00:00:00:aa:cc"
-        test_mac_dash = "00-00-00-00-aa-cc"
-        cable_name = "Ethernet0"
-
-        try:
-            # Step 1: Set mux to active
-            self.set_mux_state(appdb, cable_name, "active")
-
-            # Step 2: Add neighbor WITHOUT prior FDB entry
-            self.add_neighbor(dvs, test_ip, test_mac)
-            time.sleep(1)
-
-            # Step 3: Neighbor should be in ASIC as a regular neighbor
-            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
-
-            # Step 4: Simulate FDB learn on mux port
-            self.add_fdb(dvs, cable_name, test_mac_dash)
-            time.sleep(2)
-
-            # Step 5: Verify neighbor is mux-managed on active:
-            # - Neighbor stays in ASIC (enabled)
-            # - No tunnel route
-            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
-            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=False)
-
-            # Step 6: Toggle to standby -> neighbor should be disabled
-            self.set_mux_state(appdb, cable_name, "standby")
-            self.check_neigh_in_asic_db(asicdb, test_ip, expected=False)
-            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=True)
-
-            # Toggle back to active -> re-enabled
-            self.set_mux_state(appdb, cable_name, "active")
-            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
-            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=False)
-
-        finally:
-            self.del_neighbor(dvs, test_ip)
-            self.del_fdb(dvs, test_mac_dash)
-            self.set_mux_state(appdb, cable_name, "active")
-            time.sleep(1)
-
-    def test_fdb_aging_after_neighbor_shared_mac(
-        self, dvs, dvs_route, setup, setup_vlan, setup_mux_cable, setup_tunnel,
-        setup_peer_switch, testlog
-    ):
-        """Reproduce shared-MAC neighbor recovery bug in MuxOrch::updateFdb().
-
-        Scenario (two neighbors sharing one MAC on a standby mux port, e.g.
-        IPv6 link-local + global on the same server NIC):
-
-        1. FDB for MAC X is present on Ethernet0 (standby).
-        2. Neighbor A (IP_A / MAC X) is learned -> fully converted to a MUX
-           neighbor, present in mux_nexthop_tb_.
-        3. FDB for MAC X ages out.
-        4. Neighbor B (IP_B / MAC X) is learned while FDB is absent.
-           On master (post-#4491) updateNeighbor returns early because
-           getMuxPort() fails with no FDB and the empty-port placeholder
-           was removed. B is NOT added to mux_nexthop_tb_.
-        5. FDB for MAC X is re-learned on Ethernet0 -> MuxOrch::updateFdb
-           fires. Loop over mux_nexthop_tb_ hits A (same MAC), sets
-           found_existing_mux_neighbor=true. The fallback block that is
-           supposed to convert any stranded same-MAC neighbor is gated
-           by !found_existing_mux_neighbor, so it is skipped for B.
-
-        Expected: both A and B end up MUX-managed on standby
-        (removed from ASIC neighbor table, tunnel route installed).
-        Actual (current master): B stays as a regular ASIC neighbor with
-        no tunnel route -> unroutable toward peer ToR.
-        """
-        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
-        asicdb = dvs.get_asic_db()
-
-        ip_a = "192.168.0.210"
-        ip_b = "192.168.0.211"
-        shared_mac = "00:00:00:00:aa:dd"
-        shared_mac_dash = "00-00-00-00-aa-dd"
-        cable_name = "Ethernet0"
-
-        try:
-            # Step 1: Standby mux, prime FDB for the shared MAC on Ethernet0
-            self.set_mux_state(appdb, cable_name, "standby")
-            self.add_fdb(dvs, cable_name, shared_mac_dash)
-            time.sleep(1)
-
-            # Step 2: Neighbor A with the shared MAC arrives while FDB is
-            # present -> should be fully converted to a MUX neighbor on
-            # standby (not in ASIC, tunnel route installed).
-            self.add_neighbor(dvs, ip_a, shared_mac)
-            time.sleep(2)
-            self.check_neigh_in_asic_db(asicdb, ip_a, expected=False)
-            self.check_tunnel_route_in_app_db(dvs, [ip_a + self.IPV4_MASK], expected=True)
-
-            # Step 3: FDB for the shared MAC ages out. MuxOrch::updateFdb
-            # ignores delete events, so A stays in mux_nexthop_tb_.
-            self.del_fdb(dvs, shared_mac_dash)
-            time.sleep(1)
-
-            # Step 4: Neighbor B (different IP, same MAC) arrives while
-            # FDB is absent. On master, updateNeighbor returns early and
-            # B is NOT added to mux_nexthop_tb_; it sits as a plain
-            # NeighOrch entry in the ASIC.
-            self.add_neighbor(dvs, ip_b, shared_mac)
-            time.sleep(1)
-            self.check_neigh_in_asic_db(asicdb, ip_b, expected=True)
-            self.check_tunnel_route_in_app_db(dvs, [ip_b + self.IPV4_MASK], expected=False)
-
-            # Step 5: FDB for the shared MAC is re-learned on Ethernet0.
-            # This fires MuxOrch::updateFdb. Loop (A) hits neighbor A and
-            # sets found_existing_mux_neighbor=true, which masks the
-            # fallback that would otherwise convert B.
-            self.add_fdb(dvs, cable_name, shared_mac_dash)
-            time.sleep(2)
-
-            # Step 6: Both neighbors should now be MUX-managed on standby.
-            # A stays converted (baseline); B should ALSO be disabled and
-            # have a tunnel route installed. This assertion is the
-            # canary: it FAILS on master until the flag is replaced with
-            # per-IP tracking.
-            self.check_neigh_in_asic_db(asicdb, ip_a, expected=False)
-            self.check_tunnel_route_in_app_db(dvs, [ip_a + self.IPV4_MASK], expected=True)
-
-            self.check_neigh_in_asic_db(
-                asicdb, ip_b, expected=False
-            )  # Bug: currently True on master (B stranded)
-            self.check_tunnel_route_in_app_db(
-                dvs, [ip_b + self.IPV4_MASK], expected=True
-            )  # Bug: currently missing on master
-
-            # Step 7: Toggle to active -> both should be re-enabled and
-            # tunnel routes withdrawn (fix-validation smoke check).
-            self.set_mux_state(appdb, cable_name, "active")
-            self.check_neigh_in_asic_db(asicdb, ip_a, expected=True)
-            self.check_neigh_in_asic_db(asicdb, ip_b, expected=True)
-            self.check_tunnel_route_in_app_db(
-                dvs, [ip_a + self.IPV4_MASK, ip_b + self.IPV4_MASK], expected=False
-            )
-
-        finally:
-            self.del_neighbor(dvs, ip_a)
-            self.del_neighbor(dvs, ip_b)
-            self.del_fdb(dvs, shared_mac_dash)
-            self.set_mux_state(appdb, cable_name, "active")
-            time.sleep(1)
 
 
 # Add Dummy always-pass test at end as workaroud

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -2131,7 +2131,7 @@ class TestMuxTunnel(TestMuxTunnelBase):
            neighbor, present in mux_nexthop_tb_.
         3. FDB for MAC X ages out.
         4. Neighbor B (IP_B / MAC X) is learned while FDB is absent.
-           On master (post-#4459) updateNeighbor returns early because
+           On master (post-#4491) updateNeighbor returns early because
            getMuxPort() fails with no FDB and the empty-port placeholder
            was removed. B is NOT added to mux_nexthop_tb_.
         5. FDB for MAC X is re-learned on Ethernet0 -> MuxOrch::updateFdb
@@ -2140,14 +2140,10 @@ class TestMuxTunnel(TestMuxTunnelBase):
            supposed to convert any stranded same-MAC neighbor is gated
            by !found_existing_mux_neighbor, so it is skipped for B.
 
-        Expected (fix): both A and B end up MUX-managed on standby
+        Expected: both A and B end up MUX-managed on standby
         (removed from ASIC neighbor table, tunnel route installed).
         Actual (current master): B stays as a regular ASIC neighbor with
         no tunnel route -> unroutable toward peer ToR.
-
-        This test currently fails on master and is the canary for the
-        fix that replaces the function-scoped boolean with per-IP
-        tracking.
         """
         appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
         asicdb = dvs.get_asic_db()


### PR DESCRIPTION
## What I did

Fixes a shared-MAC neighbor recovery bug in `MuxOrch::updateFdb()` introduced by #4152.

When two mux neighbors (e.g. standby ToR + SoC behind the same server) share a MAC, the function-scoped `bool found_existing_mux_neighbor` was set by *any* same-MAC hit in the loop over `mux_nexthop_tb_`. That gated off the fallback recovery block globally, so whenever the first loop re-bound *one* of the neighbors, the *other* — sitting as a plain NeighOrch entry after FDB age-out — stayed stranded and never got promoted back into `mux_nexthop_tb_`.

Replace the boolean with `std::set<NeighborEntry> handled` that tracks the specific IPs the first loop already re-bound. The fallback now always runs when the FDB port is a mux, using `handled` as a skip filter to avoid re-processing.

## Why

Reproduces like this on master:

1. FDB primed → neighbor A added, gets MUX-managed
2. FDB ages out (del_fdb)
3. Neighbor B added while FDB is absent → stranded as plain NeighOrch entry
4. FDB re-learned → `updateFdb` fires, loop (A) re-binds A, sets the flag, fallback skipped
5. B stays stranded: no tunnel route, no ASIC neighbor entry

Added `tests/test_mux.py::test_fdb_aging_after_neighbor_shared_mac` which reproduces this end-to-end and asserts both A and B are MUX-managed with tunnel routes.

## Notes for reviewers

- The outer `for (auto vlan_alias : vlan_ports)` loop in the fallback block is technically redundant — `getMuxPort()` already rejects non-VLAN aliases, so the explicit alias filter and `getAllVlans()` iteration aren't needed. I left it alone to keep this PR focused on the bugfix; happy to do a follow-up cleanup if reviewers agree.
- No change to the first loop's logic — only the gating bool was replaced.

## How I tested

- `test_fdb_aging_after_neighbor_shared_mac` — new, fails on master, passes with fix
- Existing mux tests pass locally
