### PR TITLE
tests: fix recurring VS test flakes in portchannel and inband VRF suites

### DIFF
--- a/tests/test_inband_intf_mgmt_vrf.py
+++ b/tests/test_inband_intf_mgmt_vrf.py
@@ -3,6 +3,8 @@ import pytest
 
 from swsscommon import swsscommon
 
+from dvslib.dvs_common import wait_for_result, PollingConfig
+
 MGMT_VRF_NAME = 'mgmt'
 INBAND_INTF_NAME = 'Ethernet4'
 
@@ -119,47 +121,64 @@ class TestInbandInterface(object):
         self.setup_db(dvs)
 
         vrf_oid = self.add_mgmt_vrf(dvs)
-        self.create_inband_intf(intf_name)
+        try:
+            self.create_inband_intf(intf_name)
 
-        # check application database
-        tbl = swsscommon.Table(self.appl_db, 'INTF_TABLE')
-        intf_keys = tbl.getKeys()
-        status, fvs = tbl.get(intf_name)
-        assert status == True
-        for fv in fvs:
-            if fv[0] == 'vrf_name':
-                assert fv[1] == MGMT_VRF_NAME
+            # check application database. INTF_TABLE is populated asynchronously by
+            # intfmgrd; PortChannel-backed interfaces add an extra teamd -> kernel
+            # round-trip that can push the row beyond the default 5s poll window
+            # (observed in CI: ~5.1s). Poll up to 30s instead.
+            tbl = swsscommon.Table(self.appl_db, 'INTF_TABLE')
 
-        if not intf_name.startswith('Loopback'):
-            # check ASIC router interface database
-            # one loopback router interface one port based router interface
-            intf_entries = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE", 2)
-            for key in intf_entries:
-                fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE", key)
-                loopback = False
-                intf_vrf_oid = None
-                for k, v in fvs.items():
-                    if k == 'SAI_ROUTER_INTERFACE_ATTR_TYPE' and v == 'SAI_ROUTER_INTERFACE_TYPE_LOOPBACK':
-                        loopback = True
-                        break
-                    if k == 'SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID':
-                        intf_vrf_oid = v
-                if loopback:
-                    continue
-                assert intf_vrf_oid == vrf_oid
+            def _intf_table_ready():
+                status, fvs = tbl.get(intf_name)
+                return (bool(status), fvs)
 
-        self.remove_inband_intf(intf_name)
-        time.sleep(1)
-        # check application database
-        tbl = swsscommon.Table(self.appl_db, 'INTF_TABLE')
-        intf_keys = tbl.getKeys()
-        assert len(intf_keys) == 0
+            _, fvs = wait_for_result(
+                _intf_table_ready,
+                PollingConfig(polling_interval=1, timeout=30, strict=True),
+                failure_message="INTF_TABLE entry for {} not created in time".format(intf_name),
+            )
+            for fv in fvs:
+                if fv[0] == 'vrf_name':
+                    assert fv[1] == MGMT_VRF_NAME
 
-        if not intf_name.startswith('Loopback'):
-            self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE", 1)
- 
-        self.del_inband_mgmt_vrf()
-        self.del_mgmt_vrf(dvs)
+            if not intf_name.startswith('Loopback'):
+                # check ASIC router interface database
+                # one loopback router interface one port based router interface
+                intf_entries = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE", 2)
+                for key in intf_entries:
+                    fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE", key)
+                    loopback = False
+                    intf_vrf_oid = None
+                    for k, v in fvs.items():
+                        if k == 'SAI_ROUTER_INTERFACE_ATTR_TYPE' and v == 'SAI_ROUTER_INTERFACE_TYPE_LOOPBACK':
+                            loopback = True
+                            break
+                        if k == 'SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID':
+                            intf_vrf_oid = v
+                    if loopback:
+                        continue
+                    assert intf_vrf_oid == vrf_oid
+
+            self.remove_inband_intf(intf_name)
+            time.sleep(1)
+            # check application database
+            tbl = swsscommon.Table(self.appl_db, 'INTF_TABLE')
+            intf_keys = tbl.getKeys()
+            assert len(intf_keys) == 0
+
+            if not intf_name.startswith('Loopback'):
+                self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE", 1)
+        finally:
+            # Always tear down the mgmt VRF, even when a parametrized assertion
+            # fails. Without this, a PortChannel5 failure leaks `mgmt` VRF state
+            # and causes the subsequent Loopback1 parametrization to fail as a
+            # cascade.
+            try:
+                self.del_inband_mgmt_vrf()
+            finally:
+                self.del_mgmt_vrf(dvs)
 
 
 # Add Dummy always-pass test at end as workaroud

