### PR TITLE
LruDedup queue policy for Notification Consumer

### DIFF
--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -101,6 +101,7 @@ orchagent_SOURCES = \
             dtelorch.cpp \
             flexcounterorch.cpp \
             watermarkorch.cpp \
+            notificationconsumerstatsorch.cpp \
             policerorch.cpp \
             sfloworch.cpp \
             chassisorch.cpp \

--- a/orchagent/bfdorch.cpp
+++ b/orchagent/bfdorch.cpp
@@ -1,5 +1,6 @@
 #include "bfdorch.h"
 #include "intfsorch.h"
+#include "notificationconsumerstatsorch.h"
 #include "vrforch.h"
 #include "converter.h"
 #include "swssnet.h"
@@ -62,6 +63,10 @@ BfdOrch::BfdOrch(DBConnector *db, string tableName, TableConnector stateDbBfdSes
 
     DBConnector *notificationsDb = new DBConnector("ASIC_DB", 0);
     m_bfdStateNotificationConsumer = new swss::NotificationConsumer(notificationsDb, "NOTIFICATIONS");
+    m_bfdStateNotificationConsumer->setOpAllowList({"bfd_session_state_change"});
+    m_bfdStateNotificationConsumer->setStatsLabel("BfdOrch:bfd_session_state_change");
+    if (gNotifConsumerStatsOrch)
+        gNotifConsumerStatsOrch->registerConsumer("BfdOrch:bfd_session_state_change", m_bfdStateNotificationConsumer);
     auto bfdStateNotificatier = new Notifier(m_bfdStateNotificationConsumer, this, "BFD_STATE_NOTIFICATIONS");
 
     m_stateDbConnector = std::make_unique<swss::DBConnector>("STATE_DB", 0);

--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -7,6 +7,7 @@
 
 #include "logger.h"
 #include "tokenize.h"
+#include "notificationconsumerstatsorch.h"
 #include "fdborch.h"
 #include "crmorch.h"
 #include "notifier.h"
@@ -40,12 +41,44 @@ FdbOrch::FdbOrch(DBConnector* applDbConnector, vector<table_name_with_pri_t> app
 
     m_portsOrch->attach(this);
     m_flushNotificationsConsumer = new NotificationConsumer(applDbConnector, "FLUSHFDBREQUEST");
+    m_flushNotificationsConsumer->setOpAllowList({"ALL", "PORT", "VLAN", "PORTVLAN"});
+    m_flushNotificationsConsumer->setStatsLabel("FdbOrch:flush");
+    if (gNotifConsumerStatsOrch)
+        gNotifConsumerStatsOrch->registerConsumer("FdbOrch:flush", m_flushNotificationsConsumer);
     auto flushNotifier = new Notifier(m_flushNotificationsConsumer, this, "FLUSHFDBREQUEST");
     Orch::addExecutor(flushNotifier);
 
-    /* Add FDB notifications support from ASIC */
+    /* Add FDB notifications support from ASIC.
+     *
+     * Opt the FDB consumer into the LRU-dedup queue policy.  LruDedup
+     * collapses *byte-identical* in-flight payloads at enqueue -- two
+     * consecutive identical SAI fdb_event notifications (same vlan/mac/
+     * port/event_type) become one queue entry; distinct event types
+     * (LEARN vs AGE) and distinct ports for the same MAC are different
+     * byte strings and queue separately, so no event-shadowing happens.
+     *
+     * FdbOrch's update() is end-state-idempotent under identical
+     * payloads: repeated LEARN on the same (vlan, mac, port) is a
+     * no-op after the first; repeated AGE on an already-aged entry
+     * is a no-op; so collapsing only byte-identical duplicates
+     * preserves the final FDB_TABLE state while bounding queue depth
+     * to count(distinct in-flight payloads) instead of event rate.
+     *
+     * pri=100 / popBatchSize match swss-common's 4-arg ctor defaults;
+     * the 5-arg ctor has no defaults so they must be passed
+     * explicitly.  No change in Select-loop priority vs. the prior
+     * 2-arg call.
+     */
     m_notificationsDb = make_shared<DBConnector>("ASIC_DB", 0);
-    m_fdbNotificationConsumer = new swss::NotificationConsumer(m_notificationsDb.get(), "NOTIFICATIONS");
+    m_fdbNotificationConsumer = new swss::NotificationConsumer(
+        m_notificationsDb.get(), "NOTIFICATIONS",
+        100,                                       // pri -- match swss-common default
+        swss::DEFAULT_NC_POP_BATCH_SIZE,
+        swss::NotificationQueuePolicy::LruDedup);
+    m_fdbNotificationConsumer->setOpAllowList({"fdb_event"});
+    m_fdbNotificationConsumer->setStatsLabel("FdbOrch:fdb_event");
+    if (gNotifConsumerStatsOrch)
+        gNotifConsumerStatsOrch->registerConsumer("FdbOrch:fdb_event", m_fdbNotificationConsumer);
     auto fdbNotifier = new Notifier(m_fdbNotificationConsumer, this, "FDB_NOTIFICATIONS");
     Orch::addExecutor(fdbNotifier);
 }

--- a/orchagent/icmporch.cpp
+++ b/orchagent/icmporch.cpp
@@ -8,6 +8,7 @@
 #include "converter.h"
 #include "swssnet.h"
 #include "notifier.h"
+#include "notificationconsumerstatsorch.h"
 #include "sai_serialize.h"
 #include "directory.h"
 #include "notifications.h"
@@ -52,6 +53,10 @@ IcmpOrch::IcmpOrch(DBConnector *db, string tableName, TableConnector stateDbIcmp
 
     DBConnector *notificationsDb = new DBConnector("ASIC_DB", 0);
     m_icmpStateNotificationConsumer = new swss::NotificationConsumer(notificationsDb, "NOTIFICATIONS");
+    m_icmpStateNotificationConsumer->setOpAllowList({"icmp_echo_session_state_change"});
+    m_icmpStateNotificationConsumer->setStatsLabel("IcmpOrch:icmp_echo_session_state_change");
+    if (gNotifConsumerStatsOrch)
+        gNotifConsumerStatsOrch->registerConsumer("IcmpOrch:icmp_echo_session_state_change", m_icmpStateNotificationConsumer);
 
     // Clean up state database ICMP entries
     vector<string> keys;

--- a/orchagent/notificationconsumerstatsorch.cpp
+++ b/orchagent/notificationconsumerstatsorch.cpp
@@ -1,0 +1,101 @@
+#include "notificationconsumerstatsorch.h"
+
+#include "logger.h"
+#include "select.h"
+#include "table.h"
+#include "timer.h"
+
+#include <vector>
+
+using namespace swss;
+
+NotificationConsumerStatsOrch *gNotifConsumerStatsOrch = nullptr;
+
+namespace
+{
+constexpr const char *kStatsTable = "NOTIFICATION_CONSUMER_STATS";
+}
+
+NotificationConsumerStatsOrch::NotificationConsumerStatsOrch()
+    : Orch()
+{
+    SWSS_LOG_ENTER();
+
+    m_countersDb = std::make_shared<DBConnector>("COUNTERS_DB", 0);
+    m_table      = std::make_shared<Table>(m_countersDb.get(), kStatsTable);
+
+    auto interv = timespec { .tv_sec = kPublishIntervalSec, .tv_nsec = 0 };
+    m_timer = new SelectableTimer(interv);
+
+    auto executor = new ExecutableTimer(m_timer, this, "NOTIF_CONSUMER_STATS_TIMER");
+    Orch::addExecutor(executor);
+    m_timer->start();
+
+    SWSS_LOG_NOTICE("NotificationConsumerStatsOrch: publishing to COUNTERS_DB:%s every %ds",
+                    kStatsTable, kPublishIntervalSec);
+}
+
+void NotificationConsumerStatsOrch::registerConsumer(const std::string &name,
+                                                     NotificationConsumer *consumer)
+{
+    if (consumer == nullptr)
+    {
+        SWSS_LOG_WARN("NotificationConsumerStatsOrch::registerConsumer: null consumer for %s",
+                      name.c_str());
+        return;
+    }
+    m_consumers.push_back({name, consumer});
+    SWSS_LOG_NOTICE("NotificationConsumerStatsOrch: registered %s (channel=%s)",
+                    name.c_str(), consumer->getChannel().c_str());
+}
+
+void NotificationConsumerStatsOrch::doTask(SelectableTimer &timer)
+{
+    SWSS_LOG_ENTER();
+
+    for (const auto &entry : m_consumers)
+    {
+        // dropped_allowlist is expected to be high in the presence of a storm,
+        // as each NOTIFICATION gets delivered to ALL consumers, and all
+        // consumers except the intended recipient will drop the message.
+        auto admit_stats = entry.consumer->getStats();
+        uint64_t admitted = admit_stats.received >= admit_stats.dropped_allowlist
+                            ? admit_stats.received - admit_stats.dropped_allowlist
+                            : 0;
+        uint64_t admit_ratio = admit_stats.received
+                               ? (100 * admitted / admit_stats.received)
+                               : 0;
+
+        std::vector<FieldValueTuple> fvs;
+        fvs.emplace_back("channel", entry.consumer->getChannel());
+        fvs.emplace_back("received",          std::to_string(admit_stats.received));
+        fvs.emplace_back("dropped_allowlist", std::to_string(admit_stats.dropped_allowlist));
+        fvs.emplace_back("admitted",          std::to_string(admitted));
+        fvs.emplace_back("admit_ratio_pct",   std::to_string(admit_ratio));
+
+        // If the consumer uses LruDedup, also publish the queue-side
+        // dedup counters.  FIFO queues have no equivalent.
+        if (auto *lru = entry.consumer->getLruDedupQueue())
+        {
+            auto qs = lru->getStats();
+            // Integer percent for consistency: redis-cli scrapers see
+            // a stable type ("0".."100") instead of a mix of "0" and
+            // "75.000000".  Sub-integer granularity isn't useful here
+            // (the counter is updated once per push and the publish
+            // tick is 10 s).
+            uint64_t ratio = qs.pushed ? (100 * qs.dedup_hits / qs.pushed) : 0;
+            fvs.emplace_back("lru_pushed",          std::to_string(qs.pushed));
+            fvs.emplace_back("lru_dedup_hits",      std::to_string(qs.dedup_hits));
+            fvs.emplace_back("lru_dedup_ratio_pct", std::to_string(ratio));
+            fvs.emplace_back("lru_current_depth",   std::to_string(qs.current_depth));
+            fvs.emplace_back("lru_high_watermark",  std::to_string(qs.high_watermark));
+            fvs.emplace_back("queue_policy", "LruDedup");
+        }
+        else
+        {
+            fvs.emplace_back("queue_policy", "Fifo");
+        }
+
+        m_table->set(entry.name, fvs);
+    }
+}

--- a/orchagent/notificationconsumerstatsorch.h
+++ b/orchagent/notificationconsumerstatsorch.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "orch.h"
+
+#include "notificationconsumer.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+/*
+ * NotificationConsumerStatsOrch
+ *
+ * Periodically publishes admission + LRU-dedup counters from registered
+ * swss::NotificationConsumer instances to COUNTERS_DB so they are
+ * scrapable without bpftrace or syslog parsing.
+ *
+ * Lifecycle:
+ *
+ *   - OrchDaemon constructs this orch once, before any orch that owns a
+ *     NotificationConsumer it cares to publish.
+ *   - Each <X>Orch that wants its NotificationConsumer's stats visible
+ *     calls
+ *         gNotifConsumerStatsOrch->registerConsumer(name, consumer)
+ *     right after constructing the consumer.  Registration is opt-in
+ *     per consumer.
+ *   - A SelectableTimer fires every kPublishIntervalSec seconds; on
+ *     each tick the orch walks the registry and writes one HSET per
+ *     consumer to COUNTERS_DB:NOTIFICATION_CONSUMER_STATS:<name>.
+ *
+ * If the global pointer is null (e.g. unit tests, fabric-only daemon)
+ * the registerConsumer call is a no-op via a null check at every call
+ * site -- the timer never runs, no DB connection is opened.
+ */
+
+class NotificationConsumerStatsOrch : public Orch
+{
+public:
+    // Creates its own DBConnector to COUNTERS_DB; no orchdaemon-side
+    // table needs to be wired up.  Constructed once by OrchDaemon::init.
+    NotificationConsumerStatsOrch();
+
+    // Add a consumer to the publish set.  Stable name -- becomes the
+    // hash key in COUNTERS_DB:NOTIFICATION_CONSUMER_STATS:<name>.  The
+    // pointer must outlive this orch.
+    void registerConsumer(const std::string &name, swss::NotificationConsumer *consumer);
+
+    // Fires the COUNTERS_DB publish on every tick of the internal timer.
+    void doTask(swss::SelectableTimer &timer) override;
+
+    // This orch has no Consumer-table executors registered -- it is
+    // driven entirely by the internal SelectableTimer.  The Consumer
+    // override is kept for clarity/completeness and is not expected to run
+    // because no Consumer executors are registered.
+    void doTask(Consumer &consumer) override { /* no Consumer executors registered */ }
+
+private:
+    struct Entry
+    {
+        std::string name;
+        swss::NotificationConsumer *consumer;
+    };
+
+    std::shared_ptr<swss::DBConnector> m_countersDb;
+    std::shared_ptr<swss::Table>       m_table;
+    std::vector<Entry>                 m_consumers;
+    swss::SelectableTimer             *m_timer = nullptr;
+
+    static constexpr int kPublishIntervalSec = 10;
+};
+
+extern NotificationConsumerStatsOrch *gNotifConsumerStatsOrch;

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -14,6 +14,7 @@
 #define SAI_SWITCH_ATTR_CUSTOM_RANGE_BASE SAI_SWITCH_ATTR_CUSTOM_RANGE_START
 #include "sairedis.h"
 #include "chassisorch.h"
+#include "notificationconsumerstatsorch.h"
 #include "stporch.h"
 
 using namespace std;
@@ -192,6 +193,14 @@ bool OrchDaemon::init()
     g_events_handle = events_init_publisher("sonic-events-swss");
 
     gCrmOrch = new CrmOrch(m_configDb, CFG_CRM_TABLE_NAME);
+
+    // Construct the NotificationConsumer stats publisher before any
+    // orch that owns a NotificationConsumer it cares to publish, so
+    // each of those orchs can call
+    // gNotifConsumerStatsOrch->registerConsumer(...) from its
+    // constructor.  A null gNotifConsumerStatsOrch means publish is
+    // disabled; the registerConsumer call sites all null-check.
+    gNotifConsumerStatsOrch = new NotificationConsumerStatsOrch();
 
     TableConnector stateDbSwitchTable(m_stateDb, STATE_SWITCH_CAPABILITY_TABLE_NAME);
     TableConnector app_switch_table(m_applDb, APP_SWITCH_TABLE_NAME);
@@ -497,7 +506,7 @@ bool OrchDaemon::init()
      * when iterating ConsumerMap. This is ensured implicitly by the order of keys in ordered map.
      * For cases when Orch has to process tables in specific order, like PortsOrch during warm start, it has to override Orch::doTask()
      */
-    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, gFlowCounterRouteOrch, gIntfsOrch, gNeighOrch, gNhgMapOrch, gNhgOrch, gCbfNhgOrch, gFgNhgOrch, gRouteOrch, gCoppOrch, gQosOrch, wm_orch, gPolicerOrch, gTunneldecapOrch, sflow_orch, gDebugCounterOrch, gMacsecOrch, bgp_global_state_orch, gBfdOrch, gIcmpOrch, gSrv6Orch, gMuxOrch, mux_cb_orch, gMonitorOrch, gBfdMonitorOrch, gStpOrch};
+    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, gFlowCounterRouteOrch, gIntfsOrch, gNeighOrch, gNhgMapOrch, gNhgOrch, gCbfNhgOrch, gFgNhgOrch, gRouteOrch, gCoppOrch, gQosOrch, wm_orch, gPolicerOrch, gTunneldecapOrch, sflow_orch, gDebugCounterOrch, gMacsecOrch, bgp_global_state_orch, gBfdOrch, gIcmpOrch, gSrv6Orch, gMuxOrch, mux_cb_orch, gMonitorOrch, gBfdMonitorOrch, gStpOrch, gNotifConsumerStatsOrch};
 
     bool initialize_dtel = false;
     if (platform == BFN_PLATFORM_SUBSTRING || platform == VS_PLATFORM_SUBSTRING)

