### PR TITLE
[202511][vnetorch][vrfmgrd][fpmsyncd]: Defer VNET kernel device deletion until orchagent cleanup completes

### DIFF
--- a/cfgmgr/vrfmgr.cpp
+++ b/cfgmgr/vrfmgr.cpp
@@ -15,6 +15,13 @@
 #define MGMT_VRF_TABLE_ID 6000
 #define MGMT_VRF          "mgmt"
 
+/*
+ * Emit a SWSS_LOG_WARN every N deferrals of a VNET delete waiting on
+ * VNetOrch's STATE_VRF_OBJECT_TABLE handshake. Chosen to be visible
+ * (sustained backlog) without flooding logs on transient races.
+ */
+#define VNET_DEL_DEFER_WARN_THRESHOLD 20
+
 using namespace swss;
 
 VrfMgr::VrfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const vector<string> &tableNames) :
@@ -314,7 +321,7 @@ void VrfMgr::doTask(Consumer &consumer)
             /*
              * Delay delLink until vrf object deleted in orchagent to ensure fpmsyncd can get vrf ifname.
              * Now state VRF_TABLE|Vrf represent vrf exist in appDB, if it exist vrf device is always effective.
-             * VRFOrch add/del state VRF_OBJECT_TABLE|Vrf to represent object existence. VNETOrch is not do so now.
+             * VRFOrch/VNETOrch add/del state VRF_OBJECT_TABLE|Vrf to represent object existence.
              */
             if (consumer.getTableName() == CFG_VXLAN_EVPN_NVO_TABLE_NAME)
             {
@@ -347,8 +354,60 @@ void VrfMgr::doTask(Consumer &consumer)
             }
             else
             {
-                m_appVnetTableProducer.del(vrfName);
-                m_stateVrfTable.del(vrfName);
+                vector<FieldValueTuple> temp;
+
+                if (m_stateVrfTable.get(vrfName, temp))
+                {
+                    /*
+                     * Invariant: when m_stateVrfTable says the VNET device
+                     * exists, VNetOrch must have observed our APP_DB add and
+                     * populated STATE_VRF_OBJECT_TABLE. If isVrfObjExist() is
+                     * false here, either VNetOrch has not yet processed the
+                     * addOperation, or the state row was never written. In
+                     * either case, defer until VNetOrch catches up; emit a
+                     * rate-limited warn after a sustained backlog so a
+                     * silent infinite-defer (e.g. orchagent stuck or the
+                     * STATE_VRF_OBJECT_TABLE write was skipped) does not
+                     * go unnoticed.
+                     */
+                    if (!isVrfObjExist(vrfName))
+                    {
+                        auto& retries = m_vnetDelRetries[vrfName];
+                        if (++retries % VNET_DEL_DEFER_WARN_THRESHOLD == 0)
+                        {
+                            SWSS_LOG_WARN("VNET '%s' delete deferred %u times "
+                                "waiting for VNetOrch to populate "
+                                "STATE_VRF_OBJECT_TABLE",
+                                vrfName.c_str(), retries);
+                        }
+                        it++;
+                        continue;
+                    }
+
+                    m_appVnetTableProducer.del(vrfName);
+                    m_stateVrfTable.del(vrfName);
+                }
+
+                /*
+                 * Wait for VNetOrch to clear STATE_VRF_OBJECT_TABLE after it
+                 * processes the APP_DB delete above. Same rate-limited warn
+                 * to surface a stuck handshake.
+                 */
+                if (isVrfObjExist(vrfName))
+                {
+                    auto& retries = m_vnetDelRetries[vrfName];
+                    if (++retries % VNET_DEL_DEFER_WARN_THRESHOLD == 0)
+                    {
+                        SWSS_LOG_WARN("VNET '%s' delete deferred %u times "
+                            "waiting for VNetOrch to clear "
+                            "STATE_VRF_OBJECT_TABLE",
+                            vrfName.c_str(), retries);
+                    }
+                    it++;
+                    continue;
+                }
+
+                m_vnetDelRetries.erase(vrfName);
             }
 
             if (consumer.getTableName() != CFG_VXLAN_EVPN_NVO_TABLE_NAME)

--- a/cfgmgr/vrfmgr.h
+++ b/cfgmgr/vrfmgr.h
@@ -42,6 +42,14 @@ private:
     std::set<uint32_t> m_freeTables;
     VRFNameVNIMapTable m_vrfVniMapTable;
 
