### PR TITLE
[dashhaorch]: Remove DPU_STATE_DB entries upon DEL of HA_SET/HA_SCOPE

### DIFF
--- a/orchagent/dash/dashhaorch.cpp
+++ b/orchagent/dash/dashhaorch.cpp
@@ -391,6 +391,7 @@ bool DashHaOrch::removeHaSetEntry(const std::string &key)
     }
     m_ha_set_entries.erase(it);
     m_counter_ha_set_name_map_table->hdel("", key);
+    m_dpuStateDbHaSetTable->del(key);
     SWSS_LOG_NOTICE("Removed HA Set object for %s", key.c_str());
 
     return true;
@@ -922,6 +923,7 @@ bool DashHaOrch::removeHaScopeEntry(const std::string &key)
         }
     }
     m_ha_scope_entries.erase(it);
+    m_dpuStateDbHaScopeTable->del(key);
     SWSS_LOG_NOTICE("Removed HA Scope object for %s", key.c_str());
 
     return true;


### PR DESCRIPTION
**What I did**

Clean up the corresponding entries in DPU_STATE_DB (`DASH_HA_SET_STATE_TABLE` and `DASH_HA_SCOPE_STATE_TABLE`) when an HA_SET or HA_SCOPE entry is deleted from DPU_APPL_DB. 

**Why I did it**

Previously, on `DEL` of an HA_SET or HA_SCOPE entry, the SAI object and internal map entries were removed but the corresponding DPU_STATE_DB rows were left stale, leading to inconsistent state DB content after deletion.

**How I verified it**

TODO

**Details if related**

- `removeHaSetEntry()` now calls `m_dpuStateDbHaSetTable->del(key)`
- `removeHaScopeEntry()` now calls `m_dpuStateDbHaScopeTable->del(key)`
