### PR TITLE
[test]: Stabilize mock and VS test infrastructure

### DIFF
--- a/run-gtest-suite.py
+++ b/run-gtest-suite.py
@@ -2,6 +2,7 @@
 
 import argparse
 import subprocess
+import time
 from lxml import etree
 import sys
 
@@ -34,11 +35,32 @@ def main():
         test_args.append("--gtest_color=no")
 
     test_process = subprocess.run(args.test_binary + test_args, stdin=subprocess.DEVNULL, stdout=args.log_file, stderr=subprocess.STDOUT)
+    args.log_file.flush()
 
-    junit_xml = etree.parse(f"{args.test_name}_tr.xml")
+    junit_xml_path = f"{args.test_name}_tr.xml"
+    # On slower emulated architectures the gtest XML file can appear just after
+    # the test process exits. Retry briefly so a transient visibility delay does
+    # not mask otherwise valid test results as a harness failure.
+    junit_xml = None
+    last_error = None
+    for _ in range(50):
+        try:
+            junit_xml = etree.parse(junit_xml_path)
+            break
+        except (OSError, etree.XMLSyntaxError) as err:
+            last_error = err
+            time.sleep(0.1)
+
+    if junit_xml is None:
+        print(f"ERROR: gtest XML output '{junit_xml_path}' was not available for {args.test_name}: {last_error}", file=args.log_file)
+        print(f":test-result: FAIL {args.test_name}:missing-gtest-xml", file=args.trs_file)
+        args.log_file.flush()
+        args.trs_file.flush()
+        sys.exit(test_process.returncode or 1)
     junit_xml_root = junit_xml.getroot()
     # This code matches how gtest structures the results in its junit output format.
-    for testsuite in junit_xml_root:
+    testsuites = junit_xml_root if junit_xml_root.tag == "testsuites" else [junit_xml_root]
+    for testsuite in testsuites:
         testsuite_name = testsuite.get("name")
         for testcase in testsuite:
             testcase_name = testcase.get("name")
@@ -47,6 +69,7 @@ def main():
             result = "SKIP" if was_skipped else "FAIL" if has_failed else "PASS"
             print(f":test-result: {result} {testsuite_name}:{testcase_name}", file=args.trs_file)
 
+    args.trs_file.flush()
     sys.exit(test_process.returncode)
 
 

--- a/run-gtest-suite.py
+++ b/run-gtest-suite.py
@@ -37,7 +37,7 @@ def main():
 
     try:
         soft_nofile, hard_nofile = resource.getrlimit(resource.RLIMIT_NOFILE)
-        target_nofile = min(max(soft_nofile, 4096), hard_nofile)
+        target_nofile = hard_nofile
         if target_nofile > soft_nofile:
             resource.setrlimit(resource.RLIMIT_NOFILE, (target_nofile, hard_nofile))
     except (OSError, ValueError):

--- a/run-gtest-suite.py
+++ b/run-gtest-suite.py
@@ -5,6 +5,7 @@ import subprocess
 import time
 from lxml import etree
 import sys
+import resource
 
 
 def str2bool(value):
@@ -33,6 +34,14 @@ def main():
         test_args.append("--gtest_color=yes")
     else:
         test_args.append("--gtest_color=no")
+
+    try:
+        soft_nofile, hard_nofile = resource.getrlimit(resource.RLIMIT_NOFILE)
+        target_nofile = min(max(soft_nofile, 4096), hard_nofile)
+        if target_nofile > soft_nofile:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (target_nofile, hard_nofile))
+    except (OSError, ValueError):
+        pass
 
     test_process = subprocess.run(args.test_binary + test_args, stdin=subprocess.DEVNULL, stdout=args.log_file, stderr=subprocess.STDOUT)
     args.log_file.flush()

--- a/run-gtest-suite.py
+++ b/run-gtest-suite.py
@@ -5,7 +5,11 @@ import subprocess
 import time
 from lxml import etree
 import sys
-import resource
+
+try:
+    import resource  # POSIX-only; not available on Windows.
+except ImportError:
+    resource = None
 
 
 def str2bool(value):
@@ -35,13 +39,18 @@ def main():
     else:
         test_args.append("--gtest_color=no")
 
-    try:
-        soft_nofile, hard_nofile = resource.getrlimit(resource.RLIMIT_NOFILE)
-        target_nofile = hard_nofile
-        if target_nofile > soft_nofile:
-            resource.setrlimit(resource.RLIMIT_NOFILE, (target_nofile, hard_nofile))
-    except (OSError, ValueError):
-        pass
+    # Raise the open-file descriptor soft limit toward the hard limit so tests
+    # spawning many sockets/FDs do not exhaust the default cap. Best-effort:
+    # the `resource` module is unavailable on some platforms, and setrlimit may
+    # be denied; in either case we silently fall back to the inherited limit.
+    if resource is not None:
+        try:
+            soft_nofile, hard_nofile = resource.getrlimit(resource.RLIMIT_NOFILE)
+            target_nofile = hard_nofile
+            if target_nofile > soft_nofile:
+                resource.setrlimit(resource.RLIMIT_NOFILE, (target_nofile, hard_nofile))
+        except (OSError, ValueError):
+            pass
 
     test_process = subprocess.run(args.test_binary + test_args, stdin=subprocess.DEVNULL, stdout=args.log_file, stderr=subprocess.STDOUT)
     args.log_file.flush()

