### PR TITLE
[fdborch] Batch-drain FDB notifications in FdbOrch::doTask

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -1282,16 +1282,32 @@ void FdbOrch::doTask(NotificationConsumer& consumer)
         return;
     }
 
+    std::deque<KeyOpFieldsValuesTuple> entries;
+    consumer.pops(entries);
+
+    if (&consumer == m_fdbNotificationConsumer && entries.size() > 1000)
+    {
+        SWSS_LOG_WARN("FDB notification batch: %zu entries drained", entries.size());
+    }
+
+    for (auto& entry : entries)
+    {
+        handleNotification(consumer, entry);
+    }
+}
+
+void FdbOrch::handleNotification(NotificationConsumer& consumer, const KeyOpFieldsValuesTuple& entry)
+{
+    SWSS_LOG_ENTER();
+
+    const auto& op = kfvOp(entry);
+    const auto& data = kfvKey(entry);
+
     sai_status_t status;
-    std::string op;
-    std::string data;
-    std::vector<swss::FieldValueTuple> values;
     string alias;
     string vlan;
     Port port;
     Port vlanPort;
-
-    consumer.pop(op, data, values);
 
     if (&consumer == m_flushNotificationsConsumer)
     {

--- a/orchagent/fdborch.h
+++ b/orchagent/fdborch.h
@@ -171,6 +171,7 @@ private:
     void doTask(Consumer& consumer);
     void doTask(NotificationConsumer& consumer);
     void doTask(swss::SelectableTimer& timer) override;
+    void handleNotification(NotificationConsumer& consumer, const KeyOpFieldsValuesTuple& entry);
 
     void updateVlanMember(const VlanMemberUpdate&);
     void updatePortOperState(const PortOperStateUpdate&);


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
In `FdbOrch::doTask(NotificationConsumer&)`, replace the single `consumer.pop()` with `consumer.pops()` to drain a batch of pending entries on the notification channel per main-loop iteration instead of just one. The per-entry processing logic is factored unchanged into a new handleNotification() helper that doTask() dispatches each popped entry to.

No behavioral change for any individual notification, only the rate at which the queue is drained.

**Why I did it**
Under FDB event storms (large MAC moves etc), the producer side pushes notifications into the queue faster than the previous one-at-a-time drain could consume them. The backlog grew unboundedly, which on our deployments showed up as: 
* orchagent RSS growth tracking the queue length 
* in extreme cases, OOM / kernel panics on the device

NotificationConsumer::pops() already exists exactly for this pattern and is what some other orch agents (e.g. portsorch) use.

**How I verified it**
Built sonic-swss against the change cleanly.
The Queue length remains in check under mac storm.

**Details if related**
