### PR TITLE
[mirrororch][VS test]: Add VS tests for sampled ERSPAN port mirroring

### DIFF
--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -31,6 +31,8 @@
 #define MIRROR_SESSION_DST_PORT             "dst_port"
 #define MIRROR_SESSION_DIRECTION            "direction"
 #define MIRROR_SESSION_TYPE                 "type"
+#define MIRROR_SESSION_SAMPLE_RATE          "sample_rate"
+#define MIRROR_SESSION_TRUNCATE_SIZE        "truncate_size"
 
 #define MIRROR_SESSION_DEFAULT_VLAN_PRI 0
 #define MIRROR_SESSION_DEFAULT_VLAN_CFI 0
@@ -47,6 +49,7 @@
 extern sai_switch_api_t *sai_switch_api;
 extern sai_mirror_api_t *sai_mirror_api;
 extern sai_port_api_t *sai_port_api;
+extern sai_samplepacket_api_t *sai_samplepacket_api;
 
 extern sai_object_id_t  gSwitchId;
 extern PortsOrch*       gPortsOrch;
@@ -59,6 +62,9 @@ MirrorEntry::MirrorEntry(const string& platform) :
         dscp(8),
         ttl(255),
         queue(0),
+        sample_rate(0),
+        truncate_size(0),
+        samplepacketId(SAI_NULL_OBJECT_ID),
         sessionId(0),
         refCount(0)
 {
@@ -473,6 +479,14 @@ task_process_status MirrorOrch::createEntry(const string& key, const vector<Fiel
             {
                 entry.type = fvValue(i);
             }
+            else if (fvField(i) == MIRROR_SESSION_SAMPLE_RATE)
+            {
+                entry.sample_rate = to_uint<uint32_t>(fvValue(i));
+            }
+            else if (fvField(i) == MIRROR_SESSION_TRUNCATE_SIZE)
+            {
+                entry.truncate_size = to_uint<uint32_t>(fvValue(i));
+            }
             else
             {
                 SWSS_LOG_ERROR("Failed to parse session %s configuration. Unknown attribute %s", key.c_str(), fvField(i).c_str());
@@ -494,6 +508,22 @@ task_process_status MirrorOrch::createEntry(const string& key, const vector<Fiel
     if (src_ip_initialized && dst_ip_initialized && entry.srcIp.getIp().family != entry.dstIp.getIp().family)
     {
         SWSS_LOG_ERROR("Address family of source and destination IPs is different");
+        return task_process_status::task_invalid_entry;
+    }
+
+    // Truncate size requires sampled mirroring to be enabled
+    if (entry.truncate_size > 0 && entry.sample_rate == 0)
+    {
+        SWSS_LOG_ERROR("Truncate size requires sampled mirroring to be enabled for session %s",
+                       key.c_str());
+        return task_process_status::task_invalid_entry;
+    }
+
+    // Sampled mirroring requires RX direction
+    if (entry.sample_rate > 0 && entry.direction != MIRROR_RX_DIRECTION)
+    {
+        SWSS_LOG_ERROR("Sampled mirroring requires RX direction for session %s",
+                       key.c_str());
         return task_process_status::task_invalid_entry;
     }
 
@@ -811,7 +841,9 @@ bool MirrorOrch::updateSession(const string& name, MirrorEntry& session)
 bool MirrorOrch::setUnsetPortMirror(Port port,
                                     bool ingress,
                                     bool set,
-                                    sai_object_id_t sessionId)
+                                    sai_object_id_t sessionId,
+                                    sai_object_id_t samplepacketId,
+                                    uint32_t sample_rate)
 {
     // Check if the mirror direction is supported by the ASIC
     if (ingress && !m_switchOrch->isPortIngressMirrorSupported())
@@ -826,6 +858,70 @@ bool MirrorOrch::setUnsetPortMirror(Port port,
     }
 
     sai_status_t status;
+
+    if (sample_rate > 0 && ingress)
+    {
+        // Sampled mirroring path: use SAMPLEPACKET_ENABLE + SAMPLE_MIRROR_SESSION
+        sai_attribute_t sp_attr;
+        sp_attr.id = SAI_PORT_ATTR_INGRESS_SAMPLEPACKET_ENABLE;
+        sp_attr.value.oid = set ? samplepacketId : SAI_NULL_OBJECT_ID;
+
+        sai_attribute_t mirror_attr;
+        mirror_attr.id = SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION;
+        if (set)
+        {
+            mirror_attr.value.objlist.count = 1;
+            mirror_attr.value.objlist.list = &sessionId;
+        }
+        else
+        {
+            mirror_attr.value.objlist.count = 0;
+        }
+
+        // Set/clear in correct order
+        if (set)
+        {
+            // Set: SAMPLEPACKET_ENABLE first, then SAMPLE_MIRROR_SESSION
+            status = sai_port_api->set_port_attribute(port.m_port_id, &sp_attr);
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to set SAMPLEPACKET_ENABLE on port %s, status %d",
+                                port.m_alias.c_str(), status);
+                return false;
+            }
+            status = sai_port_api->set_port_attribute(port.m_port_id, &mirror_attr);
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to set SAMPLE_MIRROR_SESSION on port %s, status %d",
+                                port.m_alias.c_str(), status);
+                // Rollback: clear SAMPLEPACKET_ENABLE
+                sp_attr.value.oid = SAI_NULL_OBJECT_ID;
+                sai_port_api->set_port_attribute(port.m_port_id, &sp_attr);
+                return false;
+            }
+        }
+        else
+        {
+            // Clear: SAMPLE_MIRROR_SESSION first, then SAMPLEPACKET_ENABLE (reverse order)
+            status = sai_port_api->set_port_attribute(port.m_port_id, &mirror_attr);
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to clear SAMPLE_MIRROR_SESSION on port %s, status %d",
+                                port.m_alias.c_str(), status);
+                return false;
+            }
+            status = sai_port_api->set_port_attribute(port.m_port_id, &sp_attr);
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to clear SAMPLEPACKET_ENABLE on port %s, status %d",
+                                port.m_alias.c_str(), status);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // Full mirror path (existing behavior)
     sai_attribute_t port_attr;
     port_attr.id = ingress ? SAI_PORT_ATTR_INGRESS_MIRROR_SESSION:
                            SAI_PORT_ATTR_EGRESS_MIRROR_SESSION;
@@ -896,7 +992,7 @@ bool MirrorOrch::configurePortMirrorSession(const string& name, MirrorEntry& ses
             }
             if (session.direction == MIRROR_RX_DIRECTION  || session.direction == MIRROR_BOTH_DIRECTION)
             {
-                if (!setUnsetPortMirror(port, true, set, session.sessionId))
+                if (!setUnsetPortMirror(port, true, set, session.sessionId, session.samplepacketId, session.sample_rate))
                 {
                     SWSS_LOG_ERROR("Failed to configure mirror session %s port %s",
                         name.c_str(), port.m_alias.c_str());
@@ -905,7 +1001,7 @@ bool MirrorOrch::configurePortMirrorSession(const string& name, MirrorEntry& ses
             }
             if (session.direction == MIRROR_TX_DIRECTION || session.direction == MIRROR_BOTH_DIRECTION)
             {
-                if (!setUnsetPortMirror(port, false, set, session.sessionId))
+                if (!setUnsetPortMirror(port, false, set, session.sessionId, session.samplepacketId, session.sample_rate))
                 {
                     SWSS_LOG_ERROR("Failed to configure mirror session %s port %s",
                         name.c_str(), port.m_alias.c_str());
@@ -1079,6 +1175,18 @@ bool MirrorOrch::activateSession(const string& name, MirrorEntry& session)
 
     session.status = true;
 
+    // Create SamplePacket if sample_rate > 0
+    if (session.sample_rate > 0)
+    {
+        if (!createSamplePacket(name, session))
+        {
+            SWSS_LOG_ERROR("Failed to create samplepacket, removing mirror session %s", name.c_str());
+            sai_mirror_api->remove_mirror_session(session.sessionId);
+            session.status = false;
+            return false;
+        }
+    }
+
     if (!session.src_port.empty() && !session.direction.empty())
     {
         status = configurePortMirrorSession(name, session, true);
@@ -1116,6 +1224,16 @@ bool MirrorOrch::deactivateSession(const string& name, MirrorEntry& session)
         if (status == false)
         {
             SWSS_LOG_ERROR("Failed to deactivate port mirror session %s", name.c_str());
+            return false;
+        }
+    }
+
+    // Remove SamplePacket if it exists
+    if (session.samplepacketId != SAI_NULL_OBJECT_ID)
+    {
+        if (!removeSamplePacket(name, session))
+        {
+            SWSS_LOG_ERROR("Failed to remove samplepacket for session %s", name.c_str());
             return false;
         }
     }
@@ -1175,6 +1293,79 @@ bool MirrorOrch::updateSessionDstMac(const string& name, MirrorEntry& session)
 
     setSessionState(name, session, MIRROR_SESSION_DST_MAC_ADDRESS);
 
+    return true;
+}
+
+
+bool MirrorOrch::createSamplePacket(const string& name, MirrorEntry& session)
+{
+    SWSS_LOG_ENTER();
+
+    sai_attribute_t attrs[4];
+    uint32_t attr_count = 0;
+
+    attrs[attr_count].id = SAI_SAMPLEPACKET_ATTR_SAMPLE_RATE;
+    attrs[attr_count].value.u32 = session.sample_rate;
+    attr_count++;
+
+    attrs[attr_count].id = SAI_SAMPLEPACKET_ATTR_TYPE;
+    attrs[attr_count].value.s32 = SAI_SAMPLEPACKET_TYPE_MIRROR_SESSION;
+    attr_count++;
+
+    if (session.truncate_size > 0)
+    {
+        attrs[attr_count].id = SAI_SAMPLEPACKET_ATTR_TRUNCATE_ENABLE;
+        attrs[attr_count].value.booldata = true;
+        attr_count++;
+
+        attrs[attr_count].id = SAI_SAMPLEPACKET_ATTR_TRUNCATE_SIZE;
+        attrs[attr_count].value.u32 = session.truncate_size;
+        attr_count++;
+    }
+
+    sai_status_t status = sai_samplepacket_api->create_samplepacket(
+        &session.samplepacketId, gSwitchId, attr_count, attrs);
+
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to create samplepacket for session %s, status %d",
+                       name.c_str(), status);
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_SAMPLEPACKET, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
+    }
+
+    SWSS_LOG_NOTICE("Created samplepacket for session %s, rate %u, truncate %u",
+                    name.c_str(), session.sample_rate, session.truncate_size);
+    return true;
+}
+
+bool MirrorOrch::removeSamplePacket(const string& name, MirrorEntry& session)
+{
+    SWSS_LOG_ENTER();
+
+    if (session.samplepacketId == SAI_NULL_OBJECT_ID)
+    {
+        return true;
+    }
+
+    sai_status_t status = sai_samplepacket_api->remove_samplepacket(session.samplepacketId);
+
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to remove samplepacket for session %s, status %d",
+                       name.c_str(), status);
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_SAMPLEPACKET, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
+    }
+
+    session.samplepacketId = SAI_NULL_OBJECT_ID;
+    SWSS_LOG_NOTICE("Removed samplepacket for session %s", name.c_str());
     return true;
 }
 

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -784,6 +784,22 @@ void MirrorOrch::setSessionState(const string& name, const MirrorEntry& session,
      fvVector.emplace_back(MIRROR_SESSION_NEXT_HOP_IP, value);
     }
 
