### PR TITLE
orchagent: add per-Executor task timing instrumentation

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -973,6 +973,90 @@ void OrchDaemon::logRotate() {
 }
 
 
+void OrchDaemon::initTaskStatsChannel()
+{
+    SWSS_LOG_ENTER();
+
+    m_taskStatsDb = std::make_unique<swss::DBConnector>("APPL_DB", 0);
+    m_taskStatsQuery = std::make_unique<swss::NotificationConsumer>(
+            m_taskStatsDb.get(), "ORCH_TASK_STATS_QUERY");
+    m_taskStatsReply = std::make_unique<swss::NotificationProducer>(
+            m_taskStatsDb.get(), "ORCH_TASK_STATS_REPLY");
+
+    m_select->addSelectable(m_taskStatsQuery.get());
+}
+
+void OrchDaemon::handleTaskStatsQuery()
+{
+    SWSS_LOG_ENTER();
+
+    std::string op;
+    std::string data;
+    std::vector<swss::FieldValueTuple> req_values;
+    m_taskStatsQuery->pop(op, data, req_values);
+
+    std::vector<swss::FieldValueTuple> reply_values;
+
+    if (op == "show")
+    {
+        reply_values.reserve(m_taskStats.size());
+        // Helper: round a P^2 double estimate to a non-negative uint64.
+        auto round_p2 = [](double v) -> uint64_t
+        {
+            return static_cast<uint64_t>(v < 0.0 ? 0.0 : v + 0.5);
+        };
+
+        for (auto &kv : m_taskStats)
+        {
+            auto &s = kv.second;
+            // Pipe-separated, 14 fields:
+            //   count | total_run_ns
+            //   | median_run_ns | q1_run_ns | q3_run_ns | max_run_ns
+            //   | high_outliers | low_outliers
+            //   | sched_count | total_sched_ns
+            //   | median_sched_ns | q1_sched_ns | q3_sched_ns | max_sched_ns
+            // Empty slots emit zeros so the CLI can format them as "-".
+            uint64_t med_run = (s.count == 0) ? 0 : round_p2(s.median.value());
+            uint64_t q1_run  = (s.count == 0) ? 0 : round_p2(s.q1.value());
+            uint64_t q3_run  = (s.count == 0) ? 0 : round_p2(s.q3.value());
+
+            uint64_t med_sched = (s.sched_count == 0) ? 0 : round_p2(s.sched_median.value());
+            uint64_t q1_sched  = (s.sched_count == 0) ? 0 : round_p2(s.sched_q1.value());
+            uint64_t q3_sched  = (s.sched_count == 0) ? 0 : round_p2(s.sched_q3.value());
+
+            std::string v = std::to_string(s.count) + "|"
+                          + std::to_string(s.total_ns) + "|"
+                          + std::to_string(med_run) + "|"
+                          + std::to_string(q1_run) + "|"
+                          + std::to_string(q3_run) + "|"
+                          + std::to_string(s.max_ns) + "|"
+                          + std::to_string(s.high_outliers) + "|"
+                          + std::to_string(s.low_outliers) + "|"
+                          + std::to_string(s.sched_count) + "|"
+                          + std::to_string(s.total_sched_ns) + "|"
+                          + std::to_string(med_sched) + "|"
+                          + std::to_string(q1_sched) + "|"
+                          + std::to_string(q3_sched) + "|"
+                          + std::to_string(s.sched_max_ns);
+            reply_values.emplace_back(kv.first, v);
+        }
+        m_taskStatsReply->send("ok", "", reply_values);
+    }
+    else if (op == "clear")
+    {
+        for (auto &kv : m_taskStats)
+        {
+            kv.second.reset();
+        }
+        m_taskStatsReply->send("ok", "", reply_values);
+    }
+    else
+    {
+        SWSS_LOG_WARN("ORCH_TASK_STATS_QUERY: unknown op '%s'", op.c_str());
+        m_taskStatsReply->send("error", "unknown op", reply_values);
+    }
+}
+
 void OrchDaemon::start(long heartBeatInterval)
 {
     SWSS_LOG_ENTER();
@@ -985,6 +1069,8 @@ void OrchDaemon::start(long heartBeatInterval)
     {
         m_select->addSelectables(o->getSelectables());
     }
+
+    initTaskStatsChannel();
 
     auto tstart = std::chrono::high_resolution_clock::now();
 
@@ -1016,6 +1102,7 @@ void OrchDaemon::start(long heartBeatInterval)
         {
             tstart = std::chrono::high_resolution_clock::now();
 
+            { TaskTimer t(m_taskStats["flush"]); flush(); }
             /*
              * Log an error message periodically if a previous SAI API call failed with
              * an unrecoverable error.
@@ -1047,7 +1134,7 @@ void OrchDaemon::start(long heartBeatInterval)
              * accumulated. Still it is possible that small amount of
              * requests live in it. When the daemon has nothing to do, it
              * is a good chance to flush the pipeline  */
-            flush();
+            { TaskTimer t(m_taskStats["flush"]); flush(); }
 
             if (gRingBuffer)
             {
@@ -1070,11 +1157,17 @@ void OrchDaemon::start(long heartBeatInterval)
         {
             SWSS_LOG_NOTICE("Performing %s log rotate", Recorder::Instance().sairedis.getName().c_str());
             Recorder::Instance().sairedis.setRotate(false);
-            logRotate();
+            { TaskTimer t(m_taskStats["logRotate"]); logRotate(); }
+        }
+
+        if (s == m_taskStatsQuery.get())
+        {
+            handleTaskStatsQuery();
+            continue;
         }
 
         auto *c = (Executor *)s;
-        c->execute();
+        { TaskTimer t(m_taskStats[c->getName()]); c->execute(); }
 
         /* After each iteration, periodically check all m_toSync map to
          * execute all the remaining tasks that need to be retried. */
@@ -1122,7 +1215,7 @@ void OrchDaemon::start(long heartBeatInterval)
                     }
 
                     // Flush sairedis's redis pipeline
-                    flush();
+                    { TaskTimer t(m_taskStats["flush"]); flush(); }
 
                     SWSS_LOG_WARN("Orchagent is frozen for warm restart!");
                     freezeAndHeartBeat(UINT_MAX, heartBeatInterval);

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -1,11 +1,21 @@
 #ifndef SWSS_ORCHDAEMON_H
 #define SWSS_ORCHDAEMON_H
 
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
 #include <unistd.h>
 
 #include "dbconnector.h"
 #include "producerstatetable.h"
 #include "consumertable.h"
+#include "notificationconsumer.h"
+#include "notificationproducer.h"
 #include "zmqserver.h"
 #include "select.h"
 
@@ -68,6 +78,296 @@
 #include "shlorch.h"
 
 using namespace swss;
+
+// P-square quantile estimator (Jain & Chlamtac, 1985).
+// O(1) memory, O(1) per update; tracks an estimate of a single quantile p
+// over a stream without keeping the samples. Used here to track Q1, median,
+// and Q3 of per-Executor run times so the median is robust to tail outliers
+// and so high/low outliers can be classified by the Tukey 1.5*IQR rule
+// without buffering history.
+class P2Quantile
+{
+public:
+    explicit P2Quantile(double p) : m_p(p) {}
+
+    // Insert a sample and update the quantile estimate.
+    void add(double x)
+    {
+        // Bootstrap: hold the first 5 samples, sort them on the 5th to
+        // initialize the markers.
+        if (!m_bootstrapped)
+        {
+            m_init_buf[m_n++] = x;
+            if (m_n == 5)
+            {
+                std::sort(m_init_buf, m_init_buf + 5);
+                for (int i = 0; i < 5; ++i)
+                {
+                    m_q[i] = m_init_buf[i];
+                    m_pos[i] = i + 1;          // 1..5 (1-based)
+                }
+                m_np[0] = 1.0;
+                m_np[1] = 1.0 + 2.0 * m_p;
+                m_np[2] = 1.0 + 4.0 * m_p;
+                m_np[3] = 3.0 + 2.0 * m_p;
+                m_np[4] = 5.0;
+                m_dn[0] = 0.0;
+                m_dn[1] = m_p / 2.0;
+                m_dn[2] = m_p;
+                m_dn[3] = (1.0 + m_p) / 2.0;
+                m_dn[4] = 1.0;
+                m_bootstrapped = true;
+            }
+            return;
+        }
+
+        // Find the cell k that x falls into. Adjust q[0] / q[4] if x is a
+        // new extremum.
+        int k;
+        if (x < m_q[0])      { m_q[0] = x; k = 0; }
+        else if (x >= m_q[4]) { m_q[4] = x; k = 3; }
+        else
+        {
+            for (k = 0; k < 4; ++k)
+                if (m_q[k] <= x && x < m_q[k + 1]) break;
+        }
+
+        // Increment positions of markers above k.
+        for (int i = k + 1; i < 5; ++i) m_pos[i] += 1.0;
+
+        // Update desired positions for all markers.
+        for (int i = 0; i < 5; ++i) m_np[i] += m_dn[i];
+
+        // Adjust the three interior markers if needed.
+        for (int i = 1; i < 4; ++i)
+        {
+            double d = m_np[i] - m_pos[i];
+            if ((d >=  1.0 && (m_pos[i + 1] - m_pos[i]) >  1.0) ||
+                (d <= -1.0 && (m_pos[i - 1] - m_pos[i]) < -1.0))
+            {
+                int s = (d >= 0.0) ? 1 : -1;
+                double qp = parabolic(i, s);
+                if (m_q[i - 1] < qp && qp < m_q[i + 1])
+                    m_q[i] = qp;
+                else
+                    m_q[i] = linear(i, s);
+                m_pos[i] += s;
+            }
+        }
+    }
+
+    // Whether the estimator has seen the >=5 samples needed to bootstrap.
+    bool ready() const { return m_bootstrapped; }
+
+    // Best-effort estimate of the tracked quantile. Before bootstrap it
+    // sorts the (<=5) buffered samples in place; callers that care about
+    // stability should gate on ready().
+    double value() const
+    {
+        if (m_bootstrapped) return m_q[2];
+        if (m_n == 0) return 0.0;
+        // Manual selection sort over a bounded prefix — keeps GCC's
+        // array-bounds analysis happy under -Werror.
+        double tmp[5] = {0, 0, 0, 0, 0};
+        const int n = (m_n < 5) ? m_n : 5;
+        for (int i = 0; i < n; ++i) tmp[i] = m_init_buf[i];
+        for (int i = 0; i + 1 < n; ++i)
+        {
+            int best = i;
+            for (int j = i + 1; j < n; ++j)
+                if (tmp[j] < tmp[best]) best = j;
+            if (best != i)
+            {
+                double t = tmp[i]; tmp[i] = tmp[best]; tmp[best] = t;
+            }
+        }
+        int idx = static_cast<int>(std::round(m_p * (n - 1)));
+        if (idx < 0) idx = 0;
+        if (idx > n - 1) idx = n - 1;
+        return tmp[idx];
+    }
+
+    void reset()
+    {
+        m_n = 0;
+        m_bootstrapped = false;
+        for (int i = 0; i < 5; ++i)
+        {
+            m_q[i] = 0.0;
+            m_pos[i] = 0.0;
+            m_np[i] = 0.0;
+            m_dn[i] = 0.0;
+            m_init_buf[i] = 0.0;
+        }
+    }
+
+private:
+    double parabolic(int i, int s) const
+    {
+        double t1 = static_cast<double>(s) / (m_pos[i + 1] - m_pos[i - 1]);
+        double t2 = (m_pos[i] - m_pos[i - 1] + s) * (m_q[i + 1] - m_q[i])
+                    / (m_pos[i + 1] - m_pos[i]);
+        double t3 = (m_pos[i + 1] - m_pos[i] - s) * (m_q[i] - m_q[i - 1])
+                    / (m_pos[i] - m_pos[i - 1]);
+        return m_q[i] + t1 * (t2 + t3);
+    }
+
+    double linear(int i, int s) const
+    {
+        return m_q[i] + s * (m_q[i + s] - m_q[i]) / (m_pos[i + s] - m_pos[i]);
+    }
+
+    double m_p;
+    double m_q[5]        = {0, 0, 0, 0, 0};   // marker heights
+    double m_pos[5]      = {0, 0, 0, 0, 0};   // current marker positions (1-based)
+    double m_np[5]       = {0, 0, 0, 0, 0};   // desired positions
+    double m_dn[5]       = {0, 0, 0, 0, 0};   // desired position increments
+    double m_init_buf[5] = {0, 0, 0, 0, 0};
+    int    m_n            = 0;
+    bool   m_bootstrapped = false;
+};
+
+struct ExecutorStat
+{
+    // Don't classify outliers until P² has seen enough samples for the
+    // IQR estimate to stabilize. Until then the bootstrap markers can
+    // collapse to identical heights (IQR=0) and the Tukey rule flags
+    // every non-equal sample as an outlier.
+    static constexpr uint64_t OUTLIER_WARMUP = 30;
+
+    // ---------- Per-run wall-clock duration ----------
+    uint64_t count    = 0;
+    uint64_t total_ns = 0;
+    uint64_t max_ns   = 0;
+
+    // Robust quantile estimators for run time. The median is what the
+    // CLI reports as the headline number; q1/q3 also drive the Tukey
+    // rule and feed the show table's quartile column.
+    P2Quantile q1{0.25};
+    P2Quantile median{0.50};
+    P2Quantile q3{0.75};
+
+    // Tukey 1.5*IQR outlier counts: x > Q3 + 1.5*IQR (high) or
+    // x < Q1 - 1.5*IQR (low). Classified before the new sample is folded
+    // into the estimators so the estimators self-converge regardless.
+    uint64_t high_outliers = 0;
+    uint64_t low_outliers  = 0;
+
+    // ---------- Scheduling latency ----------
+    // Time between the previous run's TaskTimer dtor (i.e. when this
+    // Executor finished the last run() and yielded back to the select
+    // loop) and the next TaskTimer ctor (next time the loop scheduled
+    // it). 0 = "no prior return yet"; uses steady_clock ticks so only
+    // the delta matters.
+    uint64_t last_return_ns = 0;
+    uint64_t sched_count    = 0;
+    uint64_t total_sched_ns = 0;
+    uint64_t sched_max_ns   = 0;
+    P2Quantile sched_q1{0.25};
+    P2Quantile sched_median{0.50};
+    P2Quantile sched_q3{0.75};
+
+    void record_run(uint64_t ns)
+    {
+        ++count;
+        total_ns += ns;
+        if (ns > max_ns) max_ns = ns;
+
+        if (count >= OUTLIER_WARMUP && median.ready())
+        {
+            double q1v = q1.value();
+            double q3v = q3.value();
+            double iqr = q3v - q1v;
+            double xd  = static_cast<double>(ns);
+            if (iqr > 0.0)
+            {
+                if (xd > q3v + 1.5 * iqr)      ++high_outliers;
+                else if (xd < q1v - 1.5 * iqr) ++low_outliers;
+            }
+        }
+
+        double xd = static_cast<double>(ns);
+        q1.add(xd);
+        median.add(xd);
+        q3.add(xd);
+    }
+
+    void record_sched(uint64_t ns)
+    {
+        ++sched_count;
+        total_sched_ns += ns;
+        if (ns > sched_max_ns) sched_max_ns = ns;
+        double xd = static_cast<double>(ns);
+        sched_q1.add(xd);
+        sched_median.add(xd);
+        sched_q3.add(xd);
+    }
+
+    // Backwards-compatible name kept for any caller still on the old
+    // single-record path; equivalent to record_run().
+    void record(uint64_t ns) { record_run(ns); }
+
+    void reset()
+    {
+        count = 0;
+        total_ns = 0;
+        max_ns = 0;
+        q1.reset();
+        median.reset();
+        q3.reset();
+        high_outliers = 0;
+        low_outliers  = 0;
+
+        last_return_ns = 0;
+        sched_count    = 0;
+        total_sched_ns = 0;
+        sched_max_ns   = 0;
+        sched_q1.reset();
+        sched_median.reset();
+        sched_q3.reset();
+    }
+};
+
+class TaskTimer
+{
+public:
+    explicit TaskTimer(ExecutorStat& slot)
+        : t0_(std::chrono::steady_clock::now()), slot_(slot)
+    {
+        // Scheduling latency: gap between the previous run's dtor
+        // (last_return_ns) and now (t0_). Skip on the first invocation
+        // for a given slot — there's no "previous" yet.
+        if (slot_.last_return_ns != 0)
+        {
+            uint64_t now_ns = static_cast<uint64_t>(
+                std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    t0_.time_since_epoch()).count());
+            if (now_ns > slot_.last_return_ns)
+            {
+                slot_.record_sched(now_ns - slot_.last_return_ns);
+            }
+        }
+    }
+
+    ~TaskTimer()
+    {
+        auto end_tp = std::chrono::steady_clock::now();
+        uint64_t run_ns = static_cast<uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(
+                end_tp - t0_).count());
+        slot_.record_run(run_ns);
+        slot_.last_return_ns = static_cast<uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(
+                end_tp.time_since_epoch()).count());
+    }
+
+    TaskTimer(const TaskTimer&) = delete;
+    TaskTimer& operator=(const TaskTimer&) = delete;
+
+private:
+    std::chrono::steady_clock::time_point t0_;
+    ExecutorStat& slot_;
+};
 
 class OrchDaemon
 {
@@ -133,6 +433,19 @@ protected:
     std::vector<Orch *> m_orchList;
     Select *m_select;
     std::chrono::time_point<std::chrono::high_resolution_clock> m_lastHeartBeat;
+
+    // Per-Executor / inline-operation timing stats. Single-threaded:
+    // mutated only from the main select loop (instrumentation + query
+    // handler), so no atomics are needed.
+    std::unordered_map<std::string, ExecutorStat> m_taskStats;
+
+    // Notification channel plumbing for `show/clear orchagent tasks`.
+    std::unique_ptr<swss::DBConnector>           m_taskStatsDb;
+    std::unique_ptr<swss::NotificationConsumer>  m_taskStatsQuery;
+    std::unique_ptr<swss::NotificationProducer>  m_taskStatsReply;
+
+    void initTaskStatsChannel();
+    void handleTaskStatsQuery();
 
     void flush();
 

--- a/tests/mock_tests/orchdaemon_ut.cpp
+++ b/tests/mock_tests/orchdaemon_ut.cpp
@@ -5,8 +5,11 @@
 #include "dbconnector.h"
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <random>
+#include <thread>
 #include "mock_sai_switch.h"
 #include "saihelper.h"
+#include "json.h"
 
 #include <csignal>
 
@@ -14,6 +17,10 @@ extern sai_switch_api_t* sai_switch_api;
 sai_switch_api_t test_sai_switch;
 
 extern volatile sig_atomic_t gOrchShutdownRequested;
+
+// Global mock-hiredis reply used to feed pub/sub notification messages into a
+// NotificationConsumer (see tests/mock_tests/mock_hiredis.cpp).
+extern redisReply *mockReply;
 
 namespace orchdaemon_test
 {
@@ -59,6 +66,294 @@ namespace orchdaemon_test
         EXPECT_CALL(mock_sai_switch_, set_switch_attribute( _, _)).WillOnce(Return(SAI_STATUS_SUCCESS));
 
         orchd->logRotate();
+    }
+
+    TEST(ExecutorStatTest, RecordAndReset)
+    {
+        ExecutorStat s;
+
+        // Empty state.
+        EXPECT_EQ(s.count, 0u);
+        EXPECT_EQ(s.total_ns, 0u);
+        EXPECT_EQ(s.max_ns, 0u);
+
+        // First sample sets count/total/max.
+        s.record(50);
+        EXPECT_EQ(s.count, 1u);
+        EXPECT_EQ(s.total_ns, 50u);
+        EXPECT_EQ(s.max_ns, 50u);
+
+        // Subsequent samples track the running max.
+        s.record(10);
+        s.record(200);
+        s.record(75);
+        EXPECT_EQ(s.count, 4u);
+        EXPECT_EQ(s.total_ns, 50u + 10u + 200u + 75u);
+        EXPECT_EQ(s.max_ns, 200u);
+
+        // Reset returns to empty state.
+        s.reset();
+        EXPECT_EQ(s.count, 0u);
+        EXPECT_EQ(s.total_ns, 0u);
+        EXPECT_EQ(s.max_ns, 0u);
+
+        // Recording after reset behaves like a fresh slot.
+        s.record(7);
+        EXPECT_EQ(s.count, 1u);
+        EXPECT_EQ(s.max_ns, 7u);
+    }
+
+    TEST(ExecutorStatTest, FieldValueTupleRoundTrip)
+    {
+        // Serialize → deserialize using the same 14-field pipe-separated
+        // format OrchDaemon::handleTaskStatsQuery() / show orchagent
+        // tasks use:
+        //   count | total_run_ns
+        //   | median_run_ns | q1_run_ns | q3_run_ns | max_run_ns
+        //   | high_outliers | low_outliers
+        //   | sched_count | total_sched_ns
+        //   | median_sched_ns | q1_sched_ns | q3_sched_ns | max_sched_ns
+        std::unordered_map<std::string, ExecutorStat> stats;
+
+        auto &port = stats["PortsOrch"];
+        // Seven run samples so median P² is bootstrapped (>=5).
+        for (uint64_t v : {100ull, 110ull, 105ull, 95ull, 100ull, 102ull, 98ull})
+            port.record_run(v);
+        // Six sched samples so the sched P² is also bootstrapped.
+        for (uint64_t v : {50ull, 60ull, 55ull, 45ull, 52ull, 58ull})
+            port.record_sched(v);
+
+        auto &flush = stats["flush"];
+        flush.record_run(1000);
+
+        // Empty slot to confirm count==0 path: sentinels must come out
+        // as 0 on the wire (otherwise the CLI would print UINT64_MAX).
+        stats["NeverRan"];
+
+        auto round_p2 = [](double v) -> uint64_t
+        {
+            return static_cast<uint64_t>(v < 0.0 ? 0.0 : v + 0.5);
+        };
+
+        std::vector<swss::FieldValueTuple> fvs;
+        for (auto &kv : stats)
+        {
+            auto &s = kv.second;
+            uint64_t med_run = (s.count == 0) ? 0 : round_p2(s.median.value());
+            uint64_t q1_run  = (s.count == 0) ? 0 : round_p2(s.q1.value());
+            uint64_t q3_run  = (s.count == 0) ? 0 : round_p2(s.q3.value());
+            uint64_t med_sc  = (s.sched_count == 0) ? 0 : round_p2(s.sched_median.value());
+            uint64_t q1_sc   = (s.sched_count == 0) ? 0 : round_p2(s.sched_q1.value());
+            uint64_t q3_sc   = (s.sched_count == 0) ? 0 : round_p2(s.sched_q3.value());
+
+            std::string v = std::to_string(s.count) + "|"
+                          + std::to_string(s.total_ns) + "|"
+                          + std::to_string(med_run) + "|"
+                          + std::to_string(q1_run) + "|"
+                          + std::to_string(q3_run) + "|"
+                          + std::to_string(s.max_ns) + "|"
+                          + std::to_string(s.high_outliers) + "|"
+                          + std::to_string(s.low_outliers) + "|"
+                          + std::to_string(s.sched_count) + "|"
+                          + std::to_string(s.total_sched_ns) + "|"
+                          + std::to_string(med_sc) + "|"
+                          + std::to_string(q1_sc) + "|"
+                          + std::to_string(q3_sc) + "|"
+                          + std::to_string(s.sched_max_ns);
+            fvs.emplace_back(kv.first, v);
+        }
+
+        struct Parsed {
+            uint64_t count, total_ns;
+            uint64_t median_run_ns, q1_run_ns, q3_run_ns, max_run_ns;
+            uint64_t high_outliers, low_outliers;
+            uint64_t sched_count, total_sched_ns;
+            uint64_t median_sched_ns, q1_sched_ns, q3_sched_ns, max_sched_ns;
+        };
+        std::unordered_map<std::string, Parsed> parsed;
+        for (const auto &fv : fvs)
+        {
+            const std::string &k = fvField(fv);
+            const std::string &v = fvValue(fv);
+
+            std::vector<std::string> parts;
+            size_t start = 0;
+            while (start <= v.size())
+            {
+                size_t end = v.find('|', start);
+                if (end == std::string::npos) end = v.size();
+                parts.emplace_back(v.substr(start, end - start));
+                start = end + 1;
+            }
+            ASSERT_EQ(parts.size(), 14u);
+
+            Parsed p;
+            p.count           = std::stoull(parts[0]);
+            p.total_ns        = std::stoull(parts[1]);
+            p.median_run_ns   = std::stoull(parts[2]);
+            p.q1_run_ns       = std::stoull(parts[3]);
+            p.q3_run_ns       = std::stoull(parts[4]);
+            p.max_run_ns      = std::stoull(parts[5]);
+            p.high_outliers   = std::stoull(parts[6]);
+            p.low_outliers    = std::stoull(parts[7]);
+            p.sched_count     = std::stoull(parts[8]);
+            p.total_sched_ns  = std::stoull(parts[9]);
+            p.median_sched_ns = std::stoull(parts[10]);
+            p.q1_sched_ns     = std::stoull(parts[11]);
+            p.q3_sched_ns     = std::stoull(parts[12]);
+            p.max_sched_ns    = std::stoull(parts[13]);
+            parsed[k] = p;
+        }
+
+        ASSERT_EQ(parsed.size(), stats.size());
+
+        EXPECT_EQ(parsed["PortsOrch"].count, 7u);
+        EXPECT_EQ(parsed["PortsOrch"].total_ns, 100u + 110u + 105u + 95u + 100u + 102u + 98u);
+        EXPECT_EQ(parsed["PortsOrch"].max_run_ns, 110u);
+        // Median of {95, 98, 100, 100, 102, 105, 110} is 100. With only
+        // 5–7 samples P² is rough; allow a generous band.
+        EXPECT_GE(parsed["PortsOrch"].median_run_ns, 90u);
+        EXPECT_LE(parsed["PortsOrch"].median_run_ns, 110u);
+        // <30 samples (OUTLIER_WARMUP) -> classifier disabled.
+        EXPECT_EQ(parsed["PortsOrch"].high_outliers, 0u);
+        EXPECT_EQ(parsed["PortsOrch"].low_outliers,  0u);
+
+        EXPECT_EQ(parsed["PortsOrch"].sched_count, 6u);
+        EXPECT_EQ(parsed["PortsOrch"].total_sched_ns,
+                  50u + 60u + 55u + 45u + 52u + 58u);
+        EXPECT_EQ(parsed["PortsOrch"].max_sched_ns, 60u);
+        EXPECT_GE(parsed["PortsOrch"].median_sched_ns, 40u);
+        EXPECT_LE(parsed["PortsOrch"].median_sched_ns, 65u);
+
+        EXPECT_EQ(parsed["flush"].count, 1u);
+        EXPECT_EQ(parsed["flush"].total_ns, 1000u);
+        EXPECT_EQ(parsed["flush"].max_run_ns, 1000u);
+        EXPECT_EQ(parsed["flush"].median_run_ns, 1000u);
+        EXPECT_EQ(parsed["flush"].sched_count, 0u);
+        EXPECT_EQ(parsed["flush"].total_sched_ns, 0u);
+        EXPECT_EQ(parsed["flush"].median_sched_ns, 0u);
+
+        EXPECT_EQ(parsed["NeverRan"].count, 0u);
+        EXPECT_EQ(parsed["NeverRan"].total_ns, 0u);
+        EXPECT_EQ(parsed["NeverRan"].median_run_ns, 0u);
+        EXPECT_EQ(parsed["NeverRan"].max_run_ns, 0u);
+        EXPECT_EQ(parsed["NeverRan"].high_outliers, 0u);
+        EXPECT_EQ(parsed["NeverRan"].low_outliers,  0u);
+        EXPECT_EQ(parsed["NeverRan"].sched_count, 0u);
+        EXPECT_EQ(parsed["NeverRan"].total_sched_ns, 0u);
+        EXPECT_EQ(parsed["NeverRan"].max_sched_ns, 0u);
+    }
+
+    TEST(TaskTimerTest, RecordsSchedLatencyAfterFirstRun)
+    {
+        // First TaskTimer instance: no prior return, so sched_count
+        // stays 0. Second instance arrives some time later and records
+        // a non-zero sched-latency sample.
+        ExecutorStat s;
+
+        {
+            TaskTimer t(s);
+            std::this_thread::sleep_for(std::chrono::microseconds(50));
+        }
+        EXPECT_EQ(s.count, 1u);
+        EXPECT_EQ(s.sched_count, 0u);   // first run has no "previous"
+        EXPECT_GT(s.last_return_ns, 0u);
+
+        // Sleep so there's a measurable gap between dtor and ctor.
+        std::this_thread::sleep_for(std::chrono::microseconds(200));
+
+        {
+            TaskTimer t(s);
+            std::this_thread::sleep_for(std::chrono::microseconds(50));
+        }
+        EXPECT_EQ(s.count, 2u);
+        EXPECT_EQ(s.sched_count, 1u);
+        EXPECT_GT(s.sched_max_ns, 0u);
+    }
+
+    TEST(P2QuantileTest, MedianConvergesOnUniform)
+    {
+        // P² (Jain & Chlamtac) is approximate. Feed a deterministic,
+        // pseudo-random uniform stream over [0, 9999] and check the
+        // median estimate is within a sensible tolerance of the true
+        // median (~4999.5).
+        P2Quantile median(0.5);
+        std::mt19937 gen(42);
+        std::uniform_int_distribution<int> dist(0, 9999);
+        for (int i = 0; i < 10000; ++i)
+            median.add(static_cast<double>(dist(gen)));
+        EXPECT_TRUE(median.ready());
+        EXPECT_NEAR(median.value(), 5000.0, 200.0);
+    }
+
+    TEST(P2QuantileTest, MedianRobustToOutliers)
+    {
+        // 1000 samples uniformly in [95, 105] establish the median ~100.
+        // Add 20 moderate outliers (3x the typical value) — far outside
+        // any reasonable IQR but not pathological. Arithmetic mean would
+        // shift to ~104; the P² median should stay close to 100.
+        //
+        // Note: P² with extreme outliers (e.g. 1e9 in a stream that
+        // averages 100) is known to drift because parabolic
+        // interpolation of q[4] propagates inward. The Tukey-rule
+        // outlier counters handle that scenario; this test pins the
+        // contract that for realistic tail tasks the median tracks the
+        // body of the distribution, not the tail.
+        P2Quantile median(0.5);
+        std::mt19937 gen(42);
+        std::uniform_int_distribution<int> dist(95, 105);
+        for (int i = 0; i < 1000; ++i) median.add(static_cast<double>(dist(gen)));
+        for (int i = 0; i < 20;   ++i) median.add(300.0);
+        EXPECT_TRUE(median.ready());
+        EXPECT_NEAR(median.value(), 100.0, 10.0);
+    }
+
+    TEST(ExecutorStatTest, OutlierClassification)
+    {
+        // 200 in-range samples around 100 establish Q1 ~95, Q3 ~105,
+        // IQR ~10, so high cutoff is ~120 and low cutoff is ~80.
+        ExecutorStat s;
+        for (int i = 0; i < 200; ++i)
+        {
+            s.record(static_cast<uint64_t>(95 + (i % 11)));   // 95..105
+        }
+        const uint64_t high_before = s.high_outliers;
+        const uint64_t low_before  = s.low_outliers;
+
+        // Five clear high outliers (way past Q3 + 1.5*IQR).
+        for (int i = 0; i < 5; ++i) s.record(10'000);
+        // Four clear low outliers (well below Q1 - 1.5*IQR; needs to be
+        // negative-ish, but ns is unsigned so use 0).
+        for (int i = 0; i < 4; ++i) s.record(0);
+
+        EXPECT_GE(s.high_outliers - high_before, 5u);
+        EXPECT_GE(s.low_outliers  - low_before,  4u);
+    }
+
+    TEST(ExecutorStatTest, ResetClearsP2)
+    {
+        ExecutorStat s;
+        for (int i = 0; i < 10; ++i) s.record(100);
+        ASSERT_TRUE(s.median.ready());
+        s.reset();
+        EXPECT_FALSE(s.median.ready());
+        EXPECT_EQ(s.high_outliers, 0u);
+        EXPECT_EQ(s.low_outliers,  0u);
+    }
+
+    TEST(TaskTimerTest, RecordsOnDestruction)
+    {
+        ExecutorStat s;
+        EXPECT_EQ(s.count, 0u);
+        {
+            TaskTimer t(s);
+            // Burn a few microseconds so we can assert the timer
+            // recorded a non-zero duration.
+            std::this_thread::sleep_for(std::chrono::microseconds(100));
+        }
+        EXPECT_EQ(s.count, 1u);
+        EXPECT_GT(s.total_ns, 0u);
+        EXPECT_EQ(s.max_ns, s.total_ns);
     }
 
     TEST_F(OrchDaemonTest, ringBuffer)
@@ -299,6 +594,133 @@ namespace orchdaemon_test
         EXPECT_EQ(gMockExitCallCount, 1);
         EXPECT_EQ(gMockExitStatus, 0);
         EXPECT_FALSE(Recorder::Instance().swss.isAsyncEnabled());
+    }
+
+    // Recursively free a UT-only redisReply tree allocated with calloc().
+    // mock_hiredis::redisGetReply() hands out a copy per call (freed by the
+    // RedisReply wrapper), so the original mockReply tree is owned by the test
+    // and must be released here to avoid leaking across the test binary.
+    static void freeMockReplyTree(redisReply *reply)
+    {
+        if (reply == nullptr)
+        {
+            return;
+        }
+        for (size_t i = 0; i < reply->elements; i++)
+        {
+            freeMockReplyTree(reply->element[i]);
+        }
+        free(reply->element);
+        free(reply->str);
+        free(reply);
+    }
+
+    // Feed a single "<op>" notification (no extra field/value pairs) into a
+    // NotificationConsumer's internal queue via the mock-hiredis global reply,
+    // exactly as the other mock_tests inject pub/sub messages. After this
+    // returns, OrchDaemon::handleTaskStatsQuery() can pop() the message
+    // straight off the queue.
+    static void feedTaskStatsQuery(swss::NotificationConsumer *nc, const std::string &op)
+    {
+        // NotificationProducer::send() prepends (op, data) to the value list;
+        // mirror that framing so NotificationConsumer::pop() extracts op.
+        std::vector<swss::FieldValueTuple> framed;
+        framed.emplace_back(op, "");
+        std::string msg = swss::JSon::buildJson(framed);
+
+        mockReply = (redisReply *)calloc(1, sizeof(redisReply));
+        mockReply->type = REDIS_REPLY_ARRAY;
+        mockReply->elements = 3;
+        mockReply->element = (redisReply **)calloc(mockReply->elements, sizeof(redisReply *));
+        mockReply->element[2] = (redisReply *)calloc(1, sizeof(redisReply));
+        mockReply->element[2]->type = REDIS_REPLY_STRING;
+        mockReply->element[2]->str = (char *)calloc(msg.length() + 1, sizeof(char));
+        memcpy(mockReply->element[2]->str, msg.c_str(), msg.length());
+        mockReply->element[2]->len = (int)msg.length();
+
+        nc->readData();
+
+        // Release the test-owned tree and clear the global so the subsequent
+        // reply-producer PUBLISH (which also routes through the mocked
+        // redisGetReply) does not re-parse it.
+        freeMockReplyTree(mockReply);
+        mockReply = nullptr;
+    }
+
+    // initTaskStatsChannel() must wire up the APPL_DB notification channels and
+    // register the query consumer with the daemon's Select. Exercises the
+    // channel-setup path that OrchDaemon::start() runs before the select loop.
+    TEST_F(OrchDaemonTest, TaskStatsChannelInit)
+    {
+        orchd->initTaskStatsChannel();
+
+        // The DB handle and both notification channels must be wired up, and
+        // the query consumer registered with the daemon's Select (addSelectable
+        // is exercised inside initTaskStatsChannel()).
+        ASSERT_NE(orchd->m_taskStatsDb, nullptr);
+        ASSERT_NE(orchd->m_taskStatsQuery, nullptr);
+        ASSERT_NE(orchd->m_taskStatsReply, nullptr);
+    }
+
+    // "show": handleTaskStatsQuery() must serialize every slot in m_taskStats
+    // (both populated and empty) into the reply without mutating the stats.
+    TEST_F(OrchDaemonTest, TaskStatsQueryShow)
+    {
+        orchd->initTaskStatsChannel();
+
+        // A populated slot (>=5 run samples so the P^2 estimators bootstrap and
+        // the median.value() serialization branch runs) plus sched samples...
+        auto &ports = orchd->m_taskStats["PortsOrch"];
+        for (uint64_t v : {100ull, 110ull, 105ull, 95ull, 100ull, 102ull, 98ull})
+            ports.record_run(v);
+        for (uint64_t v : {50ull, 60ull, 55ull, 45ull, 52ull, 58ull})
+            ports.record_sched(v);
+        // ...and an empty slot to cover the count==0 serialization branch.
+        orchd->m_taskStats["NeverRan"];
+
+        feedTaskStatsQuery(orchd->m_taskStatsQuery.get(), "show");
+        orchd->handleTaskStatsQuery();
+
+        // "show" is read-only: the accumulated stats must be untouched.
+        EXPECT_EQ(orchd->m_taskStats["PortsOrch"].count, 7u);
+        EXPECT_EQ(orchd->m_taskStats["PortsOrch"].sched_count, 6u);
+        EXPECT_EQ(orchd->m_taskStats["NeverRan"].count, 0u);
+    }
+
+    // "clear": handleTaskStatsQuery() must reset every slot in place, keeping
+    // the keys but zeroing the counters and P^2 estimators.
+    TEST_F(OrchDaemonTest, TaskStatsQueryClear)
+    {
+        orchd->initTaskStatsChannel();
+
+        auto &ports = orchd->m_taskStats["PortsOrch"];
+        for (int i = 0; i < 10; ++i) ports.record_run(100);
+        ASSERT_EQ(orchd->m_taskStats["PortsOrch"].count, 10u);
+        ASSERT_TRUE(orchd->m_taskStats["PortsOrch"].median.ready());
+
+        feedTaskStatsQuery(orchd->m_taskStatsQuery.get(), "clear");
+        orchd->handleTaskStatsQuery();
+
+        // Slot key retained but fully reset.
+        ASSERT_NE(orchd->m_taskStats.find("PortsOrch"), orchd->m_taskStats.end());
+        EXPECT_EQ(orchd->m_taskStats["PortsOrch"].count, 0u);
+        EXPECT_EQ(orchd->m_taskStats["PortsOrch"].total_ns, 0u);
+        EXPECT_FALSE(orchd->m_taskStats["PortsOrch"].median.ready());
+    }
+
+    // An unrecognized op must hit the error branch and leave stats untouched.
+    TEST_F(OrchDaemonTest, TaskStatsQueryUnknownOp)
+    {
+        orchd->initTaskStatsChannel();
+
+        auto &ports = orchd->m_taskStats["PortsOrch"];
+        for (int i = 0; i < 3; ++i) ports.record_run(100);
+
+        feedTaskStatsQuery(orchd->m_taskStatsQuery.get(), "bogus");
+        orchd->handleTaskStatsQuery();
+
+        // Unknown op is a no-op against the stats.
+        EXPECT_EQ(orchd->m_taskStats["PortsOrch"].count, 3u);
     }
 
 }


