### PR TITLE
orchagent: Fix end-iterator dereference in SflowOrch debug log

### DIFF
--- a/orchagent/sfloworch.cpp
+++ b/orchagent/sfloworch.cpp
@@ -399,7 +399,7 @@ void SflowOrch::doTask(Consumer &consumer)
 
             SWSS_LOG_DEBUG(" Existing Cfg portOid %" PRIx64 " admin %d rate %d dir %s", 
                             port.m_port_id, (unsigned int)admin_state, rate, 
-                            sflowInfo->second.m_sample_dir.c_str());
+                            (sflowInfo != m_sflowPortInfoMap.end()) ? sflowInfo->second.m_sample_dir.c_str() : "n/a");
 
             sflowExtractInfo(kfvFieldsValues(tuple), admin_state, rate, dir);
 

--- a/orchagent/sfloworch.cpp
+++ b/orchagent/sfloworch.cpp
@@ -456,7 +456,7 @@ void SflowOrch::doTask(Consumer &consumer)
 
             SWSS_LOG_DEBUG(" Existing Cfg portOid %" PRIx64 " admin %d rate %d dir %s", 
                             port.m_port_id, (unsigned int)admin_state, rate, 
-                            sflowInfo->second.m_sample_dir.c_str());
+                            (sflowInfo != m_sflowPortInfoMap.end()) ? sflowInfo->second.m_sample_dir.c_str() : "n/a");
 
             sflowExtractInfo(kfvFieldsValues(tuple), admin_state, rate, dir);
 

--- a/tests/mock_tests/sfloworh_ut.cpp
+++ b/tests/mock_tests/sfloworh_ut.cpp
@@ -368,6 +368,44 @@ namespace sflow_test
             ASSERT_FALSE(Portal::SflowOrchInternal::getSflowStatusEnable(mock_orch.get()));
         }
     }
+
+    /* First SET for a port is not in m_sflowPortInfoMap; debug log must not deref end(). */
+    TEST_F(SflowOrchTest, SflowSessionSetOnPortNotInMapDoesNotCrash)
+    {
+        MockSflowOrch mock_orch;
+        auto enable = deque<KeyOpFieldsValuesTuple>(
+            {
+                {
+                    "global",
+                    SET_COMMAND,
+                    {
+                        {"admin_state", "up"}
+                    }
+                }
+            });
+        mock_orch.doSflowTableTask(enable);
+        ASSERT_TRUE(Portal::SflowOrchInternal::getSflowStatusEnable(mock_orch.get()));
+
+        auto session = deque<KeyOpFieldsValuesTuple>(
+            {
+                {
+                    "Ethernet0",
+                    SET_COMMAND,
+                    {
+                        {"admin_state", "up"},
+                        {"sample_rate", "1000"},
+                        {"sample_direction", "rx"}
+                    }
+                }
+            });
+        EXPECT_NO_THROW(mock_orch.doSflowSessionTableTask(session));
+
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+        auto info = Portal::SflowOrchInternal::getSflowPortInfoMap(mock_orch.get());
+        EXPECT_NE(info.find(port.m_port_id), info.end());
+    }
+
     TEST_F(SflowOrchTest, SflowAddPortRejectsConflictingEgressBinding)
     {
         MockSflowOrch mock_orch;


### PR DESCRIPTION
**What I did**

Fixed an end-iterator dereference in a SWSS_LOG_DEBUG call in SflowOrch::doTask().

**Why I did it**

The debug log at line 400 accesses `sflowInfo->second.m_sample_dir` outside the `if (sflowInfo != m_sflowPortInfoMap.end())` guard block. When a port has no sFlow entry, `sflowInfo` is an end iterator, and dereferencing it is undefined behavior that can crash orchagent.

**How I verified it**

Code inspection — the fix guards the access with a ternary check on iterator validity. No behavioral change when the entry exists.

Signed-off-by: Uma Ramanathan <uramanathan@upscaleai.com>