### PR TITLE
[vnetorch] Add ipv6 link local ip2me route for VNETs

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -104,12 +104,11 @@ bool VNetVrfObject::createObj(vector<sai_attribute_t>& attrs)
         }
         gFlowCounterRouteOrch->onAddVR(router_id);
 
-        /* Install IPv6 link-local trap routes (fe80::/10
-         * catch-all into the newly created VNET VR. RouteOrch's
-         * constructor only installs these for the default VR, so without
-         * this call IPv6 link-local traffic destined to interfaces in
-         * this VNET (e.g. unnumbered BGP) is dropped at the chip. */
-        gRouteOrch->addLinkLocalRouteToMe(router_id, IpPrefix("fe80::/10"));
+        /* Install IPv6 link-local trap routes (fe80::/10) to trap control packet so CPU. RouteOrch's
+         * constructor only installs these for the default VR */
+        IpPrefix default_link_local_prefix("fe80::/10");
+        gRouteOrch->addLinkLocalRouteToMe(router_id, default_link_local_prefix);
+        SWSS_LOG_INFO("Created link local ipv6 route %s for vnet %s to cpu", default_link_local_prefix.to_string().c_str(), vnet_name_.c_str());
 
         return true;
     };
@@ -357,10 +356,10 @@ VNetVrfObject::~VNetVrfObject()
     {
         if (it != gVirtualRouterId)
         {
-            /* Remove the IPv6 link-local trap routes installed at VR
-             * creation. Must precede remove_virtual_router or SAI will
-             * reject the VR delete because of dependent route entries. */
-            gRouteOrch->delLinkLocalRouteToMe(it, IpPrefix("fe80::/10"));
+            /* Remove the IPv6 link-local trap routes installed at VR creation */
+            IpPrefix default_link_local_prefix("fe80::/10");
+            gRouteOrch->delLinkLocalRouteToMe(it, default_link_local_prefix);
+            SWSS_LOG_INFO("Deleted link local ipv6 route %s for vnet %s to cpu", default_link_local_prefix.to_string().c_str(), vnet_name_.c_str());
 
             sai_status_t status = sai_virtual_router_api->remove_virtual_router(it);
             if (status != SAI_STATUS_SUCCESS)

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -109,19 +109,8 @@ bool VNetVrfObject::createObj(vector<sai_attribute_t>& attrs)
          * constructor only installs these for the default VR, so without
          * this call IPv6 link-local traffic destined to interfaces in
          * this VNET (e.g. unnumbered BGP) is dropped at the chip. */
-        if (gRouteOrch)
-        {
-            try
-            {
-                gRouteOrch->addLinkLocalRouteToMe(
-                    router_id, IpPrefix("fe80::/10"));
-            }
-            catch (const std::exception& e)
-            {
-                SWSS_LOG_ERROR("Failed to add link-local trap routes for "
-                               "VNET '%s': %s", vnet_name_.c_str(), e.what());
-            }
-        }
+        gRouteOrch->addLinkLocalRouteToMe(router_id, IpPrefix("fe80::/10"));
+
         return true;
     };
 
@@ -371,20 +360,7 @@ VNetVrfObject::~VNetVrfObject()
             /* Remove the IPv6 link-local trap routes installed at VR
              * creation. Must precede remove_virtual_router or SAI will
              * reject the VR delete because of dependent route entries. */
-            if (gRouteOrch)
-            {
-                try
-                {
-                    gRouteOrch->delLinkLocalRouteToMe(
-                        it, IpPrefix("fe80::/10"));
-                }
-                catch (const std::exception& e)
-                {
-                    SWSS_LOG_WARN("Failed to remove link-local trap routes "
-                                  "for VNET '%s': %s",
-                                  vnet_name_.c_str(), e.what());
-                }
-            }
+            gRouteOrch->delLinkLocalRouteToMe(it, IpPrefix("fe80::/10"));
 
             sai_status_t status = sai_virtual_router_api->remove_virtual_router(it);
             if (status != SAI_STATUS_SUCCESS)

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -103,6 +103,25 @@ bool VNetVrfObject::createObj(vector<sai_attribute_t>& attrs)
             throw std::runtime_error("Failed to create VR object");
         }
         gFlowCounterRouteOrch->onAddVR(router_id);
+
+        /* Install IPv6 link-local trap routes (fe80::/10
+         * catch-all into the newly created VNET VR. RouteOrch's
+         * constructor only installs these for the default VR, so without
+         * this call IPv6 link-local traffic destined to interfaces in
+         * this VNET (e.g. unnumbered BGP) is dropped at the chip. */
+        if (gRouteOrch)
+        {
+            try
+            {
+                gRouteOrch->addLinkLocalRouteToMe(
+                    router_id, IpPrefix("fe80::/10"));
+            }
+            catch (const std::exception& e)
+            {
+                SWSS_LOG_ERROR("Failed to add link-local trap routes for "
+                               "VNET '%s': %s", vnet_name_.c_str(), e.what());
+            }
+        }
         return true;
     };
 