+    if (attr.empty() || attr == MIRROR_SESSION_SAMPLE_RATE)
+    {
+        if (session.sample_rate > 0)
+        {
+            fvVector.emplace_back(MIRROR_SESSION_SAMPLE_RATE, to_string(session.sample_rate));
+        }
+    }
+
+    if (attr.empty() || attr == MIRROR_SESSION_TRUNCATE_SIZE)
+    {
+        if (session.truncate_size > 0)
+        {
+            fvVector.emplace_back(MIRROR_SESSION_TRUNCATE_SIZE, to_string(session.truncate_size));
+        }
+    }
+
     m_mirrorTable.set(name, fvVector);
 }
 

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -391,12 +391,7 @@ task_process_status MirrorOrch::createEntry(const string& key, const vector<Fiel
     bool src_ip_initialized = false;
     bool dst_ip_initialized = false;
 
-    auto session = m_syncdMirrors.find(key);
-    if (session != m_syncdMirrors.end())
-    {
-        SWSS_LOG_NOTICE("Failed to create session %s: object already exists", key.c_str());
-        return task_process_status::task_duplicated;
-    }
+
 
     string platform = getenv("platform") ? getenv("platform") : "";
     MirrorEntry entry(platform);
@@ -550,6 +545,22 @@ task_process_status MirrorOrch::createEntry(const string& key, const vector<Fiel
     SWSS_LOG_NOTICE("Created mirror session %s", key.c_str());
 
     return task_process_status::task_success;
+}
+
+task_process_status MirrorOrch::updateEntry(const string& key, const vector<FieldValueTuple>& data)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("Updating mirror session %s", key.c_str());
+
+    auto task_status = deleteEntry(key);
+    if (task_status != task_process_status::task_success)
+    {
+        SWSS_LOG_ERROR("Failed to delete existing mirror session %s during update", key.c_str());
+        return task_status;
+    }
+
+    return createEntry(key, data);
 }
 
 task_process_status MirrorOrch::deleteEntry(const string& name)
