### PR TITLE
Fix SAI library order for mock test linking.

### DIFF
--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -13,7 +13,7 @@ TESTS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests
 
 noinst_PROGRAMS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_response_publisher tests_nbrmgrd tests_teamsyncd
 
-LDADD_SAI = -lsaimeta -lsaimetadata -lsaivs -lsairedis
+LDADD_SAI = -lsaivs -lsairedis -lsaimeta -lsaimetadata
 
 if DEBUG
 DBGFLAGS = -ggdb -DDEBUG


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixed the SAI library link order used by tests/mock_tests so libsaivs and libsairedis are linked before their dependency libraries, libsaimeta and libsaimetadata.

**Why I did it**
The swss CI build started building tests/mock_tests after the platform-vpp artifact changed to a branch that no longer provides the old libsai.so from saivpp. This exposed a latent link-order issue where libsaivs.so could not resolve SAI metadata and serialization symbols such as sai_serialize_*, sai_metadata_*, and saimeta::Meta::*.

**How I verified it**
Running azure swss CI/CD

**Details if related**
