### PR TITLE
[orchagent] WRED queue counters on VOQ-chassis platforms: split stat list + register on VOQ OIDs

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -429,10 +429,28 @@ const vector<sai_port_stat_t> wred_port_stat_ids =
     SAI_PORT_STAT_WRED_DROPPED_PACKETS
 };
 
+/* Used on platforms where WRED stats are exposed at the egress queue
+ * object (SAI_QUEUE_TYPE_UNICAST/MULTICAST/ALL). On these platforms
+ * the egress queue maintains both WRED-drop counters
+ * (SAI_QUEUE_STAT_WRED_DROPPED_*) and WRED-ECN-marked counters
+ * (SAI_QUEUE_STAT_WRED_ECN_MARKED_*) for packets and bytes. */
 static const vector<sai_queue_stat_t> wred_queue_stat_ids =
 {
     SAI_QUEUE_STAT_WRED_ECN_MARKED_PACKETS,
     SAI_QUEUE_STAT_WRED_ECN_MARKED_BYTES,
+    SAI_QUEUE_STAT_WRED_DROPPED_PACKETS,
+    SAI_QUEUE_STAT_WRED_DROPPED_BYTES
+};
+
+/* Used on platforms where WRED stats are exposed at the
+ * virtual-output-queue object (SAI_QUEUE_TYPE_UNICAST_VOQ). On these
+ * platforms WRED drops are counted at the ingress VOQ, so the
+ * WRED-drop counters (SAI_QUEUE_STAT_WRED_DROPPED_*) are exposed on
+ * the VOQ object. WRED ECN marking is performed at egress and the
+ * WRED-ECN-marked counters are exposed only on the egress queue
+ * object — not on the VOQ — and are therefore not registered here. */
+static const vector<sai_queue_stat_t> wred_voq_stat_ids =
+{
     SAI_QUEUE_STAT_WRED_DROPPED_PACKETS,
     SAI_QUEUE_STAT_WRED_DROPPED_BYTES
 };
@@ -9758,7 +9776,12 @@ void PortsOrch::addWredQueueFlexCountersPerPortPerQueueIndex(const Port& port, s
     std::unordered_set<string> counter_stats;
     std::vector<sai_object_id_t> queue_ids;
 
-    for (const auto& it: wred_queue_stat_ids)
+    /* Pick the stats list that matches where this platform exposes WRED
+     * counters: on VOQ chassis the WRED drop counters live at the VOQ
+     * object; on platforms that expose WRED at the egress queue the
+     * egress queue carries both WRED drop and WRED ECN-marked counters. */
+    const auto& stat_ids = voq ? wred_voq_stat_ids : wred_queue_stat_ids;
+    for (const auto& it: stat_ids)
     {
         counter_stats.emplace(sai_serialize_queue_stat(it));
     }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -9743,6 +9743,17 @@ void PortsOrch::addWredQueueFlexCounters(map<string, FlexCounterQueueStates> que
                 addWredQueueFlexCountersPerPort(it.second, queuesStateVector.at(it.second.m_alias), true);
             }
         }
+
+        if (it.second.m_type == Port::SYSTEM)
+        {
+            if (!queuesStateVector.count(it.second.m_alias))
+            {
+                auto maxQueueNumber = getNumberOfPortSupportedQueueCounters(it.second.m_alias);
+                FlexCounterQueueStates flexCounterQueueState(maxQueueNumber);
+                queuesStateVector.insert(make_pair(it.second.m_alias, flexCounterQueueState));
+            }
+            addWredQueueFlexCountersPerPort(it.second, queuesStateVector.at(it.second.m_alias), true);
+        }
     }
 
     m_isWredQueueCounterMapGenerated = true;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -9696,9 +9696,13 @@ void PortsOrch::generateWredPortCounterMap()
 
 /****
 *  Func Name  : addWredQueueFlexCounters
-*  Parameters : queueStateVector 
+*  Parameters : queueStateVector
 *  Returns    : void
-*  Description: Top level API to Set WRED flex counters for Queues
+*  Description: Top level API to Set WRED flex counters for Queues.
+*               On VOQ systems, WRED drop counters are exposed at the
+*               ingress VOQ object. This function therefore registers both
+*               egress queue OIDs and (on VOQ switches) the per-port VOQ
+*               OIDs for WRED stats collection.
 **/
 void PortsOrch::addWredQueueFlexCounters(map<string, FlexCounterQueueStates> queuesStateVector)
 {
@@ -9733,7 +9737,11 @@ void PortsOrch::addWredQueueFlexCounters(map<string, FlexCounterQueueStates> que
                 }
                 queuesStateVector.insert(make_pair(it.second.m_alias, flexCounterQueueState));
             }
