### PR TITLE
Fix orchagent Port PHY Serdes Invalid VID on Removal

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -10207,6 +10207,23 @@ bool PortsOrch::setPortSerdesAttribute(sai_object_id_t port_id, sai_object_id_t 
 
     if (port_attr.value.oid != SAI_NULL_OBJECT_ID)
     {
+        // Remove old mapping from memory map
+        m_portIdToSerdesId.erase(port_id);
+
+        // Remove old mapping from COUNTERS_DB
+        m_portSerdesIdToPortIdTable->hdel("", sai_serialize_object_id(port_attr.value.oid));
+        SWSS_LOG_INFO("Removed old COUNTERS_PORT_SERDES_ID_TO_PORT_ID_MAP entry: serdes_id:0x%" PRIx64,
+                     port_attr.value.oid);
+
+        // Clear the phy port serdes countersIDList
+        Port p;
+        if (getPort(port_id, p) && p.m_type == Port::Type::PHY &&
+            flex_counters_orch->getPortPhySerdesAttrCountersState())
+        {
+            port_phy_serdes_attr_manager.clearCounterIdList(port_attr.value.oid);
+        }
+
+        // Remove SAI port serdes object
         status = sai_port_api->remove_port_serdes(port_attr.value.oid);
         if (status != SAI_STATUS_SUCCESS)
         {
@@ -10216,24 +10233,6 @@ bool PortsOrch::setPortSerdesAttribute(sai_object_id_t port_id, sai_object_id_t 
             if (handle_status != task_success)
             {
                 return parseHandleSaiStatusFailure(handle_status);
-            }
-        }
-        else
-        {
-            // Remove old mapping from memory map
-            m_portIdToSerdesId.erase(port_id);
-
-            // Remove old mapping from COUNTERS_DB
-            m_portSerdesIdToPortIdTable->hdel("", sai_serialize_object_id(port_attr.value.oid));
-            SWSS_LOG_INFO("Removed old COUNTERS_PORT_SERDES_ID_TO_PORT_ID_MAP entry: serdes_id:0x%" PRIx64,
-                         port_attr.value.oid);
-
-            //clear the phy port serdes countersIDList
-            Port p;
-            if (getPort(port_id, p) && p.m_type == Port::Type::PHY &&
-                flex_counters_orch->getPortPhySerdesAttrCountersState())
-            {
-                port_phy_serdes_attr_manager.clearCounterIdList(port_attr.value.oid);
             }
         }
     }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Removing a check such that old VID mappings are always removed after the successful creation of a new Port PHY Serdes SAI object for the purposes of reconfiguration and replacing the previous one.
The order of removal has also been rearranged such that VID mappings are removed before the actual removal of the Port PHY Serdes SAI object.

**Why I did it**
When a serdes is reconfigured (happens some time after initialization), the SAI object(s) for the Port PHY Serdes Attribute has to be recreated. This means to go look for any objects with references to Port PHY Serdes Attributes, clearing VID references for those objects, and re-creating them.

Afterwards, there will be a function call to clear counter ids on the old VID ref'd objects.

Currently, this ordering of object removal before VID mapping removal will cause the ERR syslog print:
```
port VID oid:0x90000000008bf, was not found (probably port was removed/
splitted) and will remove from counters now
```
This is a harmless print, but still should not happen nonetheless. It is generating lots of noise.

If we are calling `setPortSerdesAttribute()`, then we need a new serdes object. By the time the function removes the old object, it has already successfully created the new one.

This means old mappings are no longer needed, regardless of whether if the old object is successfully removed or not.


Fixes https://github.com/sonic-net/sonic-swss/issues/4642

**How I verified it**
The syslog ERR no longer prints on config reload on TH5. `sonic-mgmt` tests also shows no fallout.

**Details if related**
