### PR TITLE
[202511][teamsyncd] Cherry-pick #4534: Fix SIGSEGV crash during teamd container restart

### DIFF
--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -174,21 +174,54 @@ void TeamSync::addLag(const string &lagName, int ifindex, bool admin_state,
 
     FieldValueTuple s("state", "ok");
     fvVector.push_back(s);
-    if (m_warmstart)
-    {
-        m_stateLagTablePreserved[lagName] = fvVector;
-    }
-    else
-    {
-        m_stateLagTable.set(lagName, fvVector);
-    }
 
     if (lag_update)
     {
-        /* Create the team instance */
-        auto sync = make_shared<TeamPortSync>(lagName, ifindex, &m_lagMemberTable);
-        m_teamSelectables[lagName] = sync;
-        m_selectablesToAdd.insert(lagName);
+        /* Create the team instance.
+         * On container restart, teamsyncd may receive RTM_NEWLINK for pre-existing
+         * team devices (from the kernel's initial dump) before teammgrd has had a
+         * chance to recreate them via "teamd -r".  The recreate deletes the old
+         * kernel device first, so team_init() fails with EADDRNOTAVAIL (errno 99)
+         * because the ifindex is no longer valid.  Catch the exception here so it
+         * does not propagate through NetLink::readData() into Select::poll_descriptors,
+         * which would abort the entire netlink processing loop.  When teamd finishes
+         * recreating the device the kernel emits a fresh RTM_NEWLINK with the correct
+         * new ifindex and addLag() is called again, at which point initialization
+         * succeeds.
+         * STATE_DB is written only after the team instance is successfully created
+         * to prevent dependent services (e.g. intfmgrd) from acting on a LAG that
+         * teamd has not yet finished setting up. */
+        try
+        {
+            auto sync = make_shared<TeamPortSync>(lagName, ifindex, &m_lagMemberTable);
+            if (m_warmstart)
+            {
+                m_stateLagTablePreserved[lagName] = fvVector;
+            }
+            else
+            {
+                m_stateLagTable.set(lagName, fvVector);
+            }
+            m_teamSelectables[lagName] = sync;
+            m_selectablesToAdd.insert(lagName);
+        }
+        catch (const system_error& e)
+        {
+            SWSS_LOG_ERROR("addLag: Failed to initialize team handler for LAG %s "
+                           "(ifindex %d): %d:%s. Waiting for next RTM_NEWLINK.",
+                           lagName.c_str(), ifindex, e.code().value(), e.what());
+        }
+    }
+    else
+    {
+        if (m_warmstart)
+        {
+            m_stateLagTablePreserved[lagName] = fvVector;
+        }
+        else
+        {
+            m_stateLagTable.set(lagName, fvVector);
+        }
     }
 }
 

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -315,10 +315,14 @@ tests_response_publisher_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhired
         -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread
 
 tests_teamsyncd_SOURCES = teamsync_ut.cpp \
-                          $(top_srcdir)/teamsyncd/teamsync.cpp
+                          $(top_srcdir)/teamsyncd/teamsync.cpp \
+                          mock_dbconnector.cpp \
+                          mock_table.cpp \
+                          mock_hiredis.cpp \
+                          mock_redisreply.cpp
 
 tests_teamsyncd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/teamsyncd
 tests_teamsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
 tests_teamsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_teamsyncd_INCLUDES)
 tests_teamsyncd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 \
-        -lswsscommon -lgtest -lgtest_main -lpthread -lteam -lteamdctl
+        -lswsscommon -ldl -lhiredis -lgtest -lgtest_main -lpthread -lteam -lteamdctl -lnl-route-3

--- a/tests/mock_tests/teamsync_ut.cpp
+++ b/tests/mock_tests/teamsync_ut.cpp
@@ -5,6 +5,7 @@
 #include <team.h>
 #include <teamdctl.h>
 #include "teamsync.h"
+#include "mock_table.h"
 
 static unsigned int (*callback_sleep)(unsigned int seconds) = NULL;
 static int (*callback_team_init)(struct team_handle *th, uint32_t ifindex) = NULL;
@@ -181,5 +182,72 @@ namespace teamportsync_test
         callback_teamdctl_connect = cb_teamdctl_connect;
         callback_teamdctl_config_get_raw_direct = cb_teamdctl_config_get_raw_direct_success;
         swss::TeamSync::TeamPortSync("testLag", 4, NULL);
