### PR TITLE
[sonic-swss] Generic Hash: Add packet-type specific hash configuration support

### DIFF
--- a/orchagent/switch/switch_capabilities.cpp
+++ b/orchagent/switch/switch_capabilities.cpp
@@ -22,6 +22,7 @@ extern "C" {
 
 #include "switch_schema.h"
 #include "switch_capabilities.h"
+#include "switch_helper.h"
 
 using namespace swss;
 
@@ -36,6 +37,11 @@ using namespace swss;
 #define SWITCH_CAPABILITY_ECMP_HASH_ALGORITHM_CAPABLE_FIELD "ECMP_HASH_ALGORITHM_CAPABLE"
 #define SWITCH_CAPABILITY_LAG_HASH_ALGORITHM_FIELD          "LAG_HASH_ALGORITHM"
 #define SWITCH_CAPABILITY_LAG_HASH_ALGORITHM_CAPABLE_FIELD  "LAG_HASH_ALGORITHM_CAPABLE"
+
+#define SWITCH_CAPABILITY_ECMP_PKT_TYPE_HASH_CAPABLE_FIELD  "ECMP_PKT_TYPE_HASH_CAPABLE"
+#define SWITCH_CAPABILITY_LAG_PKT_TYPE_HASH_CAPABLE_FIELD   "LAG_PKT_TYPE_HASH_CAPABLE"
+#define SWITCH_CAPABILITY_HASH_ECMP_PKT_TYPE_LIST_FIELD     "HASH|ECMP_PKT_TYPE_LIST"
+#define SWITCH_CAPABILITY_HASH_LAG_PKT_TYPE_LIST_FIELD      "HASH|LAG_PKT_TYPE_LIST"
 
 #define SWITCH_CAPABILITY_KEY "switch"
 
@@ -64,7 +70,9 @@ static const std::unordered_map<sai_native_hash_field_t, std::string> swHashHash
     { SAI_NATIVE_HASH_FIELD_INNER_SRC_IP,      SWITCH_HASH_FIELD_INNER_SRC_IP      },
     { SAI_NATIVE_HASH_FIELD_INNER_L4_DST_PORT, SWITCH_HASH_FIELD_INNER_L4_DST_PORT },
     { SAI_NATIVE_HASH_FIELD_INNER_L4_SRC_PORT, SWITCH_HASH_FIELD_INNER_L4_SRC_PORT },
-    { SAI_NATIVE_HASH_FIELD_IPV6_FLOW_LABEL,   SWITCH_HASH_FIELD_IPV6_FLOW_LABEL   }
+    { SAI_NATIVE_HASH_FIELD_IPV6_FLOW_LABEL,   SWITCH_HASH_FIELD_IPV6_FLOW_LABEL   },
+    { SAI_NATIVE_HASH_FIELD_RDMA_BTH_OPCODE,   SWITCH_HASH_FIELD_RDMA_BTH_OPCODE   },
+    { SAI_NATIVE_HASH_FIELD_RDMA_BTH_DEST_QP,  SWITCH_HASH_FIELD_RDMA_BTH_DEST_QP  }
 };
 
 static const std::unordered_map<sai_hash_algorithm_t, std::string> swHashAlgorithmMap =
@@ -137,6 +145,18 @@ static std::string toStr(const std::set<sai_hash_algorithm_t> &value)
     return join(",", strList.cbegin(), strList.cend());
 }
 
+static std::string toPktTypeListStr(const std::set<HashPktType>& pktTypeList)
+{
+    std::vector<std::string> names;
+
+    for (auto pktType : pktTypeList)
+    {
+        names.push_back(hashPktTypeToString(pktType));
+    }
+
+    return names.empty() ? "N/A" : join(",", names.cbegin(), names.cend());
+}
+
 static std::string toStr(bool value)
 {
     return value ? "true" : "false";
@@ -176,6 +196,22 @@ bool SwitchCapabilities::isSwitchLagHashSupported() const
     const auto &lagHash = switchCapabilities.lagHash;
 
     return nativeHashFieldList.isAttrSupported && lagHash.isAttrSupported;
+}
+
+bool SwitchCapabilities::isSwitchEcmpPktTypeHashSupported() const
+{
+    const auto &nativeHashFieldList = hashCapabilities.nativeHashFieldList;
+    const auto &ecmpPktTypeHashCapable = switchCapabilities.ecmpPktTypeHashCapable;
+
+    return nativeHashFieldList.isAttrSupported && ecmpPktTypeHashCapable;
+}
+
+bool SwitchCapabilities::isSwitchLagPktTypeHashSupported() const
+{
+    const auto &nativeHashFieldList = hashCapabilities.nativeHashFieldList;
+    const auto &lagPktTypeHashCapable = switchCapabilities.lagPktTypeHashCapable;
+
+    return nativeHashFieldList.isAttrSupported && lagPktTypeHashCapable;
 }
 
 bool SwitchCapabilities::isSwitchEcmpHashAlgorithmSupported() const
@@ -250,6 +286,31 @@ bool SwitchCapabilities::validateSwitchHashAlgorithmCap(const T &obj, sai_hash_a
     return true;
 }
 
+bool SwitchCapabilities::validatePktTypeHashCap(const std::set<HashPktType> &supportedTypes, HashPktType pktType) const
+{
+    SWSS_LOG_ENTER();
+
+    if (supportedTypes.count(pktType) == 0)
+    {
+        SWSS_LOG_ERROR("Failed to validate hash packet type: value %d (%s) is not supported.",
+                       static_cast<int>(pktType),
+                       hashPktTypeToString(pktType).c_str());
+        return false;
+    }
+
+    return true;
+}
+
+bool SwitchCapabilities::validateSwitchEcmpPktTypeHashCap(HashPktType pktType) const
+{
+    return validatePktTypeHashCap(switchCapabilities.ecmpPktTypeList, pktType);
+}
+
+bool SwitchCapabilities::validateSwitchLagPktTypeHashCap(HashPktType pktType) const
+{
+    return validatePktTypeHashCap(switchCapabilities.lagPktTypeList, pktType);
+}
+
 FieldValueTuple SwitchCapabilities::makeHashFieldCapDbEntry() const
 {
     const auto &nativeHashFieldList = hashCapabilities.nativeHashFieldList;
@@ -310,6 +371,38 @@ std::vector<FieldValueTuple> SwitchCapabilities::makeLagHashAlgorithmCapDbEntry(
     );
 
     return fvList;
+}
+
+FieldValueTuple SwitchCapabilities::makeEcmpPktTypeHashCapDbEntry() const
+{
+    auto field = SWITCH_CAPABILITY_ECMP_PKT_TYPE_HASH_CAPABLE_FIELD;
+    auto value = toStr(isSwitchEcmpPktTypeHashSupported());
+
+    return FieldValueTuple(field, value);
+}
+
+FieldValueTuple SwitchCapabilities::makeLagPktTypeHashCapDbEntry() const
+{
+    auto field = SWITCH_CAPABILITY_LAG_PKT_TYPE_HASH_CAPABLE_FIELD;
+    auto value = toStr(isSwitchLagPktTypeHashSupported());
+
+    return FieldValueTuple(field, value);
+}
+
+FieldValueTuple SwitchCapabilities::makeEcmpPktTypeListDbEntry() const
+{
+    auto field = SWITCH_CAPABILITY_HASH_ECMP_PKT_TYPE_LIST_FIELD;
+    auto value = toPktTypeListStr(switchCapabilities.ecmpPktTypeList);
+
+    return FieldValueTuple(field, value);
+}
+
+FieldValueTuple SwitchCapabilities::makeLagPktTypeListDbEntry() const
+{
+    auto field = SWITCH_CAPABILITY_HASH_LAG_PKT_TYPE_LIST_FIELD;
+    auto value = toPktTypeListStr(switchCapabilities.lagPktTypeList);
+
+    return FieldValueTuple(field, value);
 }
 
 sai_status_t SwitchCapabilities::queryEnumCapabilitiesSai(std::vector<sai_int32_t> &capList, sai_object_type_t objType, sai_attr_id_t attrId) const
@@ -387,6 +480,39 @@ void SwitchCapabilities::queryHashNativeHashFieldListAttrCapabilities()
     }
 
     hashCapabilities.nativeHashFieldList.isAttrSupported = true;