@@ -1775,7 +1786,14 @@ void MirrorOrch::doTask(Consumer& consumer)
 
         if (op == SET_COMMAND)
         {
-            task_status = createEntry(key, kfvFieldsValues(t));
+            if (sessionExists(key))
+            {
+                task_status = updateEntry(key, kfvFieldsValues(t));
+            }
+            else
+            {
+                task_status = createEntry(key, kfvFieldsValues(t));
+            }
         }
         else if (op == DEL_COMMAND)
         {

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -553,14 +553,123 @@ task_process_status MirrorOrch::updateEntry(const string& key, const vector<Fiel
 
     SWSS_LOG_NOTICE("Updating mirror session %s", key.c_str());
 
-    auto task_status = deleteEntry(key);
-    if (task_status != task_process_status::task_success)
+    auto sessionIter = m_syncdMirrors.find(key);
+    if (sessionIter == m_syncdMirrors.end())
     {
-        SWSS_LOG_ERROR("Failed to delete existing mirror session %s during update", key.c_str());
-        return task_status;
+        SWSS_LOG_ERROR("Failed to update non-existent mirror session %s", key.c_str());
+        return task_process_status::task_invalid_entry;
     }
 
-    return createEntry(key, data);
+    auto& session = sessionIter->second;
+
+    // Determine if any immutable fields have changed
+    bool immutable_changed = false;
+    uint32_t new_sample_rate = session.sample_rate;
+    uint32_t new_truncate_size = session.truncate_size;
+
+    for (auto& fv : data)
+    {
+        const auto& field = fvField(fv);
+        const auto& value = fvValue(fv);
+
+        if (field == MIRROR_SESSION_SAMPLE_RATE)
+        {
+            new_sample_rate = to_uint<uint32_t>(value);
+        }
+        else if (field == MIRROR_SESSION_TRUNCATE_SIZE)
+        {
+            new_truncate_size = to_uint<uint32_t>(value);
+        }
+        else if (field == MIRROR_SESSION_SRC_IP ||
+                 field == MIRROR_SESSION_DST_IP ||
+                 field == MIRROR_SESSION_GRE_TYPE ||
+                 field == MIRROR_SESSION_DSCP ||
+                 field == MIRROR_SESSION_TTL ||
+                 field == MIRROR_SESSION_QUEUE ||
+                 field == MIRROR_SESSION_SRC_PORT ||
+                 field == MIRROR_SESSION_DIRECTION ||
+                 field == MIRROR_SESSION_POLICER)
+        {
+            immutable_changed = true;
+        }
+    }
+
+    // If any immutable fields changed, must delete and recreate
+    if (immutable_changed)
+    {
+        SWSS_LOG_NOTICE("Immutable fields changed for session %s, performing delete+recreate", key.c_str());
+        auto task_status = deleteEntry(key);
+        if (task_status != task_process_status::task_success)
+        {
+            SWSS_LOG_ERROR("Failed to delete mirror session %s during update", key.c_str());
+            return task_status;
+        }
+        return createEntry(key, data);
+    }
+
+    // Only mutable fields (sample_rate, truncate_size) changed - update in-place
+    bool sample_rate_changed = (new_sample_rate != session.sample_rate);
+    bool truncate_size_changed = (new_truncate_size != session.truncate_size);
+
+    if (!sample_rate_changed && !truncate_size_changed)
+    {
+        SWSS_LOG_NOTICE("No field changes detected for session %s", key.c_str());
+        return task_process_status::task_success;
+    }
+
+    // If samplepacket exists, update its attributes in-place
+    if (session.samplepacketId != SAI_NULL_OBJECT_ID)
+    {
+        if (sample_rate_changed)
+        {
+            sai_attribute_t attr;
+            attr.id = SAI_SAMPLEPACKET_ATTR_SAMPLE_RATE;
+            attr.value.u32 = new_sample_rate;
+            sai_status_t status = sai_samplepacket_api->set_samplepacket_attribute(
+                session.samplepacketId, &attr);
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to update sample_rate for session %s, status %d", key.c_str(), status);
+                return task_process_status::task_failed;
+            }
+            session.sample_rate = new_sample_rate;
+            SWSS_LOG_NOTICE("Updated sample_rate to %u for session %s", new_sample_rate, key.c_str());
+        }
+
+        if (truncate_size_changed)
+        {
+            sai_attribute_t attr;
+            attr.id = SAI_SAMPLEPACKET_ATTR_TRUNCATE_SIZE;
+            attr.value.u32 = new_truncate_size;
+            sai_status_t status = sai_samplepacket_api->set_samplepacket_attribute(
+                session.samplepacketId, &attr);
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to update truncate_size for session %s, status %d", key.c_str(), status);
+                return task_process_status::task_failed;
+            }
+            session.truncate_size = new_truncate_size;
+            SWSS_LOG_NOTICE("Updated truncate_size to %u for session %s", new_truncate_size, key.c_str());
+        }
+    }
+    else
+    {
+        // No samplepacket exists (full mirror path) but sample_rate/truncate_size changed
+        // Need to transition from full mirror to sampled path - delete+recreate
+        SWSS_LOG_NOTICE("Transitioning session %s from full mirror to sampled path, performing delete+recreate", key.c_str());
+        auto task_status = deleteEntry(key);
+        if (task_status != task_process_status::task_success)
+        {
+            SWSS_LOG_ERROR("Failed to delete mirror session %s during path transition", key.c_str());
+            return task_status;
+        }
+        return createEntry(key, data);
+    }
+
+    // Update STATE_DB with new values
+    setSessionState(key, session);
+
+    return task_process_status::task_success;
 }
 
 task_process_status MirrorOrch::deleteEntry(const string& name)

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -388,6 +388,13 @@ task_process_status MirrorOrch::createEntry(const string& key, const vector<Fiel
 {
     SWSS_LOG_ENTER();
 
+
+    if (m_syncdMirrors.find(key) != m_syncdMirrors.end())
+    {
+        SWSS_LOG_ERROR("Mirror session %s already exists", key.c_str());
+        return task_process_status::task_invalid_entry;
+    }
+
     bool src_ip_initialized = false;
     bool dst_ip_initialized = false;
 
@@ -476,11 +483,21 @@ task_process_status MirrorOrch::createEntry(const string& key, const vector<Fiel
             }
             else if (fvField(i) == MIRROR_SESSION_SAMPLE_RATE)
             {
-                entry.sample_rate = to_uint<uint32_t>(fvValue(i));
+                try {
+                    entry.sample_rate = to_uint<uint32_t>(fvValue(i));
+                } catch (const exception& e) {
+                    SWSS_LOG_ERROR("Invalid sample_rate for session %s: %s", key.c_str(), e.what());
+                    return task_process_status::task_invalid_entry;
+                }
             }
             else if (fvField(i) == MIRROR_SESSION_TRUNCATE_SIZE)
             {
-                entry.truncate_size = to_uint<uint32_t>(fvValue(i));
+                try {
+                    entry.truncate_size = to_uint<uint32_t>(fvValue(i));
+                } catch (const exception& e) {
+                    SWSS_LOG_ERROR("Invalid truncate_size for session %s: %s", key.c_str(), e.what());
+                    return task_process_status::task_invalid_entry;
+                }
             }
             else
             {
@@ -995,8 +1012,15 @@ bool MirrorOrch::setUnsetPortMirror(Port port,
 
     sai_status_t status;
 
-    if (sample_rate > 0 && ingress)
+    if (sample_rate > 0)
     {
+        if (!ingress)
+        {
+            SWSS_LOG_ERROR("Sampled mirroring on egress is not supported for port %s",
+                            port.m_alias.c_str());
+            return false;
+        }
+
         // Sampled mirroring path: use SAMPLEPACKET_ENABLE + SAMPLE_MIRROR_SESSION
         sai_attribute_t sp_attr;
         sp_attr.id = SAI_PORT_ATTR_INGRESS_SAMPLEPACKET_ENABLE;
@@ -1314,7 +1338,14 @@ bool MirrorOrch::activateSession(const string& name, MirrorEntry& session)
     // Create SamplePacket if sample_rate > 0
     if (session.sample_rate > 0)
     {
-        if (!createSamplePacket(name, session))
+        if (!m_switchOrch->isPortIngressSampleMirrorSupported())
+        {
+            SWSS_LOG_WARN("Sampled mirroring not supported on this platform, "
+                          "falling back to full mirror for session %s", name.c_str());
+            session.sample_rate = 0;
+            session.truncate_size = 0;
+        }
+        else if (!createSamplePacket(name, session))
         {
             SWSS_LOG_ERROR("Failed to create samplepacket, removing mirror session %s", name.c_str());
             sai_mirror_api->remove_mirror_session(session.sessionId);
@@ -1329,6 +1360,12 @@ bool MirrorOrch::activateSession(const string& name, MirrorEntry& session)
         if (status == false)
         {
             SWSS_LOG_ERROR("Failed to activate port mirror session %s", name.c_str());
+            // Clean up samplepacket if it was created
+            if (session.samplepacketId != SAI_NULL_OBJECT_ID)
+            {
+                removeSamplePacket(name, session);
+            }
+            sai_mirror_api->remove_mirror_session(session.sessionId);
             session.status = false;
             return false;
         }
@@ -1450,13 +1487,22 @@ bool MirrorOrch::createSamplePacket(const string& name, MirrorEntry& session)
 
     if (session.truncate_size > 0)
     {
-        attrs[attr_count].id = SAI_SAMPLEPACKET_ATTR_TRUNCATE_ENABLE;
-        attrs[attr_count].value.booldata = true;
-        attr_count++;
+        if (!m_switchOrch->isSamplepacketTruncationSupported())
+        {
+            SWSS_LOG_WARN("Truncation not supported on this platform, "
+                          "skipping truncation for session %s", name.c_str());
+            session.truncate_size = 0;
+        }
+        else
+        {
+            attrs[attr_count].id = SAI_SAMPLEPACKET_ATTR_TRUNCATE_ENABLE;
+            attrs[attr_count].value.booldata = true;
+            attr_count++;
 
-        attrs[attr_count].id = SAI_SAMPLEPACKET_ATTR_TRUNCATE_SIZE;
-        attrs[attr_count].value.u32 = session.truncate_size;
-        attr_count++;
+            attrs[attr_count].id = SAI_SAMPLEPACKET_ATTR_TRUNCATE_SIZE;
+            attrs[attr_count].value.u32 = session.truncate_size;
+            attr_count++;
+        }
     }
 
     sai_status_t status = sai_samplepacket_api->create_samplepacket(
@@ -1466,16 +1512,20 @@ bool MirrorOrch::createSamplePacket(const string& name, MirrorEntry& session)
     {
         SWSS_LOG_ERROR("Failed to create samplepacket for session %s, status %d",
                        name.c_str(), status);
+        session.samplepacketId = SAI_NULL_OBJECT_ID;
         task_process_status handle_status = handleSaiCreateStatus(SAI_API_SAMPLEPACKET, status);
         if (handle_status != task_success)
         {
             return parseHandleSaiStatusFailure(handle_status);
         }
     }
+    else
+    {
+        SWSS_LOG_NOTICE("Created samplepacket for session %s, rate %u, truncate %u",
+                        name.c_str(), session.sample_rate, session.truncate_size);
+    }
 
-    SWSS_LOG_NOTICE("Created samplepacket for session %s, rate %u, truncate %u",
-                    name.c_str(), session.sample_rate, session.truncate_size);
-    return true;
+    return (status == SAI_STATUS_SUCCESS);
 }
 
 bool MirrorOrch::removeSamplePacket(const string& name, MirrorEntry& session)

--- a/orchagent/mirrororch.h
+++ b/orchagent/mirrororch.h
@@ -57,6 +57,11 @@ struct MirrorEntry
         sai_object_id_t portId;
     } neighborInfo;
 
+    // Sampled mirroring fields
+    uint32_t sample_rate;                        // 0 = full mirror (default)
+    uint32_t truncate_size;                      // 0 = no truncation (default)
+    sai_object_id_t samplepacketId;              // SAI_NULL_OBJECT_ID if not sampled
+
     sai_object_id_t sessionId;
 
     int64_t refCount;
@@ -136,8 +141,14 @@ private:
     bool validateSrcPortList(const string& srcPort);
     bool validateDstPort(const string& dstPort);
     bool setUnsetPortMirror(Port port, bool ingress, bool set,
-                                    sai_object_id_t sessionId);
+                                    sai_object_id_t sessionId,
+                                    sai_object_id_t samplepacketId = SAI_NULL_OBJECT_ID,
+                                    uint32_t sample_rate = 0);
     bool configurePortMirrorSession(const string&, MirrorEntry&, bool enable);
+
+    // Sampled mirroring helpers
+    bool createSamplePacket(const string& name, MirrorEntry& session);
+    bool removeSamplePacket(const string& name, MirrorEntry& session);
 
     void doTask(Consumer& consumer);
 };

--- a/orchagent/mirrororch.h
+++ b/orchagent/mirrororch.h
@@ -113,6 +113,7 @@ private:
     bool isHwResourcesAvailable();
 
     task_process_status createEntry(const string&, const vector<FieldValueTuple>&);
+    task_process_status updateEntry(const string&, const vector<FieldValueTuple>&);
     task_process_status deleteEntry(const string&);
 
     bool activateSession(const string&, MirrorEntry&);

--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -166,7 +166,7 @@ SwitchOrch::SwitchOrch(DBConnector *db, vector<TableConnector>& connectors, Tabl
     querySwitchTpidCapability();
     querySwitchPortEgressSampleCapability();
     querySwitchPortMirrorCapability();
-    querySwitchSampledMirrorCapability();
+    querySwitchSamplePacketCapability();
     querySwitchHashDefaults();
     setSwitchIcmpOffloadCapability();
     setFastLinkupCapability();
@@ -1958,7 +1958,7 @@ void SwitchOrch::querySwitchPortMirrorCapability()
     set_switch_capability(fvVector);
 }
 
-void SwitchOrch::querySwitchSampledMirrorCapability()
+void SwitchOrch::querySwitchSamplePacketCapability()
 {
     vector<FieldValueTuple> fvVector;
     sai_status_t status = SAI_STATUS_SUCCESS;

--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -166,6 +166,7 @@ SwitchOrch::SwitchOrch(DBConnector *db, vector<TableConnector>& connectors, Tabl
     querySwitchTpidCapability();
     querySwitchPortEgressSampleCapability();
     querySwitchPortMirrorCapability();
+    querySwitchSampledMirrorCapability();
     querySwitchHashDefaults();
     setSwitchIcmpOffloadCapability();
     setFastLinkupCapability();
@@ -1952,6 +1953,87 @@ void SwitchOrch::querySwitchPortMirrorCapability()
             m_portEgressMirrorSupported = false;
         }
         SWSS_LOG_NOTICE("port egress mirror capability %d", capability.set_implemented);
+    }
+
+    set_switch_capability(fvVector);
+}
+
+void SwitchOrch::querySwitchSampledMirrorCapability()
+{
+    vector<FieldValueTuple> fvVector;
+    sai_status_t status = SAI_STATUS_SUCCESS;
+    sai_attr_capability_t capability;
+
+    // Check if SAI is capable of handling Port ingress sample mirror session
+    status = sai_query_attribute_capability(gSwitchId, SAI_OBJECT_TYPE_PORT,
+                            SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION, &capability);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_WARN("Could not query port ingress sample mirror capability %d", status);
+        fvVector.emplace_back(SWITCH_CAPABILITY_TABLE_PORT_INGRESS_SAMPLE_MIRROR_CAPABLE, "false");
+        m_portIngressSampleMirrorSupported = false;
+    }
+    else
+    {
+        if (capability.set_implemented)
+        {
+            fvVector.emplace_back(SWITCH_CAPABILITY_TABLE_PORT_INGRESS_SAMPLE_MIRROR_CAPABLE, "true");
+            m_portIngressSampleMirrorSupported = true;
+        }
+        else
+        {
+            fvVector.emplace_back(SWITCH_CAPABILITY_TABLE_PORT_INGRESS_SAMPLE_MIRROR_CAPABLE, "false");
+            m_portIngressSampleMirrorSupported = false;
+        }
+        SWSS_LOG_NOTICE("port ingress sample mirror capability %d", capability.set_implemented);
+    }
+
+    // Check if SAI is capable of handling Port egress sample mirror session
+    status = sai_query_attribute_capability(gSwitchId, SAI_OBJECT_TYPE_PORT,
+                            SAI_PORT_ATTR_EGRESS_SAMPLE_MIRROR_SESSION, &capability);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_WARN("Could not query port egress sample mirror capability %d", status);
+        fvVector.emplace_back(SWITCH_CAPABILITY_TABLE_PORT_EGRESS_SAMPLE_MIRROR_CAPABLE, "false");
+        m_portEgressSampleMirrorSupported = false;
+    }
+    else
+    {
+        if (capability.set_implemented)
+        {
+            fvVector.emplace_back(SWITCH_CAPABILITY_TABLE_PORT_EGRESS_SAMPLE_MIRROR_CAPABLE, "true");
+            m_portEgressSampleMirrorSupported = true;
+        }
+        else
+        {
+            fvVector.emplace_back(SWITCH_CAPABILITY_TABLE_PORT_EGRESS_SAMPLE_MIRROR_CAPABLE, "false");
+            m_portEgressSampleMirrorSupported = false;
+        }
+        SWSS_LOG_NOTICE("port egress sample mirror capability %d", capability.set_implemented);
+    }
+
+    // Check if SAI is capable of handling samplepacket truncation
+    status = sai_query_attribute_capability(gSwitchId, SAI_OBJECT_TYPE_SAMPLEPACKET,
+                            SAI_SAMPLEPACKET_ATTR_TRUNCATE_ENABLE, &capability);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_WARN("Could not query samplepacket truncation capability %d", status);
+        fvVector.emplace_back(SWITCH_CAPABILITY_TABLE_SAMPLEPACKET_TRUNCATION_CAPABLE, "false");
+        m_samplepacketTruncationSupported = false;
+    }
+    else
+    {
+        if (capability.set_implemented)
+        {
+            fvVector.emplace_back(SWITCH_CAPABILITY_TABLE_SAMPLEPACKET_TRUNCATION_CAPABLE, "true");
+            m_samplepacketTruncationSupported = true;
+        }
+        else
+        {
+            fvVector.emplace_back(SWITCH_CAPABILITY_TABLE_SAMPLEPACKET_TRUNCATION_CAPABLE, "false");
+            m_samplepacketTruncationSupported = false;
+        }
+        SWSS_LOG_NOTICE("samplepacket truncation capability %d", capability.set_implemented);
     }
 
     set_switch_capability(fvVector);

--- a/orchagent/switchorch.h
+++ b/orchagent/switchorch.h
@@ -108,7 +108,7 @@ private:
     void querySwitchTpidCapability();
     void querySwitchPortEgressSampleCapability();
     void querySwitchPortMirrorCapability();
-    void querySwitchSampledMirrorCapability();
+    void querySwitchSamplePacketCapability();
 
     // Statistics
     void generateSwitchCounterNameMap() const;

--- a/orchagent/switchorch.h
+++ b/orchagent/switchorch.h
@@ -33,6 +33,9 @@
 #define SWITCH_CAPABILITY_TABLE_REG_NOTICE_ASIC_SDK_HEALTH_CATEGORY    "REG_NOTICE_ASIC_SDK_HEALTH_CATEGORY"
 #define SWITCH_CAPABILITY_TABLE_PORT_INGRESS_MIRROR_CAPABLE            "PORT_INGRESS_MIRROR_CAPABLE"
 #define SWITCH_CAPABILITY_TABLE_PORT_EGRESS_MIRROR_CAPABLE             "PORT_EGRESS_MIRROR_CAPABLE"
+#define SWITCH_CAPABILITY_TABLE_PORT_INGRESS_SAMPLE_MIRROR_CAPABLE  "PORT_INGRESS_SAMPLE_MIRROR_CAPABLE"
+#define SWITCH_CAPABILITY_TABLE_PORT_EGRESS_SAMPLE_MIRROR_CAPABLE   "PORT_EGRESS_SAMPLE_MIRROR_CAPABLE"
+#define SWITCH_CAPABILITY_TABLE_SAMPLEPACKET_TRUNCATION_CAPABLE     "SAMPLEPACKET_TRUNCATION_CAPABLE"
 
 #define SWITCH_STAT_COUNTER_FLEX_COUNTER_GROUP "SWITCH_STAT_COUNTER"
 
@@ -88,6 +91,9 @@ public:
     // Mirror capability interface for MirrorOrch
     bool isPortIngressMirrorSupported() const { return m_portIngressMirrorSupported; }
     bool isPortEgressMirrorSupported() const { return m_portEgressMirrorSupported; }
+    bool isPortIngressSampleMirrorSupported() const { return m_portIngressSampleMirrorSupported; }
+    bool isPortEgressSampleMirrorSupported() const { return m_portEgressSampleMirrorSupported; }
+    bool isSamplepacketTruncationSupported() const { return m_samplepacketTruncationSupported; }
 
 private:
     void doTask(Consumer &consumer);
@@ -102,6 +108,7 @@ private:
     void querySwitchTpidCapability();
     void querySwitchPortEgressSampleCapability();
     void querySwitchPortMirrorCapability();
+    void querySwitchSampledMirrorCapability();
 
     // Statistics
     void generateSwitchCounterNameMap() const;
@@ -184,6 +191,9 @@ private:
     // Port mirror capabilities
     bool m_portIngressMirrorSupported = false;
     bool m_portEgressMirrorSupported = false;
+    bool m_portIngressSampleMirrorSupported = false;
+    bool m_portEgressSampleMirrorSupported = false;
+    bool m_samplepacketTruncationSupported = false;
 
     // ASIC SDK health event
     std::shared_ptr<swss::DBConnector> m_stateDbForNotification = nullptr;

--- a/tests/dvslib/dvs_mirror.py
+++ b/tests/dvslib/dvs_mirror.py
@@ -41,6 +41,31 @@ class DVSMirror(object):
 
         self.config_db.create_entry("MIRROR_SESSION", name, mirror_entry)
 
+
+    def create_erspan_session_sampled(self, name, src, dst, gre, dscp, ttl, queue,
+                                       policer=None, src_ports=None, direction="RX",
+                                       sample_rate=None, truncate_size=None):
+        mirror_entry = {
+            "type": "ERSPAN",
+            "src_ip": src,
+            "dst_ip": dst,
+            "gre_type": gre,
+            "dscp": dscp,
+            "ttl": ttl,
+            "queue": queue,
+            "direction": direction
+        }
+
+        if policer:
+            mirror_entry["policer"] = policer
+        if src_ports:
+            mirror_entry["src_port"] = src_ports
+        if sample_rate:
+            mirror_entry["sample_rate"] = sample_rate
+        if truncate_size:
+            mirror_entry["truncate_size"] = truncate_size
+
+        self.config_db.create_entry("MIRROR_SESSION", name, mirror_entry)
     def remove_mirror_session(self, name):
         self.config_db.delete_entry("MIRROR_SESSION", name)
 

--- a/tests/dvslib/dvs_mirror.py
+++ b/tests/dvslib/dvs_mirror.py
@@ -66,6 +66,7 @@ class DVSMirror(object):
             mirror_entry["truncate_size"] = truncate_size
 
         self.config_db.create_entry("MIRROR_SESSION", name, mirror_entry)
+
     def remove_mirror_session(self, name):
         self.config_db.delete_entry("MIRROR_SESSION", name)
 

--- a/tests/mock_tests/mirrororch_ut.cpp
+++ b/tests/mock_tests/mirrororch_ut.cpp
@@ -53,5 +53,124 @@ namespace mirrororch_test
         auto ret = gMirrorOrch->setUnsetPortMirror(dummyPort, /*ingress*/ false, /*set*/ true, /*sessionId*/ SAI_NULL_OBJECT_ID);
         ASSERT_FALSE(ret);
     }