@@ -349,6 +368,24 @@ VNetVrfObject::~VNetVrfObject()
     {
         if (it != gVirtualRouterId)
         {
+            /* Remove the IPv6 link-local trap routes installed at VR
+             * creation. Must precede remove_virtual_router or SAI will
+             * reject the VR delete because of dependent route entries. */
+            if (gRouteOrch)
+            {
+                try
+                {
+                    gRouteOrch->delLinkLocalRouteToMe(
+                        it, IpPrefix("fe80::/10"));
+                }
+                catch (const std::exception& e)
+                {
+                    SWSS_LOG_WARN("Failed to remove link-local trap routes "
+                                  "for VNET '%s': %s",
+                                  vnet_name_.c_str(), e.what());
+                }
+            }
+
             sai_status_t status = sai_virtual_router_api->remove_virtual_router(it);
             if (status != SAI_STATUS_SUCCESS)
             {

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -3667,6 +3667,7 @@ class TestVnetOrch(object):
             self.set_admin_status("Ethernet0", "down")
             self.cdb.delete_entry("INTERFACE", "Ethernet0")
 
+
     '''
     IP2Me link-local trap route install test for VNET VRs(fe80::/10 tracp to CPU route)
     '''

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -3576,7 +3576,6 @@ class TestVnetOrch(object):
         self.set_admin_status("Ethernet4", "down")
 
 
-
     '''
     VNET tunnel route with a directly-connected local endpoint.
     '''
@@ -3667,6 +3666,77 @@ class TestVnetOrch(object):
             self.remove_ip_address("Ethernet0", "20.20.20.1/24")
             self.set_admin_status("Ethernet0", "down")
             self.cdb.delete_entry("INTERFACE", "Ethernet0")
+
+    '''
+    IP2Me link-local trap route install test for VNET VRs(fe80::/10 tracp to CPU route)
+    '''
+    def test_vnet_ip2me_link_local(self, dvs, testlog):
+        self.setup_db(dvs)
+
+        asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
+        vnet_obj = self.get_vnet_obj()
+
+        tunnel_name = "tunnel_ip2me"
+        vnet_name = "Vnet_ip2me"
+
+        vnet_obj.fetch_exist_entries(dvs)
+        pre_routes = get_exist_entries(dvs, vnet_obj.ASIC_ROUTE_ENTRY)
+        default_vr = get_default_vr_id(dvs)
+
+        create_vxlan_tunnel(dvs, tunnel_name, "10.10.10.10")
+        create_vnet_entry(dvs, vnet_name, tunnel_name, "20001", "")
+        vnet_obj.check_vnet_entry(dvs, vnet_name)
+        time.sleep(2)
+
+        post_routes = get_exist_entries(dvs, vnet_obj.ASIC_ROUTE_ENTRY)
+        new_routes = post_routes - pre_routes
+        print("DBG new_route_count=%d" % len(new_routes))
+        for r in sorted(new_routes):
+            print("DBG new_route: %s" % r)
+
+        ll_keys = []
+        ll_prefixes = []
+        for key in new_routes:
+            try:
+                payload = json.loads(key)
+            except (ValueError, IndexError):
+                continue
+            dest = payload.get("dest", "")
+            if dest.startswith("fe80:"):
+                ll_keys.append(key)
+                ll_prefixes.append(dest)
+
+        assert ll_prefixes == ["fe80::/10"], (
+            "Expected exactly one link-local trap route fe80::/10 in VNET VR, "
+            "got %s; full new_routes=%s" % (ll_prefixes, sorted(new_routes))
+        )
+
+        rt_tbl = swsscommon.Table(asic_db, vnet_obj.ASIC_ROUTE_ENTRY)
+        for k in ll_keys:
+            payload = json.loads(k)
+            assert payload.get("vr") and payload["vr"] != default_vr, (
+                "Link-local route %s programmed in default VR" % k
+            )
+            status, fvs = rt_tbl.get(k)
+            assert status, "Failed to fetch attributes for %s" % k
+            attrs = dict(fvs)
+            action = attrs.get("SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION")
+            assert action == "SAI_PACKET_ACTION_FORWARD", (
+                "Link-local route %s action=%s, expected FORWARD-to-CPU" % (k, action)
+            )
+            nh = attrs.get("SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", "")
+            assert nh, "Link-local route %s missing next hop (CPU port)" % k
+
+        delete_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_del_vnet_entry(dvs, vnet_name)
+        delete_vxlan_tunnel(dvs, tunnel_name)
+        time.sleep(2)
+
+        final_routes = get_exist_entries(dvs, vnet_obj.ASIC_ROUTE_ENTRY)
+        for k in ll_keys:
+            assert k not in final_routes, (
+                "Link-local trap route %s not cleaned up after VNET delete" % k
+            )
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying

--- a/tests/vnet_lib.py
+++ b/tests/vnet_lib.py
@@ -889,6 +889,11 @@ class VnetVxlanVrfTunnel(object):
         self.vnet_vr_ids.update(new_vr_ids)
         self.vr_map[name] = { 'ing':new_vr_ids[0], 'egr':new_vr_ids[0], 'peer':peer_list }
 
+        # IP2Me link-local routes (fe80::/10) are added to every new VR
+        # by VNETOrch (to support unnumbered BGP in the VNET VRF). Absorb them into the baseline
+        # so subsequent route-count assertions remain accurate.
+        self.routes = get_exist_entries(dvs, self.ASIC_ROUTE_ENTRY)
+
     def check_default_vnet_entry(self, dvs, name):
         asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
         #Check virtual router objects


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Install the IPv6 link-local IP2Me trap route (`fe80::/10`) into every newly created VNET virtual router in `VNetOrch`, and tear it down before the VR is destroyed. Mirrors the equivalent `RouteOrch` behavior that exists today only for the default VR and the VRF code path (added by #3973)

**Why I did it**
Unnumbered BGP relies entirely on IPv6 link-local addressing (peers exchange via `fe80::...%if`). When a SONiC interface is placed in a VNET (i.e. a non-default VRF backed by a VxLAN tunnel), the chip needs a `fe80::/10`-to-CPU MY_IP entry **in that VNET's virtual router**, otherwise inbound BGP TCP/179 and ICMPv6 (RA / NS / NA) destined for the device's own link-local address are silently dropped before reaching the kernel/FRR.

**How I verified it**
Unit Test
Physical DUT test

**Details if related**