--- a/tests/test_portchannel.py
+++ b/tests/test_portchannel.py
@@ -6,6 +6,8 @@ import itertools
 
 from swsscommon import swsscommon
 
+from dvslib.dvs_common import wait_for_result, PollingConfig
+
 
 @pytest.mark.usefixtures('dvs_lag_manager')
 class TestPortchannel(object):
@@ -156,11 +158,30 @@ class TestPortchannel(object):
 
         #  TESTS here that LACP key is valid and equls to the expected LACP key
         #  The expected LACP key in the number at the end of the Port-Channel name with a prefix '1'
-        for portchannel in itertools.chain(portchannelNames, portchannelNamesAuto):
+        #  teamd may take more than the initial 1s sleep above to publish member state into
+        #  `teamdctl ... state dump` (especially on slow/loaded VS test agents). Poll until the
+        #  expected JSON shape appears rather than failing on the first attempt with KeyError.
+        def _get_lacp_key(portchannel):
             (exit_code, output) = dvs.runcmd("teamdctl " + portchannel[0] + " state dump")
-            port_state_dump = json.loads(output)
-            lacp_key = port_state_dump["ports"][portchannel[1]]["runner"]["actor_lacpdu_info"]["key"]
-            assert lacp_key == portchannel[2]
+            if exit_code != 0 or not output:
+                return None
+            try:
+                port_state_dump = json.loads(output)
+                return port_state_dump["ports"][portchannel[1]]["runner"]["actor_lacpdu_info"]["key"]
+            except (ValueError, KeyError, TypeError):
+                return None
+
+        polling_config = PollingConfig(polling_interval=1, timeout=30, strict=True)
+        for portchannel in itertools.chain(portchannelNames, portchannelNamesAuto):
+            def _check_lacp_key(pc=portchannel):
+                key = _get_lacp_key(pc)
+                return (key == pc[2], key)
+            wait_for_result(
+                _check_lacp_key,
+                polling_config,
+                failure_message="teamd LACP key for {} not ready (expected {!r})".format(
+                    portchannel[0], portchannel[2]),
+            )
 
         # remove PortChannel members
         tbl = swsscommon.Table(self.cdb, "PORTCHANNEL_MEMBER")
@@ -388,18 +409,29 @@ class TestPortchannel(object):
         time.sleep(1)
 
         # Check ASIC DB
-        # get TPID and validate it to be 0x9200 (37376)
+        # get TPID and validate it to be 0x9200 (37376). The TPID write travels
+        # CONFIG_DB -> APPL_DB -> orchagent -> ASIC_DB; on slow VS hosts this
+        # round-trip can exceed the previous static 1s sleep. Poll until the
+        # ASIC entry reflects the configured TPID instead of asserting once.
         atbl = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_LAG")
-        lag = atbl.getKeys()[0]
-        (status, fvs) = atbl.get(lag)
-        assert status == True
-        asic_tpid = "0"
 
-        for fv in fvs:
-            if fv[0] == "SAI_LAG_ATTR_TPID":
-                asic_tpid = fv[1]
+        def _check_tpid():
+            keys = atbl.getKeys()
+            if not keys:
+                return (False, None)
+            (status, fvs) = atbl.get(keys[0])
+            if not status:
+                return (False, None)
+            for fv in fvs:
+                if fv[0] == "SAI_LAG_ATTR_TPID":
+                    return (fv[1] == "37376", fv[1])
+            return (False, None)
 
-        assert asic_tpid == "37376"
+        wait_for_result(
+            _check_tpid,
+            PollingConfig(polling_interval=1, timeout=30, strict=True),
+            failure_message="ASIC_DB SAI_LAG_ATTR_TPID did not reach 37376 in time",
+        )
 
         # remove port channel
         tbl = swsscommon.Table(cdb, "PORTCHANNEL")