+
+    TEST_F(MirrorOrchTest, SampledPathUsesCorrectPortAttributes)
+    {
+        // Verify setUnsetPortMirror enters sampled path when sample_rate > 0
+        ASSERT_NE(gSwitchOrch, nullptr);
+        ASSERT_NE(gMirrorOrch, nullptr);
+
+        gSwitchOrch->m_portIngressMirrorSupported = true;
+        gSwitchOrch->m_portIngressSampleMirrorSupported = true;
+
+        Port dummyPort;
+        dummyPort.m_port_id = SAI_NULL_OBJECT_ID;
+
+        // Sampled path: sample_rate > 0 with samplepacketId
+        // SAI mock may fail but function should not crash
+        gMirrorOrch->setUnsetPortMirror(dummyPort, /*ingress*/ true, /*set*/ true,
+                                        /*sessionId*/ SAI_NULL_OBJECT_ID,
+                                        /*samplepacketId*/ (sai_object_id_t)0x1234,
+                                        /*sample_rate*/ 50000);
+    }
+
+    TEST_F(MirrorOrchTest, FullMirrorPathWhenSampleRateZero)
+    {
+        // Verify setUnsetPortMirror uses full mirror path when sample_rate == 0
+        ASSERT_NE(gSwitchOrch, nullptr);
+        ASSERT_NE(gMirrorOrch, nullptr);
+
+        gSwitchOrch->m_portIngressMirrorSupported = true;
+
+        Port dummyPort;
+        dummyPort.m_port_id = SAI_NULL_OBJECT_ID;
+
+        // Full mirror path: sample_rate == 0
+        gMirrorOrch->setUnsetPortMirror(dummyPort, /*ingress*/ true, /*set*/ true,
+                                        /*sessionId*/ SAI_NULL_OBJECT_ID,
+                                        /*samplepacketId*/ SAI_NULL_OBJECT_ID,
+                                        /*sample_rate*/ 0);
+    }
+
+    TEST_F(MirrorOrchTest, FallbackToFullMirrorWhenSampledUnsupported)
+    {
+        // Verify activateSession falls back to full mirror when sampled not supported
+        ASSERT_NE(gSwitchOrch, nullptr);
+        ASSERT_NE(gMirrorOrch, nullptr);
+
+        gSwitchOrch->m_portIngressMirrorSupported = true;
+        gSwitchOrch->m_portIngressSampleMirrorSupported = false;
+
+        MirrorEntry entry("");
+        entry.sample_rate = 50000;
+        entry.truncate_size = 128;
+
+        // Simulate: activateSession should detect unsupported and clear sample_rate
+        // We test the capability check logic directly
+        if (!gSwitchOrch->isPortIngressSampleMirrorSupported())
+        {
+            entry.sample_rate = 0;
+            entry.truncate_size = 0;
+        }
+        ASSERT_EQ(entry.sample_rate, (uint32_t)0);
+        ASSERT_EQ(entry.truncate_size, (uint32_t)0);
+    }
+
+    TEST_F(MirrorOrchTest, SkipTruncationWhenUnsupported)
+    {
+        // Verify createSamplePacket skips truncation when not supported
+        ASSERT_NE(gSwitchOrch, nullptr);
+        ASSERT_NE(gMirrorOrch, nullptr);
+
+        gSwitchOrch->m_portIngressSampleMirrorSupported = true;
+        gSwitchOrch->m_samplepacketTruncationSupported = false;
+
+        MirrorEntry entry("");
+        entry.sample_rate = 50000;
+        entry.truncate_size = 128;
+
+        // createSamplePacket should detect truncation unsupported and clear truncate_size
+        gMirrorOrch->createSamplePacket("test_session", entry);
+        ASSERT_EQ(entry.truncate_size, (uint32_t)0);
+    }
+
+    TEST_F(MirrorOrchTest, RemoveSamplePacketHandlesNullOid)
+    {
+        // Verify removeSamplePacket handles NULL samplepacketId gracefully
+        ASSERT_NE(gMirrorOrch, nullptr);
+
+        MirrorEntry entry("");
+        entry.samplepacketId = SAI_NULL_OBJECT_ID;
+
+        bool ret = gMirrorOrch->removeSamplePacket("test_session", entry);
+        ASSERT_TRUE(ret);
+        ASSERT_EQ(entry.samplepacketId, SAI_NULL_OBJECT_ID);
+    }
+
+    TEST_F(MirrorOrchTest, MirrorEntryDefaultValues)
+    {
+        // Verify MirrorEntry initializes new fields correctly
+        MirrorEntry entry("");
+        ASSERT_EQ(entry.sample_rate, (uint32_t)0);
+        ASSERT_EQ(entry.truncate_size, (uint32_t)0);
+        ASSERT_EQ(entry.samplepacketId, SAI_NULL_OBJECT_ID);
+    }
+
+    TEST_F(MirrorOrchTest, ValidationRejectsTruncateWithoutSampleRate)
+    {
+        // Verify createEntry rejects truncate_size > 0 when sample_rate == 0
+        ASSERT_NE(gMirrorOrch, nullptr);
+
+        vector<FieldValueTuple> data;
+        data.emplace_back("type", "ERSPAN");
+        data.emplace_back("src_ip", "10.0.0.1");
+        data.emplace_back("dst_ip", "10.0.0.2");
+        data.emplace_back("dscp", "8");
+        data.emplace_back("ttl", "64");
+        data.emplace_back("truncate_size", "128");
+
+        auto status = gMirrorOrch->createEntry("invalid_session", data);
+        ASSERT_EQ(status, task_process_status::task_invalid_entry);
+    }
 }
 

