### PR TITLE
[vnetorch] Refactor nextHop::ips to std::vector<IpAddress> to support link-local ECMP

### DIFF
--- a/orchagent/chassisorch.cpp
+++ b/orchagent/chassisorch.cpp
@@ -33,7 +33,13 @@ void ChassisOrch::addRouteToPassThroughRouteTable(const VNetNextHopUpdate& updat
     std::vector<FieldValueTuple> fvVector;
     fvVector.emplace_back("redistribute", "true");
     fvVector.emplace_back("next_vrf_name", update.vnet);
-    fvVector.emplace_back("next_hop_ip", update.nexthop.ips.to_string());
+    std::string ips_csv;
+    for (const auto& ip : update.nexthop.ips)
+    {
+        if (!ips_csv.empty()) ips_csv += ",";
+        ips_csv += ip.to_string();
+    }
+    fvVector.emplace_back("next_hop_ip", ips_csv);
     fvVector.emplace_back("ifname", update.nexthop.ifname);
     fvVector.emplace_back("source", "CHASSIS_ORCH");
     const std::string everflow_route = IpPrefix(update.destination.to_string()).to_string();

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1796,9 +1796,6 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
     }
     else
     {
-        // Populate next hop group string. nh.ips is now a std::vector that
-        // preserves duplicate IPs: unnumbered ECMP (which uses a
-        // shared link-local nexthop IP placeholder across paths) but over different ifnames.
         auto ifnames = tokenize(nh.ifname, ',');
         size_t idx = 0;
         for (const auto& ip : nh.ips)

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1802,7 +1802,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         {
             if (idx >= ifnames.size())
             {
-                SWSS_LOG_WARN("nexthop ip/ifname count mismatch for VNET route");
+                SWSS_LOG_ERROR("Nexthop ip/ifname count mismatch for VNET %s route %s", vnet.c_str(), ipPrefix.to_string().c_str());
                 break;
             }
             if (!nhg_str.empty())

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -206,13 +206,13 @@ string VNetVrfObject::getProfile(IpPrefix& ipPrefix)
 void VNetVrfObject::increaseNextHopRefCount(const nextHop& nh)
 {
     /* Return when there is no next hop (dropped) */
-    if (nh.ips.getSize() == 0)
+    if (nh.ips.empty())
     {
         return;
     }
-    else if (nh.ips.getSize() == 1)
+    else if (nh.ips.size() == 1)
     {
-        NextHopKey nexthop(nh.ips.to_string(), nh.ifname);
+        NextHopKey nexthop(nh.ips.front().to_string(), nh.ifname);
         if (nexthop.ip_address.isZero())
         {
             gIntfsOrch->increaseRouterIntfsRefCount(nexthop.alias);
@@ -230,13 +230,13 @@ void VNetVrfObject::increaseNextHopRefCount(const nextHop& nh)
 void VNetVrfObject::decreaseNextHopRefCount(const nextHop& nh)
 {
     /* Return when there is no next hop (dropped) */
-    if (nh.ips.getSize() == 0)
+    if (nh.ips.empty())
     {
         return;
     }
-    else if (nh.ips.getSize() == 1)
+    else if (nh.ips.size() == 1)
     {
-        NextHopKey nexthop(nh.ips.to_string(), nh.ifname);
+        NextHopKey nexthop(nh.ips.front().to_string(), nh.ifname);
         if (nexthop.ip_address.isZero())
         {
             gIntfsOrch->decreaseRouterIntfsRefCount(nexthop.alias);
@@ -1735,7 +1735,10 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         return true;
     }
 
-    bool is_subnet = (!nh.ips.getSize() || nh.ips.contains("0.0.0.0")) ? true : false;
+    bool is_subnet = (nh.ips.empty() ||
+                      std::any_of(nh.ips.begin(), nh.ips.end(),
+                                  [](const IpAddress& a) { return a.isZero(); }))
+                     ? true : false;
 
     Port port;
     if (is_subnet && (!gPortsOrch->getPort(nh.ifname, port) || (port.m_rif_id == SAI_NULL_OBJECT_ID)))
@@ -1793,17 +1796,23 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
     }
     else
     {
-        // Populate next hop group string
+        // Populate next hop group string. nh.ips is now a std::vector that
+        // preserves duplicate IPs: unnumbered ECMP (which uses a
+        // shared link-local nexthop IP placeholder across paths) but over different ifnames.
         auto ifnames = tokenize(nh.ifname, ',');
-        int idx = 0;
-        for (auto it : nh.ips.getIpAddresses())
+        size_t idx = 0;
+        for (const auto& ip : nh.ips)
         {
+            if (idx >= ifnames.size())
+            {
+                SWSS_LOG_WARN("nexthop ip/ifname count mismatch for VNET route");
+                break;
+            }
             if (!nhg_str.empty())
             {
                 nhg_str += ",";
             }
-
-            nhg_str += it.to_string() + "@" + ifnames[idx];
+            nhg_str += ip.to_string() + "@" + ifnames[idx];
             idx++;
         }
     }
@@ -1854,7 +1863,7 @@ bool VNetRouteOrch::handleRoutes(const Request& request)
 {
     SWSS_LOG_ENTER();
 
-    IpAddresses ip_addresses;
+    std::vector<IpAddress> ip_addresses;
     string ifname = "";
 
     for (const auto& name: request.getAttrFieldNames())
@@ -1866,7 +1875,10 @@ bool VNetRouteOrch::handleRoutes(const Request& request)
         else if (name == "nexthop")
         {
             auto ipstr = request.getAttrString(name);
-            ip_addresses = IpAddresses(ipstr);
+            for (const auto& tok : tokenize(ipstr, ','))
+            {
+                ip_addresses.emplace_back(tok);
+            }
         }
         else
         {

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1872,9 +1872,17 @@ bool VNetRouteOrch::handleRoutes(const Request& request)
         else if (name == "nexthop")
         {
             auto ipstr = request.getAttrString(name);
-            for (const auto& tok : tokenize(ipstr, ','))
+
+            if (!ipstr.empty())
             {
-                ip_addresses.emplace_back(tok);
+                for (const auto& tok : tokenize(ipstr, ','))
+                {
+                    if (tok.empty())
+                    {
+                        continue;
+                    }
+                    ip_addresses.emplace_back(tok);
+                }
             }
         }
         else

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -168,7 +168,7 @@ private:
 
 struct nextHop
 {
-    IpAddresses ips;
+    std::vector<IpAddress> ips;
     string ifname;
 };
 

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -62,6 +62,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 flowcounterrouteorch_ut.cpp \
                 orchdaemon_ut.cpp \
                 intfsorch_ut.cpp \
+                chassisorch_ut.cpp \
                 evpnmhorch_ut.cpp \
                 vxlanorch_ut.cpp \
                 mux_rollback_ut.cpp \

--- a/tests/mock_tests/chassisorch_ut.cpp
+++ b/tests/mock_tests/chassisorch_ut.cpp
@@ -1,0 +1,204 @@
+// chassisorch_ut.cpp
+//
+// Unit tests for ChassisOrch
+//
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <sstream>
+
+#include "ut_helper.h"
+#include "mock_orchagent_main.h"
+#include "mock_table.h"
+#include "gtest/gtest.h"
+
+extern "C" {
+    #include "sai.h"
+}
+
+#define private public
+#define protected public
+#include "chassisorch.h"
+#undef protected
+#undef private
+
+namespace chassisorch_test
+{
+    using namespace std;
+    using namespace swss;
+
+    class ChassisOrchTest : public ::testing::Test
+    {
+    protected:
+        shared_ptr<DBConnector> m_app_db;
+        shared_ptr<DBConnector> m_config_db;
+        unique_ptr<ChassisOrch> m_chassisOrch;
+
+        void SetUp() override
+        {
+            testing_db::reset();
+            m_app_db    = make_shared<DBConnector>("APPL_DB", 0);
+            m_config_db = make_shared<DBConnector>("CONFIG_DB", 0);
+
+            // Init chassisorch
+            vector<string> tables = { "CHASSIS_UT_TABLE" };
+            m_chassisOrch.reset(new ChassisOrch(m_config_db.get(),
+                                                m_app_db.get(),
+                                                tables,
+                                                nullptr /* VNetRouteOrch */));
+        }
+
+        void TearDown() override
+        {
+            m_chassisOrch.reset();
+            testing_db::reset();
+        }
+
+        // Read a single entry out of the APP_PASS_THROUGH_ROUTE_TABLE_NAME
+        // that ChassisOrch writes to.
+        bool getPassThroughRoute(const string& key, vector<FieldValueTuple>& fvs)
+        {
+            Table t(m_app_db.get(), APP_PASS_THROUGH_ROUTE_TABLE_NAME);
+            fvs.clear();
+            return t.get(key, fvs);
+        }
+
+        static string getField(const vector<FieldValueTuple>& fvs, const string& field)
+        {
+            for (const auto& fv : fvs)
+            {
+                if (fvField(fv) == field) return fvValue(fv);
+            }
+            return "";
+        }
+
+        static VNetNextHopUpdate makeUpdate(const string& op,
+                                            const string& vnet,
+                                            const string& dst,
+                                            const vector<string>& nhIps,
+                                            const string& ifname)
+        {
+            VNetNextHopUpdate u;
+            u.op          = op;
+            u.vnet        = vnet;
+            u.destination = IpAddress(dst);
+            u.prefix      = IpPrefix(u.destination.to_string() +
+                                     (u.destination.isV4() ? "/32" : "/128"));
+            for (const auto& s : nhIps)
+            {
+                u.nexthop.ips.emplace_back(IpAddress(s));
+            }
+            u.nexthop.ifname = ifname;
+            return u;
+        }
+    };
+
+    // Single IPv4 nexthop
+    TEST_F(ChassisOrchTest, AddRoute_SingleIpv4)
+    {
+        auto u = makeUpdate(SET_COMMAND, "Vnet1", "10.0.0.1",
+                            { "192.168.1.1" }, "Ethernet0");
+        m_chassisOrch->addRouteToPassThroughRouteTable(u);
+
+        vector<FieldValueTuple> fvs;
+        ASSERT_TRUE(getPassThroughRoute("10.0.0.1/32", fvs));
+        EXPECT_EQ(getField(fvs, "next_hop_ip"), "192.168.1.1");
+        EXPECT_EQ(getField(fvs, "next_vrf_name"), "Vnet1");
+        EXPECT_EQ(getField(fvs, "ifname"), "Ethernet0");
+        EXPECT_EQ(getField(fvs, "source"), "CHASSIS_ORCH");
+        EXPECT_EQ(getField(fvs, "redistribute"), "true");
+    }
+
+    // ECMP IPv4: three nexthops must serialize as "a,b,c" with no
+    // trailing comma. This is the primary behavior added by the PR.
+    TEST_F(ChassisOrchTest, AddRoute_EcmpIpv4)
+    {
+        auto u = makeUpdate(SET_COMMAND, "Vnet1", "10.0.0.2",
+                            { "192.168.1.1", "192.168.1.2", "192.168.1.3" },
+                            "Ethernet4");
+        m_chassisOrch->addRouteToPassThroughRouteTable(u);
+
+        vector<FieldValueTuple> fvs;
+        ASSERT_TRUE(getPassThroughRoute("10.0.0.2/32", fvs));
+        EXPECT_EQ(getField(fvs, "next_hop_ip"),
+                  "192.168.1.1,192.168.1.2,192.168.1.3");
+        EXPECT_EQ(getField(fvs, "ifname"), "Ethernet4");
+    }
+
+    // ECMP IPv6
+    TEST_F(ChassisOrchTest, AddRoute_EcmpIpv6LinkLocal)
+    {
+        auto u = makeUpdate(SET_COMMAND, "Vnet2", "2001:db8::1",
+                            { "fe80::1", "fe80::2" },
+                            "Ethernet8,Ethernet12");
+        m_chassisOrch->addRouteToPassThroughRouteTable(u);
+
+        vector<FieldValueTuple> fvs;
+        ASSERT_TRUE(getPassThroughRoute("2001:db8::1/128", fvs));
+        EXPECT_EQ(getField(fvs, "next_hop_ip"), "fe80::1,fe80::2");
+        EXPECT_EQ(getField(fvs, "ifname"), "Ethernet8,Ethernet12");
+    }
+
+    // Negative case - empty nexthop vector must not crash and
+    // must yield an empty "next_hop_ip" field (never a stray comma).
+    TEST_F(ChassisOrchTest, AddRoute_EmptyNexthops)
+    {
+        auto u = makeUpdate(SET_COMMAND, "Vnet3", "10.0.0.3",
+                            {}, "");
+        m_chassisOrch->addRouteToPassThroughRouteTable(u);
+
+        vector<FieldValueTuple> fvs;
+        ASSERT_TRUE(getPassThroughRoute("10.0.0.3/32", fvs));
+        EXPECT_EQ(getField(fvs, "next_hop_ip"), "");
+        EXPECT_EQ(getField(fvs, "ifname"), "");
+    }
+
+    // Delete path: after a set + explicit delete the row must be gone.
+    TEST_F(ChassisOrchTest, DeleteRoute)
+    {
+        auto u = makeUpdate(SET_COMMAND, "Vnet1", "10.0.0.4",
+                            { "192.168.1.1" }, "Ethernet0");
+        m_chassisOrch->addRouteToPassThroughRouteTable(u);
+
+        vector<FieldValueTuple> fvs;
+        ASSERT_TRUE(getPassThroughRoute("10.0.0.4/32", fvs));
+
+        m_chassisOrch->deleteRoutePassThroughRouteTable(u);
+        EXPECT_FALSE(getPassThroughRoute("10.0.0.4/32", fvs));
+    }
+
+    // Observer::update() with SET_COMMAND should reach addRoute and
+    // produce comma separated form for a multi-nexthop update.
+    TEST_F(ChassisOrchTest, Update_SetDispatch)
+    {
+        auto u = makeUpdate(SET_COMMAND, "Vnet1", "10.0.0.5",
+                            { "192.168.1.10", "192.168.1.11" },
+                            "Ethernet0");
+        m_chassisOrch->update(SUBJECT_TYPE_NEXTHOP_CHANGE,
+                              static_cast<void*>(&u));
+
+        vector<FieldValueTuple> fvs;
+        ASSERT_TRUE(getPassThroughRoute("10.0.0.5/32", fvs));
+        EXPECT_EQ(getField(fvs, "next_hop_ip"),
+                  "192.168.1.10,192.168.1.11");
+    }
+
+    // Observer::update() with anything other than SET_COMMAND must
+    // result in delete path.
+    TEST_F(ChassisOrchTest, Update_DelDispatch)
+    {
+        auto uAdd = makeUpdate(SET_COMMAND, "Vnet1", "10.0.0.6",
+                               { "192.168.1.20" }, "Ethernet0");
+        m_chassisOrch->addRouteToPassThroughRouteTable(uAdd);
+        vector<FieldValueTuple> fvs;
+        ASSERT_TRUE(getPassThroughRoute("10.0.0.6/32", fvs));
+
+        auto uDel = uAdd;
+        uDel.op = DEL_COMMAND;
+        m_chassisOrch->update(SUBJECT_TYPE_NEXTHOP_CHANGE,
+                              static_cast<void*>(&uDel));
+
+        EXPECT_FALSE(getPassThroughRoute("10.0.0.6/32", fvs));
+    }
+}

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -3576,19 +3576,7 @@ class TestVnetOrch(object):
         self.set_admin_status("Ethernet4", "down")
 
     '''
-    ECMP VNET local route with duplicate nexthop IP but different ifname, used for Link Local nexthops learned via FRR/BGP
-    '''
-    '''
-    One VNET + one prefix through 5 phases:
-      A) Create route with 2 ifnames sharing the same nexthop IP -> 2-member NHG,
-         distinct RIFs per member (the duplicate-IP fix).
-      B) Re-issue route with 1 ifname  -> NHG removed, route collapses to a single NH.
-      C) Re-issue route with 2 ifnames -> new 2-member NHG, both RIFs.
-      D) Flap the veth carrier of one ifname DOWN. PortsOrch oper-status change
-         drives NeighOrch.ifChangeInformNextHop -> RouteOrch.invalidnexthopinNextHopGroup,
-         which must implicitly remove the down member from the NHG (no test-driven
-         re-issue of the route). NHG stays, drops to 1 member.
-      E) Flap the veth back UP, re-add the neighbor -> NHG returns to 2 members.
+    Test 37: ECMP VNET local route with duplicate nexthop IP but different ifname, used for Link Local nexthops learned via FRR/BGP
     '''
     def test_vnet_local_route_ecmp_unnumbered(self, dvs, testlog):
         self.setup_db(dvs)
@@ -3635,7 +3623,8 @@ class TestVnetOrch(object):
         rif_tbl   = swsscommon.Table(asic_db_conn, "ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE")
         nhgm_tbl  = swsscommon.Table(asic_db_conn, "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER")
         counters_db = swsscommon.DBConnector(swsscommon.COUNTERS_DB, dvs.redis_sock, 0)
-        port_name_map = counters_db.hgetall("COUNTERS_PORT_NAME_MAP") or {}
+        port_name_map = dvs.counters_db.get_entry("COUNTERS_PORT_NAME_MAP", "")
+        port_name_map = dict(port_name_map)
 
         def _rif_for_port(port_name):
             port_oid = port_name_map.get(port_name)

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -3622,7 +3622,6 @@ class TestVnetOrch(object):
         nh_tbl    = swsscommon.Table(asic_db_conn, "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP")
         rif_tbl   = swsscommon.Table(asic_db_conn, "ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE")
         nhgm_tbl  = swsscommon.Table(asic_db_conn, "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER")
-        counters_db = swsscommon.DBConnector(swsscommon.COUNTERS_DB, dvs.redis_sock, 0)
         port_name_map = dvs.get_counters_db().get_entry("COUNTERS_PORT_NAME_MAP", "")
         port_name_map = dict(port_name_map)
 

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -3936,57 +3936,5 @@ class TestVnetOrch(object):
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
-
-    """
-    Parity proof: VNET local route with explicit nexthop="0.0.0.0" must be
-    classified as a subnet route (is_subnet=True), bound to the interface RIF,
-    just like the empty-nexthop case. Pins down the behavior of the
-    is_subnet check after the refactor from
-        nh.ips.contains("0.0.0.0")
-    to
-        std::any_of(nh.ips, [](auto& a){ return a.isZero(); })
-    For IPv4 the two predicates are functionally equivalent; this test locks
-    that equivalence in.
-    """
-    def test_vnet_local_route_subnet_zero_ipv4(self, dvs, testlog):
-        self.setup_db(dvs)
-
-        vnet_obj = self.get_vnet_obj()
-        tunnel_name = "tunnel_subnet_zero_v4"
-        vnet_name = "Vnet5097"
-        if_a = "Ethernet60"
-        prefix = "10.97.0.0/24"
-
-        vnet_obj.fetch_exist_entries(dvs)
-        create_vxlan_tunnel(dvs, tunnel_name, "10.10.10.97")
-        create_vnet_entry(dvs, vnet_name, tunnel_name, "5097", "")
-        vnet_obj.check_vnet_entry(dvs, vnet_name)
-        vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, vnet_name, "5097")
-        vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, "10.10.10.97")
-
-        create_phy_interface(dvs, if_a, vnet_name, "10.97.0.1/24")
-        vnet_obj.check_router_interface(dvs, if_a, vnet_name)
-
-        vnet_obj.fetch_exist_entries(dvs)
-        # The actual parity check: explicit "0.0.0.0" nexthop on an IPv4
-        # subnet must take the is_subnet branch and create an ASIC route bound
-        # to the interface RIF (same outcome as nexthop="").
-        create_vnet_local_routes(dvs, prefix, vnet_name, if_a, nexthop="0.0.0.0")
-        vnet_obj.check_vnet_local_routes(dvs, vnet_name)
-
-        # Clean-up
-        delete_vnet_local_routes(dvs, prefix, vnet_name)
-        vnet_obj.check_del_vnet_local_routes(dvs, vnet_name, prefix)
-
-        delete_phy_interface(dvs, if_a, "10.97.0.1/24")
-        vnet_obj.check_del_router_interface(dvs, if_a)
-
-        delete_vnet_entry(dvs, vnet_name)
-        vnet_obj.check_del_vnet_entry(dvs, vnet_name)
-
-        delete_vxlan_tunnel(dvs, tunnel_name)
-        vnet_obj.check_del_vxlan_tunnel(dvs)
-
-
 def test_nonflaky_dummy():
     pass

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -3623,7 +3623,7 @@ class TestVnetOrch(object):
         rif_tbl   = swsscommon.Table(asic_db_conn, "ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE")
         nhgm_tbl  = swsscommon.Table(asic_db_conn, "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER")
         counters_db = swsscommon.DBConnector(swsscommon.COUNTERS_DB, dvs.redis_sock, 0)
-        port_name_map = dvs.counters_db.get_entry("COUNTERS_PORT_NAME_MAP", "")
+        port_name_map = dvs.get_counters_db().get_entry("COUNTERS_PORT_NAME_MAP", "")
         port_name_map = dict(port_name_map)
 
         def _rif_for_port(port_name):

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -3575,6 +3575,201 @@ class TestVnetOrch(object):
         self.remove_ip_address("Ethernet4", "9.1.0.1/32")
         self.set_admin_status("Ethernet4", "down")
 
+    '''
+    ECMP VNET local route with duplicate nexthop IP but different ifname, used for Link Local nexthops learned via FRR/BGP
+    '''
+    '''
+    One VNET + one prefix through 5 phases:
+      A) Create route with 2 ifnames sharing the same nexthop IP -> 2-member NHG,
+         distinct RIFs per member (the duplicate-IP fix).
+      B) Re-issue route with 1 ifname  -> NHG removed, route collapses to a single NH.
+      C) Re-issue route with 2 ifnames -> new 2-member NHG, both RIFs.
+      D) Flap the veth carrier of one ifname DOWN. PortsOrch oper-status change
+         drives NeighOrch.ifChangeInformNextHop -> RouteOrch.invalidnexthopinNextHopGroup,
+         which must implicitly remove the down member from the NHG (no test-driven
+         re-issue of the route). NHG stays, drops to 1 member.
+      E) Flap the veth back UP, re-add the neighbor -> NHG returns to 2 members.
+    '''
+    def test_vnet_local_route_ecmp_unnumbered(self, dvs, testlog):
+        self.setup_db(dvs)
+
+        vnet_obj = self.get_vnet_obj()
+
+        tunnel_name = 'tunnel_ecmp_unified'
+        vnet_name = "Vnet5099"
+        prefix = "10.99.0.0/24"
+        # Ethernet20 -> dvs.servers[5], Ethernet16 -> dvs.servers[4]
+        if_a, srv_a = "Ethernet20", 5
+        if_b, srv_b = "Ethernet16", 4
+        nh_ip = "169.254.0.1"
+        mac_a = "00:01:02:03:04:05"
+        mac_b = "00:01:02:03:04:06"
+
+        vnet_obj.fetch_exist_entries(dvs)
+
+        create_vxlan_tunnel(dvs, tunnel_name, '99.99.99.99')
+        create_vnet_entry(dvs, vnet_name, tunnel_name, '5099', "")
+        vnet_obj.check_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, vnet_name, '5099')
+        vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, '99.99.99.99')
+
+        create_phy_interface(dvs, if_a, vnet_name, "10.77.0.4/30")
+        vnet_obj.check_router_interface(dvs, if_a, vnet_name)
+        create_phy_interface(dvs, if_b, vnet_name, "10.77.0.8/30")
+        vnet_obj.check_router_interface(dvs, if_b, vnet_name)
+
+        self.set_admin_status(if_a, "up")
+        self.set_admin_status(if_b, "up")
+
+        self.add_neighbor(if_a, nh_ip, mac_a)
+        self.add_neighbor(if_b, nh_ip, mac_b)
+
+        vnet_obj.fetch_exist_entries(dvs)
+        base_nhg  = len(vnet_obj.nhgs)
+        base_nhgm = len(vnet_obj.nhgms)
+
+        asic_db_conn = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
+        route_tbl = swsscommon.Table(asic_db_conn, "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY")
+        nhg_tbl   = swsscommon.Table(asic_db_conn, "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP_GROUP")
+        nh_tbl    = swsscommon.Table(asic_db_conn, "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP")
+        rif_tbl   = swsscommon.Table(asic_db_conn, "ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE")
+        nhgm_tbl  = swsscommon.Table(asic_db_conn, "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER")
+        counters_db = swsscommon.DBConnector(swsscommon.COUNTERS_DB, dvs.redis_sock, 0)
+        port_name_map = counters_db.hgetall("COUNTERS_PORT_NAME_MAP") or {}
+
+        def _rif_for_port(port_name):
+            port_oid = port_name_map.get(port_name)
+            assert port_oid, "no OID for %s" % port_name
+            for rif_key in rif_tbl.getKeys():
+                status, fvs = rif_tbl.get(rif_key)
+                if status and dict(fvs).get("SAI_ROUTER_INTERFACE_ATTR_PORT_ID") == port_oid:
+                    return rif_key
+            assert False, "no RIF for port %s" % port_name
+
+        def _nhgm_rifs(nhg_oid):
+            rifs = set()
+            for k in nhgm_tbl.getKeys():
+                s, f = nhgm_tbl.get(k)
+                f = dict(f)
+                if f.get("SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID") == nhg_oid:
+                    s2, nf = nh_tbl.get(f["SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID"])
+                    rifs.add(dict(nf).get("SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID"))
+            return rifs
+
+        def _nh_rif(nh_oid):
+            s, f = nh_tbl.get(nh_oid)
+            return dict(f).get("SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID")
+
+        def _wait_route_nh(expect_type, timeout=15):
+            for _ in range(timeout * 2):
+                route_keys = [k for k in route_tbl.getKeys() if prefix in k]
+                if route_keys:
+                    status, fvs = route_tbl.get(route_keys[0])
+                    if status:
+                        oid = dict(fvs).get("SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID")
+                        if oid:
+                            is_nhg = nhg_tbl.get(oid)[0]
+                            is_nh  = nh_tbl.get(oid)[0]
+                            if expect_type == "nhg" and is_nhg:
+                                return oid
+                            if expect_type == "nh" and is_nh and not is_nhg:
+                                return oid
+                time.sleep(0.5)
+            assert False, "route %s NEXT_HOP_ID never resolved to a %s" % (prefix, expect_type)
+
+        def _wait_nhgm_count(want_total, timeout=10):
+            for _ in range(timeout * 2):
+                vnet_obj.fetch_exist_entries(dvs)
+                if len(vnet_obj.nhgms) == want_total:
+                    return
+                time.sleep(0.5)
+            assert False, "NHG member count never reached %d (last: %d)" % (want_total, len(vnet_obj.nhgms))
+
+        rif_a = _rif_for_port(if_a)
+        rif_b = _rif_for_port(if_b)
+
+        # ---- Phase A: 2 ifnames, duplicate IP -> 2-member NHG ----
+        create_vnet_local_routes(dvs, prefix, vnet_name,
+                                 '%s,%s' % (if_a, if_b),
+                                 '%s,%s' % (nh_ip, nh_ip))
+        vnet_obj.check_vnet_local_routes(dvs, vnet_name)
+        nhg_oid_a = _wait_route_nh("nhg")
+        vnet_obj.fetch_exist_entries(dvs)
+        assert len(vnet_obj.nhgs)  == base_nhg  + 1, "Phase A: NHG not created"
+        assert len(vnet_obj.nhgms) == base_nhgm + 2, "Phase A: 2 NHG members expected"
+        assert _nhgm_rifs(nhg_oid_a) == {rif_a, rif_b}, \
+            "Phase A: NHG must contain distinct RIFs for %s and %s (duplicate-IP fix)" % (if_a, if_b)
+
+        # ---- Phase B: shrink to 1 ifname -> NHG removed, single NH on rif_a ----
+        create_vnet_local_routes(dvs, prefix, vnet_name, if_a, nh_ip)
+        nh_oid_b = _wait_route_nh("nh")
+        vnet_obj.fetch_exist_entries(dvs)
+        assert len(vnet_obj.nhgs)  == base_nhg, \
+            "Phase B: NHG should be removed; delta %d" % (len(vnet_obj.nhgs) - base_nhg)
+        assert len(vnet_obj.nhgms) == base_nhgm, \
+            "Phase B: NHG members should be removed; delta %d" % (len(vnet_obj.nhgms) - base_nhgm)
+        assert _nh_rif(nh_oid_b) == rif_a, \
+            "Phase B: surviving NH must point at %s's RIF (rif_a=%s, got %s)" % (if_a, rif_a, _nh_rif(nh_oid_b))
+
+        # ---- Phase C: grow back to 2 ifnames -> new 2-member NHG ----
+        create_vnet_local_routes(dvs, prefix, vnet_name,
+                                 '%s,%s' % (if_a, if_b),
+                                 '%s,%s' % (nh_ip, nh_ip))
+        nhg_oid_c = _wait_route_nh("nhg")
+        vnet_obj.fetch_exist_entries(dvs)
+        assert len(vnet_obj.nhgs)  == base_nhg  + 1, "Phase C: NHG not re-created"
+        assert len(vnet_obj.nhgms) == base_nhgm + 2, "Phase C: 2 NHG members expected"
+        assert _nhgm_rifs(nhg_oid_c) == {rif_a, rif_b}, \
+            "Phase C: reformed NHG must contain both RIFs"
+
+        # ---- Phase D: implicit link-down. Flap veth carrier of if_b; PortsOrch
+        # oper-status change -> NeighOrch.ifChangeInformNextHop ->
+        # RouteOrch.invalidnexthopinNextHopGroup must prune the if_b member
+        # NHG stays, drops to 1 member.
+        dvs.servers[srv_b].runcmd("ip link set down dev eth0")
+        self.set_admin_status(if_b, "down")
+        _wait_nhgm_count(base_nhgm + 1)
+        nhg_oid_d = _wait_route_nh("nhg")
+        vnet_obj.fetch_exist_entries(dvs)
+        assert len(vnet_obj.nhgs)  == base_nhg + 1, \
+            "Phase D: NHG must still exist with 1 member"
+        assert _nhgm_rifs(nhg_oid_d) == {rif_a}, \
+            "Phase D: surviving NHG member must be rif_a (got %s)" % _nhgm_rifs(nhg_oid_d)
+
+        # ---- Phase E: bring if_b back up + re-learn neighbor -> NHG reforms ----
+        dvs.servers[srv_b].runcmd("ip link set up dev eth0")
+        self.set_admin_status(if_b, "up")
+        self.add_neighbor(if_b, nh_ip, mac_b)
+        _wait_nhgm_count(base_nhgm + 2)
+        nhg_oid_e = _wait_route_nh("nhg")
+        vnet_obj.fetch_exist_entries(dvs)
+        assert len(vnet_obj.nhgs)  == base_nhg  + 1, "Phase E: NHG should still exist"
+        assert _nhgm_rifs(nhg_oid_e) == {rif_a, rif_b}, \
+            "Phase E: NHG must again contain both RIFs"
+
+        # ---- Cleanup ----
+        delete_vnet_local_routes(dvs, prefix, vnet_name)
+        vnet_obj.check_del_vnet_local_routes(dvs, vnet_name, prefix)
+        vnet_obj.fetch_exist_entries(dvs)
+        assert len(vnet_obj.nhgs)  == base_nhg
+        assert len(vnet_obj.nhgms) == base_nhgm
+
+        self.remove_neighbor(if_a, nh_ip)
+        self.remove_neighbor(if_b, nh_ip)
+        self.set_admin_status(if_a, "down")
+        self.set_admin_status(if_b, "down")
+
+        delete_phy_interface(dvs, if_a, "10.77.0.4/30")
+        vnet_obj.check_del_router_interface(dvs, if_a)
+        delete_phy_interface(dvs, if_b, "10.77.0.8/30")
+        vnet_obj.check_del_router_interface(dvs, if_b)
+
+        delete_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_del_vnet_entry(dvs, vnet_name)
+
+        delete_vxlan_tunnel(dvs, tunnel_name)
+        vnet_obj.check_del_vxlan_tunnel(dvs)
+
 
     '''
     VNET tunnel route with a directly-connected local endpoint.
@@ -3741,5 +3936,57 @@ class TestVnetOrch(object):
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
+
+    """
+    Parity proof: VNET local route with explicit nexthop="0.0.0.0" must be
+    classified as a subnet route (is_subnet=True), bound to the interface RIF,
+    just like the empty-nexthop case. Pins down the behavior of the
+    is_subnet check after the refactor from
+        nh.ips.contains("0.0.0.0")
+    to
+        std::any_of(nh.ips, [](auto& a){ return a.isZero(); })
+    For IPv4 the two predicates are functionally equivalent; this test locks
+    that equivalence in.
+    """
+    def test_vnet_local_route_subnet_zero_ipv4(self, dvs, testlog):
+        self.setup_db(dvs)
+
+        vnet_obj = self.get_vnet_obj()
+        tunnel_name = "tunnel_subnet_zero_v4"
+        vnet_name = "Vnet5097"
+        if_a = "Ethernet60"
+        prefix = "10.97.0.0/24"
+
+        vnet_obj.fetch_exist_entries(dvs)
+        create_vxlan_tunnel(dvs, tunnel_name, "10.10.10.97")
+        create_vnet_entry(dvs, vnet_name, tunnel_name, "5097", "")
+        vnet_obj.check_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, vnet_name, "5097")
+        vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, "10.10.10.97")
+
+        create_phy_interface(dvs, if_a, vnet_name, "10.97.0.1/24")
+        vnet_obj.check_router_interface(dvs, if_a, vnet_name)
+
+        vnet_obj.fetch_exist_entries(dvs)
+        # The actual parity check: explicit "0.0.0.0" nexthop on an IPv4
+        # subnet must take the is_subnet branch and create an ASIC route bound
+        # to the interface RIF (same outcome as nexthop="").
+        create_vnet_local_routes(dvs, prefix, vnet_name, if_a, nexthop="0.0.0.0")
+        vnet_obj.check_vnet_local_routes(dvs, vnet_name)
+
+        # Clean-up
+        delete_vnet_local_routes(dvs, prefix, vnet_name)
+        vnet_obj.check_del_vnet_local_routes(dvs, vnet_name, prefix)
+
+        delete_phy_interface(dvs, if_a, "10.97.0.1/24")
+        vnet_obj.check_del_router_interface(dvs, if_a)
+
+        delete_vnet_entry(dvs, vnet_name)
+        vnet_obj.check_del_vnet_entry(dvs, vnet_name)
+
+        delete_vxlan_tunnel(dvs, tunnel_name)
+        vnet_obj.check_del_vxlan_tunnel(dvs)
+
+
 def test_nonflaky_dummy():
     pass


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Changed the type of nextHop::ips in orchagent/vnetorch.h from IpAddresses (a std::set-backed wrapper) to std::vector<IpAddress>

**Why I did it**
The unnumbered-BGP / RFC 5549 installs local VNET routes(VNET_ROUTE_TABLE) whose nexthop list can contain duplicate IP addresses (the same IPv4 link-local gateway resolved over multiple physical
interfaces — one ECMP member per egress port). The previous IpAddresses (set) type silently dedup'd those entries, collapsing N-way ECMP down to a single nexthop and breaking ecmp. Switching to std::vector preserves duplicates and lets the downstream SAI nexthop-group programming see all members.

Sample config example:
```
 127.0.0.1:6379[0]> HGETALL "VNET_ROUTE_TABLE:Vnet5099:10.99.0.0/24"
 1) "ifname"
 2) "Ethernet20,Ethernet16"
 3) "nexthop"
 4) "169.254.0.1,169.254.0.1"
 ```

**How I verified it**
Unit Test
Physical DUT test

**Details if related**
