### PR TITLE
[202511][muxorch] Backport FDB-after-neighbor conversion for host-route mode

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <set>
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -1459,6 +1460,7 @@ void MuxOrch::updateFdb(const FdbUpdate& update)
     NeighborEntry neigh;
     MacAddress mac;
     MuxCable* ptr;
+    std::set<NeighborEntry> handled;
     for (auto nh = mux_nexthop_tb_.begin(); nh != mux_nexthop_tb_.end(); ++nh)
     {
         auto res = neigh_orch_->getNeighborEntry(nh->first, neigh, mac);
@@ -1466,6 +1468,8 @@ void MuxOrch::updateFdb(const FdbUpdate& update)
         {
             continue;
         }
+
+        handled.insert(nh->first);
 
         if (nh->second != update.entry.port_name)
         {
@@ -1485,6 +1489,51 @@ void MuxOrch::updateFdb(const FdbUpdate& update)
                 ptr = getMuxCable(update.entry.port_name);
                 ptr->updateNeighbor(nh->first, true);
             }
+        }
+    }
+
+    // Handle case where neighbor exists in NeighOrch but is not yet tracked as a mux neighbor.
+    // This happens when a neighbor resolves on a mux port before its FDB entry is available:
+    // NeighOrch::addNeighbor installs it as a direct Vlan next hop (active-side path) because
+    // the FDB lookup fails and MuxOrch::isNeighborActive defaults to true. When the FDB entry
+    // finally arrives here, we need to locate any such stranded neighbors by MAC and convert
+    // them via MuxCable::updateNeighbor so the standby path installs a tunnel next hop.
+    if (isMuxExists(update.entry.port_name))
+    {
+        ptr = getMuxCable(update.entry.port_name);
+        const NeighborTable& neighbor_table = gNeighOrch->getNeighborTable();
+        for (const auto& neighbor_pair : neighbor_table)
+        {
+            const NeighborEntry& neighbor_entry = neighbor_pair.first;
+            const auto& neighbor_data = neighbor_pair.second;
+
+            if (handled.count(neighbor_entry))
+            {
+                continue;
+            }
+
+            if (neighbor_data.mac != update.entry.mac)
+            {
+                continue;
+            }
+
+            // Verify the neighbor sits on a Vlan interface whose FDB lookup
+            // resolves to the same port we just received the update for.
+            // getMuxPort returns false for non-Vlan interfaces, preventing
+            // conversion of unrelated neighbors that happen to share a MAC.
+            string resolved_port;
+            if (!getMuxPort(update.entry.mac, neighbor_entry.alias, resolved_port) ||
+                resolved_port != update.entry.port_name)
+            {
+                continue;
+            }
+
+            SWSS_LOG_NOTICE("FDB update on mux port %s — converting stranded neighbor %s (MAC %s)",
+                            update.entry.port_name.c_str(),
+                            neighbor_entry.ip_address.to_string().c_str(),
+                            update.entry.mac.to_string().c_str());
+
+            ptr->updateNeighbor(neighbor_entry, true);
         }
     }
 }

--- a/orchagent/neighorch.h
+++ b/orchagent/neighorch.h
@@ -110,6 +110,7 @@ public:
     void updateSrv6Nexthop(const NextHopKey &, const sai_object_id_t &);
     bool ifChangeInformRemoteNextHop(const string &, bool);
     void getMuxNeighborsForPort(string port_name, NeighborTable &m_neighbors);
+    const NeighborTable& getNeighborTable() const { return m_syncdNeighbors; }
 
     void clearBulkers();
 

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -1978,6 +1978,174 @@ class TestMuxTunnel(TestMuxTunnelBase):
             ]
         )
 