+    }
+}
+
+namespace teamsync_test
+{
+    /* Subclass to expose the protected addLag() for unit testing. */
+    class TeamSyncUnderTest : public swss::TeamSync
+    {
+    public:
+        TeamSyncUnderTest(swss::DBConnector *db, swss::DBConnector *stateDb, swss::Select *sel)
+            : swss::TeamSync(db, stateDb, sel) {}
+        using swss::TeamSync::addLag;
+    };
+
+    struct TeamSyncTest : public ::testing::Test
+    {
+        virtual void SetUp() override
+        {
+            callback_sleep = cb_sleep;
+            callback_team_init = NULL;
+            callback_team_change_handler = NULL;
+            callback_teamdctl_connect = NULL;
+            callback_teamdctl_config_get_raw_direct = cb_teamdctl_config_get_raw_direct_force_error;
+            callback_teamdctl_disconnect = cb_teamdctl_disconnect;
+            testing_db::reset();
+        }
+
+        virtual void TearDown() override
+        {
+            callback_sleep = NULL;
+            callback_team_init = NULL;
+            callback_team_change_handler = NULL;
+            callback_teamdctl_connect = NULL;
+            callback_teamdctl_config_get_raw_direct = NULL;
+            callback_teamdctl_disconnect = NULL;
+            testing_db::reset();
+        }
+    };
+
+    /* Verify that when TeamPortSync construction fails (team_init returns an
+     * error for an invalid ifindex), addLag() catches the system_error
+     * internally and does not propagate it to the caller. */
+    TEST_F(TeamSyncTest, AddLagTeamInitFails)
+    {
+        swss::DBConnector db(0, "localhost", 0, 0);
+        swss::DBConnector stateDb(1, "localhost", 0, 0);
+        TeamSyncUnderTest ts(&db, &stateDb, nullptr);
+
+        /* ifindex 0 is invalid; the real team_init() will fail, causing
+         * TeamPortSync to throw system_error, which addLag() must catch. */
+        ts.addLag("testLag", 0, true, true, 1500);
+    }
+
+    /* Verify that addLag() successfully creates the team instance and writes
+     * the LAG state when all underlying calls succeed. */
+    TEST_F(TeamSyncTest, AddLagSucceeds)
+    {
+        callback_team_init = cb_team_init;
+        callback_team_change_handler = cb_team_change_handler;
+        callback_teamdctl_connect = cb_teamdctl_connect;
+        callback_teamdctl_config_get_raw_direct = cb_teamdctl_config_get_raw_direct_success;
+
+        swss::DBConnector db(0, "localhost", 0, 0);
+        swss::DBConnector stateDb(1, "localhost", 0, 0);
+        TeamSyncUnderTest ts(&db, &stateDb, nullptr);
+
+        ts.addLag("testLag", 4, true, true, 1500);
     }
 }


### PR DESCRIPTION
**Cherry-pick of #4534 to 202511 branch.**

Original PR: https://github.com/sonic-net/sonic-swss/pull/4534
Original commit: 4305596156d70e9797e8a881b3d19b46de0bce0d
Original author: @prhoskot

**Why I did it**
Commit fe19634 ("Connect to teamd before adding the lag to STATE_DB") added `teamdctl_connect()` to the `TeamPortSync` constructor to verify teamd is live before writing to STATE_DB. However, this introduced a crash during teamd container restart.

On restart, teamd is launched with `-r` (recreate flag), which deletes and recreates each PortChannel kernel device with a new ifindex. Before recreation, the kernel emits `RTM_NEWLINK` for the pre-existing devices (initial dump). `teamsyncd` calls `addLag()` -> `TeamPortSync` constructor with the old ifindex. `team_init(old_ifindex)` succeeds (device still exists), but `teamdctl_connect()` fails with `ECONNREFUSED` (errno 111) because teamd's socket is not yet bound. The catch block sleeps 1s before retrying. During that sleep, `teamd -r` deletes the old kernel device and creates a new one with a new ifindex. On retry, `team_init(old_ifindex)` fails with `EADDRNOTAVAIL` (errno 99). After `max_retries=3`, the constructor throws `std::system_error`.

The exception propagates uncaught through `addLag()` -> `onMsg()` -> libnl's C callback stack -> `NetLink::readData()` (no catch) -> `Select::poll_descriptors()` (catches only `runtime_error`, logs `readData error`, returns `ERROR`). The main loop ignores the SELECT error, continues in a corrupted state, and eventually crashes with SIGSEGV in libnl-route-3 at a NULL pointer dereference.

**What I did**
Wrap `make_shared<TeamPortSync>()` in a `try`/`catch(const system_error&)` in `addLag()` and move the STATE_DB write inside the try block so it only happens after the team instance is successfully created. When the constructor fails, `addLag()` returns cleanly without inserting into `m_teamSelectables`. When `teamd -r` finishes recreating the device, the kernel emits a fresh `RTM_NEWLINK` with the correct new ifindex, `addLag()` is called again, and initialization succeeds.

**How I verified it**
Ran sonic-mgmt tests to verify there is no teamsyncd crash. Unit test `teamsync_ut.cpp` added (cherry-picked from PR #4534).

**Cherry-pick conflict resolution**
- `tests/mock_tests/Makefile.am`: The PR's diff context happened to include a `LOG_DRIVER = $(top_srcdir)/run-gtest-suite.py` line that exists on master (added by an unrelated commit) but not on 202511. Took the intentional change (updated `tests_teamsyncd_LDADD` to add `-ldl -lhiredis -lnl-route-3`) and skipped the `LOG_DRIVER` context line, since adding it would alter test-runner behavior for all existing 202511 tests (out of scope for this fix).
- `teamsyncd/teamsync.cpp` and `tests/mock_tests/teamsync_ut.cpp`: cherry-picked cleanly, no resolution needed.

Verified `git diff upstream/202511` matches the original PR's diff exactly (excluding the unrelated `LOG_DRIVER` line).
