### PR TITLE
FdbOrch: use DedupQueue for FDB notifications

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -45,7 +45,10 @@ FdbOrch::FdbOrch(DBConnector* applDbConnector, vector<table_name_with_pri_t> app
 
     /* Add FDB notifications support from ASIC */
     m_notificationsDb = make_shared<DBConnector>("ASIC_DB", 0);
-    m_fdbNotificationConsumer = new swss::NotificationConsumer(m_notificationsDb.get(), "NOTIFICATIONS");
+    m_fdbNotificationConsumer = new swss::NotificationConsumer(
+            m_notificationsDb.get(), "NOTIFICATIONS",
+            100, DEFAULT_NC_POP_BATCH_SIZE,
+            std::make_shared<swss::NotificationConsumer::DedupQueue>());
     auto fdbNotifier = new Notifier(m_fdbNotificationConsumer, this, "FDB_NOTIFICATIONS");
     Orch::addExecutor(fdbNotifier);
 }

--- a/orchagent/p4orch/tests/fake_notificationconsumer.cpp
+++ b/orchagent/p4orch/tests/fake_notificationconsumer.cpp
@@ -4,8 +4,9 @@ namespace swss
 {
 
 NotificationConsumer::NotificationConsumer(swss::DBConnector *db, const std::string &channel, int pri,
-                                           size_t popBatchSize)
-    : Selectable(pri), POP_BATCH_SIZE(popBatchSize), m_db(db), m_subscribe(NULL), m_channel(channel)
+                                           size_t popBatchSize, std::shared_ptr<Queue> queue)
+    : Selectable(pri), POP_BATCH_SIZE(popBatchSize), m_db(db), m_subscribe(NULL), m_channel(channel),
+      m_queue(std::move(queue))
 {
     SWSS_LOG_ENTER();
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Updated `FdbOrch` to construct its FDB `NotificationConsumer` with a `DedupQueue` instead of the default queue. Updated the P4Orch test fake (fake_notificationconsumer.cpp) to match the new constructor signature.

**Why I did it**
A storm of MAC moves can bombard the orchagent's Rx queue at a rate higher than it can process. With a plain FIFO every duplicate FDB event is queued and processed individually, amplifying the backlog and delaying convergence. Using DedupQueue on this channel keeps only the latest occurrence of each FDB event, dropping intermediate duplicates while preserving correctness. 

**How I verified it**
Ran a MAC move storm against orchagent on a test setup and tracked the FDB notification queue depth and orchagent RSS over time.

*Before*
Under sustained MAC storm the FDB notification queue size grew unbounded, with orchagent unable to drain it as fast as events arrived.

*After*
With DedupQueue: the queue size stayed constant / trended down even while the storm continued, since duplicate FDB events collapse into a single latest entry before reaching the orch processing path.

**Details if related**
This PR is dependent on https://github.com/sonic-net/sonic-swss-common/pull/1198 being merged first