--- a/orchagent/p4orch/p4orch.cpp
+++ b/orchagent/p4orch/p4orch.cpp
@@ -1,4 +1,5 @@
 #include "p4orch.h"
+#include "../notificationconsumerstatsorch.h"
 
 #include <map>
 #include <memory>
@@ -116,9 +117,13 @@ P4Orch::P4Orch(swss::DBConnector* db, std::vector<std::string> tableNames,
     Orch::addExecutor(ext_executor);
     m_extCounterStatsTimer->start();
 
-    // Add port state change notification handling support
-    swss::DBConnector notificationsDb("ASIC_DB", 0);
-    m_portStatusNotificationConsumer = new swss::NotificationConsumer(&notificationsDb, "NOTIFICATIONS");
+    // Add port state change notification handling support.
+    m_notificationsDb = std::make_shared<swss::DBConnector>("ASIC_DB", 0);
+    m_portStatusNotificationConsumer = new swss::NotificationConsumer(m_notificationsDb.get(), "NOTIFICATIONS");
+    m_portStatusNotificationConsumer->setOpAllowList({"port_state_change"});
+    m_portStatusNotificationConsumer->setStatsLabel("P4Orch:port_state_change");
+    if (gNotifConsumerStatsOrch)
+        gNotifConsumerStatsOrch->registerConsumer("P4Orch:port_state_change", m_portStatusNotificationConsumer);
     auto portStatusNotifier = new Notifier(m_portStatusNotificationConsumer, this, "PORT_STATUS_NOTIFICATIONS");
     Orch::addExecutor(portStatusNotifier);
 }