+    def test_fdb_after_neighbor_on_standby_mux(
+        self, dvs, dvs_route, setup, setup_vlan, setup_mux_cable, setup_tunnel,
+        setup_peer_switch, testlog
+    ):
+        """Test neighbor conversion to MUX neighbor when FDB is learned after neighbor (host-route mode).
+
+        When a new neighbor is learned on a standby mux port and the FDB entry
+        for that MAC has not yet been learned, MuxOrch::updateNeighbor fails to
+        associate the neighbor with the mux port (FDB lookup fails). The neighbor
+        is never added to mux_nexthop_tb_ and disableNeighbor is never called.
+
+        This test verifies that when the FDB entry is later learned on the mux port,
+        the neighbor gets properly converted to a MUX neighbor and disabled (standby).
+        """
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        test_ip = "192.168.0.200"
+        test_mac = "00:00:00:00:aa:bb"
+        test_mac_dash = "00-00-00-00-aa-bb"
+        cable_name = "Ethernet0"
+
+        try:
+            self.set_mux_state(appdb, cable_name, "standby")
+
+            # Neighbor arrives with no prior FDB entry -> installed as
+            # direct Vlan next hop, not yet mux-managed.
+            self.add_neighbor(dvs, test_ip, test_mac)
+            time.sleep(1)
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+
+            # FDB learn arrives -> updateFdb fallback should convert the
+            # stranded neighbor, remove it from ASIC, install tunnel route.
+            self.add_fdb(dvs, cable_name, test_mac_dash)
+            time.sleep(2)
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=True)
+
+            # Toggle to active -> re-enabled.
+            self.set_mux_state(appdb, cable_name, "active")
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=False)
+
+            # Toggle back to standby -> disabled again.
+            self.set_mux_state(appdb, cable_name, "standby")
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=True)
+
+        finally:
+            self.del_neighbor(dvs, test_ip)
+            self.del_fdb(dvs, test_mac_dash)
+            self.set_mux_state(appdb, cable_name, "active")
+            time.sleep(1)
+
+    def test_fdb_after_neighbor_on_active_mux(
+        self, dvs, dvs_route, setup, setup_vlan, setup_mux_cable, setup_tunnel,
+        setup_peer_switch, testlog
+    ):
+        """Same scenario as the standby test but with the mux port active.
+
+        The neighbor should be registered as a MUX neighbor and remain enabled.
+        """
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        test_ip = "192.168.0.201"
+        test_mac = "00:00:00:00:aa:cc"
+        test_mac_dash = "00-00-00-00-aa-cc"
+        cable_name = "Ethernet0"
+
+        try:
+            self.set_mux_state(appdb, cable_name, "active")
+
+            self.add_neighbor(dvs, test_ip, test_mac)
+            time.sleep(1)
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+
+            self.add_fdb(dvs, cable_name, test_mac_dash)
+            time.sleep(2)
+
+            # On active, neighbor stays in ASIC and no tunnel route is installed.
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=False)
+
+            self.set_mux_state(appdb, cable_name, "standby")
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=True)
+
+            self.set_mux_state(appdb, cable_name, "active")
+            self.check_neigh_in_asic_db(asicdb, test_ip, expected=True)
+            self.check_tunnel_route_in_app_db(dvs, [test_ip + self.IPV4_MASK], expected=False)
+
+        finally:
+            self.del_neighbor(dvs, test_ip)
+            self.del_fdb(dvs, test_mac_dash)
+            self.set_mux_state(appdb, cable_name, "active")
+            time.sleep(1)
+
+    def test_fdb_aging_after_neighbor_shared_mac(
+        self, dvs, dvs_route, setup, setup_vlan, setup_mux_cable, setup_tunnel,
+        setup_peer_switch, testlog
+    ):
+        """Regression test for shared-MAC neighbor recovery in MuxOrch::updateFdb.
+
+        Two neighbors share one MAC on a standby mux port (e.g. IPv6
+        link-local + global on the same server NIC). A gets converted
+        while its FDB is present; FDB then ages; B arrives while FDB is
+        absent and never reaches mux_nexthop_tb_; FDB re-learns.
+
+        The per-IP `handled` set must not let A's MAC match mask the
+        conversion of stranded B. Both A and B must end up MUX-managed.
+        """
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        ip_a = "192.168.0.210"
+        ip_b = "192.168.0.211"
+        shared_mac = "00:00:00:00:aa:dd"
+        shared_mac_dash = "00-00-00-00-aa-dd"
+        cable_name = "Ethernet0"
+
+        try:
+            self.set_mux_state(appdb, cable_name, "standby")
+            self.add_fdb(dvs, cable_name, shared_mac_dash)
+            time.sleep(1)
+
+            # A arrives with FDB present -> fully converted.
+            self.add_neighbor(dvs, ip_a, shared_mac)
+            time.sleep(2)
+            self.check_neigh_in_asic_db(asicdb, ip_a, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [ip_a + self.IPV4_MASK], expected=True)
+
+            # FDB ages out (updateFdb ignores deletes; A stays in mux_nexthop_tb_).
+            self.del_fdb(dvs, shared_mac_dash)
+            time.sleep(1)
+
+            # B arrives while FDB is absent -> updateNeighbor returns early,
+            # B never reaches mux_nexthop_tb_ and sits in ASIC as a plain neighbor.
+            self.add_neighbor(dvs, ip_b, shared_mac)
+            time.sleep(1)
+            self.check_neigh_in_asic_db(asicdb, ip_b, expected=True)
+            self.check_tunnel_route_in_app_db(dvs, [ip_b + self.IPV4_MASK], expected=False)
+
+            # FDB re-learns on the mux port. A's MAC match must not suppress
+            # the fallback conversion of B.
+            self.add_fdb(dvs, cable_name, shared_mac_dash)
+            time.sleep(2)
+
+            self.check_neigh_in_asic_db(asicdb, ip_a, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [ip_a + self.IPV4_MASK], expected=True)
+            self.check_neigh_in_asic_db(asicdb, ip_b, expected=False)
+            self.check_tunnel_route_in_app_db(dvs, [ip_b + self.IPV4_MASK], expected=True)
+
+            # Toggle to active -> both re-enabled.
+            self.set_mux_state(appdb, cable_name, "active")
+            self.check_neigh_in_asic_db(asicdb, ip_a, expected=True)
+            self.check_neigh_in_asic_db(asicdb, ip_b, expected=True)
+            self.check_tunnel_route_in_app_db(
+                dvs, [ip_a + self.IPV4_MASK, ip_b + self.IPV4_MASK], expected=False
+            )
+
+        finally:
+            self.del_neighbor(dvs, ip_a)
+            self.del_neighbor(dvs, ip_b)
+            self.del_fdb(dvs, shared_mac_dash)
+            self.set_mux_state(appdb, cable_name, "active")
+            time.sleep(1)
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():


