### PR TITLE
[orchagent][fpmsyncd]: Consolidate route performance knobs to SYSTEM_DEFAULTS

### DIFF
--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -151,8 +151,8 @@ static decltype(auto) makeNlAddr(const T& ip)
 
 
 RouteSync::RouteSync(RedisPipeline *pipeline) :
-    // When the feature ORCH_NORTHBOND_ROUTE_ZMQ_ENABLED is enabled, route events must be sent to orchagent via the ZMQ channel.
-    m_zmqClient(create_local_zmq_client(ORCH_NORTHBOND_ROUTE_ZMQ_ENABLED, false)),
+    // When route_performance zmq is enabled, route events must be sent to orchagent via the ZMQ channel.
+    m_zmqClient(create_route_perf_zmq_client()),
     m_routeTable(createProducerStateTable(pipeline, APP_ROUTE_TABLE_NAME, true, m_zmqClient)),
     m_nexthop_groupTable(pipeline, APP_NEXTHOP_GROUP_TABLE_NAME, true),
     m_label_routeTable(createProducerStateTable(pipeline, APP_LABEL_ROUTE_TABLE_NAME, true, m_zmqClient)),

--- a/lib/orch_zmq_config.cpp
+++ b/lib/orch_zmq_config.cpp
@@ -103,6 +103,42 @@ bool swss::get_feature_status(std::string feature, bool default_value)
     return *enabled == "true";
 }
 