@@ -440,17 +472,30 @@ class TestPortchannel(object):
         (exitcode, _) = dvs.runcmd("ip link set dev PortChannel111 carrier on")
         assert exitcode == 0, "ip link set failed"
 
-        # verify port-channel members netdev oper status
-        tbl =  swsscommon.Table(state_db, "PORT_TABLE")
-        status, fvs = tbl.get("Ethernet0")
-        assert status is True
-        fvs = dict(fvs)
-        assert fvs['netdev_oper_status'] == 'up'
+        # verify port-channel members netdev oper status. The portmgr netlink listener
+        # may take more than the 1s waited above to propagate the carrier change to
+        # STATE_DB, especially on busy CI agents. Poll until the field flips to "up".
+        tbl = swsscommon.Table(state_db, "PORT_TABLE")
 
-        status, fvs = tbl.get("Ethernet4")
-        assert status is True
-        fvs = dict(fvs)
-        assert fvs['netdev_oper_status'] == 'up'
+        def _check_netdev_oper_up(port):
+            def _poll():
+                status, fvs = tbl.get(port)
+                if not status:
+                    return (False, {})
+                d = dict(fvs)
+                return (d.get('netdev_oper_status') == 'up', d)
+            return _poll
+
+        wait_for_result(
+            _check_netdev_oper_up("Ethernet0"),
+            PollingConfig(polling_interval=1, timeout=30, strict=True),
+            failure_message="Ethernet0 netdev_oper_status did not become 'up' in time",
+        )
+        wait_for_result(
+            _check_netdev_oper_up("Ethernet4"),
+            PollingConfig(polling_interval=1, timeout=30, strict=True),
+            failure_message="Ethernet4 netdev_oper_status did not become 'up' in time",
+        )
 
         # verify a PORT_TABLE entry containing the PortChannel is NOT created
         # in APPDB (sonic-buildimage Issue #21688)


### PR DESCRIPTION
**What I did**

* Microsoft ADO (number only): 38062421

Stabilize four chronically flaky VS tests in tests/test_portchannel.py and tests/test_inband_intf_mgmt_vrf.py by replacing single-shot time.sleep(1) + immediate assert patterns with bounded polling loops, and adding a try/finally cleanup of the mgmt VRF in test_InbandIntf.

Affected tests:
test_portchannel.py::test_Portchannel_lacpkey
test_portchannel.py::test_Portchannel_tpid
test_portchannel.py::test_portchannel_member_netdev_oper_status
test_inband_intf_mgmt_vrf.py::test_InbandIntf (covers all 4 parametrizations + cascade into Loopback1)

**Why I did it**

These tests have been failing on every recent sonic-sairedis PR-checker run (ADO builds 1118214 / 1118474 / 1118703 / 1118888). Build 1118888 in particular failed all 3 retries and blocked the PR with no actual code regression.

Root causes:
Each failing test sleeps 1 second and then asserts on state that is produced asynchronously by teamd, orchagent, or portmgrd. When the VS container is even slightly slow, the assert fires before the state appears — the underlying logic is correct, only the wait is wrong.
test_InbandIntf creates the mgmt VRF at the top but never removes it on assertion failure. When [PortChannel5] times out, the leaked VRF causes [Loopback1] to fail with RTNETLINK answers: File exists, double-counting one root cause and masking the real signal.

**How I verified it**

Reproduced both failures locally using the same VS image that the failing CI builds consume (docker-sonic-vs:Azure.sonic-sairedis.20260520.8.asan-False, taken from build 1118703 artifact).

Without this PR (baseline):
```
FAILED test_portchannel.py::test_Portchannel_lacpkey            KeyError: 'ports'
FAILED test_inband_intf_mgmt_vrf.py::test_InbandIntf[PortChannel5]  INTF_TABLE timeout
FAILED test_inband_intf_mgmt_vrf.py::test_InbandIntf[Loopback1]     RTNETLINK answers: File exists
```
With this PR:
```
test_portchannel.py             7 passed
test_inband_intf_mgmt_vrf.py    6 passed
```

Test-only change; no production code, DB schema, or orchagent behavior modified. Polling preserves the same final assertion and adds a 30-second upper bound, well within the existing pytest timeout budget.

Related ADO builds: 1118214, 1118474, 1118703, 1118888.

Dummy Sairedis PR to include this fix: https://github.com/sonic-net/sonic-sairedis/pull/1902

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>