### PR TITLE
muxorch: add MUX subnet slicing (anchor supernet + slice-aware NH state)

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -410,8 +410,12 @@ static bool remove_nh_tunnel(sai_object_id_t nh_id, IpAddress& ipAddr)
     return true;
 }
 
-MuxCable::MuxCable(string name, IpPrefix& srv_ip4, IpPrefix& srv_ip6, IpAddress peer_ip, MuxCableType cable_type, MuxNbrHandlerType nbr_handler_type)
-         :mux_name_(name), srv_ip4_(srv_ip4), srv_ip6_(srv_ip6), peer_ip4_(peer_ip), cable_type_(cable_type), nbr_handler_type_(nbr_handler_type)
+MuxCable::MuxCable(string name, IpPrefix& srv_ip4, IpPrefix& srv_ip6, IpAddress peer_ip, MuxCableType cable_type, MuxNbrHandlerType nbr_handler_type, IpPrefix slice_ip6)
+         :mux_name_(name),
+          cable_type_(cable_type),
+          nbr_handler_type_(nbr_handler_type),
+          srv_ip4_(srv_ip4), srv_ip6_(srv_ip6), peer_ip4_(peer_ip),
+          slice_ip6_(slice_ip6)
 {
     mux_orch_ = gDirectory.get<MuxOrch*>();
     mux_cb_orch_ = gDirectory.get<MuxCableOrch*>();
@@ -457,6 +461,7 @@ bool MuxCable::stateInitActive()
         return false;
     }
 
+    refreshSliceRoute();
     return true;
 }
 
@@ -482,6 +487,7 @@ bool MuxCable::stateActive()
         return false;
     }
 
+    refreshSliceRoute();
     return true;
 }
 
@@ -500,6 +506,8 @@ bool MuxCable::stateStandby()
     {
         return false;
     }