--- a/orchagent/p4orch/p4orch.h
+++ b/orchagent/p4orch/p4orch.h
@@ -96,6 +96,9 @@ class P4Orch : public ZmqOrch
     std::unique_ptr<TunnelDecapGroupManager> m_tunnelDecapGroupManager;
     std::unique_ptr<ExtTablesManager> m_extTablesManager;
 
+    // DBConnector backing the port-state notification consumer.
+    std::shared_ptr<swss::DBConnector> m_notificationsDb;
+
     // Notification consumer for port state change
     swss::NotificationConsumer *m_portStatusNotificationConsumer;
 

--- a/orchagent/p4orch/tests/Makefile.am
+++ b/orchagent/p4orch/tests/Makefile.am
@@ -64,6 +64,7 @@ p4orch_tests_SOURCES = $(ORCHAGENT_DIR)/orch.cpp \
 		       fake_consumerstatetable.cpp \
 		       fake_subscriberstatetable.cpp \
 		       fake_notificationconsumer.cpp \
+		       fake_notificationconsumerstatsorch.cpp \
 		       fake_table.cpp \
 		       fake_aclorch.cpp \
 		       fake_zmqserver.cpp \

--- a/orchagent/p4orch/tests/fake_notificationconsumer.cpp
+++ b/orchagent/p4orch/tests/fake_notificationconsumer.cpp
@@ -5,9 +5,45 @@ namespace swss
 
 NotificationConsumer::NotificationConsumer(swss::DBConnector *db, const std::string &channel, int pri,
                                            size_t popBatchSize)
