### PR TITLE
Fix multi-asic VoQ entries being silently dropped

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -39,7 +39,7 @@ extern string gMySwitchType;
 extern int32_t gVoqMySwitchId;
 extern RouteOrch *gRouteOrch;
 extern bool gTraditionalFlexCounter;
-extern bool isChassisDbInUse();
+extern bool isVoqChassisDbInUse();
 
 const int IntfsOrch::intfsorch_pri = 35;
 
@@ -100,7 +100,7 @@ IntfsOrch::IntfsOrch(DBConnector *db, vector<table_name_with_pri_t> tableNames, 
                                  RIF_PLUGIN_FIELD,
                                  rifRateSha);
 
-    if(isChassisDbInUse())
+    if(isVoqChassisDbInUse())
     {
         //Add subscriber to process VOQ system interface
         string tableName = CHASSIS_APP_SYSTEM_INTERFACE_TABLE_NAME;
@@ -109,6 +109,7 @@ IntfsOrch::IntfsOrch(DBConnector *db, vector<table_name_with_pri_t> tableNames, 
     }
 
 }
+
 
 sai_object_id_t IntfsOrch::getRouterIntfsId(const string &alias)
 {
@@ -1504,7 +1505,7 @@ bool IntfsOrch::addRouterIntfs(sai_object_id_t vrf_id, Port &port, string loopba
 
     SWSS_LOG_NOTICE("Create router interface %s MTU %u", port.m_alias.c_str(), port.m_mtu);
 
-    if(isChassisDbInUse())
+    if(isVoqChassisDbInUse())
     {
         // Sync the interface of local port/LAG to the SYSTEM_INTERFACE table of CHASSIS_APP_DB
         voqSyncAddIntf(port.m_alias);
@@ -1557,7 +1558,7 @@ bool IntfsOrch::removeRouterIntfs(Port &port)
 
     SWSS_LOG_NOTICE("Remove router interface for port %s", port.m_alias.c_str());
 
-    if(isChassisDbInUse())
+    if(isVoqChassisDbInUse())
     {
         // Sync the removal of interface of local port/LAG to the SYSTEM_INTERFACE table of CHASSIS_APP_DB
         voqSyncDelIntf(port.m_alias);
@@ -1972,4 +1973,3 @@ void IntfsOrch::voqSyncIntfState(string &alias, bool isUp)
     }
 
 }
-

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -84,7 +84,7 @@ bool gRouteStateAsyncPublish = false;
 uint32_t create_switch_timeout = 0;
 bool gMultiAsicVoq = false;
 
-bool isChassisDbInUse()
+bool isVoqChassisDbInUse()
 {
     return gMultiAsicVoq;
 }

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -24,6 +24,8 @@ extern int32_t gVoqMySwitchId;
 extern BfdOrch *gBfdOrch;
 extern size_t gMaxBulkSize;
 extern string gMyHostName;
+extern string gMyAsicName;
+extern bool gMultiAsicVoq;
 
 extern bool isChassisDbInUse();
 
@@ -2247,11 +2249,29 @@ void NeighOrch::doVoqSystemNeighTask(Consumer &consumer)
 
         string alias = key.substr(0, found);
 
-        size_t pos = alias.find('|');
-        std::string port_hostname = (pos != std::string::npos) ? alias.substr(0, pos) : alias;
-        if(gIntfsOrch->isLocalSystemPortIntf(alias))
+        // Multi-ASIC VoQ aliases use <hostname>|<asic>|<local-alias>.
+        const auto alias_tokens = tokenize(alias, '|');
+        std::string port_hostname = alias_tokens.empty() ? alias : alias_tokens[0];
+        bool is_local_by_host_asic = false;
+        if (gMySwitchType == "voq" && gMyHostName == port_hostname)
         {
-            //Synced local neighbor. Skip
+            if (!gMultiAsicVoq)
+            {
+                is_local_by_host_asic = true;
+            }
+            else
+            {
+                std::string port_asic = alias_tokens.size() > 1 ? alias_tokens[1] : "";
+                SWSS_LOG_DEBUG("doVoqSystemNeighTask: alias=%s hostname=%s asic=%s local_asic=%s",
+                               alias.c_str(), port_hostname.c_str(), port_asic.c_str(), gMyAsicName.c_str());
+                is_local_by_host_asic = (port_asic == gMyAsicName);
+            }
+        }
+        bool is_local_intf = gIntfsOrch->isLocalSystemPortIntf(alias);
+        if(is_local_intf || is_local_by_host_asic)
+        {
+            SWSS_LOG_DEBUG("doVoqSystemNeighTask: skipping local neighbor %s (isLocalIntf=%d isLocalByHostAsic=%d)",
+                           alias.c_str(), is_local_intf, is_local_by_host_asic);
             it = consumer.m_toSync.erase(it);
             continue;
         }

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -27,7 +27,6 @@ extern BfdOrch *gBfdOrch;
 extern size_t gMaxBulkSize;
 extern string gMyHostName;
 extern string gMyAsicName;
-extern bool gMultiAsicVoq;
 
 extern bool isChassisDbInUse();
 
@@ -2251,27 +2250,20 @@ void NeighOrch::doVoqSystemNeighTask(Consumer &consumer)
 
         string alias = key.substr(0, found);
 
-        // Multi-ASIC VoQ aliases use <hostname>|<asic>|<local-alias>.
+        // VoQ aliases can include <hostname>|<asic>|<local-alias> even without chassis DB.
         const auto alias_tokens = tokenize(alias, '|');
         std::string port_hostname = alias_tokens.empty() ? alias : alias_tokens[0];
         bool is_local_by_host_asic = false;
-        if (gMySwitchType == "voq" && gMyHostName == port_hostname)
+        if (gMySwitchType == "voq" && isChassisDbInUse() && gMyHostName == port_hostname)
         {
-            if (!gMultiAsicVoq)
-            {
-                is_local_by_host_asic = true;
-            }
-            else
-            {
-                std::string port_asic = alias_tokens.size() > 1 ? alias_tokens[1] : "";
-                std::string lower_port_asic = port_asic;
-                std::string lower_my_asic = gMyAsicName;
-                boost::algorithm::to_lower(lower_port_asic);
-                boost::algorithm::to_lower(lower_my_asic);
-                SWSS_LOG_DEBUG("doVoqSystemNeighTask: alias=%s hostname=%s asic=%s local_asic=%s",
-                               alias.c_str(), port_hostname.c_str(), port_asic.c_str(), gMyAsicName.c_str());
-                is_local_by_host_asic = (lower_port_asic == lower_my_asic);
-            }
+            std::string port_asic = alias_tokens.size() > 1 ? alias_tokens[1] : "";
+            std::string lower_port_asic = port_asic;
+            std::string lower_my_asic = gMyAsicName;
+            boost::algorithm::to_lower(lower_port_asic);
+            boost::algorithm::to_lower(lower_my_asic);
+            SWSS_LOG_DEBUG("doVoqSystemNeighTask: alias=%s hostname=%s asic=%s local_asic=%s",
+                           alias.c_str(), port_hostname.c_str(), port_asic.c_str(), gMyAsicName.c_str());
+            is_local_by_host_asic = (lower_port_asic == lower_my_asic);
         }
         bool is_local_intf = gIntfsOrch->isLocalSystemPortIntf(alias);
         if(is_local_intf || is_local_by_host_asic)

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -28,7 +28,7 @@ extern size_t gMaxBulkSize;
 extern string gMyHostName;
 extern string gMyAsicName;
 
-extern bool isChassisDbInUse();
+extern bool isVoqChassisDbInUse();
 
 const int neighorch_pri = 30;
 
@@ -51,7 +51,7 @@ NeighOrch::NeighOrch(DBConnector *appDb, string tableName, IntfsOrch *intfsOrch,
         gBfdOrch->attach(this);
     }
 
-    if(isChassisDbInUse())
+    if(isVoqChassisDbInUse())
     {
         //Add subscriber to process VOQ system neigh
         tableName = CHASSIS_APP_SYSTEM_NEIGH_TABLE_NAME;
@@ -1592,7 +1592,7 @@ bool NeighOrch::addNeighbor(NeighborContext& ctx)
     NeighborUpdate update = { neighborEntry, macAddress, true };
     notify(SUBJECT_TYPE_NEIGH_CHANGE, static_cast<void *>(&update));
 
-    if(isChassisDbInUse())
+    if(isVoqChassisDbInUse())
     {
         //Sync the neighbor to add to the CHASSIS_APP_DB
         voqSyncAddNeigh(alias, ip_address, macAddress, neighbor_entry);
@@ -1765,7 +1765,7 @@ bool NeighOrch::removeNeighbor(NeighborContext& ctx, bool disable)
     NeighborUpdate update = { neighborEntry, MacAddress(), false };
     notify(SUBJECT_TYPE_NEIGH_CHANGE, static_cast<void *>(&update));
 
-    if(isChassisDbInUse())
+    if(isVoqChassisDbInUse())
     {
         //Sync the neighbor to delete from the CHASSIS_APP_DB
         voqSyncDelNeigh(alias, ip_address);
@@ -2254,7 +2254,7 @@ void NeighOrch::doVoqSystemNeighTask(Consumer &consumer)
         const auto alias_tokens = tokenize(alias, '|');
         std::string port_hostname = alias_tokens.empty() ? alias : alias_tokens[0];
         bool is_local_by_host_asic = false;
-        if (gMySwitchType == "voq" && isChassisDbInUse() && gMyHostName == port_hostname)
+        if (isVoqChassisDbInUse() && gMyHostName == port_hostname)
         {
             std::string port_asic = alias_tokens.size() > 1 ? alias_tokens[1] : "";
             std::string lower_port_asic = port_asic;

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -9,6 +9,8 @@
 #include "subscriberstatetable.h"
 #include "nhgorch.h"
 
+#include <boost/algorithm/string.hpp>
+
 extern sai_neighbor_api_t*         sai_neighbor_api;
 extern sai_next_hop_api_t*         sai_next_hop_api;
 
@@ -2262,9 +2264,13 @@ void NeighOrch::doVoqSystemNeighTask(Consumer &consumer)
             else
             {
                 std::string port_asic = alias_tokens.size() > 1 ? alias_tokens[1] : "";
+                std::string lower_port_asic = port_asic;
+                std::string lower_my_asic = gMyAsicName;
+                boost::algorithm::to_lower(lower_port_asic);
+                boost::algorithm::to_lower(lower_my_asic);
                 SWSS_LOG_DEBUG("doVoqSystemNeighTask: alias=%s hostname=%s asic=%s local_asic=%s",
                                alias.c_str(), port_hostname.c_str(), port_asic.c_str(), gMyAsicName.c_str());
-                is_local_by_host_asic = (port_asic == gMyAsicName);
+                is_local_by_host_asic = (lower_port_asic == lower_my_asic);
             }
         }
         bool is_local_intf = gIntfsOrch->isLocalSystemPortIntf(alias);

--- a/orchagent/p4orch/tests/test_main.cpp
+++ b/orchagent/p4orch/tests/test_main.cpp
@@ -42,7 +42,7 @@ string gMySwitchType = "switch";
 event_handle_t g_events_handle;
 
 bool gMultiAsicVoq = false;
-bool isChassisDbInUse()
+bool isVoqChassisDbInUse()
 {
     return gMultiAsicVoq;
 }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -6426,12 +6426,26 @@ void PortsOrch::doLagMemberTask(Consumer &consumer)
         {
             if (gMySwitchType == "voq")
             {
-                size_t pos = lag_alias.find('|');
-                std::string port_hostname = (pos != std::string::npos) ? lag_alias.substr(0, pos) : lag_alias;
+                // Multi-ASIC VoQ aliases use <hostname>|<asic>|<local-alias>.
+                const auto alias_tokens = tokenize(lag_alias, '|');
+                std::string port_hostname = alias_tokens.empty() ? lag_alias : alias_tokens[0];
                 if (gMyHostName == port_hostname)
                 {
-                    it = consumer.m_toSync.erase(it);
-                    continue;
+                    if (!gMultiAsicVoq)
+                    {
+                        SWSS_LOG_DEBUG("doLagMemberTask: erasing local entry %s (single-asic voq)", lag_alias.c_str());
+                        it = consumer.m_toSync.erase(it);
+                        continue;
+                    }
+                    std::string port_asic = alias_tokens.size() > 1 ? alias_tokens[1] : "";
+                    SWSS_LOG_DEBUG("doLagMemberTask: lag_alias=%s hostname=%s asic=%s local_asic=%s",
+                                   lag_alias.c_str(), port_hostname.c_str(), port_asic.c_str(), gMyAsicName.c_str());
+                    if (port_asic == gMyAsicName)
+                    {
+                        SWSS_LOG_DEBUG("doLagMemberTask: erasing local entry %s (same host and asic)", lag_alias.c_str());
+                        it = consumer.m_toSync.erase(it);
+                        continue;
+                    }
                 }
             }
             SWSS_LOG_INFO("Failed to locate LAG %s", lag_alias.c_str());

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -76,7 +76,7 @@ extern string gMyHostName;
 extern string gMyAsicName;
 extern EvpnMhOrch *gEvpnMhOrch;
 extern event_handle_t g_events_handle;
-extern bool isChassisDbInUse();
+extern bool isVoqChassisDbInUse();
 extern bool gMultiAsicVoq;
 
 // defines ------------------------------------------------------------------------------------------------------------
@@ -1133,7 +1133,7 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
         Orch::addExecutor(portHostTxReadyNotificatier);
     }
 
-    if (isChassisDbInUse())
+    if (isVoqChassisDbInUse())
     {
         string tableName;
         //Add subscriber to process system LAG (System PortChannel) table
@@ -6433,7 +6433,7 @@ void PortsOrch::doLagMemberTask(Consumer &consumer)
                 std::string port_hostname = alias_tokens.empty() ? lag_alias : alias_tokens[0];
                 if (gMyHostName == port_hostname)
                 {
-                    if (isChassisDbInUse())
+                    if (isVoqChassisDbInUse())
                     {
                         std::string port_asic = alias_tokens.size() > 1 ? alias_tokens[1] : "";
                         std::string lower_port_asic = port_asic;
@@ -6533,7 +6533,7 @@ void PortsOrch::doLagMemberTask(Consumer &consumer)
                 }
             }
 
-            if (isChassisDbInUse() && (port.m_type != Port::SYSTEM))
+            if (isVoqChassisDbInUse() && (port.m_type != Port::SYSTEM))
             {
                //Sync to SYSTEM_LAG_MEMBER_TABLE of CHASSIS_APP_DB
                voqSyncAddLagMember(lag, port, status);
@@ -8309,7 +8309,7 @@ bool PortsOrch::removeLag(Port lag)
 
     m_counterLagTable->hdel("", lag.m_alias);
 
-    if (isChassisDbInUse())
+    if (isVoqChassisDbInUse())
     {
         // Free the lag id, if this is local LAG
 
@@ -8422,7 +8422,7 @@ bool PortsOrch::addLagMember(Port &lag, Port &port, string member_status)
     LagMemberUpdate update = { lag, port, true };
     notify(SUBJECT_TYPE_LAG_MEMBER_CHANGE, static_cast<void *>(&update));
 
-    if (isChassisDbInUse())
+    if (isVoqChassisDbInUse())
     {
         //Sync to SYSTEM_LAG_MEMBER_TABLE of CHASSIS_APP_DB
         voqSyncAddLagMember(lag, port, member_status);
@@ -8470,7 +8470,7 @@ bool PortsOrch::removeLagMember(Port &lag, Port &port)
     LagMemberUpdate update = { lag, port, false };
     notify(SUBJECT_TYPE_LAG_MEMBER_CHANGE, static_cast<void *>(&update));
 
-    if (isChassisDbInUse())
+    if (isVoqChassisDbInUse())
     {
         //Sync to SYSTEM_LAG_MEMBER_TABLE of CHASSIS_APP_DB
         voqSyncDelLagMember(lag, port);
@@ -10113,7 +10113,7 @@ void PortsOrch::updatePortOperStatus(Port &port, sai_port_oper_status_t status)
         }
     }
 
-    if(isChassisDbInUse())
+    if(isVoqChassisDbInUse())
     {
         if (gIntfsOrch->isLocalSystemPortIntf(port.m_alias))
         {

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -6428,27 +6428,30 @@ void PortsOrch::doLagMemberTask(Consumer &consumer)
         {
             if (gMySwitchType == "voq")
             {
-                // Multi-ASIC VoQ aliases use <hostname>|<asic>|<local-alias>.
+                // VoQ LAG aliases can include <hostname>|<asic>|<local-alias> even without chassis DB.
                 const auto alias_tokens = tokenize(lag_alias, '|');
                 std::string port_hostname = alias_tokens.empty() ? lag_alias : alias_tokens[0];
                 if (gMyHostName == port_hostname)
                 {
-                    if (!gMultiAsicVoq)
+                    if (isChassisDbInUse())
+                    {
+                        std::string port_asic = alias_tokens.size() > 1 ? alias_tokens[1] : "";
+                        std::string lower_port_asic = port_asic;
+                        std::string lower_my_asic = gMyAsicName;
+                        boost::algorithm::to_lower(lower_port_asic);
+                        boost::algorithm::to_lower(lower_my_asic);
+                        SWSS_LOG_DEBUG("doLagMemberTask: lag_alias=%s hostname=%s asic=%s local_asic=%s",
+                                       lag_alias.c_str(), port_hostname.c_str(), port_asic.c_str(), gMyAsicName.c_str());
+                        if (lower_port_asic == lower_my_asic)
+                        {
+                            SWSS_LOG_DEBUG("doLagMemberTask: erasing local entry %s (same host and asic)", lag_alias.c_str());
+                            it = consumer.m_toSync.erase(it);
+                            continue;
+                        }
+                    }
+                    else
                     {
                         SWSS_LOG_DEBUG("doLagMemberTask: erasing local entry %s (single-asic voq)", lag_alias.c_str());
-                        it = consumer.m_toSync.erase(it);
-                        continue;
-                    }
-                    std::string port_asic = alias_tokens.size() > 1 ? alias_tokens[1] : "";
-                    std::string lower_port_asic = port_asic;
-                    std::string lower_my_asic = gMyAsicName;
-                    boost::algorithm::to_lower(lower_port_asic);
-                    boost::algorithm::to_lower(lower_my_asic);
-                    SWSS_LOG_DEBUG("doLagMemberTask: lag_alias=%s hostname=%s asic=%s local_asic=%s",
-                                   lag_alias.c_str(), port_hostname.c_str(), port_asic.c_str(), gMyAsicName.c_str());
-                    if (lower_port_asic == lower_my_asic)
-                    {
-                        SWSS_LOG_DEBUG("doLagMemberTask: erasing local entry %s (same host and asic)", lag_alias.c_str());
                         it = consumer.m_toSync.erase(it);
                         continue;
                     }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -24,6 +24,8 @@
 #include <sstream>
 #include <unordered_set>
 
+#include <boost/algorithm/string.hpp>
+
 #include <netinet/if_ether.h>
 #include "net/if.h"
 
@@ -6438,9 +6440,13 @@ void PortsOrch::doLagMemberTask(Consumer &consumer)
                         continue;
                     }
                     std::string port_asic = alias_tokens.size() > 1 ? alias_tokens[1] : "";
+                    std::string lower_port_asic = port_asic;
+                    std::string lower_my_asic = gMyAsicName;
+                    boost::algorithm::to_lower(lower_port_asic);
+                    boost::algorithm::to_lower(lower_my_asic);
                     SWSS_LOG_DEBUG("doLagMemberTask: lag_alias=%s hostname=%s asic=%s local_asic=%s",
                                    lag_alias.c_str(), port_hostname.c_str(), port_asic.c_str(), gMyAsicName.c_str());
-                    if (port_asic == gMyAsicName)
+                    if (lower_port_asic == lower_my_asic)
                     {
                         SWSS_LOG_DEBUG("doLagMemberTask: erasing local entry %s (same host and asic)", lag_alias.c_str());
                         it = consumer.m_toSync.erase(it);

--- a/tests/mock_tests/mock_orchagent_main.cpp
+++ b/tests/mock_tests/mock_orchagent_main.cpp
@@ -28,7 +28,7 @@ VRFOrch *gVrfOrch;
 void syncd_apply_view() {}
 
 bool gMultiAsicVoq = false;
-bool isChassisDbInUse()
+bool isVoqChassisDbInUse()
 {
     return gMultiAsicVoq;
 }

--- a/tests/mock_tests/neighorch_ut.cpp
+++ b/tests/mock_tests/neighorch_ut.cpp
@@ -11,8 +11,14 @@
 #include "mock_orchagent_main.h"
 #include "mock_sai_api.h"
 #include "mock_orch_test.h"
+#include "subscriberstatetable.h"
 
 EXTERN_MOCK_FNS
+
+extern std::string gMySwitchType;
+extern std::string gMyHostName;
+extern std::string gMyAsicName;
+extern bool gMultiAsicVoq;
 
 namespace neighorch_test
 {
@@ -28,6 +34,22 @@ namespace neighorch_test
     static const NeighborEntry VLAN2000_NEIGH = NeighborEntry(TEST_IP, VLAN_2000);
     static const NeighborEntry VLAN3000_NEIGH = NeighborEntry(TEST_IP, VLAN_3000);
     static const NeighborEntry VLAN4000_NEIGH = NeighborEntry(TEST_IP, VLAN_4000);
+
+    struct VoqGlobalsGuard
+    {
+        string switch_type = gMySwitchType;
+        string host_name = gMyHostName;
+        string asic_name = gMyAsicName;
+        bool multi_asic_voq = gMultiAsicVoq;
+
+        ~VoqGlobalsGuard()
+        {
+            gMySwitchType = switch_type;
+            gMyHostName = host_name;
+            gMyAsicName = asic_name;
+            gMultiAsicVoq = multi_asic_voq;
+        }
+    };
 
     class NeighOrchTest : public MockOrchTest
     {
@@ -47,6 +69,34 @@ namespace neighorch_test
             gNeighOrch->addExistingData(&neigh_table);
             static_cast<Orch *>(gNeighOrch)->doTask();
             neigh_table.del(key);
+        }
+
+        std::unique_ptr<Consumer> CreateVoqSystemNeighConsumer()
+        {
+            return std::unique_ptr<Consumer>(new Consumer(
+                new swss::SubscriberStateTable(
+                    m_chassis_app_db.get(),
+                    CHASSIS_APP_SYSTEM_NEIGH_TABLE_NAME,
+                    swss::TableConsumable::DEFAULT_POP_BATCH_SIZE,
+                    0),
+                gNeighOrch,
+                CHASSIS_APP_SYSTEM_NEIGH_TABLE_NAME));
+        }
+
+        void AddVoqSystemNeighTask(Consumer &consumer, const string &alias)
+        {
+            string key = alias + consumer.getConsumerTable()->getTableNameSeparator() + TEST_IP;
+            consumer.addToSync({ key, SET_COMMAND, { { "encap_index", "1" }, { "neigh", MAC1 } } });
+        }
+
+        void SetVoqInbandPortReady()
+        {
+            string inband_alias = "Vlan4094";
+            Port inband_port;
+            inband_port.m_alias = inband_alias;
+            inband_port.m_type = Port::VLAN;
+            gPortsOrch->m_portList[inband_alias] = inband_port;
+            gPortsOrch->m_inbandPortName = inband_alias;
         }
 
         void ApplyInitialConfigs()
@@ -188,6 +238,44 @@ namespace neighorch_test
             RestoreSaiApis();
         }
     };
+
+    TEST_F(NeighOrchTest, SystemNeighFromDifferentAsicOnSameHost)
+    {
+        VoqGlobalsGuard guard;
+        gMySwitchType = "voq";
+        gMyHostName = "Linecard1";
+        gMyAsicName = "Asic0";
+        gMultiAsicVoq = true;
+        SetVoqInbandPortReady();
+
+        auto consumer = CreateVoqSystemNeighConsumer();
+        string remote_asic_alias = gMyHostName + "|Asic1|Ethernet999";
+        AddVoqSystemNeighTask(*consumer, remote_asic_alias);
+
+        gNeighOrch->doVoqSystemNeighTask(*consumer);
+
+        ASSERT_EQ(consumer->m_toSync.size(), 1u);
+        EXPECT_EQ(kfvKey(consumer->m_toSync.begin()->second),
+                  remote_asic_alias + consumer->getConsumerTable()->getTableNameSeparator() + TEST_IP);
+    }
+
+    TEST_F(NeighOrchTest, SystemNeighFromSameAsicOnSameHost)
+    {
+        VoqGlobalsGuard guard;
+        gMySwitchType = "voq";
+        gMyHostName = "Linecard1";
+        gMyAsicName = "Asic0";
+        gMultiAsicVoq = true;
+        SetVoqInbandPortReady();
+
+        auto consumer = CreateVoqSystemNeighConsumer();
+        string local_asic_alias = gMyHostName + "|" + gMyAsicName + "|Ethernet999";
+        AddVoqSystemNeighTask(*consumer, local_asic_alias);
+
+        gNeighOrch->doVoqSystemNeighTask(*consumer);
+
+        ASSERT_TRUE(consumer->m_toSync.empty());
+    }
 
     TEST_F(NeighOrchTest, MultiVlanDuplicateNeighbor)
     {

--- a/tests/mock_tests/neighorch_ut.cpp
+++ b/tests/mock_tests/neighorch_ut.cpp
@@ -51,6 +51,35 @@ namespace neighorch_test
         }
     };
 
+    struct PortListGuard
+    {
+        string alias;
+        bool port_exists;
+        Port port;
+
+        explicit PortListGuard(const string &alias) : alias(alias)
+        {
+            auto port_it = gPortsOrch->m_portList.find(alias);
+            port_exists = (port_it != gPortsOrch->m_portList.end());
+            if (port_exists)
+            {
+                port = port_it->second;
+            }
+        }
+
+        ~PortListGuard()
+        {
+            if (port_exists)
+            {
+                gPortsOrch->m_portList[alias] = port;
+            }
+            else
+            {
+                gPortsOrch->m_portList.erase(alias);
+            }
+        }
+    };
+
     class NeighOrchTest : public MockOrchTest
     {
     protected:
@@ -97,6 +126,17 @@ namespace neighorch_test
             inband_port.m_type = Port::VLAN;
             gPortsOrch->m_portList[inband_alias] = inband_port;
             gPortsOrch->m_inbandPortName = inband_alias;
+        }
+
+        void AddRemoteSystemPort(const string &alias)
+        {
+            Port remote_system_port;
+            remote_system_port.m_alias = alias;
+            remote_system_port.m_type = Port::SYSTEM;
+            remote_system_port.m_rif_id = SAI_NULL_OBJECT_ID;
+            remote_system_port.m_system_port_info.alias = alias;
+            remote_system_port.m_system_port_info.type = SAI_SYSTEM_PORT_TYPE_REMOTE;
+            gPortsOrch->m_portList[alias] = remote_system_port;
         }
 
         void ApplyInitialConfigs()
@@ -250,6 +290,8 @@ namespace neighorch_test
 
         auto consumer = CreateVoqSystemNeighConsumer();
         string remote_asic_alias = gMyHostName + "|Asic1|Ethernet999";
+        PortListGuard port_guard(remote_asic_alias);
+        AddRemoteSystemPort(remote_asic_alias);
         AddVoqSystemNeighTask(*consumer, remote_asic_alias);
 
         gNeighOrch->doVoqSystemNeighTask(*consumer);

--- a/tests/mock_tests/neighorch_ut.cpp
+++ b/tests/mock_tests/neighorch_ut.cpp
@@ -269,7 +269,7 @@ namespace neighorch_test
         SetVoqInbandPortReady();
 
         auto consumer = CreateVoqSystemNeighConsumer();
-        string local_asic_alias = gMyHostName + "|" + gMyAsicName + "|Ethernet999";
+        string local_asic_alias = gMyHostName + "|asic0|Ethernet999";
         AddVoqSystemNeighTask(*consumer, local_asic_alias);
 
         gNeighOrch->doVoqSystemNeighTask(*consumer);

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -37,6 +37,10 @@ namespace std {
 
 extern redisReply *mockReply;
 extern sai_redis_communication_mode_t gRedisCommunicationMode;
+extern string gMySwitchType;
+extern string gMyHostName;
+extern string gMyAsicName;
+extern bool gMultiAsicVoq;
 using ::testing::_;
 using ::testing::StrictMock;
 
@@ -4786,6 +4790,99 @@ namespace portsorch_test
         ts.clear();
         consumer->dumpPendingTasks(ts);
         ASSERT_FALSE(ts.empty());
+    }
+
+    /* Test that a LAG member entry from a different ASIC on the same host is NOT
+     * erased from the consumer table in VoQ mode. The entry has the same hostname
+     * but a different ASIC name, so it must remain pending.
+     */
+    TEST_F(PortsOrchTest, LagMemberFromDifferentAsicOnSameHost)
+    {
+        string savedSwitchType = gMySwitchType;
+        bool savedMultiAsicVoq = gMultiAsicVoq;
+        gMySwitchType = "voq";
+        gMultiAsicVoq = true;
+
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        Table lagMemberTable = Table(m_app_db.get(), APP_LAG_MEMBER_TABLE_NAME);
+
+        auto ports = ut_helper::getInitialSaiPorts();
+
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+        portTable.set("PortInitDone", { { } });
+
+        // LAG member from same hostname but different ASIC (Asic1 vs local Asic0)
+        string remoteAsicLag = gMyHostName + "|Asic1|PortChannel999";
+        lagMemberTable.set(
+            remoteAsicLag + lagMemberTable.getTableNameSeparator() + ports.begin()->first,
+            { {"status", "enabled"} });
+
+        gPortsOrch->addExistingData(&portTable);
+        gPortsOrch->addExistingData(&lagMemberTable);
+
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        // Entry must NOT be erased — it's for a different ASIC on the same host
+        vector<string> ts;
+        auto exec = gPortsOrch->getExecutor(APP_LAG_MEMBER_TABLE_NAME);
+        auto consumer = static_cast<Consumer*>(exec);
+        consumer->dumpPendingTasks(ts);
+        ASSERT_FALSE(ts.empty());
+
+        gMySwitchType = savedSwitchType;
+        gMultiAsicVoq = savedMultiAsicVoq;
+    }
+
+    /* Test that a LAG member entry from the same ASIC on the same host IS erased
+     * from the consumer table in VoQ mode. Both hostname and ASIC name match the
+     * local instance, so the entry is a duplicate local reference and should be
+     * silently dropped.
+     */
+    TEST_F(PortsOrchTest, LagMemberFromSameAsicOnSameHost)
+    {
+        string savedSwitchType = gMySwitchType;
+        bool savedMultiAsicVoq = gMultiAsicVoq;
+        gMySwitchType = "voq";
+        gMultiAsicVoq = true;
+
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        Table lagMemberTable = Table(m_app_db.get(), APP_LAG_MEMBER_TABLE_NAME);
+
+        auto ports = ut_helper::getInitialSaiPorts();
+
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+        portTable.set("PortInitDone", { { } });
+
+        // LAG member from same hostname AND same ASIC (Asic0 matches local gMyAsicName)
+        string localAsicLag = gMyHostName + "|" + gMyAsicName + "|PortChannel999";
+        lagMemberTable.set(
+            localAsicLag + lagMemberTable.getTableNameSeparator() + ports.begin()->first,
+            { {"status", "enabled"} });
+
+        gPortsOrch->addExistingData(&portTable);
+        gPortsOrch->addExistingData(&lagMemberTable);
+
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        // Entry MUST be erased — same hostname and same ASIC means local duplicate
+        vector<string> ts;
+        auto exec = gPortsOrch->getExecutor(APP_LAG_MEMBER_TABLE_NAME);
+        auto consumer = static_cast<Consumer*>(exec);
+        consumer->dumpPendingTasks(ts);
+        ASSERT_TRUE(ts.empty());
+
+        gMySwitchType = savedSwitchType;
+        gMultiAsicVoq = savedMultiAsicVoq;
     }
 
     /* This test checks that a LAG member validation happens on orchagent level

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -53,6 +53,20 @@ namespace portsorch_test
     // SAI default ports
     std::map<std::string, std::vector<swss::FieldValueTuple>> defaultPortList;
 
+    struct VoqGlobalsGuard
+    {
+        string switch_type = gMySwitchType;
+        string asic_name = gMyAsicName;
+        bool multi_asic_voq = gMultiAsicVoq;
+
+        ~VoqGlobalsGuard()
+        {
+            gMySwitchType = switch_type;
+            gMyAsicName = asic_name;
+            gMultiAsicVoq = multi_asic_voq;
+        }
+    };
+
     sai_port_api_t ut_sai_port_api;
     sai_port_api_t *pold_sai_port_api;
     sai_switch_api_t ut_sai_switch_api;
@@ -4798,9 +4812,7 @@ namespace portsorch_test
      */
     TEST_F(PortsOrchTest, LagMemberFromDifferentAsicOnSameHost)
     {
-        string savedSwitchType = gMySwitchType;
-        string savedAsicName = gMyAsicName;
-        bool savedMultiAsicVoq = gMultiAsicVoq;
+        VoqGlobalsGuard guard;
         gMySwitchType = "voq";
         gMyAsicName = "Asic0";
         gMultiAsicVoq = true;
@@ -4835,10 +4847,6 @@ namespace portsorch_test
         auto consumer = static_cast<Consumer*>(exec);
         consumer->dumpPendingTasks(ts);
         ASSERT_FALSE(ts.empty());
-
-        gMySwitchType = savedSwitchType;
-        gMyAsicName = savedAsicName;
-        gMultiAsicVoq = savedMultiAsicVoq;
     }
 
     /* Test that a LAG member entry from the same ASIC on the same host IS erased
@@ -4848,9 +4856,7 @@ namespace portsorch_test
      */
     TEST_F(PortsOrchTest, LagMemberFromSameAsicOnSameHost)
     {
-        string savedSwitchType = gMySwitchType;
-        string savedAsicName = gMyAsicName;
-        bool savedMultiAsicVoq = gMultiAsicVoq;
+        VoqGlobalsGuard guard;
         gMySwitchType = "voq";
         gMyAsicName = "Asic0";
         gMultiAsicVoq = true;
@@ -4885,10 +4891,6 @@ namespace portsorch_test
         auto consumer = static_cast<Consumer*>(exec);
         consumer->dumpPendingTasks(ts);
         ASSERT_TRUE(ts.empty());
-
-        gMySwitchType = savedSwitchType;
-        gMyAsicName = savedAsicName;
-        gMultiAsicVoq = savedMultiAsicVoq;
     }
 
     /* This test checks that a LAG member validation happens on orchagent level

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -4799,8 +4799,10 @@ namespace portsorch_test
     TEST_F(PortsOrchTest, LagMemberFromDifferentAsicOnSameHost)
     {
         string savedSwitchType = gMySwitchType;
+        string savedAsicName = gMyAsicName;
         bool savedMultiAsicVoq = gMultiAsicVoq;
         gMySwitchType = "voq";
+        gMyAsicName = "Asic0";
         gMultiAsicVoq = true;
 
         Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
@@ -4835,6 +4837,7 @@ namespace portsorch_test
         ASSERT_FALSE(ts.empty());
 
         gMySwitchType = savedSwitchType;
+        gMyAsicName = savedAsicName;
         gMultiAsicVoq = savedMultiAsicVoq;
     }
 
@@ -4846,8 +4849,10 @@ namespace portsorch_test
     TEST_F(PortsOrchTest, LagMemberFromSameAsicOnSameHost)
     {
         string savedSwitchType = gMySwitchType;
+        string savedAsicName = gMyAsicName;
         bool savedMultiAsicVoq = gMultiAsicVoq;
         gMySwitchType = "voq";
+        gMyAsicName = "Asic0";
         gMultiAsicVoq = true;
 
         Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
@@ -4864,7 +4869,7 @@ namespace portsorch_test
         portTable.set("PortInitDone", { { } });
 
         // LAG member from same hostname AND same ASIC (Asic0 matches local gMyAsicName)
-        string localAsicLag = gMyHostName + "|" + gMyAsicName + "|PortChannel999";
+        string localAsicLag = gMyHostName + "|asic0|PortChannel999";
         lagMemberTable.set(
             localAsicLag + lagMemberTable.getTableNameSeparator() + ports.begin()->first,
             { {"status", "enabled"} });
@@ -4882,6 +4887,7 @@ namespace portsorch_test
         ASSERT_TRUE(ts.empty());
 
         gMySwitchType = savedSwitchType;
+        gMyAsicName = savedAsicName;
         gMultiAsicVoq = savedMultiAsicVoq;
     }
 


### PR DESCRIPTION
Do not drop notifications when its coming from a different asic.

Fixes: https://github.com/sonic-net/sonic-buildimage/issues/27283

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Make changes to compare both hostnames and asic names for multi-asic devices. Improve unit test to check for this case.

**Why I did it**
Currently we only match the hostname and drop the notification if the hostname is equal to the hostname of the port. This also drops messages coming from a neigh asic that shares the same hostname.

**How I verified it**
Ran the new test here to verify it passes with this fix: https://github.com/sonic-net/sonic-mgmt/pull/24826

This was verified in 202605 by patching this fix and the sonic-mgmt enhancement that tests for this exact regression: https://github.com/sonic-net/sonic-mgmt/pull/24826

**Tested branches**
- [x] 202605
- [x] 202511