+    /*
+     * Per-VNET retry counter for the delete-time wait on VNetOrch
+     * STATE_VRF_OBJECT_TABLE handshake. Used to emit a rate-limited
+     * SWSS_LOG_WARN if a VNET delete is deferred for an unreasonably long
+     * time, so a stuck handshake fails loudly instead of hanging silently.
+     */
+    std::unordered_map<std::string, uint32_t> m_vnetDelRetries;
+
     Table m_stateVrfTable, m_stateVrfObjectTable;
     ProducerStateTable m_appVrfTableProducer, m_appVnetTableProducer, m_appVxlanVrfTableProducer;
 };

--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -1195,10 +1195,10 @@ Stores information for physical switch ports managed by the switch chip. Ports t
     state               = "ok"                      ; vrf entry exist in app_db, if yes vrf device must exist
 
 ### VRF_OBJECT_TABLE
-    ;State for vrf object status, vrf exist in vrforch
+    ;State for vrf/vnet object status, vrf/vnet exist in vrforch/vnetorch
 
-    key                 = VRF_OBJECT_TABLE|vrf_name ; vrf_name start with 'Vrf' prefix
-    state               = "ok"                      ; vrf entry exist in orchagent
+    key                 = VRF_OBJECT_TABLE|vrf_name ; vrf_name start with 'Vrf' or 'Vnet' prefix
+    state               = "ok"                      ; vrf/vnet entry exist in orchagent
 
 ### BUFFER_MAX_PARAM_TABLE
     ;Available only when the switch is running in dynamic buffer model

--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -1722,6 +1722,22 @@ void RouteSync::onMsg(int nlmsg_type, struct nl_object *obj)
 {
     if (nlmsg_type == RTM_NEWLINK || nlmsg_type == RTM_DELLINK)
     {
+        struct rtnl_link *link_obj = (struct rtnl_link *)obj;
+        const char *link_name = rtnl_link_get_name(link_obj);
+        int link_ifindex = rtnl_link_get_ifindex(link_obj);
+
+        if (link_name)
+        {
+            if (strncmp(link_name, VRF_PREFIX, strlen(VRF_PREFIX)) == 0 ||
+                strncmp(link_name, VNET_PREFIX, strlen(VNET_PREFIX)) == 0 ||
+                strncmp(link_name, MGMT_VRF_PREFIX, strlen(MGMT_VRF_PREFIX)) == 0)
+            {
+                SWSS_LOG_NOTICE("VRF link event: %s dev %s ifindex %d",
+                    (nlmsg_type == RTM_NEWLINK) ? "RTM_NEWLINK" : "RTM_DELLINK",
+                    link_name, link_ifindex);
+            }
+        }
+
         nl_cache_refill(m_nl_sock, m_link_cache);
         return;
     }
@@ -1750,8 +1766,30 @@ void RouteSync::onMsg(int nlmsg_type, struct nl_object *obj)
     if (master_index)
     {
         /* Get the name of the master device */
-        getIfName(master_index, master_name, IFNAMSIZ);
-    
+        if (!getIfName(master_index, master_name, IFNAMSIZ))
+        {
+            char prefix_buf[MAX_ADDR_SIZE + 1] = {0};
+            struct nl_addr *dip = rtnl_route_get_dst(route_obj);
+            if (dip)
+            {
+                nl_addr2str(dip, prefix_buf, MAX_ADDR_SIZE);
+            }
+
+            if (nlmsg_type == RTM_DELROUTE)
+            {
+                SWSS_LOG_INFO("Failed to get interface name for ifindex %u prefix %s, "
+                    "skipping route delete (VRF device may have been deleted)",
+                    master_index, prefix_buf);
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Failed to get interface name for ifindex %u prefix %s, "
+                    "skipping route add (VRF device may have been deleted)",
+                    master_index, prefix_buf);
+            }
+            return;
+        }
+
         /* If the master device name starts with VNET_PREFIX, it is a VNET route.
            The VNET name is exactly the name of the associated master device. */
         if (string(master_name).find(VNET_PREFIX) == 0)

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -252,7 +252,7 @@ bool OrchDaemon::init()
     };
 
     VNetOrch *vnet_orch;
-    vnet_orch = new VNetOrch(m_applDb, APP_VNET_TABLE_NAME);
+    vnet_orch = new VNetOrch(m_applDb, APP_VNET_TABLE_NAME, m_stateDb);
 
     gDirectory.set(vnet_orch);
     VNetCfgRouteOrch *cfg_vnet_rt_orch = new VNetCfgRouteOrch(m_configDb, m_applDb, cfg_vnet_tables);

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -374,8 +374,9 @@ std::unique_ptr<T> VNetOrch::createObject(const string& vnet_name, const VNetInf
     return vnet_obj;
 }
 