-    : Selectable(pri), POP_BATCH_SIZE(popBatchSize), m_db(db), m_subscribe(NULL), m_channel(channel)
+    : Selectable(pri), POP_BATCH_SIZE(popBatchSize), m_db(db), m_subscribe(NULL), m_channel(channel),
+      m_queue(std::make_unique<FifoNotificationQueue>())
 {
     SWSS_LOG_ENTER();
+}
+
+NotificationConsumer::NotificationConsumer(swss::DBConnector *db, const std::string &channel, int pri,
+                                           size_t popBatchSize, NotificationQueuePolicy policy)
+    : Selectable(pri), POP_BATCH_SIZE(popBatchSize), m_db(db), m_subscribe(NULL), m_channel(channel),
+      m_queue(policy == NotificationQueuePolicy::LruDedup
+              ? std::unique_ptr<NotificationQueueBase>(std::make_unique<LruDedupNotificationQueue>(channel))
+              : std::unique_ptr<NotificationQueueBase>(std::make_unique<FifoNotificationQueue>()))
+{
+    SWSS_LOG_ENTER();
+}
+
+void NotificationConsumer::setStatsLabel(const std::string &label)
+{
+    m_stats_label = label;
+}
+
+void NotificationConsumer::setOpAllowList(std::unordered_set<std::string> ops)
+{
+    m_op_allowlist = std::move(ops);
+}
+
+LruDedupNotificationQueue* NotificationConsumer::getLruDedupQueue() const
+{
+    return dynamic_cast<LruDedupNotificationQueue*>(m_queue.get());
+}
+
+void NotificationConsumer::maybeLogStats()
+{
+    // no-op in tests
+}
+
+void LruDedupNotificationQueue::maybeLogStats()
+{
+    // no-op in tests
 }
 
 } // namespace swss

