### PR TITLE
[orchagent] publish per-consumer queue depth to STATE_DB

### DIFF
--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -959,12 +959,12 @@ void Orch::dumpPendingTasks(vector<string> &ts)
     }
 }
 
-std::vector<std::pair<std::string, size_t>> Orch::getConsumerPendingCounts()
+std::vector<std::pair<std::string, size_t>> Orch::getConsumerPendingCounts() const
 {
     std::vector<std::pair<std::string, size_t>> result;
-    for (auto &it : m_consumerMap)
+    for (const auto &it : m_consumerMap)
     {
-        ConsumerBase* consumer = dynamic_cast<ConsumerBase *>(it.second.get());
+        const ConsumerBase* consumer = dynamic_cast<const ConsumerBase *>(it.second.get());
         if (consumer != NULL)
         {
             result.emplace_back(it.first, consumer->m_toSync.size());

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -959,6 +959,20 @@ void Orch::dumpPendingTasks(vector<string> &ts)
     }
 }
 
+std::vector<std::pair<std::string, size_t>> Orch::getConsumerPendingCounts()
+{
+    std::vector<std::pair<std::string, size_t>> result;
+    for (auto &it : m_consumerMap)
+    {
+        ConsumerBase* consumer = dynamic_cast<ConsumerBase *>(it.second.get());
+        if (consumer != NULL)
+        {
+            result.emplace_back(it.first, consumer->m_toSync.size());
+        }
+    }
+    return result;
+}
+
 void Orch::flushResponses()
 {
     m_publisher.flush();

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -326,7 +326,7 @@ public:
      * executors in this Orch. Used by OrchDaemon for queue-depth telemetry.
      * Non-ConsumerBase executors (NotificationConsumer, ExecutableTimer) are
      * skipped — they don't have an m_toSync queue. */
-    std::vector<std::pair<std::string, size_t>> getConsumerPendingCounts();
+    std::vector<std::pair<std::string, size_t>> getConsumerPendingCounts() const;
 
     void createRetryCache(const std::string &executorName);
     RetryCache* getRetryCache(const std::string &executorName);

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -321,7 +321,13 @@ public:
     virtual void onWarmBootEnd() { }
 
     void dumpPendingTasks(std::vector<std::string> &ts);
-    
+
+    /* Return list of (consumer_name, pending_task_count) for all ConsumerBase
+     * executors in this Orch. Used by OrchDaemon for queue-depth telemetry.
+     * Non-ConsumerBase executors (NotificationConsumer, ExecutableTimer) are
+     * skipped — they don't have an m_toSync queue. */
+    std::vector<std::pair<std::string, size_t>> getConsumerPendingCounts();
+
     void createRetryCache(const std::string &executorName);
     RetryCache* getRetryCache(const std::string &executorName);
     ConsumerBase* getConsumerBase(const std::string &executorName);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -94,7 +94,7 @@ OrchDaemon::OrchDaemon(DBConnector *applDb, DBConnector *configDb, DBConnector *
 
     if (m_stateDb != nullptr)
     {
-        m_queueDepthTable.reset(new Table(m_stateDb, "ORCHAGENT_QUEUE"));
+        m_queueDepthTable.reset(new Table(m_stateDb, ORCHAGENT_QUEUE_TABLE_NAME));
     }
     m_lastQueueDepthPublish = std::chrono::high_resolution_clock::now();
 }
@@ -931,13 +931,13 @@ void OrchDaemon::publishQueueDepth()
         return;
     }
 
-    for (Orch *o : m_orchList)
+    for (const Orch *o : m_orchList)
     {
-        for (auto &nc : o->getConsumerPendingCounts())
+        for (const auto &[name, count] : o->getConsumerPendingCounts())
         {
             std::vector<FieldValueTuple> values;
-            values.emplace_back("pending_count", std::to_string(nc.second));
-            m_queueDepthTable->set(nc.first, values);
+            values.emplace_back("pending_count", std::to_string(count));
+            m_queueDepthTable->set(name, values);
         }
     }
 }
@@ -1011,9 +1011,9 @@ void OrchDaemon::start(long heartBeatInterval)
             flush();
         }
 