-VNetOrch::VNetOrch(DBConnector *db, const std::string& tableName, VNET_EXEC op)
-         : Orch2(db, tableName, request_)
+VNetOrch::VNetOrch(DBConnector *db, const std::string& tableName, DBConnector *stateDb, VNET_EXEC op)
+         : Orch2(db, tableName, request_),
+           m_stateVrfObjectTable(stateDb, STATE_VRF_OBJECT_TABLE_NAME)
 {
     vnet_exec_ = op;
 
@@ -518,6 +519,15 @@ bool VNetOrch::addOperation(const Request& request)
                 }
 
                 SWSS_LOG_NOTICE("VNET '%s' was added ", vnet_name.c_str());
+
+                /*
+                 * Publish to STATE_VRF_OBJECT_TABLE so vrfmgrd knows the SAI
+                 * VNet object exists and can defer kernel delLink() on a
+                 * subsequent VNET delete until VNetOrch finishes cleanup.
+                 * Mirrors VRFOrch::doTask() behavior; see VrfMgr::doTask()
+                 * polling on isVrfObjExist() for the consumer side.
+                 */
+                m_stateVrfObjectTable.hset(vnet_name, "state", "ok");
             }
             else
             {
@@ -599,6 +609,21 @@ bool VNetOrch::delOperation(const Request& request)
     }
 
     vnet_table_.erase(vnet_name);
+
+    /*
+     * Placement is load-bearing: this del() must remain on the success path
+     * (after vnet_table_.erase, after the SAI VNet object has been freed and
+     * any per-VNET cleanup above has succeeded). vrfmgrd polls this row in
+     * its VNET delete path and defers delLink() until the row disappears.
+     * If a partial cleanup failure above caused us to return false earlier
+     * (e.g. getRouteCount() != 0 or removeVxlanTunnelMap() returned false),
+     * the row is intentionally kept so the framework retries without
+     * prematurely allowing the kernel device to be removed. Do not lift
+     * this del() into an earlier branch or wrap it in cleanup-failure paths.
+     */
+    m_stateVrfObjectTable.del(vnet_name);
+
+    SWSS_LOG_NOTICE("VNET '%s' was removed", vnet_name.c_str());
 
     return true;
 }

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -243,7 +243,7 @@ typedef std::unordered_map<std::string, VNetObject_T> VNetTable;
 class VNetOrch : public Orch2
 {
 public:
-    VNetOrch(DBConnector *db, const std::string&, VNET_EXEC op = VNET_EXEC::VNET_EXEC_VRF);
+    VNetOrch(DBConnector *db, const std::string&, DBConnector *stateDb, VNET_EXEC op = VNET_EXEC::VNET_EXEC_VRF);
 
     bool setIntf(const string& alias, const string name, const IpPrefix *prefix = nullptr, const bool adminUp = true, const uint32_t mtu = 0);
     bool delIntf(const string& alias, const string name, const IpPrefix *prefix = nullptr);
@@ -297,6 +297,7 @@ private:
     VNetTable vnet_table_;
     VNetRequest request_;
     VNET_EXEC vnet_exec_;
+    swss::Table m_stateVrfObjectTable;
 
 };
 

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -61,6 +61,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 flowcounterrouteorch_ut.cpp \
                 orchdaemon_ut.cpp \
                 intfsorch_ut.cpp \
+                vnetorch_ut.cpp \
                 mux_rollback_ut.cpp \
                 warmrestartassist_ut.cpp \
                 test_failure_handling.cpp \

--- a/tests/mock_tests/flowcounterrouteorch_ut.cpp
+++ b/tests/mock_tests/flowcounterrouteorch_ut.cpp
@@ -147,7 +147,7 @@ namespace flowcounterrouteorch_test
                 CFG_VNET_RT_TUNNEL_TABLE_NAME
             };
 
-            auto* vnet_orch = new VNetOrch(m_app_db.get(), APP_VNET_TABLE_NAME);
+            auto* vnet_orch = new VNetOrch(m_app_db.get(), APP_VNET_TABLE_NAME, m_state_db.get());
             gDirectory.set(vnet_orch);
             auto* cfg_vnet_rt_orch = new VNetCfgRouteOrch(m_config_db.get(), m_app_db.get(), cfg_vnet_tables);
             gDirectory.set(cfg_vnet_rt_orch);

