### PR TITLE
[202511][orchagent/dash]: Remove retry logic, add failure handling and exception safety

### DIFF
--- a/orchagent/dash/dashaclgroupmgr.cpp
+++ b/orchagent/dash/dashaclgroupmgr.cpp
@@ -234,7 +234,7 @@ task_process_status DashAclGroupMgr::remove(const string& group_id)
     if (isBound(group))
     {
         SWSS_LOG_ERROR("ACL group %s still has %zu references", group_id.c_str(), group.m_in_tables.size() + group.m_out_tables.size());
-        return task_need_retry;
+        return task_failed;
     }
 
     remove(group);
@@ -385,8 +385,8 @@ task_process_status DashAclGroupMgr::createRule(const string& group_id, const st
     auto group_it = m_groups_table.find(group_id);
     if (group_it == m_groups_table.end())
     {
-        SWSS_LOG_INFO("ACL group %s doesn't exist, waiting for group creating before creating rule %s", group_id.c_str(), rule_id.c_str());
-        return task_need_retry;
+        SWSS_LOG_ERROR("ACL group %s doesn't exist, cannot create rule %s", group_id.c_str(), rule_id.c_str());
+        return task_failed;
     }
     auto& group = group_it->second;
 
@@ -394,8 +394,8 @@ task_process_status DashAclGroupMgr::createRule(const string& group_id, const st
     {
         if (!m_dash_acl_orch->getDashAclTagMgr().exists(tag_id))
         {
-            SWSS_LOG_INFO("ACL tag %s doesn't exist, waiting for tag creating before creating rule %s", tag_id.c_str(), rule_id.c_str());
-            return task_need_retry;
+            SWSS_LOG_ERROR("ACL src tag %s doesn't exist, cannot create rule %s", tag_id.c_str(), rule_id.c_str());
+            return task_failed;
         }
     }
 
@@ -403,8 +403,8 @@ task_process_status DashAclGroupMgr::createRule(const string& group_id, const st
     {
         if (!m_dash_acl_orch->getDashAclTagMgr().exists(tag_id))
         {
-            SWSS_LOG_INFO("ACL tag %s doesn't exist, waiting for tag creating before creating rule %s", tag_id.c_str(), rule_id.c_str());
-            return task_need_retry;
+            SWSS_LOG_ERROR("ACL dst tag %s doesn't exist, cannot create rule %s", tag_id.c_str(), rule_id.c_str());
+            return task_failed;
         }
     }
 
@@ -457,8 +457,8 @@ task_process_status DashAclGroupMgr::bind(const string& group_id, const string& 
     auto eni = m_dash_orch->getEni(eni_id);
     if (!eni)
     {
-        SWSS_LOG_INFO("eni %s cannot be found", eni_id.c_str());
-        return task_need_retry;
+        SWSS_LOG_ERROR("ENI %s not found, cannot bind ACL group %s", eni_id.c_str(), group_id.c_str());
+        return task_failed;
     }
 
     bind(group, *eni, direction, stage);

--- a/orchagent/dash/dashaclorch.cpp
+++ b/orchagent/dash/dashaclorch.cpp
@@ -4,6 +4,7 @@
 #include <swss/ipaddress.h>
 
 #include <swssnet.h>
+#include <exception>
 
 #include "dashaclorch.h"
 #include "taskworker.h"
@@ -116,36 +117,29 @@ void DashAclOrch::doTask(ConsumerBase &consumer)
     auto itr = consumer.m_toSync.begin();
     while (itr != consumer.m_toSync.end())
     {
-        task_process_status task_status = task_failed;
         auto &message = itr->second;
+        const string &key = kfvKey(message);
         const string &op = kfvOp(message);
 
-        auto task = TaskMap.find(make_tuple(table_name, op));
-        if (task != TaskMap.end())
+        try
         {
-            task_status = task->second->process(kfvKey(message), kfvFieldsValues(message));
-        }
-        else
-        {
-            SWSS_LOG_ERROR(
-                "Unknown task : %s - %s",
-                table_name.c_str(),
-                op.c_str());
-        }
+            task_process_status task_status = task_failed;
+            auto task = TaskMap.find(make_tuple(table_name, op));
+            if (task != TaskMap.end())
+            {
+                task_status = task->second->process(key, kfvFieldsValues(message));
+            }
+            else
+            {
+                SWSS_LOG_ERROR(
+                    "Unknown task : %s - %s",
+                    table_name.c_str(),
+                    op.c_str());
+            }
 
-        if (task_status == task_need_retry)
-        {
-            SWSS_LOG_DEBUG(
-                "Task %s - %s need retry",
-                table_name.c_str(),
-                op.c_str());
-            ++itr;
-        }
-        else
-        {
             if (task_status != task_success)
             {
-                SWSS_LOG_WARN("Task %s - %s fail",
+                SWSS_LOG_ERROR("Task %s - %s failed",
                               table_name.c_str(),
                               op.c_str());
             }
@@ -157,6 +151,11 @@ void DashAclOrch::doTask(ConsumerBase &consumer)
                     op.c_str());
             }
 
+            itr = consumer.m_toSync.erase(itr);
+        }
+        catch (const std::exception& e)
+        {
+            SWSS_LOG_ERROR("Exception caught processing %s entry %s: %s", table_name.c_str(), key.c_str(), e.what());
             itr = consumer.m_toSync.erase(itr);
         }
     }

--- a/orchagent/dash/dashmeterorch.cpp
+++ b/orchagent/dash/dashmeterorch.cpp
@@ -3,6 +3,7 @@
 #include <swss/redisutility.h>
 #include <swss/ipaddress.h>
 #include <swssnet.h>
+#include <exception>
 
 #include "directory.h"
 #include "dashmeterorch.h"
@@ -223,7 +224,7 @@ bool DashMeterOrch::addMeterPolicy(const string& meter_policy, MeterPolicyContex
         task_process_status handle_status = handleSaiCreateStatus((sai_api_t) SAI_API_DASH_METER, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            return false;
         }
     }
 
@@ -240,7 +241,7 @@ bool DashMeterOrch::removeMeterPolicy(const string& meter_policy)
 
     if (isMeterPolicyBound(meter_policy))
     {
-        SWSS_LOG_WARN("Cannot remove bound meter policy %s", meter_policy.c_str());
+        SWSS_LOG_ERROR("Cannot remove bound meter policy %s", meter_policy.c_str());
         return false;
     }
 
@@ -255,7 +256,7 @@ bool DashMeterOrch::removeMeterPolicy(const string& meter_policy)
     if (rule_count != 0)
     {
         SWSS_LOG_INFO("Failed to remove meter policy %s due to rule count %d ", meter_policy.c_str(), rule_count);
-        return true;
+        return false;
     }
 
     sai_status_t status = sai_dash_meter_api->remove_meter_policy(meter_policy_oid);
@@ -265,7 +266,7 @@ bool DashMeterOrch::removeMeterPolicy(const string& meter_policy)
         task_process_status handle_status = handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_METER, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            return false;
         }
     }
 
@@ -288,45 +289,46 @@ void DashMeterOrch::doTaskMeterPolicyTable(ConsumerBase& consumer)
         auto op = kfvOp(tuple);
         const string& key = kfvKey(tuple);
 
-        if (op == SET_COMMAND)
+        try
         {
-            MeterPolicyContext ctxt;
-            ctxt.meter_policy = key;
+            if (op == SET_COMMAND)
+            {
+                MeterPolicyContext ctxt;
+                ctxt.meter_policy = key;
 
-            if (!parsePbMessage(kfvFieldsValues(tuple), ctxt.metadata))
-            {
-                SWSS_LOG_WARN("Requires protobuff at MeterPolicy :%s", key.c_str());
+                if (!parsePbMessage(kfvFieldsValues(tuple), ctxt.metadata))
+                {
+                    SWSS_LOG_WARN("Requires protobuff at MeterPolicy :%s", key.c_str());
+                    it = consumer.m_toSync.erase(it);
+                    continue;
+                }
+                if (!addMeterPolicy(key, ctxt))
+                {
+                    SWSS_LOG_ERROR("Failed to process meter policy %s", key.c_str());
+                }
                 it = consumer.m_toSync.erase(it);
-                continue;
             }
-            if (addMeterPolicy(key, ctxt))
+            else if (op == DEL_COMMAND)
             {
+                if (!removeMeterPolicy(key))
+                {
+                    SWSS_LOG_ERROR("Failed to remove meter policy %s", key.c_str());
+                }
                 it = consumer.m_toSync.erase(it);
             }
             else
             {
-                it++;
-            }
-        }
-        else if (op == DEL_COMMAND)
-        {
-            if (removeMeterPolicy(key))
-            {
+                SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
                 it = consumer.m_toSync.erase(it);
             }
-            else
-            {
-                it++;
-            }
         }
-        else
+        catch (const std::exception& e)
         {
-            SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
+            SWSS_LOG_ERROR("Exception caught processing %s entry %s: %s", consumer.getTableName().c_str(), key.c_str(), e.what());
             it = consumer.m_toSync.erase(it);
         }
     }
 }
-
 
 bool DashMeterOrch::addMeterRule(const string& key, MeterRuleBulkContext& ctxt)
 {
@@ -342,14 +344,16 @@ bool DashMeterOrch::addMeterRule(const string& key, MeterRuleBulkContext& ctxt)
     if (isMeterPolicyBound(ctxt.meter_policy))
     {
         SWSS_LOG_WARN("Cannot add new rule %s to Meter policy %s as it is already bound", key.c_str(), ctxt.meter_policy.c_str());
+        ctxt.pre_op_result = DASH_RESULT_FAILURE;
         return true;
     }
 
     sai_object_id_t meter_policy_oid = getMeterPolicyOid(ctxt.meter_policy);
     if (meter_policy_oid == SAI_NULL_OBJECT_ID)
     {
-        SWSS_LOG_INFO("Retry for rule %s as meter policy %s not found", key.c_str(), ctxt.meter_policy.c_str());
-        return false;
+        SWSS_LOG_ERROR("Meter policy %s not found for rule %s", ctxt.meter_policy.c_str(), key.c_str());
+        ctxt.pre_op_result = DASH_RESULT_FAILURE;
+        return true;
     }
 
     auto& object_ids = ctxt.object_ids;
@@ -447,16 +451,21 @@ bool DashMeterOrch::removeMeterRulePost(const string& key, const MeterRuleBulkCo
     sai_status_t status = *it_status++;
     if (status != SAI_STATUS_SUCCESS)
     {
-        // Retry later if object has non-zero reference to it
         if (status == SAI_STATUS_NOT_EXECUTED)
         {
+            SWSS_LOG_ERROR("Failed to remove meter rule entry for %s, dropping notification", key.c_str());
             return false;
+        }
+        if (status == SAI_STATUS_ITEM_NOT_FOUND)
+        {
+            SWSS_LOG_INFO("Meter rule entry for %s already removed", key.c_str());
+            return true;
         }
         SWSS_LOG_ERROR("Failed to remove meter rule entry for %s", key.c_str());
         task_process_status handle_status = handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_METER, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            return false;
         }
     }
 
@@ -467,7 +476,6 @@ bool DashMeterOrch::removeMeterRulePost(const string& key, const MeterRuleBulkCo
 
     return true;
 }
-
 
 void DashMeterOrch::doTaskMeterRuleTable(ConsumerBase& consumer)
 {
@@ -485,59 +493,69 @@ void DashMeterOrch::doTaskMeterRuleTable(ConsumerBase& consumer)
             KeyOpFieldsValuesTuple tuple = it->second;
             const string& key = kfvKey(tuple);
             auto op = kfvOp(tuple);
-            auto rc = toBulk.emplace(std::piecewise_construct,
-                    std::forward_as_tuple(key, op),
-                    std::forward_as_tuple());
-            bool inserted = rc.second;
-            auto &ctxt = rc.first->second;
 
-            if (!inserted)
+            try
             {
-                ctxt.clear();
-            }
+                auto rc = toBulk.emplace(std::piecewise_construct,
+                        std::forward_as_tuple(key, op),
+                        std::forward_as_tuple());
+                bool inserted = rc.second;
+                auto &ctxt = rc.first->second;
 
-            string& meter_policy = ctxt.meter_policy;
-            uint32_t& rule_num   = ctxt.rule_num;
-
-            vector<string> keys = tokenize(key, ':');
-            meter_policy = keys[0];
-            string rule_num_str;
-            size_t pos = key.find(":", meter_policy.length());
-            rule_num_str = key.substr(pos + 1);
-            rule_num = stoi(rule_num_str);
-
-            if (op == SET_COMMAND)
-            {
-                if (!parsePbMessage(kfvFieldsValues(tuple), ctxt.metadata))
+                if (!inserted)
                 {
-                    SWSS_LOG_WARN("Requires protobuff at MeterRule :%s", key.c_str());
-                    it = consumer.m_toSync.erase(it);
-                    continue;
+                    ctxt.clear();
                 }
-                if (addMeterRule(key, ctxt))
+
+                string& meter_policy = ctxt.meter_policy;
+                uint32_t& rule_num   = ctxt.rule_num;
+
+                vector<string> keys = tokenize(key, ':');
+                meter_policy = keys[0];
+                string rule_num_str;
+                size_t pos = key.find(":", meter_policy.length());
+                rule_num_str = key.substr(pos + 1);
+                rule_num = stoi(rule_num_str);
+
+                if (op == SET_COMMAND)
                 {
-                    it = consumer.m_toSync.erase(it);
+                    if (!parsePbMessage(kfvFieldsValues(tuple), ctxt.metadata))
+                    {
+                        SWSS_LOG_WARN("Requires protobuff at MeterRule :%s", key.c_str());
+                        it = consumer.m_toSync.erase(it);
+                        continue;
+                    }
+                    if (addMeterRule(key, ctxt))
+                    {
+                        it = consumer.m_toSync.erase(it);
+                    }
+                    else
+                    {
+                        it++;
+                    }
+                }
+                else if (op == DEL_COMMAND)
+                {
+                    if (removeMeterRule(key, ctxt))
+                    {
+                        it = consumer.m_toSync.erase(it);
+                    }
+                    else
+                    {
+                        it++;
+                    }
                 }
                 else
                 {
-                    it++;
-                }
-            }
-            else if (op == DEL_COMMAND)
-            {
-                if (removeMeterRule(key, ctxt))
-                {
+                    SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
                     it = consumer.m_toSync.erase(it);
                 }
-                else
-                {
-                    it++;
-                }
             }
-            else
+            catch (const std::exception& e)
             {
-                SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
+                SWSS_LOG_ERROR("Exception caught processing %s entry %s: %s", consumer.getTableName().c_str(), key.c_str(), e.what());
                 it = consumer.m_toSync.erase(it);
+                continue;
             }
         }
 
@@ -549,50 +567,54 @@ void DashMeterOrch::doTaskMeterRuleTable(ConsumerBase& consumer)
             KeyOpFieldsValuesTuple t = it_prev->second;
             string key = kfvKey(t);
             string op = kfvOp(t);
-            auto found = toBulk.find(make_pair(key, op));
-            if (found == toBulk.end())
+            try
             {
-                it_prev++;
-                continue;
-            }
-
-            const auto& ctxt = found->second;
-            const auto& object_statuses = ctxt.object_statuses;
-            const auto& object_ids = ctxt.object_ids;
-
-            if (op == SET_COMMAND)
-            {
-                if (object_ids.empty())
+                auto found = toBulk.find(make_pair(key, op));
+                if (found == toBulk.end())
                 {
                     it_prev++;
                     continue;
                 }
 
-                if (addMeterRulePost(key, ctxt))
+                const auto& ctxt = found->second;
+                const auto& object_statuses = ctxt.object_statuses;
+                const auto& object_ids = ctxt.object_ids;
+
+                if (op == SET_COMMAND)
                 {
+                    if (object_ids.empty())
+                    {
+                        SWSS_LOG_ERROR("Missing meter rule create results for %s", key.c_str());
+                        it_prev = consumer.m_toSync.erase(it_prev);
+                        continue;
+                    }
+
+                    if (!addMeterRulePost(key, ctxt))
+                    {
+                        SWSS_LOG_ERROR("Failed post-processing meter rule %s", key.c_str());
+                    }
                     it_prev = consumer.m_toSync.erase(it_prev);
                 }
-                else
+                else if (op == DEL_COMMAND)
                 {
-                    it_prev++;
+                    if (object_statuses.empty())
+                    {
+                        SWSS_LOG_ERROR("Missing meter rule remove results for %s", key.c_str());
+                        it_prev = consumer.m_toSync.erase(it_prev);
+                        continue;
+                    }
+
+                    if (!removeMeterRulePost(key, ctxt))
+                    {
+                        SWSS_LOG_ERROR("Failed post-processing meter rule removal %s", key.c_str());
+                    }
+                    it_prev = consumer.m_toSync.erase(it_prev);
                 }
             }
-            else if (op == DEL_COMMAND)
+            catch (const std::exception& e)
             {
-                if (object_statuses.empty())
-                {
-                    it_prev++;
-                    continue;
-                }
-
-                if (removeMeterRulePost(key, ctxt))
-                {
-                    it_prev = consumer.m_toSync.erase(it_prev);
-                }
-                else
-                {
-                    it_prev++;
-                }
+                SWSS_LOG_ERROR("Exception caught in post-processing %s entry %s: %s", consumer.getTableName().c_str(), key.c_str(), e.what());
+                it_prev = consumer.m_toSync.erase(it_prev);
             }
         }
     }

--- a/orchagent/dash/dashmeterorch.h
+++ b/orchagent/dash/dashmeterorch.h
@@ -44,6 +44,7 @@ struct MeterRuleBulkContext
     dash::meter_rule::MeterRule metadata;
     std::deque<sai_object_id_t> object_ids;
     std::deque<sai_status_t> object_statuses;
+    uint32_t pre_op_result = DASH_RESULT_SUCCESS;
     MeterRuleBulkContext() {}
     MeterRuleBulkContext(const MeterRuleBulkContext&) = delete;
     MeterRuleBulkContext(MeterRuleBulkContext&&) = delete;
@@ -51,6 +52,7 @@ struct MeterRuleBulkContext
     void clear()
     {
         object_statuses.clear();
+        pre_op_result = DASH_RESULT_SUCCESS;
     }
 };
 

--- a/orchagent/dash/dashorch.cpp
+++ b/orchagent/dash/dashorch.cpp
@@ -338,24 +338,29 @@ bool DashOrch::removeApplianceEntry(const string& appliance_id)
                 return false;
             }
         }
+        appliance_entries_[appliance_id].metadata.clear_sip();
     }
     else
     {
         SWSS_LOG_WARN("Failed to convert SIP for appliance %s during removal, skipping VIP cleanup", appliance_id.c_str());
     }
 
-    sai_direction_lookup_entry_t direction_lookup_entry;
-    direction_lookup_entry.switch_id = gSwitchId;
-    direction_lookup_entry.vni = entry.vm_vni();
-    status = sai_dash_direction_lookup_api->remove_direction_lookup_entry(&direction_lookup_entry);
-    if (status != SAI_STATUS_SUCCESS)
+    if (entry.vm_vni() != 0)
     {
-        SWSS_LOG_ERROR("Failed to remove direction lookup entry for %s", appliance_id.c_str());
-        task_process_status handle_status = handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_DIRECTION_LOOKUP, status);
-        if (handle_status != task_success)
+        sai_direction_lookup_entry_t direction_lookup_entry;
+        direction_lookup_entry.switch_id = gSwitchId;
+        direction_lookup_entry.vni = entry.vm_vni();
+        status = sai_dash_direction_lookup_api->remove_direction_lookup_entry(&direction_lookup_entry);
+        if (status != SAI_STATUS_SUCCESS)
         {
-            return false;
+            SWSS_LOG_ERROR("Failed to remove direction lookup entry for %s", appliance_id.c_str());
+            task_process_status handle_status = handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_DIRECTION_LOOKUP, status);
+            if (handle_status != task_success)
+            {
+                return false;
+            }
         }
+        appliance_entries_[appliance_id].metadata.clear_vm_vni();
     }
 
     auto sai_appliance_id = appliance_entries_[appliance_id].appliance_id;

--- a/orchagent/dash/dashorch.cpp
+++ b/orchagent/dash/dashorch.cpp
@@ -129,11 +129,46 @@ bool DashOrch::addApplianceEntry(const string& appliance_id, const dash::applian
     if (!appliance_entries_.empty())
     {
         SWSS_LOG_ERROR("Appliance entry is a singleton and already exists");
+        return true;
+    }
+
+    sai_object_id_t sai_appliance_id = SAI_NULL_OBJECT_ID;
+    if (!createApplianceSaiObjects(appliance_id, entry, sai_appliance_id))
+    {
         return false;
     }
 
-    sai_object_id_t sai_appliance_id = 0UL;
+    appliance_entries_[appliance_id] = ApplianceEntry { sai_appliance_id, entry };
+    // clear out the trusted VNIs list. They will be readded by addApplianceTrustedVni() after successful creation to ensure that internal cache state is consistent with SAI state
+    appliance_entries_[appliance_id].metadata.clear_trusted_vnis_list();
+    SWSS_LOG_NOTICE("Created appliance, vip and direction lookup entries for %s", appliance_id.c_str());
+
+    if (!entry.trusted_vnis_list().empty())
+    {
+        bool all_trusted_vnis_added = addApplianceTrustedVni(appliance_id, entry);
+        if (!all_trusted_vnis_added)
+        {
+            SWSS_LOG_ERROR("Failed to add all trusted vni entries for appliance %s. Removing appliance entry.", appliance_id.c_str());
+            removeApplianceEntry(appliance_id);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool DashOrch::createApplianceSaiObjects(const string& appliance_id, const dash::appliance::Appliance &entry, sai_object_id_t &sai_appliance_id)
+{
+    SWSS_LOG_ENTER();
+
     sai_status_t status;
+
+    sai_vip_entry_t vip_entry;
+    vip_entry.switch_id = gSwitchId;
+
+    sai_direction_lookup_entry_t direction_lookup_entry;
+    direction_lookup_entry.switch_id = gSwitchId;
+    direction_lookup_entry.vni = entry.vm_vni();
 
     sai_attr_capability_t capability;
     status = sai_query_attribute_capability(gSwitchId, (sai_object_type_t)SAI_OBJECT_TYPE_DASH_APPLIANCE, SAI_DASH_APPLIANCE_ATTR_LOCAL_REGION_ID, &capability);
@@ -152,17 +187,23 @@ bool DashOrch::addApplianceEntry(const string& appliance_id, const dash::applian
             task_process_status handle_status = handleSaiCreateStatus((sai_api_t) SAI_API_DASH_APPLIANCE, status);
             if (handle_status != task_success)
             {
-                return parseHandleSaiStatusFailure(handle_status);
+                return false;
             }
         }
     }
 
-    sai_vip_entry_t vip_entry;
-    vip_entry.switch_id = gSwitchId;
     if (!to_sai(entry.sip(), vip_entry.vip))
     {
+        SWSS_LOG_ERROR("Failed to convert SIP for appliance %s", appliance_id.c_str());
+        // Cleanup: only appliance may have been created
+        if (sai_appliance_id != SAI_NULL_OBJECT_ID)
+        {
+            sai_dash_appliance_api->remove_dash_appliance(sai_appliance_id);
+            sai_appliance_id = SAI_NULL_OBJECT_ID;
+        }
         return false;
     }
+
     sai_attribute_t appliance_attr;
     appliance_attr.id = SAI_VIP_ENTRY_ATTR_ACTION;
     appliance_attr.value.u32 = SAI_VIP_ENTRY_ACTION_ACCEPT;
@@ -173,14 +214,16 @@ bool DashOrch::addApplianceEntry(const string& appliance_id, const dash::applian
         task_process_status handle_status = handleSaiCreateStatus((sai_api_t) SAI_API_DASH_VIP, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            if (sai_appliance_id != SAI_NULL_OBJECT_ID)
+            {
+                sai_dash_appliance_api->remove_dash_appliance(sai_appliance_id);
+                sai_appliance_id = SAI_NULL_OBJECT_ID;
+            }
+            return false;
         }
     }
 
-    sai_direction_lookup_entry_t direction_lookup_entry;
     vector<sai_attribute_t> direction_lookup_attrs;
-    direction_lookup_entry.switch_id = gSwitchId;
-    direction_lookup_entry.vni = entry.vm_vni();
     appliance_attr.id = SAI_DIRECTION_LOOKUP_ENTRY_ATTR_ACTION;
     if (entry.has_outbound_direction_lookup())
     {
@@ -208,21 +251,12 @@ bool DashOrch::addApplianceEntry(const string& appliance_id, const dash::applian
         task_process_status handle_status = handleSaiCreateStatus((sai_api_t) SAI_API_DASH_DIRECTION_LOOKUP, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
-        }
-    }
-    appliance_entries_[appliance_id] = ApplianceEntry { sai_appliance_id, entry };
-    // clear out the trusted VNIs list. They will be readded by addApplianceTrustedVni() after successful creation to ensure that internal cache state is consistent with SAI state
-    appliance_entries_[appliance_id].metadata.clear_trusted_vnis_list();
-    SWSS_LOG_NOTICE("Created appliance, vip and direction lookup entries for %s", appliance_id.c_str());
-
-    if (!entry.trusted_vnis_list().empty())
-    {
-        bool all_trusted_vnis_added = addApplianceTrustedVni(appliance_id, entry);
-        if (!all_trusted_vnis_added)
-        {
-            SWSS_LOG_ERROR("Failed to add all trusted vni entries for appliance %s. Removing appliance entry.", appliance_id.c_str());
-            removeApplianceEntry(appliance_id);
+            sai_dash_vip_api->remove_vip_entry(&vip_entry);
+            if (sai_appliance_id != SAI_NULL_OBJECT_ID)
+            {
+                sai_dash_appliance_api->remove_dash_appliance(sai_appliance_id);
+                sai_appliance_id = SAI_NULL_OBJECT_ID;
+            }
             return false;
         }
     }
@@ -255,7 +289,6 @@ bool DashOrch::addApplianceTrustedVni(const std::string& appliance_id, const das
             task_process_status handle_status = handleSaiCreateStatus((sai_api_t)SAI_API_DASH_TRUSTED_VNI, status);
             if (handle_status != task_success)
             {
-                parseHandleSaiStatusFailure(handle_status);
                 success = false;
                 continue;
             }
@@ -293,19 +326,22 @@ bool DashOrch::removeApplianceEntry(const string& appliance_id)
 
     sai_vip_entry_t vip_entry;
     vip_entry.switch_id = gSwitchId;
-    if (!to_sai(entry.sip(), vip_entry.vip))
+    if (to_sai(entry.sip(), vip_entry.vip))
     {
-        return false;
-    }
-    status = sai_dash_vip_api->remove_vip_entry(&vip_entry);
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_ERROR("Failed to remove vip entry for %s", appliance_id.c_str());
-        task_process_status handle_status = handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_VIP, status);
-        if (handle_status != task_success)
+        status = sai_dash_vip_api->remove_vip_entry(&vip_entry);
+        if (status != SAI_STATUS_SUCCESS)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            SWSS_LOG_ERROR("Failed to remove vip entry for %s", appliance_id.c_str());
+            task_process_status handle_status = handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_VIP, status);
+            if (handle_status != task_success)
+            {
+                return false;
+            }
         }
+    }
+    else
+    {
+        SWSS_LOG_WARN("Failed to convert SIP for appliance %s during removal, skipping VIP cleanup", appliance_id.c_str());
     }
 
     sai_direction_lookup_entry_t direction_lookup_entry;
@@ -318,12 +354,12 @@ bool DashOrch::removeApplianceEntry(const string& appliance_id)
         task_process_status handle_status = handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_DIRECTION_LOOKUP, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            return false;
         }
     }
 
     auto sai_appliance_id = appliance_entries_[appliance_id].appliance_id;
-    if (sai_appliance_id != 0UL)
+    if (sai_appliance_id != SAI_NULL_OBJECT_ID)
     {
         status = sai_dash_appliance_api->remove_dash_appliance(sai_appliance_id);
         if (status != SAI_STATUS_SUCCESS && status != SAI_STATUS_NOT_IMPLEMENTED)
@@ -332,7 +368,7 @@ bool DashOrch::removeApplianceEntry(const string& appliance_id)
             task_process_status handle_status = handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_APPLIANCE, status);
             if (handle_status != task_success)
             {
-                return parseHandleSaiStatusFailure(handle_status);
+                return false;
             }
         }
     }
@@ -368,7 +404,6 @@ bool DashOrch::removeApplianceTrustedVni(const std::string& appliance_id, const 
             task_process_status handle_status = handleSaiRemoveStatus((sai_api_t)SAI_API_DASH_TRUSTED_VNI, status);
             if (handle_status != task_success)
             {
-                parseHandleSaiStatusFailure(handle_status);
                 success = false;
                 continue;
             }
@@ -391,45 +426,53 @@ void DashOrch::doTaskApplianceTable(ConsumerBase& consumer)
         KeyOpFieldsValuesTuple t = it->second;
         string appliance_id = kfvKey(t);
         string op = kfvOp(t);
-        result = DASH_RESULT_SUCCESS;
 
-        if (op == SET_COMMAND)
+        try
         {
-            dash::appliance::Appliance entry;
+            result = DASH_RESULT_SUCCESS;
 
-            if (!parsePbMessage(kfvFieldsValues(t), entry))
+            if (op == SET_COMMAND)
             {
-                SWSS_LOG_WARN("Requires protobuff at appliance :%s", appliance_id.c_str());
+                dash::appliance::Appliance entry;
+
+                if (!parsePbMessage(kfvFieldsValues(t), entry))
+                {
+                    SWSS_LOG_ERROR("Requires protobuff at appliance :%s", appliance_id.c_str());
+                    writeResultToDB(dash_appliance_result_table_, appliance_id, DASH_RESULT_FAILURE);
+                    it = consumer.m_toSync.erase(it);
+                    continue;
+                }
+
+                if (!addApplianceEntry(appliance_id, entry))
+                {
+                    SWSS_LOG_ERROR("Failed to add appliance entry for %s", appliance_id.c_str());
+                    result = DASH_RESULT_FAILURE;
+                }
                 it = consumer.m_toSync.erase(it);
-                continue;
+                writeResultToDB(dash_appliance_result_table_, appliance_id, result);
             }
-
-            if (addApplianceEntry(appliance_id, entry))
+            else if (op == DEL_COMMAND)
             {
+                if (removeApplianceEntry(appliance_id))
+                {
+                    removeResultFromDB(dash_appliance_result_table_, appliance_id);
+                }
+                else
+                {
+                    SWSS_LOG_ERROR("Failed to remove appliance entry for %s", appliance_id.c_str());
+                }
                 it = consumer.m_toSync.erase(it);
             }
             else
             {
-                result = DASH_RESULT_FAILURE;
-                it++;
-            }
-            writeResultToDB(dash_appliance_result_table_, appliance_id, result);
-        }
-        else if (op == DEL_COMMAND)
-        {
-            if (removeApplianceEntry(appliance_id))
-            {
+                SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
                 it = consumer.m_toSync.erase(it);
-                removeResultFromDB(dash_appliance_result_table_, appliance_id);
-            }
-            else
-            {
-                it++;
             }
         }
-        else
+        catch (const std::exception& e)
         {
-            SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
+            SWSS_LOG_ERROR("Exception caught processing %s entry %s: %s", consumer.getTableName().c_str(), appliance_id.c_str(), e.what());
+            writeResultToDB(dash_appliance_result_table_, appliance_id, DASH_RESULT_FAILURE);
             it = consumer.m_toSync.erase(it);
         }
     }
@@ -478,56 +521,65 @@ void DashOrch::doTaskRoutingTypeTable(ConsumerBase& consumer)
         KeyOpFieldsValuesTuple t = it->second;
         string routing_type_str = kfvKey(t);
         string op = kfvOp(t);
-        dash::route_type::RoutingType routing_type;
-        result = DASH_RESULT_SUCCESS;
 
-        std::transform(routing_type_str.begin(), routing_type_str.end(), routing_type_str.begin(), ::toupper);
-        routing_type_str = "ROUTING_TYPE_" + routing_type_str;
-
-        if (!dash::route_type::RoutingType_Parse(routing_type_str, &routing_type))
+        try
         {
-            SWSS_LOG_WARN("Invalid routing type %s", routing_type_str.c_str());
-            it = consumer.m_toSync.erase(it);
-            continue;
-        }
+            dash::route_type::RoutingType routing_type;
+            result = DASH_RESULT_SUCCESS;
 
-        if (op == SET_COMMAND)
-        {
-            dash::route_type::RouteType entry;
+            std::transform(routing_type_str.begin(), routing_type_str.end(), routing_type_str.begin(), ::toupper);
+            routing_type_str = "ROUTING_TYPE_" + routing_type_str;
 
-            if (!parsePbMessage(kfvFieldsValues(t), entry))
+            if (!dash::route_type::RoutingType_Parse(routing_type_str, &routing_type))
             {
-                SWSS_LOG_WARN("Requires protobuff at routing type :%s", routing_type_str.c_str());
+                SWSS_LOG_ERROR("Invalid routing type %s", routing_type_str.c_str());
+                writeResultToDB(dash_routing_type_result_table_, routing_type_str, DASH_RESULT_FAILURE);
                 it = consumer.m_toSync.erase(it);
                 continue;
             }
 
-            if (addRoutingTypeEntry(routing_type, entry))
+            if (op == SET_COMMAND)
             {
+                dash::route_type::RouteType entry;
+
+                if (!parsePbMessage(kfvFieldsValues(t), entry))
+                {
+                    SWSS_LOG_ERROR("Requires protobuff at routing type :%s", routing_type_str.c_str());
+                    writeResultToDB(dash_routing_type_result_table_, routing_type_str, DASH_RESULT_FAILURE);
+                    it = consumer.m_toSync.erase(it);
+                    continue;
+                }
+
+                if (!addRoutingTypeEntry(routing_type, entry))
+                {
+                    SWSS_LOG_ERROR("Failed to add routing type entry for %s", routing_type_str.c_str());
+                    result = DASH_RESULT_FAILURE;
+                }
+                it = consumer.m_toSync.erase(it);
+                writeResultToDB(dash_routing_type_result_table_, routing_type_str, result);
+            }
+            else if (op == DEL_COMMAND)
+            {
+                if (removeRoutingTypeEntry(routing_type))
+                {
+                    removeResultFromDB(dash_routing_type_result_table_, routing_type_str);
+                }
+                else
+                {
+                    SWSS_LOG_ERROR("Failed to remove routing type entry for %s", routing_type_str.c_str());
+                }
                 it = consumer.m_toSync.erase(it);
             }
             else
             {
-                result = DASH_RESULT_FAILURE;
-                it++;
-            }
-            writeResultToDB(dash_routing_type_result_table_, routing_type_str, result);
-        }
-        else if (op == DEL_COMMAND)
-        {
-            if (removeRoutingTypeEntry(routing_type))
-            {
+                SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
                 it = consumer.m_toSync.erase(it);
-                removeResultFromDB(dash_routing_type_result_table_, routing_type_str);
-            }
-            else
-            {
-                it++;
             }
         }
-        else
+        catch (const std::exception& e)
         {
-            SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
+            SWSS_LOG_ERROR("Exception caught processing %s entry %s: %s", consumer.getTableName().c_str(), routing_type_str.c_str(), e.what());
+            writeResultToDB(dash_routing_type_result_table_, routing_type_str, DASH_RESULT_FAILURE);
             it = consumer.m_toSync.erase(it);
         }
     }
@@ -551,7 +603,7 @@ bool DashOrch::setEniAdminState(const string& eni, const EniEntry& entry)
         task_process_status handle_status = handleSaiSetStatus((sai_api_t) SAI_API_DASH_ENI, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            return false;
         }
     }
     eni_entries_[eni].metadata.set_admin_state(entry.metadata.admin_state());
@@ -568,13 +620,13 @@ bool DashOrch::addEniObject(const string& eni, EniEntry& entry)
 
     if (!vnet.empty() && gVnetNameToId.find(vnet) == gVnetNameToId.end())
     {
-        SWSS_LOG_INFO("Retry as vnet %s not found", vnet.c_str());
+        SWSS_LOG_ERROR("Failed to find vnet %s for ENI %s", vnet.c_str(), eni.c_str());
         return false;
     }
 
     if (appliance_entries_.empty())
     {
-        SWSS_LOG_INFO("Retry as no appliance table entry found");
+        SWSS_LOG_ERROR("No appliance table entry found for ENI %s", eni.c_str());
         return false;
     }
 
@@ -589,7 +641,7 @@ bool DashOrch::addEniObject(const string& eni, EniEntry& entry)
         sai_object_id_t meter_policy_oid = dash_meter_orch->getMeterPolicyOid(v4_meter_policy);
         if (meter_policy_oid == SAI_NULL_OBJECT_ID)
         {
-            SWSS_LOG_INFO("Retry as v4 meter_policy %s not found", v4_meter_policy.c_str());
+            SWSS_LOG_ERROR("Failed to find v4 meter_policy %s for ENI %s", v4_meter_policy.c_str(), eni.c_str());
             return false;
         }
     }
@@ -598,7 +650,7 @@ bool DashOrch::addEniObject(const string& eni, EniEntry& entry)
         sai_object_id_t meter_policy_oid = dash_meter_orch->getMeterPolicyOid(v6_meter_policy);
         if (meter_policy_oid == SAI_NULL_OBJECT_ID)
         {
-            SWSS_LOG_INFO("Retry as v6 meter_policy %s not found", v6_meter_policy.c_str());
+            SWSS_LOG_ERROR("Failed to find v6 meter_policy %s for ENI %s", v6_meter_policy.c_str(), eni.c_str());
             return false;
         }
     }
@@ -734,7 +786,7 @@ bool DashOrch::addEniObject(const string& eni, EniEntry& entry)
         task_process_status handle_status = handleSaiCreateStatus((sai_api_t) SAI_API_DASH_ENI, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            return false;
         }
     }
 
@@ -779,7 +831,7 @@ bool DashOrch::addEniAddrMapEntry(const string& eni, const EniEntry& entry)
         task_process_status handle_status = handleSaiCreateStatus((sai_api_t) SAI_API_DASH_ENI, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            return false;
         }
     }
 
@@ -817,7 +869,6 @@ bool DashOrch::addEniTrustedVnis(const std::string& eni, const EniEntry& entry)
             task_process_status handle_status = handleSaiCreateStatus((sai_api_t)SAI_API_DASH_TRUSTED_VNI, status);
             if (handle_status != task_success)
             {
-                parseHandleSaiStatusFailure(handle_status);
                 success = false;
                 continue;
             }
@@ -849,13 +900,25 @@ bool DashOrch::addEni(const string& eni, EniEntry &entry)
         return true;
     }
 
-    if (!addEniObject(eni, entry) || !addEniAddrMapEntry(eni, entry))
+    if (!addEniObject(eni, entry))
     {
         return false;
     }
+
     eni_entries_[eni] = entry;
     // clear out the trusted VNIs list. They will be readded by addEniTrustedVni() after successful creation to ensure that internal cache state is consistent with SAI state
     eni_entries_[eni].metadata.clear_trusted_vnis_list();
+
+    if (!addEniAddrMapEntry(eni, entry))
+    {
+        SWSS_LOG_ERROR("Failed to add ENI address map entry for %s. Removing ENI object.", eni.c_str());
+        if (!removeEniObject(eni))
+        {
+            SWSS_LOG_ERROR("Failed to remove ENI object while cleaning up %s", eni.c_str());
+        }
+        eni_entries_.erase(eni);
+        return false;
+    }
 
     if (!entry.metadata.trusted_vnis_list().empty())
     {
@@ -898,16 +961,16 @@ bool DashOrch::removeEniObject(const string& eni)
     sai_status_t status = sai_dash_eni_api->remove_eni(entry.eni_id);
     if (status != SAI_STATUS_SUCCESS)
     {
-        //Retry later if object is in use
         if (status == SAI_STATUS_OBJECT_IN_USE)
         {
+            SWSS_LOG_ERROR("Failed to remove ENI object for %s: object in use", eni.c_str());
             return false;
         }
         SWSS_LOG_ERROR("Failed to remove ENI object for %s", eni.c_str());
         task_process_status handle_status = handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_ENI, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            return false;
         }
     }
 
@@ -953,7 +1016,7 @@ bool DashOrch::removeEniAddrMapEntry(const string& eni)
         task_process_status handle_status = handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_ENI, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            return false;
         }
     }
 
@@ -991,7 +1054,6 @@ bool DashOrch::removeEniTrustedVnis(const std::string& eni, const EniEntry& entr
             task_process_status handle_status = handleSaiRemoveStatus((sai_api_t)SAI_API_DASH_TRUSTED_VNI, status);
             if (handle_status != task_success)
             {
-                parseHandleSaiStatusFailure(handle_status);
                 success = false;
                 continue;
             }
@@ -1041,47 +1103,55 @@ void DashOrch::doTaskEniTable(ConsumerBase& consumer)
     uint32_t result;
     while (it != consumer.m_toSync.end())
     {
-        auto t = it->second;
+        KeyOpFieldsValuesTuple t = it->second;
         string eni = kfvKey(t);
         string op = kfvOp(t);
-        result = DASH_RESULT_SUCCESS;
-        if (op == SET_COMMAND)
+
+        try
         {
-            EniEntry entry;
-
-            if (!parsePbMessage(kfvFieldsValues(t), entry.metadata))
+            result = DASH_RESULT_SUCCESS;
+            if (op == SET_COMMAND)
             {
-                SWSS_LOG_WARN("Requires protobuff at ENI :%s", eni.c_str());
+                EniEntry entry;
+
+                if (!parsePbMessage(kfvFieldsValues(t), entry.metadata))
+                {
+                    SWSS_LOG_ERROR("Requires protobuff at ENI :%s", eni.c_str());
+                    writeResultToDB(dash_eni_result_table_, eni, DASH_RESULT_FAILURE);
+                    it = consumer.m_toSync.erase(it);
+                    continue;
+                }
+
+                if (!addEni(eni, entry))
+                {
+                    SWSS_LOG_ERROR("Failed to add ENI entry for %s", eni.c_str());
+                    result = DASH_RESULT_FAILURE;
+                }
                 it = consumer.m_toSync.erase(it);
-                continue;
+                writeResultToDB(dash_eni_result_table_, eni, result);
             }
-
-            if (addEni(eni, entry))
+            else if (op == DEL_COMMAND)
             {
+                if (removeEni(eni))
+                {
+                    removeResultFromDB(dash_eni_result_table_, eni);
+                }
+                else
+                {
+                    SWSS_LOG_ERROR("Failed to remove ENI entry for %s", eni.c_str());
+                }
                 it = consumer.m_toSync.erase(it);
             }
             else
             {
-                result = DASH_RESULT_FAILURE;
-                it++;
-            }
-            writeResultToDB(dash_eni_result_table_, eni, result);
-        }
-        else if (op == DEL_COMMAND)
-        {
-            if (removeEni(eni))
-            {
+                SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
                 it = consumer.m_toSync.erase(it);
-                removeResultFromDB(dash_eni_result_table_, eni);
-            }
-            else
-            {
-                it++;
             }
         }
-        else
+        catch (const std::exception& e)
         {
-            SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
+            SWSS_LOG_ERROR("Exception caught processing %s entry %s: %s", consumer.getTableName().c_str(), eni.c_str(), e.what());
+            writeResultToDB(dash_eni_result_table_, eni, DASH_RESULT_FAILURE);
             it = consumer.m_toSync.erase(it);
         }
     }
@@ -1125,45 +1195,53 @@ void DashOrch::doTaskQosTable(ConsumerBase& consumer)
         KeyOpFieldsValuesTuple t = it->second;
         string qos_name = kfvKey(t);
         string op = kfvOp(t);
-        result = DASH_RESULT_SUCCESS;
 
-        if (op == SET_COMMAND)
+        try
         {
-            dash::qos::Qos entry;
+            result = DASH_RESULT_SUCCESS;
 
-            if (!parsePbMessage(kfvFieldsValues(t), entry))
+            if (op == SET_COMMAND)
             {
-                SWSS_LOG_WARN("Requires protobuff at QOS :%s", qos_name.c_str());
+                dash::qos::Qos entry;
+
+                if (!parsePbMessage(kfvFieldsValues(t), entry))
+                {
+                    SWSS_LOG_ERROR("Requires protobuff at QOS :%s", qos_name.c_str());
+                    writeResultToDB(dash_qos_result_table_, qos_name, DASH_RESULT_FAILURE);
+                    it = consumer.m_toSync.erase(it);
+                    continue;
+                }
+
+                if (!addQosEntry(qos_name, entry))
+                {
+                    SWSS_LOG_ERROR("Failed to add QOS entry for %s", qos_name.c_str());
+                    result = DASH_RESULT_FAILURE;
+                }
                 it = consumer.m_toSync.erase(it);
-                continue;
+                writeResultToDB(dash_qos_result_table_, qos_name, result);
             }
-
-            if (addQosEntry(qos_name, entry))
+            else if (op == DEL_COMMAND)
             {
+                if (removeQosEntry(qos_name))
+                {
+                    removeResultFromDB(dash_qos_result_table_, qos_name);
+                }
+                else
+                {
+                    SWSS_LOG_ERROR("Failed to remove QOS entry for %s", qos_name.c_str());
+                }
                 it = consumer.m_toSync.erase(it);
             }
             else
             {
-                result = DASH_RESULT_FAILURE;
-                it++;
-            }
-            writeResultToDB(dash_qos_result_table_, qos_name, result);
-        }
-        else if (op == DEL_COMMAND)
-        {
-            if (removeQosEntry(qos_name))
-            {
+                SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
                 it = consumer.m_toSync.erase(it);
-                removeResultFromDB(dash_qos_result_table_, qos_name);
-            }
-            else
-            {
-                it++;
             }
         }
-        else
+        catch (const std::exception& e)
         {
-            SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
+            SWSS_LOG_ERROR("Exception caught processing %s entry %s: %s", consumer.getTableName().c_str(), qos_name.c_str(), e.what());
+            writeResultToDB(dash_qos_result_table_, qos_name, DASH_RESULT_FAILURE);
             it = consumer.m_toSync.erase(it);
         }
     }
@@ -1176,7 +1254,7 @@ bool DashOrch::setEniRoute(const std::string& eni, const dash::eni_route::EniRou
 
     if (eni_entries_.find(eni) == eni_entries_.end())
     {
-        SWSS_LOG_INFO("ENI %s not yet created, not programming ENI route entry", eni.c_str());
+        SWSS_LOG_ERROR("ENI %s not yet created, cannot program ENI route entry", eni.c_str());
         return false;
     }
 
@@ -1184,7 +1262,7 @@ bool DashOrch::setEniRoute(const std::string& eni, const dash::eni_route::EniRou
     sai_object_id_t route_group_oid = dash_route_orch->getRouteGroupOid(entry.group_id());
     if (route_group_oid == SAI_NULL_OBJECT_ID)
     {
-        SWSS_LOG_INFO("Route group not yet created, skipping route entry for ENI %s", entry.group_id().c_str());
+        SWSS_LOG_ERROR("Route group %s not found, cannot set route entry for ENI %s", entry.group_id().c_str(), eni.c_str());
         return false;
     }
 
@@ -1216,7 +1294,7 @@ bool DashOrch::setEniRoute(const std::string& eni, const dash::eni_route::EniRou
         task_process_status handle_status = handleSaiSetStatus((sai_api_t) SAI_API_DASH_ENI, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            return false;
         }
     }
     eni_route_entries_[eni] = entry;
@@ -1255,7 +1333,7 @@ bool DashOrch::removeEniRoute(const std::string& eni)
             task_process_status handle_status = handleSaiSetStatus((sai_api_t) SAI_API_DASH_ENI, status);
             if (handle_status != task_success)
             {
-                return parseHandleSaiStatusFailure(handle_status);
+                return false;
             }
         }
     }
@@ -1278,45 +1356,53 @@ void DashOrch::doTaskEniRouteTable(ConsumerBase& consumer)
         KeyOpFieldsValuesTuple t = it->second;
         string eni = kfvKey(t);
         string op = kfvOp(t);
-        result = DASH_RESULT_SUCCESS;
 
-        if (op == SET_COMMAND)
+        try
         {
-            dash::eni_route::EniRoute entry;
+            result = DASH_RESULT_SUCCESS;
 
-            if (!parsePbMessage(kfvFieldsValues(t), entry))
+            if (op == SET_COMMAND)
             {
-                SWSS_LOG_WARN("Requires protobuf at ENI route:%s", eni.c_str());
+                dash::eni_route::EniRoute entry;
+
+                if (!parsePbMessage(kfvFieldsValues(t), entry))
+                {
+                    SWSS_LOG_ERROR("Requires protobuf at ENI route:%s", eni.c_str());
+                    writeResultToDB(dash_eni_route_result_table_, eni, DASH_RESULT_FAILURE);
+                    it = consumer.m_toSync.erase(it);
+                    continue;
+                }
+
+                if (!setEniRoute(eni, entry))
+                {
+                    SWSS_LOG_ERROR("Failed to set ENI route for %s", eni.c_str());
+                    result = DASH_RESULT_FAILURE;
+                }
                 it = consumer.m_toSync.erase(it);
-                continue;
+                writeResultToDB(dash_eni_route_result_table_, eni, result);
             }
-
-            if (setEniRoute(eni, entry))
+            else if (op == DEL_COMMAND)
             {
+                if (removeEniRoute(eni))
+                {
+                    removeResultFromDB(dash_eni_route_result_table_, eni);
+                }
+                else
+                {
+                    SWSS_LOG_ERROR("Failed to remove ENI route for %s", eni.c_str());
+                }
                 it = consumer.m_toSync.erase(it);
             }
             else
             {
-                result = DASH_RESULT_FAILURE;
-                it++;
-            }
-            writeResultToDB(dash_eni_route_result_table_, eni, result);
-        }
-        else if (op == DEL_COMMAND)
-        {
-            if (removeEniRoute(eni))
-            {
+                SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
                 it = consumer.m_toSync.erase(it);
-                removeResultFromDB(dash_eni_route_result_table_, eni);
-            }
-            else
-            {
-                it++;
             }
         }
-        else
+        catch (const std::exception& e)
         {
-            SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
+            SWSS_LOG_ERROR("Exception caught processing %s entry %s: %s", consumer.getTableName().c_str(), eni.c_str(), e.what());
+            writeResultToDB(dash_eni_route_result_table_, eni, DASH_RESULT_FAILURE);
             it = consumer.m_toSync.erase(it);
         }
     }

--- a/orchagent/dash/dashorch.h
+++ b/orchagent/dash/dashorch.h
@@ -84,6 +84,7 @@ private:
     void doTaskEniRouteTable(ConsumerBase &consumer);
     void doTaskRouteGroupTable(ConsumerBase &consumer);
     bool addApplianceEntry(const std::string& appliance_id, const dash::appliance::Appliance &entry);
+    bool createApplianceSaiObjects(const std::string& appliance_id, const dash::appliance::Appliance &entry, sai_object_id_t &sai_appliance_id);
     bool addApplianceTrustedVni(const std::string& appliance_id, const dash::appliance::Appliance& entry);
     bool removeApplianceEntry(const std::string& appliance_id);
     bool removeApplianceTrustedVni(const std::string& appliance_id, const dash::appliance::Appliance& entry);

--- a/orchagent/dash/dashportmaporch.cpp
+++ b/orchagent/dash/dashportmaporch.cpp
@@ -4,6 +4,7 @@
 #include "taskworker.h"
 #include "bulker.h"
 #include "pbutils.h"
+#include <exception>
 
 extern size_t gMaxBulkSize;
 extern sai_dash_outbound_port_map_api_t *sai_dash_outbound_port_map_api;
@@ -63,52 +64,61 @@ void DashPortMapOrch::doTaskPortMapTable(ConsumerBase &consumer)
         swss::KeyOpFieldsValuesTuple tuple = it->second;
         std::string port_map_id = kfvKey(tuple);
         std::string op = kfvOp(tuple);
-        auto rc = toBulk.emplace(std::piecewise_construct,
-                                 std::forward_as_tuple(port_map_id, op),
-                                 std::forward_as_tuple());
-        bool inserted = rc.second;
-        auto &ctxt = rc.first->second;
-        result = DASH_RESULT_SUCCESS;
-        SWSS_LOG_INFO("Processing port map entry: %s, operation: %s", port_map_id.c_str(), op.c_str());
 
-        if (!inserted)
+        try
         {
-            ctxt.clear();
-        }
+            auto rc = toBulk.emplace(std::piecewise_construct,
+                                     std::forward_as_tuple(port_map_id, op),
+                                     std::forward_as_tuple());
+            bool inserted = rc.second;
+            auto &ctxt = rc.first->second;
+            result = DASH_RESULT_SUCCESS;
+            SWSS_LOG_INFO("Processing port map entry: %s, operation: %s", port_map_id.c_str(), op.c_str());
 
-        if (op == SET_COMMAND)
-        {
-            // the only info we need is the port map ID which is provided in the key
-            // no need to parse protobuf message here
-
-            if (addPortMap(port_map_id, ctxt))
+            if (!inserted)
             {
-                it = consumer.m_toSync.erase(it);
-                // the only reason to remove from consumer prior to flush is if the port map already exists,
-                // so treat it like a success
-                writeResultToDB(dash_port_map_result_table_, port_map_id, result);
+                ctxt.clear();
+            }
+
+            if (op == SET_COMMAND)
+            {
+                // the only info we need is the port map ID which is provided in the key
+                // no need to parse protobuf message here
+
+                if (addPortMap(port_map_id, ctxt))
+                {
+                    it = consumer.m_toSync.erase(it);
+                    writeResultToDB(dash_port_map_result_table_, port_map_id, ctxt.pre_op_result);
+                }
+                else
+                {
+                    it++;
+                }
+            }
+            else if (op == DEL_COMMAND)
+            {
+                if (removePortMap(port_map_id, ctxt))
+                {
+                    it = consumer.m_toSync.erase(it);
+                    removeResultFromDB(dash_port_map_result_table_, port_map_id);
+                }
+                else
+                {
+                    it++;
+                }
             }
             else
             {
-                it++;
-            }
-        }
-        else if (op == DEL_COMMAND)
-        {
-            if (removePortMap(port_map_id, ctxt))
-            {
+                SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
                 it = consumer.m_toSync.erase(it);
-                removeResultFromDB(dash_port_map_result_table_, port_map_id);
-            }
-            else
-            {
-                it++;
             }
         }
-        else
+        catch (const std::exception& e)
         {
-            SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
+            SWSS_LOG_ERROR("Exception caught processing %s entry %s: %s", consumer.getTableName().c_str(), port_map_id.c_str(), e.what());
+            writeResultToDB(dash_port_map_result_table_, port_map_id, DASH_RESULT_FAILURE);
             it = consumer.m_toSync.erase(it);
+            continue;
         }
     }
 
@@ -120,49 +130,61 @@ void DashPortMapOrch::doTaskPortMapTable(ConsumerBase &consumer)
         swss::KeyOpFieldsValuesTuple tuple = it_prev->second;
         std::string port_map_id = kfvKey(tuple);
         std::string op = kfvOp(tuple);
-        result = DASH_RESULT_SUCCESS;
-        auto found = toBulk.find(std::make_pair(port_map_id, op));
-        if (found == toBulk.end())
+        try
         {
-            it_prev++;
-            continue;
-        }
-
-        auto &ctxt = found->second;
-        if (ctxt.port_map_oids.empty() && ctxt.port_map_statuses.empty())
-        {
-            it_prev++;
-            continue;
-        }
-
-        if (op == SET_COMMAND)
-        {
-            if (addPortMapPost(port_map_id, ctxt))
+            result = DASH_RESULT_SUCCESS;
+            auto found = toBulk.find(std::make_pair(port_map_id, op));
+            if (found == toBulk.end())
             {
-                it_prev = consumer.m_toSync.erase(it_prev);
+                it_prev++;
+                continue;
             }
-            else
+
+            auto &ctxt = found->second;
+            if (ctxt.port_map_oids.empty() && ctxt.port_map_statuses.empty())
             {
+                SWSS_LOG_ERROR("Missing port map bulk results for %s", port_map_id.c_str());
                 result = DASH_RESULT_FAILURE;
-                it_prev++;
-            }
-            writeResultToDB(dash_port_map_result_table_, port_map_id, result);
-        }
-        else if (op == DEL_COMMAND)
-        {
-            if (removePortMapPost(port_map_id, ctxt))
-            {
+                writeResultToDB(dash_port_map_result_table_, port_map_id, result);
                 it_prev = consumer.m_toSync.erase(it_prev);
-                removeResultFromDB(dash_port_map_result_table_, port_map_id);
+                continue;
+            }
+
+            if (op == SET_COMMAND)
+            {
+                bool handled = addPortMapPost(port_map_id, ctxt);
+                bool create_succeeded = !ctxt.port_map_oids.empty() && ctxt.port_map_oids.front() != SAI_NULL_OBJECT_ID;
+                if (!handled || !create_succeeded)
+                {
+                    SWSS_LOG_ERROR("Failed post-processing port map %s", port_map_id.c_str());
+                    result = DASH_RESULT_FAILURE;
+                }
+                it_prev = consumer.m_toSync.erase(it_prev);
+                writeResultToDB(dash_port_map_result_table_, port_map_id, result);
+            }
+            else if (op == DEL_COMMAND)
+            {
+                bool handled = removePortMapPost(port_map_id, ctxt);
+                bool remove_succeeded = !ctxt.port_map_statuses.empty() && ctxt.port_map_statuses.front() == SAI_STATUS_SUCCESS;
+                if (!handled || !remove_succeeded)
+                {
+                    SWSS_LOG_ERROR("Failed post-processing port map removal %s", port_map_id.c_str());
+                }
+                else
+                {
+                    removeResultFromDB(dash_port_map_result_table_, port_map_id);
+                }
+                it_prev = consumer.m_toSync.erase(it_prev);
             }
             else
             {
-                it_prev++;
+                SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
+                it_prev = consumer.m_toSync.erase(it_prev);
             }
         }
-        else
+        catch (const std::exception& e)
         {
-            SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
+            SWSS_LOG_ERROR("Exception caught in post-processing %s entry %s: %s", consumer.getTableName().c_str(), port_map_id.c_str(), e.what());
             it_prev = consumer.m_toSync.erase(it_prev);
         }
     }
@@ -261,14 +283,19 @@ bool DashPortMapOrch::removePortMapPost(const std::string &port_map_id, DashPort
     {
         if (status == SAI_STATUS_NOT_EXECUTED)
         {
-            SWSS_LOG_INFO("Port map %s not removed, will retry later", port_map_id.c_str());
+            SWSS_LOG_ERROR("Port map %s not removed, dropping notification", port_map_id.c_str());
             return false;
         }
+        if (status == SAI_STATUS_ITEM_NOT_FOUND)
+        {
+            SWSS_LOG_INFO("Port map %s already removed", port_map_id.c_str());
+            return true;
+        }
         SWSS_LOG_ERROR("Failed to remove port map %s, status: %s", port_map_id.c_str(), sai_serialize_status(status).c_str());
-        task_process_status handle_status = handleSaiCreateStatus((sai_api_t)SAI_API_DASH_OUTBOUND_PORT_MAP, status);
+        task_process_status handle_status = handleSaiRemoveStatus((sai_api_t)SAI_API_DASH_OUTBOUND_PORT_MAP, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            return false;
         }
     }
 
@@ -292,63 +319,73 @@ void DashPortMapOrch::doTaskPortMapRangeTable(ConsumerBase &consumer)
         swss::KeyOpFieldsValuesTuple tuple = it->second;
         std::string key = kfvKey(tuple);
         std::string op = kfvOp(tuple);
-        auto rc = toBulk.emplace(std::piecewise_construct,
-                                 std::forward_as_tuple(key, op),
-                                 std::forward_as_tuple());
-        bool inserted = rc.second;
-        auto &ctxt = rc.first->second;
-        result = DASH_RESULT_FAILURE;
-        SWSS_LOG_INFO("Processing port map range entry: %s, operation: %s", key.c_str(), op.c_str());
 
-        if (!inserted)
+        try
         {
-            ctxt.clear();
-        }
+            auto rc = toBulk.emplace(std::piecewise_construct,
+                                     std::forward_as_tuple(key, op),
+                                     std::forward_as_tuple());
+            bool inserted = rc.second;
+            auto &ctxt = rc.first->second;
+            result = DASH_RESULT_SUCCESS;
+            SWSS_LOG_INFO("Processing port map range entry: %s, operation: %s", key.c_str(), op.c_str());
 
-        if (!parsePortMapRange(key, ctxt))
-        {
-            SWSS_LOG_ERROR("Failed to parse port map range key: %s", key.c_str());
-            it = consumer.m_toSync.erase(it);
-            continue;
-        }
-
-        if (op == SET_COMMAND)
-        {
-            if (!parsePbMessage(kfvFieldsValues(tuple), ctxt.metadata))
+            if (!inserted)
             {
-                SWSS_LOG_ERROR("Failed to parse protobuf message for port map range %s", key.c_str());
+                ctxt.clear();
+            }
+
+            if (!parsePortMapRange(key, ctxt))
+            {
+                SWSS_LOG_ERROR("Failed to parse port map range key: %s", key.c_str());
+                writeResultToDB(dash_port_map_range_result_table_, key, DASH_RESULT_FAILURE);
                 it = consumer.m_toSync.erase(it);
                 continue;
             }
 
-            if (addPortMapRange(ctxt))
+            if (op == SET_COMMAND)
             {
-                it = consumer.m_toSync.erase(it);
-                // if we ever remove from consumer early, that means parsing was unsuccessful and a retry will not help,
-                // so treat it as a failure
-                writeResultToDB(dash_port_map_range_result_table_, key, result);
+                if (!parsePbMessage(kfvFieldsValues(tuple), ctxt.metadata))
+                {
+                    SWSS_LOG_ERROR("Failed to parse protobuf message for port map range %s", key.c_str());
+                    writeResultToDB(dash_port_map_range_result_table_, key, DASH_RESULT_FAILURE);
+                    it = consumer.m_toSync.erase(it);
+                    continue;
+                }
+
+                if (addPortMapRange(ctxt))
+                {
+                    it = consumer.m_toSync.erase(it);
+                    writeResultToDB(dash_port_map_range_result_table_, key, ctxt.pre_op_result);
+                }
+                else
+                {
+                    it++;
+                }
+            }
+            else if (op == DEL_COMMAND)
+            {
+                if (removePortMapRange(ctxt))
+                {
+                    it = consumer.m_toSync.erase(it);
+                }
+                else
+                {
+                    it++;
+                }
             }
             else
             {
-                it++;
-            }
-        }
-        else if (op == DEL_COMMAND)
-        {
-            if (removePortMapRange(ctxt))
-            {
+                SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
                 it = consumer.m_toSync.erase(it);
-                removeResultFromDB(dash_port_map_range_result_table_, key);
-            }
-            else
-            {
-                it++;
             }
         }
-        else
+        catch (const std::exception& e)
         {
-            SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
+            SWSS_LOG_ERROR("Exception caught processing %s entry %s: %s", consumer.getTableName().c_str(), key.c_str(), e.what());
+            writeResultToDB(dash_port_map_range_result_table_, key, DASH_RESULT_FAILURE);
             it = consumer.m_toSync.erase(it);
+            continue;
         }
     }
 
@@ -359,48 +396,62 @@ void DashPortMapOrch::doTaskPortMapRangeTable(ConsumerBase &consumer)
         swss::KeyOpFieldsValuesTuple tuple = it_prev->second;
         std::string key = kfvKey(tuple);
         std::string op = kfvOp(tuple);
-        result = DASH_RESULT_SUCCESS;
-        auto found = toBulk.find(std::make_pair(key, op));
-        if (found == toBulk.end())
+        try
         {
-            it_prev++;
-            continue;
-        }
-        auto &ctxt = found->second;
-        if (ctxt.port_map_range_statuses.empty())
-        {
-            it_prev++;
-            continue;
-        }
-
-        if (op == SET_COMMAND)
-        {
-            if (addPortMapRangePost(ctxt))
+            result = DASH_RESULT_SUCCESS;
+            auto found = toBulk.find(std::make_pair(key, op));
+            if (found == toBulk.end())
             {
-                it_prev = consumer.m_toSync.erase(it_prev);
+                it_prev++;
+                continue;
             }
-            else
+            auto &ctxt = found->second;
+            if (ctxt.port_map_range_statuses.empty())
             {
+                SWSS_LOG_ERROR("Missing port map range bulk results for %s", key.c_str());
                 result = DASH_RESULT_FAILURE;
-                it_prev++;
-            }
-            writeResultToDB(dash_port_map_range_result_table_, key, result);
-        }
-        else if (op == DEL_COMMAND)
-        {
-            if (removePortMapRangePost(ctxt))
-            {
+                writeResultToDB(dash_port_map_range_result_table_, key, result);
                 it_prev = consumer.m_toSync.erase(it_prev);
-                removeResultFromDB(dash_port_map_range_result_table_, key);
+                continue;
+            }
+
+            if (op == SET_COMMAND)
+            {
+                bool handled = addPortMapRangePost(ctxt);
+                bool create_succeeded = ctxt.port_map_range_statuses.front() == SAI_STATUS_SUCCESS ||
+                                        ctxt.port_map_range_statuses.front() == SAI_STATUS_ITEM_ALREADY_EXISTS;
+                if (!handled || !create_succeeded)
+                {
+                    SWSS_LOG_ERROR("Failed post-processing port map range %s", key.c_str());
+                    result = DASH_RESULT_FAILURE;
+                }
+                it_prev = consumer.m_toSync.erase(it_prev);
+                writeResultToDB(dash_port_map_range_result_table_, key, result);
+            }
+            else if (op == DEL_COMMAND)
+            {
+                bool handled = removePortMapRangePost(ctxt);
+                bool remove_succeeded = ctxt.port_map_range_statuses.front() == SAI_STATUS_SUCCESS ||
+                                        ctxt.port_map_range_statuses.front() == SAI_STATUS_ITEM_NOT_FOUND;
+                if (!handled || !remove_succeeded)
+                {
+                    SWSS_LOG_ERROR("Failed post-processing port map range removal %s", key.c_str());
+                }
+                else
+                {
+                    removeResultFromDB(dash_port_map_range_result_table_, key);
+                }
+                it_prev = consumer.m_toSync.erase(it_prev);
             }
             else
             {
-                it_prev++;
+                SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
+                it_prev = consumer.m_toSync.erase(it_prev);
             }
         }
-        else
+        catch (const std::exception& e)
         {
-            SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
+            SWSS_LOG_ERROR("Exception caught in post-processing %s entry %s: %s", consumer.getTableName().c_str(), key.c_str(), e.what());
             it_prev = consumer.m_toSync.erase(it_prev);
         }
     }
@@ -413,8 +464,9 @@ bool DashPortMapOrch::addPortMapRange(DashPortMapRangeBulkContext &ctxt)
     auto parent_it = port_map_table_.find(ctxt.parent_map_id);
     if (parent_it == port_map_table_.end())
     {
-        SWSS_LOG_INFO("Parent port map %s does not exist for port map range", ctxt.parent_map_id.c_str());
-        return false;
+        SWSS_LOG_ERROR("Parent port map %s does not exist for port map range %d-%d", ctxt.parent_map_id.c_str(), ctxt.start_port, ctxt.end_port);
+        ctxt.pre_op_result = DASH_RESULT_FAILURE;
+        return true;
     }
 
     sai_outbound_port_map_port_range_entry_t entry;
@@ -432,6 +484,7 @@ bool DashPortMapOrch::addPortMapRange(DashPortMapRangeBulkContext &ctxt)
     if (action_it == gPortMapRangeActionMap.end())
     {
         SWSS_LOG_ERROR("Unknown port map range action: %s", dash::outbound_port_map_range::PortMapRangeAction_Name(ctxt.metadata.action()).c_str());
+        ctxt.pre_op_result = DASH_RESULT_FAILURE;
         return true;
     }
 
@@ -443,6 +496,7 @@ bool DashPortMapOrch::addPortMapRange(DashPortMapRangeBulkContext &ctxt)
     if (!to_sai(ctxt.metadata.backend_ip(), attr.value.ipaddr))
     {
         SWSS_LOG_ERROR("Failed to convert backend IP %s to SAI format", ctxt.metadata.backend_ip().DebugString().c_str());
+        ctxt.pre_op_result = DASH_RESULT_FAILURE;
         return true;
     }
     attrs.push_back(attr);
@@ -485,7 +539,7 @@ bool DashPortMapOrch::addPortMapRangePost(DashPortMapRangeBulkContext &ctxt)
         task_process_status handle_status = handleSaiCreateStatus((sai_api_t)SAI_API_DASH_OUTBOUND_PORT_MAP, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            return false;
         }
     }
 
@@ -535,16 +589,21 @@ bool DashPortMapOrch::removePortMapRangePost(DashPortMapRangeBulkContext &ctxt)
     sai_status_t status = *it_status++;
     if (status != SAI_STATUS_SUCCESS)
     {
+        if (status == SAI_STATUS_NOT_EXECUTED)
+        {
+            SWSS_LOG_ERROR("Port map range for %s not removed because bulk operation was not executed", ctxt.parent_map_id.c_str());
+            return false;
+        }
         if (status == SAI_STATUS_ITEM_NOT_FOUND)
         {
             SWSS_LOG_INFO("Port map range for %s already removed", ctxt.parent_map_id.c_str());
             return true;
         }
         SWSS_LOG_ERROR("Failed to remove port map range for %s, status: %s", ctxt.parent_map_id.c_str(), sai_serialize_status(status).c_str());
-        task_process_status handle_status = handleSaiCreateStatus((sai_api_t)SAI_API_DASH_OUTBOUND_PORT_MAP, status);
+        task_process_status handle_status = handleSaiRemoveStatus((sai_api_t)SAI_API_DASH_OUTBOUND_PORT_MAP, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            return false;
         }
     }
 

--- a/orchagent/dash/dashportmaporch.h
+++ b/orchagent/dash/dashportmaporch.h
@@ -4,12 +4,13 @@
 #include "zmqorch.h"
 #include "dash_api/outbound_port_map_range.pb.h"
 #include "bulker.h"
+#include "dashorch.h"
 
 struct DashPortMapBulkContext
 {
     std::deque<sai_object_id_t> port_map_oids;
     std::deque<sai_status_t> port_map_statuses;
-    uint32_t pre_op_result = 0;
+    uint32_t pre_op_result = DASH_RESULT_SUCCESS;
 
     DashPortMapBulkContext() {}
     DashPortMapBulkContext(const DashPortMapBulkContext &) = delete;
@@ -19,7 +20,7 @@ struct DashPortMapBulkContext
     {
         port_map_oids.clear();
         port_map_statuses.clear();
-        pre_op_result = 0;
+        pre_op_result = DASH_RESULT_SUCCESS;
     }
 };
 
@@ -30,7 +31,7 @@ struct DashPortMapRangeBulkContext
     int end_port;
     dash::outbound_port_map_range::OutboundPortMapRange metadata;
     std::deque<sai_status_t> port_map_range_statuses;
-    uint32_t pre_op_result = 0;
+    uint32_t pre_op_result = DASH_RESULT_SUCCESS;
 
     DashPortMapRangeBulkContext() {}
     DashPortMapRangeBulkContext(const DashPortMapRangeBulkContext &) = delete;
@@ -39,7 +40,7 @@ struct DashPortMapRangeBulkContext
     void clear()
     {
         port_map_range_statuses.clear();
-        pre_op_result = 0;
+        pre_op_result = DASH_RESULT_SUCCESS;
     }
 };
 

--- a/orchagent/dash/dashportmaporch.h
+++ b/orchagent/dash/dashportmaporch.h
@@ -9,6 +9,7 @@ struct DashPortMapBulkContext
 {
     std::deque<sai_object_id_t> port_map_oids;
     std::deque<sai_status_t> port_map_statuses;
+    uint32_t pre_op_result = 0;
 
     DashPortMapBulkContext() {}
     DashPortMapBulkContext(const DashPortMapBulkContext &) = delete;
@@ -18,6 +19,7 @@ struct DashPortMapBulkContext
     {
         port_map_oids.clear();
         port_map_statuses.clear();
+        pre_op_result = 0;
     }
 };
 
@@ -28,6 +30,7 @@ struct DashPortMapRangeBulkContext
     int end_port;
     dash::outbound_port_map_range::OutboundPortMapRange metadata;
     std::deque<sai_status_t> port_map_range_statuses;
+    uint32_t pre_op_result = 0;
 
     DashPortMapRangeBulkContext() {}
     DashPortMapRangeBulkContext(const DashPortMapRangeBulkContext &) = delete;
@@ -36,6 +39,7 @@ struct DashPortMapRangeBulkContext
     void clear()
     {
         port_map_range_statuses.clear();
+        pre_op_result = 0;
     }
 };
 

--- a/orchagent/dash/dashrouteorch.cpp
+++ b/orchagent/dash/dashrouteorch.cpp
@@ -242,6 +242,9 @@ bool DashRouteOrch::removeOutboundRouting(const string& route_group, const IpPre
 
     if (isRouteGroupBound(ctxt.route_group))
     {
+        // Route group is still bound to an ENI, so the route cannot be removed.
+        // Always consume the entry; the existing result row in APP_STATE_DB is left
+        // intact, signaling to the controller that the DEL did not succeed.
         SWSS_LOG_ERROR("Cannot remove route from route group %s as it is already bound", ctxt.route_group.c_str());
         return true;
     }

--- a/orchagent/dash/dashrouteorch.cpp
+++ b/orchagent/dash/dashrouteorch.cpp
@@ -65,31 +65,37 @@ bool DashRouteOrch::addOutboundRouting(const string& key, OutboundRoutingBulkCon
     if (isRouteGroupBound(ctxt.route_group))
     {
         SWSS_LOG_WARN("Cannot add new route to route group %s as it is already bound", ctxt.route_group.c_str());
+        ctxt.pre_op_result = DASH_RESULT_FAILURE;
         return true;
     }
     sai_object_id_t route_group_oid = this->getRouteGroupOid(ctxt.route_group);
     if (route_group_oid == SAI_NULL_OBJECT_ID)
     {
-        SWSS_LOG_INFO("Retry as route group %s not found", ctxt.route_group.c_str());
-        return false;
+        SWSS_LOG_ERROR("Route group %s not found for outbound routing entry %s", ctxt.route_group.c_str(), key.c_str());
+        ctxt.pre_op_result = DASH_RESULT_FAILURE;
+        return true;
     }
 
     std::string routing_type_str = dash::route_type::RoutingType_Name(ctxt.metadata.routing_type());
     if (ctxt.metadata.routing_type() == dash::route_type::RoutingType::ROUTING_TYPE_VNET &&
         ctxt.metadata.has_vnet() && gVnetNameToId.find(ctxt.metadata.vnet()) == gVnetNameToId.end())
     {
-        SWSS_LOG_INFO("Retry as vnet %s not found for routing type %s",
-                      ctxt.metadata.vnet().c_str(),
-                      routing_type_str.c_str());
-        return false;
+        SWSS_LOG_ERROR("VNET %s not found for outbound routing entry %s (routing type %s)",
+                       ctxt.metadata.vnet().c_str(),
+                       key.c_str(),
+                       routing_type_str.c_str());
+        ctxt.pre_op_result = DASH_RESULT_FAILURE;
+        return true;
     }
     if (ctxt.metadata.routing_type() == dash::route_type::RoutingType::ROUTING_TYPE_VNET_DIRECT &&
         ctxt.metadata.has_vnet_direct() && gVnetNameToId.find(ctxt.metadata.vnet_direct().vnet()) == gVnetNameToId.end())
     {
-        SWSS_LOG_INFO("Retry as vnet %s not found for routing type %s",
-                      ctxt.metadata.vnet_direct().vnet().c_str(),
-                      routing_type_str.c_str());
-        return false;
+        SWSS_LOG_ERROR("VNET %s not found for outbound routing entry %s (routing type %s)",
+                       ctxt.metadata.vnet_direct().vnet().c_str(),
+                       key.c_str(),
+                       routing_type_str.c_str());
+        ctxt.pre_op_result = DASH_RESULT_FAILURE;
+        return true;
     }
 
     sai_outbound_routing_entry_t outbound_routing_entry;
@@ -103,8 +109,9 @@ bool DashRouteOrch::addOutboundRouting(const string& key, OutboundRoutingBulkCon
     auto it = sOutboundAction.find(ctxt.metadata.routing_type());
     if (it == sOutboundAction.end())
     {
-        SWSS_LOG_WARN("Routing type %s for outbound routing entry %s not allowed", routing_type_str.c_str(), key.c_str());
-        return false;
+        SWSS_LOG_ERROR("Routing type %s for outbound routing entry %s not allowed", routing_type_str.c_str(), key.c_str());
+        ctxt.pre_op_result = DASH_RESULT_FAILURE;
+        return true;
     }
 
     outbound_routing_attr.id = SAI_OUTBOUND_ROUTING_ENTRY_ATTR_ACTION;
@@ -118,7 +125,7 @@ bool DashRouteOrch::addOutboundRouting(const string& key, OutboundRoutingBulkCon
     else if (ctxt.metadata.routing_type() == dash::route_type::RoutingType::ROUTING_TYPE_VNET
         && ctxt.metadata.has_vnet()
         && !ctxt.metadata.vnet().empty())
-    {   
+    {
         outbound_routing_attr.id = SAI_OUTBOUND_ROUTING_ENTRY_ATTR_DST_VNET_ID;
         outbound_routing_attr.value.oid = gVnetNameToId[ctxt.metadata.vnet()];
         outbound_routing_attrs.push_back(outbound_routing_attr);
@@ -135,15 +142,18 @@ bool DashRouteOrch::addOutboundRouting(const string& key, OutboundRoutingBulkCon
         outbound_routing_attr.id = SAI_OUTBOUND_ROUTING_ENTRY_ATTR_OVERLAY_IP;
         if (!to_sai(ctxt.metadata.vnet_direct().overlay_ip(), outbound_routing_attr.value.ipaddr))
         {
-            return false;
+            SWSS_LOG_ERROR("Failed to convert overlay IP for outbound routing entry %s", key.c_str());
+            ctxt.pre_op_result = DASH_RESULT_FAILURE;
+            return true;
         }
         outbound_routing_attrs.push_back(outbound_routing_attr);
     }
     else
     {
-        SWSS_LOG_WARN("Routing type %s for outbound routing entry %s either invalid or missing required attributes",
-                        dash::route_type::RoutingType_Name(ctxt.metadata.routing_type()).c_str(), key.c_str());
-        return false;
+        SWSS_LOG_ERROR("Routing type %s for outbound routing entry %s either invalid or missing required attributes",
+                       dash::route_type::RoutingType_Name(ctxt.metadata.routing_type()).c_str(), key.c_str());
+        ctxt.pre_op_result = DASH_RESULT_FAILURE;
+        return true;
     }
 
     if (ctxt.metadata.has_underlay_sip() && ctxt.metadata.underlay_sip().has_ipv4())
@@ -151,7 +161,9 @@ bool DashRouteOrch::addOutboundRouting(const string& key, OutboundRoutingBulkCon
         outbound_routing_attr.id = SAI_OUTBOUND_ROUTING_ENTRY_ATTR_UNDERLAY_SIP;
         if (!to_sai(ctxt.metadata.underlay_sip(), outbound_routing_attr.value.ipaddr))
         {
-            return false;
+            SWSS_LOG_ERROR("Failed to convert underlay SIP for outbound routing entry %s", key.c_str());
+            ctxt.pre_op_result = DASH_RESULT_FAILURE;
+            return true;
         }
         outbound_routing_attrs.push_back(outbound_routing_attr);
     }
@@ -174,8 +186,9 @@ bool DashRouteOrch::addOutboundRouting(const string& key, OutboundRoutingBulkCon
         sai_object_id_t tunnel_oid = dash_tunnel_orch->getTunnelOid(ctxt.metadata.tunnel());
         if (tunnel_oid == SAI_NULL_OBJECT_ID)
         {
-            SWSS_LOG_INFO("Retry as tunnel %s not found", ctxt.metadata.tunnel().c_str());
-            return false;
+            SWSS_LOG_ERROR("Tunnel %s not found for outbound routing entry %s", ctxt.metadata.tunnel().c_str(), key.c_str());
+            ctxt.pre_op_result = DASH_RESULT_FAILURE;
+            return true;
         }
         outbound_routing_attr.id = SAI_OUTBOUND_ROUTING_ENTRY_ATTR_DASH_TUNNEL_ID;
         outbound_routing_attr.value.oid = tunnel_oid;
@@ -203,17 +216,16 @@ bool DashRouteOrch::addOutboundRoutingPost(const string& key, const OutboundRout
     sai_status_t status = *it_status++;
     if (status != SAI_STATUS_SUCCESS)
     {
+        SWSS_LOG_ERROR("Failed to create outbound routing entry for %s", key.c_str());
         if (status == SAI_STATUS_ITEM_ALREADY_EXISTS)
         {
-            // Retry if item exists in the bulker
-            return false;
+            return true;
         }
 
-        SWSS_LOG_ERROR("Failed to create outbound routing entry for %s", key.c_str());
         task_process_status handle_status = handleSaiCreateStatus((sai_api_t) SAI_API_DASH_OUTBOUND_ROUTING, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            return false;
         }
     }
 
@@ -230,8 +242,8 @@ bool DashRouteOrch::removeOutboundRouting(const string& route_group, const IpPre
 
     if (isRouteGroupBound(ctxt.route_group))
     {
-        SWSS_LOG_WARN("Cannot remove route from route group %s as it is already bound", ctxt.route_group.c_str());
-        return false;
+        SWSS_LOG_ERROR("Cannot remove route from route group %s as it is already bound", ctxt.route_group.c_str());
+        return true;
     }
 
     auto& object_statuses = ctxt.object_statuses;
@@ -257,25 +269,28 @@ bool DashRouteOrch::removeOutboundRoutingPost(const string& key, const OutboundR
 
     auto it_status = object_statuses.begin();
     sai_status_t status = *it_status++;
-    if (status != SAI_STATUS_SUCCESS)
+    if (status == SAI_STATUS_SUCCESS)
     {
-        if (status == SAI_STATUS_NOT_EXECUTED)
-        {
-            // Retry if bulk operation did not execute
-            return false;
-        }
-        SWSS_LOG_ERROR("Failed to remove outbound routing entry for %s", key.c_str());
-        task_process_status handle_status = handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_OUTBOUND_ROUTING, status);
-        if (handle_status != task_success)
-        {
-            return parseHandleSaiStatusFailure(handle_status);
-        }
+        gCrmOrch->decCrmResUsedCounter(ctxt.destination.isV4() ? CrmResourceType::CRM_DASH_IPV4_OUTBOUND_ROUTING : CrmResourceType::CRM_DASH_IPV6_OUTBOUND_ROUTING);
+        SWSS_LOG_INFO("Outbound routing entry for %s removed", key.c_str());
+        return true;
     }
-
-    gCrmOrch->decCrmResUsedCounter(ctxt.destination.isV4() ? CrmResourceType::CRM_DASH_IPV4_OUTBOUND_ROUTING : CrmResourceType::CRM_DASH_IPV6_OUTBOUND_ROUTING);
-
-    SWSS_LOG_INFO("Outbound routing entry for %s removed", key.c_str());
-
+    if (status == SAI_STATUS_NOT_EXECUTED)
+    {
+        SWSS_LOG_ERROR("Failed to remove outbound routing entry for %s: bulk operation was not executed", key.c_str());
+        return false;
+    }
+    if (status == SAI_STATUS_ITEM_NOT_FOUND)
+    {
+        SWSS_LOG_INFO("Outbound routing entry for %s already removed", key.c_str());
+        return true;
+    }
+    task_process_status handle_status = handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_OUTBOUND_ROUTING, status);
+    if (handle_status != task_success)
+    {
+        SWSS_LOG_ERROR("Failed to remove outbound routing entry for %s", key.c_str());
+        return false;
+    }
     return true;
 }
 
@@ -295,75 +310,82 @@ void DashRouteOrch::doTaskRouteTable(ConsumerBase& consumer)
             KeyOpFieldsValuesTuple tuple = it->second;
             const string& key = kfvKey(tuple);
             auto op = kfvOp(tuple);
-            auto rc = toBulk.emplace(std::piecewise_construct,
-                    std::forward_as_tuple(key, op),
-                    std::forward_as_tuple());
-            bool inserted = rc.second;
-            auto &ctxt = rc.first->second;
-            result = DASH_RESULT_SUCCESS;
 
-            if (!inserted)
+            try
             {
-                ctxt.clear();
-            }
+                auto rc = toBulk.emplace(std::piecewise_construct,
+                        std::forward_as_tuple(key, op),
+                        std::forward_as_tuple());
+                bool inserted = rc.second;
+                auto &ctxt = rc.first->second;
+                result = DASH_RESULT_SUCCESS;
 
-            string& route_group = ctxt.route_group;
-            IpPrefix& destination = ctxt.destination;
-
-            vector<string> keys = tokenize(key, ':');
-            route_group = keys[0];
-            string ip_str;
-            size_t pos = key.find(":", route_group.length());
-            ip_str = key.substr(pos + 1);
-            destination = IpPrefix(ip_str);
-
-            if (op == SET_COMMAND)
-            {
-                if (!parsePbMessage(kfvFieldsValues(tuple), ctxt.metadata))
+                if (!inserted)
                 {
-                    SWSS_LOG_WARN("Requires protobuff at OutboundRouting :%s", key.c_str());
-                    it = consumer.m_toSync.erase(it);
-                    continue;
+                    ctxt.clear();
                 }
-                if (ctxt.metadata.routing_type() == dash::route_type::RoutingType::ROUTING_TYPE_UNSPECIFIED)
+
+                string& route_group = ctxt.route_group;
+                IpPrefix& destination = ctxt.destination;
+
+                vector<string> keys = tokenize(key, ':');
+                route_group = keys[0];
+                string ip_str;
+                size_t pos = key.find(":", route_group.length());
+                ip_str = key.substr(pos + 1);
+                destination = IpPrefix(ip_str);
+
+                if (op == SET_COMMAND)
                 {
-                    // Route::action_type is deprecated in favor of Route::routing_type. For messages still using the old action_type field,
-                    // copy it to the new routing_type field. All subsequent operations will use the new field.
-                    #pragma GCC diagnostic push
-                    #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-                    ctxt.metadata.set_routing_type(ctxt.metadata.action_type());
-                    #pragma GCC diagnostic pop
+                    if (!parsePbMessage(kfvFieldsValues(tuple), ctxt.metadata))
+                    {
+                        SWSS_LOG_ERROR("Requires protobuff at OutboundRouting :%s", key.c_str());
+                        writeResultToDB(dash_route_result_table_, key, DASH_RESULT_FAILURE);
+                        it = consumer.m_toSync.erase(it);
+                        continue;
+                    }
+                    if (ctxt.metadata.routing_type() == dash::route_type::RoutingType::ROUTING_TYPE_UNSPECIFIED)
+                    {
+                        // Route::action_type is deprecated in favor of Route::routing_type. For messages still using the old action_type field,
+                        // copy it to the new routing_type field. All subsequent operations will use the new field.
+                        #pragma GCC diagnostic push
+                        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+                        ctxt.metadata.set_routing_type(ctxt.metadata.action_type());
+                        #pragma GCC diagnostic pop
+                    }
+                    if (addOutboundRouting(key, ctxt))
+                    {
+                        it = consumer.m_toSync.erase(it);
+                        writeResultToDB(dash_route_result_table_, key, ctxt.pre_op_result);
+                    }
+                    else
+                    {
+                        it++;
+                    }
                 }
-                if (addOutboundRouting(key, ctxt))
+                else if (op == DEL_COMMAND)
                 {
-                    it = consumer.m_toSync.erase(it);
-                    /*
-                     * Write result only when removing from consumer in pre-op
-                     * For other cases, this will be handled in post-op
-                     */
-                    writeResultToDB(dash_route_result_table_, key, result);
+                    if (removeOutboundRouting(route_group, destination, ctxt))
+                    {
+                        it = consumer.m_toSync.erase(it);
+                    }
+                    else
+                    {
+                        it++;
+                    }
                 }
                 else
                 {
-                    it++;
-                }
-            }
-            else if (op == DEL_COMMAND)
-            {
-                if (removeOutboundRouting(route_group, destination, ctxt))
-                {
+                    SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
                     it = consumer.m_toSync.erase(it);
-                    removeResultFromDB(dash_route_result_table_, key);
-                }
-                else
-                {
-                    it++;
                 }
             }
-            else
+            catch (const std::exception& e)
             {
-                SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
+                SWSS_LOG_ERROR("Exception caught processing %s entry %s: %s", consumer.getTableName().c_str(), key.c_str(), e.what());
+                writeResultToDB(dash_route_result_table_, key, DASH_RESULT_FAILURE);
                 it = consumer.m_toSync.erase(it);
+                continue;
             }
         }
 
@@ -375,46 +397,50 @@ void DashRouteOrch::doTaskRouteTable(ConsumerBase& consumer)
             KeyOpFieldsValuesTuple t = it_prev->second;
             string key = kfvKey(t);
             string op = kfvOp(t);
-            result = DASH_RESULT_SUCCESS;
-            auto found = toBulk.find(make_pair(key, op));
-            if (found == toBulk.end())
-            {
-                it_prev++;
-                continue;
-            }
 
-            const auto& ctxt = found->second;
-            const auto& object_statuses = ctxt.object_statuses;
-            if (object_statuses.empty())
+            try
             {
-                it_prev++;
-                continue;
-            }
-
-            if (op == SET_COMMAND)
-            {
-                if (addOutboundRoutingPost(key, ctxt))
-                {
-                    it_prev = consumer.m_toSync.erase(it_prev);
-                }
-                else
+                result = DASH_RESULT_SUCCESS;
+                auto found = toBulk.find(make_pair(key, op));
+                if (found == toBulk.end())
                 {
                     it_prev++;
+                    continue;
+                }
+
+                const auto& ctxt = found->second;
+                const auto& object_statuses = ctxt.object_statuses;
+                if (object_statuses.empty())
+                {
+                    SWSS_LOG_ERROR("No bulk status returned for outbound routing entry %s", key.c_str());
                     result = DASH_RESULT_FAILURE;
-                }
-                writeResultToDB(dash_route_result_table_, key, result);
-            }
-            else if (op == DEL_COMMAND)
-            {
-                if (removeOutboundRoutingPost(key, ctxt))
-                {
+                    writeResultToDB(dash_route_result_table_, key, result);
                     it_prev = consumer.m_toSync.erase(it_prev);
-                    removeResultFromDB(dash_route_result_table_, key);
+                    continue;
                 }
-                else
+
+                if (op == SET_COMMAND)
                 {
-                    it_prev++;
+                    if (!addOutboundRoutingPost(key, ctxt))
+                    {
+                        result = DASH_RESULT_FAILURE;
+                    }
+                    it_prev = consumer.m_toSync.erase(it_prev);
+                    writeResultToDB(dash_route_result_table_, key, result);
                 }
+                else if (op == DEL_COMMAND)
+                {
+                    if (removeOutboundRoutingPost(key, ctxt))
+                    {
+                        removeResultFromDB(dash_route_result_table_, key);
+                    }
+                    it_prev = consumer.m_toSync.erase(it_prev);
+                }
+            }
+            catch (const std::exception& e)
+            {
+                SWSS_LOG_ERROR("Exception caught in post-processing %s entry %s: %s", consumer.getTableName().c_str(), key.c_str(), e.what());
+                it_prev = consumer.m_toSync.erase(it_prev);
             }
         }
     }
@@ -426,13 +452,15 @@ bool DashRouteOrch::addInboundRouting(const string& key, InboundRoutingBulkConte
 
     if (!dash_orch_->getEni(ctxt.eni))
     {
-        SWSS_LOG_INFO("Retry as ENI entry %s not found", ctxt.eni.c_str());
-        return false;
+        SWSS_LOG_ERROR("ENI entry %s not found for inbound routing entry %s", ctxt.eni.c_str(), key.c_str());
+        ctxt.pre_op_result = DASH_RESULT_FAILURE;
+        return true;
     }
     if (ctxt.metadata.has_vnet() && gVnetNameToId.find(ctxt.metadata.vnet()) == gVnetNameToId.end())
     {
-        SWSS_LOG_INFO("Retry as vnet %s not found", ctxt.metadata.vnet().c_str());
-        return false;
+        SWSS_LOG_ERROR("VNET %s not found for inbound routing entry %s", ctxt.metadata.vnet().c_str(), key.c_str());
+        ctxt.pre_op_result = DASH_RESULT_FAILURE;
+        return true;
     }
 
     sai_inbound_routing_entry_t inbound_routing_entry;
@@ -492,17 +520,16 @@ bool DashRouteOrch::addInboundRoutingPost(const string& key, const InboundRoutin
     sai_status_t status = *it_status++;
     if (status != SAI_STATUS_SUCCESS)
     {
+        SWSS_LOG_ERROR("Failed to create inbound routing entry for %s", key.c_str());
         if (status == SAI_STATUS_ITEM_ALREADY_EXISTS)
         {
-            // Retry if item exists in the bulker
-            return false;
+            return true;
         }
 
-        SWSS_LOG_ERROR("Failed to create inbound routing entry");
         task_process_status handle_status = handleSaiCreateStatus((sai_api_t) SAI_API_DASH_INBOUND_ROUTING, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            return false;
         }
     }
 
@@ -543,25 +570,28 @@ bool DashRouteOrch::removeInboundRoutingPost(const string& key, const InboundRou
 
     auto it_status = object_statuses.begin();
     sai_status_t status = *it_status++;
-    if (status != SAI_STATUS_SUCCESS)
+    if (status == SAI_STATUS_SUCCESS)
     {
-        if (status == SAI_STATUS_NOT_EXECUTED)
-        {
-            // Retry if bulk operation did not execute
-            return false;
-        }
-        SWSS_LOG_ERROR("Failed to remove inbound routing entry for %s", key.c_str());
-        task_process_status handle_status = handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_INBOUND_ROUTING, status);
-        if (handle_status != task_success)
-        {
-            return parseHandleSaiStatusFailure(handle_status);
-        }
+        gCrmOrch->decCrmResUsedCounter(ctxt.sip.isV4() ? CrmResourceType::CRM_DASH_IPV4_INBOUND_ROUTING : CrmResourceType::CRM_DASH_IPV6_INBOUND_ROUTING);
+        SWSS_LOG_INFO("Inbound routing entry for %s removed", key.c_str());
+        return true;
     }
-
-    gCrmOrch->decCrmResUsedCounter(ctxt.sip.isV4() ? CrmResourceType::CRM_DASH_IPV4_INBOUND_ROUTING : CrmResourceType::CRM_DASH_IPV6_INBOUND_ROUTING);
-
-    SWSS_LOG_INFO("Inbound routing entry for %s removed", key.c_str());
-
+    if (status == SAI_STATUS_NOT_EXECUTED)
+    {
+        SWSS_LOG_ERROR("Failed to remove inbound routing entry for %s: bulk operation was not executed", key.c_str());
+        return false;
+    }
+    if (status == SAI_STATUS_ITEM_NOT_FOUND)
+    {
+        SWSS_LOG_INFO("Inbound routing entry for %s already removed", key.c_str());
+        return true;
+    }
+    task_process_status handle_status = handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_INBOUND_ROUTING, status);
+    if (handle_status != task_success)
+    {
+        SWSS_LOG_ERROR("Failed to remove inbound routing entry for %s", key.c_str());
+        return false;
+    }
     return true;
 }
 
@@ -581,93 +611,100 @@ void DashRouteOrch::doTaskRouteRuleTable(ConsumerBase& consumer)
             KeyOpFieldsValuesTuple tuple = it->second;
             const string& key = kfvKey(tuple);
             auto op = kfvOp(tuple);
-            auto rc = toBulk.emplace(std::piecewise_construct,
-                    std::forward_as_tuple(key, op),
-                    std::forward_as_tuple());
-            bool inserted = rc.second;
-            auto &ctxt = rc.first->second;
-            result = DASH_RESULT_SUCCESS;
 
-            if (!inserted)
+            try
             {
-                ctxt.clear();
-            }
+                auto rc = toBulk.emplace(std::piecewise_construct,
+                        std::forward_as_tuple(key, op),
+                        std::forward_as_tuple());
+                bool inserted = rc.second;
+                auto &ctxt = rc.first->second;
+                result = DASH_RESULT_SUCCESS;
 
-            string& eni = ctxt.eni;
-            uint32_t& vni = ctxt.vni;
-            IpAddress& sip = ctxt.sip;
-            IpAddress& sip_mask = ctxt.sip_mask;
-            uint32_t& priority = ctxt.priority;
-            IpPrefix prefix;
-
-            // expect key in format {{eni}}:{{vni}}:{{prefix/tag}}:{{priority}}
-            size_t first_colon = key.find(":");
-            size_t second_colon = key.find(":", first_colon == string::npos ? first_colon : first_colon + 1);
-            eni = key.substr(0, first_colon);
-            vni = to_uint<uint32_t>(key.substr(first_colon + 1, second_colon - first_colon - 1));
-
-            priority = 0;
-
-            // the key format was changed to include priority field. in case old key format is used where the priority is not present, we should not crash and default to priority 0.
-            string prefix_and_optional_priority = key.substr(second_colon + 1);
-            string ip_str = prefix_and_optional_priority;
-            size_t last_colon = prefix_and_optional_priority.rfind(':');
-            if (last_colon != string::npos)
-            {
-                string maybe_priority = prefix_and_optional_priority.substr(last_colon + 1);
-                bool is_priority = !maybe_priority.empty() &&
-                                   all_of(maybe_priority.begin(), maybe_priority.end(),
-                                          [](unsigned char c)
-                                          { return std::isdigit(c); });
-                if (is_priority)
+                if (!inserted)
                 {
-                    priority = to_uint<uint32_t>(maybe_priority);
-                    ip_str = prefix_and_optional_priority.substr(0, last_colon);
+                    ctxt.clear();
                 }
-            }
-            prefix = IpPrefix(ip_str);
 
-            sip = prefix.getIp();
-            sip_mask = prefix.getMask();
+                string& eni = ctxt.eni;
+                uint32_t& vni = ctxt.vni;
+                IpAddress& sip = ctxt.sip;
+                IpAddress& sip_mask = ctxt.sip_mask;
+                uint32_t& priority = ctxt.priority;
+                IpPrefix prefix;
 
-            if (op == SET_COMMAND)
-            {
-                if (!parsePbMessage(kfvFieldsValues(tuple), ctxt.metadata))
+                // expect key in format {{eni}}:{{vni}}:{{prefix/tag}}:{{priority}}
+                size_t first_colon = key.find(":");
+                size_t second_colon = key.find(":", first_colon == string::npos ? first_colon : first_colon + 1);
+                eni = key.substr(0, first_colon);
+                vni = to_uint<uint32_t>(key.substr(first_colon + 1, second_colon - first_colon - 1));
+
+                priority = 0;
+
+                // the key format was changed to include priority field. in case old key format is used where the priority is not present, we should not crash and default to priority 0.
+                string prefix_and_optional_priority = key.substr(second_colon + 1);
+                string ip_str = prefix_and_optional_priority;
+                size_t last_colon = prefix_and_optional_priority.rfind(':');
+                if (last_colon != string::npos)
                 {
-                    SWSS_LOG_WARN("Requires protobuff at InboundRouting :%s", key.c_str());
-                    it = consumer.m_toSync.erase(it);
-                    continue;
+                    string maybe_priority = prefix_and_optional_priority.substr(last_colon + 1);
+                    bool is_priority = !maybe_priority.empty() &&
+                                       all_of(maybe_priority.begin(), maybe_priority.end(),
+                                              [](unsigned char c)
+                                              { return std::isdigit(c); });
+                    if (is_priority)
+                    {
+                        priority = to_uint<uint32_t>(maybe_priority);
+                        ip_str = prefix_and_optional_priority.substr(0, last_colon);
+                    }
                 }
-                if (addInboundRouting(key, ctxt))
+                prefix = IpPrefix(ip_str);
+
+                sip = prefix.getIp();
+                sip_mask = prefix.getMask();
+
+                if (op == SET_COMMAND)
                 {
-                    it = consumer.m_toSync.erase(it);
-                    /*
-                     * Write result only when removing from consumer in pre-op
-                     * For other cases, this will be handled in post-op
-                     */
-                    writeResultToDB(dash_route_rule_result_table_, key, result);
+                    if (!parsePbMessage(kfvFieldsValues(tuple), ctxt.metadata))
+                    {
+                        SWSS_LOG_ERROR("Requires protobuff at InboundRouting :%s", key.c_str());
+                        writeResultToDB(dash_route_rule_result_table_, key, DASH_RESULT_FAILURE);
+                        it = consumer.m_toSync.erase(it);
+                        continue;
+                    }
+                    if (addInboundRouting(key, ctxt))
+                    {
+                        it = consumer.m_toSync.erase(it);
+                        writeResultToDB(dash_route_rule_result_table_, key, ctxt.pre_op_result);
+                    }
+                    else
+                    {
+                        it++;
+                    }
+                }
+                else if (op == DEL_COMMAND)
+                {
+                    if (removeInboundRouting(key, ctxt))
+                    {
+                        it = consumer.m_toSync.erase(it);
+                    }
+                    else
+                    {
+                        it++;
+                    }
                 }
                 else
                 {
-                    it++;
-                }
-            }
-            else if (op == DEL_COMMAND)
-            {
-                if (removeInboundRouting(key, ctxt))
-                {
+                    SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
                     it = consumer.m_toSync.erase(it);
-                    removeResultFromDB(dash_route_rule_result_table_, key);
-                }
-                else
-                {
-                    it++;
                 }
             }
-            else
+            catch (const std::exception& e)
             {
-                SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
+                SWSS_LOG_ERROR("Exception caught processing %s entry %s: %s", consumer.getTableName().c_str(), key.c_str(), e.what());
+                writeResultToDB(dash_route_rule_result_table_, key, DASH_RESULT_FAILURE);
                 it = consumer.m_toSync.erase(it);
+                continue;
             }
         }
 
@@ -679,46 +716,50 @@ void DashRouteOrch::doTaskRouteRuleTable(ConsumerBase& consumer)
             KeyOpFieldsValuesTuple t = it_prev->second;
             string key = kfvKey(t);
             string op = kfvOp(t);
-            result = DASH_RESULT_SUCCESS;
-            auto found = toBulk.find(make_pair(key, op));
-            if (found == toBulk.end())
-            {
-                it_prev++;
-                continue;
-            }
 
-            const auto& ctxt = found->second;
-            const auto& object_statuses = ctxt.object_statuses;
-            if (object_statuses.empty())
+            try
             {
-                it_prev++;
-                continue;
-            }
-
-            if (op == SET_COMMAND)
-            {
-                if (addInboundRoutingPost(key, ctxt))
+                result = DASH_RESULT_SUCCESS;
+                auto found = toBulk.find(make_pair(key, op));
+                if (found == toBulk.end())
                 {
-                    it_prev = consumer.m_toSync.erase(it_prev);
+                    it_prev++;
+                    continue;
                 }
-                else
+
+                const auto& ctxt = found->second;
+                const auto& object_statuses = ctxt.object_statuses;
+                if (object_statuses.empty())
                 {
+                    SWSS_LOG_ERROR("No bulk status returned for inbound routing entry %s", key.c_str());
                     result = DASH_RESULT_FAILURE;
-                    it_prev++;
-                }
-                writeResultToDB(dash_route_rule_result_table_, key, result);
-            }
-            else if (op == DEL_COMMAND)
-            {
-                if (removeInboundRoutingPost(key, ctxt))
-                {
+                    writeResultToDB(dash_route_rule_result_table_, key, result);
                     it_prev = consumer.m_toSync.erase(it_prev);
-                    removeResultFromDB(dash_route_rule_result_table_, key);
+                    continue;
                 }
-                else
+
+                if (op == SET_COMMAND)
                 {
-                    it_prev++;
+                    if (!addInboundRoutingPost(key, ctxt))
+                    {
+                        result = DASH_RESULT_FAILURE;
+                    }
+                    it_prev = consumer.m_toSync.erase(it_prev);
+                    writeResultToDB(dash_route_rule_result_table_, key, result);
                 }
+                else if (op == DEL_COMMAND)
+                {
+                    if (removeInboundRoutingPost(key, ctxt))
+                    {
+                        removeResultFromDB(dash_route_rule_result_table_, key);
+                    }
+                    it_prev = consumer.m_toSync.erase(it_prev);
+                }
+            }
+            catch (const std::exception& e)
+            {
+                SWSS_LOG_ERROR("Exception caught in post-processing %s entry %s: %s", consumer.getTableName().c_str(), key.c_str(), e.what());
+                it_prev = consumer.m_toSync.erase(it_prev);
             }
         }
     }
@@ -742,7 +783,7 @@ bool DashRouteOrch::addRouteGroup(const string& route_group, const dash::route_g
         task_process_status handle_status = handleSaiCreateStatus((sai_api_t) SAI_API_DASH_OUTBOUND_ROUTING, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            return false;
         }
     }
 
@@ -772,16 +813,15 @@ bool DashRouteOrch::removeRouteGroup(const string& route_group)
     sai_status_t status = sai_dash_outbound_routing_api->remove_outbound_routing_group(route_group_oid);
     if (status != SAI_STATUS_SUCCESS)
     {
-        //Retry later if object is in use
+        SWSS_LOG_ERROR("Failed to remove route group %s", route_group.c_str());
         if (status == SAI_STATUS_OBJECT_IN_USE)
         {
             return false;
         }
-        SWSS_LOG_ERROR("Failed to remove route group %s", route_group.c_str());
         task_process_status handle_status = handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_OUTBOUND_ROUTING, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            return false;
         }
     }
 
@@ -855,43 +895,46 @@ void DashRouteOrch::doTaskRouteGroupTable(ConsumerBase& consumer)
         auto t = it->second;
         string route_group = kfvKey(t);
         string op = kfvOp(t);
-        result = DASH_RESULT_SUCCESS;
-        if (op == SET_COMMAND)
-        {
-            dash::route_group::RouteGroup entry;
-            if (!parsePbMessage(kfvFieldsValues(t), entry))
-            {
-                SWSS_LOG_WARN("Requires protobuf at RouteGroup :%s", route_group.c_str());
-                it = consumer.m_toSync.erase(it);
-                continue;
-            }
 
-            if (addRouteGroup(route_group, entry))
+        try
+        {
+            result = DASH_RESULT_SUCCESS;
+            if (op == SET_COMMAND)
             {
+                dash::route_group::RouteGroup entry;
+                if (!parsePbMessage(kfvFieldsValues(t), entry))
+                {
+                    SWSS_LOG_ERROR("Requires protobuf at RouteGroup :%s", route_group.c_str());
+                    writeResultToDB(dash_route_group_result_table_, route_group, DASH_RESULT_FAILURE);
+                    it = consumer.m_toSync.erase(it);
+                    continue;
+                }
+
+                if (!addRouteGroup(route_group, entry))
+                {
+                    result = DASH_RESULT_FAILURE;
+                }
+                it = consumer.m_toSync.erase(it);
+                writeResultToDB(dash_route_group_result_table_, route_group, result, entry.version());
+            }
+            else if (op == DEL_COMMAND)
+            {
+                if (removeRouteGroup(route_group))
+                {
+                    removeResultFromDB(dash_route_group_result_table_, route_group);
+                }
                 it = consumer.m_toSync.erase(it);
             }
             else
             {
-                result = DASH_RESULT_FAILURE;
-                it++;
-            }
-            writeResultToDB(dash_route_group_result_table_, route_group, result, entry.version());
-        }
-        else if (op == DEL_COMMAND)
-        {
-            if (removeRouteGroup(route_group))
-            {
+                SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
                 it = consumer.m_toSync.erase(it);
-                removeResultFromDB(dash_route_group_result_table_, route_group);
-            }
-            else
-            {
-                it++;
             }
         }
-        else
+        catch (const std::exception& e)
         {
-            SWSS_LOG_ERROR("Unknown operation %s", op.c_str());
+            SWSS_LOG_ERROR("Exception caught processing %s entry %s: %s", consumer.getTableName().c_str(), route_group.c_str(), e.what());
+            writeResultToDB(dash_route_group_result_table_, route_group, DASH_RESULT_FAILURE);
             it = consumer.m_toSync.erase(it);
         }
     }

--- a/orchagent/dash/dashrouteorch.h
+++ b/orchagent/dash/dashrouteorch.h
@@ -26,6 +26,7 @@ struct OutboundRoutingBulkContext
     swss::IpPrefix destination;
     dash::route::Route metadata;
     std::deque<sai_status_t> object_statuses;
+    uint32_t pre_op_result = DASH_RESULT_SUCCESS;
     OutboundRoutingBulkContext() {}
     OutboundRoutingBulkContext(const OutboundRoutingBulkContext&) = delete;
     OutboundRoutingBulkContext(OutboundRoutingBulkContext&&) = delete;
@@ -33,6 +34,7 @@ struct OutboundRoutingBulkContext
     void clear()
     {
         object_statuses.clear();
+        pre_op_result = DASH_RESULT_SUCCESS;
     }
 };
 
@@ -45,6 +47,7 @@ struct InboundRoutingBulkContext
     uint32_t priority;
     dash::route_rule::RouteRule metadata;
     std::deque<sai_status_t> object_statuses;
+    uint32_t pre_op_result = DASH_RESULT_SUCCESS;
     InboundRoutingBulkContext() {}
     InboundRoutingBulkContext(const InboundRoutingBulkContext&) = delete;
     InboundRoutingBulkContext(InboundRoutingBulkContext&&) = delete;
@@ -52,6 +55,7 @@ struct InboundRoutingBulkContext
     void clear()
     {
         object_statuses.clear();
+        pre_op_result = DASH_RESULT_SUCCESS;
     }
 };
 

--- a/orchagent/dash/dashtagmgr.cpp
+++ b/orchagent/dash/dashtagmgr.cpp
@@ -83,8 +83,8 @@ task_process_status DashTagMgr::remove(const string& tag_id)
 
     if (!tag_it->second.m_groups.empty())
     {
-        SWSS_LOG_WARN("Prefix tag %s is still in use by ACL rule(s)", tag_id.c_str());
-        return task_need_retry;
+        SWSS_LOG_ERROR("Prefix tag %s is still in use by ACL rule(s)", tag_id.c_str());
+        return task_failed;
     }
 
     m_tag_table.erase(tag_it);

--- a/orchagent/dash/dashtunnelorch.cpp
+++ b/orchagent/dash/dashtunnelorch.cpp
@@ -306,13 +306,13 @@ bool DashTunnelOrch::addTunnel(const std::string& tunnel_name, DashTunnelBulkCon
     }
     std::vector<sai_attribute_t> tunnel_attrs;
     sai_attribute_t tunnel_attr;
-    bool remove_from_consumer = true;
+    bool pre_op_exit_early = true;
 
     bool exists = (tunnel_table_.find(tunnel_name) != tunnel_table_.end());
     if (exists)
     {
         SWSS_LOG_WARN("DASH tunnel %s already exists", tunnel_name.c_str());
-        return remove_from_consumer;
+        return pre_op_exit_early;
     }
 
     tunnel_attr.id = SAI_DASH_TUNNEL_ATTR_MAX_MEMBER_SIZE;
@@ -331,7 +331,7 @@ bool DashTunnelOrch::addTunnel(const std::string& tunnel_name, DashTunnelBulkCon
         default:
             SWSS_LOG_ERROR("Unsupported encap type %d", ctxt.metadata.encap_type());
             ctxt.pre_op_result = DASH_RESULT_FAILURE;
-            return remove_from_consumer;
+            return pre_op_exit_early;
     }
     tunnel_attrs.push_back(tunnel_attr);
 
@@ -364,8 +364,8 @@ bool DashTunnelOrch::addTunnel(const std::string& tunnel_name, DashTunnelBulkCon
     object_ids.emplace_back();
     tunnel_bulker_.create_entry(&object_ids.back(), (uint32_t) tunnel_attrs.size(), tunnel_attrs.data());
 
-    remove_from_consumer = false;
-    return remove_from_consumer;
+    pre_op_exit_early = false;
+    return pre_op_exit_early;
 }
 
 void DashTunnelOrch::addTunnelNextHops(const std::string& tunnel_name, DashTunnelBulkContext& ctxt)
@@ -386,11 +386,11 @@ bool DashTunnelOrch::addTunnelPost(const std::string& tunnel_name, DashTunnelBul
 {
     SWSS_LOG_ENTER();
 
-    bool remove_from_consumer = true;
+    bool processing_complete = true;
     const auto& object_ids = ctxt.tunnel_object_ids;
     if (object_ids.empty())
     {
-        return remove_from_consumer;
+        return processing_complete;
     }
 
     auto it_id = object_ids.begin();
@@ -405,11 +405,11 @@ bool DashTunnelOrch::addTunnelPost(const std::string& tunnel_name, DashTunnelBul
     {
         DashTunnelEntry entry = { tunnel_oid, std::map<std::string, DashTunnelEndpointEntry>(), std::string() };
         tunnel_table_[tunnel_name] = entry;
-        remove_from_consumer = (ctxt.metadata.endpoints_size() == 1);
+        processing_complete = (ctxt.metadata.endpoints_size() == 1);
         SWSS_LOG_INFO("Tunnel entry added for %s", tunnel_name.c_str());
     }
 
-    return addTunnelNextHopsPost(tunnel_name, ctxt, remove_from_consumer);
+    return addTunnelNextHopsPost(tunnel_name, ctxt, processing_complete);
 }
 
 bool DashTunnelOrch::addTunnelNextHopsPost(const std::string& tunnel_name, DashTunnelBulkContext& ctxt, const bool parent_tunnel_removed)
@@ -421,7 +421,7 @@ bool DashTunnelOrch::addTunnelNextHopsPost(const std::string& tunnel_name, DashT
         return parent_tunnel_removed;
     }
 
-    bool remove_from_consumer = true;
+    bool processing_complete = true;
     const auto& nhop_oids = ctxt.tunnel_nhop_object_ids;
     auto it_nhop = nhop_oids.begin();
     for (auto ip : ctxt.metadata.endpoints())
@@ -448,9 +448,9 @@ bool DashTunnelOrch::addTunnelNextHopsPost(const std::string& tunnel_name, DashT
         tunnel_table_[tunnel_name].endpoints[to_string(ip)] = endpoint;
         SWSS_LOG_INFO("Tunnel next hop entry added for tunnel %s, endpoint %s", tunnel_name.c_str(), to_string(ip).c_str());
         addTunnelMember(tunnel_table_[tunnel_name].tunnel_oid, nhop_oid, ctxt);
-        remove_from_consumer = false; // if we add at least one tunnel member, tunnel needs to stay in consumer for tunnel member post-bulk ops
+        processing_complete = false; // if we add at least one tunnel member, tunnel needs to stay in consumer for tunnel member post-bulk ops
     }
-    return remove_from_consumer;
+    return processing_complete;
 }
 
 void DashTunnelOrch::addTunnelMember(const sai_object_id_t tunnel_oid, const sai_object_id_t nhop_oid, DashTunnelBulkContext& ctxt)
@@ -475,7 +475,7 @@ void DashTunnelOrch::addTunnelMember(const sai_object_id_t tunnel_oid, const sai
 bool DashTunnelOrch::addTunnelMemberPost(const std::string& tunnel_name, const DashTunnelBulkContext& ctxt)
 {
     SWSS_LOG_ENTER();
-    bool remove_from_consumer = true;
+    bool success = true;
     const auto& member_oids = ctxt.tunnel_member_object_ids;
     auto it_member = member_oids.begin();
     for (auto ip : ctxt.metadata.endpoints())
@@ -489,19 +489,19 @@ bool DashTunnelOrch::addTunnelMemberPost(const std::string& tunnel_name, const D
         tunnel_table_[tunnel_name].endpoints[to_string(ip)].tunnel_member_oid = member_oid;
         SWSS_LOG_INFO("Tunnel member entry added for tunnel %s, endpoint %s", tunnel_name.c_str(), to_string(ip).c_str());
     }
-    return remove_from_consumer;
+    return success;
 }
 
 bool DashTunnelOrch::removeTunnel(const std::string& tunnel_name, DashTunnelBulkContext& ctxt)
 {
     SWSS_LOG_ENTER();
-    bool remove_from_consumer = true;
+    bool pre_op_exit_early = true;
 
     auto it = tunnel_table_.find(tunnel_name);
     if (it == tunnel_table_.end())
     {
         SWSS_LOG_WARN("Failed to find DASH tunnel %s to remove", tunnel_name.c_str());
-        return remove_from_consumer;
+        return pre_op_exit_early;
     }
 
     auto& endpoints = it->second.endpoints;
@@ -515,24 +515,24 @@ bool DashTunnelOrch::removeTunnel(const std::string& tunnel_name, DashTunnelBulk
     object_statuses.emplace_back();
     tunnel_bulker_.remove_entry(&object_statuses.back(), it->second.tunnel_oid);
 
-    remove_from_consumer = false;
-    return remove_from_consumer;
+    pre_op_exit_early = false;
+    return pre_op_exit_early;
 }
 
 bool DashTunnelOrch::removeTunnelPost(const std::string& tunnel_name, const DashTunnelBulkContext& ctxt)
 {
     SWSS_LOG_ENTER();
-    bool remove_from_consumer = removeTunnelEndpointsPost(tunnel_name, ctxt);
-    if (!remove_from_consumer)
+    bool success = removeTunnelEndpointsPost(tunnel_name, ctxt);
+    if (!success)
     {
         // If endpoint removal failed, exit immediately since the tunnel can't be deleted if endpoints still exist
-        return remove_from_consumer;
+        return success;
     }
 
     const auto& object_statuses = ctxt.tunnel_object_statuses;
     if (object_statuses.empty())
     {
-        return remove_from_consumer;
+        return success;
     }
 
     auto it_status = object_statuses.begin();
@@ -542,23 +542,23 @@ bool DashTunnelOrch::removeTunnelPost(const std::string& tunnel_name, const Dash
         if (status == SAI_STATUS_OBJECT_IN_USE)
         {
             SWSS_LOG_ERROR("DASH tunnel %s is in use, cannot remove", tunnel_name.c_str());
-            remove_from_consumer = false;
-            return remove_from_consumer;
+            success = false;
+            return success;
         }
 
         task_process_status handle_status = handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_TUNNEL, status);
         if (handle_status != task_success)
         {
-            remove_from_consumer = true;
-            return remove_from_consumer;
+            success = true;
+            return success;
         }
     }
 
     tunnel_table_.erase(tunnel_name);
     SWSS_LOG_NOTICE("DASH tunnel entry removed for %s", tunnel_name.c_str());
 
-    remove_from_consumer = true;
-    return remove_from_consumer;
+    success = true;
+    return success;
 }
 
 void DashTunnelOrch::removeTunnelEndpoints(const std::string& tunnel_name, DashTunnelBulkContext& ctxt)
@@ -597,13 +597,13 @@ void DashTunnelOrch::removeTunnelEndpoints(const std::string& tunnel_name, DashT
 bool DashTunnelOrch::removeTunnelEndpointsPost(const std::string& tunnel_name, const DashTunnelBulkContext& ctxt)
 {
     SWSS_LOG_ENTER();
-    bool remove_from_consumer = true;
+    bool success = true;
 
     const auto& tunnel_member_statuses = ctxt.tunnel_member_object_statuses;
     const auto& tunnel_nhop_statuses = ctxt.tunnel_nhop_object_statuses;
     if (tunnel_member_statuses.empty() && tunnel_nhop_statuses.empty())
     {
-        return remove_from_consumer;
+        return success;
     }
 
     auto tm_it_status = tunnel_member_statuses.begin();
@@ -631,7 +631,7 @@ bool DashTunnelOrch::removeTunnelEndpointsPost(const std::string& tunnel_name, c
         {
             SWSS_LOG_ERROR("DASH tunnel next hop removal for tunnel %s endpoint %s failed with %s", tunnel_name.c_str(), endpoint_it->first.c_str(), sai_serialize_status(nh_status).c_str());
             handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_TUNNEL, nh_status);
-            remove_from_consumer = false;
+            success = false;
         }
         else
         {
@@ -642,5 +642,5 @@ bool DashTunnelOrch::removeTunnelEndpointsPost(const std::string& tunnel_name, c
         endpoint_it++;
     }
 
-    return remove_from_consumer;
+    return success;
 }

--- a/orchagent/dash/dashtunnelorch.cpp
+++ b/orchagent/dash/dashtunnelorch.cpp
@@ -6,6 +6,7 @@
 #include "pbutils.h"
 #include "directory.h"
 #include "saihelper.h"
+#include <exception>
 
 extern size_t gMaxBulkSize;
 extern sai_dash_tunnel_api_t* sai_dash_tunnel_api;
@@ -111,55 +112,60 @@ void DashTunnelOrch::doTask(ConsumerBase &consumer)
             swss::KeyOpFieldsValuesTuple t = it->second;
             std::string tunnel_name = kfvKey(t);
             std::string op = kfvOp(t);
-            auto rc = toBulk.emplace(std::piecewise_construct,
-                    std::forward_as_tuple(tunnel_name, op),
-                    std::forward_as_tuple());
-            bool inserted = rc.second;
-            auto& ctxt = rc.first->second;
-            result = DASH_RESULT_SUCCESS;
-            if (!inserted)
+
+            try
             {
-                ctxt.clear();
+                auto rc = toBulk.emplace(std::piecewise_construct,
+                        std::forward_as_tuple(tunnel_name, op),
+                        std::forward_as_tuple());
+                bool inserted = rc.second;
+                auto& ctxt = rc.first->second;
+                result = DASH_RESULT_SUCCESS;
+                if (!inserted)
+                {
+                    ctxt.clear();
+                }
+                if (op == SET_COMMAND)
+                {
+                    if (!parsePbMessage(kfvFieldsValues(t), ctxt.metadata))
+                    {
+                        SWSS_LOG_ERROR("Requires protobuf at Tunnel :%s", tunnel_name.c_str());
+                        writeResultToDB(dash_tunnel_result_table_, tunnel_name, DASH_RESULT_FAILURE);
+                        it = consumer.m_toSync.erase(it);
+                        continue;
+                    }
+                    if (addTunnel(tunnel_name, ctxt))
+                    {
+                        it = consumer.m_toSync.erase(it);
+                        writeResultToDB(dash_tunnel_result_table_, tunnel_name, ctxt.pre_op_result);
+                    }
+                    else
+                    {
+                        it++;
+                    }
+                }
+                else if (op == DEL_COMMAND)
+                {
+                    if (removeTunnel(tunnel_name, ctxt))
+                    {
+                        /*
+                         * Postpone removal of result from result table until after
+                         * tunnel members are removed.
+                         */
+                        it = consumer.m_toSync.erase(it);
+                    }
+                    else
+                    {
+                        it++;
+                    }
+                }
             }
-            if (op == SET_COMMAND)
+            catch (const std::exception& e)
             {
-                if (!parsePbMessage(kfvFieldsValues(t), ctxt.metadata))
-                {
-                    SWSS_LOG_WARN("Requires protobuf at Tunnel :%s", tunnel_name.c_str());
-                    it = consumer.m_toSync.erase(it);
-                    continue;
-                }
-                if (addTunnel(tunnel_name, ctxt))
-                {
-                    it = consumer.m_toSync.erase(it);
-                    /*
-                     * Write result only when removing from consumer in pre-op
-                     * For other cases, this will be handled in post-op
-                     * TODO: There are cases where addTunnel returns true for
-                     * errors that are not retried. Such cases need to be
-                     * written to result table as a failure instead of success.
-                     */
-                    writeResultToDB(dash_tunnel_result_table_, tunnel_name, result);
-                }
-                else
-                {
-                    it++;
-                }
-            }
-            else if (op == DEL_COMMAND)
-            {
-                if (removeTunnel(tunnel_name, ctxt))
-                {
-                    /*
-                     * Postpone removal of result from result table until after
-                     * tunnel members are removed.
-                     */
-                    it = consumer.m_toSync.erase(it);
-                }
-                else
-                {
-                    it++;
-                }
+                SWSS_LOG_ERROR("Exception caught processing %s entry %s: %s", consumer.getTableName().c_str(), tunnel_name.c_str(), e.what());
+                writeResultToDB(dash_tunnel_result_table_, tunnel_name, DASH_RESULT_FAILURE);
+                it = consumer.m_toSync.erase(it);
+                continue;
             }
         }
 
@@ -173,47 +179,70 @@ void DashTunnelOrch::doTask(ConsumerBase &consumer)
             swss::KeyOpFieldsValuesTuple t = it_prev->second;
             std::string tunnel_name = kfvKey(t);
             std::string op = kfvOp(t);
-            result = DASH_RESULT_SUCCESS;
-            auto found = toBulk.find(std::make_pair(tunnel_name, op));
-            if (found == toBulk.end())
-            {
-                it_prev++;
-                continue;
-            }
-            auto& ctxt = found->second;
 
-            if (op == SET_COMMAND)
+            try
             {
-                if (addTunnelPost(tunnel_name, ctxt))
+                result = DASH_RESULT_SUCCESS;
+                auto found = toBulk.find(std::make_pair(tunnel_name, op));
+                if (found == toBulk.end())
                 {
-                    it_prev = consumer.m_toSync.erase(it_prev);
-                    /*
-                     * The result should be written here only if the tunnel has
-                     * one endpoint. For more tunnel endpoints, we need to wait
-                     * until after tunnel members post-op.
-                     */
-                    if (ctxt.metadata.endpoints_size() == 1)
+                    it_prev++;
+                    continue;
+                }
+                auto& ctxt = found->second;
+
+                if (op == SET_COMMAND)
+                {
+                    bool handled = addTunnelPost(tunnel_name, ctxt);
+                    bool tunnel_created = !ctxt.tunnel_object_ids.empty() && ctxt.tunnel_object_ids.front() != SAI_NULL_OBJECT_ID;
+                    if (handled)
                     {
-                        writeResultToDB(dash_tunnel_result_table_, tunnel_name,
-                                        result);
+                        if (!tunnel_created)
+                        {
+                            result = DASH_RESULT_FAILURE;
+                        }
+                        it_prev = consumer.m_toSync.erase(it_prev);
+                        /*
+                         * The result should be written here only if the tunnel has
+                         * one endpoint. For more tunnel endpoints, we need to wait
+                         * until after tunnel members post-op unless tunnel creation
+                         * already failed.
+                         */
+                        if (ctxt.metadata.endpoints_size() == 1 || result == DASH_RESULT_FAILURE)
+                        {
+                            writeResultToDB(dash_tunnel_result_table_, tunnel_name,
+                                            result);
+                        }
+                    }
+                    else if (!ctxt.tunnel_member_object_ids.empty())
+                    {
+                        it_prev++;
+                    }
+                    else
+                    {
+                        SWSS_LOG_ERROR("Failed post-processing DASH tunnel %s", tunnel_name.c_str());
+                        result = DASH_RESULT_FAILURE;
+                        it_prev = consumer.m_toSync.erase(it_prev);
+                        writeResultToDB(dash_tunnel_result_table_, tunnel_name, result);
                     }
                 }
-                else
+                else if (op == DEL_COMMAND)
                 {
-                    it_prev++;
+                    if (removeTunnelPost(tunnel_name, ctxt))
+                    {
+                        removeResultFromDB(dash_tunnel_result_table_, tunnel_name);
+                    }
+                    else
+                    {
+                        SWSS_LOG_ERROR("Failed post-processing DASH tunnel removal %s", tunnel_name.c_str());
+                    }
+                    it_prev = consumer.m_toSync.erase(it_prev);
                 }
             }
-            else if (op == DEL_COMMAND)
+            catch (const std::exception& e)
             {
-                if (removeTunnelPost(tunnel_name, ctxt))
-                {
-                    it_prev = consumer.m_toSync.erase(it_prev);
-                    removeResultFromDB(dash_tunnel_result_table_, tunnel_name);
-                }
-                else
-                {
-                    it_prev++;
-                }
+                SWSS_LOG_ERROR("Exception caught in post-processing %s entry %s: %s", consumer.getTableName().c_str(), tunnel_name.c_str(), e.what());
+                it_prev = consumer.m_toSync.erase(it_prev);
             }
         }
 
@@ -225,34 +254,40 @@ void DashTunnelOrch::doTask(ConsumerBase &consumer)
             swss::KeyOpFieldsValuesTuple t = it_prev->second;
             std::string tunnel_name = kfvKey(t);
             std::string op = kfvOp(t);
-            result = DASH_RESULT_SUCCESS;
-            auto found = toBulk.find(std::make_pair(tunnel_name, op));
-            if (found == toBulk.end())
-            {
-                it_prev++;
-                continue;
-            }
-            auto& ctxt = found->second;
 
-            if (op == SET_COMMAND)
+            try
             {
-                if (addTunnelMemberPost(tunnel_name, ctxt))
+                result = DASH_RESULT_SUCCESS;
+                auto found = toBulk.find(std::make_pair(tunnel_name, op));
+                if (found == toBulk.end())
                 {
+                    it_prev++;
+                    continue;
+                }
+                auto& ctxt = found->second;
+
+                if (op == SET_COMMAND)
+                {
+                    if (!addTunnelMemberPost(tunnel_name, ctxt))
+                    {
+                        SWSS_LOG_ERROR("Failed post-processing DASH tunnel members for %s", tunnel_name.c_str());
+                        result = DASH_RESULT_FAILURE;
+                    }
+                    it_prev = consumer.m_toSync.erase(it_prev);
+                    /*
+                     * Write result for tunnels with more than one endpoint.
+                     */
+                    writeResultToDB(dash_tunnel_result_table_, tunnel_name, result);
+                }
+                else if (op == DEL_COMMAND)
+                {
+                    // We should never get here
                     it_prev = consumer.m_toSync.erase(it_prev);
                 }
-                else
-                {
-                    result = DASH_RESULT_FAILURE;
-                    it_prev++;
-                }
-                /*
-                 * Write result for tunnels with more than one endpoint.
-                 */
-                writeResultToDB(dash_tunnel_result_table_, tunnel_name, result);
             }
-            else if (op == DEL_COMMAND)
+            catch (const std::exception& e)
             {
-                // We should never get here
+                SWSS_LOG_ERROR("Exception caught in post-processing %s entry %s: %s", consumer.getTableName().c_str(), tunnel_name.c_str(), e.what());
                 it_prev = consumer.m_toSync.erase(it_prev);
             }
         }
@@ -265,8 +300,9 @@ bool DashTunnelOrch::addTunnel(const std::string& tunnel_name, DashTunnelBulkCon
     auto dash_orch = gDirectory.get<DashOrch*>();
     if (!dash_orch->hasApplianceEntry())
     {
-        SWSS_LOG_WARN("DASH appliance entry not found, skipping DASH tunnel %s creation", tunnel_name.c_str());
-        return false;
+        SWSS_LOG_ERROR("DASH appliance entry not found, skipping DASH tunnel %s creation", tunnel_name.c_str());
+        ctxt.pre_op_result = DASH_RESULT_FAILURE;
+        return true;
     }
     std::vector<sai_attribute_t> tunnel_attrs;
     sai_attribute_t tunnel_attr;
@@ -294,6 +330,7 @@ bool DashTunnelOrch::addTunnel(const std::string& tunnel_name, DashTunnelBulkCon
             break;
         default:
             SWSS_LOG_ERROR("Unsupported encap type %d", ctxt.metadata.encap_type());
+            ctxt.pre_op_result = DASH_RESULT_FAILURE;
             return remove_from_consumer;
     }
     tunnel_attrs.push_back(tunnel_attr);
@@ -368,7 +405,7 @@ bool DashTunnelOrch::addTunnelPost(const std::string& tunnel_name, DashTunnelBul
     {
         DashTunnelEntry entry = { tunnel_oid, std::map<std::string, DashTunnelEndpointEntry>(), std::string() };
         tunnel_table_[tunnel_name] = entry;
-        remove_from_consumer = false;
+        remove_from_consumer = (ctxt.metadata.endpoints_size() == 1);
         SWSS_LOG_INFO("Tunnel entry added for %s", tunnel_name.c_str());
     }
 
@@ -488,7 +525,7 @@ bool DashTunnelOrch::removeTunnelPost(const std::string& tunnel_name, const Dash
     bool remove_from_consumer = removeTunnelEndpointsPost(tunnel_name, ctxt);
     if (!remove_from_consumer)
     {
-        // If endpoint removal requires a retry, exit immediately since the tunnel can't be deleted if endpoints still exist
+        // If endpoint removal failed, exit immediately since the tunnel can't be deleted if endpoints still exist
         return remove_from_consumer;
     }
 
@@ -504,8 +541,7 @@ bool DashTunnelOrch::removeTunnelPost(const std::string& tunnel_name, const Dash
     {
         if (status == SAI_STATUS_OBJECT_IN_USE)
         {
-            // Retry later if object has non-zero reference to it
-            SWSS_LOG_WARN("DASH tunnel %s is in use, cannot remove", tunnel_name.c_str());
+            SWSS_LOG_ERROR("DASH tunnel %s is in use, cannot remove", tunnel_name.c_str());
             remove_from_consumer = false;
             return remove_from_consumer;
         }
@@ -513,7 +549,7 @@ bool DashTunnelOrch::removeTunnelPost(const std::string& tunnel_name, const Dash
         task_process_status handle_status = handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_TUNNEL, status);
         if (handle_status != task_success)
         {
-            remove_from_consumer = parseHandleSaiStatusFailure(handle_status);
+            remove_from_consumer = true;
             return remove_from_consumer;
         }
     }
@@ -579,12 +615,8 @@ bool DashTunnelOrch::removeTunnelEndpointsPost(const std::string& tunnel_name, c
         sai_status_t nh_status = *nh_it_status++;
         if (tm_status != SAI_STATUS_SUCCESS)
         {
-            SWSS_LOG_WARN("DASH tunnel member removal for tunnel %s endpoint %s failed with %s", tunnel_name.c_str(), endpoint_it->first.c_str(), sai_serialize_status(tm_status).c_str());
-            task_process_status handle_status = handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_TUNNEL, tm_status);
-            if (handle_status == task_need_retry)
-            {
-                remove_from_consumer = false;
-            }
+            SWSS_LOG_ERROR("DASH tunnel member removal for tunnel %s endpoint %s failed with %s", tunnel_name.c_str(), endpoint_it->first.c_str(), sai_serialize_status(tm_status).c_str());
+            handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_TUNNEL, tm_status);
         }
         else
         {
@@ -597,12 +629,9 @@ bool DashTunnelOrch::removeTunnelEndpointsPost(const std::string& tunnel_name, c
 
         if (nh_status != SAI_STATUS_SUCCESS)
         {
-            SWSS_LOG_WARN("DASH tunnel next hop removal for tunnel %s endpoint %s failed with %s", tunnel_name.c_str(), endpoint_it->first.c_str(), sai_serialize_status(tm_status).c_str());
-            task_process_status handle_status = handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_TUNNEL, nh_status);
-            if (handle_status == task_need_retry)
-            {
-                remove_from_consumer = false;
-            }
+            SWSS_LOG_ERROR("DASH tunnel next hop removal for tunnel %s endpoint %s failed with %s", tunnel_name.c_str(), endpoint_it->first.c_str(), sai_serialize_status(nh_status).c_str());
+            handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_TUNNEL, nh_status);
+            remove_from_consumer = false;
         }
         else
         {

--- a/orchagent/dash/dashtunnelorch.h
+++ b/orchagent/dash/dashtunnelorch.h
@@ -29,6 +29,8 @@ struct DashTunnelBulkContext
     std::deque<sai_status_t> tunnel_nhop_object_statuses;
     dash::tunnel::Tunnel metadata;
 
+    uint32_t pre_op_result = 0;
+
     DashTunnelBulkContext() {}
     DashTunnelBulkContext(const DashTunnelBulkContext&) = delete;
     DashTunnelBulkContext(DashTunnelBulkContext&&) = delete;
@@ -41,6 +43,7 @@ struct DashTunnelBulkContext
         tunnel_member_object_statuses.clear();
         tunnel_nhop_object_ids.clear();
         tunnel_nhop_object_statuses.clear();
+        pre_op_result = 0;
     }
 };
 

--- a/orchagent/dash/dashtunnelorch.h
+++ b/orchagent/dash/dashtunnelorch.h
@@ -6,6 +6,7 @@
 #include "dbconnector.h"
 #include "zmqorch.h"
 #include "zmqserver.h"
+#include "dashorch.h"
 
 struct DashTunnelEndpointEntry
 {
@@ -29,7 +30,7 @@ struct DashTunnelBulkContext
     std::deque<sai_status_t> tunnel_nhop_object_statuses;
     dash::tunnel::Tunnel metadata;
 
-    uint32_t pre_op_result = 0;
+    uint32_t pre_op_result = DASH_RESULT_SUCCESS;
 
     DashTunnelBulkContext() {}
     DashTunnelBulkContext(const DashTunnelBulkContext&) = delete;
@@ -43,7 +44,7 @@ struct DashTunnelBulkContext
         tunnel_member_object_statuses.clear();
         tunnel_nhop_object_ids.clear();
         tunnel_nhop_object_statuses.clear();
-        pre_op_result = 0;
+        pre_op_result = DASH_RESULT_SUCCESS;
     }
 };
 

--- a/orchagent/dash/dashvnetorch.cpp
+++ b/orchagent/dash/dashvnetorch.cpp
@@ -590,16 +590,16 @@ bool DashVnetOrch::addVnetMapPost(const string& key, const VnetMapBulkContext& c
 {
     SWSS_LOG_ENTER();
 
-    bool remove_from_consumer = addOutboundCaToPaPost(key, ctxt) && addPaValidationPost(key, ctxt);
-    if (!remove_from_consumer)
+    bool success = addOutboundCaToPaPost(key, ctxt) && addPaValidationPost(key, ctxt);
+    if (!success)
     {
         SWSS_LOG_ERROR("addVnetMapPost failed for %s ", key.c_str());
-        return remove_from_consumer;
+        return success;
     }
 
     SWSS_LOG_INFO("Vnet map added for %s", key.c_str());
 
-    return remove_from_consumer;
+    return success;
 }
 
 void DashVnetOrch::removeOutboundCaToPa(const string& key, VnetMapBulkContext& ctxt)
@@ -690,7 +690,7 @@ bool DashVnetOrch::removeOutboundCaToPaPost(const string& key, const VnetMapBulk
 bool DashVnetOrch::removePaValidationPost(const string& key, const DashVnetBulkContext& ctxt)
 {
     SWSS_LOG_ENTER();
-    bool remove_from_consumer = true;
+    bool success = true;
 
     const auto& object_statuses = ctxt.pa_validation_statuses;
     if (object_statuses.empty())
@@ -711,7 +711,7 @@ bool DashVnetOrch::removePaValidationPost(const string& key, const DashVnetBulkC
             handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_PA_VALIDATION, status);
             // Leave the IP in underlay_ips so the cache stays consistent with ASIC_DB
             // and signal the caller that removal did not fully succeed.
-            remove_from_consumer = false;
+            success = false;
             it_ip++;
             continue;
         }
@@ -727,22 +727,22 @@ bool DashVnetOrch::removePaValidationPost(const string& key, const DashVnetBulkC
         it_ip = vnet_table_[ctxt.vnet_name].underlay_ips.erase(it_ip);
         gCrmOrch->decCrmResUsedCounter(underlay_ip.isV4() ? CrmResourceType::CRM_DASH_IPV4_PA_VALIDATION : CrmResourceType::CRM_DASH_IPV6_PA_VALIDATION);
     }
-    return remove_from_consumer;
+    return success;
 }
 
 bool DashVnetOrch::removeVnetMapPost(const string& key, const VnetMapBulkContext& ctxt)
 {
     SWSS_LOG_ENTER();
 
-    bool remove_from_consumer = removeOutboundCaToPaPost(key, ctxt);
-    if (!remove_from_consumer)
+    bool success = removeOutboundCaToPaPost(key, ctxt);
+    if (!success)
     {
         SWSS_LOG_ERROR("removeVnetMapPost failed for %s ", key.c_str());
-        return remove_from_consumer;
+        return success;
     }
     SWSS_LOG_INFO("Vnet map removed for %s", key.c_str());
 
-    return remove_from_consumer;
+    return success;
 }
 
 void DashVnetOrch::doTaskVnetMapTable(ConsumerBase& consumer)

--- a/orchagent/dash/dashvnetorch.cpp
+++ b/orchagent/dash/dashvnetorch.cpp
@@ -704,24 +704,27 @@ bool DashVnetOrch::removePaValidationPost(const string& key, const DashVnetBulkC
     {
         sai_status_t status = *it_status++;
         swss::IpAddress underlay_ip(*it_ip);
-        if (status != SAI_STATUS_SUCCESS)
+        if (status != SAI_STATUS_SUCCESS && status != SAI_STATUS_ITEM_NOT_FOUND)
         {
-            if (status == SAI_STATUS_OBJECT_IN_USE)
-            {
-                SWSS_LOG_ERROR("PA validation entry for Vnet %s IP %s still in use",
-                                ctxt.vnet_name.c_str(), it_ip->c_str());
-                it_ip++;
-                continue;
-            }
-
-            SWSS_LOG_ERROR("Failed to remove PA validation entry for %s", key.c_str());
-            
+            SWSS_LOG_ERROR("Failed to remove PA validation entry for Vnet %s IP %s",
+                           ctxt.vnet_name.c_str(), it_ip->c_str());
+            handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_PA_VALIDATION, status);
+            // Leave the IP in underlay_ips so the cache stays consistent with ASIC_DB
+            // and signal the caller that removal did not fully succeed.
+            remove_from_consumer = false;
+            it_ip++;
+            continue;
         }
-        it_ip = vnet_table_[ctxt.vnet_name].underlay_ips.erase(it_ip);
-        if (*it_status == SAI_STATUS_SUCCESS)
+        if (status == SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_INFO("PA validation entry for %s removed", key.c_str());
         }
+        else
+        {
+            SWSS_LOG_INFO("PA validation entry for Vnet %s IP %s already removed",
+                          ctxt.vnet_name.c_str(), it_ip->c_str());
+        }
+        it_ip = vnet_table_[ctxt.vnet_name].underlay_ips.erase(it_ip);
         gCrmOrch->decCrmResUsedCounter(underlay_ip.isV4() ? CrmResourceType::CRM_DASH_IPV4_PA_VALIDATION : CrmResourceType::CRM_DASH_IPV6_PA_VALIDATION);
     }
     return remove_from_consumer;

--- a/orchagent/dash/dashvnetorch.cpp
+++ b/orchagent/dash/dashvnetorch.cpp
@@ -63,8 +63,9 @@ bool DashVnetOrch::addVnet(const string& vnet_name, DashVnetBulkContext& ctxt)
     DashOrch* dash_orch = gDirectory.get<DashOrch*>();
     if (!dash_orch->hasApplianceEntry())
     {
-        SWSS_LOG_INFO("Retry as no appliance table entry found");
-        return false;
+        SWSS_LOG_ERROR("Failed to create vnet entry for %s: no appliance table entry found", vnet_name.c_str());
+        ctxt.pre_op_result = DASH_RESULT_FAILURE;
+        return true;
     }
 
     uint32_t attr_count = 1;
@@ -148,16 +149,21 @@ bool DashVnetOrch::removeVnetPost(const string& vnet_name, const DashVnetBulkCon
     sai_status_t status = *it_status++;
     if (status != SAI_STATUS_SUCCESS)
     {
-        // Retry later if object has non-zero reference to it
         if (status == SAI_STATUS_NOT_EXECUTED)
         {
+            SWSS_LOG_ERROR("Failed to remove vnet entry for %s: object remove was not executed", vnet_name.c_str());
             return false;
+        }
+        if (status == SAI_STATUS_ITEM_NOT_FOUND)
+        {
+            SWSS_LOG_INFO("Vnet entry for %s already removed", vnet_name.c_str());
+            return true;
         }
         SWSS_LOG_ERROR("Failed to remove vnet entry for %s", vnet_name.c_str());
         task_process_status handle_status = handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_VNET, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            return false;
         }
     }
 
@@ -187,56 +193,63 @@ void DashVnetOrch::doTaskVnetTable(ConsumerBase& consumer)
             KeyOpFieldsValuesTuple tuple = it->second;
             const string& key = kfvKey(tuple);
             auto op = kfvOp(tuple);
-            auto rc = toBulk.emplace(std::piecewise_construct,
-                    std::forward_as_tuple(key, op),
-                    std::forward_as_tuple());
-            bool inserted = rc.second;
-            auto& vnet_ctxt = rc.first->second;
-            result = DASH_RESULT_SUCCESS;
 
-            if (!inserted)
+            try
             {
-                vnet_ctxt.clear();
-            }
-            vnet_ctxt.vnet_name = key;
-            if (op == SET_COMMAND)
-            {
-                if (!parsePbMessage(kfvFieldsValues(tuple), vnet_ctxt.metadata))
+                auto rc = toBulk.emplace(std::piecewise_construct,
+                        std::forward_as_tuple(key, op),
+                        std::forward_as_tuple());
+                bool inserted = rc.second;
+                auto& vnet_ctxt = rc.first->second;
+                result = DASH_RESULT_SUCCESS;
+
+                if (!inserted)
                 {
-                    SWSS_LOG_WARN("Requires protobuff at Vnet :%s", key.c_str());
-                    it = consumer.m_toSync.erase(it);
-                    continue;
+                    vnet_ctxt.clear();
                 }
-                if (addVnet(key, vnet_ctxt))
+                vnet_ctxt.vnet_name = key;
+                if (op == SET_COMMAND)
                 {
-                    it = consumer.m_toSync.erase(it);
-                    /*
-                     * Write result only when removing from consumer in pre-op
-                     * For other cases, this will be handled in post-op
-                     */
-                    writeResultToDB(dash_vnet_result_table_, key, result);
+                    if (!parsePbMessage(kfvFieldsValues(tuple), vnet_ctxt.metadata))
+                    {
+                        SWSS_LOG_ERROR("Requires protobuff at Vnet :%s", key.c_str());
+                        writeResultToDB(dash_vnet_result_table_, key, DASH_RESULT_FAILURE);
+                        it = consumer.m_toSync.erase(it);
+                        continue;
+                    }
+                    if (addVnet(key, vnet_ctxt))
+                    {
+                        it = consumer.m_toSync.erase(it);
+                        writeResultToDB(dash_vnet_result_table_, key, vnet_ctxt.pre_op_result);
+                    }
+                    else
+                    {
+                        it++;
+                    }
+                }
+                else if (op == DEL_COMMAND)
+                {
+                    if (removeVnet(key, vnet_ctxt))
+                    {
+                        it = consumer.m_toSync.erase(it);
+                    }
+                    else
+                    {
+                        it++;
+                    }
                 }
                 else
                 {
-                    it++;
-                }
-            }
-            else if (op == DEL_COMMAND)
-            {
-                if (removeVnet(key, vnet_ctxt))
-                {
+                    SWSS_LOG_ERROR("Invalid command %s", op.c_str());
                     it = consumer.m_toSync.erase(it);
-                    removeResultFromDB(dash_vnet_result_table_, key);
-                }
-                else
-                {
-                    it++;
                 }
             }
-            else
+            catch (const std::exception& e)
             {
-                SWSS_LOG_ERROR("Invalid command %s", op.c_str());
+                SWSS_LOG_ERROR("Exception caught processing %s entry %s: %s", consumer.getTableName().c_str(), key.c_str(), e.what());
+                writeResultToDB(dash_vnet_result_table_, key, DASH_RESULT_FAILURE);
                 it = consumer.m_toSync.erase(it);
+                continue;
             }
         }
 
@@ -250,49 +263,52 @@ void DashVnetOrch::doTaskVnetTable(ConsumerBase& consumer)
 
             string key = kfvKey(t);
             string op = kfvOp(t);
-            result = DASH_RESULT_SUCCESS;
-            auto found = toBulk.find(make_pair(key, op));
-            if (found == toBulk.end())
+            try
             {
-                it_prev++;
-                continue;
-            }
-
-            const auto& vnet_ctxt = found->second;
-            const auto& object_ids = vnet_ctxt.object_ids;
-            const auto& vnet_statuses = vnet_ctxt.vnet_statuses;
-            const auto& pa_validation_statuses = vnet_ctxt.pa_validation_statuses;
-
-            if (object_ids.empty() && vnet_statuses.empty() && pa_validation_statuses.empty())
-            {
-                it_prev++;
-                continue;
-            }
-
-            if (op == SET_COMMAND)
-            {
-               if (addVnetPost(key, vnet_ctxt))
+                result = DASH_RESULT_SUCCESS;
+                auto found = toBulk.find(make_pair(key, op));
+                if (found == toBulk.end())
                 {
-                    it_prev = consumer.m_toSync.erase(it_prev);
+                    it_prev++;
+                    continue;
                 }
-                else
+
+                const auto& vnet_ctxt = found->second;
+                const auto& object_ids = vnet_ctxt.object_ids;
+                const auto& vnet_statuses = vnet_ctxt.vnet_statuses;
+                const auto& pa_validation_statuses = vnet_ctxt.pa_validation_statuses;
+
+                if (object_ids.empty() && vnet_statuses.empty() && pa_validation_statuses.empty())
                 {
+                    SWSS_LOG_ERROR("No bulk results found for VNET %s %s", op.c_str(), key.c_str());
                     result = DASH_RESULT_FAILURE;
-                    it_prev++;
-                }
-                writeResultToDB(dash_vnet_result_table_, key, result);
-            }
-            else if (op == DEL_COMMAND)
-            {
-               if (removeVnetPost(key, vnet_ctxt))
-                {
+                    writeResultToDB(dash_vnet_result_table_, key, result);
                     it_prev = consumer.m_toSync.erase(it_prev);
-                    removeResultFromDB(dash_vnet_result_table_, key);
+                    continue;
                 }
-                else
+
+                if (op == SET_COMMAND)
                 {
-                    it_prev++;
+                   if (!addVnetPost(key, vnet_ctxt))
+                    {
+                        result = DASH_RESULT_FAILURE;
+                    }
+                    it_prev = consumer.m_toSync.erase(it_prev);
+                    writeResultToDB(dash_vnet_result_table_, key, result);
                 }
+                else if (op == DEL_COMMAND)
+                {
+                   if (removeVnetPost(key, vnet_ctxt))
+                    {
+                        removeResultFromDB(dash_vnet_result_table_, key);
+                    }
+                    it_prev = consumer.m_toSync.erase(it_prev);
+                }
+            }
+            catch (const std::exception& e)
+            {
+                SWSS_LOG_ERROR("Exception caught in post-processing %s entry %s: %s", consumer.getTableName().c_str(), key.c_str(), e.what());
+                it_prev = consumer.m_toSync.erase(it_prev);
             }
         }
     }
@@ -314,8 +330,9 @@ bool DashVnetOrch::addOutboundCaToPa(const string& key, VnetMapBulkContext& ctxt
     dash::route_type::RouteType route_type_actions;
     if (!dash_orch->getRouteTypeActions(ctxt.metadata.routing_type(), route_type_actions))
     {
-        SWSS_LOG_INFO("Failed to get route type actions for %s", key.c_str());
-        return false;
+        SWSS_LOG_ERROR("Failed to get route type actions for %s", key.c_str());
+        ctxt.pre_op_result = DASH_RESULT_FAILURE;
+        return true;
     }
 
     uint32_t routing_type_tunnel_key = 0;
@@ -335,6 +352,7 @@ bool DashVnetOrch::addOutboundCaToPa(const string& key, VnetMapBulkContext& ctxt
             else
             {
                 SWSS_LOG_ERROR("Invalid encap type %d for %s", action.encap_type(), key.c_str());
+                ctxt.pre_op_result = DASH_RESULT_FAILURE;
                 return true;
             }
 
@@ -345,7 +363,7 @@ bool DashVnetOrch::addOutboundCaToPa(const string& key, VnetMapBulkContext& ctxt
 
             outbound_ca_to_pa_attr.id = SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_UNDERLAY_DIP;
             to_sai(ctxt.metadata.underlay_ip(), outbound_ca_to_pa_attr.value.ipaddr);
-            outbound_ca_to_pa_attrs.push_back(outbound_ca_to_pa_attr); 
+            outbound_ca_to_pa_attrs.push_back(outbound_ca_to_pa_attr);
 
         }
     }
@@ -356,8 +374,9 @@ bool DashVnetOrch::addOutboundCaToPa(const string& key, VnetMapBulkContext& ctxt
         auto tunnel_oid = gDirectory.get<DashTunnelOrch*>()->getTunnelOid(ctxt.metadata.tunnel());
         if (tunnel_oid == SAI_NULL_OBJECT_ID)
         {
-            SWSS_LOG_INFO("Tunnel %s for VnetMap %s does not exist yet", ctxt.metadata.tunnel().c_str(), key.c_str());
-            return false;
+            SWSS_LOG_ERROR("Tunnel %s for VnetMap %s does not exist", ctxt.metadata.tunnel().c_str(), key.c_str());
+            ctxt.pre_op_result = DASH_RESULT_FAILURE;
+            return true;
         }
         outbound_ca_to_pa_attr.id = SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_DASH_TUNNEL_ID;
         outbound_ca_to_pa_attr.value.oid = tunnel_oid;
@@ -412,9 +431,10 @@ bool DashVnetOrch::addOutboundCaToPa(const string& key, VnetMapBulkContext& ctxt
                 gDirectory.get<DashPortMapOrch*>()->getPortMapOid(ctxt.metadata.port_map());
             if (port_map_oid == SAI_NULL_OBJECT_ID)
             {
-                SWSS_LOG_ERROR("Portmap %s for VnetMap %s does not exist yet",
+                SWSS_LOG_ERROR("Portmap %s for VnetMap %s does not exist",
                                ctxt.metadata.port_map().c_str(), key.c_str());
-                return false;
+                ctxt.pre_op_result = DASH_RESULT_FAILURE;
+                return true;
             }
             outbound_ca_to_pa_attr.id = SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_OUTBOUND_PORT_MAP_ID;
             outbound_ca_to_pa_attr.value.oid = port_map_oid;
@@ -489,8 +509,9 @@ bool DashVnetOrch::addVnetMap(const string& key, VnetMapBulkContext& ctxt)
     bool vnet_exists = (gVnetNameToId.find(ctxt.vnet_name) != gVnetNameToId.end());
     if (!vnet_exists)
     {
-        SWSS_LOG_INFO("Not creating VNET map for %s since VNET %s doesn't exist", key.c_str(), ctxt.vnet_name.c_str());
-        return false;
+        SWSS_LOG_ERROR("Not creating VNET map for %s since VNET %s doesn't exist", key.c_str(), ctxt.vnet_name.c_str());
+        ctxt.pre_op_result = DASH_RESULT_FAILURE;
+        return true;
     }
     return addOutboundCaToPa(key, ctxt);
 }
@@ -518,7 +539,7 @@ bool DashVnetOrch::addOutboundCaToPaPost(const string& key, const VnetMapBulkCon
         task_process_status handle_status = handleSaiCreateStatus((sai_api_t) SAI_API_DASH_OUTBOUND_CA_TO_PA, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            return false;
         }
     }
 
@@ -554,7 +575,7 @@ bool DashVnetOrch::addPaValidationPost(const string& key, const VnetMapBulkConte
         task_process_status handle_status = handleSaiCreateStatus((sai_api_t) SAI_API_DASH_PA_VALIDATION, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            return false;
         }
     }
 
@@ -639,9 +660,9 @@ bool DashVnetOrch::removeOutboundCaToPaPost(const string& key, const VnetMapBulk
     sai_status_t status = *it_status++;
     if (status != SAI_STATUS_SUCCESS)
     {
-        // Retry later if object has non-zero reference to it
         if (status == SAI_STATUS_NOT_EXECUTED)
         {
+            SWSS_LOG_ERROR("Failed to remove outbound CA to PA entry for %s: object remove was not executed", key.c_str());
             return false;
         }
 
@@ -655,7 +676,7 @@ bool DashVnetOrch::removeOutboundCaToPaPost(const string& key, const VnetMapBulk
         task_process_status handle_status = handleSaiRemoveStatus((sai_api_t) SAI_API_DASH_OUTBOUND_CA_TO_PA, status);
         if (handle_status != task_success)
         {
-            return parseHandleSaiStatusFailure(handle_status);
+            return false;
         }
     }
 
@@ -685,12 +706,10 @@ bool DashVnetOrch::removePaValidationPost(const string& key, const DashVnetBulkC
         swss::IpAddress underlay_ip(*it_ip);
         if (status != SAI_STATUS_SUCCESS)
         {
-            // Retry later if object has non-zero reference to it
             if (status == SAI_STATUS_OBJECT_IN_USE)
             {
-                SWSS_LOG_INFO("PA validation entry for Vnet %s IP %s still in use",
+                SWSS_LOG_ERROR("PA validation entry for Vnet %s IP %s still in use",
                                 ctxt.vnet_name.c_str(), it_ip->c_str());
-                remove_from_consumer = false;
                 it_ip++;
                 continue;
             }
@@ -739,75 +758,82 @@ void DashVnetOrch::doTaskVnetMapTable(ConsumerBase& consumer)
             KeyOpFieldsValuesTuple tuple = it->second;
             const string& key = kfvKey(tuple);
             auto op = kfvOp(tuple);
-            auto rc = toBulk.emplace(std::piecewise_construct,
-                    std::forward_as_tuple(key, op),
-                    std::forward_as_tuple());
-            bool inserted = rc.second;
-            auto& ctxt = rc.first->second;
-            result = DASH_RESULT_SUCCESS;
 
-            if (!inserted)
+            try
             {
-                ctxt.clear();
-            }
+                auto rc = toBulk.emplace(std::piecewise_construct,
+                        std::forward_as_tuple(key, op),
+                        std::forward_as_tuple());
+                bool inserted = rc.second;
+                auto& ctxt = rc.first->second;
+                result = DASH_RESULT_SUCCESS;
 
-            string& vnet_name = ctxt.vnet_name;
-            IpAddress& dip = ctxt.dip;
-
-            vector<string> keys = tokenize(key, ':');
-            vnet_name = keys[0];
-            size_t pos = key.find(":", vnet_name.length());
-            string ip_str = key.substr(pos + 1);
-            dip = IpAddress(ip_str);
-
-            if (op == SET_COMMAND)
-            {
-                if (!parsePbMessage(kfvFieldsValues(tuple), ctxt.metadata))
+                if (!inserted)
                 {
-                    SWSS_LOG_WARN("Requires protobuff at VnetMap :%s", key.c_str());
-                    it = consumer.m_toSync.erase(it);
-                    continue;
+                    ctxt.clear();
                 }
-                if (ctxt.metadata.routing_type() == dash::route_type::RoutingType::ROUTING_TYPE_UNSPECIFIED)
+
+                string& vnet_name = ctxt.vnet_name;
+                IpAddress& dip = ctxt.dip;
+
+                vector<string> keys = tokenize(key, ':');
+                vnet_name = keys[0];
+                size_t pos = key.find(":", vnet_name.length());
+                string ip_str = key.substr(pos + 1);
+                dip = IpAddress(ip_str);
+
+                if (op == SET_COMMAND)
                 {
-                    // VnetMapping::action_type is deprecated in favor of VnetMapping::routing_type. For messages still using the old action_type field,
-                    // copy it to the new routing_type field. All subsequent operations will use the new field.
-                    #pragma GCC diagnostic push
-                    #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-                    SWSS_LOG_WARN("VnetMapping::action_type is deprecated. Use VnetMapping::routing_type instead");
-                    ctxt.metadata.set_routing_type(ctxt.metadata.action_type());
-                    #pragma GCC diagnostic pop
+                    if (!parsePbMessage(kfvFieldsValues(tuple), ctxt.metadata))
+                    {
+                        SWSS_LOG_ERROR("Requires protobuff at VnetMap :%s", key.c_str());
+                        writeResultToDB(dash_vnet_map_result_table_, key, DASH_RESULT_FAILURE);
+                        it = consumer.m_toSync.erase(it);
+                        continue;
+                    }
+                    if (ctxt.metadata.routing_type() == dash::route_type::RoutingType::ROUTING_TYPE_UNSPECIFIED)
+                    {
+                        // VnetMapping::action_type is deprecated in favor of VnetMapping::routing_type. For messages still using the old action_type field,
+                        // copy it to the new routing_type field. All subsequent operations will use the new field.
+                        #pragma GCC diagnostic push
+                        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+                        SWSS_LOG_WARN("VnetMapping::action_type is deprecated. Use VnetMapping::routing_type instead");
+                        ctxt.metadata.set_routing_type(ctxt.metadata.action_type());
+                        #pragma GCC diagnostic pop
+                    }
+                    if (addVnetMap(key, ctxt))
+                    {
+                        it = consumer.m_toSync.erase(it);
+                        writeResultToDB(dash_vnet_map_result_table_, key, ctxt.pre_op_result);
+                    }
+                    else
+                    {
+                        it++;
+                    }
                 }
-                if (addVnetMap(key, ctxt))
+                else if (op == DEL_COMMAND)
                 {
-                    it = consumer.m_toSync.erase(it);
-                    /*
-                     * Write result only when removing from consumer in pre-op
-                     * For other cases, this will be handled in post-op
-                     */
-                    writeResultToDB(dash_vnet_map_result_table_, key, result);
+                    if (removeVnetMap(key, ctxt))
+                    {
+                        it = consumer.m_toSync.erase(it);
+                    }
+                    else
+                    {
+                        it++;
+                    }
                 }
                 else
                 {
-                    it++;
-                }
-            }
-            else if (op == DEL_COMMAND)
-            {
-                if (removeVnetMap(key, ctxt))
-                {
+                    SWSS_LOG_ERROR("Invalid command %s", op.c_str());
                     it = consumer.m_toSync.erase(it);
-                    removeResultFromDB(dash_vnet_map_result_table_, key);
-                }
-                else
-                {
-                    it++;
                 }
             }
-            else
+            catch (const std::exception& e)
             {
-                SWSS_LOG_ERROR("Invalid command %s", op.c_str());
+                SWSS_LOG_ERROR("Exception caught processing %s entry %s: %s", consumer.getTableName().c_str(), key.c_str(), e.what());
+                writeResultToDB(dash_vnet_map_result_table_, key, DASH_RESULT_FAILURE);
                 it = consumer.m_toSync.erase(it);
+                continue;
             }
         }
 
@@ -820,47 +846,50 @@ void DashVnetOrch::doTaskVnetMapTable(ConsumerBase& consumer)
             KeyOpFieldsValuesTuple t = it_prev->second;
             string key = kfvKey(t);
             string op = kfvOp(t);
-            result = DASH_RESULT_SUCCESS;
-            auto found = toBulk.find(make_pair(key, op));
-            if (found == toBulk.end())
+            try
             {
-                it_prev++;
-                continue;
-            }
-
-            const auto& ctxt = found->second;
-            const auto& outbound_ca_to_pa_object_statuses = ctxt.outbound_ca_to_pa_object_statuses;
-            const auto& pa_validation_object_statuses = ctxt.pa_validation_object_statuses;
-            if (outbound_ca_to_pa_object_statuses.empty() && pa_validation_object_statuses.empty())
-            {
-                it_prev++;
-                continue;
-            }
-
-            if (op == SET_COMMAND)
-            {
-                if (addVnetMapPost(key, ctxt))
+                result = DASH_RESULT_SUCCESS;
+                auto found = toBulk.find(make_pair(key, op));
+                if (found == toBulk.end())
                 {
-                    it_prev = consumer.m_toSync.erase(it_prev);
+                    it_prev++;
+                    continue;
                 }
-                else
+
+                const auto& ctxt = found->second;
+                const auto& outbound_ca_to_pa_object_statuses = ctxt.outbound_ca_to_pa_object_statuses;
+                const auto& pa_validation_object_statuses = ctxt.pa_validation_object_statuses;
+                if (outbound_ca_to_pa_object_statuses.empty() && pa_validation_object_statuses.empty())
                 {
+                    SWSS_LOG_ERROR("No bulk results found for VNET map %s %s", op.c_str(), key.c_str());
                     result = DASH_RESULT_FAILURE;
-                    it_prev++;
-                }
-                writeResultToDB(dash_vnet_map_result_table_, key, result);
-            }
-            else if (op == DEL_COMMAND)
-            {
-                if (removeVnetMapPost(key, ctxt))
-                {
+                    writeResultToDB(dash_vnet_map_result_table_, key, result);
                     it_prev = consumer.m_toSync.erase(it_prev);
-                    removeResultFromDB(dash_vnet_map_result_table_, key);
+                    continue;
                 }
-                else
+
+                if (op == SET_COMMAND)
                 {
-                    it_prev++;
+                    if (!addVnetMapPost(key, ctxt))
+                    {
+                        result = DASH_RESULT_FAILURE;
+                    }
+                    it_prev = consumer.m_toSync.erase(it_prev);
+                    writeResultToDB(dash_vnet_map_result_table_, key, result);
                 }
+                else if (op == DEL_COMMAND)
+                {
+                    if (removeVnetMapPost(key, ctxt))
+                    {
+                        removeResultFromDB(dash_vnet_map_result_table_, key);
+                    }
+                    it_prev = consumer.m_toSync.erase(it_prev);
+                }
+            }
+            catch (const std::exception& e)
+            {
+                SWSS_LOG_ERROR("Exception caught in post-processing %s entry %s: %s", consumer.getTableName().c_str(), key.c_str(), e.what());
+                it_prev = consumer.m_toSync.erase(it_prev);
             }
         }
     }

--- a/orchagent/dash/dashvnetorch.h
+++ b/orchagent/dash/dashvnetorch.h
@@ -33,6 +33,7 @@ struct DashVnetBulkContext
     std::deque<sai_object_id_t> object_ids;
     std::deque<sai_status_t> vnet_statuses;
     std::deque<sai_status_t> pa_validation_statuses;
+    uint32_t pre_op_result = 0;
     DashVnetBulkContext() {}
 
     DashVnetBulkContext(const DashVnetBulkContext&) = delete;
@@ -43,6 +44,7 @@ struct DashVnetBulkContext
         object_ids.clear();
         vnet_statuses.clear();
         pa_validation_statuses.clear();
+        pre_op_result = 0;
     }
 };
 
@@ -53,6 +55,7 @@ struct VnetMapBulkContext
     dash::vnet_mapping::VnetMapping metadata;
     std::deque<sai_status_t> outbound_ca_to_pa_object_statuses;
     std::deque<sai_status_t> pa_validation_object_statuses;
+    uint32_t pre_op_result = 0;
     VnetMapBulkContext() {}
 
     VnetMapBulkContext(const VnetMapBulkContext&) = delete;
@@ -62,6 +65,7 @@ struct VnetMapBulkContext
     {
         outbound_ca_to_pa_object_statuses.clear();
         pa_validation_object_statuses.clear();
+        pre_op_result = 0;
     }
 };
 

--- a/orchagent/dash/dashvnetorch.h
+++ b/orchagent/dash/dashvnetorch.h
@@ -13,6 +13,7 @@
 #include "timer.h"
 #include "zmqorch.h"
 #include "zmqserver.h"
+#include "dashorch.h"
 
 #include "dash_api/vnet.pb.h"
 #include "dash_api/vnet_mapping.pb.h"
@@ -33,7 +34,7 @@ struct DashVnetBulkContext
     std::deque<sai_object_id_t> object_ids;
     std::deque<sai_status_t> vnet_statuses;
     std::deque<sai_status_t> pa_validation_statuses;
-    uint32_t pre_op_result = 0;
+    uint32_t pre_op_result = DASH_RESULT_SUCCESS;
     DashVnetBulkContext() {}
 
     DashVnetBulkContext(const DashVnetBulkContext&) = delete;
@@ -44,7 +45,7 @@ struct DashVnetBulkContext
         object_ids.clear();
         vnet_statuses.clear();
         pa_validation_statuses.clear();
-        pre_op_result = 0;
+        pre_op_result = DASH_RESULT_SUCCESS;
     }
 };
 
@@ -55,7 +56,7 @@ struct VnetMapBulkContext
     dash::vnet_mapping::VnetMapping metadata;
     std::deque<sai_status_t> outbound_ca_to_pa_object_statuses;
     std::deque<sai_status_t> pa_validation_object_statuses;
-    uint32_t pre_op_result = 0;
+    uint32_t pre_op_result = DASH_RESULT_SUCCESS;
     VnetMapBulkContext() {}
 
     VnetMapBulkContext(const VnetMapBulkContext&) = delete;
@@ -65,7 +66,7 @@ struct VnetMapBulkContext
     {
         outbound_ca_to_pa_object_statuses.clear();
         pa_validation_object_statuses.clear();
-        pre_op_result = 0;
+        pre_op_result = DASH_RESULT_SUCCESS;
     }
 };
 

--- a/tests/dash/dash_db.py
+++ b/tests/dash/dash_db.py
@@ -49,9 +49,24 @@ APP_DB_TO_PROTOBUF_MAP = {
     swsscommon.APP_DASH_TUNNEL_TABLE_NAME: Tunnel
 }
 
+APP_DB_DEL_ORDER = [
+    swsscommon.APP_DASH_ENI_ROUTE_TABLE_NAME,
+    swsscommon.APP_DASH_VNET_MAPPING_TABLE_NAME,
+    swsscommon.APP_DASH_ROUTE_TABLE_NAME,
+    swsscommon.APP_DASH_ROUTE_RULE_TABLE_NAME,
+    swsscommon.APP_DASH_ENI_TABLE_NAME,
+    swsscommon.APP_DASH_TUNNEL_TABLE_NAME,
+    swsscommon.APP_DASH_ROUTE_GROUP_TABLE_NAME,
+    swsscommon.APP_DASH_VNET_TABLE_NAME,
+    swsscommon.APP_DASH_ROUTING_TYPE_TABLE_NAME,
+    swsscommon.APP_DASH_METER_POLICY_TABLE_NAME,
+    swsscommon.APP_DASH_METER_RULE_TABLE_NAME,
+    swsscommon.APP_DASH_APPLIANCE_TABLE_NAME
+]
+
 
 def del_all_keys(dash_db):
-    for table_name in APP_DB_TO_PROTOBUF_MAP.keys():
+    for table_name in APP_DB_DEL_ORDER:
         keys = dash_db.get_app_db_keys(table_name)
         for key in keys:
             dash_db.remove_app_db_entry(table_name, key)

--- a/tests/dash/test_dash_acl.py
+++ b/tests/dash/test_dash_acl.py
@@ -488,7 +488,8 @@ class TestAcl(object):
         ctx.asic_dash_acl_rule_table.wait_for_n_keys(num_keys=0)
         ctx.create_acl_group(ACL_GROUP_1, IpVersion.IP_VERSION_IPV4)
 
-        ctx.asic_dash_acl_rule_table.wait_for_n_keys(num_keys=1)
+        time.sleep(3)
+        ctx.asic_dash_acl_rule_table.wait_for_n_keys(num_keys=0)
 
         # Create acl rule with nonexistent acl group, which should never get programmed to ASIC_DB
         ctx.create_acl_rule("0", "0",
@@ -496,13 +497,13 @@ class TestAcl(object):
                             src_addr=["192.168.0.1/32", "192.168.1.2/30"], dst_addr=["192.168.0.1/32", "192.168.1.2/30"],
                             src_port=[PortRange(0,1)], dst_port=[PortRange(0,1)])
         time.sleep(3)
-        ctx.asic_dash_acl_rule_table.wait_for_n_keys(num_keys=1)
+        ctx.asic_dash_acl_rule_table.wait_for_n_keys(num_keys=0)
 
         ctx.create_acl_rule(ACL_GROUP_1, ACL_RULE_2,
                             priority=1, action=Action.ACTION_PERMIT, terminating=False,
                             src_addr=["192.168.0.1/32", "192.168.1.2/30"], dst_addr=["192.168.0.1/32", "192.168.1.2/30"],
                             src_port=[PortRange(0,1)], dst_port=[PortRange(0,1)])
-        ctx.asic_dash_acl_rule_table.wait_for_n_keys(num_keys=2)
+        ctx.asic_dash_acl_rule_table.wait_for_n_keys(num_keys=1)
 
 
     # @pytest.mark.parametrize("bind_group", [True, False])
@@ -778,21 +779,6 @@ class TestAcl(object):
         time.sleep(3)
         ctx.asic_dash_acl_rule_table.wait_for_n_keys(num_keys=0)
 
-        tagsrc_prefixes = {"1.2.3.4/32", "5.6.0.0/16"}
-        ctx.create_prefix_tag(TAG_1, IpVersion.IP_VERSION_IPV4, tagsrc_prefixes)
-
-        # The rule should not be created since the TAG_2 is not created yet
-        time.sleep(3)
-        ctx.asic_dash_acl_rule_table.wait_for_n_keys(num_keys=0)
-
-        tagdst_prefixes = {"10.20.30.40/32", "50.60.0.0/16"}
-        ctx.create_prefix_tag(TAG_2, IpVersion.IP_VERSION_IPV4, tagdst_prefixes)
-
-        rule_id= ctx.asic_dash_acl_rule_table.wait_for_n_keys(num_keys=1)[0]
-        rule_attr = ctx.asic_dash_acl_rule_table[rule_id]
-
-        assert prefix_list_to_set(rule_attr["SAI_DASH_ACL_RULE_ATTR_SIP"]) == tagsrc_prefixes
-        assert prefix_list_to_set(rule_attr["SAI_DASH_ACL_RULE_ATTR_DIP"]) == tagdst_prefixes
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down

--- a/tests/dash/test_dash_pl.py
+++ b/tests/dash/test_dash_pl.py
@@ -34,11 +34,11 @@ NUM_PORTS = 2
 def common_setup_teardown(dash_db: DashDB, dvs):
     dvs.runcmd("swssloglevel -l INFO -c orchagent") 
     dash_db.set_app_db_entry(APP_DASH_APPLIANCE_TABLE_NAME, APPLIANCE_ID, APPLIANCE_CONFIG)
+    dash_db.set_app_db_entry(APP_DASH_ROUTING_TYPE_TABLE_NAME, PRIVATELINK, ROUTING_TYPE_PL_CONFIG)
     dash_db.set_app_db_entry(APP_DASH_VNET_TABLE_NAME, VNET1, VNET_CONFIG)
     dash_db.set_app_db_entry(APP_DASH_ENI_TABLE_NAME, ENI_ID, ENI_CONFIG)
     dash_db.set_app_db_entry(APP_DASH_VNET_MAPPING_TABLE_NAME, VNET1, VNET_MAP_IP1, VNET_MAPPING_CONFIG_PRIVATELINK)
     dash_db.set_app_db_entry(APP_DASH_ROUTE_GROUP_TABLE_NAME, ROUTE_GROUP1, ROUTE_GROUP1_CONFIG)
-    dash_db.set_app_db_entry(APP_DASH_ROUTING_TYPE_TABLE_NAME, PRIVATELINK, ROUTING_TYPE_PL_CONFIG)
     # Don't set DASH_ROUTE_TABLE and DASH_ENI_ROUTE_TABLE entries here for flexibility, test cases will set them as needed
 
     yield
@@ -79,8 +79,8 @@ def test_pl_outbound_ca_to_pa_attrs(dash_db: DashDB):
     assert_sai_attribute_exists(SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_DASH_ENCAPSULATION, outbound_attrs, SAI_DASH_ENCAPSULATION_NVGRE)
     assert_sai_attribute_exists(SAI_OUTBOUND_CA_TO_PA_ENTRY_ATTR_UNDERLAY_DIP, outbound_attrs, UNDERLAY_IP)
 
-    dash_db.set_app_db_entry(APP_DASH_VNET_MAPPING_TABLE_NAME, VNET1, VNET_MAP_IP2, VNET_MAPPING_CONFIG_PLNSG)
     dash_db.set_app_db_entry(APP_DASH_TUNNEL_TABLE_NAME, TUNNEL1, TUNNEL1_CONFIG)
+    dash_db.set_app_db_entry(APP_DASH_VNET_MAPPING_TABLE_NAME, VNET1, VNET_MAP_IP2, VNET_MAPPING_CONFIG_PLNSG)
     new_keys = dash_db.wait_for_asic_db_keys("ASIC_STATE:SAI_OBJECT_TYPE_OUTBOUND_CA_TO_PA_ENTRY", old_keys=outbound_ca_to_pa_keys)
     assert len(new_keys) == 1, f"Expected 1 new outbound ca to pa entries, found {len(new_keys)}"
     tunnels = dash_db.wait_for_asic_db_keys("ASIC_STATE:SAI_OBJECT_TYPE_DASH_TUNNEL")

--- a/tests/dash/test_dash_vnet.py
+++ b/tests/dash/test_dash_vnet.py
@@ -217,45 +217,6 @@ class TestDash(TestFlexCountersBase):
         assert_sai_attribute_exists("SAI_OUTBOUND_ROUTING_ENTRY_ATTR_METER_CLASS_OR", routing_attrs, self.outbound_metering_class_or)
         assert_sai_attribute_exists("SAI_OUTBOUND_ROUTING_ENTRY_ATTR_METER_CLASS_AND", routing_attrs, self.outbound_metering_class_and)
 
-    def test_outbound_routing_dependency(self, dash_db: DashDB):
-        vnet = "Vnet2"
-        prefix1 = "10.1.1.0/24"
-        prefix2 = "10.1.2.0/24"
-        overlay_ip = "10.0.0.7"
-        group_id = ROUTE_GROUP1
-        guid = "559c6ce8-26ab-5651-b946-ccc6e8f930b2"
-
-        pb = Route()
-        pb.action_type = RoutingType.ROUTING_TYPE_VNET
-        pb.vnet = vnet
-        dash_db.create_route(group_id, prefix1, {"pb": pb.SerializeToString()})
-
-        pb = Route()
-        pb.action_type = RoutingType.ROUTING_TYPE_VNET_DIRECT
-        pb.vnet_direct.vnet = vnet
-        pb.vnet_direct.overlay_ip.ipv4 = socket.htonl(int(ipaddress.ip_address(overlay_ip)))
-        dash_db.create_route(group_id, prefix2, {"pb": pb.SerializeToString()})
-
-        time.sleep(2)
-        keys = dash_db.get_asic_db_keys(ASIC_OUTBOUND_ROUTING_TABLE)
-        # Outbound routes for prefix1 and prefix2 are not ready before Vnet2 creation
-        assert len(keys) == 1
-
-        pb = Vnet()
-        pb.vni = int("45655")
-        pb.guid.value = bytes.fromhex(uuid.UUID(guid).hex)
-        dash_db.create_vnet(vnet, {"pb": pb.SerializeToString()})
-        keys = dash_db.wait_for_asic_db_keys(ASIC_VNET_TABLE, min_keys=2)
-        assert len(keys) == 2
-
-        routing_entries = dash_db.wait_for_asic_db_keys(ASIC_OUTBOUND_ROUTING_TABLE, min_keys=3)
-        # Outbound routes for prefix1 and prefix2 are ready after Vnet2 creation
-        assert len(routing_entries) == 3
-
-        dash_db.remove_route(group_id, prefix1)
-        dash_db.remove_route(group_id, prefix2)
-        dash_db.remove_vnet(vnet)
-
     def test_eni_route(self, dash_db: DashDB):
         pb = EniRoute()
         pb.group_id = ROUTE_GROUP1

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -72,7 +72,9 @@ tests_SOURCES = aclorch_ut.cpp \
                 dashvnetorch_ut.cpp \
                 dashhaorch_ut.cpp \
                 dashrouteorch_ut.cpp \
+                dashtunnelorch_ut.cpp \
                 dashportmaporch_ut.cpp \
+                dashmeterorch_ut.cpp \
                 twamporch_ut.cpp \
                 stporch_ut.cpp \
                 srv6orch_ut.cpp \

--- a/tests/mock_tests/dashmeterorch_ut.cpp
+++ b/tests/mock_tests/dashmeterorch_ut.cpp
@@ -1,0 +1,421 @@
+#define private public
+#include "directory.h"
+#undef private
+#define protected public
+#include "orch.h"
+#undef protected
+#include "ut_helper.h"
+#include "mock_orchagent_main.h"
+#include "mock_sai_api.h"
+#include "mock_dash_orch_test.h"
+#include "dash_api/meter_policy.pb.h"
+#include "dash_api/meter_rule.pb.h"
+#include "dash_api/types.pb.h"
+
+EXTERN_MOCK_FNS
+
+namespace dashmeterorch_test
+{
+    DEFINE_SAI_GENERIC_APIS_MOCK(dash_meter, meter_policy, meter_rule)
+
+    using namespace mock_orch_test;
+    using ::testing::DoAll;
+    using ::testing::Return;
+    using ::testing::SaveArg;
+    using ::testing::SaveArgPointee;
+    using ::testing::SetArgPointee;
+    using ::testing::SetArrayArgument;
+    using ::testing::Throw;
+
+    class DashMeterOrchTest : public MockDashOrchTest
+    {
+    protected:
+        std::string meterPolicy1 = "METER_POLICY_1";
+
+        void ApplySaiMock() override
+        {
+            INIT_SAI_API_MOCK(dash_meter);
+            MockSaiApis();
+        }
+
+        void PreTearDown() override
+        {
+            RestoreSaiApis();
+            DEINIT_SAI_API_MOCK(dash_meter);
+        }
+
+        dash::meter_policy::MeterPolicy BuildMeterPolicy(bool ipv4 = true)
+        {
+            dash::meter_policy::MeterPolicy meter_policy;
+            meter_policy.set_ip_version(ipv4 ? dash::types::IP_VERSION_IPV4 : dash::types::IP_VERSION_IPV6);
+            return meter_policy;
+        }
+
+        dash::meter_rule::MeterRule BuildMeterRule(const std::string &ip = "10.0.0.0",
+                                                   const std::string &mask = "255.255.255.0",
+                                                   uint32_t meteringClass = 1,
+                                                   uint32_t priority = 10)
+        {
+            dash::meter_rule::MeterRule meter_rule;
+            meter_rule.mutable_ip_prefix()->mutable_ip()->set_ipv4(swss::IpAddress(ip).getV4Addr());
+            meter_rule.mutable_ip_prefix()->mutable_mask()->set_ipv4(swss::IpAddress(mask).getV4Addr());
+            meter_rule.set_metering_class(meteringClass);
+            meter_rule.set_priority(priority);
+            return meter_rule;
+        }
+
+        std::string MeterRuleKey(uint32_t ruleNum) const
+        {
+            return meterPolicy1 + ":" + std::to_string(ruleNum);
+        }
+
+        void ProcessDashTupleRaw(const std::string &tableName,
+                                 const std::string &key,
+                                 const std::string &op,
+                                 const std::vector<swss::FieldValueTuple> &fvs)
+        {
+            Orch *target_orch = *(dash_table_orch_map.at(tableName));
+            auto consumer = std::make_unique<Consumer>(
+                new swss::ConsumerStateTable(m_app_db.get(), tableName),
+                target_orch, tableName);
+            consumer->addToSync(swss::KeyOpFieldsValuesTuple(key, op, fvs));
+            target_orch->doTask(*consumer.get());
+            EXPECT_EQ(consumer->m_toSync.begin(), consumer->m_toSync.end());
+        }
+    };
+
+    TEST_F(DashMeterOrchTest, AddRemoveMeterPolicy)
+    {
+        auto meterPolicy = BuildMeterPolicy();
+        sai_object_id_t createdOid = 0x1111;
+        sai_object_id_t removedOid = SAI_NULL_OBJECT_ID;
+
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_policy)
+            .WillOnce(DoAll(SetArgPointee<0>(createdOid), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_CALL(*mock_sai_dash_meter_api, remove_meter_policy)
+            .WillOnce(DoAll(SaveArg<0>(&removedOid), Return(SAI_STATUS_SUCCESS)));
+
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy);
+        EXPECT_EQ(m_DashMeterOrch->getMeterPolicyOid(meterPolicy1), createdOid);
+
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy, false);
+        EXPECT_EQ(removedOid, createdOid);
+        EXPECT_EQ(m_DashMeterOrch->getMeterPolicyOid(meterPolicy1), SAI_NULL_OBJECT_ID);
+    }
+
+    TEST_F(DashMeterOrchTest, AddDuplicateMeterPolicy)
+    {
+        auto meterPolicy = BuildMeterPolicy();
+        sai_object_id_t createdOid = 0x1112;
+
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_policy)
+            .Times(1)
+            .WillOnce(DoAll(SetArgPointee<0>(createdOid), Return(SAI_STATUS_SUCCESS)));
+
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy);
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy);
+        EXPECT_EQ(m_DashMeterOrch->getMeterPolicyOid(meterPolicy1), createdOid);
+    }
+
+    TEST_F(DashMeterOrchTest, RemoveNonExistentMeterPolicy)
+    {
+        EXPECT_CALL(*mock_sai_dash_meter_api, remove_meter_policy).Times(0);
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, BuildMeterPolicy(), false);
+        EXPECT_EQ(m_DashMeterOrch->getMeterPolicyOid(meterPolicy1), SAI_NULL_OBJECT_ID);
+    }
+
+    TEST_F(DashMeterOrchTest, RemoveBoundMeterPolicy)
+    {
+        auto meterPolicy = BuildMeterPolicy();
+        sai_object_id_t createdOid = 0x1113;
+
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_policy)
+            .WillOnce(DoAll(SetArgPointee<0>(createdOid), Return(SAI_STATUS_SUCCESS)));
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy);
+
+        m_DashMeterOrch->incrMeterPolicyEniBindCount(meterPolicy1);
+        EXPECT_EQ(m_DashMeterOrch->getMeterPolicyEniBindCount(meterPolicy1), 1);
+
+        EXPECT_CALL(*mock_sai_dash_meter_api, remove_meter_policy).Times(0);
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy, false);
+        EXPECT_EQ(m_DashMeterOrch->getMeterPolicyOid(meterPolicy1), createdOid);
+    }
+
+    TEST_F(DashMeterOrchTest, RemoveMeterPolicyWithRules)
+    {
+        auto meterPolicy = BuildMeterPolicy();
+        auto meterRule = BuildMeterRule();
+        std::vector<sai_status_t> successStatus = {SAI_STATUS_SUCCESS};
+        sai_object_id_t policyOid = 0x1114;
+        sai_object_id_t ruleOid = 0x2114;
+
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_policy)
+            .WillOnce(DoAll(SetArgPointee<0>(policyOid), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_rules)
+            .WillOnce(DoAll(SetArgPointee<5>(ruleOid), SetArrayArgument<6>(successStatus.begin(), successStatus.end()), Return(SAI_STATUS_SUCCESS)));
+
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy);
+        SetDashTable(APP_DASH_METER_RULE_TABLE_NAME, MeterRuleKey(0), meterRule);
+
+        EXPECT_CALL(*mock_sai_dash_meter_api, remove_meter_policy).Times(0);
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy, false);
+        EXPECT_EQ(m_DashMeterOrch->getMeterPolicyOid(meterPolicy1), policyOid);
+    }
+
+    TEST_F(DashMeterOrchTest, MeterPolicySaiCreateFailure)
+    {
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_policy)
+            .WillOnce(Return(SAI_STATUS_INSUFFICIENT_RESOURCES));
+
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, BuildMeterPolicy(), true, true);
+        EXPECT_EQ(m_DashMeterOrch->getMeterPolicyOid(meterPolicy1), SAI_NULL_OBJECT_ID);
+    }
+
+    TEST_F(DashMeterOrchTest, MeterPolicySaiRemoveFailure)
+    {
+        auto meterPolicy = BuildMeterPolicy();
+        sai_object_id_t createdOid = 0x1115;
+
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_policy)
+            .WillOnce(DoAll(SetArgPointee<0>(createdOid), Return(SAI_STATUS_SUCCESS)));
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy);
+
+        EXPECT_CALL(*mock_sai_dash_meter_api, remove_meter_policy)
+            .WillOnce(Return(SAI_STATUS_INVALID_PARAMETER));
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy, false, true);
+
+        EXPECT_EQ(m_DashMeterOrch->getMeterPolicyOid(meterPolicy1), createdOid);
+    }
+
+    TEST_F(DashMeterOrchTest, MissingProtobufMeterPolicy)
+    {
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_policy).Times(0);
+        SetDashTableRaw(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, {}, true, true);
+        EXPECT_EQ(m_DashMeterOrch->getMeterPolicyOid(meterPolicy1), SAI_NULL_OBJECT_ID);
+    }
+
+    TEST_F(DashMeterOrchTest, AddRemoveMeterRule)
+    {
+        auto meterPolicy = BuildMeterPolicy();
+        auto meterRule = BuildMeterRule();
+        std::vector<sai_status_t> successStatus = {SAI_STATUS_SUCCESS};
+        sai_object_id_t policyOid = 0x1116;
+        sai_object_id_t ruleOid = 0x2116;
+        sai_object_id_t removedRuleOid = SAI_NULL_OBJECT_ID;
+        sai_object_id_t removedPolicyOid = SAI_NULL_OBJECT_ID;
+
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_policy)
+            .WillOnce(DoAll(SetArgPointee<0>(policyOid), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_rules)
+            .WillOnce(DoAll(SetArgPointee<5>(ruleOid), SetArrayArgument<6>(successStatus.begin(), successStatus.end()), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_CALL(*mock_sai_dash_meter_api, remove_meter_rules)
+            .WillOnce(DoAll(SaveArgPointee<1>(&removedRuleOid), SetArrayArgument<3>(successStatus.begin(), successStatus.end()), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_CALL(*mock_sai_dash_meter_api, remove_meter_policy)
+            .WillOnce(DoAll(SaveArg<0>(&removedPolicyOid), Return(SAI_STATUS_SUCCESS)));
+
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy);
+        SetDashTable(APP_DASH_METER_RULE_TABLE_NAME, MeterRuleKey(0), meterRule);
+        SetDashTable(APP_DASH_METER_RULE_TABLE_NAME, MeterRuleKey(0), meterRule, false);
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy, false);
+
+        EXPECT_EQ(removedRuleOid, ruleOid);
+        EXPECT_EQ(removedPolicyOid, policyOid);
+    }
+
+    TEST_F(DashMeterOrchTest, MeterRuleMissingPolicy)
+    {
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_rules).Times(0);
+        SetDashTable(APP_DASH_METER_RULE_TABLE_NAME, MeterRuleKey(0), BuildMeterRule(), true, true);
+    }
+
+    TEST_F(DashMeterOrchTest, MeterRuleBoundPolicy)
+    {
+        auto meterPolicy = BuildMeterPolicy();
+        sai_object_id_t policyOid = 0x1117;
+
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_policy)
+            .WillOnce(DoAll(SetArgPointee<0>(policyOid), Return(SAI_STATUS_SUCCESS)));
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy);
+
+        m_DashMeterOrch->incrMeterPolicyEniBindCount(meterPolicy1);
+
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_rules).Times(0);
+        SetDashTable(APP_DASH_METER_RULE_TABLE_NAME, MeterRuleKey(0), BuildMeterRule(), true, true);
+        EXPECT_EQ(m_DashMeterOrch->getMeterPolicyOid(meterPolicy1), policyOid);
+    }
+
+    TEST_F(DashMeterOrchTest, MeterRuleSaiCreateFailure)
+    {
+        auto meterPolicy = BuildMeterPolicy();
+        auto meterRule = BuildMeterRule();
+        std::vector<sai_status_t> createStatus = {SAI_STATUS_INSUFFICIENT_RESOURCES};
+        sai_object_id_t policyOid = 0x1118;
+        sai_object_id_t removedPolicyOid = SAI_NULL_OBJECT_ID;
+
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_policy)
+            .WillOnce(DoAll(SetArgPointee<0>(policyOid), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_rules)
+            .WillOnce(DoAll(SetArgPointee<5>(SAI_NULL_OBJECT_ID), SetArrayArgument<6>(createStatus.begin(), createStatus.end()), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_CALL(*mock_sai_dash_meter_api, remove_meter_policy)
+            .WillOnce(DoAll(SaveArg<0>(&removedPolicyOid), Return(SAI_STATUS_SUCCESS)));
+
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy);
+        SetDashTable(APP_DASH_METER_RULE_TABLE_NAME, MeterRuleKey(0), meterRule, true, true);
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy, false);
+
+        EXPECT_EQ(removedPolicyOid, policyOid);
+    }
+
+    TEST_F(DashMeterOrchTest, MeterRuleSaiRemoveFailure)
+    {
+        auto meterPolicy = BuildMeterPolicy();
+        auto meterRule = BuildMeterRule();
+        std::vector<sai_status_t> successStatus = {SAI_STATUS_SUCCESS};
+        std::vector<sai_status_t> removeStatus = {SAI_STATUS_INVALID_PARAMETER};
+        sai_object_id_t policyOid = 0x1119;
+        sai_object_id_t ruleOid = 0x2119;
+
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_policy)
+            .WillOnce(DoAll(SetArgPointee<0>(policyOid), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_rules)
+            .WillOnce(DoAll(SetArgPointee<5>(ruleOid), SetArrayArgument<6>(successStatus.begin(), successStatus.end()), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_CALL(*mock_sai_dash_meter_api, remove_meter_rules)
+            .WillOnce(DoAll(SetArrayArgument<3>(removeStatus.begin(), removeStatus.end()), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_CALL(*mock_sai_dash_meter_api, remove_meter_policy).Times(0);
+
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy);
+        SetDashTable(APP_DASH_METER_RULE_TABLE_NAME, MeterRuleKey(0), meterRule);
+        SetDashTable(APP_DASH_METER_RULE_TABLE_NAME, MeterRuleKey(0), meterRule, false, true);
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy, false, true);
+
+        EXPECT_EQ(m_DashMeterOrch->getMeterPolicyOid(meterPolicy1), policyOid);
+    }
+
+    TEST_F(DashMeterOrchTest, MeterRuleSaiRemoveNotExecuted)
+    {
+        auto meterPolicy = BuildMeterPolicy();
+        auto meterRule = BuildMeterRule();
+        std::vector<sai_status_t> successStatus = {SAI_STATUS_SUCCESS};
+        std::vector<sai_status_t> removeStatus = {SAI_STATUS_NOT_EXECUTED};
+        sai_object_id_t policyOid = 0x1120;
+        sai_object_id_t ruleOid = 0x2120;
+
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_policy)
+            .WillOnce(DoAll(SetArgPointee<0>(policyOid), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_rules)
+            .WillOnce(DoAll(SetArgPointee<5>(ruleOid), SetArrayArgument<6>(successStatus.begin(), successStatus.end()), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_CALL(*mock_sai_dash_meter_api, remove_meter_rules)
+            .WillOnce(DoAll(SetArrayArgument<3>(removeStatus.begin(), removeStatus.end()), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_CALL(*mock_sai_dash_meter_api, remove_meter_policy).Times(0);
+
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy);
+        SetDashTable(APP_DASH_METER_RULE_TABLE_NAME, MeterRuleKey(0), meterRule);
+        SetDashTable(APP_DASH_METER_RULE_TABLE_NAME, MeterRuleKey(0), meterRule, false, true);
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy, false, true);
+    }
+
+    TEST_F(DashMeterOrchTest, MeterRuleSaiRemoveItemNotFound)
+    {
+        auto meterPolicy = BuildMeterPolicy();
+        auto meterRule = BuildMeterRule();
+        std::vector<sai_status_t> successStatus = {SAI_STATUS_SUCCESS};
+        std::vector<sai_status_t> removeStatus = {SAI_STATUS_ITEM_NOT_FOUND};
+        sai_object_id_t policyOid = 0x1121;
+        sai_object_id_t ruleOid = 0x2121;
+
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_policy)
+            .WillOnce(DoAll(SetArgPointee<0>(policyOid), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_rules)
+            .WillOnce(DoAll(SetArgPointee<5>(ruleOid), SetArrayArgument<6>(successStatus.begin(), successStatus.end()), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_CALL(*mock_sai_dash_meter_api, remove_meter_rules)
+            .WillOnce(DoAll(SetArrayArgument<3>(removeStatus.begin(), removeStatus.end()), Return(SAI_STATUS_SUCCESS)));
+
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy);
+        SetDashTable(APP_DASH_METER_RULE_TABLE_NAME, MeterRuleKey(0), meterRule);
+        SetDashTable(APP_DASH_METER_RULE_TABLE_NAME, MeterRuleKey(0), meterRule, false, true);
+    }
+
+    TEST_F(DashMeterOrchTest, MissingProtobufMeterRule)
+    {
+        auto meterPolicy = BuildMeterPolicy();
+        sai_object_id_t policyOid = 0x1122;
+
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_policy)
+            .WillOnce(DoAll(SetArgPointee<0>(policyOid), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_rules).Times(0);
+
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy);
+        SetDashTableRaw(APP_DASH_METER_RULE_TABLE_NAME, MeterRuleKey(0), {}, true, true);
+    }
+
+    TEST_F(DashMeterOrchTest, MeterPolicyCreateDeleteChurn)
+    {
+        auto meterPolicy = BuildMeterPolicy();
+
+        for (int i = 0; i < 3; ++i)
+        {
+            sai_object_id_t createdOid = 0x1200 + static_cast<sai_object_id_t>(i);
+            EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_policy)
+                .WillOnce(DoAll(SetArgPointee<0>(createdOid), Return(SAI_STATUS_SUCCESS)));
+            SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy);
+
+            EXPECT_CALL(*mock_sai_dash_meter_api, remove_meter_policy)
+                .WillOnce(Return(SAI_STATUS_SUCCESS));
+            SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy, false);
+        }
+    }
+
+    TEST_F(DashMeterOrchTest, MeterRuleCreateDeleteChurn)
+    {
+        auto meterPolicy = BuildMeterPolicy();
+        auto meterRule = BuildMeterRule();
+        std::vector<sai_status_t> successStatus = {SAI_STATUS_SUCCESS};
+        sai_object_id_t policyOid = 0x1123;
+
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_policy)
+            .WillOnce(DoAll(SetArgPointee<0>(policyOid), Return(SAI_STATUS_SUCCESS)));
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy);
+
+        for (int i = 0; i < 3; ++i)
+        {
+            sai_object_id_t ruleOid = 0x2200 + static_cast<sai_object_id_t>(i);
+            EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_rules)
+                .WillOnce(DoAll(SetArgPointee<5>(ruleOid), SetArrayArgument<6>(successStatus.begin(), successStatus.end()), Return(SAI_STATUS_SUCCESS)));
+            SetDashTable(APP_DASH_METER_RULE_TABLE_NAME, MeterRuleKey(0), meterRule);
+
+            EXPECT_CALL(*mock_sai_dash_meter_api, remove_meter_rules)
+                .WillOnce(DoAll(SetArrayArgument<3>(successStatus.begin(), successStatus.end()), Return(SAI_STATUS_SUCCESS)));
+            SetDashTable(APP_DASH_METER_RULE_TABLE_NAME, MeterRuleKey(0), meterRule, false);
+        }
+
+        EXPECT_CALL(*mock_sai_dash_meter_api, remove_meter_policy)
+            .WillOnce(Return(SAI_STATUS_SUCCESS));
+        SetDashTable(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, meterPolicy, false);
+    }
+
+    TEST_F(DashMeterOrchTest, MeterPolicyUnknownOpAndException)
+    {
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_policy)
+            .WillOnce(Throw(std::runtime_error("meter policy failure")));
+
+        ProcessDashTupleRaw(APP_DASH_METER_POLICY_TABLE_NAME, meterPolicy1, "UNKNOWN", {});
+        ProcessDashTupleRaw(APP_DASH_METER_POLICY_TABLE_NAME,
+                            meterPolicy1,
+                            SET_COMMAND,
+                            {{"pb", BuildMeterPolicy().SerializeAsString()}});
+    }
+
+    TEST_F(DashMeterOrchTest, MeterRuleUnknownOpAndInvalidKey)
+    {
+        EXPECT_CALL(*mock_sai_dash_meter_api, create_meter_rules).Times(0);
+
+        ProcessDashTupleRaw(APP_DASH_METER_RULE_TABLE_NAME,
+                            MeterRuleKey(0),
+                            "UNKNOWN",
+                            {{"pb", BuildMeterRule().SerializeAsString()}});
+        ProcessDashTupleRaw(APP_DASH_METER_RULE_TABLE_NAME,
+                            meterPolicy1 + ":invalid",
+                            SET_COMMAND,
+                            {{"pb", BuildMeterRule().SerializeAsString()}});
+    }
+}

--- a/tests/mock_tests/dashorch_ut.cpp
+++ b/tests/mock_tests/dashorch_ut.cpp
@@ -24,22 +24,35 @@ namespace dashorch_test
     {
     public:
         MockDashHaOrch(DBConnector *db, const std::vector<std::string> &tableNames, DashOrch *dash_orch, BfdOrch *bfd_orch, DBConnector *app_state_db, ZmqServer *zmqServer)
-            : DashHaOrch(db, tableNames, dash_orch, bfd_orch, app_state_db, zmqServer) {}
+            : DashHaOrch(db, tableNames, dash_orch, bfd_orch, app_state_db, zmqServer), m_ha_role_for_eni(dash::types::HA_ROLE_ACTIVE) {}
+
+        void setHaRoleForEni(dash::types::HaRole role) { m_ha_role_for_eni = role; }
 
         HaScopeEntry getHaScopeForEni(const std::string& eni) override
         {
             HaScopeEntry entry;
 
             entry.ha_scope_id = 0x123456789ABCDEF0ULL;
-            entry.metadata.set_ha_role(dash::types::HA_ROLE_ACTIVE);
+            entry.metadata.set_ha_role(m_ha_role_for_eni);
             entry.metadata.set_disabled(false);
 
             return entry;
         }
+
+    private:
+        dash::types::HaRole m_ha_role_for_eni;
+    };
+
+    class TestableDashOrch : public DashOrch
+    {
+    public:
+        TestableDashOrch(swss::DBConnector* db, std::vector<std::string>& tables, swss::DBConnector* app_state_db, swss::ZmqServer* zmqServer)
+            : DashOrch(db, tables, app_state_db, zmqServer) {}
     };
 
     DEFINE_SAI_GENERIC_APIS_MOCK(dash_appliance, dash_appliance)
-    DEFINE_SAI_GENERIC_APIS_MOCK(dash_eni, eni)
+    DEFINE_SAI_API_COMBINED_MOCK(dash_eni, eni, eni_ether_address_map)
+    DEFINE_SAI_ENTRY_APIS_MOCK(dash_vip, vip)
     DEFINE_SAI_ENTRY_APIS_MOCK(dash_trusted_vni, global_trusted_vni, eni_trusted_vni)
     DEFINE_SAI_ENTRY_APIS_MOCK(dash_direction_lookup, direction_lookup)
     using namespace mock_orch_test;
@@ -50,6 +63,7 @@ namespace dashorch_test
     using ::testing::SaveArgPointee;
     using ::testing::Invoke;
     using ::testing::InSequence;
+    using ::testing::Throw;
     using dash::types::ValueOrRange;
 
     ValueOrRange GenVni(int value)
@@ -82,13 +96,15 @@ namespace dashorch_test
         }
     }
     class DashOrchTest : public MockDashOrchTest, public ::testing::WithParamInterface<std::tuple<ValueOrRange, ValueOrRange>> {
-    private:
+    protected:
         std::unique_ptr<MockDashHaOrch> m_mock_dash_ha_orch;
-        
+
+    private:
         void ApplySaiMock()
         {
             INIT_SAI_API_MOCK(dash_appliance);
             INIT_SAI_API_MOCK(dash_eni);
+            INIT_SAI_API_MOCK(dash_vip);
             INIT_SAI_API_MOCK(dash_trusted_vni);
             INIT_SAI_API_MOCK(dash_direction_lookup);
             MockSaiApis();
@@ -96,9 +112,8 @@ namespace dashorch_test
 
         void PostSetUp()
         {
-            // Skip HA orch mocking for now since the dummy value returned by getHaScopeForEni is causing ENI creation to fail.
-            // m_mock_dash_ha_orch = std::make_unique<MockDashHaOrch>(m_dpu_app_db.get(), std::vector<std::string>{APP_DASH_HA_SET_TABLE_NAME, APP_DASH_HA_SCOPE_TABLE_NAME}, m_DashOrch, nullptr, m_dpu_app_state_db.get(), nullptr);
-            // m_DashOrch->setDashHaOrch(m_mock_dash_ha_orch.get());
+            // Mock is not created here so tests that only need DashOrch (e.g. trusted VNI tests) are not
+            // affected by the dummy getHaScopeForEni(). The two tests that need the mock create it locally.
         }
 
         void PreTearDown() override
@@ -106,6 +121,7 @@ namespace dashorch_test
             RestoreSaiApis();
             DEINIT_SAI_API_MOCK(dash_direction_lookup);
             DEINIT_SAI_API_MOCK(dash_trusted_vni);
+            DEINIT_SAI_API_MOCK(dash_vip);
             DEINIT_SAI_API_MOCK(dash_eni);
             DEINIT_SAI_API_MOCK(dash_appliance);
         }
@@ -151,6 +167,16 @@ namespace dashorch_test
                     }
                 }
                 return ;
+            }
+            void VerifyHaFlowOwner(std::vector<sai_attribute_t> &actual_attrs, bool expected_value)
+            {
+                for (auto attr : actual_attrs) {
+                    if (attr.id == SAI_ENI_ATTR_IS_HA_FLOW_OWNER) {
+                        EXPECT_EQ(attr.value.booldata, expected_value);
+                        return;
+                    }
+                }
+                FAIL() << "SAI_ENI_ATTR_IS_HA_FLOW_OWNER not found in attributes";
             }
     };
 
@@ -218,6 +244,20 @@ namespace dashorch_test
         SetDashTable(APP_DASH_ENI_TABLE_NAME, "eni1", eni);
         VerifyEniMode(actual_attrs, SAI_DASH_ENI_MODE_VM); // Default
         SetDashTable(APP_DASH_ENI_TABLE_NAME, "eni1", eni, false);
+    }
+
+    TEST_F(DashOrchTest, RemoveNonExistentEni)
+    {
+        CreateApplianceEntry();
+        CreateVnet();
+        EXPECT_CALL(*mock_sai_dash_eni_api, remove_eni).Times(0);
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, dash::eni::Eni(), false, true);
+    }
+
+    TEST_F(DashOrchTest, RemoveNonExistentAppliance)
+    {
+        EXPECT_CALL(*mock_sai_dash_appliance_api, remove_dash_appliance).Times(0);
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, dash::appliance::Appliance(), false, true);
     }
 
     TEST_F(DashOrchTest, CreateRemoveApplianceTrustedVnisSingleValue)
@@ -297,7 +337,7 @@ namespace dashorch_test
                 .Times(1);
         }
 
-        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, appliance, true, false);
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, appliance, true, true);
     }
 
     TEST_F(DashOrchTest, CreateRemoveApplianceTrustedVniRemoveFail)
@@ -318,7 +358,7 @@ namespace dashorch_test
         }
 
         SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, appliance);
-        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, dash::appliance::Appliance(), false, false);
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, dash::appliance::Appliance(), false, true);
     }
 
     TEST_F(DashOrchTest, CreateRemoveApplianceTrustedVnisMixed)
@@ -498,7 +538,7 @@ namespace dashorch_test
                 .Times(1);
         }
 
-        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, eni, true, false);
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, eni, true, true);
     }
 
     TEST_F(DashOrchTest, CreateRemoveEniTrustedVniRemoveFail)
@@ -523,7 +563,7 @@ namespace dashorch_test
         }
 
         SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, eni);
-        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, dash::eni::Eni(), false, false);
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, dash::eni::Eni(), false, true);
     }
 
     TEST_F(DashOrchTest, CreateRemoveEniTrustedVnisMixed)
@@ -681,4 +721,792 @@ namespace dashorch_test
         SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, appliance);
         VerifyDirectionLookup(actual_attrs, SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_OUTBOUND_DIRECTION);
     }
+
+    TEST_F(DashOrchTest, CreateEniWithHaScopeStandbyRole)
+    {
+        m_mock_dash_ha_orch = std::make_unique<MockDashHaOrch>(m_dpu_app_db.get(), std::vector<std::string>{APP_DASH_HA_SET_TABLE_NAME, APP_DASH_HA_SCOPE_TABLE_NAME}, m_DashOrch, nullptr, m_dpu_app_state_db.get(), nullptr);
+        m_DashOrch->setDashHaOrch(m_mock_dash_ha_orch.get());
+
+        CreateApplianceEntry();
+        CreateVnet();
+        m_mock_dash_ha_orch->setHaRoleForEni(dash::types::HA_ROLE_STANDBY);
+
+        std::vector<sai_attribute_t> actual_attrs;
+        EXPECT_CALL(*mock_sai_dash_eni_api, create_eni).Times(1).WillOnce(
+            DoAll(
+                [&actual_attrs](sai_object_id_t *eni_id, sai_object_id_t switch_id, uint32_t attr_count, const sai_attribute_t *attr_list) {
+                    actual_attrs.assign(attr_list, attr_list + attr_count);
+                },
+                Invoke(old_sai_dash_eni_api, &sai_dash_eni_api_t::create_eni)));
+
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, BuildEniEntry());
+        VerifyHaFlowOwner(actual_attrs, false);
+
+        m_DashOrch->setDashHaOrch(nullptr);
+    }
+
+    TEST_F(DashOrchTest, CreateEniWithHaScopeOtherRole)
+    {
+        m_mock_dash_ha_orch = std::make_unique<MockDashHaOrch>(m_dpu_app_db.get(), std::vector<std::string>{APP_DASH_HA_SET_TABLE_NAME, APP_DASH_HA_SCOPE_TABLE_NAME}, m_DashOrch, nullptr, m_dpu_app_state_db.get(), nullptr);
+        m_DashOrch->setDashHaOrch(m_mock_dash_ha_orch.get());
+
+        CreateApplianceEntry();
+        CreateVnet();
+        m_mock_dash_ha_orch->setHaRoleForEni(dash::types::HA_ROLE_SWITCHING_TO_ACTIVE);
+
+        std::vector<sai_attribute_t> actual_attrs;
+        EXPECT_CALL(*mock_sai_dash_eni_api, create_eni).Times(1).WillOnce(
+            DoAll(
+                [&actual_attrs](sai_object_id_t *eni_id, sai_object_id_t switch_id, uint32_t attr_count, const sai_attribute_t *attr_list) {
+                    actual_attrs.assign(attr_list, attr_list + attr_count);
+                },
+                Invoke(old_sai_dash_eni_api, &sai_dash_eni_api_t::create_eni)));
+
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, BuildEniEntry());
+        VerifyHaFlowOwner(actual_attrs, false);
+
+        m_DashOrch->setDashHaOrch(nullptr);
+    }
+
+    TEST_F(DashOrchTest, CreateEniMissingVnetNotRetried)
+    {
+        CreateApplianceEntry();
+        // Build ENI referencing a VNET that doesn't exist
+        dash::eni::Eni eni = BuildEniEntry();
+        eni.set_vnet("NON_EXISTENT_VNET");
+        EXPECT_CALL(*mock_sai_dash_eni_api, create_eni).Times(0);
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, eni, true, true);
+    }
+
+    TEST_F(DashOrchTest, CreateEniMissingApplianceNotRetried)
+    {
+        // Do NOT create appliance — ENI requires appliance to exist
+        CreateVnet();
+        EXPECT_CALL(*mock_sai_dash_eni_api, create_eni).Times(0);
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, BuildEniEntry(), true, true);
+    }
+
+    TEST_F(DashOrchTest, CreateEniSaiFailureNotRetried)
+    {
+        CreateApplianceEntry();
+        CreateVnet();
+        EXPECT_CALL(*mock_sai_dash_eni_api, create_eni)
+            .WillOnce(Return(SAI_STATUS_INSUFFICIENT_RESOURCES));
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, BuildEniEntry(), true, true);
+    }
+
+    TEST_F(DashOrchTest, EniRouteMissingEniNotRetried)
+    {
+        CreateApplianceEntry();
+        // Do NOT create ENI — ENI route references eni1 which doesn't exist
+        dash::eni_route::EniRoute eni_route;
+        eni_route.set_group_id(route_group1);
+        SetDashTable(APP_DASH_ENI_ROUTE_TABLE_NAME, eni1, eni_route, true, true);
+    }
+
+    TEST_F(DashOrchTest, EniRouteMissingRouteGroupNotRetried)
+    {
+        CreateApplianceEntry();
+        CreateVnet();
+        auto eni = BuildEniEntry();
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, eni);
+        // Do NOT create route group — ENI route references route_group1 which doesn't exist
+        dash::eni_route::EniRoute eni_route;
+        eni_route.set_group_id(route_group1);
+        SetDashTable(APP_DASH_ENI_ROUTE_TABLE_NAME, eni1, eni_route, true, true);
+    }
+
+    TEST_F(DashOrchTest, ApplianceTrustedVniFailCleanupAllowsRetry)
+    {
+        dash::appliance::Appliance appliance = BuildApplianceEntry();
+        appliance.mutable_trusted_vnis_list()->Add()->set_value(100);
+
+        {
+            InSequence seq;
+            // First attempt: appliance created, VNI fails, appliance removed
+            EXPECT_CALL(*mock_sai_dash_appliance_api, create_dash_appliance).Times(1);
+            EXPECT_CALL(*mock_sai_dash_trusted_vni_api, create_global_trusted_vni_entry)
+                .WillOnce(Return(SAI_STATUS_FAILURE));
+            EXPECT_CALL(*mock_sai_dash_appliance_api, remove_dash_appliance).Times(1);
+            // Second attempt: all SAI calls re-issued (cache was cleared)
+            EXPECT_CALL(*mock_sai_dash_appliance_api, create_dash_appliance).Times(1);
+            EXPECT_CALL(*mock_sai_dash_trusted_vni_api, create_global_trusted_vni_entry).Times(1);
+        }
+
+        // First attempt fails
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, appliance, true, true);
+        // Second attempt succeeds — verifies cache was not populated by failed first attempt
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, appliance, true, true);
+    }
+
+    TEST_F(DashOrchTest, EniTrustedVniFailCleanupAllowsRetry)
+    {
+        CreateApplianceEntry();
+        CreateVnet();
+
+        dash::eni::Eni eni = BuildEniEntry();
+        eni.mutable_trusted_vnis_list()->Add()->set_value(200);
+
+        {
+            InSequence seq;
+            // First attempt: ENI created, VNI fails, ENI removed
+            EXPECT_CALL(*mock_sai_dash_eni_api, create_eni).Times(1);
+            EXPECT_CALL(*mock_sai_dash_trusted_vni_api, create_eni_trusted_vni_entry)
+                .WillOnce(Return(SAI_STATUS_FAILURE));
+            EXPECT_CALL(*mock_sai_dash_eni_api, remove_eni).Times(1);
+            // Second attempt: all SAI calls re-issued (cache was cleared)
+            EXPECT_CALL(*mock_sai_dash_eni_api, create_eni).Times(1);
+            EXPECT_CALL(*mock_sai_dash_trusted_vni_api, create_eni_trusted_vni_entry).Times(1);
+        }
+
+        // First attempt fails
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, eni, true, true);
+        // Second attempt succeeds — verifies cache was not populated by failed first attempt
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, eni, true, true);
+    }
+
+    TEST_F(DashOrchTest, AddRemoveEniRoute)
+    {
+        CreateApplianceEntry();
+        CreateVnet();
+        auto eni = BuildEniEntry();
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, eni);
+        AddOutboundRoutingGroup();
+
+        // SET ENI route — binds ENI to route group
+        dash::eni_route::EniRoute eni_route;
+        eni_route.set_group_id(route_group1);
+        SetDashTable(APP_DASH_ENI_ROUTE_TABLE_NAME, eni1, eni_route, true, true);
+
+        // DEL ENI route — unbinds
+        SetDashTable(APP_DASH_ENI_ROUTE_TABLE_NAME, eni1, dash::eni_route::EniRoute(), false, true);
+    }
+
+    TEST_F(DashOrchTest, AddRemoveTunnel)
+    {
+        CreateApplianceEntry();
+        AddTunnel();
+        RemoveTunnel();
+    }
+
+    TEST_F(DashOrchTest, RemoveEniPartialFailurePreservesCache)
+    {
+        CreateApplianceEntry();
+        CreateVnet();
+        auto eni = BuildEniEntry();
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, eni);
+
+        {
+            InSequence seq;
+            // First remove attempt: remove_eni fails
+            EXPECT_CALL(*mock_sai_dash_eni_api, remove_eni)
+                .WillOnce(Return(SAI_STATUS_OBJECT_IN_USE));
+            // Second remove attempt: remove_eni succeeds (cache was preserved)
+            EXPECT_CALL(*mock_sai_dash_eni_api, remove_eni).Times(1);
+        }
+
+        // First attempt — SAI failure, consumer still emptied but cache preserved
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, dash::eni::Eni(), false, true);
+        // Second attempt — succeeds because cache was preserved, so remove_eni is called again
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, dash::eni::Eni(), false, true);
+    }
+
+    TEST_F(DashOrchTest, RemoveApplianceDirectionLookupFailurePreservesCache)
+    {
+        CreateApplianceEntry();
+
+        {
+            InSequence seq;
+            // First remove attempt: direction_lookup remove fails
+            EXPECT_CALL(*mock_sai_dash_direction_lookup_api, remove_direction_lookup_entry)
+                .WillOnce(Return(SAI_STATUS_FAILURE));
+            // Second remove attempt: direction_lookup and appliance removes succeed
+            EXPECT_CALL(*mock_sai_dash_direction_lookup_api, remove_direction_lookup_entry).Times(1);
+            EXPECT_CALL(*mock_sai_dash_appliance_api, remove_dash_appliance).Times(1);
+        }
+
+        // First attempt — direction lookup removal fails, cache preserved
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, dash::appliance::Appliance(), false, true);
+        // Second attempt — succeeds, all SAI remove calls re-issued
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, dash::appliance::Appliance(), false, true);
+    }
+
+    TEST_F(DashOrchTest, RemoveApplianceTrustedVniFailurePreservesCache)
+    {
+        dash::appliance::Appliance appliance = BuildApplianceEntry();
+        appliance.mutable_trusted_vnis_list()->Add()->set_value(100);
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, appliance);
+
+        {
+            InSequence seq;
+            // First remove attempt: trusted VNI removal fails
+            EXPECT_CALL(*mock_sai_dash_trusted_vni_api, remove_global_trusted_vni_entry)
+                .WillOnce(Return(SAI_STATUS_FAILURE));
+            // Second remove attempt: all removals succeed
+            EXPECT_CALL(*mock_sai_dash_trusted_vni_api, remove_global_trusted_vni_entry).Times(1);
+            EXPECT_CALL(*mock_sai_dash_appliance_api, remove_dash_appliance).Times(1);
+        }
+
+        // First attempt — VNI removal fails, cache preserved
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, dash::appliance::Appliance(), false, true);
+        // Second attempt — succeeds
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, dash::appliance::Appliance(), false, true);
+    }
+
+    TEST_F(DashOrchTest, MissingProtobufAppliance)
+    {
+        // SET with no pb field — should be consumed without creating anything
+        EXPECT_CALL(*mock_sai_dash_appliance_api, create_dash_appliance).Times(0);
+        SetDashTableRaw(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, {}, true, true);
+    }
+
+    TEST_F(DashOrchTest, InvalidProtobufAppliance)
+    {
+        // SET with garbage pb field — should be consumed without creating anything
+        EXPECT_CALL(*mock_sai_dash_appliance_api, create_dash_appliance).Times(0);
+        SetDashTableRaw(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, {{ "pb", "not_valid_protobuf" }}, true, true);
+    }
+
+    TEST_F(DashOrchTest, MissingProtobufEni)
+    {
+        CreateApplianceEntry();
+        CreateVnet();
+        EXPECT_CALL(*mock_sai_dash_eni_api, create_eni).Times(0);
+        SetDashTableRaw(APP_DASH_ENI_TABLE_NAME, eni1, {}, true, true);
+    }
+
+    TEST_F(DashOrchTest, MissingProtobufEniRoute)
+    {
+        CreateApplianceEntry();
+        CreateVnet();
+        SetDashTableRaw(APP_DASH_ENI_ROUTE_TABLE_NAME, eni1, {}, true, true);
+    }
+
+    TEST_F(DashOrchTest, InvalidRoutingTypeKey)
+    {
+        // Invalid routing type string that cannot be parsed
+        SetDashTableRaw(APP_DASH_ROUTING_TYPE_TABLE_NAME, "INVALID_NOT_A_REAL_TYPE",
+                        {{ "pb", dash::route_type::RouteType().SerializeAsString() }}, true, true);
+    }
+
+    TEST_F(DashOrchTest, EniCreateDeleteChurn)
+    {
+        CreateApplianceEntry();
+        CreateVnet();
+        auto eni = BuildEniEntry();
+
+        // Cycle ENI create/delete multiple times
+        for (int i = 0; i < 3; i++)
+        {
+            EXPECT_CALL(*mock_sai_dash_eni_api, create_eni).Times(1);
+            SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, eni);
+
+            EXPECT_CALL(*mock_sai_dash_eni_api, remove_eni).Times(1);
+            SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, dash::eni::Eni(), false, true);
+        }
+    }
+
+    TEST_F(DashOrchTest, EniCreateFailThenSucceed)
+    {
+        CreateApplianceEntry();
+        CreateVnet();
+        auto eni = BuildEniEntry();
+
+        {
+            InSequence seq;
+            // First create fails
+            EXPECT_CALL(*mock_sai_dash_eni_api, create_eni)
+                .WillOnce(Return(SAI_STATUS_INSUFFICIENT_RESOURCES));
+            // Second create succeeds
+            EXPECT_CALL(*mock_sai_dash_eni_api, create_eni).Times(1);
+        }
+
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, eni, true, true);
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, eni, true, true);
+    }
+
+    TEST_F(DashOrchTest, MultipleEniCreateDelete)
+    {
+        CreateApplianceEntry();
+        CreateVnet();
+        auto eni = BuildEniEntry();
+        std::string eni2 = "ENI_2";
+
+        // Create two different ENIs
+        EXPECT_CALL(*mock_sai_dash_eni_api, create_eni).Times(2);
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, eni);
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni2, eni);
+
+        // Delete both
+        EXPECT_CALL(*mock_sai_dash_eni_api, remove_eni).Times(2);
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, dash::eni::Eni(), false, true);
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni2, dash::eni::Eni(), false, true);
+    }
+
+    TEST_F(DashOrchTest, EniRouteBindUnbindChurn)
+    {
+        CreateApplianceEntry();
+        CreateVnet();
+        auto eni = BuildEniEntry();
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, eni);
+        AddOutboundRoutingGroup();
+
+        dash::eni_route::EniRoute eni_route;
+        eni_route.set_group_id(route_group1);
+
+        // Bind/unbind multiple times
+        for (int i = 0; i < 3; i++)
+        {
+            SetDashTable(APP_DASH_ENI_ROUTE_TABLE_NAME, eni1, eni_route, true, true);
+            SetDashTable(APP_DASH_ENI_ROUTE_TABLE_NAME, eni1, dash::eni_route::EniRoute(), false, true);
+        }
+    }
+
+    TEST_F(DashOrchTest, ApplianceVipCreateFailCleansUpAppliance)
+    {
+        dash::appliance::Appliance appliance = BuildApplianceEntry();
+
+        {
+            InSequence seq;
+            EXPECT_CALL(*mock_sai_dash_appliance_api, create_dash_appliance).Times(1);
+            EXPECT_CALL(*mock_sai_dash_vip_api, create_vip_entry)
+                .WillOnce(Return(SAI_STATUS_FAILURE));
+            EXPECT_CALL(*mock_sai_dash_appliance_api, remove_dash_appliance).Times(1);
+        }
+
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, appliance, true, true);
+        EXPECT_TRUE(m_DashOrch->appliance_entries_.empty());
+    }
+
+    TEST_F(DashOrchTest, ApplianceDirectionLookupFailCleansUpVipAndAppliance)
+    {
+        dash::appliance::Appliance appliance = BuildApplianceEntry();
+
+        {
+            InSequence seq;
+            EXPECT_CALL(*mock_sai_dash_appliance_api, create_dash_appliance).Times(1);
+            EXPECT_CALL(*mock_sai_dash_vip_api, create_vip_entry).Times(1);
+            EXPECT_CALL(*mock_sai_dash_direction_lookup_api, create_direction_lookup_entry)
+                .WillOnce(Return(SAI_STATUS_FAILURE));
+            EXPECT_CALL(*mock_sai_dash_vip_api, remove_vip_entry).Times(1);
+            EXPECT_CALL(*mock_sai_dash_appliance_api, remove_dash_appliance).Times(1);
+        }
+
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, appliance, true, true);
+        EXPECT_TRUE(m_DashOrch->appliance_entries_.empty());
+    }
+
+    TEST_F(DashOrchTest, AddRemoveRoutingType)
+    {
+        dash::route_type::RouteType route_type;
+        route_type.add_items()->set_action_type(dash::route_type::ACTION_TYPE_STATICENCAP);
+
+        SetDashTable(APP_DASH_ROUTING_TYPE_TABLE_NAME, "VNET", route_type);
+        ASSERT_EQ(m_DashOrch->routing_type_entries_.count(dash::route_type::ROUTING_TYPE_VNET), 1u);
+
+        SetDashTable(APP_DASH_ROUTING_TYPE_TABLE_NAME, "VNET", dash::route_type::RouteType(), false);
+        EXPECT_TRUE(m_DashOrch->routing_type_entries_.empty());
+    }
+
+    TEST_F(DashOrchTest, RemoveNonExistentRoutingType)
+    {
+        SetDashTable(APP_DASH_ROUTING_TYPE_TABLE_NAME, "VNET", dash::route_type::RouteType(), false);
+        EXPECT_TRUE(m_DashOrch->routing_type_entries_.empty());
+    }
+
+    TEST_F(DashOrchTest, RoutingTypeMissingProtobuf)
+    {
+        SetDashTableRaw(APP_DASH_ROUTING_TYPE_TABLE_NAME, "VNET", {}, true, true);
+        EXPECT_TRUE(m_DashOrch->routing_type_entries_.empty());
+    }
+
+    TEST_F(DashOrchTest, RoutingTypeUnknownOp)
+    {
+        auto consumer = make_unique<Consumer>(
+            new swss::ConsumerStateTable(m_app_db.get(), APP_DASH_ROUTING_TYPE_TABLE_NAME),
+            m_DashOrch, APP_DASH_ROUTING_TYPE_TABLE_NAME);
+        consumer->addToSync(swss::KeyOpFieldsValuesTuple(
+            "VNET", "UNKNOWN", {{"pb", dash::route_type::RouteType().SerializeAsString()}}));
+
+        m_DashOrch->doTask(*consumer);
+        EXPECT_EQ(consumer->m_toSync.begin(), consumer->m_toSync.end());
+        EXPECT_TRUE(m_DashOrch->routing_type_entries_.empty());
+    }
+
+    TEST_F(DashOrchTest, AddRemoveQos)
+    {
+        dash::qos::Qos qos;
+        qos.set_bw(100);
+        qos.set_cps(200);
+        qos.set_flows(300);
+
+        SetDashTable(APP_DASH_QOS_TABLE_NAME, "QOS_1", qos);
+        ASSERT_EQ(m_DashOrch->qos_entries_.count("QOS_1"), 1u);
+        EXPECT_EQ(m_DashOrch->qos_entries_["QOS_1"].bw(), 100);
+
+        SetDashTable(APP_DASH_QOS_TABLE_NAME, "QOS_1", dash::qos::Qos(), false);
+        EXPECT_TRUE(m_DashOrch->qos_entries_.empty());
+    }
+
+    TEST_F(DashOrchTest, QosMissingProtobuf)
+    {
+        SetDashTableRaw(APP_DASH_QOS_TABLE_NAME, "QOS_1", {}, true, true);
+        EXPECT_TRUE(m_DashOrch->qos_entries_.empty());
+    }
+
+    TEST_F(DashOrchTest, QosUnknownOp)
+    {
+        auto consumer = make_unique<Consumer>(
+            new swss::ConsumerStateTable(m_app_db.get(), APP_DASH_QOS_TABLE_NAME),
+            m_DashOrch, APP_DASH_QOS_TABLE_NAME);
+        consumer->addToSync(swss::KeyOpFieldsValuesTuple(
+            "QOS_1", "UNKNOWN", {{"pb", dash::qos::Qos().SerializeAsString()}}));
+
+        m_DashOrch->doTask(*consumer);
+        EXPECT_EQ(consumer->m_toSync.begin(), consumer->m_toSync.end());
+        EXPECT_TRUE(m_DashOrch->qos_entries_.empty());
+    }
+
+    TEST_F(DashOrchTest, QosCreateDeleteChurn)
+    {
+        dash::qos::Qos qos;
+        qos.set_bw(100);
+        qos.set_cps(200);
+        qos.set_flows(300);
+
+        for (int i = 0; i < 3; i++)
+        {
+            SetDashTable(APP_DASH_QOS_TABLE_NAME, "QOS_1", qos);
+            ASSERT_EQ(m_DashOrch->qos_entries_.count("QOS_1"), 1u);
+            SetDashTable(APP_DASH_QOS_TABLE_NAME, "QOS_1", dash::qos::Qos(), false);
+            EXPECT_TRUE(m_DashOrch->qos_entries_.empty());
+        }
+    }
+
+    TEST_F(DashOrchTest, EniAdminStateUpdateSaiFailure)
+    {
+        CreateApplianceEntry();
+        CreateVnet();
+        auto eni = BuildEniEntry();
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, eni);
+
+        eni.set_admin_state(dash::eni::STATE_DISABLED);
+        EXPECT_CALL(*mock_sai_dash_eni_api, set_eni_attribute)
+            .WillOnce(Return(SAI_STATUS_FAILURE));
+
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, eni, true, true);
+        ASSERT_EQ(m_DashOrch->eni_entries_.count(eni1), 1u);
+        EXPECT_EQ(m_DashOrch->eni_entries_[eni1].metadata.admin_state(), dash::eni::STATE_ENABLED);
+    }
+
+    TEST_F(DashOrchTest, EniMissingV6MeterPolicy)
+    {
+        CreateApplianceEntry();
+        CreateVnet();
+
+        auto eni = BuildEniEntry();
+        eni.set_v6_meter_policy_id("MISSING_V6_POLICY");
+
+        EXPECT_CALL(*mock_sai_dash_eni_api, create_eni).Times(0);
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, eni, true, true);
+        EXPECT_TRUE(m_DashOrch->eni_entries_.empty());
+    }
+
+    TEST_F(DashOrchTest, EniAddrMapCreateFailCleansUpEniObject)
+    {
+        CreateApplianceEntry();
+        CreateVnet();
+        auto eni = BuildEniEntry();
+
+        {
+            InSequence seq;
+            EXPECT_CALL(*mock_sai_dash_eni_api, create_eni).Times(1);
+            EXPECT_CALL(*mock_sai_dash_eni_api, create_eni_ether_address_map_entry)
+                .WillOnce(Return(SAI_STATUS_FAILURE));
+            EXPECT_CALL(*mock_sai_dash_eni_api, remove_eni).Times(1);
+        }
+
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, eni, true, true);
+        EXPECT_TRUE(m_DashOrch->eni_entries_.empty());
+    }
+
+    TEST_F(DashOrchTest, EniRouteSetSaiFailure)
+    {
+        CreateApplianceEntry();
+        CreateVnet();
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, BuildEniEntry());
+        AddOutboundRoutingGroup();
+
+        dash::eni_route::EniRoute eni_route;
+        eni_route.set_group_id(route_group1);
+
+        EXPECT_CALL(*mock_sai_dash_eni_api, set_eni_attribute)
+            .WillOnce(Return(SAI_STATUS_FAILURE));
+        SetDashTable(APP_DASH_ENI_ROUTE_TABLE_NAME, eni1, eni_route, true, true);
+        EXPECT_TRUE(m_DashOrch->eni_route_entries_.empty());
+    }
+
+    TEST_F(DashOrchTest, EniRouteRemoveSaiFailure)
+    {
+        CreateApplianceEntry();
+        CreateVnet();
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, BuildEniEntry());
+        AddOutboundRoutingGroup();
+
+        dash::eni_route::EniRoute eni_route;
+        eni_route.set_group_id(route_group1);
+        SetDashTable(APP_DASH_ENI_ROUTE_TABLE_NAME, eni1, eni_route, true, true);
+        ASSERT_EQ(m_DashOrch->eni_route_entries_.count(eni1), 1u);
+
+        EXPECT_CALL(*mock_sai_dash_eni_api, set_eni_attribute)
+            .WillOnce(Return(SAI_STATUS_FAILURE));
+        SetDashTable(APP_DASH_ENI_ROUTE_TABLE_NAME, eni1, dash::eni_route::EniRoute(), false, true);
+        EXPECT_EQ(m_DashOrch->eni_route_entries_.count(eni1), 1u);
+    }
+
+    TEST_F(DashOrchTest, EniRouteUnknownOp)
+    {
+        auto consumer = make_unique<Consumer>(
+            new swss::ConsumerStateTable(m_app_db.get(), APP_DASH_ENI_ROUTE_TABLE_NAME),
+            m_DashOrch, APP_DASH_ENI_ROUTE_TABLE_NAME);
+        consumer->addToSync(swss::KeyOpFieldsValuesTuple(
+            eni1, "UNKNOWN", {{"pb", dash::eni_route::EniRoute().SerializeAsString()}}));
+
+        m_DashOrch->doTask(*consumer);
+        EXPECT_EQ(consumer->m_toSync.begin(), consumer->m_toSync.end());
+        EXPECT_TRUE(m_DashOrch->eni_route_entries_.empty());
+    }
+
+    TEST_F(DashOrchTest, ApplianceInvalidSipCleansUpAppliance)
+    {
+        // Appliance entry with local_region_id set (triggers create_dash_appliance)
+        // but no SIP set — to_sai(entry.sip()) fails in createApplianceSaiObjects,
+        // and the created appliance must be cleaned up.
+        dash::appliance::Appliance appliance;
+        appliance.set_local_region_id(100);
+        appliance.set_vm_vni(9999);
+        // Intentionally do not set sip — to_sai will fail
+
+        // create_dash_appliance is called; assign a non-null OID so cleanup path is exercised
+        sai_object_id_t fake_oid = 0x1234ABCD;
+        {
+            InSequence seq;
+            EXPECT_CALL(*mock_sai_dash_appliance_api, create_dash_appliance)
+                .WillOnce(DoAll(SetArgPointee<0>(fake_oid), Return(SAI_STATUS_SUCCESS)));
+            EXPECT_CALL(*mock_sai_dash_appliance_api, remove_dash_appliance).Times(1);
+        }
+        EXPECT_CALL(*mock_sai_dash_vip_api, create_vip_entry).Times(0);
+
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, appliance, true, true);
+        EXPECT_TRUE(m_DashOrch->appliance_entries_.empty());
+    }
+
+    TEST_F(DashOrchTest, ApplianceVipFailureCleansUpApplianceWithLocalRegionId)
+    {
+        // Variation of ApplianceVipCreateFailCleansUpAppliance, but with local_region_id set
+        // so create_dash_appliance is called and produces a non-null OID.  This exercises
+        // the cleanup path that frees sai_appliance_id (lines 220-224 in dashorch.cpp).
+        dash::appliance::Appliance appliance = BuildApplianceEntry();
+        appliance.set_local_region_id(123);
+
+        sai_object_id_t fake_oid = 0x99999;
+        sai_object_id_t removed_oid = SAI_NULL_OBJECT_ID;
+        {
+            InSequence seq;
+            EXPECT_CALL(*mock_sai_dash_appliance_api, create_dash_appliance)
+                .WillOnce(DoAll(SetArgPointee<0>(fake_oid), Return(SAI_STATUS_SUCCESS)));
+            EXPECT_CALL(*mock_sai_dash_vip_api, create_vip_entry)
+                .WillOnce(Return(SAI_STATUS_FAILURE));
+            EXPECT_CALL(*mock_sai_dash_appliance_api, remove_dash_appliance)
+                .WillOnce(DoAll(SaveArg<0>(&removed_oid), Return(SAI_STATUS_SUCCESS)));
+        }
+
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, appliance, true, true);
+        EXPECT_TRUE(m_DashOrch->appliance_entries_.empty());
+        EXPECT_EQ(removed_oid, fake_oid);
+    }
+
+    TEST_F(DashOrchTest, ApplianceDirectionLookupFailureCleansUpApplianceWithLocalRegionId)
+    {
+        // Variation that exercises the direction-lookup-failure cleanup with a non-null
+        // sai_appliance_id, covering lines 258-262 in dashorch.cpp.
+        dash::appliance::Appliance appliance = BuildApplianceEntry();
+        appliance.set_local_region_id(456);
+
+        sai_object_id_t fake_oid = 0xDEADBEEF;
+        sai_object_id_t removed_oid = SAI_NULL_OBJECT_ID;
+        {
+            InSequence seq;
+            EXPECT_CALL(*mock_sai_dash_appliance_api, create_dash_appliance)
+                .WillOnce(DoAll(SetArgPointee<0>(fake_oid), Return(SAI_STATUS_SUCCESS)));
+            EXPECT_CALL(*mock_sai_dash_vip_api, create_vip_entry).Times(1);
+            EXPECT_CALL(*mock_sai_dash_direction_lookup_api, create_direction_lookup_entry)
+                .WillOnce(Return(SAI_STATUS_FAILURE));
+            EXPECT_CALL(*mock_sai_dash_vip_api, remove_vip_entry).Times(1);
+            EXPECT_CALL(*mock_sai_dash_appliance_api, remove_dash_appliance)
+                .WillOnce(DoAll(SaveArg<0>(&removed_oid), Return(SAI_STATUS_SUCCESS)));
+        }
+
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, appliance, true, true);
+        EXPECT_TRUE(m_DashOrch->appliance_entries_.empty());
+        EXPECT_EQ(removed_oid, fake_oid);
+    }
+
+    TEST_F(DashOrchTest, RemoveApplianceWithLocalRegionId)
+    {
+        // Create appliance with local_region_id so create_dash_appliance is called and
+        // a non-null SAI ID is cached.  Removal should then call remove_dash_appliance
+        // (covering lines 365-377 of dashorch.cpp).
+        dash::appliance::Appliance appliance = BuildApplianceEntry();
+        appliance.set_local_region_id(789);
+
+        sai_object_id_t fake_oid = 0x1111ABCD;
+        sai_object_id_t removed_oid = SAI_NULL_OBJECT_ID;
+        {
+            InSequence seq;
+            EXPECT_CALL(*mock_sai_dash_appliance_api, create_dash_appliance)
+                .WillOnce(DoAll(SetArgPointee<0>(fake_oid), Return(SAI_STATUS_SUCCESS)));
+            EXPECT_CALL(*mock_sai_dash_appliance_api, remove_dash_appliance)
+                .WillOnce(DoAll(SaveArg<0>(&removed_oid), Return(SAI_STATUS_SUCCESS)));
+        }
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, appliance);
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, dash::appliance::Appliance(), false, true);
+
+        EXPECT_TRUE(m_DashOrch->appliance_entries_.empty());
+        EXPECT_EQ(removed_oid, fake_oid);
+    }
+
+    TEST_F(DashOrchTest, RemoveApplianceSaiAppliancesRemoveFailurePreservesCache)
+    {
+        // Variation of RemoveApplianceWithLocalRegionId where the SAI appliance remove
+        // returns a non-recoverable error.  Cache must be preserved (covers line 374).
+        dash::appliance::Appliance appliance = BuildApplianceEntry();
+        appliance.set_local_region_id(789);
+
+        sai_object_id_t fake_oid = 0x12345678;
+        {
+            InSequence seq;
+            EXPECT_CALL(*mock_sai_dash_appliance_api, create_dash_appliance)
+                .WillOnce(DoAll(SetArgPointee<0>(fake_oid), Return(SAI_STATUS_SUCCESS)));
+            EXPECT_CALL(*mock_sai_dash_appliance_api, remove_dash_appliance)
+                .WillOnce(Return(SAI_STATUS_FAILURE));
+            // Second remove succeeds (explicitly mocked because fake_oid is not a real saivs OID)
+            EXPECT_CALL(*mock_sai_dash_appliance_api, remove_dash_appliance)
+                .WillOnce(Return(SAI_STATUS_SUCCESS));
+        }
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, appliance);
+        // First DEL — remove fails, cache preserved
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, dash::appliance::Appliance(), false, true);
+        EXPECT_EQ(m_DashOrch->appliance_entries_.count(appliance1), 1u);
+        // Second DEL — succeeds
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, dash::appliance::Appliance(), false, true);
+        EXPECT_TRUE(m_DashOrch->appliance_entries_.empty());
+    }
+
+    TEST_F(DashOrchTest, RemoveApplianceWithInvalidCachedSip)
+    {
+        // Create an appliance normally, then mutate the cached entry to have an invalid
+        // SIP so the to_sai() call in removeApplianceEntry fails — exercising the
+        // "skipping VIP cleanup" warning path (line 345 in dashorch.cpp).
+        CreateApplianceEntry();
+        ASSERT_EQ(m_DashOrch->appliance_entries_.count(appliance1), 1u);
+
+        // Replace the cached metadata's sip with an empty one (neither ipv4 nor ipv6 set)
+        m_DashOrch->appliance_entries_[appliance1].metadata.clear_sip();
+
+        // VIP cleanup should be skipped; direction lookup remove is still called.
+        EXPECT_CALL(*mock_sai_dash_vip_api, remove_vip_entry).Times(0);
+        EXPECT_CALL(*mock_sai_dash_direction_lookup_api, remove_direction_lookup_entry).Times(1);
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, dash::appliance::Appliance(), false, true);
+        EXPECT_TRUE(m_DashOrch->appliance_entries_.empty());
+    }
+
+    TEST_F(DashOrchTest, ApplianceExceptionInDoTaskConsumed)
+    {
+        // A SAI exception during appliance processing should be caught, an ERROR-level
+        // failure result written, and the consumer entry removed (covers lines 475-482).
+        dash::appliance::Appliance appliance = BuildApplianceEntry();
+        EXPECT_CALL(*mock_sai_dash_appliance_api, create_dash_appliance)
+            .WillOnce(Throw(std::runtime_error("simulated SAI exception")));
+
+        SetDashTable(APP_DASH_APPLIANCE_TABLE_NAME, appliance1, appliance, true, true);
+        EXPECT_TRUE(m_DashOrch->appliance_entries_.empty());
+    }
+
+    TEST_F(DashOrchTest, EniExceptionInDoTaskConsumed)
+    {
+        // A SAI exception during ENI add should be caught and the consumer entry removed
+        // (covers lines 1160-1167 in dashorch.cpp).
+        CreateApplianceEntry();
+        CreateVnet();
+        auto eni = BuildEniEntry();
+
+        EXPECT_CALL(*mock_sai_dash_eni_api, create_eni)
+            .WillOnce(Throw(std::runtime_error("simulated SAI exception")));
+
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, eni, true, true);
+        EXPECT_TRUE(m_DashOrch->eni_entries_.empty());
+    }
+
+    TEST_F(DashOrchTest, EniRouteExceptionInDoTaskConsumed)
+    {
+        // A SAI exception during ENI route set should be caught and the consumer entry
+        // removed (covers lines 1411-1418 in dashorch.cpp).
+        CreateApplianceEntry();
+        CreateVnet();
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, BuildEniEntry());
+        AddOutboundRoutingGroup();
+
+        dash::eni_route::EniRoute eni_route;
+        eni_route.set_group_id(route_group1);
+
+        EXPECT_CALL(*mock_sai_dash_eni_api, set_eni_attribute)
+            .WillOnce(Throw(std::runtime_error("simulated SAI exception")));
+        SetDashTable(APP_DASH_ENI_ROUTE_TABLE_NAME, eni1, eni_route, true, true);
+        EXPECT_TRUE(m_DashOrch->eni_route_entries_.empty());
+    }
+
+    TEST_F(DashOrchTest, AddRemoveEniWritesAndClearsResult)
+    {
+        // Ensure that a full ENI create+remove cycle writes a SUCCESS result on add
+        // and removes the result on delete.  Exercises the post-write/post-remove
+        // paths in doTaskEniTable and the corresponding meter-counter and CRM cleanup
+        // (line 982 / line 1032 in dashorch.cpp).
+        CreateApplianceEntry();
+        CreateVnet();
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, BuildEniEntry());
+        ASSERT_EQ(m_DashOrch->eni_entries_.count(eni1), 1u);
+
+        // Now remove — covers the success path through removeEniAddrMapEntry which
+        // decrements the CRM counter for ETHER_ADDRESS_MAP.
+        SetDashTable(APP_DASH_ENI_TABLE_NAME, eni1, dash::eni::Eni(), false, true);
+        EXPECT_TRUE(m_DashOrch->eni_entries_.empty());
+    }
+
+    TEST_F(DashOrchTest, RoutingTypeWritesResultOnSet)
+    {
+        // After a successful SET, the routing-type result table must contain a
+        // SUCCESS entry (covers line 562 in dashorch.cpp).
+        dash::route_type::RouteType route_type;
+        route_type.add_items()->set_action_type(dash::route_type::ACTION_TYPE_STATICENCAP);
+        SetDashTable(APP_DASH_ROUTING_TYPE_TABLE_NAME, "VNET", route_type);
+
+        swss::Table result_table(m_dpu_app_state_db.get(), APP_DASH_ROUTING_TYPE_TABLE_NAME);
+        std::vector<swss::FieldValueTuple> fvs;
+        EXPECT_TRUE(result_table.get("ROUTING_TYPE_VNET", fvs));
+    }
+
+    TEST_F(DashOrchTest, QosWritesResultOnSet)
+    {
+        // After a successful SET, the QOS result table must contain a SUCCESS entry
+        // (covers line 1230 in dashorch.cpp).
+        dash::qos::Qos qos;
+        qos.set_bw(100);
+        SetDashTable(APP_DASH_QOS_TABLE_NAME, "QOS_1", qos);
+
+        swss::Table result_table(m_dpu_app_state_db.get(), APP_DASH_QOS_TABLE_NAME);
+        std::vector<swss::FieldValueTuple> fvs;
+        EXPECT_TRUE(result_table.get("QOS_1", fvs));
+    }
+
 }

--- a/tests/mock_tests/dashportmaporch_ut.cpp
+++ b/tests/mock_tests/dashportmaporch_ut.cpp
@@ -189,7 +189,7 @@ namespace dashportmaporch_test
         key_stream << port_map1 << ":" << port_map1_start_port << "-" << port_map1_end_port;
         std::string key = key_stream.str();
         EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_map_port_range_entries).Times(0);
-        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, key, port_map_range, true, false);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, key, port_map_range, true, true);
     }
 
     TEST_F(DashPortMapOrchTest, RemoveInUsePortMap)
@@ -205,6 +205,364 @@ namespace dashportmaporch_test
         SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, dash::outbound_port_map::OutboundPortMap());
         SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, port_map_range_key, port_map_range);
 
-        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, dash::outbound_port_map::OutboundPortMap(), false, false);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, dash::outbound_port_map::OutboundPortMap(), false, true);
+    }
+
+    TEST_F(DashPortMapOrchTest, PortMapSaiCreateFailureNotRetried)
+    {
+        dash::outbound_port_map::OutboundPortMap port_map;
+        std::vector<sai_object_id_t> exp_oids = {SAI_NULL_OBJECT_ID};
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_INSUFFICIENT_RESOURCES};
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_maps)
+            .WillOnce(DoAll(SetArgPointee<5>(SAI_NULL_OBJECT_ID), SetArrayArgument<6>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, port_map, true, true);
+    }
+
+    TEST_F(DashPortMapOrchTest, PortMapSaiRemoveFailureNotRetried)
+    {
+        dash::outbound_port_map::OutboundPortMap port_map;
+        // First create a port map
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_maps);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, port_map);
+
+        // Then try to remove with SAI failure
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_INVALID_PARAMETER};
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, remove_outbound_port_maps)
+            .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, port_map, false, true);
+    }
+
+    TEST_F(DashPortMapOrchTest, PortMapRangeSaiCreateFailureNotRetried)
+    {
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_maps);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, dash::outbound_port_map::OutboundPortMap());
+
+        auto port_map_range = BuildOutboundPortMapRange();
+        std::stringstream key_stream;
+        key_stream << port_map1 << ":" << port_map1_start_port << "-" << port_map1_end_port;
+        std::string key = key_stream.str();
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_INSUFFICIENT_RESOURCES};
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_map_port_range_entries)
+            .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, key, port_map_range, true, true);
+    }
+
+    TEST_F(DashPortMapOrchTest, PortMapRangeSaiRemoveFailureNotRetried)
+    {
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_maps);
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_map_port_range_entries);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, dash::outbound_port_map::OutboundPortMap());
+
+        auto port_map_range = BuildOutboundPortMapRange();
+        std::stringstream key_stream;
+        key_stream << port_map1 << ":" << port_map1_start_port << "-" << port_map1_end_port;
+        std::string key = key_stream.str();
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, key, port_map_range);
+
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_INVALID_PARAMETER};
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, remove_outbound_port_map_port_range_entries)
+            .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, key, port_map_range, false, true);
+    }
+
+    TEST_F(DashPortMapOrchTest, InvalidPortMapRangeKeyFormat)
+    {
+        // Key should be "parent_map_id:start_port-end_port", send invalid format
+        auto port_map_range = BuildOutboundPortMapRange();
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_map_port_range_entries).Times(0);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, "INVALID_KEY_NO_COLON", port_map_range, true, true);
+    }
+
+    TEST_F(DashPortMapOrchTest, InvalidPortMapRangePortValues)
+    {
+        // Key with non-numeric port values
+        auto port_map_range = BuildOutboundPortMapRange();
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_map_port_range_entries).Times(0);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, "PORT_MAP_1:abc-def", port_map_range, true, true);
+    }
+
+    TEST_F(DashPortMapOrchTest, MissingProtobufPortMapRange)
+    {
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_maps);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, dash::outbound_port_map::OutboundPortMap());
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_map_port_range_entries).Times(0);
+        std::stringstream key_stream;
+        key_stream << port_map1 << ":" << port_map1_start_port << "-" << port_map1_end_port;
+        SetDashTableRaw(APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, key_stream.str(), {}, true, true);
+    }
+
+    TEST_F(DashPortMapOrchTest, PortMapCreateDeleteChurn)
+    {
+        dash::outbound_port_map::OutboundPortMap port_map;
+
+        for (int i = 0; i < 3; i++)
+        {
+            EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_maps).Times(1);
+            SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, port_map);
+
+            EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, remove_outbound_port_maps).Times(1);
+            SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, port_map, false, true);
+        }
+    }
+
+    TEST_F(DashPortMapOrchTest, PortMapRangeCreateDeleteChurn)
+    {
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_maps);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, dash::outbound_port_map::OutboundPortMap());
+
+        auto port_map_range = BuildOutboundPortMapRange();
+        std::stringstream key_stream;
+        key_stream << port_map1 << ":" << port_map1_start_port << "-" << port_map1_end_port;
+        std::string key = key_stream.str();
+
+        for (int i = 0; i < 3; i++)
+        {
+            EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_map_port_range_entries).Times(1);
+            SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, key, port_map_range);
+
+            EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, remove_outbound_port_map_port_range_entries).Times(1);
+            SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, key, port_map_range, false, true);
+        }
+    }
+
+    TEST_F(DashPortMapOrchTest, PortMapRangeKeyMissingRange)
+    {
+        // Key should be "port_map:start-end" — send just port_map without range
+        auto port_map_range = BuildOutboundPortMapRange();
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_map_port_range_entries).Times(0);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, port_map1, port_map_range, true, true);
+    }
+
+    TEST_F(DashPortMapOrchTest, PortMapRangeKeyMissingEndPort)
+    {
+        // Key should be "port_map:start-end" — send port_map:start without end
+        auto port_map_range = BuildOutboundPortMapRange();
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_map_port_range_entries).Times(0);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME,
+                     port_map1 + ":1000", port_map_range, true, true);
+    }
+
+    TEST_F(DashPortMapOrchTest, PortMapRangeAlreadyExistsInSai)
+    {
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_maps);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, dash::outbound_port_map::OutboundPortMap());
+
+        auto port_map_range = BuildOutboundPortMapRange();
+        std::stringstream key_stream;
+        key_stream << port_map1 << ":" << port_map1_start_port << "-" << port_map1_end_port;
+        std::string key = key_stream.str();
+
+        // First create succeeds normally
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_map_port_range_entries);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, key, port_map_range);
+
+        // Second create returns ITEM_ALREADY_EXISTS from bulker — should be treated as success
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_ITEM_ALREADY_EXISTS};
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_map_port_range_entries)
+            .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, key, port_map_range, true, true);
+    }
+
+    TEST_F(DashPortMapOrchTest, PortMapUnknownOpInPreLoop)
+    {
+        auto consumer = make_unique<Consumer>(
+            new swss::ConsumerStateTable(m_app_db.get(), APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME),
+            m_dashPortMapOrch, APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME);
+        consumer->addToSync(swss::KeyOpFieldsValuesTuple(
+            port_map1, "UNKNOWN", {{"pb", dash::outbound_port_map::OutboundPortMap().SerializeAsString()}}));
+
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_maps).Times(0);
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, remove_outbound_port_maps).Times(0);
+        static_cast<Orch *>(m_dashPortMapOrch)->doTask(*consumer);
+        EXPECT_EQ(consumer->m_toSync.begin(), consumer->m_toSync.end());
+    }
+
+    TEST_F(DashPortMapOrchTest, PortMapDuplicateSetClearsBulkContext)
+    {
+        // Submit two SET ops for the same key in a single doTask invocation.
+        // The second SET enters the same toBulk slot (inserted=false), triggering ctxt.clear()
+        // which resets the bulk context vectors.
+        auto consumer = make_unique<Consumer>(
+            new swss::ConsumerStateTable(m_app_db.get(), APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME),
+            m_dashPortMapOrch, APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME);
+        consumer->addToSync({
+            swss::KeyOpFieldsValuesTuple(port_map1, SET_COMMAND,
+                {{"pb", dash::outbound_port_map::OutboundPortMap().SerializeAsString()}}),
+            swss::KeyOpFieldsValuesTuple(port_map1, SET_COMMAND,
+                {{"pb", dash::outbound_port_map::OutboundPortMap().SerializeAsString()}})
+        });
+        // Both SETs collapse into one bulk slot, so create_outbound_port_maps is called once.
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_maps).Times(1);
+        static_cast<Orch *>(m_dashPortMapOrch)->doTask(*consumer);
+        EXPECT_EQ(consumer->m_toSync.begin(), consumer->m_toSync.end());
+    }
+
+    TEST_F(DashPortMapOrchTest, PortMapRemoveItemNotFoundTreatedAsSuccess)
+    {
+        dash::outbound_port_map::OutboundPortMap port_map;
+
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_maps);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, port_map);
+
+        // Remove returns ITEM_NOT_FOUND — removePortMapPost should return true (idempotent)
+        // and the consumer entry must be consumed.
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_ITEM_NOT_FOUND};
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, remove_outbound_port_maps)
+            .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, port_map, false, true);
+    }
+
+    TEST_F(DashPortMapOrchTest, PortMapRemoveNotExecutedKeepsCache)
+    {
+        dash::outbound_port_map::OutboundPortMap port_map;
+
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_maps);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, port_map);
+
+        // Bulker returns NOT_EXECUTED — should be logged as error, port map remains in cache
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_NOT_EXECUTED};
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, remove_outbound_port_maps)
+            .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, port_map, false, true);
+        EXPECT_NE(m_dashPortMapOrch->getPortMapOid(port_map1), SAI_NULL_OBJECT_ID);
+    }
+
+    TEST_F(DashPortMapOrchTest, PortMapRangeUnknownOpInPreLoop)
+    {
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_maps);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, dash::outbound_port_map::OutboundPortMap());
+
+        auto port_map_range = BuildOutboundPortMapRange();
+        std::stringstream key_stream;
+        key_stream << port_map1 << ":" << port_map1_start_port << "-" << port_map1_end_port;
+        std::string key = key_stream.str();
+
+        auto consumer = make_unique<Consumer>(
+            new swss::ConsumerStateTable(m_app_db.get(), APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME),
+            m_dashPortMapOrch, APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME);
+        consumer->addToSync(swss::KeyOpFieldsValuesTuple(
+            key, "UNKNOWN", {{"pb", port_map_range.SerializeAsString()}}));
+
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_map_port_range_entries).Times(0);
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, remove_outbound_port_map_port_range_entries).Times(0);
+        static_cast<Orch *>(m_dashPortMapOrch)->doTask(*consumer);
+        EXPECT_EQ(consumer->m_toSync.begin(), consumer->m_toSync.end());
+    }
+
+    TEST_F(DashPortMapOrchTest, PortMapRangeDuplicateSetClearsBulkContext)
+    {
+        // Pre-create parent port map
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_maps);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, dash::outbound_port_map::OutboundPortMap());
+
+        auto port_map_range = BuildOutboundPortMapRange();
+        std::stringstream key_stream;
+        key_stream << port_map1 << ":" << port_map1_start_port << "-" << port_map1_end_port;
+        std::string key = key_stream.str();
+
+        auto consumer = make_unique<Consumer>(
+            new swss::ConsumerStateTable(m_app_db.get(), APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME),
+            m_dashPortMapOrch, APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME);
+        consumer->addToSync({
+            swss::KeyOpFieldsValuesTuple(key, SET_COMMAND, {{"pb", port_map_range.SerializeAsString()}}),
+            swss::KeyOpFieldsValuesTuple(key, SET_COMMAND, {{"pb", port_map_range.SerializeAsString()}})
+        });
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_map_port_range_entries).Times(1);
+        static_cast<Orch *>(m_dashPortMapOrch)->doTask(*consumer);
+        EXPECT_EQ(consumer->m_toSync.begin(), consumer->m_toSync.end());
+    }
+
+    TEST_F(DashPortMapOrchTest, PortMapRangeRemoveItemNotFoundConsumed)
+    {
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_maps);
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_map_port_range_entries);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, dash::outbound_port_map::OutboundPortMap());
+
+        auto port_map_range = BuildOutboundPortMapRange();
+        std::stringstream key_stream;
+        key_stream << port_map1 << ":" << port_map1_start_port << "-" << port_map1_end_port;
+        std::string key = key_stream.str();
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, key, port_map_range);
+
+        // Remove returns ITEM_NOT_FOUND — treated as success
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_ITEM_NOT_FOUND};
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, remove_outbound_port_map_port_range_entries)
+            .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, key, port_map_range, false, true);
+    }
+
+    TEST_F(DashPortMapOrchTest, PortMapRangeRemoveNotExecutedConsumed)
+    {
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_maps);
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_map_port_range_entries);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, dash::outbound_port_map::OutboundPortMap());
+
+        auto port_map_range = BuildOutboundPortMapRange();
+        std::stringstream key_stream;
+        key_stream << port_map1 << ":" << port_map1_start_port << "-" << port_map1_end_port;
+        std::string key = key_stream.str();
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, key, port_map_range);
+
+        // Remove returns NOT_EXECUTED — should be logged as error and dropped
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_NOT_EXECUTED};
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, remove_outbound_port_map_port_range_entries)
+            .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, key, port_map_range, false, true);
+    }
+
+    TEST_F(DashPortMapOrchTest, PortMapRangeInvalidAction)
+    {
+        // Pre-create parent port map
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_maps);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, dash::outbound_port_map::OutboundPortMap());
+
+        // Build a port map range with an unmapped action (default value 0 = INVALID)
+        dash::outbound_port_map_range::OutboundPortMapRange port_map_range;
+        port_map_range.mutable_backend_ip()->set_ipv4(port_map1_backend_ip.getV4Addr());
+        // Don't call set_action() — leave it at the default unmapped value
+        port_map_range.set_backend_port_base(port_map1_backend_port_base);
+
+        std::stringstream key_stream;
+        key_stream << port_map1 << ":" << port_map1_start_port << "-" << port_map1_end_port;
+        std::string key = key_stream.str();
+
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_map_port_range_entries).Times(0);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, key, port_map_range, true, true);
+    }
+
+    TEST_F(DashPortMapOrchTest, PortMapRangeInvalidBackendIp)
+    {
+        // Pre-create parent port map
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_maps);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, port_map1, dash::outbound_port_map::OutboundPortMap());
+
+        // Build a port map range with a backend_ip that has neither ipv4 nor ipv6 set (to_sai fails)
+        dash::outbound_port_map_range::OutboundPortMapRange port_map_range;
+        port_map_range.mutable_backend_ip(); // empty IP address
+        port_map_range.set_action(dash::outbound_port_map_range::PortMapRangeAction::ACTION_MAP_PRIVATE_LINK_SERVICE);
+        port_map_range.set_backend_port_base(port_map1_backend_port_base);
+
+        std::stringstream key_stream;
+        key_stream << port_map1 << ":" << port_map1_start_port << "-" << port_map1_end_port;
+        std::string key = key_stream.str();
+
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, create_outbound_port_map_port_range_entries).Times(0);
+        SetDashTable(APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, key, port_map_range, true, true);
+    }
+
+    TEST_F(DashPortMapOrchTest, PortMapDoubleDeleteNoopClearsBulkContext)
+    {
+        // Two DEL ops for the same nonexistent port_map id should both be consumed (no-op).
+        // The second DEL enters the same toBulk slot (inserted=false), triggering ctxt.clear().
+        auto consumer = make_unique<Consumer>(
+            new swss::ConsumerStateTable(m_app_db.get(), APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME),
+            m_dashPortMapOrch, APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME);
+        consumer->addToSync({
+            swss::KeyOpFieldsValuesTuple(port_map1, DEL_COMMAND, {}),
+            swss::KeyOpFieldsValuesTuple(port_map1, DEL_COMMAND, {})
+        });
+        EXPECT_CALL(*mock_sai_dash_outbound_port_map_api, remove_outbound_port_maps).Times(0);
+        static_cast<Orch *>(m_dashPortMapOrch)->doTask(*consumer);
+        EXPECT_EQ(consumer->m_toSync.begin(), consumer->m_toSync.end());
     }
 }

--- a/tests/mock_tests/dashrouteorch_ut.cpp
+++ b/tests/mock_tests/dashrouteorch_ut.cpp
@@ -14,20 +14,29 @@
 #include "dash_api/qos.pb.h"
 #include "dash_api/eni_route.pb.h"
 #include "swssnet.h"
+#include "crmorch.h"
 
 EXTERN_MOCK_FNS
 namespace dashrouteorch_test
 {
-    DEFINE_SAI_API_MOCK(dash_outbound_routing, outbound_routing);
+    DEFINE_SAI_API_COMBINED_MOCK(dash_outbound_routing, outbound_routing_group, outbound_routing);
     DEFINE_SAI_API_MOCK(dash_inbound_routing, inbound_routing);
     using namespace mock_orch_test;
+    using ::testing::_;
     using ::testing::InSequence;
     using ::testing::DoAll;
     using ::testing::SaveArgPointee;
     using ::testing::Invoke;
-
+    using ::testing::Return;
+    using ::testing::SetArrayArgument;
     class DashRouteOrchTest : public MockDashOrchTest, public ::testing::WithParamInterface<std::tuple<swss::IpPrefix, int>>
     {
+    protected:
+        uint32_t GetCrmUsedCount(CrmResourceType type)
+        {
+            return gCrmOrch->m_resourcesMap.at(type).countersMap["STATS"].usedCounter;
+        }
+
         void PostSetUp()
         {
             CreateApplianceEntry();
@@ -41,6 +50,14 @@ namespace dashrouteorch_test
             INIT_SAI_API_MOCK(dash_outbound_routing);
             INIT_SAI_API_MOCK(dash_inbound_routing);
             MockSaiApis();
+        }
+
+        std::unique_ptr<Consumer> CreateDashRouteConsumer(const std::string &tableName)
+        {
+            return std::make_unique<Consumer>(
+                new swss::ConsumerStateTable(m_app_db.get(), tableName),
+                m_DashRouteOrch,
+                tableName);
         }
 
         void PreTearDown()
@@ -83,7 +100,7 @@ namespace dashrouteorch_test
             EXPECT_CALL(*mock_sai_dash_outbound_routing_api, create_outbound_routing_entries).Times(1);
         }
         AddOutboundRoutingGroup();
-        AddOutboundRoutingEntry(false);
+        AddOutboundRoutingEntry(true);
         
         AddTunnel();
         AddOutboundRoutingEntry();
@@ -148,4 +165,515 @@ namespace dashrouteorch_test
             const std::string priority_str = (priority >= 0) ? std::to_string(priority) : "None";
             return "InboundRouting_" + addr_family + "_Priority_" + priority_str;
         });
+
+    TEST_F(DashRouteOrchTest, RemoveNonexistOutboundRoutingDoesNotDecrementCrm)
+    {
+        uint32_t baselineUsed = GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_OUTBOUND_ROUTING);
+        // Remove non-existent outbound routing entry should return SAI_STATUS_ITEM_NOT_FOUND and not decrement the CRM used count
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_ITEM_NOT_FOUND};
+        EXPECT_CALL(*mock_sai_dash_outbound_routing_api, remove_outbound_routing_entries)
+            .Times(1).WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        RemoveOutboundRoutingEntry();
+        EXPECT_EQ(GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_OUTBOUND_ROUTING), baselineUsed);
+    }
+
+    TEST_F(DashRouteOrchTest, AddRemoveInboundRoutingEntry)
+    {
+        AddInboundRoutingEntry();
+        RemoveInboundRoutingEntry();
+    }
+
+    TEST_F(DashRouteOrchTest, AddRemoveRouteGroup)
+    {
+        AddOutboundRoutingGroup();
+        SetDashTable(APP_DASH_ROUTE_GROUP_TABLE_NAME, route_group1, dash::route_group::RouteGroup(), false, true);
+    }
+
+    TEST_F(DashRouteOrchTest, InboundRouteSaiCreateFailureNotRetried)
+    {
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_INVALID_PARAMETER};
+        EXPECT_CALL(*mock_sai_dash_inbound_routing_api, create_inbound_routing_entries)
+            .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        AddInboundRoutingEntry(true);
+    }
+
+    TEST_F(DashRouteOrchTest, RemoveNonexistInboundRoutingDoesNotDecrementCrm)
+    {
+        uint32_t baselineUsed = GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_INBOUND_ROUTING);
+        // Remove non-existent inbound routing entry should return SAI_STATUS_ITEM_NOT_FOUND and not decrement the CRM used count
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_ITEM_NOT_FOUND};
+        EXPECT_CALL(*mock_sai_dash_inbound_routing_api, remove_inbound_routing_entries)
+            .Times(1).WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        RemoveInboundRoutingEntry();
+        EXPECT_EQ(GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_INBOUND_ROUTING), baselineUsed);
+    }
+
+    TEST_F(DashRouteOrchTest, OutboundRouteMissingVnetNotRetried)
+    {
+        // Route references VNET but VNET doesn't exist (PostSetUp creates it, so we need a route referencing a different VNET)
+        dash::route::Route route = dash::route::Route();
+        route.set_routing_type(dash::route_type::ROUTING_TYPE_VNET);
+        route.set_vnet("NON_EXISTENT_VNET");
+        EXPECT_CALL(*mock_sai_dash_outbound_routing_api, create_outbound_routing_entries).Times(0);
+        AddOutboundRoutingGroup();
+        SetDashTable(APP_DASH_ROUTE_TABLE_NAME, route_group1 + ":1.2.3.4/32", route, true, true);
+    }
+
+    TEST_F(DashRouteOrchTest, OutboundRouteSaiInvalidParameterNotRetried)
+    {
+        AddOutboundRoutingGroup();
+        AddTunnel();
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_INVALID_PARAMETER};
+        EXPECT_CALL(*mock_sai_dash_outbound_routing_api, create_outbound_routing_entries)
+            .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        AddOutboundRoutingEntry(true);
+    }
+
+    TEST_F(DashRouteOrchTest, OutboundRouteSaiInsufficientResourcesNotRetried)
+    {
+        AddOutboundRoutingGroup();
+        AddTunnel();
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_INSUFFICIENT_RESOURCES};
+        EXPECT_CALL(*mock_sai_dash_outbound_routing_api, create_outbound_routing_entries)
+            .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        AddOutboundRoutingEntry(true);
+    }
+
+    TEST_F(DashRouteOrchTest, OutboundRouteMissingRouteGroupNotRetried)
+    {
+        EXPECT_CALL(*mock_sai_dash_outbound_routing_api, create_outbound_routing_entries).Times(0);
+        dash::route::Route route = dash::route::Route();
+        route.set_routing_type(dash::route_type::ROUTING_TYPE_VNET);
+        route.set_vnet(vnet1);
+        SetDashTable(APP_DASH_ROUTE_TABLE_NAME, route_group1 + ":1.2.3.4/32", route, true, true);
+    }
+
+    TEST_F(DashRouteOrchTest, InboundRouteMissingEniNotRetried)
+    {
+        // Inbound route references an ENI that doesn't exist
+        dash::route_rule::RouteRule rule = dash::route_rule::RouteRule();
+        rule.set_pa_validation(true);
+        EXPECT_CALL(*mock_sai_dash_inbound_routing_api, create_inbound_routing_entries).Times(0);
+        SetDashTable(APP_DASH_ROUTE_RULE_TABLE_NAME, "NON_EXISTENT_ENI:5555:10.0.0.0/24", rule, true, true);
+    }
+
+    TEST_F(DashRouteOrchTest, RouteGroupSaiRemoveInUseNotRetried)
+    {
+        AddOutboundRoutingGroup();
+        // Route group remove with bound routes should not retry.
+        // Bind a route to the group, then try to remove the group
+        AddTunnel();
+        AddOutboundRoutingEntry();
+        // Removing the route group while routes are bound should consume the notification
+        SetDashTable(APP_DASH_ROUTE_GROUP_TABLE_NAME, route_group1, dash::route_group::RouteGroup(), false, true);
+    }
+
+    TEST_F(DashRouteOrchTest, OutboundRouteSaiRemoveNotExecutedNotRetried)
+    {
+        AddOutboundRoutingGroup();
+        AddTunnel();
+        AddOutboundRoutingEntry();
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_NOT_EXECUTED};
+        EXPECT_CALL(*mock_sai_dash_outbound_routing_api, remove_outbound_routing_entries)
+            .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        RemoveOutboundRoutingEntry(true);
+    }
+
+    TEST_F(DashRouteOrchTest, InboundRouteSaiRemoveNotExecutedNotRetried)
+    {
+        AddInboundRoutingEntry();
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_NOT_EXECUTED};
+        EXPECT_CALL(*mock_sai_dash_inbound_routing_api, remove_inbound_routing_entries)
+            .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        RemoveInboundRoutingEntry(true);
+    }
+
+    TEST_F(DashRouteOrchTest, RemoveNonExistentRouteGroup)
+    {
+        SetDashTable(APP_DASH_ROUTE_GROUP_TABLE_NAME, route_group1, dash::route_group::RouteGroup(), false, true);
+    }
+
+    TEST_F(DashRouteOrchTest, MissingProtobufOutboundRoute)
+    {
+        AddOutboundRoutingGroup();
+        EXPECT_CALL(*mock_sai_dash_outbound_routing_api, create_outbound_routing_entries).Times(0);
+        SetDashTableRaw(APP_DASH_ROUTE_TABLE_NAME, route_group1 + ":1.2.3.4/32", {}, true, true);
+    }
+
+    TEST_F(DashRouteOrchTest, InvalidProtobufOutboundRoute)
+    {
+        AddOutboundRoutingGroup();
+        EXPECT_CALL(*mock_sai_dash_outbound_routing_api, create_outbound_routing_entries).Times(0);
+        SetDashTableRaw(APP_DASH_ROUTE_TABLE_NAME, route_group1 + ":1.2.3.4/32", {{ "pb", "garbage" }}, true, true);
+    }
+
+    TEST_F(DashRouteOrchTest, MissingProtobufInboundRoute)
+    {
+        EXPECT_CALL(*mock_sai_dash_inbound_routing_api, create_inbound_routing_entries).Times(0);
+        SetDashTableRaw(APP_DASH_ROUTE_RULE_TABLE_NAME, eni1 + ":5555:10.0.0.0/24", {}, true, true);
+    }
+
+    TEST_F(DashRouteOrchTest, MissingProtobufRouteGroup)
+    {
+        SetDashTableRaw(APP_DASH_ROUTE_GROUP_TABLE_NAME, route_group1, {}, true, true);
+    }
+
+    TEST_F(DashRouteOrchTest, InvalidKeyOutboundRoute)
+    {
+        // Invalid keys should be caught per-item and consumed without throwing.
+        AddOutboundRoutingGroup();
+        dash::route::Route route = dash::route::Route();
+        route.set_routing_type(dash::route_type::ROUTING_TYPE_VNET);
+        route.set_vnet(vnet1);
+        EXPECT_CALL(*mock_sai_dash_outbound_routing_api, create_outbound_routing_entries).Times(0);
+        EXPECT_NO_THROW(
+            SetDashTable(APP_DASH_ROUTE_TABLE_NAME, route_group1 + ":not_an_ip", route, true, true));
+    }
+
+    TEST_F(DashRouteOrchTest, InvalidKeyInboundRoute)
+    {
+        // Invalid keys should be caught per-item and consumed without throwing.
+        dash::route_rule::RouteRule rule = dash::route_rule::RouteRule();
+        EXPECT_CALL(*mock_sai_dash_inbound_routing_api, create_inbound_routing_entries).Times(0);
+        EXPECT_NO_THROW(
+            SetDashTable(APP_DASH_ROUTE_RULE_TABLE_NAME, eni1 + ":not_a_vni:10.0.0.0/24", rule, true, true));
+    }
+
+    TEST_F(DashRouteOrchTest, OutboundRouteCreateDeleteChurn)
+    {
+        AddOutboundRoutingGroup();
+        AddTunnel();
+
+        for (int i = 0; i < 3; i++)
+        {
+            EXPECT_CALL(*mock_sai_dash_outbound_routing_api, create_outbound_routing_entries).Times(1);
+            AddOutboundRoutingEntry();
+
+            EXPECT_CALL(*mock_sai_dash_outbound_routing_api, remove_outbound_routing_entries).Times(1);
+            RemoveOutboundRoutingEntry();
+        }
+    }
+
+    TEST_F(DashRouteOrchTest, InboundRouteCreateDeleteChurn)
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            EXPECT_CALL(*mock_sai_dash_inbound_routing_api, create_inbound_routing_entries).Times(1);
+            AddInboundRoutingEntry();
+
+            EXPECT_CALL(*mock_sai_dash_inbound_routing_api, remove_inbound_routing_entries).Times(1);
+            RemoveInboundRoutingEntry();
+        }
+    }
+
+    TEST_F(DashRouteOrchTest, RouteGroupCreateDeleteChurn)
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            AddOutboundRoutingGroup();
+            SetDashTable(APP_DASH_ROUTE_GROUP_TABLE_NAME, route_group1, dash::route_group::RouteGroup(), false, true);
+        }
+    }
+
+    TEST_F(DashRouteOrchTest, OutboundRouteCreateFailThenSucceed)
+    {
+        AddOutboundRoutingGroup();
+        AddTunnel();
+
+        {
+            InSequence seq;
+            // First create returns INVALID_PARAMETER
+            EXPECT_CALL(*mock_sai_dash_outbound_routing_api, create_outbound_routing_entries)
+                .WillOnce([](uint32_t count, const sai_outbound_routing_entry_t*, const uint32_t*, const sai_attribute_t**, sai_bulk_op_error_mode_t, sai_status_t* statuses) {
+                    statuses[0] = SAI_STATUS_INVALID_PARAMETER;
+                    return SAI_STATUS_SUCCESS;
+                });
+            // Second create succeeds
+            EXPECT_CALL(*mock_sai_dash_outbound_routing_api, create_outbound_routing_entries).Times(1);
+        }
+
+        AddOutboundRoutingEntry(true);
+        AddOutboundRoutingEntry();
+    }
+
+    TEST_F(DashRouteOrchTest, OutboundRouteKeyMissingPrefix)
+    {
+        // Key should be "route_group:ip_prefix" — send just route group without prefix
+        AddOutboundRoutingGroup();
+        dash::route::Route route = dash::route::Route();
+        route.set_routing_type(dash::route_type::ROUTING_TYPE_VNET);
+        route.set_vnet(vnet1);
+        EXPECT_CALL(*mock_sai_dash_outbound_routing_api, create_outbound_routing_entries).Times(0);
+        EXPECT_NO_THROW(
+            SetDashTable(APP_DASH_ROUTE_TABLE_NAME, route_group1, route, true, true));
+    }
+
+    TEST_F(DashRouteOrchTest, InboundRouteKeyMissingVniAndPrefix)
+    {
+        // Key should be "eni:vni:prefix" — send just ENI without vni/prefix
+        dash::route_rule::RouteRule rule = dash::route_rule::RouteRule();
+        EXPECT_CALL(*mock_sai_dash_inbound_routing_api, create_inbound_routing_entries).Times(0);
+        EXPECT_NO_THROW(
+            SetDashTable(APP_DASH_ROUTE_RULE_TABLE_NAME, eni1, rule, true, true));
+    }
+
+    TEST_F(DashRouteOrchTest, InboundRouteKeyMissingPrefix)
+    {
+        // Key should be "eni:vni:prefix" — send eni:vni without prefix
+        dash::route_rule::RouteRule rule = dash::route_rule::RouteRule();
+        EXPECT_CALL(*mock_sai_dash_inbound_routing_api, create_inbound_routing_entries).Times(0);
+        EXPECT_NO_THROW(
+            SetDashTable(APP_DASH_ROUTE_RULE_TABLE_NAME, eni1 + ":5555", rule, true, true));
+    }
+
+    TEST_F(DashRouteOrchTest, OutboundRouteAlreadyExistsInSai)
+    {
+        AddOutboundRoutingGroup();
+        AddTunnel();
+        // First create succeeds normally
+        AddOutboundRoutingEntry();
+        // Second create returns ITEM_ALREADY_EXISTS from bulker — should be treated as success
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_ITEM_ALREADY_EXISTS};
+        EXPECT_CALL(*mock_sai_dash_outbound_routing_api, create_outbound_routing_entries)
+            .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        AddOutboundRoutingEntry(true);
+    }
+
+    TEST_F(DashRouteOrchTest, InboundRouteAlreadyExistsInSai)
+    {
+        // First create succeeds normally
+        AddInboundRoutingEntry();
+        // Second create returns ITEM_ALREADY_EXISTS from bulker — should be treated as success
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_ITEM_ALREADY_EXISTS};
+        EXPECT_CALL(*mock_sai_dash_inbound_routing_api, create_inbound_routing_entries)
+            .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        AddInboundRoutingEntry(true);
+    }
+
+    TEST_F(DashRouteOrchTest, OutboundRouteBoundRouteGroupNotRetried)
+    {
+        AddOutboundRoutingGroup();
+        m_DashRouteOrch->bindRouteGroup(route_group1);
+
+        dash::route::Route route;
+        route.set_routing_type(dash::route_type::ROUTING_TYPE_VNET);
+        route.set_vnet(vnet1);
+
+        EXPECT_CALL(*mock_sai_dash_outbound_routing_api, create_outbound_routing_entries).Times(0);
+        SetDashTable(APP_DASH_ROUTE_TABLE_NAME, route_group1 + ":5.6.7.8/32", route, true, true);
+
+        m_DashRouteOrch->unbindRouteGroup(route_group1);
+    }
+
+    TEST_F(DashRouteOrchTest, OutboundRouteVnetDirectMissingVnet)
+    {
+        m_DashRouteOrch->route_group_oid_map_[route_group1] = 0x1234;
+
+        dash::route::Route route;
+        route.set_routing_type(dash::route_type::ROUTING_TYPE_VNET_DIRECT);
+        route.mutable_vnet_direct()->mutable_overlay_ip()->set_ipv4(swss::IpAddress("5.6.7.8").getV4Addr());
+
+        OutboundRoutingBulkContext ctxt;
+        ctxt.route_group = route_group1;
+        ctxt.destination = swss::IpPrefix("1.2.3.4/32");
+        ctxt.metadata = route;
+
+        EXPECT_TRUE(m_DashRouteOrch->addOutboundRouting(route_group1 + ":1.2.3.4/32", ctxt));
+        EXPECT_EQ(ctxt.pre_op_result, DASH_RESULT_FAILURE);
+        EXPECT_TRUE(ctxt.object_statuses.empty());
+    }
+
+    TEST_F(DashRouteOrchTest, OutboundRouteInvalidRoutingType)
+    {
+        m_DashRouteOrch->route_group_oid_map_[route_group1] = 0x1234;
+
+        dash::route::Route route;
+        route.set_routing_type(static_cast<dash::route_type::RoutingType>(999));
+
+        OutboundRoutingBulkContext ctxt;
+        ctxt.route_group = route_group1;
+        ctxt.destination = swss::IpPrefix("1.2.3.4/32");
+        ctxt.metadata = route;
+
+        EXPECT_TRUE(m_DashRouteOrch->addOutboundRouting(route_group1 + ":1.2.3.4/32", ctxt));
+        EXPECT_EQ(ctxt.pre_op_result, DASH_RESULT_FAILURE);
+        EXPECT_TRUE(ctxt.object_statuses.empty());
+    }
+
+    TEST_F(DashRouteOrchTest, OutboundRouteVnetDirectMissingOverlayIp)
+    {
+        m_DashRouteOrch->route_group_oid_map_[route_group1] = 0x1234;
+
+        dash::route::Route route;
+        route.set_routing_type(dash::route_type::ROUTING_TYPE_VNET_DIRECT);
+        route.mutable_vnet_direct()->set_vnet(vnet1);
+
+        OutboundRoutingBulkContext ctxt;
+        ctxt.route_group = route_group1;
+        ctxt.destination = swss::IpPrefix("1.2.3.4/32");
+        ctxt.metadata = route;
+
+        EXPECT_TRUE(m_DashRouteOrch->addOutboundRouting(route_group1 + ":1.2.3.4/32", ctxt));
+        EXPECT_EQ(ctxt.pre_op_result, DASH_RESULT_FAILURE);
+        EXPECT_TRUE(ctxt.object_statuses.empty());
+    }
+
+    TEST_F(DashRouteOrchTest, RemoveOutboundRouteBoundRouteGroup)
+    {
+        AddOutboundRoutingGroup();
+        m_DashRouteOrch->bindRouteGroup(route_group1);
+
+        EXPECT_CALL(*mock_sai_dash_outbound_routing_api, remove_outbound_routing_entries).Times(0);
+        RemoveOutboundRoutingEntry();
+
+        m_DashRouteOrch->unbindRouteGroup(route_group1);
+    }
+
+    TEST_F(DashRouteOrchTest, OutboundRouteDeprecatedActionTypeFallback)
+    {
+        AddOutboundRoutingGroup();
+
+        dash::route::Route route;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        route.set_action_type(dash::route_type::ROUTING_TYPE_VNET);
+#pragma GCC diagnostic pop
+        route.set_vnet(vnet1);
+
+        EXPECT_CALL(*mock_sai_dash_outbound_routing_api, create_outbound_routing_entries).Times(1);
+        SetDashTable(APP_DASH_ROUTE_TABLE_NAME, route_group1 + ":9.9.9.9/32", route, true, true);
+    }
+
+    TEST_F(DashRouteOrchTest, OutboundRouteUnknownOp)
+    {
+        auto consumer = CreateDashRouteConsumer(APP_DASH_ROUTE_TABLE_NAME);
+        consumer->m_toSync.emplace(
+            route_group1 + ":1.2.3.4/32",
+            swss::KeyOpFieldsValuesTuple(route_group1 + ":1.2.3.4/32", "UNKNOWN", {}));
+
+        m_DashRouteOrch->doTaskRouteTable(*consumer);
+
+        EXPECT_TRUE(consumer->m_toSync.empty());
+    }
+
+    TEST_F(DashRouteOrchTest, OutboundRouteDuplicateSetClearsContext)
+    {
+        AddOutboundRoutingGroup();
+
+        auto consumer = CreateDashRouteConsumer(APP_DASH_ROUTE_TABLE_NAME);
+        std::string key = route_group1 + ":1.2.3.4/32";
+
+        dash::route::Route validRoute;
+        validRoute.set_routing_type(dash::route_type::ROUTING_TYPE_VNET);
+        validRoute.set_vnet(vnet1);
+
+        dash::route::Route invalidRoute;
+        invalidRoute.set_routing_type(dash::route_type::ROUTING_TYPE_VNET_DIRECT);
+        invalidRoute.mutable_vnet_direct()->set_vnet(vnet1);
+
+        consumer->m_toSync.emplace(key, swss::KeyOpFieldsValuesTuple(key, SET_COMMAND, {{"pb", validRoute.SerializeAsString()}}));
+        consumer->m_toSync.emplace(key, swss::KeyOpFieldsValuesTuple(key, SET_COMMAND, {{"pb", invalidRoute.SerializeAsString()}}));
+
+        EXPECT_CALL(*mock_sai_dash_outbound_routing_api, create_outbound_routing_entries).Times(1);
+        m_DashRouteOrch->doTaskRouteTable(*consumer);
+
+        EXPECT_TRUE(consumer->m_toSync.empty());
+    }
+
+    TEST_F(DashRouteOrchTest, InboundRouteMissingVnet)
+    {
+        dash::route_rule::RouteRule rule;
+        rule.set_pa_validation(true);
+        rule.set_vnet("NON_EXISTENT_VNET");
+
+        EXPECT_CALL(*mock_sai_dash_inbound_routing_api, create_inbound_routing_entries).Times(0);
+        SetDashTable(APP_DASH_ROUTE_RULE_TABLE_NAME, eni1 + ":5555:10.0.1.0/24", rule, true, true);
+    }
+
+    TEST_F(DashRouteOrchTest, InboundRouteSaiRemoveFailureNotRetried)
+    {
+        AddInboundRoutingEntry();
+
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_INVALID_PARAMETER};
+        EXPECT_CALL(*mock_sai_dash_inbound_routing_api, remove_inbound_routing_entries)
+            .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        RemoveInboundRoutingEntry(true);
+    }
+
+    TEST_F(DashRouteOrchTest, InboundRouteUnknownOp)
+    {
+        auto consumer = CreateDashRouteConsumer(APP_DASH_ROUTE_RULE_TABLE_NAME);
+        consumer->m_toSync.emplace(
+            eni1 + ":5555:10.0.0.0/24",
+            swss::KeyOpFieldsValuesTuple(eni1 + ":5555:10.0.0.0/24", "UNKNOWN", {}));
+
+        m_DashRouteOrch->doTaskRouteRuleTable(*consumer);
+
+        EXPECT_TRUE(consumer->m_toSync.empty());
+    }
+
+    TEST_F(DashRouteOrchTest, InboundRouteDuplicateSetClearsContext)
+    {
+        auto consumer = CreateDashRouteConsumer(APP_DASH_ROUTE_RULE_TABLE_NAME);
+        std::string key = eni1 + ":5555:10.0.0.0/24";
+
+        dash::route_rule::RouteRule validRule;
+        validRule.set_pa_validation(true);
+
+        dash::route_rule::RouteRule invalidRule;
+        invalidRule.set_pa_validation(true);
+        invalidRule.set_vnet("NON_EXISTENT_VNET");
+
+        consumer->m_toSync.emplace(key, swss::KeyOpFieldsValuesTuple(key, SET_COMMAND, {{"pb", validRule.SerializeAsString()}}));
+        consumer->m_toSync.emplace(key, swss::KeyOpFieldsValuesTuple(key, SET_COMMAND, {{"pb", invalidRule.SerializeAsString()}}));
+
+        EXPECT_CALL(*mock_sai_dash_inbound_routing_api, create_inbound_routing_entries).Times(1);
+        m_DashRouteOrch->doTaskRouteRuleTable(*consumer);
+
+        EXPECT_TRUE(consumer->m_toSync.empty());
+    }
+
+    TEST_F(DashRouteOrchTest, RouteGroupSaiCreateFailure)
+    {
+        dash::route_group::RouteGroup route_group;
+        route_group.set_version("1");
+        route_group.set_guid("group_guid");
+
+        EXPECT_CALL(*mock_sai_dash_outbound_routing_api, create_outbound_routing_group).WillOnce(Return(SAI_STATUS_INVALID_PARAMETER));
+        SetDashTable(APP_DASH_ROUTE_GROUP_TABLE_NAME, route_group1, route_group, true, true);
+
+        EXPECT_EQ(m_DashRouteOrch->getRouteGroupOid(route_group1), SAI_NULL_OBJECT_ID);
+    }
+
+    TEST_F(DashRouteOrchTest, RouteGroupRemoveSaiFailureNotInUse)
+    {
+        AddOutboundRoutingGroup();
+
+        EXPECT_CALL(*mock_sai_dash_outbound_routing_api, remove_outbound_routing_group(_)).WillOnce(Return(SAI_STATUS_INVALID_PARAMETER));
+        SetDashTable(APP_DASH_ROUTE_GROUP_TABLE_NAME, route_group1, dash::route_group::RouteGroup(), false, true);
+
+        EXPECT_NE(m_DashRouteOrch->getRouteGroupOid(route_group1), SAI_NULL_OBJECT_ID);
+    }
+
+    TEST_F(DashRouteOrchTest, RemoveBoundRouteGroup)
+    {
+        AddOutboundRoutingGroup();
+        m_DashRouteOrch->bindRouteGroup(route_group1);
+
+        EXPECT_CALL(*mock_sai_dash_outbound_routing_api, remove_outbound_routing_group(_)).Times(0);
+        SetDashTable(APP_DASH_ROUTE_GROUP_TABLE_NAME, route_group1, dash::route_group::RouteGroup(), false, true);
+
+        EXPECT_NE(m_DashRouteOrch->getRouteGroupOid(route_group1), SAI_NULL_OBJECT_ID);
+        m_DashRouteOrch->unbindRouteGroup(route_group1);
+    }
+
+    TEST_F(DashRouteOrchTest, RouteGroupUnknownOp)
+    {
+        auto consumer = CreateDashRouteConsumer(APP_DASH_ROUTE_GROUP_TABLE_NAME);
+        consumer->m_toSync.emplace(route_group1, swss::KeyOpFieldsValuesTuple(route_group1, "UNKNOWN", {}));
+
+        m_DashRouteOrch->doTaskRouteGroupTable(*consumer);
+
+        EXPECT_TRUE(consumer->m_toSync.empty());
+    }
 }

--- a/tests/mock_tests/dashtunnelorch_ut.cpp
+++ b/tests/mock_tests/dashtunnelorch_ut.cpp
@@ -1,0 +1,564 @@
+#include <algorithm>
+#include <sstream>
+
+#define private public
+#include "dashtunnelorch.h"
+#undef private
+#define protected public
+#include "orch.h"
+#undef protected
+#include "ut_helper.h"
+#include "mock_orchagent_main.h"
+#include "mock_sai_api.h"
+#include "mock_dash_orch_test.h"
+#include "dash_api/tunnel.pb.h"
+#include "table.h"
+
+EXTERN_MOCK_FNS
+
+namespace dashtunnelorch_test
+{
+    DEFINE_SAI_GENERIC_APIS_MOCK(dash_tunnel, dash_tunnel, dash_tunnel_member, dash_tunnel_next_hop)
+
+    using namespace mock_orch_test;
+    using ::testing::DoAll;
+    using ::testing::InSequence;
+    using ::testing::Invoke;
+    using ::testing::Return;
+
+    class DashTunnelOrchTest : public MockDashOrchTest
+    {
+    protected:
+        void ApplySaiMock() override
+        {
+            INIT_SAI_API_MOCK(dash_tunnel);
+            MockSaiApis();
+        }
+
+        void PostSetUp() override
+        {
+            CreateApplianceEntry();
+        }
+
+        void PreTearDown() override
+        {
+            RestoreSaiApis();
+            DEINIT_SAI_API_MOCK(dash_tunnel);
+        }
+
+        dash::tunnel::Tunnel BuildTunnel(const std::vector<std::string> &endpoints,
+                                        dash::route_type::EncapType encapType = dash::route_type::ENCAP_TYPE_VXLAN)
+        {
+            dash::tunnel::Tunnel tunnel;
+            tunnel.set_encap_type(encapType);
+            tunnel.set_vni(5555);
+            for (const auto &endpoint : endpoints)
+            {
+                auto *ip = tunnel.add_endpoints();
+                ip->set_ipv4(swss::IpAddress(endpoint).getV4Addr());
+            }
+            return tunnel;
+        }
+
+        dash::tunnel::Tunnel BuildTunnelWithUnsetEndpoints(size_t endpointCount)
+        {
+            dash::tunnel::Tunnel tunnel;
+            tunnel.set_encap_type(dash::route_type::ENCAP_TYPE_VXLAN);
+            tunnel.set_vni(5555);
+            for (size_t i = 0; i < endpointCount; ++i)
+            {
+                tunnel.add_endpoints();
+            }
+            return tunnel;
+        }
+
+        std::unique_ptr<Consumer> MakeTunnelConsumer()
+        {
+            return std::make_unique<Consumer>(
+                new swss::ConsumerStateTable(m_app_db.get(), APP_DASH_TUNNEL_TABLE_NAME),
+                m_DashTunnelOrch, APP_DASH_TUNNEL_TABLE_NAME);
+        }
+
+        bool HasTunnelResult(const std::string &tunnelName)
+        {
+            swss::Table resultTable(m_dpu_app_state_db.get(), APP_DASH_TUNNEL_TABLE_NAME);
+            std::vector<swss::FieldValueTuple> fvs;
+            return resultTable.get(tunnelName, fvs);
+        }
+
+        std::string GetTunnelResult(const std::string &tunnelName)
+        {
+            swss::Table resultTable(m_dpu_app_state_db.get(), APP_DASH_TUNNEL_TABLE_NAME);
+            std::string result;
+            EXPECT_TRUE(resultTable.hget(tunnelName, "result", result));
+            return result;
+        }
+
+        void ExpectTunnelResult(const std::string &tunnelName, uint32_t expectedResult)
+        {
+            EXPECT_EQ(GetTunnelResult(tunnelName), std::to_string(expectedResult));
+        }
+    };
+
+    class DashTunnelOrchNoApplianceTest : public DashTunnelOrchTest
+    {
+    protected:
+        void PostSetUp() override
+        {
+        }
+    };
+
+    TEST_F(DashTunnelOrchTest, AddRemoveTunnel)
+    {
+        auto tunnel = BuildTunnel({"2.2.2.2"});
+        sai_object_id_t createdTunnelOid = 0x101;
+        sai_object_id_t removedTunnelOid = SAI_NULL_OBJECT_ID;
+        swss::IpAddress expectedEndpoint("2.2.2.2");
+        swss::IpAddress expectedVip("1.1.1.1");
+
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_next_hops).Times(0);
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_members).Times(0);
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnels)
+            .WillOnce(Invoke([&](sai_object_id_t, uint32_t object_count, const uint32_t *attr_count,
+                                 const sai_attribute_t **attr_list, sai_bulk_op_error_mode_t,
+                                 sai_object_id_t *object_ids, sai_status_t *object_statuses) {
+                EXPECT_EQ(object_count, 1u);
+                EXPECT_EQ(attr_count[0], 5u);
+
+                std::map<int32_t, sai_attribute_t> attrs;
+                for (uint32_t i = 0; i < attr_count[0]; ++i)
+                {
+                    attrs[attr_list[0][i].id] = attr_list[0][i];
+                }
+
+                EXPECT_EQ(attrs[SAI_DASH_TUNNEL_ATTR_MAX_MEMBER_SIZE].value.u32, 1u);
+                EXPECT_EQ(attrs[SAI_DASH_TUNNEL_ATTR_DASH_ENCAPSULATION].value.u32,
+                          SAI_DASH_ENCAPSULATION_VXLAN);
+                EXPECT_EQ(attrs[SAI_DASH_TUNNEL_ATTR_TUNNEL_KEY].value.u32, 5555u);
+                EXPECT_EQ(attrs[SAI_DASH_TUNNEL_ATTR_SIP].value.ipaddr.addr_family,
+                          SAI_IP_ADDR_FAMILY_IPV4);
+                EXPECT_EQ(attrs[SAI_DASH_TUNNEL_ATTR_SIP].value.ipaddr.addr.ip4,
+                          expectedVip.getV4Addr());
+                EXPECT_EQ(attrs[SAI_DASH_TUNNEL_ATTR_DIP].value.ipaddr.addr_family,
+                          SAI_IP_ADDR_FAMILY_IPV4);
+                EXPECT_EQ(attrs[SAI_DASH_TUNNEL_ATTR_DIP].value.ipaddr.addr.ip4,
+                          expectedEndpoint.getV4Addr());
+
+                object_ids[0] = createdTunnelOid;
+                object_statuses[0] = SAI_STATUS_SUCCESS;
+                return SAI_STATUS_SUCCESS;
+            }));
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, remove_dash_tunnels)
+            .WillOnce(Invoke([&](uint32_t object_count, const sai_object_id_t *object_ids,
+                                 sai_bulk_op_error_mode_t, sai_status_t *object_statuses) {
+                EXPECT_EQ(object_count, 1u);
+                removedTunnelOid = object_ids[0];
+                object_statuses[0] = SAI_STATUS_SUCCESS;
+                return SAI_STATUS_SUCCESS;
+            }));
+
+        SetDashTable(APP_DASH_TUNNEL_TABLE_NAME, tunnel1, tunnel);
+        EXPECT_EQ(m_DashTunnelOrch->getTunnelOid(tunnel1), createdTunnelOid);
+        ExpectTunnelResult(tunnel1, DASH_RESULT_SUCCESS);
+
+        SetDashTable(APP_DASH_TUNNEL_TABLE_NAME, tunnel1, dash::tunnel::Tunnel(), false);
+        EXPECT_EQ(removedTunnelOid, createdTunnelOid);
+        EXPECT_EQ(m_DashTunnelOrch->getTunnelOid(tunnel1), SAI_NULL_OBJECT_ID);
+        EXPECT_FALSE(HasTunnelResult(tunnel1));
+    }
+
+    TEST_F(DashTunnelOrchNoApplianceTest, AddTunnelMissingAppliance)
+    {
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnels).Times(0);
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_next_hops).Times(0);
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_members).Times(0);
+
+        SetDashTable(APP_DASH_TUNNEL_TABLE_NAME, tunnel1, BuildTunnel({"2.2.2.2"}));
+        EXPECT_EQ(m_DashTunnelOrch->getTunnelOid(tunnel1), SAI_NULL_OBJECT_ID);
+        ExpectTunnelResult(tunnel1, DASH_RESULT_FAILURE);
+    }
+
+    TEST_F(DashTunnelOrchTest, DuplicateTunnelSetClearsContextOnParseFailure)
+    {
+        auto consumer = MakeTunnelConsumer();
+        auto invalidTunnel = BuildTunnel({"2.2.2.2"}, dash::route_type::ENCAP_TYPE_UNSPECIFIED);
+
+        consumer->addToSync(swss::KeyOpFieldsValuesTuple(
+            tunnel1, SET_COMMAND, {{"pb", invalidTunnel.SerializeAsString()}}));
+        consumer->addToSync(swss::KeyOpFieldsValuesTuple(tunnel1, SET_COMMAND, {}));
+
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnels).Times(0);
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_next_hops).Times(0);
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_members).Times(0);
+
+        m_DashTunnelOrch->doTask(*consumer);
+        EXPECT_TRUE(consumer->m_toSync.empty());
+        ExpectTunnelResult(tunnel1, DASH_RESULT_FAILURE);
+    }
+
+    TEST_F(DashTunnelOrchTest, TunnelSaiCreateFailure)
+    {
+        std::vector<sai_status_t> createStatuses = {SAI_STATUS_INSUFFICIENT_RESOURCES};
+
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_next_hops).Times(0);
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_members).Times(0);
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnels)
+            .WillOnce(Invoke([&](sai_object_id_t, uint32_t object_count, const uint32_t *,
+                                 const sai_attribute_t **, sai_bulk_op_error_mode_t,
+                                 sai_object_id_t *object_ids, sai_status_t *object_statuses) {
+                EXPECT_EQ(object_count, 1u);
+                object_ids[0] = SAI_NULL_OBJECT_ID;
+                std::copy(createStatuses.begin(), createStatuses.end(), object_statuses);
+                return SAI_STATUS_SUCCESS;
+            }));
+
+        SetDashTable(APP_DASH_TUNNEL_TABLE_NAME, tunnel1, BuildTunnel({"2.2.2.2"}));
+        EXPECT_EQ(m_DashTunnelOrch->getTunnelOid(tunnel1), SAI_NULL_OBJECT_ID);
+        ExpectTunnelResult(tunnel1, DASH_RESULT_FAILURE);
+    }
+
+    TEST_F(DashTunnelOrchTest, MissingProtobufTunnel)
+    {
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnels).Times(0);
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_next_hops).Times(0);
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_members).Times(0);
+
+        SetDashTableRaw(APP_DASH_TUNNEL_TABLE_NAME, tunnel1, {}, true, true);
+        ExpectTunnelResult(tunnel1, DASH_RESULT_FAILURE);
+    }
+
+    TEST_F(DashTunnelOrchTest, TunnelCreateDeleteChurn)
+    {
+        auto tunnel = BuildTunnel({"2.2.2.2"});
+
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_next_hops).Times(0);
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_members).Times(0);
+        for (int i = 0; i < 3; ++i)
+        {
+            sai_object_id_t tunnelOid = static_cast<sai_object_id_t>(0x200 + i);
+            EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnels)
+                .WillOnce(Invoke([=](sai_object_id_t, uint32_t object_count, const uint32_t *,
+                                     const sai_attribute_t **, sai_bulk_op_error_mode_t,
+                                     sai_object_id_t *object_ids, sai_status_t *object_statuses) {
+                    EXPECT_EQ(object_count, 1u);
+                    object_ids[0] = tunnelOid;
+                    object_statuses[0] = SAI_STATUS_SUCCESS;
+                    return SAI_STATUS_SUCCESS;
+                }));
+            SetDashTable(APP_DASH_TUNNEL_TABLE_NAME, tunnel1, tunnel);
+            EXPECT_EQ(m_DashTunnelOrch->getTunnelOid(tunnel1), tunnelOid);
+
+            EXPECT_CALL(*mock_sai_dash_tunnel_api, remove_dash_tunnels)
+                .WillOnce(Invoke([=](uint32_t object_count, const sai_object_id_t *object_ids,
+                                     sai_bulk_op_error_mode_t, sai_status_t *object_statuses) {
+                    EXPECT_EQ(object_count, 1u);
+                    EXPECT_EQ(object_ids[0], tunnelOid);
+                    object_statuses[0] = SAI_STATUS_SUCCESS;
+                    return SAI_STATUS_SUCCESS;
+                }));
+            SetDashTable(APP_DASH_TUNNEL_TABLE_NAME, tunnel1, dash::tunnel::Tunnel(), false);
+            EXPECT_EQ(m_DashTunnelOrch->getTunnelOid(tunnel1), SAI_NULL_OBJECT_ID);
+        }
+    }
+
+    TEST_F(DashTunnelOrchTest, TunnelRemoveSaiInUse)
+    {
+        auto tunnel = BuildTunnel({"2.2.2.2"});
+        sai_object_id_t tunnelOid = 0x301;
+
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_next_hops).Times(0);
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_members).Times(0);
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnels)
+            .WillOnce(Invoke([&](sai_object_id_t, uint32_t, const uint32_t *, const sai_attribute_t **,
+                                 sai_bulk_op_error_mode_t, sai_object_id_t *object_ids,
+                                 sai_status_t *object_statuses) {
+                object_ids[0] = tunnelOid;
+                object_statuses[0] = SAI_STATUS_SUCCESS;
+                return SAI_STATUS_SUCCESS;
+            }));
+        SetDashTable(APP_DASH_TUNNEL_TABLE_NAME, tunnel1, tunnel);
+
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, remove_dash_tunnels)
+            .WillOnce(Invoke([&](uint32_t, const sai_object_id_t *, sai_bulk_op_error_mode_t,
+                                 sai_status_t *object_statuses) {
+                object_statuses[0] = SAI_STATUS_OBJECT_IN_USE;
+                return SAI_STATUS_SUCCESS;
+            }));
+        SetDashTable(APP_DASH_TUNNEL_TABLE_NAME, tunnel1, dash::tunnel::Tunnel(), false);
+
+        EXPECT_EQ(m_DashTunnelOrch->getTunnelOid(tunnel1), tunnelOid);
+        ExpectTunnelResult(tunnel1, DASH_RESULT_SUCCESS);
+    }
+
+    TEST_F(DashTunnelOrchTest, TunnelRemoveSaiFailure)
+    {
+        auto tunnel = BuildTunnel({"2.2.2.2"});
+        sai_object_id_t tunnelOid = 0x302;
+
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_next_hops).Times(0);
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_members).Times(0);
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnels)
+            .WillOnce(Invoke([&](sai_object_id_t, uint32_t, const uint32_t *, const sai_attribute_t **,
+                                 sai_bulk_op_error_mode_t, sai_object_id_t *object_ids,
+                                 sai_status_t *object_statuses) {
+                object_ids[0] = tunnelOid;
+                object_statuses[0] = SAI_STATUS_SUCCESS;
+                return SAI_STATUS_SUCCESS;
+            }));
+        SetDashTable(APP_DASH_TUNNEL_TABLE_NAME, tunnel1, tunnel);
+
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, remove_dash_tunnels)
+            .WillOnce(Invoke([&](uint32_t, const sai_object_id_t *, sai_bulk_op_error_mode_t,
+                                 sai_status_t *object_statuses) {
+                object_statuses[0] = SAI_STATUS_INVALID_PARAMETER;
+                return SAI_STATUS_SUCCESS;
+            }));
+        SetDashTable(APP_DASH_TUNNEL_TABLE_NAME, tunnel1, dash::tunnel::Tunnel(), false);
+
+        EXPECT_EQ(m_DashTunnelOrch->getTunnelOid(tunnel1), tunnelOid);
+        EXPECT_FALSE(HasTunnelResult(tunnel1));
+    }
+
+    TEST_F(DashTunnelOrchTest, TunnelUnknownOp)
+    {
+        auto tunnel = BuildTunnel({"2.2.2.2"});
+        auto consumer = MakeTunnelConsumer();
+        consumer->addToSync(swss::KeyOpFieldsValuesTuple(
+            tunnel1, SET_COMMAND, {{"pb", tunnel.SerializeAsString()}}));
+
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_next_hops).Times(0);
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_members).Times(0);
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnels)
+            .WillOnce(Invoke([&](sai_object_id_t, uint32_t, const uint32_t *, const sai_attribute_t **,
+                                 sai_bulk_op_error_mode_t, sai_object_id_t *object_ids,
+                                 sai_status_t *object_statuses) {
+                object_ids[0] = 0x401;
+                object_statuses[0] = SAI_STATUS_SUCCESS;
+                consumer->addToSync(swss::KeyOpFieldsValuesTuple("UNKNOWN_TUNNEL", "UNKNOWN", {}));
+                return SAI_STATUS_SUCCESS;
+            }));
+
+        m_DashTunnelOrch->doTask(*consumer);
+        ASSERT_EQ(consumer->m_toSync.size(), 1u);
+        EXPECT_EQ(kfvKey(consumer->m_toSync.begin()->second), "UNKNOWN_TUNNEL");
+        EXPECT_EQ(kfvOp(consumer->m_toSync.begin()->second), "UNKNOWN");
+        ExpectTunnelResult(tunnel1, DASH_RESULT_SUCCESS);
+        consumer->m_toSync.clear();
+    }
+
+    TEST_F(DashTunnelOrchTest, AddTunnelMultiEndpoint)
+    {
+        auto tunnel = BuildTunnel({"2.2.2.2", "3.3.3.3"});
+        std::vector<sai_object_id_t> nhopOids = {0x501, 0x502};
+        std::vector<sai_object_id_t> memberOids = {0x601, 0x602};
+        sai_object_id_t tunnelOid = 0x503;
+
+        {
+            InSequence seq;
+            EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnels)
+                .WillOnce(Invoke([&](sai_object_id_t, uint32_t object_count, const uint32_t *,
+                                     const sai_attribute_t **, sai_bulk_op_error_mode_t,
+                                     sai_object_id_t *object_ids, sai_status_t *object_statuses) {
+                    EXPECT_EQ(object_count, 1u);
+                    object_ids[0] = tunnelOid;
+                    object_statuses[0] = SAI_STATUS_SUCCESS;
+                    return SAI_STATUS_SUCCESS;
+                }));
+            EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_next_hops)
+                .WillOnce(Invoke([&](sai_object_id_t, uint32_t object_count, const uint32_t *,
+                                     const sai_attribute_t **, sai_bulk_op_error_mode_t,
+                                     sai_object_id_t *object_ids, sai_status_t *object_statuses) {
+                    EXPECT_EQ(object_count, nhopOids.size());
+                    std::copy(nhopOids.begin(), nhopOids.end(), object_ids);
+                    std::fill(object_statuses, object_statuses + object_count, SAI_STATUS_SUCCESS);
+                    return SAI_STATUS_SUCCESS;
+                }));
+            EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_members)
+                .WillOnce(Invoke([&](sai_object_id_t, uint32_t object_count, const uint32_t *,
+                                     const sai_attribute_t **, sai_bulk_op_error_mode_t,
+                                     sai_object_id_t *object_ids, sai_status_t *object_statuses) {
+                    EXPECT_EQ(object_count, memberOids.size());
+                    std::copy(memberOids.begin(), memberOids.end(), object_ids);
+                    std::fill(object_statuses, object_statuses + object_count, SAI_STATUS_SUCCESS);
+                    return SAI_STATUS_SUCCESS;
+                }));
+        }
+
+        SetDashTable(APP_DASH_TUNNEL_TABLE_NAME, tunnel1, tunnel);
+
+        EXPECT_EQ(m_DashTunnelOrch->getTunnelOid(tunnel1), tunnelOid);
+        ASSERT_EQ(m_DashTunnelOrch->tunnel_table_[tunnel1].endpoints.size(), 2u);
+        EXPECT_EQ(m_DashTunnelOrch->tunnel_table_[tunnel1].endpoints["2.2.2.2"].tunnel_nhop_oid, nhopOids[0]);
+        EXPECT_EQ(m_DashTunnelOrch->tunnel_table_[tunnel1].endpoints["2.2.2.2"].tunnel_member_oid, memberOids[0]);
+        EXPECT_EQ(m_DashTunnelOrch->tunnel_table_[tunnel1].endpoints["3.3.3.3"].tunnel_nhop_oid, nhopOids[1]);
+        EXPECT_EQ(m_DashTunnelOrch->tunnel_table_[tunnel1].endpoints["3.3.3.3"].tunnel_member_oid, memberOids[1]);
+        ExpectTunnelResult(tunnel1, DASH_RESULT_SUCCESS);
+    }
+
+    TEST_F(DashTunnelOrchTest, TunnelMemberCreateFailure)
+    {
+        auto tunnel = BuildTunnel({"2.2.2.2", "3.3.3.3"});
+        std::vector<sai_object_id_t> nhopOids = {0x511, 0x512};
+        std::vector<sai_object_id_t> memberOids = {SAI_NULL_OBJECT_ID, SAI_NULL_OBJECT_ID};
+        std::vector<sai_status_t> memberStatuses = {SAI_STATUS_FAILURE, SAI_STATUS_FAILURE};
+        sai_object_id_t tunnelOid = 0x513;
+
+        {
+            InSequence seq;
+            EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnels)
+                .WillOnce(Invoke([&](sai_object_id_t, uint32_t, const uint32_t *, const sai_attribute_t **,
+                                     sai_bulk_op_error_mode_t, sai_object_id_t *object_ids,
+                                     sai_status_t *object_statuses) {
+                    object_ids[0] = tunnelOid;
+                    object_statuses[0] = SAI_STATUS_SUCCESS;
+                    return SAI_STATUS_SUCCESS;
+                }));
+            EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_next_hops)
+                .WillOnce(Invoke([&](sai_object_id_t, uint32_t object_count, const uint32_t *,
+                                     const sai_attribute_t **, sai_bulk_op_error_mode_t,
+                                     sai_object_id_t *object_ids, sai_status_t *object_statuses) {
+                    std::copy(nhopOids.begin(), nhopOids.end(), object_ids);
+                    std::fill(object_statuses, object_statuses + object_count, SAI_STATUS_SUCCESS);
+                    return SAI_STATUS_SUCCESS;
+                }));
+            EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_members)
+                .WillOnce(Invoke([&](sai_object_id_t, uint32_t object_count, const uint32_t *,
+                                     const sai_attribute_t **, sai_bulk_op_error_mode_t,
+                                     sai_object_id_t *object_ids, sai_status_t *object_statuses) {
+                    std::copy(memberOids.begin(), memberOids.end(), object_ids);
+                    std::copy(memberStatuses.begin(), memberStatuses.end(), object_statuses);
+                    EXPECT_EQ(object_count, memberOids.size());
+                    return SAI_STATUS_SUCCESS;
+                }));
+        }
+
+        SetDashTable(APP_DASH_TUNNEL_TABLE_NAME, tunnel1, tunnel);
+
+        EXPECT_EQ(m_DashTunnelOrch->tunnel_table_[tunnel1].endpoints["2.2.2.2"].tunnel_member_oid,
+                  SAI_NULL_OBJECT_ID);
+        EXPECT_EQ(m_DashTunnelOrch->tunnel_table_[tunnel1].endpoints["3.3.3.3"].tunnel_member_oid,
+                  SAI_NULL_OBJECT_ID);
+        ExpectTunnelResult(tunnel1, DASH_RESULT_SUCCESS);
+    }
+
+    TEST_F(DashTunnelOrchTest, TunnelEndpointRemovalFailure)
+    {
+        auto tunnel = BuildTunnel({"2.2.2.2", "3.3.3.3"});
+        std::vector<sai_object_id_t> nhopOids = {0x521, 0x522};
+        std::vector<sai_object_id_t> memberOids = {0x621, 0x622};
+        sai_object_id_t tunnelOid = 0x523;
+
+        {
+            InSequence seq;
+            EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnels)
+                .WillOnce(Invoke([&](sai_object_id_t, uint32_t, const uint32_t *, const sai_attribute_t **,
+                                     sai_bulk_op_error_mode_t, sai_object_id_t *object_ids,
+                                     sai_status_t *object_statuses) {
+                    object_ids[0] = tunnelOid;
+                    object_statuses[0] = SAI_STATUS_SUCCESS;
+                    return SAI_STATUS_SUCCESS;
+                }));
+            EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_next_hops)
+                .WillOnce(Invoke([&](sai_object_id_t, uint32_t object_count, const uint32_t *,
+                                     const sai_attribute_t **, sai_bulk_op_error_mode_t,
+                                     sai_object_id_t *object_ids, sai_status_t *object_statuses) {
+                    std::copy(nhopOids.begin(), nhopOids.end(), object_ids);
+                    std::fill(object_statuses, object_statuses + object_count, SAI_STATUS_SUCCESS);
+                    return SAI_STATUS_SUCCESS;
+                }));
+            EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_members)
+                .WillOnce(Invoke([&](sai_object_id_t, uint32_t object_count, const uint32_t *,
+                                     const sai_attribute_t **, sai_bulk_op_error_mode_t,
+                                     sai_object_id_t *object_ids, sai_status_t *object_statuses) {
+                    std::copy(memberOids.begin(), memberOids.end(), object_ids);
+                    std::fill(object_statuses, object_statuses + object_count, SAI_STATUS_SUCCESS);
+                    return SAI_STATUS_SUCCESS;
+                }));
+        }
+        SetDashTable(APP_DASH_TUNNEL_TABLE_NAME, tunnel1, tunnel);
+
+        {
+            InSequence seq;
+            EXPECT_CALL(*mock_sai_dash_tunnel_api, remove_dash_tunnel_members)
+                .WillOnce(Invoke([&](uint32_t object_count, const sai_object_id_t *,
+                                     sai_bulk_op_error_mode_t, sai_status_t *object_statuses) {
+                    EXPECT_EQ(object_count, 2u);
+                    std::fill(object_statuses, object_statuses + object_count, SAI_STATUS_SUCCESS);
+                    return SAI_STATUS_SUCCESS;
+                }));
+            EXPECT_CALL(*mock_sai_dash_tunnel_api, remove_dash_tunnels)
+                .WillOnce(Invoke([&](uint32_t object_count, const sai_object_id_t *object_ids,
+                                     sai_bulk_op_error_mode_t, sai_status_t *object_statuses) {
+                    EXPECT_EQ(object_count, 1u);
+                    EXPECT_EQ(object_ids[0], tunnelOid);
+                    object_statuses[0] = SAI_STATUS_SUCCESS;
+                    return SAI_STATUS_SUCCESS;
+                }));
+            EXPECT_CALL(*mock_sai_dash_tunnel_api, remove_dash_tunnel_next_hops)
+                .WillOnce(Invoke([&](uint32_t object_count, const sai_object_id_t *,
+                                     sai_bulk_op_error_mode_t, sai_status_t *object_statuses) {
+                    EXPECT_EQ(object_count, 2u);
+                    std::fill(object_statuses, object_statuses + object_count, SAI_STATUS_FAILURE);
+                    return SAI_STATUS_SUCCESS;
+                }));
+        }
+
+        SetDashTable(APP_DASH_TUNNEL_TABLE_NAME, tunnel1, dash::tunnel::Tunnel(), false);
+
+        EXPECT_EQ(m_DashTunnelOrch->getTunnelOid(tunnel1), tunnelOid);
+        ASSERT_EQ(m_DashTunnelOrch->tunnel_table_[tunnel1].endpoints.size(), 2u);
+        // Both endpoints remain because nhop removal failed; member OIDs are cleared
+        for (auto it = m_DashTunnelOrch->tunnel_table_[tunnel1].endpoints.begin();
+             it != m_DashTunnelOrch->tunnel_table_[tunnel1].endpoints.end(); ++it)
+        {
+            EXPECT_EQ(it->second.tunnel_member_oid, SAI_NULL_OBJECT_ID);
+            EXPECT_NE(it->second.tunnel_nhop_oid, SAI_NULL_OBJECT_ID);
+        }
+        ExpectTunnelResult(tunnel1, DASH_RESULT_SUCCESS);
+    }
+
+    TEST_F(DashTunnelOrchTest, TunnelDeletePreOpException)
+    {
+        DashTunnelEntry entry;
+        entry.tunnel_oid = SAI_NULL_OBJECT_ID;
+        m_DashTunnelOrch->tunnel_table_[tunnel1] = entry;
+
+        auto consumer = MakeTunnelConsumer();
+        consumer->addToSync(swss::KeyOpFieldsValuesTuple(tunnel1, DEL_COMMAND, {}));
+
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, remove_dash_tunnels).Times(0);
+
+        m_DashTunnelOrch->doTask(*consumer);
+        EXPECT_TRUE(consumer->m_toSync.empty());
+        ExpectTunnelResult(tunnel1, DASH_RESULT_FAILURE);
+    }
+
+    TEST_F(DashTunnelOrchTest, TunnelPostProcessingException)
+    {
+        auto tunnel = BuildTunnelWithUnsetEndpoints(2);
+
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnels)
+            .WillOnce(Invoke([&](sai_object_id_t, uint32_t, const uint32_t *, const sai_attribute_t **,
+                                 sai_bulk_op_error_mode_t, sai_object_id_t *object_ids,
+                                 sai_status_t *object_statuses) {
+                object_ids[0] = 0x701;
+                object_statuses[0] = SAI_STATUS_SUCCESS;
+                return SAI_STATUS_SUCCESS;
+            }));
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_next_hops)
+            .WillOnce(Invoke([&](sai_object_id_t, uint32_t object_count, const uint32_t *,
+                                 const sai_attribute_t **, sai_bulk_op_error_mode_t,
+                                 sai_object_id_t *object_ids, sai_status_t *object_statuses) {
+                EXPECT_EQ(object_count, 2u);
+                object_ids[0] = 0x702;
+                object_ids[1] = 0x703;
+                object_statuses[0] = SAI_STATUS_SUCCESS;
+                object_statuses[1] = SAI_STATUS_SUCCESS;
+                return SAI_STATUS_SUCCESS;
+            }));
+        EXPECT_CALL(*mock_sai_dash_tunnel_api, create_dash_tunnel_members).Times(0);
+
+        SetDashTable(APP_DASH_TUNNEL_TABLE_NAME, "BROKEN_TUNNEL", tunnel);
+        EXPECT_FALSE(HasTunnelResult("BROKEN_TUNNEL"));
+    }
+}

--- a/tests/mock_tests/dashvnetorch_ut.cpp
+++ b/tests/mock_tests/dashvnetorch_ut.cpp
@@ -15,6 +15,9 @@
 #include "dash_api/eni_route.pb.h"
 #include "gtest/gtest.h"
 #include "crmorch.h"
+#include "table.h"
+
+#include <deque>
 
 EXTERN_MOCK_FNS
 
@@ -39,6 +42,60 @@ namespace dashvnetorch_test
             CrmOrch::CrmResourceEntry entry = CrmOrch::CrmResourceEntry("", CrmThresholdType::CRM_PERCENTAGE, 0, 1);
             gCrmOrch->getResAvailability(type, entry);
             return entry.countersMap["STATS"].usedCounter;
+        }
+
+        void ProcessDashEntries(const std::string &table_name,
+                                const std::deque<swss::KeyOpFieldsValuesTuple> &entries,
+                                bool expect_empty = true)
+        {
+            Orch *target_orch = *(dash_table_orch_map.at(table_name));
+            auto consumer = std::make_unique<Consumer>(
+                new swss::ConsumerStateTable(m_app_db.get(), table_name),
+                target_orch, table_name);
+            consumer->addToSync(entries);
+            target_orch->doTask(*consumer.get());
+
+            if (expect_empty)
+            {
+                EXPECT_EQ(consumer->m_toSync.begin(), consumer->m_toSync.end());
+            }
+            else
+            {
+                EXPECT_NE(consumer->m_toSync.begin(), consumer->m_toSync.end());
+            }
+        }
+
+        void ProcessDashTupleRaw(const std::string &table_name,
+                                 const std::string &key,
+                                 const std::string &op,
+                                 const std::vector<swss::FieldValueTuple> &fvs,
+                                 bool expect_empty = true)
+        {
+            ProcessDashEntries(table_name, {swss::KeyOpFieldsValuesTuple(key, op, fvs)}, expect_empty);
+        }
+
+        bool DashResultExists(const std::string &table_name, const std::string &key)
+        {
+            swss::Table table(m_dpu_app_state_db.get(), table_name);
+            std::vector<swss::FieldValueTuple> values;
+            return table.get(key, values);
+        }
+
+        uint32_t GetDashResult(const std::string &table_name, const std::string &key)
+        {
+            swss::Table table(m_dpu_app_state_db.get(), table_name);
+            std::vector<swss::FieldValueTuple> values;
+            EXPECT_TRUE(table.get(key, values));
+            for (const auto &fv : values)
+            {
+                if (fvField(fv) == "result")
+                {
+                    return static_cast<uint32_t>(std::stoul(fvValue(fv)));
+                }
+            }
+
+            ADD_FAILURE() << "Result field not found for key " << key;
+            return 0xffffffffu;
         }
 
         void ApplySaiMock() override
@@ -102,7 +159,7 @@ namespace dashvnetorch_test
         EXPECT_CALL(*mock_sai_dash_pa_validation_api, create_pa_validation_entries)
             .Times(0);
         AddVnetEncapRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
-        AddVnetMap(false);
+        AddVnetMap(true);
     }
 
     TEST_F(DashVnetOrchTest, AddExistingOutboundCaToPaSuccessful)
@@ -165,9 +222,412 @@ namespace dashvnetorch_test
 
         EXPECT_CALL(*mock_sai_dash_pa_validation_api, remove_pa_validation_entries)
             .Times(1).WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
-        RemoveVnet(false);
+        RemoveVnet(true);
 
         int actualUsed = GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_PA_VALIDATION);
         EXPECT_EQ(expectedUsed, actualUsed);
+    }
+
+    TEST_F(DashVnetOrchTest, VnetSaiCreateFailureNotRetried)
+    {
+        std::vector<sai_object_id_t> exp_oids = {SAI_NULL_OBJECT_ID};
+        EXPECT_CALL(*mock_sai_dash_vnet_api, create_vnets)
+            .WillOnce(DoAll(SetArrayArgument<5>(exp_oids.begin(), exp_oids.end()), Return(SAI_STATUS_INSUFFICIENT_RESOURCES)));
+        CreateVnet();
+    }
+
+    TEST_F(DashVnetOrchTest, VnetMapSaiCreateInvalidParameterNotRetried)
+    {
+        AddVnetEncapRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
+        CreateVnet();
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_INVALID_PARAMETER};
+        EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries)
+            .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        AddVnetMap(true);
+    }
+
+    TEST_F(DashVnetOrchTest, RemoveNonExistentVnet)
+    {
+        EXPECT_CALL(*mock_sai_dash_vnet_api, remove_vnets).Times(0);
+        RemoveVnet(true);
+    }
+
+    TEST_F(DashVnetOrchTest, VnetRemoveItemNotFoundSuccess)
+    {
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_ITEM_NOT_FOUND};
+
+        CreateVnet();
+        int expectedUsed = GetCrmUsedCount(CrmResourceType::CRM_DASH_VNET);
+
+        EXPECT_CALL(*mock_sai_dash_vnet_api, remove_vnets)
+            .Times(1)
+            .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+        RemoveVnet();
+
+        EXPECT_EQ(expectedUsed, GetCrmUsedCount(CrmResourceType::CRM_DASH_VNET));
+        EXPECT_FALSE(DashResultExists(APP_DASH_VNET_TABLE_NAME, vnet1));
+    }
+
+    TEST_F(DashVnetOrchTest, VnetUnknownOpConsumed)
+    {
+        dash::vnet::Vnet vnet;
+        vnet.set_vni(5555);
+
+        EXPECT_CALL(*mock_sai_dash_vnet_api, create_vnets).Times(0);
+        EXPECT_CALL(*mock_sai_dash_vnet_api, remove_vnets).Times(0);
+
+        ProcessDashTupleRaw(APP_DASH_VNET_TABLE_NAME, vnet1, "UNKNOWN",
+                            {{"pb", vnet.SerializeAsString()}});
+
+        EXPECT_FALSE(DashResultExists(APP_DASH_VNET_TABLE_NAME, vnet1));
+    }
+
+    TEST_F(DashVnetOrchTest, VnetDuplicateDeleteNoopClearsBulkContext)
+    {
+        EXPECT_CALL(*mock_sai_dash_vnet_api, remove_vnets).Times(0);
+
+        ProcessDashEntries(
+            APP_DASH_VNET_TABLE_NAME,
+            {
+                swss::KeyOpFieldsValuesTuple(vnet1, DEL_COMMAND, {}),
+                swss::KeyOpFieldsValuesTuple(vnet1, DEL_COMMAND, {})
+            });
+    }
+
+    TEST_F(DashVnetOrchTest, VnetMapMissingRouteTypeActions)
+    {
+        std::string key = vnet1 + ":" + vnet_map_ip1;
+
+        CreateVnet();
+
+        EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries).Times(0);
+        EXPECT_CALL(*mock_sai_dash_pa_validation_api, create_pa_validation_entries).Times(0);
+
+        AddVnetMap();
+
+        EXPECT_EQ(GetDashResult(APP_DASH_VNET_MAPPING_TABLE_NAME, key), 1u);
+    }
+
+    TEST_F(DashVnetOrchTest, VnetMapDuplicateEntry)
+    {
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_ITEM_ALREADY_EXISTS};
+
+        AddVnetEncapRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
+        CreateVnet();
+        AddVnetMap();
+
+        int expectedCaUsed = GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_OUTBOUND_CA_TO_PA);
+        int expectedPaUsed = GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_PA_VALIDATION);
+
+        EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries)
+            .Times(1)
+            .WillOnce(DoAll(SetArrayArgument<5>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_CALL(*mock_sai_dash_pa_validation_api, create_pa_validation_entries).Times(0);
+
+        AddVnetMap();
+
+        EXPECT_EQ(expectedCaUsed, GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_OUTBOUND_CA_TO_PA));
+        EXPECT_EQ(expectedPaUsed, GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_PA_VALIDATION));
+    }
+
+    TEST_F(DashVnetOrchTest, VnetMapMissingPortMap)
+    {
+        std::string key = vnet1 + ":" + vnet_map_ip2;
+
+        AddPLRoutingType();
+        CreateVnet();
+
+        EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries).Times(0);
+        EXPECT_CALL(*mock_sai_dash_pa_validation_api, create_pa_validation_entries).Times(0);
+
+        AddVnetMapPL();
+
+        EXPECT_EQ(GetDashResult(APP_DASH_VNET_MAPPING_TABLE_NAME, key), 1u);
+    }
+
+    TEST_F(DashVnetOrchTest, VnetMapPaValidationSaiFailure)
+    {
+        std::vector<sai_status_t> create_status = {SAI_STATUS_SUCCESS};
+        std::vector<sai_status_t> pa_validation_status = {SAI_STATUS_INVALID_PARAMETER};
+        std::string key = vnet1 + ":" + vnet_map_ip1;
+
+        AddVnetEncapRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
+        CreateVnet();
+
+        EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries)
+            .Times(1)
+            .WillOnce(DoAll(SetArrayArgument<5>(create_status.begin(), create_status.end()), Return(SAI_STATUS_SUCCESS)));
+        EXPECT_CALL(*mock_sai_dash_pa_validation_api, create_pa_validation_entries)
+            .Times(1)
+            .WillOnce(DoAll(SetArrayArgument<5>(pa_validation_status.begin(), pa_validation_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+        AddVnetMap();
+
+        EXPECT_EQ(GetDashResult(APP_DASH_VNET_MAPPING_TABLE_NAME, key), 1u);
+    }
+
+    TEST_F(DashVnetOrchTest, VnetMapRemoveSaiNotExecuted)
+    {
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_NOT_EXECUTED};
+        std::string key = vnet1 + ":" + vnet_map_ip1;
+
+        AddVnetEncapRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
+        CreateVnet();
+        AddVnetMap();
+
+        int expectedUsed = GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_OUTBOUND_CA_TO_PA);
+
+        EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, remove_outbound_ca_to_pa_entries)
+            .Times(1)
+            .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+        RemoveVnetMap();
+
+        EXPECT_EQ(expectedUsed, GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_OUTBOUND_CA_TO_PA));
+        EXPECT_TRUE(DashResultExists(APP_DASH_VNET_MAPPING_TABLE_NAME, key));
+    }
+
+    TEST_F(DashVnetOrchTest, VnetMapRemoveSaiFailure)
+    {
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_INVALID_PARAMETER};
+        std::string key = vnet1 + ":" + vnet_map_ip1;
+
+        AddVnetEncapRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
+        CreateVnet();
+        AddVnetMap();
+
+        int expectedUsed = GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_OUTBOUND_CA_TO_PA);
+
+        EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, remove_outbound_ca_to_pa_entries)
+            .Times(1)
+            .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+        RemoveVnetMap();
+
+        EXPECT_EQ(expectedUsed, GetCrmUsedCount(CrmResourceType::CRM_DASH_IPV4_OUTBOUND_CA_TO_PA));
+        EXPECT_TRUE(DashResultExists(APP_DASH_VNET_MAPPING_TABLE_NAME, key));
+    }
+
+    TEST_F(DashVnetOrchTest, VnetMapUnknownOpConsumed)
+    {
+        dash::vnet_mapping::VnetMapping vnet_map;
+        // Use a unique key to avoid collision with result entries left by prior tests
+        std::string key = vnet1 + ":9.9.9.9";
+
+        vnet_map.set_routing_type(dash::route_type::ROUTING_TYPE_VNET_ENCAP);
+        vnet_map.mutable_underlay_ip()->set_ipv4(swss::IpAddress("7.7.7.7").getV4Addr());
+
+        EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries).Times(0);
+        EXPECT_CALL(*mock_sai_dash_pa_validation_api, create_pa_validation_entries).Times(0);
+
+        ProcessDashTupleRaw(APP_DASH_VNET_MAPPING_TABLE_NAME, key, "UNKNOWN",
+                            {{"pb", vnet_map.SerializeAsString()}});
+
+        EXPECT_FALSE(DashResultExists(APP_DASH_VNET_MAPPING_TABLE_NAME, key));
+    }
+
+    TEST_F(DashVnetOrchTest, VnetMapDuplicateFailedAddClearsBulkContext)
+    {
+        dash::vnet_mapping::VnetMapping vnet_map;
+        std::string key = vnet1 + ":" + vnet_map_ip1;
+
+        CreateVnet();
+        vnet_map.set_routing_type(dash::route_type::ROUTING_TYPE_VNET_ENCAP);
+        vnet_map.mutable_underlay_ip()->set_ipv4(swss::IpAddress("7.7.7.7").getV4Addr());
+
+        EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries).Times(0);
+        EXPECT_CALL(*mock_sai_dash_pa_validation_api, create_pa_validation_entries).Times(0);
+
+        ProcessDashEntries(
+            APP_DASH_VNET_MAPPING_TABLE_NAME,
+            {
+                swss::KeyOpFieldsValuesTuple(key, SET_COMMAND, {{"pb", vnet_map.SerializeAsString()}}),
+                swss::KeyOpFieldsValuesTuple(key, SET_COMMAND, {{"pb", vnet_map.SerializeAsString()}})
+            });
+
+        EXPECT_EQ(GetDashResult(APP_DASH_VNET_MAPPING_TABLE_NAME, key), 1u);
+    }
+
+    TEST_F(DashVnetOrchTest, VnetMapDeprecatedActionTypeFallback)
+    {
+        dash::vnet_mapping::VnetMapping vnet_map;
+        std::string key = vnet1 + ":" + vnet_map_ip1;
+
+        AddVnetEncapRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
+        CreateVnet();
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        vnet_map.set_action_type(dash::route_type::ROUTING_TYPE_VNET_ENCAP);
+#pragma GCC diagnostic pop
+        vnet_map.mutable_underlay_ip()->set_ipv4(swss::IpAddress("7.7.7.7").getV4Addr());
+
+        EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries).Times(1);
+        EXPECT_CALL(*mock_sai_dash_pa_validation_api, create_pa_validation_entries).Times(1);
+
+        ProcessDashTupleRaw(APP_DASH_VNET_MAPPING_TABLE_NAME, key, SET_COMMAND,
+                            {{"pb", vnet_map.SerializeAsString()}});
+
+        EXPECT_EQ(GetDashResult(APP_DASH_VNET_MAPPING_TABLE_NAME, key), 0u);
+    }
+
+    class DashVnetOrchNoApplianceTest : public MockDashOrchTest
+    {
+    protected:
+        int GetCrmUsedCount(CrmResourceType type)
+        {
+            CrmOrch::CrmResourceEntry entry = CrmOrch::CrmResourceEntry("", CrmThresholdType::CRM_PERCENTAGE, 0, 1);
+            gCrmOrch->getResAvailability(type, entry);
+            return entry.countersMap["STATS"].usedCounter;
+        }
+
+        void ApplySaiMock() override
+        {
+            INIT_SAI_API_MOCK(dash_vnet);
+            INIT_SAI_API_MOCK(dash_outbound_ca_to_pa);
+            INIT_SAI_API_MOCK(dash_pa_validation);
+            MockSaiApis();
+        }
+
+        void PostSetUp() override
+        {
+            // Do NOT create appliance — tests need to verify behavior without it
+        }
+        void PreTearDown() override
+        {
+            RestoreSaiApis();
+            DEINIT_SAI_API_MOCK(dash_outbound_ca_to_pa);
+            DEINIT_SAI_API_MOCK(dash_pa_validation);
+            DEINIT_SAI_API_MOCK(dash_vnet);
+        }
+    };
+
+    TEST_F(DashVnetOrchNoApplianceTest, CreateVnetMissingApplianceNotRetried)
+    {
+        EXPECT_CALL(*mock_sai_dash_vnet_api, create_vnets).Times(0);
+        dash::vnet::Vnet vnet = dash::vnet::Vnet();
+        vnet.set_vni(5555);
+        SetDashTable(APP_DASH_VNET_TABLE_NAME, "VNET_1", vnet, true, true);
+    }
+
+    TEST_F(DashVnetOrchTest, MissingProtobufVnet)
+    {
+        EXPECT_CALL(*mock_sai_dash_vnet_api, create_vnets).Times(0);
+        SetDashTableRaw(APP_DASH_VNET_TABLE_NAME, "VNET_TEST", {}, true, true);
+    }
+
+    TEST_F(DashVnetOrchTest, InvalidProtobufVnetMap)
+    {
+        EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries).Times(0);
+        CreateVnet();
+        SetDashTableRaw(APP_DASH_VNET_MAPPING_TABLE_NAME, vnet1 + ":1.2.3.4", {{ "pb", "garbage" }}, true, true);
+    }
+
+    TEST_F(DashVnetOrchTest, InvalidKeyVnetMap)
+    {
+        // Invalid keys should be caught per-item and consumed without throwing.
+        CreateVnet();
+        dash::vnet_mapping::VnetMapping vnet_map = dash::vnet_mapping::VnetMapping();
+        vnet_map.set_routing_type(dash::route_type::ROUTING_TYPE_VNET_ENCAP);
+        vnet_map.mutable_underlay_ip()->set_ipv4(swss::IpAddress("7.7.7.7").getV4Addr());
+        EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries).Times(0);
+        EXPECT_NO_THROW(
+            SetDashTable(APP_DASH_VNET_MAPPING_TABLE_NAME, vnet1 + ":not_an_ip", vnet_map, true, true));
+    }
+
+    TEST_F(DashVnetOrchTest, VnetMapKeyMissingIp)
+    {
+        // Key should be "vnet:ip" — send just vnet without IP
+        CreateVnet();
+        dash::vnet_mapping::VnetMapping vnet_map = dash::vnet_mapping::VnetMapping();
+        vnet_map.set_routing_type(dash::route_type::ROUTING_TYPE_VNET_ENCAP);
+        vnet_map.mutable_underlay_ip()->set_ipv4(swss::IpAddress("7.7.7.7").getV4Addr());
+        EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries).Times(0);
+        EXPECT_NO_THROW(
+            SetDashTable(APP_DASH_VNET_MAPPING_TABLE_NAME, vnet1, vnet_map, true, true));
+    }
+
+    TEST_F(DashVnetOrchTest, RemoveVnetSaiFailureWritesFailureResult)
+    {
+        // When SAI vnet remove returns an unrecoverable error code, the orch should
+        // not retry — the consumer entry is consumed and a failure result is recorded.
+        // Exercises lines 162-167 in dashvnetorch.cpp.
+        std::vector<sai_status_t> exp_status = {SAI_STATUS_INVALID_PARAMETER};
+        CreateVnet();
+        EXPECT_CALL(*mock_sai_dash_vnet_api, remove_vnets)
+            .Times(1)
+            .WillOnce(DoAll(SetArrayArgument<3>(exp_status.begin(), exp_status.end()), Return(SAI_STATUS_SUCCESS)));
+
+        RemoveVnet();
+        EXPECT_TRUE(DashResultExists(APP_DASH_VNET_TABLE_NAME, vnet1));
+    }
+
+    TEST_F(DashVnetOrchTest, VnetMapTunnelNotFoundConsumed)
+    {
+        // VnetMap entry references a tunnel that does not exist — addOutboundCaToPa
+        // should set pre_op_result to FAILURE and return true so the entry is consumed
+        // before reaching the bulker.  Covers lines 377-379 in dashvnetorch.cpp.
+        std::string key = vnet1 + ":" + vnet_map_ip1;
+
+        AddVnetEncapRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
+        CreateVnet();
+
+        dash::vnet_mapping::VnetMapping vnet_map = dash::vnet_mapping::VnetMapping();
+        vnet_map.set_routing_type(dash::route_type::ROUTING_TYPE_VNET_ENCAP);
+        vnet_map.mutable_underlay_ip()->set_ipv4(swss::IpAddress("7.7.7.7").getV4Addr());
+        vnet_map.set_tunnel("NONEXISTENT_TUNNEL");
+
+        EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries).Times(0);
+        SetDashTable(APP_DASH_VNET_MAPPING_TABLE_NAME, key, vnet_map, true, true);
+        EXPECT_EQ(GetDashResult(APP_DASH_VNET_MAPPING_TABLE_NAME, key), 1u);
+    }
+
+    TEST_F(DashVnetOrchTest, VnetMapInvalidEncapTypeConsumed)
+    {
+        // VnetMap with a routing type whose encap type is invalid (not VXLAN/NVGRE) —
+        // addOutboundCaToPa should set pre_op_result to FAILURE and return true.
+        // Covers the "Invalid encap type" path in addOutboundCaToPa.
+        std::string key = vnet1 + ":" + vnet_map_ip1;
+        AddVnetEncapRoutingType(dash::route_type::ENCAP_TYPE_UNSPECIFIED);
+        CreateVnet();
+
+        dash::vnet_mapping::VnetMapping vnet_map = dash::vnet_mapping::VnetMapping();
+        vnet_map.set_routing_type(dash::route_type::ROUTING_TYPE_VNET_ENCAP);
+        vnet_map.mutable_underlay_ip()->set_ipv4(swss::IpAddress("7.7.7.7").getV4Addr());
+
+        EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries).Times(0);
+        SetDashTable(APP_DASH_VNET_MAPPING_TABLE_NAME, key, vnet_map, true, true);
+        EXPECT_EQ(GetDashResult(APP_DASH_VNET_MAPPING_TABLE_NAME, key), 1u);
+    }
+
+    TEST_F(DashVnetOrchTest, VnetCreateDeleteChurn)
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            EXPECT_CALL(*mock_sai_dash_vnet_api, create_vnets).Times(1);
+            CreateVnet();
+
+            EXPECT_CALL(*mock_sai_dash_vnet_api, remove_vnets).Times(1);
+            RemoveVnet();
+        }
+    }
+
+    TEST_F(DashVnetOrchTest, VnetMapCreateDeleteChurn)
+    {
+        AddVnetEncapRoutingType(dash::route_type::ENCAP_TYPE_VXLAN);
+        CreateVnet();
+
+        // PA validation is per-VNET underlay IP, only created on first add
+        EXPECT_CALL(*mock_sai_dash_pa_validation_api, create_pa_validation_entries).Times(1);
+
+        for (int i = 0; i < 3; i++)
+        {
+            EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, create_outbound_ca_to_pa_entries).Times(1);
+            AddVnetMap();
+
+            EXPECT_CALL(*mock_sai_dash_outbound_ca_to_pa_api, remove_outbound_ca_to_pa_entries).Times(1);
+            RemoveVnetMap();
+        }
     }
 }

--- a/tests/mock_tests/mock_dash_orch_test.cpp
+++ b/tests/mock_tests/mock_dash_orch_test.cpp
@@ -6,6 +6,11 @@ namespace mock_orch_test
 
     void MockDashOrchTest::SetDashTable(std::string table_name, std::string key, const google::protobuf::Message &message, bool set, bool expect_empty)
     {
+        SetDashTableRaw(table_name, key, { { "pb", message.SerializeAsString() } }, set, expect_empty);
+    }
+
+    void MockDashOrchTest::SetDashTableRaw(std::string table_name, std::string key, const std::vector<swss::FieldValueTuple> &fvs, bool set, bool expect_empty)
+    {
         auto it = dash_table_orch_map.find(table_name);
         if (it == dash_table_orch_map.end())
         {
@@ -17,8 +22,7 @@ namespace mock_orch_test
             new swss::ConsumerStateTable(m_app_db.get(), table_name),
             target_orch, table_name);
         std::string op = set ? SET_COMMAND : DEL_COMMAND;
-        consumer->addToSync(
-            swss::KeyOpFieldsValuesTuple(key, op, { { "pb", message.SerializeAsString() } }));
+        consumer->addToSync(swss::KeyOpFieldsValuesTuple(key, op, fvs));
         target_orch->doTask(*consumer.get());
 
         auto it2 = consumer->m_toSync.begin();
@@ -101,12 +105,35 @@ namespace mock_orch_test
         SetDashTable(APP_DASH_ROUTE_TABLE_NAME, route_group1 + ":1.2.3.4/32", route, true, expect_empty);
     }
 
+    void MockDashOrchTest::RemoveOutboundRoutingEntry(bool expect_empty)
+    {
+        SetDashTable(APP_DASH_ROUTE_TABLE_NAME, route_group1 + ":1.2.3.4/32", dash::route::Route(), false, expect_empty);
+    }
+
+    void MockDashOrchTest::AddInboundRoutingEntry(bool expect_empty)
+    {
+        dash::route_rule::RouteRule rule = dash::route_rule::RouteRule();
+        rule.set_pa_validation(true);
+        rule.set_vnet(vnet1);
+        SetDashTable(APP_DASH_ROUTE_RULE_TABLE_NAME, eni1 + ":5555:10.0.0.0/24", rule, true, expect_empty);
+    }
+
+    void MockDashOrchTest::RemoveInboundRoutingEntry(bool expect_empty)
+    {
+        SetDashTable(APP_DASH_ROUTE_RULE_TABLE_NAME, eni1 + ":5555:10.0.0.0/24", dash::route_rule::RouteRule(), false, expect_empty);
+    }
+
     void MockDashOrchTest::AddTunnel()
     {
         dash::tunnel::Tunnel tunnel = dash::tunnel::Tunnel();
         tunnel.set_encap_type(dash::route_type::ENCAP_TYPE_VXLAN);
         tunnel.set_vni(5555);
         SetDashTable(APP_DASH_TUNNEL_TABLE_NAME, tunnel1, tunnel);
+    }
+
+    void MockDashOrchTest::RemoveTunnel()
+    {
+        SetDashTable(APP_DASH_TUNNEL_TABLE_NAME, tunnel1, dash::tunnel::Tunnel(), false);
     }
 
     void MockDashOrchTest::AddVnetMap(bool expect_empty)

--- a/tests/mock_tests/mock_dash_orch_test.h
+++ b/tests/mock_tests/mock_dash_orch_test.h
@@ -12,15 +12,20 @@ namespace mock_orch_test
                 {APP_DASH_VNET_MAPPING_TABLE_NAME, (Orch**) &m_dashVnetOrch},
                 {APP_DASH_APPLIANCE_TABLE_NAME, (Orch**) &m_DashOrch},
                 {APP_DASH_ROUTING_TYPE_TABLE_NAME, (Orch**) &m_DashOrch},
+                {APP_DASH_QOS_TABLE_NAME, (Orch**) &m_DashOrch},
                 {APP_DASH_ROUTE_GROUP_TABLE_NAME, (Orch**) &m_DashRouteOrch},
                 {APP_DASH_ROUTE_TABLE_NAME, (Orch**) &m_DashRouteOrch},
                 {APP_DASH_ROUTE_RULE_TABLE_NAME, (Orch**) &m_DashRouteOrch},
                 {APP_DASH_TUNNEL_TABLE_NAME, (Orch**) &m_DashTunnelOrch},
                 {APP_DASH_ENI_TABLE_NAME, (Orch**) &m_DashOrch},
+                {APP_DASH_ENI_ROUTE_TABLE_NAME, (Orch**) &m_DashOrch},
                 { APP_DASH_OUTBOUND_PORT_MAP_TABLE_NAME, (Orch **)&m_dashPortMapOrch },
-                { APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, (Orch **)&m_dashPortMapOrch }
+                { APP_DASH_OUTBOUND_PORT_MAP_RANGE_TABLE_NAME, (Orch **)&m_dashPortMapOrch },
+                { APP_DASH_METER_POLICY_TABLE_NAME, (Orch **)&m_DashMeterOrch },
+                { APP_DASH_METER_RULE_TABLE_NAME, (Orch **)&m_DashMeterOrch }
             };
             void SetDashTable(std::string table_name, std::string key, const google::protobuf::Message &message, bool set = true, bool expect_empty = true);
+            void SetDashTableRaw(std::string table_name, std::string key, const std::vector<swss::FieldValueTuple> &fvs, bool set = true, bool expect_empty = true);
             dash::appliance::Appliance BuildApplianceEntry();
             void CreateApplianceEntry();
             void AddVnetEncapRoutingType(dash::route_type::EncapType encap_type);
@@ -31,7 +36,11 @@ namespace mock_orch_test
             void RemoveVnetMap();
             void AddOutboundRoutingGroup();
             void AddOutboundRoutingEntry(bool expect_empty = true);
+            void RemoveOutboundRoutingEntry(bool expect_empty = true);
+            void AddInboundRoutingEntry(bool expect_empty = true);
+            void RemoveInboundRoutingEntry(bool expect_empty = true);
             void AddTunnel();
+            void RemoveTunnel();
             void AddVnetMapPL(bool expect_empty = true);
             void RemoveVnetMapPL(bool expect_empty = true);
             void AddPortMap();

--- a/tests/mock_tests/mock_sai_api.h
+++ b/tests/mock_tests/mock_sai_api.h
@@ -266,10 +266,11 @@ This is required since some sai_api do not support this function call yet.
 /* Helper macros to iterate over multiple sai_object_type inputs */
 #define FOR_EACH_1(action, api_name, x) action(api_name, x)
 #define FOR_EACH_2(action, api_name, x, ...) action(api_name, x) FOR_EACH_1(action, api_name, __VA_ARGS__)
+#define FOR_EACH_3(action, api_name, x, ...) action(api_name, x) FOR_EACH_2(action, api_name, __VA_ARGS__)
 
-#define GET_FOR_EACH_MACRO(_1, _2, NAME, ...) NAME
+#define GET_FOR_EACH_MACRO(_1, _2, _3, NAME, ...) NAME
 #define FOR_EACH(action, api_name, ...) \
-    GET_FOR_EACH_MACRO(__VA_ARGS__, FOR_EACH_2, FOR_EACH_1)(action, api_name, __VA_ARGS__)
+    GET_FOR_EACH_MACRO(__VA_ARGS__, FOR_EACH_3, FOR_EACH_2, FOR_EACH_1)(action, api_name, __VA_ARGS__)
 
 #define DEFINE_ON_CALL_DEFAULTS(sai_api_name, sai_object_type)                                                                 \
     ON_CALL(*this, create_##sai_object_type).WillByDefault([this](GENERIC_CREATE_PARAMS(sai_object_type)) {                    \


### PR DESCRIPTION
Cherry-pick from master PR sonic-net/sonic-swss#4566 to 202511 branch.

Remove all retry logic from DASH orchestrators so consumer notifications
are always consumed. Add correct failure reporting to DPU_APPL_STATE_DB,
partial failure cleanup for multi-SAI operations, per-item exception
handling, and idempotent handling for ITEM_ALREADY_EXISTS/ITEM_NOT_FOUND.

#### Changes per orchestrator
- `dashorch.cpp/.h`: Refactored Appliance/ENI creation into helper methods with partial-failure cleanup; pre-op result tracking via bulk context.
- `dashrouteorch`, `dashvnetorch`, `dashtunnelorch`, `dashmeterorch`, `dashportmaporch`: Removed retry logic; moved pre-op result into bulk context structs; treat `ITEM_ALREADY_EXISTS` / `ITEM_NOT_FOUND` as success (idempotent).
- `dashaclorch`, `dashaclgroupmgr`, `dashtagmgr`: Retry-removal cleanups.

#### Test coverage
- New test files: `dashmeterorch_ut.cpp`, `dashtunnelorch_ut.cpp`.
- Expanded coverage in `dashorch_ut.cpp`, `dashrouteorch_ut.cpp`, `dashvnetorch_ut.cpp`, `dashportmaporch_ut.cpp` covering prerequisite failures, SAI failure handling, partial-failure cleanup, per-item exceptions, churn patterns, malformed inputs, idempotent `ITEM_NOT_FOUND`/`ITEM_ALREADY_EXISTS`, unknown ops, and result-table assertions.
- Extended `mock_sai_api.h` to support 3-object generic SAI mocks.
- Added meter/portmap/QOS table mappings in `mock_dash_orch_test.h`.
- Added `AddInboundRoutingEntry`/`RemoveInboundRoutingEntry`/`RemoveOutboundRoutingEntry` test helpers in `mock_dash_orch_test.cpp/.h`.

Updates DASH VS tests to clean up configurations in the correct order.

All 245 mock DASH tests and 538 total mock tests pass.

#### What I did
```
git checkout -b remove-dash-retry-logic-202511 public/202511
git cherry-pick <squashed-commit-from-master-pr>
# resolved conflicts; ported infrastructure to 202511
```

#### Related PR
- master: sonic-net/sonic-swss#4566