### PR TITLE
intfmgrd: make IP address and link adds idempotent

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -12,6 +12,7 @@
 #include "subscriberstatetable.h"
 #include <swss/redisutility.h>
 #include "subintf.h"
+#include <sys/stat.h>
 
 using namespace std;
 using namespace swss;
@@ -89,11 +90,26 @@ void IntfMgr::setIntfIp(const string &alias, const string &opCmd,
     string          broadcastIpStr = ipPrefix.getBroadcastIp().to_string();
     int             prefixLen = ipPrefix.getMaskLength();
 
+    /*
+     * Use iproute2's idempotent "replace" instead of "add" on the SET path.
+     * The kernel netdev state can outlive intfmgrd (warm-restart replay) and
+     * can also be re-seen mid-run via the Centralized subtype L3 replay in
+     * doPortTableTask, which re-invokes doIntfAddrTask(SET_COMMAND) for every
+     * configured prefix on a host port/LAG every time STATE_PORT_TABLE
+     * transitions to "ok". Plain "ip address add" then returns rc 2
+     * ("File exists") for prefixes the kernel already has, which we surface
+     * as SWSS_LOG_ERROR and analyze_logs flags as a test failure even though
+     * the configured state is correct. "ip address replace" no-ops with rc 0
+     * if the same prefix is already on the dev, and adds it otherwise -- same
+     * end state as "add", just idempotent. "del" is intentionally untouched.
+     */
+    const string ipOp = (opCmd == "add") ? "replace" : opCmd;
+
     if (ipPrefix.isV4())
     {
         (prefixLen < 31) ?
-        (cmd << IP_CMD << " address " << shellquote(opCmd) << " " << shellquote(ipPrefixStr) << " broadcast " << shellquote(broadcastIpStr) <<" dev " << shellquote(alias)) :
-        (cmd << IP_CMD << " address " << shellquote(opCmd) << " " << shellquote(ipPrefixStr) << " dev " << shellquote(alias));
+        (cmd << IP_CMD << " address " << shellquote(ipOp) << " " << shellquote(ipPrefixStr) << " broadcast " << shellquote(broadcastIpStr) <<" dev " << shellquote(alias)) :
+        (cmd << IP_CMD << " address " << shellquote(ipOp) << " " << shellquote(ipPrefixStr) << " dev " << shellquote(alias));
     }
     else
     {
@@ -111,9 +127,9 @@ void IntfMgr::setIntfIp(const string &alias, const string &opCmd,
         }
 
         (prefixLen < 127) ?
-        (cmd << IP_CMD << " -6 address " << shellquote(opCmd) << " " << shellquote(ipPrefixStr) << " broadcast " << shellquote(broadcastIpStr) <<
+        (cmd << IP_CMD << " -6 address " << shellquote(ipOp) << " " << shellquote(ipPrefixStr) << " broadcast " << shellquote(broadcastIpStr) <<
          " dev " << shellquote(alias) << metric) :
-        (cmd << IP_CMD << " -6 address " << shellquote(opCmd) << " " << shellquote(ipPrefixStr) << " dev " << shellquote(alias) << metric);
+        (cmd << IP_CMD << " -6 address " << shellquote(ipOp) << " " << shellquote(ipPrefixStr) << " dev " << shellquote(alias) << metric);
     }
 
     int ret = swss::exec(cmd.str(), res);
@@ -266,12 +282,34 @@ void IntfMgr::addLoopbackIntf(const string &alias)
     stringstream cmd;
     string res;
 
+    /*
+     * Skip the kernel "ip link add" if the netdev already exists. The
+     * in-process m_loopbackIntfList dedups within a single intfmgrd lifetime
+     * and on cold boot flushLoopbackIntfs() wipes stale dummies first, but
+     * across a warm restart the kernel keeps Loopback* while m_loopbackIntfList
+     * starts empty -- so the unconditional "ip link add" returns rc 2
+     * ("File exists") and gets logged as ERR (analyze_logs then fails the
+     * warm-reboot test even though the netdev is correctly present). Probe
+     * /sys/class/net/<alias> via lstat (same idiom as TeamMgr::isPortMaster
+     * in cfgmgr/teammgr.cpp) and only issue the add if the kernel doesn't
+     * already have it.
+     */
+    struct stat sb;
+    const string sysPath = "/sys/class/net/" + alias;
+    if (lstat(sysPath.c_str(), &sb) == 0)
+    {
+        SWSS_LOG_INFO("Loopback %s already present in kernel; skipping link add", alias.c_str());
+        return;
+    }
+
     cmd << IP_CMD << " link add " << alias << " mtu " << LOOPBACK_DEFAULT_MTU_STR << " type dummy";
     int ret = swss::exec(cmd.str(), res);
     if (ret)
     {
         SWSS_LOG_ERROR("Command '%s' failed with rc %d", cmd.str().c_str(), ret);
+        return;
     }
+    SWSS_LOG_INFO("Added loopback interface %s", alias.c_str());
 }
 
 void IntfMgr::delLoopbackIntf(const string &alias)
@@ -400,6 +438,27 @@ void IntfMgr::addHostSubIntf(const string&intf, const string &subIntf, const str
 {
     stringstream cmd;
     string res;
+
+    /*
+     * Same warm-restart hole as addLoopbackIntf: m_subIntfList is in-process
+     * state and starts empty after a warm restart, but the kernel kept the
+     * sub-interface netdev (e.g. Ethernet0_4.50). The caller then sets
+     * needHostVlanCreate=true and we land here with a netdev that already
+     * exists, "ip link add link ... type vlan id ..." returns rc 2
+     * ("File exists") and gets logged as ERROR. Probe /sys/class/net/<subIntf>
+     * via lstat (same idiom as TeamMgr::isPortMaster and the Loopback fix in
+     * addLoopbackIntf) and treat the kernel's pre-existing netdev as success.
+     * Matches the "cache says yes, kernel says no" repair at the caller site
+     * (subIntf path in doIntfGeneralTask), just for the inverse direction.
+     */
+    struct stat sb;
+    const string sysPath = "/sys/class/net/" + subIntf;
+    if (lstat(sysPath.c_str(), &sb) == 0)
+    {
+        SWSS_LOG_INFO("Sub-interface %s already present in kernel; skipping ip link add link=%s vlan=%s",
+                      subIntf.c_str(), intf.c_str(), vlan.c_str());
+        return;
+    }
 
     cmd << IP_CMD " link add link " << shellquote(intf) << " name " << shellquote(subIntf) << " type vlan id " << shellquote(vlan);
     EXEC_WITH_ERROR_THROW(cmd.str(), res);
@@ -928,7 +987,6 @@ bool IntfMgr::doIntfGeneralTask(const vector<string>& keys,
             {
                 addLoopbackIntf(alias);
                 m_loopbackIntfList.insert(alias);
-                SWSS_LOG_INFO("Added %s loopback interface", alias.c_str());
             }
 
             if (adminStatus.empty())

--- a/tests/mock_tests/intfmgrd/intfmgr_ut.cpp
+++ b/tests/mock_tests/intfmgrd/intfmgr_ut.cpp
@@ -21,7 +21,12 @@ bool FailBridgeFdbCommand = false;
 int cb(const std::string &cmd, std::string &stdout){
     mockCallArgs.push_back(cmd);
     if (cmd == "sysctl -w net.ipv6.conf.\"Ethernet0\".disable_ipv6=0") Ethernet0IPv6Set = true;
-    else if (cmd.find("/sbin/ip -6 address \"add\"") == 0) {
+    /*
+     * setIntfIp now emits the idempotent "replace" form on the SET path
+     * (cfgmgr/intfmgr.cpp::setIntfIp); the IPv6 retry-after-enableIpv6Flag
+     * behavior under test still goes through this branch.
+     */
+    else if (cmd.find("/sbin/ip -6 address \"replace\"") == 0) {
         return Ethernet0IPv6Set ? 0 : 2;
     }
     else if (cmd == "/sbin/ip link set \"Ethernet64.10\" \"up\""){
@@ -33,6 +38,14 @@ int cb(const std::string &cmd, std::string &stdout){
     }
     else if (cmd.find("bridge fdb") == 0) {
         return FailBridgeFdbCommand ? 1 : 0;
+    }
+    /*
+     * Drive the failure-after-lstat-miss branch in addLoopbackIntf
+     * (testAddLoopbackIntfCreateFailure). The alias is unique to that test so
+     * no other test path matches.
+     */
+    else if (cmd.find("/sbin/ip link add LoopbackFailMe ") == 0) {
+        return 1;
     }
     else {
         return 0;
@@ -118,7 +131,8 @@ namespace intfmgr_ut
         intfmgr.doIntfAddrTask(keys, data, "SET");
         int ip_cmd_called = 0;
         for (auto cmd : mockCallArgs){
-            if (cmd.find("/sbin/ip -6 address \"add\"") == 0){
+            /* setIntfIp emits the idempotent "replace" form on the SET path. */
+            if (cmd.find("/sbin/ip -6 address \"replace\"") == 0){
                 ip_cmd_called++;
             }
         }
@@ -142,7 +156,8 @@ namespace intfmgr_ut
         intfmgr.doIntfAddrTask(keys, data, "SET");
         int ip_cmd_called = 0;
         for (auto cmd : mockCallArgs){
-            if (cmd.find("/sbin/ip -6 address \"add\"") == 0){
+            /* setIntfIp emits the idempotent "replace" form on the SET path. */
+            if (cmd.find("/sbin/ip -6 address \"replace\"") == 0){
                 ip_cmd_called++;
             }
         }
@@ -199,31 +214,35 @@ namespace intfmgr_ut
         portData.emplace_back("admin_status", "up");
         intfmgr.doPortTableTask("Ethernet0", portData, "SET");
 
-        /* Verify that only IPv6 link-local address add was called */
-        int ipv6_ll_add_called = 0;
-        int ipv6_global_add_called = 0;
-        int ipv4_add_called = 0;
+        /*
+         * Verify that only the IPv6 link-local address was replayed.
+         * setIntfIp now emits the idempotent "replace" form on SET, so we match
+         * on the new op token. Global IPv6 / IPv4 must still produce zero hits.
+         */
+        int ipv6_ll_replay_called = 0;
+        int ipv6_global_replay_called = 0;
+        int ipv4_replay_called = 0;
         for (const auto &cmd : mockCallArgs)
         {
-            if (cmd.find("/sbin/ip -6 address \"add\"") != std::string::npos &&
+            if (cmd.find("/sbin/ip -6 address \"replace\"") != std::string::npos &&
                 cmd.find("fe80::1/64") != std::string::npos)
             {
-                ipv6_ll_add_called++;
+                ipv6_ll_replay_called++;
             }
-            if (cmd.find("/sbin/ip -6 address \"add\"") != std::string::npos &&
+            if (cmd.find("/sbin/ip -6 address \"replace\"") != std::string::npos &&
                 cmd.find("2001::8/64") != std::string::npos)
             {
-                ipv6_global_add_called++;
+                ipv6_global_replay_called++;
             }
-            if (cmd.find("/sbin/ip address \"add\"") != std::string::npos &&
+            if (cmd.find("/sbin/ip address \"replace\"") != std::string::npos &&
                 cmd.find("10.0.0.1/31") != std::string::npos)
             {
-                ipv4_add_called++;
+                ipv4_replay_called++;
             }
         }
-        ASSERT_EQ(ipv6_ll_add_called, 1);
-        ASSERT_EQ(ipv6_global_add_called, 0);
-        ASSERT_EQ(ipv4_add_called, 0);
+        ASSERT_EQ(ipv6_ll_replay_called, 1);
+        ASSERT_EQ(ipv6_global_replay_called, 0);
+        ASSERT_EQ(ipv4_replay_called, 0);
 
         /* Now delete the link-local address and verify it is no longer replayed */
         intfmgr.doIntfAddrTask(llKeys, emptyData, "DEL");
@@ -232,16 +251,16 @@ namespace intfmgr_ut
         mockCallArgs.clear();
         intfmgr.doPortTableTask("Ethernet0", portData, "SET");
 
-        ipv6_ll_add_called = 0;
+        ipv6_ll_replay_called = 0;
         for (const auto &cmd : mockCallArgs)
         {
-            if (cmd.find("/sbin/ip -6 address \"add\"") != std::string::npos &&
+            if (cmd.find("/sbin/ip -6 address \"replace\"") != std::string::npos &&
                 cmd.find("fe80::1/64") != std::string::npos)
             {
-                ipv6_ll_add_called++;
+                ipv6_ll_replay_called++;
             }
         }
-        ASSERT_EQ(ipv6_ll_add_called, 0);
+        ASSERT_EQ(ipv6_ll_replay_called, 0);
     }
 
     TEST_F(IntfMgrTest, testNoReplayLLOnAdminDown){
@@ -268,15 +287,88 @@ namespace intfmgr_ut
         portData.emplace_back("admin_status", "down");
         intfmgr.doPortTableTask("Ethernet0", portData, "SET");
 
-        int ipv6_add_called = 0;
+        /* setIntfIp emits the "replace" op token on SET; no replay should fire. */
+        int ipv6_replay_called = 0;
         for (const auto &cmd : mockCallArgs)
         {
-            if (cmd.find("/sbin/ip -6 address \"add\"") != std::string::npos)
+            if (cmd.find("/sbin/ip -6 address \"replace\"") != std::string::npos)
             {
-                ipv6_add_called++;
+                ipv6_replay_called++;
             }
         }
-        ASSERT_EQ(ipv6_add_called, 0);
+        ASSERT_EQ(ipv6_replay_called, 0);
+    }
+
+    /*
+     * Warm-restart short-circuit in addLoopbackIntf: if the kernel already
+     * has the netdev, we lstat /sys/class/net/<alias>, log INFO, and return
+     * without emitting an "ip link add". /sys/class/net/lo is reliably
+     * present on every Linux runtime, including the Azure pipeline
+     * container, so it's the cheapest fixture for the lstat==0 branch.
+     */
+    TEST_F(IntfMgrTest, testAddLoopbackIntfAlreadyPresent){
+        swss::IntfMgr intfmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_intf_tables);
+        mockCallArgs.clear();
+
+        intfmgr.addLoopbackIntf("lo");
+
+        int link_add_seen = 0;
+        for (const auto &cmd : mockCallArgs)
+        {
+            if (cmd.find("/sbin/ip link add lo ") != std::string::npos)
+            {
+                link_add_seen++;
+            }
+        }
+        ASSERT_EQ(link_add_seen, 0);
+    }
+
+    /*
+     * Failure path in addLoopbackIntf: alias is absent from /sys/class/net
+     * (so we don't short-circuit), the mock cb returns non-zero for the
+     * "ip link add", the function logs ERR and returns without falling into
+     * the success-log path. Asserts the command was actually emitted (so the
+     * lstat-miss branch is exercised) and the function returned cleanly.
+     */
+    TEST_F(IntfMgrTest, testAddLoopbackIntfCreateFailure){
+        swss::IntfMgr intfmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_intf_tables);
+        mockCallArgs.clear();
+
+        intfmgr.addLoopbackIntf("LoopbackFailMe");
+
+        int link_add_seen = 0;
+        for (const auto &cmd : mockCallArgs)
+        {
+            if (cmd.find("/sbin/ip link add LoopbackFailMe ") != std::string::npos)
+            {
+                link_add_seen++;
+            }
+        }
+        ASSERT_EQ(link_add_seen, 1);
+    }
+
+    /*
+     * Warm-restart short-circuit in addHostSubIntf: when the sub-interface
+     * netdev already exists in the kernel, we skip "ip link add link ...".
+     * Reuse "lo" as the alias since /sys/class/net/lo is always present;
+     * lstat doesn't care that it isn't actually a vlan device.
+     */
+    TEST_F(IntfMgrTest, testAddHostSubIntfAlreadyPresent){
+        swss::IntfMgr intfmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_intf_tables);
+        mockCallArgs.clear();
+
+        intfmgr.addHostSubIntf("Ethernet0", "lo", "10");
+
+        int link_add_seen = 0;
+        for (const auto &cmd : mockCallArgs)
+        {
+            if (cmd.find("/sbin/ip link add link") != std::string::npos &&
+                cmd.find("\"lo\"") != std::string::npos)
+            {
+                link_add_seen++;
+            }
+        }
+        ASSERT_EQ(link_add_seen, 0);
     }
 
     TEST_F(IntfMgrTest, testSetSagFdbEntryValidationAndBridgeCommand){


### PR DESCRIPTION
## Description

`intfmgrd` was emitting `SWSS_LOG_ERROR` for kernel ops that landed against already-configured state, which `analyze_logs` flagged and failed otherwise-passing tests (notably `TestVrfWarmReboot.test_vrf_swss_warm_reboot`):

```
ERR swss#intfmgrd: :- setIntfIp: Command '/sbin/ip address "add" "10.0.0.56/31" dev "PortChannel101"' failed with rc 2
ERR swss#intfmgrd: :- addLoopbackIntf: Command '/sbin/ip link add Loopback0 mtu 65536 type dummy' failed with rc 2
```

`rc 2` is iproute2's exit code for "RTNETLINK answers: File exists" — the address/netdev was already programmed, so the `add` failed but the configured end state was correct. Two paths can produce this:

- **Warm-restart replay** — the kernel keeps `Loopback*`, host sub-interface netdevs (`Ethernet0_4.50`), `PortChannel*`/`Vlan*` netdevs and their addresses across an intfmgrd restart, but the in-process `m_loopbackIntfList` / `m_subIntfList` caches start empty and CONFIG_DB is replayed in full.
- **Centralized-subtype L3 replay** — `doPortTableTask` re-runs `doIntfAddrTask(SET_COMMAND)` for every configured prefix on a host port/LAG every time `STATE_PORT_TABLE` transitions to `ok` (link flap), and the kernel keeps the address through a link-state flap.

## Changes

**`cfgmgr/intfmgr.cpp`** — make the three vulnerable kernel ops idempotent:

- `setIntfIp` SET path — emit iproute2's `replace` instead of `add`. `replace` no-ops with rc 0 when the same prefix is already on the dev, and adds it otherwise. The `del` path is intentionally untouched.
- `addLoopbackIntf` — `lstat` `/sys/class/net/<alias>` before issuing `ip link add ... type dummy`; if the kernel already has the dummy, log `SWSS_LOG_INFO` and return success.
- `addHostSubIntf` — symmetric `lstat` pre-check before issuing `ip link add link ... type vlan id ...`.

**`tests/mock_tests/intfmgrd/intfmgr_ut.cpp`** — update the existing IPv6 retry-after-`enableIpv6Flag` mock to match the new literal `replace` op token in `setIntfIp`'s emitted command.

## Test plan

- [ ] `TestVrfWarmReboot.test_vrf_swss_warm_reboot` — expect 0 `setIntfIp`/`addLoopbackIntf` ERR matches in `analyze_logs` post-test.
- [ ] Existing intfmgr UTs (`testSettingIpv6Flag`, `testNoSettingIpv6Flag`, `testSetAdminStatusFailToNotOkSubInt`, `testSetAdminStatusFailToOkSubInt`) pass.
- [ ] Cold-boot config apply unchanged (first call: prefix not present → `replace` adds, identical to former `add`; loopback not present → `lstat` returns ENOENT → `ip link add` runs as before).
- [ ] Sub-interface warm reboot — sub-intf re-creation no longer logs ERR.

Fixes: https://github.com/sonic-net/sonic-mgmt/issues/10394