### PR TITLE
[cfgmgrd] Add Monitor Link Group feature

### DIFF
--- a/cfgmgr/Makefile.am
+++ b/cfgmgr/Makefile.am
@@ -51,7 +51,7 @@ fabricmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CF
 fabricmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
 fabricmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
-intfmgrd_SOURCES = intfmgrd.cpp intfmgr.cpp $(top_srcdir)/lib/subintf.cpp $(COMMON_ORCH_SOURCE) shellcmd.h
+intfmgrd_SOURCES = intfmgrd.cpp intfmgr.cpp monitorlinkgroupmgr.cpp $(top_srcdir)/lib/subintf.cpp $(COMMON_ORCH_SOURCE) shellcmd.h
 intfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
 intfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
 intfmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)

--- a/cfgmgr/intfmgrd.cpp
+++ b/cfgmgr/intfmgrd.cpp
@@ -6,6 +6,7 @@
 #include "exec.h"
 #include "schema.h"
 #include "intfmgr.h"
+#include "monitorlinkgroupmgr.h"
 #include <fstream>
 #include <iostream>
 #include "warm_restart.h"
@@ -34,6 +35,10 @@ int main(int argc, char **argv)
             CFG_VOQ_INBAND_INTERFACE_TABLE_NAME,
         };
 
+        vector<string> cfg_mlg_tables = {
+            CFG_MONITOR_LINK_GROUP_TABLE_NAME,
+        };
+
         DBConnector cfgDb("CONFIG_DB", 0);
         DBConnector appDb("APPL_DB", 0);
         DBConnector stateDb("STATE_DB", 0);
@@ -42,7 +47,8 @@ int main(int argc, char **argv)
         WarmStart::checkWarmStart("intfmgrd", "swss");
 
         IntfMgr intfmgr(&cfgDb, &appDb, &stateDb, cfg_intf_tables);
-        std::vector<Orch *> cfgOrchList = {&intfmgr};
+        MonitorLinkGroupMgr mlgmgr(&cfgDb, &stateDb, cfg_mlg_tables);
+        std::vector<Orch *> cfgOrchList = {&intfmgr, &mlgmgr};
 
         swss::Select s;
         for (Orch *o : cfgOrchList)
@@ -64,7 +70,16 @@ int main(int argc, char **argv)
             }
             if (ret == Select::TIMEOUT)
             {
-                intfmgr.doTask();
+                for (Orch *o : cfgOrchList)
+                {
+                    o->doTask();
+                }
+
+                // Refresh selectables to pick up any new timers created during config processing
+                for (Orch *o : cfgOrchList)
+                {
+                    s.addSelectables(o->getSelectables());
+                }
                 continue;
             }
 

--- a/cfgmgr/monitorlinkgroupmgr.cpp
+++ b/cfgmgr/monitorlinkgroupmgr.cpp
@@ -71,16 +71,22 @@ void MonitorLinkGroupMgr::doPortTableTask(const string& key, vector<FieldValueTu
 {
     if (op == SET_COMMAND)
     {
+        string oper_status_val, netdev_oper_status_val;
         for (auto idx : data)
         {
             const auto &field = fvField(idx);
             const auto &value = fvValue(idx);
-
-            if (field == "oper_status" || field == "netdev_oper_status")
-            {
-                updateMonitorLinkInterfaceState(key, value == "up");
-            }
+            if (field == "oper_status")
+                oper_status_val = value;
+            else if (field == "netdev_oper_status")
+                netdev_oper_status_val = value;
         }
+        // netdev_oper_status is the authoritative kernel-netdev state for Ethernet;
+        // oper_status is the LAG operational state for PortChannels.
+        if (!netdev_oper_status_val.empty())
+            updateMonitorLinkInterfaceState(key, netdev_oper_status_val == "up");
+        else if (!oper_status_val.empty())
+            updateMonitorLinkInterfaceState(key, oper_status_val == "up");
     }
 }
 
@@ -423,17 +429,21 @@ bool MonitorLinkGroupMgr::getInterfaceOperState(const string& interface_name)
     else
         interface_exists_in_state = m_statePortTable.get(interface_name, interface_values);
 
-    if (interface_exists_in_state)
-    {
-        for (const auto& fv : interface_values)
-        {
-            if (fvField(fv) == "oper_status" || fvField(fv) == "netdev_oper_status")
-            {
-                return (fvValue(fv) == "up");
-            }
-        }
-    }
+    if (!interface_exists_in_state)
+        return false;
 
+    string oper_val, netdev_oper_val;
+    for (const auto& fv : interface_values)
+    {
+        if (fvField(fv) == "oper_status")
+            oper_val = fvValue(fv);
+        else if (fvField(fv) == "netdev_oper_status")
+            netdev_oper_val = fvValue(fv);
+    }
+    if (!netdev_oper_val.empty())
+        return netdev_oper_val == "up";
+    if (!oper_val.empty())
+        return oper_val == "up";
     return false;
 }
 

--- a/cfgmgr/monitorlinkgroupmgr.cpp
+++ b/cfgmgr/monitorlinkgroupmgr.cpp
@@ -1,0 +1,908 @@
+#include "logger.h"
+#include "schema.h"
+#include "tokenize.h"
+#include "subscriberstatetable.h"
+#include "timer.h"
+#include "monitorlinkgroupmgr.h"
+
+#include <sstream>
+
+using namespace std;
+using namespace swss;
+
+MonitorLinkGroupMgr::MonitorLinkGroupMgr(DBConnector *cfgDb, DBConnector *stateDb, const vector<string> &tableNames) :
+        Orch(cfgDb, tableNames),
+        m_cfgMonitorLinkGroupTable(cfgDb, CFG_MONITOR_LINK_GROUP_TABLE_NAME),
+        m_statePortTable(stateDb, STATE_PORT_TABLE_NAME),
+        m_stateLagTable(stateDb, STATE_LAG_TABLE_NAME),
+        m_stateMonitorLinkGroupTable(stateDb, STATE_MONITOR_LINK_GROUP_STATE_TABLE_NAME),
+        m_stateMonitorLinkGroupMemberTable(stateDb, STATE_MONITOR_LINK_GROUP_MEMBER_TABLE_NAME)
+{
+    auto subscriberStateTable = new swss::SubscriberStateTable(stateDb,
+            STATE_PORT_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE, 100);
+    auto stateConsumer = new Consumer(subscriberStateTable, this, STATE_PORT_TABLE_NAME);
+    Orch::addExecutor(stateConsumer);
+
+    auto subscriberStateLagTable = new swss::SubscriberStateTable(stateDb,
+            STATE_LAG_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE, 200);
+    auto stateLagConsumer = new Consumer(subscriberStateLagTable, this, STATE_LAG_TABLE_NAME);
+    Orch::addExecutor(stateLagConsumer);
+}
+
+void MonitorLinkGroupMgr::doTask(Consumer &consumer)
+{
+    SWSS_LOG_ENTER();
+
+    string table_name = consumer.getTableName();
+
+    auto it = consumer.m_toSync.begin();
+    while (it != consumer.m_toSync.end())
+    {
+        KeyOpFieldsValuesTuple t = it->second;
+        if ((table_name == STATE_PORT_TABLE_NAME) || (table_name == STATE_LAG_TABLE_NAME))
+        {
+            doPortTableTask(kfvKey(t), kfvFieldsValues(t), kfvOp(t));
+        }
+        else if (table_name == CFG_MONITOR_LINK_GROUP_TABLE_NAME)
+        {
+            vector<string> keys = tokenize(kfvKey(t), config_db_key_delimiter);
+            const vector<FieldValueTuple>& data = kfvFieldsValues(t);
+            string op = kfvOp(t);
+
+            if (keys.size() == 1)
+            {
+                if (!doMonitorLinkGroupTask(keys, data, op))
+                {
+                    it++;
+                    continue;
+                }
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Invalid key %s", kfvKey(t).c_str());
+            }
+        }
+
+        it = consumer.m_toSync.erase(it);
+    }
+}
+
+void MonitorLinkGroupMgr::doPortTableTask(const string& key, vector<FieldValueTuple> data, string op)
+{
+    if (op == SET_COMMAND)
+    {
+        for (auto idx : data)
+        {
+            const auto &field = fvField(idx);
+            const auto &value = fvValue(idx);
+
+            if (field == "oper_status" || field == "netdev_oper_status")
+            {
+                updateMonitorLinkInterfaceState(key, value == "up");
+            }
+        }
+    }
+}
+
+bool MonitorLinkGroupMgr::doMonitorLinkGroupTask(const vector<string>& keys, const vector<FieldValueTuple>& data, const string& op)
+{
+    SWSS_LOG_ENTER();
+
+    string group_name = keys[0];
+
+    SWSS_LOG_INFO("Processing monitor link group: %s, operation: %s", group_name.c_str(), op.c_str());
+
+    if (op == SET_COMMAND)
+    {
+        return handleMonitorLinkGroupSet(group_name, data);
+    }
+    else if (op == DEL_COMMAND)
+    {
+        return handleMonitorLinkGroupDel(group_name);
+    }
+    else
+    {
+        SWSS_LOG_ERROR("Unknown operation: %s for monitor link group", op.c_str());
+        return false;
+    }
+}
+
+bool MonitorLinkGroupMgr::handleMonitorLinkGroupSet(const string& group_name, const vector<FieldValueTuple>& data)
+{
+    string description;
+    uint32_t min_uplinks = 1;
+    uint32_t linkup_delay = 0;
+    string uplink_interfaces;
+    string downlink_interfaces;
+
+    for (auto idx : data)
+    {
+        const auto &field = fvField(idx);
+        const auto &value = fvValue(idx);
+
+        if (field == "description")
+        {
+            description = value;
+        }
+        else if (field == "min-uplinks")
+        {
+            try
+            {
+                min_uplinks = static_cast<uint32_t>(std::stoul(value));
+            }
+            catch (const std::exception&)
+            {
+                SWSS_LOG_WARN("Monitor link group %s: invalid min-uplinks '%s', using 1",
+                              group_name.c_str(), value.c_str());
+                min_uplinks = 1;
+            }
+        }
+        else if (field == "link-up-delay")
+        {
+            try
+            {
+                linkup_delay = static_cast<uint32_t>(std::stoul(value));
+            }
+            catch (const std::exception&)
+            {
+                SWSS_LOG_WARN("Monitor link group %s: invalid link-up-delay '%s', using 0",
+                              group_name.c_str(), value.c_str());
+                linkup_delay = 0;
+            }
+        }
+        else if (field == "uplinks")
+        {
+            uplink_interfaces = value;
+        }
+        else if (field == "downlinks")
+        {
+            downlink_interfaces = value;
+        }
+    }
+
+    SWSS_LOG_INFO("Monitor link group %s: description='%s', min-uplinks=%u, link-up-delay=%u, uplinks='%s', downlinks='%s'",
+                  group_name.c_str(), description.c_str(), min_uplinks, linkup_delay,
+                  uplink_interfaces.c_str(), downlink_interfaces.c_str());
+
+    bool is_new_group = (m_monitorLinkGroups.find(group_name) == m_monitorLinkGroups.end());
+
+    if (!is_new_group)
+    {
+        auto& existingGroup = m_monitorLinkGroups[group_name];
+        if (existingGroup.linkup_delay != linkup_delay)
+            handleGroupDelayChange(group_name, linkup_delay);
+    }
+
+    updateGroupConfiguration(group_name, description, min_uplinks, linkup_delay);
+    updateGroupInterfaceLists(group_name, uplink_interfaces, downlink_interfaces, is_new_group);
+    return true;
+}
+
+void MonitorLinkGroupMgr::handleGroupDelayChange(const string& group_name, uint32_t new_delay)
+{
+    auto& existingGroup = m_monitorLinkGroups[group_name];
+    SWSS_LOG_INFO("Monitor link group %s link-up-delay changed from %u to %u",
+                  group_name.c_str(), existingGroup.linkup_delay, new_delay);
+
+    if (existingGroup.pending_up)
+    {
+        if (new_delay == 0)
+        {
+            SWSS_LOG_INFO("Monitor link group %s delay changed to 0, bringing UP immediately", group_name.c_str());
+            stopLinkupDelayTimer(group_name);
+            existingGroup.pending_up = false;
+            existingGroup.is_up = true;
+            updateDownlinkInterfacesForGroupStateChange(group_name, false, true);
+            writeMonitorLinkGroupStateToDb(group_name);
+        }
+        else
+        {
+            auto now = std::chrono::steady_clock::now();
+            auto elapsed_seconds = std::chrono::duration_cast<std::chrono::seconds>(
+                now - existingGroup.delay_start_time).count();
+
+            if (elapsed_seconds >= new_delay)
+            {
+                SWSS_LOG_INFO("Monitor link group %s delay reduced to %u but %ld seconds already elapsed, bringing UP immediately",
+                              group_name.c_str(), new_delay, elapsed_seconds);
+                stopLinkupDelayTimer(group_name);
+                existingGroup.pending_up = false;
+                existingGroup.is_up = true;
+                updateDownlinkInterfacesForGroupStateChange(group_name, false, true);
+                writeMonitorLinkGroupStateToDb(group_name);
+            }
+            else
+            {
+                uint32_t remaining_seconds = new_delay - static_cast<uint32_t>(elapsed_seconds);
+                SWSS_LOG_INFO("Monitor link group %s delay reduced, restarting timer with %u seconds remaining (new delay: %u, elapsed: %ld)",
+                              group_name.c_str(), remaining_seconds, new_delay, elapsed_seconds);
+
+                stopLinkupDelayTimer(group_name);
+
+                if (existingGroup.linkup_delay_timer != nullptr)
+                {
+                    auto interv = timespec { .tv_sec = static_cast<time_t>(remaining_seconds), .tv_nsec = 0 };
+                    existingGroup.linkup_delay_timer->setInterval(interv);
+                    existingGroup.linkup_delay_timer->start();
+                    // Keep original delay_start_time so future reductions work correctly
+                    SWSS_LOG_DEBUG("MonitorLinkGroupMgr: Started timer with %u seconds for group %s", remaining_seconds, group_name.c_str());
+                }
+            }
+        }
+    }
+}
+
+void MonitorLinkGroupMgr::updateGroupConfiguration(const string& group_name, const string& description,
+                                       uint32_t min_uplinks, uint32_t linkup_delay)
+{
+    MonitorLinkGroupInfo& groupInfo = m_monitorLinkGroups[group_name];
+    groupInfo.description = description;
+    groupInfo.min_uplinks = min_uplinks;
+    groupInfo.linkup_delay = linkup_delay;
+
+    SWSS_LOG_NOTICE("Monitor link group %s configured successfully (total groups: %zu)",
+                    group_name.c_str(), m_monitorLinkGroups.size());
+}
+
+void MonitorLinkGroupMgr::updateGroupInterfaceLists(const string& group_name, const string& uplink_interfaces, const string& downlink_interfaces, bool initial_creation)
+{
+    MonitorLinkGroupInfo& groupInfo = m_monitorLinkGroups[group_name];
+
+    std::set<std::string> new_uplink_interfaces;
+    if (!uplink_interfaces.empty())
+    {
+        std::stringstream ss(uplink_interfaces);
+        std::string interface;
+        while (std::getline(ss, interface, ','))
+        {
+            interface.erase(0, interface.find_first_not_of(" \t"));
+            interface.erase(interface.find_last_not_of(" \t") + 1);
+            if (!interface.empty())
+            {
+                new_uplink_interfaces.insert(interface);
+            }
+        }
+    }
+
+    std::set<std::string> new_downlink_interfaces;
+    if (!downlink_interfaces.empty())
+    {
+        std::stringstream ss(downlink_interfaces);
+        std::string interface;
+        while (std::getline(ss, interface, ','))
+        {
+            interface.erase(0, interface.find_first_not_of(" \t"));
+            interface.erase(interface.find_last_not_of(" \t") + 1);
+            if (!interface.empty())
+            {
+                new_downlink_interfaces.insert(interface);
+            }
+        }
+    }
+
+    // Create a copy to avoid iterator invalidation when removeInterfaceFromGroup modifies the set
+    std::set<std::string> current_uplink_interfaces = groupInfo.uplink_interfaces;
+    for (const auto& interface : current_uplink_interfaces)
+    {
+        if (new_uplink_interfaces.find(interface) == new_uplink_interfaces.end())
+        {
+            removeInterfaceFromGroup(group_name, interface, "uplink");
+        }
+    }
+
+    // Create a copy to avoid iterator invalidation when removeInterfaceFromGroup modifies the set
+    std::set<std::string> current_downlink_interfaces = groupInfo.downlink_interfaces;
+    for (const auto& interface : current_downlink_interfaces)
+    {
+        if (new_downlink_interfaces.find(interface) == new_downlink_interfaces.end())
+        {
+            removeInterfaceFromGroup(group_name, interface, "downlink");
+        }
+    }
+
+    for (const auto& interface : new_uplink_interfaces)
+    {
+        if (groupInfo.uplink_interfaces.find(interface) == groupInfo.uplink_interfaces.end())
+        {
+            addInterfaceToGroup(group_name, interface, "uplink");
+        }
+    }
+
+    for (const auto& interface : new_downlink_interfaces)
+    {
+        if (groupInfo.downlink_interfaces.find(interface) == groupInfo.downlink_interfaces.end())
+        {
+            addInterfaceToGroup(group_name, interface, "downlink");
+        }
+    }
+
+    groupInfo.uplink_interfaces = new_uplink_interfaces;
+    groupInfo.downlink_interfaces = new_downlink_interfaces;
+
+    SWSS_LOG_INFO("Monitor link group %s interface lists updated: %zu uplinks, %zu downlinks",
+                  group_name.c_str(), new_uplink_interfaces.size(), new_downlink_interfaces.size());
+
+    updateMonitorLinkGroupState(group_name, initial_creation);
+}
+
+bool MonitorLinkGroupMgr::handleMonitorLinkGroupDel(const string& group_name)
+{
+    SWSS_LOG_INFO("Deleting monitor link group: %s", group_name.c_str());
+
+    auto groupIt = m_monitorLinkGroups.find(group_name);
+    if (groupIt != m_monitorLinkGroups.end())
+    {
+        uint32_t removed_uplinks = static_cast<uint32_t>(groupIt->second.uplink_interfaces.size());
+        uint32_t removed_downlinks = static_cast<uint32_t>(groupIt->second.downlink_interfaces.size());
+        uint32_t removed_total = removed_uplinks + removed_downlinks;
+
+        // Remove uplink interfaces: erase this group from their uplink_groups;
+        // only delete the interface entry if it belongs to no group at all anymore.
+        for (const auto& interface_name : groupIt->second.uplink_interfaces)
+        {
+            auto interfaceIt = m_monitorLinkInterfaces.find(interface_name);
+            if (interfaceIt == m_monitorLinkInterfaces.end()) continue;
+            interfaceIt->second.uplink_groups.erase(group_name);
+            if (!interfaceIt->second.in_any_group())
+                m_monitorLinkInterfaces.erase(interfaceIt);
+            SWSS_LOG_INFO("Removed uplink interface %s from deleted group %s",
+                          interface_name.c_str(), group_name.c_str());
+        }
+
+        // Remove downlink interfaces: erase this group from their downlink_groups;
+        // delete STATE_DB entry and interface entry only if no groups remain.
+        for (const auto& interface_name : groupIt->second.downlink_interfaces)
+        {
+            auto interfaceIt = m_monitorLinkInterfaces.find(interface_name);
+            if (interfaceIt != m_monitorLinkInterfaces.end())
+            {
+                interfaceIt->second.downlink_groups.erase(group_name);
+
+                bool group_is_up = groupIt->second.is_up && !groupIt->second.pending_up;
+                if (!group_is_up && interfaceIt->second.down_group_count > 0)
+                {
+                    interfaceIt->second.down_group_count--;
+                }
+
+                if (!interfaceIt->second.in_any_group())
+                {
+                    m_stateMonitorLinkGroupMemberTable.del(interface_name);
+                    SWSS_LOG_NOTICE("Removed STATE_DB entry for downlink interface %s to restore config state",
+                                    interface_name.c_str());
+                    m_monitorLinkInterfaces.erase(interfaceIt);
+                }
+                else
+                {
+                    writeMonitorLinkGroupMemberStateToDb(interface_name);
+                    SWSS_LOG_INFO("Updated downlink interface %s state (still in %zu other groups)",
+                                  interface_name.c_str(),
+                                  interfaceIt->second.uplink_groups.size() + interfaceIt->second.downlink_groups.size());
+                }
+            }
+            SWSS_LOG_INFO("Removed downlink interface %s from deleted group %s",
+                          interface_name.c_str(), group_name.c_str());
+        }
+
+        stopLinkupDelayTimer(group_name);
+
+        // Note: We do NOT erase the executor from m_consumerMap here.
+        // The executor/timer remains registered in the Select loop.
+        // If the group is recreated, startLinkupDelayTimer() will recover
+        // the timer pointer from the existing executor and reuse it.
+        // This avoids issues with fd reuse where the new timer's fd might
+        // conflict with the old entry in Select's m_objects map.
+        if (groupIt->second.linkup_delay_timer != nullptr)
+        {
+            SWSS_LOG_NOTICE("MonitorLinkGroupMgr: Keeping executor for deleted group %s (timer stopped, will be reused if group is recreated)",
+                            group_name.c_str());
+            // Clear our reference - the executor still owns the timer
+            groupIt->second.linkup_delay_timer = nullptr;
+        }
+
+        m_monitorLinkGroups.erase(groupIt);
+        m_stateMonitorLinkGroupTable.del(group_name);
+
+        SWSS_LOG_NOTICE("Monitor link group %s deleted successfully (removed %u uplinks, %u downlinks, %u total interfaces, remaining groups: %zu)",
+                        group_name.c_str(), removed_uplinks, removed_downlinks, removed_total, m_monitorLinkGroups.size());
+    }
+    else
+    {
+        SWSS_LOG_WARN("Attempted to delete non-existent monitor link group: %s", group_name.c_str());
+    }
+
+    return true;
+}
+
+bool MonitorLinkGroupMgr::getInterfaceOperState(const string& interface_name)
+{
+    vector<FieldValueTuple> interface_values;
+    bool interface_exists_in_state = false;
+
+    if (interface_name.find(PORTCHANNEL_PREFIX) == 0)
+        interface_exists_in_state = m_stateLagTable.get(interface_name, interface_values);
+    else
+        interface_exists_in_state = m_statePortTable.get(interface_name, interface_values);
+
+    if (interface_exists_in_state)
+    {
+        for (const auto& fv : interface_values)
+        {
+            if (fvField(fv) == "oper_status" || fvField(fv) == "netdev_oper_status")
+            {
+                return (fvValue(fv) == "up");
+            }
+        }
+    }
+
+    return false;
+}
+
+void MonitorLinkGroupMgr::addInterfaceToGroup(const string& group_name, const string& interface_name, const string& link_type)
+{
+    SWSS_LOG_INFO("Adding interface %s as %s to group %s", interface_name.c_str(), link_type.c_str(), group_name.c_str());
+
+    bool interface_exists = (m_monitorLinkInterfaces.find(interface_name) != m_monitorLinkInterfaces.end());
+    MonitorLinkInterfaceInfo& interfaceInfo = m_monitorLinkInterfaces[interface_name];
+
+    if (!interface_exists)
+    {
+        interfaceInfo.is_up = getInterfaceOperState(interface_name);
+        SWSS_LOG_INFO("Monitor link interface %s initial state: %s",
+                      interface_name.c_str(), interfaceInfo.is_up ? "up" : "down");
+    }
+
+    MonitorLinkGroupInfo& groupInfo = m_monitorLinkGroups[group_name];
+    if (link_type == "uplink")
+    {
+        interfaceInfo.uplink_groups.insert(group_name);
+        groupInfo.uplink_interfaces.insert(interface_name);
+        if (interfaceInfo.is_up)
+        {
+            groupInfo.uplink_up_count++;
+        }
+    }
+    else if (link_type == "downlink")
+    {
+        interfaceInfo.downlink_groups.insert(group_name);
+        groupInfo.downlink_interfaces.insert(interface_name);
+
+        bool group_is_up = groupInfo.is_up && !groupInfo.pending_up;
+        if (!group_is_up)
+        {
+            interfaceInfo.down_group_count++;
+        }
+
+        writeMonitorLinkGroupMemberStateToDb(interface_name);
+    }
+
+    SWSS_LOG_INFO("Added interface %s (%s) to group %s (state: %s, %u uplinks up)",
+                  interface_name.c_str(), link_type.c_str(), group_name.c_str(),
+                  interfaceInfo.is_up ? "up" : "down", groupInfo.uplink_up_count);
+}
+
+void MonitorLinkGroupMgr::removeInterfaceFromGroup(const string& group_name, const string& interface_name, const string& link_type)
+{
+    SWSS_LOG_INFO("Removing interface %s (%s) from group %s", interface_name.c_str(), link_type.c_str(), group_name.c_str());
+
+    auto interfaceIt = m_monitorLinkInterfaces.find(interface_name);
+    if (interfaceIt == m_monitorLinkInterfaces.end())
+    {
+        SWSS_LOG_WARN("Attempted to remove non-existent monitor link interface: %s", interface_name.c_str());
+        return;
+    }
+
+    // Verify the interface belongs to the specified group in the specified role
+    bool member = interfaceIt->second.uplink_groups.count(group_name) ||
+                  interfaceIt->second.downlink_groups.count(group_name);
+    if (!member)
+    {
+        SWSS_LOG_WARN("Interface %s does not belong to group %s. Cannot remove from group it's not in.",
+                       interface_name.c_str(), group_name.c_str());
+        return;
+    }
+
+    auto groupIt = m_monitorLinkGroups.find(group_name);
+    if (groupIt != m_monitorLinkGroups.end())
+    {
+        if (link_type == "uplink")
+        {
+            groupIt->second.uplink_interfaces.erase(interface_name);
+            // Decrement up count if interface was up
+            if (interfaceIt->second.is_up && groupIt->second.uplink_up_count > 0)
+            {
+                groupIt->second.uplink_up_count--;
+                SWSS_LOG_INFO("Decremented uplink count for group %s to %u after removing interface %s",
+                              group_name.c_str(), groupIt->second.uplink_up_count, interface_name.c_str());
+            }
+        }
+        else if (link_type == "downlink")
+        {
+            groupIt->second.downlink_interfaces.erase(interface_name);
+
+            // Decrement down_group_count if this group was blocking the interface
+            bool group_is_up = groupIt->second.is_up && !groupIt->second.pending_up;
+            if (!group_is_up && interfaceIt->second.down_group_count > 0)
+            {
+                interfaceIt->second.down_group_count--;
+            }
+        }
+
+        updateMonitorLinkGroupState(group_name);
+    }
+
+    if (link_type == "uplink")
+        interfaceIt->second.uplink_groups.erase(group_name);
+    else
+        interfaceIt->second.downlink_groups.erase(group_name);
+
+    if (link_type == "downlink")
+    {
+        writeMonitorLinkGroupMemberStateToDb(interface_name);
+    }
+
+    if (!interfaceIt->second.in_any_group())
+    {
+        m_stateMonitorLinkGroupMemberTable.del(interface_name);
+        m_monitorLinkInterfaces.erase(interfaceIt);
+        SWSS_LOG_INFO("Monitor link interface %s removed from all groups", interface_name.c_str());
+    }
+    else
+    {
+        size_t remaining = interfaceIt->second.uplink_groups.size() + interfaceIt->second.downlink_groups.size();
+        SWSS_LOG_INFO("Monitor link interface %s removed from group %s (still in %zu other groups)",
+                      interface_name.c_str(), group_name.c_str(), remaining);
+    }
+}
+
+void MonitorLinkGroupMgr::updateMonitorLinkGroupState(const std::string& group_name, bool skip_delay)
+{
+    auto groupIt = m_monitorLinkGroups.find(group_name);
+    if (groupIt == m_monitorLinkGroups.end())
+    {
+        SWSS_LOG_INFO("Group %s not found, cannot update state", group_name.c_str());
+        return;
+    }
+
+    uint32_t threshold = groupIt->second.min_uplinks;
+    uint32_t delay_seconds = groupIt->second.linkup_delay;
+
+    bool should_be_up = (groupIt->second.uplink_up_count >= threshold);
+    bool current_state = groupIt->second.is_up;
+    bool is_pending = groupIt->second.pending_up;
+
+    if (should_be_up && !current_state && !is_pending)
+    {
+        if (delay_seconds > 0 && !skip_delay)
+        {
+            groupIt->second.pending_up = true;
+            updateDownlinkInterfacesForGroupStateChange(group_name, false, false);
+            startLinkupDelayTimer(group_name);
+            SWSS_LOG_NOTICE("Monitor link group %s starting %u second linkup delay before going UP (%u uplinks up, threshold: %u)",
+                            group_name.c_str(), delay_seconds, groupIt->second.uplink_up_count, threshold);
+        }
+        else
+        {
+            groupIt->second.is_up = true;
+            updateDownlinkInterfacesForGroupStateChange(group_name, false, true);
+            SWSS_LOG_NOTICE("Monitor link group %s state changed: UP (%u uplinks up, threshold: %u)",
+                            group_name.c_str(), groupIt->second.uplink_up_count, threshold);
+        }
+    }
+    else if (!should_be_up && (current_state || is_pending))
+    {
+        stopLinkupDelayTimer(group_name);
+        if (is_pending)
+        {
+            groupIt->second.pending_up = false;
+            SWSS_LOG_NOTICE("Monitor link group %s cancelled linkup delay (%u uplinks up, threshold: %u)",
+                            group_name.c_str(), groupIt->second.uplink_up_count, threshold);
+        }
+        if (current_state)
+        {
+            groupIt->second.is_up = false;
+            updateDownlinkInterfacesForGroupStateChange(group_name, true, false);
+            SWSS_LOG_NOTICE("Monitor link group %s state changed: DOWN (%u uplinks up, threshold: %u)",
+                            group_name.c_str(), groupIt->second.uplink_up_count, threshold);
+        }
+    }
+
+    writeMonitorLinkGroupStateToDb(group_name);
+}
+
+void MonitorLinkGroupMgr::doTask(SelectableTimer &timer)
+{
+    timer.stop();
+
+    for (auto& group_pair : m_monitorLinkGroups) {
+        if (group_pair.second.linkup_delay_timer == &timer) {
+            SWSS_LOG_NOTICE("Monitor link group %s linkup delay timer expired", group_pair.first.c_str());
+            handleLinkupDelayExpired(group_pair.first);
+            return;
+        }
+    }
+
+    SWSS_LOG_WARN("MonitorLinkGroupMgr: Linkup delay timer expired but no matching group found");
+}
+
+void MonitorLinkGroupMgr::startLinkupDelayTimer(const std::string& group_name)
+{
+    auto groupIt = m_monitorLinkGroups.find(group_name);
+    if (groupIt == m_monitorLinkGroups.end())
+    {
+        SWSS_LOG_ERROR("MonitorLinkGroupMgr: Cannot start linkup delay timer for unknown group %s", group_name.c_str());
+        return;
+    }
+
+    MonitorLinkGroupInfo& group_info = groupIt->second;
+    uint32_t delay_seconds = group_info.linkup_delay;
+
+    if (delay_seconds > 0)
+    {
+        string executor_name = "MONITOR_LINK_LINKUP_DELAY_" + group_name;
+        Executor* existing_executor = Orch::getExecutor(executor_name);
+        if (existing_executor != nullptr)
+        {
+            if (group_info.linkup_delay_timer == nullptr)
+            {
+                // Group was deleted and recreated — recover timer pointer from executor
+                ExecutableTimer* exec_timer = dynamic_cast<ExecutableTimer*>(existing_executor);
+                if (exec_timer != nullptr)
+                {
+                    group_info.linkup_delay_timer = exec_timer->getSelectableTimer();
+                    SWSS_LOG_NOTICE("MonitorLinkGroupMgr: Recovered timer pointer from existing executor for group %s",
+                                    group_name.c_str());
+                }
+                else
+                {
+                    SWSS_LOG_ERROR("MonitorLinkGroupMgr: Executor %s exists but is not ExecutableTimer for group %s",
+                                   executor_name.c_str(), group_name.c_str());
+                    return;
+                }
+            }
+            group_info.linkup_delay_timer->stop();
+        }
+        else if (group_info.linkup_delay_timer == nullptr)
+        {
+            auto interv = timespec { .tv_sec = 1, .tv_nsec = 0 };
+            group_info.linkup_delay_timer = new SelectableTimer(interv);
+
+            auto executor = new ExecutableTimer(group_info.linkup_delay_timer, this, executor_name);
+
+            SWSS_LOG_NOTICE("MonitorLinkGroupMgr: Creating linkup delay timer for group %s (executor=%s)",
+                            group_name.c_str(), executor_name.c_str());
+
+            try {
+                Orch::addExecutor(executor);
+            } catch (const std::exception& e) {
+                SWSS_LOG_ERROR("MonitorLinkGroupMgr: Failed to add linkup delay executor for group %s: %s", group_name.c_str(), e.what());
+                // Executor destructor will delete the timer (m_selectable)
+                delete executor;
+                group_info.linkup_delay_timer = nullptr;
+                throw;
+            }
+        }
+        else
+        {
+            group_info.linkup_delay_timer->stop();
+        }
+
+        auto interv = timespec { .tv_sec = static_cast<time_t>(delay_seconds), .tv_nsec = 0 };
+        group_info.linkup_delay_timer->setInterval(interv);
+        group_info.linkup_delay_timer->start();
+        group_info.delay_start_time = std::chrono::steady_clock::now();
+
+        SWSS_LOG_NOTICE("MonitorLinkGroupMgr: Started %u second linkup delay timer for group %s",
+                        delay_seconds, group_name.c_str());
+    }
+}
+
+void MonitorLinkGroupMgr::stopLinkupDelayTimer(const std::string& group_name)
+{
+    auto groupIt = m_monitorLinkGroups.find(group_name);
+    if (groupIt == m_monitorLinkGroups.end())
+    {
+        return;
+    }
+
+    if (groupIt->second.linkup_delay_timer != nullptr)
+    {
+        groupIt->second.linkup_delay_timer->stop();
+        SWSS_LOG_DEBUG("MonitorLinkGroupMgr: Stopped linkup delay timer for group %s", group_name.c_str());
+    }
+}
+
+void MonitorLinkGroupMgr::handleLinkupDelayExpired(const std::string& group_name)
+{
+    auto groupIt = m_monitorLinkGroups.find(group_name);
+    if (groupIt == m_monitorLinkGroups.end())
+    {
+        SWSS_LOG_ERROR("MonitorLinkGroupMgr: Cannot handle linkup delay expiry for unknown group %s", group_name.c_str());
+        return;
+    }
+
+    MonitorLinkGroupInfo& group_info = groupIt->second;
+
+    if (!group_info.pending_up)
+    {
+        SWSS_LOG_WARN("MonitorLinkGroupMgr: Linkup delay timer expired for group %s but group is not pending UP", group_name.c_str());
+        return;
+    }
+
+    uint32_t threshold = group_info.min_uplinks;
+
+    if (group_info.uplink_up_count >= threshold)
+    {
+        group_info.pending_up = false;
+        group_info.is_up = true;
+
+        updateDownlinkInterfacesForGroupStateChange(group_name, false, true);
+        writeMonitorLinkGroupStateToDb(group_name);
+
+        SWSS_LOG_NOTICE("MonitorLinkGroupMgr: Monitor link group %s state changed: UP after linkup delay (%u uplinks up, threshold: %u)",
+                        group_name.c_str(), group_info.uplink_up_count, threshold);
+    }
+    else
+    {
+        group_info.pending_up = false;
+
+        SWSS_LOG_NOTICE("MonitorLinkGroupMgr: Monitor link group %s cancelled linkup delay - threshold no longer met (%u uplinks up, threshold: %u)",
+                        group_name.c_str(), group_info.uplink_up_count, threshold);
+    }
+}
+
+void MonitorLinkGroupMgr::writeMonitorLinkGroupStateToDb(const std::string& group_name)
+{
+    auto groupIt = m_monitorLinkGroups.find(group_name);
+    if (groupIt == m_monitorLinkGroups.end())
+        return;
+
+    std::string state;
+    if (groupIt->second.pending_up)
+        state = "pending";
+    else if (groupIt->second.is_up)
+        state = "up";
+    else
+        state = "down";
+
+    std::string uplink_interfaces_str;
+    bool first = true;
+    for (const auto& interface : groupIt->second.uplink_interfaces)
+    {
+        if (!first) uplink_interfaces_str += ",";
+        uplink_interfaces_str += interface;
+        first = false;
+    }
+
+    std::string downlink_interfaces_str;
+    first = true;
+    for (const auto& interface : groupIt->second.downlink_interfaces)
+    {
+        if (!first) downlink_interfaces_str += ",";
+        downlink_interfaces_str += interface;
+        first = false;
+    }
+
+    std::vector<FieldValueTuple> fvVector;
+    fvVector.emplace_back("state", state);
+    fvVector.emplace_back("description", groupIt->second.description);
+    fvVector.emplace_back("uplinks", uplink_interfaces_str);
+    fvVector.emplace_back("downlinks", downlink_interfaces_str);
+    fvVector.emplace_back("link_up_threshold", std::to_string(groupIt->second.min_uplinks));
+    fvVector.emplace_back("link_up_delay", std::to_string(groupIt->second.linkup_delay));
+
+    SWSS_LOG_INFO("Writing to STATE_DB for group %s: state='%s', uplinks='%s', downlinks='%s'",
+                  group_name.c_str(), state.c_str(), uplink_interfaces_str.c_str(), downlink_interfaces_str.c_str());
+
+    m_stateMonitorLinkGroupTable.set(group_name, fvVector);
+}
+
+void MonitorLinkGroupMgr::writeMonitorLinkGroupMemberStateToDb(const std::string& interface_name)
+{
+    std::vector<FieldValueTuple> fvVector;
+
+    auto interfaceIt = m_monitorLinkInterfaces.find(interface_name);
+    if (interfaceIt == m_monitorLinkInterfaces.end() || interfaceIt->second.downlink_groups.empty())
+        return;
+
+    std::string state = (interfaceIt->second.down_group_count == 0) ? "allow_up" : "force_down";
+    fvVector.emplace_back("state", state);
+
+    // Build down_due_to: groups in this interface's downlink_groups that are currently DOWN/PENDING
+    std::string down_due_to_str;
+    bool first = true;
+    for (const auto& group_name : interfaceIt->second.downlink_groups)
+    {
+        auto groupIt = m_monitorLinkGroups.find(group_name);
+        if (groupIt != m_monitorLinkGroups.end())
+        {
+            bool group_is_up = groupIt->second.is_up && !groupIt->second.pending_up;
+            if (!group_is_up)
+            {
+                if (!first) down_due_to_str += ",";
+                down_due_to_str += group_name;
+                first = false;
+            }
+        }
+    }
+
+    fvVector.emplace_back("down_due_to", down_due_to_str);
+
+    SWSS_LOG_INFO("Writing to STATE_DB for interface %s: state='%s', down_due_to='%s'",
+                  interface_name.c_str(), state.c_str(), down_due_to_str.c_str());
+
+    m_stateMonitorLinkGroupMemberTable.set(interface_name, fvVector);
+}
+
+bool MonitorLinkGroupMgr::updateMonitorLinkInterfaceState(const std::string& interface_name, bool is_up)
+{
+    auto interfaceIt = m_monitorLinkInterfaces.find(interface_name);
+    if (interfaceIt == m_monitorLinkInterfaces.end())
+        return false;
+
+    bool previous_state = interfaceIt->second.is_up;
+    if (previous_state == is_up)
+        return true;
+
+    interfaceIt->second.is_up = is_up;
+
+    // Uplink oper change drives group state; downlink oper change does not
+    for (const auto& group_name : interfaceIt->second.uplink_groups)
+    {
+        auto groupIt = m_monitorLinkGroups.find(group_name);
+        if (groupIt == m_monitorLinkGroups.end()) continue;
+
+        if (is_up && !previous_state)
+        {
+            groupIt->second.uplink_up_count++;
+            SWSS_LOG_INFO("Monitor link interface %s (uplink) in group %s went UP (%u uplinks up)",
+                          interface_name.c_str(), group_name.c_str(), groupIt->second.uplink_up_count);
+        }
+        else if (!is_up && previous_state)
+        {
+            if (groupIt->second.uplink_up_count > 0) groupIt->second.uplink_up_count--;
+            SWSS_LOG_INFO("Monitor link interface %s (uplink) in group %s went DOWN (%u uplinks up)",
+                          interface_name.c_str(), group_name.c_str(), groupIt->second.uplink_up_count);
+        }
+        updateMonitorLinkGroupState(group_name);
+    }
+
+    return true;
+}
+
+void MonitorLinkGroupMgr::updateDownlinkInterfacesForGroupStateChange(const std::string& group_name, bool group_was_up, bool group_is_up)
+{
+    auto groupIt = m_monitorLinkGroups.find(group_name);
+    if (groupIt == m_monitorLinkGroups.end())
+        return;
+
+    if (group_was_up == group_is_up)
+        return;
+
+    // No link_type guard needed: iterating the group's own downlink_interfaces set,
+    // so every interface here is definitionally a downlink of this group.
+    for (const auto& interface_name : groupIt->second.downlink_interfaces)
+    {
+        auto interfaceIt = m_monitorLinkInterfaces.find(interface_name);
+        if (interfaceIt == m_monitorLinkInterfaces.end()) continue;
+
+        if (!group_was_up && group_is_up)
+        {
+            if (interfaceIt->second.down_group_count > 0)
+                interfaceIt->second.down_group_count--;
+        }
+        else if (group_was_up && !group_is_up)
+        {
+            interfaceIt->second.down_group_count++;
+        }
+
+        writeMonitorLinkGroupMemberStateToDb(interface_name);
+
+        SWSS_LOG_INFO("MonitorLinkGroupMgr: Updated STATE_DB for interface %s due to group %s state change (%s → %s)",
+                     interface_name.c_str(), group_name.c_str(),
+                     group_was_up ? "UP" : "DOWN", group_is_up ? "UP" : "DOWN");
+    }
+
+    SWSS_LOG_DEBUG("MonitorLinkGroupMgr: Updated down_group_count for %zu downlink interfaces in group %s (%s → %s)",
+                   groupIt->second.downlink_interfaces.size(), group_name.c_str(),
+                   group_was_up ? "UP" : "DOWN", group_is_up ? "UP" : "DOWN");
+}