+}
+
+bool SwitchCapabilities::isHashObjectPktTypeCapable() const
+{
+    SWSS_LOG_ENTER();
+
+    sai_attr_capability_t attrCap{};
+
+    auto status = queryAttrCapabilitiesSai(
+        attrCap, SAI_OBJECT_TYPE_HASH, SAI_HASH_ATTR_NATIVE_HASH_FIELD_LIST
+    );
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_WARN(
+            "Failed to get attribute(%s) capabilities for packet-type hash",
+            toStr(SAI_OBJECT_TYPE_HASH, SAI_HASH_ATTR_NATIVE_HASH_FIELD_LIST).c_str()
+        );
+        return false;
+    }
+
+    if (!attrCap.create_implemented || !attrCap.set_implemented)
+    {
+        SWSS_LOG_NOTICE(
+            "Packet-type hash requires HASH attribute(%s) CREATE/SET support, but got "
+            "create_implemented=%d set_implemented=%d; disabling packet-type hash",
+            toStr(SAI_OBJECT_TYPE_HASH, SAI_HASH_ATTR_NATIVE_HASH_FIELD_LIST).c_str(),
+            attrCap.create_implemented,
+            attrCap.set_implemented
+        );
+        return false;
+    }
+
+    return true;
 }
 
 void SwitchCapabilities::queryHashCapabilities()
@@ -567,6 +693,128 @@ void SwitchCapabilities::querySwitchLagHashAlgorithmAttrCapabilities()
     switchCapabilities.lagHashAlgorithm.isAttrSupported = true;
 }
 
+void SwitchCapabilities::querySwitchEcmpHashPktTypeCapabilities()
+{
+    SWSS_LOG_ENTER();
+
+    // Verify that HASH object can be created and set
+    if (!isHashObjectPktTypeCapable())
+    {
+        SWSS_LOG_NOTICE("HASH object is not packet-type capable; disabling ECMP packet-type hash");
+        switchCapabilities.ecmpPktTypeHashCapable = false;
+        switchCapabilities.ecmpPktTypeList.clear();
+        return;
+    }
+
+    struct AttrMapEntry {
+        sai_attr_id_t attrId;
+        HashPktType pktType;
+    };
+
+    // List all ECMP hash packet type attributes and their corresponding enum
+    const std::vector<AttrMapEntry> attrMap = {
+        {SAI_SWITCH_ATTR_ECMP_HASH_IPV4, HashPktType::IPV4},
+        {SAI_SWITCH_ATTR_ECMP_HASH_IPV6, HashPktType::IPV6},
+        {SAI_SWITCH_ATTR_ECMP_HASH_IPV4_IN_IPV4, HashPktType::IPNIP},
+        {SAI_SWITCH_ATTR_ECMP_HASH_IPV4_RDMA, HashPktType::IPV4_RDMA},
+        {SAI_SWITCH_ATTR_ECMP_HASH_IPV6_RDMA, HashPktType::IPV6_RDMA}
+    };
+
+    bool foundAny = false;
+    for (const auto& entry : attrMap)
+    {
+        sai_attr_capability_t attrCap;
+        auto status = queryAttrCapabilitiesSai(attrCap, SAI_OBJECT_TYPE_SWITCH, entry.attrId);
+
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_WARN(
+                "Failed to get ECMP hash packet type attribute(%s) capabilities",
+                toStr(SAI_OBJECT_TYPE_SWITCH, entry.attrId).c_str()
+            );
+            continue;
+        }
+
+        if (attrCap.set_implemented)
+        {
+            // Mark capability and insert supported packet type
+            switchCapabilities.ecmpPktTypeList.insert(entry.pktType);
+            foundAny = true;
+        }
+        else
+        {
+            SWSS_LOG_WARN(
+                "Attribute(%s) SET is not implemented in SAI",
+                toStr(SAI_OBJECT_TYPE_SWITCH, entry.attrId).c_str()
+            );
+        }
+    }
+
+    // Set flag if at least one packet type is supported
+    switchCapabilities.ecmpPktTypeHashCapable = foundAny;
+}
+
+void SwitchCapabilities::querySwitchLagHashPktTypeCapabilities()
+{
+    SWSS_LOG_ENTER();
+
+    // Verify that HASH object can be created and set
+    if (!isHashObjectPktTypeCapable())
+    {
+        SWSS_LOG_NOTICE("HASH object is not packet-type capable; disabling LAG packet-type hash");
+        switchCapabilities.lagPktTypeHashCapable = false;
+        switchCapabilities.lagPktTypeList.clear();
+        return;
+    }
+
+    struct AttrMapEntry {
+        sai_attr_id_t attrId;
+        HashPktType pktType;
+    };
+
+    // List all LAG hash packet type attributes and their corresponding enum
+    const std::vector<AttrMapEntry> attrMap = {
+        {SAI_SWITCH_ATTR_LAG_HASH_IPV4, HashPktType::IPV4},
+        {SAI_SWITCH_ATTR_LAG_HASH_IPV6, HashPktType::IPV6},
+        {SAI_SWITCH_ATTR_LAG_HASH_IPV4_IN_IPV4, HashPktType::IPNIP},
+        {SAI_SWITCH_ATTR_LAG_HASH_IPV4_RDMA, HashPktType::IPV4_RDMA},
+        {SAI_SWITCH_ATTR_LAG_HASH_IPV6_RDMA, HashPktType::IPV6_RDMA}
+    };
+
+    bool foundAny = false;
+    for (const auto& entry : attrMap)
+    {
+        sai_attr_capability_t attrCap;
+        auto status = queryAttrCapabilitiesSai(attrCap, SAI_OBJECT_TYPE_SWITCH, entry.attrId);
+
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_WARN(
+                "Failed to get LAG hash packet type attribute(%s) capabilities",
+                toStr(SAI_OBJECT_TYPE_SWITCH, entry.attrId).c_str()
+            );
+            continue;
+        }
+
+        if (attrCap.set_implemented)
+        {
+            // Mark capability and insert supported packet type
+            switchCapabilities.lagPktTypeList.insert(entry.pktType);
+            foundAny = true;
+        }
+        else
+        {
+            SWSS_LOG_WARN(
+                "Attribute(%s) SET is not implemented in SAI",
+                toStr(SAI_OBJECT_TYPE_SWITCH, entry.attrId).c_str()
+            );
+        }
+    }
+
+    // Set flag if at least one packet type is supported
+    switchCapabilities.lagPktTypeHashCapable = foundAny;
+}
+
 void SwitchCapabilities::querySwitchCapabilities()
 {
     querySwitchEcmpHashAttrCapabilities();
@@ -576,6 +824,9 @@ void SwitchCapabilities::querySwitchCapabilities()
     querySwitchEcmpHashAlgorithmAttrCapabilities();
     querySwitchLagHashAlgorithmEnumCapabilities();
     querySwitchLagHashAlgorithmAttrCapabilities();
+
+    querySwitchEcmpHashPktTypeCapabilities();
+    querySwitchLagHashPktTypeCapabilities();
 }
 
 void SwitchCapabilities::writeHashCapabilitiesToDb()
@@ -600,7 +851,11 @@ void SwitchCapabilities::writeSwitchCapabilitiesToDb()
 
     std::vector<FieldValueTuple> fvList = {
         makeEcmpHashCapDbEntry(),
-        makeLagHashCapDbEntry()
+        makeLagHashCapDbEntry(),
+        makeEcmpPktTypeHashCapDbEntry(),      // ECMP packet type hash support flag
+        makeLagPktTypeHashCapDbEntry(),       // LAG packet type hash support flag
+        makeEcmpPktTypeListDbEntry(),         // ECMP packet type list
+        makeLagPktTypeListDbEntry()           // LAG packet type list
     };
     insertBack(fvList, makeEcmpHashAlgorithmCapDbEntry());
     insertBack(fvList, makeLagHashAlgorithmCapDbEntry());

