### PR TITLE
[dash]: Add ENI OID mapping and DPU counter DB support

### DIFF
--- a/orchagent/dash/dashorch.cpp
+++ b/orchagent/dash/dashorch.cpp
@@ -66,6 +66,10 @@ DashOrch::DashOrch(DBConnector *db, vector<string> &tableName, DBConnector *app_
 
     m_counter_db = std::shared_ptr<DBConnector>(new DBConnector("COUNTERS_DB", 0));
     m_eni_name_table = make_unique<Table>(m_counter_db.get(), COUNTERS_ENI_NAME_MAP);
+    m_eni_oid_table = make_unique<Table>(m_counter_db.get(), COUNTERS_ENI_OID_MAP);
+    m_dpu_counter_db = std::shared_ptr<DBConnector>(new DBConnector("DPU_COUNTERS_DB", 0, true));
+    m_dpu_eni_name_table = make_unique<Table>(m_dpu_counter_db.get(), COUNTERS_ENI_NAME_MAP);
+    m_dpu_eni_oid_table = make_unique<Table>(m_dpu_counter_db.get(), COUNTERS_ENI_OID_MAP);
     dash_eni_result_table_ = make_unique<Table>(app_state_db, APP_DASH_ENI_TABLE_NAME);
     dash_eni_route_result_table_ = make_unique<Table>(app_state_db, APP_DASH_ENI_ROUTE_TABLE_NAME);
     dash_qos_result_table_ = make_unique<Table>(app_state_db, APP_DASH_QOS_TABLE_NAME);
@@ -1377,9 +1381,16 @@ void DashOrch::addEniMapEntry(sai_object_id_t oid, const string &name)
 
     const auto id = sai_serialize_object_id(oid);
     SWSS_LOG_INFO("Adding ENI map entry for %s, id: %s", name.c_str(), id.c_str());
+
     std::vector<FieldValueTuple> eniNameFvs;
     eniNameFvs.emplace_back(name, id);
     m_eni_name_table->set("", eniNameFvs);
+    m_dpu_eni_name_table->set("", eniNameFvs);
+
+    std::vector<FieldValueTuple> eniOidFvs;
+    eniOidFvs.emplace_back(id, name);
+    m_eni_oid_table->set("", eniOidFvs);
+    m_dpu_eni_oid_table->set("", eniOidFvs);
 }
 
 void DashOrch::removeEniMapEntry(sai_object_id_t oid, const string &name) 
@@ -1393,7 +1404,13 @@ void DashOrch::removeEniMapEntry(sai_object_id_t oid, const string &name)
     }
 
     m_eni_name_table->hdel("", name);
-    SWSS_LOG_INFO("Removing ENI map entry for %s, id: %s", name.c_str(), sai_serialize_object_id(oid).c_str());
+    m_dpu_eni_name_table->hdel("", name);
+
+    const auto id = sai_serialize_object_id(oid);
+    m_eni_oid_table->hdel("", id);
+    m_dpu_eni_oid_table->hdel("", id);
+
+    SWSS_LOG_INFO("Removing ENI map entry for %s, id: %s", name.c_str(), id.c_str());
 }
 
 dash::types::IpAddress DashOrch::getApplianceVip()

--- a/orchagent/dash/dashorch.h
+++ b/orchagent/dash/dashorch.h
@@ -113,7 +113,11 @@ protected:
 
 private:
     std::unique_ptr<swss::Table> m_eni_name_table;
+    std::unique_ptr<swss::Table> m_eni_oid_table;
     std::shared_ptr<swss::DBConnector> m_counter_db;
+    std::shared_ptr<swss::DBConnector> m_dpu_counter_db;
+    std::unique_ptr<swss::Table> m_dpu_eni_name_table;
+    std::unique_ptr<swss::Table> m_dpu_eni_oid_table;
     std::shared_ptr<swss::DBConnector> m_asic_db;
     DashHaOrch* m_dash_ha_orch = nullptr;
     bool m_ha_flow_owner_attr_supported = false;

--- a/tests/mock_tests/database_config.json
+++ b/tests/mock_tests/database_config.json
@@ -91,6 +91,11 @@
             "id": 17,
             "separator": "|",
             "instance": "redis"
+        },
+        "DPU_COUNTERS_DB": {
+            "id": 18,
+            "separator": ":",
+            "instance": "redis"
         }
     },
     "VERSION" : "1.0"


### PR DESCRIPTION
## Description
Add COUNTERS_ENI_OID_MAP table to map ENI OIDs to names, enabling counter collection by OID lookup. Also add DPU_COUNTERS_DB support so ENI name and OID mappings are mirrored to the DPU counter database for NPU-side counter polling.

Expected mapping format:
```
admin@sonic-dpu:~$ sonic-db-cli COUNTERS_DB hgetall "COUNTERS_ENI_NAME_MAP"
{'eni1': 'oid:0x7008000000020', 'eni2': 'oid:0x7008000000021'}

admin@sonic-dpu:~$ sonic-db-cli COUNTERS_DB hgetall "COUNTERS_ENI_OID_MAP"
{'oid:0x7008000000020': 'eni1', 'oid:0x7008000000021': 'eni2'}
```

## Changes
- Add `m_eni_oid_table` for OID-to-name mapping in COUNTERS_DB
- Add `m_dpu_counter_db`, `m_dpu_eni_name_table`, `m_dpu_eni_oid_table` for DPU_COUNTERS_DB mirroring
- Update `addEniMapEntry`/`removeEniMapEntry` to maintain all four tables
- Add DPU_COUNTERS_DB (id 18) to mock test database config

## Testing
- All 424 C++ mock tests pass
