### PR TITLE
Revert "Fix orchagent 100% CPU spin when gOrchUnhealthy is set"

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -1,7 +1,6 @@
 #include <unistd.h>
 #include <unordered_map>
 #include <chrono>
-#include <thread>
 #include <limits.h>
 #include <errno.h>
 #include <signal.h>
@@ -966,15 +965,12 @@ void OrchDaemon::start(long heartBeatInterval)
         }
 
         /*
-         * When gOrchUnhealthy is set, the Select event loop spins with
-         * epoll_wait(timeout=0) because poll_descriptors phase 1 always
-         * finds "ready" Selectables (the notification channel stays readable
-         * after the SAI failure), so the blocking phase 2 poll is never
-         * reached. This causes 100% CPU. Sleep to throttle the loop.
+         * Log an error message periodically if a previous SAI API call failed with
+         * an unrecoverable error.
          */
-        if (gOrchUnhealthy && ret != Select::TIMEOUT)
+        if (gOrchUnhealthy)
         {
-            std::this_thread::sleep_for(std::chrono::milliseconds(SELECT_TIMEOUT));
+            SWSS_LOG_ERROR("%s", gSaiErrorString.c_str());
         }
 
         auto tend = std::chrono::high_resolution_clock::now();
@@ -985,16 +981,6 @@ void OrchDaemon::start(long heartBeatInterval)
         if (diff.count() >= SELECT_TIMEOUT)
         {
             tstart = std::chrono::high_resolution_clock::now();
-
-            /*
-             * Log an error message periodically if a previous SAI API call failed with
-             * an unrecoverable error. Rate-limit to once per SELECT_TIMEOUT interval
-             * to avoid busy-loop CPU spin from excessive syslog writes.
-             */
-            if (gOrchUnhealthy)
-            {
-                SWSS_LOG_ERROR("%s", gSaiErrorString.c_str());
-            }
 
             flush();
         }

--- a/tests/mock_tests/test_failure_handling.cpp
+++ b/tests/mock_tests/test_failure_handling.cpp
@@ -3,8 +3,6 @@
 #include <sys/mman.h>
 
 extern sai_switch_api_t *sai_switch_api;
-extern bool gOrchUnhealthy;
-extern string gSaiErrorString;
 
 namespace saifailure_test
 {
@@ -87,35 +85,6 @@ namespace saifailure_test
         handleSaiRemoveStatus(SAI_API_LAG, SAI_STATUS_FAILURE);
         ASSERT_EQ(*_sai_syncd_notifications_count, ++notif_count);
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
-
-        _unhook_sai_switch_api();
-    }
-
-    TEST_F(SaiFailureTest, handleSaiFailureSetsOrchUnhealthy)
-    {
-        /*
-         * Verify that handleSaiFailure sets gOrchUnhealthy and gSaiErrorString.
-         * The orchdaemon main loop relies on gOrchUnhealthy to log the error
-         * message periodically (rate-limited to once per SELECT_TIMEOUT).
-         * Previously the log was emitted on every select iteration, causing
-         * ~37K syslog writes/sec and 100% CPU when the select loop was busy.
-         */
-        _hook_sai_switch_api();
-
-        gOrchUnhealthy = false;
-        gSaiErrorString.clear();
-
-        handleSaiCreateStatus(SAI_API_HOSTIF, SAI_STATUS_FAILURE);
-
-        ASSERT_TRUE(gOrchUnhealthy);
-        ASSERT_FALSE(gSaiErrorString.empty());
-        ASSERT_NE(gSaiErrorString.find("SAI_API_HOSTIF"), string::npos);
-        ASSERT_NE(gSaiErrorString.find("SAI_STATUS_FAILURE"), string::npos);
-        ASSERT_NE(gSaiErrorString.find("create"), string::npos);
-
-        // Reset for other tests
-        gOrchUnhealthy = false;
-        gSaiErrorString.clear();
 
         _unhook_sai_switch_api();
     }


### PR DESCRIPTION
Reverts sonic-net/sonic-swss#4274 to unblock the sonic-swss submodule ref update for sonic-buildimage https://github.com/sonic-net/sonic-buildimage/pull/26918. 
PR checker history: build history [Pipelines - Runs for Azure.sonic-buildimage](https://dev.azure.com/mssonic/build/_build?definitionId=1&branchFilter=58336%2C58336%2C58336%2C58336%2C58336%2C58336%2C58336%2C58336%2C58336%2C58336). The t0 test always failed on sanity check.

