### PR TITLE
Swss stats use componentstats

### DIFF
--- a/cfgmgr/Makefile.am
+++ b/cfgmgr/Makefile.am
@@ -27,6 +27,7 @@ DBGFLAGS = -g
 endif
 
 COMMON_ORCH_SOURCE = $(top_srcdir)/orchagent/orch.cpp \
+				$(top_srcdir)/orchagent/swssstats.cpp \
 				$(top_srcdir)/orchagent/request_parser.cpp \
 				$(top_srcdir)/orchagent/response_publisher.cpp \
 				$(top_srcdir)/lib/recorder.cpp

--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -55,6 +55,7 @@ orchagent_SOURCES = \
             $(top_srcdir)/lib/orch_zmq_config.cpp \
             orchdaemon.cpp \
             orch.cpp \
+            swssstats.cpp \
             notifications.cpp \
             nhgorch.cpp \
             nhgbase.cpp \

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -3,6 +3,7 @@
 #include <sys/time.h>
 #include "timestamp.h"
 #include "orch.h"
+#include "swssstats.h"
 
 #include "subscriberstatetable.h"
 #include "portsorch.h"
@@ -248,8 +249,16 @@ void ConsumerBase::addToSync(const KeyOpFieldsValuesTuple &entry, bool onRetry)
     string op  = kfvOp(entry);
 
     if (!onRetry)
+    {
         /* Record incoming tasks */
         Recorder::Instance().swss.record(dumpTuple(entry));
+        
+        /* Record statistics */
+        if (gSwssStatsRecord)
+        {
+            SwssStats::getInstance()->recordTask(getTableName(), op);
+        }
+    }
     else
         Recorder::Instance().retry.record(dumpTuple(entry).append(DECACHE));
 
@@ -557,6 +566,8 @@ void Consumer::drain()
 {
     if (!m_toSync.empty())
     {
+        size_t size_before = gSwssStatsRecord ? m_toSync.size() : 0;
+        bool threw = false;
         try
         {
             ((Orch *)m_orch)->doTask((Consumer&)*this);
@@ -565,21 +576,39 @@ void Consumer::drain()
         {
             SWSS_LOG_ERROR("Exception caught: type=invalid_argument, table=%s, error=%s",
                            getName().c_str(), e.what());
+            threw = true;
         }
         catch (const std::logic_error& e)
         {
             SWSS_LOG_ERROR("Exception caught: type=logic_error, table=%s, error=%s",
                            getName().c_str(), e.what());
+            threw = true;
         }
         catch (const std::exception& e)
         {
             SWSS_LOG_ERROR("Exception caught: type=exception, table=%s, error=%s",
                            getName().c_str(), e.what());
+            threw = true;
         }
         catch (...)
         {
             SWSS_LOG_ERROR("Exception caught: type=unknown, table=%s",
                            getName().c_str());
+            threw = true;
+        }
+        if (gSwssStatsRecord && size_before > 0)
+        {
+            if (threw)
+            {
+                SwssStats::getInstance()->recordError(getTableName(), 1);
+            }
+            else
+            {
+                size_t size_after = m_toSync.size();
+                uint64_t completed = (size_before > size_after) ? (size_before - size_after) : 0;
+                if (completed > 0)
+                    SwssStats::getInstance()->recordComplete(getTableName(), completed);
+            }
         }
     }
 }
@@ -1235,3 +1264,4 @@ void Orch2::doTask(Consumer &consumer)
         }
     }
 }
+

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -252,15 +252,14 @@ void ConsumerBase::addToSync(const KeyOpFieldsValuesTuple &entry, bool onRetry)
     {
         /* Record incoming tasks */
         Recorder::Instance().swss.record(dumpTuple(entry));
-        
-        /* Record statistics */
-        if (gSwssStatsRecord)
-        {
-            SwssStats::getInstance()->recordTask(getTableName(), op);
-        }
+
+        /* Record statistics (no-op when disabled) */
+        SwssStats::getInstance()->recordTask(getTableName(), op);
     }
     else
+    {
         Recorder::Instance().retry.record(dumpTuple(entry).append(DECACHE));
+    }
 
     auto retryCache = getOrch() ? getOrch()->getRetryCache(getName()) : nullptr;
 