--- a/orchagent/p4orch/tests/fake_notificationconsumerstatsorch.cpp
+++ b/orchagent/p4orch/tests/fake_notificationconsumerstatsorch.cpp
@@ -1,0 +1,30 @@
+// Minimal stub for p4orch unit tests.  The real
+// NotificationConsumerStatsOrch lives in
+// orchagent/notificationconsumerstatsorch.cpp and is constructed by
+// OrchDaemon::init().  p4orch tests don't construct an OrchDaemon,
+// so we provide the global pointer as null -- the
+// `if (gNotifConsumerStatsOrch)` guard in P4Orch's constructor will
+// then skip registration without crashing.
+//
+// The linker still needs definitions of any method P4Orch::ctor
+// references symbolically.  P4Orch.cpp guards every call site under
+// the null check so registerConsumer is never actually invoked, but
+// the symbol must resolve.  Provide no-op definitions here.
+
+#include "../../notificationconsumerstatsorch.h"
+
+NotificationConsumerStatsOrch *gNotifConsumerStatsOrch = nullptr;
+
+NotificationConsumerStatsOrch::NotificationConsumerStatsOrch()
+    : Orch()
+{
+}
+
+void NotificationConsumerStatsOrch::registerConsumer(const std::string &,
+                                                     swss::NotificationConsumer *)
+{
+}
+
+void NotificationConsumerStatsOrch::doTask(swss::SelectableTimer &)
+{
+}

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -32,6 +32,7 @@
 #include "converter.h"
 #include "sai_serialize.h"
 #include "crmorch.h"
