### PR TITLE
[pfcwdorch]: Clean up PFC_WD_TABLE_INSTORM on PFC watchdog stop

### DIFF
--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -667,6 +667,13 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::unregisterFromWdDb(const Port& po
         // Clean up
         string countersKey = this->getCountersTable()->getTableName() + this->getCountersTable()->getTableNameSeparator() + sai_serialize_object_id(queueId);
         this->getCountersDb()->hdel(countersKey, {"PFC_WD_DETECTION_TIME", "PFC_WD_RESTORATION_TIME", "PFC_WD_ACTION", "PFC_WD_STATUS"});
+
+        // Drop this queue's PFC_WD_TABLE_INSTORM field so a stale row can't
+        // replay a phantom storm on warm restart.
+        string instormKey = m_applTable->getTableName()
+            + m_applTable->getTableNameSeparator()
+            + port.m_alias;
+        m_applDb->hdel(instormKey, to_string(i));
     }
 
 }


### PR DESCRIPTION
**What I did**

Clean up the stale `PFC_WD_TABLE_INSTORM:<port>` entry in APPL_DB when PFC watchdog is stopped on a port. In `PfcWdSwOrch::unregisterFromWdDb()`, the per-queue cleanup loop already removed the COUNTERS_DB watchdog fields; this change additionally drops each queue's field from the port's `INSTORM` hash so the table is consistent once watchdog is stopped.

**Why I did it**

When PFC watchdog is stopped on a port while one or more of its queues are in storm, the per-queue fields under `PFC_WD_TABLE_INSTORM:<port>` were left behind (e.g. `PFC_WD_TABLE_INSTORM:Ethernet20` -> `{'3':'storm','4':'storm'}`) with no active storm.

The stale row is replayed on warm boot: on startup, pfcwdorch drains the `APP_PFC_WD_TABLE` consumer, reads the stale in-storm queues, and re-enters the storm handler even though no storm exists.

**How I verified it**

- `pfcwd start` on a port, inject a storm so the queue is detected as stormed and `PFC_WD_TABLE_INSTORM:<port>` is populated.
- `pfcwd stop <port>`; confirm `sonic-db-cli APPL_DB HGETALL PFC_WD_TABLE_INSTORM:<port>` returns `{}`.
- Warm restart swss with no active storm; confirm the port no longer comes up in `show pfcwd stats` as stormed.

**Details if related**

Related to #1691, which addresses the same stale in-storm state for warm-reboot but also bundles a broader portsorch/big-red-switch refactor and has remained unmerged since 2021. This PR is a minimal, self-contained fix for the pfcwd-stop case only.

Fixes #4667