### PR TITLE
Southbound ZMQ runtime enablement

### DIFF
--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -196,10 +196,49 @@ void initSaiApi()
 {
     SWSS_LOG_ENTER();
 
-    if (ifstream(CONTEXT_CFG_FILE))
+    std::ifstream ifs(CONTEXT_CFG_FILE);
+    if (ifs.good())
     {
         SWSS_LOG_NOTICE("Context config file %s exists", CONTEXT_CFG_FILE);
         gProfileMap[SAI_REDIS_KEY_CONTEXT_CONFIG] = CONTEXT_CFG_FILE;
+
+        // If -z zmq_sync was passed but the JSON disables zmq for the default
+        // context, demote gRedisCommunicationMode to REDIS_SYNC. Notification
+        // handlers in notifications.cpp gate forwarding on this global, so it
+        // must reflect the actual transport sairedis will use. Symmetric with
+        // the fallback in sairedis/syncd Syncd.cpp.
+        if (gRedisCommunicationMode == SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC)
+        {
+            try
+            {
+                nlohmann::json j;
+                ifs >> j;
+
+                for (auto& item : j["CONTEXTS"])
+                {
+                    uint32_t guid = item["guid"];
+                    if (guid != 0)
+                    {
+                        continue;
+                    }
+
+                    if (item.contains("zmq_enable") && item["zmq_enable"] == false)
+                    {
+                        SWSS_LOG_NOTICE(
+                            "context %u: zmq_enable=false in %s, demoting "
+                            "gRedisCommunicationMode from ZMQ_SYNC to REDIS_SYNC",
+                            guid, CONTEXT_CFG_FILE);
+                        gRedisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC;
+                    }
+                    break;
+                }
+            }
+            catch (const std::exception& e)
+            {
+                SWSS_LOG_WARN("Failed to parse %s for comm-mode resolution: %s",
+                              CONTEXT_CFG_FILE, e.what());
+            }
+        }
     }
 
     sai_api_initialize(0, (const sai_service_method_table_t *)&test_services);
@@ -329,61 +368,8 @@ void initFlexCounterTables()
     }
 }
 
-// If orchagent was started with -z zmq_sync but context_config.json explicitly
-// disables zmq for the default context, demote gRedisCommunicationMode to
-// REDIS_SYNC. Notification handlers in notifications.cpp gate forwarding on
-// this global, so it must reflect the actual transport sairedis will use.
-// Symmetric with the fallback in sairedis/syncd Syncd.cpp.
-static void resolveCommunicationModeFromContextConfig()
-{
-    if (gRedisCommunicationMode != SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC)
-    {
-        return;
-    }
-
-    std::ifstream ifs(CONTEXT_CFG_FILE);
-    if (!ifs.good())
-    {
-        return;
-    }
-
-    try
-    {
-        nlohmann::json j;
-        ifs >> j;
-
-        for (auto& item : j["CONTEXTS"])
-        {
-            uint32_t guid = item["guid"];
-            if (guid != 0)
-            {
-                continue;
-            }
-
-            if (item.contains("zmq_enable") && item["zmq_enable"] == false)
-            {
-                SWSS_LOG_NOTICE(
-                    "context %u: zmq_enable=false in %s, demoting "
-                    "gRedisCommunicationMode from ZMQ_SYNC to REDIS_SYNC",
-                    guid, CONTEXT_CFG_FILE);
-                gRedisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC;
-            }
-            return;
-        }
-    }
-    catch (const std::exception& e)
-    {
-        SWSS_LOG_WARN("Failed to parse %s for comm-mode resolution: %s",
-                      CONTEXT_CFG_FILE, e.what());
-    }
-}
-
 void initSaiRedis()
 {
-    // Resolve comm-mode against context_config.json before sending it to
-    // sairedis, so notifications.cpp and sairedis agree on the transport.
-    resolveCommunicationModeFromContextConfig();
-
     // SAI_REDIS_SWITCH_ATTR_SYNC_MODE attribute only setBuffer and g_syncMode to true
     // since it is not using ASIC_DB, we can execute it before create_switch
     // when g_syncMode is set to true here, create_switch will wait the response from syncd

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -17,6 +17,7 @@ extern "C" {
 #include <vector>
 #include <linux/limits.h>
 #include <net/if.h>
+#include <nlohmann/json.hpp>
 #include "timestamp.h"
 #include "sai_serialize.h"
 #include "saihelper.h"
@@ -328,8 +329,61 @@ void initFlexCounterTables()
     }
 }
 
