### PR TITLE
[portsorch]: Downgrade log level for PORT_PHY_SERDES_ATTR no serdes object

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -9453,7 +9453,7 @@ void PortsOrch::clearPortPhySerdesAttrCounterMap()
 
         if (port_serdes_id == SAI_NULL_OBJECT_ID)
         {
-            SWSS_LOG_ERROR("PORT_PHY_SERDES_ATTR: Port %s has no serdes object", it.second.m_alias.c_str());
+            SWSS_LOG_WARN("PORT_PHY_SERDES_ATTR: Port %s has no serdes object", it.second.m_alias.c_str());
             continue;
         }
 

--- a/tests/mock_tests/portphyserdesattr_ut.cpp
+++ b/tests/mock_tests/portphyserdesattr_ut.cpp
@@ -502,5 +502,25 @@ namespace portphyserdesattr_test
         // Cleanup
         gPortsOrch->clearPortPhySerdesAttrCounterMap();
     }
+
+    // Covers clearPortPhySerdesAttrCounterMap() when a PHY port has no serdes OID (WARN path).
+    TEST_F(PortSerdesAttrTest, ClearPortPhySerdesAttrCounterMap_NoSerdesObject)
+    {
+        ASSERT_NE(gPortsOrch, nullptr);
+
+        sai_object_id_t phy_port_id = SAI_NULL_OBJECT_ID;
+        for (const auto &it : gPortsOrch->m_portList)
+        {
+            if (it.second.m_type == Port::Type::PHY)
+            {
+                phy_port_id = it.second.m_port_id;
+                gPortsOrch->m_portIdToSerdesId.erase(phy_port_id);
+                break;
+            }
+        }
+        ASSERT_NE(phy_port_id, SAI_NULL_OBJECT_ID);
+
+        gPortsOrch->clearPortPhySerdesAttrCounterMap();
+    }
 } // namespace portphyserdesattr_test
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

In clearPortPhySerdesAttrCounterMap(), changed the log level from SWSS_LOG_ERROR to SWSS_LOG_WARN when a port has no serdes object.

**Why I did it**

On platforms that do not support serdes, port_serdes_id is SAI_NULL_OBJECT_ID, which is expected behavior. However, this was logged at ERROR level, causing false alarms in loganalyzer.

This is the same class of issue fixed in #4467 (getPortSerdesIdFromPortId()), but in a different code path, clearPortPhySerdesAttrCounterMap() iterates all ports and logs ERROR for any port without a serdes object, even on platforms where serdes is simply not implemented.

**How I verified it**

On a platform that does not support serdes, confirmed that the log no longer appears at ERR level in syslog.

**Details if related**
