### PR TITLE
orchagent: add tx_precoding / rx_precoding support using SAI

### DIFF
--- a/orchagent/port/portcnt.h
+++ b/orchagent/port/portcnt.h
@@ -211,6 +211,16 @@ public:
         } rxpolarity; // Port serdes RX polarity
 
         struct {
+            std::vector<std::uint32_t> value;
+            bool is_set = false;
+        } tx_precoding; // Port serdes tx_precoding (per-lane)
+
+        struct {
+            std::vector<std::uint32_t> value;
+            bool is_set = false;
+        } rx_precoding; // Port serdes rx_precoding (per-lane)
+
+        struct {
             std::string value;
             bool is_set = false;
         } custom_collection; // Port serdes custom_collection

--- a/orchagent/port/porthlpr.cpp
+++ b/orchagent/port/porthlpr.cpp
@@ -795,6 +795,8 @@ template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::regn_bfm1p) &se
 template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::regn_bfm1n) &serdes, const std::string &field, const std::string &value) const;
 template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::txpolarity) &serdes, const std::string &field, const std::string &value) const;
 template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::rxpolarity) &serdes, const std::string &field, const std::string &value) const;
+template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::tx_precoding) &serdes, const std::string &field, const std::string &value) const;
+template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::rx_precoding) &serdes, const std::string &field, const std::string &value) const;
 template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::custom_collection) &serdes, const std::string &field, const std::string &value) const;
 
 
