### PR TITLE
natmgr: conditionally install fullcone DNAT rule based on pool port r…

### DIFF
--- a/cfgmgr/natmgr.cpp
+++ b/cfgmgr/natmgr.cpp
@@ -5718,8 +5718,16 @@ void NatMgr::enableNatFeature(void)
     SWSS_LOG_INFO("Adding Dynamic NAT rules");
     addDynamicNatRules();
 
-    /* Add full-cone PRE-ROUTING DNAT rule in the kernel */
-    setFullConeDnatIptablesRule(ADD);
+    /* Add full-cone PRE-ROUTING DNAT rule in the kernel only if
+     * a dynamic NAT pool with a port range is configured */
+    for (auto it = m_natPoolInfo.begin(); it != m_natPoolInfo.end(); it++)
+    {
+        if (!(*it).second.port_range.empty() && ((*it).second.port_range != "NULL"))
+        {
+           setFullConeDnatIptablesRule(ADD);
+           break;
+        }
+    }
 
     SWSS_LOG_INFO("NAT Refresh timer start ");
     m_natRefreshTimer->start();
@@ -5756,8 +5764,16 @@ void NatMgr::disableNatFeature(void)
     m_appNatGlobalTableProducer.set(appKey, fvVector);
     SWSS_LOG_INFO("Disabled NAT Admin Mode to APPL_DB");
 
-    /* Delete full-cone PRE-ROUTING DNAT rule in the kernel */
-    setFullConeDnatIptablesRule(DELETE);
+    /* Delete full-cone PRE-ROUTING DNAT rule in the kernel only if
+     * a dynamic NAT pool with a port range was configured */
+    for (auto it = m_natPoolInfo.begin(); it != m_natPoolInfo.end(); it++)
+    {
+         if (!(*it).second.port_range.empty() && ((*it).second.port_range != "NULL"))
+         {
+            setFullConeDnatIptablesRule(DELETE);
+            break;
+         }
+    }
 
     SWSS_LOG_INFO("NAT Refresh timer stop ");
     m_natRefreshTimer->stop();


### PR DESCRIPTION
Problem:
When NAT is enabled via `config nat feature enable`, `enableNatFeature()` 
in `sonic-swss/cfgmgr/natmgr.cpp` at line 5722 unconditionally calls 
`setFullConeDnatIptablesRule(ADD)`, which installs this iptables rule 
regardless of whether fullcone NAT is configured:

    DNAT  all  --  0.0.0.0/0  0.0.0.0/0  to:1.1.1.1

The `1.1.1.1` destination is intentionally arbitrary when the `--fullcone.` 
flag is active, the kernel ignores it. However, when no fullcone pool is 
configured, the kernel reads the rule literally and redirects ALL incoming 
traffic to `1.1.1.1`, breaking OSPF, BGP, and other routing protocols.

Fixes sonic-net/sonic-buildimage#27097

Root Cause:
`setFullConeDnatIptablesRule()` is called unconditionally at:
- `sonic-swss/cfgmgr/natmgr.cpp` line 5722 in `enableNatFeature().`
- `sonic-swss/cfgmgr/natmgr.cpp` line 5760 in `disableNatFeature().`

Unlike every other rule in those functions, which only act when relevant 
config exists, this call had no condition around it.

Fullcone NAT is only relevant when a dynamic NAT pool has a port range 
configured. Without a port range, fullcone makes no sense; there is no 
mechanism to route arbitrary incoming packets to the correct internal device.

Fix:
In both `enableNatFeature()` and `disableNatFeature()`, wrap the 
`setFullConeDnatIptablesRule()` call with a check — only install/remove 
The fullcone rule if at least one NAT pool has a port range configured.

Testing:
- NAT enabled, no config → iptables nat table stays empty 
- NAT enabled, static NAT only → fullcone rule not installed 
- NAT enabled, dynamic pool without port range → fullcone rule not installed 
- NAT enabled, dynamic pool with port range → fullcone rule installed correctly 