--- a/tests/mock_tests/mirrororch_ut.cpp
+++ b/tests/mock_tests/mirrororch_ut.cpp
@@ -54,44 +54,6 @@ namespace mirrororch_test
         ASSERT_FALSE(ret);
     }
 
-    TEST_F(MirrorOrchTest, SampledPathUsesCorrectPortAttributes)
-    {
-        // Verify setUnsetPortMirror enters sampled path when sample_rate > 0
-        ASSERT_NE(gSwitchOrch, nullptr);
-        ASSERT_NE(gMirrorOrch, nullptr);
-
-        gSwitchOrch->m_portIngressMirrorSupported = true;
-        gSwitchOrch->m_portIngressSampleMirrorSupported = true;
-
-        Port dummyPort;
-        dummyPort.m_port_id = SAI_NULL_OBJECT_ID;
-
-        // Sampled path: sample_rate > 0 with samplepacketId
-        // SAI mock may fail but function should not crash
-        gMirrorOrch->setUnsetPortMirror(dummyPort, /*ingress*/ true, /*set*/ true,
-                                        /*sessionId*/ SAI_NULL_OBJECT_ID,
-                                        /*samplepacketId*/ (sai_object_id_t)0x1234,
-                                        /*sample_rate*/ 50000);
-    }
-
-    TEST_F(MirrorOrchTest, FullMirrorPathWhenSampleRateZero)
-    {
-        // Verify setUnsetPortMirror uses full mirror path when sample_rate == 0
-        ASSERT_NE(gSwitchOrch, nullptr);
-        ASSERT_NE(gMirrorOrch, nullptr);
-
-        gSwitchOrch->m_portIngressMirrorSupported = true;
-
-        Port dummyPort;
-        dummyPort.m_port_id = SAI_NULL_OBJECT_ID;
-
-        // Full mirror path: sample_rate == 0
-        gMirrorOrch->setUnsetPortMirror(dummyPort, /*ingress*/ true, /*set*/ true,
-                                        /*sessionId*/ SAI_NULL_OBJECT_ID,
-                                        /*samplepacketId*/ SAI_NULL_OBJECT_ID,
-                                        /*sample_rate*/ 0);
-    }
-
     TEST_F(MirrorOrchTest, FallbackToFullMirrorWhenSampledUnsupported)
     {
         // Verify activateSession falls back to full mirror when sampled not supported
@@ -105,8 +67,8 @@ namespace mirrororch_test
         entry.sample_rate = 50000;
         entry.truncate_size = 128;
 
-        // Simulate: activateSession should detect unsupported and clear sample_rate
-        // We test the capability check logic directly
+        // Note: activateSession requires full neighbor/route resolution which is
+        // not available in mock environment. Testing capability check logic directly.
         if (!gSwitchOrch->isPortIngressSampleMirrorSupported())
         {
             entry.sample_rate = 0;

--- a/tests/mock_tests/switchorch_ut.cpp
+++ b/tests/mock_tests/switchorch_ut.cpp
@@ -328,6 +328,14 @@ namespace switchorch_test
         ASSERT_TRUE(ingress_exists);
         bool egress_exists = gSwitchOrch->m_switchTable.hget("switch", SWITCH_CAPABILITY_TABLE_PORT_EGRESS_MIRROR_CAPABLE, value);
         ASSERT_TRUE(egress_exists);
+
+        // Test that sampled mirror capabilities are queried and stored
+        bool ingress_sample_exists = gSwitchOrch->m_switchTable.hget("switch", SWITCH_CAPABILITY_TABLE_PORT_INGRESS_SAMPLE_MIRROR_CAPABLE, value);
+        ASSERT_TRUE(ingress_sample_exists);
+        bool egress_sample_exists = gSwitchOrch->m_switchTable.hget("switch", SWITCH_CAPABILITY_TABLE_PORT_EGRESS_SAMPLE_MIRROR_CAPABLE, value);
+        ASSERT_TRUE(egress_sample_exists);
+        bool truncation_exists = gSwitchOrch->m_switchTable.hget("switch", SWITCH_CAPABILITY_TABLE_SAMPLEPACKET_TRUNCATION_CAPABLE, value);
+        ASSERT_TRUE(truncation_exists);
     }
 
     TEST_F(SwitchOrchTest, SwitchOrchTestCheckCapabilityUnsupported)
@@ -354,6 +362,14 @@ namespace switchorch_test
         ASSERT_TRUE(ingress_exists);
         bool egress_exists = gSwitchOrch->m_switchTable.hget("switch", SWITCH_CAPABILITY_TABLE_PORT_EGRESS_MIRROR_CAPABLE, value);
         ASSERT_TRUE(egress_exists);
+
+        // Test that sampled mirror capabilities are queried and stored
+        bool ingress_sample_exists = gSwitchOrch->m_switchTable.hget("switch", SWITCH_CAPABILITY_TABLE_PORT_INGRESS_SAMPLE_MIRROR_CAPABLE, value);
+        ASSERT_TRUE(ingress_sample_exists);
+        bool egress_sample_exists = gSwitchOrch->m_switchTable.hget("switch", SWITCH_CAPABILITY_TABLE_PORT_EGRESS_SAMPLE_MIRROR_CAPABLE, value);
+        ASSERT_TRUE(egress_sample_exists);
+        bool truncation_exists = gSwitchOrch->m_switchTable.hget("switch", SWITCH_CAPABILITY_TABLE_SAMPLEPACKET_TRUNCATION_CAPABLE, value);
+        ASSERT_TRUE(truncation_exists);
 
         // case: unsupported severity. To satisfy coverage.
         vector<string> ts;

--- a/tests/test_mirror_sampled_erspan.py
+++ b/tests/test_mirror_sampled_erspan.py
@@ -1,0 +1,146 @@
+# This test suite covers the functionality of sampled port mirroring with truncation on ERSPAN sessions
+import pytest
+
+@pytest.mark.usefixtures("testlog")
+@pytest.mark.usefixtures('dvs_vlan_manager')
+@pytest.mark.usefixtures('dvs_lag_manager')
+@pytest.mark.usefixtures('dvs_mirror_manager')
+class TestSampledMirror(object):
+
+    def _setup_mirror_session(self, dvs, session, src_ports, sample_rate=None, truncate_size=None):
+        """Helper to set up network and create a sampled ERSPAN mirror session"""
+        dvs.setup_db()
+        pmap = dvs.counters_db.get_entry("COUNTERS_PORT_NAME_MAP", "")
+        pmap = dict(pmap)
+
+        # create sampled mirror session
+        self.dvs_mirror.create_erspan_session_sampled(
+            session, "1.1.1.1", "2.2.2.2", "0x8949", "8", "64", "0",
+            src_ports=src_ports, direction="RX",
+            sample_rate=sample_rate, truncate_size=truncate_size)
+
+        # Session starts inactive until route exists
+        self.dvs_mirror.verify_session_status(session, status="inactive")
+
+        # Bring up port and create route to dst_ip
+        dvs.set_interface_status("Ethernet16", "up")
+        dvs.add_ip_address("Ethernet16", "10.0.0.0/30")
+        dvs.add_neighbor("Ethernet16", "10.0.0.1", "02:04:06:08:10:12")
+        dvs.add_route("2.2.2.2", "10.0.0.1")
+        self.dvs_mirror.verify_session_status(session, status="active")
+
+        return pmap
+
+    def _teardown_mirror_session(self, dvs, session):
+        """Helper to tear down network and remove mirror session"""
+        dvs.remove_route("2.2.2.2")
+        dvs.remove_neighbor("Ethernet16", "10.0.0.1")
+        dvs.remove_ip_address("Ethernet16", "10.0.0.0/30")
+        dvs.set_interface_status("Ethernet16", "down")
+        self.dvs_mirror.remove_mirror_session(session)
+        self.dvs_mirror.verify_no_mirror()
+
+    def test_SampledMirrorCreateRemove(self, dvs, testlog):
+        """
+        Test sampled ERSPAN mirror session create and remove.
+        Verify SAMPLEPACKET object is created in ASIC_DB with correct attributes.
+        """
+        session = "SAMPLED_SESSION"
+        pmap = self._setup_mirror_session(dvs, session, "Ethernet12", sample_rate="50000")
+
+        # Verify SAMPLEPACKET object exists in ASIC_DB
+        samplepacket_keys = dvs.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", 1)
+        samplepacket_entry = dvs.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", samplepacket_keys[0])
+
+        # Verify correct attributes
+        assert samplepacket_entry["SAI_SAMPLEPACKET_ATTR_SAMPLE_RATE"] == "50000"
+        assert samplepacket_entry["SAI_SAMPLEPACKET_ATTR_TYPE"] == "SAI_SAMPLEPACKET_TYPE_MIRROR_SESSION"
+
+        # Verify port attributes
+        fvs = dvs.counters_db.get_entry("COUNTERS_PORT_NAME_MAP", "")
+        fvs = dict(fvs)
+        port_oid = fvs.get("Ethernet12")
+        port_entry = dvs.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid)
+        assert "SAI_PORT_ATTR_INGRESS_SAMPLEPACKET_ENABLE" in port_entry
+        assert "SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION" in port_entry
+
+        # Remove and verify cleanup
+        self._teardown_mirror_session(dvs, session)
+        dvs.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", 0)
+
+    def test_SampledMirrorWithTruncation(self, dvs, testlog):
+        """
+        Test sampled ERSPAN mirror session with truncation.
+        Verify truncation attributes are set on SAMPLEPACKET object.
+        """
+        session = "SAMPLED_TRUNCATE_SESSION"
+        pmap = self._setup_mirror_session(dvs, session, "Ethernet12",
+                                          sample_rate="50000", truncate_size="128")
+
+        # Verify SAMPLEPACKET with truncation
+        samplepacket_keys = dvs.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", 1)
+        samplepacket_entry = dvs.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", samplepacket_keys[0])
+
+        assert samplepacket_entry["SAI_SAMPLEPACKET_ATTR_SAMPLE_RATE"] == "50000"
+        assert samplepacket_entry["SAI_SAMPLEPACKET_ATTR_TYPE"] == "SAI_SAMPLEPACKET_TYPE_MIRROR_SESSION"
+        assert samplepacket_entry["SAI_SAMPLEPACKET_ATTR_TRUNCATE_ENABLE"] == "true"
+        assert samplepacket_entry["SAI_SAMPLEPACKET_ATTR_TRUNCATE_SIZE"] == "128"
+
+        self._teardown_mirror_session(dvs, session)
+
+    def test_NoSamplePacketWhenSampleRateAbsent(self, dvs, testlog):
+        """
+        Test backward compatibility: no SAMPLEPACKET created when sample_rate is not configured.
+        """
+        session = "FULL_MIRROR_SESSION"
+
+        dvs.setup_db()
+        # Create regular ERSPAN session without sample_rate
+        self.dvs_mirror.create_erspan_session(
+            session, "1.1.1.1", "2.2.2.2", "0x8949", "8", "64", "0",
+            src_ports="Ethernet12", direction="RX")
+
+        dvs.set_interface_status("Ethernet16", "up")
+        dvs.add_ip_address("Ethernet16", "10.0.0.0/30")
+        dvs.add_neighbor("Ethernet16", "10.0.0.1", "02:04:06:08:10:12")
+        dvs.add_route("2.2.2.2", "10.0.0.1")
+        self.dvs_mirror.verify_session_status(session, status="active")
+
+        # Verify NO SAMPLEPACKET object in ASIC_DB
+        dvs.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", 0)
+
+        # Verify full mirror path (INGRESS_MIRROR_SESSION, not SAMPLE_MIRROR_SESSION)
+        fvs = dvs.counters_db.get_entry("COUNTERS_PORT_NAME_MAP", "")
+        fvs = dict(fvs)
+        port_oid = fvs.get("Ethernet12")
+        port_entry = dvs.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid)
+        assert "SAI_PORT_ATTR_INGRESS_MIRROR_SESSION" in port_entry
+
+        self._teardown_mirror_session(dvs, session)
+
+    def test_SampledMirrorStateDB(self, dvs, testlog):
+        """
+        Test that sample_rate and truncate_size are written to STATE_DB.
+        """
+        session = "SAMPLED_STATE_SESSION"
+        pmap = self._setup_mirror_session(dvs, session, "Ethernet12",
+                                          sample_rate="50000", truncate_size="128")
+
+        # Verify STATE_DB has sample_rate and truncate_size
+        state_entry = dvs.state_db.wait_for_entry("MIRROR_SESSION_TABLE", session)
+        assert state_entry.get("sample_rate") == "50000"
+        assert state_entry.get("truncate_size") == "128"
+
+        self._teardown_mirror_session(dvs, session)
+
+    def test_SampledMirrorCapabilityInStateDB(self, dvs, testlog):
+        """
+        Test that sampled mirror capability entries exist in STATE_DB.
+        """
+        dvs.setup_db()
+
+        # Verify capability entries exist
+        cap_entry = dvs.state_db.wait_for_entry("SWITCH_CAPABILITY", "switch")
+        assert "PORT_INGRESS_SAMPLE_MIRROR_CAPABLE" in cap_entry
+        assert "PORT_EGRESS_SAMPLE_MIRROR_CAPABLE" in cap_entry
+        assert "SAMPLEPACKET_TRUNCATION_CAPABLE" in cap_entry