--- a/tests/mock_tests/fdborch/flush_syncd_notif_ut.cpp
+++ b/tests/mock_tests/fdborch/flush_syncd_notif_ut.cpp
@@ -67,6 +67,7 @@ namespace fdb_syncd_flush_test
         std::shared_ptr<swss::DBConnector> m_chassis_app_db;
         std::shared_ptr<PortsOrch> m_portsOrch;
         std::shared_ptr<FdbOrch> m_fdborch;
+        VxlanTunnelOrch *m_vxlanTunnelOrch = nullptr;
 
         virtual void SetUp() override
         {   
@@ -122,10 +123,10 @@ namespace fdb_syncd_flush_test
             // 3) Crmorch
             ASSERT_EQ(gCrmOrch, nullptr);
             gCrmOrch = new CrmOrch(m_config_db.get(), CFG_CRM_TABLE_NAME);
-            VxlanTunnelOrch *vxlan_tunnel_orch_1 = new VxlanTunnelOrch(m_state_db.get(), m_app_db.get(), APP_VXLAN_TUNNEL_TABLE_NAME);
-            gDirectory.set(vxlan_tunnel_orch_1);
-            
-             // Construct fdborch
+            m_vxlanTunnelOrch = new VxlanTunnelOrch(m_state_db.get(), m_app_db.get(), APP_VXLAN_TUNNEL_TABLE_NAME);
+            gDirectory.set(m_vxlanTunnelOrch);
+
+            // Construct fdborch
             vector<table_name_with_pri_t> app_fdb_tables = {
                 { APP_FDB_TABLE_NAME,        FdbOrch::fdborch_pri},
                 { APP_VXLAN_FDB_TABLE_NAME,  FdbOrch::fdborch_pri},
@@ -147,6 +148,10 @@ namespace fdb_syncd_flush_test
             gSwitchOrch = nullptr;
             delete gCrmOrch;
             gCrmOrch = nullptr;
+
+            delete m_vxlanTunnelOrch;
+            m_vxlanTunnelOrch = nullptr;
+
             gDirectory.m_values.clear();
             ut_helper::uninitSaiApi();
         }

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -613,6 +613,7 @@ namespace portsorch_test
         shared_ptr<swss::DBConnector> m_counters_db;
         shared_ptr<swss::DBConnector> m_chassis_app_db;
         shared_ptr<swss::DBConnector> m_asic_db;
+        FlexCounterOrch *m_flexCounterOrch = nullptr;
 
         PortsOrchTest()
         {
@@ -666,8 +667,8 @@ namespace portsorch_test
             vector<string> flex_counter_tables = {
                 CFG_FLEX_COUNTER_TABLE_NAME
             };
-            auto* flexCounterOrch = new FlexCounterOrch(m_config_db.get(), flex_counter_tables);
-            gDirectory.set(flexCounterOrch);
+            m_flexCounterOrch = new FlexCounterOrch(m_config_db.get(), flex_counter_tables);
+            gDirectory.set(m_flexCounterOrch);
 
             vector<string> buffer_tables = { APP_BUFFER_POOL_TABLE_NAME,
                                              APP_BUFFER_PROFILE_TABLE_NAME,
@@ -801,6 +802,8 @@ namespace portsorch_test
             gSwitchOrch = nullptr;
             delete gMlagOrch;
             gMlagOrch = nullptr;
+            delete m_flexCounterOrch;
+            m_flexCounterOrch = nullptr;
             // clear orchs saved in directory
             gDirectory.m_values.clear();
         }

--- a/tests/mock_tests/routeorch_ut.cpp
+++ b/tests/mock_tests/routeorch_ut.cpp
@@ -430,6 +430,10 @@ namespace routeorch_test
             delete gFlowCounterRouteOrch;
             gFlowCounterRouteOrch = nullptr;
 
+            // Drop directory references before deleting orchs registered there,
+            // so later tests cannot observe stale pointers.
+            gDirectory.m_values.clear();
+
             delete gRouteOrch;
             gRouteOrch = nullptr;
 

--- a/tests/mock_tests/routeorch_ut.cpp
+++ b/tests/mock_tests/routeorch_ut.cpp
@@ -140,6 +140,10 @@ namespace routeorch_test
 
     struct RouteOrchTest : public ::testing::Test
     {
+        FlexCounterOrch *m_flexCounterOrch = nullptr;
+        EvpnNvoOrch *m_evpnNvoOrch = nullptr;
+        MuxOrch *m_muxOrch = nullptr;
+
         RouteOrchTest()
         {
         }
@@ -234,8 +238,8 @@ namespace routeorch_test
             vector<string> flex_counter_tables = {
                 CFG_FLEX_COUNTER_TABLE_NAME
             };
-            auto* flexCounterOrch = new FlexCounterOrch(m_config_db.get(), flex_counter_tables);
-            gDirectory.set(flexCounterOrch);
+            m_flexCounterOrch = new FlexCounterOrch(m_config_db.get(), flex_counter_tables);
+            gDirectory.set(m_flexCounterOrch);
 
             static const  vector<string> route_pattern_tables = {
                 CFG_FLOW_COUNTER_ROUTE_PATTERN_TABLE_NAME,
@@ -247,8 +251,8 @@ namespace routeorch_test
             gVrfOrch = new VRFOrch(m_app_db.get(), APP_VRF_TABLE_NAME, m_state_db.get(), STATE_VRF_OBJECT_TABLE_NAME);
             gDirectory.set(gVrfOrch);
 
-            EvpnNvoOrch *evpn_orch = new EvpnNvoOrch(m_app_db.get(), APP_VXLAN_EVPN_NVO_TABLE_NAME);
-            gDirectory.set(evpn_orch);
+            m_evpnNvoOrch = new EvpnNvoOrch(m_app_db.get(), APP_VXLAN_EVPN_NVO_TABLE_NAME);
+            gDirectory.set(m_evpnNvoOrch);
 
             ASSERT_EQ(gIntfsOrch, nullptr);
             gIntfsOrch = new IntfsOrch(m_app_db.get(), APP_INTF_TABLE_NAME, gVrfOrch, m_chassis_app_db.get());
@@ -280,8 +284,8 @@ namespace routeorch_test
                 CFG_MUX_CABLE_TABLE_NAME,
                 CFG_PEER_SWITCH_TABLE_NAME
             };
-            MuxOrch *mux_orch = new MuxOrch(m_config_db.get(), mux_tables, gTunneldecapOrch, gNeighOrch, gFdbOrch);
-            gDirectory.set(mux_orch);
+            m_muxOrch = new MuxOrch(m_config_db.get(), mux_tables, gTunneldecapOrch, gNeighOrch, gFdbOrch);
+            gDirectory.set(m_muxOrch);
 
             ASSERT_EQ(gFgNhgOrch, nullptr);
             const int fgnhgorch_pri = 15;
@@ -420,6 +424,12 @@ namespace routeorch_test
             delete gFgNhgOrch;
             gFgNhgOrch = nullptr;
 
+            delete gNhgOrch;
+            gNhgOrch = nullptr;
+
+            delete gFlowCounterRouteOrch;
+            gFlowCounterRouteOrch = nullptr;
+
             delete gRouteOrch;
             gRouteOrch = nullptr;
 
@@ -428,6 +438,15 @@ namespace routeorch_test
 
             delete gBufferOrch;
             gBufferOrch = nullptr;
+
+            delete m_muxOrch;
+            m_muxOrch = nullptr;
+
+            delete m_evpnNvoOrch;
+            m_evpnNvoOrch = nullptr;
+
+            delete m_flexCounterOrch;
+            m_flexCounterOrch = nullptr;
 
             sai_route_api = pold_sai_route_api;
             ut_helper::uninitSaiApi();

--- a/tests/test_acl_mark.py
+++ b/tests/test_acl_mark.py
@@ -1,5 +1,6 @@
 import pytest
 from requests import request
+from dvslib.dvs_common import PollingConfig, wait_for_result
 
 OVERLAY_TABLE_TYPE = "UNDERLAY_SET_DSCP"
 OVERLAY_TABLE_NAME = "OVERLAY_MARK_META_TEST"
@@ -99,32 +100,60 @@ class TestAclMarkMeta:
 
 
     def get_acl_rules_with_action(self, dvs_acl, total_rules):
-        """Verify that there are N rules in the ASIC DB."""
-        members = dvs_acl.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY",
-                                               total_rules)
+        """Verify that there are N fully programmed ACL rules in ASIC DB."""
+        return self.wait_for_acl_rules_with_action(dvs_acl, total_rules)
 
-        member_groups = []
-        table_member_map = {}
-        for member in members:
-            fvs = dvs_acl.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", member)
-            table_id = fvs.get("SAI_ACL_ENTRY_ATTR_TABLE_ID")
-            entry = {}
-            entry['id'] = member
-            action = fvs.get("SAI_ACL_ENTRY_ATTR_ACTION_SET_DSCP")
-            if action:
-                entry['action_type'] = "dscp"
-                entry['action_value'] = action
-                meta = fvs.get("SAI_ACL_ENTRY_ATTR_FIELD_ACL_USER_META")
-                entry['match_meta'] = meta.split('&')[0]
-            action = fvs.get("SAI_ACL_ENTRY_ATTR_ACTION_SET_ACL_META_DATA")
-            if action:
-                entry['action_type'] = "meta"
-                entry['action_value'] = action
+    def wait_for_acl_rules_with_action(self, dvs_acl, total_rules):
+        def _get_acl_rules_with_action():
+            members = dvs_acl.asic_db.wait_for_n_keys(
+                "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY",
+                total_rules,
+                polling_config=PollingConfig(timeout=0, strict=False)
+            )
+            if len(members) != total_rules:
+                return False, {}
 
-            if table_id not in table_member_map:
-                table_member_map[table_id] = []
-            table_member_map[table_id].append(entry)
-        return table_member_map
+            table_member_map = {}
+            for member in members:
+                fvs = dvs_acl.asic_db.wait_for_entry(
+                    "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY",
+                    member,
+                    polling_config=PollingConfig(timeout=0, strict=False)
+                )
+                if not fvs:
+                    return False, table_member_map
+
+                table_id = fvs.get("SAI_ACL_ENTRY_ATTR_TABLE_ID")
+                entry = {'id': member}
+                action = fvs.get("SAI_ACL_ENTRY_ATTR_ACTION_SET_DSCP")
+                if action:
+                    meta = fvs.get("SAI_ACL_ENTRY_ATTR_FIELD_ACL_USER_META")
+                    if not meta:
+                        return False, table_member_map
+                    entry['action_type'] = "dscp"
+                    entry['action_value'] = action
+                    entry['match_meta'] = meta.split('&')[0]
+
+                action = fvs.get("SAI_ACL_ENTRY_ATTR_ACTION_SET_ACL_META_DATA")
+                if action:
+                    entry['action_type'] = "meta"
+                    entry['action_value'] = action
+
+                if 'action_type' not in entry or not table_id:
+                    return False, table_member_map
+
+                if table_id not in table_member_map:
+                    table_member_map[table_id] = []
+                table_member_map[table_id].append(entry)
+
+            return True, table_member_map
+
+        _, table_rules = wait_for_result(
+            _get_acl_rules_with_action,
+            PollingConfig(timeout=30.0),
+            f"ACL rules with actions were not fully programmed, expected={total_rules}"
+        )
+        return table_rules
 
     def verify_acl_rules_with_action(self, table_names, acl_table_id, table_rules, meta, dscp):
         for i in range(0, len(table_names)):
@@ -439,6 +468,7 @@ class TestAclMarkMeta:
             for i in range(1, 9):
                 dvs_acl.remove_acl_rule(OVERLAY_TABLE_NAME, str(i))
                 dvs_acl.verify_acl_rule_status(OVERLAY_TABLE_NAME, str(i), None)
+            dvs_acl.verify_no_acl_rules()
         dvs_acl.verify_no_acl_rules()
 
  # Add Dummy always-pass test at end as workaroud

--- a/tests/test_drop_counters.py
+++ b/tests/test_drop_counters.py
@@ -2,6 +2,7 @@ import time
 import pytest
 
 from swsscommon import swsscommon
+from dvslib.dvs_common import PollingConfig, wait_for_result
 
 # Supported drop counters
 PORT_INGRESS_DROPS = 'PORT_INGRESS_DROPS'
@@ -64,6 +65,7 @@ PORT_TABLE_NAME = "PORT"
 # applying changes to config DB
 class TestDropCounters(object):
     def setup_db(self, dvs):
+        self.dvs = dvs
         self.asic_db = swsscommon.DBConnector(1, dvs.redis_sock, 0)
         self.config_db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
         self.flex_db = swsscommon.DBConnector(5, dvs.redis_sock, 0)
@@ -74,6 +76,36 @@ class TestDropCounters(object):
         status, fields = table.get(key)
         assert status
         return fields
+
+    def waitForFlexState(self, stats, counter_list_type):
+        flex_db = self.dvs.get_flex_db()
+
+        def _all_flex_entries_match():
+            keys = flex_db.get_keys(FLEX_COUNTER_TABLE)
+            if not keys:
+                return (False, None)
+
+            observed = {}
+            for oid in keys:
+                attributes = flex_db.get_entry(FLEX_COUNTER_TABLE, oid)
+                if len(attributes) != 1:
+                    return (False, attributes)
+
+                tracked_stats = attributes.get(counter_list_type)
+                if tracked_stats is None:
+                    return (False, attributes)
+
+                observed[oid] = tracked_stats
+                if not all(stat in tracked_stats for stat in stats):
+                    return (False, observed)
+
+            return (True, observed)
+
+        wait_for_result(_all_flex_entries_match, PollingConfig(1, 20, strict=True))
+
+    def waitForNoFlexCounter(self, oid):
+        flex_db = self.dvs.get_flex_db()
+        flex_db.wait_for_deleted_entry(FLEX_COUNTER_TABLE, oid, PollingConfig(1, 20, strict=True))
 
     def checkFlexCounterGroup(self):
         flex_group_table = swsscommon.Table(self.flex_db, FLEX_COUNTER_GROUP_TABLE)
@@ -96,17 +128,6 @@ class TestDropCounters(object):
                 assert group_contents == FLEX_STATUS_ENABLE
             else:
                 assert False
-
-    def checkFlexState(self, stats, counter_list_type):
-        flex_counter_table = swsscommon.Table(self.flex_db, FLEX_COUNTER_TABLE)
-
-        for oid in flex_counter_table.getKeys():
-            attributes = self.genericGetAndAssert(flex_counter_table, oid)
-            assert len(attributes) == 1
-            field, tracked_stats = attributes[0]
-            assert field == counter_list_type
-            for stat in stats:
-                assert stat in tracked_stats
 
     def checkASICState(self, counter, counter_type, reasons):
         asic_state_table = swsscommon.Table(self.asic_db, ASIC_STATE_TABLE)
@@ -227,7 +248,7 @@ class TestDropCounters(object):
 
         # Verify that the flex counters have been created to poll the new
         # counter.
-        self.checkFlexState([PORT_STAT_BASE], PORT_DEBUG_COUNTER_LIST)
+        self.waitForFlexState([PORT_STAT_BASE], PORT_DEBUG_COUNTER_LIST)
 
         # Verify that the drop counter has been added to ASIC DB with the
         # correct reason added.
@@ -272,7 +293,7 @@ class TestDropCounters(object):
 
         # Verify that the flex counters have been created to poll the new
         # counter.
-        self.checkFlexState([PORT_STAT_BASE], PORT_DEBUG_COUNTER_LIST)
+        self.waitForFlexState([PORT_STAT_BASE], PORT_DEBUG_COUNTER_LIST)
 
         # Verify that the drop counter has been added to ASIC DB with the
         # correct reason added.
@@ -363,7 +384,7 @@ class TestDropCounters(object):
         # Verify that a counter has been created. We will verify the state of
         # the counter in the next step.
         assert len(asic_state_table.getKeys()) == 1
-        self.checkFlexState([SWITCH_STAT_BASE], SWITCH_DEBUG_COUNTER_LIST)
+        self.waitForFlexState([SWITCH_STAT_BASE], SWITCH_DEBUG_COUNTER_LIST)
 
         reason2 = 'ACL_ANY'
         self.add_drop_reason(name, reason2)
@@ -402,7 +423,7 @@ class TestDropCounters(object):
         # Verify that a counter has been created. We will verify the state of
         # the counter in the next step.
         assert len(asic_state_table.getKeys()) == 1
-        self.checkFlexState([SWITCH_STAT_BASE], SWITCH_DEBUG_COUNTER_LIST)
+        self.waitForFlexState([SWITCH_STAT_BASE], SWITCH_DEBUG_COUNTER_LIST)
 
         self.remove_drop_reason(name, reason2)
         time.sleep(3)
@@ -437,7 +458,7 @@ class TestDropCounters(object):
         # Verify that a counter has been created. We will verify the state of
         # the counter in the next step.
         assert len(asic_state_table.getKeys()) == 1
-        self.checkFlexState([SWITCH_STAT_BASE], SWITCH_DEBUG_COUNTER_LIST)
+        self.waitForFlexState([SWITCH_STAT_BASE], SWITCH_DEBUG_COUNTER_LIST)
 
         self.remove_drop_reason(name, reason1)
         time.sleep(3)
@@ -471,7 +492,7 @@ class TestDropCounters(object):
         # Verify that a counter has been created. We will verify the state of
         # the counter in the next step.
         assert len(asic_state_table.getKeys()) == 1
-        self.checkFlexState([SWITCH_STAT_BASE], SWITCH_DEBUG_COUNTER_LIST)
+        self.waitForFlexState([SWITCH_STAT_BASE], SWITCH_DEBUG_COUNTER_LIST)
 
         reason2 = 'ACL_ANY'
         self.add_drop_reason(name, reason2)
@@ -517,7 +538,7 @@ class TestDropCounters(object):
         # Verify that a counter has been created. We will verify the state of
         # the counter in the next step.
         assert len(asic_state_table.getKeys()) == 1
-        self.checkFlexState([SWITCH_STAT_BASE], SWITCH_DEBUG_COUNTER_LIST)
+        self.waitForFlexState([SWITCH_STAT_BASE], SWITCH_DEBUG_COUNTER_LIST)
 
         reason2 = 'ACL_ANY'
         self.add_drop_reason(name, reason2)
@@ -566,7 +587,7 @@ class TestDropCounters(object):
         # Verify that a counter has been created. We will verify the state of
         # the counter in the next step.
         assert len(asic_state_table.getKeys()) == 1
-        self.checkFlexState([SWITCH_STAT_BASE], SWITCH_DEBUG_COUNTER_LIST)
+        self.waitForFlexState([SWITCH_STAT_BASE], SWITCH_DEBUG_COUNTER_LIST)
 
         self.remove_drop_reason(name, reason2)
         time.sleep(3)
@@ -682,10 +703,8 @@ class TestDropCounters(object):
         # get counter oid
         oid = self.getPortOid(dvs, PORT)
 
-        # verifies debug coutner dont exist for port
-        flex_counter_table = swsscommon.Table(self.flex_db, FLEX_COUNTER_TABLE)
-        status, fields = flex_counter_table.get(oid)
-        assert len(fields) == 0
+        # verifies debug counter doesn't exist for port
+        self.waitForNoFlexCounter(oid)
  
         # add debug counters
         name1 = 'DEBUG_0'
@@ -700,19 +719,16 @@ class TestDropCounters(object):
         self.add_drop_reason(name2, reason2)
         time.sleep(3)
  
-        # verifies debug counter exist for port
-        flex_counter_table = swsscommon.Table(self.flex_db, FLEX_COUNTER_TABLE)
-        status, fields = flex_counter_table.get(oid)
-        assert status == True
-        assert len(fields) == 1
+        # verifies debug counter exists for port
+        self.waitForFlexState([PORT_STAT_BASE, 'SAI_PORT_STAT_OUT_CONFIGURED_DROP_REASONS_1_DROPPED_PKTS'],
+                              PORT_DEBUG_COUNTER_LIST)
          
         # remove port and wait until it was removed from ASIC DB
         self.dvs_port.remove_port(PORT)
         dvs.get_asic_db().wait_for_deleted_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", oid)
 
-        # verify that debug counter were removed
-        status, fields = flex_counter_table.get(oid)
-        assert len(fields) == 0
+        # verify that debug counters were removed
+        self.waitForNoFlexCounter(oid)
  
         # add port and wait until the port is added on asic db
         num_of_keys_without_port = len(dvs.get_asic_db().get_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT"))
@@ -722,9 +738,8 @@ class TestDropCounters(object):
         
         # verifies that debug counters were added for port
         oid = self.getPortOid(dvs, PORT)
-        status, fields = flex_counter_table.get(oid)
-        assert status == True
-        assert len(fields) == 1
+        self.waitForFlexState([PORT_STAT_BASE, 'SAI_PORT_STAT_OUT_CONFIGURED_DROP_REASONS_1_DROPPED_PKTS'],
+                              PORT_DEBUG_COUNTER_LIST)
         
         # Cleanup for the next test.
         self.delete_drop_counter(name1)
@@ -759,7 +774,7 @@ class TestDropCounters(object):
 
         # Verify that the flex counters are correctly tracking two different
         # drop counters.
-        self.checkFlexState([PORT_STAT_BASE, PORT_STAT_INDEX_1], PORT_DEBUG_COUNTER_LIST)
+        self.waitForFlexState([PORT_STAT_BASE, PORT_STAT_INDEX_1], PORT_DEBUG_COUNTER_LIST)
 
         # Verify that there are two entries in the ASIC DB, one for each counter.
         asic_keys = asic_state_table.getKeys()
@@ -773,7 +788,7 @@ class TestDropCounters(object):
 
         # Verify that the flex counters are tracking ONE drop counter after
         # the update.
-        self.checkFlexState([PORT_STAT_BASE], PORT_DEBUG_COUNTER_LIST)
+        self.waitForFlexState([PORT_STAT_BASE], PORT_DEBUG_COUNTER_LIST)
 
         # Verify that there is ONE entry in the ASIC DB after the update.
         asic_keys = asic_state_table.getKeys()

--- a/tests/test_inband_intf_mgmt_vrf.py
+++ b/tests/test_inband_intf_mgmt_vrf.py
@@ -14,7 +14,33 @@ class TestInbandInterface(object):
         self.asic_db = dvs.get_asic_db()
         self.cfg_db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
 
+    def wait_for_table_entry(self, db, table_name, key, exists=True):
+        tbl = swsscommon.Table(db, table_name)
+        for _ in range(10):
+            status, fvs = tbl.get(key)
+            if status == exists:
+                return status, fvs
+            time.sleep(1)
+        assert status == exists
+        return status, fvs
+
+    def wait_for_vrf_table_empty(self):
+        tbl = swsscommon.Table(self.appl_db, 'VRF_TABLE')
+        for _ in range(10):
+            vrf_keys = tbl.getKeys()
+            if len(vrf_keys) == 0:
+                return
+            time.sleep(1)
+        assert len(vrf_keys) == 0
+
+    def cleanup_mgmt_vrf(self, dvs):
+        tbl = swsscommon.Table(self.cfg_db, 'MGMT_VRF_CONFIG')
+        tbl._del('vrf_global')
+        dvs.runcmd(["sh", "-c", "ip link show mgmt >/dev/null 2>&1 && ip link del mgmt || true"])
+        self.wait_for_vrf_table_empty()
+
     def add_mgmt_vrf(self, dvs):
+        self.cleanup_mgmt_vrf(dvs)
         initial_entries = set(self.asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_VIRTUAL_ROUTER")) 
         dvs.runcmd("ip link add mgmt type vrf table 6000")
         dvs.runcmd("ifconfig mgmt up")
@@ -49,15 +75,14 @@ class TestInbandInterface(object):
         time.sleep(5)
 
         # check application database 
-        tbl = swsscommon.Table(self.appl_db, 'VRF_TABLE')
-        vrf_keys = tbl.getKeys()
-        assert len(vrf_keys) == 0
+        self.wait_for_vrf_table_empty()
 
     def del_mgmt_vrf(self, dvs):
-        dvs.runcmd("ip link del mgmt")
         tbl = swsscommon.Table(self.cfg_db, 'MGMT_VRF_CONFIG')
         tbl._del('vrf_global')
+        dvs.runcmd(["sh", "-c", "ip link show mgmt >/dev/null 2>&1 && ip link del mgmt || true"])
         time.sleep(5)
+        self.wait_for_vrf_table_empty()
 
     def create_inband_intf(self, interface):
         cfg_tbl = cfg_key = cfg_fvs = None
@@ -119,15 +144,19 @@ class TestInbandInterface(object):
     @pytest.mark.parametrize('intf_name', ['Ethernet4', 'Vlan100', 'PortChannel5', 'Loopback1'])
     def test_InbandIntf(self, intf_name, dvs, testlog):
         self.setup_db(dvs)
+        vrf_created = False
+        intf_created = False
 
-        vrf_oid = self.add_mgmt_vrf(dvs)
         try:
+            vrf_oid = self.add_mgmt_vrf(dvs)
+            vrf_created = True
             self.create_inband_intf(intf_name)
+            intf_created = True
 
-            # check application database. INTF_TABLE is populated asynchronously by
-            # intfmgrd; PortChannel-backed interfaces add an extra teamd -> kernel
-            # round-trip that can push the row beyond the default 5s poll window
-            # (observed in CI: ~5.1s). Poll up to 30s instead.
+            # check application database. INTF_TABLE is populated asynchronously
+            # by intfmgrd; PortChannel-backed interfaces add an extra teamd ->
+            # kernel round-trip that can push the row beyond the default poll
+            # window (observed in CI: ~5.1s). Poll up to 30s instead.
             tbl = swsscommon.Table(self.appl_db, 'INTF_TABLE')
 
             def _intf_table_ready():
@@ -160,23 +189,23 @@ class TestInbandInterface(object):
                     if loopback:
                         continue
                     assert intf_vrf_oid == vrf_oid
-
-            self.remove_inband_intf(intf_name)
-            time.sleep(1)
-            # check application database
-            tbl = swsscommon.Table(self.appl_db, 'INTF_TABLE')
-            intf_keys = tbl.getKeys()
-            assert len(intf_keys) == 0
-
-            if not intf_name.startswith('Loopback'):
-                self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE", 1)
         finally:
             # Always tear down the mgmt VRF, even when a parametrized assertion
             # fails. Without this, a PortChannel5 failure leaks `mgmt` VRF state
             # and causes the subsequent Loopback1 parametrization to fail as a
             # cascade.
             try:
-                self.del_inband_mgmt_vrf()
+                if intf_created:
+                    self.remove_inband_intf(intf_name)
+                    time.sleep(1)
+                    # check application database
+                    self.wait_for_table_entry(self.appl_db, 'INTF_TABLE', intf_name, exists=False)
+
+                    if not intf_name.startswith('Loopback'):
+                        self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE", 1)
+
+                if vrf_created:
+                    self.del_inband_mgmt_vrf()
             finally:
                 self.del_mgmt_vrf(dvs)
 

--- a/tests/test_inband_intf_mgmt_vrf.py
+++ b/tests/test_inband_intf_mgmt_vrf.py
@@ -24,14 +24,17 @@ class TestInbandInterface(object):
         assert status == exists
         return status, fvs
 
-    def wait_for_vrf_table_empty(self):
-        tbl = swsscommon.Table(self.appl_db, 'VRF_TABLE')
+    def wait_for_table_empty(self, table_name):
+        tbl = swsscommon.Table(self.appl_db, table_name)
         for _ in range(10):
-            vrf_keys = tbl.getKeys()
-            if len(vrf_keys) == 0:
+            keys = tbl.getKeys()
+            if len(keys) == 0:
                 return
             time.sleep(1)
-        assert len(vrf_keys) == 0
+        assert len(keys) == 0
+
+    def wait_for_vrf_table_empty(self):
+        self.wait_for_table_empty('VRF_TABLE')
 
     def cleanup_mgmt_vrf(self, dvs):
         tbl = swsscommon.Table(self.cfg_db, 'MGMT_VRF_CONFIG')
@@ -200,6 +203,7 @@ class TestInbandInterface(object):
                     time.sleep(1)
                     # check application database
                     self.wait_for_table_entry(self.appl_db, 'INTF_TABLE', intf_name, exists=False)
+                    self.wait_for_table_empty('INTF_TABLE')
 
                     if not intf_name.startswith('Loopback'):
                         self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE", 1)

--- a/tests/test_mux_prefixroute.py
+++ b/tests/test_mux_prefixroute.py
@@ -5,7 +5,7 @@ import itertools
 
 from ipaddress import ip_network, ip_address, IPv4Address
 from swsscommon import swsscommon
-from dvslib.dvs_common import PollingConfig
+from dvslib.dvs_common import PollingConfig, wait_for_result
 
 from mux_neigh_miss_tests import *
 
@@ -190,14 +190,12 @@ class TestMuxTunnelBase():
         # gets nexthop oid
         nexthop_keys = asicdb.get_keys(self.ASIC_NEXTHOP_TABLE)
 
-        nexthop_oid = ''
         for nexthop_key in nexthop_keys:
             entry = asicdb.get_entry(self.ASIC_NEXTHOP_TABLE, nexthop_key)
-            if entry["SAI_NEXT_HOP_ATTR_IP"] == nexthop:
-                nexthop_oid = nexthop_key
-                break
+            if entry.get("SAI_NEXT_HOP_ATTR_IP") == nexthop:
+                return nexthop_key
 
-        return nexthop_oid
+        return ''
     
     def get_route_nexthop_oid(self, route_key, asicdb):
         # gets nexthop oid
@@ -296,15 +294,47 @@ class TestMuxTunnelBase():
         """
         Checks if nexthop is a member of a given route
         """
-        route_key = dvs_route.check_asicdb_route_entries([route])
-        route_nexthop_oid = self.get_route_nexthop_oid(route_key[0], asicdb)
+        def _access_function():
+            route_key = dvs_route.check_asicdb_route_entries([route])
+            route_nexthop_oid = self.get_route_nexthop_oid(route_key[0], asicdb)
 
-        if tunnel:
-            return route_nexthop_oid == nexthop
+            if tunnel:
+                if route_nexthop_oid == nexthop:
+                    return (True, None)
 
-        nexthop_oid = self.get_nexthop_oid(asicdb, nexthop)
+                nhg_members = asicdb.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER")
+                for member in nhg_members:
+                    fvs = asicdb.get_entry("ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER", member)
+                    if fvs.get("SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID") != route_nexthop_oid:
+                        continue
+                    if fvs.get("SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID") == nexthop:
+                        return (True, None)
 
-        return route_nexthop_oid == nexthop_oid
+                return (False, None)
+
+            nexthop_oid = self.get_nexthop_oid(asicdb, nexthop)
+            if not nexthop_oid:
+                return (False, None)
+
+            if route_nexthop_oid == nexthop_oid:
+                return (True, None)
+
+            nhg_members = asicdb.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER")
+            for member in nhg_members:
+                fvs = asicdb.get_entry("ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER", member)
+                if fvs.get("SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID") != route_nexthop_oid:
+                    continue
+                if fvs.get("SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID") == nexthop_oid:
+                    return (True, None)
+
+            return (False, None)
+
+        status, _ = wait_for_result(
+            _access_function,
+            PollingConfig(polling_interval=0.1, timeout=5.0, strict=False)
+        )
+
+        return status
 
     def add_neighbor(self, dvs, ip, mac):
         if ip_address(ip).version == 6:


### PR DESCRIPTION
#### Why I did it

These test fixes were found while validating EVPN MH, but they are not EVPN-MH specific. Moving them to master separately improves shared test stability and reduces the EVPN MH PR scope.

#### How I did it

- Made `run-gtest-suite.py` more robust for missing/delayed gtest XML output and FD pressure.
- Cleaned stale mgmt VRF state before in-band interface tests.
- Fixed mock test object lifetime leaks in fdborch/portsorch/routeorch tests.
- Stabilized mux prefix-route nexthop checks by polling for convergence and handling NHG members.

#### How I verified it

- `git diff --check github/master..HEAD`
- `python3 -m py_compile run-gtest-suite.py tests/test_inband_intf_mgmt_vrf.py tests/test_mux_prefixroute.py`
- Verified missing gtest XML is reported as a clear test failure while preserving the original return code.