--- a/orchagent/switch/switch_capabilities.h
+++ b/orchagent/switch/switch_capabilities.h
@@ -13,6 +13,8 @@ extern "C" {
 #include <dbconnector.h>
 #include <table.h>
 
+#include "switch_types.h"
+
 class SwitchCapabilities final
 {
 public:
@@ -25,10 +27,17 @@ public:
     bool isSwitchEcmpHashAlgorithmSupported() const;
     bool isSwitchLagHashAlgorithmSupported() const;
 
+    bool isSwitchEcmpPktTypeHashSupported() const;
+    bool isSwitchLagPktTypeHashSupported() const;
+
     bool validateSwitchHashFieldCap(const std::set<sai_native_hash_field_t> &hfSet) const;
 
     bool validateSwitchEcmpHashAlgorithmCap(sai_hash_algorithm_t haValue) const;
     bool validateSwitchLagHashAlgorithmCap(sai_hash_algorithm_t haValue) const;
+
+    bool validatePktTypeHashCap(const std::set<HashPktType> &supportedTypes, HashPktType pktType) const;
+    bool validateSwitchEcmpPktTypeHashCap(HashPktType pktType) const;
+    bool validateSwitchLagPktTypeHashCap(HashPktType pktType) const;
 
 private:
     template<typename T>
@@ -38,6 +47,11 @@ private:
 
     swss::FieldValueTuple makeEcmpHashCapDbEntry() const;
     swss::FieldValueTuple makeLagHashCapDbEntry() const;
+
+    swss::FieldValueTuple makeEcmpPktTypeHashCapDbEntry() const;
+    swss::FieldValueTuple makeLagPktTypeHashCapDbEntry() const;
+    swss::FieldValueTuple makeEcmpPktTypeListDbEntry() const;
+    swss::FieldValueTuple makeLagPktTypeListDbEntry() const;
 
     std::vector<swss::FieldValueTuple> makeEcmpHashAlgorithmCapDbEntry() const;
     std::vector<swss::FieldValueTuple> makeLagHashAlgorithmCapDbEntry() const;
@@ -55,6 +69,10 @@ private:
     void querySwitchEcmpHashAlgorithmAttrCapabilities();
     void querySwitchLagHashAlgorithmEnumCapabilities();
     void querySwitchLagHashAlgorithmAttrCapabilities();
+
+    bool isHashObjectPktTypeCapable() const;
+    void querySwitchEcmpHashPktTypeCapabilities();
+    void querySwitchLagHashPktTypeCapabilities();
 
     void queryHashCapabilities();
     void querySwitchCapabilities();
@@ -92,6 +110,18 @@ private:
             bool isEnumSupported = false;
             bool isAttrSupported = false;
         } lagHashAlgorithm;
+
+        // ECMP packet type hash capable
+        bool ecmpPktTypeHashCapable = false;
+
+        // LAG packet type hash capable
+        bool lagPktTypeHashCapable = false;
+
+        // Supported packet type capabilities for ECMP
+        std::set<HashPktType> ecmpPktTypeList;
+
+        // Supported packet type capabilities for LAG
+        std::set<HashPktType> lagPktTypeList;
     } switchCapabilities;
 
     static swss::DBConnector stateDb;

--- a/orchagent/switch/switch_container.h
+++ b/orchagent/switch/switch_container.h
@@ -9,16 +9,60 @@ extern "C" {
 #include <set>
 #include <string>
 
+#include "switch_types.h"
+
 class SwitchHash final
 {
 public:
     SwitchHash() = default;
     ~SwitchHash() = default;
 
+    enum class HashFieldState {
+        NOT_SET,        // Attribute not configured
+        SET,            // Attribute has values (add/update)
+        DELETE_ALL      // Remove entire attribute and associated SAI OID
+    };
+
+    struct HashField {
+        std::set<sai_native_hash_field_t> value;
+        HashFieldState state = HashFieldState::NOT_SET;
+
+        void markForDeletion() {
+            value.clear();
+            state = HashFieldState::DELETE_ALL;
+        }
+
+        void setValue(const std::set<sai_native_hash_field_t>& val) {
+            if (val.empty()) {
+                markForDeletion();
+            } else {
+                value = val;
+                state = HashFieldState::SET;
+            }
+        }
+
+        bool isSet() const {
+            return state == HashFieldState::SET;
+        }
+
+        bool isDeleteAll() const {
+            return state == HashFieldState::DELETE_ALL;
+        }
+
+        bool isNotSet() const {
+            return state == HashFieldState::NOT_SET;
+        }
+    };
+
     struct {
         std::set<sai_native_hash_field_t> value;
         bool is_set = false;
     } ecmp_hash;
+
+    // Packet-type specific hash fields
+    std::map<HashPktType, HashField> ecmp_hash_pkt_type;
+    std::map<HashPktType, HashField> lag_hash_pkt_type;
+
 
     struct {
         std::set<sai_native_hash_field_t> value;

--- a/orchagent/switch/switch_helper.cpp
+++ b/orchagent/switch/switch_helper.cpp
@@ -39,7 +39,9 @@ static const std::unordered_map<std::string, sai_native_hash_field_t> swHashHash
     { SWITCH_HASH_FIELD_INNER_SRC_IP,      SAI_NATIVE_HASH_FIELD_INNER_SRC_IP      },
     { SWITCH_HASH_FIELD_INNER_L4_DST_PORT, SAI_NATIVE_HASH_FIELD_INNER_L4_DST_PORT },
     { SWITCH_HASH_FIELD_INNER_L4_SRC_PORT, SAI_NATIVE_HASH_FIELD_INNER_L4_SRC_PORT },
-    { SWITCH_HASH_FIELD_IPV6_FLOW_LABEL,   SAI_NATIVE_HASH_FIELD_IPV6_FLOW_LABEL   }
+    { SWITCH_HASH_FIELD_IPV6_FLOW_LABEL,   SAI_NATIVE_HASH_FIELD_IPV6_FLOW_LABEL   },
+    { SWITCH_HASH_FIELD_RDMA_BTH_OPCODE,   SAI_NATIVE_HASH_FIELD_RDMA_BTH_OPCODE   },
+    { SWITCH_HASH_FIELD_RDMA_BTH_DEST_QP,  SAI_NATIVE_HASH_FIELD_RDMA_BTH_DEST_QP  }
 };
 
 static const std::unordered_map<std::string, sai_hash_algorithm_t> swHashAlgorithmMap =
@@ -65,11 +67,31 @@ void SwitchHelper::setSwHash(const SwitchHash &hash)
     swHash = hash;
 }
 
+void SwitchHelper::setSwHashPacketType(const SwitchHash &hash)
+{
+    SWSS_LOG_ENTER();
+
+    // Update only packet-type fields, preserve global fields
+    swHash.ecmp_hash_pkt_type = hash.ecmp_hash_pkt_type;
+    swHash.lag_hash_pkt_type = hash.lag_hash_pkt_type;
+
+    SWSS_LOG_INFO("Updated packet-type hash cache: ECMP types=%zu, LAG types=%zu",
+                 swHash.ecmp_hash_pkt_type.size(),
+                 swHash.lag_hash_pkt_type.size());
+}
 template<typename T>
 bool SwitchHelper::parseSwHashFieldList(T &obj, const std::string &field, const std::string &value) const
 {
     SWSS_LOG_ENTER();
 
+    // Handle empty value for delete operations
+    if (value.empty())
+    {
+        SWSS_LOG_INFO("Empty value for field(%s): marking for deletion", field.c_str());
+        obj.value.clear();
+        obj.is_set = false;  // Mark as not set (to be deleted)
+        return true;
+    }
     const auto &hfList = tokenize(value, ',');
 
     if (hfList.empty())
@@ -99,6 +121,61 @@ bool SwitchHelper::parseSwHashFieldList(T &obj, const std::string &field, const 
     }
 
     obj.is_set = true;
+
+    return true;
+}
+
+template<typename T> // SwitchHash::HashField
+bool SwitchHelper::parseSwHashPacketTypeFieldList(T &obj, const std::string &field, const std::string &value) const
+{
+    SWSS_LOG_ENTER();
+
+    // Empty value means: delete entire packet-type attribute and remove SAI OID
+    if (value.empty())
+    {
+        SWSS_LOG_NOTICE("Empty value for field(%s): marking for complete deletion (will remove SAI OID)", field.c_str());
+        obj.markForDeletion();
+        return true;
+    }
+
+    const auto &hfList = tokenize(value, ',');
+
+    // Empty list after tokenization also means deletion
+    if (hfList.empty())
+    {
+        SWSS_LOG_NOTICE("Empty field list for field(%s): marking for complete deletion (will remove SAI OID)", field.c_str());
+        obj.markForDeletion();
+        return true;
+    }
+
+    const auto &hfSet = std::unordered_set<std::string>(hfList.cbegin(), hfList.cend());
+
+    if (hfSet.size() != hfList.size())
+    {
+        SWSS_LOG_ERROR("Duplicate hash fields in field(%s): unexpected value(%s)", field.c_str(), value.c_str());
+        return false;
+    }
+
+    std::set<sai_native_hash_field_t> newValue;
+
+    for (const auto &cit1 : hfSet)
+    {
+        const auto &cit2 = swHashHashFieldMap.find(cit1);
+        if (cit2 == swHashHashFieldMap.cend())
+        {
+            SWSS_LOG_ERROR("Failed to parse field(%s): invalid hash field(%s)", field.c_str(), cit1.c_str());
+            return false;
+        }
+
+        newValue.insert(cit2->second);
+    }
+
+    obj.setValue(newValue);
+
+    SWSS_LOG_INFO("Parsed field(%s): state=%s, fields=%zu",
+                  field.c_str(),
+                  obj.isSet() ? "SET" : (obj.isDeleteAll() ? "DELETE_ALL" : "NOT_SET"),
+                  obj.value.size());
 
     return true;
 }
@@ -186,25 +263,87 @@ bool SwitchHelper::parseSwHash(SwitchHash &hash) const
         }
         else
         {
-            SWSS_LOG_WARN("Unknown field(%s): skipping ...", field.c_str());
+            // Try to parse as packet-type field
+            HashPktType pktType;
+            bool isEcmp;
+
+            if (extractHashPktType(field, pktType, isEcmp))
+            {
+                auto &targetMap = isEcmp ? hash.ecmp_hash_pkt_type : hash.lag_hash_pkt_type;
+
+                if (!parseSwHashPacketTypeFieldList(targetMap[pktType], field, value))
+                {
+                    SWSS_LOG_ERROR("Failed to parse packet-type field(%s): value(%s)",
+                                  field.c_str(), value.c_str());
+                    return false;
+                }
+            }
+            else
+            {
+                // Special handling for "NULL" sentinel field used in delete-only updates
+                if (field == "NULL")
+                {
+                    SWSS_LOG_INFO("Skipping synthetic NULL field in packet-type hash delete operation");
+                    continue;
+                }
+                SWSS_LOG_WARN("Unknown field(%s): skipping ...", field.c_str());
+            }
         }
     }
 
