### PR TITLE
Use STATE_DB to read and write SAI failure status

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -50,9 +50,7 @@ sai_object_id_t gUnderlayIfId;
 sai_object_id_t gSwitchId = SAI_NULL_OBJECT_ID;
 MacAddress gMacAddress;
 MacAddress gVxlanMacAddress;
-bool gOrchUnhealthy = false;
 extern volatile sig_atomic_t gOrchShutdownRequested;
-string gSaiErrorString;
 
 extern size_t gMaxBulkSize;
 
@@ -429,7 +427,6 @@ int main(int argc, char **argv)
 
     SWSS_LOG_ENTER();
 
-    gOrchUnhealthy = false;
     WarmStart::initialize("orchagent", "swss");
     WarmStart::checkWarmStart("orchagent", "swss");
 
@@ -608,6 +605,11 @@ int main(int argc, char **argv)
     );
     Recorder::Instance().sairedis.setLocation(record_location);
     Recorder::Instance().sairedis.setFileName(sairedis_rec_filename);
+
+    /* Initialize SAI failure health table before SAI init so all
+     * handleSaiFailure() paths can persist status to STATE_DB. */
+    initSaiFailureTable();
+    setSaiFailureStatus(false);
 
     /* Initialize sairedis */
     initSaiApi();

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -10,6 +10,7 @@
 #include "warm_restart.h"
 #include <iostream>
 #include "orch_zmq_config.h"
+#include "saihelper.h"
 
 #define SAI_SWITCH_ATTR_CUSTOM_RANGE_BASE SAI_SWITCH_ATTR_CUSTOM_RANGE_START
 #include "sairedis.h"
@@ -31,8 +32,6 @@ extern sai_switch_api_t*           sai_switch_api;
 extern sai_object_id_t             gSwitchId;
 extern string                      gMySwitchType;
 extern string                      gMySwitchSubType;
-extern bool                        gOrchUnhealthy;
-extern string                      gSaiErrorString;
 volatile sig_atomic_t              gOrchShutdownRequested = 0;
 
 extern void syncd_apply_view();
@@ -973,15 +972,6 @@ void OrchDaemon::start(long heartBeatInterval)
             break;
         }
 
-        /*
-         * Log an error message periodically if a previous SAI API call failed with
-         * an unrecoverable error.
-         */
-        if (gOrchUnhealthy)
-        {
-            SWSS_LOG_ERROR("%s", gSaiErrorString.c_str());
-        }
-
         auto tend = std::chrono::high_resolution_clock::now();
         heartBeat(tend, heartBeatInterval);
 
