### PR TITLE
[DVS] Fix DVS code coverage by gracefully stopping DVS services during teardown

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -493,12 +493,9 @@ class DockerVirtualSwitch:
             return
         try:
             # Generate the gcda files
-            self.runcmd('killall5 -15')
+            self.stop_swss()
+            self.runcmd('supervisorctl stop all')
             time.sleep(1)
-
-            # Stop the services to reduce the CPU comsuption
-            if self.cleanup:
-                self.runcmd('supervisorctl stop all')
 
             # Generate the converage info by lcov and copy to the host
             cmd = f"docker exec {self.ctn.short_id} sh -c 'cd $BUILD_DIR; rm -rf **/.libs ./lib/libSaiRedis*; lcov -c --directory . --no-external --exclude tests --ignore-errors gcov,unused --output-file /tmp/coverage.info && lcov --add-tracefile /tmp/coverage.info -o /tmp/coverage.info; sed -i \"s#SF:$BUILD_DIR/#SF:#\" /tmp/coverage.info; lcov_cobertura /tmp/coverage.info -o /tmp/coverage.xml'"
@@ -1967,7 +1964,8 @@ def manage_dvs(request) -> str:
 
         else:
             # First generate GCDA files for GCov
-            dvs.runcmd('killall5 -15')
+            dvs.stop_swss()
+            dvs.runcmd("supervisorctl stop all")
             # If not re-creating the DVS, restart container
             # between modules to ensure a consistent start state
             dvs.net_cleanup()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -498,7 +498,7 @@ class DockerVirtualSwitch:
             time.sleep(1)
 
             # Generate the converage info by lcov and copy to the host
-            cmd = f"docker exec {self.ctn.short_id} sh -c 'cd $BUILD_DIR; rm -rf **/.libs ./lib/libSaiRedis*; lcov -c --directory . --no-external --exclude tests --ignore-errors gcov,unused --output-file /tmp/coverage.info && lcov --add-tracefile /tmp/coverage.info -o /tmp/coverage.info; sed -i \"s#SF:$BUILD_DIR/#SF:#\" /tmp/coverage.info; lcov_cobertura /tmp/coverage.info -o /tmp/coverage.xml'"
+            cmd = f"docker exec {self.ctn.short_id} sh -c 'cd $BUILD_DIR; rm -rf **/.libs ./lib/libSaiRedis*; lcov --demangle-cpp -c --directory . --no-external --exclude tests --ignore-errors gcov,unused --output-file /tmp/coverage.info && lcov --add-tracefile /tmp/coverage.info -o /tmp/coverage.info; sed -i \"s#SF:$BUILD_DIR/#SF:#\" /tmp/coverage.info; lcov_cobertura /tmp/coverage.info -o /tmp/coverage.xml'"
             subprocess.getstatusoutput(cmd)
             cmd = f"docker exec {self.ctn.short_id} sh -c 'cd $BUILD_DIR; find . -name *.gcda -type f   -exec tar -rf /tmp/gcda.tar {{}} \\;'"
             subprocess.getstatusoutput(cmd)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When tearing down DVS tests, instead of using `killall5 -15` to stop services in the DVS and generate the `.gcda` files needed to measure code coverage, use `dvs.stop_swss()` and `supervisorctl stop all` instead to ensure graceful shutdown of orchagent and other services.

**Why I did it**
VS tests rely on sending `SIGTERM` to processes in the DVS container to generate `.gcda` files containing code coverage information. https://github.com/sonic-net/sonic-swss/pull/4400 introduced graceful `SIGTERM` handling in orchagent which calls the `OrchDaemon` destructor which subsequently calls the destructors of each orch. Some of these destructors are dependent on other services (e.g. syncd). When the test session runs `killall5 -15`, it may kill other services (e.g. syncd) before the orch destructors finish running, causing orchagent to crash with `SIGABRT` and preventing the `.gcda` files from being generated.

We can see that prior to the above PR being merged, overall code coverage was around 77% (https://dev.azure.com/mssonic/build/_build/results?buildId=1098386&view=codecoverage-tab). In the first successful pipeline run after the PR is merged, code coverage dropped to 55% (https://dev.azure.com/mssonic/build/_build/results?buildId=1100825&view=codecoverage-tab) which can be explained by the VS tests no longer providing coverage information for orchagent.

**How I verified it**
Total code coverage with this PR is 76%, much closer to the original coverage rate:
<img width="1110" height="502" alt="image" src="https://github.com/user-attachments/assets/6499120e-1d0b-4b25-bc31-8bd27d44efb7" />
https://dev.azure.com/mssonic/build/_build/results?buildId=1128255&view=codecoverage-tab

The difference is likely due to changes in coverage that were merged after #4400 broke VS test coverage calculation.

**Details if related**