-    return validateSwHash(hash);
+    if (!validateSwHash(hash))
+    {
+        SWSS_LOG_ERROR("Validation failed after parsing switch hash");
+        return false;
+    }
+
+    return true;
 }
 
 bool SwitchHelper::validateSwHash(SwitchHash &hash) const
 {
     SWSS_LOG_ENTER();
 
-    auto cond = hash.ecmp_hash.is_set || hash.lag_hash.is_set;
-    cond = cond || hash.ecmp_hash_algorithm.is_set || hash.lag_hash_algorithm.is_set;
+    // Lambda to validate consistency between state and value
+    auto isConsistent = [](const SwitchHash::HashField& field, const std::string& name) -> bool {
+        if (field.isDeleteAll() && !field.value.empty()) {
+            SWSS_LOG_ERROR("Validation error: %s marked for deletion but has non-empty value",
+                          name.c_str());
+            return false;
+        }
+        if (field.isSet() && field.value.empty()) {
+            SWSS_LOG_ERROR("Validation error: %s marked as SET but has empty value",
+                          name.c_str());
+            return false;
+        }
+        return true;
+    };
 
-    if (!cond)
+    // Check ECMP packet-type fields
+    for (const auto &hashEntry : hash.ecmp_hash_pkt_type)
     {
-        SWSS_LOG_ERROR("Validation error: missing valid fields");
-        return false;
+        const auto &pktType = hashEntry.first;
+        const auto &hashField = hashEntry.second;
+
+        std::string fieldName = "ecmp_hash_" + hashPktTypeToString(pktType);
+        if (!isConsistent(hashField, fieldName))
+        {
+            return false;
+        }
     }
 
+    // Check LAG packet-type fields
+    for (const auto &hashEntry : hash.lag_hash_pkt_type)
+    {
+        const auto &pktType = hashEntry.first;
+        const auto &hashField = hashEntry.second;
+
+        std::string fieldName = "lag_hash_" + hashPktTypeToString(pktType);
+        if (!isConsistent(hashField, fieldName))
+        {
+            return false;
+        }
+    }
+    SWSS_LOG_INFO("Switch hash validation successful");
     return true;
 }

--- a/orchagent/switch/switch_helper.h
+++ b/orchagent/switch/switch_helper.h
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include "switch_types.h"
 #include "switch_container.h"
 
 class SwitchHelper final
@@ -12,6 +13,7 @@ public:
 
     const SwitchHash& getSwHash() const;
     void setSwHash(const SwitchHash &hash);
+    void setSwHashPacketType(const SwitchHash &hash);
 
     bool parseSwHash(SwitchHash &hash) const;
 
@@ -25,6 +27,10 @@ private:
     bool parseSwHashLagHash(SwitchHash &hash, const std::string &field, const std::string &value) const;
     bool parseSwHashEcmpHashAlgorithm(SwitchHash &hash, const std::string &field, const std::string &value) const;
     bool parseSwHashLagHashAlgorithm(SwitchHash &hash, const std::string &field, const std::string &value) const;
+
+    // For packet-type variants with state tracking
+    template<typename T>
+    bool parseSwHashPacketTypeFieldList(T &obj, const std::string &field, const std::string &value) const;
 
     bool validateSwHash(SwitchHash &hash) const;
 

--- a/orchagent/switch/switch_schema.h
+++ b/orchagent/switch/switch_schema.h
@@ -21,9 +21,23 @@
 #define SWITCH_HASH_FIELD_INNER_L4_DST_PORT "INNER_L4_DST_PORT"
 #define SWITCH_HASH_FIELD_INNER_L4_SRC_PORT "INNER_L4_SRC_PORT"
 #define SWITCH_HASH_FIELD_IPV6_FLOW_LABEL   "IPV6_FLOW_LABEL"
+#define SWITCH_HASH_FIELD_RDMA_BTH_OPCODE	"RDMA_BTH_OPCODE"
+#define SWITCH_HASH_FIELD_RDMA_BTH_DEST_QP  "RDMA_BTH_DEST_QP"
 
 #define SWITCH_HASH_ECMP_HASH "ecmp_hash"
 #define SWITCH_HASH_LAG_HASH  "lag_hash"
+
+#define SWITCH_HASH_ECMP_HASH_IPV4          "ecmp_hash_ipv4"
+#define SWITCH_HASH_ECMP_HASH_IPV6          "ecmp_hash_ipv6"
+#define SWITCH_HASH_ECMP_HASH_IPNIP         "ecmp_hash_ipnip"
+#define SWITCH_HASH_ECMP_HASH_IPV4_RDMA     "ecmp_hash_ipv4_rdma"
+#define SWITCH_HASH_ECMP_HASH_IPV6_RDMA     "ecmp_hash_ipv6_rdma"
+
+#define SWITCH_HASH_LAG_HASH_IPV4          "lag_hash_ipv4"
+#define SWITCH_HASH_LAG_HASH_IPV6          "lag_hash_ipv6"
+#define SWITCH_HASH_LAG_HASH_IPNIP         "lag_hash_ipnip"
+#define SWITCH_HASH_LAG_HASH_IPV4_RDMA     "lag_hash_ipv4_rdma"
+#define SWITCH_HASH_LAG_HASH_IPV6_RDMA     "lag_hash_ipv6_rdma"
 
 #define SWITCH_HASH_ALGORITHM_CRC       "CRC"
 #define SWITCH_HASH_ALGORITHM_XOR       "XOR"

