### PR TITLE
orchagent: Add missing catch(out_of_range) in QoS map handlers

### DIFF
--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -1087,6 +1087,12 @@ bool DscpToFcMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &
             delete[] list_attr.value.qosmap.list;
             return false;
         }
+        catch(const out_of_range& e)
+        {
+            SWSS_LOG_ERROR("Got exception during conversion: %s", e.what());
+            delete[] list_attr.value.qosmap.list;
+            return false;
+        }
     }
     attributes.push_back(list_attr);
     return true;
@@ -1181,6 +1187,12 @@ bool ExpToFcMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &t
             delete[] list_attr.value.qosmap.list;
             return false;
         }
+        catch(const out_of_range& e)
+        {
+            SWSS_LOG_ERROR("Got exception during conversion: %s", e.what());
+            delete[] list_attr.value.qosmap.list;
+            return false;
+        }
     }
     attributes.push_back(list_attr);
     return true;
@@ -1249,6 +1261,12 @@ bool TcToDscpMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &
                             list_attr.value.qosmap.list[ind].value.dscp);
         }
         catch(const invalid_argument& e)
+        {
+            SWSS_LOG_ERROR("Got exception during conversion: %s", e.what());
+            delete[] list_attr.value.qosmap.list;
+            return false;
+        }
+        catch(const out_of_range& e)
         {
             SWSS_LOG_ERROR("Got exception during conversion: %s", e.what());
             delete[] list_attr.value.qosmap.list;

--- a/tests/mock_tests/qosorch_ut.cpp
+++ b/tests/mock_tests/qosorch_ut.cpp
@@ -1626,4 +1626,38 @@ namespace qosorch_test
         static_cast<Orch *>(tunnel_decap_orch)->doTask();
         entries.clear();
     }
+
+    TEST_F(QosOrchTest, QosOrchTestOutOfRangeDscpToFcMap)
+    {
+        // Push an entry with an overflow value to trigger out_of_range in stoi
+        Table dscpToFcMapTable = Table(m_config_db.get(), CFG_DSCP_TO_FC_MAP_TABLE_NAME);
+        dscpToFcMapTable.set("OVERFLOW_MAP",
+                             {
+                                 {"99999999999", "0"}
+                             });
+        gQosOrch->addExistingData(&dscpToFcMapTable);
+        static_cast<Orch *>(gQosOrch)->doTask();
+    }
+
+    TEST_F(QosOrchTest, QosOrchTestOutOfRangeExpToFcMap)
+    {
+        Table expToFcMapTable = Table(m_config_db.get(), CFG_EXP_TO_FC_MAP_TABLE_NAME);
+        expToFcMapTable.set("OVERFLOW_MAP",
+                            {
+                                {"99999999999", "0"}
+                            });
+        gQosOrch->addExistingData(&expToFcMapTable);
+        static_cast<Orch *>(gQosOrch)->doTask();
+    }
+
+    TEST_F(QosOrchTest, QosOrchTestOutOfRangeTcToDscpMap)
+    {
+        Table tcToDscpMapTable = Table(m_config_db.get(), CFG_TC_TO_DSCP_MAP_TABLE_NAME);
+        tcToDscpMapTable.set("OVERFLOW_MAP",
+                             {
+                                 {"0", "99999999999"}
+                             });
+        gQosOrch->addExistingData(&tcToDscpMapTable);
+        static_cast<Orch *>(gQosOrch)->doTask();
+    }
 }


### PR DESCRIPTION
**What I did**

Added missing `catch(std::out_of_range)` blocks in three QoS map handler functions: `DscpToFcMapHandler`, `ExpToFcMapHandler`, and `TcToDscpMapHandler`.

**Why I did it**

Each function allocates a `sai_qos_map_t` array with `new[]` and calls `stoi()` inside a try block, but only catches `std::invalid_argument`. If `stoi()` throws `std::out_of_range` (e.g. input value exceeds INT_MAX), the exception propagates without freeing the array, causing a memory leak.

`Dot1pToTcMapHandler` already correctly catches both exceptions — this fix brings the other three handlers to the same standard.

**How I verified it**

Code inspection — the fix adds `catch(out_of_range)` alongside the existing `catch(invalid_argument)`, with the same cleanup logic (delete[] + return false). No behavioral change for valid inputs. All existing tests pass.

Signed-off-by: Uma Ramanathan <uramanathan@upscaleai.com>