### PR TITLE
[STP] Adding loop guard support

### DIFF
--- a/cfgmgr/stpmgr.cpp
+++ b/cfgmgr/stpmgr.cpp
@@ -580,6 +580,10 @@ void StpMgr::processStpPortAttr(const string op,
             {
                 msg->root_guard = (value == "true") ? 1 : 0;
             }
+            else if (field == "loop_guard")
+            {
+                msg->loop_guard = (value == "true") ? 1 : 0;
+            }
             else if (field == "bpdu_guard")
             {
                 msg->bpdu_guard = (value == "true") ? 1 : 0;

--- a/cfgmgr/stpmgr.h
+++ b/cfgmgr/stpmgr.h
@@ -174,6 +174,7 @@ typedef struct STP_PORT_CONFIG_MSG {
     char        intf_name[IFNAMSIZ];
     uint8_t     enabled;
     uint8_t     root_guard;
+    uint8_t     loop_guard;
     uint8_t     bpdu_guard;
     uint8_t     bpdu_guard_do_disable;
     uint8_t     portfast;           // PVST only

--- a/cfgmgr/stpmgr.h
+++ b/cfgmgr/stpmgr.h
@@ -185,7 +185,7 @@ typedef struct STP_PORT_CONFIG_MSG {
     int         priority;
     int         count;
     VLAN_ATTR   vlan_list[0];
-} STP_PORT_CONFIG_MSG;;
+} STP_PORT_CONFIG_MSG;
 
 typedef struct STP_VLAN_MEM_CONFIG_MSG {
     uint8_t opcode;   // enable/disable
@@ -306,4 +306,3 @@ private:
 
 }
 #endif
-


### PR DESCRIPTION
## Summary
Add loop guard field support to STP port config message handling.

## Changes
- Add `loop_guard` field in `STP_PORT_CONFIG_MSG`.
- Parse and propagate `loop_guard` from STP_PORT table updates to stpd message.

## Files
- cfgmgr/stpmgr.cpp
- cfgmgr/stpmgr.h

## Dependency
- sonic-stp PR: https://github.com/sonic-net/sonic-stp/pull/88