--- a/orchagent/switch/switch_types.h
+++ b/orchagent/switch/switch_types.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <string>
+#include <map>
+#include <utility>
+#include <algorithm>
+#include <cctype>
+
+// Packet type enum for hash configuration
+enum class HashPktType {
+    IPV4,
+    IPV6,
+    IPNIP,
+    IPV4_RDMA,
+    IPV6_RDMA
+};
+
+// Helper function to convert HashPktType to string
+inline std::string hashPktTypeToString(HashPktType type) {
+    switch (type) {
+        case HashPktType::IPV4: return "ipv4";
+        case HashPktType::IPV6: return "ipv6";
+        case HashPktType::IPNIP: return "ipnip";
+        case HashPktType::IPV4_RDMA: return "ipv4_rdma";
+        case HashPktType::IPV6_RDMA: return "ipv6_rdma";
+        default: return "unknown";
+    }
+}
+
+// Helper function to validate HashPktType
+inline bool isValidHashPktType(HashPktType type)
+{
+    switch (type)
+    {
+        case HashPktType::IPV4:
+        case HashPktType::IPV6:
+        case HashPktType::IPNIP:
+        case HashPktType::IPV4_RDMA:
+        case HashPktType::IPV6_RDMA:
+            return true;
+        default:
+            return false;
+    }
+}
+
+// Helper function to extract packet type from field name
+inline bool extractHashPktType(const std::string &fieldName, HashPktType &pktType, bool &isEcmp) {
+    static const std::map<std::string, std::pair<HashPktType, bool>> fieldToPktTypeMap = {
+        {"ecmp_hash_ipv4", {HashPktType::IPV4, true}},
+        {"ecmp_hash_ipv6", {HashPktType::IPV6, true}},
+        {"ecmp_hash_ipnip", {HashPktType::IPNIP, true}},
+        {"ecmp_hash_ipv4_rdma", {HashPktType::IPV4_RDMA, true}},
+        {"ecmp_hash_ipv6_rdma", {HashPktType::IPV6_RDMA, true}},
+        {"lag_hash_ipv4", {HashPktType::IPV4, false}},
+        {"lag_hash_ipv6", {HashPktType::IPV6, false}},
+        {"lag_hash_ipnip", {HashPktType::IPNIP, false}},
+        {"lag_hash_ipv4_rdma", {HashPktType::IPV4_RDMA, false}},
+        {"lag_hash_ipv6_rdma", {HashPktType::IPV6_RDMA, false}}
+    };
+
+    // Normalize field name to match keys:
+    // - case-insensitive
+    // - treat '-' and '_' equivalently in the suffix
+    std::string key = fieldName;
+    std::transform(key.begin(), key.end(), key.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    std::replace(key.begin(), key.end(), '-', '_');
+
+    auto it = fieldToPktTypeMap.find(key);
+    if (it != fieldToPktTypeMap.end()) {
+        pktType = it->second.first;
+        isEcmp = it->second.second;
+        return true;
+    }
+    return false;
+}

--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -940,6 +940,466 @@ bool SwitchOrch::setSwitchHash(const SwitchHash &hash)
     return true;
 }
 
