### PR TITLE
[buffermgrd] Keep SHP desired state during retry

### DIFF
--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -2075,10 +2075,6 @@ task_process_status BufferMgrDynamic::waitWithRetry(const function<bool()> &chec
         {
             sleep(m_saiSyncPollIntervalSec);
         }
-        else
-        {
-            usleep(100000);
-        }
 
         if (checker())
         {

--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -1,6 +1,7 @@
 #include <fstream>
 #include <iostream>
 #include <string.h>
+#include <unistd.h>
 #include "logger.h"
 #include "dbconnector.h"
 #include "producerstatetable.h"
@@ -27,6 +28,8 @@
  */
 using namespace std;
 using namespace swss;
+
+static constexpr int BUFFER_PROFILE_SYNC_WAIT_SECONDS = 30;
 
 BufferMgrDynamic::BufferMgrDynamic(DBConnector *cfgDb, DBConnector *stateDb, DBConnector *applDb, DBConnector *applStateDb, const vector<TableConnector> &tables, shared_ptr<vector<KeyOpFieldsValuesTuple>> gearboxInfo, shared_ptr<vector<KeyOpFieldsValuesTuple>> zeroProfilesInfo) :
         Orch(tables),
@@ -2121,6 +2124,27 @@ task_process_status BufferMgrDynamic::checkPendingProfilesSyncStatus()
     return task_process_status::task_success;
 }
 
+task_process_status BufferMgrDynamic::waitPendingProfilesSyncStatus()
+{
+    for (int i = 0; i <= BUFFER_PROFILE_SYNC_WAIT_SECONDS; i++)
+    {
+        auto status = checkPendingProfilesSyncStatus();
+        if (status == task_process_status::task_success)
+        {
+            return status;
+        }
+
+        if (i < BUFFER_PROFILE_SYNC_WAIT_SECONDS)
+        {
+            sleep(1);
+        }
+    }
+
+    SWSS_LOG_ERROR("Timed out waiting for %zu BUFFER_PROFILE entries to sync to SAI",
+                   m_shpProfilesToCheck.size());
+    return task_process_status::task_failed;
+}
+
 task_process_status BufferMgrDynamic::handleCableLenTable(KeyOpFieldsValuesTuple &tuple)
 {
     string op = kfvOp(tuple);
@@ -2564,6 +2588,7 @@ task_process_status BufferMgrDynamic::handleBufferPoolTable(KeyOpFieldsValuesTup
              * False        | Static    | False               | False
              */
             bool willSHPBeEnabledBySize = isNonZero(newSHPSize);
+
             if (newSHPSize != m_configuredSharedHeadroomPoolSize)
             {
                 bool isSHPEnabledBySize = isNonZero(m_configuredSharedHeadroomPoolSize);
@@ -2576,36 +2601,18 @@ task_process_status BufferMgrDynamic::handleBufferPoolTable(KeyOpFieldsValuesTup
                     }
                 }
 
-                // Check if we are in retry mode (profiles waiting for SAI sync)
+                m_configuredSharedHeadroomPoolSize = newSHPSize;
+                refreshSharedHeadroomPool(false, isSHPEnabledBySize != willSHPBeEnabledBySize);
+
+                // Check if there are profiles waiting for SAI sync
                 if (!m_shpProfilesToCheck.empty())
                 {
-                    // Retry mode: only check SAI sync status, don't refresh profiles
-                    SWSS_LOG_NOTICE("Retry mode: checking pending profiles");
-                    auto status = checkPendingProfilesSyncStatus();
-                    if (status == task_process_status::task_need_retry)
+                    // The desired SHP size is already in memory; wait here so
+                    // a replay cannot skip profiles that are still in flight.
+                    auto status = waitPendingProfilesSyncStatus();
+                    if (status != task_process_status::task_success)
                     {
-                        return task_process_status::task_need_retry;
-                    }
-                    // Profiles synced successfully, update configuration and continue
-                    m_configuredSharedHeadroomPoolSize = newSHPSize;
-                }
-                else
-                {
-                    // Not retry mode: refresh profiles
-                    string oldSHPSize = m_configuredSharedHeadroomPoolSize;
-                    m_configuredSharedHeadroomPoolSize = newSHPSize;
-                    refreshSharedHeadroomPool(false, isSHPEnabledBySize != willSHPBeEnabledBySize);
-
-                    // Check if there are profiles waiting for SAI sync
-                    if (!m_shpProfilesToCheck.empty())
-                    {
-                        auto status = checkPendingProfilesSyncStatus();
-                        if (status == task_process_status::task_need_retry)
-                        {
-                            // Rollback configuration change
-                            m_configuredSharedHeadroomPoolSize = oldSHPSize;
-                            return task_process_status::task_need_retry;
-                        }
+                        return status;
                     }
                 }
             }

--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -2106,7 +2106,7 @@ bool BufferMgrDynamic::isLosslessProfileSyncedInSai(const string &profileName)
 
 task_process_status BufferMgrDynamic::checkPendingProfilesSyncStatus()
 {
-    SWSS_LOG_DEBUG("Checking SAI sync status for %zu profiles", m_shpProfilesToCheck.size());
+    SWSS_LOG_INFO("Checking SAI sync status for %zu profiles", m_shpProfilesToCheck.size());
     m_applBufferProfileTable.flush();
 
     for (const auto &profileName : m_shpProfilesToCheck)
@@ -2129,20 +2129,21 @@ task_process_status BufferMgrDynamic::waitPendingProfilesSyncStatus()
     SWSS_LOG_NOTICE("Checking SAI sync status up to %d times for %zu BUFFER_PROFILE entries",
                     BUFFER_PROFILE_SYNC_MAX_CHECKS, m_shpProfilesToCheck.size());
 
-    for (int i = 1; i <= BUFFER_PROFILE_SYNC_MAX_CHECKS; i++)
+    auto status = checkPendingProfilesSyncStatus();
+    if (status == task_process_status::task_success)
     {
-        auto status = checkPendingProfilesSyncStatus();
+        return status;
+    }
+
+    for (int i = 0; i < BUFFER_PROFILE_SYNC_MAX_CHECKS - 1; i++)
+    {
+        sleep(1);
+
+        status = checkPendingProfilesSyncStatus();
         if (status == task_process_status::task_success)
         {
             return status;
         }
-
-        if (i == BUFFER_PROFILE_SYNC_MAX_CHECKS)
-        {
-            break;
-        }
-
-        sleep(1);
     }
 
     SWSS_LOG_ERROR("Timed out waiting for %zu BUFFER_PROFILE entries to sync to SAI",

--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -2059,9 +2059,10 @@ bool BufferMgrDynamic::isSharedHeadroomPoolEnabledInSai()
 
 task_process_status BufferMgrDynamic::waitWithRetry(const function<bool()> &checker, const string &description)
 {
-    SWSS_LOG_NOTICE("Checking SAI sync status: %d checks (up to ~%d s) for %s",
+    const unsigned int maxWaitSec = (BUFFER_PROFILE_SYNC_MAX_CHECKS - 1) * m_saiSyncPollIntervalSec;
+    SWSS_LOG_NOTICE("Checking SAI sync status: %d checks (up to ~%u s) for %s",
                     BUFFER_PROFILE_SYNC_MAX_CHECKS,
-                    BUFFER_PROFILE_SYNC_MAX_CHECKS - 1,
+                    maxWaitSec,
                     description.c_str());
 
     if (checker())

--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -58,7 +58,8 @@ BufferMgrDynamic::BufferMgrDynamic(DBConnector *cfgDb, DBConnector *stateDb, DBC
         m_bufferObjectsPending(true),
         m_bufferCompletelyInitialized(false),
         m_bufferProfileApplDbWritten(false),
-        m_mmuSizeNumber(0)
+        m_mmuSizeNumber(0),
+        m_saiSyncPollIntervalSec(1)
 {
     SWSS_LOG_ENTER();
 
@@ -2058,8 +2059,10 @@ bool BufferMgrDynamic::isSharedHeadroomPoolEnabledInSai()
 
 task_process_status BufferMgrDynamic::waitWithRetry(const function<bool()> &checker, const string &description)
 {
-    SWSS_LOG_NOTICE("Checking SAI sync status up to %d times for %s",
-                    BUFFER_PROFILE_SYNC_MAX_CHECKS, description.c_str());
+    SWSS_LOG_NOTICE("Checking SAI sync status: %d checks (up to ~%d s) for %s",
+                    BUFFER_PROFILE_SYNC_MAX_CHECKS,
+                    BUFFER_PROFILE_SYNC_MAX_CHECKS - 1,
+                    description.c_str());
 
     if (checker())
     {
@@ -2068,7 +2071,14 @@ task_process_status BufferMgrDynamic::waitWithRetry(const function<bool()> &chec
 
     for (int i = 0; i < BUFFER_PROFILE_SYNC_MAX_CHECKS - 1; i++)
     {
-        sleep(1);
+        if (m_saiSyncPollIntervalSec > 0)
+        {
+            sleep(m_saiSyncPollIntervalSec);
+        }
+        else
+        {
+            usleep(100000);
+        }
 
         if (checker())
         {

--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -2076,7 +2076,7 @@ task_process_status BufferMgrDynamic::waitWithRetry(const function<bool()> &chec
         }
     }
 
-    SWSS_LOG_ERROR("CRITICAL: Timed out waiting for %s to sync to SAI, desired in-memory state is preserved, manual intervention is required",
+    SWSS_LOG_ERROR("Timed out waiting for %s to sync to SAI, desired in-memory state is preserved, manual intervention is required",
                    description.c_str());
     return task_process_status::task_failed;
 }

--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -2021,9 +2021,12 @@ task_process_status BufferMgrDynamic::handleDefaultLossLessBufferParam(KeyOpFiel
         bool willSHPBeEnabled = isNonZero(newRatio);
         if (m_portInitDone && (!isSHPEnabled) && willSHPBeEnabled)
         {
-            if (!isSharedHeadroomPoolEnabledInSai())
+            // Keep the ratio enable event out of m_toSync; stale SET fields
+            // can outlive the user's later delete-field intent.
+            auto status = waitSharedHeadroomPoolEnabledInSai();
+            if (status != task_process_status::task_success)
             {
-                return task_process_status::task_need_retry;
+                return status;
             }
         }
         SWSS_LOG_INFO("Recalculate shared buffer pool size due to over subscribe ratio has been updated from %s to %s",
@@ -2051,6 +2054,37 @@ bool BufferMgrDynamic::isSharedHeadroomPoolEnabledInSai()
     }
 
     return true;
+}
+
+task_process_status BufferMgrDynamic::waitWithRetry(const function<bool()> &checker, const string &description)
+{
+    SWSS_LOG_NOTICE("Checking SAI sync status up to %d times for %s",
+                    BUFFER_PROFILE_SYNC_MAX_CHECKS, description.c_str());
+
+    if (checker())
+    {
+        return task_process_status::task_success;
+    }
+
+    for (int i = 0; i < BUFFER_PROFILE_SYNC_MAX_CHECKS - 1; i++)
+    {
+        sleep(1);
+
+        if (checker())
+        {
+            return task_process_status::task_success;
+        }
+    }
+
+    SWSS_LOG_ERROR("CRITICAL: Timed out waiting for %s to sync to SAI, desired in-memory state is preserved, manual intervention is required",
+                   description.c_str());
+    return task_process_status::task_failed;
+}
+
+task_process_status BufferMgrDynamic::waitSharedHeadroomPoolEnabledInSai()
+{
+    return waitWithRetry([this]() { return isSharedHeadroomPoolEnabledInSai(); },
+                         "shared headroom pool");
 }
 
 bool BufferMgrDynamic::isLosslessProfileSyncedInSai(const string &profileName)
@@ -2126,29 +2160,10 @@ task_process_status BufferMgrDynamic::checkPendingProfilesSyncStatus()
 
 task_process_status BufferMgrDynamic::waitPendingProfilesSyncStatus()
 {
-    SWSS_LOG_NOTICE("Checking SAI sync status up to %d times for %zu BUFFER_PROFILE entries",
-                    BUFFER_PROFILE_SYNC_MAX_CHECKS, m_shpProfilesToCheck.size());
-
-    auto status = checkPendingProfilesSyncStatus();
-    if (status == task_process_status::task_success)
-    {
-        return status;
-    }
-
-    for (int i = 0; i < BUFFER_PROFILE_SYNC_MAX_CHECKS - 1; i++)
-    {
-        sleep(1);
-
-        status = checkPendingProfilesSyncStatus();
-        if (status == task_process_status::task_success)
-        {
-            return status;
-        }
-    }
-
-    SWSS_LOG_ERROR("Timed out waiting for %zu BUFFER_PROFILE entries to sync to SAI",
-                   m_shpProfilesToCheck.size());
-    return task_process_status::task_failed;
+    return waitWithRetry([this]() {
+                             return checkPendingProfilesSyncStatus() == task_process_status::task_success;
+                         },
+                         to_string(m_shpProfilesToCheck.size()) + " BUFFER_PROFILE entries");
 }
 
 task_process_status BufferMgrDynamic::handleCableLenTable(KeyOpFieldsValuesTuple &tuple)
@@ -2601,9 +2616,12 @@ task_process_status BufferMgrDynamic::handleBufferPoolTable(KeyOpFieldsValuesTup
 
                 if (m_portInitDone && (!isSHPEnabledBySize) && willSHPBeEnabledBySize)
                 {
-                    if (!isSharedHeadroomPoolEnabledInSai())
+                    // Keep the enable event out of m_toSync; stale SET fields
+                    // can outlive the user's later delete-field intent.
+                    auto status = waitSharedHeadroomPoolEnabledInSai();
+                    if (status != task_process_status::task_success)
                     {
-                        return task_process_status::task_need_retry;
+                        return status;
                     }
                 }
 

--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -29,7 +29,7 @@
 using namespace std;
 using namespace swss;
 
-static constexpr int BUFFER_PROFILE_SYNC_WAIT_SECONDS = 30;
+static constexpr int BUFFER_PROFILE_SYNC_MAX_CHECKS = 30;
 
 BufferMgrDynamic::BufferMgrDynamic(DBConnector *cfgDb, DBConnector *stateDb, DBConnector *applDb, DBConnector *applStateDb, const vector<TableConnector> &tables, shared_ptr<vector<KeyOpFieldsValuesTuple>> gearboxInfo, shared_ptr<vector<KeyOpFieldsValuesTuple>> zeroProfilesInfo) :
         Orch(tables),
@@ -2106,7 +2106,7 @@ bool BufferMgrDynamic::isLosslessProfileSyncedInSai(const string &profileName)
 
 task_process_status BufferMgrDynamic::checkPendingProfilesSyncStatus()
 {
-    SWSS_LOG_NOTICE("Checking SAI sync status for %zu profiles", m_shpProfilesToCheck.size());
+    SWSS_LOG_DEBUG("Checking SAI sync status for %zu profiles", m_shpProfilesToCheck.size());
     m_applBufferProfileTable.flush();
 
     for (const auto &profileName : m_shpProfilesToCheck)
@@ -2126,7 +2126,10 @@ task_process_status BufferMgrDynamic::checkPendingProfilesSyncStatus()
 
 task_process_status BufferMgrDynamic::waitPendingProfilesSyncStatus()
 {
-    for (int i = 0; i <= BUFFER_PROFILE_SYNC_WAIT_SECONDS; i++)
+    SWSS_LOG_NOTICE("Checking SAI sync status up to %d times for %zu BUFFER_PROFILE entries",
+                    BUFFER_PROFILE_SYNC_MAX_CHECKS, m_shpProfilesToCheck.size());
+
+    for (int i = 1; i <= BUFFER_PROFILE_SYNC_MAX_CHECKS; i++)
     {
         auto status = checkPendingProfilesSyncStatus();
         if (status == task_process_status::task_success)
@@ -2134,10 +2137,12 @@ task_process_status BufferMgrDynamic::waitPendingProfilesSyncStatus()
             return status;
         }
 
-        if (i < BUFFER_PROFILE_SYNC_WAIT_SECONDS)
+        if (i == BUFFER_PROFILE_SYNC_MAX_CHECKS)
         {
-            sleep(1);
+            break;
         }
+
+        sleep(1);
     }
 
     SWSS_LOG_ERROR("Timed out waiting for %zu BUFFER_PROFILE entries to sync to SAI",

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -271,6 +271,9 @@ private:
     // Profiles waiting for SAI sync in refreshSharedHeadroomPool
     std::vector<std::string> m_shpProfilesToCheck;
 
+    // Seconds between SAI sync polls in waitWithRetry. 0 selects a 100 ms poll.
+    unsigned int m_saiSyncPollIntervalSec;
+
     // Initializers
     void initTableHandlerMap();
     void parseGearboxInfo(std::shared_ptr<std::vector<KeyOpFieldsValuesTuple>> gearboxInfo);

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -305,6 +305,7 @@ private:
     bool isSharedHeadroomPoolEnabledInSai();
     bool isLosslessProfileSyncedInSai(const std::string &profileName);
     task_process_status checkPendingProfilesSyncStatus();
+    task_process_status waitPendingProfilesSyncStatus();
     void refreshSharedHeadroomPool(bool enable_state_updated_by_ratio, bool enable_state_updated_by_size);
     task_process_status checkBufferProfileDirection(const std::string &profiles, buffer_direction_t dir);
     std::string constructZeroProfileListFromNormalProfileList(const std::string &normalProfileList, const std::string &port);

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -5,6 +5,7 @@
 #include "producerstatetable.h"
 #include "orch.h"
 
+#include <functional>
 #include <map>
 #include <set>
 #include <string>
@@ -304,6 +305,8 @@ private:
     bool isHeadroomResourceValid(const std::string &port, const buffer_profile_t &profile, const std::string &new_pg);
     bool isSharedHeadroomPoolEnabledInSai();
     bool isLosslessProfileSyncedInSai(const std::string &profileName);
+    task_process_status waitWithRetry(const std::function<bool()> &checker, const std::string &description);
+    task_process_status waitSharedHeadroomPoolEnabledInSai();
     task_process_status checkPendingProfilesSyncStatus();
     task_process_status waitPendingProfilesSyncStatus();
     void refreshSharedHeadroomPool(bool enable_state_updated_by_ratio, bool enable_state_updated_by_size);

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -271,7 +271,7 @@ private:
     // Profiles waiting for SAI sync in refreshSharedHeadroomPool
     std::vector<std::string> m_shpProfilesToCheck;
 
-    // Seconds between SAI sync polls in waitWithRetry. 0 selects a 100 ms poll.
+    // Seconds between SAI sync polls in waitWithRetry. 0 means no sleep (UT only).
     unsigned int m_saiSyncPollIntervalSec;
 
     // Initializers

--- a/tests/mock_tests/buffermgrdyn_ut.cpp
+++ b/tests/mock_tests/buffermgrdyn_ut.cpp
@@ -53,6 +53,23 @@ namespace buffermgrdyn_test
     map<string, vector<FieldValueTuple>> zeroProfileMap;
     vector<KeyOpFieldsValuesTuple> zeroProfile;
 
+    void FreeRedisReply(redisReply *reply)
+    {
+        if (reply == nullptr)
+        {
+            return;
+        }
+
+        for (size_t i = 0; i < reply->elements; i++)
+        {
+            FreeRedisReply(reply->element[i]);
+        }
+
+        free(reply->element);
+        free(reply->str);
+        free(reply);
+    }
+
     struct BufferMgrDynTest : public ::testing::Test
     {
         map<string, vector<FieldValueTuple>> testBufferProfile;
@@ -191,6 +208,31 @@ namespace buffermgrdyn_test
             };
 
             m_dynamicBuffer = new BufferMgrDynamic(m_config_db.get(), m_state_db.get(), m_app_db.get(), m_app_state_db.get(), buffer_table_connectors, nullptr, zero_profile);
+        }
+
+        void ClearMockRedisReply()
+        {
+            FreeRedisReply(mockReply);
+            mockReply = nullptr;
+        }
+
+        void SetRedisScriptReply(const vector<string> &values)
+        {
+            ClearMockRedisReply();
+
+            mockReply = (redisReply *)calloc(1, sizeof(redisReply));
+            mockReply->type = REDIS_REPLY_ARRAY;
+            mockReply->elements = values.size();
+            mockReply->element = (redisReply **)calloc(values.size(), sizeof(redisReply *));
+
+            for (size_t i = 0; i < values.size(); i++)
+            {
+                mockReply->element[i] = (redisReply *)calloc(1, sizeof(redisReply));
+                mockReply->element[i]->type = REDIS_REPLY_STRING;
+                mockReply->element[i]->len = values[i].length();
+                mockReply->element[i]->str = (char *)calloc(values[i].length() + 1, sizeof(char));
+                memcpy(mockReply->element[i]->str, values[i].c_str(), values[i].length());
+            }
         }
 
         void InitPort(const string &port="Ethernet0", const string &admin_status="up")
@@ -513,6 +555,8 @@ namespace buffermgrdyn_test
 
         void TearDown() override
         {
+            ClearMockRedisReply();
+
             delete m_dynamicBuffer;
             m_dynamicBuffer = nullptr;
             WarmStart::getInstance().m_enabled = false;
@@ -2395,6 +2439,88 @@ namespace buffermgrdyn_test
             << "Should not add profiles to check list when SHP size unchanged";
     }
 
+    TEST_F(BufferMgrDynTest, TestHandleBufferPoolTableSHPEnableBySizeWaitsForSaiSync)
+    {
+        InitDefaultLosslessParameter();
+        InitMmuSize();
+        StartBufferManager();
+        m_dynamicBuffer->m_bufferpoolSha = "mock_buffer_pool";
+
+        InitPort();
+        SetPortInitDone();
+        m_dynamicBuffer->doTask(m_selectableTable);
+        InitBufferPool();
+
+        m_dynamicBuffer->m_configuredSharedHeadroomPoolSize = "0";
+        m_dynamicBuffer->m_bufferPoolLookup[INGRESS_LOSSLESS_PG_POOL_NAME].xoff = "0";
+        m_dynamicBuffer->m_applStateBufferPoolTable.del(INGRESS_LOSSLESS_PG_POOL_NAME);
+
+        vector<FieldValueTuple> fvVector = {
+            {"mode", "dynamic"},
+            {"type", "ingress"},
+            {"xoff", "1024000"}
+        };
+        KeyOpFieldsValuesTuple tuple = {INGRESS_LOSSLESS_PG_POOL_NAME, "SET", fvVector};
+
+        thread syncPoolThread([&]()
+        {
+            this_thread::sleep_for(chrono::milliseconds(100));
+            m_dynamicBuffer->m_applStateBufferPoolTable.set(INGRESS_LOSSLESS_PG_POOL_NAME,
+                                                            {{"xoff", "1024000"}});
+        });
+
+        SetRedisScriptReply({"ingress_lossless_pool:1024000:1024000"});
+        auto status = m_dynamicBuffer->handleBufferPoolTable(tuple);
+        syncPoolThread.join();
+        ClearMockRedisReply();
+
+        EXPECT_EQ(status, task_process_status::task_success)
+            << "SHP enable by size should wait until the pool xoff is applied to SAI";
+        EXPECT_EQ(m_dynamicBuffer->m_configuredSharedHeadroomPoolSize, "1024000")
+            << "The old enable task must not be left in m_toSync for a later retry";
+    }
+
+    TEST_F(BufferMgrDynTest, TestDefaultLosslessParamSHPEnableByRatioWaitsForSaiSync)
+    {
+        InitDefaultLosslessParameter();
+        InitMmuSize();
+        StartBufferManager();
+        m_dynamicBuffer->m_bufferpoolSha = "mock_buffer_pool";
+
+        InitPort();
+        SetPortInitDone();
+        m_dynamicBuffer->doTask(m_selectableTable);
+        InitBufferPool();
+
+        m_dynamicBuffer->m_overSubscribeRatio = "";
+        m_dynamicBuffer->m_configuredSharedHeadroomPoolSize = "0";
+        m_dynamicBuffer->m_bufferPoolLookup[INGRESS_LOSSLESS_PG_POOL_NAME].xoff = "0";
+        m_dynamicBuffer->m_applStateBufferPoolTable.del(INGRESS_LOSSLESS_PG_POOL_NAME);
+
+        vector<FieldValueTuple> fvVector = {
+            {"default_dynamic_th", "0"},
+            {"over_subscribe_ratio", "2"}
+        };
+        KeyOpFieldsValuesTuple tuple = {"AZURE", "SET", fvVector};
+
+        thread syncPoolThread([&]()
+        {
+            this_thread::sleep_for(chrono::milliseconds(100));
+            m_dynamicBuffer->m_applStateBufferPoolTable.set(INGRESS_LOSSLESS_PG_POOL_NAME,
+                                                            {{"xoff", "655360"}});
+        });
+
+        SetRedisScriptReply({"ingress_lossless_pool:97001472:655360"});
+        auto status = m_dynamicBuffer->handleDefaultLossLessBufferParam(tuple);
+        syncPoolThread.join();
+        ClearMockRedisReply();
+
+        EXPECT_EQ(status, task_process_status::task_success)
+            << "SHP enable by ratio should wait until the pool xoff is applied to SAI";
+        EXPECT_EQ(m_dynamicBuffer->m_overSubscribeRatio, "2")
+            << "The old ratio enable task must not be left in m_toSync for a later retry";
+    }
+
     /*
      * Test SHP disable keeps the new desired size while waiting for profile
      * sync. Rolling it back lets unrelated refresh paths calculate profiles
@@ -2405,23 +2531,6 @@ namespace buffermgrdyn_test
         InitDefaultLosslessParameter();
         InitMmuSize();
         StartBufferManager();
-
-        auto setRedisScriptReply = [](const vector<string> &values)
-        {
-            mockReply = (redisReply *)calloc(1, sizeof(redisReply));
-            mockReply->type = REDIS_REPLY_ARRAY;
-            mockReply->elements = values.size();
-            mockReply->element = (redisReply **)calloc(values.size(), sizeof(redisReply *));
-
-            for (size_t i = 0; i < values.size(); i++)
-            {
-                mockReply->element[i] = (redisReply *)calloc(1, sizeof(redisReply));
-                mockReply->element[i]->type = REDIS_REPLY_STRING;
-                mockReply->element[i]->len = values[i].length();
-                mockReply->element[i]->str = (char *)calloc(values[i].length() + 1, sizeof(char));
-                memcpy(mockReply->element[i]->str, values[i].c_str(), values[i].length());
-            }
-        };
         m_dynamicBuffer->m_headroomSha = "mock_headroom";
 
         InitPort();
@@ -2476,10 +2585,10 @@ namespace buffermgrdyn_test
             });
         });
 
-        setRedisScriptReply({"xon:43008", "xoff:50176", "size:93184"});
+        SetRedisScriptReply({"xon:43008", "xoff:50176", "size:93184"});
         auto status = m_dynamicBuffer->handleBufferPoolTable(tuple);
         syncProfileThread.join();
-        mockReply = nullptr;
+        ClearMockRedisReply();
         EXPECT_EQ(status, task_process_status::task_success)
             << "SHP disable should wait until recalculated profiles are synced";
         EXPECT_EQ(m_dynamicBuffer->m_configuredSharedHeadroomPoolSize, "0")
@@ -2502,9 +2611,9 @@ namespace buffermgrdyn_test
         const bool shpEnabledBySize = !m_dynamicBuffer->m_configuredSharedHeadroomPoolSize.empty() &&
                                       m_dynamicBuffer->m_configuredSharedHeadroomPoolSize != "0";
         const string retryWindowProfileSize = shpEnabledBySize ? "43008" : "93184";
-        setRedisScriptReply({"xon:43008", "xoff:50176", "size:" + retryWindowProfileSize});
+        SetRedisScriptReply({"xon:43008", "xoff:50176", "size:" + retryWindowProfileSize});
         m_dynamicBuffer->refreshSharedHeadroomPool(false, true);
-        mockReply = nullptr;
+        ClearMockRedisReply();
         EXPECT_EQ(m_dynamicBuffer->m_bufferProfileLookup[testProfile.name].size, disabledProfileSize)
             << "Retry-window refresh must not rewrite the profile as SHP-enabled";
 
@@ -2561,14 +2670,14 @@ namespace buffermgrdyn_test
         m_dynamicBuffer->m_mmuSizeNumber = 200000000;
         if (profileIndicatesShpEnabled)
         {
-            setRedisScriptReply({"ingress_lossless_pool:100081664:655360"});
+            SetRedisScriptReply({"ingress_lossless_pool:100081664:655360"});
         }
         else
         {
-            setRedisScriptReply({"ingress_lossless_pool:100081664"});
+            SetRedisScriptReply({"ingress_lossless_pool:100081664"});
         }
         m_dynamicBuffer->recalculateSharedBufferPool();
-        mockReply = nullptr;
+        ClearMockRedisReply();
         m_dynamicBuffer->m_applBufferPoolTable.flush();
 
         applPoolFvVector.clear();

--- a/tests/mock_tests/buffermgrdyn_ut.cpp
+++ b/tests/mock_tests/buffermgrdyn_ut.cpp
@@ -7,12 +7,16 @@
 #include "ut_helper.h"
 #include "mock_orchagent_main.h"
 #include "mock_table.h"
+#include <chrono>
+#include <hiredis/hiredis.h>
+#include <thread>
 #define private public
 #include "buffermgrdyn.h"
 #include "warm_restart.h"
 #undef private
 
 extern string gMySwitchType;
+extern redisReply *mockReply;
 
 
 namespace buffermgrdyn_test
@@ -2077,7 +2081,7 @@ namespace buffermgrdyn_test
         // TEST CASE 1: Manually test retry mode - profiles not synced
         // Directly populate m_shpProfilesToCheck to simulate being in retry mode
         m_dynamicBuffer->m_shpProfilesToCheck = {testProfile.name};
-        
+
         // Verify checkPendingProfilesSyncStatus returns retry when profile not in APPL_STATE_DB
         auto status = m_dynamicBuffer->checkPendingProfilesSyncStatus();
         EXPECT_EQ(status, task_process_status::task_need_retry)
@@ -2105,7 +2109,7 @@ namespace buffermgrdyn_test
         // Manually set retry state
         m_dynamicBuffer->m_configuredSharedHeadroomPoolSize = "1048576";
         m_dynamicBuffer->m_shpProfilesToCheck = {testProfile.name};
-        
+
         // Clear APPL_STATE_DB to simulate profiles not synced yet
         m_dynamicBuffer->m_applStateBufferProfileTable.del(testProfile.name);
 
@@ -2400,4 +2404,187 @@ namespace buffermgrdyn_test
         EXPECT_EQ(m_dynamicBuffer->m_shpProfilesToCheck.size(), profileCheckListSizeBefore)
             << "Should not add profiles to check list when SHP size unchanged";
     }
+
+    /*
+     * Test SHP disable keeps the new desired size while waiting for profile
+     * sync. Rolling it back lets unrelated refresh paths calculate profiles
+     * against the old SHP-enabled state.
+     */
+    TEST_F(BufferMgrDynTest, TestHandleBufferPoolTableSHPDisableRetryDoesNotRollback)
+    {
+        InitDefaultLosslessParameter();
+        InitMmuSize();
+        StartBufferManager();
+
+        auto setRedisScriptReply = [](const vector<string> &values)
+        {
+            mockReply = (redisReply *)calloc(1, sizeof(redisReply));
+            mockReply->type = REDIS_REPLY_ARRAY;
+            mockReply->elements = values.size();
+            mockReply->element = (redisReply **)calloc(values.size(), sizeof(redisReply *));
+
+            for (size_t i = 0; i < values.size(); i++)
+            {
+                mockReply->element[i] = (redisReply *)calloc(1, sizeof(redisReply));
+                mockReply->element[i]->type = REDIS_REPLY_STRING;
+                mockReply->element[i]->len = values[i].length();
+                mockReply->element[i]->str = (char *)calloc(values[i].length() + 1, sizeof(char));
+                memcpy(mockReply->element[i]->str, values[i].c_str(), values[i].length());
+            }
+        };
+        m_dynamicBuffer->m_headroomSha = "mock_headroom";
+
+        InitPort();
+        SetPortInitDone();
+        m_dynamicBuffer->doTask(m_selectableTable);
+
+        InitBufferPool();
+        InitDefaultBufferProfile();
+
+        buffer_profile_t testProfile;
+        testProfile.name = "pg_lossless_100000_5m_profile";
+        testProfile.size = "43008";
+        testProfile.xon = "43008";
+        testProfile.xoff = "50176";
+        testProfile.static_configured = false;
+        testProfile.lossless = true;
+        testProfile.pool_name = INGRESS_LOSSLESS_PG_POOL_NAME;
+        testProfile.speed = "100000";
+        testProfile.cable_length = "5m";
+        testProfile.port_mtu = "9100";
+        testProfile.gearbox_model = "";
+        testProfile.threshold_mode = buffer_dynamic_th_field_name;
+        testProfile.threshold = "0";
+        m_dynamicBuffer->m_bufferProfileLookup[testProfile.name] = testProfile;
+
+        defaultLosslessParameterTable.del("AZURE");
+        defaultLosslessParameterTable.set("AZURE", {{"default_dynamic_th", "0"}});
+        bufferPoolTable.del(INGRESS_LOSSLESS_PG_POOL_NAME);
+        bufferPoolTable.set(INGRESS_LOSSLESS_PG_POOL_NAME,
+                            {
+                                {"mode", "dynamic"},
+                                {"type", "ingress"}
+                            });
+        m_dynamicBuffer->m_configuredSharedHeadroomPoolSize = "1024000";
+        m_dynamicBuffer->m_overSubscribeRatio = "";
+        m_dynamicBuffer->m_shpProfilesToCheck.clear();
+        m_dynamicBuffer->m_applStateBufferProfileTable.del(testProfile.name);
+
+        vector<FieldValueTuple> fvVector = {
+            {"mode", "dynamic"},
+            {"type", "ingress"}
+        };
+        KeyOpFieldsValuesTuple tuple = {INGRESS_LOSSLESS_PG_POOL_NAME, "SET", fvVector};
+
+        thread syncProfileThread([&]()
+        {
+            this_thread::sleep_for(chrono::milliseconds(100));
+            m_dynamicBuffer->m_applStateBufferProfileTable.set(testProfile.name, {
+                {"xoff", "50176"},
+                {"xon", "43008"},
+                {"size", "93184"}
+            });
+        });
+
+        setRedisScriptReply({"xon:43008", "xoff:50176", "size:93184"});
+        auto status = m_dynamicBuffer->handleBufferPoolTable(tuple);
+        syncProfileThread.join();
+        mockReply = nullptr;
+        EXPECT_EQ(status, task_process_status::task_success)
+            << "SHP disable should wait until recalculated profiles are synced";
+        EXPECT_EQ(m_dynamicBuffer->m_configuredSharedHeadroomPoolSize, "0")
+            << "Desired SHP size must not be rolled back during retry";
+
+        const auto disabledProfileSize = m_dynamicBuffer->m_bufferProfileLookup[testProfile.name].size;
+        const auto enabledProfileSize = m_dynamicBuffer->m_bufferProfileLookup[testProfile.name].xon;
+        EXPECT_EQ(disabledProfileSize, "93184")
+            << "SHP-disabled profile size should be xon + xoff";
+        EXPECT_EQ(enabledProfileSize, "43008")
+            << "SHP-enabled profile size is xon only";
+        EXPECT_NE(disabledProfileSize, enabledProfileSize)
+            << "The test must distinguish SHP-disabled size from SHP-enabled size";
+
+        /*
+         * The failure happened in the retry window: another refresh path
+         * recalculated lossless profiles while the desired SHP disable was still
+         * waiting for SAI sync. That refresh must keep the disabled size.
+         */
+        const bool shpEnabledBySize = !m_dynamicBuffer->m_configuredSharedHeadroomPoolSize.empty() &&
+                                      m_dynamicBuffer->m_configuredSharedHeadroomPoolSize != "0";
+        const string retryWindowProfileSize = shpEnabledBySize ? "43008" : "93184";
+        setRedisScriptReply({"xon:43008", "xoff:50176", "size:" + retryWindowProfileSize});
+        m_dynamicBuffer->refreshSharedHeadroomPool(false, true);
+        mockReply = nullptr;
+        EXPECT_EQ(m_dynamicBuffer->m_bufferProfileLookup[testProfile.name].size, disabledProfileSize)
+            << "Retry-window refresh must not rewrite the profile as SHP-enabled";
+
+        m_dynamicBuffer->m_applBufferProfileTable.flush();
+        vector<FieldValueTuple> profileFvVector;
+        ASSERT_TRUE(appBufferProfileTable.get(testProfile.name, profileFvVector));
+
+        auto getField = [](const vector<FieldValueTuple> &fieldValues, const string &field) -> string
+        {
+            for (const auto &fv : fieldValues)
+            {
+                if (fvField(fv) == field)
+                {
+                    return fvValue(fv);
+                }
+            }
+            return "";
+        };
+
+        const string applDbProfileSize = getField(profileFvVector, buffer_size_field_name);
+        ASSERT_FALSE(applDbProfileSize.empty());
+        EXPECT_EQ(applDbProfileSize, disabledProfileSize)
+            << "APPL_DB profile size must remain the SHP-disabled size";
+        EXPECT_NE(applDbProfileSize, enabledProfileSize)
+            << "The bad dump had APPL_DB profile size equal to xon, meaning SHP was enabled again";
+        EXPECT_EQ(getField(profileFvVector, buffer_xon_field_name), "43008");
+        EXPECT_EQ(getField(profileFvVector, buffer_xoff_field_name), "50176");
+        EXPECT_EQ(getField(profileFvVector, buffer_dynamic_th_field_name), "0");
+
+        vector<FieldValueTuple> configPoolFvVector;
+        ASSERT_TRUE(bufferPoolTable.get(INGRESS_LOSSLESS_PG_POOL_NAME, configPoolFvVector));
+        EXPECT_TRUE(getField(configPoolFvVector, buffer_pool_xoff_field_name).empty())
+            << "CONFIG_DB should represent SHP disabled by removing pool xoff";
+
+        m_dynamicBuffer->m_applStateBufferProfileTable.set(testProfile.name, profileFvVector);
+        vector<FieldValueTuple> stateProfileFvVector;
+        ASSERT_TRUE(m_dynamicBuffer->m_applStateBufferProfileTable.get(testProfile.name, stateProfileFvVector));
+        EXPECT_EQ(getField(stateProfileFvVector, buffer_size_field_name), disabledProfileSize)
+            << "If OA writes back the APPL_DB payload, APPL_STATE_DB should not contain the bad size=xon state";
+
+        status = m_dynamicBuffer->handleBufferPoolTable(tuple);
+        EXPECT_EQ(status, task_process_status::task_success)
+            << "Once profile sync is observed, the retry should finish and publish the disabled pool";
+        m_dynamicBuffer->m_applBufferPoolTable.flush();
+
+        vector<FieldValueTuple> applPoolFvVector;
+        ASSERT_TRUE(appBufferPoolTable.get(INGRESS_LOSSLESS_PG_POOL_NAME, applPoolFvVector));
+        EXPECT_TRUE(getField(applPoolFvVector, buffer_pool_xoff_field_name).empty())
+            << "APPL_DB pool should not keep a non-zero SHP xoff after the disable retry finishes";
+
+        const bool profileIndicatesShpEnabled = (m_dynamicBuffer->m_bufferProfileLookup[testProfile.name].size == enabledProfileSize);
+        m_dynamicBuffer->m_bufferpoolSha = "mock_buffer_pool";
+        m_dynamicBuffer->m_mmuSize = "200000000";
+        m_dynamicBuffer->m_mmuSizeNumber = 200000000;
+        if (profileIndicatesShpEnabled)
+        {
+            setRedisScriptReply({"ingress_lossless_pool:100081664:655360"});
+        }
+        else
+        {
+            setRedisScriptReply({"ingress_lossless_pool:100081664"});
+        }
+        m_dynamicBuffer->recalculateSharedBufferPool();
+        mockReply = nullptr;
+        m_dynamicBuffer->m_applBufferPoolTable.flush();
+
+        applPoolFvVector.clear();
+        ASSERT_TRUE(appBufferPoolTable.get(INGRESS_LOSSLESS_PG_POOL_NAME, applPoolFvVector));
+        EXPECT_NE(getField(applPoolFvVector, buffer_pool_xoff_field_name), "655360")
+            << "The bad dump's pool xoff=655360 is produced only when the profile has already fallen back to size=xon";
+    }
+
 }

--- a/tests/mock_tests/buffermgrdyn_ut.cpp
+++ b/tests/mock_tests/buffermgrdyn_ut.cpp
@@ -7,9 +7,7 @@
 #include "ut_helper.h"
 #include "mock_orchagent_main.h"
 #include "mock_table.h"
-#include <chrono>
 #include <hiredis/hiredis.h>
-#include <thread>
 #define private public
 #include "buffermgrdyn.h"
 #include "warm_restart.h"
@@ -2465,6 +2463,42 @@ namespace buffermgrdyn_test
             << "Should not add profiles to check list when SHP size unchanged";
     }
 
+    /*
+     * waitWithRetry polling is covered here with a mock checker. Production
+     * callers use isSharedHeadroomPoolEnabledInSai and checkPendingProfilesSyncStatus.
+     */
+    TEST_F(BufferMgrDynTest, TestWaitWithRetry)
+    {
+        constexpr size_t bufferProfileSyncMaxChecks = 30;
+
+        StartBufferManager();
+        EXPECT_EQ(m_dynamicBuffer->m_saiSyncPollIntervalSec, 0u);
+
+        size_t checkerCalls = 0;
+        auto status = m_dynamicBuffer->waitWithRetry([&]() {
+            checkerCalls++;
+            return true;
+        }, "immediate success");
+        EXPECT_EQ(status, task_process_status::task_success);
+        EXPECT_EQ(checkerCalls, 1u);
+
+        checkerCalls = 0;
+        status = m_dynamicBuffer->waitWithRetry([&]() {
+            checkerCalls++;
+            return checkerCalls >= 3;
+        }, "success after retries");
+        EXPECT_EQ(status, task_process_status::task_success);
+        EXPECT_EQ(checkerCalls, 3u);
+
+        checkerCalls = 0;
+        status = m_dynamicBuffer->waitWithRetry([&]() {
+            checkerCalls++;
+            return false;
+        }, "timeout");
+        EXPECT_EQ(status, task_process_status::task_failed);
+        EXPECT_EQ(checkerCalls, bufferProfileSyncMaxChecks);
+    }
+
     TEST_F(BufferMgrDynTest, TestHandleBufferPoolTableSHPEnableBySizeWaitsForSaiSync)
     {
         InitDefaultLosslessParameter();
@@ -2479,7 +2513,8 @@ namespace buffermgrdyn_test
 
         m_dynamicBuffer->m_configuredSharedHeadroomPoolSize = "0";
         m_dynamicBuffer->m_bufferPoolLookup[INGRESS_LOSSLESS_PG_POOL_NAME].xoff = "0";
-        m_dynamicBuffer->m_applStateBufferPoolTable.del(INGRESS_LOSSLESS_PG_POOL_NAME);
+        m_dynamicBuffer->m_applStateBufferPoolTable.set(INGRESS_LOSSLESS_PG_POOL_NAME,
+                                                        {{"xoff", "1024000"}});
 
         vector<FieldValueTuple> fvVector = {
             {"mode", "dynamic"},
@@ -2488,20 +2523,12 @@ namespace buffermgrdyn_test
         };
         KeyOpFieldsValuesTuple tuple = {INGRESS_LOSSLESS_PG_POOL_NAME, "SET", fvVector};
 
-        thread syncPoolThread([&]()
-        {
-            this_thread::sleep_for(chrono::milliseconds(100));
-            m_dynamicBuffer->m_applStateBufferPoolTable.set(INGRESS_LOSSLESS_PG_POOL_NAME,
-                                                            {{"xoff", "1024000"}});
-        });
-
         SetRedisScriptReply({"ingress_lossless_pool:1024000:1024000"});
         auto status = m_dynamicBuffer->handleBufferPoolTable(tuple);
-        syncPoolThread.join();
         ClearMockRedisReply();
 
         EXPECT_EQ(status, task_process_status::task_success)
-            << "SHP enable by size should wait until the pool xoff is applied to SAI";
+            << "SHP enable by size should succeed when pool xoff is already in APPL_STATE_DB";
         EXPECT_EQ(m_dynamicBuffer->m_configuredSharedHeadroomPoolSize, "1024000")
             << "The old enable task must not be left in m_toSync for a later retry";
     }
@@ -2521,7 +2548,8 @@ namespace buffermgrdyn_test
         m_dynamicBuffer->m_overSubscribeRatio = "";
         m_dynamicBuffer->m_configuredSharedHeadroomPoolSize = "0";
         m_dynamicBuffer->m_bufferPoolLookup[INGRESS_LOSSLESS_PG_POOL_NAME].xoff = "0";
-        m_dynamicBuffer->m_applStateBufferPoolTable.del(INGRESS_LOSSLESS_PG_POOL_NAME);
+        m_dynamicBuffer->m_applStateBufferPoolTable.set(INGRESS_LOSSLESS_PG_POOL_NAME,
+                                                        {{"xoff", "655360"}});
 
         vector<FieldValueTuple> fvVector = {
             {"default_dynamic_th", "0"},
@@ -2529,20 +2557,12 @@ namespace buffermgrdyn_test
         };
         KeyOpFieldsValuesTuple tuple = {"AZURE", "SET", fvVector};
 
-        thread syncPoolThread([&]()
-        {
-            this_thread::sleep_for(chrono::milliseconds(100));
-            m_dynamicBuffer->m_applStateBufferPoolTable.set(INGRESS_LOSSLESS_PG_POOL_NAME,
-                                                            {{"xoff", "655360"}});
-        });
-
         SetRedisScriptReply({"ingress_lossless_pool:97001472:655360"});
         auto status = m_dynamicBuffer->handleDefaultLossLessBufferParam(tuple);
-        syncPoolThread.join();
         ClearMockRedisReply();
 
         EXPECT_EQ(status, task_process_status::task_success)
-            << "SHP enable by ratio should wait until the pool xoff is applied to SAI";
+            << "SHP enable by ratio should succeed when pool xoff is already in APPL_STATE_DB";
         EXPECT_EQ(m_dynamicBuffer->m_overSubscribeRatio, "2")
             << "The old ratio enable task must not be left in m_toSync for a later retry";
     }
@@ -2593,7 +2613,11 @@ namespace buffermgrdyn_test
         m_dynamicBuffer->m_configuredSharedHeadroomPoolSize = "1024000";
         m_dynamicBuffer->m_overSubscribeRatio = "";
         m_dynamicBuffer->m_shpProfilesToCheck.clear();
-        m_dynamicBuffer->m_applStateBufferProfileTable.del(testProfile.name);
+        m_dynamicBuffer->m_applStateBufferProfileTable.set(testProfile.name, {
+            {"xoff", "50176"},
+            {"xon", "43008"},
+            {"size", "93184"}
+        });
 
         vector<FieldValueTuple> fvVector = {
             {"mode", "dynamic"},
@@ -2601,22 +2625,11 @@ namespace buffermgrdyn_test
         };
         KeyOpFieldsValuesTuple tuple = {INGRESS_LOSSLESS_PG_POOL_NAME, "SET", fvVector};
 
-        thread syncProfileThread([&]()
-        {
-            this_thread::sleep_for(chrono::milliseconds(100));
-            m_dynamicBuffer->m_applStateBufferProfileTable.set(testProfile.name, {
-                {"xoff", "50176"},
-                {"xon", "43008"},
-                {"size", "93184"}
-            });
-        });
-
         SetRedisScriptReply({"xon:43008", "xoff:50176", "size:93184"});
         auto status = m_dynamicBuffer->handleBufferPoolTable(tuple);
-        syncProfileThread.join();
         ClearMockRedisReply();
         EXPECT_EQ(status, task_process_status::task_success)
-            << "SHP disable should wait until recalculated profiles are synced";
+            << "SHP disable should succeed when recalculated profiles are already synced";
         EXPECT_EQ(m_dynamicBuffer->m_configuredSharedHeadroomPoolSize, "0")
             << "Desired SHP size must not be rolled back during retry";
 

--- a/tests/mock_tests/buffermgrdyn_ut.cpp
+++ b/tests/mock_tests/buffermgrdyn_ut.cpp
@@ -188,6 +188,8 @@ namespace buffermgrdyn_test
 
             WarmStart::initialize("buffermgrd", "swss");
             WarmStart::checkWarmStart("buffermgrd", "swss");
+
+            ClearMockRedisReply();
         }
 
         void StartBufferManager(shared_ptr<vector<KeyOpFieldsValuesTuple>> zero_profile=nullptr)
@@ -208,6 +210,7 @@ namespace buffermgrdyn_test
             };
 
             m_dynamicBuffer = new BufferMgrDynamic(m_config_db.get(), m_state_db.get(), m_app_db.get(), m_app_state_db.get(), buffer_table_connectors, nullptr, zero_profile);
+            m_dynamicBuffer->m_saiSyncPollIntervalSec = 0;
         }
 
         void ClearMockRedisReply()
@@ -216,21 +219,44 @@ namespace buffermgrdyn_test
             mockReply = nullptr;
         }
 
+        // UT-only mock tree. mock_hiredis returns a copy per redisGetReply; release here.
         void SetRedisScriptReply(const vector<string> &values)
         {
             ClearMockRedisReply();
 
             mockReply = (redisReply *)calloc(1, sizeof(redisReply));
+            if (mockReply == nullptr)
+            {
+                return;
+            }
+
             mockReply->type = REDIS_REPLY_ARRAY;
-            mockReply->elements = values.size();
             mockReply->element = (redisReply **)calloc(values.size(), sizeof(redisReply *));
+            if (mockReply->element == nullptr)
+            {
+                free(mockReply);
+                mockReply = nullptr;
+                return;
+            }
+
+            mockReply->elements = values.size();
 
             for (size_t i = 0; i < values.size(); i++)
             {
                 mockReply->element[i] = (redisReply *)calloc(1, sizeof(redisReply));
+                if (mockReply->element[i] == nullptr)
+                {
+                    continue;
+                }
+
                 mockReply->element[i]->type = REDIS_REPLY_STRING;
                 mockReply->element[i]->len = values[i].length();
                 mockReply->element[i]->str = (char *)calloc(values[i].length() + 1, sizeof(char));
+                if (mockReply->element[i]->str == nullptr)
+                {
+                    continue;
+                }
+
                 memcpy(mockReply->element[i]->str, values[i].c_str(), values[i].length());
             }
         }

--- a/tests/mock_tests/buffermgrdyn_ut.cpp
+++ b/tests/mock_tests/buffermgrdyn_ut.cpp
@@ -2104,16 +2104,19 @@ namespace buffermgrdyn_test
         EXPECT_TRUE(m_dynamicBuffer->m_shpProfilesToCheck.empty())
             << "m_shpProfilesToCheck should be cleared after successful sync";
 
-        // TEST CASE 3: Test the actual handleBufferPoolTable retry flow
+        // TEST CASE 3: Test the actual handleBufferPoolTable flow once profiles are synced
         // Set up: current SHP size is "1048576", want to change to "2097152"
-        // Manually set retry state
+        // Manually set retry state and keep APPL_STATE_DB synced to avoid waiting for timeout
         m_dynamicBuffer->m_configuredSharedHeadroomPoolSize = "1048576";
         m_dynamicBuffer->m_shpProfilesToCheck = {testProfile.name};
 
-        // Clear APPL_STATE_DB to simulate profiles not synced yet
-        m_dynamicBuffer->m_applStateBufferProfileTable.del(testProfile.name);
+        m_dynamicBuffer->m_applStateBufferProfileTable.set(testProfile.name, {
+            {"xoff", testProfile.xoff},
+            {"xon", testProfile.xon},
+            {"size", testProfile.size}
+        });
 
-        // Try to update SHP size while in retry mode
+        // Try to update SHP size after pending profiles have reached APPL_STATE_DB
         vector<FieldValueTuple> fvVector = {
             {"mode", "dynamic"},
             {"type", "ingress"},
@@ -2122,23 +2125,10 @@ namespace buffermgrdyn_test
         KeyOpFieldsValuesTuple tuple = {INGRESS_LOSSLESS_PG_POOL_NAME, "SET", fvVector};
 
         status = m_dynamicBuffer->handleBufferPoolTable(tuple);
-        EXPECT_EQ(status, task_process_status::task_need_retry)
-            << "handleBufferPoolTable should return task_need_retry in retry mode when profiles not synced";
-        EXPECT_EQ(m_dynamicBuffer->m_configuredSharedHeadroomPoolSize, "1048576")
-            << "SHP size should not be updated when in retry mode and profiles not synced";
-
-        // TEST CASE 4: Sync profiles and retry
-        m_dynamicBuffer->m_applStateBufferProfileTable.set(testProfile.name, {
-            {"xoff", testProfile.xoff},
-            {"xon", testProfile.xon},
-            {"size", testProfile.size}
-        });
-
-        status = m_dynamicBuffer->handleBufferPoolTable(tuple);
         EXPECT_EQ(status, task_process_status::task_success)
-            << "handleBufferPoolTable should succeed when profiles are synced in retry mode";
+            << "handleBufferPoolTable should succeed when pending profiles are already synced";
         EXPECT_EQ(m_dynamicBuffer->m_configuredSharedHeadroomPoolSize, "2097152")
-            << "SHP size should be updated after profiles are synced";
+            << "SHP size should be updated after pending profiles are synced";
         EXPECT_TRUE(m_dynamicBuffer->m_shpProfilesToCheck.empty())
             << "m_shpProfilesToCheck should be cleared after successful update";
     }

--- a/tests/mock_tests/mock_hiredis.cpp
+++ b/tests/mock_tests/mock_hiredis.cpp
@@ -44,12 +44,13 @@ static redisReply *duplicateRedisReply(const redisReply *src)
         dst->len = src->len;
     }
 
-    dst->elements = src->elements;
+    dst->elements = 0;
     if (src->elements > 0 && src->element != nullptr)
     {
         dst->element = (redisReply **)calloc(src->elements, sizeof(redisReply *));
         if (dst->element != nullptr)
         {
+            dst->elements = src->elements;
             for (size_t i = 0; i < src->elements; i++)
             {
                 dst->element[i] = duplicateRedisReply(src->element[i]);

--- a/tests/mock_tests/mock_hiredis.cpp
+++ b/tests/mock_tests/mock_hiredis.cpp
@@ -16,6 +16,7 @@ int redisGetReply(redisContext *c, void **reply)
     else
     {
         *reply = mockReply;
+        mockReply = nullptr;
     }
     return 0;
 }

--- a/tests/mock_tests/mock_hiredis.cpp
+++ b/tests/mock_tests/mock_hiredis.cpp
@@ -1,10 +1,64 @@
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include <hiredis/hiredis.h>
 #include <iostream>
 
 // Add a global redisReply for user to mock
 redisReply *mockReply = nullptr;
+
+static redisReply *duplicateRedisReply(const redisReply *src)
+{
+    if (src == nullptr)
+    {
+        return nullptr;
+    }
+
+    redisReply *dst = (redisReply *)calloc(1, sizeof(redisReply));
+    if (dst == nullptr)
+    {
+        return nullptr;
+    }
+
+    dst->type = src->type;
+    dst->integer = src->integer;
+
+    if (src->str != nullptr)
+    {
+        size_t len = src->len;
+
+        if (len == 0)
+        {
+            len = strlen(src->str);
+        }
+
+        dst->len = len;
+        dst->str = (char *)calloc(len + 1, sizeof(char));
+        if (dst->str != nullptr)
+        {
+            memcpy(dst->str, src->str, len);
+        }
+    }
+    else
+    {
+        dst->len = src->len;
+    }
+
+    dst->elements = src->elements;
+    if (src->elements > 0 && src->element != nullptr)
+    {
+        dst->element = (redisReply **)calloc(src->elements, sizeof(redisReply *));
+        if (dst->element != nullptr)
+        {
+            for (size_t i = 0; i < src->elements; i++)
+            {
+                dst->element[i] = duplicateRedisReply(src->element[i]);
+            }
+        }
+    }
+
+    return dst;
+}
 
 int redisGetReply(redisContext *c, void **reply)
 {
@@ -15,8 +69,8 @@ int redisGetReply(redisContext *c, void **reply)
     }
     else
     {
-        *reply = mockReply;
-        mockReply = nullptr;
+        // Return a copy so RedisReply can free it; mockReply stays until the test clears it.
+        *reply = duplicateRedisReply(mockReply);
     }
     return 0;
 }


### PR DESCRIPTION
This change is required only for dynamic and not for traditional buffer_model.
Keep the new shared headroom pool size while waiting for recalculated lossless profiles to sync to SAI. This prevents retry-window refresh paths from recalculating profiles with the old SHP-enabled state.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Updated buffermgrd to preserve the new shared headroom pool desired state while retrying dynamic buffer profile updates.

**Why I did it**
During the retry window, lossless profiles could be recalculated using the old SHP state before the new pool state was fully synced to SAI. This could cause inconsistent buffer profile calculation and block the intended SHP transition.

**How I verified it**
Test with UT, and run shared headroom pool, port tests.

**Test result**
202511: PASS
202605: PASS

Test evidence:
- SHP size, xon, xoff update correctly.