### PR TITLE
Fix race condition between logrotate SIGHUP and Orchdaemon startup

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -431,6 +431,19 @@ int main(int argc, char **argv)
     WarmStart::checkWarmStart("orchagent", "swss");
 
     /*
+     * Block SIGHUP signal until the Recorder is initialized and the SIGHUP
+     * handler is installed to avoid race conditions.
+     */
+    sigset_t hupmask;
+    sigemptyset(&hupmask);
+    sigaddset(&hupmask, SIGHUP);
+    if (sigprocmask(SIG_BLOCK, &hupmask, nullptr))
+    {
+        SWSS_LOG_ERROR("failed to block SIGHUP during startup");
+        exit(1);
+    }
+
+    /*
      * Construct the Recorder singleton before registering fatal handlers so
      * fatal_signal_handler() never triggers function-local static initialization.
      */
@@ -439,6 +452,12 @@ int main(int argc, char **argv)
     if (signal(SIGHUP, sighup_handler) == SIG_ERR)
     {
         SWSS_LOG_ERROR("failed to setup SIGHUP action");
+        exit(1);
+    }
+
+    if (sigprocmask(SIG_UNBLOCK, &hupmask, nullptr))
+    {
+        SWSS_LOG_ERROR("failed to unblock SIGHUP during startup");
         exit(1);
     }
 

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -974,8 +974,6 @@ void OrchDaemon::start(long heartBeatInterval)
 {
     SWSS_LOG_ENTER();
 
-    Recorder::Instance().sairedis.setRotate(false);
-
     ring_thread = std::thread(&OrchDaemon::popRingBuffer, this);
 
     for (Orch *o : m_orchList)

--- a/tests/mock_tests/orchdaemon_ut.cpp
+++ b/tests/mock_tests/orchdaemon_ut.cpp
@@ -8,6 +8,7 @@
 #include "mock_sai_switch.h"
 #include "saihelper.h"
 
+extern volatile sig_atomic_t gOrchShutdownRequested;
 extern sai_switch_api_t* sai_switch_api;
 sai_switch_api_t test_sai_switch;
 
@@ -55,6 +56,15 @@ namespace orchdaemon_test
         EXPECT_CALL(mock_sai_switch_, set_switch_attribute( _, _)).WillOnce(Return(SAI_STATUS_SUCCESS));
 
         orchd->logRotate();
+    }
+
+    TEST_F(OrchDaemonTest, sairedisLogRotateFlagNotClearedAtStartup)
+    {
+        Recorder::Instance().sairedis.setRotate(true);
+        // Need to set shutdown flag, otherwise start() will loop indefinitely
+        gOrchShutdownRequested = true;
+        orchd->start(1000);
+        EXPECT_TRUE(Recorder::Instance().sairedis.isRotate());
     }
 
     TEST_F(OrchDaemonTest, ringBuffer)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
- In `OrchDaemon::start()`, don't blindly set the sairedis recorder log rotate flag to false. If a log rotate fires before `OrchDaemon::start()` runs, we still want to honor it.
- In `orchagent/main.cpp`, block SIGHUP until the Recorder singleton is initialized an the SIGHUP handler is installed. This eliminates the possibility that a SIGHUP is sent by the logrotate service after the recorder is created but before the handler is installed, which would lead to the same bug described below (recorder writing to sairedis.rec.1 instead of sairedis.rec).
 
**Why I did it**
During the orchagent startup sequence, a race condition is possible where a log rotation occurs after the SIGHUP handler is installed in `main.cpp` but before `OrchDaemon::start()` is reached. If this happens, the SIGHUP handler will correctly set the logrotate flag to `true` for the sairedis recorder; however, this flag gets reset to `false` by `OrchDaemon::start()` which means that the sairedis recorder will continue writing to the old, rotated file (sairedis.rec.1). The new file (sairedis.rec) created by the logrotate service will remain empty. Since it's empty, the logrotate service will not send a SIGHUP to orchagent the next time it fires which means that the sairedis recorder will continue writing to the old sairedis.rec.1 file. 

**How I verified it**
Run new unit test which verifies flag is not cleared by `OrchDaemon::start()`

**Details if related**
