### PR TITLE
[202511][dash]: Add ENI OID mapping and DPU counter DB support

### DIFF
--- a/orchagent/dash/dashorch.cpp
+++ b/orchagent/dash/dashorch.cpp
@@ -66,6 +66,10 @@ DashOrch::DashOrch(DBConnector *db, vector<string> &tableName, DBConnector *app_
     m_asic_db = std::shared_ptr<DBConnector>(new DBConnector("ASIC_DB", 0));
     m_counter_db = std::shared_ptr<DBConnector>(new DBConnector("COUNTERS_DB", 0));
     m_eni_name_table = make_unique<Table>(m_counter_db.get(), COUNTERS_ENI_NAME_MAP);
+    m_eni_oid_table = make_unique<Table>(m_counter_db.get(), COUNTERS_ENI_OID_MAP);
+    m_dpu_counter_db = std::shared_ptr<DBConnector>(new DBConnector("DPU_COUNTERS_DB", 0, true));
+    m_dpu_eni_name_table = make_unique<Table>(m_dpu_counter_db.get(), COUNTERS_ENI_NAME_MAP);
+    m_dpu_eni_oid_table = make_unique<Table>(m_dpu_counter_db.get(), COUNTERS_ENI_OID_MAP);
     dash_eni_result_table_ = make_unique<Table>(app_state_db, APP_DASH_ENI_TABLE_NAME);
     dash_eni_route_result_table_ = make_unique<Table>(app_state_db, APP_DASH_ENI_ROUTE_TABLE_NAME);
     dash_qos_result_table_ = make_unique<Table>(app_state_db, APP_DASH_QOS_TABLE_NAME);
@@ -1430,9 +1434,16 @@ void DashOrch::addEniMapEntry(sai_object_id_t oid, const string &name) {
 
     const auto id = sai_serialize_object_id(oid);
     SWSS_LOG_INFO("Adding ENI map entry for %s, id: %s", name.c_str(), id.c_str());
+
     std::vector<FieldValueTuple> eniNameFvs;
     eniNameFvs.emplace_back(name, id);
     m_eni_name_table->set("", eniNameFvs);
+    m_dpu_eni_name_table->set("", eniNameFvs);
+
+    std::vector<FieldValueTuple> eniOidFvs;
+    eniOidFvs.emplace_back(id, name);
+    m_eni_oid_table->set("", eniOidFvs);
+    m_dpu_eni_oid_table->set("", eniOidFvs);
 }
 
 void DashOrch::removeEniMapEntry(sai_object_id_t oid, const string &name) {
@@ -1445,7 +1456,13 @@ void DashOrch::removeEniMapEntry(sai_object_id_t oid, const string &name) {
     }
 
     m_eni_name_table->hdel("", name);
-    SWSS_LOG_INFO("Removing ENI map entry for %s, id: %s", name.c_str(), sai_serialize_object_id(oid).c_str());
+    m_dpu_eni_name_table->hdel("", name);
+
+    const auto id = sai_serialize_object_id(oid);
+    m_eni_oid_table->hdel("", id);
+    m_dpu_eni_oid_table->hdel("", id);
+
+    SWSS_LOG_INFO("Removing ENI map entry for %s, id: %s", name.c_str(), id.c_str());
 }
 
 void DashOrch::addEniToFC(sai_object_id_t oid, const string &name)

--- a/orchagent/dash/dashorch.h
+++ b/orchagent/dash/dashorch.h
@@ -110,7 +110,11 @@ private:
     std::unordered_set<std::string> m_counter_stats;
     std::unique_ptr<swss::Table> m_eni_name_table;
     std::unique_ptr<swss::Table> m_vid_to_rid_table;
+    std::unique_ptr<swss::Table> m_eni_oid_table;
     std::shared_ptr<swss::DBConnector> m_counter_db;
+    std::shared_ptr<swss::DBConnector> m_dpu_counter_db;
+    std::unique_ptr<swss::Table> m_dpu_eni_name_table;
+    std::unique_ptr<swss::Table> m_dpu_eni_oid_table;
     std::shared_ptr<swss::DBConnector> m_asic_db;
     swss::SelectableTimer* m_fc_update_timer = nullptr;
     DashHaOrch* m_dash_ha_orch = nullptr;

--- a/tests/mock_tests/database_config.json
+++ b/tests/mock_tests/database_config.json
@@ -91,6 +91,11 @@
             "id": 17,
             "separator": "|",
             "instance": "redis"
+        },
+        "DPU_COUNTERS_DB": {
+            "id": 18,
+            "separator": ":",
+            "instance": "redis"
         }
     },
     "VERSION" : "1.0"


### PR DESCRIPTION
Cherry-pick of https://github.com/sonic-net/sonic-swss/commit/7698ae5d99a6b030a57c764703938a112881e01d to the 202511 branch.

**Original PR**: #4540

### Changes
- Add `m_eni_oid_table` for OID-to-name mapping in COUNTERS_DB
- Add `m_dpu_counter_db`, `m_dpu_eni_name_table`, `m_dpu_eni_oid_table` for DPU_COUNTERS_DB mirroring
- Update `addEniMapEntry`/`removeEniMapEntry` to maintain all four tables
- Add DPU_COUNTERS_DB (id 18) to mock test database config

Signed-off-by: Lawrence Lee <lawlee@microsoft.com>