--- a/cfgmgr/monitorlinkgroupmgr.cpp
+++ b/cfgmgr/monitorlinkgroupmgr.cpp
@@ -51,11 +51,7 @@ void MonitorLinkGroupMgr::doTask(Consumer &consumer)
 
             if (keys.size() == 1)
             {
-                if (!doMonitorLinkGroupTask(keys, data, op))
-                {
-                    it++;
-                    continue;
-                }
+                doMonitorLinkGroupTask(keys, data, op);
             }
             else
             {
@@ -88,9 +84,13 @@ void MonitorLinkGroupMgr::doPortTableTask(const string& key, vector<FieldValueTu
         else if (!oper_status_val.empty())
             updateMonitorLinkInterfaceState(key, oper_status_val == "up");
     }
+    else if (op == DEL_COMMAND)
+    {
+        updateMonitorLinkInterfaceState(key, false);
+    }
 }
 
-bool MonitorLinkGroupMgr::doMonitorLinkGroupTask(const vector<string>& keys, const vector<FieldValueTuple>& data, const string& op)
+void MonitorLinkGroupMgr::doMonitorLinkGroupTask(const vector<string>& keys, const vector<FieldValueTuple>& data, const string& op)
 {
     SWSS_LOG_ENTER();
 
@@ -100,16 +100,15 @@ bool MonitorLinkGroupMgr::doMonitorLinkGroupTask(const vector<string>& keys, con
 
     if (op == SET_COMMAND)
     {
-        return handleMonitorLinkGroupSet(group_name, data);
+        handleMonitorLinkGroupSet(group_name, data);
     }
     else if (op == DEL_COMMAND)
     {
-        return handleMonitorLinkGroupDel(group_name);
+        handleMonitorLinkGroupDel(group_name);
     }
     else
     {
         SWSS_LOG_ERROR("Unknown operation: %s for monitor link group", op.c_str());
-        return false;
     }
 }
 
@@ -401,7 +400,7 @@ bool MonitorLinkGroupMgr::handleMonitorLinkGroupDel(const string& group_name)
         {
             SWSS_LOG_NOTICE("MonitorLinkGroupMgr: Keeping executor for deleted group %s (timer stopped, will be reused if group is recreated)",
                             group_name.c_str());
-            // Clear our reference - the executor still owns the timer
+            m_timerToGroup.erase(groupIt->second.linkup_delay_timer);
             groupIt->second.linkup_delay_timer = nullptr;
         }
 
@@ -424,10 +423,9 @@ bool MonitorLinkGroupMgr::getInterfaceOperState(const string& interface_name)
     vector<FieldValueTuple> interface_values;
     bool interface_exists_in_state = false;
 
-    if (interface_name.find(PORTCHANNEL_PREFIX) == 0)
+    interface_exists_in_state = m_statePortTable.get(interface_name, interface_values);
+    if (!interface_exists_in_state)
         interface_exists_in_state = m_stateLagTable.get(interface_name, interface_values);
-    else
-        interface_exists_in_state = m_statePortTable.get(interface_name, interface_values);
 
     if (!interface_exists_in_state)
         return false;
@@ -502,12 +500,13 @@ void MonitorLinkGroupMgr::removeInterfaceFromGroup(const string& group_name, con
     }
 
     // Verify the interface belongs to the specified group in the specified role
-    bool member = interfaceIt->second.uplink_groups.count(group_name) ||
-                  interfaceIt->second.downlink_groups.count(group_name);
+    bool member = (link_type == "uplink")
+        ? interfaceIt->second.uplink_groups.count(group_name) > 0
+        : interfaceIt->second.downlink_groups.count(group_name) > 0;
     if (!member)
     {
-        SWSS_LOG_WARN("Interface %s does not belong to group %s. Cannot remove from group it's not in.",
-                       interface_name.c_str(), group_name.c_str());
+        SWSS_LOG_WARN("Interface %s does not belong to group %s as %s. Cannot remove.",
+                       interface_name.c_str(), group_name.c_str(), link_type.c_str());
         return;
     }
 
@@ -537,7 +536,6 @@ void MonitorLinkGroupMgr::removeInterfaceFromGroup(const string& group_name, con
             }
         }
 
-        updateMonitorLinkGroupState(group_name);
     }
 
     if (link_type == "uplink")
