### PR TITLE
[orchagent] sweep pending tasks on SELECT_TIMEOUT (no ring buffer path)

### DIFF
--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -959,6 +959,19 @@ void Orch::dumpPendingTasks(vector<string> &ts)
     }
 }
 
+bool Orch::hasPendingTasks()
+{
+    for (auto &it : m_consumerMap)
+    {
+        ConsumerBase* consumer = dynamic_cast<ConsumerBase *>(it.second.get());
+        if (consumer != NULL && consumer->hasPendingTasks())
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 void Orch::flushResponses()
 {
     m_publisher.flush();

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -959,11 +959,11 @@ void Orch::dumpPendingTasks(vector<string> &ts)
     }
 }
 
-bool Orch::hasPendingTasks()
+bool Orch::hasPendingTasks() const
 {
-    for (auto &it : m_consumerMap)
+    for (const auto &it : m_consumerMap)
     {
-        ConsumerBase* consumer = dynamic_cast<ConsumerBase *>(it.second.get());
+        const ConsumerBase* consumer = dynamic_cast<const ConsumerBase *>(it.second.get());
         if (consumer != NULL && consumer->hasPendingTasks())
         {
             return true;

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -169,6 +169,9 @@ public:
     std::string dumpTuple(const swss::KeyOpFieldsValuesTuple &tuple);
     void dumpPendingTasks(std::vector<std::string> &ts);
 
+    /* Return true if any tasks are pending in m_toSync. Cheap, O(1) per call. */
+    bool hasPendingTasks() const { return !m_toSync.empty(); }
+
     /* Store the latest 'golden' status */
     // TODO: hide?
     SyncMap m_toSync;
@@ -321,7 +324,11 @@ public:
     virtual void onWarmBootEnd() { }
 
     void dumpPendingTasks(std::vector<std::string> &ts);
-    
+
+    /* Return true if any consumer in this Orch has pending tasks in m_toSync.
+     * Used by the main loop to decide whether to sweep on SELECT_TIMEOUT. */
+    bool hasPendingTasks();
+
     void createRetryCache(const std::string &executorName);
     RetryCache* getRetryCache(const std::string &executorName);
     ConsumerBase* getConsumerBase(const std::string &executorName);

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -327,7 +327,7 @@ public:
 
     /* Return true if any consumer in this Orch has pending tasks in m_toSync.
      * Used by the main loop to decide whether to sweep on SELECT_TIMEOUT. */
-    bool hasPendingTasks();
+    bool hasPendingTasks() const;
 
     void createRetryCache(const std::string &executorName);
     RetryCache* getRetryCache(const std::string &executorName);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -881,11 +881,9 @@ bool OrchDaemon::init()
     return true;
 }
 
-bool OrchDaemon::hasPendingTasks()
+bool OrchDaemon::hasPendingTasks() const
 {
-    SWSS_LOG_ENTER();
-
-    for (Orch *o : m_orchList)
+    for (const Orch *o : m_orchList)
     {
         if (o->hasPendingTasks())
         {
@@ -1033,13 +1031,16 @@ void OrchDaemon::start(long heartBeatInterval)
             }
             else if (hasPendingTasks())
             {
-                /* Without ring buffer, the doTask sweep below would never run on
-                 * SELECT_TIMEOUT. That leaves entries that returned task_need_retry
-                 * (or its bool-pattern equivalent) stuck in m_toSync until an
-                 * unrelated external event fires. On a quiescent system that can
-                 * be indefinitely long. Opportunistically sweep here when there
-                 * are pending tasks so transient SAI conditions (TABLE_FULL freeing
-                 * up later, dependencies becoming ready) get periodic re-attempts. */
+                /* Without ring buffer, the SELECT_TIMEOUT branch otherwise just
+                 * flushes the sairedis pipeline and `continue`s. That leaves
+                 * entries which returned task_need_retry (or its bool-pattern
+                 * equivalent in routeorch/neighorch/fdborch) stuck in m_toSync
+                 * until an unrelated external event fires the per-orch doTask
+                 * sweep after c->execute(). On a quiescent system that gap can
+                 * be indefinitely long. Opportunistically sweep here when any
+                 * orch has pending tasks so transient SAI conditions
+                 * (TABLE_FULL freeing up later, dependencies becoming ready)
+                 * get periodic re-attempts. */
                 for (Orch *o : m_orchList)
                     o->doTask();
             }

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -881,6 +881,20 @@ bool OrchDaemon::init()
     return true;
 }
 
+bool OrchDaemon::hasPendingTasks()
+{
+    SWSS_LOG_ENTER();
+
+    for (Orch *o : m_orchList)
+    {
+        if (o->hasPendingTasks())
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 /* Flush redis through sairedis interface */
 void OrchDaemon::flush()
 {
@@ -1016,6 +1030,18 @@ void OrchDaemon::start(long heartBeatInterval)
                     for (Orch *o : m_orchList)
                         o->doTask();
                 }
+            }
+            else if (hasPendingTasks())
+            {
+                /* Without ring buffer, the doTask sweep below would never run on
+                 * SELECT_TIMEOUT. That leaves entries that returned task_need_retry
+                 * (or its bool-pattern equivalent) stuck in m_toSync until an
+                 * unrelated external event fires. On a quiescent system that can
+                 * be indefinitely long. Opportunistically sweep here when there
+                 * are pending tasks so transient SAI conditions (TABLE_FULL freeing
+                 * up later, dependencies becoming ready) get periodic re-attempts. */
+                for (Orch *o : m_orchList)
+                    o->doTask();
             }
 
             continue;

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -134,7 +134,7 @@ protected:
     /* Return true if any orch in m_orchList has pending tasks. Used to gate
      * the retry sweep on the SELECT_TIMEOUT path so idle systems with stuck
      * retries get periodic re-attempts without waiting for the next event. */
-    bool hasPendingTasks();
+    bool hasPendingTasks() const;
 
     void heartBeat(std::chrono::time_point<std::chrono::high_resolution_clock> tcurrent, long interval);
 

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -131,6 +131,11 @@ protected:
 
     void flush();
 
+    /* Return true if any orch in m_orchList has pending tasks. Used to gate
+     * the retry sweep on the SELECT_TIMEOUT path so idle systems with stuck
+     * retries get periodic re-attempts without waiting for the next event. */
+    bool hasPendingTasks();
+
     void heartBeat(std::chrono::time_point<std::chrono::high_resolution_clock> tcurrent, long interval);
 
     void freezeAndHeartBeat(unsigned int duration, long interval);

--- a/tests/mock_tests/orchdaemon_ut.cpp
+++ b/tests/mock_tests/orchdaemon_ut.cpp
@@ -248,4 +248,116 @@ namespace orchdaemon_test
         orchd->disableRingBuffer();
     }
 
+    // Helper: push one SET tuple into the consumer's m_toSync so
+    // ConsumerBase::hasPendingTasks() returns true. Mirrors what the real
+    // ProducerStateTable hop does when an upstream daemon writes APPL_DB.
+    static void hasPendingSeedTask(Orch *o, const std::string &table, const std::string &key)
+    {
+        auto *c = dynamic_cast<ConsumerBase *>(o->getExecutor(table));
+        ASSERT_NE(c, nullptr);
+        swss::KeyOpFieldsValuesTuple kfvt{key, SET_COMMAND, {{"f", "v"}}};
+        c->addToSync(kfvt);
+    }
+
+    TEST_F(OrchDaemonTest, ConsumerBaseHasPendingTasks)
+    {
+        // ConsumerBase::hasPendingTasks is an inline !m_toSync.empty() check.
+        // Verify both the empty and non-empty states.
+        std::vector<std::string> tables{"HPT_TABLE_A"};
+        auto orch = std::make_shared<Orch>(&appl_db, tables);
+
+        auto *c = dynamic_cast<ConsumerBase *>(orch->getExecutor("HPT_TABLE_A"));
+        ASSERT_NE(c, nullptr);
+
+        // Fresh consumer: m_toSync is empty -> hasPendingTasks() == false.
+        EXPECT_FALSE(c->hasPendingTasks());
+
+        // After addToSync, m_toSync grows -> hasPendingTasks() == true.
+        swss::KeyOpFieldsValuesTuple kfvt{"key1", SET_COMMAND, {{"f", "v"}}};
+        c->addToSync(kfvt);
+        EXPECT_TRUE(c->hasPendingTasks());
+
+        // Drain m_toSync; the consumer is empty again.
+        c->m_toSync.clear();
+        EXPECT_FALSE(c->hasPendingTasks());
+    }
+
+    TEST_F(OrchDaemonTest, OrchHasPendingTasks)
+    {
+        // Orch::hasPendingTasks() walks m_consumerMap and returns true iff
+        // any ConsumerBase in the Orch has a non-empty m_toSync.
+        std::vector<std::string> tables{"HPT_TABLE_A", "HPT_TABLE_B"};
+        auto orch = std::make_shared<Orch>(&appl_db, tables);
+
+        // All consumers fresh -> no pending tasks.
+        EXPECT_FALSE(orch->hasPendingTasks());
+
+        // Seed one consumer; the Orch now reports pending.
+        hasPendingSeedTask(orch.get(), "HPT_TABLE_A", "k1");
+        EXPECT_TRUE(orch->hasPendingTasks());
+
+        // Seed the other consumer; still true.
+        hasPendingSeedTask(orch.get(), "HPT_TABLE_B", "k1");
+        EXPECT_TRUE(orch->hasPendingTasks());
+
+        // Drain only TABLE_A; TABLE_B still has work -> still true.
+        auto *cA = dynamic_cast<ConsumerBase *>(orch->getExecutor("HPT_TABLE_A"));
+        ASSERT_NE(cA, nullptr);
+        cA->m_toSync.clear();
+        EXPECT_TRUE(orch->hasPendingTasks());
+
+        // Drain TABLE_B too -> false.
+        auto *cB = dynamic_cast<ConsumerBase *>(orch->getExecutor("HPT_TABLE_B"));
+        ASSERT_NE(cB, nullptr);
+        cB->m_toSync.clear();
+        EXPECT_FALSE(orch->hasPendingTasks());
+    }
+
+    TEST_F(OrchDaemonTest, OrchDaemonHasPendingTasks)
+    {
+        // OrchDaemon::hasPendingTasks() iterates m_orchList. It gates the new
+        // SELECT_TIMEOUT retry sweep added in this PR: when there is no ring
+        // buffer and at least one orch has pending tasks, doTask() runs on
+        // every orch in m_orchList. Idle systems with empty queues stay cheap.
+
+        // Empty m_orchList -> no pending tasks.
+        ASSERT_TRUE(orchd->m_orchList.empty());
+        EXPECT_FALSE(orchd->hasPendingTasks());
+
+        std::vector<std::string> tablesA{"HPT_DAEMON_A"};
+        std::vector<std::string> tablesB{"HPT_DAEMON_B"};
+        auto orchA = std::make_shared<Orch>(&appl_db, tablesA);
+        auto orchB = std::make_shared<Orch>(&appl_db, tablesB);
+
+        orchd->m_orchList.push_back(orchA.get());
+        orchd->m_orchList.push_back(orchB.get());
+
+        // Both Orchs fresh, no pending tasks -> daemon reports false.
+        EXPECT_FALSE(orchd->hasPendingTasks());
+
+        // Pending in the second Orch only — daemon must still report true,
+        // i.e. the iteration must not short-circuit at the first empty Orch.
+        hasPendingSeedTask(orchB.get(), "HPT_DAEMON_B", "k1");
+        EXPECT_TRUE(orchd->hasPendingTasks());
+
+        // Pending in the first Orch as well -> still true.
+        hasPendingSeedTask(orchA.get(), "HPT_DAEMON_A", "k1");
+        EXPECT_TRUE(orchd->hasPendingTasks());
+
+        // Drain orchB only -> orchA still has work -> still true.
+        auto *cB = dynamic_cast<ConsumerBase *>(orchB->getExecutor("HPT_DAEMON_B"));
+        ASSERT_NE(cB, nullptr);
+        cB->m_toSync.clear();
+        EXPECT_TRUE(orchd->hasPendingTasks());
+
+        // Drain orchA -> all queues empty -> false again.
+        auto *cA = dynamic_cast<ConsumerBase *>(orchA->getExecutor("HPT_DAEMON_A"));
+        ASSERT_NE(cA, nullptr);
+        cA->m_toSync.clear();
+        EXPECT_FALSE(orchd->hasPendingTasks());
+
+        // Cleanup so subsequent fixture-shared tests start from a clean list.
+        orchd->m_orchList.clear();
+    }
+
 }


### PR DESCRIPTION
**What I did**

Extend the `OrchDaemon::start()` main loop so that on `SELECT_TIMEOUT`, the retry sweep `for (Orch *o : m_orchList) o->doTask();` is also invoked when the ring buffer feature is **not** configured (the default build), gated on `hasPendingTasks()`.

Adds three small helpers:
- `ConsumerBase::hasPendingTasks() const` — inline O(1) check of `!m_toSync.empty()`
- `Orch::hasPendingTasks() const` — iterates `m_consumerMap`, returns true if any consumer has pending work
- `OrchDaemon::hasPendingTasks() const` — iterates `m_orchList`, returns true if any orch has pending work

Modifies the `TIMEOUT` branch in `OrchDaemon::start()`:

```cpp
if (gRingBuffer) {
    // existing ring-buffer logic
} else if (hasPendingTasks()) {
    for (Orch *o : m_orchList)
        o->doTask();
}
```

**Why I did it**

Today the `SELECT_TIMEOUT` branch (`SELECT_TIMEOUT = 1000ms`) does `flush(); continue;` and skips the per-orch `doTask()` sweep. The sweep only runs after `c->execute()` on the event path. That means any entry left in `m_toSync` after returning `task_need_retry` (or `false` in the bool-return pattern in routeorch/neighorch/fdborch) does not get a retry attempt until an unrelated external event fires.

On a quiescent system this can be indefinitely long. A transient SAI condition like `SAI_STATUS_TABLE_FULL` freeing up later, or a dependency becoming ready (RIF created, neighbor resolved), only gets re-attempted when something else wakes the loop. Operators see this as "the route never came back" until they touch some other table.

The existing ring-buffer code path (`gRingBuffer != nullptr`) already does this sweep when the buffer is idle — so the behavior is correct when ring buffer is enabled, but inconsistent (and worse) when it is not. This change makes the no-ring-buffer path do the equivalent sweep, gated on `hasPendingTasks()` so idle systems with empty queues do not burn CPU walking the orch list every second.

**How I verified it**

- Built locally; existing `make check` test suite still passes.
- Reproduced the original behavior by adding a deliberate retry-loop in routeorch on a test branch: without this change, retries paused until I issued an unrelated config change; with this change, retries fire on every `SELECT_TIMEOUT` (~1 Hz) until they succeed.
- Verified that under a fully idle system (no pending tasks), the new code path is a single comparison and adds negligible CPU.

**Details if related**

This PR is scoped to the smallest change that closes the idle-system retry gap. No new dependencies, no behavior change for the ring-buffer path, no operator-visible config knob added.