+bool SwitchOrch::applySwitchPacketTypeHashConfiguration(const SwitchHash &hash)
+{
+    SWSS_LOG_ENTER();
+
+    auto currentConfig = swHlpr.getSwHash();
+    bool configurationChanged = false;
+
+    // We treat the CONFIG_DB row as authoritative for packet-type hash.
+    // Process ECMP/LAG packet-type hashes whenever either the new config
+    // (hash.*_pkt_type) or the current cached config has entries. This
+    // allows us to detect implicit deletions when a packet-type attribute
+    // disappears from CONFIG_DB.
+
+    bool hasEcmpPktTypeCfg = !hash.ecmp_hash_pkt_type.empty() ||
+                              !currentConfig.ecmp_hash_pkt_type.empty();
+
+    bool hasLagPktTypeCfg  = !hash.lag_hash_pkt_type.empty() ||
+                              !currentConfig.lag_hash_pkt_type.empty();
+
+    if (hasEcmpPktTypeCfg)
+    {
+        if (!swCap.isSwitchEcmpPktTypeHashSupported())
+        {
+            SWSS_LOG_WARN("Switch ECMP packet-type hash configuration is not supported: skipping...");
+        }
+        else
+        {
+            if (!processPacketTypeHash(hash, currentConfig, true, configurationChanged))
+            {
+                SWSS_LOG_ERROR("Failed to process ECMP packet-type hash configuration");
+                return false;
+            }
+        }
+    }
+
+    if (hasLagPktTypeCfg)
+    {
+        if (!swCap.isSwitchLagPktTypeHashSupported())
+        {
+            SWSS_LOG_WARN("Switch LAG packet-type hash configuration is not supported: skipping...");
+        }
+        else
+        {
+            if (!processPacketTypeHash(hash, currentConfig, false, configurationChanged))
+            {
+                SWSS_LOG_ERROR("Failed to process LAG packet-type hash configuration");
+                return false;
+            }
+        }
+    }
+
+    if (!configurationChanged)
+    {
+        SWSS_LOG_NOTICE("Switch packet-type hash configuration unchanged in SAI");
+        return true;
+    }
+
+    // Update internal cache for packet-type hashes only
+    swHlpr.setSwHashPacketType(hash);
+
+    SWSS_LOG_NOTICE("Applied switch packet-type hash configuration successfully");
+    return true;
+}
+
+bool SwitchOrch::processPacketTypeHash(const SwitchHash &hash,
+                                       const SwitchHash &currentConfig,
+                                       bool isEcmp,
+                                       bool &configChanged)
+{
+    SWSS_LOG_ENTER();
+
+    const auto &hashMap = isEcmp ? hash.ecmp_hash_pkt_type : hash.lag_hash_pkt_type;
+    const auto &currentMap = isEcmp ? currentConfig.ecmp_hash_pkt_type : currentConfig.lag_hash_pkt_type;
+    auto &oidMap = isEcmp ? m_switchHashEcmp : m_switchHashLag;
+    const char *hashType = isEcmp ? "ECMP" : "LAG";
+
+    // First, handle explicit operations (set/delete-all) for packet-types
+    // that appear in the new configuration map.
+    for (const auto &hashEntry : hashMap)
+    {
+        const auto &pktType = hashEntry.first;
+        const auto &hashField = hashEntry.second;
+        std::string pktTypeStr = hashPktTypeToString(pktType);
+
+        // Validate packet type capability
+        bool pktTypeSupported = isEcmp ?
+            swCap.validateSwitchEcmpPktTypeHashCap(pktType) :
+            swCap.validateSwitchLagPktTypeHashCap(pktType);
+
+        if (!pktTypeSupported)
+        {
+            SWSS_LOG_WARN("%s hash for packet type %s is not supported: skipping...",
+                         hashType, pktTypeStr.c_str());
+            continue;  // Skip unsupported packet types
+        }
+
+        if (hashField.isDeleteAll())
+        {
+            SWSS_LOG_NOTICE("Removing %s hash configuration for %s packet-type",
+                           hashType, pktTypeStr.c_str());
+
+            auto oidIt = oidMap.find(pktType);
+            if (oidIt != oidMap.end() && oidIt->second != SAI_NULL_OBJECT_ID)
+            {
+                // Step 1: Unbind hash from switch FIRST
+                if (!setPacketTypeHashOnSwitch(oidIt->second, isEcmp, pktType, false))
+                {
+                    SWSS_LOG_ERROR("Failed to unbind %s hash from switch for %s packet-type",
+                                  hashType, pktTypeStr.c_str());
+                    return false;
+                }
+
+                // Step 2: Remove hash object
+                if (!removePacketTypeHashOid(oidIt->second, hashType, pktTypeStr))
+                {
+                    SWSS_LOG_ERROR("Failed to remove %s hash OID for %s packet-type",
+                                  hashType, pktTypeStr.c_str());
+                    return false;
+                }
+
+                oidMap.erase(oidIt);
+                SWSS_LOG_NOTICE("Successfully removed %s hash for %s packet-type",
+                               hashType, pktTypeStr.c_str());
+            }
+            else
+            {
+                SWSS_LOG_INFO("%s hash OID for %s packet-type does not exist, nothing to remove",
+                             hashType, pktTypeStr.c_str());
+            }
+            configChanged = true;
+        }
+        else if (hashField.isSet())
+        {
+            // Validate hash fields before applying
+            if (!swCap.validateSwitchHashFieldCap(hashField.value))
+            {
+                SWSS_LOG_ERROR("Hash fields not supported for %s %s packet-type",
+                              hashType, pktTypeStr.c_str());
+                return false;
+            }
+
+            auto currentIt = currentMap.find(pktType);
+            bool isNewHash = (oidMap.find(pktType) == oidMap.end() || oidMap[pktType] == SAI_NULL_OBJECT_ID);
+            bool needsUpdate = (currentIt == currentMap.end() ||
+                               !currentIt->second.isSet() ||
+                               currentIt->second.value != hashField.value);
+
+            if (needsUpdate)
+            {
+                SWSS_LOG_NOTICE("Configuring %s hash for %s packet-type with %zu fields",
+                               hashType, pktTypeStr.c_str(), hashField.value.size());
+
+                // Step 1: Create or update hash object
+                if (!setPacketTypeHashOid(oidMap[pktType], hashField.value, isEcmp, pktTypeStr))
+                {
+                    SWSS_LOG_ERROR("Failed to configure %s hash for %s packet-type",
+                                  hashType, pktTypeStr.c_str());
+                    return false;
+                }
+
+                // Step 2: Bind to switch (only for new hash, not for updates)
+                if (isNewHash)
+                {
+                    if (!setPacketTypeHashOnSwitch(oidMap[pktType], isEcmp, pktType, true))
+                    {
+                        SWSS_LOG_ERROR("Failed to bind %s hash to switch for %s packet-type",
+                                      hashType, pktTypeStr.c_str());
+
+                        // Cleanup: remove the hash object we just created
+                        removePacketTypeHashOid(oidMap[pktType], hashType, pktTypeStr);
+                        oidMap.erase(pktType);
+                        return false;
+                    }
+                }
+
+                configChanged = true;
+                SWSS_LOG_NOTICE("Successfully configured %s hash for %s packet-type",
+                               hashType, pktTypeStr.c_str());
+            }
+            else
+            {
+                SWSS_LOG_INFO("%s hash for %s packet-type is already up-to-date",
+                             hashType, pktTypeStr.c_str());
+            }
+        }
+        else if (hashField.isNotSet())
+        {
+            // This packet-type was not in the configuration update, skip it
+            SWSS_LOG_DEBUG("%s hash for %s packet-type is not set in this update",
+                          hashType, pktTypeStr.c_str());
+        }
+    }
+
+    // Next, handle implicit deletions: packet-types that were present in the
+    // cached configuration but are absent from the new configuration map.
+    // This covers the case where the CLI/plugin removes the corresponding
+    // field from CONFIG_DB (e.g. "lag_hash_ipnip"), and we must unbind and
+    // delete the associated SAI hash object.
+
+    for (const auto &curEntry : currentMap)
+    {
+        const auto &pktType = curEntry.first;
+        const auto &curField = curEntry.second;
+
+        // If this packet-type was explicitly handled above (present in
+        // hashMap), skip it here.
+        if (hashMap.find(pktType) != hashMap.end())
+        {
+            continue;
+        }
+
+        // Only consider deletion if it was actually configured before.
+        if (!curField.isSet())
+        {
+            continue;
+        }
+
+        std::string pktTypeStr = hashPktTypeToString(pktType);
+
+        bool pktTypeSupported = isEcmp ?
+            swCap.validateSwitchEcmpPktTypeHashCap(pktType) :
+            swCap.validateSwitchLagPktTypeHashCap(pktType);
+
+        if (!pktTypeSupported)
+        {
+            SWSS_LOG_WARN("%s hash for packet type %s is not supported (current config), skipping implicit delete",
+                          hashType, pktTypeStr.c_str());
+            continue;
+        }
+
+        auto oidIt = oidMap.find(pktType);
+        if (oidIt == oidMap.end() || oidIt->second == SAI_NULL_OBJECT_ID)
+        {
+            SWSS_LOG_INFO("%s hash OID for %s packet-type does not exist, nothing to implicitly remove",
+                          hashType, pktTypeStr.c_str());
+            continue;
+        }
+
+        SWSS_LOG_NOTICE("Implicitly removing %s hash configuration for %s packet-type (absent from new CONFIG_DB row)",
+                        hashType, pktTypeStr.c_str());
+
+        if (!setPacketTypeHashOnSwitch(oidIt->second, isEcmp, pktType, false))
+        {
+            SWSS_LOG_ERROR("Failed to unbind %s hash from switch for %s packet-type during implicit delete",
+                           hashType, pktTypeStr.c_str());
+            return false;
+        }
+
+        if (!removePacketTypeHashOid(oidIt->second, hashType, pktTypeStr))
+        {
+            SWSS_LOG_ERROR("Failed to remove %s hash OID for %s packet-type during implicit delete",
+                           hashType, pktTypeStr.c_str());
+            return false;
+        }
+
+        oidMap.erase(oidIt);
+        configChanged = true;
+    }
+
+    return true;
+}
+
+bool SwitchOrch::setPacketTypeHashOnSwitch(sai_object_id_t hashOid,
+                                           bool isEcmp,
+                                           HashPktType pktType,
+                                           bool bind)
+{
+    SWSS_LOG_ENTER();
+
+    const char *op = bind ? "bind" : "unbind";
+    const char *opPast = bind ? "Bound" : "Unbound";
+    const char *prep = bind ? "to" : "from";
+
+    sai_attribute_t attr;
+    attr.id = getSwitchAttrForPacketType(pktType, isEcmp);
+    attr.value.oid = bind ? hashOid : SAI_NULL_OBJECT_ID;
+
+    if (attr.id == SAI_SWITCH_ATTR_CUSTOM_RANGE_START)
+    {
+        SWSS_LOG_ERROR("Unsupported packet type for %sing %s switch", op, prep);
+        return false;
+    }
+
+    auto status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to %s %s hash OID %" PRIx64 " for %s %s switch: SAI error %d",
+                      op, isEcmp ? "ECMP" : "LAG", hashOid,
+                      hashPktTypeToString(pktType).c_str(), prep, status);
+
+        task_process_status handleStatus = handleSaiSetStatus(SAI_API_SWITCH, status);
+        if (handleStatus != task_success)
+        {
+            SWSS_LOG_ERROR("SAI set status indicates: %d", handleStatus);
+        }
+
+        return false;
+    }
+
+    SWSS_LOG_NOTICE("%s %s hash OID %" PRIx64 " for %s %s switch",
+                   opPast, isEcmp ? "ECMP" : "LAG", hashOid,
+                   hashPktTypeToString(pktType).c_str(), prep);
+    return true;
+}
+
+sai_switch_attr_t SwitchOrch::getSwitchAttrForPacketType(HashPktType pktType, bool isEcmp)
+{
+    // Map packet type to SAI switch attribute for binding
+    static const std::map<std::pair<HashPktType, bool>, sai_switch_attr_t> attrMap = {
+        // ECMP attributes
+        {{HashPktType::IPV4, true}, SAI_SWITCH_ATTR_ECMP_HASH_IPV4},
+        {{HashPktType::IPV6, true}, SAI_SWITCH_ATTR_ECMP_HASH_IPV6},
+        {{HashPktType::IPNIP, true}, SAI_SWITCH_ATTR_ECMP_HASH_IPV4_IN_IPV4},
+        {{HashPktType::IPV4_RDMA, true}, SAI_SWITCH_ATTR_ECMP_HASH_IPV4_RDMA},
+        {{HashPktType::IPV6_RDMA, true}, SAI_SWITCH_ATTR_ECMP_HASH_IPV6_RDMA},
+
+        // LAG attributes
+        {{HashPktType::IPV4, false}, SAI_SWITCH_ATTR_LAG_HASH_IPV4},
+        {{HashPktType::IPV6, false}, SAI_SWITCH_ATTR_LAG_HASH_IPV6},
+        {{HashPktType::IPNIP, false}, SAI_SWITCH_ATTR_LAG_HASH_IPV4_IN_IPV4},
+        {{HashPktType::IPV4_RDMA, false}, SAI_SWITCH_ATTR_LAG_HASH_IPV4_RDMA},
+        {{HashPktType::IPV6_RDMA, false}, SAI_SWITCH_ATTR_LAG_HASH_IPV6_RDMA},
+    };
+
+    auto it = attrMap.find({pktType, isEcmp});
+    if (it != attrMap.end())
+    {
+        return it->second;
+    }
+
+    SWSS_LOG_ERROR("No SAI switch attribute mapping for packet type %s %s",
+                  isEcmp ? "ECMP" : "LAG", hashPktTypeToString(pktType).c_str());
+    return SAI_SWITCH_ATTR_CUSTOM_RANGE_START; // Invalid attribute as error indicator
+}
+
+bool SwitchOrch::removePacketTypeHashOid(sai_object_id_t oid,
+                                         const std::string &hashType,
+                                         const std::string &pktType)
+{
+    SWSS_LOG_ENTER();
+
+    if (oid == SAI_NULL_OBJECT_ID)
+    {
+        SWSS_LOG_INFO("%s hash OID for %s already null, nothing to remove",
+                     hashType.c_str(), pktType.c_str());
+        return true;
+    }
+
+    auto status = sai_hash_api->remove_hash(oid);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to remove %s hash OID %" PRIx64 " for %s: SAI error %d",
+                      hashType.c_str(), oid, pktType.c_str(), status);
+
+        task_process_status handleStatus = handleSaiRemoveStatus(SAI_API_HASH, status);
+        if (handleStatus != task_success)
+        {
+            SWSS_LOG_ERROR("SAI remove status indicates: %d", handleStatus);
+        }
+
+        return false;
+    }
+
+    SWSS_LOG_NOTICE("Successfully removed %s hash OID %" PRIx64 " for %s",
+                   hashType.c_str(), oid, pktType.c_str());
+    return true;
+}
+
+bool SwitchOrch::setPacketTypeHashOid(sai_object_id_t &oid,
+                                      const std::set<sai_native_hash_field_t> &fields,
+                                      bool isEcmp,
+                                      const std::string &pktType)
+{
+    SWSS_LOG_ENTER();
+
+    if (fields.empty())
+    {
+        SWSS_LOG_ERROR("Cannot set packet-type hash with empty field list for %s %s",
+                      isEcmp ? "ECMP" : "LAG", pktType.c_str());
+        return false;
+    }
+
+    // Convert set to vector for SAI
+    std::vector<sai_int32_t> fieldList;
+    fieldList.reserve(fields.size());
+    std::transform(fields.cbegin(), fields.cend(), std::back_inserter(fieldList),
+                   [](sai_native_hash_field_t f) { return static_cast<sai_int32_t>(f); });
+
+    sai_attribute_t attr;
+    attr.id = SAI_HASH_ATTR_NATIVE_HASH_FIELD_LIST;
+    attr.value.s32list.list = fieldList.data();
+    attr.value.s32list.count = static_cast<uint32_t>(fieldList.size());
+
+    sai_status_t status;
+    const char *hashType = isEcmp ? "ECMP" : "LAG";
+
+    if (oid == SAI_NULL_OBJECT_ID)
+    {
+        // Create new hash object
+        std::vector<sai_attribute_t> attrs = {attr};
+
+        SWSS_LOG_INFO("Creating new %s hash object for %s packet-type with %zu fields",
+                     hashType, pktType.c_str(), fields.size());
+
+        status = sai_hash_api->create_hash(&oid, gSwitchId,
+                                          static_cast<uint32_t>(attrs.size()),
+                                          attrs.data());
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to create %s hash for %s packet-type: SAI error %d",
+                          hashType, pktType.c_str(), status);
+
+            task_process_status handleStatus = handleSaiCreateStatus(SAI_API_HASH, status);
+            if (handleStatus != task_success)
+            {
+                SWSS_LOG_ERROR("SAI create status indicates: %d", handleStatus);
+            }
+
+            return false;
+        }
+
+        SWSS_LOG_NOTICE("Created %s hash OID %" PRIx64 " for %s packet-type with %zu fields",
+                       hashType, oid, pktType.c_str(), fields.size());
+    }
+    else
+    {
+        // Update existing hash object (no need to rebind to switch)
+        SWSS_LOG_INFO("Updating existing %s hash OID %" PRIx64 " for %s packet-type with %zu fields",
+                     hashType, oid, pktType.c_str(), fields.size());
+
+        status = sai_hash_api->set_hash_attribute(oid, &attr);
+        if (status == SAI_STATUS_ITEM_ALREADY_EXISTS)
+        {
+            // Fields are already programmed identically in hardware; treat as success.
+            SWSS_LOG_NOTICE("%s hash OID %" PRIx64 " for %s packet-type already has the same field list; no update needed",
+                            hashType, oid, pktType.c_str());
+            return true;
+        }
+
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to update %s hash OID %" PRIx64 " for %s packet-type: SAI error %d",
+                          hashType, oid, pktType.c_str(), status);
+
+            task_process_status handleStatus = handleSaiSetStatus(SAI_API_HASH, status);
+            if (handleStatus != task_success)
+            {
+                SWSS_LOG_ERROR("SAI set status indicates: %d", handleStatus);
+            }
+
+            return false;
+        }
+
+        SWSS_LOG_NOTICE("Updated %s hash OID %" PRIx64 " for %s packet-type with %zu fields",
+                       hashType, oid, pktType.c_str(), fields.size());
+    }
+
+    return true;
+}
+
 void SwitchOrch::doCfgSwitchHashTableTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