+
+    refreshSliceRoute();
 
     if (!aclHandler(port.m_port_id, mux_name_))
     {
@@ -681,6 +689,14 @@ void MuxCable::updateNeighbor(NextHopKey nh, bool add)
 {
     SWSS_LOG_NOTICE("Processing update on neighbor %s for mux %s, add %d, state %d",
                      nh.ip_address.to_string().c_str(), mux_name_.c_str(), add, state_);
+
+    if (!add && hasSlicePrefix() && nh.ip_address == srv_ip6_.getIp())
+    {
+        SWSS_LOG_ERROR("Mux %s: anchor %s removed while slice %s active; supernet route will be withdrawn",
+                       mux_name_.c_str(), nh.ip_address.to_string().c_str(),
+                       slice_ip6_.to_string().c_str());
+    }
+
     sai_object_id_t tnh = mux_orch_->getNextHopTunnelId(MUX_TUNNEL, peer_ip4_);
     nbr_handler_->update(nh, tnh, add, state_);
     if (add)
@@ -692,6 +708,13 @@ void MuxCable::updateNeighbor(NextHopKey nh, bool add)
         mux_orch_->removeNexthop(nh);
     }
     updateRoutesForNextHop(nh);
+
+    // If the changed neighbor is the slice anchor (server_ipv6), the slice
+    // route NH may need to be (re)installed or withdrawn.
+    if (hasSlicePrefix() && nh.ip_address == srv_ip6_.getIp())
+    {
+        refreshSliceRoute();
+    }
 }
 
 /**
@@ -733,6 +756,81 @@ void MuxCable::updateRoutesForNextHop(NextHopKey nh)
             mux_orch_->updateRoute(rt->prefix);
         }
     }
+}
+
+void MuxCable::refreshSliceRoute()
+{
+    if (!hasSlicePrefix())
+    {
+        withdrawSliceRoute();
+        return;
+    }
+
+    IpPrefix slice_pfx = slice_ip6_;
+    IpAddress anchor_ip = srv_ip6_.getIp();
+    NextHopKey anchor_nh(anchor_ip, mux_name_);
+    sai_object_id_t desired = nbr_handler_->getNextHopId(anchor_nh);
+
+    if (desired == SAI_NULL_OBJECT_ID)
+    {
+        if (slice_route_nh_oid_ != SAI_NULL_OBJECT_ID)
+        {
+            SWSS_LOG_NOTICE("Mux %s: anchor %s not ready, withdrawing slice route %s",
+                            mux_name_.c_str(), anchor_ip.to_string().c_str(),
+                            slice_pfx.to_string().c_str());
+            withdrawSliceRoute();
+        }
+        return;
+    }
+
+    if (slice_route_nh_oid_ == SAI_NULL_OBJECT_ID)
+    {
+        sai_status_t status = create_route(slice_pfx, desired);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Mux %s: failed to install slice route %s nh 0x%" PRIx64 " rv %d",
+                           mux_name_.c_str(), slice_pfx.to_string().c_str(),
+                           desired, status);
+            return;
+        }
+        slice_route_nh_oid_ = desired;
+        SWSS_LOG_NOTICE("Mux %s: installed slice route %s -> anchor nh 0x%" PRIx64,
+                        mux_name_.c_str(), slice_pfx.to_string().c_str(), desired);
+    }
+    else if (slice_route_nh_oid_ != desired)
+    {
+        sai_status_t status = set_route(slice_pfx, desired);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Mux %s: failed to update slice route %s nh 0x%" PRIx64 " rv %d",
+                           mux_name_.c_str(), slice_pfx.to_string().c_str(),
+                           desired, status);
+            return;
+        }
+        SWSS_LOG_NOTICE("Mux %s: slice route %s nh 0x%" PRIx64 " -> 0x%" PRIx64,
+                        mux_name_.c_str(), slice_pfx.to_string().c_str(),
+                        slice_route_nh_oid_, desired);
+        slice_route_nh_oid_ = desired;
+    }
+}
+
+void MuxCable::withdrawSliceRoute()
+{
+    if (slice_route_nh_oid_ == SAI_NULL_OBJECT_ID)
+    {
+        return;
+    }
+    IpPrefix slice_pfx = slice_ip6_;
+    sai_status_t status = remove_route(slice_pfx);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Mux %s: failed to remove slice route %s rv %d (state retained for retry)",
+                       mux_name_.c_str(), slice_pfx.to_string().c_str(), status);
+        return;
+    }
+    SWSS_LOG_NOTICE("Mux %s: removed slice route %s",
+                    mux_name_.c_str(), slice_pfx.to_string().c_str());
+    slice_route_nh_oid_ = SAI_NULL_OBJECT_ID;
 }
 
 void MuxNbrHandler::update(NextHopKey nh, sai_object_id_t tunnelId, bool add, MuxState state)
@@ -1675,6 +1773,52 @@ MuxCable* MuxOrch::findMuxCableInSubnet(IpAddress ip)
     return nullptr;
 }
 
+MuxCable* MuxOrch::findMuxCableBySlice(IpAddress ip)
+{
+    for (auto it = mux_cable_tb_.begin(); it != mux_cable_tb_.end(); it++)
+    {
+        MuxCable* ptr = it->second.get();
+        if (ptr->isIpInSlice(ip))
+        {
+            return ptr;
+        }
+    }
+
+    SWSS_LOG_INFO("No mux cable found with slice containing ip %s",
+                  ip.to_string().c_str());
+    return nullptr;
+}
+
+bool MuxOrch::isInSliceSuppressed(const IpAddress& ip)
+{
+    // Fast bail when no slice is configured anywhere.
+    if (!isAnySliceConfigured())
+    {
+        return false;
+    }
+
+    MuxCable* cable = findMuxCableBySlice(ip);
+    if (!cable)
+    {
+        return false;
+    }
+
+    // Anchor (server_ipv6) is always programmed as a host neighbor.
+    if (ip == cable->getServerIp6().getIp())
+    {
+        return false;
+    }
+
+    // soc_ipv4 / soc_ipv6 (skip neighbors) keep existing semantics.
+    if (skip_neighbors_.find(ip) != skip_neighbors_.end())
+    {
+        return false;
+    }
+
+    return true;
+}
+
+
 bool MuxOrch::isMuxPortPrefixNbr(const IpAddress& nbr, const MacAddress& mac, string& alias)
 {
     // If prefix nbrs are not supported, return false
@@ -1823,6 +1967,12 @@ void MuxOrch::updateFdb(const FdbUpdate& update)
     // Handle existing MUX neighbors that might be moving between ports
     for (auto nh = mux_nexthop_tb_.begin(); nh != mux_nexthop_tb_.end(); ++nh)
     {
+        // Only programmed NHs have a SAI neighbor to move.
+        if (!muxNhIsProgrammed(nh->second.state))
+        {
+            continue;
+        }
+
         auto res = neigh_orch_->getNeighborEntry(nh->first, neigh, mac);
         if (!res || update.entry.mac != mac)
         {
@@ -1831,16 +1981,16 @@ void MuxOrch::updateFdb(const FdbUpdate& update)
 
         found_existing_mux_neighbor = true;
 
-        if (nh->second != update.entry.port_name)
+        if (nh->second.port_name != update.entry.port_name)
         {
-            if (!nh->second.empty() && isMuxExists(nh->second))
+            if (!nh->second.port_name.empty() && isMuxExists(nh->second.port_name))
             {
-                ptr = getMuxCable(nh->second);
+                ptr = getMuxCable(nh->second.port_name);
                 if (ptr->isIpInSubnet(nh->first.ip_address))
                 {
                     continue;
                 }
-                nh->second = update.entry.port_name;
+                nh->second.port_name = update.entry.port_name;
                 ptr->updateNeighbor(nh->first, false);
             }
 
@@ -1901,12 +2051,42 @@ void MuxOrch::updateFdb(const FdbUpdate& update)
 
 bool MuxOrch::convertNeighborToMux(const NeighborEntry& neighbor_entry, const string& port_name, const string& context)
 {
+
     // Verify MUX cable exists and is properly configured before conversion
     MuxCable* ptr = getMuxCable(port_name);
     if (!ptr)
     {
         SWSS_LOG_WARN("MUX cable for port %s not found, skipping neighbor conversion", port_name.c_str());
         return false;
+    }
+
+    // Slice gate: in-slice IP on its owning slice port stays suppressed;
+    // FDB resolution must not re-program the SAI neighbor.
+    bool slice_owner_match = false;
+    if (isInSliceSuppressed(neighbor_entry.ip_address))
+    {
+        const std::string owner_port = findSliceOwnerPort(neighbor_entry.ip_address);
+        slice_owner_match = !owner_port.empty() && owner_port == port_name;
+    }
+    if (slice_owner_match)
+    {
+        NextHopKey nh_key = { neighbor_entry.ip_address, neighbor_entry.alias };
+        auto existing = mux_nexthop_tb_.find(nh_key);
+        if (existing == mux_nexthop_tb_.end() ||
+            existing->second.state != MuxNhState::SuppressedResolved)
+        {
+            // Tear down any SAI neighbor that slipped through before recording the row.
+            if (existing == mux_nexthop_tb_.end())
+            {
+                neigh_orch_->disableNeighbor(neighbor_entry);
+            }
+            mux_nexthop_tb_[nh_key] = MuxNhEntry(port_name, MuxNhState::SuppressedResolved);
+        }
+        SWSS_LOG_NOTICE("Skipping convertNeighborToMux for %s on %s (%s): in-slice, keep suppressed",
+                        neighbor_entry.ip_address.to_string().c_str(),
+                        neighbor_entry.alias.c_str(),
+                        context.c_str());
+        return true;
     }
 
     // Get tunnel nexthop if needed (for standby state)
@@ -1923,7 +2103,7 @@ bool MuxOrch::convertNeighborToMux(const NeighborEntry& neighbor_entry, const st
     {
         // Add to MUX nexthop table
         NextHopKey nh_key = { neighbor_entry.ip_address, neighbor_entry.alias };
-        mux_nexthop_tb_[nh_key] = port_name;
+        mux_nexthop_tb_[nh_key] = MuxNhEntry(port_name);
 
         // Update MUX cable with the new neighbor
         ptr->updateNeighbor(nh_key, true);
@@ -1983,6 +2163,123 @@ void MuxOrch::updateNeighbor(const NeighborUpdate& update)
         removeStandaloneTunnelRoute(update.entry.ip_address);
     }
 
+    // slice gate. Runs before the per-cable subnet loop so slice
+    // decisions are independent of subnet overlap.
+    if (isAnySliceConfigured())
+    {
+        NextHopKey nh_key(update.entry.ip_address, update.entry.alias);
+
+        if (update.add && isInSliceSuppressed(update.entry.ip_address))
+        {
+            auto existing = mux_nexthop_tb_.find(nh_key);
+
+            // Already programmed (e.g. unsuppression mid-flight); don't disable.
+            if (existing != mux_nexthop_tb_.end() &&
+                muxNhIsProgrammed(existing->second.state))
+            {
+                SWSS_LOG_INFO("Slice NH %s: already programmed on %s, skipping slice gate",
+                              update.entry.ip_address.to_string().c_str(),
+                              existing->second.port_name.c_str());
+                return;
+            }
+
+            // Placeholder + real route refs: promote to Programmed via the cable.
+            if (existing != mux_nexthop_tb_.end() &&
+                existing->second.state == MuxNhState::PlaceholderUnresolved &&
+                hasRouteRefsForNh(nh_key))
+            {
+                const std::string owner_port = existing->second.port_name.empty()
+                    ? findSliceOwnerPort(update.entry.ip_address)
+                    : existing->second.port_name;
+
+                MuxCable* owner_cable = nullptr;
+                auto cable_it = mux_cable_tb_.find(owner_port);
+                if (cable_it != mux_cable_tb_.end())
+                {
+                    owner_cable = cable_it->second.get();
+                }
+
+                mux_nexthop_tb_.erase(existing);
+
+                if (owner_cable)
+                {
+                    SWSS_LOG_NOTICE("Slice NH %s: learn promoted placeholder -> Programmed on %s",
+                                    update.entry.ip_address.to_string().c_str(),
+                                    owner_port.c_str());
+                    owner_cable->updateNeighbor(update.entry, true);
+
+                    // Verify the cable replaced the placeholder with a programmed row.
+                    // If not, restore the placeholder so the table stays consistent
+                    // with the route refs that are still tracking this NH.
+                    auto post = mux_nexthop_tb_.find(nh_key);
+                    if (post == mux_nexthop_tb_.end() ||
+                        !muxNhIsProgrammed(post->second.state))
+                    {
+                        SWSS_LOG_ERROR("Slice NH %s: placeholder promotion did not program on %s; restoring placeholder",
+                                       update.entry.ip_address.to_string().c_str(),
+                                       owner_port.c_str());
+                        mux_nexthop_tb_[nh_key] = MuxNhEntry(owner_port, MuxNhState::PlaceholderUnresolved);
+                    }
+                    return;
+                }
+
+                SWSS_LOG_WARN("Slice NH %s: placeholder owner port '%s' not found; falling back",
+                              update.entry.ip_address.to_string().c_str(),
+                              owner_port.c_str());
+                // Safety net: fall through to default subnet loop.
+            }
+            else
+            {
+                const std::string owner_port = findSliceOwnerPort(update.entry.ip_address);
+
+                // Port affinity: if FDB resolves the MAC to a non-owner port,
+                // the IP lives behind a different cable; skip suppress.
+                std::string fdb_port;
+                if (getMuxPort(update.mac, update.entry.alias, fdb_port) &&
+                    !fdb_port.empty() && fdb_port != owner_port)
+                {
+                    SWSS_LOG_NOTICE("Slice gate: %s FDB-resolved on %s (slice owner %s); skip suppress",
+                                    update.entry.ip_address.to_string().c_str(),
+                                    fdb_port.c_str(), owner_port.c_str());
+                    return;
+                }
+
+                // Only record SuppressedResolved on successful disable so the
+                // table never disagrees with ASIC state.
+                if (!neigh_orch_->disableNeighbor(update.entry))
+                {
+                    SWSS_LOG_WARN("Slice suppress: disableNeighbor failed for %s on %s; leaving SAI neighbor programmed",
+                                  update.entry.ip_address.to_string().c_str(),
+                                  update.entry.alias.c_str());
+                    return;
+                }
+
+                mux_nexthop_tb_[nh_key] = MuxNhEntry(owner_port, MuxNhState::SuppressedResolved);
+
+                SWSS_LOG_INFO("Slice-suppressed neighbor %s on %s (owner=%s, SuppressedResolved)",
+                              update.entry.ip_address.to_string().c_str(),
+                              update.entry.alias.c_str(),
+                              owner_port.c_str());
+                return;
+            }
+        }
+
+        // Remove of a previously-suppressed NH: no SAI mux NH ever existed,
+        // just drop the tracking row.
+        if (!update.add)
+        {
+            auto nh_it = mux_nexthop_tb_.find(nh_key);
+            if (nh_it != mux_nexthop_tb_.end() &&
+                nh_it->second.state == MuxNhState::SuppressedResolved)
+            {
+                SWSS_LOG_INFO("Slice-suppressed neighbor %s removed",
+                              update.entry.ip_address.to_string().c_str());
+                mux_nexthop_tb_.erase(nh_it);
+                return;
+            }
+        }
+    }
+
     // Check if neighbor is in MUX subnet
     for (auto it = mux_cable_tb_.begin(); it != mux_cable_tb_.end(); it++)
     {
@@ -2019,8 +2316,8 @@ void MuxOrch::updateNeighbor(const NeighborUpdate& update)
         auto it = mux_nexthop_tb_.find(update.entry);
         if (it != mux_nexthop_tb_.end())
         {
-            SWSS_LOG_INFO("port %s, nexthop %s", port.c_str(), it->second.c_str());
-            port = it->second;
+            SWSS_LOG_INFO("port %s, nexthop %s", port.c_str(), it->second.port_name.c_str());
+            port = it->second.port_name;
             removeNexthop(update.entry);
         }
     }
@@ -2042,7 +2339,7 @@ void MuxOrch::updateNeighbor(const NeighborUpdate& update)
 
 void MuxOrch::addNexthop(NextHopKey nh, string muxName)
 {
-    mux_nexthop_tb_[nh] = muxName;
+    mux_nexthop_tb_[nh] = MuxNhEntry(muxName);
 }
 
 void MuxOrch::removeNexthop(NextHopKey nh)
@@ -2051,13 +2348,22 @@ void MuxOrch::removeNexthop(NextHopKey nh)
 }
 
 /**
- * @brief checks if mux nexthop tb contains nexthop
+ * @brief checks if a given nexthop is programmed as a mux SAI nexthop
  * @param nexthop NextHopKey
- * @return true if a mux contains the nexthop
+ * @return true iff the nexthop is currently in MuxNhState ProgrammedActive
+ *         or ProgrammedStandby (i.e. has a SAI mux NH OID). Suppressed /
+ *         Placeholder entries return false — they're tracked by MuxOrch
+ *         but RouteOrch must NOT treat them as mux-managed for SAI route
+ *         purposes (no OID exists).
  */
 bool MuxOrch::containsNextHop(const NextHopKey& nexthop)
 {
-    return mux_nexthop_tb_.find(nexthop) != mux_nexthop_tb_.end();
+    auto it = mux_nexthop_tb_.find(nexthop);
+    if (it == mux_nexthop_tb_.end())
+    {
+        return false;
+    }
+    return muxNhIsProgrammed(it->second.state);
 }
 
 /**
@@ -2091,7 +2397,14 @@ bool MuxOrch::hasPrefixBasedMuxNexthop(const std::set<NextHopKey>& nextHops)
             continue;
         }
 
-        if (isMuxCablePrefixBased(it->second))
+        // Only consider programmed mux NHs: Suppressed / Placeholder
+        // entries have no SAI NH OID and must not influence NHG building.
+        if (!muxNhIsProgrammed(it->second.state))
+        {
+            continue;
+        }
+
+        if (isMuxCablePrefixBased(it->second.port_name))
         {
             return true;
         }
@@ -2107,7 +2420,7 @@ string MuxOrch::getNexthopMuxName(NextHopKey nh)
         return std::string();
     }
 
-    return mux_nexthop_tb_[nh];
+    return mux_nexthop_tb_[nh].port_name;
 }
 
 sai_object_id_t MuxOrch::getNextHopId(const NextHopKey &nh)
@@ -2117,7 +2430,7 @@ sai_object_id_t MuxOrch::getNextHopId(const NextHopKey &nh)
         return SAI_NULL_OBJECT_ID;
     }
 
-    auto mux_name = mux_nexthop_tb_[nh];
+    auto mux_name = mux_nexthop_tb_[nh].port_name;
     if (!isMuxExists(mux_name))
     {
         SWSS_LOG_INFO("Mux entry for nh '%s' port '%s' doesn't exist",
@@ -2128,6 +2441,290 @@ sai_object_id_t MuxOrch::getNextHopId(const NextHopKey &nh)
     auto ptr = getMuxCable(mux_name);
 
     return ptr->getNextHopId(nh);
+}
+
+
+bool MuxOrch::hasKnownMuxNextHop(const NextHopKey& nh) const
+{
+    return mux_nexthop_tb_.find(nh) != mux_nexthop_tb_.end();
+}
+
+bool MuxOrch::hasProgrammedMuxNextHop(const NextHopKey& nh) const
+{
+    auto it = mux_nexthop_tb_.find(nh);
+    if (it == mux_nexthop_tb_.end())
+    {
+        return false;
+    }
+    return muxNhIsProgrammed(it->second.state);
+}
+
+sai_object_id_t MuxOrch::getProgrammedNextHopId(const NextHopKey& nh)
+{
+    if (!hasProgrammedMuxNextHop(nh))
+    {
+        return SAI_NULL_OBJECT_ID;
+    }
+    // Reuse the existing OID lookup so we stay consistent with the
+    // MuxNbrHandler::neighbors_ cache where the real OID lives.
+    return getNextHopId(nh);
+}
+
+std::string MuxOrch::getMuxOwnerIfKnown(const NextHopKey& nh) const
+{
+    auto it = mux_nexthop_tb_.find(nh);
+    if (it == mux_nexthop_tb_.end())
+    {
+        return std::string();
+    }
+    return it->second.port_name;
+}
+
+MuxNhState MuxOrch::getNhState(const NextHopKey& nh) const
+{
+    auto it = mux_nexthop_tb_.find(nh);
+    if (it == mux_nexthop_tb_.end())
+    {
+        return MuxNhState::PlaceholderUnresolved;
+    }
+    return it->second.state;
+}
+
+
+void MuxOrch::addRouteRefForNh(const NextHopKey& nh, const RouteKey& route)
+{
+    nh_route_refs_[nh].insert(route);
+}
+
+void MuxOrch::removeRouteRefForNh(const NextHopKey& nh, const RouteKey& route)
+{
+    auto it = nh_route_refs_.find(nh);
+    if (it == nh_route_refs_.end())
+    {
+        return;
+    }
+    it->second.erase(route);
+    if (it->second.empty())
+    {
+        nh_route_refs_.erase(it);
+    }
+}
+
+bool MuxOrch::hasRouteRefsForNh(const NextHopKey& nh) const
+{
+    auto it = nh_route_refs_.find(nh);
+    return it != nh_route_refs_.end() && !it->second.empty();
+}
+
+size_t MuxOrch::routeRefCountForNh(const NextHopKey& nh) const
+{
+    auto it = nh_route_refs_.find(nh);
+    if (it == nh_route_refs_.end())
+    {
+        return 0;
+    }
+    return it->second.size();
+}
+
+std::string MuxOrch::findSliceOwnerPort(const IpAddress& ip) const
+{
+    for (auto it = mux_cable_tb_.begin(); it != mux_cable_tb_.end(); it++)
+    {
+        if (it->second->isIpInSlice(ip))
+        {
+            return it->first;
+        }
+    }
+    return std::string();
+}
+
+void MuxOrch::unsuppressNeighbor(const NextHopKey& nh)
+{
+
+    auto it = mux_nexthop_tb_.find(nh);
+    if (it == mux_nexthop_tb_.end())
+    {
+        return;
+    }
+
+    const std::string owner_port = it->second.port_name;
+    if (owner_port.empty() || !isMuxExists(owner_port))
+    {
+        SWSS_LOG_WARN("Slice unsuppress: owner port '%s' unknown for NH %s",
+                      owner_port.c_str(), nh.ip_address.to_string().c_str());
+        return;
+    }
+
+    // Flip state to Programmed BEFORE enableNeighbor: that call fires
+    // NeighborUpdate synchronously, re-entering updateNeighbor's slice gate
+    // which must see Programmed to skip re-disabling.
+    it->second.state = MuxNhState::ProgrammedActive;
+
+    NeighborEntry nbr(nh.ip_address, nh.alias);
+    if (!neigh_orch_->enableNeighbor(nbr))
+    {
+        SWSS_LOG_WARN("Slice unsuppress: enableNeighbor failed for %s; aborting",
+                      nh.ip_address.to_string().c_str());
+        auto rb = mux_nexthop_tb_.find(nh);
+        if (rb != mux_nexthop_tb_.end())
+        {
+            rb->second.state = MuxNhState::SuppressedResolved;
+        }
+        return;
+    }
+
+    // cable->updateNeighbor(true) programs the SAI mux NH and overwrites
+    // mux_nexthop_tb_[nh] via addNexthop() (defaults to ProgrammedActive).
+    MuxCable* cable = getMuxCable(owner_port);
+    cable->updateNeighbor(nh, true);
+
+    SWSS_LOG_NOTICE("Slice unsuppress NH %s on %s (state=Programmed)",
+                    nh.ip_address.to_string().c_str(), owner_port.c_str());
+}
+
+void MuxOrch::reSuppressNeighbor(const NextHopKey& nh)
+{
+
+    auto it = mux_nexthop_tb_.find(nh);
+    if (it == mux_nexthop_tb_.end())
+    {
+        return;
+    }
+
+    const std::string owner_port = it->second.port_name;
+    if (owner_port.empty() || !isMuxExists(owner_port))
+    {
+        return;
+    }
+
+    // updateNeighbor(false) tears down the SAI mux NH and erases
+    // mux_nexthop_tb_[nh]; we re-insert as SuppressedResolved below.
+    MuxCable* cable = getMuxCable(owner_port);
+    cable->updateNeighbor(nh, false);
+
+    NeighborEntry nbr(nh.ip_address, nh.alias);
+    if (!neigh_orch_->disableNeighbor(nbr))
+    {
+        SWSS_LOG_WARN("Slice re-suppress: disableNeighbor failed for %s; "
+                      "SAI may still hold neighbor",
+                      nh.ip_address.to_string().c_str());
+    }
+
+    mux_nexthop_tb_[nh] = MuxNhEntry(owner_port, MuxNhState::SuppressedResolved);
+
+    SWSS_LOG_NOTICE("Slice re-suppress NH %s on %s (state=SuppressedResolved)",
+                    nh.ip_address.to_string().c_str(), owner_port.c_str());
+}
+
+void MuxOrch::onRouteAdd(const NextHopKey& nh, const RouteKey& route)
+{
+
+    if (!isAnySliceConfigured())
+    {
+        return;
+    }
+    // Slice config lives in the default VRF; routes in other VRFs are unrelated.
+    if (route.vrf_id != gVirtualRouterId)
+    {
+        return;
+    }
+    if (!isInSliceSuppressed(nh.ip_address))
+    {
+        return;
+    }
+
+    addRouteRefForNh(nh, route);
+
+    auto it = mux_nexthop_tb_.find(nh);
+    if (it == mux_nexthop_tb_.end())
+    {
+        // Route before learn: leave a placeholder so the eventual learn
+        // promotes to Programmed instead of suppressing.
+        const std::string owner = findSliceOwnerPort(nh.ip_address);
+        mux_nexthop_tb_[nh] = MuxNhEntry(owner, MuxNhState::PlaceholderUnresolved);
+        SWSS_LOG_INFO("Slice route arrived before learn for %s; placeholder (owner=%s)",
+                      nh.ip_address.to_string().c_str(), owner.c_str());
+        return;
+    }
+
+    if (it->second.state == MuxNhState::SuppressedResolved)
+    {
+        unsuppressNeighbor(nh);
+    }
+    // Placeholder/Programmed: ref bump is sufficient.
+}
+
+void MuxOrch::onRouteRemove(const NextHopKey& nh, const RouteKey& route)
+{
+
+    if (!isAnySliceConfigured())
+    {
+        return;
+    }
+    if (route.vrf_id != gVirtualRouterId)
+    {
+        return;
+    }
+    removeRouteRefForNh(nh, route);
+
+    auto it = mux_nexthop_tb_.find(nh);
+    if (it == mux_nexthop_tb_.end())
+    {
+        return;
+    }
+
+    if (!isInSliceSuppressed(nh.ip_address))
+    {
+        return;
+    }
+
+    if (!hasRouteRefsForNh(nh) && muxNhIsProgrammed(it->second.state))
+    {
+        // Defer: NHG bulker hasn't flushed; neighbor_remove would hit
+        // OBJECT_IN_USE. drainPendingReSuppress runs post-flush.
+        m_pendingReSuppress.insert(nh);
+        SWSS_LOG_INFO("Slice NH %s queued for deferred re-suppress (refs=0)",
+                      nh.ip_address.to_string().c_str());
+    }
+    else if (!hasRouteRefsForNh(nh) && it->second.state == MuxNhState::PlaceholderUnresolved)
+    {
+        // Placeholder's only ref is gone and learn never arrived; drop it.
+        mux_nexthop_tb_.erase(it);
+        SWSS_LOG_INFO("Slice NH %s placeholder dropped (no refs, no learn)",
+                      nh.ip_address.to_string().c_str());
+    }
+}
+
+void MuxOrch::drainPendingReSuppress()
+{
+    if (m_pendingReSuppress.empty())
+    {
+        return;
+    }
+    auto pending = std::move(m_pendingReSuppress);
+    m_pendingReSuppress.clear();
+
+    for (const auto& nh : pending)
+    {
+        // A new route may have re-acquired this NH within the same tick;
+        // double-check refs before re-suppressing.
+        if (hasRouteRefsForNh(nh))
+        {
+            SWSS_LOG_INFO("Slice NH %s: re-suppress skipped (ref re-acquired)",
+                          nh.ip_address.to_string().c_str());
+            continue;
+        }
+        auto it = mux_nexthop_tb_.find(nh);
+        if (it == mux_nexthop_tb_.end() || !muxNhIsProgrammed(it->second.state))
+        {
+            continue;
+        }
+        if (!isInSliceSuppressed(nh.ip_address))
+        {
+            continue;
+        }
+        reSuppressNeighbor(nh);
+    }
 }
 
 void MuxOrch::update(SubjectType type, void *cntx)
@@ -2203,12 +2800,15 @@ bool MuxOrch::handleMuxCfg(const Request& request)
 {
     SWSS_LOG_ENTER();
 
+
     auto srv_ip = request.getAttrIpPrefix("server_ipv4");
     auto srv_ip6 = request.getAttrIpPrefix("server_ipv6");
 
     MuxCableType cable_type = MuxCableType::ACTIVE_STANDBY;
     auto nbr_handler_type = MuxNbrHandlerType::NBR_HANDLER_HOST_ROUTE;
     std::set<IpAddress> skip_neighbors;
+    IpPrefix slice_ip6("::/0");
+    bool slice_ip6_present = false;
 
     const auto& port_name = request.getKeyString(0);
     auto op = request.getOperation();
@@ -2245,6 +2845,24 @@ bool MuxOrch::handleMuxCfg(const Request& request)
                 }
             }
         }
+        else if (name == "server_ipv6_subnet")
+        {
+            auto pfx = request.getAttrIpPrefix("server_ipv6_subnet");
+            if (pfx.isV4())
+            {
+                SWSS_LOG_ERROR("Mux port '%s': server_ipv6_subnet must be IPv6, rejecting '%s'",
+                               port_name.c_str(), pfx.to_string().c_str());
+                return false;
+            }
+            if (pfx.getIp().isZero())
+            {
+                SWSS_LOG_ERROR("Mux port '%s': server_ipv6_subnet must not be a zero-base prefix, rejecting '%s'",
+                               port_name.c_str(), pfx.to_string().c_str());
+                return false;
+            }
+            slice_ip6 = pfx;
+            slice_ip6_present = true;
+        }
     }
 
     if (op == SET_COMMAND)
@@ -2265,6 +2883,17 @@ bool MuxOrch::handleMuxCfg(const Request& request)
                 return false;
             }
 
+            // Runtime mutation of slice prefix is not allowed. Only compare
+            // when the field was present in this request — partial SET updates
+            // that omit server_ipv6_subnet must not trigger a false mismatch.
+            if (mux_cable && slice_ip6_present && !(mux_cable->getSlicePrefix() == slice_ip6))
+            {
+                SWSS_LOG_ERROR("server_ipv6_subnet change is not allowed for existing mux port '%s'. "
+                               "Please delete and recreate the mux port.",
+                               port_name.c_str());
+                return false;
+            }
+
             return true;
         }
 
@@ -2277,20 +2906,40 @@ bool MuxOrch::handleMuxCfg(const Request& request)
                 "prefix-route" : "host-route", port_name.c_str());
 
         mux_cable_tb_[port_name] = std::make_unique<MuxCable>
-                                   (MuxCable(port_name, srv_ip, srv_ip6, mux_peer_switch_, cable_type, nbr_handler_type));
+                                   (MuxCable(port_name, srv_ip, srv_ip6, mux_peer_switch_, cable_type, nbr_handler_type, slice_ip6));
         addSkipNeighbors(skip_neighbors, port_name);
+
+        if (slice_ip6_present)
+        {
+            ++m_slicedCableCount;
+            SWSS_LOG_NOTICE("Mux port '%s' configured with server_ipv6_subnet %s (sliced cable count=%zu)",
+                            port_name.c_str(), slice_ip6.to_string().c_str(), m_slicedCableCount);
+        }
 
         // Set neighbor_mode in state DB MUX_CABLE_TABLE
         std::string neighbor_mode_str = (nbr_handler_type == MuxNbrHandlerType::NBR_HANDLER_PREFIX_BASED) ? "prefix-route" : "host-route";
         state_mux_cable_table_->hset(port_name, "neighbor_mode", neighbor_mode_str);
         SWSS_LOG_INFO("Set neighbor_mode '%s' for port '%s' in state DB", neighbor_mode_str.c_str(), port_name.c_str());
 
+        // Publish slice prefix (CONFIG_DB server_ipv6_subnet) to STATE_DB so
+        // operators can see which cables are sliced and which prefix is in
+        // effect. Field name mirrors the CONFIG_DB schema.
+        if (slice_ip6_present)
+        {
+            state_mux_cable_table_->hset(port_name, "server_ipv6_subnet",
+                                         slice_ip6.to_string());
+        }
+        else
+        {
+            state_mux_cable_table_->hdel(port_name, "server_ipv6_subnet");
+        }
+
         // Add neighbors that were learned before this mux port was configured.
         NeighborTable m_neighbors;
         gNeighOrch->getMuxNeighborsForPort(port_name, m_neighbors);
         for (const auto &entry : m_neighbors)
         {
-            bool nexthop_found = containsNextHop(entry.first);
+            bool nexthop_found = hasKnownMuxNextHop(entry.first);
             bool is_skip_neighbor = isSkipNeighbor(entry.first.ip_address);
             if (!nexthop_found && !is_skip_neighbor)
             {
@@ -2314,6 +2963,44 @@ bool MuxOrch::handleMuxCfg(const Request& request)
             }
         }
 
+        // Late-slice reconcile: the loop above only covers FDB-resolved
+        // neighbors. Replay any in-slice IPs (plus the anchor) from
+        // NeighOrch so the slice gate can suppress hosts and promote the
+        // anchor; updateNeighbor is idempotent for the rest.
+        if (slice_ip6_present)
+        {
+            const NeighborTable& all_neighbors = gNeighOrch->getNeighborTable();
+            const IpAddress anchor_ip = srv_ip6.getIp();
+            for (const auto& nentry : all_neighbors)
+            {
+                const IpAddress& ip = nentry.first.ip_address;
+                const bool is_anchor = (ip == anchor_ip);
+                if (!is_anchor && !slice_ip6.isAddressInSubnet(ip))
+                {
+                    continue;
+                }
+                if (!is_anchor && !isInSliceSuppressed(ip))
+                {
+                    continue;
+                }
+                NextHopKey nh_key(ip, nentry.first.alias);
+                if (!is_anchor)
+                {
+                    auto existing = mux_nexthop_tb_.find(nh_key);
+                    if (existing != mux_nexthop_tb_.end() &&
+                        existing->second.state == MuxNhState::SuppressedResolved)
+                    {
+                        continue;
+                    }
+                }
+                SWSS_LOG_NOTICE("Slice reconcile: replaying %s %s for late slice on %s",
+                                is_anchor ? "anchor" : "neighbor",
+                                ip.to_string().c_str(), port_name.c_str());
+                NeighborUpdate replay = { nentry.first, nentry.second.mac, 1 };
+                updateNeighbor(replay);
+            }
+        }
+
         SWSS_LOG_NOTICE("Mux entry for port '%s' was added, cable type %d", port_name.c_str(), cable_type);
     }
     else
@@ -2325,7 +3012,55 @@ bool MuxOrch::handleMuxCfg(const Request& request)
         }
 
         removeSkipNeighbors(skip_neighbors);
+        {
+            auto it = mux_cable_tb_.find(port_name);
+            if (it != mux_cable_tb_.end() && it->second->hasSlicePrefix())
+            {
+                if (m_slicedCableCount > 0)
+                {
+                    --m_slicedCableCount;
+                }
+                SWSS_LOG_NOTICE("Mux port '%s' removed had slice prefix (sliced cable count=%zu)",
+                                port_name.c_str(), m_slicedCableCount);
+
+                // Drop non-programmed slice rows owned by this port; they
+                // have no SAI footprint but would dangle through queries.
+                // Programmed rows are handled by the normal cable teardown.
+                // Previously-suppressed in-slice neighbors are intentionally
+                // NOT re-programmed: re-enabling at scale would flood TCAM.
+                std::set<NextHopKey> orphaned_nhs;
+                for (auto nh_it = mux_nexthop_tb_.begin(); nh_it != mux_nexthop_tb_.end(); )
+                {
+                    if (nh_it->second.port_name == port_name &&
+                        (nh_it->second.state == MuxNhState::SuppressedResolved ||
+                         nh_it->second.state == MuxNhState::PlaceholderUnresolved))
+                    {
+                        SWSS_LOG_NOTICE("Slice cable '%s' removed: dropping %s NH %s",
+                                        port_name.c_str(),
+                                        nh_it->second.state == MuxNhState::SuppressedResolved
+                                            ? "suppressed" : "placeholder",
+                                        nh_it->first.ip_address.to_string().c_str());
+                        orphaned_nhs.insert(nh_it->first);
+                        nh_it = mux_nexthop_tb_.erase(nh_it);
+                    }
+                    else
+                    {
+                        ++nh_it;
+                    }
+                }
+                for (const auto& nh : orphaned_nhs)
+                {
+                    m_pendingReSuppress.erase(nh);
+                    nh_route_refs_.erase(nh);
+                }
+
+                // Withdraw supernet route while the cable still exists.
+                it->second->withdrawSliceRoute();
+            }
+        }
         mux_cable_tb_.erase(port_name);
+
+        state_mux_cable_table_->hdel(port_name, "server_ipv6_subnet");
 
         SWSS_LOG_NOTICE("Mux cable for port '%s' was removed", port_name.c_str());
     }

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -2072,6 +2072,19 @@ bool MuxOrch::convertNeighborToMux(const NeighborEntry& neighbor_entry, const st
     {
         NextHopKey nh_key = { neighbor_entry.ip_address, neighbor_entry.alias };
         auto existing = mux_nexthop_tb_.find(nh_key);
+
+        // Route-ref-pinned NH: leave Programmed state intact. Overwriting to
+        // SuppressedResolved here would leave the SAI mux NH live while the
+        // table claims it is suppressed, breaking getProgrammedNextHopId().
+        if (existing != mux_nexthop_tb_.end() &&
+            muxNhIsProgrammed(existing->second.state))
+        {
+            SWSS_LOG_INFO("Slice gate (convert): %s on %s already Programmed (route-pinned); preserving",
+                          neighbor_entry.ip_address.to_string().c_str(),
+                          port_name.c_str());
+            return true;
+        }
+
         if (existing == mux_nexthop_tb_.end() ||
             existing->second.state != MuxNhState::SuppressedResolved)
         {
@@ -2232,35 +2245,40 @@ void MuxOrch::updateNeighbor(const NeighborUpdate& update)
             {
                 const std::string owner_port = findSliceOwnerPort(update.entry.ip_address);
 
-                // Port affinity: if FDB resolves the MAC to a non-owner port,
-                // the IP lives behind a different cable; skip suppress.
+                // Port affinity: if FDB resolves the MAC to a non-owner mux
+                // port, the IP lives behind a different cable. Skip suppress
+                // and fall through to the normal mux subnet loop so that
+                // cable's state machine (incl. standby tunnel) applies.
                 std::string fdb_port;
-                if (getMuxPort(update.mac, update.entry.alias, fdb_port) &&
-                    !fdb_port.empty() && fdb_port != owner_port)
-                {
-                    SWSS_LOG_NOTICE("Slice gate: %s FDB-resolved on %s (slice owner %s); skip suppress",
-                                    update.entry.ip_address.to_string().c_str(),
-                                    fdb_port.c_str(), owner_port.c_str());
-                    return;
-                }
+                bool fdb_on_non_owner =
+                    getMuxPort(update.mac, update.entry.alias, fdb_port) &&
+                    !fdb_port.empty() && fdb_port != owner_port;
 
-                // Only record SuppressedResolved on successful disable so the
-                // table never disagrees with ASIC state.
-                if (!neigh_orch_->disableNeighbor(update.entry))
+                if (!fdb_on_non_owner)
                 {
-                    SWSS_LOG_WARN("Slice suppress: disableNeighbor failed for %s on %s; leaving SAI neighbor programmed",
+                    // Only record SuppressedResolved on successful disable so
+                    // the table never disagrees with ASIC state.
+                    if (!neigh_orch_->disableNeighbor(update.entry))
+                    {
+                        SWSS_LOG_WARN("Slice suppress: disableNeighbor failed for %s on %s; leaving SAI neighbor programmed",
+                                      update.entry.ip_address.to_string().c_str(),
+                                      update.entry.alias.c_str());
+                        return;
+                    }
+
+                    mux_nexthop_tb_[nh_key] = MuxNhEntry(owner_port, MuxNhState::SuppressedResolved);
+
+                    SWSS_LOG_INFO("Slice-suppressed neighbor %s on %s (owner=%s, SuppressedResolved)",
                                   update.entry.ip_address.to_string().c_str(),
-                                  update.entry.alias.c_str());
+                                  update.entry.alias.c_str(),
+                                  owner_port.c_str());
                     return;
                 }
 
-                mux_nexthop_tb_[nh_key] = MuxNhEntry(owner_port, MuxNhState::SuppressedResolved);
-
-                SWSS_LOG_INFO("Slice-suppressed neighbor %s on %s (owner=%s, SuppressedResolved)",
-                              update.entry.ip_address.to_string().c_str(),
-                              update.entry.alias.c_str(),
-                              owner_port.c_str());
-                return;
+                SWSS_LOG_NOTICE("Slice gate: %s FDB-resolved on %s (slice owner %s); fall through to mux handling",
+                                update.entry.ip_address.to_string().c_str(),
+                                fdb_port.c_str(), owner_port.c_str());
+                // Fall through to mux subnet loop below.
             }
         }
 
@@ -2902,6 +2920,32 @@ bool MuxOrch::handleMuxCfg(const Request& request)
             SWSS_LOG_INFO("Mux Peer switch addr not yet configured, port '%s'", port_name.c_str());
             return false;
         }
+
+        // Reject a slice prefix that overlaps any existing cable's slice:
+        // findMuxCableBySlice returns the first match, so overlapping slices
+        // would suppress hosts against a non-deterministic owner.
+        if (slice_ip6_present)
+        {
+            for (const auto& kv : mux_cable_tb_)
+            {
+                if (!kv.second->hasSlicePrefix())
+                {
+                    continue;
+                }
+                const IpPrefix& existing = kv.second->getSlicePrefix();
+                if (existing.isAddressInSubnet(slice_ip6.getIp()) ||
+                    slice_ip6.isAddressInSubnet(existing.getIp()))
+                {
+                    SWSS_LOG_ERROR("Mux port '%s': server_ipv6_subnet %s overlaps cable '%s' slice %s; rejecting",
+                                   port_name.c_str(),
+                                   slice_ip6.to_string().c_str(),
+                                   kv.first.c_str(),
+                                   existing.to_string().c_str());
+                    return false;
+                }
+            }
+        }
+
         SWSS_LOG_NOTICE("Mux nbr_type set to %s for port %s", nbr_handler_type == MuxNbrHandlerType::NBR_HANDLER_PREFIX_BASED ?
                 "prefix-route" : "host-route", port_name.c_str());
 

--- a/orchagent/muxorch.h
+++ b/orchagent/muxorch.h
@@ -10,6 +10,7 @@
 #include "tunneldecaporch.h"
 #include "aclorch.h"
 #include "neighorch.h"
+#include "routeorch.h"
 #include "bulker.h"
 
 enum MuxState
@@ -132,7 +133,7 @@ public:
 class MuxCable
 {
 public:
-    MuxCable(string name, IpPrefix& srv_ip4, IpPrefix& srv_ip6, IpAddress peer_ip, MuxCableType cable_type, MuxNbrHandlerType nbr_handler_type);
+    MuxCable(string name, IpPrefix& srv_ip4, IpPrefix& srv_ip6, IpAddress peer_ip, MuxCableType cable_type, MuxNbrHandlerType nbr_handler_type, IpPrefix slice_ip6 = IpPrefix("::/0"));
 
     bool isActive() const
     {
@@ -149,6 +150,20 @@ public:
     bool isStateChangeFailed() { return st_chg_failed_; }
 
     bool isIpInSubnet(IpAddress ip);
+
+    // ---- subnet slicing (configuration view) -------------------------
+    // hasSlicePrefix() is the per-cable flag derived from server_ipv6_subnet
+    // being configured (non-zero base). isIpInSlice() answers "would this IP
+    // be governed by this cable's slice prefix?" — anchor / skip-neighbor
+    // policy is layered on top by MuxOrch::isInSliceSuppressed().
+    bool hasSlicePrefix() const { return !slice_ip6_.getIp().isZero(); }
+    const IpPrefix& getSlicePrefix() const { return slice_ip6_; }
+    const IpPrefix& getServerIp6() const { return srv_ip6_; }
+    bool isIpInSlice(const IpAddress& ip) const
+    {
+        return (hasSlicePrefix() && !ip.isV4() && slice_ip6_.isAddressInSubnet(ip));
+    }
+
     void updateNeighbor(NextHopKey nh, bool add);
     void updateRoutes();
     void updateRoutesForNextHop(NextHopKey nh);
@@ -156,6 +171,16 @@ public:
     {
         return nbr_handler_->getNextHopId(nh);
     }
+
+    // subnet slicing: anchor (supernet) route covering the slice prefix.
+    // Installed at SAI level with the server_ipv6 anchor NH so traffic to
+    // any in-slice IP forwards while per-host NHs stay SuppressedResolved.
+    // Swap-in-place on ACTIVE<->STANDBY flips; withdraw on cable delete /
+    // anchor NH null.
+    void refreshSliceRoute();
+    void withdrawSliceRoute();
+    bool isSliceRouteInstalled() const { return slice_route_nh_oid_ != SAI_NULL_OBJECT_ID; }
+    sai_object_id_t getSliceRouteNh() const { return slice_route_nh_oid_; }
 
     MuxNbrHandlerType getNbrHandlerType() const
     {
@@ -182,6 +207,12 @@ private:
     IpPrefix srv_ip4_, srv_ip6_;
     IpAddress peer_ip4_;
 
+    // subnet slicing: optional per-cable IPv6 slice prefix sourced from
+    // CONFIG_DB MUX_CABLE.server_ipv6_subnet. Default-constructed "::/0"
+    // means "no slice configured" — checked via hasSlicePrefix().
+    IpPrefix slice_ip6_;
+    sai_object_id_t slice_route_nh_oid_ = SAI_NULL_OBJECT_ID;
+
     MuxOrch *mux_orch_;
     MuxCableOrch *mux_cb_orch_;
     MuxStateOrch *mux_state_orch_;
@@ -203,6 +234,7 @@ const request_description_t mux_cfg_request_description = {
                 { "cable_type", REQ_T_STRING },
                 { "prober_type", REQ_T_STRING },
                 { "neighbor_mode", REQ_T_STRING },
+                { "server_ipv6_subnet", REQ_T_IP_PREFIX },
             },
             { }
 };
@@ -216,7 +248,57 @@ struct NHTunnel
 typedef std::unique_ptr<MuxCable> MuxCable_T;
 typedef std::map<std::string, MuxCable_T> MuxCableTb;
 typedef std::map<IpAddress, NHTunnel> MuxTunnelNHs;
-typedef std::map<NextHopKey, std::string> NextHopTb;
+
+// subnet-slicing state machine. Tracks the lifecycle of a NH known to
+// MuxOrch so that route/neighbor flows can query a single source of truth
+// instead of inferring from parallel boolean stores.
+//
+//   PlaceholderUnresolved - a route asked about this NH before any neighbor
+//                           learn arrived. No SAI neighbor exists; the entry
+//                           is a forward-reference so we can find it when
+//                           the learn finally happens.
+//   SuppressedResolved    - the neighbor is known/learned but intentionally
+//                           NOT in the ASIC (slice-suppressed). SAI neighbor
+//                           does not exist.
+//   ProgrammedActive      - normal mux NH on the active path; SAI neighbor
+//                           OID lives in MuxNbrHandler::neighbors_.
+//   ProgrammedStandby     - normal mux NH on the standby path; OID is the
+//                           tunnel NH.
+//
+// Invariants: ProgrammedActive/Standby ⇒ a real SAI OID exists in
+// MuxNbrHandler::neighbors_. PlaceholderUnresolved / SuppressedResolved
+// ⇒ no SAI OID. Callers MUST NOT use raw mux_nexthop_tb_ membership as
+// a proxy for "has programmed OID"; use the typed query API below.
+enum class MuxNhState
+{
+    PlaceholderUnresolved,
+    SuppressedResolved,
+    ProgrammedActive,
+    ProgrammedStandby,
+};
+
+struct MuxNhEntry
+{
+    std::string port_name;
+    MuxNhState  state;
+
+    MuxNhEntry()
+        : port_name(), state(MuxNhState::PlaceholderUnresolved) {}
+    MuxNhEntry(const std::string& p)
+        : port_name(p),
+          state(p.empty() ? MuxNhState::PlaceholderUnresolved
+                          : MuxNhState::ProgrammedActive) {}
+    MuxNhEntry(const std::string& p, MuxNhState s)
+        : port_name(p), state(s) {}
+};
+
+inline bool muxNhIsProgrammed(MuxNhState s)
+{
+    return s == MuxNhState::ProgrammedActive
+        || s == MuxNhState::ProgrammedStandby;
+}
+
+typedef std::map<NextHopKey, MuxNhEntry> NextHopTb;
 typedef std::map<IpPrefix, NextHopKey> MuxRouteTb;
 
 class MuxCfgRequest : public Request
@@ -270,6 +352,20 @@ public:
     }
 
     MuxCable* findMuxCableInSubnet(IpAddress);
+
+    // ---- subnet slicing (lookup + decision helpers) ------------------
+    // Find the cable whose slice prefix encloses `ip` (nullptr if none).
+    MuxCable* findMuxCableBySlice(IpAddress);
+
+    // True iff some cable's slice prefix encloses `ip` and `ip` is neither
+    // the anchor (server_ipv6) nor a skip-neighbor (soc_ipv4 / soc_ipv6).
+    // IP-only; callers needing port-affinity apply it separately.
+    bool isInSliceSuppressed(const IpAddress& ip);
+
+    // Fast gate for non-slice deployments: true iff at least one cable
+    // has a slice prefix. Lets callers skip slice work at ~0 cost.
+    bool isAnySliceConfigured() const { return m_slicedCableCount > 0; }
+
     bool isMuxPortPrefixNbr(const IpAddress&, const MacAddress&, string&);
     bool isNeighborActive(const IpAddress&, const MacAddress&, string&);
     void update(SubjectType, void *);
@@ -281,6 +377,50 @@ public:
     bool hasPrefixBasedMuxNexthop(const std::set<NextHopKey>&);
     string getNexthopMuxName(NextHopKey);
     sai_object_id_t getNextHopId(const NextHopKey&);
+
+    // ---- typed query API ---------------------------------------------
+    // Prefer these over raw mux_nexthop_tb_ membership checks; they tolerate
+    // PlaceholderUnresolved / SuppressedResolved entries safely.
+
+    // True iff `nh` is tracked (any state).
+    bool hasKnownMuxNextHop(const NextHopKey& nh) const;
+
+    // True iff `nh` is currently programmed in SAI (Active or Standby).
+    bool hasProgrammedMuxNextHop(const NextHopKey& nh) const;
+
+    // SAI OID only for state ∈ {ProgrammedActive, ProgrammedStandby};
+    // SAI_NULL_OBJECT_ID otherwise.
+    sai_object_id_t getProgrammedNextHopId(const NextHopKey& nh);
+
+    // Owning cable name regardless of state; empty if not tracked.
+    std::string getMuxOwnerIfKnown(const NextHopKey& nh) const;
+
+    // Current state for `nh`; PlaceholderUnresolved if not tracked.
+    // Distinguish "not tracked" via hasKnownMuxNextHop().
+    MuxNhState getNhState(const NextHopKey& nh) const;
+
+    // ---- per-NH route reference tracking -----------------------------
+    // Tracks routes that pin an in-slice NH as un-suppressed. The last
+    // route removal drops the ref count to zero and queues the NH for
+    // re-suppress via drainPendingReSuppress().
+    void addRouteRefForNh(const NextHopKey& nh, const RouteKey& route);
+    void removeRouteRefForNh(const NextHopKey& nh, const RouteKey& route);
+    bool hasRouteRefsForNh(const NextHopKey& nh) const;
+    size_t routeRefCountForNh(const NextHopKey& nh) const;
+
+    // ---- slice route ↔ NH state hooks --------------------------------
+    // RouteOrch calls these so slice NH state stays in lock-step with
+    // route programming.
+    //   onRouteAdd:             before bulker flush; un-suppresses the NH
+    //                           so route_create finds a valid SAI OID.
+    //   onRouteRemove:          drops the ref synchronously; queues the
+    //                           NH for re-suppress.
+    //   drainPendingReSuppress: runs after bulker flush + NHG teardown
+    //                           so SAI neighbor_remove avoids OBJECT_IN_USE.
+    // All three are no-ops when isAnySliceConfigured() is false.
+    void onRouteAdd(const NextHopKey& nh, const RouteKey& route);
+    void onRouteRemove(const NextHopKey& nh, const RouteKey& route);
+    void drainPendingReSuppress();
 
     sai_object_id_t createNextHopTunnel(std::string tunnelKey, IpAddress& ipAddr);
     bool removeNextHopTunnel(std::string tunnelKey, IpAddress& ipAddr);
@@ -314,6 +454,7 @@ private:
     // Helper function to convert neighbor to MUX neighbor
     bool convertNeighborToMux(const NeighborEntry& neighbor_entry, const string& port_name, const string& context);
 
+
     /***
      * Methods for managing tunnel routes for neighbor IPs not associated
      * with a specific mux cable
@@ -343,6 +484,30 @@ private:
     MuxCableTb mux_cable_tb_;
     MuxTunnelNHs mux_tunnel_nh_;
     NextHopTb mux_nexthop_tb_;
+
+    // per-NH route reference tracking. Populated/drained by the
+    // RouteOrch hooks (added to a follow-up). MuxOrch uses this to
+    // answer "is this NH still referenced by any route?" deterministically
+    // without polling RouteOrch state. NextHopRouteTable is defined in
+    // routeorch.h as map<NextHopKey, set<RouteKey>>.
+    NextHopRouteTable nh_route_refs_;
+
+    // deferred re-suppress queue. NHs are enqueued here when their last
+    // route ref drops; drainPendingReSuppress() processes the queue at the
+    // end of RouteOrch::doTask, after NHG teardown has released SAI refs.
+    std::set<NextHopKey> m_pendingReSuppress;
+
+    // Slice internal helpers — drive the state transitions. Owner
+    // port + cable presence are validated inside; safe to call multiple
+    // times.
+    void unsuppressNeighbor(const NextHopKey& nh);
+    void reSuppressNeighbor(const NextHopKey& nh);
+    std::string findSliceOwnerPort(const IpAddress& ip) const;
+
+    // subnet slicing fast gate: number of configured cables that have a
+    // non-zero slice prefix. Maintained by handleMuxCfg on cable add/remove
+    // so isAnySliceConfigured() is O(1).
+    size_t m_slicedCableCount = 0;
 
     handler_map handler_map_;
 

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1249,6 +1249,17 @@ void RouteOrch::doTask(ConsumerBase& consumer)
         {
             m_srv6Orch->removeSrv6Nexthops(m_bulkSrv6NhgReducedVec);
         }
+
+        // Drain queued re-suppress AFTER NHG/srv6 teardown so SAI
+        // neighbor_remove doesn't hit OBJECT_IN_USE.
+        {
+            MuxOrch* mux_orch_drain = gDirectory.get<MuxOrch*>();
+            if (mux_orch_drain)
+            {
+                mux_orch_drain->drainPendingReSuppress();
+            }
+        }
+
         /* No Update to Default Route so we can return */
         if (!(v4_default_nhg_key.getSize()) && !(v6_default_nhg_key.getSize()))
         {
@@ -2023,6 +2034,25 @@ bool RouteOrch::addRoute(RouteBulkContext& ctx, const NextHopGroupKey &nextHops)
         srv6_nh = true;
     }
 
