### PR TITLE
[neighsyncd] Retry transient ENETDOWN during neighbor restore

### DIFF
--- a/neighsyncd/restore_neighbors.py
+++ b/neighsyncd/restore_neighbors.py
@@ -250,25 +250,40 @@ def restore_update_kernel_neighbors(intf_neigh_map, timeout=DEF_TIME_OUT):
                 intf_idx = ipclass.link_lookup(ifname=intf)[0]
                 # create socket per intf to send packets
                 s = conf.L2socket(iface=intf)
+                retry_intf = False
+                try:
+                    # Only two families: 'IPv4' and 'IPv6'
+                    for family in ip_family.keys():
+                        # if ip address assigned and if we have neighs in this family, restore them
+                        src_ip = first_ip_on_intf(intf, family)
+                        if src_ip and (family in family_neigh_map):
+                            neigh_list = family_neigh_map[family]
+                            for dst_ip, dmac in neigh_list:
+                                # use netlink to set neighbor entries
+                                set_neigh_in_kernel(ipclass, family, intf_idx, dst_ip, dmac)
 
-                # Only two families: 'IPv4' and 'IPv6'
-                for family in ip_family.keys():
-                    # if ip address assigned and if we have neighs in this family, restore them
-                    src_ip = first_ip_on_intf(intf, family)
-                    if src_ip and (family in family_neigh_map):
-                        neigh_list = family_neigh_map[family]
-                        for dst_ip, dmac in neigh_list:
-                            # use netlink to set neighbor entries
-                            set_neigh_in_kernel(ipclass, family, intf_idx, dst_ip, dmac)
+                                log_info('Sending Neigh with family: {}, intf_idx: {}, ip: {}, mac: {}'.format(
+                                family, intf_idx, dst_ip, dmac))
+                                # sending arp/ns packet to update kernel neigh info
+                                try:
+                                    s.send(build_arp_ns_pkt(family, src_mac, src_ip, dst_ip))
+                                except OSError as e:
+                                    if e.errno == errno.ENETDOWN:
+                                        log_warning('Interface {} went down while restoring {} neighbor {}; retrying'.format(
+                                        intf, family, dst_ip))
+                                        retry_intf = True
+                                        break
+                                    raise
+                            if retry_intf:
+                                break
+                            # delete this family on the intf
+                            del intf_neigh_map[intf][family]
+                finally:
+                    # close the pkt socket
+                    s.close()
 
-                            log_info('Sending Neigh with family: {}, intf_idx: {}, ip: {}, mac: {}'.format(
-                            family, intf_idx, dst_ip, dmac))
-                            # sending arp/ns packet to update kernel neigh info
-                            s.send(build_arp_ns_pkt(family, src_mac, src_ip, dst_ip))
-                        # delete this family on the intf
-                        del intf_neigh_map[intf][family]
-                # close the pkt socket
-                s.close()
+                if retry_intf:
+                    continue
 
                 # if all families are deleted, remove the key
                 if len(intf_neigh_map[intf]) == 0:


### PR DESCRIPTION
#### Why I did it
`restore_neighbors.py` can race with `intfmgrd` moving L3 interfaces into a user-defined VRF during fast-reboot. The kernel briefly clears `IFF_LOWER_UP` during the VRF master change; if the restore script sends the ARP/NS packet inside that small window, the AF_PACKET send fails with `ENETDOWN` and the script exits before setting `NEIGH_RESTORE_TABLE|Flags`, leaving `neighsyncd` stuck.

This addresses sonic-net/sonic-buildimage#27108.

#### How I did it
Catch only `OSError(errno.ENETDOWN)` around the ARP/NS send path, keep the remaining interface/family entries in the restore map, close the packet socket, and let the existing outer retry loop try the interface again. Other errors still propagate as before.

#### How to verify it
- `python3 -m py_compile neighsyncd/restore_neighbors.py`
- `git diff --check`