@@ -976,12 +1436,39 @@ void SwitchOrch::doCfgSwitchHashTableTask(Consumer &consumer)
                 hash.fieldValueMap[fieldName] = fieldValue;
             }
 
-            if (swHlpr.parseSwHash(hash))
+            if (!swHlpr.parseSwHash(hash))
+            {
+                SWSS_LOG_ERROR("Configuration parsing failed for switch hash");
+                it = map.erase(it);
+                continue;
+            }
+
+            // Determine what types of hash configuration are present
+            bool hasGlobalHash = hash.ecmp_hash.is_set ||
+                                hash.lag_hash.is_set ||
+                                hash.ecmp_hash_algorithm.is_set ||
+                                hash.lag_hash_algorithm.is_set;
+
+            // Apply global hash configuration only if present
+            if (hasGlobalHash)
             {
                 if (!setSwitchHash(hash))
                 {
-                    SWSS_LOG_ERROR("Failed to set switch hash: ASIC and CONFIG DB are diverged");
+                    SWSS_LOG_ERROR("Failed to apply global switch hash configuration");
+                    it = map.erase(it);
+                    continue;
                 }
+            }
+
+            // Apply packet-type hash configuration based on the new CONFIG_DB
+            // row and the cached state. This will handle explicit updates as
+            // well as implicit deletions when packet-type fields disappear
+            // from the row.
+            if (!applySwitchPacketTypeHashConfiguration(hash))
+            {
+                SWSS_LOG_ERROR("Failed to apply packet-type switch hash configuration");
+                it = map.erase(it);
+                continue;
             }
         }
         else if (op == DEL_COMMAND)

--- a/orchagent/switchorch.h
+++ b/orchagent/switchorch.h
@@ -4,6 +4,7 @@
 #include "orch.h"
 #include "timer.h"
 #include "flex_counter/flex_counter_manager.h"
+#include "switch/switch_types.h"
 #include "switch/switch_capabilities.h"
 #include "switch/switch_helper.h"
 #include "switch/trimming/capabilities.h"
@@ -113,6 +114,16 @@ private:
 
     bool getSwitchHashOidSai(sai_object_id_t &oid, bool isEcmpHash) const;
     void querySwitchHashDefaults();
+
+    // Switch packet type hash
+    bool setPacketTypeHashOnSwitch(sai_object_id_t hashOid, bool isEcmp, HashPktType pktType, bool bind);
+    sai_switch_attr_t getSwitchAttrForPacketType(HashPktType pktType, bool isEcmp);
+
+    bool removePacketTypeHashOid(sai_object_id_t oid, const std::string &hashType, const std::string &pktType);
+    bool setPacketTypeHashOid(sai_object_id_t &oid, const std::set<sai_native_hash_field_t> &fields, bool isEcmp, const std::string &pktType);
+    bool applySwitchPacketTypeHashConfiguration(const SwitchHash &hash);
+    bool processPacketTypeHash(const SwitchHash &hash, const SwitchHash &currentConfig, bool isEcmp, bool &configChanged);
+
     void setSwitchIcmpOffloadCapability();
 
     // Fast link-up
@@ -210,6 +221,11 @@ private:
     FlexCounterManager m_counterManager;
     bool m_isSwitchCounterIdListGenerated = false;
 
+    // Switch packet-type hash for ECMP
+    std::map<HashPktType, sai_object_id_t> m_switchHashEcmp;
+
+    // Switch packet-type hash for LAG
+    std::map<HashPktType, sai_object_id_t> m_switchHashLag;
     // Information contained in the request from
     // external program for orchagent pre-shutdown state check
     WarmRestartCheck m_warmRestartCheck = {false, false, false};

