### PR TITLE
Filter out recycle port from attribute queries that are not applicable

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4156,7 +4156,8 @@ void PortsOrch::registerPort(Port &p)
     }
     if (flex_counters_orch->getPortPhyAttrCounterState())
     {
-        if (!m_supported_phy_attrs.empty() && p.m_type == Port::Type::PHY)
+        if (!m_supported_phy_attrs.empty() && p.m_type == Port::Type::PHY &&
+            p.m_role != Port::Role::Rec && p.m_role != Port::Role::Inb)
         {
             auto supported_attrs = getPortPhySupportedAttrs(p.m_port_id, p.m_alias.c_str());
             if (!supported_attrs.empty())
@@ -4288,7 +4289,8 @@ void PortsOrch::deInitPort(string alias, sai_object_id_t port_id)
     {
         wred_port_stat_manager.clearCounterIdList(p.m_port_id);
     }
-    if (!m_supported_phy_attrs.empty() && p.m_type == Port::Type::PHY)
+    if (!m_supported_phy_attrs.empty() && p.m_type == Port::Type::PHY &&
+        p.m_role != Port::Role::Rec && p.m_role != Port::Role::Inb)
     {
         port_phy_attr_manager.clearCounterIdList(p.m_port_id);
     }
@@ -4501,6 +4503,13 @@ bool PortsOrch::programSerdes(
     sai_object_id_t switch_id,
     PortSerdesAttrMap_t &serdes_attr)
 {
+    if (port.m_role == Port::Role::Rec || port.m_role == Port::Role::Inb)
+    {
+        SWSS_LOG_INFO("Skipping serdes programming for recirc/inband port %s",
+                      port.m_alias.c_str());
+        return true;
+    }
+
     // Validate port_id and determine serdes type
     const char* serdes_type_name;
     if (port_id == port.m_port_id)
@@ -9253,7 +9262,9 @@ void PortsOrch::generatePortPhyAttrCounterMap()
 
     for (const auto& it: m_portList)
     {
-        if (it.second.m_type == Port::Type::PHY)
+        if (it.second.m_type == Port::Type::PHY &&
+            it.second.m_role != Port::Role::Rec &&
+            it.second.m_role != Port::Role::Inb)
         {
             auto supported_attrs = getPortPhySupportedAttrs(it.second.m_port_id, it.second.m_alias.c_str());
             if (!supported_attrs.empty())
@@ -9436,7 +9447,9 @@ void PortsOrch::clearPortPhySerdesAttrCounterMap()
     for (const auto& it: m_portList)
     {
         // Clear counter stats only for PHY ports that were previously configured
-        if (it.second.m_type != Port::Type::PHY)
+        if (it.second.m_type != Port::Type::PHY ||
+            it.second.m_role == Port::Role::Rec ||
+            it.second.m_role == Port::Role::Inb)
         {
             continue;
         }
@@ -10270,6 +10283,13 @@ bool PortsOrch::setPortMediaType(Port& port, const string &media_type)
 void PortsOrch::removePortSerdesAttribute(sai_object_id_t port_id)
 {
     SWSS_LOG_ENTER();
+
+    Port port;
+    if (getPort(port_id, port) &&
+        (port.m_role == Port::Role::Rec || port.m_role == Port::Role::Inb))
+    {
+        return;
+    }
 
     sai_attribute_t port_attr;
     sai_status_t status;

--- a/tests/mock_tests/portphyattr_ut.cpp
+++ b/tests/mock_tests/portphyattr_ut.cpp
@@ -12,6 +12,7 @@
 #include "mock_table.h"
 
 #include <memory>
+#include <set>
 #include <string>
 
 extern SwitchOrch *gSwitchOrch;
@@ -26,6 +27,15 @@ namespace portphyattr_test
     sai_port_api_t *old_sai_port_api;
     sai_port_api_t ut_sai_port_api;
 
+    // Records which port OIDs were probed for the PHY-attr ids, so tests can
+    // assert that recycle/inband ports never reach SAI on the filtered out paths.
+    static std::set<sai_object_id_t> g_phy_attr_queried_port_ids;
+
+    // Records which port OIDs were queried for SAI_PORT_ATTR_PORT_SERDES_ID
+    // (attr 108). Used to verify the serdes program/remove paths skip
+    // recycle/inband ports.
+    static std::set<sai_object_id_t> g_serdes_id_queried_port_ids;
+
     sai_status_t mock_get_port_attribute(
         _In_ sai_object_id_t port_id,
         _In_ uint32_t attr_count,
@@ -35,14 +45,20 @@ namespace portphyattr_test
              || attr_list[0].id == SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK)
             && attr_list[0].value.portlanelatchstatuslist.count == 0)
         {
+            g_phy_attr_queried_port_ids.insert(port_id);
             attr_list[0].value.portlanelatchstatuslist.count = 8;
             return SAI_STATUS_BUFFER_OVERFLOW;
         }
         else if (attr_list[0].id == SAI_PORT_ATTR_RX_SNR &&
                  attr_list[0].value.portsnrlist.count == 0)
         {
+            g_phy_attr_queried_port_ids.insert(port_id);
             attr_list[0].value.portsnrlist.count = 8;
             return SAI_STATUS_BUFFER_OVERFLOW;
+        }
+        else if (attr_list[0].id == SAI_PORT_ATTR_PORT_SERDES_ID)
+        {
+            g_serdes_id_queried_port_ids.insert(port_id);
         }
 
         // For all other attributes, call the original SAI API
@@ -255,5 +271,145 @@ namespace portphyattr_test
         }
 
         SUCCEED() << "Unsupported platform scenario handled gracefully";
+    }
+
+    /**
+     * Verify generatePortPhyAttrCounterMap does NOT issue PHY-attr SAI probes
+     * against ports whose role is Recirculation or Inband. The brcm SAI rejects
+     * these probes for recycle ports with "Unknown port attribute"; the filter
+     * in portsorch must keep them out of the iteration.
+     */
+    TEST_F(PortAttrTest, RecirculationAndInbandPortsSkippedInGenerateCounterMap)
+    {
+        ASSERT_NE(gPortsOrch, nullptr);
+        ASSERT_FALSE(gPortsOrch->m_supported_phy_attrs.empty());
+
+        // Inject synthetic Rec and Inb ports that share Port::Type::PHY with
+        // regular ports — only the role distinguishes them.
+        const sai_object_id_t rec_oid = 0xFEED0001;
+        const sai_object_id_t inb_oid = 0xFEED0002;
+
+        Port rec_port("Ethernet-Rec0", Port::Type::PHY);
+        rec_port.m_port_id = rec_oid;
+        rec_port.m_role = Port::Role::Rec;
+        gPortsOrch->m_portList["Ethernet-Rec0"] = rec_port;
+
+        Port inb_port("Ethernet-IB0", Port::Type::PHY);
+        inb_port.m_port_id = inb_oid;
+        inb_port.m_role = Port::Role::Inb;
+        gPortsOrch->m_portList["Ethernet-IB0"] = inb_port;
+
+        g_phy_attr_queried_port_ids.clear();
+        gPortsOrch->generatePortPhyAttrCounterMap();
+
+        EXPECT_EQ(g_phy_attr_queried_port_ids.count(rec_oid), 0u)
+            << "Recirculation port was unexpectedly probed for PHY attrs";
+        EXPECT_EQ(g_phy_attr_queried_port_ids.count(inb_oid), 0u)
+            << "Inband port was unexpectedly probed for PHY attrs";
+
+        // Sanity: at least one regular Ext-role port should have been probed.
+        EXPECT_GT(g_phy_attr_queried_port_ids.size(), 0u)
+            << "Expected at least one regular port to be probed";
+    }
+
+    /**
+     * Mirror of the above for clearPortPhyAttrCounterMap: it must also skip
+     * Rec/Inb ports so the disable path matches the enable path.
+     */
+    TEST_F(PortAttrTest, RecirculationAndInbandPortsSkippedInClearCounterMap)
+    {
+        ASSERT_NE(gPortsOrch, nullptr);
+        ASSERT_FALSE(gPortsOrch->m_supported_phy_attrs.empty());
+
+        const sai_object_id_t rec_oid = 0xFEED1001;
+        const sai_object_id_t inb_oid = 0xFEED1002;
+
+        Port rec_port("Ethernet-Rec0", Port::Type::PHY);
+        rec_port.m_port_id = rec_oid;
+        rec_port.m_role = Port::Role::Rec;
+        gPortsOrch->m_portList["Ethernet-Rec0"] = rec_port;
+
+        Port inb_port("Ethernet-IB0", Port::Type::PHY);
+        inb_port.m_port_id = inb_oid;
+        inb_port.m_role = Port::Role::Inb;
+        gPortsOrch->m_portList["Ethernet-IB0"] = inb_port;
+
+        // clearPortPhyAttrCounterMap doesn't issue SAI gets, so we just ensure
+        // it walks without throwing and silently skips Rec/Inb. This guards
+        // against a future regression where the loop forgets the role check.
+        try {
+            gPortsOrch->clearPortPhyAttrCounterMap();
+        } catch (const std::exception &e) {
+            FAIL() << "clearPortPhyAttrCounterMap threw: " << e.what();
+        }
+        SUCCEED();
+    }
+
+    /**
+     * programSerdes must short-circuit and return success for Rec/Inb ports —
+     * recycle ports do not have a SERDES object, and the brcm SAI rejects
+     * SAI_PORT_ATTR_PORT_SERDES_ID GETs on them with "Unknown port attribute".
+     * Pass an obviously-invalid port_id to ensure the gate fires before the
+     * port_id-vs-port validation block (which would otherwise return false).
+     */
+    TEST_F(PortAttrTest, ProgramSerdesSkipsRecirculationPort)
+    {
+        ASSERT_NE(gPortsOrch, nullptr);
+
+        Port rec_port("Ethernet-Rec0", Port::Type::PHY);
+        rec_port.m_port_id = 0xCC110001;
+        rec_port.m_role = Port::Role::Rec;
+
+        std::map<sai_port_serdes_attr_t, std::vector<uint32_t>> serdes_attr;
+        // Deliberately pass a port_id that doesn't match any of port.m_port_id
+        // / m_line_side_id / m_system_side_id. Without the gate, the validation
+        // block returns false; with the gate, the function returns true before
+        // ever inspecting port_id.
+        const sai_object_id_t bogus_port_id = 0xDEADBEEFCAFEFEEDULL;
+
+        g_serdes_id_queried_port_ids.clear();
+        EXPECT_TRUE(gPortsOrch->programSerdes(rec_port, bogus_port_id, gSwitchId, serdes_attr));
+        EXPECT_EQ(g_serdes_id_queried_port_ids.count(bogus_port_id), 0u);
+        EXPECT_EQ(g_serdes_id_queried_port_ids.count(rec_port.m_port_id), 0u);
+
+        // Same expectation for Inband role.
+        Port inb_port("Ethernet-IB0", Port::Type::PHY);
+        inb_port.m_port_id = 0xCC110002;
+        inb_port.m_role = Port::Role::Inb;
+        EXPECT_TRUE(gPortsOrch->programSerdes(inb_port, bogus_port_id, gSwitchId, serdes_attr));
+    }
+
+    /**
+     * removePortSerdesAttribute must be a no-op for Rec/Inb ports — it should
+     * not issue the SAI_PORT_ATTR_PORT_SERDES_ID GET that the brcm SAI's
+     * recycle-port handler rejects.
+     */
+    TEST_F(PortAttrTest, RemovePortSerdesAttributeSkipsRecirculationPort)
+    {
+        ASSERT_NE(gPortsOrch, nullptr);
+
+        const sai_object_id_t rec_oid = 0xCC220001;
+        const sai_object_id_t inb_oid = 0xCC220002;
+
+        Port rec_port("Ethernet-Rec0", Port::Type::PHY);
+        rec_port.m_port_id = rec_oid;
+        rec_port.m_role = Port::Role::Rec;
+        gPortsOrch->m_portList["Ethernet-Rec0"] = rec_port;
+        gPortsOrch->saiOidToAlias[rec_oid] = "Ethernet-Rec0";
+
+        Port inb_port("Ethernet-IB0", Port::Type::PHY);
+        inb_port.m_port_id = inb_oid;
+        inb_port.m_role = Port::Role::Inb;
+        gPortsOrch->m_portList["Ethernet-IB0"] = inb_port;
+        gPortsOrch->saiOidToAlias[inb_oid] = "Ethernet-IB0";
+
+        g_serdes_id_queried_port_ids.clear();
+        gPortsOrch->removePortSerdesAttribute(rec_oid);
+        gPortsOrch->removePortSerdesAttribute(inb_oid);
+
+        EXPECT_EQ(g_serdes_id_queried_port_ids.count(rec_oid), 0u)
+            << "removePortSerdesAttribute issued SAI GET on a recycle port";
+        EXPECT_EQ(g_serdes_id_queried_port_ids.count(inb_oid), 0u)
+            << "removePortSerdesAttribute issued SAI GET on an inband port";
     }
 } // namespace portphyattr_test

--- a/tests/mock_tests/portphyattr_ut.cpp
+++ b/tests/mock_tests/portphyattr_ut.cpp
@@ -284,6 +284,12 @@ namespace portphyattr_test
         ASSERT_NE(gPortsOrch, nullptr);
         ASSERT_FALSE(gPortsOrch->m_supported_phy_attrs.empty());
 
+        // Anchor a real front-panel port (Ext role) so we can assert it IS
+        // probed alongside the Rec/Inb skip checks below.
+        Port fp_port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", fp_port));
+        const sai_object_id_t fp_oid = fp_port.m_port_id;
+
         // Inject synthetic Rec and Inb ports that share Port::Type::PHY with
         // regular ports — only the role distinguishes them.
         const sai_object_id_t rec_oid = 0xFEED0001;
@@ -307,9 +313,10 @@ namespace portphyattr_test
         EXPECT_EQ(g_phy_attr_queried_port_ids.count(inb_oid), 0u)
             << "Inband port was unexpectedly probed for PHY attrs";
 
-        // Sanity: at least one regular Ext-role port should have been probed.
-        EXPECT_GT(g_phy_attr_queried_port_ids.size(), 0u)
-            << "Expected at least one regular port to be probed";
+        // The Ext-role FP port must be probed — proves the gate is selective,
+        // not blanket-skipping every PHY port.
+        EXPECT_GT(g_phy_attr_queried_port_ids.count(fp_oid), 0u)
+            << "Front-panel port " << fp_port.m_alias << " (Ext) was not probed";
     }
 
     /**
@@ -320,6 +327,12 @@ namespace portphyattr_test
     {
         ASSERT_NE(gPortsOrch, nullptr);
         ASSERT_FALSE(gPortsOrch->m_supported_phy_attrs.empty());
+
+        // Confirm a real Ext-role FP port is in m_portList so the iteration
+        // exercises the gate on a non-Rec/Inb port (not just the skip path).
+        Port fp_port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", fp_port));
+        ASSERT_FALSE(fp_port.m_alias.empty());
 
         const sai_object_id_t rec_oid = 0xFEED1001;
         const sai_object_id_t inb_oid = 0xFEED1002;
@@ -335,7 +348,7 @@ namespace portphyattr_test
         gPortsOrch->m_portList["Ethernet-IB0"] = inb_port;
 
         // clearPortPhyAttrCounterMap doesn't issue SAI gets, so we just ensure
-        // it walks without throwing and silently skips Rec/Inb. This guards
+        // it walks without throwing across Rec/Inb/FP entries. This guards
         // against a future regression where the loop forgets the role check.
         try {
             gPortsOrch->clearPortPhyAttrCounterMap();
@@ -377,6 +390,19 @@ namespace portphyattr_test
         inb_port.m_port_id = 0xCC110002;
         inb_port.m_role = Port::Role::Inb;
         EXPECT_TRUE(gPortsOrch->programSerdes(inb_port, bogus_port_id, gSwitchId, serdes_attr));
+
+        // A real Ext-role FP port must NOT be gated: programSerdes proceeds
+        // past the role check, validates port_id, and the downstream
+        // setPortSerdesAttribute call issues a SAI_PORT_ATTR_PORT_SERDES_ID GET
+        // recorded by the mock. We don't pin the return value (admin-status /
+        // serdes-create can fail for unrelated VS reasons); only that the GET
+        // was issued, proving the gate is selective.
+        Port fp_port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", fp_port));
+        const sai_object_id_t fp_oid = fp_port.m_port_id;
+        gPortsOrch->programSerdes(fp_port, fp_oid, gSwitchId, serdes_attr);
+        EXPECT_GT(g_serdes_id_queried_port_ids.count(fp_oid), 0u)
+            << "programSerdes did not issue SAI GET on FP port " << fp_port.m_alias;
     }
 
     /**
@@ -387,6 +413,11 @@ namespace portphyattr_test
     TEST_F(PortAttrTest, RemovePortSerdesAttributeSkipsRecirculationPort)
     {
         ASSERT_NE(gPortsOrch, nullptr);
+
+        // Real Ext-role FP port to exercise the non-Rec/Inb path.
+        Port fp_port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", fp_port));
+        const sai_object_id_t fp_oid = fp_port.m_port_id;
 
         const sai_object_id_t rec_oid = 0xCC220001;
         const sai_object_id_t inb_oid = 0xCC220002;
@@ -406,10 +437,14 @@ namespace portphyattr_test
         g_serdes_id_queried_port_ids.clear();
         gPortsOrch->removePortSerdesAttribute(rec_oid);
         gPortsOrch->removePortSerdesAttribute(inb_oid);
+        gPortsOrch->removePortSerdesAttribute(fp_oid);
 
         EXPECT_EQ(g_serdes_id_queried_port_ids.count(rec_oid), 0u)
             << "removePortSerdesAttribute issued SAI GET on a recycle port";
         EXPECT_EQ(g_serdes_id_queried_port_ids.count(inb_oid), 0u)
             << "removePortSerdesAttribute issued SAI GET on an inband port";
+        EXPECT_GT(g_serdes_id_queried_port_ids.count(fp_oid), 0u)
+            << "removePortSerdesAttribute did not issue SAI GET on FP port "
+            << fp_port.m_alias;
     }
 } // namespace portphyattr_test

--- a/tests/mock_tests/portphyattr_ut.cpp
+++ b/tests/mock_tests/portphyattr_ut.cpp
@@ -360,7 +360,7 @@ namespace portphyattr_test
         rec_port.m_port_id = 0xCC110001;
         rec_port.m_role = Port::Role::Rec;
 
-        std::map<sai_port_serdes_attr_t, std::vector<uint32_t>> serdes_attr;
+        std::map<sai_port_serdes_attr_t, SerdesValue> serdes_attr;
         // Deliberately pass a port_id that doesn't match any of port.m_port_id
         // / m_line_side_id / m_system_side_id. Without the gate, the validation
         // block returns false; with the gate, the function returns true before

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -107,14 +107,23 @@ namespace portsorch_test
         }
         else if (attr_count == 1 && attr_list[0].id == SAI_PORT_ATTR_PORT_SERDES_ID)
         {
-            // Check if serdes exists for this port
+            // Prefer test-tracked serdes if present.
             auto it = _port_to_serdes_map.find(port_id);
             if (it != _port_to_serdes_map.end()) {
                 attr_list[0].value.oid = it->second;
-            } else {
-                attr_list[0].value.oid = SAI_NULL_OBJECT_ID;
+                status = SAI_STATUS_SUCCESS;
             }
-            status = SAI_STATUS_SUCCESS;
+            // Fall through to the real SAI only for genuine VS PORT objects so
+            // default-port serdes (auto-created during init_switch) gets cleaned
+            // up. Synthetic OIDs used by gearbox tests (e.g., 0x2100...) decode
+            // to non-PORT types and would throw inside libsairedis-meta.
+            else if (sai_object_type_query(port_id) == SAI_OBJECT_TYPE_PORT) {
+                status = pold_sai_port_api->get_port_attribute(port_id, attr_count, attr_list);
+            }
+            else {
+                attr_list[0].value.oid = SAI_NULL_OBJECT_ID;
+                status = SAI_STATUS_SUCCESS;
+            }
         }
         else
         {
@@ -361,6 +370,7 @@ namespace portsorch_test
     {
         _sai_remove_port_serdes_calls.push_back(port_serdes_id);
 
+        bool tracked = false;
         // Erase any port-to-serdes mappings that reference this serdes ID,
         // so subsequent SAI_PORT_ATTR_PORT_SERDES_ID queries reflect removal.
         for (auto it = _port_to_serdes_map.begin(); it != _port_to_serdes_map.end(); )
@@ -368,11 +378,20 @@ namespace portsorch_test
             if (it->second == port_serdes_id)
             {
                 it = _port_to_serdes_map.erase(it);
+                tracked = true;
             }
             else
             {
                 ++it;
             }
+        }
+
+        // Forward to real SAI only for genuine PORT_SERDES OIDs so default VS
+        // port serdes objects get cleaned up. Test-fabricated OIDs would throw
+        // inside libsairedis-meta.
+        if (!tracked && sai_object_type_query(port_serdes_id) == SAI_OBJECT_TYPE_PORT_SERDES)
+        {
+            return pold_sai_port_api->remove_port_serdes(port_serdes_id);
         }
 
         return SAI_STATUS_SUCCESS;
@@ -1097,7 +1116,9 @@ namespace portsorch_test
         auto &ports = defaultPortList;
         ASSERT_TRUE(!ports.empty());
 
-        // default Ethernet0 has different lanes so create_ports() is triggered
+        // default Ethernet0 has different lanes so create_ports() is triggered.
+        // Set role explicitly: PortConfig::role.value has no default initializer,
+        // so leaving it unset would propagate uninitialized memory into Port::m_role.
         std::vector<FieldValueTuple> fvList = {
             { "alias",               alias       },
             { "index",               "0"         },
@@ -1112,6 +1133,7 @@ namespace portsorch_test
             { "tpid",                "0x8101"    },
             { "pfc_asym",            "on"        },
             { "admin_status",        "up"        },
+            { "role",                "Ext"       },
             { "description",         "FP port"   }
         };
 

--- a/tests/mock_tests/ut_saihelper.cpp
+++ b/tests/mock_tests/ut_saihelper.cpp
@@ -199,7 +199,13 @@ namespace ut_helper
                 { "lanes", lanes_str },
                 { "speed", "1000" },
                 { "mtu", "6000" },
-                { "admin_status", "up" }
+                { "admin_status", "up" },
+                // PortConfig::role.value has no default initializer; without
+                // an explicit role here, p.m_role is read from uninitialized
+                // memory and intermittently matches Rec/Inb, which would make
+                // the recycle/inband gates in portsorch silently skip serdes
+                // and PHY-attr setup for these ports.
+                { "role", "Ext" }
             };
 
             auto key = FRONT_PANEL_PORT_PREFIX + to_string(i);


### PR DESCRIPTION
**What I did**
Issue:
https://github.com/sonic-net/sonic-swss/issues/4546

SAI throws error below messages that are causing tests (e.g: qos/test_sched_strict_priority.py) to fail. Some of the attribute queries (related to phy and serdes) are not applicable to recycle and inband ports. Even though these queries are harmless they are causing the test noise. This PR avoids queries on recycle/inband ports for attributes that are not applicable:

SAI_PORT_ATTR_PORT_SERDES_ID
SAI_PORT_ATTR_RX_SIGNAL_DETECT
SAI_PORT_ATTR_RX_SNR

Recent changes made in the following PRs introduced querying these attributes recently:
https://github.com/sonic-net/sonic-swss/pull/4214
https://github.com/sonic-net/sonic-swss/pull/4223

2026 Apr 22 21:21:44.650275 humm221 ERR syncd#syncd: [none] SAI_API_PORT:_brcm_sai_get_recycle_port_attribute:18198 Unknown port attribute 149 passed
2026 Apr 22 21:21:44.650275 humm221 ERR syncd#syncd: [none] SAI_API_PORT:_brcm_sai_get_recycle_port_attribute:18206 Error processing port attributes for attr_id:149
2026 Apr 22 21:21:44.650718 humm221 ERR syncd#syncd: [none] SAI_API_PORT:_brcm_sai_get_recycle_port_attribute:18198 Unknown port attribute 170 passed
2026 Apr 22 21:21:44.650718 humm221 ERR syncd#syncd: [none] SAI_API_PORT:_brcm_sai_get_recycle_port_attribute:18206 Error processing port attributes for attr_id:170

E 2026 May 1 23:41:29.634232 humm221 ERR syncd#syncd: [none] SAI_API_PORT:_brcm_sai_get_recycle_port_attribute:18198 Unknown port attribute 108 passed
E
E 2026 May 1 23:41:29.634232 humm221 ERR syncd#syncd: [none] SAI_API_PORT:_brcm_sai_get_recycle_port_attribute:18206 Error processing port attributes for attr_id:108
E

**Why I did it**
Tests (e.g: qos/test_sched_strict_priority.py) failing with the above error messages

**How I verified it**
Tests (e.g: qos/test_sched_strict_priority.py) no longer throw error messages

**Details if related**