--- a/tests/mock_tests/fpmsyncd/test_routesync.cpp
+++ b/tests/mock_tests/fpmsyncd/test_routesync.cpp
@@ -1882,3 +1882,81 @@ TEST_F(FpmSyncdResponseTest, TestVnetRouteMsgWithZmqDisabled_OnlyNonEmptyFields)
 
     rtnl_route_put(test_route);
 }
+
+/*
+ * Tests for the early-return path when getIfName() fails on a route whose
+ * master device (VRF/VNET) has been deleted. The fix in onMsg() logs at
+ * INFO for RTM_DELROUTE (benign post-deletion cleanup) and at ERROR for
+ * RTM_NEWROUTE (unexpected), then returns without writing to APP_DB.
+ */
+TEST_F(FpmSyncdResponseTest, RouteDeleteOnMissingVrfDeviceLogsInfoAndSkips)
+{
+    Table route_table(m_db.get(), APP_ROUTE_TABLE_NAME);
+    Table vnet_route_table(m_db.get(), APP_VNET_RT_TABLE_NAME);
+
+    auto createRoute = [](const char* prefix, uint32_t table_id) -> rtnl_route* {
+        rtnl_route* route = rtnl_route_alloc();
+        nl_addr* dst_addr;
+        nl_addr_parse(prefix, AF_INET, &dst_addr);
+        rtnl_route_set_dst(route, dst_addr);
+        rtnl_route_set_type(route, RTN_UNICAST);
+        rtnl_route_set_protocol(route, RTPROT_STATIC);
+        rtnl_route_set_family(route, AF_INET);
+        rtnl_route_set_scope(route, RT_SCOPE_UNIVERSE);
+        rtnl_route_set_table(route, table_id);
+        nl_addr_put(dst_addr);
+        return route;
+    };
+
+    const char* test_prefix = "10.99.0.0/24";
+    uint32_t stale_table_id = 9999;
+    rtnl_route* test_route = createRoute(test_prefix, stale_table_id);
+
+    EXPECT_CALL(m_mockRouteSync, getIfName(stale_table_id, _, _))
+        .WillOnce(Return(false));
+
+    m_mockRouteSync.onMsg(RTM_DELROUTE, (nl_object*)test_route);
+
+    /* Early return: nothing should be written to either route table. */
+    vector<FieldValueTuple> fvs;
+    EXPECT_FALSE(route_table.get("Vrf9999:" + std::string(test_prefix), fvs));
+    EXPECT_FALSE(vnet_route_table.get("Vnet9999:" + std::string(test_prefix), fvs));
+
+    rtnl_route_put(test_route);
+}
+
+TEST_F(FpmSyncdResponseTest, RouteAddOnMissingVrfDeviceLogsErrorAndSkips)
+{
+    Table route_table(m_db.get(), APP_ROUTE_TABLE_NAME);
+    Table vnet_route_table(m_db.get(), APP_VNET_RT_TABLE_NAME);
+
+    auto createRoute = [](const char* prefix, uint32_t table_id) -> rtnl_route* {
+        rtnl_route* route = rtnl_route_alloc();
+        nl_addr* dst_addr;
+        nl_addr_parse(prefix, AF_INET, &dst_addr);
+        rtnl_route_set_dst(route, dst_addr);
+        rtnl_route_set_type(route, RTN_UNICAST);
+        rtnl_route_set_protocol(route, RTPROT_STATIC);
+        rtnl_route_set_family(route, AF_INET);
+        rtnl_route_set_scope(route, RT_SCOPE_UNIVERSE);
+        rtnl_route_set_table(route, table_id);
+        nl_addr_put(dst_addr);
+        return route;
+    };
+
+    const char* test_prefix = "10.99.1.0/24";
+    uint32_t stale_table_id = 9998;
+    rtnl_route* test_route = createRoute(test_prefix, stale_table_id);
+
+    EXPECT_CALL(m_mockRouteSync, getIfName(stale_table_id, _, _))
+        .WillOnce(Return(false));
+
+    m_mockRouteSync.onMsg(RTM_NEWROUTE, (nl_object*)test_route);
+
+    /* Early return: nothing should be written to either route table. */
+    vector<FieldValueTuple> fvs;
+    EXPECT_FALSE(route_table.get("Vrf9998:" + std::string(test_prefix), fvs));
+    EXPECT_FALSE(vnet_route_table.get("Vnet9998:" + std::string(test_prefix), fvs));
+
+    rtnl_route_put(test_route);
+}

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -138,7 +138,7 @@ namespace intfsorch_test
                 CFG_VNET_RT_TUNNEL_TABLE_NAME
             };
 