### PR DESCRIPTION
## Summary

Backport of master PRs #4459 and #4507 to `202511` (host-route only). Fixes a `dualtor_neighbor_check` failure case where neighbors stranded on a standby mux port are never converted to tunnel next hops.

## Problem

Neighbors learned on a mux Vlan port before the FDB learns their MAC are installed as direct Vlan next hops and never reconciled to tunnel next hops when the FDB entry finally arrives, leaving them stranded as black-hole routes on standby ports.

Specifically:
- `NeighOrch::addNeighbor` calls `MuxOrch::isNeighborActive`, which defaults to `true` when the FDB lookup fails — so the neighbor is installed as a direct Vlan next hop (active-side path).
- `MuxOrch::updateNeighbor` is called next, but `getMuxPort` also fails the FDB lookup and returns early without a port, so no reconciliation happens.
- When the FDB entry arrives later, `MuxOrch::updateFdb` only walks `mux_nexthop_tb_` — which does not contain these stranded neighbors — so they are never converted.

## Fix

`MuxOrch::updateFdb` gains a fallback scan: on any FDB add for a mux port, walk `NeighOrch`'s synced neighbors and convert any same-MAC entry whose Vlan resolves via `getMuxPort` to this port. A per-IP `handled` set tracks neighbors already processed by the existing `mux_nexthop_tb_` loop, preventing the shared-MAC masking bug that #4507 addressed.

## What's included

- **#4459** — [muxorch] Fix FDB-after-neighbor conversion for host-route mode
- **#4507** — muxorch: fix shared-MAC neighbor recovery in updateFdb

Master's prefix-route branching (`convertNeighborToMux()` helper, `prefix_route && !isSkipNeighbor` skip) is omitted — `202511` has no prefix-route infrastructure (no #4152 / `MuxNbrHandlerType` / `isMuxCablePrefixBased`). The fix is adapted for host-route only via a direct `MuxCable::updateNeighbor(nh, true)` call.

Master's outer `vlan_ports` loop is also omitted — `getMuxPort` already filters non-Vlan interfaces, making the outer loop redundant.

## Tests

Adds three unit tests to `tests/test_mux.py` ported from master+#4507:
- `test_fdb_after_neighbor_on_standby_mux` — neighbor-then-FDB on standby port converts to tunnel NH
- `test_fdb_after_neighbor_on_active_mux` — neighbor-then-FDB on active port installs direct NH
- `test_fdb_aging_after_neighbor_shared_mac` — shared-MAC regression guard (#4507)

Signed-off-by: Nikola Dancejic <ndancejic@microsoft.com>