-            addWredQueueFlexCountersPerPort(it.second, queuesStateVector.at(it.second.m_alias));
+            addWredQueueFlexCountersPerPort(it.second, queuesStateVector.at(it.second.m_alias), false);
+            if (gMySwitchType == "voq")
+            {
+                addWredQueueFlexCountersPerPort(it.second, queuesStateVector.at(it.second.m_alias), true);
+            }
         }
     }
 
@@ -9742,25 +9750,37 @@ void PortsOrch::addWredQueueFlexCounters(map<string, FlexCounterQueueStates> que
 
 /****
 *  Func Name  : addWredQueueFlexCountersPerPort
-*  Parameters : port and Queuestate
+*  Parameters : port, Queuestate, voq (true for VOQ stats, false for egress queue stats)
 *  Returns    : void
-*  Description: Port level API to program flexcounter for queues
+*  Description: Port level API to program flexcounter for queues.
+*               When voq=true, registers VOQ OIDs (m_port_voq_ids) for stats.
+*               When voq=false, registers egress queue OIDs (m_queue_ids) for stats.
 **/
-void PortsOrch::addWredQueueFlexCountersPerPort(const Port& port, FlexCounterQueueStates& queuesState)
+void PortsOrch::addWredQueueFlexCountersPerPort(const Port& port, FlexCounterQueueStates& queuesState, bool voq)
 {
-    /* Add stat counters to flex_counter */
+    std::vector<sai_object_id_t> queue_ids;
 
-    for (size_t queueIndex = 0; queueIndex < port.m_queue_ids.size(); ++queueIndex)
+    if (voq)
+    {
+        queue_ids = m_port_voq_ids[port.m_alias];
+    }
+    else
+    {
+        queue_ids = port.m_queue_ids;
+    }
+
+    for (size_t queueIndex = 0; queueIndex < queue_ids.size(); ++queueIndex)
     {
         sai_queue_type_t queueType;
         uint8_t queueRealIndex = 0;
-        if (getQueueTypeAndIndex(port.m_queue_ids[queueIndex], queueType, queueRealIndex))
+        if (getQueueTypeAndIndex(queue_ids[queueIndex], queueType, queueRealIndex))
         {
-            if (!queuesState.isQueueCounterEnabled(queueRealIndex))
+            // VOQ counters are always enabled in VOQ systems
+            if ((gMySwitchType != "voq") && !queuesState.isQueueCounterEnabled(queueRealIndex))
             {
                 continue;
             }
-            addWredQueueFlexCountersPerPortPerQueueIndex(port, queueIndex, false, queueType);
+            addWredQueueFlexCountersPerPortPerQueueIndex(port, queueIndex, voq, queueType);
         }
     }
 }

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -530,7 +530,7 @@ private:
     void addQueueWatermarkFlexCountersPerPortPerQueueIndex(const Port& port, size_t queueIndex, sai_queue_type_t queueType);
 
     bool m_isWredQueueCounterMapGenerated = false;
-    void addWredQueueFlexCountersPerPort(const Port& port, FlexCounterQueueStates& queuesState);
+    void addWredQueueFlexCountersPerPort(const Port& port, FlexCounterQueueStates& queuesState, bool voq = false);
     void addWredQueueFlexCountersPerPortPerQueueIndex(const Port& port, size_t queueIndex, bool voq, sai_queue_type_t queueType);
 
     bool m_isPriorityGroupMapGenerated = false;

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -941,7 +941,79 @@ class TestVirtualChassis(object):
 
         flex_db = dvs.get_flex_db()
         flex_db.wait_for_n_keys("FLEX_COUNTER_TABLE:QUEUE_STAT_COUNTER", num_queues_to_be_polled)
- 
+
+    def test_voq_wred_queue_counter(self, vct):
+        """Verify WRED flex counter registration on a VOQ-chassis line card.
+
+        Exercises both registration paths in
+        PortsOrch::addWredQueueFlexCounters: the egress-queue path (all 4
+        WRED stats) and the per-port VOQ path (WRED_DROPPED_* only). The
+        WRED_ECN_MARKED_* counters are intentionally not registered on
+        the VOQ object because ECN marking on VOQ-chassis platforms is
+        reported at the egress queue object, not at the ingress VOQ.
+        """
+        if vct is None:
+            return
+        dvss = vct.dvss
+        dvs = None
+        for name in dvss.keys():
+            if "supervisor" in name:
+                continue
+            dvs = dvss[name]
+            break
+        assert dvs
+
+        _, _ = dvs.runcmd("counterpoll wredqueue enable")
+
+        # Layout matches test_voq_egress_queue_counter above
+        num_voqs_per_port = 8
+        num_queues_per_local_port = 20
+        num_ports_per_linecard = 32
+        num_local_ports = 32
+        num_linecards = 3
+        num_egress_queues = num_local_ports * num_queues_per_local_port
+        num_voqs = num_ports_per_linecard * num_voqs_per_port * num_linecards
+        num_queues_to_be_polled = num_voqs + num_egress_queues
+
+        flex_db = dvs.get_flex_db()
+        flex_db.wait_for_n_keys(
+            "FLEX_COUNTER_TABLE:WRED_ECN_QUEUE_STAT_COUNTER",
+            num_queues_to_be_polled,
+        )
+
+        # Verify stat-list semantics: VOQ entries register only
+        # WRED_DROPPED_*; egress entries register all four.
+        counters_db = dvs.get_counters_db()
+        voq_name_map = counters_db.get_entry("COUNTERS_VOQ_NAME_MAP", "")
+        queue_name_map = counters_db.get_entry("COUNTERS_QUEUE_NAME_MAP", "")
+        assert voq_name_map, "No VOQ name map populated on linecard"
+        assert queue_name_map, "No queue name map populated on linecard"
+
+        sample_voq_oid = next(iter(voq_name_map.values()))
+        voq_stat_list = flex_db.db_connection.hgetall(
+            "FLEX_COUNTER_TABLE:WRED_ECN_QUEUE_STAT_COUNTER:" + sample_voq_oid
+        ).get("QUEUE_COUNTER_ID_LIST", "")
+        assert "WRED_DROPPED_PACKETS" in voq_stat_list
+        assert "WRED_DROPPED_BYTES" in voq_stat_list
+        assert "WRED_ECN_MARKED_PACKETS" not in voq_stat_list, \
+            "ECN-marked stat must not be registered on VOQ object"
+        assert "WRED_ECN_MARKED_BYTES" not in voq_stat_list
+
+        voq_oid_set = set(voq_name_map.values())
+        egress_oid = None
+        for oid in queue_name_map.values():
+            if oid not in voq_oid_set:
+                egress_oid = oid
+                break
+        assert egress_oid, "No egress-only queue OID found"
+        egress_stat_list = flex_db.db_connection.hgetall(
+            "FLEX_COUNTER_TABLE:WRED_ECN_QUEUE_STAT_COUNTER:" + egress_oid
+        ).get("QUEUE_COUNTER_ID_LIST", "")
+        assert "WRED_DROPPED_PACKETS" in egress_stat_list
+        assert "WRED_DROPPED_BYTES" in egress_stat_list
+        assert "WRED_ECN_MARKED_PACKETS" in egress_stat_list
+        assert "WRED_ECN_MARKED_BYTES" in egress_stat_list
+
     def test_chassis_wred_profile_on_system_ports(self, vct):
         """Test whether wred profile is applied on system ports in VoQ chassis.
         """


### PR DESCRIPTION
## What
Two-commit change that brings working `show queue wredcounters --voq`
to VOQ-chassis platforms in upstream SwSS:

1. **`5828407` — Split the WRED stat list per queue type.** Add
   `wred_voq_stat_ids` (only `WRED_DROPPED_*`) alongside the existing
   `wred_queue_stat_ids` (all 4). Pick the right list at registration
   time using the existing `voq` parameter on
   `addWredQueueFlexCountersPerPortPerQueueIndex`.

2. **`ec1a94a` — Register WRED flex counters on VOQ OIDs.** Extend
   `addWredQueueFlexCountersPerPort` with a `voq` flag and, from
   `addWredQueueFlexCounters`, additionally call it with `voq=true`
   when `gMySwitchType == \"voq\"`. Bypass the per-queue counter-enabled
   gating for VOQ (those are always on for VOQ systems).

## Why
Stock upstream SwSS has two gaps that together prevent VOQ-chassis
users from seeing per-VOQ WRED drop visibility:

- **Gap 1: VOQ OIDs are never registered for WRED stats.**
  `addWredQueueFlexCounters` only iterates `port.m_queue_ids` (egress);
  `m_port_voq_ids` are not wired into the WRED flex counter group.
  So `show queue wredcounters --voq` has no data even on platforms
  whose SAI fully supports VOQ WRED counters.

- **Gap 2: A naive VOQ-OID registration trips on
  `WRED_ECN_MARKED_*`.** That counter describes packets transmitted
  with the CE bit set — an egress-side action — and is not
  architecturally exposed on `SAI_QUEUE_TYPE_UNICAST_VOQ` queues.
  When SAI is asked for an unsupported stat as part of a bulk read
  it typically returns `SAI_STATUS_NOT_SUPPORTED`, which makes
  FlexCounter abort the entire bulk for that queue. Result: even
  the WRED-drop counters that *are* valid on a VOQ never reach the
  COUNTERS table, and rows show as N/A.

This PR closes both gaps. Detail in
https://github.com/sonic-net/sonic-swss/issues/4544.

## How
Two commits, separated for review clarity. Either could in
principle land independently — but only the combination delivers
working VOQ WRED counters. Splitting them keeps the defensive
correctness (commit 1) reviewable in isolation from the new
registration call site (commit 2).

No changes to:
- header signatures of `addWredQueueFlexCountersPerPortPerQueueIndex`
  (signature already had the `voq` param upstream)
- the WRED port counter path
- the egress queue WRED counter path

`addWredQueueFlexCountersPerPort` gains a defaulted `bool voq = false`
in the header so existing call sites are source-compatible.

## How to verify
On a VOQ-chassis platform with this PR:

```
admin@<chassis-lc>:~$ show queue wredcounters --voq | head -10
                       Port    Voq    WredDrp/pkts    WredDrp/bytes    EcnMarked/pkts    EcnMarked/bytes
-------------------------  -----  --------------  ---------------  ----------------  -----------------
<host>|<asic>|EthernetX     VOQ0               0                0               N/A                N/A
<host>|<asic>|EthernetX     VOQ1               0                0               N/A                N/A
<host>|<asic>|EthernetX     VOQ2               0                0               N/A                N/A
<host>|<asic>|EthernetX     VOQ3               0                0               N/A                N/A
...
```

Drive WRED-drop traffic on a VOQ and `WredDrp/pkts` and
`WredDrp/bytes` increment numerically; `EcnMarked/*` stays N/A
(those are exposed on the egress queue, not the VOQ).

`show queue wredcounters` (egress) is unchanged on all platforms.
No new SAI errors on the bulk WRED `getStats` path for VOQ OIDs.


## Which release branch to backport/forwardport
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511