### PR TITLE
[HFT] Remove redundant per-direction port stats SAI attributes

### DIFF
--- a/orchagent/high_frequency_telemetry/hftelprofile.cpp
+++ b/orchagent/high_frequency_telemetry/hftelprofile.cpp
@@ -711,14 +711,6 @@ sai_object_id_t HFTelProfile::getTAMTelTypeObjID(sai_object_type_t object_type)
         attr.id = SAI_TAM_TEL_TYPE_ATTR_SWITCH_ENABLE_PORT_STATS;
         attr.value.booldata = true;
         attrs.push_back(attr);
-
-        attr.id = SAI_TAM_TEL_TYPE_ATTR_SWITCH_ENABLE_PORT_STATS_INGRESS;
-        attr.value.booldata = true;
-        attrs.push_back(attr);
-
-        attr.id = SAI_TAM_TEL_TYPE_ATTR_SWITCH_ENABLE_PORT_STATS_EGRESS;
-        attr.value.booldata = true;
-        attrs.push_back(attr);
     }
     else if (object_type == SAI_OBJECT_TYPE_BUFFER_POOL ||
              object_type == SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP)


### PR DESCRIPTION
**What I did**
Remove redundant per-direction port stats SAI attributes

**Why I did it**
SAI_TAM_TEL_TYPE_ATTR_SWITCH_ENABLE_PORT_STATS already covers both ingress and egress, making the explicit
SAI_TAM_TEL_TYPE_ATTR_SWITCH_ENABLE_PORT_STATS_EGRESS and SAI_TAM_TEL_TYPE_ATTR_SWITCH_ENABLE_PORT_STATS_INGRESS attributes redundant. In SINGLE mode only one attribute can be set to true at a time, so setting all three caused a conflict.

**How I verified it**
Run HFT tests

**Details if related**