-        // Publish per-consumer queue depth to STATE_DB every 5 s. Independent of
-        // SELECT_TIMEOUT so it fires under load as well as idle.
-        constexpr int QUEUE_DEPTH_PUBLISH_INTERVAL_SEC = 5;
+        // Publish per-consumer queue depth to STATE_DB every
+        // QUEUE_DEPTH_PUBLISH_INTERVAL_SEC. Independent of SELECT_TIMEOUT so it
+        // fires under load as well as idle.
         auto qdiff = std::chrono::duration_cast<std::chrono::seconds>(tend - m_lastQueueDepthPublish);
         if (qdiff.count() >= QUEUE_DEPTH_PUBLISH_INTERVAL_SEC)
         {

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -933,11 +933,13 @@ void OrchDaemon::publishQueueDepth()
 
     for (const Orch *o : m_orchList)
     {
-        for (const auto &[name, count] : o->getConsumerPendingCounts())
+        // Note: structured bindings would be cleaner here, but orchagent
+        // builds with -std=c++14 (configure.ac).
+        for (const auto &nameAndCount : o->getConsumerPendingCounts())
         {
             std::vector<FieldValueTuple> values;
-            values.emplace_back("pending_count", std::to_string(count));
-            m_queueDepthTable->set(name, values);
+            values.emplace_back("pending_count", std::to_string(nameAndCount.second));
+            m_queueDepthTable->set(nameAndCount.first, values);
         }
     }
 }

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -1,6 +1,9 @@
 #include <unistd.h>
 #include <unordered_map>
 #include <chrono>
+#include <cstdlib>
+#include <cxxabi.h>
+#include <typeinfo>
 #include <limits.h>
 #include <errno.h>
 #include <signal.h>
@@ -95,6 +98,16 @@ OrchDaemon::OrchDaemon(DBConnector *applDb, DBConnector *configDb, DBConnector *
     if (m_stateDb != nullptr)
     {
         m_queueDepthTable.reset(new Table(m_stateDb, ORCHAGENT_QUEUE_TABLE_NAME));
+
+        // Wipe any pre-existing ORCHAGENT_QUEUE rows on startup. A previous
+        // orchagent run may have left rows for consumers that this run will
+        // not register (e.g., warm-restart reconfig, code change).
+        std::vector<std::string> existingKeys;
+        m_queueDepthTable->getKeys(existingKeys);
+        for (const auto &k : existingKeys)
+        {
+            m_queueDepthTable->del(k);
+        }
     }
     m_lastQueueDepthPublish = std::chrono::high_resolution_clock::now();
 }
@@ -922,6 +935,18 @@ void OrchDaemon::flush()
     }
 }
 
+// Demangle a typeid().name() (compiler-mangled) into a human-readable class
+// name (e.g. "9RouteOrch" -> "RouteOrch"). On non-GCC/Clang or demangle
+// failure, returns the input unchanged.
+static std::string demangleClassName(const char *mangled)
+{
+    int status = 0;
+    char *demangled = abi::__cxa_demangle(mangled, nullptr, nullptr, &status);
+    std::string out = (status == 0 && demangled != nullptr) ? std::string(demangled) : std::string(mangled);
+    std::free(demangled);
+    return out;
+}
+
 void OrchDaemon::publishQueueDepth()
 {
     SWSS_LOG_ENTER();
@@ -931,17 +956,43 @@ void OrchDaemon::publishQueueDepth()
         return;
     }
 
+    std::unordered_set<std::string> currentKeys;
+
     for (const Orch *o : m_orchList)
     {
-        // Note: structured bindings would be cleaner here, but orchagent
-        // builds with -std=c++14 (configure.ac).
+        // The Orch class name is used to qualify the STATE_DB key because
+        // consumer table names alone are not unique across m_orchList. For
+        // example, CFG_FLEX_COUNTER_TABLE is registered as a consumer in
+        // both WatermarkOrch and FlexCounterOrch; an unqualified key would
+        // overwrite one with the other every publish cycle.
+        const std::string orchName = demangleClassName(typeid(*o).name());
         for (const auto &nameAndCount : o->getConsumerPendingCounts())
         {
+            const std::string &consumerName = nameAndCount.first;
+            const std::string key = orchName + "|" + consumerName;
+
             std::vector<FieldValueTuple> values;
             values.emplace_back("pending_count", std::to_string(nameAndCount.second));
-            m_queueDepthTable->set(nameAndCount.first, values);
+            values.emplace_back("orch", orchName);
+            values.emplace_back("consumer", consumerName);
+            m_queueDepthTable->set(key, values);
+
+            currentKeys.insert(key);
         }
     }