### PR DESCRIPTION
#### What I did

Add per-Executor wall-clock and scheduling-latency stats to
orchagent, surfaced via a notification channel for a future
`show orchagent tasks` CLI.

- `ExecutorStat`: count/total/max + P^2 quantile estimators
  (Q1/median/Q3) for run time, with a Tukey 1.5*IQR outlier
  classifier (30-sample warmup gate).
- `TaskTimer` (RAII): wraps `Executor::execute()` and the inline
  `flush()` / `logRotate()` call sites in `OrchDaemon::start()`.
  Also records scheduling latency = gap between consecutive runs.
- Two APPL_DB notification channels (`ORCH_TASK_STATS_QUERY` /
  `ORCH_TASK_STATS_REPLY`) handle show/clear on the main thread,
  no atomics needed.
- 8 new mock unit tests for `ExecutorStat`, `P2Quantile`,
  `TaskTimer`.

No functional change to the existing select-loop or Orch logic;
the RAII timers add a small (sub-microsecond) overhead per
Executor dispatch.

#### Why I did it
Incremental step to satisfy the tasks listed in the HLD - https://github.com/sonic-net/SONiC/pull/2328
This improves debug ability when doing interactive debugging. It give improved visibility into the various Executors inside Orchagent.

#### How I verified it

Unit tests:
```
cd tests/mock_tests && make check
```
New tests:
- ExecutorStatTest.RecordAndReset / ResetClearsP2
- ExecutorStatTest.FieldValueTupleRoundTrip
- ExecutorStatTest.OutlierClassification
- P2QuantileTest.MedianConvergesOnUniform
- P2QuantileTest.MedianRobustToOutliers
- TaskTimerTest.RecordsOnDestruction
- TaskTimerTest.RecordsSchedLatencyAfterFirstRun

#### Details if related