### PR TITLE
Fix HFTelOrch double-delete of NotificationConsumer on shutdown

### DIFF
--- a/orchagent/high_frequency_telemetry/hftelorch.cpp
+++ b/orchagent/high_frequency_telemetry/hftelorch.cpp
@@ -78,14 +78,16 @@ HFTelOrch::HFTelOrch(
     createNetlinkChannel("sonic_stel", "ipfix");
     createTAM();
 
-    m_asic_notification_consumer = make_shared<NotificationConsumer>(&m_asic_db, "NOTIFICATIONS");
-    auto notifier = new Notifier(m_asic_notification_consumer.get(), this, "TAM_TEL_TYPE_STATE");
+    m_asic_notification_consumer = new NotificationConsumer(&m_asic_db, "NOTIFICATIONS");
+    auto notifier = new Notifier(m_asic_notification_consumer, this, "TAM_TEL_TYPE_STATE");
     sai_attribute_t attr;
     attr.id = SAI_SWITCH_ATTR_TAM_TEL_TYPE_CONFIG_CHANGE_NOTIFY;
     attr.value.ptr = (void *)on_tam_tel_type_config_change;
     if (sai_switch_api->set_switch_attribute(gSwitchId, &attr) != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to set SAI_SWITCH_ATTR_TAM_TEL_TYPE_CONFIG_CHANGE_NOTIFY");
+        delete notifier;
+        m_asic_notification_consumer = nullptr;
         throw runtime_error("HFTelOrch initialization failure (failed to set tam tel type config change notify)");
     }
 
@@ -490,7 +492,7 @@ void HFTelOrch::doTask(swss::NotificationConsumer &consumer)
     std::string data;
     std::vector<swss::FieldValueTuple> values;
 
-    if (&consumer != m_asic_notification_consumer.get())
+    if (&consumer != m_asic_notification_consumer)
     {
         SWSS_LOG_DEBUG("Is not TAM notification");
         return;

--- a/orchagent/high_frequency_telemetry/hftelorch.h
+++ b/orchagent/high_frequency_telemetry/hftelorch.h
@@ -34,7 +34,7 @@ public:
 private:
     swss::Table m_state_telemetry_session;
     swss::DBConnector m_asic_db;
-    std::shared_ptr<swss::NotificationConsumer> m_asic_notification_consumer;
+    swss::NotificationConsumer* m_asic_notification_consumer = nullptr;
 
     std::unordered_map<std::string, std::shared_ptr<HFTelProfile>> m_name_profile_mapping;
     std::unordered_map<sai_object_type_t, std::unordered_set<std::shared_ptr<HFTelProfile>>> m_type_profile_mapping;

--- a/tests/mock_tests/hftelorch_ut.cpp
+++ b/tests/mock_tests/hftelorch_ut.cpp
@@ -184,4 +184,53 @@ namespace hftelorch_test
             },
             runtime_error);
     }
+
+    class HFTelOrchShutdownTest : public ::testing::Test
+    {
+    protected:
+        shared_ptr<swss::DBConnector> m_config_db;
+        shared_ptr<swss::DBConnector> m_state_db;
+
+        void SetUp() override
+        {
+            map<string, string> profile = {
+                {"SAI_VS_SWITCH_TYPE", "SAI_VS_SWITCH_TYPE_BCM56850"},
+                {"KV_DEVICE_MAC_ADDRESS", "20:03:04:05:06:00"},
+            };
+
+            ASSERT_EQ(ut_helper::initSaiApi(profile), SAI_STATUS_SUCCESS);
+
+            sai_attribute_t attr{};
+            attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+            attr.value.booldata = true;
+
+            ASSERT_EQ(sai_switch_api->create_switch(&gSwitchId, 1, &attr), SAI_STATUS_SUCCESS);
+
+            m_config_db = make_shared<swss::DBConnector>("CONFIG_DB", 0);
+            m_state_db = make_shared<swss::DBConnector>("STATE_DB", 0);
+        }
+
+        void TearDown() override
+        {
+            ASSERT_EQ(sai_switch_api->remove_switch(gSwitchId), SAI_STATUS_SUCCESS);
+            gSwitchId = SAI_NULL_OBJECT_ID;
+
+            ASSERT_EQ(ut_helper::uninitSaiApi(), SAI_STATUS_SUCCESS);
+        }
+    };
+
+    /*
+     * Successful ctor then dtor: Notifier/Executor owns the ASIC NotificationConsumer.
+     * Regression for double-delete on shutdown (shared_ptr member + ~Executor).
+     */
+    TEST_F(HFTelOrchShutdownTest, DestructorDoesNotDoubleDeleteNotificationConsumer)
+    {
+        const vector<string> stel_tables = {
+            CFG_HIGH_FREQUENCY_TELEMETRY_PROFILE_TABLE_NAME,
+            CFG_HIGH_FREQUENCY_TELEMETRY_GROUP_TABLE_NAME,
+        };
+
+        auto orch = make_unique<HFTelOrch>(m_config_db.get(), m_state_db.get(), stel_tables);
+        orch.reset();
+    }
 }