+    // Notify MuxOrch before SAI route_create is staged: any
+    // SuppressedResolved NH gets unsuppressed so its OID exists at flush.
+    if (!overlay_nh && !srv6_nh)
+    {
+        MuxOrch* mux_orch = gDirectory.get<MuxOrch*>();
+        if (mux_orch && mux_orch->isAnySliceConfigured())
+        {
+            RouteKey rt_key = { vrf_id, ipPrefix };
+            for (const auto& nh : nextHops.getNextHops())
+            {
+                if (nh.ip_address.isZero() || nh.isIntfNextHop())
+                {
+                    continue;
+                }
+                mux_orch->onRouteAdd(nh, rt_key);
+            }
+        }
+    }
+
     auto it_route = m_syncdRoutes.at(vrf_id).find(ipPrefix);
 
     if (m_fgNhgOrch->isRouteFineGrained(vrf_id, ipPrefix, nextHops))
@@ -2599,6 +2629,41 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
         {
             decreaseNextHopRefCount(it_route->second.nhg_key);
             auto ol_nextHops = it_route->second.nhg_key;
+
+            // Drop per-NH refs for the old NHG so an NH no longer used
+            // by any route becomes eligible for re-suppress at end of
+            // doTask. Skip NHs that survive in the new NHG — onRouteAdd
+            // above already counted them under the same RouteKey, so
+            // removing here would falsely queue a still-referenced NH.
+            if (!ol_nextHops.is_overlay_nexthop() && !ol_nextHops.is_srv6_nexthop())
+            {
+                MuxOrch* mux_orch_upd = gDirectory.get<MuxOrch*>();
+                if (mux_orch_upd && mux_orch_upd->isAnySliceConfigured())
+                {
+                    std::set<NextHopKey> new_nhs;
+                    if (!nextHops.is_overlay_nexthop() && !nextHops.is_srv6_nexthop())
+                    {
+                        for (const auto& nh : nextHops.getNextHops())
+                        {
+                            new_nhs.insert(nh);
+                        }
+                    }
+                    RouteKey rt_key = { vrf_id, ipPrefix };
+                    for (const auto& nh : ol_nextHops.getNextHops())
+                    {
+                        if (nh.ip_address.isZero() || nh.isIntfNextHop())
+                        {
+                            continue;
+                        }
+                        if (new_nhs.find(nh) != new_nhs.end())
+                        {
+                            continue;
+                        }
+                        mux_orch_upd->onRouteRemove(nh, rt_key);
+                    }
+                }
+            }
+
             if (ol_nextHops.is_srv6_nexthop())
             {
                 m_bulkSrv6NhgReducedVec.emplace_back(ol_nextHops);
@@ -2965,6 +3030,28 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
 
     SWSS_LOG_INFO("Remove route %s with next hop(s) %s",
             ipPrefix.to_string().c_str(), it_route->second.nhg_key.to_string().c_str());
+
+    // Drop per-NH ref now that SAI route_remove succeeded; queued
+    // re-suppress runs later in doTask once NHGs holding this NH drain.
+    {
+        const NextHopGroupKey& gone_nhg = it_route->second.nhg_key;
+        if (!gone_nhg.is_overlay_nexthop() && !gone_nhg.is_srv6_nexthop())
+        {
+            MuxOrch* mux_orch_post = gDirectory.get<MuxOrch*>();
+            if (mux_orch_post && mux_orch_post->isAnySliceConfigured())
+            {
+                RouteKey rt_key = { vrf_id, ipPrefix };
+                for (const auto& nh : gone_nhg.getNextHops())
+                {
+                    if (nh.ip_address.isZero() || nh.isIntfNextHop())
+                    {
+                        continue;
+                    }
+                    mux_orch_post->onRouteRemove(nh, rt_key);
+                }
+            }
+        }
+    }
 
     /* Publish removal status, removes route entry from APPL STATE DB */
     publishRouteState(ctx);

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -62,6 +62,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 orchdaemon_ut.cpp \
                 intfsorch_ut.cpp \
                 mux_rollback_ut.cpp \
+                mux_subnet_slicing_ut.cpp \
                 warmrestartassist_ut.cpp \
                 test_failure_handling.cpp \
                 switchorch_ut.cpp \

--- a/tests/mock_tests/mux_subnet_slicing_ut.cpp
+++ b/tests/mock_tests/mux_subnet_slicing_ut.cpp
@@ -1,0 +1,592 @@
+#define private public
+#include "directory.h"
+#undef private
+#define protected public
+#include "orch.h"
+#undef protected
+#include "ut_helper.h"
+#define private public
+#define protected public
+#include "muxorch.h"
+#undef protected
+#undef private
+#include "mock_orchagent_main.h"
+#include "mock_orch_test.h"
+#include "ipaddress.h"
+#include "ipprefix.h"
+#include "gtest/gtest.h"
+#include <string>
+
+namespace mux_subnet_slicing_test
+{
+    using namespace std;
+    using namespace mock_orch_test;
+    using namespace swss;
+
+    // -----------------------------------------------------------------
+    // Test helpers backed by MuxOrch internals (mux_nexthop_tb_ for NH
+    // state, nh_route_refs_ for per-NH route refs).
+    // -----------------------------------------------------------------
+    static size_t getSliceSuppressedCount(MuxOrch* orch, const std::string& port)
+    {
+        size_t n = 0;
+        for (const auto& kv : orch->mux_nexthop_tb_)
+        {
+            if (kv.second.port_name == port &&
+                kv.second.state == MuxNhState::SuppressedResolved)
+            {
+                ++n;
+            }
+        }
+        return n;
+    }
+
+    static bool isSliceSuppressed(MuxOrch* orch, const IpAddress& ip)
+    {
+        for (const auto& kv : orch->mux_nexthop_tb_)
+        {
+            if (kv.first.ip_address == ip &&
+                kv.second.state == MuxNhState::SuppressedResolved)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static bool isReferencedByRouteNh(MuxOrch* orch, const IpAddress& ip)
+    {
+        for (const auto& kv : orch->nh_route_refs_)
+        {
+            if (kv.first.ip_address == ip && !kv.second.empty())
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Per-cable refcount: total live route refs across every NH whose
+    // owning port matches `port`.
+    static size_t getRouteNhRefCountForPort(MuxOrch* orch, const std::string& port)
+    {
+        size_t n = 0;
+        for (const auto& kv : orch->nh_route_refs_)
+        {
+            if (kv.first.alias == port)
+            {
+                n += kv.second.size();
+            }
+        }
+        return n;
+    }
+
+    // Drive a route NH add/remove the way RouteOrch does: per-NH
+    // onRouteAdd/onRouteRemove plus a drainPendingReSuppress() at the
+    // end of the remove tick (mirrors RouteOrch::doTask).
+    static void applyRouteNhChange(MuxOrch* orch,
+                                   const NextHopGroupKey& nhg,
+                                   sai_object_id_t vrf,
+                                   const IpPrefix& prefix,
+                                   bool add)
+    {
+        RouteKey rk{vrf, prefix};
+        for (const auto& nh : nhg.getNextHops())
+        {
+            if (add)
+            {
+                orch->onRouteAdd(nh, rk);
+            }
+            else
+            {
+                orch->onRouteRemove(nh, rk);
+            }
+        }
+        if (!add)
+        {
+            orch->drainPendingReSuppress();
+        }
+    }
+
+    static const string SLICE_INTERFACE = "Ethernet4";
+    static const string NON_SLICE_INTERFACE = "Ethernet8";
+
+    static const string SLICE_SERVER_IP4   = "192.168.0.2";
+    static const string SLICE_SERVER_IP6   = "fc00::100";
+    static const string SLICE_PREFIX       = "fc00::/64";
+    static const string IN_SLICE_NEIGHBOR  = "fc00::200";
+    static const string IN_SLICE_NEIGHBOR2 = "fc00::deef";
+    static const string OUT_OF_SLICE_IP    = "fc01::1";
+
+    static const string NON_SLICE_SERVER_IP4 = "192.168.0.3";
+    static const string NON_SLICE_SERVER_IP6 = "fd00::100";
+
+    class MuxSubnetSlicingTest : public MockOrchTest
+    {
+    protected:
+        void ApplyInitialConfigs() override
+        {
+            Table peer_switch_table = Table(m_config_db.get(), CFG_PEER_SWITCH_TABLE_NAME);
+            Table decap_tunnel_table = Table(m_app_db.get(), APP_TUNNEL_DECAP_TABLE_NAME);
+            Table decap_term_table = Table(m_app_db.get(), APP_TUNNEL_DECAP_TERM_TABLE_NAME);
+            Table mux_cable_table = Table(m_config_db.get(), CFG_MUX_CABLE_TABLE_NAME);
+            Table port_table = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+            Table vlan_table = Table(m_app_db.get(), APP_VLAN_TABLE_NAME);
+            Table vlan_member_table = Table(m_app_db.get(), APP_VLAN_MEMBER_TABLE_NAME);
+            Table intf_table = Table(m_app_db.get(), APP_INTF_TABLE_NAME);
+
+            auto ports = ut_helper::getInitialSaiPorts();
+            port_table.set(SLICE_INTERFACE, ports[SLICE_INTERFACE]);
+            port_table.set(NON_SLICE_INTERFACE, ports[NON_SLICE_INTERFACE]);
+            port_table.set("PortConfigDone", { { "count", to_string(2) } });
+            port_table.set("PortInitDone", { {} });
+
+            vlan_table.set(VLAN_1000, { { "admin_status", "up" },
+                                        { "mtu", "9100" },
+                                        { "mac", "00:aa:bb:cc:dd:ee" } });
+            vlan_member_table.set(
+                VLAN_1000 + vlan_member_table.getTableNameSeparator() + SLICE_INTERFACE,
+                { { "tagging_mode", "untagged" } });
+            vlan_member_table.set(
+                VLAN_1000 + vlan_member_table.getTableNameSeparator() + NON_SLICE_INTERFACE,
+                { { "tagging_mode", "untagged" } });
+
+            intf_table.set(VLAN_1000, { { "grat_arp", "enabled" },
+                                        { "proxy_arp", "enabled" },
+                                        { "mac_addr", "00:00:00:00:00:00" } });
+            intf_table.set(
+                VLAN_1000 + intf_table.getTableNameSeparator() + "192.168.0.1/21",
+                { { "scope", "global" }, { "family", "IPv4" } });
+            intf_table.set(
+                VLAN_1000 + intf_table.getTableNameSeparator() + "fc00::1/64",
+                { { "scope", "global" }, { "family", "IPv6" } });
+
+            decap_term_table.set(
+                "MuxTunnel0" + decap_term_table.getTableNameSeparator() + "2.2.2.2",
+                { { "src_ip", "1.1.1.1" }, { "term_type", "P2P" } });
+
+            decap_tunnel_table.set("MuxTunnel0",
+                { { "dscp_mode", "uniform" },
+                  { "src_ip", "1.1.1.1" },
+                  { "ecn_mode", "copy_from_outer" },
+                  { "encap_ecn_mode", "standard" },
+                  { "ttl_mode", "pipe" },
+                  { "tunnel_type", "IPINIP" } });
+
+            peer_switch_table.set(PEER_SWITCH_HOSTNAME, { { "address_ipv4", PEER_IPV4_ADDRESS } });
+
+            mux_cable_table.set(SLICE_INTERFACE,
+                { { "server_ipv4", SLICE_SERVER_IP4 + "/32" },
+                  { "server_ipv6", SLICE_SERVER_IP6 + "/128" },
+                  { "server_ipv6_subnet", SLICE_PREFIX },
+                  { "state", "auto" } });
+
+            mux_cable_table.set(NON_SLICE_INTERFACE,
+                { { "server_ipv4", NON_SLICE_SERVER_IP4 + "/32" },
+                  { "server_ipv6", NON_SLICE_SERVER_IP6 + "/128" },
+                  { "state", "auto" } });
+
+            gPortsOrch->addExistingData(&port_table);
+            gPortsOrch->addExistingData(&vlan_table);
+            gPortsOrch->addExistingData(&vlan_member_table);
+            static_cast<Orch *>(gPortsOrch)->doTask();
+
+            gIntfsOrch->addExistingData(&intf_table);
+            static_cast<Orch *>(gIntfsOrch)->doTask();
+
+            m_TunnelDecapOrch->addExistingData(&decap_tunnel_table);
+            m_TunnelDecapOrch->addExistingData(&decap_term_table);
+            static_cast<Orch *>(m_TunnelDecapOrch)->doTask();
+
+            m_MuxOrch->addExistingData(&peer_switch_table);
+            static_cast<Orch *>(m_MuxOrch)->doTask();
+
+            m_MuxOrch->addExistingData(&mux_cable_table);
+            static_cast<Orch *>(m_MuxOrch)->doTask();
+        }
+
+        MuxCable* getSliceCable()  { return m_MuxOrch->getMuxCable(SLICE_INTERFACE); }
+        MuxCable* getPlainCable()  { return m_MuxOrch->getMuxCable(NON_SLICE_INTERFACE); }
+    };
+
+    // --- Parsing tests ---------------------------------------------------
+
+    TEST_F(MuxSubnetSlicingTest, ParsesValidSlicePrefix)
+    {
+        MuxCable* cable = getSliceCable();
+        ASSERT_NE(cable, nullptr);
+        EXPECT_TRUE(cable->hasSlicePrefix());
+        EXPECT_EQ(cable->getSlicePrefix(), IpPrefix(SLICE_PREFIX));
+    }
+
+    TEST_F(MuxSubnetSlicingTest, NoSlicePrefixWhenFieldAbsent)
+    {
+        MuxCable* cable = getPlainCable();
+        ASSERT_NE(cable, nullptr);
+        EXPECT_FALSE(cable->hasSlicePrefix());
+    }
+
+    TEST_F(MuxSubnetSlicingTest, RejectsIpv4SlicePrefix)
+    {
+        // Use a fresh cable name so prior tests' redis residue can't leak in.
+        const std::string port = "Ethernet12";
+        Table mux_cable_table = Table(m_config_db.get(), CFG_MUX_CABLE_TABLE_NAME);
+        mux_cable_table.del(port);
+        mux_cable_table.set(port,
+            { { "server_ipv4", NON_SLICE_SERVER_IP4 + "/32" },
+              { "server_ipv6", NON_SLICE_SERVER_IP6 + "/128" },
+              { "server_ipv6_subnet", "10.0.0.0/24" },
+              { "state", "auto" } });
+        m_MuxOrch->addExistingData(&mux_cable_table);
+        static_cast<Orch *>(m_MuxOrch)->doTask();
+
+        EXPECT_EQ(m_MuxOrch->mux_cable_tb_.count(port), 0u);
+    }
+
+    TEST_F(MuxSubnetSlicingTest, RejectsZeroBaseSlicePrefix)
+    {
+        const std::string port = "Ethernet12";
+        Table mux_cable_table = Table(m_config_db.get(), CFG_MUX_CABLE_TABLE_NAME);
+        mux_cable_table.del(port);
+        mux_cable_table.set(port,
+            { { "server_ipv4", NON_SLICE_SERVER_IP4 + "/32" },
+              { "server_ipv6", NON_SLICE_SERVER_IP6 + "/128" },
+              { "server_ipv6_subnet", "::/64" },
+              { "state", "auto" } });
+        m_MuxOrch->addExistingData(&mux_cable_table);
+        static_cast<Orch *>(m_MuxOrch)->doTask();
+
+        EXPECT_EQ(m_MuxOrch->mux_cable_tb_.count(port), 0u);
+    }
+
+    // --- findMuxCableBySlice --------------------------------------------
+
+    TEST_F(MuxSubnetSlicingTest, FindMuxCableBySliceMatchesEnclosing)
+    {
+        MuxCable* cable = m_MuxOrch->findMuxCableBySlice(IpAddress(IN_SLICE_NEIGHBOR));
+        ASSERT_NE(cable, nullptr);
+        EXPECT_EQ(cable, getSliceCable());
+    }
+
+    TEST_F(MuxSubnetSlicingTest, FindMuxCableBySliceMissesOutsideAddress)
+    {
+        EXPECT_EQ(m_MuxOrch->findMuxCableBySlice(IpAddress(OUT_OF_SLICE_IP)), nullptr);
+    }
+
+    TEST_F(MuxSubnetSlicingTest, FindMuxCableBySliceIgnoresIpv4)
+    {
+        EXPECT_EQ(m_MuxOrch->findMuxCableBySlice(IpAddress(SLICE_SERVER_IP4)), nullptr);
+    }
+
+    // --- isInSliceSuppressed --------------------------------------------
+
+    TEST_F(MuxSubnetSlicingTest, SuppressesInSliceNeighbor)
+    {
+        EXPECT_TRUE(m_MuxOrch->isInSliceSuppressed(IpAddress(IN_SLICE_NEIGHBOR)));
+        EXPECT_TRUE(m_MuxOrch->isInSliceSuppressed(IpAddress(IN_SLICE_NEIGHBOR2)));
+    }
+
+    TEST_F(MuxSubnetSlicingTest, DoesNotSuppressSliceAnchor)
+    {
+        EXPECT_FALSE(m_MuxOrch->isInSliceSuppressed(IpAddress(SLICE_SERVER_IP6)));
+    }
+
+    TEST_F(MuxSubnetSlicingTest, DoesNotSuppressOutOfSliceAddress)
+    {
+        EXPECT_FALSE(m_MuxOrch->isInSliceSuppressed(IpAddress(OUT_OF_SLICE_IP)));
+    }
+
+    TEST_F(MuxSubnetSlicingTest, DoesNotSuppressIpv4)
+    {
+        EXPECT_FALSE(m_MuxOrch->isInSliceSuppressed(IpAddress(SLICE_SERVER_IP4)));
+    }
+
+    TEST_F(MuxSubnetSlicingTest, DoesNotSuppressSkipNeighbor)
+    {
+        IpAddress soc(IN_SLICE_NEIGHBOR2);
+        m_MuxOrch->addSkipNeighbors({ soc }, SLICE_INTERFACE);
+        EXPECT_FALSE(m_MuxOrch->isInSliceSuppressed(soc));
+        EXPECT_TRUE(m_MuxOrch->isInSliceSuppressed(IpAddress(IN_SLICE_NEIGHBOR)));
+        m_MuxOrch->removeSkipNeighbors({ soc });
+        EXPECT_TRUE(m_MuxOrch->isInSliceSuppressed(soc));
+    }
+
+    TEST_F(MuxSubnetSlicingTest, DoesNotSuppressWhenNoSliceConfigured)
+    {
+        EXPECT_FALSE(m_MuxOrch->isInSliceSuppressed(IpAddress(NON_SLICE_SERVER_IP6)));
+    }
+
+    // --- Partial-SET mutation guard -------------------------------------
+
+    TEST_F(MuxSubnetSlicingTest, PartialUpdateWithoutSlicePrefixIsAllowed)
+    {
+        Table mux_cable_table = Table(m_config_db.get(), CFG_MUX_CABLE_TABLE_NAME);
+        // Re-apply WITHOUT server_ipv6_subnet — should not be flagged as a mismatch.
+        mux_cable_table.set(SLICE_INTERFACE,
+            { { "server_ipv4", SLICE_SERVER_IP4 + "/32" },
+              { "server_ipv6", SLICE_SERVER_IP6 + "/128" },
+              { "state", "auto" } });
+        m_MuxOrch->addExistingData(&mux_cable_table);
+        static_cast<Orch *>(m_MuxOrch)->doTask();
+
+        MuxCable* cable = getSliceCable();
+        ASSERT_NE(cable, nullptr);
+        // Slice prefix must still be in effect.
+        EXPECT_TRUE(cable->hasSlicePrefix());
+        EXPECT_EQ(cable->getSlicePrefix(), IpPrefix(SLICE_PREFIX));
+    }
+
+    // --- Stage 2a: updateNeighbor slice gate ----------------------------
+
+    TEST_F(MuxSubnetSlicingTest, UpdateNeighborTracksInSliceNeighbor)
+    {
+        EXPECT_EQ(getSliceSuppressedCount(m_MuxOrch, SLICE_INTERFACE), 0u);
+
+        NeighborEntry entry(IpAddress(IN_SLICE_NEIGHBOR), SLICE_INTERFACE);
+        NeighborUpdate update = { entry, MacAddress("00:aa:bb:cc:dd:01"), true };
+        m_MuxOrch->updateNeighbor(update);
+
+        EXPECT_TRUE(isSliceSuppressed(m_MuxOrch, IpAddress(IN_SLICE_NEIGHBOR)));
+        EXPECT_EQ(getSliceSuppressedCount(m_MuxOrch, SLICE_INTERFACE), 1u);
+        // In-slice neighbor MUST NOT be programmed as a per-host mux nexthop.
+        EXPECT_FALSE(m_MuxOrch->containsNextHop(NextHopKey(IpAddress(IN_SLICE_NEIGHBOR), SLICE_INTERFACE)));
+    }
+
+    TEST_F(MuxSubnetSlicingTest, UpdateNeighborUntracksOnRemove)
+    {
+        NeighborEntry entry(IpAddress(IN_SLICE_NEIGHBOR), SLICE_INTERFACE);
+        m_MuxOrch->updateNeighbor({ entry, MacAddress("00:aa:bb:cc:dd:02"), true });
+        ASSERT_EQ(getSliceSuppressedCount(m_MuxOrch, SLICE_INTERFACE), 1u);
+
+        m_MuxOrch->updateNeighbor({ entry, MacAddress("00:aa:bb:cc:dd:02"), false });
+        EXPECT_FALSE(isSliceSuppressed(m_MuxOrch, IpAddress(IN_SLICE_NEIGHBOR)));
+        EXPECT_EQ(getSliceSuppressedCount(m_MuxOrch, SLICE_INTERFACE), 0u);
+    }
+
+    TEST_F(MuxSubnetSlicingTest, UpdateNeighborSkipsSliceAnchor)
+    {
+        NeighborEntry entry(IpAddress(SLICE_SERVER_IP6), SLICE_INTERFACE);
+        m_MuxOrch->updateNeighbor({ entry, MacAddress("00:aa:bb:cc:dd:03"), true });
+
+        EXPECT_FALSE(isSliceSuppressed(m_MuxOrch, IpAddress(SLICE_SERVER_IP6)));
+        EXPECT_EQ(getSliceSuppressedCount(m_MuxOrch, SLICE_INTERFACE), 0u);
+    }
+
+    TEST_F(MuxSubnetSlicingTest, UpdateNeighborSkipsSkipNeighbor)
+    {
+        IpAddress soc(IN_SLICE_NEIGHBOR2);
+        m_MuxOrch->addSkipNeighbors({ soc }, SLICE_INTERFACE);
+
+        NeighborEntry entry(soc, SLICE_INTERFACE);
+        m_MuxOrch->updateNeighbor({ entry, MacAddress("00:aa:bb:cc:dd:04"), true });
+
+        EXPECT_FALSE(isSliceSuppressed(m_MuxOrch, soc));
+        EXPECT_EQ(getSliceSuppressedCount(m_MuxOrch, SLICE_INTERFACE), 0u);
+
+        m_MuxOrch->removeSkipNeighbors({ soc });
+    }
+
+    TEST_F(MuxSubnetSlicingTest, UpdateNeighborIgnoresIpv4ForSliceGate)
+    {
+        NeighborEntry entry(IpAddress(SLICE_SERVER_IP4), SLICE_INTERFACE);
+        m_MuxOrch->updateNeighbor({ entry, MacAddress("00:aa:bb:cc:dd:05"), true });
+
+        EXPECT_EQ(getSliceSuppressedCount(m_MuxOrch, SLICE_INTERFACE), 0u);
+    }
+
+    TEST_F(MuxSubnetSlicingTest, UpdateNeighborVlanAliasWithoutFdbStillSuppresses)
+    {
+        // Regression guard for the port-affinity fix: when the neighbor's
+        // alias is a VLAN but no FDB entry exists yet for the MAC, getMuxPort
+        // returns an empty port name. The slice gate must NOT fall through —
+        // it should still suppress the in-slice IP, preserving the
+        // race-tolerant default for not-yet-learned FDB entries.
+        NeighborEntry entry(IpAddress(IN_SLICE_NEIGHBOR), VLAN_1000);
+        m_MuxOrch->updateNeighbor({ entry, MacAddress("00:aa:bb:cc:dd:fa"), true });
+
+        EXPECT_TRUE(isSliceSuppressed(m_MuxOrch, IpAddress(IN_SLICE_NEIGHBOR)));
+        EXPECT_EQ(getSliceSuppressedCount(m_MuxOrch, SLICE_INTERFACE), 1u);
+    }
+
+    TEST_F(MuxSubnetSlicingTest, UpdateNeighborOutOfSliceIpUnaffected)
+    {
+        NeighborEntry entry(IpAddress(OUT_OF_SLICE_IP), SLICE_INTERFACE);
+        m_MuxOrch->updateNeighbor({ entry, MacAddress("00:aa:bb:cc:dd:06"), true });
+
+        EXPECT_FALSE(isSliceSuppressed(m_MuxOrch, IpAddress(OUT_OF_SLICE_IP)));
+        EXPECT_EQ(getSliceSuppressedCount(m_MuxOrch, SLICE_INTERFACE), 0u);
+    }
+
+    // --- Stage 2a: convertNeighborToMux slice gate ----------------------
+
+    // Slice suppression is routed through MuxOrch::updateNeighbor only;
+    // convertNeighborToMux is not a state-mutating path for slice tracking.
+
+    TEST_F(MuxSubnetSlicingTest, ConvertNeighborToMuxDoesNotShortCircuitAnchor)
+    {
+        NeighborEntry entry(IpAddress(SLICE_SERVER_IP6), SLICE_INTERFACE);
+        // Anchor must not be added to the suppressed set even if the call
+        // exits later for unrelated reasons.
+        (void)m_MuxOrch->convertNeighborToMux(entry, SLICE_INTERFACE, "unit test");
+
+        EXPECT_FALSE(isSliceSuppressed(m_MuxOrch, IpAddress(SLICE_SERVER_IP6)));
+        EXPECT_EQ(getSliceSuppressedCount(m_MuxOrch, SLICE_INTERFACE), 0u);
+    }
+
+    // ---------------------------------------------------------------------
+    // Route-NH skip (un-suppress in-slice IPs used as route NHs)
+    // ---------------------------------------------------------------------
+    //
+    // These tests drive MuxOrch::onRouteNexthopsChange directly with
+    // NextHopGroupKey values, mirroring how RouteOrch invokes it on
+    // addRoute/removeRoute. NeighOrch enable/disable calls inside the hook
+    // are safe no-ops when the IP isn't in m_syncdNeighbors, so the fixture
+    // doesn't need to seed neighbors for these checks.
+
+    TEST_F(MuxSubnetSlicingTest, RouteNhAddUnsuppressesInSliceIp)
+    {
+        // Baseline: in-slice IP is within the slice scope (gate predicate).
+        EXPECT_TRUE(m_MuxOrch->isInSliceSuppressed(IpAddress(IN_SLICE_NEIGHBOR)));
+
+        NextHopGroupKey nhg(IN_SLICE_NEIGHBOR + std::string("@") + SLICE_INTERFACE);
+        applyRouteNhChange(m_MuxOrch, nhg, gVirtualRouterId, IpPrefix("2001:db8::/64"), true);
+
+        EXPECT_TRUE(isReferencedByRouteNh(m_MuxOrch, IpAddress(IN_SLICE_NEIGHBOR)));
+        // Route arrived before learn → PlaceholderUnresolved, not Suppressed.
+        EXPECT_FALSE(isSliceSuppressed(m_MuxOrch, IpAddress(IN_SLICE_NEIGHBOR)));
+        EXPECT_EQ(getRouteNhRefCountForPort(m_MuxOrch, SLICE_INTERFACE), 1u);
+    }
+
+    TEST_F(MuxSubnetSlicingTest, RouteNhRemoveResuppressesWhenLastReferenceGone)
+    {
+        NextHopGroupKey nhg(IN_SLICE_NEIGHBOR + std::string("@") + SLICE_INTERFACE);
+        applyRouteNhChange(m_MuxOrch, nhg, gVirtualRouterId, IpPrefix("2001:db8::/64"), true);
+        applyRouteNhChange(m_MuxOrch, nhg, gVirtualRouterId, IpPrefix("2001:db8::/64"), false);
+
+        EXPECT_FALSE(isReferencedByRouteNh(m_MuxOrch, IpAddress(IN_SLICE_NEIGHBOR)));
+        EXPECT_TRUE(m_MuxOrch->isInSliceSuppressed(IpAddress(IN_SLICE_NEIGHBOR)));
+        EXPECT_EQ(getRouteNhRefCountForPort(m_MuxOrch, SLICE_INTERFACE), 0u);
+    }
+
+    TEST_F(MuxSubnetSlicingTest, RouteNhRefcountedAcrossMultipleRoutes)
+    {
+        // Learn the neighbor first so it's actually in SuppressedResolved
+        // state — we only enter that state via the learn path.
+        NeighborEntry entry(IpAddress(IN_SLICE_NEIGHBOR), SLICE_INTERFACE);
+        m_MuxOrch->updateNeighbor({ entry, MacAddress("00:aa:bb:cc:dd:ff"), true });
+        ASSERT_TRUE(isSliceSuppressed(m_MuxOrch, IpAddress(IN_SLICE_NEIGHBOR)));
+
+        NextHopGroupKey nhg1(IN_SLICE_NEIGHBOR + std::string("@") + SLICE_INTERFACE);
+        NextHopGroupKey nhg2(IN_SLICE_NEIGHBOR + std::string("@") + SLICE_INTERFACE);
+        applyRouteNhChange(m_MuxOrch, nhg1, gVirtualRouterId, IpPrefix("2001:db8:1::/64"), true);
+        applyRouteNhChange(m_MuxOrch, nhg2, gVirtualRouterId, IpPrefix("2001:db8:2::/64"), true);
+
+        EXPECT_FALSE(isSliceSuppressed(m_MuxOrch, IpAddress(IN_SLICE_NEIGHBOR)));
+
+        // Removing one of the two routes keeps the IP un-suppressed.
+        applyRouteNhChange(m_MuxOrch, nhg1, gVirtualRouterId, IpPrefix("2001:db8:1::/64"), false);
+        EXPECT_FALSE(isSliceSuppressed(m_MuxOrch, IpAddress(IN_SLICE_NEIGHBOR)));
+        EXPECT_TRUE(isReferencedByRouteNh(m_MuxOrch, IpAddress(IN_SLICE_NEIGHBOR)));
+
+        // Last route gone: re-suppress.
+        applyRouteNhChange(m_MuxOrch, nhg2, gVirtualRouterId, IpPrefix("2001:db8:2::/64"), false);
+        EXPECT_TRUE(isSliceSuppressed(m_MuxOrch, IpAddress(IN_SLICE_NEIGHBOR)));
+    }
+
+    TEST_F(MuxSubnetSlicingTest, RouteNhEcmpGroupHandlesAllInSliceMembers)
+    {
+        // Learn both NHs into SuppressedResolved first.
+        NeighborEntry e1(IpAddress(IN_SLICE_NEIGHBOR),  SLICE_INTERFACE);
+        NeighborEntry e2(IpAddress(IN_SLICE_NEIGHBOR2), SLICE_INTERFACE);
+        m_MuxOrch->updateNeighbor({ e1, MacAddress("00:aa:bb:cc:dd:01"), true });
+        m_MuxOrch->updateNeighbor({ e2, MacAddress("00:aa:bb:cc:dd:02"), true });
+        ASSERT_TRUE(isSliceSuppressed(m_MuxOrch, IpAddress(IN_SLICE_NEIGHBOR)));
+        ASSERT_TRUE(isSliceSuppressed(m_MuxOrch, IpAddress(IN_SLICE_NEIGHBOR2)));
+
+        // ECMP group with two in-slice NHs — both should be un-suppressed.
+        NextHopGroupKey nhg(IN_SLICE_NEIGHBOR + std::string("@") + SLICE_INTERFACE +
+                            std::string(",") +
+                            IN_SLICE_NEIGHBOR2 + std::string("@") + SLICE_INTERFACE);
+        applyRouteNhChange(m_MuxOrch, nhg, gVirtualRouterId, IpPrefix("2001:db8::/64"), true);
+
+        EXPECT_FALSE(isSliceSuppressed(m_MuxOrch, IpAddress(IN_SLICE_NEIGHBOR)));
+        EXPECT_FALSE(isSliceSuppressed(m_MuxOrch, IpAddress(IN_SLICE_NEIGHBOR2)));
+        EXPECT_EQ(getRouteNhRefCountForPort(m_MuxOrch, SLICE_INTERFACE), 2u);
+
+        applyRouteNhChange(m_MuxOrch, nhg, gVirtualRouterId, IpPrefix("2001:db8::/64"), false);
+        EXPECT_TRUE(isSliceSuppressed(m_MuxOrch, IpAddress(IN_SLICE_NEIGHBOR)));
+        EXPECT_TRUE(isSliceSuppressed(m_MuxOrch, IpAddress(IN_SLICE_NEIGHBOR2)));
+    }
+
+    TEST_F(MuxSubnetSlicingTest, RouteNhIgnoresOutOfSliceIp)
+    {
+        NextHopGroupKey nhg(OUT_OF_SLICE_IP + std::string("@") + SLICE_INTERFACE);
+        applyRouteNhChange(m_MuxOrch, nhg, gVirtualRouterId, IpPrefix("2001:db8::/64"), true);
+
+        EXPECT_EQ(getRouteNhRefCountForPort(m_MuxOrch, SLICE_INTERFACE), 0u);
+        EXPECT_FALSE(m_MuxOrch->isInSliceSuppressed(IpAddress(OUT_OF_SLICE_IP)));
+    }
+
+    TEST_F(MuxSubnetSlicingTest, RouteNhIgnoresIpv4)
+    {
+        // IPv4 NHs cannot be in an IPv6 slice — must be a no-op.
+        NextHopGroupKey nhg(SLICE_SERVER_IP4 + std::string("@") + SLICE_INTERFACE);
+        applyRouteNhChange(m_MuxOrch, nhg, gVirtualRouterId, IpPrefix("2001:db8::/64"), true);
+        EXPECT_EQ(getRouteNhRefCountForPort(m_MuxOrch, SLICE_INTERFACE), 0u);
+    }
+
+    TEST_F(MuxSubnetSlicingTest, RouteNhIgnoresSliceAnchor)
+    {
+        // server_ipv6 itself is the slice anchor: it's never slice-suppressed,
+        // so a route pointing to it must not bump the refcount.
+        NextHopGroupKey nhg(SLICE_SERVER_IP6 + std::string("@") + SLICE_INTERFACE);
+        applyRouteNhChange(m_MuxOrch, nhg, gVirtualRouterId, IpPrefix("2001:db8::/64"), true);
+        EXPECT_EQ(getRouteNhRefCountForPort(m_MuxOrch, SLICE_INTERFACE), 0u);
+        EXPECT_FALSE(m_MuxOrch->isInSliceSuppressed(IpAddress(SLICE_SERVER_IP6)));
+    }
+
+    TEST_F(MuxSubnetSlicingTest, RouteNhIgnoresSkipNeighbor)
+    {
+        // soc_ip / explicitly skipped neighbors are out of slice-suppression
+        // scope already; a route NH onto one should not be refcounted.
+        IpAddress soc("fc00::301");
+        m_MuxOrch->addSkipNeighbors({ soc }, SLICE_INTERFACE);
+        NextHopGroupKey nhg(soc.to_string() + std::string("@") + SLICE_INTERFACE);
+        applyRouteNhChange(m_MuxOrch, nhg, gVirtualRouterId, IpPrefix("2001:db8::/64"), true);
+        EXPECT_EQ(getRouteNhRefCountForPort(m_MuxOrch, SLICE_INTERFACE), 0u);
+        m_MuxOrch->removeSkipNeighbors({ soc });
+    }
+
+    TEST_F(MuxSubnetSlicingTest, RouteNhIgnoresNonDefaultVrf)
+    {
+        // Slice is scoped to the default VRF only; events from other VRFs
+        // must be ignored entirely.
+        NextHopGroupKey nhg(IN_SLICE_NEIGHBOR + std::string("@") + SLICE_INTERFACE);
+        const sai_object_id_t bogus_vrf = 0xDEADBEEF;
+        applyRouteNhChange(m_MuxOrch, nhg, bogus_vrf, IpPrefix("2001:db8::/64"), true);
+        EXPECT_EQ(getRouteNhRefCountForPort(m_MuxOrch, SLICE_INTERFACE), 0u);
+        EXPECT_TRUE(m_MuxOrch->isInSliceSuppressed(IpAddress(IN_SLICE_NEIGHBOR)));
+    }
+
+    TEST_F(MuxSubnetSlicingTest, RouteNhRemovesSliceSuppressedTrackingOnUnsuppress)
+    {
+        // If an in-slice IP is currently tracked as slice-suppressed (e.g.
+        // because a neighbor was learned and gated), a later route NH ref
+        // should remove it from the suppressed set.
+        NeighborEntry entry(IpAddress(IN_SLICE_NEIGHBOR), SLICE_INTERFACE);
+        m_MuxOrch->updateNeighbor({ entry, MacAddress("00:aa:bb:cc:dd:ff"), true });
+        ASSERT_EQ(getSliceSuppressedCount(m_MuxOrch, SLICE_INTERFACE), 1u);
+
+        NextHopGroupKey nhg(IN_SLICE_NEIGHBOR + std::string("@") + SLICE_INTERFACE);
+        applyRouteNhChange(m_MuxOrch, nhg, gVirtualRouterId, IpPrefix("2001:db8::/64"), true);
+        EXPECT_EQ(getSliceSuppressedCount(m_MuxOrch, SLICE_INTERFACE), 0u);
+
+        // Drop the route: with no live neighbor in NeighOrch the deferred
+        // drain has nothing to gate, but the IP must once again be considered
+        // slice-suppressed from RouteOrch's perspective.
+        applyRouteNhChange(m_MuxOrch, nhg, gVirtualRouterId, IpPrefix("2001:db8::/64"), false);
+        static_cast<Orch *>(m_MuxOrch)->doTask();
+        EXPECT_FALSE(isReferencedByRouteNh(m_MuxOrch, IpAddress(IN_SLICE_NEIGHBOR)));
+        EXPECT_TRUE(m_MuxOrch->isInSliceSuppressed(IpAddress(IN_SLICE_NEIGHBOR)));
+    }
+}

--- a/tests/test_mux_subnet_slice.py
+++ b/tests/test_mux_subnet_slice.py
@@ -17,7 +17,7 @@ import json
 from ipaddress import ip_address
 from swsscommon import swsscommon
 
-from test_mux import TestMuxTunnelBase, create_fvs, tunnel_nh_id
+from test_mux import TestMuxTunnelBase
 
 
 ACTIVE = "active"
@@ -400,7 +400,6 @@ class TestMuxSubnetSlice(TestMuxSubnetSliceBase):
     ):
         """Link-local IPv6 neighbors are out-of-slice by definition."""
         appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
-        asicdb = dvs.get_asic_db()
         try:
             self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
             self.add_fdb(dvs, self.SLICED_PORT_A, self.MAC_A1_DASH)
@@ -989,6 +988,110 @@ class TestMuxSubnetSlice(TestMuxSubnetSliceBase):
             )
         finally:
             config_db.delete_entry(self.CONFIG_MUX_CABLE, self.LATE_CFG_PORT)
+
+
+    def test_slice_cable_removed_cleans_state(
+        self, dvs, dvs_route, setup, setup_vlan, setup_peer_switch,
+        setup_tunnel, setup_mux_cable, testlog
+    ):
+        """Deleting a slice-configured MUX_CABLE entry must withdraw the
+        supernet route, clear STATE_DB slice fields, and drop suppressed NHs.
+        Covers the slice cable teardown path in setMuxCable(remove)."""
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+        config_db = dvs.get_config_db()
+
+        self.add_fdb(dvs, self.SLICED_PORT_A, self.MAC_A1_DASH)
+        self.add_neighbor(dvs, self.SERVER_IPV6_A, self.MAC_A1)
+        self.add_neighbor(dvs, self.IN_SLICE_A_1, self.MAC_A1)
+        self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+        try:
+            self.wait_for_slice_route(
+                asicdb, self.SLICE_PREFIX_A, self.SERVER_IPV6_A, present=True
+            )
+            self.check_state_db_slice_fields(
+                dvs, self.SLICED_PORT_A, expected_prefix=self.SLICE_PREFIX_A
+            )
+
+            # Tear down the slice-configured cable.
+            config_db.delete_entry(self.CONFIG_MUX_CABLE, self.SLICED_PORT_A)
+            time.sleep(2)
+
+            # Supernet route gone; STATE_DB slice field gone.
+            self.wait_for_slice_route(
+                asicdb, self.SLICE_PREFIX_A, self.SERVER_IPV6_A, present=False
+            )
+            entry = self.get_state_db_mux_entry(dvs, self.SLICED_PORT_A)
+            assert "server_ipv6_subnet" not in entry, (
+                f"slice field not cleared after cable removal: {entry}"
+            )
+        finally:
+            # Restore so later tests in same session see the original config.
+            config_db.create_entry(
+                self.CONFIG_MUX_CABLE, self.SLICED_PORT_A,
+                {
+                    "server_ipv4":        self.SERV2_IPV4 + self.IPV4_MASK,
+                    "server_ipv6":        self.SERVER_IPV6_A + self.IPV6_MASK,
+                    "server_ipv6_subnet": self.SLICE_PREFIX_A,
+                },
+            )
+            self.del_neighbor(dvs, self.SERVER_IPV6_A)
+            self.del_neighbor(dvs, self.IN_SLICE_A_1)
+            self.del_fdb(dvs, self.MAC_A1_DASH)
+
+    def test_mux_state_flip_updates_slice_route_nh(
+        self, dvs, dvs_route, setup, setup_vlan, setup_peer_switch,
+        setup_tunnel, setup_mux_cable, testlog
+    ):
+        """Flipping the sliced port's mux state changes the anchor NH OID
+        (direct neighbor vs. tunnel NH). The slice route must follow.
+        Covers the set_route branch in MuxCable::refreshSliceRoute."""
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        self.add_fdb(dvs, self.SLICED_PORT_A, self.MAC_A1_DASH)
+        self.add_neighbor(dvs, self.SERVER_IPV6_A, self.MAC_A1)
+        self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+        try:
+            self.wait_for_slice_route(
+                asicdb, self.SLICE_PREFIX_A, self.SERVER_IPV6_A, present=True
+            )
+            active_rt_key = self.find_route_key_for_prefix(
+                asicdb, self.SLICE_PREFIX_A
+            )
+            assert active_rt_key, "slice route missing on ACTIVE"
+            active_nh = self.get_route_nexthop_ip(asicdb, active_rt_key)
+
+            # STANDBY: anchor resolves via tunnel NH; slice route NH OID
+            # must change but route prefix remains present.
+            self.set_mux_state(appdb, self.SLICED_PORT_A, STANDBY)
+            time.sleep(2)
+            standby_rt_key = self.find_route_key_for_prefix(
+                asicdb, self.SLICE_PREFIX_A
+            )
+            assert standby_rt_key, "slice route disappeared on STANDBY"
+            standby_nh = self.get_route_nexthop_ip(asicdb, standby_rt_key)
+            assert active_nh != standby_nh, (
+                f"slice route NH did not change on state flip "
+                f"(active={active_nh}, standby={standby_nh})"
+            )
+
+            # Back to ACTIVE: NH flips again.
+            self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+            time.sleep(2)
+            back_rt_key = self.find_route_key_for_prefix(
+                asicdb, self.SLICE_PREFIX_A
+            )
+            assert back_rt_key, "slice route disappeared on ACTIVE re-set"
+            back_nh = self.get_route_nexthop_ip(asicdb, back_rt_key)
+            assert back_nh != standby_nh, (
+                f"slice route NH did not flip back to ACTIVE "
+                f"(standby={standby_nh}, back={back_nh})"
+            )
+        finally:
+            self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+            self.del_neighbor(dvs, self.SERVER_IPV6_A)
+            self.del_fdb(dvs, self.MAC_A1_DASH)
 
 
 # Dummy always-pass test at end as workaround for the issue where a Flaky

--- a/tests/test_mux_subnet_slice.py
+++ b/tests/test_mux_subnet_slice.py
@@ -1,0 +1,889 @@
+"""VS tests for the dualtor mux subnet slicing feature.
+
+Subnet slicing lets a MUX_CABLE entry declare a `server_ipv6_subnet` prefix.
+For neighbors whose IPv6 falls inside that prefix, MuxOrch suppresses the SAI
+neighbor and instead programs a single ASIC slice prefix route anchored on the
+mux's configured `server_ipv6`. The anchor `server_ipv6` itself, out-of-slice
+IPv6 neighbors, IPv4 neighbors, and link-local neighbors are unaffected.
+
+Mirrors `test_mux.py` but only carries tests whose expected behavior changes
+under slicing.
+"""
+
+import time
+import pytest
+import json
+
+from ipaddress import ip_address
+from swsscommon import swsscommon
+
+from test_mux import TestMuxTunnelBase, create_fvs, tunnel_nh_id
+
+
+ACTIVE = "active"
+STANDBY = "standby"
+TOGGLE = {ACTIVE: STANDBY, STANDBY: ACTIVE}
+
+
+class TestMuxSubnetSliceBase(TestMuxTunnelBase):
+    """Shared constants, mux config overrides, and slicing-specific helpers."""
+
+    STATE_MUX_CABLE_TABLE = "MUX_CABLE_TABLE"
+    APP_ROUTE_TABLE       = "ROUTE_TABLE"
+
+    # ---- Topology ----------------------------------------------------------
+    # Ethernet0  -> non-sliced (control)
+    # Ethernet4  -> sliced; server_ipv6 inside slice prefix
+    # Ethernet8  -> sliced; server_ipv6 inside slice prefix (overrides parent
+    #               SERV3_IPV6 so the anchor sits inside the slice)
+    SLICED_PORT_A     = "Ethernet4"
+    SLICED_PORT_B     = "Ethernet8"
+    NON_SLICED_PORT   = "Ethernet0"
+
+    # /120 keeps slices inside the VLAN /64 (fc02:1000::/64) with room for
+    # out-of-slice host range.
+    SLICE_PREFIX_A    = "fc02:1000::100/120"   # covers ::100 .. ::1ff
+    SLICE_PREFIX_B    = "fc02:1000::200/120"   # covers ::200 .. ::2ff
+
+    # Anchor server_ipv6 must sit inside the slice. SERV2_IPV6 is ::101 already;
+    # SLICED_PORT_B overrides to ::201.
+    SERVER_IPV6_A     = TestMuxTunnelBase.SERV2_IPV6   # fc02:1000::101
+    SERVER_IPV6_B     = "fc02:1000::201"
+
+    # In-slice neighbors (expected to be suppressed).
+    IN_SLICE_A_1      = "fc02:1000::150"
+    IN_SLICE_A_2      = "fc02:1000::160"
+    IN_SLICE_B_1      = "fc02:1000::250"
+    IN_SLICE_B_2      = "fc02:1000::260"
+
+    # Out-of-slice but still in VLAN — expected to be programmed normally.
+    OUT_OF_SLICE_IPV6 = "fc02:1000::ff"
+    OUT_OF_SLICE_IPV6_2 = "fc02:1000::301"
+
+    # Other neighbor classes that must remain unaffected.
+    IPV4_ON_SLICED    = "192.168.0.150"
+    LINK_LOCAL_NEIGH  = "fe80::1"
+
+    MAC_A1            = "00:aa:00:00:00:01"
+    MAC_A1_DASH       = "00-aa-00-00-00-01"
+    MAC_A2            = "00:aa:00:00:00:02"
+    MAC_A2_DASH       = "00-aa-00-00-00-02"
+    MAC_B1            = "00:bb:00:00:00:01"
+    MAC_B1_DASH       = "00-bb-00-00-00-01"
+
+    # Reserved for the "configure mux + slice AFTER neighbor learn" test.
+    # Added to Vlan1000 by the override below but intentionally not
+    # pre-configured as a mux cable.
+    LATE_CFG_PORT     = "Ethernet12"
+    LATE_SLICE_PREFIX = "fc02:1000::400/120"
+    LATE_SERVER_IPV4  = "192.168.0.103"
+    LATE_SERVER_IPV6  = "fc02:1000::401"
+    LATE_IN_SLICE     = "fc02:1000::450"
+    LATE_MAC          = "00:cc:00:00:00:01"
+    LATE_MAC_DASH     = "00-cc-00-00-00-01"
+
+    # Add LATE_CFG_PORT to Vlan1000 without configuring it as a mux cable.
+    def create_vlan_interface(self, dvs):
+        super().create_vlan_interface(dvs)
+        confdb = dvs.get_config_db()
+        confdb.create_entry(
+            "VLAN_MEMBER", "Vlan1000|" + self.LATE_CFG_PORT,
+            {"tagging_mode": "untagged"},
+        )
+        dvs.port_admin_set(self.LATE_CFG_PORT, "up")
+
+    def create_mux_cable(self, confdb):
+        # Ethernet0 — non-sliced control
+        fvs = {
+            "server_ipv4":   self.SERV1_IPV4 + self.IPV4_MASK,
+            "server_ipv6":   self.SERV1_IPV6 + self.IPV6_MASK,
+            "soc_ipv4":      self.SERV1_SOC_IPV4 + self.IPV4_MASK,
+            "cable_type":    "active-active",
+        }
+        confdb.create_entry(self.CONFIG_MUX_CABLE, self.NON_SLICED_PORT, fvs)
+
+        # Ethernet4 — sliced
+        fvs = {
+            "server_ipv4":         self.SERV2_IPV4 + self.IPV4_MASK,
+            "server_ipv6":         self.SERVER_IPV6_A + self.IPV6_MASK,
+            "server_ipv6_subnet":  self.SLICE_PREFIX_A,
+        }
+        confdb.create_entry(self.CONFIG_MUX_CABLE, self.SLICED_PORT_A, fvs)
+
+        # Ethernet8 — sliced; server_ipv6 overridden to sit inside the slice.
+        fvs = {
+            "server_ipv4":         self.SERV3_IPV4 + self.IPV4_MASK,
+            "server_ipv6":         self.SERVER_IPV6_B + self.IPV6_MASK,
+            "server_ipv6_subnet":  self.SLICE_PREFIX_B,
+        }
+        confdb.create_entry(self.CONFIG_MUX_CABLE, self.SLICED_PORT_B, fvs)
+
+    def get_route_nexthop_ip(self, asicdb, route_key):
+        """Return the SAI_NEXT_HOP_ATTR_IP of the route's nexthop OID, or ''."""
+        route_entry = asicdb.get_entry(self.ASIC_ROUTE_TABLE, route_key)
+        nh_oid = route_entry.get("SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID")
+        if not nh_oid:
+            return ""
+        nh_entry = asicdb.get_entry(self.ASIC_NEXTHOP_TABLE, nh_oid)
+        return nh_entry.get("SAI_NEXT_HOP_ATTR_IP", "")
+
+    def find_route_key_for_prefix(self, asicdb, prefix):
+        """Return the ASIC route key matching `dest`=prefix, or '' if missing."""
+        for key in asicdb.get_keys(self.ASIC_ROUTE_TABLE):
+            try:
+                parsed = json.loads(key)
+            except Exception:
+                continue
+            if parsed.get("dest") == prefix:
+                return key
+        return ""
+
+    def wait_for_slice_route(self, asicdb, prefix, expected_nh_ip, present=True,
+                             timeout=10):
+        """Poll for the slice prefix route and (optionally) its anchor NH."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            key = self.find_route_key_for_prefix(asicdb, prefix)
+            if present and key:
+                nh_ip = self.get_route_nexthop_ip(asicdb, key)
+                if expected_nh_ip is None or nh_ip == expected_nh_ip:
+                    return key
+            elif not present and not key:
+                return ""
+            time.sleep(0.5)
+        if present:
+            assert False, (
+                f"Slice route {prefix} not present "
+                f"(or wrong NH; expected anchor {expected_nh_ip}) within {timeout}s"
+            )
+        else:
+            assert False, f"Slice route {prefix} still present after {timeout}s"
+
+    def get_state_db_mux_entry(self, dvs, port):
+        state_db = dvs.get_state_db()
+        return state_db.get_entry(self.STATE_MUX_CABLE_TABLE, port) or {}
+
+    def check_state_db_slice_fields(self, dvs, port, expected_prefix=None):
+        """Assert STATE_DB MUX_CABLE_TABLE server_ipv6_subnet for `port`."""
+        entry = self.get_state_db_mux_entry(dvs, port)
+        if expected_prefix is None:
+            assert "server_ipv6_subnet" not in entry, (
+                f"Did not expect server_ipv6_subnet for {port}, got {entry}"
+            )
+            return
+        assert entry.get("server_ipv6_subnet") == expected_prefix, (
+            f"{port} server_ipv6_subnet: expected {expected_prefix}, got {entry}"
+        )
+
+    def expect_neighbor_suppressed(self, dvs, asicdb, ip, mac, port_mac_dash,
+                                   sliced_port):
+        """Add neighbor + FDB, expect it NOT to land in ASIC neigh table."""
+        # FDB first so MuxOrch can resolve the neighbor to a mux port.
+        self.add_fdb(dvs, sliced_port, port_mac_dash)
+        self.add_neighbor(dvs, ip, mac)
+        time.sleep(1)
+        self.check_neigh_in_asic_db(asicdb, ip, expected=False)
+
+    def expect_neighbor_programmed(self, dvs, asicdb, ip, mac, port_mac_dash,
+                                   port):
+        self.add_fdb(dvs, port, port_mac_dash)
+        self.add_neighbor(dvs, ip, mac)
+        time.sleep(1)
+        self.check_neigh_in_asic_db(asicdb, ip, expected=True)
+
+
+class TestMuxSubnetSlice(TestMuxSubnetSliceBase):
+    """Tests for dualtor mux subnet slicing."""
+
+    @pytest.fixture(scope='class')
+    def setup(self, dvs):
+        """Mirror TestMuxTunnel.setup: register QoS maps needed by tunnel
+        creation. Required as a dependency by setup_tunnel/setup_peer_switch
+        consumers even when individual slicing tests don't read its return
+        values."""
+        db = dvs.get_config_db()
+        asicdb = dvs.get_asic_db()
+
+        tc_to_dscp_map_oid = self.add_qos_map(db, asicdb, swsscommon.CFG_TC_TO_DSCP_MAP_TABLE_NAME, self.TUNNEL_QOS_MAP_NAME, self.TC_TO_DSCP_MAP)
+        tc_to_queue_map_oid = self.add_qos_map(db, asicdb, swsscommon.CFG_TC_TO_QUEUE_MAP_TABLE_NAME, self.TUNNEL_QOS_MAP_NAME, self.TC_TO_QUEUE_MAP)
+        dscp_to_tc_map_oid = self.add_qos_map(db, asicdb, swsscommon.CFG_DSCP_TO_TC_MAP_TABLE_NAME, self.TUNNEL_QOS_MAP_NAME, self.DSCP_TO_TC_MAP)
+        tc_to_pg_map_oid = self.add_qos_map(db, asicdb, swsscommon.CFG_TC_TO_PRIORITY_GROUP_MAP_TABLE_NAME, self.TUNNEL_QOS_MAP_NAME, self.TC_TO_PRIORITY_GROUP_MAP)
+
+        yield tc_to_dscp_map_oid, tc_to_queue_map_oid, dscp_to_tc_map_oid, tc_to_pg_map_oid
+
+        self.remove_qos_map(db, swsscommon.CFG_TC_TO_DSCP_MAP_TABLE_NAME, tc_to_dscp_map_oid)
+        self.remove_qos_map(db, swsscommon.CFG_TC_TO_QUEUE_MAP_TABLE_NAME, tc_to_queue_map_oid)
+        self.remove_qos_map(db, swsscommon.CFG_DSCP_TO_TC_MAP_TABLE_NAME, dscp_to_tc_map_oid)
+        self.remove_qos_map(db, swsscommon.CFG_TC_TO_PRIORITY_GROUP_MAP_TABLE_NAME, tc_to_pg_map_oid)
+
+    def test_anchor_server_ipv6_always_programmed(
+        self, dvs, dvs_route, setup, setup_vlan, setup_peer_switch,
+        setup_tunnel, setup_mux_cable, testlog
+    ):
+        """Anchor `server_ipv6` is always programmed in ASIC, even inside the
+        slice."""
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+        self.add_neighbor(dvs, self.SERVER_IPV6_A, self.MAC_A1)
+        try:
+            self.check_neigh_in_asic_db(asicdb, self.SERVER_IPV6_A, expected=True)
+        finally:
+            self.del_neighbor(dvs, self.SERVER_IPV6_A)
+
+    def test_slice_route_installed(
+        self, dvs, dvs_route, setup, setup_vlan, setup_peer_switch,
+        setup_tunnel, setup_mux_cable, testlog
+    ):
+        """The slice prefix route is installed in ASIC pointing at the anchor."""
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        # Anchor must be resolved so the slice route has a real NH.
+        self.add_fdb(dvs, self.SLICED_PORT_A, self.MAC_A1_DASH)
+        self.add_neighbor(dvs, self.SERVER_IPV6_A, self.MAC_A1)
+        self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+        try:
+            self.wait_for_slice_route(
+                asicdb, self.SLICE_PREFIX_A, self.SERVER_IPV6_A, present=True
+            )
+        finally:
+            self.del_neighbor(dvs, self.SERVER_IPV6_A)
+            self.del_fdb(dvs, self.MAC_A1_DASH)
+
+    def test_state_db_slice_fields(
+        self, dvs, dvs_route, setup, setup_vlan, setup_peer_switch,
+        setup_tunnel, setup_mux_cable, testlog
+    ):
+        """STATE_DB MUX_CABLE_TABLE publishes server_ipv6_subnet on sliced
+        ports only."""
+        # Sliced port shows the prefix; non-sliced does not.
+        self.check_state_db_slice_fields(
+            dvs, self.SLICED_PORT_A,
+            expected_prefix=self.SLICE_PREFIX_A,
+        )
+        self.check_state_db_slice_fields(dvs, self.NON_SLICED_PORT,
+                                         expected_prefix=None)
+
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+        try:
+            # Add one in-slice and one out-of-slice neighbor on the same port.
+            self.expect_neighbor_suppressed(
+                dvs, asicdb, self.IN_SLICE_A_1, self.MAC_A1,
+                self.MAC_A1_DASH, self.SLICED_PORT_A,
+            )
+            self.expect_neighbor_programmed(
+                dvs, asicdb, self.OUT_OF_SLICE_IPV6, self.MAC_A2,
+                self.MAC_A2_DASH, self.SLICED_PORT_A,
+            )
+            time.sleep(1)
+            self.check_state_db_slice_fields(
+                dvs, self.SLICED_PORT_A,
+                expected_prefix=self.SLICE_PREFIX_A,
+            )
+        finally:
+            self.del_neighbor(dvs, self.IN_SLICE_A_1)
+            self.del_neighbor(dvs, self.OUT_OF_SLICE_IPV6)
+            self.del_fdb(dvs, self.MAC_A1_DASH)
+            self.del_fdb(dvs, self.MAC_A2_DASH)
+
+    def test_in_slice_neighbor_suppressed(
+        self, dvs, dvs_route, setup, setup_vlan, setup_peer_switch,
+        setup_tunnel, setup_mux_cable, testlog
+    ):
+        """In-slice IPv6 neighbor is not programmed in the SAI neighbor table
+        on either active or standby; the slice prefix route covers it."""
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        # Ensure anchor is resolved so the slice route exists.
+        self.add_fdb(dvs, self.SLICED_PORT_A, self.MAC_A1_DASH)
+        self.add_neighbor(dvs, self.SERVER_IPV6_A, self.MAC_A1)
+
+        try:
+            for state in (ACTIVE, STANDBY):
+                self.set_mux_state(appdb, self.SLICED_PORT_A, state)
+                self.add_neighbor(dvs, self.IN_SLICE_A_1, self.MAC_A1)
+                time.sleep(1)
+                self.check_neigh_in_asic_db(
+                    asicdb, self.IN_SLICE_A_1, expected=False
+                )
+                # No tunnel host-route either — the slice route takes over.
+                self.check_tunnel_route_in_app_db(
+                    dvs, [self.IN_SLICE_A_1 + self.IPV6_MASK], expected=False
+                )
+            # Restore ACTIVE so the slice route NH is the anchor (VLAN NH),
+            # not the tunnel NH from the STANDBY iteration above.
+            self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+            self.add_neighbor(dvs, self.SERVER_IPV6_A, self.MAC_A1)
+            self.wait_for_slice_route(
+                asicdb, self.SLICE_PREFIX_A, self.SERVER_IPV6_A, present=True,
+            )
+        finally:
+            self.del_neighbor(dvs, self.IN_SLICE_A_1)
+            self.del_neighbor(dvs, self.SERVER_IPV6_A)
+            self.del_fdb(dvs, self.MAC_A1_DASH)
+            self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+
+    def test_out_of_slice_neighbor_programmed(
+        self, dvs, dvs_route, setup, setup_vlan, setup_peer_switch,
+        setup_tunnel, setup_mux_cable, testlog
+    ):
+        """Out-of-slice IPv6 neighbor on a sliced port behaves like the
+        non-slice path: programmed when active, tunnel-routed when standby."""
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        self.del_neighbor(dvs, self.OUT_OF_SLICE_IPV6)
+        self.del_fdb(dvs, self.MAC_A1_DASH)
+        self.set_mux_state(appdb, self.SLICED_PORT_A, STANDBY)
+        time.sleep(1)
+        self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+        time.sleep(1)
+
+        try:
+            self.expect_neighbor_programmed(
+                dvs, asicdb, self.OUT_OF_SLICE_IPV6, self.MAC_A1,
+                self.MAC_A1_DASH, self.SLICED_PORT_A,
+            )
+            # Standby: removed from ASIC, tunnel host-route installed.
+            self.set_mux_state(appdb, self.SLICED_PORT_A, STANDBY)
+            self.check_neigh_in_asic_db(
+                asicdb, self.OUT_OF_SLICE_IPV6, expected=False
+            )
+            self.check_tunnel_route_in_app_db(
+                dvs, [self.OUT_OF_SLICE_IPV6 + self.IPV6_MASK], expected=True
+            )
+            # Back to active.
+            self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+            self.check_neigh_in_asic_db(
+                asicdb, self.OUT_OF_SLICE_IPV6, expected=True
+            )
+            self.check_tunnel_route_in_app_db(
+                dvs, [self.OUT_OF_SLICE_IPV6 + self.IPV6_MASK], expected=False
+            )
+        finally:
+            self.del_neighbor(dvs, self.OUT_OF_SLICE_IPV6)
+            self.del_fdb(dvs, self.MAC_A1_DASH)
+
+    def test_ipv4_neighbor_on_sliced_port(
+        self, dvs, dvs_route, setup, setup_vlan, setup_peer_switch,
+        setup_tunnel, setup_mux_cable, testlog
+    ):
+        """IPv4 neighbors on a sliced port are never affected by slicing."""
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+        try:
+            self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+            self.expect_neighbor_programmed(
+                dvs, asicdb, self.IPV4_ON_SLICED, self.MAC_A1,
+                self.MAC_A1_DASH, self.SLICED_PORT_A,
+            )
+            # Standby still flips to tunnel route per existing behavior.
+            self.set_mux_state(appdb, self.SLICED_PORT_A, STANDBY)
+            self.check_neigh_in_asic_db(asicdb, self.IPV4_ON_SLICED, expected=False)
+            self.check_tunnel_route_in_app_db(
+                dvs, [self.IPV4_ON_SLICED + self.IPV4_MASK], expected=True
+            )
+        finally:
+            self.del_neighbor(dvs, self.IPV4_ON_SLICED)
+            self.del_fdb(dvs, self.MAC_A1_DASH)
+            self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+
+    def test_link_local_neighbor_on_sliced_port(
+        self, dvs, dvs_route, setup, setup_vlan, setup_peer_switch,
+        setup_tunnel, setup_mux_cable, testlog
+    ):
+        """Link-local IPv6 neighbors are out-of-slice by definition."""
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+        try:
+            self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+            self.add_fdb(dvs, self.SLICED_PORT_A, self.MAC_A1_DASH)
+            self.add_neighbor(dvs, self.LINK_LOCAL_NEIGH, self.MAC_A1)
+            time.sleep(1)
+            # We don't strictly require it in ASIC (link-local isn't always
+            # programmed via the same path), but it must NOT be suppressed
+            # by the slice — confirm it's not absent due to slicing by
+            # checking that no slice-anchored host route claims it.
+            assert ip_address(self.LINK_LOCAL_NEIGH).is_link_local
+            self.check_tunnel_route_in_app_db(
+                dvs, [self.LINK_LOCAL_NEIGH + self.IPV6_MASK], expected=False
+            )
+        finally:
+            self.del_neighbor(dvs, self.LINK_LOCAL_NEIGH)
+            self.del_fdb(dvs, self.MAC_A1_DASH)
+
+    def test_slice_only_on_one_port(
+        self, dvs, dvs_route, setup, setup_vlan, setup_peer_switch,
+        setup_tunnel, setup_mux_cable, testlog
+    ):
+        """Slice config on port A doesn't affect the non-sliced port: an
+        out-of-slice IP added on Ethernet0 is programmed normally."""
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        try:
+            self.set_mux_state(appdb, self.NON_SLICED_PORT, ACTIVE)
+            self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+
+            # Out-of-slice IP on the non-sliced port: normal programming.
+            self.expect_neighbor_programmed(
+                dvs, asicdb, self.OUT_OF_SLICE_IPV6_2, self.MAC_A1,
+                self.MAC_A1_DASH, self.NON_SLICED_PORT,
+            )
+        finally:
+            self.del_neighbor(dvs, self.OUT_OF_SLICE_IPV6_2)
+            self.del_fdb(dvs, self.MAC_A1_DASH)
+
+    # An IP inside slice A's prefix but FDB-learned on a different mux port
+    # must NOT be slice-suppressed (port-affinity cross-check).
+    def test_in_slice_ip_learned_on_non_slice_port_is_unsuppressed(
+        self, dvs, dvs_route, setup, setup_vlan, setup_peer_switch,
+        setup_tunnel, setup_mux_cable, testlog
+    ):
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        # IP that is inside SLICED_PORT_A's slice (fc02:1000::100/120) but
+        # learned via FDB on NON_SLICED_PORT (Ethernet0).
+        cross_ip = self.IN_SLICE_A_2  # fc02:1000::160
+
+        try:
+            self.set_mux_state(appdb, self.NON_SLICED_PORT, ACTIVE)
+            self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+
+            # Anchor SLICED_PORT_A so its slice route is installed.
+            self.add_fdb(dvs, self.SLICED_PORT_A, self.MAC_A1_DASH)
+            self.add_neighbor(dvs, self.SERVER_IPV6_A, self.MAC_A1)
+            self.wait_for_slice_route(
+                asicdb, self.SLICE_PREFIX_A, self.SERVER_IPV6_A, present=True
+            )
+            self.check_state_db_slice_fields(
+                dvs, self.SLICED_PORT_A,
+                expected_prefix=self.SLICE_PREFIX_A,
+            )
+
+            # FDB resolves the MAC to the non-sliced port.
+            self.add_fdb(dvs, self.NON_SLICED_PORT, self.MAC_A2_DASH)
+            self.add_neighbor(dvs, cross_ip, self.MAC_A2)
+            time.sleep(1)
+
+            # Neighbor programmed in ASIC (not suppressed by port A's slice).
+            self.check_neigh_in_asic_db(asicdb, cross_ip, expected=True)
+            self.check_state_db_slice_fields(
+                dvs, self.SLICED_PORT_A,
+                expected_prefix=self.SLICE_PREFIX_A,
+            )
+            # Slice route on port A still resolves via the anchor.
+            self.wait_for_slice_route(
+                asicdb, self.SLICE_PREFIX_A, self.SERVER_IPV6_A, present=True
+            )
+        finally:
+            self.del_neighbor(dvs, cross_ip)
+            self.del_neighbor(dvs, self.SERVER_IPV6_A)
+            self.del_fdb(dvs, self.MAC_A1_DASH)
+            self.del_fdb(dvs, self.MAC_A2_DASH)
+
+    def test_in_slice_ip_move_between_ports(
+        self, dvs, dvs_route, setup, setup_vlan, setup_peer_switch,
+        setup_tunnel, setup_mux_cable, testlog
+    ):
+        """An in-slice IP that FDB-resolves to the slice owner is suppressed.
+        After the MAC moves to a different mux port, the port-affinity
+        cross-check unsuppresses the neighbor (it now belongs to that other
+        port and must be programmed normally). Slice routes on both ports
+        remain intact."""
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+
+        ip = self.IN_SLICE_A_1
+        try:
+            # Anchor both ports.
+            self.add_fdb(dvs, self.SLICED_PORT_A, self.MAC_A1_DASH)
+            self.add_neighbor(dvs, self.SERVER_IPV6_A, self.MAC_A1)
+            self.add_fdb(dvs, self.SLICED_PORT_B, self.MAC_B1_DASH)
+            self.add_neighbor(dvs, self.SERVER_IPV6_B, self.MAC_B1)
+            self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+            self.set_mux_state(appdb, self.SLICED_PORT_B, ACTIVE)
+
+            # In-slice neighbor learned on port A (the slice owner) — suppressed.
+            self.add_fdb(dvs, self.SLICED_PORT_A, self.MAC_A2_DASH)
+            self.add_neighbor(dvs, ip, self.MAC_A2)
+            time.sleep(1)
+            self.check_neigh_in_asic_db(asicdb, ip, expected=False)
+
+            # Same MAC now appears on port B (move). The IP still falls under
+            # slice A's prefix, but it no longer FDB-resolves to the slice
+            # owner — the port-affinity cross-check unsuppresses the neighbor
+            # so traffic to the moved host can still be delivered.
+            self.add_fdb(dvs, self.SLICED_PORT_B, self.MAC_A2_DASH)
+            time.sleep(2)
+            self.check_neigh_in_asic_db(asicdb, ip, expected=True)
+
+            # Both slice routes must still be present and resolve via their
+            # respective anchors.
+            self.wait_for_slice_route(
+                asicdb, self.SLICE_PREFIX_A, self.SERVER_IPV6_A, present=True
+            )
+            self.wait_for_slice_route(
+                asicdb, self.SLICE_PREFIX_B, self.SERVER_IPV6_B, present=True
+            )
+        finally:
+            self.del_neighbor(dvs, ip)
+            self.del_neighbor(dvs, self.SERVER_IPV6_A)
+            self.del_neighbor(dvs, self.SERVER_IPV6_B)
+            self.del_fdb(dvs, self.MAC_A1_DASH)
+            self.del_fdb(dvs, self.MAC_A2_DASH)
+            self.del_fdb(dvs, self.MAC_B1_DASH)
+
+    # Slice route tracks anchor state: active = VLAN NH, standby = tunnel NH.
+    def test_slice_route_follows_mux_state(
+        self, dvs, dvs_route, setup, setup_vlan, setup_peer_switch,
+        setup_tunnel, setup_mux_cable, testlog
+    ):
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+        self.check_tnl_nexthop_in_asic_db(asicdb)
+
+        try:
+            self.add_fdb(dvs, self.SLICED_PORT_A, self.MAC_A1_DASH)
+            self.add_neighbor(dvs, self.SERVER_IPV6_A, self.MAC_A1)
+
+            # Active: slice route resolves to the anchor neighbor (non-tunnel NH).
+            self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+            key = self.wait_for_slice_route(
+                asicdb, self.SLICE_PREFIX_A, self.SERVER_IPV6_A, present=True
+            )
+            self.check_nexthop_in_asic_db(asicdb, key, standby=False)
+
+            # Standby: slice route resolves to tunnel NH.
+            self.set_mux_state(appdb, self.SLICED_PORT_A, STANDBY)
+            key = self.find_route_key_for_prefix(asicdb, self.SLICE_PREFIX_A)
+            assert key, "slice route disappeared during state transition"
+            self.check_nexthop_in_asic_db(asicdb, key, standby=True)
+
+            # Back to active.
+            self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+            key = self.wait_for_slice_route(
+                asicdb, self.SLICE_PREFIX_A, self.SERVER_IPV6_A, present=True
+            )
+            self.check_nexthop_in_asic_db(asicdb, key, standby=False)
+        finally:
+            self.del_neighbor(dvs, self.SERVER_IPV6_A)
+            self.del_fdb(dvs, self.MAC_A1_DASH)
+
+    # Neighbor learned before mux config: slice install deferred until the
+    # MUX_CABLE entry (with slice prefix) lands. Uses LATE_CFG_PORT which is
+    # added to Vlan1000 but left un-mux-configured by the override above.
+    def test_neighbor_learned_before_mux_config_with_slice(
+        self, dvs, dvs_route, setup, setup_vlan, setup_peer_switch,
+        setup_tunnel, setup_mux_cable, testlog
+    ):
+        """Adapted from test_mux.test_neighbor_learned_before_mux_config: when
+        an in-slice neighbor is learned before the MUX_CABLE entry, the slice
+        config (arriving later) suppresses it via the reconcile sweep."""
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+        config_db = dvs.get_config_db()
+
+        in_slice_ip = self.LATE_IN_SLICE
+        anchor_ip = self.LATE_SERVER_IPV6
+        try:
+            # Step 1: learn neighbor + anchor BEFORE any MUX_CABLE entry for
+            # this port. They should land in the ASIC as regular VLAN
+            # neighbors.
+            self.add_fdb(dvs, self.LATE_CFG_PORT, self.LATE_MAC_DASH)
+            self.add_neighbor(dvs, anchor_ip, self.LATE_MAC)
+            self.add_neighbor(dvs, in_slice_ip, self.LATE_MAC)
+            time.sleep(2)
+            self.check_neigh_in_asic_db(asicdb, in_slice_ip, expected=True)
+            self.check_neigh_in_asic_db(asicdb, anchor_ip, expected=True)
+
+            # Step 2: configure the mux cable WITH slice prefix. Anchor stays
+            # programmed; in-slice neighbor must be reconciled to suppressed
+            # and the slice prefix route must be installed.
+            config_db.create_entry(
+                self.CONFIG_MUX_CABLE, self.LATE_CFG_PORT,
+                {
+                    "server_ipv4":        self.LATE_SERVER_IPV4 + self.IPV4_MASK,
+                    "server_ipv6":        anchor_ip + self.IPV6_MASK,
+                    "server_ipv6_subnet": self.LATE_SLICE_PREFIX,
+                },
+            )
+            self.set_mux_state(appdb, self.LATE_CFG_PORT, ACTIVE)
+            time.sleep(3)
+            self.check_neigh_in_asic_db(asicdb, in_slice_ip, expected=False)
+            self.check_neigh_in_asic_db(asicdb, anchor_ip, expected=True)
+            self.wait_for_slice_route(
+                asicdb, self.LATE_SLICE_PREFIX, anchor_ip, present=True
+            )
+        finally:
+            self.del_neighbor(dvs, in_slice_ip)
+            self.del_neighbor(dvs, anchor_ip)
+            self.del_fdb(dvs, self.LATE_MAC_DASH)
+            config_db.delete_entry(self.CONFIG_MUX_CABLE, self.LATE_CFG_PORT)
+
+    def test_runtime_slice_change_rejected(
+        self, dvs, dvs_route, setup, setup_vlan, setup_peer_switch,
+        setup_tunnel, setup_mux_cable, testlog
+    ):
+        """Attempting to change server_ipv6_subnet on an existing MUX_CABLE
+        entry must be rejected; the original prefix stays in STATE_DB."""
+        config_db = dvs.get_config_db()
+        # Try to switch from /120 to /112 on the fly.
+        config_db.create_entry(
+            self.CONFIG_MUX_CABLE, self.SLICED_PORT_A,
+            {
+                "server_ipv4":        self.SERV2_IPV4 + self.IPV4_MASK,
+                "server_ipv6":        self.SERVER_IPV6_A + self.IPV6_MASK,
+                "server_ipv6_subnet": "fc02:1000::100/112",
+            },
+        )
+        time.sleep(1)
+        # STATE_DB must still reflect the original prefix.
+        self.check_state_db_slice_fields(
+            dvs, self.SLICED_PORT_A, expected_prefix=self.SLICE_PREFIX_A
+        )
+
+    def test_route_nh_in_slice_unsuppresses_neighbor(
+        self, dvs, intf_fdb_map, dvs_route, setup, setup_vlan,
+        setup_peer_switch, setup_tunnel, setup_mux_cable, testlog
+    ):
+        """When a route's nexthop points at an in-slice IP, that IP is
+        un-suppressed (programmed as a full SAI neighbor) for the lifetime
+        of the route."""
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+        mac_E4 = intf_fdb_map[self.SLICED_PORT_A]
+
+        # Anchor + suppressed in-slice neighbor.
+        self.add_neighbor(dvs, self.SERVER_IPV6_A, mac_E4)
+        self.add_neighbor(dvs, self.IN_SLICE_A_1, mac_E4)
+        self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+        time.sleep(2)
+
+        rtprefix = "2024:abcd::/64"
+        try:
+            self.check_neigh_in_asic_db(asicdb, self.IN_SLICE_A_1, expected=False)
+
+            # Install route whose NH is the in-slice IP.
+            self.add_route(dvs, rtprefix, [self.IN_SLICE_A_1])
+            time.sleep(3)
+
+            # In-slice IP must now be programmed.
+            self.check_neigh_in_asic_db(asicdb, self.IN_SLICE_A_1, expected=True)
+        finally:
+            self.del_route(dvs, rtprefix)
+            self.del_neighbor(dvs, self.IN_SLICE_A_1)
+            self.del_neighbor(dvs, self.SERVER_IPV6_A)
+
+    def test_route_delete_resuppresses_neighbor(
+        self, dvs, intf_fdb_map, dvs_route, setup, setup_vlan,
+        setup_peer_switch, setup_tunnel, setup_mux_cable, testlog
+    ):
+        """When the route is removed, the in-slice neighbor goes back to
+        being suppressed (refcount 1 -> 0)."""
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+        mac_E4 = intf_fdb_map[self.SLICED_PORT_A]
+
+        self.add_neighbor(dvs, self.SERVER_IPV6_A, mac_E4)
+        self.add_neighbor(dvs, self.IN_SLICE_A_1, mac_E4)
+        self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+        time.sleep(2)
+
+        rtprefix = "2024:abcd:1::/64"
+        try:
+            self.add_route(dvs, rtprefix, [self.IN_SLICE_A_1])
+            time.sleep(3)
+            self.check_neigh_in_asic_db(asicdb, self.IN_SLICE_A_1, expected=True)
+
+            self.del_route(dvs, rtprefix)
+            time.sleep(2)
+            self.check_neigh_in_asic_db(asicdb, self.IN_SLICE_A_1, expected=False)
+        finally:
+            self.del_neighbor(dvs, self.IN_SLICE_A_1)
+            self.del_neighbor(dvs, self.SERVER_IPV6_A)
+
+    def test_multi_nexthop_with_in_slice_member(
+        self, dvs, intf_fdb_map, dvs_route, setup, setup_vlan,
+        setup_peer_switch, setup_tunnel, setup_mux_cable, testlog
+    ):
+        """ECMP route with one in-slice NH and one out-of-slice NH on the same
+        sliced port: the in-slice NH gets un-suppressed for the route's
+        lifetime; removing the route re-suppresses it."""
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+        mac_E4 = intf_fdb_map[self.SLICED_PORT_A]
+
+        self.add_neighbor(dvs, self.SERVER_IPV6_A, mac_E4)
+        self.add_neighbor(dvs, self.IN_SLICE_A_1, mac_E4)
+        self.add_neighbor(dvs, self.OUT_OF_SLICE_IPV6, mac_E4)
+        self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+        time.sleep(2)
+
+        rtprefix = "2024:abcd:2::/64"
+        try:
+            self.add_route(dvs, rtprefix, [self.IN_SLICE_A_1, self.OUT_OF_SLICE_IPV6])
+            time.sleep(3)
+            self.check_neigh_in_asic_db(asicdb, self.IN_SLICE_A_1, expected=True)
+            self.check_neigh_in_asic_db(asicdb, self.OUT_OF_SLICE_IPV6, expected=True)
+
+            self.del_route(dvs, rtprefix)
+            time.sleep(2)
+            self.check_neigh_in_asic_db(asicdb, self.IN_SLICE_A_1, expected=False)
+            self.check_neigh_in_asic_db(asicdb, self.OUT_OF_SLICE_IPV6, expected=True)
+        finally:
+            self.del_neighbor(dvs, self.IN_SLICE_A_1)
+            self.del_neighbor(dvs, self.OUT_OF_SLICE_IPV6)
+            self.del_neighbor(dvs, self.SERVER_IPV6_A)
+
+    def test_route_nh_swap_releases_old_in_slice_nh(
+        self, dvs, intf_fdb_map, dvs_route, setup, setup_vlan,
+        setup_peer_switch, setup_tunnel, setup_mux_cable, testlog
+    ):
+        """Route SET (NHG change) on the SAME prefix from in-slice NH A to NH B
+        must release A's refcount. After the swap, only B should remain
+        un-suppressed; removing the route then re-suppresses B.
+
+        Regression test for: refcount leak when a route's nexthops are
+        updated in-place without an intermediate DEL.
+        """
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+        mac_E4 = intf_fdb_map[self.SLICED_PORT_A]
+
+        self.add_neighbor(dvs, self.SERVER_IPV6_A, mac_E4)
+        self.add_neighbor(dvs, self.IN_SLICE_A_1, mac_E4)
+        self.add_neighbor(dvs, self.IN_SLICE_A_2, mac_E4)
+        self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+        time.sleep(2)
+
+        rtprefix = "2024:abcd:3::/64"
+        try:
+            # SET with NH A1 -> A1 unsuppressed.
+            self.add_route(dvs, rtprefix, [self.IN_SLICE_A_1])
+            time.sleep(2)
+            self.check_neigh_in_asic_db(asicdb, self.IN_SLICE_A_1, expected=True)
+            self.check_neigh_in_asic_db(asicdb, self.IN_SLICE_A_2, expected=False)
+
+            # SET same prefix with NH A2 (no DEL in between) -> A1 must drop,
+            # A2 must come up.
+            self.add_route(dvs, rtprefix, [self.IN_SLICE_A_2])
+            time.sleep(3)
+            self.check_neigh_in_asic_db(asicdb, self.IN_SLICE_A_2, expected=True)
+            self.check_neigh_in_asic_db(asicdb, self.IN_SLICE_A_1, expected=False)
+
+            # DEL -> A2 also goes back to suppressed.
+            self.del_route(dvs, rtprefix)
+            time.sleep(2)
+            self.check_neigh_in_asic_db(asicdb, self.IN_SLICE_A_2, expected=False)
+        finally:
+            self.del_neighbor(dvs, self.IN_SLICE_A_1)
+            self.del_neighbor(dvs, self.IN_SLICE_A_2)
+            self.del_neighbor(dvs, self.SERVER_IPV6_A)
+
+    def test_route_ecmp_member_dropped_resuppresses(
+        self, dvs, intf_fdb_map, dvs_route, setup, setup_vlan,
+        setup_peer_switch, setup_tunnel, setup_mux_cable, testlog
+    ):
+        """Route SET shrinks ECMP {A1, A2} -> {A1}. A2 must be re-suppressed
+        even though the route still exists, since it's no longer a NH.
+        """
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+        mac_E4 = intf_fdb_map[self.SLICED_PORT_A]
+
+        self.add_neighbor(dvs, self.SERVER_IPV6_A, mac_E4)
+        self.add_neighbor(dvs, self.IN_SLICE_A_1, mac_E4)
+        self.add_neighbor(dvs, self.IN_SLICE_A_2, mac_E4)
+        self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+        time.sleep(2)
+
+        rtprefix = "2024:abcd:4::/64"
+        try:
+            self.add_route(dvs, rtprefix, [self.IN_SLICE_A_1, self.IN_SLICE_A_2])
+            time.sleep(3)
+            self.check_neigh_in_asic_db(asicdb, self.IN_SLICE_A_1, expected=True)
+            self.check_neigh_in_asic_db(asicdb, self.IN_SLICE_A_2, expected=True)
+
+            # Shrink to single NH; A2 must drop out.
+            self.add_route(dvs, rtprefix, [self.IN_SLICE_A_1])
+            time.sleep(3)
+            self.check_neigh_in_asic_db(asicdb, self.IN_SLICE_A_1, expected=True)
+            self.check_neigh_in_asic_db(asicdb, self.IN_SLICE_A_2, expected=False)
+
+            self.del_route(dvs, rtprefix)
+            time.sleep(2)
+            self.check_neigh_in_asic_db(asicdb, self.IN_SLICE_A_1, expected=False)
+        finally:
+            self.del_neighbor(dvs, self.IN_SLICE_A_1)
+            self.del_neighbor(dvs, self.IN_SLICE_A_2)
+            self.del_neighbor(dvs, self.SERVER_IPV6_A)
+
+    # FDB-after-neighbor race for in-slice IPv6: end state must be suppressed
+    # by the slice.
+    def test_fdb_after_in_slice_neighbor_on_standby_mux(
+        self, dvs, dvs_route, setup, setup_vlan, setup_mux_cable,
+        setup_tunnel, setup_peer_switch, testlog
+    ):
+        """In-slice neighbor learned before its FDB ends up suppressed.
+
+        Slice suppression is IP-only (doesn't wait for FDB), so the neighbor
+        is suppressed immediately. We verify the final state."""
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+        ip = self.IN_SLICE_A_2
+
+        try:
+            self.set_mux_state(appdb, self.SLICED_PORT_A, STANDBY)
+            self.add_neighbor(dvs, ip, self.MAC_A2)
+            self.add_fdb(dvs, self.SLICED_PORT_A, self.MAC_A2_DASH)
+            time.sleep(2)
+            self.check_neigh_in_asic_db(asicdb, ip, expected=False)
+            self.check_tunnel_route_in_app_db(
+                dvs, [ip + self.IPV6_MASK], expected=False
+            )
+
+            # Toggle to active — still suppressed (slice covers it).
+            self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+            self.check_neigh_in_asic_db(asicdb, ip, expected=False)
+        finally:
+            self.del_neighbor(dvs, ip)
+            self.del_fdb(dvs, self.MAC_A2_DASH)
+            self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+
+    def test_fdb_after_in_slice_neighbor_on_active_mux(
+        self, dvs, dvs_route, setup, setup_vlan, setup_mux_cable,
+        setup_tunnel, setup_peer_switch, testlog
+    ):
+        """Same FDB-after-neighbor race on an ACTIVE mux: slice still
+        suppresses the in-slice neighbor at steady state."""
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+        ip = self.IN_SLICE_A_1
+
+        try:
+            self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+            self.add_neighbor(dvs, ip, self.MAC_A1)
+            self.add_fdb(dvs, self.SLICED_PORT_A, self.MAC_A1_DASH)
+            time.sleep(2)
+            # Active + in-slice -> suppressed by slice (no tunnel route).
+            self.check_neigh_in_asic_db(asicdb, ip, expected=False)
+            self.check_tunnel_route_in_app_db(
+                dvs, [ip + self.IPV6_MASK], expected=False
+            )
+        finally:
+            self.del_neighbor(dvs, ip)
+            self.del_fdb(dvs, self.MAC_A1_DASH)
+
+
+# Dummy always-pass test at end as workaround for the issue where a Flaky
+# fail on the final test invokes module tear-down before retrying.
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_mux_subnet_slice.py
+++ b/tests/test_mux_subnet_slice.py
@@ -883,6 +883,114 @@ class TestMuxSubnetSlice(TestMuxSubnetSliceBase):
             self.del_fdb(dvs, self.MAC_A1_DASH)
 
 
+    def test_route_pinned_nh_survives_fdb_churn(
+        self, dvs, intf_fdb_map, dvs_route, setup, setup_vlan,
+        setup_peer_switch, setup_tunnel, setup_mux_cable, testlog
+    ):
+        """An in-slice NH un-suppressed by a route ref must stay Programmed
+        when a later FDB event re-runs convertNeighborToMux on the same NH.
+        Regression for convertNeighborToMux overwriting Programmed state."""
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+        mac_E4 = intf_fdb_map[self.SLICED_PORT_A]
+
+        self.add_neighbor(dvs, self.SERVER_IPV6_A, mac_E4)
+        self.add_neighbor(dvs, self.IN_SLICE_A_1, mac_E4)
+        self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+        time.sleep(2)
+
+        rtprefix = "2024:abcd:f::/64"
+        try:
+            self.check_neigh_in_asic_db(asicdb, self.IN_SLICE_A_1, expected=False)
+            self.add_route(dvs, rtprefix, [self.IN_SLICE_A_1])
+            time.sleep(3)
+            self.check_neigh_in_asic_db(asicdb, self.IN_SLICE_A_1, expected=True)
+
+            # Force FDB churn: clear and re-add the FDB entry that resolves
+            # the in-slice MAC. This re-runs the slice gate in
+            # convertNeighborToMux for an already-Programmed NH.
+            self.del_fdb(dvs, self.MAC_A1_DASH)
+            time.sleep(1)
+            self.add_fdb(dvs, self.SLICED_PORT_A, self.MAC_A1_DASH)
+            time.sleep(2)
+
+            # NH must remain Programmed in ASIC: route still has a valid NH.
+            self.check_neigh_in_asic_db(asicdb, self.IN_SLICE_A_1, expected=True)
+        finally:
+            self.del_route(dvs, rtprefix)
+            self.del_neighbor(dvs, self.IN_SLICE_A_1)
+            self.del_neighbor(dvs, self.SERVER_IPV6_A)
+            self.del_fdb(dvs, self.MAC_A1_DASH)
+
+    def test_cross_port_in_slice_fdb_falls_through_to_mux(
+        self, dvs, dvs_route, setup, setup_vlan, setup_peer_switch,
+        setup_tunnel, setup_mux_cable, testlog
+    ):
+        """An in-slice IP whose FDB resolves to a non-owner mux port must
+        get that port's mux state machine, including standby tunnel
+        behavior. Regression for the slice gate returning early."""
+        appdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        asicdb = dvs.get_asic_db()
+        cross_ip = self.IN_SLICE_A_2  # inside SLICED_PORT_A's slice
+
+        try:
+            self.set_mux_state(appdb, self.SLICED_PORT_A, ACTIVE)
+            self.set_mux_state(appdb, self.NON_SLICED_PORT, STANDBY)
+
+            # MAC resolves to NON_SLICED_PORT (which is STANDBY).
+            self.add_fdb(dvs, self.NON_SLICED_PORT, self.MAC_A2_DASH)
+            self.add_neighbor(dvs, cross_ip, self.MAC_A2)
+            time.sleep(2)
+
+            # Standby owner -> tunnel host-route, no direct neighbor in ASIC.
+            self.check_neigh_in_asic_db(asicdb, cross_ip, expected=False)
+            self.check_tunnel_route_in_app_db(
+                dvs, [cross_ip + self.IPV6_MASK], expected=True
+            )
+
+            # Flip the owning port to ACTIVE -> direct neighbor, no tunnel.
+            self.set_mux_state(appdb, self.NON_SLICED_PORT, ACTIVE)
+            time.sleep(2)
+            self.check_neigh_in_asic_db(asicdb, cross_ip, expected=True)
+            self.check_tunnel_route_in_app_db(
+                dvs, [cross_ip + self.IPV6_MASK], expected=False
+            )
+        finally:
+            self.del_neighbor(dvs, cross_ip)
+            self.del_fdb(dvs, self.MAC_A2_DASH)
+            self.set_mux_state(appdb, self.NON_SLICED_PORT, ACTIVE)
+
+    def test_overlapping_slice_prefix_rejected(
+        self, dvs, dvs_route, setup, setup_vlan, setup_peer_switch,
+        setup_tunnel, setup_mux_cable, testlog
+    ):
+        """A new mux cable whose server_ipv6_subnet overlaps an existing
+        cable's slice must be rejected: no STATE_DB entry created."""
+        config_db = dvs.get_config_db()
+        # SLICED_PORT_A holds fc02:1000::100/120. Try a /112 supernet on a
+        # different port — it strictly contains the existing slice.
+        config_db.create_entry(
+            self.CONFIG_MUX_CABLE, self.LATE_CFG_PORT,
+            {
+                "server_ipv4":        "192.168.0.252/32",
+                "server_ipv6":        "fc02:1000::401/128",
+                "server_ipv6_subnet": "fc02:1000::/112",
+            },
+        )
+        time.sleep(1)
+        try:
+            entry = self.get_state_db_mux_entry(dvs, self.LATE_CFG_PORT)
+            assert "server_ipv6_subnet" not in entry, (
+                f"Overlapping slice was not rejected; got {entry}"
+            )
+            # Existing slice must remain intact.
+            self.check_state_db_slice_fields(
+                dvs, self.SLICED_PORT_A, expected_prefix=self.SLICE_PREFIX_A
+            )
+        finally:
+            config_db.delete_entry(self.CONFIG_MUX_CABLE, self.LATE_CFG_PORT)
+
+
 # Dummy always-pass test at end as workaround for the issue where a Flaky
 # fail on the final test invokes module tear-down before retrying.
 def test_nonflaky_dummy():


### PR DESCRIPTION
**What I did**

Add MUX subnet slicing to orchagent. A configured per-cable `server_ipv6_subnet` lets a single supernet route stand in for the in-slice host neighbors that would otherwise consume one SAI neighbor + NHG slot apiece. The cable's `server_ipv6` neighbor anchors the supernet route, and in-slice host learns are suppressed at the NeighOrch learn path. Routes whose nexthop falls inside a slice transiently un-suppress the specific NH (refcount-based) so route programming keeps working.

The change is split across two commits:

1. `muxorch: add subnet slicing framework` — per-NH state machine (`MuxNhState`), slicing config parsing, anchor supernet route, per-NH route-ref tracking, typed query API, slice gate (`isInSliceSuppressed`) and slice lookup (`findMuxCableBySlice`). Mock UTs exercise the framework in isolation.
2. `routeorch: wire subnet slicing into route programming` — RouteOrch calls `onRouteAdd` before bulker flush (so `route_create` finds a valid NH OID) and `onRouteRemove` + `drainPendingReSuppress` after flush (so SAI `neighbor_remove` avoids `OBJECT_IN_USE`). VS tests cover the end-to-end behavior.

**Why I did it**

Dualtor ToRs running with large in-slice neighbor counts were hitting neighbor / NHG table pressure. Collapsing the in-slice population to a single supernet route bounded by the anchor reclaims headroom without changing dataplane reachability for in-slice hosts.

**How I verified it**

- Mock UTs: 32/32 pass.
- VS tests (`tests/test_mux_subnet_slice.py`): 21/21 pass against a freshly built orchagent. Coverage includes anchor-always-programmed, slice route install/withdraw, in-slice suppression, out-of-slice / IPv4 / link-local passthrough, multi-port slicing, cross-port FDB resolution, port move, slice route follow-state, late-config reconcile, runtime slice-change rejection, route NH refcount un-/re-suppress, multi-NH and ECMP shrink, NH swap, and FDB-after-neighbor (standby and active).
- No legacy mux tests regressed.

**Details if related**

Backport candidates:

- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