--- a/tests/test_mirror_sampled_erspan.py
+++ b/tests/test_mirror_sampled_erspan.py
@@ -46,7 +46,7 @@ class TestSampledMirror(object):
         Verify SAMPLEPACKET object is created in ASIC_DB with correct attributes.
         """
         session = "SAMPLED_SESSION"
-        pmap = self._setup_mirror_session(dvs, session, "Ethernet12", sample_rate="50000")
+        self._setup_mirror_session(dvs, session, "Ethernet12", sample_rate="50000")
 
         # Verify SAMPLEPACKET object exists in ASIC_DB
         samplepacket_keys = dvs.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", 1)
@@ -74,7 +74,7 @@ class TestSampledMirror(object):
         Verify truncation attributes are set on SAMPLEPACKET object.
         """
         session = "SAMPLED_TRUNCATE_SESSION"
-        pmap = self._setup_mirror_session(dvs, session, "Ethernet12",
+        self._setup_mirror_session(dvs, session, "Ethernet12",
                                           sample_rate="50000", truncate_size="128")
 
         # Verify SAMPLEPACKET with truncation
@@ -123,7 +123,7 @@ class TestSampledMirror(object):
         Test that sample_rate and truncate_size are written to STATE_DB.
         """
         session = "SAMPLED_STATE_SESSION"
-        pmap = self._setup_mirror_session(dvs, session, "Ethernet12",
+        self._setup_mirror_session(dvs, session, "Ethernet12",
                                           sample_rate="50000", truncate_size="128")
 
         # Verify STATE_DB has sample_rate and truncate_size
@@ -144,3 +144,238 @@ class TestSampledMirror(object):
         assert "PORT_INGRESS_SAMPLE_MIRROR_CAPABLE" in cap_entry
         assert "PORT_EGRESS_SAMPLE_MIRROR_CAPABLE" in cap_entry
         assert "SAMPLEPACKET_TRUNCATION_CAPABLE" in cap_entry
+
+    def test_SampledMirrorUpdateRate(self, dvs, testlog):
+        """
+        Test updating sample_rate on an active sampled ERSPAN mirror session.
+        Verify SAMPLEPACKET object in ASIC_DB is updated in-place with new rate.
+        """
+        session = "SAMPLED_UPDATE_SESSION"
+        self._setup_mirror_session(dvs, session, "Ethernet12", sample_rate="50000")
+
+        # Verify initial SAMPLEPACKET
+        samplepacket_keys = dvs.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", 1)
+        samplepacket_entry = dvs.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", samplepacket_keys[0])
+        assert samplepacket_entry["SAI_SAMPLEPACKET_ATTR_SAMPLE_RATE"] == "50000"
+
+        # Update sample_rate via CONFIG_DB
+        dvs.config_db.update_entry("MIRROR_SESSION", session, {"sample_rate": "100000"})
+
+        # Verify SAMPLEPACKET updated in ASIC_DB
+        dvs.asic_db.wait_for_field_match("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET",
+                                          samplepacket_keys[0],
+                                          {"SAI_SAMPLEPACKET_ATTR_SAMPLE_RATE": "100000"})
+
+        # Verify still only 1 samplepacket (in-place update, not recreate)
+        dvs.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", 1)
+
+        self._teardown_mirror_session(dvs, session)
+
+    def test_SampledMirrorInvalidDirection(self, dvs, testlog):
+        """
+        Test that sampled mirroring with TX direction is rejected.
+        Sampled mirroring only supports RX (ingress) direction.
+        """
+        session = "SAMPLED_INVALID_DIR_SESSION"
+
+        dvs.setup_db()
+        # Create sampled session with TX direction - should be rejected
+        self.dvs_mirror.create_erspan_session_sampled(
+            session, "1.1.1.1", "2.2.2.2", "0x8949", "8", "64", "0",
+            src_ports="Ethernet12", direction="TX",
+            sample_rate="50000")
+
+        # Session should not be created in STATE_DB
+        self.dvs_mirror.verify_session_status(session, expected=0)
+
+        # Verify NO SAMPLEPACKET in ASIC_DB
+        dvs.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", 0)
+
+        # Verify NO mirror session in ASIC_DB
+        dvs.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION", 0)
+
+    def test_SampledMirrorInvalidTruncateWithoutRate(self, dvs, testlog):
+        """
+        Test that truncate_size without sample_rate is rejected.
+        Truncation requires sampled mirroring to be enabled.
+        """
+        session = "SAMPLED_INVALID_TRUNC_SESSION"
+
+        dvs.setup_db()
+        # Create session with truncate_size but no sample_rate - should be rejected
+        self.dvs_mirror.create_erspan_session_sampled(
+            session, "1.1.1.1", "2.2.2.2", "0x8949", "8", "64", "0",
+            src_ports="Ethernet12", direction="RX",
+            truncate_size="128")
+
+        # Session should not be created in STATE_DB
+        self.dvs_mirror.verify_session_status(session, expected=0)
+
+        # Verify NO SAMPLEPACKET in ASIC_DB
+        dvs.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", 0)
+
+    def test_SampledMirrorPortCleanup(self, dvs, testlog):
+        """
+        Test that port attributes are properly cleaned up after removing a sampled mirror session.
+        Verify SAMPLEPACKET_ENABLE and SAMPLE_MIRROR_SESSION are cleared from port.
+        """
+        session = "SAMPLED_CLEANUP_SESSION"
+        self._setup_mirror_session(dvs, session, "Ethernet12", sample_rate="50000")
+
+        # Verify port has sampled mirror attributes set
+        fvs = dvs.counters_db.get_entry("COUNTERS_PORT_NAME_MAP", "")
+        fvs = dict(fvs)
+        port_oid = fvs.get("Ethernet12")
+        port_entry = dvs.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid)
+        assert "SAI_PORT_ATTR_INGRESS_SAMPLEPACKET_ENABLE" in port_entry
+        assert "SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION" in port_entry
+
+        # Remove mirror session
+        self._teardown_mirror_session(dvs, session)
+
+        # Verify SAMPLEPACKET object removed
+        dvs.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", 0)
+
+        # Verify port attributes cleaned up
+        port_entry = dvs.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid)
+        # After cleanup, SAMPLEPACKET_ENABLE should be null or absent
+        if "SAI_PORT_ATTR_INGRESS_SAMPLEPACKET_ENABLE" in port_entry:
+            assert port_entry["SAI_PORT_ATTR_INGRESS_SAMPLEPACKET_ENABLE"] == "oid:0x0"
+        if "SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION" in port_entry:
+            assert port_entry["SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION"] == "0:null"
+
+    def test_SampledMirrorMultipleSrcPorts(self, dvs, testlog):
+        """
+        Test sampled ERSPAN mirror session with multiple source ports.
+        Verify both ports have SAMPLEPACKET_ENABLE and SAMPLE_MIRROR_SESSION set.
+        """
+        session = "SAMPLED_MULTI_PORT_SESSION"
+        self._setup_mirror_session(dvs, session, "Ethernet0,Ethernet4", sample_rate="50000")
+
+        # Verify SAMPLEPACKET object exists
+        dvs.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", 1)
+
+        # Verify both ports have sampled mirror attributes
+        fvs = dvs.counters_db.get_entry("COUNTERS_PORT_NAME_MAP", "")
+        fvs = dict(fvs)
+        for port_name in ["Ethernet0", "Ethernet4"]:
+            port_oid = fvs.get(port_name)
+            port_entry = dvs.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid)
+            assert "SAI_PORT_ATTR_INGRESS_SAMPLEPACKET_ENABLE" in port_entry, \
+                f"SAMPLEPACKET_ENABLE not set on {port_name}"
+            assert "SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION" in port_entry, \
+                f"SAMPLE_MIRROR_SESSION not set on {port_name}"
+
+        self._teardown_mirror_session(dvs, session)
+    def test_PathTransitionFullToSampled(self, dvs, testlog):
+        """
+        Test path transition from full mirror to sampled mirror.
+        Create a full mirror session, then update with sample_rate.
+        Verify SAMPLEPACKET object is created and port attributes switch
+        from INGRESS_MIRROR_SESSION to INGRESS_SAMPLE_MIRROR_SESSION.
+        """
+        session = "PATH_FULL_TO_SAMPLED"
+
+        dvs.setup_db()
+        # Create regular ERSPAN session without sample_rate (full mirror)
+        self.dvs_mirror.create_erspan_session(
+            session, "1.1.1.1", "2.2.2.2", "0x8949", "8", "64", "0",
+            src_ports="Ethernet12", direction="RX")
+
+        dvs.set_interface_status("Ethernet16", "up")
+        dvs.add_ip_address("Ethernet16", "10.0.0.0/30")
+        dvs.add_neighbor("Ethernet16", "10.0.0.1", "02:04:06:08:10:12")
+        dvs.add_route("2.2.2.2", "10.0.0.1")
+        self.dvs_mirror.verify_session_status(session, status="active")
+
+        # Verify full mirror path - no SAMPLEPACKET
+        dvs.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", 0)
+        fvs = dict(dvs.counters_db.get_entry("COUNTERS_PORT_NAME_MAP", ""))
+        port_oid = fvs.get("Ethernet12")
+        port_entry = dvs.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid)
+        assert "SAI_PORT_ATTR_INGRESS_MIRROR_SESSION" in port_entry
+
+        # Transition to sampled mirror by adding sample_rate
+        dvs.config_db.update_entry("MIRROR_SESSION", session, {"sample_rate": "50000"})
+
+        # Verify SAMPLEPACKET created (delete+recreate path)
+        dvs.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", 1)
+        samplepacket_keys = dvs.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", 1)
+        samplepacket_entry = dvs.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", samplepacket_keys[0])
+        assert samplepacket_entry["SAI_SAMPLEPACKET_ATTR_SAMPLE_RATE"] == "50000"
+
+        # Verify port switched to sampled mirror attributes
+        port_entry = dvs.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid)
+        assert "SAI_PORT_ATTR_INGRESS_SAMPLEPACKET_ENABLE" in port_entry
+        assert "SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION" in port_entry
+
+        self._teardown_mirror_session(dvs, session)
+        dvs.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", 0)
+
+    def test_PathTransitionSampledToFull(self, dvs, testlog):
+        """
+        Test path transition from sampled mirror to full mirror.
+        Create a sampled session, then remove sample_rate by re-creating without it.
+        Verify SAMPLEPACKET object is removed and port attributes switch
+        from INGRESS_SAMPLE_MIRROR_SESSION back to INGRESS_MIRROR_SESSION.
+        """
+        session = "PATH_SAMPLED_TO_FULL"
+        self._setup_mirror_session(dvs, session, "Ethernet12", sample_rate="50000")
+
+        # Verify sampled mirror path
+        dvs.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", 1)
+        fvs = dict(dvs.counters_db.get_entry("COUNTERS_PORT_NAME_MAP", ""))
+        port_oid = fvs.get("Ethernet12")
+        port_entry = dvs.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid)
+        assert "SAI_PORT_ATTR_INGRESS_SAMPLEPACKET_ENABLE" in port_entry
+        assert "SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION" in port_entry
+
+        # Transition to full mirror: remove mirror session and recreate without sample_rate
+        dvs.remove_route("2.2.2.2")
+        dvs.remove_neighbor("Ethernet16", "10.0.0.1")
+        dvs.remove_ip_address("Ethernet16", "10.0.0.0/30")
+        dvs.set_interface_status("Ethernet16", "down")
+        self.dvs_mirror.remove_mirror_session(session)
+        self.dvs_mirror.verify_no_mirror()
+
+        # Recreate as full mirror (no sample_rate)
+        self.dvs_mirror.create_erspan_session(
+            session, "1.1.1.1", "2.2.2.2", "0x8949", "8", "64", "0",
+            src_ports="Ethernet12", direction="RX")
+
+        dvs.set_interface_status("Ethernet16", "up")
+        dvs.add_ip_address("Ethernet16", "10.0.0.0/30")
+        dvs.add_neighbor("Ethernet16", "10.0.0.1", "02:04:06:08:10:12")
+        dvs.add_route("2.2.2.2", "10.0.0.1")
+        self.dvs_mirror.verify_session_status(session, status="active")
+
+        # Verify SAMPLEPACKET removed
+        dvs.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", 0)
+
+        # Verify port switched back to full mirror attributes
+        port_entry = dvs.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid)
+        assert "SAI_PORT_ATTR_INGRESS_MIRROR_SESSION" in port_entry
+
+        self._teardown_mirror_session(dvs, session)
+    def test_SampledMirrorInvalidBothDirection(self, dvs, testlog):
+        """
+        Test that sampled mirroring with BOTH direction is rejected.
+        Sampled mirroring only supports RX (ingress) direction.
+        """
+        session = "SAMPLED_INVALID_BOTH_SESSION"
+
+        dvs.setup_db()
+        # Create sampled session with BOTH direction - should be rejected
+        self.dvs_mirror.create_erspan_session_sampled(
+            session, "1.1.1.1", "2.2.2.2", "0x8949", "8", "64", "0",
+            src_ports="Ethernet12", direction="BOTH",
+            sample_rate="50000")
+
+        # Session should not be created in STATE_DB
+        self.dvs_mirror.verify_session_status(session, expected=0)
+
+        # Verify NO SAMPLEPACKET in ASIC_DB
+        dvs.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", 0)
+
+        # Verify NO mirror session in ASIC_DB
+        dvs.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION", 0)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

 **What I did**
Added virtual switch (VS) integration tests for sampled ERSPAN port mirroring with truncation support.

 - New test file: tests/test_mirror_sampled_erspan.py with 13 test cases
 - Extended tests/dvslib/dvs_mirror.py with create_erspan_session_sampled() helper
 
Test coverage:

 - Create/Delete: SAMPLEPACKET object lifecycle, port attribute binding and cleanup, truncation attributes
 - Update: in-place sample_rate update, path transition (full mirror ↔ sampled mirror)
 - Invalid input rejection: sample_rate with direction=TX or BOTH, truncate_size without sample_rate
 - Backward compatibility: no SAMPLEPACKET created when sample_rate absent
 - State and capability: STATE_DB field verification, switch capability entries, multiple source port binding
 
 **Why I did it**
To validate the key software logic paths of the sampled mirroring pipeline from `CONFIG_DB` → MirrorOrch → `ASIC_DB`, including create/delete lifecycle, in-place update, path transitions, invalid input rejection, and backward compatibility.
 
 **How I verified it**
 Tests are validated against the virtual switch (vssyncd). Each test verifies the CONFIG_DB → MirrorOrch → ASIC_DB pipeline via ASIC_DB and STATE_DB assertions.

**Details if related**
 Depends on: https://github.com/sonic-net/sonic-swss/pull/4502.
 
Note: The switchorch/mirrororch changes in the diff are from #4502 and will disappear after it is merged and this PR is rebased.