-            auto* vnet_orch = new VNetOrch(m_app_db.get(), APP_VNET_TABLE_NAME);
+            auto* vnet_orch = new VNetOrch(m_app_db.get(), APP_VNET_TABLE_NAME, m_state_db.get());
             gDirectory.set(vnet_orch);
             auto* cfg_vnet_rt_orch = new VNetCfgRouteOrch(m_config_db.get(), m_app_db.get(), cfg_vnet_tables);
             gDirectory.set(cfg_vnet_rt_orch);

--- a/tests/mock_tests/mock_orch_test.cpp
+++ b/tests/mock_tests/mock_orch_test.cpp
@@ -315,7 +315,7 @@ void MockOrchTest::SetUp()
     gDirectory.set(m_VxlanTunnelOrch);
     ut_orch_list.push_back((Orch **)&m_VxlanTunnelOrch);
 
-    m_vnetOrch = new VNetOrch(m_app_db.get(), APP_VNET_TABLE_NAME);
+    m_vnetOrch = new VNetOrch(m_app_db.get(), APP_VNET_TABLE_NAME, m_state_db.get());
     gDirectory.set(m_vnetOrch);
     ut_orch_list.push_back((Orch **)&m_vnetOrch);
 

--- a/tests/mock_tests/vnetorch_ut.cpp
+++ b/tests/mock_tests/vnetorch_ut.cpp
@@ -1,0 +1,120 @@
+#define private public
+#include "directory.h"
+#undef private
+#define protected public
+#include "orch.h"
+#undef protected
+#include "ut_helper.h"
+#include "mock_orchagent_main.h"
+#include "mock_orch_test.h"
+#include "vxlanorch.h"
+#include "vnetorch.h"
+#include "gtest/gtest.h"
+#include <string>
+
+namespace vnetorch_test
+{
+    using namespace std;
+    using namespace mock_orch_test;
+
+    static const string TUNNEL_NAME = "tunnel_ut";
+    static const string VNET_NAME   = "Vnet_ut";
+
+    /*
+     * Drives VNetOrch::addOperation and VNetOrch::delOperation through
+     * the SET_COMMAND / DEL_COMMAND happy paths so the new
+     * STATE_VRF_OBJECT_TABLE writes (hset on add, del + the trailing
+     * "VNET '%s' was removed" SWSS_LOG_NOTICE on remove) are exercised.
+     *
+     * Mirrors the MockOrchTest pattern used by mux_rollback_ut.cpp.
+     * The MockOrchTest base already wires VxlanTunnelOrch and VNetOrch
+     * (with a non-null state DB so STATE_VRF_OBJECT_TABLE is constructed),
+     * so the only fixture-specific setup is to pre-register a Vxlan tunnel
+     * via VxlanTunnelOrch::addTunnel() — no SAI calls are needed for that
+     * registration; the SAI tunnel HW is materialized lazily by
+     * createVxlanTunnelMap() inside VNetOrch::addOperation against the
+     * SAI VS backend brought up by ut_helper::initSaiApi().
+     */
+    class VNetOrchTest : public MockOrchTest
+    {
+    protected:
+        void ApplyInitialConfigs() override
+        {
+            auto src_ip = swss::IpAddress("10.1.0.1");
+            auto dst_ip = swss::IpAddress("0.0.0.0");
+            auto *tunnel = new VxlanTunnel(TUNNEL_NAME,
+                                           src_ip, dst_ip, TNL_CREATION_SRC_CLI);
+            m_VxlanTunnelOrch->addTunnel(TUNNEL_NAME, tunnel);
+        }
+
+        void driveVNetTask(const std::string &key, const std::string &op,
+                           const std::vector<swss::FieldValueTuple> &fvs)
+        {
+            std::deque<swss::KeyOpFieldsValuesTuple> entries;
+            entries.push_back({key, op, fvs});
+            auto *consumer = dynamic_cast<Consumer *>(
+                m_vnetOrch->getExecutor(APP_VNET_TABLE_NAME));
+            ASSERT_NE(consumer, nullptr);
+            consumer->addToSync(entries);
+            static_cast<Orch *>(m_vnetOrch)->doTask();
+        }
+    };
+
+    /*
+     * Verifies the STATE_VRF_OBJECT_TABLE handshake VNetOrch publishes for
+     * vrfmgrd. Without the fix in this commit, addOperation would not
+     * populate the row and delOperation would not clear it, breaking the
+     * "defer kernel delLink() until VNetOrch is done" coordination that
+     * vrfmgrd polls via isVrfObjExist().
+     */
+    TEST_F(VNetOrchTest, VnetAddDelStateVrfObjectTableLifecycle)
+    {
+        swss::Table state_vrf_obj_table(m_state_db.get(),
+                                        STATE_VRF_OBJECT_TABLE_NAME);
+
+        std::vector<swss::FieldValueTuple> fvs;
+        EXPECT_FALSE(state_vrf_obj_table.get(VNET_NAME, fvs));
+
+        /*
+         * scope is left empty (i.e. "default") on purpose — that keeps
+         * VNetVrfObject::createObj() on the gVirtualRouterId path and
+         * avoids exercising the SAI virtual_router_api in this fixture,
+         * which is not the subject of this test.
+         */
+        driveVNetTask(VNET_NAME, SET_COMMAND, {
+            {"vxlan_tunnel",   TUNNEL_NAME},
+            {"vni",            "5037"},
+            {"scope",          ""},
+            {"src_mac",        "00:11:22:33:44:55"},
+        });
+
+        EXPECT_TRUE(m_vnetOrch->isVnetExists(VNET_NAME));
+
+        fvs.clear();
+        ASSERT_TRUE(state_vrf_obj_table.get(VNET_NAME, fvs))
+            << "STATE_VRF_OBJECT_TABLE['" << VNET_NAME
+            << "'] missing after VNetOrch::addOperation";
+        bool seen_state_ok = false;
+        for (const auto &fv : fvs)
+        {
+            if (fvField(fv) == "state" && fvValue(fv) == "ok")
+            {
+                seen_state_ok = true;
+                break;
+            }
+        }
+        EXPECT_TRUE(seen_state_ok)
+            << "Expected STATE_VRF_OBJECT_TABLE['" << VNET_NAME
+            << "']['state'] == 'ok' after VNetOrch::addOperation";
+
+        driveVNetTask(VNET_NAME, DEL_COMMAND, {});
+
+        EXPECT_FALSE(m_vnetOrch->isVnetExists(VNET_NAME));
+
+        fvs.clear();
+        EXPECT_FALSE(state_vrf_obj_table.get(VNET_NAME, fvs))
+            << "STATE_VRF_OBJECT_TABLE['" << VNET_NAME
+            << "'] still present after VNetOrch::delOperation -- vrfmgrd "
+               "would block waiting for it to clear";
+    }
+}

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -3319,6 +3319,64 @@ class TestVnetOrch(object):
         delete_vxlan_tunnel(dvs, tunnel_name)
         vnet_obj.check_del_vxlan_tunnel(dvs)
 
