### PR TITLE
[vlanmgr] apply VLAN mtu to host netdev

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <limits>
 #include "logger.h"
 #include "producerstatetable.h"
 #include "macaddress.h"
@@ -398,12 +399,6 @@ void VlanMgr::doVlanTask(Consumer &consumer)
                 else if (fvField(i) == "mtu")
                 {
                     mtu = fvValue(i);
-                    /*
-                     * TODO: support host VLAN mtu setting.
-                     * Host VLAN mtu should be set only after member configured
-                     * and VLAN state is not UNKNOWN.
-                     */
-                    SWSS_LOG_DEBUG("%s mtu %s: Host VLAN mtu setting to be supported.", key.c_str(), mtu.c_str());
                 }
                 else if (fvField(i) == "members@") {
                     members = fvValue(i);
@@ -425,8 +420,46 @@ void VlanMgr::doVlanTask(Consumer &consumer)
                 fvVector.push_back(a);
             }
 
-            FieldValueTuple m("mtu", mtu);
-            fvVector.push_back(m);
+            /*
+             * Apply MTU to the host Vlan<id> netdev. addHostVlan above
+             * (for new VLANs) or the warm-restart skip earlier guarantee
+             * the netdev exists. A VLAN sub-interface's MTU is independent
+             * of its bridge members (unlike team/bond), so no member-gating
+             * is needed. Only push the value to APPL_DB if the kernel
+             * accepted it, to keep kernel / APPL_DB / SAI in sync; mirrors
+             * how PortMgr::setPortMtu only writes APPL_DB on success.
+             */
+            uint32_t mtu_val = 0;
+            bool mtu_valid = false;
+            try
+            {
+                unsigned long long parsed = std::stoull(mtu);
+                if (parsed > std::numeric_limits<uint32_t>::max())
+                {
+                    throw std::out_of_range("mtu exceeds uint32_t range");
+                }
+                mtu_val = static_cast<uint32_t>(parsed);
+                mtu_valid = true;
+            }
+            catch (const std::exception &e)
+            {
+                SWSS_LOG_ERROR("Invalid MTU '%s' for %s: %s",
+                               mtu.c_str(), key.c_str(), e.what());
+            }
+
+            if (mtu_valid)
+            {
+                if (setHostVlanMtu(vlan_id, mtu_val))
+                {
+                    FieldValueTuple m("mtu", mtu);
+                    fvVector.push_back(m);
+                }
+                else
+                {
+                    SWSS_LOG_WARN("Failed to set MTU %u on %s; check bridge/member MTUs",
+                                  mtu_val, key.c_str());
+                }
+            }
 
             FieldValueTuple mc("mac", mac);
             fvVector.push_back(mc);

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -174,6 +174,123 @@ class TestVlan(object):
         self.dvs_vlan.remove_vlan(vlan)
         self.dvs_vlan.get_and_verify_vlan_ids(0)
 