+#include "notificationconsumerstatsorch.h"
 #include "countercheckorch.h"
 #include "notifier.h"
 #include "fdborch.h"
@@ -1065,15 +1066,37 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
         }
     }
 
-    /* Add port oper status notification support */
+    /* Add port oper status notification support.
+     * Opt the port-state consumers into the LRU-dedup queue policy:
+     * port up/down and port-host-tx-ready are end-state-idempotent
+     * under byte-identical payloads (the latest state per port is
+     * what matters), so collapsing duplicates bounds queue depth.
+     * Also install an op-allowlist so cross-fanout messages on the
+     * shared "NOTIFICATIONS" channel are dropped at admission. */
     m_notificationsDb = make_shared<DBConnector>("ASIC_DB", 0);
-    m_portStatusNotificationConsumer = new swss::NotificationConsumer(m_notificationsDb.get(), "NOTIFICATIONS");
+    m_portStatusNotificationConsumer = new swss::NotificationConsumer(
+        m_notificationsDb.get(), "NOTIFICATIONS",
+        100,                                       // pri -- match swss-common default
+        swss::DEFAULT_NC_POP_BATCH_SIZE,
+        swss::NotificationQueuePolicy::LruDedup);
+    m_portStatusNotificationConsumer->setOpAllowList({"port_state_change"});
+    m_portStatusNotificationConsumer->setStatsLabel("PortsOrch:port_state_change");
+    if (gNotifConsumerStatsOrch)
+        gNotifConsumerStatsOrch->registerConsumer("PortsOrch:port_state_change", m_portStatusNotificationConsumer);
     auto portStatusNotificatier = new Notifier(m_portStatusNotificationConsumer, this, "PORT_STATUS_NOTIFICATIONS");
     Orch::addExecutor(portStatusNotificatier);
 
     if (m_cmisModuleAsicSyncSupported)
     {
-        m_portHostTxReadyNotificationConsumer = new swss::NotificationConsumer(m_notificationsDb.get(), "NOTIFICATIONS");
+        m_portHostTxReadyNotificationConsumer = new swss::NotificationConsumer(
+            m_notificationsDb.get(), "NOTIFICATIONS",
+            100,                                       // pri -- match swss-common default
+            swss::DEFAULT_NC_POP_BATCH_SIZE,
+            swss::NotificationQueuePolicy::LruDedup);
+        m_portHostTxReadyNotificationConsumer->setOpAllowList({"port_host_tx_ready"});
+        m_portHostTxReadyNotificationConsumer->setStatsLabel("PortsOrch:port_host_tx_ready");
+        if (gNotifConsumerStatsOrch)
+            gNotifConsumerStatsOrch->registerConsumer("PortsOrch:port_host_tx_ready", m_portHostTxReadyNotificationConsumer);
         auto portHostTxReadyNotificatier = new Notifier(m_portHostTxReadyNotificationConsumer, this, "PORT_HOST_TX_NOTIFICATIONS");
         Orch::addExecutor(portHostTxReadyNotificatier);
     }