+
+    // DEL keys that were published last cycle but are no longer in the
+    // current snapshot (a consumer was removed, an Orch was torn down, etc.)
+    // so STATE_DB always reflects the currently-running orchagent's
+    // consumer set.
+    for (const auto &k : m_lastPublishedQueueKeys)
+    {
+        if (currentKeys.find(k) == currentKeys.end())
+        {
+            m_queueDepthTable->del(k);
+        }
+    }
+    m_lastPublishedQueueKeys = std::move(currentKeys);
 }
 
 /* Release the file handle so the log can be rotated */

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -91,6 +91,12 @@ OrchDaemon::OrchDaemon(DBConnector *applDb, DBConnector *configDb, DBConnector *
     SWSS_LOG_ENTER();
     m_select = new Select();
     m_lastHeartBeat = std::chrono::high_resolution_clock::now();
+
+    if (m_stateDb != nullptr)
+    {
+        m_queueDepthTable.reset(new Table(m_stateDb, "ORCHAGENT_QUEUE"));
+    }
+    m_lastQueueDepthPublish = std::chrono::high_resolution_clock::now();
 }
 
 OrchDaemon::~OrchDaemon()
@@ -916,6 +922,26 @@ void OrchDaemon::flush()
     }
 }
 
+void OrchDaemon::publishQueueDepth()
+{
+    SWSS_LOG_ENTER();
+
+    if (m_queueDepthTable == nullptr)
+    {
+        return;
+    }
+
+    for (Orch *o : m_orchList)
+    {
+        for (auto &nc : o->getConsumerPendingCounts())
+        {
+            std::vector<FieldValueTuple> values;
+            values.emplace_back("pending_count", std::to_string(nc.second));
+            m_queueDepthTable->set(nc.first, values);
+        }
+    }
+}
+
 /* Release the file handle so the log can be rotated */
 void OrchDaemon::logRotate() {
     SWSS_LOG_ENTER();
@@ -983,6 +1009,16 @@ void OrchDaemon::start(long heartBeatInterval)
             tstart = std::chrono::high_resolution_clock::now();
 
             flush();
+        }
+
+        // Publish per-consumer queue depth to STATE_DB every 5 s. Independent of
+        // SELECT_TIMEOUT so it fires under load as well as idle.
+        constexpr int QUEUE_DEPTH_PUBLISH_INTERVAL_SEC = 5;
+        auto qdiff = std::chrono::duration_cast<std::chrono::seconds>(tend - m_lastQueueDepthPublish);
+        if (qdiff.count() >= QUEUE_DEPTH_PUBLISH_INTERVAL_SEC)
+        {
+            m_lastQueueDepthPublish = tend;
+            publishQueueDepth();
         }
 
         if (ret == Select::ERROR)

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -4,6 +4,7 @@
 #include "dbconnector.h"
 #include "producerstatetable.h"
 #include "consumertable.h"
+#include "table.h"
 #include "zmqserver.h"
 #include "select.h"
 
@@ -129,7 +130,16 @@ protected:
     Select *m_select;
     std::chrono::time_point<std::chrono::high_resolution_clock> m_lastHeartBeat;
 
+    // Queue-depth telemetry. Publishes STATE_DB:ORCHAGENT_QUEUE|<consumer>
+    // entries with pending_count, every QUEUE_DEPTH_PUBLISH_INTERVAL_SEC.
+    std::unique_ptr<swss::Table> m_queueDepthTable;
+    std::chrono::time_point<std::chrono::high_resolution_clock> m_lastQueueDepthPublish;
+
     void flush();
+
+    /* Publish per-consumer pending-count snapshot to STATE_DB. Called periodically
+     * from start(). Safe to call when m_queueDepthTable is null (no-op). */
+    void publishQueueDepth();
 
     void heartBeat(std::chrono::time_point<std::chrono::high_resolution_clock> tcurrent, long interval);
 

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -1,6 +1,8 @@
 #ifndef SWSS_ORCHDAEMON_H
 #define SWSS_ORCHDAEMON_H
 
+#include <unordered_set>
+
 #include "dbconnector.h"
 #include "producerstatetable.h"
 #include "consumertable.h"
@@ -130,12 +132,20 @@ protected:
     Select *m_select;
     std::chrono::time_point<std::chrono::high_resolution_clock> m_lastHeartBeat;
 