+bool swss::get_route_perf_zmq_enabled()
+{
+    std::shared_ptr<std::string> value = nullptr;
+
+    try
+    {
+        swss::DBConnector config_db("CONFIG_DB", 0);
+        value = config_db.hget(SYSTEM_DEFAULTS_SWSS_ZMQ_KEY, SYSTEM_DEFAULTS_STATUS_FIELD);
+    }
+    catch (const std::runtime_error &e)
+    {
+        SWSS_LOG_ERROR("Failed to read swss_zmq status: %s", e.what());
+        return false;
+    }
+
+    if (!value)
+    {
+        SWSS_LOG_NOTICE("swss_zmq status not found, default disabled.");
+        return false;
+    }
+
+    SWSS_LOG_NOTICE("swss_zmq status: %s", value->c_str());
+    return *value == "enabled";
+}
+
+std::shared_ptr<swss::ZmqClient> swss::create_route_perf_zmq_client()
+{
+    if (get_route_perf_zmq_enabled())
+    {
+        SWSS_LOG_NOTICE("Route perf ZMQ enabled, creating local ZMQ client");
+        return create_zmq_client(ZMQ_LOCAL_ADDRESS);
+    }
+
+    return nullptr;
+}
+
 std::shared_ptr<swss::ZmqClient> swss::create_local_zmq_client(std::string feature, bool default_value)
 {
     auto enable = get_feature_status(feature, default_value);

--- a/lib/orch_zmq_config.h
+++ b/lib/orch_zmq_config.h
@@ -21,9 +21,10 @@
 #define ORCH_NORTHBOND_DASH_ZMQ_ENABLED "orch_northbond_dash_zmq_enabled"
 
 /*
- * Feature flag to enable the fpmsyncd to send ROUTE events to orchagent via the ZMQ channel.
+ * Route performance knob in SYSTEM_DEFAULTS table.
  */
-#define ORCH_NORTHBOND_ROUTE_ZMQ_ENABLED "orch_northbond_route_zmq_enabled"
+#define SYSTEM_DEFAULTS_SWSS_ZMQ_KEY    "SYSTEM_DEFAULTS|swss_zmq"
+#define SYSTEM_DEFAULTS_STATUS_FIELD    "status"
 
 namespace swss {
 
@@ -36,6 +37,10 @@ std::shared_ptr<ZmqClient> create_zmq_client(std::string zmq_address, std::strin
 std::shared_ptr<ZmqServer> create_zmq_server(std::string zmq_address, std::string vrf="");
 
 bool get_feature_status(std::string feature, bool default_value);
+
+bool get_route_perf_zmq_enabled();
+
+std::shared_ptr<swss::ZmqClient> create_route_perf_zmq_client();
 
 std::shared_ptr<swss::ZmqClient> create_local_zmq_client(std::string feature, bool default_value);
 

--- a/orchagent/fgnhgorch.cpp
+++ b/orchagent/fgnhgorch.cpp
@@ -24,7 +24,7 @@ extern PortsOrch *gPortsOrch;
 
 FgNhgOrch::FgNhgOrch(DBConnector *db, DBConnector *appDb, DBConnector *stateDb, vector<table_name_with_pri_t> &tableNames, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch) :
         Orch(db, tableNames),
-        m_zmqClient(create_local_zmq_client(ORCH_NORTHBOND_ROUTE_ZMQ_ENABLED, false)),
+        m_zmqClient(create_route_perf_zmq_client()),
         m_neighOrch(neighOrch),
         m_intfsOrch(intfsOrch),
         m_vrfOrch(vrfOrch),

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -340,10 +340,10 @@ bool OrchDaemon::init()
     };
 
     // Enable the fpmsyncd service to send Route events to orchagent via the ZMQ channel.
-    auto enable_route_zmq = get_feature_status(ORCH_NORTHBOND_ROUTE_ZMQ_ENABLED, false);
-    auto route_zmq_sever = enable_route_zmq ? m_zmqServer : nullptr;
+    auto enable_route_zmq = get_route_perf_zmq_enabled();
+    auto route_zmq_server = enable_route_zmq ? m_zmqServer : nullptr;
 
-    gRouteOrch = new RouteOrch(m_applDb, route_tables, gSwitchOrch, gNeighOrch, gIntfsOrch, vrf_orch, gFgNhgOrch, gSrv6Orch, route_zmq_sever);
+    gRouteOrch = new RouteOrch(m_applDb, route_tables, gSwitchOrch, gNeighOrch, gIntfsOrch, vrf_orch, gFgNhgOrch, gSrv6Orch, route_zmq_server);
     gNhgOrch = new NhgOrch(m_applDb, APP_NEXTHOP_GROUP_TABLE_NAME);
     gCbfNhgOrch = new CbfNhgOrch(m_applDb, APP_CLASS_BASED_NEXT_HOP_GROUP_TABLE_NAME);
 

--- a/orchagent/routeresync.cpp
+++ b/orchagent/routeresync.cpp
@@ -21,8 +21,8 @@ int main(int argc, char **argv)
     SWSS_LOG_ENTER();
     DBConnector db("APPL_DB", 0);
 
-    // When the feature ORCH_NORTHBOND_ROUTE_ZMQ_ENABLED is enabled, route events must be sent to orchagent via the ZMQ channel.
-    std::shared_ptr<ZmqClient> zmqClient = create_local_zmq_client(ORCH_NORTHBOND_ROUTE_ZMQ_ENABLED, false);
+    // When route_performance zmq is enabled, route events must be sent to orchagent via the ZMQ channel.
+    std::shared_ptr<ZmqClient> zmqClient = create_route_perf_zmq_client();
     std::shared_ptr<ProducerStateTable> r = createProducerStateTable(&db, APP_ROUTE_TABLE_NAME, zmqClient);
 
     if (argc != 2)

--- a/tests/mock_tests/zmq_orch_ut.cpp
+++ b/tests/mock_tests/zmq_orch_ut.cpp
@@ -180,3 +180,40 @@ TEST(ZmqOrchTest, GetFeatureStatusException)
     enabled = swss::get_feature_status(HGET_THROW_EXCEPTION_FIELD_NAME, false);
     EXPECT_FALSE(enabled);
 }
+
+TEST(ZmqOrchTest, GetRoutePerfZmqEnabled)
+{
+    DBConnector config_db("CONFIG_DB", 0);
+
+    // Test: enabled
+    config_db.hset(SYSTEM_DEFAULTS_SWSS_ZMQ_KEY, SYSTEM_DEFAULTS_STATUS_FIELD, "enabled");
+    EXPECT_TRUE(swss::get_route_perf_zmq_enabled());
+
+    // Test: disabled
+    config_db.hset(SYSTEM_DEFAULTS_SWSS_ZMQ_KEY, SYSTEM_DEFAULTS_STATUS_FIELD, "disabled");
+    EXPECT_FALSE(swss::get_route_perf_zmq_enabled());
+
+    // Test: missing key → default false
+    config_db.del(SYSTEM_DEFAULTS_SWSS_ZMQ_KEY);
+    EXPECT_FALSE(swss::get_route_perf_zmq_enabled());
+}
+
+TEST(ZmqOrchTest, CreateRoutePerfZmqClient)
+{
+    DBConnector config_db("CONFIG_DB", 0);
+
+    // When enabled: returns a non-null ZmqClient
+    config_db.hset(SYSTEM_DEFAULTS_SWSS_ZMQ_KEY, SYSTEM_DEFAULTS_STATUS_FIELD, "enabled");
+    auto client = swss::create_route_perf_zmq_client();
+    EXPECT_NE(client, nullptr);
+
+    // When disabled: returns nullptr
+    config_db.hset(SYSTEM_DEFAULTS_SWSS_ZMQ_KEY, SYSTEM_DEFAULTS_STATUS_FIELD, "disabled");
+    client = swss::create_route_perf_zmq_client();
+    EXPECT_EQ(client, nullptr);
+
+    // When key missing: returns nullptr
+    config_db.del(SYSTEM_DEFAULTS_SWSS_ZMQ_KEY);
+    client = swss::create_route_perf_zmq_client();
+    EXPECT_EQ(client, nullptr);
+}


### PR DESCRIPTION
**What I did**

Consolidated route performance knobs from `DEVICE_METADATA|localhost` into flat `SYSTEM_DEFAULTS` entries:

- `SYSTEM_DEFAULTS|swss_zmq` (status: enabled/disabled) — ZMQ communication
- `SYSTEM_DEFAULTS|async_rec` (status: enabled/disabled) — async APPL_STATE_DB recording

Replaced per-feature CONFIG_DB reads with two centralized helper functions:
- `get_route_perf_zmq_enabled()` — reads `SYSTEM_DEFAULTS|swss_zmq` status
- `create_route_perf_zmq_client()` — creates ZMQ client when swss_zmq is enabled

**Why I did it**

The existing 4 knobs (`async_swss_rec`, `route_state_async_publish`, `orch_northbond_route_zmq_enabled`, `orch_southbound_zmq_enabled`) were scattered across DEVICE_METADATA and each read independently. This consolidation:
1. Reduces 4 knobs to 2 (northbound/southbound ZMQ → unified `swss_zmq`)
2. Follows the standard `SYSTEM_DEFAULTS_LIST` pattern (key=name, leaf=status)
3. Centralizes CONFIG_DB reads into a reusable helper library (`lib/orch_zmq_config`)

**How I did it**

- Added `lib/orch_zmq_config.h` and `lib/orch_zmq_config.cpp` with:
  - Macros for key/field names (`SYSTEM_DEFAULTS_SWSS_ZMQ_KEY`, `SYSTEM_DEFAULTS_ASYNC_REC_KEY`, `SYSTEM_DEFAULTS_STATUS_FIELD`)
  - `get_route_perf_zmq_enabled()` and `create_route_perf_zmq_client()` functions
- Updated `orchagent/orchdaemon.cpp` to use centralized helpers
- Updated `orchagent/main.cpp` to use centralized helpers
- Removed dead `ORCH_NORTHBOND_ROUTE_ZMQ_ENABLED` macro from `orchagent/orchdaemon.h`
- Added unit tests in `tests/mock_tests/zmq_orch_ut.cpp`

**How to verify it**

Unit tests:
```
cd tests/mock_tests && make tests && ./tests --gtest_filter="ZmqOrchTest.*"
```

Integration (on KVM testbed with VS image):
```
sonic-db-cli CONFIG_DB hset "SYSTEM_DEFAULTS|swss_zmq" status enabled
config save -y && config reload -y
ps aux | grep orchagent  # should show -z zmq_sync
```

**Merge order**: This PR and sonic-sairedis #1922 merge first. Then sonic-buildimage #27674 bumps submodules.

Companion PRs:
- sonic-buildimage: https://github.com/sonic-net/sonic-buildimage/pull/27674
- sonic-sairedis: https://github.com/sonic-net/sonic-sairedis/pull/1922
- sonic-net/SONiC (doc): https://github.com/sonic-net/SONiC/pull/2359