--- a/orchagent/twamporch.cpp
+++ b/orchagent/twamporch.cpp
@@ -1,6 +1,7 @@
 #include "twamporch.h"
 #include "vrforch.h"
 #include "crmorch.h"
+#include "notificationconsumerstatsorch.h"
 #include "logger.h"
 #include "swssnet.h"
 #include "converter.h"
@@ -147,6 +148,10 @@ TwampOrch::TwampOrch(TableConnector confDbConnector, TableConnector stateDbConne
     /* Add TWAMP session event notification support */
     DBConnector *notificationsDb = new DBConnector("ASIC_DB", 0);
     m_twampNotificationConsumer = new swss::NotificationConsumer(notificationsDb, "NOTIFICATIONS");
+    m_twampNotificationConsumer->setOpAllowList({"twamp_session_event"});
+    m_twampNotificationConsumer->setStatsLabel("TwampOrch:twamp_session_event");
+    if (gNotifConsumerStatsOrch)
+        gNotifConsumerStatsOrch->registerConsumer("TwampOrch:twamp_session_event", m_twampNotificationConsumer);
     auto twampNotifier = new Notifier(m_twampNotificationConsumer, this, "TWAMP_NOTIFICATIONS");
     Orch::addExecutor(twampNotifier);
     register_event_notif = false;

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -145,6 +145,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 $(top_srcdir)/orchagent/dtelorch.cpp \
                 $(top_srcdir)/orchagent/flexcounterorch.cpp \
                 $(top_srcdir)/orchagent/watermarkorch.cpp \
+                $(top_srcdir)/orchagent/notificationconsumerstatsorch.cpp \
                 $(top_srcdir)/orchagent/chassisorch.cpp \
                 $(top_srcdir)/orchagent/sfloworch.cpp \
                 $(top_srcdir)/orchagent/debugcounterorch.cpp \


### PR DESCRIPTION
**What I did**
Wires every orchagent-owned `NotificationConsumer` to the swss-common primitives (companion PR) and adds `NotificationConsumerStatsOrch` to publish per-consumer counters to `COUNTERS_DB:NOTIFICATION_CONSUMER_STATS:<name>`.

**How I did it**
 Consumer | Queue policy | Allowlist |
|---|---|---|
| `FdbOrch:fdb_event` | LruDedup | `{fdb_event}` |
| `FdbOrch:flush` | Fifo | `{ALL, PORT, VLAN, PORTVLAN}` |
| `PortsOrch:port_state_change` | LruDedup | `{port_state_change}` |
| `PortsOrch:port_host_tx_ready` (CMIS only) | LruDedup | `{port_host_tx_ready}` |
| `BfdOrch:bfd_session_state_change` | Fifo | `{bfd_session_state_change}` |
| `IcmpOrch:icmp_echo_session_state_change` | Fifo | `{icmp_echo_session_state_change}` |
| `TwampOrch:twamp_session_event` | Fifo | `{twamp_session_event}` |
| `P4Orch:port_state_change` | Fifo | `{port_state_change}` |

Each consumer also calls `setStatsLabel(...)` with the same key it registers under in `COUNTERS_DB:NOTIFICATION_CONSUMER_STATS:<name>`. The COUNTERS_DB publish includes:

| field | meaning |
|---|---|
| `channel` | Redis channel SUBSCRIBE'd to |
| `received` | total `processReply` admissions |
| `dropped_allowlist` | dropped at admission by the op-allowlist |
| `admitted` | `received - dropped_allowlist` |
| `admit_ratio_pct` | integer percent |
| `queue_policy` | `"Fifo"` or `"LruDedup"` |
| `lru_pushed` / `lru_dedup_hits` / `lru_dedup_ratio_pct` / `lru_current_depth` / `lru_high_watermark` | LruDedup consumers only |

`gNotifConsumerStatsOrch` is constructed early in `OrchDaemon::init` and added to `m_orchList`. All registration call sites null-check the global so unit-test contexts that don't construct an `OrchDaemon` remain unaffected.

**How I verified it**
Unit Tests

**Details if related**
HLD: https://github.com/sonic-net/SONiC/pull/2334
sonic-sairedis PR: https://github.com/sonic-net/sonic-sairedis/pull/1899
sonic-swss-common PR: https://github.com/sonic-net/sonic-swss-common/pull/1191