-    // Queue-depth telemetry. Publishes STATE_DB:ORCHAGENT_QUEUE|<consumer>
-    // entries with pending_count, every QUEUE_DEPTH_PUBLISH_INTERVAL_SEC.
+    // Queue-depth telemetry. Publishes STATE_DB:ORCHAGENT_QUEUE|<Orch>|<consumer>
+    // rows with pending_count, orch, consumer fields, every
+    // QUEUE_DEPTH_PUBLISH_INTERVAL_SEC. The Orch class name is included in the
+    // key because consumer names alone are not unique across m_orchList (e.g.,
+    // CFG_FLEX_COUNTER_TABLE is registered in both WatermarkOrch and
+    // FlexCounterOrch).
     static constexpr const char *ORCHAGENT_QUEUE_TABLE_NAME = "ORCHAGENT_QUEUE";
     static constexpr int QUEUE_DEPTH_PUBLISH_INTERVAL_SEC = 5;
     std::unique_ptr<swss::Table> m_queueDepthTable;
     std::chrono::time_point<std::chrono::high_resolution_clock> m_lastQueueDepthPublish;
+    // Keys written in the previous publishQueueDepth() call. Used to DEL keys
+    // that disappear from the current snapshot (consumer removed, Orch torn
+    // down) so STATE_DB does not accumulate stale rows.
+    std::unordered_set<std::string> m_lastPublishedQueueKeys;
 
     void flush();
 

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -132,6 +132,8 @@ protected:
 
     // Queue-depth telemetry. Publishes STATE_DB:ORCHAGENT_QUEUE|<consumer>
     // entries with pending_count, every QUEUE_DEPTH_PUBLISH_INTERVAL_SEC.
+    static constexpr const char *ORCHAGENT_QUEUE_TABLE_NAME = "ORCHAGENT_QUEUE";
+    static constexpr int QUEUE_DEPTH_PUBLISH_INTERVAL_SEC = 5;
     std::unique_ptr<swss::Table> m_queueDepthTable;
     std::chrono::time_point<std::chrono::high_resolution_clock> m_lastQueueDepthPublish;
 

--- a/tests/mock_tests/orchdaemon_ut.cpp
+++ b/tests/mock_tests/orchdaemon_ut.cpp
@@ -248,4 +248,121 @@ namespace orchdaemon_test
         orchd->disableRingBuffer();
     }
 