+    def test_VlanHostNetdevMtu(self, dvs):
+        """Verify that writing mtu to CONFIG_DB VLAN table is applied to the
+        kernel Vlan<id> netdev and reflected in APPL_DB — and that when the
+        kernel rejects the MTU, neither the kernel netdev nor APPL_DB get
+        the bogus value (mirrors PortMgr::setPortMtu's "APPL_DB only on
+        kernel success" behaviour). Regression test for the long-standing
+        TODO in VlanMgr::doVlanTask where the host VLAN mtu was parsed but
+        never pushed through `ip link set Vlan<id> mtu <v>`.
+        """
+        dvs.setup_db()
+
+        vlan = "42"
+        vlan_interface = "Vlan{}".format(vlan)
+        good_mtu = "1500"
+        # Exceeds any reasonable netdev maxmtu (2^16-1 = 65535); kernel
+        # returns -ERANGE via vlan_dev_change_mtu().
+        bad_mtu = "99999"
+
+        def read_kernel_mtu():
+            _, out = dvs.runcmd(['sh', '-c', "cat /sys/class/net/{}/mtu".format(vlan_interface)])
+            return out.strip()
+
+        self.dvs_vlan.create_vlan(vlan)
+        self.dvs_vlan.get_and_verify_vlan_ids(1)
+
+        # After create, kernel Vlan netdev inherits bridge default (9100).
+        assert read_kernel_mtu() == "9100"
+
+        # Happy path: write mtu to CONFIG_DB VLAN table — vlanmgrd should
+        # run `ip link set Vlan<id> mtu <v>` and echo the value into APPL_DB.
+        dvs.set_mtu(vlan_interface, good_mtu)
+
+        wait_for_result(lambda: (read_kernel_mtu() == good_mtu, None),
+                        PollingConfig(polling_interval=0.2, timeout=5, strict=True))
+        self.dvs_vlan.app_db.wait_for_field_match("VLAN_TABLE", vlan_interface, {"mtu": good_mtu})
+
+        # Failure path: push a value the kernel will reject. Kernel and
+        # APPL_DB must both remain at good_mtu, and vlanmgrd must log WARN.
+        marker = dvs.add_log_marker()
+        dvs.set_mtu(vlan_interface, bad_mtu)
+
+        # Poll for 2s to ensure vlanmgrd never applies the bad value.
+        # A fixed sleep would be flaky on loaded CI runners; polling keeps
+        # the invariant explicit (MTU must never become bad_mtu).
+        poll_end = time.time() + 2.0
+        while time.time() < poll_end:
+            assert read_kernel_mtu() == good_mtu, \
+                "kernel MTU changed to bad value despite rejection"
+            time.sleep(0.2)
+
+        fvs = self.dvs_vlan.app_db.get_entry("VLAN_TABLE", vlan_interface)
+        assert fvs.get("mtu") == good_mtu, \
+            "APPL_DB mtu was updated to bad value {} (expected {})".format(
+                fvs.get("mtu"), good_mtu)
+
+        self.check_syslog(dvs, marker, "vlanmgrd", "Failed to set MTU", vlan_interface, 1)
+
+        self.dvs_vlan.remove_vlan(vlan)
+        self.dvs_vlan.get_and_verify_vlan_ids(0)
+
+        # isNewVlan path: create a VLAN with mtu already present in the initial
+        # CONFIG_DB entry (as opposed to updating mtu on an existing VLAN).
+        # The first SET event goes through addHostVlan followed immediately by
+        # setHostVlanMtu with the operator-supplied value.
+        create_vlan = "43"
+        create_vlan_interface = "Vlan{}".format(create_vlan)
+        create_mtu = "1500"
+
+        def read_create_kernel_mtu():
+            _, out = dvs.runcmd(['sh', '-c', "cat /sys/class/net/{}/mtu".format(create_vlan_interface)])
+            return out.strip()
+
+        self.dvs_vlan.config_db.create_entry(
+            "VLAN", create_vlan_interface, {"vlanid": create_vlan, "mtu": create_mtu})
+        self.dvs_vlan.get_and_verify_vlan_ids(1)
+
+        wait_for_result(lambda: (read_create_kernel_mtu() == create_mtu, None),
+                        PollingConfig(polling_interval=0.2, timeout=5, strict=True))
+        self.dvs_vlan.app_db.wait_for_field_match(
+            "VLAN_TABLE", create_vlan_interface, {"mtu": create_mtu})
+
+        self.dvs_vlan.remove_vlan(create_vlan)
+        self.dvs_vlan.get_and_verify_vlan_ids(0)
+
+        # Overflow path: value parses as unsigned long long but exceeds
+        # uint32_t::max. The explicit bounds check in doVlanTask must throw
+        # std::out_of_range, the catch block must log SWSS_LOG_ERROR with
+        # "Invalid MTU", and neither the kernel netdev nor APPL_DB are
+        # touched.
+        overflow_vlan = "44"
+        overflow_vlan_interface = "Vlan{}".format(overflow_vlan)
+        overflow_mtu = "5000000000"  # > 2^32-1 = 4294967295
+
+        def read_overflow_kernel_mtu():
+            _, out = dvs.runcmd(['sh', '-c',
+                                 "cat /sys/class/net/{}/mtu".format(overflow_vlan_interface)])
+            return out.strip()
+
+        self.dvs_vlan.create_vlan(overflow_vlan)
+        self.dvs_vlan.get_and_verify_vlan_ids(1)
+        assert read_overflow_kernel_mtu() == "9100"
+
+        marker = dvs.add_log_marker()
+        dvs.set_mtu(overflow_vlan_interface, overflow_mtu)
+
+        # Poll for 2s confirming the kernel MTU never picks up the bogus value.
+        poll_end = time.time() + 2.0
+        while time.time() < poll_end:
+            assert read_overflow_kernel_mtu() == "9100", \
+                "kernel MTU changed despite overflow"
+            time.sleep(0.2)
+
+        self.check_syslog(dvs, marker, "vlanmgrd", "Invalid MTU", overflow_vlan_interface, 1)
+
+        self.dvs_vlan.remove_vlan(overflow_vlan)
+        self.dvs_vlan.get_and_verify_vlan_ids(0)
+
     @pytest.mark.skipif(StrictVersion(distro.linux_distribution()[1]) <= StrictVersion('8.9'),
                         reason="Debian 8.9 or before has no support")
     @pytest.mark.parametrize("test_input, expected", [


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

`VlanMgr::doVlanTask` parsed the mtu field from `CONFIG_DB` `VLAN` but never pushed it through to the kernel via `ip link set Vlan<id> mtu <v>` — only propagated it to APPL_DB.

The 2017 TODO ("support host VLAN mtu setting") is now addressed: after `addHostVlan / updateVlanAdminState`, call the existing `setHostVlanMtu` helper and only write mtu to `APPL_DB` if the kernel accepted it.

A VLAN interface's MTU is independent of its bridge members (unlike team/bond), so the "member configured" half of the TODO doesn't correspond to a real kernel constraint and is dropped. As opposed to vlan, this is handled in portchannel case by forcing port-channel's mtu on it's member interfaces. We can't do this for vlan as the member interfaces could be part of multiple vlans, and do not have 1x1 relationship like portchannel and their members.

DVS test test_VlanHostNetdevMtu covers both the apply and reject paths.

closes# https://github.com/sonic-net/sonic-buildimage/issues/27017

**Why I did it**

`VlanMgr::doVlanTask `parsed the mtu field from `CONFIG_DB` `VLAN` but never pushed it through to the kernel via `ip link set Vlan<id> mtu <v>`

**How I verified it**

Added a DVS test (test_VlanHostNetdevMtu) to verify actual mtu programming in kernel, and that passes:
```
test_vlan.py::TestVlan::test_VlanHostNetdevMtu PASSED                    [  9%]
```

One can manually verify this by doing:
```
redis-cli -n 4 HSET 'VLAN|Vlan100' mtu 1500
ip link show Vlan100
```

**Details if related**