+// If orchagent was started with -z zmq_sync but context_config.json explicitly
+// disables zmq for the default context, demote gRedisCommunicationMode to
+// REDIS_SYNC. Notification handlers in notifications.cpp gate forwarding on
+// this global, so it must reflect the actual transport sairedis will use.
+// Symmetric with the fallback in sairedis/syncd Syncd.cpp.
+static void resolveCommunicationModeFromContextConfig()
+{
+    if (gRedisCommunicationMode != SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC)
+    {
+        return;
+    }
+
+    std::ifstream ifs(CONTEXT_CFG_FILE);
+    if (!ifs.good())
+    {
+        return;
+    }
+
+    try
+    {
+        nlohmann::json j;
+        ifs >> j;
+
+        for (auto& item : j["CONTEXTS"])
+        {
+            uint32_t guid = item["guid"];
+            if (guid != 0)
+            {
+                continue;
+            }
+
+            if (item.contains("zmq_enable") && item["zmq_enable"] == false)
+            {
+                SWSS_LOG_NOTICE(
+                    "context %u: zmq_enable=false in %s, demoting "
+                    "gRedisCommunicationMode from ZMQ_SYNC to REDIS_SYNC",
+                    guid, CONTEXT_CFG_FILE);
+                gRedisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC;
+            }
+            return;
+        }
+    }
+    catch (const std::exception& e)
+    {
+        SWSS_LOG_WARN("Failed to parse %s for comm-mode resolution: %s",
+                      CONTEXT_CFG_FILE, e.what());
+    }
+}
+
 void initSaiRedis()
 {
+    // Resolve comm-mode against context_config.json before sending it to
+    // sairedis, so notifications.cpp and sairedis agree on the transport.
+    resolveCommunicationModeFromContextConfig();
+
     // SAI_REDIS_SWITCH_ATTR_SYNC_MODE attribute only setBuffer and g_syncMode to true
     // since it is not using ASIC_DB, we can execute it before create_switch
     // when g_syncMode is set to true here, create_switch will wait the response from syncd

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -192,6 +192,56 @@ const sai_service_method_table_t test_services = {
     test_profile_get_next_value
 };
 
+// Resolve gRedisCommunicationMode against context_config.json. When -z zmq_sync
+// was requested but the JSON disables zmq for the default context (guid=0),
+// demote to REDIS_SYNC. Notification handlers in notifications.cpp gate
+// forwarding on this global, so it must reflect the actual transport sairedis
+// will use. Symmetric with the fallback in sairedis/syncd Syncd.cpp.
+//
+// Takes an istream so it streams directly from the open file in production and
+// from std::istringstream in unit tests, with no intermediate copy.
+sai_redis_communication_mode_t resolveCommunicationModeFromContextConfig(
+        std::istream& jsonStream,
+        sai_redis_communication_mode_t currentMode)
+{
+    if (currentMode != SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC)
+    {
+        return currentMode;
+    }
+
+    try
+    {
+        nlohmann::json j;
+        jsonStream >> j;
+
+        for (auto& item : j["CONTEXTS"])
+        {
+            uint32_t guid = item["guid"];
+            if (guid != 0)
+            {
+                continue;
+            }
+
+            if (item.contains("zmq_enable") && item["zmq_enable"] == false)
+            {
+                SWSS_LOG_NOTICE(
+                    "context %u: zmq_enable=false in context config, demoting "
+                    "gRedisCommunicationMode from ZMQ_SYNC to REDIS_SYNC",
+                    guid);
+                return SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC;
+            }
+            break;
+        }
+    }
+    catch (const std::exception& e)
+    {
+        SWSS_LOG_WARN("Failed to parse context config for comm-mode resolution: %s",
+                      e.what());
+    }
+
+    return currentMode;
+}
+
 void initSaiApi()
 {
     SWSS_LOG_ENTER();
@@ -202,43 +252,8 @@ void initSaiApi()
         SWSS_LOG_NOTICE("Context config file %s exists", CONTEXT_CFG_FILE);
         gProfileMap[SAI_REDIS_KEY_CONTEXT_CONFIG] = CONTEXT_CFG_FILE;
 
-        // If -z zmq_sync was passed but the JSON disables zmq for the default
-        // context, demote gRedisCommunicationMode to REDIS_SYNC. Notification
-        // handlers in notifications.cpp gate forwarding on this global, so it
-        // must reflect the actual transport sairedis will use. Symmetric with
-        // the fallback in sairedis/syncd Syncd.cpp.
-        if (gRedisCommunicationMode == SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC)
-        {
-            try
-            {
-                nlohmann::json j;
-                ifs >> j;
-
-                for (auto& item : j["CONTEXTS"])
-                {
-                    uint32_t guid = item["guid"];
-                    if (guid != 0)
-                    {
-                        continue;
-                    }
-
-                    if (item.contains("zmq_enable") && item["zmq_enable"] == false)
-                    {
-                        SWSS_LOG_NOTICE(
-                            "context %u: zmq_enable=false in %s, demoting "
-                            "gRedisCommunicationMode from ZMQ_SYNC to REDIS_SYNC",
-                            guid, CONTEXT_CFG_FILE);
-                        gRedisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC;
-                    }
-                    break;
-                }
-            }
-            catch (const std::exception& e)
-            {
-                SWSS_LOG_WARN("Failed to parse %s for comm-mode resolution: %s",
-                              CONTEXT_CFG_FILE, e.what());
-            }
-        }
+        gRedisCommunicationMode = resolveCommunicationModeFromContextConfig(
+            ifs, gRedisCommunicationMode);
     }
 
     sai_api_initialize(0, (const sai_service_method_table_t *)&test_services);

--- a/orchagent/saihelper.h
+++ b/orchagent/saihelper.h
@@ -2,7 +2,13 @@
 
 #include "gearboxutils.h"
 
+#include <iosfwd>
 #include <string>
+
+extern "C" {
+#include "sairedis.h"
+}
+
 #include "orch.h"
 #include "producertable.h"
 #include "events.h"
@@ -14,6 +20,10 @@ void initFlexCounterTables();
 void initSaiApi();
 void initSaiRedis();
 sai_status_t initSaiPhyApi(swss::gearbox_phy_t *phy);
+
+sai_redis_communication_mode_t resolveCommunicationModeFromContextConfig(
+        std::istream& jsonStream,
+        sai_redis_communication_mode_t currentMode);
 
 /* Handling SAI status*/
 task_process_status handleSaiCreateStatus(sai_api_t api, sai_status_t status, void *context = nullptr);

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -84,6 +84,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 mock_dash_orch_test.cpp \
                 zmq_orch_ut.cpp \
                 retrycache_ut.cpp \
+                saihelper_ut.cpp \
                 mock_saihelper.cpp \
                 mirrororch_ut.cpp \
                 $(top_srcdir)/warmrestart/warmRestartHelper.cpp \

--- a/tests/mock_tests/saihelper_ut.cpp
+++ b/tests/mock_tests/saihelper_ut.cpp
@@ -1,0 +1,81 @@
+#include "ut_helper.h"
+#include "saihelper.h"
+
+#include <sstream>
+
+namespace saihelper_test
+{
+    TEST(ResolveCommunicationModeFromContextConfig, NonZmqInputUnchanged)
+    {
+        std::istringstream iss(R"({"CONTEXTS":[{"guid":0,"zmq_enable":false}]})");
+        EXPECT_EQ(SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC,
+                  resolveCommunicationModeFromContextConfig(
+                      iss, SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC));
+    }
+
+    TEST(ResolveCommunicationModeFromContextConfig, RedisSyncInputUnchanged)
+    {
+        std::istringstream iss(R"({"CONTEXTS":[{"guid":0,"zmq_enable":false}]})");
+        EXPECT_EQ(SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC,
+                  resolveCommunicationModeFromContextConfig(
+                      iss, SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC));
+    }
+
+    TEST(ResolveCommunicationModeFromContextConfig, ZmqDisabledForGuidZeroDemotes)
+    {
+        std::istringstream iss(R"({"CONTEXTS":[{"guid":0,"zmq_enable":false}]})");
+        EXPECT_EQ(SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC,
+                  resolveCommunicationModeFromContextConfig(
+                      iss, SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC));
+    }
+
+    TEST(ResolveCommunicationModeFromContextConfig, ZmqEnabledForGuidZeroUnchanged)
+    {
+        std::istringstream iss(R"({"CONTEXTS":[{"guid":0,"zmq_enable":true}]})");
+        EXPECT_EQ(SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC,
+                  resolveCommunicationModeFromContextConfig(
+                      iss, SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC));
+    }
+
+    TEST(ResolveCommunicationModeFromContextConfig, MissingZmqEnableUnchanged)
+    {
+        std::istringstream iss(R"({"CONTEXTS":[{"guid":0}]})");
+        EXPECT_EQ(SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC,
+                  resolveCommunicationModeFromContextConfig(
+                      iss, SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC));
+    }
+
+    TEST(ResolveCommunicationModeFromContextConfig, NonZeroGuidSkipped)
+    {
+        // Only guid=0 (the default context) is consulted; non-zero guids are
+        // ignored even if they disable zmq.
+        std::istringstream iss(R"({"CONTEXTS":[{"guid":1,"zmq_enable":false}]})");
+        EXPECT_EQ(SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC,
+                  resolveCommunicationModeFromContextConfig(
+                      iss, SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC));
+    }
+
+    TEST(ResolveCommunicationModeFromContextConfig, FindsGuidZeroAmongMultiple)
+    {
+        std::istringstream iss(R"({"CONTEXTS":[{"guid":1,"zmq_enable":true},{"guid":0,"zmq_enable":false}]})");
+        EXPECT_EQ(SAI_REDIS_COMMUNICATION_MODE_REDIS_SYNC,
+                  resolveCommunicationModeFromContextConfig(
+                      iss, SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC));
+    }
+
+    TEST(ResolveCommunicationModeFromContextConfig, MalformedJsonUnchanged)
+    {
+        std::istringstream iss("not valid json");
+        EXPECT_EQ(SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC,
+                  resolveCommunicationModeFromContextConfig(
+                      iss, SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC));
+    }
+
+    TEST(ResolveCommunicationModeFromContextConfig, MissingContextsKeyUnchanged)
+    {
+        std::istringstream iss(R"({"OTHER_KEY":[]})");
+        EXPECT_EQ(SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC,
+                  resolveCommunicationModeFromContextConfig(
+                      iss, SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC));
+    }
+}


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

In `orchagent/saihelper.cpp`, added `resolveCommunicationModeFromContextConfig(std::istream&, sai_redis_communication_mode_t)` and call it from `initSaiApi()`. `initSaiApi()` opens `/usr/share/sonic/hwsku/context_config.json` once and streams it straight into the helper. If `zmq_enable=false` for the default context (`guid=0`), the helper returns `REDIS_SYNC`; otherwise it returns the input mode unchanged. The result is stored in `gRedisCommunicationMode` before `initSaiRedis()` sends the comm-mode attribute to sairedis.

**Why I did it**

When the southbound-ZMQ runtime knob is in play, `context_config.json` is the source of truth for whether ZMQ is actually used. `gRedisCommunicationMode` is set unconditionally from the `-z` cmdline flag in `main.cpp` and is then read by five notification callbacks in `notifications.cpp` (`on_port_state_change`, `on_ha_set_event`, `on_ha_scope_event`, etc.) to decide whether to forward events to ASIC_DB via `NotificationProducer`.

If the JSON disables ZMQ but `-z zmq_sync` was passed, sairedis silently falls back to `RedisChannel` (see [sonic-sairedis#1835](https://github.com/sonic-net/sonic-sairedis/pull/1835)). The orchagent global was previously left at `ZMQ_SYNC` in that case, so notification handlers would forward events as if ZMQ were active, wrong path. This change keeps the global aligned with the actual transport, symmetric with the fallback in `syncd/Syncd.cpp`.

**How I verified it**

- Unit tests in `tests/mock_tests/saihelper_ut.cpp` cover every branch of the helper: non-ZMQ inputs unchanged, `zmq_enable=false` for `guid=0` demotes, `zmq_enable=true` unchanged, missing `zmq_enable` key unchanged, non-zero guid skipped, `guid=0` found among multiple contexts, malformed JSON unchanged with WARN, and missing CONTEXTS key unchanged.
- Inspected the no-op paths in production: with no `context_config.json` present, the `ifs.good()` check skips the helper entirely and `gRedisCommunicationMode` is left as-is.
- Ran the route benchmark with both ZMQ-enabled and ZMQ-disabled JSON configurations end-to-end; routes program correctly and notifications take the correct path in each mode.

**Details if related**

Companion PR: [sonic-net/sonic-sairedis#1835](https://github.com/sonic-net/sonic-sairedis/pull/1835), adds the runtime knob, default endpoint changes, and the matching syncd-side fallback. This swss PR is required so notification routing tracks the transport sairedis actually selects.