+    // Two distinct Orch subclasses that intentionally share the same consumer
+    // table name. This mirrors the real situation where CFG_FLEX_COUNTER_TABLE
+    // is registered as a consumer in both WatermarkOrch and FlexCounterOrch.
+    // Their demangled class names must be present in the STATE_DB key so the
+    // two rows do not collide.
+    class QueueDepthTestOrchA : public Orch
+    {
+      public:
+        QueueDepthTestOrchA(DBConnector *db, const std::vector<std::string> &tables)
+            : Orch(db, tables) {}
+        void doTask(Consumer &) override {}
+    };
+
+    class QueueDepthTestOrchB : public Orch
+    {
+      public:
+        QueueDepthTestOrchB(DBConnector *db, const std::vector<std::string> &tables)
+            : Orch(db, tables) {}
+        void doTask(Consumer &) override {}
+    };
+
+    static void seedPendingTask(Orch *o, const std::string &table, const std::string &key)
+    {
+        auto *c = dynamic_cast<ConsumerBase *>(o->getExecutor(table));
+        ASSERT_NE(c, nullptr);
+        swss::KeyOpFieldsValuesTuple kfvt{key, SET_COMMAND, {{"f", "v"}}};
+        c->addToSync(kfvt);
+    }
+
+    TEST_F(OrchDaemonTest, PublishQueueDepth)
+    {
+        // Sanity: the publisher table was created in the daemon constructor.
+        ASSERT_NE(orchd->m_queueDepthTable, nullptr);
+
+        // Build two Orchs whose consumers intentionally share a table name.
+        const std::string kSharedTable = "QUEUE_DEPTH_UT_DUP_TABLE";
+        const std::string kOrchAOnly   = "QUEUE_DEPTH_UT_A_ONLY";
+        const std::string kOrchBOnly   = "QUEUE_DEPTH_UT_B_ONLY";
+        auto orchA = std::make_shared<QueueDepthTestOrchA>(
+            &appl_db, std::vector<std::string>{kSharedTable, kOrchAOnly});
+        auto orchB = std::make_shared<QueueDepthTestOrchB>(
+            &appl_db, std::vector<std::string>{kSharedTable, kOrchBOnly});
+
+        // Pre-seed a stale row to verify it gets removed once the orch is no
+        // longer in m_orchList. (Simulates a row left over from a previous
+        // orchagent run that registered a now-removed consumer.)
+        const std::string kStaleKey = "GhostOrch|GHOST_TABLE";
+        orchd->m_queueDepthTable->set(
+            kStaleKey, {{"pending_count", "42"}, {"orch", "GhostOrch"}, {"consumer", "GHOST_TABLE"}});
+        orchd->m_lastPublishedQueueKeys.insert(kStaleKey);
+
+        // Seed different pending counts so we can tell the two rows apart.
+        seedPendingTask(orchA.get(), kSharedTable, "k1");
+        seedPendingTask(orchA.get(), kSharedTable, "k2");  // OrchA: 2 pending
+        seedPendingTask(orchA.get(), kOrchAOnly,   "ka");  // OrchA-only: 1
+        seedPendingTask(orchB.get(), kSharedTable, "k3");  // OrchB: 1 pending
+        // OrchB's kOrchBOnly consumer stays empty; should still publish 0.
+
+        orchd->m_orchList.push_back(orchA.get());
+        orchd->m_orchList.push_back(orchB.get());
+
+        orchd->publishQueueDepth();
+
+        const std::string kKeyAShared =
+            std::string("orchdaemon_test::QueueDepthTestOrchA|") + kSharedTable;
+        const std::string kKeyBShared =
+            std::string("orchdaemon_test::QueueDepthTestOrchB|") + kSharedTable;
+        const std::string kKeyAOnly =
+            std::string("orchdaemon_test::QueueDepthTestOrchA|") + kOrchAOnly;
+        const std::string kKeyBOnly =
+            std::string("orchdaemon_test::QueueDepthTestOrchB|") + kOrchBOnly;
+
+        // Both Orchs' rows for the shared table must coexist — the per-Orch
+        // class name in the key prevents the collision Copilot called out.
+        std::string val;
+        ASSERT_TRUE(orchd->m_queueDepthTable->hget(kKeyAShared, "pending_count", val));
+        EXPECT_EQ(val, "2");
+        ASSERT_TRUE(orchd->m_queueDepthTable->hget(kKeyBShared, "pending_count", val));
+        EXPECT_EQ(val, "1");
+        ASSERT_TRUE(orchd->m_queueDepthTable->hget(kKeyAOnly, "pending_count", val));
+        EXPECT_EQ(val, "1");
+        ASSERT_TRUE(orchd->m_queueDepthTable->hget(kKeyBOnly, "pending_count", val));
+        EXPECT_EQ(val, "0");
+        ASSERT_TRUE(orchd->m_queueDepthTable->hget(kKeyAShared, "orch", val));
+        EXPECT_EQ(val, "orchdaemon_test::QueueDepthTestOrchA");
+        ASSERT_TRUE(orchd->m_queueDepthTable->hget(kKeyAShared, "consumer", val));
+        EXPECT_EQ(val, kSharedTable);
+
+        // Stale key from prior cycle (not in current snapshot) must be gone.
+        EXPECT_FALSE(orchd->m_queueDepthTable->hget(kStaleKey, "pending_count", val));
+
+        // Now drop OrchB from m_orchList and re-publish. OrchB's rows should
+        // be DELed; OrchA's rows should remain.
+        orchd->m_orchList.pop_back();
+        orchd->publishQueueDepth();
+
+        EXPECT_TRUE(orchd->m_queueDepthTable->hget(kKeyAShared, "pending_count", val));
+        EXPECT_FALSE(orchd->m_queueDepthTable->hget(kKeyBShared, "pending_count", val));
+        EXPECT_FALSE(orchd->m_queueDepthTable->hget(kKeyBOnly, "pending_count", val));
+
+        // Cleanup so subsequent tests start from an empty publisher table.
+        orchd->m_orchList.clear();
+        orchd->publishQueueDepth();
+    }
+
+    TEST_F(OrchDaemonTest, PublishQueueDepthEmptyOrchListIsNoOp)
+    {
+        ASSERT_NE(orchd->m_queueDepthTable, nullptr);
+        ASSERT_TRUE(orchd->m_orchList.empty());
+
+        // Nothing should crash and nothing should be written.
+        orchd->publishQueueDepth();
+        std::vector<std::string> keys;
+        orchd->m_queueDepthTable->getKeys(keys);
+        EXPECT_TRUE(keys.empty());
+    }
+
 }


### PR DESCRIPTION
**What I did**

Add periodic queue-depth telemetry. Every 5 seconds `OrchDaemon` walks `m_orchList` and writes one row per `ConsumerBase` consumer to `STATE_DB`, qualified by the owning Orch's class name:

```
STATE_DB:ORCHAGENT_QUEUE|<OrchClass>|<consumer>
  pending_count: <m_toSync.size()>
  orch:          <OrchClass>
  consumer:      <consumer>
```

Why the Orch class name is in the key: consumer table names alone are not unique across `m_orchList`. For example `CFG_FLEX_COUNTER_TABLE` is registered as a consumer in `WatermarkOrch`, `FlexCounterOrch`, and one more place. Without the Orch prefix the rows collide and one queue is hidden from telemetry every publish cycle. The Orch name is obtained from `typeid(*o).name()` + `abi::__cxa_demangle`. The `orch` and `consumer` row fields are also included so CLI consumers don't have to parse the key.

Adds:
- `Orch::getConsumerPendingCounts() const` — returns `vector<(consumer_name, count)>` for telemetry
- `OrchDaemon::m_queueDepthTable` — `std::unique_ptr<swss::Table>` for the STATE_DB write
- `OrchDaemon::m_lastQueueDepthPublish` — last-publish timestamp
- `OrchDaemon::m_lastPublishedQueueKeys` — set of keys written in the previous cycle, used to DEL stale rows
- `OrchDaemon::publishQueueDepth()` — snapshot writer + stale-key DEL pass
- Class-scope constants `ORCHAGENT_QUEUE_TABLE_NAME` and `QUEUE_DEPTH_PUBLISH_INTERVAL_SEC`
- A 5-second tick in the main loop, **independent of `SELECT_TIMEOUT`** so publishing fires under load as well as idle
- Stale-key cleanup at two points:
  1. **At startup** the constructor wipes any pre-existing `ORCHAGENT_QUEUE|*` rows so rows left by a previous orchagent process aren't mistaken for current state.
  2. **Each publish cycle** any key written in the previous snapshot but not the current one is DELed (covers dynamic Orch teardown, warm-restart reconfig, consumer rename).

**Why I did it**

Today the only ways to see in-flight orchagent state are:
- grep `/var/log/swss/swss.rec` (the tuple-ingest recorder file)
- trigger warm-restart readiness check, which calls `dumpPendingTasks` once

Neither is convenient for routine operator observation of "is route programming backed up?" or "did neighbor processing stall behind a port-up burst?". The lack of a structured telemetry surface is one of the larger operability gaps in orchagent today — there's no `show orchagent queue` CLI, no Prometheus scrape target, no monit-pollable metric.

This PR adds the producer side: a structured, per-(Orch, consumer) pending-count snapshot in STATE_DB, refreshed every 5 s. The companion CLI consumer is the linked sonic-utilities PR.

**How I verified it**

- Built locally; existing `make check` test suite passes.
- New unit tests in `tests/mock_tests/orchdaemon_ut.cpp`:
  - `PublishQueueDepth` — constructs two test Orch subclasses that intentionally register the same consumer table name, verifies both rows coexist in STATE_DB with their owning-Orch class names in the key, verifies `pending_count`/`orch`/`consumer` fields, seeds a stale key into `m_lastPublishedQueueKeys` and verifies it's DELed, then removes one Orch from `m_orchList` and verifies its rows are DELed on the next publish.
  - `PublishQueueDepthEmptyOrchListIsNoOp` — empty `m_orchList` doesn't crash and writes nothing.
- Manually verified output with `redis-cli -n 6 KEYS 'ORCHAGENT_QUEUE|*'` and `HGETALL` after running orchagent under load — `pending_count` reflects `m_toSync.size()` per consumer and updates every 5 s.
- Verified that with all queues empty the cost is one `m_toSync.size()` call per consumer every 5 s plus one Redis `HSET` per consumer (well under 1 ms total even for several dozen consumers).
- Confirmed no behavior change to event handling, retry sweep, warm-restart, or any existing flow. This is purely additive telemetry.

**Details if related**

Companion PR adds the operator CLI:
- **sonic-net/sonic-utilities#4567**: `[show] add 'show orchagent queue' CLI for per-consumer pending task counts` — https://github.com/sonic-net/sonic-utilities/pull/4567

These two PRs together implement queue-depth telemetry. They are independent: this swss PR is operationally useful on its own (any STATE_DB consumer can read the new table), and the utilities PR fails gracefully when run against a build that lacks the swss-side telemetry (prints a friendly hint that the table is empty).

This PR is intentionally minimal: one `Table`, one timer, one method, plus the small stale-key bookkeeping. No new config knobs, no behavior change to existing flows.