+    '''
+    Test 37 - Delete VNET while routes are still present.
+    Verifies that VNetOrch writes to STATE_VRF_OBJECT_TABLE on VNET creation,
+    defers VNET deletion until routes are removed, and properly cleans up.
+
+    Without the fix (VNetOrch STATE_VRF_OBJECT_TABLE support), the
+    wait_for_vnet_obj_in_state_db() call will fail because VNetOrch
+    never wrote to that table.
+    '''
+    def test_vnet_orch_37(self, dvs, testlog):
+        vnet_obj = self.get_vnet_obj()
+
+        tunnel_name = 'tunnel_37'
+
+        vnet_obj.fetch_exist_entries(dvs)
+
+        create_vxlan_tunnel(dvs, tunnel_name, '10.10.10.37')
+        create_vnet_entry(dvs, 'Vnet_5037', tunnel_name, '5037', "")
+
+        vnet_obj.check_vnet_entry(dvs, 'Vnet_5037')
+        vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, 'Vnet_5037', '5037')
+        vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, '10.10.10.37')
+
+        wait_for_vnet_obj_in_state_db(dvs, 'Vnet_5037')
+
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vnet_routes(dvs, "100.200.1.1/32", 'Vnet_5037', '10.10.10.51')
+        vnet_obj.check_vnet_routes(dvs, 'Vnet_5037', '10.10.10.51', tunnel_name)
+        check_state_db_routes(dvs, 'Vnet_5037', "100.200.1.1/32", ['10.10.10.51'])
+
+        create_vnet_routes(dvs, "100.200.2.1/32", 'Vnet_5037', '10.10.10.52')
+        vnet_obj.check_vnet_routes(dvs, 'Vnet_5037', '10.10.10.52', tunnel_name)
+        check_state_db_routes(dvs, 'Vnet_5037', "100.200.2.1/32", ['10.10.10.52'])
+
+        delete_vnet_entry(dvs, 'Vnet_5037')
+
+        time.sleep(2)
+        check_vnet_obj_in_state_db(dvs, 'Vnet_5037')
+
+        delete_vnet_routes(dvs, "100.200.1.1/32", 'Vnet_5037')
+        vnet_obj.check_del_vnet_routes(dvs, 'Vnet_5037', ["100.200.1.1/32"])
+        check_remove_state_db_routes(dvs, 'Vnet_5037', "100.200.1.1/32")
+
+        delete_vnet_routes(dvs, "100.200.2.1/32", 'Vnet_5037')
+        vnet_obj.check_del_vnet_routes(dvs, 'Vnet_5037', ["100.200.2.1/32"])
+        check_remove_state_db_routes(dvs, 'Vnet_5037', "100.200.2.1/32")
+
+        wait_for_vnet_obj_removed_from_state_db(dvs, 'Vnet_5037')
+
+        app_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        route_tbl = swsscommon.Table(app_db, "VNET_ROUTE_TUNNEL_TABLE")
+        keys = route_tbl.getKeys()
+        stale_routes = [k for k in keys if k.startswith('Vnet_5037:')]
+        assert len(stale_routes) == 0, "Stale VNET routes in APP_DB: %s" % stale_routes
+
+        delete_vxlan_tunnel(dvs, tunnel_name)
+        vnet_obj.check_del_vxlan_tunnel(dvs)
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/vnet_lib.py
+++ b/tests/vnet_lib.py
@@ -526,6 +526,42 @@ def check_remove_state_db_routes(dvs, vnet, prefix):
     assert vnet + '|' + prefix not in keys
 
 