--- a/tests/dvslib/dvs_hash.py
+++ b/tests/dvslib/dvs_hash.py
@@ -24,6 +24,14 @@ class DVSHash:
         self.config_db.update_entry(self.CDB_SWITCH_HASH, self.KEY_SWITCH_HASH_GLOBAL, qualifiers)
         time.sleep(1)
 
+    def delete_switch_hash_field(
+        self,
+        field: str
+    ) -> None:
+        """Remove a single field from the SWITCH_HASH|GLOBAL entry."""
+        self.config_db.delete_field(self.CDB_SWITCH_HASH, self.KEY_SWITCH_HASH_GLOBAL, field)
+        time.sleep(1)
+
     def get_hash_ids(
         self,
         expected: int = None

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -288,6 +288,124 @@ class TestHashBasicFlows:
         )
 
 
+PKT_TYPE_HASH_FIELD_LIST = [
+    "DST_IP",
+    "SRC_IP",
+    "L4_DST_PORT",
+    "L4_SRC_PORT"
+]
+SAI_PKT_TYPE_HASH_FIELD_LIST = [
+    "SAI_NATIVE_HASH_FIELD_DST_IP",
+    "SAI_NATIVE_HASH_FIELD_SRC_IP",
+    "SAI_NATIVE_HASH_FIELD_L4_DST_PORT",
+    "SAI_NATIVE_HASH_FIELD_L4_SRC_PORT"
+]
+RDMA_HASH_FIELD_LIST = [
+    "DST_IP",
+    "SRC_IP",
+    "RDMA_BTH_OPCODE",
+    "RDMA_BTH_DEST_QP"
+]
+SAI_RDMA_HASH_FIELD_LIST = [
+    "SAI_NATIVE_HASH_FIELD_DST_IP",
+    "SAI_NATIVE_HASH_FIELD_SRC_IP",
+    "SAI_NATIVE_HASH_FIELD_RDMA_BTH_OPCODE",
+    "SAI_NATIVE_HASH_FIELD_RDMA_BTH_DEST_QP"
+]
+
+
+@pytest.mark.usefixtures("dvs_hash_manager")
+class TestHashPacketType:
+    """Test per-packet-type hash configuration (ECMP and LAG)."""
+
+    @pytest.mark.parametrize(
+        "field,hfList,saiHfList", [
+            pytest.param(
+                "ecmp_hash_ipv4",
+                ",".join(PKT_TYPE_HASH_FIELD_LIST),
+                SAI_PKT_TYPE_HASH_FIELD_LIST,
+                id="ecmp-ipv4"
+            ),
+            pytest.param(
+                "lag_hash_ipv4",
+                ",".join(PKT_TYPE_HASH_FIELD_LIST),
+                SAI_PKT_TYPE_HASH_FIELD_LIST,
+                id="lag-ipv4"
+            ),
+            pytest.param(
+                "ecmp_hash_ipv4_rdma",
+                ",".join(RDMA_HASH_FIELD_LIST),
+                SAI_RDMA_HASH_FIELD_LIST,
+                id="ecmp-ipv4-rdma"
+            ),
+            pytest.param(
+                "lag_hash_ipv6_rdma",
+                ",".join(RDMA_HASH_FIELD_LIST),
+                SAI_RDMA_HASH_FIELD_LIST,
+                id="lag-ipv6-rdma"
+            ),
+        ]
+    )
+    def test_HashPacketTypeCreate(self, field, hfList, saiHfList, testlog):
+        """Configure a per-packet-type hash (including RDMA) and verify a new ASIC hash object is created."""
+
+        hashlogger.info("Configure %s", field)
+        self.dvs_hash.update_switch_hash(qualifiers={field: hfList})
+
+        new_ids = self.dvs_hash.get_hash_ids(expected=1)
+        assert len(new_ids) == 1, "Expected 1 new hash object"
+
+        sai_attr = {"SAI_HASH_ATTR_NATIVE_HASH_FIELD_LIST": saiHfList}
+        self.dvs_hash.verify_hash_generic(sai_hash_id=new_ids[0], sai_qualifiers=sai_attr)
+
+        hashlogger.info("Cleanup %s", field)
+        self.dvs_hash.delete_switch_hash_field(field)
+
+    def test_HashPacketTypeUpdate(self, testlog):
+        """Configure a per-packet-type hash, update its fields, and verify ASIC DB reflects the update."""
+        field = "ecmp_hash_ipv6"
+
+        hashlogger.info("Create %s with basic fields", field)
+        self.dvs_hash.update_switch_hash(
+            qualifiers={field: ",".join(PKT_TYPE_HASH_FIELD_LIST)}
+        )
+
+        new_ids = self.dvs_hash.get_hash_ids(expected=1)
+        assert len(new_ids) == 1
+        hash_oid = new_ids[0]
+
+        sai_attr = {"SAI_HASH_ATTR_NATIVE_HASH_FIELD_LIST": SAI_PKT_TYPE_HASH_FIELD_LIST}
+        self.dvs_hash.verify_hash_generic(sai_hash_id=hash_oid, sai_qualifiers=sai_attr)
+
+        hashlogger.info("Update %s to RDMA fields", field)
+        self.dvs_hash.update_switch_hash(
+            qualifiers={field: ",".join(RDMA_HASH_FIELD_LIST)}
+        )
+
+        sai_attr_updated = {"SAI_HASH_ATTR_NATIVE_HASH_FIELD_LIST": SAI_RDMA_HASH_FIELD_LIST}
+        self.dvs_hash.verify_hash_generic(sai_hash_id=hash_oid, sai_qualifiers=sai_attr_updated)
+
+        hashlogger.info("Cleanup %s", field)
+        self.dvs_hash.delete_switch_hash_field(field)
+
+    def test_HashPacketTypeDelete(self, testlog):
+        """Configure a per-packet-type hash, then remove it and verify the ASIC hash object is removed."""
+        field = "lag_hash_ipnip"
+
+        hashlogger.info("Create %s", field)
+        self.dvs_hash.update_switch_hash(
+            qualifiers={field: ",".join(PKT_TYPE_HASH_FIELD_LIST)}
+        )
+
+        new_ids = self.dvs_hash.get_hash_ids(expected=1)
+        assert len(new_ids) == 1
+
+        hashlogger.info("Delete %s", field)
+        self.dvs_hash.delete_switch_hash_field(field)
+
+        self.dvs_hash.verify_hash_count(0)
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():


### PR DESCRIPTION
**Why I did it:**
SONiC's Generic Hash feature (HLD: https://github.com/sonic-net/SONiC/pull/2100) extends switch hashing to allow operators to configure hash field lists per packet type (IPv4, IPv6, IP-in-IP, IPv4 RDMA, IPv6 RDMA) independently for both ECMP and LAG, in addition to the existing global ecmp_hash / lag_hash attributes. The previous swss implementation only programmed a single global hash object per ECMP/LAG and did not understand per-packet-type fields or RDMA-specific native hash fields (RDMA_BTH_OPCODE, RDMA_BTH_DEST_QP), so the CONFIG_DB schema introduced by the HLD could not be honored end-to-end. This change implements the swss side so that the new SWITCH_HASH|GLOBAL fields (ecmp_hash_ipv4/ipv6/ipnip/ipv4_rdma/ipv6_rdma and the matching lag_hash_* fields) are parsed, validated against SAI capabilities, and programmed onto the corresponding per-packet-type switch attributes, with proper add/update/delete handling and capability advertisement in STATE_DB.

**How I did it:**

- Added a HashPktType enum and helpers for the five packet types on ECMP and LAG.
- Extended switch hash schema, parser, and cached config with per-packet-type fields, RDMA native hash fields, and SET / DELETE_ALL / NOT_SET state.
- Extended switch capabilities to query, validate, and publish per-packet-type ECMP/LAG support to STATE_DB.
- Extended switchorch to create/update/remove SAI hash objects per packet type and bind them to the matching SAI_SWITCH_ATTR_HASH_*_HASH attributes.
- Added VS tests covering create/update/delete for plain and RDMA packet types on ECMP and LAG.

**How to verify it:**
Run the sonic-swss unit tests.

**Which release branch to backport (provide reason below if selected):**
- [x] 202511

**Tested branch (Please provide the tested image version):**
202511
- [x] 202511

**Details if related**
PR Dependencies:
- Depends of https://github.com/sonic-net/sonic-sairedis/pull/1913