@@ -1273,6 +1275,20 @@ bool PortHelper::parsePortConfig(PortConfig &port) const
         else if (serdes_field == PORT_RX_POLARITY)
         {
             if (!this->parsePortSerdes(serdes->rxpolarity, field, value))
+            {
+                return false;
+            }
+        }
+        else if (serdes_field == PORT_TX_PRECODING)
+        {
+            if (!this->parsePortSerdes(serdes->tx_precoding, field, value))
+            {
+                return false;
+            }
+        }
+        else if (serdes_field == PORT_RX_PRECODING)
+        {
+            if (!this->parsePortSerdes(serdes->rx_precoding, field, value))
             {
                 return false;
             }

--- a/orchagent/port/portschema.h
+++ b/orchagent/port/portschema.h
@@ -91,6 +91,8 @@
 #define PORT_REGN_BFM1N            "regn_bfm1n"
 #define PORT_TX_POLARITY            "txpolarity"
 #define PORT_RX_POLARITY            "rxpolarity"
+#define PORT_TX_PRECODING           "tx_precoding"
+#define PORT_RX_PRECODING           "rx_precoding"
 #define PORT_CUSTOM_SERDES_ATTRS   "custom_serdes_attrs"
 #define PORT_ROLE                  "role"
 #define PORT_ADMIN_STATUS          "admin_status"

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -571,6 +571,16 @@ static void getPortSerdesAttr(PortSerdesAttrMap_t &map, const decltype(PortConfi
     {
         map[SAI_PORT_SERDES_ATTR_RX_POLARITY] = SerdesValue(serdes.rxpolarity.value);
     }
+
+    if (serdes.tx_precoding.is_set)
+    {
+        map[SAI_PORT_SERDES_ATTR_TX_PRECODING] = SerdesValue(serdes.tx_precoding.value);
+    }
+
+    if (serdes.rx_precoding.is_set)
+    {
+        map[SAI_PORT_SERDES_ATTR_RX_PRECODING] = SerdesValue(serdes.rx_precoding.value);
+    }
 }
 
 static bool isPathTracingSupported()

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -1473,6 +1473,8 @@ namespace portsorch_test
                 { "post2",         "0x10,0x12,0x11,0x13"         },
                 { "post3",         "0x10,0x12,0x11,0x13"         },
                 { "attn",          "0x80,0x82,0x81,0x83"         },
+                { "tx_precoding",  "0x1,0x0,0x1,0x0"             },
+                { "rx_precoding",  "0x0,0x1,0x0,0x1"             },
                 { "unreliable_los","off"                         },
                 { "ob_m2lp",       "0x4,0x6,0x5,0x7"             },
                 { "ob_alev_out",   "0xf,0x11,0x10,0x12"          },
@@ -1570,6 +1572,14 @@ namespace portsorch_test
         // Verify attn
         std::vector<std::uint32_t> attn = { 0x80, 0x82, 0x81, 0x83 };
         ASSERT_EQ(p.m_serdes_attrs.at(SAI_PORT_SERDES_ATTR_TX_FIR_ATTN), SerdesValue(attn));
+
+        // Verify tx_precoding
+        std::vector<std::uint32_t> tx_precoding = { 0x1, 0x0, 0x1, 0x0 };
+        ASSERT_EQ(p.m_serdes_attrs.at(SAI_PORT_SERDES_ATTR_TX_PRECODING), SerdesValue(tx_precoding));
+
+        // Verify rx_precoding
+        std::vector<std::uint32_t> rx_precoding = { 0x0, 0x1, 0x0, 0x1 };
+        ASSERT_EQ(p.m_serdes_attrs.at(SAI_PORT_SERDES_ATTR_RX_PRECODING), SerdesValue(rx_precoding));
 
         // Verify ob_m2lp
         std::vector<std::uint32_t> ob_m2lp = { 0x4, 0x6, 0x5, 0x7 };


### PR DESCRIPTION
**What I did**

Add `tx_precoding` and `rx_precoding` as per-lane SerDes attributes parsed from `APP_DB:PORT_TABLE` and programmed via `SAI_PORT_SERDES_ATTR_{TX,RX}_PRECODING`:

- `orchagent/port/portschema.h` — `PORT_TX_PRECODING` / `PORT_RX_PRECODING` field names
- `orchagent/port/portcnt.h` — storage + `is_set` flag on `PortSerdes_t`
- `orchagent/port/porthlpr.cpp` — parser branches in `parsePortConfig` + template instantiations of `parsePortSerdes`
- `orchagent/portsorch.cpp::getPortSerdesAttr` — emits the two SAI attrs into the attribute map consumed by `create_port_serdes()`
- `tests/mock_tests/portsorch_ut.cpp` — extends `PortAdvancedConfig` with asymmetric per-lane values and asserts SAI attr mapping

**Work item tracking**
- Microsoft ADO **(number only)**:

**How I did it**
1. Defined the new `tx_precoding` / `rx_precoding` field names in `portschema.h`.
2. Added storage for the per-lane values and an `is_set` flag on `PortSerdes_t` in `portcnt.h`, so a value is only programmed when explicitly configured.
3. Added parser branches in `porthlpr.cpp::parsePortConfig` and instantiated `parsePortSerdes` for the new fields, so the comma-separated per-lane values from `APP_DB:PORT_TABLE` are parsed into the `PortSerdes_t` structure.
4. In `portsorch.cpp::getPortSerdesAttr`, emitted `SAI_PORT_SERDES_ATTR_TX_PRECODING` / `SAI_PORT_SERDES_ATTR_RX_PRECODING` into the attribute map consumed by `create_port_serdes()`, gated on the corresponding `is_set` flag.

**How to verify it**

- Unit test: `tests/mock_tests/portsorch_ut.cpp` `PortAdvancedConfig` was extended with asymmetric per-lane `tx_precoding` / `rx_precoding` values and asserts that the correct `SAI_PORT_SERDES_ATTR_{TX,RX}_PRECODING` values are passed to SAI. Run the mock tests.
- Manual: set `tx_precoding` / `rx_precoding` (comma-separated per-lane values) on a port in `APP_DB:PORT_TABLE`, then confirm via the SAI/syncd logs that the corresponding `SAI_PORT_SERDES_ATTR_{TX,RX}_PRECODING` attributes are created with the expected per-lane values.

**Description for the changelog**
orchagent: add per-lane tx_precoding / rx_precoding SerDes support programmed via SAI.