### PR TITLE
orchagent: Replace operator[] with find() in AclRuleManager::getAclRule

### DIFF
--- a/orchagent/p4orch/acl_rule_manager.cpp
+++ b/orchagent/p4orch/acl_rule_manager.cpp
@@ -715,11 +715,17 @@ ReturnCode AclRuleManager::validateAclRuleAppDbEntry(const P4AclRuleAppDbEntry &
 
 P4AclRule *AclRuleManager::getAclRule(const std::string &acl_table_name, const std::string &acl_rule_key)
 {
-    if (m_aclRuleTables[acl_table_name].find(acl_rule_key) == m_aclRuleTables[acl_table_name].end())
+    auto table_it = m_aclRuleTables.find(acl_table_name);
+    if (table_it == m_aclRuleTables.end())
     {
         return nullptr;
     }
-    return &m_aclRuleTables[acl_table_name][acl_rule_key];
+    auto rule_it = table_it->second.find(acl_rule_key);
+    if (rule_it == table_it->second.end())
+    {
+        return nullptr;
+    }
+    return &rule_it->second;
 }
 
 ReturnCode AclRuleManager::setAclRuleCounterStats(const P4AclRule &acl_rule)

--- a/orchagent/p4orch/tests/acl_manager_test.cpp
+++ b/orchagent/p4orch/tests/acl_manager_test.cpp
@@ -6500,5 +6500,14 @@ TEST_F(AclManagerTest, AclRuleVerifyStateAsicDbTest)
             swss::FieldValueTuple{"SAI_POLICER_ATTR_GREEN_PACKET_ACTION", "SAI_PACKET_ACTION_COPY"}});
 }
 
+TEST_F(AclManagerTest, GetAclRuleMissingTableDoesNotInsert)
+{
+    const auto size_before = acl_rule_manager_->m_aclRuleTables.size();
+    EXPECT_EQ(nullptr, GetAclRule("NO_SUCH_TABLE", "NO_SUCH_RULE"));
+    EXPECT_EQ(size_before, acl_rule_manager_->m_aclRuleTables.size());
+    EXPECT_EQ(acl_rule_manager_->m_aclRuleTables.end(),
+              acl_rule_manager_->m_aclRuleTables.find("NO_SUCH_TABLE"));
+}
+
 } // namespace test
 } // namespace p4orch

--- a/orchagent/p4orch/tests/acl_manager_test.cpp
+++ b/orchagent/p4orch/tests/acl_manager_test.cpp
@@ -1116,6 +1116,17 @@ class AclManagerTest : public ::testing::Test
         return acl_rule_manager_->getAclRule(acl_table_name, acl_rule_key);
     }
 
+    size_t GetAclRuleTableCount() const
+    {
+        return acl_rule_manager_->m_aclRuleTables.size();
+    }
+
+    bool HasAclRuleTable(const std::string &acl_table_name) const
+    {
+        return acl_rule_manager_->m_aclRuleTables.find(acl_table_name) !=
+               acl_rule_manager_->m_aclRuleTables.end();
+    }
+
     ReturnCode ProcessAddTableRequest(const P4AclTableDefinitionAppDbEntry &app_db_entry)
     {
         return acl_table_manager_->processAddTableRequest(app_db_entry);
@@ -6502,11 +6513,10 @@ TEST_F(AclManagerTest, AclRuleVerifyStateAsicDbTest)
 
 TEST_F(AclManagerTest, GetAclRuleMissingTableDoesNotInsert)
 {
-    const auto size_before = acl_rule_manager_->m_aclRuleTables.size();
+    const auto size_before = GetAclRuleTableCount();
     EXPECT_EQ(nullptr, GetAclRule("NO_SUCH_TABLE", "NO_SUCH_RULE"));
-    EXPECT_EQ(size_before, acl_rule_manager_->m_aclRuleTables.size());
-    EXPECT_EQ(acl_rule_manager_->m_aclRuleTables.end(),
-              acl_rule_manager_->m_aclRuleTables.find("NO_SUCH_TABLE"));
+    EXPECT_EQ(size_before, GetAclRuleTableCount());
+    EXPECT_FALSE(HasAclRuleTable("NO_SUCH_TABLE"));
 }
 
 } // namespace test


### PR DESCRIPTION
**What I did**

Replaced `std::map::operator[]` with `find()` in `AclRuleManager::getAclRule()`.

**Why I did it**

`getAclRule()` uses `m_aclRuleTables[acl_table_name]` which calls `operator[]` on the outer map. When `acl_table_name` is absent, this silently default-constructs an empty inner map, creating a phantom table entry. Subsequent iterations or size checks on `m_aclRuleTables` will then see a stale key with no rules.

Using `find()` on both the outer and inner maps makes the lookup side-effect-free.

**How I verified it**

Code inspection — the fix is mechanical. No behavioral change when the table and rule exist. All existing tests pass.

Signed-off-by: Uma Ramanathan <uramanathan@upscaleai.com>