+def check_vnet_obj_in_state_db(dvs, vnet_name):
+    state_db = swsscommon.DBConnector(swsscommon.STATE_DB, dvs.redis_sock, 0)
+    tbl = swsscommon.Table(state_db, "VRF_OBJECT_TABLE")
+    status, fvs = tbl.get(vnet_name)
+    assert status, "VNET '%s' not found in VRF_OBJECT_TABLE" % vnet_name
+    fvs = dict(fvs)
+    assert fvs.get('state') == 'ok', "VNET '%s' state is not 'ok' in VRF_OBJECT_TABLE" % vnet_name
+
+
+def wait_for_vnet_obj_in_state_db(dvs, vnet_name):
+    state_db = swsscommon.DBConnector(swsscommon.STATE_DB, dvs.redis_sock, 0)
+    tbl = swsscommon.Table(state_db, "VRF_OBJECT_TABLE")
+
+    def _access_function():
+        status, fvs = tbl.get(vnet_name)
+        if not status:
+            return (False, None)
+        fvs = dict(fvs)
+        return (fvs.get('state') == 'ok', fvs)
+
+    wait_for_result(_access_function,
+                    failure_message="VNET '%s' not found in VRF_OBJECT_TABLE" % vnet_name)
+
+
+def wait_for_vnet_obj_removed_from_state_db(dvs, vnet_name):
+    state_db = swsscommon.DBConnector(swsscommon.STATE_DB, dvs.redis_sock, 0)
+    tbl = swsscommon.Table(state_db, "VRF_OBJECT_TABLE")
+
+    def _access_function():
+        keys = tbl.getKeys()
+        return (vnet_name not in keys, None)
+
+    wait_for_result(_access_function,
+                    failure_message="VNET '%s' still in VRF_OBJECT_TABLE" % vnet_name)
+
+
 def check_routes_advertisement(dvs, prefix, profile=""):
     state_db = swsscommon.DBConnector(swsscommon.STATE_DB, dvs.redis_sock, 0)
     tbl =  swsscommon.Table(state_db, "ADVERTISE_NETWORK_TABLE")


### PR DESCRIPTION
Cherry-pick of #4499 from `master` to `202511`.

**What I did**

Coordinate VNET kernel device deletion with orchagent route cleanup so that fpmsyncd can resolve the VRF ifindex for any in-flight `RTM_DELROUTE` messages from FRR. Three commits:

1. `[fpmsyncd]: Log the correct error and reduce severity for VRF route delete log`
   - Check the `getIfName()` return value in `RouteSync::onMsg()` and return early on failure with a clear message including the `ifindex` and route prefix (previously the empty `master_name` produced a misleading `Invalid VRF name` log in `onRouteMsg()`).
   - Use `ERROR` severity for route adds (unexpected) and `INFO` for route deletes (benign post-deletion cleanup).
   - Log VRF/VNET link events (`RTM_NEWLINK`/`RTM_DELLINK`) with device name and ifindex at `NOTICE`, consistent with portsyncd/fdbsyncd, so operators can correlate VRF name to ifindex from logs.