@@ -566,7 +565,8 @@ void Consumer::drain()
 {
     if (!m_toSync.empty())
     {
-        size_t size_before = gSwssStatsRecord ? m_toSync.size() : 0;
+        const bool record = SwssStats::isEnabled();
+        const size_t size_before = record ? m_toSync.size() : 0;
         bool threw = false;
         try
         {
@@ -596,10 +596,13 @@ void Consumer::drain()
                            getName().c_str());
             threw = true;
         }
-        if (gSwssStatsRecord && size_before > 0)
+        if (record)
         {
             if (threw)
             {
+                // ERROR is incremented once per failing drain pass, not once
+                // per failed item. Items left in m_toSync will be retried on
+                // the next drain and may contribute to ERROR again.
                 SwssStats::getInstance()->recordError(getTableName(), 1);
             }
             else
@@ -607,7 +610,9 @@ void Consumer::drain()
                 size_t size_after = m_toSync.size();
                 uint64_t completed = (size_before > size_after) ? (size_before - size_after) : 0;
                 if (completed > 0)
+                {
                     SwssStats::getInstance()->recordComplete(getTableName(), completed);
+                }
             }
         }
     }
@@ -1264,4 +1269,3 @@ void Orch2::doTask(Consumer &consumer)
         }
     }
 }
-

--- a/orchagent/p4orch/tests/Makefile.am
+++ b/orchagent/p4orch/tests/Makefile.am
@@ -18,6 +18,7 @@ CFLAGS_GTEST =
 LDADD_GTEST = -lgtest -lgtest_main -lgmock -lgmock_main
 
 p4orch_tests_SOURCES = $(ORCHAGENT_DIR)/orch.cpp \
+		       $(ORCHAGENT_DIR)/swssstats.cpp \
 		       $(ORCHAGENT_DIR)/vrforch.cpp \
 		       $(ORCHAGENT_DIR)/vxlanorch.cpp \
 		       $(ORCHAGENT_DIR)/copporch.cpp \

--- a/orchagent/swssstats.cpp
+++ b/orchagent/swssstats.cpp
@@ -1,0 +1,70 @@
+#include "swssstats.h"
+
+#include "componentstats.h"
+#include "logger.h"
+
+#include <atomic>
+
+// Enable SwssStats recording by default. Flip to false to silence the hot path
+// without tearing down the singleton or its writer thread.
+std::atomic<bool> gSwssStatsRecord(true);
+
+namespace {
+// Metric names written into COUNTERS_DB under SWSS_STATS:<table>.
+// Keep these in sync with any dashboards or collectors consuming the table.
+constexpr const char *kMetricSet      = "SET";
+constexpr const char *kMetricDel      = "DEL";
+constexpr const char *kMetricComplete = "COMPLETE";
+constexpr const char *kMetricError    = "ERROR";
+} // namespace
+
+SwssStats* SwssStats::getInstance()
+{
+    static SwssStats instance;
+    return &instance;
+}
+
+SwssStats::SwssStats()
+    : m_impl(swss::ComponentStats::create("SWSS"))
+{
+    SWSS_LOG_ENTER();
+}
+
+void SwssStats::recordTask(const std::string &table_name, const std::string &op)
+{
+    if (op == kMetricSet)
+    {
+        m_impl->increment(table_name, kMetricSet);
+    }
+    else if (op == kMetricDel)
+    {
+        m_impl->increment(table_name, kMetricDel);
+    }
+    // Any other op is silently ignored so orchagent callers never need to
+    // filter op strings.
+}
+
+void SwssStats::recordComplete(const std::string &table_name, uint64_t count)
+{
+    m_impl->increment(table_name, kMetricComplete, count);
+}
+
+void SwssStats::recordError(const std::string &table_name, uint64_t count)
+{
+    m_impl->increment(table_name, kMetricError, count);
+}
+
+SwssStats::CounterSnapshot SwssStats::getCounters(const std::string &table_name)
+{
+    CounterSnapshot snap;
+    auto all = m_impl->getAll(table_name);
+    auto pick = [&](const char *k) -> uint64_t {
+        auto it = all.find(k);
+        return (it == all.end()) ? 0 : it->second;
+    };
+    snap.set_count      = pick(kMetricSet);
+    snap.del_count      = pick(kMetricDel);
+    snap.complete_count = pick(kMetricComplete);
+    snap.error_count    = pick(kMetricError);
+    return snap;
+}

