### PR TITLE
Replace aclorch environment variable platform with ASIC_VENDOR

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3484,7 +3484,7 @@ void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, Mirr
     // Right now, verified platforms that support mirroring IPv6 packets are
     // Broadcom and Mellanox. Virtual switch is also supported for testing
     // purposes.
-    string platform = getenv("platform") ? getenv("platform") : "";
+    string platform = getenv("ASIC_VENDOR") ? getenv("ASIC_VENDOR") : "";
     string sub_platform = getenv("sub_platform") ? getenv("sub_platform") : "";
     if (platform == BRCM_PLATFORM_SUBSTRING ||
             platform == CISCO_8000_PLATFORM_SUBSTRING ||

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3484,7 +3484,8 @@ void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, Mirr
     // Right now, verified platforms that support mirroring IPv6 packets are
     // Broadcom and Mellanox. Virtual switch is also supported for testing
     // purposes.
-    string platform = getenv("ASIC_VENDOR") ? getenv("ASIC_VENDOR") : "";
+    string platform = getenv("ASIC_VENDOR") ? getenv("ASIC_VENDOR") :
+            getenv("platform") ? getenv("platform") : "";
     string sub_platform = getenv("sub_platform") ? getenv("sub_platform") : "";
     if (platform == BRCM_PLATFORM_SUBSTRING ||
             platform == CISCO_8000_PLATFORM_SUBSTRING ||


### PR DESCRIPTION
**What I did**

Changed the platform variable from `platform` to `ASIC_VENDOR` to fix issue #4530.

**Why I did it**

`ASIC_VENDOR` is the correct runtime indicator for ASIC/platform capability and is consistently available in SWSS containers, while `platform` refers to a specific hardware platform.

**How I verified it**

admin@sonic:~$ docker exec -it swss env
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin HOSTNAME=sonic
TERM=xterm
NAMESPACE_PREFIX=asic
PLATFORM=x86_64-micas_m2-w6510-48v8c-r0
RUNTIME_OWNER=local
**ASIC_VENDOR=broadcom**
NAMESPACE_ID=
NAMESPACE_COUNT=
DEV=
CONTAINER_NAME=swss
SYSLOG_TARGET_IP=127.0.0.1
IMAGENAME=docker-orchagent
DISTRO=bookworm
DEBIAN_FRONTEND=noninteractive
HOME=/root

**Details if related**
No.