--- a/tests/mock_tests/hftelorch_ut.cpp
+++ b/tests/mock_tests/hftelorch_ut.cpp
@@ -2,12 +2,48 @@
 #include "ut_helper.h"
 #include "mock_orchagent_main.h"
 #include "high_frequency_telemetry/hftelorch.h"
+#include "schema.h"
 #include <gtest/gtest.h>
+#include <memory>
+
+extern sai_switch_api_t *sai_switch_api;
 
 namespace hftelorch_test
 {
     using namespace std;
     using hftel_is_supported_ut::SaiHookGuard;
+
+    namespace constructor_ut
+    {
+        sai_switch_api_t *pold_sai_switch_api = nullptr;
+        sai_switch_api_t ut_sai_switch_api{};
+
+        sai_status_t _ut_stub_sai_set_switch_attribute(
+            _In_ sai_object_id_t switch_id,
+            _In_ const sai_attribute_t *attr)
+        {
+            if (attr->id == SAI_SWITCH_ATTR_TAM_TEL_TYPE_CONFIG_CHANGE_NOTIFY)
+            {
+                return SAI_STATUS_FAILURE;
+            }
+
+            return pold_sai_switch_api->set_switch_attribute(switch_id, attr);
+        }
+
+        void hookSaiSwitchApi()
+        {
+            ut_sai_switch_api = *sai_switch_api;
+            pold_sai_switch_api = sai_switch_api;
+            ut_sai_switch_api.set_switch_attribute = _ut_stub_sai_set_switch_attribute;
+            sai_switch_api = &ut_sai_switch_api;
+        }
+
+        void unhookSaiSwitchApi()
+        {
+            sai_switch_api = pold_sai_switch_api;
+            pold_sai_switch_api = nullptr;
+        }
+    }
 
     class HFTelOrchIsSupportedTest : public ::testing::Test
     {
@@ -90,5 +126,62 @@ namespace hftelorch_test
     {
         SaiHookGuard guard(hftel_is_supported_ut::setSaiHookSwitchNotifySetNotImplemented);
         EXPECT_FALSE(HFTelOrch::isSupportedHFTel(gSwitchId));
+    }
+
+    class HFTelOrchConstructorTest : public ::testing::Test
+    {
+    protected:
+        shared_ptr<swss::DBConnector> m_config_db;
+        shared_ptr<swss::DBConnector> m_state_db;
+
+        void SetUp() override
+        {
+            map<string, string> profile = {
+                {"SAI_VS_SWITCH_TYPE", "SAI_VS_SWITCH_TYPE_BCM56850"},
+                {"KV_DEVICE_MAC_ADDRESS", "20:03:04:05:06:00"},
+            };
+
+            ASSERT_EQ(ut_helper::initSaiApi(profile), SAI_STATUS_SUCCESS);
+
+            sai_attribute_t attr{};
+            attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+            attr.value.booldata = true;
+
+            ASSERT_EQ(sai_switch_api->create_switch(&gSwitchId, 1, &attr), SAI_STATUS_SUCCESS);
+
+            m_config_db = make_shared<swss::DBConnector>("CONFIG_DB", 0);
+            m_state_db = make_shared<swss::DBConnector>("STATE_DB", 0);
+
+            constructor_ut::hookSaiSwitchApi();
+        }
+
+        void TearDown() override
+        {
+            constructor_ut::unhookSaiSwitchApi();
+
+            ASSERT_EQ(sai_switch_api->remove_switch(gSwitchId), SAI_STATUS_SUCCESS);
+            gSwitchId = SAI_NULL_OBJECT_ID;
+
+            ASSERT_EQ(ut_helper::uninitSaiApi(), SAI_STATUS_SUCCESS);
+        }
+    };
+
+    /*
+     * Forces set_switch_attribute for TAM_TEL_TYPE_CONFIG_CHANGE_NOTIFY to fail.
+     * Covers constructor error cleanup: delete notifier and nullptr consumer.
+     */
+    TEST_F(HFTelOrchConstructorTest, ConstructorFailsWhenTamNotifySetFails)
+    {
+        const vector<string> stel_tables = {
+            CFG_HIGH_FREQUENCY_TELEMETRY_PROFILE_TABLE_NAME,
+            CFG_HIGH_FREQUENCY_TELEMETRY_GROUP_TABLE_NAME,
+        };
+
+        EXPECT_THROW(
+            {
+                HFTelOrch orch(m_config_db.get(), m_state_db.get(), stel_tables);
+                (void)orch;
+            },
+            runtime_error);
     }
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
**What I did**

Fixed a double-delete of the HFTel ASIC `NotificationConsumer` in `HFTelOrch` by aligning ownership with the orchagent `Executor` model.

- Replaced `std::shared_ptr<swss::NotificationConsumer>` with a non-owning `swss::NotificationConsumer*` in `hftelorch.h`.
- Allocate the consumer with `new` and pass it directly to `Notifier` in `hftelorch.cpp` (same pattern as `PortsOrch`).
- On failed `SAI_SWITCH_ATTR_TAM_TEL_TYPE_CONFIG_CHANGE_NOTIFY` registration, delete the `Notifier` and clear the pointer before throwing.
- Updated `doTask(NotificationConsumer&)` to compare against the raw pointer instead of `shared_ptr::get()`.

**Why I did it**

`HFTelOrch` was introduced in `a18824e6` (#3759) with dual ownership: a `shared_ptr` member and a `Notifier`/`Executor` that also deletes `m_selectable` in `~Executor()`. On graceful shutdown, `~HFTelOrch` destroyed the consumer first and `~Orch` destroyed it again, causing SIGSEGV in `redisFree()` during `~NotificationConsumer`.

This was observed on SONiC as repeated orchagent cores during stop/restart. The failure is most visible once full teardown runs (e.g. after graceful SIGTERM/SIGINT shutdown paths such as #4400), but the ownership bug has existed since HFTel was added.

**How I verified it**

- Code review against `orch.h` (`Executor` owns and deletes `m_selectable`) and `portsorch.cpp` (reference ownership pattern).
- `git diff --check` on the changed files (no whitespace issues).
- Prior GDB analysis on DUT: stack showed double `~NotificationConsumer`, `redisFree()`, and `std::_Sp_counted_base::_M_release()`; no SAI failure in `sairedis.rec` at crash time.

Recommended DUT verification (post-build):

1. Confirm HFTel is enabled: `sudo grep -i "High Frequency Telemetry" /var/log/syslog`
2. Stop/restart orchagent repeatedly: `docker exec swss supervisorctl stop orchagent` (or restart `swss`)
3. Confirm no new cores: `ls -lt /var/core/orchagent*.core*`

**Details if related**

- Introduced by: `a18824e6` — [orchagent]: HFTOrch init (#3759)
- Often exposed by: graceful orchagent shutdown / repeated restarts (related: `bd39b131` — [orchagent] Async swss.rec (#4400))
- Scope: `orchagent/high_frequency_telemetry/hftelorch.{h,cpp}` only
- Do not delete the consumer in `~HFTelOrch`; `~Executor` handles it after `addExecutor()`
- Observed: six identical orchagent cores on DUT over ~48 minutes (2026-05-19);

Fixed the issue https://github.com/sonic-net/sonic-buildimage/issues/27464