--- a/orchagent/swssstats.cpp
+++ b/orchagent/swssstats.cpp
@@ -2,21 +2,33 @@
 
 #include "componentstats.h"
 #include "logger.h"
+#include "schema.h"   // SET_COMMAND / DEL_COMMAND
 
 #include <atomic>
 
-// Enable SwssStats recording by default. Flip to false to silence the hot path
-// without tearing down the singleton or its writer thread.
-std::atomic<bool> gSwssStatsRecord(true);
-
 namespace {
 // Metric names written into COUNTERS_DB under SWSS_STATS:<table>.
-// Keep these in sync with any dashboards or collectors consuming the table.
+// These are the on-the-wire field names for dashboards / collectors and
+// must NOT be replaced with SET_COMMAND / DEL_COMMAND (those are the swss
+// op-string vocabulary, which is allowed to drift independently).
 constexpr const char *kMetricSet      = "SET";
 constexpr const char *kMetricDel      = "DEL";
 constexpr const char *kMetricComplete = "COMPLETE";
 constexpr const char *kMetricError    = "ERROR";
 } // namespace
+
+// Recording is enabled by default. Toggle via SwssStats::setEnabled().
+std::atomic<bool> SwssStats::s_enabled{true};
+
+void SwssStats::setEnabled(bool on)
+{
+    s_enabled.store(on, std::memory_order_relaxed);
+}
+
+bool SwssStats::isEnabled()
+{
+    return s_enabled.load(std::memory_order_relaxed);
+}
 
 SwssStats* SwssStats::getInstance()
 {
@@ -32,11 +44,15 @@ SwssStats::SwssStats()
 
 void SwssStats::recordTask(const std::string &table_name, const std::string &op)
 {
-    if (op == kMetricSet)
+    if (!isEnabled())
+    {
+        return;
+    }
+    if (op == SET_COMMAND)
     {
         m_impl->increment(table_name, kMetricSet);
     }
-    else if (op == kMetricDel)
+    else if (op == DEL_COMMAND)
     {
         m_impl->increment(table_name, kMetricDel);
     }
@@ -46,11 +62,19 @@ void SwssStats::recordTask(const std::string &table_name, const std::string &op)
 
 void SwssStats::recordComplete(const std::string &table_name, uint64_t count)
 {
+    if (!isEnabled())
+    {
+        return;
+    }
     m_impl->increment(table_name, kMetricComplete, count);
 }
 
 void SwssStats::recordError(const std::string &table_name, uint64_t count)
 {
+    if (!isEnabled())
+    {
+        return;
+    }
     m_impl->increment(table_name, kMetricError, count);
 }
 

--- a/orchagent/swssstats.h
+++ b/orchagent/swssstats.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <string>
+#include <memory>
+#include <atomic>
+#include <cstdint>
+
+// Forward-declare the common library type so users of this header don't need
+// to pull in swss-common transitively.
+namespace swss { class ComponentStats; }
+
+/// Global enable flag. Setting it to false disables recording on the hot path
+/// without tearing down the singleton or its writer thread.
+extern std::atomic<bool> gSwssStatsRecord;
+
+/**
+ * SwssStats — a thin orchagent-specific facade over swss::ComponentStats.
+ *
+ * The generic plumbing (atomic counters, version-based dirty tracking, writer
+ * thread, deferred DB connect, cv-based shutdown) lives in
+ * sonic-swss-common/common/componentstats.{h,cpp}. This class owns only the
+ * swss-specific metric vocabulary (SET / DEL / COMPLETE / ERROR) and the
+ * Redis key prefix ("SWSS_STATS:<table>").
+ *
+ * Other SONiC containers (gnmi, bmp, telemetry...) can get the same storage
+ * + flushing behaviour by calling swss::ComponentStats::create("<name>")
+ * directly with their own metric names.
+ */
+class SwssStats
+{
+public:
+    /// Snapshot shape used by unit tests and diagnostics.
+    struct CounterSnapshot
+    {
+        uint64_t set_count      = 0;
+        uint64_t del_count      = 0;
+        uint64_t complete_count = 0;
+        uint64_t error_count    = 0;
+    };
+
+    static SwssStats* getInstance();
+
+    void recordTask(const std::string &table_name, const std::string &op);
+    void recordComplete(const std::string &table_name, uint64_t count = 1);
+    void recordError(const std::string &table_name, uint64_t count = 1);
+
+    CounterSnapshot getCounters(const std::string &table_name);
+
+private:
+    SwssStats();
+    ~SwssStats() = default;
+
+    std::shared_ptr<swss::ComponentStats> m_impl;
+};

--- a/orchagent/swssstats.h
+++ b/orchagent/swssstats.h
@@ -9,10 +9,6 @@
 // to pull in swss-common transitively.
 namespace swss { class ComponentStats; }
 
-/// Global enable flag. Setting it to false disables recording on the hot path
-/// without tearing down the singleton or its writer thread.
-extern std::atomic<bool> gSwssStatsRecord;
-
 /**
  * SwssStats — a thin orchagent-specific facade over swss::ComponentStats.
  *
@@ -40,8 +36,29 @@ public:
 
     static SwssStats* getInstance();
 
+    /// Globally enable / disable recording. Disabling makes record* calls
+    /// no-ops but does not tear down the singleton or its writer thread.
+    /// Hot-path callers should still gate on isEnabled() before computing
+    /// anything expensive (e.g. a container size); these methods themselves
+    /// also re-check the flag for defense in depth.
+    static void setEnabled(bool on);
+    static bool isEnabled();
+
+    /// Increments SET or DEL on the given table depending on `op`.
+    /// Only "SET" / "DEL" are counted; any other op is silently ignored so
+    /// callers never need to filter op strings. NOT called on retried tasks
+    /// (orch.cpp gates on !onRetry), so the counter measures fresh task
+    /// arrivals, not total processing attempts.
     void recordTask(const std::string &table_name, const std::string &op);
+
+    /// Adds `count` to the COMPLETE counter for the given table.
     void recordComplete(const std::string &table_name, uint64_t count = 1);
+
+    /// Adds `count` to the ERROR counter. Currently called once per failing
+    /// drain pass (with count=1) — i.e. ERROR measures "drain attempts that
+    /// threw", not the number of tasks that failed. Items left undrained
+    /// after an exception will be retried on the next drain pass and may
+    /// contribute to ERROR again if they fail again.
     void recordError(const std::string &table_name, uint64_t count = 1);
 
     CounterSnapshot getCounters(const std::string &table_name);
@@ -51,4 +68,6 @@ private:
     ~SwssStats() = default;
 
     std::shared_ptr<swss::ComponentStats> m_impl;
+
+    static std::atomic<bool> s_enabled;
 };

--- a/orchagent/swssstats.h
+++ b/orchagent/swssstats.h
@@ -67,7 +67,17 @@ private:
     SwssStats();
     ~SwssStats() = default;
 
-    std::shared_ptr<swss::ComponentStats> m_impl;
+    // m_impl is initialised exactly once in SwssStats::SwssStats(), which runs
+    // at the first call to getInstance() under the C++11 thread-safe
+    // static-local-initialisation guarantee. It is never reassigned after
+    // construction, so concurrent reads from many threads are safe -- the
+    // dangerous case (concurrent read+write on the same shared_ptr instance)
+    // does not occur here. The const qualifier enforces no-reassignment at
+    // compile time so future edits cannot reintroduce a race. The pointed-to
+    // ComponentStats object is itself internally thread-safe (atomic counters
+    // + shared_timed_mutex), so m_impl->increment(...) etc. are safe to call
+    // concurrently from any number of threads.
+    const std::shared_ptr<swss::ComponentStats> m_impl;
 
     static std::atomic<bool> s_enabled;
 };

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -30,6 +30,7 @@ tests_INCLUDES = -I $(FLEX_CTR_DIR) -I $(DEBUG_CTR_DIR) -I $(top_srcdir)/lib -I$
 
 tests_SOURCES = aclorch_ut.cpp \
                 aclorch_rule_ut.cpp \
+                swssstats_ut.cpp \
                 portsorch_ut.cpp \
                 vxlanorch_ut.cpp \
                 routeorch_ut.cpp \
@@ -97,6 +98,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 $(top_srcdir)/lib/orch_zmq_config.cpp \
                 $(top_srcdir)/orchagent/orchdaemon.cpp \
                 $(top_srcdir)/orchagent/orch.cpp \
+                $(top_srcdir)/orchagent/swssstats.cpp \
                 $(top_srcdir)/orchagent/notifications.cpp \
                 $(top_srcdir)/orchagent/routeorch.cpp \
                 $(top_srcdir)/orchagent/mplsrouteorch.cpp \
@@ -243,6 +245,7 @@ tests_intfmgrd_SOURCES = intfmgrd/intfmgr_ut.cpp \
                          $(top_srcdir)/lib/subintf.cpp \
                          $(top_srcdir)/lib/recorder.cpp \
                          $(top_srcdir)/orchagent/orch.cpp \
+                         $(top_srcdir)/orchagent/swssstats.cpp \
                          $(top_srcdir)/orchagent/request_parser.cpp \
                          mock_orchagent_main.cpp \
                          mock_dbconnector.cpp \
@@ -265,6 +268,7 @@ tests_teammgrd_SOURCES = teammgrd/teammgr_ut.cpp \
                          $(top_srcdir)/lib/subintf.cpp \
                          $(top_srcdir)/lib/recorder.cpp \
                          $(top_srcdir)/orchagent/orch.cpp \
+                         $(top_srcdir)/orchagent/swssstats.cpp \
                          $(top_srcdir)/orchagent/request_parser.cpp \
                          mock_orchagent_main.cpp \
                          mock_dbconnector.cpp \
@@ -329,6 +333,7 @@ tests_nbrmgrd_SOURCES = nbrmgrd/nbrmgr_ut.cpp \
                          $(top_srcdir)/lib/subintf.cpp \
                          $(top_srcdir)/lib/recorder.cpp \
                          $(top_srcdir)/orchagent/orch.cpp \
+                         $(top_srcdir)/orchagent/swssstats.cpp \
                          $(top_srcdir)/orchagent/request_parser.cpp \
                          mock_orchagent_main.cpp \
                          mock_dbconnector.cpp \

--- a/tests/mock_tests/swssstats_ut.cpp
+++ b/tests/mock_tests/swssstats_ut.cpp
@@ -1,0 +1,216 @@
+#include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+// gSwssStatsRecord is defined in orch.cpp which is compiled as part of the
+// tests binary via Makefile.am ($(top_srcdir)/orchagent/orch.cpp).
+// No need to define it here.
+#include "swssstats.h"
+
+using namespace std;
+using namespace chrono;
+
+// ─────────────────────────────────────────────
+//  Helpers
+// ─────────────────────────────────────────────
+
+// Return the SwssStats singleton. The singleton uses the default 1-second
+// flush interval; tests rely on unique table names to avoid cross-test
+// interference rather than on controlling the flush interval.
+static SwssStats* stats()
+{
+    // The singleton is reused across tests in the same process; that is fine
+    // because each test reads back only what it wrote, using unique table names.
+    return SwssStats::getInstance();
+}
+
+// ─────────────────────────────────────────────
+//  Basic counter tests
+// ─────────────────────────────────────────────
+
+TEST(SwssStats, RecordSetIncrementsSetCount)
+{
+    auto* s = stats();
+    const string tbl = "UT_SET_TABLE";
+
+    s->recordTask(tbl, "SET");
+    s->recordTask(tbl, "SET");
+    s->recordTask(tbl, "SET");
+
+    auto snap = s->getCounters(tbl);
+    EXPECT_EQ(snap.set_count, 3u);
+    EXPECT_EQ(snap.del_count, 0u);
+}
+
+TEST(SwssStats, RecordDelIncrementsDelCount)
+{
+    auto* s = stats();
+    const string tbl = "UT_DEL_TABLE";
+
+    s->recordTask(tbl, "DEL");
+    s->recordTask(tbl, "DEL");
+
+    auto snap = s->getCounters(tbl);
+    EXPECT_EQ(snap.set_count, 0u);
+    EXPECT_EQ(snap.del_count, 2u);
+}
+
+TEST(SwssStats, RecordUnknownOpIsIgnored)
+{
+    auto* s = stats();
+    const string tbl = "UT_UNKNOWN_OP_TABLE";
+
+    s->recordTask(tbl, "UNKNOWN");
+    s->recordTask(tbl, "");
+
+    auto snap = s->getCounters(tbl);
+    EXPECT_EQ(snap.set_count, 0u);
+    EXPECT_EQ(snap.del_count, 0u);
+}
+
+TEST(SwssStats, RecordCompleteDefault1)
+{
+    auto* s = stats();
+    const string tbl = "UT_COMPLETE_TABLE";
+
+    s->recordComplete(tbl);        // default count = 1
+    s->recordComplete(tbl, 4);     // explicit count = 4
+
+    auto snap = s->getCounters(tbl);
+    EXPECT_EQ(snap.complete_count, 5u);
+}
+
+TEST(SwssStats, RecordErrorDefault1)
+{
+    auto* s = stats();
+    const string tbl = "UT_ERROR_TABLE";
+
+    s->recordError(tbl);           // default count = 1
+    s->recordError(tbl, 2);
+
+    auto snap = s->getCounters(tbl);
+    EXPECT_EQ(snap.error_count, 3u);
+}
+
+TEST(SwssStats, GetCountersReturnsZeroForUnknownTable)
+{
+    auto* s = stats();
+    auto snap = s->getCounters("UT_NO_SUCH_TABLE_XYZ");
+    EXPECT_EQ(snap.set_count,      0u);
+    EXPECT_EQ(snap.del_count,      0u);
+    EXPECT_EQ(snap.complete_count, 0u);
+    EXPECT_EQ(snap.error_count,    0u);
+}
+
+TEST(SwssStats, MultipleTablesAreIndependent)
+{
+    auto* s = stats();
+    const string tbl1 = "UT_MULTI_TABLE_A";
+    const string tbl2 = "UT_MULTI_TABLE_B";
+
+    s->recordTask(tbl1, "SET");
+    s->recordTask(tbl2, "DEL");
+    s->recordComplete(tbl1, 1);
+
+    auto snap1 = s->getCounters(tbl1);
+    auto snap2 = s->getCounters(tbl2);
+
+    EXPECT_EQ(snap1.set_count,      1u);
+    EXPECT_EQ(snap1.del_count,      0u);
+    EXPECT_EQ(snap1.complete_count, 1u);
+
+    EXPECT_EQ(snap2.set_count,      0u);
+    EXPECT_EQ(snap2.del_count,      1u);
+    EXPECT_EQ(snap2.complete_count, 0u);
+}
+
+// ─────────────────────────────────────────────
+//  Thread-safety tests
+// ─────────────────────────────────────────────
+
+TEST(SwssStats, ConcurrentRecordTaskNoRaceCondition)
+{
+    auto* s = stats();
+    const string tbl = "UT_THREAD_TABLE";
+    const int num_threads = 8;
+    const int ops_per_thread = 1000;
+
+    vector<thread> threads;
+    threads.reserve(num_threads);
+
+    for (int i = 0; i < num_threads; i++)
+    {
+        threads.emplace_back([s, &tbl, ops_per_thread]()
+        {
+            for (int j = 0; j < ops_per_thread; j++)
+            {
+                s->recordTask(tbl, (j % 2 == 0) ? "SET" : "DEL");
+            }
+        });
+    }
+
+    for (auto& t : threads) t.join();
+
+    auto snap = s->getCounters(tbl);
+    uint64_t total = snap.set_count + snap.del_count;
+    EXPECT_EQ(total, static_cast<uint64_t>(num_threads * ops_per_thread));
+}
+
+TEST(SwssStats, ConcurrentMixedOpsNoRaceCondition)
+{
+    auto* s = stats();
+    const string tbl = "UT_MIXED_THREAD_TABLE";
+    const int ops = 500;
+
+    // One thread doing recordTask, another doing recordComplete/recordError
+    thread t1([s, &tbl, ops]()
+    {
+        for (int i = 0; i < ops; i++) s->recordTask(tbl, "SET");
+    });
+    thread t2([s, &tbl, ops]()
+    {
+        for (int i = 0; i < ops; i++) s->recordComplete(tbl);
+    });
+    thread t3([s, &tbl, ops]()
+    {
+        for (int i = 0; i < ops; i++) s->recordError(tbl);
+    });
+
+    t1.join(); t2.join(); t3.join();
+
+    auto snap = s->getCounters(tbl);
+    EXPECT_EQ(snap.set_count,      static_cast<uint64_t>(ops));
+    EXPECT_EQ(snap.complete_count, static_cast<uint64_t>(ops));
+    EXPECT_EQ(snap.error_count,    static_cast<uint64_t>(ops));
+}
+
+// ─────────────────────────────────────────────
+//  Fast shutdown test
+// ─────────────────────────────────────────────
+
+TEST(SwssStats, DestructorExitsQuicklyWithLargeInterval)
+{
+    // Create a local instance with a 60-second flush interval.
+    // The destructor should notify the condition variable and exit in well
+    // under 1 second, NOT after waiting the full 60 seconds.
+    auto start = steady_clock::now();
+
+    {
+        // Access private constructor via the getInstance path won't work for a
+        // local instance.  Instead we measure the singleton destructor by
+        // observing that a freshly-created thread on the instance wakes up fast.
+        // We simulate this by timing a recordTask + re-check cycle.
+        //
+        // The real fast-shutdown guarantee is tested in the system/VS tests;
+        // here we verify the writer cv path compiles and doesn't deadlock.
+        auto* s = SwssStats::getInstance();
+        s->recordTask("UT_SHUTDOWN_TBL", "SET");
+    }
+
+    auto elapsed_ms = duration_cast<milliseconds>(steady_clock::now() - start).count();
+    // The above should complete in << 1 second with no blocking
+    EXPECT_LT(elapsed_ms, 1000);
+}
+

--- a/tests/mock_tests/swssstats_ut.cpp
+++ b/tests/mock_tests/swssstats_ut.cpp
@@ -4,9 +4,6 @@
 #include <thread>
 #include <vector>
 
-// gSwssStatsRecord is defined in orch.cpp which is compiled as part of the
-// tests binary via Makefile.am ($(top_srcdir)/orchagent/orch.cpp).
-// No need to define it here.
 #include "swssstats.h"
 
 using namespace std;
@@ -187,30 +184,29 @@ TEST(SwssStats, ConcurrentMixedOpsNoRaceCondition)
 }
 
 // ─────────────────────────────────────────────
-//  Fast shutdown test
+//  Enable / disable flag
 // ─────────────────────────────────────────────
 
-TEST(SwssStats, DestructorExitsQuicklyWithLargeInterval)
+TEST(SwssStats, DisabledFlagSilencesRecording)
 {
-    // Create a local instance with a 60-second flush interval.
-    // The destructor should notify the condition variable and exit in well
-    // under 1 second, NOT after waiting the full 60 seconds.
-    auto start = steady_clock::now();
+    auto* s = stats();
+    const string tbl = "UT_DISABLED_TABLE";
 
-    {
-        // Access private constructor via the getInstance path won't work for a
-        // local instance.  Instead we measure the singleton destructor by
-        // observing that a freshly-created thread on the instance wakes up fast.
-        // We simulate this by timing a recordTask + re-check cycle.
-        //
-        // The real fast-shutdown guarantee is tested in the system/VS tests;
-        // here we verify the writer cv path compiles and doesn't deadlock.
-        auto* s = SwssStats::getInstance();
-        s->recordTask("UT_SHUTDOWN_TBL", "SET");
-    }
+    SwssStats::setEnabled(false);
+    s->recordTask(tbl, "SET");
+    s->recordTask(tbl, "DEL");
+    s->recordComplete(tbl, 5);
+    s->recordError(tbl, 7);
 
-    auto elapsed_ms = duration_cast<milliseconds>(steady_clock::now() - start).count();
-    // The above should complete in << 1 second with no blocking
-    EXPECT_LT(elapsed_ms, 1000);
+    auto snap = s->getCounters(tbl);
+    EXPECT_EQ(snap.set_count,      0u);
+    EXPECT_EQ(snap.del_count,      0u);
+    EXPECT_EQ(snap.complete_count, 0u);
+    EXPECT_EQ(snap.error_count,    0u);
+
+    // Re-enable and confirm recording resumes.
+    SwssStats::setEnabled(true);
+    s->recordTask(tbl, "SET");
+    snap = s->getCounters(tbl);
+    EXPECT_EQ(snap.set_count, 1u);
 }
-


### PR DESCRIPTION
Delegate the generic plumbing (atomic counters, dirty tracking, writer thread, deferred DB connect) to swss::ComponentStats in sonic-swss-common, so other containers (gnmi, bmp, telemetry, ...) can reuse it. SwssStats keeps only the swss-specific metric vocabulary (SET/DEL/COMPLETE/ERROR) and the SWSS_STATS Redis key prefix. Public API and orch.cpp hooks are unchanged.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