@@ -623,12 +621,12 @@ void MonitorLinkGroupMgr::doTask(SelectableTimer &timer)
 {
     timer.stop();
 
-    for (auto& group_pair : m_monitorLinkGroups) {
-        if (group_pair.second.linkup_delay_timer == &timer) {
-            SWSS_LOG_NOTICE("Monitor link group %s linkup delay timer expired", group_pair.first.c_str());
-            handleLinkupDelayExpired(group_pair.first);
-            return;
-        }
+    auto it = m_timerToGroup.find(&timer);
+    if (it != m_timerToGroup.end())
+    {
+        SWSS_LOG_NOTICE("Monitor link group %s linkup delay timer expired", it->second.c_str());
+        handleLinkupDelayExpired(it->second);
+        return;
     }
 
     SWSS_LOG_WARN("MonitorLinkGroupMgr: Linkup delay timer expired but no matching group found");
@@ -673,7 +671,7 @@ void MonitorLinkGroupMgr::startLinkupDelayTimer(const std::string& group_name)
         }
         else if (group_info.linkup_delay_timer == nullptr)
         {
-            auto interv = timespec { .tv_sec = 1, .tv_nsec = 0 };
+            auto interv = timespec { .tv_sec = static_cast<time_t>(delay_seconds), .tv_nsec = 0 };
             group_info.linkup_delay_timer = new SelectableTimer(interv);
 
             auto executor = new ExecutableTimer(group_info.linkup_delay_timer, this, executor_name);
@@ -696,6 +694,7 @@ void MonitorLinkGroupMgr::startLinkupDelayTimer(const std::string& group_name)
             group_info.linkup_delay_timer->stop();
         }
 
+        m_timerToGroup[group_info.linkup_delay_timer] = group_name;
         auto interv = timespec { .tv_sec = static_cast<time_t>(delay_seconds), .tv_nsec = 0 };
         group_info.linkup_delay_timer->setInterval(interv);
         group_info.linkup_delay_timer->start();
@@ -754,6 +753,7 @@ void MonitorLinkGroupMgr::handleLinkupDelayExpired(const std::string& group_name
     else
     {
         group_info.pending_up = false;
+        writeMonitorLinkGroupStateToDb(group_name);
 
         SWSS_LOG_NOTICE("MonitorLinkGroupMgr: Monitor link group %s cancelled linkup delay - threshold no longer met (%u uplinks up, threshold: %u)",
                         group_name.c_str(), group_info.uplink_up_count, threshold);

--- a/cfgmgr/monitorlinkgroupmgr.cpp
+++ b/cfgmgr/monitorlinkgroupmgr.cpp
@@ -288,20 +288,13 @@ void MonitorLinkGroupMgr::handleGroupDelayChange(const string& group_name, uint3
 
     if (existingGroup.pending_up)
     {
-        uint32_t up_count = existingGroup.monitored_up_count;
-        uint32_t total = static_cast<uint32_t>(existingGroup.monitored_interfaces.size());
-        uint32_t threshold = existingGroup.min_monitored_links;
-
         if (new_delay == 0)
         {
             SWSS_LOG_INFO("Monitor link group %s delay changed to 0, bringing UP immediately", group_name.c_str());
             stopLinkupDelayTimer(group_name);
             existingGroup.pending_up = false;
             existingGroup.is_up = true;
-            std::ostringstream reason;
-            reason << "link-up-delay reduced to 0 (monitored " << up_count << "/" << total
-                   << " >= min-monitored-links " << threshold << ")";
-            recordStateTransition(group_name, "pending", "up", reason.str());
+            recordStateTransition(group_name, "pending", "up");
             updateManagedInterfacesForGroupStateChange(group_name, false, true);
             writeMonitorLinkGroupStateToDb(group_name);
         }
@@ -318,10 +311,7 @@ void MonitorLinkGroupMgr::handleGroupDelayChange(const string& group_name, uint3
                 stopLinkupDelayTimer(group_name);
                 existingGroup.pending_up = false;
                 existingGroup.is_up = true;
-                std::ostringstream reason;
-                reason << "link-up-delay reduced, already elapsed (monitored " << up_count << "/"
-                       << total << " >= min-monitored-links " << threshold << ")";
-                recordStateTransition(group_name, "pending", "up", reason.str());
+                recordStateTransition(group_name, "pending", "up");
                 updateManagedInterfacesForGroupStateChange(group_name, false, true);
                 writeMonitorLinkGroupStateToDb(group_name);
             }
@@ -687,18 +677,13 @@ void MonitorLinkGroupMgr::updateMonitorLinkGroupState(const std::string& group_n
     bool current_state = groupIt->second.is_up;
     bool is_pending = groupIt->second.pending_up;
     uint32_t up_count = groupIt->second.monitored_up_count;
-    uint32_t total = static_cast<uint32_t>(groupIt->second.monitored_interfaces.size());
 
     if (should_be_up && !current_state && !is_pending)
     {
         if (delay_seconds > 0 && !skip_delay)
         {
             groupIt->second.pending_up = true;
-            std::ostringstream reason;
-            reason << "monitored " << up_count << "/" << total
-                   << " >= min-monitored-links " << threshold
-                   << ", starting link-up-delay";
-            recordStateTransition(group_name, "down", "pending", reason.str());
+            recordStateTransition(group_name, "down", "pending");
             updateManagedInterfacesForGroupStateChange(group_name, false, false);
             startLinkupDelayTimer(group_name);
             SWSS_LOG_NOTICE("Monitor link group %s starting %u second linkup delay before going UP (%u monitored up, threshold: %u)",
@@ -707,10 +692,7 @@ void MonitorLinkGroupMgr::updateMonitorLinkGroupState(const std::string& group_n
         else
         {
             groupIt->second.is_up = true;
-            std::ostringstream reason;
-            reason << "monitored " << up_count << "/" << total
-                   << " >= min-monitored-links " << threshold;
-            recordStateTransition(group_name, "down", "up", reason.str());
+            recordStateTransition(group_name, "down", "up");
             updateManagedInterfacesForGroupStateChange(group_name, false, true);
             SWSS_LOG_NOTICE("Monitor link group %s state changed: UP (%u monitored up, threshold: %u)",
                             group_name.c_str(), up_count, threshold);
@@ -726,11 +708,7 @@ void MonitorLinkGroupMgr::updateMonitorLinkGroupState(const std::string& group_n
         if (is_pending && !current_state)
         {
             groupIt->second.pending_up = false;
-            std::ostringstream reason;
-            reason << "monitored " << up_count << "/" << total
-                   << " < min-monitored-links " << threshold
-                   << ", cancelled link-up-delay";
-            recordStateTransition(group_name, "pending", "down", reason.str());
+            recordStateTransition(group_name, "pending", "down");
             SWSS_LOG_NOTICE("Monitor link group %s cancelled linkup delay (%u monitored up, threshold: %u)",
                             group_name.c_str(), up_count, threshold);
         }
@@ -743,10 +721,7 @@ void MonitorLinkGroupMgr::updateMonitorLinkGroupState(const std::string& group_n
                 groupIt->second.pending_up = false;
             }
             groupIt->second.is_up = false;
-            std::ostringstream reason;
-            reason << "monitored " << up_count << "/" << total
-                   << " < min-monitored-links " << threshold;
-            recordStateTransition(group_name, "up", "down", reason.str());
+            recordStateTransition(group_name, "up", "down");
             updateManagedInterfacesForGroupStateChange(group_name, true, false);
             SWSS_LOG_NOTICE("Monitor link group %s state changed: DOWN (%u monitored up, threshold: %u)",
                             group_name.c_str(), up_count, threshold);
@@ -878,17 +853,13 @@ void MonitorLinkGroupMgr::handleLinkupDelayExpired(const std::string& group_name
 
     uint32_t threshold = group_info.min_monitored_links;
     uint32_t up_count = group_info.monitored_up_count;
-    uint32_t total = static_cast<uint32_t>(group_info.monitored_interfaces.size());
 
     if (up_count >= threshold)
     {
         group_info.pending_up = false;
         group_info.is_up = true;
 
-        std::ostringstream reason;
-        reason << "link-up-delay expired (monitored " << up_count << "/" << total
-               << " >= min-monitored-links " << threshold << ")";
-        recordStateTransition(group_name, "pending", "up", reason.str());
+        recordStateTransition(group_name, "pending", "up");
 
         updateManagedInterfacesForGroupStateChange(group_name, false, true);
         writeMonitorLinkGroupStateToDb(group_name);
@@ -900,11 +871,7 @@ void MonitorLinkGroupMgr::handleLinkupDelayExpired(const std::string& group_name
     {
         group_info.pending_up = false;
 
-        std::ostringstream reason;
-        reason << "monitored " << up_count << "/" << total
-               << " < min-monitored-links " << threshold
-               << ", cancelled link-up-delay";
-        recordStateTransition(group_name, "pending", "down", reason.str());
+        recordStateTransition(group_name, "pending", "down");
 
         writeMonitorLinkGroupStateToDb(group_name);
 
@@ -963,7 +930,6 @@ void MonitorLinkGroupMgr::writeMonitorLinkGroupStateToDb(const std::string& grou
         fvVector.emplace_back("last_state_change_time", std::to_string(epoch));
         fvVector.emplace_back("last_state_change_from", g.last_state_change_from);
         fvVector.emplace_back("last_state_change_to", g.last_state_change_to);
-        fvVector.emplace_back("last_state_change_reason", g.last_state_change_reason);
     }
     if (state == "pending")
     {
@@ -971,8 +937,7 @@ void MonitorLinkGroupMgr::writeMonitorLinkGroupStateToDb(const std::string& grou
             g.pending_start_time.time_since_epoch()).count();
         fvVector.emplace_back("pending_start_time", std::to_string(epoch));
     }
-    fvVector.emplace_back("up_to_down_count", std::to_string(g.up_to_down_count));
-    fvVector.emplace_back("down_to_up_count", std::to_string(g.down_to_up_count));
+    fvVector.emplace_back("total_transitions", std::to_string(g.total_transitions));
 
     SWSS_LOG_INFO("Writing to STATE_DB for group %s: state='%s', monitored-links='%s', managed-links='%s'",
                   group_name.c_str(), state.c_str(), monitored_interfaces_str.c_str(), managed_interfaces_str.c_str());
@@ -990,8 +955,7 @@ void MonitorLinkGroupMgr::writeMonitorLinkGroupStateToDb(const std::string& grou
 
 void MonitorLinkGroupMgr::recordStateTransition(const std::string& group_name,
                                                 const std::string& from_state,
-                                                const std::string& to_state,
-                                                const std::string& reason)
+                                                const std::string& to_state)
 {
     auto groupIt = m_monitorLinkGroups.find(group_name);
     if (groupIt == m_monitorLinkGroups.end())
@@ -1004,7 +968,6 @@ void MonitorLinkGroupMgr::recordStateTransition(const std::string& group_name,
     g.has_state_change = true;
     g.last_state_change_from = from_state;
     g.last_state_change_to = to_state;
-    g.last_state_change_reason = reason;
     g.last_state_change_time = now;
 
     if (to_state == "pending")
@@ -1012,41 +975,28 @@ void MonitorLinkGroupMgr::recordStateTransition(const std::string& group_name,
         g.pending_start_time = now;
     }
 
-    // Counter rules (D-2, D-3):
-    //   * any path landing in UP bumps down_to_up_count (DOWN -> UP and PENDING -> UP).
-    //   * only a direct UP -> DOWN bumps up_to_down_count; PENDING -> DOWN is a
-    //     near-recovery-that-failed, not a flap.
-    if (to_state == "up")
-    {
-        g.down_to_up_count++;
-    }
-    else if (from_state == "up" && to_state == "down")
-    {
-        g.up_to_down_count++;
-    }
+    // Every recorded transition counts equally. The asymmetric directional counters
+    // were redundant (d2u == u2d or d2u == u2d + 1 always) and convey no information
+    // beyond what last_state_change_to + total_transitions already does.
+    g.total_transitions++;
 
-    SWSS_LOG_NOTICE("Monitor link group %s transition: %s -> %s (%s)",
-                    group_name.c_str(), from_state.c_str(), to_state.c_str(), reason.c_str());
+    SWSS_LOG_NOTICE("Monitor link group %s transition: %s -> %s",
+                    group_name.c_str(), from_state.c_str(), to_state.c_str());
 }
 
 void MonitorLinkGroupMgr::restoreGroupCountersFromStateDb(const std::string& group_name)
 {
-    // Counters live in MonitorLinkGroupInfo (in-memory) and would otherwise reset on
-    // intfmgrd restart. Telemetry/SNMP consumers expect monotonic counters, so reload
-    // them from STATE_DB if a prior incarnation left them there.
+    // total_transitions lives in MonitorLinkGroupInfo (in-memory) and would otherwise
+    // reset on intfmgrd restart. Telemetry/SNMP consumers expect monotonic counters,
+    // so reload from STATE_DB if a prior incarnation left it there.
     auto groupIt = m_monitorLinkGroups.find(group_name);
     if (groupIt == m_monitorLinkGroups.end())
         return;
 
     std::string value;
-    if (m_stateMonitorLinkGroupTable.hget(group_name, "up_to_down_count", value))
+    if (m_stateMonitorLinkGroupTable.hget(group_name, "total_transitions", value))
     {
-        try { groupIt->second.up_to_down_count = std::stoull(value); }
-        catch (const std::exception&) { /* leave at 0 */ }
-    }
-    if (m_stateMonitorLinkGroupTable.hget(group_name, "down_to_up_count", value))
-    {
-        try { groupIt->second.down_to_up_count = std::stoull(value); }
+        try { groupIt->second.total_transitions = std::stoull(value); }
         catch (const std::exception&) { /* leave at 0 */ }
     }
 }

--- a/cfgmgr/monitorlinkgroupmgr.cpp
+++ b/cfgmgr/monitorlinkgroupmgr.cpp
@@ -306,8 +306,8 @@ void MonitorLinkGroupMgr::handleGroupDelayChange(const string& group_name, uint3
 
             if (elapsed_seconds >= new_delay)
             {
-                SWSS_LOG_INFO("Monitor link group %s delay reduced to %u but %ld seconds already elapsed, bringing UP immediately",
-                              group_name.c_str(), new_delay, elapsed_seconds);
+                SWSS_LOG_INFO("Monitor link group %s delay reduced to %u but %lld seconds already elapsed, bringing UP immediately",
+                              group_name.c_str(), new_delay, static_cast<long long>(elapsed_seconds));
                 stopLinkupDelayTimer(group_name);
                 existingGroup.pending_up = false;
                 existingGroup.is_up = true;
@@ -318,8 +318,8 @@ void MonitorLinkGroupMgr::handleGroupDelayChange(const string& group_name, uint3
             else
             {
                 uint32_t remaining_seconds = new_delay - static_cast<uint32_t>(elapsed_seconds);
-                SWSS_LOG_INFO("Monitor link group %s delay reduced, restarting timer with %u seconds remaining (new delay: %u, elapsed: %ld)",
-                              group_name.c_str(), remaining_seconds, new_delay, elapsed_seconds);
+                SWSS_LOG_INFO("Monitor link group %s delay reduced, restarting timer with %u seconds remaining (new delay: %u, elapsed: %lld)",
+                              group_name.c_str(), remaining_seconds, new_delay, static_cast<long long>(elapsed_seconds));
 
                 stopLinkupDelayTimer(group_name);
 

--- a/cfgmgr/monitorlinkgroupmgr.cpp
+++ b/cfgmgr/monitorlinkgroupmgr.cpp
@@ -6,6 +6,7 @@
 #include "monitorlinkgroupmgr.h"
 
 #include <sstream>
+#include <functional>
 
 using namespace std;
 using namespace swss;
@@ -115,10 +116,10 @@ void MonitorLinkGroupMgr::doMonitorLinkGroupTask(const vector<string>& keys, con
 bool MonitorLinkGroupMgr::handleMonitorLinkGroupSet(const string& group_name, const vector<FieldValueTuple>& data)
 {
     string description;
-    uint32_t min_uplinks = 1;
+    uint32_t min_monitored_links = 1;
     uint32_t linkup_delay = 0;
-    string uplink_interfaces;
-    string downlink_interfaces;
+    string monitored_interfaces;
+    string managed_interfaces;
 
     for (auto idx : data)
     {
@@ -129,17 +130,17 @@ bool MonitorLinkGroupMgr::handleMonitorLinkGroupSet(const string& group_name, co
         {
             description = value;
         }
-        else if (field == "min-uplinks")
+        else if (field == "min-monitored-links")
         {
             try
             {
-                min_uplinks = static_cast<uint32_t>(std::stoul(value));
+                min_monitored_links = static_cast<uint32_t>(std::stoul(value));
             }
             catch (const std::exception&)
             {
-                SWSS_LOG_WARN("Monitor link group %s: invalid min-uplinks '%s', using 1",
+                SWSS_LOG_WARN("Monitor link group %s: invalid min-monitored-links '%s', using 1",
                               group_name.c_str(), value.c_str());
-                min_uplinks = 1;
+                min_monitored_links = 1;
             }
         }
         else if (field == "link-up-delay")
@@ -155,19 +156,32 @@ bool MonitorLinkGroupMgr::handleMonitorLinkGroupSet(const string& group_name, co
                 linkup_delay = 0;
             }
         }
-        else if (field == "uplinks")
+        else if (field == "monitored-links")
         {
-            uplink_interfaces = value;
+            monitored_interfaces = value;
         }
-        else if (field == "downlinks")
+        else if (field == "managed-links")
         {
-            downlink_interfaces = value;
+            managed_interfaces = value;
         }
     }
 
-    SWSS_LOG_INFO("Monitor link group %s: description='%s', min-uplinks=%u, link-up-delay=%u, uplinks='%s', downlinks='%s'",
-                  group_name.c_str(), description.c_str(), min_uplinks, linkup_delay,
-                  uplink_interfaces.c_str(), downlink_interfaces.c_str());
+    SWSS_LOG_INFO("Monitor link group %s: description='%s', min-monitored-links=%u, link-up-delay=%u, monitored-links='%s', managed-links='%s'",
+                  group_name.c_str(), description.c_str(), min_monitored_links, linkup_delay,
+                  monitored_interfaces.c_str(), managed_interfaces.c_str());
+
+    // R-6: reject configs that would form a dependency cycle between groups.
+    // Edge G -> H: a port in G.monitored is in H.managed (G's recovery waits on H).
+    // A cycle means the involved groups deadlock with no path to recovery.
+    set<string> monitored_set = parseInterfaceList(monitored_interfaces);
+    set<string> managed_set = parseInterfaceList(managed_interfaces);
+    if (wouldCreateDependencyCycle(group_name, monitored_set, managed_set))
+    {
+        SWSS_LOG_ERROR("Monitor link group %s rejected: monitored/managed interface lists "
+                       "would form a dependency cycle with existing groups",
+                       group_name.c_str());
+        return false;
+    }
 
     bool is_new_group = (m_monitorLinkGroups.find(group_name) == m_monitorLinkGroups.end());
 
@@ -178,9 +192,83 @@ bool MonitorLinkGroupMgr::handleMonitorLinkGroupSet(const string& group_name, co
             handleGroupDelayChange(group_name, linkup_delay);
     }
 
-    updateGroupConfiguration(group_name, description, min_uplinks, linkup_delay);
-    updateGroupInterfaceLists(group_name, uplink_interfaces, downlink_interfaces, is_new_group);
+    updateGroupConfiguration(group_name, description, min_monitored_links, linkup_delay);
+    updateGroupInterfaceLists(group_name, monitored_interfaces, managed_interfaces, is_new_group);
     return true;
+}
+
+set<string> MonitorLinkGroupMgr::parseInterfaceList(const string& csv)
+{
+    set<string> result;
+    if (csv.empty()) return result;
+    stringstream ss(csv);
+    string token;
+    while (std::getline(ss, token, ','))
+    {
+        // Trim ASCII whitespace
+        auto a = token.find_first_not_of(" \t");
+        if (a == string::npos) continue;
+        auto b = token.find_last_not_of(" \t");
+        result.insert(token.substr(a, b - a + 1));
+    }
+    return result;
+}
+
+bool MonitorLinkGroupMgr::wouldCreateDependencyCycle(const string& group_name,
+                                                     const set<string>& monitored,
+                                                     const set<string>& managed)
+{
+    // Build a directed graph over groups: edge G -> H iff some port appears in
+    // G.monitored AND H.managed. Cycle in this graph == deadlock recovery scenario.
+    //
+    // The existing m_monitorLinkGroups is acyclic by induction (we reject SETs that
+    // would introduce a cycle). So any newly introduced cycle must involve `group_name`.
+    // DFS from `group_name`; if we revisit `group_name` via a back-edge, reject.
+
+    // Precompute port -> set of groups in which it is a managed-link.
+    // For `group_name`, use the proposed `managed` set (not its current state if any).
+    std::map<string, set<string>> port_to_managed_groups;
+    for (const auto& kv : m_monitorLinkGroups)
+    {
+        if (kv.first == group_name) continue;  // exclude old version of the changing group
+        for (const auto& port : kv.second.managed_interfaces)
+            port_to_managed_groups[port].insert(kv.first);
+    }
+    for (const auto& port : managed)
+        port_to_managed_groups[port].insert(group_name);
+
+    set<string> visited;
+    set<string> on_stack;
+
+    std::function<bool(const string&)> dfs = [&](const string& g) -> bool
+    {
+        if (on_stack.count(g)) return true;   // back-edge: cycle
+        if (visited.count(g)) return false;
+        on_stack.insert(g);
+
+        // For each port in g's monitored set, follow edges to groups that manage it.
+        const set<string>& g_monitored = (g == group_name)
+            ? monitored
+            : m_monitorLinkGroups.at(g).monitored_interfaces;
+        for (const auto& port : g_monitored)
+        {
+            auto it = port_to_managed_groups.find(port);
+            if (it == port_to_managed_groups.end()) continue;
+            for (const auto& h : it->second)
+            {
+                if (h == g) continue;  // self-loop on a single port is also a cycle, but
+                                       // we treat that as a config-disjointness violation
+                                       // (covered by the YANG must constraint).
+                if (dfs(h)) return true;
+            }
+        }
+
+        on_stack.erase(g);
+        visited.insert(g);
+        return false;
+    };
+
+    return dfs(group_name);
 }
 
 void MonitorLinkGroupMgr::handleGroupDelayChange(const string& group_name, uint32_t new_delay)
@@ -197,7 +285,7 @@ void MonitorLinkGroupMgr::handleGroupDelayChange(const string& group_name, uint3
             stopLinkupDelayTimer(group_name);
             existingGroup.pending_up = false;
             existingGroup.is_up = true;
-            updateDownlinkInterfacesForGroupStateChange(group_name, false, true);
+            updateManagedInterfacesForGroupStateChange(group_name, false, true);
             writeMonitorLinkGroupStateToDb(group_name);
         }
         else
@@ -213,7 +301,7 @@ void MonitorLinkGroupMgr::handleGroupDelayChange(const string& group_name, uint3
                 stopLinkupDelayTimer(group_name);
                 existingGroup.pending_up = false;
                 existingGroup.is_up = true;
-                updateDownlinkInterfacesForGroupStateChange(group_name, false, true);
+                updateManagedInterfacesForGroupStateChange(group_name, false, true);
                 writeMonitorLinkGroupStateToDb(group_name);
             }
             else
@@ -238,25 +326,25 @@ void MonitorLinkGroupMgr::handleGroupDelayChange(const string& group_name, uint3
 }
 
 void MonitorLinkGroupMgr::updateGroupConfiguration(const string& group_name, const string& description,
-                                       uint32_t min_uplinks, uint32_t linkup_delay)
+                                       uint32_t min_monitored_links, uint32_t linkup_delay)
 {
     MonitorLinkGroupInfo& groupInfo = m_monitorLinkGroups[group_name];
     groupInfo.description = description;
-    groupInfo.min_uplinks = min_uplinks;
+    groupInfo.min_monitored_links = min_monitored_links;
     groupInfo.linkup_delay = linkup_delay;
 
     SWSS_LOG_NOTICE("Monitor link group %s configured successfully (total groups: %zu)",
                     group_name.c_str(), m_monitorLinkGroups.size());
 }
 
-void MonitorLinkGroupMgr::updateGroupInterfaceLists(const string& group_name, const string& uplink_interfaces, const string& downlink_interfaces, bool initial_creation)
+void MonitorLinkGroupMgr::updateGroupInterfaceLists(const string& group_name, const string& monitored_interfaces, const string& managed_interfaces, bool initial_creation)
 {
     MonitorLinkGroupInfo& groupInfo = m_monitorLinkGroups[group_name];
 
-    std::set<std::string> new_uplink_interfaces;
-    if (!uplink_interfaces.empty())
+    std::set<std::string> new_monitored_interfaces;
+    if (!monitored_interfaces.empty())
     {
-        std::stringstream ss(uplink_interfaces);
+        std::stringstream ss(monitored_interfaces);
         std::string interface;
         while (std::getline(ss, interface, ','))
         {
@@ -264,15 +352,15 @@ void MonitorLinkGroupMgr::updateGroupInterfaceLists(const string& group_name, co
             interface.erase(interface.find_last_not_of(" \t") + 1);
             if (!interface.empty())
             {
-                new_uplink_interfaces.insert(interface);
+                new_monitored_interfaces.insert(interface);
             }
         }
     }
 
-    std::set<std::string> new_downlink_interfaces;
-    if (!downlink_interfaces.empty())
+    std::set<std::string> new_managed_interfaces;
+    if (!managed_interfaces.empty())
     {
-        std::stringstream ss(downlink_interfaces);
+        std::stringstream ss(managed_interfaces);
         std::string interface;
         while (std::getline(ss, interface, ','))
         {
@@ -280,52 +368,52 @@ void MonitorLinkGroupMgr::updateGroupInterfaceLists(const string& group_name, co
             interface.erase(interface.find_last_not_of(" \t") + 1);
             if (!interface.empty())
             {
-                new_downlink_interfaces.insert(interface);
+                new_managed_interfaces.insert(interface);
             }
         }
     }
 
     // Create a copy to avoid iterator invalidation when removeInterfaceFromGroup modifies the set
-    std::set<std::string> current_uplink_interfaces = groupInfo.uplink_interfaces;
-    for (const auto& interface : current_uplink_interfaces)
+    std::set<std::string> current_monitored_interfaces = groupInfo.monitored_interfaces;
+    for (const auto& interface : current_monitored_interfaces)
     {
-        if (new_uplink_interfaces.find(interface) == new_uplink_interfaces.end())
+        if (new_monitored_interfaces.find(interface) == new_monitored_interfaces.end())
         {
-            removeInterfaceFromGroup(group_name, interface, "uplink");
+            removeInterfaceFromGroup(group_name, interface, "monitored");
         }
     }
 
     // Create a copy to avoid iterator invalidation when removeInterfaceFromGroup modifies the set
-    std::set<std::string> current_downlink_interfaces = groupInfo.downlink_interfaces;
-    for (const auto& interface : current_downlink_interfaces)
+    std::set<std::string> current_managed_interfaces = groupInfo.managed_interfaces;
+    for (const auto& interface : current_managed_interfaces)
     {
-        if (new_downlink_interfaces.find(interface) == new_downlink_interfaces.end())
+        if (new_managed_interfaces.find(interface) == new_managed_interfaces.end())
         {
-            removeInterfaceFromGroup(group_name, interface, "downlink");
+            removeInterfaceFromGroup(group_name, interface, "managed");
         }
     }
 
-    for (const auto& interface : new_uplink_interfaces)
+    for (const auto& interface : new_monitored_interfaces)
     {
-        if (groupInfo.uplink_interfaces.find(interface) == groupInfo.uplink_interfaces.end())
+        if (groupInfo.monitored_interfaces.find(interface) == groupInfo.monitored_interfaces.end())
         {
-            addInterfaceToGroup(group_name, interface, "uplink");
+            addInterfaceToGroup(group_name, interface, "monitored");
         }
     }
 
-    for (const auto& interface : new_downlink_interfaces)
+    for (const auto& interface : new_managed_interfaces)
     {
-        if (groupInfo.downlink_interfaces.find(interface) == groupInfo.downlink_interfaces.end())
+        if (groupInfo.managed_interfaces.find(interface) == groupInfo.managed_interfaces.end())
         {
-            addInterfaceToGroup(group_name, interface, "downlink");
+            addInterfaceToGroup(group_name, interface, "managed");
         }
     }
 
-    groupInfo.uplink_interfaces = new_uplink_interfaces;
-    groupInfo.downlink_interfaces = new_downlink_interfaces;
+    groupInfo.monitored_interfaces = new_monitored_interfaces;
+    groupInfo.managed_interfaces = new_managed_interfaces;
 
-    SWSS_LOG_INFO("Monitor link group %s interface lists updated: %zu uplinks, %zu downlinks",
-                  group_name.c_str(), new_uplink_interfaces.size(), new_downlink_interfaces.size());
+    SWSS_LOG_INFO("Monitor link group %s interface lists updated: %zu monitored, %zu managed",
+                  group_name.c_str(), new_monitored_interfaces.size(), new_managed_interfaces.size());
 
     updateMonitorLinkGroupState(group_name, initial_creation);
 }
@@ -337,31 +425,31 @@ bool MonitorLinkGroupMgr::handleMonitorLinkGroupDel(const string& group_name)
     auto groupIt = m_monitorLinkGroups.find(group_name);
     if (groupIt != m_monitorLinkGroups.end())
     {
-        uint32_t removed_uplinks = static_cast<uint32_t>(groupIt->second.uplink_interfaces.size());
-        uint32_t removed_downlinks = static_cast<uint32_t>(groupIt->second.downlink_interfaces.size());
-        uint32_t removed_total = removed_uplinks + removed_downlinks;
+        uint32_t removed_monitored = static_cast<uint32_t>(groupIt->second.monitored_interfaces.size());
+        uint32_t removed_managed = static_cast<uint32_t>(groupIt->second.managed_interfaces.size());
+        uint32_t removed_total = removed_monitored + removed_managed;
 
-        // Remove uplink interfaces: erase this group from their uplink_groups;
+        // Remove monitored-link interfaces: erase this group from their monitored_groups;
         // only delete the interface entry if it belongs to no group at all anymore.
-        for (const auto& interface_name : groupIt->second.uplink_interfaces)
+        for (const auto& interface_name : groupIt->second.monitored_interfaces)
         {
             auto interfaceIt = m_monitorLinkInterfaces.find(interface_name);
             if (interfaceIt == m_monitorLinkInterfaces.end()) continue;
-            interfaceIt->second.uplink_groups.erase(group_name);
+            interfaceIt->second.monitored_groups.erase(group_name);
             if (!interfaceIt->second.in_any_group())
                 m_monitorLinkInterfaces.erase(interfaceIt);
-            SWSS_LOG_INFO("Removed uplink interface %s from deleted group %s",
+            SWSS_LOG_INFO("Removed monitored-link interface %s from deleted group %s",
                           interface_name.c_str(), group_name.c_str());
         }
 
-        // Remove downlink interfaces: erase this group from their downlink_groups;
+        // Remove managed-link interfaces: erase this group from their managed_groups;
         // delete STATE_DB entry and interface entry only if no groups remain.
-        for (const auto& interface_name : groupIt->second.downlink_interfaces)
+        for (const auto& interface_name : groupIt->second.managed_interfaces)
         {
             auto interfaceIt = m_monitorLinkInterfaces.find(interface_name);
             if (interfaceIt != m_monitorLinkInterfaces.end())
             {
-                interfaceIt->second.downlink_groups.erase(group_name);
+                interfaceIt->second.managed_groups.erase(group_name);
 
                 bool group_is_up = groupIt->second.is_up && !groupIt->second.pending_up;
                 if (!group_is_up && interfaceIt->second.down_group_count > 0)
@@ -372,19 +460,19 @@ bool MonitorLinkGroupMgr::handleMonitorLinkGroupDel(const string& group_name)
                 if (!interfaceIt->second.in_any_group())
                 {
                     m_stateMonitorLinkGroupMemberTable.del(interface_name);
-                    SWSS_LOG_NOTICE("Removed STATE_DB entry for downlink interface %s to restore config state",
+                    SWSS_LOG_NOTICE("Removed STATE_DB entry for managed-link interface %s to restore config state",
                                     interface_name.c_str());
                     m_monitorLinkInterfaces.erase(interfaceIt);
                 }
                 else
                 {
                     writeMonitorLinkGroupMemberStateToDb(interface_name);
-                    SWSS_LOG_INFO("Updated downlink interface %s state (still in %zu other groups)",
+                    SWSS_LOG_INFO("Updated managed-link interface %s state (still in %zu other groups)",
                                   interface_name.c_str(),
-                                  interfaceIt->second.uplink_groups.size() + interfaceIt->second.downlink_groups.size());
+                                  interfaceIt->second.monitored_groups.size() + interfaceIt->second.managed_groups.size());
                 }
             }
-            SWSS_LOG_INFO("Removed downlink interface %s from deleted group %s",
+            SWSS_LOG_INFO("Removed managed-link interface %s from deleted group %s",
                           interface_name.c_str(), group_name.c_str());
         }
 
@@ -407,8 +495,8 @@ bool MonitorLinkGroupMgr::handleMonitorLinkGroupDel(const string& group_name)
         m_monitorLinkGroups.erase(groupIt);
         m_stateMonitorLinkGroupTable.del(group_name);
 
-        SWSS_LOG_NOTICE("Monitor link group %s deleted successfully (removed %u uplinks, %u downlinks, %u total interfaces, remaining groups: %zu)",
-                        group_name.c_str(), removed_uplinks, removed_downlinks, removed_total, m_monitorLinkGroups.size());
+        SWSS_LOG_NOTICE("Monitor link group %s deleted successfully (removed %u monitored, %u managed, %u total interfaces, remaining groups: %zu)",
+                        group_name.c_str(), removed_monitored, removed_managed, removed_total, m_monitorLinkGroups.size());
     }
     else
     {
@@ -460,19 +548,19 @@ void MonitorLinkGroupMgr::addInterfaceToGroup(const string& group_name, const st
     }
 
     MonitorLinkGroupInfo& groupInfo = m_monitorLinkGroups[group_name];
-    if (link_type == "uplink")
+    if (link_type == "monitored")
     {
-        interfaceInfo.uplink_groups.insert(group_name);
-        groupInfo.uplink_interfaces.insert(interface_name);
+        interfaceInfo.monitored_groups.insert(group_name);
+        groupInfo.monitored_interfaces.insert(interface_name);
         if (interfaceInfo.is_up)
         {
-            groupInfo.uplink_up_count++;
+            groupInfo.monitored_up_count++;
         }
     }
-    else if (link_type == "downlink")
+    else if (link_type == "managed")
     {
-        interfaceInfo.downlink_groups.insert(group_name);
-        groupInfo.downlink_interfaces.insert(interface_name);
+        interfaceInfo.managed_groups.insert(group_name);
+        groupInfo.managed_interfaces.insert(interface_name);
 
         bool group_is_up = groupInfo.is_up && !groupInfo.pending_up;
         if (!group_is_up)
@@ -483,9 +571,9 @@ void MonitorLinkGroupMgr::addInterfaceToGroup(const string& group_name, const st
         writeMonitorLinkGroupMemberStateToDb(interface_name);
     }
 
-    SWSS_LOG_INFO("Added interface %s (%s) to group %s (state: %s, %u uplinks up)",
+    SWSS_LOG_INFO("Added interface %s (%s) to group %s (state: %s, %u monitored up)",
                   interface_name.c_str(), link_type.c_str(), group_name.c_str(),
-                  interfaceInfo.is_up ? "up" : "down", groupInfo.uplink_up_count);
+                  interfaceInfo.is_up ? "up" : "down", groupInfo.monitored_up_count);
 }
 
 void MonitorLinkGroupMgr::removeInterfaceFromGroup(const string& group_name, const string& interface_name, const string& link_type)
@@ -500,9 +588,9 @@ void MonitorLinkGroupMgr::removeInterfaceFromGroup(const string& group_name, con
     }
 
     // Verify the interface belongs to the specified group in the specified role
-    bool member = (link_type == "uplink")
-        ? interfaceIt->second.uplink_groups.count(group_name) > 0
-        : interfaceIt->second.downlink_groups.count(group_name) > 0;
+    bool member = (link_type == "monitored")
+        ? interfaceIt->second.monitored_groups.count(group_name) > 0
+        : interfaceIt->second.managed_groups.count(group_name) > 0;
     if (!member)
     {
         SWSS_LOG_WARN("Interface %s does not belong to group %s as %s. Cannot remove.",
@@ -513,20 +601,20 @@ void MonitorLinkGroupMgr::removeInterfaceFromGroup(const string& group_name, con
     auto groupIt = m_monitorLinkGroups.find(group_name);
     if (groupIt != m_monitorLinkGroups.end())
     {
-        if (link_type == "uplink")
+        if (link_type == "monitored")
         {
-            groupIt->second.uplink_interfaces.erase(interface_name);
+            groupIt->second.monitored_interfaces.erase(interface_name);
             // Decrement up count if interface was up
-            if (interfaceIt->second.is_up && groupIt->second.uplink_up_count > 0)
+            if (interfaceIt->second.is_up && groupIt->second.monitored_up_count > 0)
             {
-                groupIt->second.uplink_up_count--;
-                SWSS_LOG_INFO("Decremented uplink count for group %s to %u after removing interface %s",
-                              group_name.c_str(), groupIt->second.uplink_up_count, interface_name.c_str());
+                groupIt->second.monitored_up_count--;
+                SWSS_LOG_INFO("Decremented monitored-link count for group %s to %u after removing interface %s",
+                              group_name.c_str(), groupIt->second.monitored_up_count, interface_name.c_str());
             }
         }
-        else if (link_type == "downlink")
+        else if (link_type == "managed")
         {
-            groupIt->second.downlink_interfaces.erase(interface_name);
+            groupIt->second.managed_interfaces.erase(interface_name);
 
             // Decrement down_group_count if this group was blocking the interface
             bool group_is_up = groupIt->second.is_up && !groupIt->second.pending_up;
@@ -538,12 +626,12 @@ void MonitorLinkGroupMgr::removeInterfaceFromGroup(const string& group_name, con
 
     }
 
-    if (link_type == "uplink")
-        interfaceIt->second.uplink_groups.erase(group_name);
+    if (link_type == "monitored")
+        interfaceIt->second.monitored_groups.erase(group_name);
     else
-        interfaceIt->second.downlink_groups.erase(group_name);
+        interfaceIt->second.managed_groups.erase(group_name);
 
-    if (link_type == "downlink")
+    if (link_type == "managed")
     {
         writeMonitorLinkGroupMemberStateToDb(interface_name);
     }
@@ -556,7 +644,7 @@ void MonitorLinkGroupMgr::removeInterfaceFromGroup(const string& group_name, con
     }
     else
     {
-        size_t remaining = interfaceIt->second.uplink_groups.size() + interfaceIt->second.downlink_groups.size();
+        size_t remaining = interfaceIt->second.monitored_groups.size() + interfaceIt->second.managed_groups.size();
         SWSS_LOG_INFO("Monitor link interface %s removed from group %s (still in %zu other groups)",
                       interface_name.c_str(), group_name.c_str(), remaining);
     }
@@ -571,10 +659,10 @@ void MonitorLinkGroupMgr::updateMonitorLinkGroupState(const std::string& group_n
         return;
     }
 
-    uint32_t threshold = groupIt->second.min_uplinks;
+    uint32_t threshold = groupIt->second.min_monitored_links;
     uint32_t delay_seconds = groupIt->second.linkup_delay;
 
-    bool should_be_up = (groupIt->second.uplink_up_count >= threshold);
+    bool should_be_up = (groupIt->second.monitored_up_count >= threshold);
     bool current_state = groupIt->second.is_up;
     bool is_pending = groupIt->second.pending_up;
 
@@ -583,17 +671,17 @@ void MonitorLinkGroupMgr::updateMonitorLinkGroupState(const std::string& group_n
         if (delay_seconds > 0 && !skip_delay)
         {
             groupIt->second.pending_up = true;
-            updateDownlinkInterfacesForGroupStateChange(group_name, false, false);
+            updateManagedInterfacesForGroupStateChange(group_name, false, false);
             startLinkupDelayTimer(group_name);
-            SWSS_LOG_NOTICE("Monitor link group %s starting %u second linkup delay before going UP (%u uplinks up, threshold: %u)",
-                            group_name.c_str(), delay_seconds, groupIt->second.uplink_up_count, threshold);
+            SWSS_LOG_NOTICE("Monitor link group %s starting %u second linkup delay before going UP (%u monitored up, threshold: %u)",
+                            group_name.c_str(), delay_seconds, groupIt->second.monitored_up_count, threshold);
         }
         else
         {
             groupIt->second.is_up = true;
-            updateDownlinkInterfacesForGroupStateChange(group_name, false, true);
-            SWSS_LOG_NOTICE("Monitor link group %s state changed: UP (%u uplinks up, threshold: %u)",
-                            group_name.c_str(), groupIt->second.uplink_up_count, threshold);
+            updateManagedInterfacesForGroupStateChange(group_name, false, true);
+            SWSS_LOG_NOTICE("Monitor link group %s state changed: UP (%u monitored up, threshold: %u)",
+                            group_name.c_str(), groupIt->second.monitored_up_count, threshold);
         }
     }
     else if (!should_be_up && (current_state || is_pending))
@@ -602,15 +690,15 @@ void MonitorLinkGroupMgr::updateMonitorLinkGroupState(const std::string& group_n
         if (is_pending)
         {
             groupIt->second.pending_up = false;
-            SWSS_LOG_NOTICE("Monitor link group %s cancelled linkup delay (%u uplinks up, threshold: %u)",
-                            group_name.c_str(), groupIt->second.uplink_up_count, threshold);
+            SWSS_LOG_NOTICE("Monitor link group %s cancelled linkup delay (%u monitored up, threshold: %u)",
+                            group_name.c_str(), groupIt->second.monitored_up_count, threshold);
         }
         if (current_state)
         {
             groupIt->second.is_up = false;
-            updateDownlinkInterfacesForGroupStateChange(group_name, true, false);
-            SWSS_LOG_NOTICE("Monitor link group %s state changed: DOWN (%u uplinks up, threshold: %u)",
-                            group_name.c_str(), groupIt->second.uplink_up_count, threshold);
+            updateManagedInterfacesForGroupStateChange(group_name, true, false);
+            SWSS_LOG_NOTICE("Monitor link group %s state changed: DOWN (%u monitored up, threshold: %u)",
+                            group_name.c_str(), groupIt->second.monitored_up_count, threshold);
         }
     }
 
@@ -737,26 +825,26 @@ void MonitorLinkGroupMgr::handleLinkupDelayExpired(const std::string& group_name
         return;
     }
 
-    uint32_t threshold = group_info.min_uplinks;
+    uint32_t threshold = group_info.min_monitored_links;
 
-    if (group_info.uplink_up_count >= threshold)
+    if (group_info.monitored_up_count >= threshold)
     {
         group_info.pending_up = false;
         group_info.is_up = true;
 
-        updateDownlinkInterfacesForGroupStateChange(group_name, false, true);
+        updateManagedInterfacesForGroupStateChange(group_name, false, true);
         writeMonitorLinkGroupStateToDb(group_name);
 
-        SWSS_LOG_NOTICE("MonitorLinkGroupMgr: Monitor link group %s state changed: UP after linkup delay (%u uplinks up, threshold: %u)",
-                        group_name.c_str(), group_info.uplink_up_count, threshold);
+        SWSS_LOG_NOTICE("MonitorLinkGroupMgr: Monitor link group %s state changed: UP after linkup delay (%u monitored up, threshold: %u)",
+                        group_name.c_str(), group_info.monitored_up_count, threshold);
     }
     else
     {
         group_info.pending_up = false;
         writeMonitorLinkGroupStateToDb(group_name);
 
-        SWSS_LOG_NOTICE("MonitorLinkGroupMgr: Monitor link group %s cancelled linkup delay - threshold no longer met (%u uplinks up, threshold: %u)",
-                        group_name.c_str(), group_info.uplink_up_count, threshold);
+        SWSS_LOG_NOTICE("MonitorLinkGroupMgr: Monitor link group %s cancelled linkup delay - threshold no longer met (%u monitored up, threshold: %u)",
+                        group_name.c_str(), group_info.monitored_up_count, threshold);
     }
 }
 
@@ -774,34 +862,34 @@ void MonitorLinkGroupMgr::writeMonitorLinkGroupStateToDb(const std::string& grou
     else
         state = "down";
 
-    std::string uplink_interfaces_str;
+    std::string monitored_interfaces_str;
     bool first = true;
-    for (const auto& interface : groupIt->second.uplink_interfaces)
+    for (const auto& interface : groupIt->second.monitored_interfaces)
     {
-        if (!first) uplink_interfaces_str += ",";
-        uplink_interfaces_str += interface;
+        if (!first) monitored_interfaces_str += ",";
+        monitored_interfaces_str += interface;
         first = false;
     }
 
-    std::string downlink_interfaces_str;
+    std::string managed_interfaces_str;
     first = true;
-    for (const auto& interface : groupIt->second.downlink_interfaces)
+    for (const auto& interface : groupIt->second.managed_interfaces)
     {
-        if (!first) downlink_interfaces_str += ",";
-        downlink_interfaces_str += interface;
+        if (!first) managed_interfaces_str += ",";
+        managed_interfaces_str += interface;
         first = false;
     }
 
     std::vector<FieldValueTuple> fvVector;
     fvVector.emplace_back("state", state);
     fvVector.emplace_back("description", groupIt->second.description);
-    fvVector.emplace_back("uplinks", uplink_interfaces_str);
-    fvVector.emplace_back("downlinks", downlink_interfaces_str);
-    fvVector.emplace_back("link_up_threshold", std::to_string(groupIt->second.min_uplinks));
+    fvVector.emplace_back("monitored-links", monitored_interfaces_str);
+    fvVector.emplace_back("managed-links", managed_interfaces_str);
+    fvVector.emplace_back("link_up_threshold", std::to_string(groupIt->second.min_monitored_links));
     fvVector.emplace_back("link_up_delay", std::to_string(groupIt->second.linkup_delay));
 
-    SWSS_LOG_INFO("Writing to STATE_DB for group %s: state='%s', uplinks='%s', downlinks='%s'",
-                  group_name.c_str(), state.c_str(), uplink_interfaces_str.c_str(), downlink_interfaces_str.c_str());
+    SWSS_LOG_INFO("Writing to STATE_DB for group %s: state='%s', monitored-links='%s', managed-links='%s'",
+                  group_name.c_str(), state.c_str(), monitored_interfaces_str.c_str(), managed_interfaces_str.c_str());
 
     m_stateMonitorLinkGroupTable.set(group_name, fvVector);
 }
@@ -811,16 +899,16 @@ void MonitorLinkGroupMgr::writeMonitorLinkGroupMemberStateToDb(const std::string
     std::vector<FieldValueTuple> fvVector;
 
     auto interfaceIt = m_monitorLinkInterfaces.find(interface_name);
-    if (interfaceIt == m_monitorLinkInterfaces.end() || interfaceIt->second.downlink_groups.empty())
+    if (interfaceIt == m_monitorLinkInterfaces.end() || interfaceIt->second.managed_groups.empty())
         return;
 
     std::string state = (interfaceIt->second.down_group_count == 0) ? "allow_up" : "force_down";
     fvVector.emplace_back("state", state);
 
-    // Build down_due_to: groups in this interface's downlink_groups that are currently DOWN/PENDING
+    // Build down_due_to: groups in this interface's managed_groups that are currently DOWN/PENDING
     std::string down_due_to_str;
     bool first = true;
-    for (const auto& group_name : interfaceIt->second.downlink_groups)
+    for (const auto& group_name : interfaceIt->second.managed_groups)
     {
         auto groupIt = m_monitorLinkGroups.find(group_name);
         if (groupIt != m_monitorLinkGroups.end())
@@ -855,23 +943,23 @@ bool MonitorLinkGroupMgr::updateMonitorLinkInterfaceState(const std::string& int
 
     interfaceIt->second.is_up = is_up;
 
-    // Uplink oper change drives group state; downlink oper change does not
-    for (const auto& group_name : interfaceIt->second.uplink_groups)
+    // Monitored-link oper change drives group state; managed-link oper change does not
+    for (const auto& group_name : interfaceIt->second.monitored_groups)
     {
         auto groupIt = m_monitorLinkGroups.find(group_name);
         if (groupIt == m_monitorLinkGroups.end()) continue;
 
         if (is_up && !previous_state)
         {
-            groupIt->second.uplink_up_count++;
-            SWSS_LOG_INFO("Monitor link interface %s (uplink) in group %s went UP (%u uplinks up)",
-                          interface_name.c_str(), group_name.c_str(), groupIt->second.uplink_up_count);
+            groupIt->second.monitored_up_count++;
+            SWSS_LOG_INFO("Monitor link interface %s (monitored-link) in group %s went UP (%u monitored up)",
+                          interface_name.c_str(), group_name.c_str(), groupIt->second.monitored_up_count);
         }
         else if (!is_up && previous_state)
         {
-            if (groupIt->second.uplink_up_count > 0) groupIt->second.uplink_up_count--;
-            SWSS_LOG_INFO("Monitor link interface %s (uplink) in group %s went DOWN (%u uplinks up)",
-                          interface_name.c_str(), group_name.c_str(), groupIt->second.uplink_up_count);
+            if (groupIt->second.monitored_up_count > 0) groupIt->second.monitored_up_count--;
+            SWSS_LOG_INFO("Monitor link interface %s (monitored-link) in group %s went DOWN (%u monitored up)",
+                          interface_name.c_str(), group_name.c_str(), groupIt->second.monitored_up_count);
         }
         updateMonitorLinkGroupState(group_name);
     }
@@ -879,7 +967,7 @@ bool MonitorLinkGroupMgr::updateMonitorLinkInterfaceState(const std::string& int
     return true;
 }
 
-void MonitorLinkGroupMgr::updateDownlinkInterfacesForGroupStateChange(const std::string& group_name, bool group_was_up, bool group_is_up)
+void MonitorLinkGroupMgr::updateManagedInterfacesForGroupStateChange(const std::string& group_name, bool group_was_up, bool group_is_up)
 {
     auto groupIt = m_monitorLinkGroups.find(group_name);
     if (groupIt == m_monitorLinkGroups.end())
@@ -888,9 +976,9 @@ void MonitorLinkGroupMgr::updateDownlinkInterfacesForGroupStateChange(const std:
     if (group_was_up == group_is_up)
         return;
 
-    // No link_type guard needed: iterating the group's own downlink_interfaces set,
-    // so every interface here is definitionally a downlink of this group.
-    for (const auto& interface_name : groupIt->second.downlink_interfaces)
+    // No link_type guard needed: iterating the group's own managed_interfaces set,
+    // so every interface here is definitionally a managed-link of this group.
+    for (const auto& interface_name : groupIt->second.managed_interfaces)
     {
         auto interfaceIt = m_monitorLinkInterfaces.find(interface_name);
         if (interfaceIt == m_monitorLinkInterfaces.end()) continue;
@@ -912,7 +1000,7 @@ void MonitorLinkGroupMgr::updateDownlinkInterfacesForGroupStateChange(const std:
                      group_was_up ? "UP" : "DOWN", group_is_up ? "UP" : "DOWN");
     }
 
-    SWSS_LOG_DEBUG("MonitorLinkGroupMgr: Updated down_group_count for %zu downlink interfaces in group %s (%s → %s)",
-                   groupIt->second.downlink_interfaces.size(), group_name.c_str(),
+    SWSS_LOG_DEBUG("MonitorLinkGroupMgr: Updated down_group_count for %zu managed-link interfaces in group %s (%s → %s)",
+                   groupIt->second.managed_interfaces.size(), group_name.c_str(),
                    group_was_up ? "UP" : "DOWN", group_is_up ? "UP" : "DOWN");
 }

--- a/cfgmgr/monitorlinkgroupmgr.cpp
+++ b/cfgmgr/monitorlinkgroupmgr.cpp
@@ -193,6 +193,15 @@ bool MonitorLinkGroupMgr::handleMonitorLinkGroupSet(const string& group_name, co
     }
 
     updateGroupConfiguration(group_name, description, min_monitored_links, linkup_delay);
+
+    // PR-A: first sighting of this group in this process (likely a daemon restart
+    // path) — reload transition counters from STATE_DB so telemetry/SNMP consumers
+    // see monotonic counters across an intfmgrd crash/restart.
+    if (is_new_group)
+    {
+        restoreGroupCountersFromStateDb(group_name);
+    }
+
     updateGroupInterfaceLists(group_name, monitored_interfaces, managed_interfaces, is_new_group);
     return true;
 }
@@ -279,12 +288,20 @@ void MonitorLinkGroupMgr::handleGroupDelayChange(const string& group_name, uint3
 
     if (existingGroup.pending_up)
     {
+        uint32_t up_count = existingGroup.monitored_up_count;
+        uint32_t total = static_cast<uint32_t>(existingGroup.monitored_interfaces.size());
+        uint32_t threshold = existingGroup.min_monitored_links;
+
         if (new_delay == 0)
         {
             SWSS_LOG_INFO("Monitor link group %s delay changed to 0, bringing UP immediately", group_name.c_str());
             stopLinkupDelayTimer(group_name);
             existingGroup.pending_up = false;
             existingGroup.is_up = true;
+            std::ostringstream reason;
+            reason << "link-up-delay reduced to 0 (monitored " << up_count << "/" << total
+                   << " >= min-monitored-links " << threshold << ")";
+            recordStateTransition(group_name, "pending", "up", reason.str());
             updateManagedInterfacesForGroupStateChange(group_name, false, true);
             writeMonitorLinkGroupStateToDb(group_name);
         }
@@ -301,6 +318,10 @@ void MonitorLinkGroupMgr::handleGroupDelayChange(const string& group_name, uint3
                 stopLinkupDelayTimer(group_name);
                 existingGroup.pending_up = false;
                 existingGroup.is_up = true;
+                std::ostringstream reason;
+                reason << "link-up-delay reduced, already elapsed (monitored " << up_count << "/"
+                       << total << " >= min-monitored-links " << threshold << ")";
+                recordStateTransition(group_name, "pending", "up", reason.str());
                 updateManagedInterfacesForGroupStateChange(group_name, false, true);
                 writeMonitorLinkGroupStateToDb(group_name);
             }
@@ -665,40 +686,70 @@ void MonitorLinkGroupMgr::updateMonitorLinkGroupState(const std::string& group_n
     bool should_be_up = (groupIt->second.monitored_up_count >= threshold);
     bool current_state = groupIt->second.is_up;
     bool is_pending = groupIt->second.pending_up;
+    uint32_t up_count = groupIt->second.monitored_up_count;
+    uint32_t total = static_cast<uint32_t>(groupIt->second.monitored_interfaces.size());
 
     if (should_be_up && !current_state && !is_pending)
     {
         if (delay_seconds > 0 && !skip_delay)
         {
             groupIt->second.pending_up = true;
+            std::ostringstream reason;
+            reason << "monitored " << up_count << "/" << total
+                   << " >= min-monitored-links " << threshold
+                   << ", starting link-up-delay";
+            recordStateTransition(group_name, "down", "pending", reason.str());
             updateManagedInterfacesForGroupStateChange(group_name, false, false);
             startLinkupDelayTimer(group_name);
             SWSS_LOG_NOTICE("Monitor link group %s starting %u second linkup delay before going UP (%u monitored up, threshold: %u)",
-                            group_name.c_str(), delay_seconds, groupIt->second.monitored_up_count, threshold);
+                            group_name.c_str(), delay_seconds, up_count, threshold);
         }
         else
         {
             groupIt->second.is_up = true;
+            std::ostringstream reason;
+            reason << "monitored " << up_count << "/" << total
+                   << " >= min-monitored-links " << threshold;
+            recordStateTransition(group_name, "down", "up", reason.str());
             updateManagedInterfacesForGroupStateChange(group_name, false, true);
             SWSS_LOG_NOTICE("Monitor link group %s state changed: UP (%u monitored up, threshold: %u)",
-                            group_name.c_str(), groupIt->second.monitored_up_count, threshold);
+                            group_name.c_str(), up_count, threshold);
         }
     }
     else if (!should_be_up && (current_state || is_pending))
     {
         stopLinkupDelayTimer(group_name);
-        if (is_pending)
+        // Invariant: pending_up and is_up are mutually exclusive (is_up is forced
+        // false whenever pending_up becomes true). The two branches below are
+        // structured as if/else if to make that invariant explicit; if we ever see
+        // both true at once we log loudly and self-heal in the else-if branch.
+        if (is_pending && !current_state)
         {
             groupIt->second.pending_up = false;
+            std::ostringstream reason;
+            reason << "monitored " << up_count << "/" << total
+                   << " < min-monitored-links " << threshold
+                   << ", cancelled link-up-delay";
+            recordStateTransition(group_name, "pending", "down", reason.str());
             SWSS_LOG_NOTICE("Monitor link group %s cancelled linkup delay (%u monitored up, threshold: %u)",
-                            group_name.c_str(), groupIt->second.monitored_up_count, threshold);
+                            group_name.c_str(), up_count, threshold);
         }
-        if (current_state)
+        else if (current_state)
         {
+            if (is_pending)
+            {
+                SWSS_LOG_ERROR("Monitor link group %s in inconsistent state (is_up=true && pending_up=true), clearing pending",
+                               group_name.c_str());
+                groupIt->second.pending_up = false;
+            }
             groupIt->second.is_up = false;
+            std::ostringstream reason;
+            reason << "monitored " << up_count << "/" << total
+                   << " < min-monitored-links " << threshold;
+            recordStateTransition(group_name, "up", "down", reason.str());
             updateManagedInterfacesForGroupStateChange(group_name, true, false);
             SWSS_LOG_NOTICE("Monitor link group %s state changed: DOWN (%u monitored up, threshold: %u)",
-                            group_name.c_str(), groupIt->second.monitored_up_count, threshold);
+                            group_name.c_str(), up_count, threshold);
         }
     }
 
@@ -826,25 +877,39 @@ void MonitorLinkGroupMgr::handleLinkupDelayExpired(const std::string& group_name
     }
 
     uint32_t threshold = group_info.min_monitored_links;
+    uint32_t up_count = group_info.monitored_up_count;
+    uint32_t total = static_cast<uint32_t>(group_info.monitored_interfaces.size());
 
-    if (group_info.monitored_up_count >= threshold)
+    if (up_count >= threshold)
     {
         group_info.pending_up = false;
         group_info.is_up = true;
+
+        std::ostringstream reason;
+        reason << "link-up-delay expired (monitored " << up_count << "/" << total
+               << " >= min-monitored-links " << threshold << ")";
+        recordStateTransition(group_name, "pending", "up", reason.str());
 
         updateManagedInterfacesForGroupStateChange(group_name, false, true);
         writeMonitorLinkGroupStateToDb(group_name);
 
         SWSS_LOG_NOTICE("MonitorLinkGroupMgr: Monitor link group %s state changed: UP after linkup delay (%u monitored up, threshold: %u)",
-                        group_name.c_str(), group_info.monitored_up_count, threshold);
+                        group_name.c_str(), up_count, threshold);
     }
     else
     {
         group_info.pending_up = false;
+
+        std::ostringstream reason;
+        reason << "monitored " << up_count << "/" << total
+               << " < min-monitored-links " << threshold
+               << ", cancelled link-up-delay";
+        recordStateTransition(group_name, "pending", "down", reason.str());
+
         writeMonitorLinkGroupStateToDb(group_name);
 
         SWSS_LOG_NOTICE("MonitorLinkGroupMgr: Monitor link group %s cancelled linkup delay - threshold no longer met (%u monitored up, threshold: %u)",
-                        group_name.c_str(), group_info.monitored_up_count, threshold);
+                        group_name.c_str(), up_count, threshold);
     }
 }
 
@@ -888,10 +953,102 @@ void MonitorLinkGroupMgr::writeMonitorLinkGroupStateToDb(const std::string& grou
     fvVector.emplace_back("link_up_threshold", std::to_string(groupIt->second.min_monitored_links));
     fvVector.emplace_back("link_up_delay", std::to_string(groupIt->second.linkup_delay));
 
+    // PR-A: transition tracking fields. All optional; legacy CLIs render unchanged
+    // when these are absent (first-run before any transition).
+    const auto& g = groupIt->second;
+    if (g.has_state_change)
+    {
+        auto epoch = std::chrono::duration_cast<std::chrono::seconds>(
+            g.last_state_change_time.time_since_epoch()).count();
+        fvVector.emplace_back("last_state_change_time", std::to_string(epoch));
+        fvVector.emplace_back("last_state_change_from", g.last_state_change_from);
+        fvVector.emplace_back("last_state_change_to", g.last_state_change_to);
+        fvVector.emplace_back("last_state_change_reason", g.last_state_change_reason);
+    }
+    if (state == "pending")
+    {
+        auto epoch = std::chrono::duration_cast<std::chrono::seconds>(
+            g.pending_start_time.time_since_epoch()).count();
+        fvVector.emplace_back("pending_start_time", std::to_string(epoch));
+    }
+    fvVector.emplace_back("up_to_down_count", std::to_string(g.up_to_down_count));
+    fvVector.emplace_back("down_to_up_count", std::to_string(g.down_to_up_count));
+
     SWSS_LOG_INFO("Writing to STATE_DB for group %s: state='%s', monitored-links='%s', managed-links='%s'",
                   group_name.c_str(), state.c_str(), monitored_interfaces_str.c_str(), managed_interfaces_str.c_str());
 
     m_stateMonitorLinkGroupTable.set(group_name, fvVector);
+
+    // PR-A: clear pending_start_time once we leave PENDING so external consumers
+    // don't see stale data. The set() above does a HMSET that doesn't remove keys
+    // we omit, so we have to explicitly hdel.
+    if (state != "pending")
+    {
+        m_stateMonitorLinkGroupTable.hdel(group_name, "pending_start_time");
+    }
+}
+
+void MonitorLinkGroupMgr::recordStateTransition(const std::string& group_name,
+                                                const std::string& from_state,
+                                                const std::string& to_state,
+                                                const std::string& reason)
+{
+    auto groupIt = m_monitorLinkGroups.find(group_name);
+    if (groupIt == m_monitorLinkGroups.end())
+        return;
+    if (from_state == to_state)
+        return;
+
+    MonitorLinkGroupInfo& g = groupIt->second;
+    auto now = std::chrono::system_clock::now();
+    g.has_state_change = true;
+    g.last_state_change_from = from_state;
+    g.last_state_change_to = to_state;
+    g.last_state_change_reason = reason;
+    g.last_state_change_time = now;
+
+    if (to_state == "pending")
+    {
+        g.pending_start_time = now;
+    }
+
+    // Counter rules (D-2, D-3):
+    //   * any path landing in UP bumps down_to_up_count (DOWN -> UP and PENDING -> UP).
+    //   * only a direct UP -> DOWN bumps up_to_down_count; PENDING -> DOWN is a
+    //     near-recovery-that-failed, not a flap.
+    if (to_state == "up")
+    {
+        g.down_to_up_count++;
+    }
+    else if (from_state == "up" && to_state == "down")
+    {
+        g.up_to_down_count++;
+    }
+
+    SWSS_LOG_NOTICE("Monitor link group %s transition: %s -> %s (%s)",
+                    group_name.c_str(), from_state.c_str(), to_state.c_str(), reason.c_str());
+}
+
+void MonitorLinkGroupMgr::restoreGroupCountersFromStateDb(const std::string& group_name)
+{
+    // Counters live in MonitorLinkGroupInfo (in-memory) and would otherwise reset on
+    // intfmgrd restart. Telemetry/SNMP consumers expect monotonic counters, so reload
+    // them from STATE_DB if a prior incarnation left them there.
+    auto groupIt = m_monitorLinkGroups.find(group_name);
+    if (groupIt == m_monitorLinkGroups.end())
+        return;
+
+    std::string value;
+    if (m_stateMonitorLinkGroupTable.hget(group_name, "up_to_down_count", value))
+    {
+        try { groupIt->second.up_to_down_count = std::stoull(value); }
+        catch (const std::exception&) { /* leave at 0 */ }
+    }
+    if (m_stateMonitorLinkGroupTable.hget(group_name, "down_to_up_count", value))
+    {
+        try { groupIt->second.down_to_up_count = std::stoull(value); }
+        catch (const std::exception&) { /* leave at 0 */ }
+    }
 }
 
 void MonitorLinkGroupMgr::writeMonitorLinkGroupMemberStateToDb(const std::string& interface_name)

--- a/cfgmgr/monitorlinkgroupmgr.h
+++ b/cfgmgr/monitorlinkgroupmgr.h
@@ -1,0 +1,96 @@
+#ifndef __MONITORLINKGROUPMGR__
+#define __MONITORLINKGROUPMGR__
+
+#include "dbconnector.h"
+#include "orch.h"
+#include "selectabletimer.h"
+
+#include <map>
+#include <set>
+#include <string>
+#include <chrono>
+
+namespace swss {
+
+class MonitorLinkGroupMgr : public Orch
+{
+public:
+    MonitorLinkGroupMgr(DBConnector *cfgDb, DBConnector *stateDb, const std::vector<std::string> &tableNames);
+    using Orch::doTask;
+    void doTask(SelectableTimer &timer) override;
+
+private:
+    Table m_cfgMonitorLinkGroupTable;
+    Table m_statePortTable;
+    Table m_stateLagTable;
+    Table m_stateMonitorLinkGroupTable;
+    Table m_stateMonitorLinkGroupMemberTable;
+
+    // Monitor link group and interface mapping storage
+    struct MonitorLinkGroupInfo {
+        std::string description;
+        uint32_t min_uplinks;                       // Minimum uplinks needed for group UP (parsed once at SET time)
+        uint32_t linkup_delay;                      // Seconds to wait after uplinks recover before bringing group UP
+        std::set<std::string> uplink_interfaces;    // Set of uplink interfaces in this group
+        std::set<std::string> downlink_interfaces;  // Set of downlink interfaces in this group
+        uint32_t uplink_up_count;                   // Number of uplink interfaces that are up
+        bool is_up;                                 // Group state: true if uplink_up_count >= threshold, false otherwise
+        bool pending_up;                            // True if group is waiting for link-up-delay before going UP
+        // Non-owning reference: the ExecutableTimer registered in m_consumerMap owns the underlying SelectableTimer.
+        // This pointer is a borrowed reference used only for stop()/setInterval()/start() calls.
+        SelectableTimer* linkup_delay_timer;
+        std::chrono::steady_clock::time_point delay_start_time;  // When the delay timer was started
+
+        MonitorLinkGroupInfo() : min_uplinks(1), linkup_delay(0), uplink_up_count(0), is_up(false), pending_up(false), linkup_delay_timer(nullptr) {}
+    };
+
+    struct MonitorLinkInterfaceInfo {
+        std::set<std::string> uplink_groups;   // groups where this port is an uplink
+        std::set<std::string> downlink_groups; // groups where this port is a downlink
+        bool is_up;                            // current operational state
+        int down_group_count;                  // downlink-role groups that are DOWN/PENDING
+
+        MonitorLinkInterfaceInfo() : is_up(false), down_group_count(0) {}
+
+        bool in_any_group() const { return !uplink_groups.empty() || !downlink_groups.empty(); }
+    };
+
+    // Group name -> Group info mapping
+    std::map<std::string, MonitorLinkGroupInfo> m_monitorLinkGroups;
+    // Interface name -> Interface info mapping
+    std::map<std::string, MonitorLinkInterfaceInfo> m_monitorLinkInterfaces;
+
+    void doTask(Consumer &consumer);
+    void doPortTableTask(const std::string& key, std::vector<FieldValueTuple> data, std::string op);
+    bool doMonitorLinkGroupTask(const std::vector<std::string>& keys, const std::vector<FieldValueTuple>& data, const std::string& op);
+
+    // Monitor link interface state methods
+    bool updateMonitorLinkInterfaceState(const std::string& interface_name, bool is_up);
+    void updateDownlinkInterfacesForGroupStateChange(const std::string& group_name, bool group_was_up, bool group_is_up);
+    void writeMonitorLinkGroupMemberStateToDb(const std::string& interface_name);
+
+    // Monitor link group state methods
+    void updateMonitorLinkGroupState(const std::string& group_name, bool skip_delay = false);
+    void writeMonitorLinkGroupStateToDb(const std::string& group_name);
+
+    // SelectableTimer management for linkup delay
+    void startLinkupDelayTimer(const std::string& group_name);     // Start linkup delay timer
+    void stopLinkupDelayTimer(const std::string& group_name);      // Stop linkup delay timer
+    void handleLinkupDelayExpired(const std::string& group_name);  // Handle timer expiration
+
+    // Monitor link group helper methods
+    bool handleMonitorLinkGroupSet(const std::string& group_name, const std::vector<FieldValueTuple>& data);
+    bool handleMonitorLinkGroupDel(const std::string& group_name);
+    void handleGroupDelayChange(const std::string& group_name, uint32_t new_delay);
+    void updateGroupConfiguration(const std::string& group_name, const std::string& description,
+                                  uint32_t min_uplinks, uint32_t linkup_delay);
+    void updateGroupInterfaceLists(const std::string& group_name, const std::string& uplink_interfaces,
+                                   const std::string& downlink_interfaces, bool initial_creation = false);
+    void addInterfaceToGroup(const std::string& group_name, const std::string& interface_name, const std::string& link_type);
+    void removeInterfaceFromGroup(const std::string& group_name, const std::string& interface_name, const std::string& link_type);
+    bool getInterfaceOperState(const std::string& interface_name);
+};
+
+}
+
+#endif

--- a/cfgmgr/monitorlinkgroupmgr.h
+++ b/cfgmgr/monitorlinkgroupmgr.h
@@ -48,7 +48,7 @@ private:
         std::set<std::string> uplink_groups;   // groups where this port is an uplink
         std::set<std::string> downlink_groups; // groups where this port is a downlink
         bool is_up;                            // current operational state
-        int down_group_count;                  // downlink-role groups that are DOWN/PENDING
+        uint32_t down_group_count;             // downlink-role groups that are DOWN/PENDING
 
         MonitorLinkInterfaceInfo() : is_up(false), down_group_count(0) {}
 
@@ -59,10 +59,12 @@ private:
     std::map<std::string, MonitorLinkGroupInfo> m_monitorLinkGroups;
     // Interface name -> Interface info mapping
     std::map<std::string, MonitorLinkInterfaceInfo> m_monitorLinkInterfaces;
+    // Timer pointer -> Group name reverse map for O(1) timer expiry lookup
+    std::map<SelectableTimer*, std::string> m_timerToGroup;
 
     void doTask(Consumer &consumer);
     void doPortTableTask(const std::string& key, std::vector<FieldValueTuple> data, std::string op);
-    bool doMonitorLinkGroupTask(const std::vector<std::string>& keys, const std::vector<FieldValueTuple>& data, const std::string& op);
+    void doMonitorLinkGroupTask(const std::vector<std::string>& keys, const std::vector<FieldValueTuple>& data, const std::string& op);
 
     // Monitor link interface state methods
     bool updateMonitorLinkInterfaceState(const std::string& interface_name, bool is_up);

--- a/cfgmgr/monitorlinkgroupmgr.h
+++ b/cfgmgr/monitorlinkgroupmgr.h
@@ -1,14 +1,18 @@
 #ifndef __MONITORLINKGROUPMGR__
 #define __MONITORLINKGROUPMGR__
 
-// STATE_DB table names for Monitor Link Group are added to swss-common's
-// common/schema.h by sonic-net/sonic-swss-common#1181. Until that PR merges,
-// the sonic-swss-common artifact pulled by CI does not have these macros and
+// Monitor Link Group table-name macros are added to swss-common by
+// sonic-net/sonic-swss-common#1181 (STATE_*) and generated from YANG in
+// sonic-net/sonic-buildimage#27004 (CFG_*). Until both land, the
+// sonic-swss-common artifact pulled by CI does not carry these macros and
 // this swss build fails to compile. Define here as a transitional shim with
-// #ifndef guards so the build succeeds standalone. Once swss-common#1181
-// merges and schema.h carries these macros, the #ifndef guards skip the
-// fallback and the upstream definitions take over; this block can then be
-// removed as a cleanup.
+// #ifndef guards so the build succeeds standalone. Once the dependencies
+// merge and schema.h / cfg_schema.h carry these macros, the #ifndef guards
+// skip the fallback and the upstream definitions take over; this block can
+// then be removed as a cleanup.
+#ifndef CFG_MONITOR_LINK_GROUP_TABLE_NAME
+#define CFG_MONITOR_LINK_GROUP_TABLE_NAME          "MONITOR_LINK_GROUP"
+#endif
 #ifndef STATE_MONITOR_LINK_GROUP_STATE_TABLE_NAME
 #define STATE_MONITOR_LINK_GROUP_STATE_TABLE_NAME  "MONITOR_LINK_GROUP_STATE"
 #endif

--- a/cfgmgr/monitorlinkgroupmgr.h
+++ b/cfgmgr/monitorlinkgroupmgr.h
@@ -1,6 +1,21 @@
 #ifndef __MONITORLINKGROUPMGR__
 #define __MONITORLINKGROUPMGR__
 
+// STATE_DB table names for Monitor Link Group are added to swss-common's
+// common/schema.h by sonic-net/sonic-swss-common#1181. Until that PR merges,
+// the sonic-swss-common artifact pulled by CI does not have these macros and
+// this swss build fails to compile. Define here as a transitional shim with
+// #ifndef guards so the build succeeds standalone. Once swss-common#1181
+// merges and schema.h carries these macros, the #ifndef guards skip the
+// fallback and the upstream definitions take over; this block can then be
+// removed as a cleanup.
+#ifndef STATE_MONITOR_LINK_GROUP_STATE_TABLE_NAME
+#define STATE_MONITOR_LINK_GROUP_STATE_TABLE_NAME  "MONITOR_LINK_GROUP_STATE"
+#endif
+#ifndef STATE_MONITOR_LINK_GROUP_MEMBER_TABLE_NAME
+#define STATE_MONITOR_LINK_GROUP_MEMBER_TABLE_NAME "MONITOR_LINK_GROUP_MEMBER"
+#endif
+
 #include "dbconnector.h"
 #include "orch.h"
 #include "selectabletimer.h"

--- a/cfgmgr/monitorlinkgroupmgr.h
+++ b/cfgmgr/monitorlinkgroupmgr.h
@@ -47,16 +47,14 @@ private:
         bool has_state_change;                                         // false until first transition observed
         std::string last_state_change_from;                            // "up" | "down" | "pending"
         std::string last_state_change_to;                              // "up" | "down" | "pending"
-        std::string last_state_change_reason;                          // human-readable reason
         std::chrono::system_clock::time_point last_state_change_time;  // wall-clock of last transition
         std::chrono::system_clock::time_point pending_start_time;      // wall-clock when current PENDING started
-        uint64_t up_to_down_count;                                     // direct UP -> DOWN transitions
-        uint64_t down_to_up_count;                                     // any -> UP transitions
+        uint64_t total_transitions;                                    // count of all recorded transitions
 
         MonitorLinkGroupInfo()
             : min_monitored_links(1), linkup_delay(0), monitored_up_count(0),
               is_up(false), pending_up(false), linkup_delay_timer(nullptr),
-              has_state_change(false), up_to_down_count(0), down_to_up_count(0) {}
+              has_state_change(false), total_transitions(0) {}
     };
 
     struct MonitorLinkInterfaceInfo {
@@ -90,20 +88,17 @@ private:
     void updateMonitorLinkGroupState(const std::string& group_name, bool skip_delay = false);
     void writeMonitorLinkGroupStateToDb(const std::string& group_name);
 
-    // PR-A: record a state transition (from -> to) on the group with a human-readable
-    // reason. Updates last_state_change_*, pending_start_time when entering PENDING,
-    // and bumps counters per the rules:
-    //   - down_to_up_count++ on any path landing in UP (DOWN->UP and PENDING->UP)
-    //   - up_to_down_count++ on direct UP -> DOWN only (not PENDING -> DOWN)
-    // No-op when from == to. Emits SWSS_LOG_NOTICE.
+    // PR-A: record a state transition (from -> to) on the group. Updates
+    // last_state_change_{from,to,time}, sets pending_start_time when entering
+    // PENDING, and bumps total_transitions. No-op when from == to. Emits
+    // SWSS_LOG_NOTICE.
     void recordStateTransition(const std::string& group_name,
                                const std::string& from_state,
-                               const std::string& to_state,
-                               const std::string& reason);
+                               const std::string& to_state);
 
-    // PR-A: on first sighting of a group in this process, reload up_to_down_count
-    // and down_to_up_count from STATE_DB so the counters survive intfmgrd restart.
-    // Leaves counters at 0 if the STATE_DB fields are absent or malformed.
+    // PR-A: on first sighting of a group in this process, reload total_transitions
+    // from STATE_DB so the counter survives intfmgrd restart. Leaves the counter
+    // at 0 if the STATE_DB field is absent or malformed.
     void restoreGroupCountersFromStateDb(const std::string& group_name);
 
     // SelectableTimer management for linkup delay

--- a/cfgmgr/monitorlinkgroupmgr.h
+++ b/cfgmgr/monitorlinkgroupmgr.h
@@ -41,7 +41,22 @@ private:
         SelectableTimer* linkup_delay_timer;
         std::chrono::steady_clock::time_point delay_start_time;  // When the delay timer was started
 
-        MonitorLinkGroupInfo() : min_monitored_links(1), linkup_delay(0), monitored_up_count(0), is_up(false), pending_up(false), linkup_delay_timer(nullptr) {}
+        // PR-A: transition tracking. Operators can answer "when did this last change?",
+        // "how far into the link-up-delay are we?", and "is this flapping?" by reading
+        // STATE_DB without grepping syslog.
+        bool has_state_change;                                         // false until first transition observed
+        std::string last_state_change_from;                            // "up" | "down" | "pending"
+        std::string last_state_change_to;                              // "up" | "down" | "pending"
+        std::string last_state_change_reason;                          // human-readable reason
+        std::chrono::system_clock::time_point last_state_change_time;  // wall-clock of last transition
+        std::chrono::system_clock::time_point pending_start_time;      // wall-clock when current PENDING started
+        uint64_t up_to_down_count;                                     // direct UP -> DOWN transitions
+        uint64_t down_to_up_count;                                     // any -> UP transitions
+
+        MonitorLinkGroupInfo()
+            : min_monitored_links(1), linkup_delay(0), monitored_up_count(0),
+              is_up(false), pending_up(false), linkup_delay_timer(nullptr),
+              has_state_change(false), up_to_down_count(0), down_to_up_count(0) {}
     };
 
     struct MonitorLinkInterfaceInfo {
@@ -74,6 +89,22 @@ private:
     // Monitor link group state methods
     void updateMonitorLinkGroupState(const std::string& group_name, bool skip_delay = false);
     void writeMonitorLinkGroupStateToDb(const std::string& group_name);
+
+    // PR-A: record a state transition (from -> to) on the group with a human-readable
+    // reason. Updates last_state_change_*, pending_start_time when entering PENDING,
+    // and bumps counters per the rules:
+    //   - down_to_up_count++ on any path landing in UP (DOWN->UP and PENDING->UP)
+    //   - up_to_down_count++ on direct UP -> DOWN only (not PENDING -> DOWN)
+    // No-op when from == to. Emits SWSS_LOG_NOTICE.
+    void recordStateTransition(const std::string& group_name,
+                               const std::string& from_state,
+                               const std::string& to_state,
+                               const std::string& reason);
+
+    // PR-A: on first sighting of a group in this process, reload up_to_down_count
+    // and down_to_up_count from STATE_DB so the counters survive intfmgrd restart.
+    // Leaves counters at 0 if the STATE_DB fields are absent or malformed.
+    void restoreGroupCountersFromStateDb(const std::string& group_name);
 
     // SelectableTimer management for linkup delay
     void startLinkupDelayTimer(const std::string& group_name);     // Start linkup delay timer

--- a/cfgmgr/monitorlinkgroupmgr.h
+++ b/cfgmgr/monitorlinkgroupmgr.h
@@ -29,30 +29,30 @@ private:
     // Monitor link group and interface mapping storage
     struct MonitorLinkGroupInfo {
         std::string description;
-        uint32_t min_uplinks;                       // Minimum uplinks needed for group UP (parsed once at SET time)
-        uint32_t linkup_delay;                      // Seconds to wait after uplinks recover before bringing group UP
-        std::set<std::string> uplink_interfaces;    // Set of uplink interfaces in this group
-        std::set<std::string> downlink_interfaces;  // Set of downlink interfaces in this group
-        uint32_t uplink_up_count;                   // Number of uplink interfaces that are up
-        bool is_up;                                 // Group state: true if uplink_up_count >= threshold, false otherwise
+        uint32_t min_monitored_links;                       // Minimum monitored-links needed for group UP (parsed once at SET time)
+        uint32_t linkup_delay;                      // Seconds to wait after monitored-links recover before bringing group UP
+        std::set<std::string> monitored_interfaces;    // Set of monitored interfaces in this group
+        std::set<std::string> managed_interfaces;  // Set of managed interfaces in this group
+        uint32_t monitored_up_count;                   // Number of monitored interfaces that are up
+        bool is_up;                                 // Group state: true if monitored_up_count >= threshold, false otherwise
         bool pending_up;                            // True if group is waiting for link-up-delay before going UP
         // Non-owning reference: the ExecutableTimer registered in m_consumerMap owns the underlying SelectableTimer.
         // This pointer is a borrowed reference used only for stop()/setInterval()/start() calls.
         SelectableTimer* linkup_delay_timer;
         std::chrono::steady_clock::time_point delay_start_time;  // When the delay timer was started
 
-        MonitorLinkGroupInfo() : min_uplinks(1), linkup_delay(0), uplink_up_count(0), is_up(false), pending_up(false), linkup_delay_timer(nullptr) {}
+        MonitorLinkGroupInfo() : min_monitored_links(1), linkup_delay(0), monitored_up_count(0), is_up(false), pending_up(false), linkup_delay_timer(nullptr) {}
     };
 
     struct MonitorLinkInterfaceInfo {
-        std::set<std::string> uplink_groups;   // groups where this port is an uplink
-        std::set<std::string> downlink_groups; // groups where this port is a downlink
+        std::set<std::string> monitored_groups;   // groups where this port is a monitored-link
+        std::set<std::string> managed_groups; // groups where this port is a managed-link
         bool is_up;                            // current operational state
-        uint32_t down_group_count;             // downlink-role groups that are DOWN/PENDING
+        uint32_t down_group_count;             // managed-role groups that are DOWN/PENDING
 
         MonitorLinkInterfaceInfo() : is_up(false), down_group_count(0) {}
 
-        bool in_any_group() const { return !uplink_groups.empty() || !downlink_groups.empty(); }
+        bool in_any_group() const { return !monitored_groups.empty() || !managed_groups.empty(); }
     };
 
     // Group name -> Group info mapping
@@ -68,7 +68,7 @@ private:
 
     // Monitor link interface state methods
     bool updateMonitorLinkInterfaceState(const std::string& interface_name, bool is_up);
-    void updateDownlinkInterfacesForGroupStateChange(const std::string& group_name, bool group_was_up, bool group_is_up);
+    void updateManagedInterfacesForGroupStateChange(const std::string& group_name, bool group_was_up, bool group_is_up);
     void writeMonitorLinkGroupMemberStateToDb(const std::string& interface_name);
 
     // Monitor link group state methods
@@ -85,12 +85,22 @@ private:
     bool handleMonitorLinkGroupDel(const std::string& group_name);
     void handleGroupDelayChange(const std::string& group_name, uint32_t new_delay);
     void updateGroupConfiguration(const std::string& group_name, const std::string& description,
-                                  uint32_t min_uplinks, uint32_t linkup_delay);
-    void updateGroupInterfaceLists(const std::string& group_name, const std::string& uplink_interfaces,
-                                   const std::string& downlink_interfaces, bool initial_creation = false);
+                                  uint32_t min_monitored_links, uint32_t linkup_delay);
+    void updateGroupInterfaceLists(const std::string& group_name, const std::string& monitored_interfaces,
+                                   const std::string& managed_interfaces, bool initial_creation = false);
     void addInterfaceToGroup(const std::string& group_name, const std::string& interface_name, const std::string& link_type);
     void removeInterfaceFromGroup(const std::string& group_name, const std::string& interface_name, const std::string& link_type);
     bool getInterfaceOperState(const std::string& interface_name);
+
+    // R-6: detect dependency cycles introduced by a proposed group config.
+    // Edge G -> H: some port in G.monitored is in H.managed (G waits on H to be UP).
+    // A cycle implies a deadlock recovery scenario; we reject the SET.
+    bool wouldCreateDependencyCycle(const std::string& group_name,
+                                    const std::set<std::string>& monitored,
+                                    const std::set<std::string>& managed);
+
+    // Parse a comma-separated interface list into a set (trims whitespace, drops empties).
+    static std::set<std::string> parseInterfaceList(const std::string& csv);
 };
 
 }

--- a/cfgmgr/portmgr.cpp
+++ b/cfgmgr/portmgr.cpp
@@ -15,8 +15,6 @@ PortMgr::PortMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
         Orch(tables),
         m_cfgPortTable(cfgDb, CFG_PORT_TABLE_NAME),
         m_cfgSendToIngressPortTable(cfgDb, CFG_SEND_TO_INGRESS_PORT_TABLE_NAME),
-        m_cfgLagMemberTable(cfgDb, CFG_LAG_MEMBER_TABLE_NAME),
-
         m_statePortTable(stateDb, STATE_PORT_TABLE_NAME),
         m_stateMonitorLinkGroupMemberTable(stateDb, STATE_MONITOR_LINK_GROUP_MEMBER_TABLE_NAME),
         m_appSendToIngressPortTable(appDb, APP_SEND_TO_INGRESS_PORT_TABLE_NAME),

--- a/cfgmgr/portmgr.cpp
+++ b/cfgmgr/portmgr.cpp
@@ -11,12 +11,14 @@
 using namespace std;
 using namespace swss;
 
-PortMgr::PortMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const vector<string> &tableNames) :
-        Orch(cfgDb, tableNames),
+PortMgr::PortMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const vector<TableConnector> &tables) :
+        Orch(tables),
         m_cfgPortTable(cfgDb, CFG_PORT_TABLE_NAME),
         m_cfgSendToIngressPortTable(cfgDb, CFG_SEND_TO_INGRESS_PORT_TABLE_NAME),
         m_cfgLagMemberTable(cfgDb, CFG_LAG_MEMBER_TABLE_NAME),
+
         m_statePortTable(stateDb, STATE_PORT_TABLE_NAME),
+        m_stateMonitorLinkGroupMemberTable(stateDb, STATE_MONITOR_LINK_GROUP_MEMBER_TABLE_NAME),
         m_appSendToIngressPortTable(appDb, APP_SEND_TO_INGRESS_PORT_TABLE_NAME),
         m_appPortTable(appDb, APP_PORT_TABLE_NAME)
 {
@@ -61,6 +63,9 @@ bool PortMgr::setPortAdminStatus(const string &alias, const bool up)
 {
     stringstream cmd;
     string res, cmd_str;
+
+    // Monitor link state checking is now handled at the configuration level
+    // This function just applies the admin status as requested
 
     // ip link set dev <port_name> [up|down]
     cmd << IP_CMD << " link set dev " << shellquote(alias) << (up ? " up" : " down");
@@ -143,6 +148,12 @@ void PortMgr::doTask(Consumer &consumer)
     if (table == CFG_SEND_TO_INGRESS_PORT_TABLE_NAME)
     {
         doSendToIngressPortTask(consumer);
+        return;
+    }
+
+    else if (table == STATE_MONITOR_LINK_GROUP_MEMBER_TABLE_NAME)
+    {
+        doMonitorLinkGroupMemberTask(consumer);
         return;
     }
 
@@ -234,8 +245,8 @@ void PortMgr::doTask(Consumer &consumer)
 
             if (!admin_status.empty())
             {
-                setPortAdminStatus(alias, admin_status == "up");
                 SWSS_LOG_NOTICE("Configure %s admin status to %s", alias.c_str(), admin_status.c_str());
+                applyEffectiveAdminStatus(alias);
             }
         }
         else if (op == DEL_COMMAND)
@@ -243,6 +254,109 @@ void PortMgr::doTask(Consumer &consumer)
             SWSS_LOG_NOTICE("Delete Port: %s", alias.c_str());
             m_appPortTable.del(alias);
             m_portList.erase(alias);
+        }
+
+        it = consumer.m_toSync.erase(it);
+    }
+}
+
+void PortMgr::applyEffectiveAdminStatus(const string &alias)
+{
+    // Read config intent
+    vector<FieldValueTuple> port_data;
+    if (!m_cfgPortTable.get(alias, port_data))
+        return;
+
+    bool config_admin_up = true;
+    for (const auto &fv : port_data)
+    {
+        if (fvField(fv) == "admin_status")
+        {
+            config_admin_up = (fvValue(fv) == "up");
+            break;
+        }
+    }
+
+    // Check monitor link override; absent entry means no restriction
+    bool monitor_force_down = false;
+    vector<FieldValueTuple> ml_data;
+    if (m_stateMonitorLinkGroupMemberTable.get(alias, ml_data))
+    {
+        for (const auto &fv : ml_data)
+        {
+            if (fvField(fv) == "state")
+            {
+                monitor_force_down = (fvValue(fv) == "force_down");
+                break;
+            }
+        }
+    }
+
+    bool effective_up = config_admin_up && !monitor_force_down;
+    SWSS_LOG_INFO("PortMgr: %s effective admin status: config=%s monitor=%s result=%s",
+                  alias.c_str(),
+                  config_admin_up ? "up" : "down",
+                  monitor_force_down ? "force_down" : "allow_up",
+                  effective_up ? "up" : "down");
+    setPortAdminStatus(alias, effective_up);
+}
+
+
+
+void PortMgr::doMonitorLinkGroupMemberTask(Consumer &consumer)
+{
+    SWSS_LOG_ENTER();
+
+    auto it = consumer.m_toSync.begin();
+    while (it != consumer.m_toSync.end())
+    {
+        KeyOpFieldsValuesTuple t = it->second;
+
+        string interface_name = kfvKey(t);
+        string op = kfvOp(t);
+        auto data = kfvFieldsValues(t);
+
+        // Determine interface type via CONFIG_DB rather than name prefix — avoids breakage
+        // if SONiC ever adds interface names that don't start with "Ethernet" (e.g. Ethernet-BP).
+        vector<FieldValueTuple> port_data;
+        if (!m_cfgPortTable.get(interface_name, port_data))
+        {
+            // Not a physical port (PortChannel or unknown) — handled by teammgrd
+            it = consumer.m_toSync.erase(it);
+            continue;
+        }
+
+        if (op == SET_COMMAND)
+        {
+            string monitor_link_state = "";
+            string down_due_to = "";
+
+            for (const auto &idx : data)
+            {
+                const auto &field = fvField(idx);
+                const auto &value = fvValue(idx);
+
+                if (field == "state")
+                    monitor_link_state = value;
+                else if (field == "down_due_to")
+                    down_due_to = value;
+            }
+
+            if (monitor_link_state.empty())
+            {
+                SWSS_LOG_WARN("PortMgr: No state provided for interface %s, skipping", interface_name.c_str());
+                it = consumer.m_toSync.erase(it);
+                continue;
+            }
+
+            SWSS_LOG_INFO("PortMgr: monitor link SET %s state=%s down_due_to=%s",
+                         interface_name.c_str(), monitor_link_state.c_str(), down_due_to.c_str());
+            applyEffectiveAdminStatus(interface_name);
+        }
+        else if (op == DEL_COMMAND)
+        {
+            SWSS_LOG_INFO("PortMgr: Processing monitor link group member DEL for %s", interface_name.c_str());
+            applyEffectiveAdminStatus(interface_name);
         }
 
         it = consumer.m_toSync.erase(it);
@@ -264,3 +378,5 @@ bool PortMgr::writeConfigToAppDb(const std::string &alias, std::vector<FieldValu
     m_appPortTable.set(alias, field_values);
     return true;
 }
+
+

--- a/cfgmgr/portmgr.cpp
+++ b/cfgmgr/portmgr.cpp
@@ -6,6 +6,7 @@
 #include "portmgr.h"
 #include "exec.h"
 #include "shellcmd.h"
+#include "monitorlinkgroupmgr.h"
 #include <swss/redisutility.h>
 
 using namespace std;

--- a/cfgmgr/portmgr.cpp
+++ b/cfgmgr/portmgr.cpp
@@ -266,7 +266,9 @@ void PortMgr::applyEffectiveAdminStatus(const string &alias)
     if (!m_cfgPortTable.get(alias, port_data))
         return;
 
-    bool config_admin_up = true;
+    // If admin_status is absent from CONFIG_DB, match the default that the
+    // doTask first-write path applies (DEFAULT_ADMIN_STATUS_STR == "down").
+    bool config_admin_up = false;
     for (const auto &fv : port_data)
     {
         if (fvField(fv) == "admin_status")

--- a/cfgmgr/portmgr.h
+++ b/cfgmgr/portmgr.h
@@ -24,7 +24,6 @@ public:
 private:
     Table m_cfgPortTable;
     Table m_cfgSendToIngressPortTable;
-    Table m_cfgLagMemberTable;
     Table m_statePortTable;
     Table m_stateMonitorLinkGroupMemberTable;
     ProducerStateTable m_appPortTable;

--- a/cfgmgr/portmgr.h
+++ b/cfgmgr/portmgr.h
@@ -7,6 +7,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <vector>
 
 namespace swss {
 
@@ -17,7 +18,7 @@ namespace swss {
 class PortMgr : public Orch
 {
 public:
-    PortMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const std::vector<std::string> &tableNames);
+    PortMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const std::vector<TableConnector> &tables);
 
     using Orch::doTask;
 private:
@@ -25,18 +26,20 @@ private:
     Table m_cfgSendToIngressPortTable;
     Table m_cfgLagMemberTable;
     Table m_statePortTable;
+    Table m_stateMonitorLinkGroupMemberTable;
     ProducerStateTable m_appPortTable;
     ProducerStateTable m_appSendToIngressPortTable;
-
     std::set<std::string> m_portList;
 
     void doTask(Consumer &consumer);
     void doSendToIngressPortTask(Consumer &consumer);
+    void doMonitorLinkGroupMemberTask(Consumer &consumer);
     bool writeConfigToAppDb(const std::string &alias, const std::string &field, const std::string &value);
     bool writeConfigToAppDb(const std::string &alias, std::vector<FieldValueTuple> &field_values);
     bool setPortMtu(const std::string &alias, const std::string &mtu);
     bool setPortAdminStatus(const std::string &alias, const bool up);
     bool isPortStateOk(const std::string &alias);
+    void applyEffectiveAdminStatus(const std::string &alias);
 };
 
 }

--- a/cfgmgr/portmgrd.cpp
+++ b/cfgmgr/portmgrd.cpp
@@ -24,16 +24,21 @@ int main(int argc, char **argv)
 
     try
     {
-        vector<string> cfg_port_tables = {
-            CFG_PORT_TABLE_NAME,
-            CFG_SEND_TO_INGRESS_PORT_TABLE_NAME,
-        };
-
         DBConnector cfgDb("CONFIG_DB", 0);
         DBConnector appDb("APPL_DB", 0);
         DBConnector stateDb("STATE_DB", 0);
 
-        PortMgr portmgr(&cfgDb, &appDb, &stateDb, cfg_port_tables);
+        TableConnector cfg_port_table(&cfgDb, CFG_PORT_TABLE_NAME);
+        TableConnector cfg_send_to_ingress_port_table(&cfgDb, CFG_SEND_TO_INGRESS_PORT_TABLE_NAME);
+        TableConnector state_monitor_link_group_member_table(&stateDb, STATE_MONITOR_LINK_GROUP_MEMBER_TABLE_NAME);
+
+        vector<TableConnector> tables = {
+            cfg_port_table,
+            cfg_send_to_ingress_port_table,
+            state_monitor_link_group_member_table
+        };
+
+        PortMgr portmgr(&cfgDb, &appDb, &stateDb, tables);
         vector<Orch *> cfgOrchList = {&portmgr};
 
         swss::Select s;

--- a/cfgmgr/portmgrd.cpp
+++ b/cfgmgr/portmgrd.cpp
@@ -6,6 +6,7 @@
 
 #include "exec.h"
 #include "portmgr.h"
+#include "monitorlinkgroupmgr.h"
 #include "schema.h"
 #include "select.h"
 

--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -316,42 +316,7 @@ void TeamMgr::doLagTask(Consumer &consumer)
                 m_lagList.insert(alias);
             }
 
-            if (admin_status == "up")
-            {
-                vector<FieldValueTuple> monitor_link_data;
-                if (m_stateMonitorLinkGroupMemberTable.get(alias, monitor_link_data))
-                {
-                    string monitor_link_state;
-                    for (const auto &fv : monitor_link_data)
-                    {
-                        if (fvField(fv) == "state")
-                        {
-                            monitor_link_state = fvValue(fv);
-                            break;
-                        }
-                    }
-                    if (monitor_link_state == "allow_up")
-                    {
-                        setLagAdminStatus(alias, "up");
-                        SWSS_LOG_NOTICE("Configure %s admin status to up (monitor link allows)", alias.c_str());
-                    }
-                    else
-                    {
-                        setLagAdminStatus(alias, "down");
-                        SWSS_LOG_NOTICE("Configure %s admin status blocked by monitor link (state: %s)", alias.c_str(), monitor_link_state.c_str());
-                    }
-                }
-                else
-                {
-                    setLagAdminStatus(alias, "up");
-                    SWSS_LOG_NOTICE("Configure %s admin status to up", alias.c_str());
-                }
-            }
-            else
-            {
-                setLagAdminStatus(alias, "down");
-                SWSS_LOG_NOTICE("Configure %s admin status to down", alias.c_str());
-            }
+            applyEffectiveLagAdminStatus(alias);
             setLagMtu(alias, mtu);
             if (!learn_mode.empty())
             {
@@ -536,6 +501,45 @@ bool TeamMgr::setLagAdminStatus(const string &alias, const string &admin_status)
             alias.c_str(), admin_status.c_str());
 
     return true;
+}
+
+void TeamMgr::applyEffectiveLagAdminStatus(const string &alias)
+{
+    vector<FieldValueTuple> lag_data;
+    bool config_admin_up = true;
+    if (m_cfgLagTable.get(alias, lag_data))
+    {
+        for (const auto &fv : lag_data)
+        {
+            if (fvField(fv) == "admin_status")
+            {
+                config_admin_up = (fvValue(fv) == "up");
+                break;
+            }
+        }
+    }
+
+    bool monitor_force_down = false;
+    vector<FieldValueTuple> ml_data;
+    if (m_stateMonitorLinkGroupMemberTable.get(alias, ml_data))
+    {
+        for (const auto &fv : ml_data)
+        {
+            if (fvField(fv) == "state")
+            {
+                monitor_force_down = (fvValue(fv) == "force_down");
+                break;
+            }
+        }
+    }
+
+    bool effective_up = config_admin_up && !monitor_force_down;
+    SWSS_LOG_INFO("TeamMgr: %s effective admin status: config=%s monitor=%s result=%s",
+                  alias.c_str(),
+                  config_admin_up ? "up" : "down",
+                  monitor_force_down ? "force_down" : "allow_up",
+                  effective_up ? "up" : "down");
+    setLagAdminStatus(alias, effective_up ? "up" : "down");
 }
 
 bool TeamMgr::setLagMtu(const string &alias, const string &mtu)
@@ -944,63 +948,12 @@ void TeamMgr::doMonitorLinkGroupMemberTask(Consumer &consumer)
         if (op == SET_COMMAND)
         {
             SWSS_LOG_INFO("TeamMgr: Processing monitor link group member SET for %s", interface_name.c_str());
-
-            string monitor_link_state;
-            string down_due_to;
-
-            for (const auto &idx : data)
-            {
-                const auto &field = fvField(idx);
-                const auto &value = fvValue(idx);
-
-                if (field == "state")
-                    monitor_link_state = value;
-                else if (field == "down_due_to")
-                    down_due_to = value;
-            }
-
-            if (monitor_link_state.empty())
-            {
-                SWSS_LOG_WARN("TeamMgr: No state provided for interface %s, skipping", interface_name.c_str());
-                it = consumer.m_toSync.erase(it);
-                continue;
-            }
-
-            bool config_admin_up = true;
-            for (const auto &fv : lag_data)
-            {
-                if (fvField(fv) == "admin_status")
-                {
-                    config_admin_up = (fvValue(fv) == "up");
-                    break;
-                }
-            }
-
-            bool should_be_up = (monitor_link_state == "allow_up") && config_admin_up;
-
-            SWSS_LOG_INFO("TeamMgr: Interface %s - monitor_link_state: %s, config_admin_up: %s, final_state: %s, down_due_to: %s",
-                         interface_name.c_str(), monitor_link_state.c_str(),
-                         config_admin_up ? "up" : "down", should_be_up ? "up" : "down", down_due_to.c_str());
-
-            setLagAdminStatus(interface_name, should_be_up ? "up" : "down");
+            applyEffectiveLagAdminStatus(interface_name);
         }
         else if (op == DEL_COMMAND)
         {
             SWSS_LOG_INFO("TeamMgr: Processing monitor link group member DEL for %s", interface_name.c_str());
-
-            bool config_admin_up = true;
-            for (const auto &fv : lag_data)
-            {
-                if (fvField(fv) == "admin_status")
-                {
-                    config_admin_up = (fvValue(fv) == "up");
-                    break;
-                }
-            }
-
-            SWSS_LOG_INFO("TeamMgr: Restoring interface %s to configuration state: %s",
-                         interface_name.c_str(), config_admin_up ? "up" : "down");
-            setLagAdminStatus(interface_name, config_admin_up ? "up" : "down");
+            applyEffectiveLagAdminStatus(interface_name);
         }
 
         it = consumer.m_toSync.erase(it);

--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -36,7 +36,8 @@ TeamMgr::TeamMgr(DBConnector *confDb, DBConnector *applDb, DBConnector *statDb,
     m_appLagTable(applDb, APP_LAG_TABLE_NAME),
     m_statePortTable(statDb, STATE_PORT_TABLE_NAME),
     m_stateLagTable(statDb, STATE_LAG_TABLE_NAME),
-    m_stateMACsecIngressSATable(statDb, STATE_MACSEC_INGRESS_SA_TABLE_NAME)
+    m_stateMACsecIngressSATable(statDb, STATE_MACSEC_INGRESS_SA_TABLE_NAME),
+    m_stateMonitorLinkGroupMemberTable(statDb, STATE_MONITOR_LINK_GROUP_MEMBER_TABLE_NAME)
 {
     SWSS_LOG_ENTER();
 
@@ -165,6 +166,10 @@ void TeamMgr::doTask(Consumer &consumer)
     else if (table == STATE_PORT_TABLE_NAME)
     {
         doPortUpdateTask(consumer);
+    }
+    else if (table == STATE_MONITOR_LINK_GROUP_MEMBER_TABLE_NAME)
+    {
+        doMonitorLinkGroupMemberTask(consumer);
     }
 }
 
@@ -311,7 +316,42 @@ void TeamMgr::doLagTask(Consumer &consumer)
                 m_lagList.insert(alias);
             }
 
-            setLagAdminStatus(alias, admin_status);
+            if (admin_status == "up")
+            {
+                vector<FieldValueTuple> monitor_link_data;
+                if (m_stateMonitorLinkGroupMemberTable.get(alias, monitor_link_data))
+                {
+                    string monitor_link_state;
+                    for (const auto &fv : monitor_link_data)
+                    {
+                        if (fvField(fv) == "state")
+                        {
+                            monitor_link_state = fvValue(fv);
+                            break;
+                        }
+                    }
+                    if (monitor_link_state == "allow_up")
+                    {
+                        setLagAdminStatus(alias, "up");
+                        SWSS_LOG_NOTICE("Configure %s admin status to up (monitor link allows)", alias.c_str());
+                    }
+                    else
+                    {
+                        setLagAdminStatus(alias, "down");
+                        SWSS_LOG_NOTICE("Configure %s admin status blocked by monitor link (state: %s)", alias.c_str(), monitor_link_state.c_str());
+                    }
+                }
+                else
+                {
+                    setLagAdminStatus(alias, "up");
+                    SWSS_LOG_NOTICE("Configure %s admin status to up", alias.c_str());
+                }
+            }
+            else
+            {
+                setLagAdminStatus(alias, "down");
+                SWSS_LOG_NOTICE("Configure %s admin status to down", alias.c_str());
+            }
             setLagMtu(alias, mtu);
             if (!learn_mode.empty())
             {
@@ -876,4 +916,93 @@ bool TeamMgr::removeLagMember(const string &lag, const string &member)
     SWSS_LOG_NOTICE("Remove %s from port channel %s", member.c_str(), lag.c_str());
 
     return true;
+}
+
+void TeamMgr::doMonitorLinkGroupMemberTask(Consumer &consumer)
+{
+    SWSS_LOG_ENTER();
+
+    auto it = consumer.m_toSync.begin();
+    while (it != consumer.m_toSync.end())
+    {
+        KeyOpFieldsValuesTuple t = it->second;
+
+        string interface_name = kfvKey(t);
+        string op = kfvOp(t);
+        auto data = kfvFieldsValues(t);
+
+        // Determine interface type via CONFIG_DB rather than name prefix — avoids breakage
+        // if SONiC ever adds LAG naming that doesn't start with "PortChannel".
+        vector<FieldValueTuple> lag_data;
+        if (!m_cfgLagTable.get(interface_name, lag_data))
+        {
+            // Not a LAG (Ethernet or unknown) — handled by portmgrd
+            it = consumer.m_toSync.erase(it);
+            continue;
+        }
+
+        if (op == SET_COMMAND)
+        {
+            SWSS_LOG_INFO("TeamMgr: Processing monitor link group member SET for %s", interface_name.c_str());
+
+            string monitor_link_state;
+            string down_due_to;
+
+            for (const auto &idx : data)
+            {
+                const auto &field = fvField(idx);
+                const auto &value = fvValue(idx);
+
+                if (field == "state")
+                    monitor_link_state = value;
+                else if (field == "down_due_to")
+                    down_due_to = value;
+            }
+
+            if (monitor_link_state.empty())
+            {
+                SWSS_LOG_WARN("TeamMgr: No state provided for interface %s, skipping", interface_name.c_str());
+                it = consumer.m_toSync.erase(it);
+                continue;
+            }
+
+            bool config_admin_up = true;
+            for (const auto &fv : lag_data)
+            {
+                if (fvField(fv) == "admin_status")
+                {
+                    config_admin_up = (fvValue(fv) == "up");
+                    break;
+                }
+            }
+
+            bool should_be_up = (monitor_link_state == "allow_up") && config_admin_up;
+
+            SWSS_LOG_INFO("TeamMgr: Interface %s - monitor_link_state: %s, config_admin_up: %s, final_state: %s, down_due_to: %s",
+                         interface_name.c_str(), monitor_link_state.c_str(),
+                         config_admin_up ? "up" : "down", should_be_up ? "up" : "down", down_due_to.c_str());
+
+            setLagAdminStatus(interface_name, should_be_up ? "up" : "down");
+        }
+        else if (op == DEL_COMMAND)
+        {
+            SWSS_LOG_INFO("TeamMgr: Processing monitor link group member DEL for %s", interface_name.c_str());
+
+            bool config_admin_up = true;
+            for (const auto &fv : lag_data)
+            {
+                if (fvField(fv) == "admin_status")
+                {
+                    config_admin_up = (fvValue(fv) == "up");
+                    break;
+                }
+            }
+
+            SWSS_LOG_INFO("TeamMgr: Restoring interface %s to configuration state: %s",
+                         interface_name.c_str(), config_admin_up ? "up" : "down");
+            setLagAdminStatus(interface_name, config_admin_up ? "up" : "down");
+        }
+
+        it = consumer.m_toSync.erase(it);
+    }
 }

--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -5,6 +5,7 @@
 #include "tokenize.h"
 #include "warm_restart.h"
 #include "portmgr.h"
+#include "monitorlinkgroupmgr.h"
 #include <swss/redisutility.h>
 
 #include <algorithm>

--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -507,7 +507,9 @@ bool TeamMgr::setLagAdminStatus(const string &alias, const string &admin_status)
 void TeamMgr::applyEffectiveLagAdminStatus(const string &alias)
 {
     vector<FieldValueTuple> lag_data;
-    bool config_admin_up = true;
+    // If admin_status is absent from CONFIG_DB, match the default that the
+    // doLagTask first-write path applies (DEFAULT_ADMIN_STATUS_STR == "down").
+    bool config_admin_up = false;
     if (m_cfgLagTable.get(alias, lag_data))
     {
         for (const auto &fv : lag_data)

--- a/cfgmgr/teammgr.h
+++ b/cfgmgr/teammgr.h
@@ -49,6 +49,7 @@ private:
     bool removeLagMember(const std::string &lag, const std::string &member);
 
     bool setLagAdminStatus(const std::string &alias, const std::string &admin_status);
+    void applyEffectiveLagAdminStatus(const std::string &alias);
     bool setLagMtu(const std::string &alias, const std::string &mtu);
     bool setLagLearnMode(const std::string &alias, const std::string &learn_mode);
     bool setLagTpid(const std::string &alias, const std::string &tpid);

--- a/cfgmgr/teammgr.h
+++ b/cfgmgr/teammgr.h
@@ -28,6 +28,7 @@ private:
     Table m_statePortTable;
     Table m_stateLagTable;
     Table m_stateMACsecIngressSATable;
+    Table m_stateMonitorLinkGroupMemberTable;
 
     ProducerStateTable m_appPortTable;
     ProducerStateTable m_appLagTable;
@@ -40,6 +41,7 @@ private:
     void doLagTask(Consumer &consumer);
     void doLagMemberTask(Consumer &consumer);
     void doPortUpdateTask(Consumer &consumer);
+    void doMonitorLinkGroupMemberTask(Consumer &consumer);
 
     task_process_status addLag(const std::string &alias, int min_links, bool fall_back, bool fast_rate);
     bool removeLag(const std::string &alias);

--- a/cfgmgr/teammgrd.cpp
+++ b/cfgmgr/teammgrd.cpp
@@ -6,6 +6,7 @@
 #include "select.h"
 #include "warm_restart.h"
 #include <signal.h>
+#include <sys/prctl.h>
 
 using namespace std;
 using namespace swss;
@@ -43,6 +44,14 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
+    /* Set as subreaper to adopt orphaned teamd processes */
+    if (prctl(PR_SET_CHILD_SUBREAPER, 1) < 0)
+    {
+        SWSS_LOG_ERROR("Failed to set child subreaper: %s", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+    SWSS_LOG_NOTICE("Set as child subreaper for teamd process management");
+
     try
     {
         DBConnector conf_db("CONFIG_DB", 0);
@@ -55,11 +64,13 @@ int main(int argc, char **argv)
         TableConnector conf_lag_table(&conf_db, CFG_LAG_TABLE_NAME);
         TableConnector conf_lag_member_table(&conf_db, CFG_LAG_MEMBER_TABLE_NAME);
         TableConnector state_port_table(&state_db, STATE_PORT_TABLE_NAME);
+        TableConnector state_monitor_link_group_member_table(&state_db, STATE_MONITOR_LINK_GROUP_MEMBER_TABLE_NAME);
 
         vector<TableConnector> tables = {
             conf_lag_table,
             conf_lag_member_table,
-            state_port_table
+            state_port_table,
+            state_monitor_link_group_member_table
         };
 
         TeamMgr teammgr(&conf_db, &app_db, &state_db, tables);

--- a/cfgmgr/teammgrd.cpp
+++ b/cfgmgr/teammgrd.cpp
@@ -5,6 +5,7 @@
 #include "netlink.h"
 #include "select.h"
 #include "warm_restart.h"
+#include "monitorlinkgroupmgr.h"
 #include <signal.h>
 #include <sys/prctl.h>
 

--- a/tests/mock_tests/portmgr_ut.cpp
+++ b/tests/mock_tests/portmgr_ut.cpp
@@ -29,8 +29,8 @@ namespace portmgr_ut
         virtual void SetUp() override
         {
             ::testing_db::reset();
-            vector<string> cfg_port_tables = {
-                CFG_PORT_TABLE_NAME,
+            vector<TableConnector> cfg_port_tables = {
+                {m_config_db.get(), CFG_PORT_TABLE_NAME},
             };
             m_portMgr.reset(new PortMgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_port_tables));
         }

--- a/tests/test_monitorlinkgroupmgr.py
+++ b/tests/test_monitorlinkgroupmgr.py
@@ -1,0 +1,214 @@
+import time
+import pytest
+from swsscommon import swsscommon
+from dvslib.dvs_common import PollingConfig
+
+CFG_MLG_TABLE = "MONITOR_LINK_GROUP"
+STATE_MLG_STATE_TABLE = "MONITOR_LINK_GROUP_STATE"
+STATE_MLG_MEMBER_TABLE = "MONITOR_LINK_GROUP_MEMBER"
+STATE_PORT_TABLE = "PORT_TABLE"
+
+
+class TestMonitorLinkGroup:
+    def setup_dbs(self, dvs):
+        self.cfg_db = dvs.get_config_db()
+        self.sdb = dvs.get_state_db()
+        # dvs.asicdb is AsicDbValidator(DVSDatabase) with portnamemap and wait_for_field_match
+        self.asic_db = dvs.asicdb
+
+    def set_port_oper(self, port, status):
+        """Write oper_status to STATE_DB:PORT_TABLE (simulates portsyncd)."""
+        self.sdb.create_entry(STATE_PORT_TABLE, port, {"oper_status": status})
+        time.sleep(0.5)
+
+    def set_port_cfg_admin(self, port, status):
+        self.cfg_db.update_entry("PORT", port, {"admin_status": status})
+        time.sleep(0.5)
+
+    def create_group(self, name, uplinks, downlinks, min_uplinks=1, linkup_delay=0, desc=""):
+        entry = {
+            "description": desc,
+            "uplinks": ",".join(uplinks),
+            "downlinks": ",".join(downlinks),
+            "min-uplinks": str(min_uplinks),
+            "link-up-delay": str(linkup_delay),
+        }
+        self.cfg_db.create_entry(CFG_MLG_TABLE, name, entry)
+
+    def delete_group(self, name):
+        self.cfg_db.delete_entry(CFG_MLG_TABLE, name)
+
+    def wait_group_state(self, name, state, timeout=15):
+        self.sdb.wait_for_field_match(
+            STATE_MLG_STATE_TABLE, name, {"state": state},
+            polling_config=PollingConfig(timeout=timeout),
+        )
+
+    def wait_member_state(self, port, state, timeout=15):
+        self.sdb.wait_for_field_match(
+            STATE_MLG_MEMBER_TABLE, port, {"state": state},
+            polling_config=PollingConfig(timeout=timeout),
+        )
+
+    def wait_asic_admin(self, port, up, timeout=15):
+        oid = self.asic_db.portnamemap[port]
+        self.asic_db.wait_for_field_match(
+            "ASIC_STATE:SAI_OBJECT_TYPE_PORT", oid,
+            {"SAI_PORT_ATTR_ADMIN_STATE": "true" if up else "false"},
+            polling_config=PollingConfig(timeout=timeout),
+        )
+
+    def test_group_lifecycle(self, dvs, testlog):
+        """Group add → STATE_DB appears with correct state; delete → STATE_DB cleaned up."""
+        self.setup_dbs(dvs)
+
+        self.set_port_oper("Ethernet0", "up")
+        self.set_port_oper("Ethernet4", "up")
+
+        self.create_group("ml_lifecycle", ["Ethernet0"], ["Ethernet4"])
+
+        # Uplink is up: group must be UP immediately (no link-up-delay)
+        self.wait_group_state("ml_lifecycle", "up")
+        self.wait_member_state("Ethernet4", "allow_up")
+
+        self.delete_group("ml_lifecycle")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_STATE_TABLE, "ml_lifecycle")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_MEMBER_TABLE, "Ethernet4")
+
+    def test_uplink_down_forces_downlink(self, dvs, testlog):
+        """Uplink oper-down → group DOWN + downlink force_down + ASIC false; recovery reverses all."""
+        self.setup_dbs(dvs)
+
+        self.set_port_cfg_admin("Ethernet0", "up")
+        self.set_port_cfg_admin("Ethernet4", "up")
+        self.set_port_oper("Ethernet0", "up")
+        self.set_port_oper("Ethernet4", "up")
+        self.wait_asic_admin("Ethernet4", True)
+
+        self.create_group("ml_force", ["Ethernet0"], ["Ethernet4"])
+        self.wait_group_state("ml_force", "up")
+        self.wait_member_state("Ethernet4", "allow_up")
+
+        # Uplink goes down
+        self.set_port_oper("Ethernet0", "down")
+        self.wait_group_state("ml_force", "down")
+        self.wait_member_state("Ethernet4", "force_down")
+        self.wait_asic_admin("Ethernet4", False)
+
+        # Uplink recovers
+        self.set_port_oper("Ethernet0", "up")
+        self.wait_group_state("ml_force", "up")
+        self.wait_member_state("Ethernet4", "allow_up")
+        self.wait_asic_admin("Ethernet4", True)
+
+        self.delete_group("ml_force")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_STATE_TABLE, "ml_force")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_MEMBER_TABLE, "Ethernet4")
+
+    def test_linkup_delay(self, dvs, testlog):
+        """link-up-delay=3: state is pending immediately after recovery, up after delay elapses."""
+        self.setup_dbs(dvs)
+
+        self.set_port_oper("Ethernet0", "down")
+        self.set_port_oper("Ethernet4", "up")
+
+        self.create_group("ml_delay", ["Ethernet0"], ["Ethernet4"], linkup_delay=3)
+        self.wait_group_state("ml_delay", "down")
+        self.wait_member_state("Ethernet4", "force_down")
+
+        # Uplink comes back; daemon starts 3s timer and writes state=pending
+        self.set_port_oper("Ethernet0", "up")
+
+        # T+1s: timer not yet elapsed → state must be pending
+        time.sleep(1)
+        fvs = self.sdb.get_entry(STATE_MLG_STATE_TABLE, "ml_delay")
+        assert fvs.get("state") == "pending", \
+            f"Expected pending at T+1s but got state={fvs.get('state')}"
+
+        # After delay elapses (timer fires within ~4-5s of oper-up): state becomes up
+        self.wait_group_state("ml_delay", "up", timeout=10)
+        self.wait_member_state("Ethernet4", "allow_up", timeout=10)
+
+        self.delete_group("ml_delay")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_STATE_TABLE, "ml_delay")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_MEMBER_TABLE, "Ethernet4")
+
+    def test_config_admin_down_respected(self, dvs, testlog):
+        """When config admin_status=down, monitor clearing allow_up must not raise ASIC to true."""
+        self.setup_dbs(dvs)
+
+        self.set_port_cfg_admin("Ethernet4", "down")
+        self.set_port_oper("Ethernet0", "down")
+        self.set_port_oper("Ethernet4", "up")
+
+        self.create_group("ml_cfgdown", ["Ethernet0"], ["Ethernet4"])
+        self.wait_group_state("ml_cfgdown", "down")
+        self.wait_member_state("Ethernet4", "force_down")
+        self.wait_asic_admin("Ethernet4", False)
+
+        # Uplink recovers: monitor releases Ethernet4 (allow_up), but config says down
+        self.set_port_oper("Ethernet0", "up")
+        self.wait_group_state("ml_cfgdown", "up")
+        self.wait_member_state("Ethernet4", "allow_up")
+        # Config admin_status=down must hold: ASIC stays false
+        self.wait_asic_admin("Ethernet4", False)
+
+        self.delete_group("ml_cfgdown")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_STATE_TABLE, "ml_cfgdown")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_MEMBER_TABLE, "Ethernet4")
+        self.set_port_cfg_admin("Ethernet4", "up")
+        self.wait_asic_admin("Ethernet4", True)
+
+    def test_cross_role_cascade(self, dvs, testlog):
+        """Chain topology: Eth0→uplink_A, Eth4→downlink_A+uplink_B, Eth8→downlink_B.
+        Eth0 down cascades through to Eth8; recovery cascades back up."""
+        self.setup_dbs(dvs)
+
+        for port in ("Ethernet0", "Ethernet4", "Ethernet8"):
+            self.set_port_cfg_admin(port, "up")
+            self.set_port_oper(port, "up")
+        self.wait_asic_admin("Ethernet8", True)
+
+        self.create_group("ml_chain_A", ["Ethernet0"], ["Ethernet4"])
+        self.create_group("ml_chain_B", ["Ethernet4"], ["Ethernet8"])
+        self.wait_group_state("ml_chain_A", "up")
+        self.wait_group_state("ml_chain_B", "up")
+        self.wait_member_state("Ethernet4", "allow_up")
+        self.wait_member_state("Ethernet8", "allow_up")
+
+        # Cascade down: Eth0 → group_A down → Eth4 force_down
+        self.set_port_oper("Ethernet0", "down")
+        self.wait_group_state("ml_chain_A", "down")
+        self.wait_member_state("Ethernet4", "force_down")
+        self.wait_asic_admin("Ethernet4", False)
+
+        # Simulate portsyncd propagating Eth4 admin-down → oper-down → group_B down → Eth8 force_down
+        self.set_port_oper("Ethernet4", "down")
+        self.wait_group_state("ml_chain_B", "down")
+        self.wait_member_state("Ethernet8", "force_down")
+        self.wait_asic_admin("Ethernet8", False)
+
+        # Cascade recovery: Eth0 up → group_A up → Eth4 allow_up
+        self.set_port_oper("Ethernet0", "up")
+        self.wait_group_state("ml_chain_A", "up")
+        self.wait_member_state("Ethernet4", "allow_up")
+        self.wait_asic_admin("Ethernet4", True)
+
+        # Simulate portsyncd propagating Eth4 admin-up → oper-up → group_B up → Eth8 allow_up
+        self.set_port_oper("Ethernet4", "up")
+        self.wait_group_state("ml_chain_B", "up")
+        self.wait_member_state("Ethernet8", "allow_up")
+        self.wait_asic_admin("Ethernet8", True)
+
+        # Delete B first so Eth4 (downlink_A, uplink_B) loses uplink_B; then delete A releases Eth4
+        self.delete_group("ml_chain_B")
+        self.delete_group("ml_chain_A")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_STATE_TABLE, "ml_chain_A")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_STATE_TABLE, "ml_chain_B")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_MEMBER_TABLE, "Ethernet4")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_MEMBER_TABLE, "Ethernet8")
+
+
+# Dummy always-pass test guards against module teardown on final-test flaky retry
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_monitorlinkgroupmgr.py
+++ b/tests/test_monitorlinkgroupmgr.py
@@ -17,8 +17,18 @@ class TestMonitorLinkGroup:
         self.asic_db = dvs.asicdb
 
     def set_port_oper(self, port, status):
-        """Write oper_status to STATE_DB:PORT_TABLE (simulates portsyncd)."""
-        self.sdb.create_entry(STATE_PORT_TABLE, port, {"oper_status": status})
+        """Override netdev_oper_status + oper_status in STATE_DB:PORT_TABLE.
+
+        monitorlinkgroupmgr prefers netdev_oper_status for Ethernet ports
+        (kernel-netdev is authoritative) and falls back to oper_status.
+        portsyncd in the dvs may have already written netdev_oper_status,
+        so we must overwrite that field; setting only oper_status would
+        be silently ignored.
+        """
+        self.sdb.create_entry(
+            STATE_PORT_TABLE, port,
+            {"netdev_oper_status": status, "oper_status": status},
+        )
         time.sleep(0.5)
 
     def set_port_cfg_admin(self, port, status):

--- a/tests/test_monitorlinkgroupmgr.py
+++ b/tests/test_monitorlinkgroupmgr.py
@@ -216,6 +216,61 @@ class TestMonitorLinkGroup:
         self.sdb.wait_for_deleted_entry(STATE_MLG_MEMBER_TABLE, "Ethernet4")
         self.sdb.wait_for_deleted_entry(STATE_MLG_MEMBER_TABLE, "Ethernet8")
 
+    def test_remove_monitored_link(self, dvs, testlog):
+        """Updating a group to drop a previously-included monitored or managed link
+        must run the removeInterfaceFromGroup path and clean state."""
+        self.setup_dbs(dvs)
+
+        for port in ("Ethernet0", "Ethernet4", "Ethernet8"):
+            self.set_port_cfg_admin(port, "up")
+            self.set_port_oper(port, "up")
+
+        self.create_group("ml_remove", ["Ethernet0", "Ethernet4"], ["Ethernet8"])
+        self.wait_group_state("ml_remove", "up")
+        self.wait_member_state("Ethernet8", "allow_up")
+
+        # Drop Ethernet4 from monitored-links; Ethernet0 is still up so group stays up.
+        self.create_group("ml_remove", ["Ethernet0"], ["Ethernet8"])
+        self.wait_group_state("ml_remove", "up")
+        self.wait_member_state("Ethernet8", "allow_up")
+
+        # Drop Ethernet8 from managed-links; its STATE_DB member entry must be cleared.
+        self.create_group("ml_remove", ["Ethernet0"], [])
+        self.wait_group_state("ml_remove", "up")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_MEMBER_TABLE, "Ethernet8")
+
+        self.delete_group("ml_remove")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_STATE_TABLE, "ml_remove")
+
+    def test_delay_reduced_while_pending(self, dvs, testlog):
+        """Reducing link-up-delay to 0 while a group is pending must bring it UP immediately."""
+        self.setup_dbs(dvs)
+
+        self.set_port_cfg_admin("Ethernet0", "up")
+        self.set_port_cfg_admin("Ethernet4", "up")
+        self.set_port_oper("Ethernet0", "down")
+        self.set_port_oper("Ethernet4", "up")
+
+        self.create_group("ml_delay_reduce", ["Ethernet0"], ["Ethernet4"], linkup_delay=20)
+        self.wait_group_state("ml_delay_reduce", "down")
+        self.wait_member_state("Ethernet4", "force_down")
+
+        # Eth0 recovers: with delay=20, group enters pending and stays there.
+        self.set_port_oper("Ethernet0", "up")
+        time.sleep(1)
+        fvs = self.sdb.get_entry(STATE_MLG_STATE_TABLE, "ml_delay_reduce")
+        assert fvs.get("state") == "pending", \
+            f"Expected pending after Eth0 recovery but got state={fvs.get('state')}"
+
+        # Reduce link-up-delay to 0 while pending: handleGroupDelayChange must fast-up.
+        self.create_group("ml_delay_reduce", ["Ethernet0"], ["Ethernet4"], linkup_delay=0)
+        self.wait_group_state("ml_delay_reduce", "up", timeout=5)
+        self.wait_member_state("Ethernet4", "allow_up", timeout=5)
+
+        self.delete_group("ml_delay_reduce")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_STATE_TABLE, "ml_delay_reduce")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_MEMBER_TABLE, "Ethernet4")
+
 # Dummy always-pass test guards against module teardown on final-test flaky retry
 def test_nonflaky_dummy():
     pass

--- a/tests/test_monitorlinkgroupmgr.py
+++ b/tests/test_monitorlinkgroupmgr.py
@@ -242,6 +242,96 @@ class TestMonitorLinkGroup:
         self.delete_group("ml_remove")
         self.sdb.wait_for_deleted_entry(STATE_MLG_STATE_TABLE, "ml_remove")
 
+    def test_delay_elapsed_branch(self, dvs, testlog):
+        """Reducing link-up-delay to a value <= elapsed time must fast-up the group."""
+        self.setup_dbs(dvs)
+
+        self.set_port_cfg_admin("Ethernet0", "up")
+        self.set_port_cfg_admin("Ethernet4", "up")
+        self.set_port_oper("Ethernet0", "down")
+        self.set_port_oper("Ethernet4", "up")
+
+        self.create_group("ml_delay_elapsed", ["Ethernet0"], ["Ethernet4"], linkup_delay=10)
+        self.wait_group_state("ml_delay_elapsed", "down")
+
+        self.set_port_oper("Ethernet0", "up")
+        time.sleep(3)
+        fvs = self.sdb.get_entry(STATE_MLG_STATE_TABLE, "ml_delay_elapsed")
+        assert fvs.get("state") == "pending", \
+            f"Expected pending after 3s but got state={fvs.get('state')}"
+
+        # elapsed=~3s, reduce delay to 2s: elapsed >= new_delay => fast-up
+        self.create_group("ml_delay_elapsed", ["Ethernet0"], ["Ethernet4"], linkup_delay=2)
+        self.wait_group_state("ml_delay_elapsed", "up", timeout=5)
+        self.wait_member_state("Ethernet4", "allow_up", timeout=5)
+
+        self.delete_group("ml_delay_elapsed")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_STATE_TABLE, "ml_delay_elapsed")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_MEMBER_TABLE, "Ethernet4")
+
+    def test_delay_restart_with_remaining(self, dvs, testlog):
+        """Reducing link-up-delay to a value > elapsed time must restart timer with remaining seconds."""
+        self.setup_dbs(dvs)
+
+        self.set_port_cfg_admin("Ethernet0", "up")
+        self.set_port_cfg_admin("Ethernet4", "up")
+        self.set_port_oper("Ethernet0", "down")
+        self.set_port_oper("Ethernet4", "up")
+
+        self.create_group("ml_delay_restart", ["Ethernet0"], ["Ethernet4"], linkup_delay=15)
+        self.wait_group_state("ml_delay_restart", "down")
+
+        self.set_port_oper("Ethernet0", "up")
+        time.sleep(2)
+        fvs = self.sdb.get_entry(STATE_MLG_STATE_TABLE, "ml_delay_restart")
+        assert fvs.get("state") == "pending"
+
+        # elapsed=~2s, reduce delay to 6s: elapsed < new_delay => timer restarts with ~4s remaining
+        self.create_group("ml_delay_restart", ["Ethernet0"], ["Ethernet4"], linkup_delay=6)
+        time.sleep(2)
+        fvs = self.sdb.get_entry(STATE_MLG_STATE_TABLE, "ml_delay_restart")
+        assert fvs.get("state") == "pending", \
+            f"Expected still pending at elapsed+2s but got state={fvs.get('state')}"
+
+        # After remaining time elapses, group should come up
+        self.wait_group_state("ml_delay_restart", "up", timeout=10)
+        self.wait_member_state("Ethernet4", "allow_up", timeout=10)
+
+        self.delete_group("ml_delay_restart")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_STATE_TABLE, "ml_delay_restart")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_MEMBER_TABLE, "Ethernet4")
+
+    def test_lag_in_mlg(self, dvs, testlog):
+        """A PortChannel as managed-link must be admin-down when MLG forces it,
+        and admin-up when MLG allows it; exercises teammgr/teammgrd paths."""
+        self.setup_dbs(dvs)
+
+        self.set_port_oper("Ethernet0", "up")
+
+        # Create PortChannel with admin=up
+        self.cfg_db.create_entry("PORTCHANNEL", "PortChannel0001",
+                                 {"admin_status": "up", "mtu": "9100"})
+        time.sleep(1)
+
+        self.create_group("ml_lag", ["Ethernet0"], ["PortChannel0001"])
+        self.wait_group_state("ml_lag", "up")
+        self.wait_member_state("PortChannel0001", "allow_up")
+
+        # Monitored goes down: group down, PortChannel force_down (teammgr applies admin-down)
+        self.set_port_oper("Ethernet0", "down")
+        self.wait_group_state("ml_lag", "down")
+        self.wait_member_state("PortChannel0001", "force_down")
+
+        # Recovery
+        self.set_port_oper("Ethernet0", "up")
+        self.wait_group_state("ml_lag", "up")
+        self.wait_member_state("PortChannel0001", "allow_up")
+
+        self.delete_group("ml_lag")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_STATE_TABLE, "ml_lag")
+        self.sdb.wait_for_deleted_entry(STATE_MLG_MEMBER_TABLE, "PortChannel0001")
+        self.cfg_db.delete_entry("PORTCHANNEL", "PortChannel0001")
+
     def test_delay_reduced_while_pending(self, dvs, testlog):
         """Reducing link-up-delay to 0 while a group is pending must bring it UP immediately."""
         self.setup_dbs(dvs)

--- a/tests/test_monitorlinkgroupmgr.py
+++ b/tests/test_monitorlinkgroupmgr.py
@@ -1,6 +1,4 @@
 import time
-import pytest
-from swsscommon import swsscommon
 from dvslib.dvs_common import PollingConfig
 
 CFG_MLG_TABLE = "MONITOR_LINK_GROUP"

--- a/tests/test_monitorlinkgroupmgr.py
+++ b/tests/test_monitorlinkgroupmgr.py
@@ -25,12 +25,12 @@ class TestMonitorLinkGroup:
         self.cfg_db.update_entry("PORT", port, {"admin_status": status})
         time.sleep(0.5)
 
-    def create_group(self, name, uplinks, downlinks, min_uplinks=1, linkup_delay=0, desc=""):
+    def create_group(self, name, monitored, managed, min_monitored_links=1, linkup_delay=0, desc=""):
         entry = {
             "description": desc,
-            "uplinks": ",".join(uplinks),
-            "downlinks": ",".join(downlinks),
-            "min-uplinks": str(min_uplinks),
+            "monitored-links": ",".join(monitored),
+            "managed-links": ",".join(managed),
+            "min-monitored-links": str(min_monitored_links),
             "link-up-delay": str(linkup_delay),
         }
         self.cfg_db.create_entry(CFG_MLG_TABLE, name, entry)
@@ -67,7 +67,7 @@ class TestMonitorLinkGroup:
 
         self.create_group("ml_lifecycle", ["Ethernet0"], ["Ethernet4"])
 
-        # Uplink is up: group must be UP immediately (no link-up-delay)
+        # Monitored-link is up: group must be UP immediately (no link-up-delay)
         self.wait_group_state("ml_lifecycle", "up")
         self.wait_member_state("Ethernet4", "allow_up")
 
@@ -75,8 +75,8 @@ class TestMonitorLinkGroup:
         self.sdb.wait_for_deleted_entry(STATE_MLG_STATE_TABLE, "ml_lifecycle")
         self.sdb.wait_for_deleted_entry(STATE_MLG_MEMBER_TABLE, "Ethernet4")
 
-    def test_uplink_down_forces_downlink(self, dvs, testlog):
-        """Uplink oper-down → group DOWN + downlink force_down + ASIC false; recovery reverses all."""
+    def test_monitored_down_forces_managed(self, dvs, testlog):
+        """Monitored oper-down → group DOWN + managed force_down + ASIC false; recovery reverses all."""
         self.setup_dbs(dvs)
 
         self.set_port_cfg_admin("Ethernet0", "up")
@@ -89,13 +89,13 @@ class TestMonitorLinkGroup:
         self.wait_group_state("ml_force", "up")
         self.wait_member_state("Ethernet4", "allow_up")
 
-        # Uplink goes down
+        # Monitored-link goes down
         self.set_port_oper("Ethernet0", "down")
         self.wait_group_state("ml_force", "down")
         self.wait_member_state("Ethernet4", "force_down")
         self.wait_asic_admin("Ethernet4", False)
 
-        # Uplink recovers
+        # Monitored-link recovers
         self.set_port_oper("Ethernet0", "up")
         self.wait_group_state("ml_force", "up")
         self.wait_member_state("Ethernet4", "allow_up")
@@ -116,7 +116,7 @@ class TestMonitorLinkGroup:
         self.wait_group_state("ml_delay", "down")
         self.wait_member_state("Ethernet4", "force_down")
 
-        # Uplink comes back; daemon starts 3s timer and writes state=pending
+        # Monitored-link comes back; daemon starts 3s timer and writes state=pending
         self.set_port_oper("Ethernet0", "up")
 
         # T+1s: timer not yet elapsed → state must be pending
@@ -146,7 +146,7 @@ class TestMonitorLinkGroup:
         self.wait_member_state("Ethernet4", "force_down")
         self.wait_asic_admin("Ethernet4", False)
 
-        # Uplink recovers: monitor releases Ethernet4 (allow_up), but config says down
+        # Monitored-link recovers: monitor releases Ethernet4 (allow_up), but config says down
         self.set_port_oper("Ethernet0", "up")
         self.wait_group_state("ml_cfgdown", "up")
         self.wait_member_state("Ethernet4", "allow_up")
@@ -160,7 +160,7 @@ class TestMonitorLinkGroup:
         self.wait_asic_admin("Ethernet4", True)
 
     def test_cross_role_cascade(self, dvs, testlog):
-        """Chain topology: Eth0→uplink_A, Eth4→downlink_A+uplink_B, Eth8→downlink_B.
+        """Chain topology: Eth0→monitored_A, Eth4→managed_A+monitored_B, Eth8→managed_B.
         Eth0 down cascades through to Eth8; recovery cascades back up."""
         self.setup_dbs(dvs)
 
@@ -176,7 +176,7 @@ class TestMonitorLinkGroup:
         self.wait_member_state("Ethernet4", "allow_up")
         self.wait_member_state("Ethernet8", "allow_up")
 
-        # Cascade down: Eth0 → group_A down → Eth4 force_down
+        # Cascade down: Eth0 (monitored_A) → group_A down → Eth4 force_down
         self.set_port_oper("Ethernet0", "down")
         self.wait_group_state("ml_chain_A", "down")
         self.wait_member_state("Ethernet4", "force_down")
@@ -188,7 +188,7 @@ class TestMonitorLinkGroup:
         self.wait_member_state("Ethernet8", "force_down")
         self.wait_asic_admin("Ethernet8", False)
 
-        # Cascade recovery: Eth0 up → group_A up → Eth4 allow_up
+        # Cascade recovery: Eth0 (monitored_A) up → group_A up → Eth4 allow_up
         self.set_port_oper("Ethernet0", "up")
         self.wait_group_state("ml_chain_A", "up")
         self.wait_member_state("Ethernet4", "allow_up")
@@ -200,14 +200,13 @@ class TestMonitorLinkGroup:
         self.wait_member_state("Ethernet8", "allow_up")
         self.wait_asic_admin("Ethernet8", True)
 
-        # Delete B first so Eth4 (downlink_A, uplink_B) loses uplink_B; then delete A releases Eth4
+        # Delete B first so Eth4 (managed_A, monitored_B) loses monitored_B; then delete A releases Eth4
         self.delete_group("ml_chain_B")
         self.delete_group("ml_chain_A")
         self.sdb.wait_for_deleted_entry(STATE_MLG_STATE_TABLE, "ml_chain_A")
         self.sdb.wait_for_deleted_entry(STATE_MLG_STATE_TABLE, "ml_chain_B")
         self.sdb.wait_for_deleted_entry(STATE_MLG_MEMBER_TABLE, "Ethernet4")
         self.sdb.wait_for_deleted_entry(STATE_MLG_MEMBER_TABLE, "Ethernet8")
-
 
 # Dummy always-pass test guards against module teardown on final-test flaky retry
 def test_nonflaky_dummy():


### PR DESCRIPTION
## What I did

Implement the Monitor Link Group feature in cfgmgr. A monitor link group tracks a set of uplink interfaces and automatically forces downlink interfaces admin-down when the operational uplink count drops below the configured `min-uplinks` threshold, preventing traffic black-holing when upstream connectivity is lost.

Files changed:

| File | Change |
|------|--------|
| `cfgmgr/monitorlinkgroupmgr.cpp` | New — core state machine |
| `cfgmgr/monitorlinkgroupmgr.h` | New — class definition |
| `cfgmgr/intfmgrd.cpp` | Register MonitorLinkGroupMgr in the Select loop |
| `cfgmgr/portmgr.cpp` + `.h` | applyEffectiveAdminStatus, doMonitorLinkGroupMemberTask |
| `cfgmgr/portmgrd.cpp` | Subscribe to STATE_MONITOR_LINK_GROUP_MEMBER_TABLE |
| `cfgmgr/teammgr.cpp` + `.h` | Same pattern for PortChannel interfaces |
| `cfgmgr/teammgrd.cpp` | Subscribe to STATE_MONITOR_LINK_GROUP_MEMBER_TABLE |
| `tests/mock_tests/portmgr_ut.cpp` | Unit test update for new PortMgr constructor parameter |
| `tests/test_monitorlinkgroupmgr.py` | New VS integration tests |

## Why I did it

Prevents traffic black-holing in multi-homed server, aggregation, and border leaf deployments. When uplinks fail, servers connected to downlinks continue forwarding into a black hole. Monitor Link Group takes the downlinks admin-down to signal the failure and trigger failover.

## Design

**MonitorLinkGroupMgr** runs as a sibling `Orch` inside `intfmgrd`. It subscribes to `CONFIG_DB:MONITOR_LINK_GROUP` and `STATE_DB:PORT_TABLE`/`LAG_TABLE`. The group state machine has three states:

- **DOWN**: uplink count < min-uplinks; downlinks receive `force_down`
- **PENDING**: uplink count >= min-uplinks AND link-up-delay > 0; timer running; downlinks remain `force_down`
- **UP**: threshold met and timer elapsed (or link-up-delay = 0); downlinks receive `allow_up`

On initial group creation the link-up-delay is skipped if uplinks already meet the threshold.

**Enforcement split**: MonitorLinkGroupMgr writes `allow_up` / `force_down` per-interface to `STATE_DB:MONITOR_LINK_GROUP_MEMBER`. PortMgr and TeamMgr subscribe and merge this with the configured `admin_status` before applying the effective state to the kernel netdev. MonitorLinkGroupMgr never calls `ip link set` directly.

**Multi-group membership**: an interface can be uplink in one group and downlink in another simultaneously. `force_down` wins if any group forces it down, enabling transitive cascade topologies.

**LAG identity** is confirmed via CONFIG_DB lookup rather than name-prefix matching.

## How I verified it

- `tests/test_monitorlinkgroupmgr.py` VS integration tests: group lifecycle, uplink-down force-down and recovery, link-up-delay PENDING state, config admin_status override, cross-group cascade topology
- intfmgrd, portmgrd, and teammgrd build cleanly

## Companion PRs

- sonic-swss-common: STATE_DB table name macros
- sonic-yang-models: YANG model
- sonic-utilities: `show monitor-link` CLI
- SONiC/SONiC: HLD

HLD: https://github.com/sonic-net/SONiC/pull/2308
Yang Changes: https://github.com/sonic-net/sonic-buildimage/pull/27004
Show: https://github.com/sonic-net/sonic-utilities/pull/4497
swss-common: https://github.com/sonic-net/sonic-swss-common/pull/1181