@@ -990,6 +980,16 @@ void OrchDaemon::start(long heartBeatInterval)
         if (diff.count() >= SELECT_TIMEOUT)
         {
             tstart = std::chrono::high_resolution_clock::now();
+
+            /*
+             * Log an error message periodically if a previous SAI API call failed with
+             * an unrecoverable error.
+             */
+            string orchHealthError;
+            if (getSaiFailureStatus(orchHealthError))
+            {
+                SWSS_LOG_ERROR("%s", orchHealthError.c_str());
+            }
 
             flush();
         }

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -13,7 +13,6 @@ extern "C" {
 #include <logger.h>
 #include <sairedis.h>
 #include <set>
-#include <atomic>
 #include <tuple>
 #include <vector>
 #include <linux/limits.h>
@@ -118,7 +117,7 @@ extern event_handle_t g_events_handle;
 
 unique_ptr<DBConnector> gHealthStateDb;
 unique_ptr<Table> gOrchHealthTable;
-std::atomic<bool> gOrchUnhealthyCached{false};
+bool gOrchUnhealthyCached = false;
 std::string gLastSaiError;
 
 vector<sai_object_id_t> gGearboxOids;

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -119,6 +119,7 @@ extern event_handle_t g_events_handle;
 unique_ptr<DBConnector> gHealthStateDb;
 unique_ptr<Table> gOrchHealthTable;
 std::atomic<bool> gOrchUnhealthyCached{false};
+std::string gLastSaiError;
 
 vector<sai_object_id_t> gGearboxOids;
 
@@ -1194,6 +1195,10 @@ void initSaiFailureTable()
 void setSaiFailureStatus(bool unhealthy, const std::string& error)
 {
     gOrchUnhealthyCached = unhealthy;
+    if (unhealthy && !error.empty())
+    {
+        gLastSaiError = error;
+    }
     if (!gOrchHealthTable)
     {
         return;
@@ -1222,7 +1227,7 @@ bool getSaiFailureStatus(std::string& error)
     }
     if (!gOrchHealthTable)
     {
-        error = "Orchagent is unhealthy (health table not initialized)";
+        error = gLastSaiError.empty() ? "Orchagent is unhealthy (health table not initialized)" : gLastSaiError;
         return true;
     }
     /* Fetch all fields in a single Redis round-trip */
@@ -1232,15 +1237,15 @@ bool getSaiFailureStatus(std::string& error)
         if (!gOrchHealthTable->get(PROCESS_HEALTH_KEY, fvs))
         {
             /* Key missing but cache says unhealthy — keep reporting unhealthy
-             * with a generic message rather than silently clearing. */
-            error = "Orchagent is unhealthy (STATE_DB key missing)";
+             * with the last known error rather than silently clearing. */
+            error = gLastSaiError.empty() ? "Orchagent is unhealthy (STATE_DB key missing)" : gLastSaiError;
             return true;
         }
     }
     catch (const std::exception& e)
     {
         SWSS_LOG_WARN("Failed to read health status from STATE_DB: %s", e.what());
-        error = "Orchagent is unhealthy (STATE_DB read failed)";
+        error = gLastSaiError.empty() ? "Orchagent is unhealthy (STATE_DB read failed)" : gLastSaiError;
         return true;
     }
     bool unhealthy = true;

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -13,6 +13,7 @@ extern "C" {
 #include <logger.h>
 #include <sairedis.h>
 #include <set>
+#include <atomic>
 #include <tuple>
 #include <vector>
 #include <linux/limits.h>
@@ -22,6 +23,8 @@ extern "C" {
 #include "sai_serialize.h"
 #include "saihelper.h"
 #include "orch.h"
+#include "dbconnector.h"
+#include "table.h"
 
 using namespace std;
 using namespace swss;
@@ -109,8 +112,13 @@ extern bool gTraditionalFlexCounter;
 extern bool gSyncMode;
 extern sai_redis_communication_mode_t gRedisCommunicationMode;
 extern event_handle_t g_events_handle;
-extern bool gOrchUnhealthy;
-extern string gSaiErrorString;
+
+#define STATE_PROCESS_HEALTH_TABLE_NAME "PROCESS_HEALTH"
+#define PROCESS_HEALTH_KEY "orchagent"
+
+unique_ptr<DBConnector> gHealthStateDb;
+unique_ptr<Table> gOrchHealthTable;
+std::atomic<bool> gOrchUnhealthyCached{false};
 
 vector<sai_object_id_t> gGearboxOids;
 
@@ -831,10 +839,10 @@ void handleSaiFailure(sai_api_t api, string oper, sai_status_t status, bool abor
 
     string s_api = sai_serialize_api(api);
     string s_status = sai_serialize_status(status);
-    gOrchUnhealthy = true;
-    gSaiErrorString = "Encountered failure in " + oper +
-                      " operation, SAI API: " + s_api + ", status: " + s_status;
-    SWSS_LOG_ERROR("%s", gSaiErrorString.c_str());
+    string errorString = "Encountered failure in " + oper +
+                         " operation, SAI API: " + s_api + ", status: " + s_status;
+    setSaiFailureStatus(true, errorString);
+    SWSS_LOG_ERROR("%s", errorString.c_str());
 
     // Publish a structured syslog event
     event_params_t params = {
@@ -1175,5 +1183,82 @@ std::vector<sai_stat_id_t> queryAvailableCounterStats(const sai_object_type_t ob
         stat_list.push_back(static_cast<sai_stat_id_t>(statenumlist[i]));
     }
     return stat_list;
+}
+
+void initSaiFailureTable()
+{
+    gHealthStateDb = make_unique<DBConnector>("STATE_DB", 0);
+    gOrchHealthTable = make_unique<Table>(gHealthStateDb.get(), STATE_PROCESS_HEALTH_TABLE_NAME);
+}
+
+void setSaiFailureStatus(bool unhealthy, const std::string& error)
+{
+    gOrchUnhealthyCached = unhealthy;
+    if (!gOrchHealthTable)
+    {
+        return;
+    }
+    try
+    {
+        vector<FieldValueTuple> fvs;
+        fvs.emplace_back("unhealthy", unhealthy ? "true" : "false");
+        fvs.emplace_back("error", error);
+        gOrchHealthTable->set(PROCESS_HEALTH_KEY, fvs);
+    }
+    catch (const std::exception& e)
+    {
+        SWSS_LOG_WARN("Failed to write health status to STATE_DB: %s", e.what());
+    }
+}
+
+bool getSaiFailureStatus(std::string& error)
+{
+    /* Fast path: when the local cache says healthy, skip Redis entirely.
+     * Only read STATE_DB when unhealthy, so an external reset
+     * (operator clearing the flag in Redis) is still detected. */
+    if (!gOrchUnhealthyCached)
+    {
+        return false;
+    }
+    if (!gOrchHealthTable)
+    {
+        error = "Orchagent is in unhealthy state (health table not initialized)";
+        return true;
+    }
+    /* Fetch all fields in a single Redis round-trip */
+    vector<FieldValueTuple> fvs;
+    try
+    {
+        if (!gOrchHealthTable->get(PROCESS_HEALTH_KEY, fvs))
+        {
+            /* Key missing but cache says unhealthy — keep reporting unhealthy
+             * with a generic message rather than silently clearing. */
+            error = "Orchagent is in unhealthy state (STATE_DB key missing)";
+            return true;
+        }
+    }
+    catch (const std::exception& e)
+    {
+        SWSS_LOG_WARN("Failed to read health status from STATE_DB: %s", e.what());
+        error = "Orchagent is in unhealthy state (STATE_DB read failed)";
+        return true;
+    }
+    bool unhealthy = false;
+    error = "";
+    for (const auto& fv : fvs)
+    {
+        if (fvField(fv) == "unhealthy")
+            unhealthy = (fvValue(fv) == "true");
+        else if (fvField(fv) == "error")
+            error = fvValue(fv);
+    }
+    if (!unhealthy)
+    {
+        /* External reset detected — update local cache */
+        gOrchUnhealthyCached = false;
+        error = "";
+        return false;
+    }
+    return true;
 }
 

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -1222,7 +1222,7 @@ bool getSaiFailureStatus(std::string& error)
     }
     if (!gOrchHealthTable)
     {
-        error = "Orchagent is in unhealthy state (health table not initialized)";
+        error = "Orchagent is unhealthy (health table not initialized)";
         return true;
     }
     /* Fetch all fields in a single Redis round-trip */
@@ -1233,18 +1233,18 @@ bool getSaiFailureStatus(std::string& error)
         {
             /* Key missing but cache says unhealthy — keep reporting unhealthy
              * with a generic message rather than silently clearing. */
-            error = "Orchagent is in unhealthy state (STATE_DB key missing)";
+            error = "Orchagent is unhealthy (STATE_DB key missing)";
             return true;
         }
     }
     catch (const std::exception& e)
     {
         SWSS_LOG_WARN("Failed to read health status from STATE_DB: %s", e.what());
-        error = "Orchagent is in unhealthy state (STATE_DB read failed)";
+        error = "Orchagent is unhealthy (STATE_DB read failed)";
         return true;
     }
-    bool unhealthy = false;
-    error = "";
+    bool unhealthy = true;
+    error = "Orchagent is unhealthy";
     for (const auto& fv : fvs)
     {
         if (fvField(fv) == "unhealthy")

--- a/orchagent/saihelper.h
+++ b/orchagent/saihelper.h
@@ -34,6 +34,10 @@ bool parseHandleSaiStatusFailure(task_process_status status);
 bool isSaiStatusResourceFull(sai_status_t status);
 void handleSaiFailure(sai_api_t api, std::string oper, sai_status_t status, bool abort_on_failure);
 
+void initSaiFailureTable();
+void setSaiFailureStatus(bool unhealthy, const std::string& error = "");
+bool getSaiFailureStatus(std::string& error);
+
 void setFlexCounterGroupParameter(const std::string &group,
                                   const std::string &poll_interval,
                                   const std::string &stats_mode,

--- a/tests/mock_tests/mock_orchagent_main.cpp
+++ b/tests/mock_tests/mock_orchagent_main.cpp
@@ -20,8 +20,6 @@ string gMyAsicName = "Asic0";
 bool gTraditionalFlexCounter = false;
 bool gSyncMode = false;
 sai_redis_communication_mode_t gRedisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC;
-bool gOrchUnhealthy = false;
-string gSaiErrorString;
 
 VRFOrch *gVrfOrch;
 
@@ -32,3 +30,7 @@ bool isChassisDbInUse()
 {
     return gMultiAsicVoq;
 }
+
+unique_ptr<DBConnector> gHealthStateDb;
+unique_ptr<Table> gOrchHealthTable;
+std::atomic<bool> gOrchUnhealthyCached{false};

--- a/tests/mock_tests/mock_orchagent_main.cpp
+++ b/tests/mock_tests/mock_orchagent_main.cpp
@@ -30,7 +30,3 @@ bool isChassisDbInUse()
 {
     return gMultiAsicVoq;
 }
-
-unique_ptr<DBConnector> gHealthStateDb;
-unique_ptr<Table> gOrchHealthTable;
-std::atomic<bool> gOrchUnhealthyCached{false};

--- a/tests/mock_tests/saihelper_ut.cpp
+++ b/tests/mock_tests/saihelper_ut.cpp
@@ -2,13 +2,12 @@
 #include "saihelper.h"
 #include "mock_table.h"
 
-#include <atomic>
 #include <memory>
 #include <sstream>
 
 extern std::unique_ptr<swss::DBConnector> gHealthStateDb;
 extern std::unique_ptr<swss::Table> gOrchHealthTable;
-extern std::atomic<bool> gOrchUnhealthyCached;
+extern bool gOrchUnhealthyCached;
 extern std::string gLastSaiError;
 
 namespace saihelper_test

--- a/tests/mock_tests/saihelper_ut.cpp
+++ b/tests/mock_tests/saihelper_ut.cpp
@@ -9,6 +9,7 @@
 extern std::unique_ptr<swss::DBConnector> gHealthStateDb;
 extern std::unique_ptr<swss::Table> gOrchHealthTable;
 extern std::atomic<bool> gOrchUnhealthyCached;
+extern std::string gLastSaiError;
 
 namespace saihelper_test
 {
@@ -94,12 +95,14 @@ namespace sai_failure_status_test
         void SetUp() override
         {
             testing_db::reset();
+            gLastSaiError.clear();
             initSaiFailureTable();
         }
 
         void TearDown() override
         {
             testing_db::reset();
+            gLastSaiError.clear();
         }
     };
 
@@ -175,10 +178,10 @@ namespace sai_failure_status_test
         // Delete the key from mock DB to simulate missing key
         testing_db::reset();
 
-        // getSaiFailureStatus should still report unhealthy
+        // getSaiFailureStatus should still report unhealthy with cached error
         std::string error;
         EXPECT_TRUE(getSaiFailureStatus(error));
-        EXPECT_EQ(error, "Orchagent is unhealthy (STATE_DB key missing)");
+        EXPECT_EQ(error, "SAI failure");
     }
 
     TEST_F(SaiFailureStatusTest, NullTableReturnsUnhealthy)
@@ -190,10 +193,10 @@ namespace sai_failure_status_test
         // Set cache to unhealthy (table is null, so DB write is skipped)
         setSaiFailureStatus(true, "SAI failure");
 
-        // getSaiFailureStatus should hit the null table guard
+        // getSaiFailureStatus should hit the null table guard with cached error
         std::string error;
         EXPECT_TRUE(getSaiFailureStatus(error));
-        EXPECT_EQ(error, "Orchagent is unhealthy (health table not initialized)");
+        EXPECT_EQ(error, "SAI failure");
 
         // Re-init for TearDown safety
         initSaiFailureTable();

--- a/tests/mock_tests/saihelper_ut.cpp
+++ b/tests/mock_tests/saihelper_ut.cpp
@@ -178,7 +178,7 @@ namespace sai_failure_status_test
         // getSaiFailureStatus should still report unhealthy
         std::string error;
         EXPECT_TRUE(getSaiFailureStatus(error));
-        EXPECT_EQ(error, "Orchagent is in unhealthy state (STATE_DB key missing)");
+        EXPECT_EQ(error, "Orchagent is unhealthy (STATE_DB key missing)");
     }
 
     TEST_F(SaiFailureStatusTest, NullTableReturnsUnhealthy)
@@ -193,7 +193,7 @@ namespace sai_failure_status_test
         // getSaiFailureStatus should hit the null table guard
         std::string error;
         EXPECT_TRUE(getSaiFailureStatus(error));
-        EXPECT_EQ(error, "Orchagent is in unhealthy state (health table not initialized)");
+        EXPECT_EQ(error, "Orchagent is unhealthy (health table not initialized)");
 
         // Re-init for TearDown safety
         initSaiFailureTable();

--- a/tests/mock_tests/saihelper_ut.cpp
+++ b/tests/mock_tests/saihelper_ut.cpp
@@ -1,7 +1,14 @@
 #include "ut_helper.h"
 #include "saihelper.h"
+#include "mock_table.h"
 
+#include <atomic>
+#include <memory>
 #include <sstream>
+
+extern std::unique_ptr<swss::DBConnector> gHealthStateDb;
+extern std::unique_ptr<swss::Table> gOrchHealthTable;
+extern std::atomic<bool> gOrchUnhealthyCached;
 
 namespace saihelper_test
 {
@@ -77,5 +84,118 @@ namespace saihelper_test
         EXPECT_EQ(SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC,
                   resolveCommunicationModeFromContextConfig(
                       iss, SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC));
+    }
+}
+
+namespace sai_failure_status_test
+{
+    struct SaiFailureStatusTest : public ::testing::Test
+    {
+        void SetUp() override
+        {
+            testing_db::reset();
+            initSaiFailureTable();
+        }
+
+        void TearDown() override
+        {
+            testing_db::reset();
+        }
+    };
+
+    TEST_F(SaiFailureStatusTest, InitiallyHealthy)
+    {
+        setSaiFailureStatus(false);
+        std::string error;
+        EXPECT_FALSE(getSaiFailureStatus(error));
+    }
+
+    TEST_F(SaiFailureStatusTest, SetUnhealthyReturnsTrueWithError)
+    {
+        std::string errorMsg = "Encountered failure in set operation, SAI API: SAI_API_SWITCH, status: -1";
+        setSaiFailureStatus(true, errorMsg);
+
+        std::string error;
+        EXPECT_TRUE(getSaiFailureStatus(error));
+        EXPECT_EQ(error, errorMsg);
+    }
+
+    TEST_F(SaiFailureStatusTest, ResetToHealthyAfterFailure)
+    {
+        setSaiFailureStatus(true, "some SAI error");
+
+        std::string error;
+        EXPECT_TRUE(getSaiFailureStatus(error));
+        EXPECT_EQ(error, "some SAI error");
+
+        // Reset
+        setSaiFailureStatus(false);
+        EXPECT_FALSE(getSaiFailureStatus(error));
+    }
+
+    TEST_F(SaiFailureStatusTest, ExternalResetDetected)
+    {
+        // Simulate a SAI failure
+        setSaiFailureStatus(true, "SAI failure");
+
+        std::string error;
+        EXPECT_TRUE(getSaiFailureStatus(error));
+
+        // Simulate an external operator clearing the flag in STATE_DB
+        // by writing "false" directly via the mock DB
+        swss::DBConnector db("STATE_DB", 0);
+        swss::Table tbl(&db, "PROCESS_HEALTH");
+        std::vector<swss::FieldValueTuple> fvs;
+        fvs.emplace_back("unhealthy", "false");
+        fvs.emplace_back("error", "");
+        tbl.set("orchagent", fvs);
+
+        // getSaiFailureStatus should detect the external reset
+        EXPECT_FALSE(getSaiFailureStatus(error));
+
+        // Subsequent calls should also return false (cache updated)
+        EXPECT_FALSE(getSaiFailureStatus(error));
+    }
+
+    TEST_F(SaiFailureStatusTest, MultipleFailuresOverwrite)
+    {
+        setSaiFailureStatus(true, "first error");
+        setSaiFailureStatus(true, "second error");
+
+        std::string error;
+        EXPECT_TRUE(getSaiFailureStatus(error));
+        EXPECT_EQ(error, "second error");
+    }
+
+    TEST_F(SaiFailureStatusTest, KeyMissingKeepsUnhealthy)
+    {
+        // Mark unhealthy so the cache is set
+        setSaiFailureStatus(true, "SAI failure");
+
+        // Delete the key from mock DB to simulate missing key
+        testing_db::reset();
+
+        // getSaiFailureStatus should still report unhealthy
+        std::string error;
+        EXPECT_TRUE(getSaiFailureStatus(error));
+        EXPECT_EQ(error, "Orchagent is in unhealthy state (STATE_DB key missing)");
+    }
+
+    TEST_F(SaiFailureStatusTest, NullTableReturnsUnhealthy)
+    {
+        // Null out the table directly
+        gOrchHealthTable.reset();
+        gHealthStateDb.reset();
+
+        // Set cache to unhealthy (table is null, so DB write is skipped)
+        setSaiFailureStatus(true, "SAI failure");
+
+        // getSaiFailureStatus should hit the null table guard
+        std::string error;
+        EXPECT_TRUE(getSaiFailureStatus(error));
+        EXPECT_EQ(error, "Orchagent is in unhealthy state (health table not initialized)");
+
+        // Re-init for TearDown safety
+        initSaiFailureTable();
     }
 }


### PR DESCRIPTION
**What I did**

Replaced the in-memory `gOrchUnhealthy` global boolean with a STATE_DB-backed health status table (`PROCESS_HEALTH`), enabling external reset of the orchagent unhealthy flag without restarting the process.

Changes:

- Removed `bool gOrchUnhealthy` global variable from main.cpp, orchdaemon.cpp, saihelper.cpp, and mock_orchagent_main.cpp
- Removed `string gSaiErrorString` global variable from main.cpp and mock_orchagent_main.cpp
- Added `PROCESS_HEALTH` table in STATE_DB with key orchagent and fields `unhealthy` ("true"/"false") and `error` (failure description)
- Added three non-static globals in saihelper.cpp: `gHealthStateDb`, `gOrchHealthTable`, `gOrchUnhealthyCached`
- Added three functions in saihelper.h/saihelper.cpp:
  - `initSaiFailureTable()` — creates the STATE_DB connection and table object
  - `setSaiFailureStatus()` — writes health status to STATE_DB and updates a local cache
  - `getSaiFailureStatus()` — returns cached status; only reads STATE_DB when unhealthy (to detect external resets)
- `handleSaiFailure()` calls `setSaiFailureStatus(true, errorString)` instead of setting global
- `OrchDaemon::start()` loop calls `getSaiFailureStatus()` inside the existing `SELECT_TIMEOUT` periodic block, throttling the check to ~1/second
- `main()` calls `initSaiFailureTable()` + `setSaiFailureStatus(false)` after option parsing, immediately before SAI initialization
- Added 7 mock tests for `initSaiFailureTable`/`setSaiFailureStatus`/`getSaiFailureStatus` round-trip, including external reset detection and null table guard

**Why I did it**

The `gOrchUnhealthy` flag had no reset path — once set by a non-fatal SAI failure, it stayed `true` forever, causing the orchdaemon loop to log the error every ~1 second until the process was restarted. Moving the flag to STATE_DB allows operators to clear it externally:

```
sonic-db-cli STATE_DB HSET "PROCESS_HEALTH|orchagent" "unhealthy" "false"
sonic-db-cli STATE_DB HSET "PROCESS_HEALTH|orchagent" "error" ""
```

This also makes orchagent health status observable by other SONiC components via standard DB subscriptions.

**How I verified it**

- Verified no remaining references to `gOrchUnhealthy` or `gSaiErrorString` in the codebase
- Confirmed `setSaiFailureStatus()` is only called on discrete events (startup and SAI failures), not in the polling loop
- Confirmed `getSaiFailureStatus()` uses a local cache (`gOrchUnhealthyCached`) so the healthy path incurs zero Redis I/O; the unhealthy path uses a single `HGETALL` (one Redis round-trip) to fetch both fields
- The health check in `OrchDaemon::start()` is inside the `SELECT_TIMEOUT` guard, so it runs at most once per second even when the select loop spins (e.g., after a SAI failure leaves `m_ready` non-empty)
- Health table initialization runs after option parsing, so `orchagent -h` does not require Redis
- Added 7 mock tests covering: initial healthy state, set/get unhealthy with error string, reset to healthy, external reset detection via STATE_DB, successive failure overwrites, STATE_DB key missing while cached unhealthy, and null health table guard path

**Details if related**

- STATE_DB table: `PROCESS_HEALTH|orchagent` with fields `unhealthy` and `error`
- Only `abort_on_failure=false` call sites in `handleSaiCreateStatus`, `handleSaiSetStatus`, `handleSaiRemoveStatus` leave orchagent running unhealthy — these are the paths that benefit from external reset
- Follows existing SONiC patterns (similar to `SWITCH_CAPABILITY` table in STATE_DB)
- No `sleep_for` or blocking calls added to the select loop (avoids the issue that caused PR [Fix orchagent 100% CPU spin when gOrchUnhealthy is set #4274](https://github.com/sonic-net/sonic-swss/pull/4274) to be reverted)

**Sample STATE_DB table:**
```
admin@sonic:~$ redis-cli -n 6
127.0.0.1:6379[6]> keys *HEALTH*
1) "PROCESS_HEALTH|orchagent"
2) "SYSTEM_HEALTH_INFO"
127.0.0.1:6379[6]> hgetall "PROCESS_HEALTH|orchagent"
1) "error"
2) "Encountered failure in create operation, SAI API: SAI_API_PORT, status: SAI_STATUS_INVALID_PARAMETER"
3) "unhealthy"
4) "true"
```