2. `[vnetorch][vrfmgrd]: Defer VNET kernel device deletion until orchagent cleanup completes`
   - `VNetOrch`: write to `STATE_VRF_OBJECT_TABLE` on VNET creation (`hset`) and delete on VNET removal (`del`), mirroring `VRFOrch` behavior.
   - `vrfmgrd`: apply the same `isVrfObjExist()` polling logic in the VNET delete path, deferring `delLink()` until `VNetOrch` signals completion — closing the gap called out by the existing `"VNETOrch is not do so now."` comment.
   - `vrfmgrd`: add a per-`vrfName` retry counter and a rate-limited (every `VNET_DEL_DEFER_WARN_THRESHOLD = 20` deferrals) `SWSS_LOG_WARN` on both defer paths, so a stuck handshake (state row never populated by `VNetOrch`, or never cleared) fails loudly instead of silently looping forever. The counter is reset on the success path.
   - `orchdaemon`: pass `stateDb` to the `VNetOrch` constructor. `stateDb` is now a **required** parameter (no default `nullptr`); `m_stateVrfObjectTable` is held as a value `Table` member constructed in the initializer list (matches `VRFOrch`/`VrfMgr`). This eliminates a silent fallback where a future caller forgetting to wire `stateDb` would re-introduce the race with no log trail. The three mock-test callers were updated accordingly.
   - Adds `tests/mock_tests/vnetorch_ut.cpp` covering the `STATE_VRF_OBJECT_TABLE` lifecycle (`hset` on add, `del` on remove) in `VNetOrch::addOperation` / `delOperation`.

3. `[test_vnet]: Add VS test for VNET delete with routes present`
   - New `test_vnet_orch_37` exercises the create -> add routes -> delete VNET while routes are present -> delete routes -> verify cleanup flow and asserts `STATE_VRF_OBJECT_TABLE` lifecycle.
   - Adds `check_vnet_obj_in_state_db`, `wait_for_vnet_obj_in_state_db`, and `wait_for_vnet_obj_removed_from_state_db` helpers in `vnet_lib.py`.

**Why I did it**

Without this coordination, `vrfmgrd` was deleting the kernel VRF device (`ip link del`) immediately on VNET removal, before orchagent had a chance to remove the corresponding routes from APP_DB and the kernel. This left fpmsyncd unable to resolve the VRF ifindex for any pending `RTM_DELROUTE` messages, which:

- produced the misleading `Invalid VRF name` error in the syslog, and
- left stale `VNET_ROUTE_TUNNEL_TABLE` entries in APP_DB after the VNET was gone.

`VRFOrch`/`vrfmgrd` already implemented exactly this two-phase coordination via `STATE_VRF_OBJECT_TABLE`; `VNetOrch` simply did not participate, as called out by the existing comment in the code (`"VNETOrch is not do so now."`). This change closes that gap and reuses the existing mechanism.

**How I verified it**

- Ran the new VS test `tests/test_vnet.py::TestVnetOrch::test_vnet_orch_37` and confirmed:
  - `STATE_VRF_OBJECT_TABLE` is populated for the VNET on creation.
  - VNET delete is deferred while routes are still present and orchagent is cleaning up.
  - All `VNET_ROUTE_TUNNEL_TABLE` entries for the deleted VNET are removed from APP_DB after route cleanup completes (no stale entries).
  - `STATE_VRF_OBJECT_TABLE` entry is removed once cleanup is complete.
- Added a focused mock test `tests/mock_tests/vnetorch_ut.cpp::VNetOrchTest.VnetAddDelStateVrfObjectTableLifecycle` driving `APP_VNET_TABLE` SET/DEL and asserting the `STATE_VRF_OBJECT_TABLE` row appears on add and disappears on del.
- Added two `fpmsyncd` mock tests in `tests/mock_tests/fpmsyncd/test_routesync.cpp` (`RouteDeleteOnMissingVrfDeviceLogsInfoAndSkips`, `RouteAddOnMissingVrfDeviceLogsErrorAndSkips`) covering the new `getIfName()`-failure error/info paths and asserting the early-return contract (no APP_DB write on failure).
- Verified existing `test_vnet.py` and orchagent mock-test suites still pass.
- On a system reproducing the original issue, confirmed the `Invalid VRF name` log is no longer emitted on VNET deletion and that no stale routes are left behind.

**Details if related**

- Reuses the `STATE_VRF_OBJECT_TABLE` schema already documented in `doc/swss-schema.md` (minor wording update to clarify both `VRFOrch` and `VNetOrch` write to it).
- No SAI behavior changes; only an additional STATE_DB hand-off between `VNetOrch` and `vrfmgrd`.
