### PR TITLE
Link Event Damping support

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3753,6 +3753,33 @@ ReturnCode PortsOrch::setPortLinkEventDampingAiedConfig(Port &port,
                                                         sai_redis_link_event_damping_algo_aied_config_t &config) {
 
     SWSS_LOG_ENTER();
+
+    // Validate decay_half_life must not exceed max_suppress_time
+    if (config.decay_half_life > config.max_suppress_time)
+    {
+        SWSS_LOG_WARN("Invalid link event damping configuration for port %s: "
+                      "decay_half_life (%u ms) must not exceed max_suppress_time (%u ms)",
+                      port.m_alias.c_str(), config.decay_half_life, config.max_suppress_time);
+    }
+
+    // Validate suppress_threshold must be greater than reuse_threshold
+    if (config.suppress_threshold <= config.reuse_threshold)
+    {
+        SWSS_LOG_WARN("Invalid link event damping configuration for port %s: "
+                      "suppress_threshold (%u) must be greater than reuse_threshold (%u)",
+                      port.m_alias.c_str(), config.suppress_threshold, config.reuse_threshold);
+    }
+
+    // Validate flap_penalty is reasonable relative to suppress_threshold
+    // A single flap should not immediately trigger suppression, so flap_penalty should be less than suppress_threshold
+    if (config.flap_penalty >= config.suppress_threshold)
+    {
+        SWSS_LOG_WARN("Link event damping configuration for port %s: "
+                      "flap_penalty (%u) is greater than or equal to suppress_threshold (%u). "
+                      "A single flap will immediately trigger suppression.",
+                      port.m_alias.c_str(), config.flap_penalty, config.suppress_threshold);
+    }
+
     sai_attribute_t attr;
     attr.id = SAI_REDIS_PORT_ATTR_LINK_EVENT_DAMPING_ALGO_AIED_CONFIG;
     attr.value.ptr = (void *) &config;


### PR DESCRIPTION
**What I did**

As per HLD, the decay-half-life should be less than max_suppress_time. Also, the reuse_threshold should be less than suppress_threshold. Added these two damping config params check and logged warning messages.

**Why I did it**
Added warning logs so that user knows the invalid configs are applied.

**How I verified it**
Unit test

**Details if related**
1. Decay half life more than max suppress time:
2026 Jun  8 10:51:31.563755 sonic NOTICE pmon#CmisManagerTask[39]: *** ('Ethernet24', 'CONFIG_DB', 'PORT') handle_port_update_event() fvp {'admin_status': 'up', 'alias': 'et-0/0/3', 'fec': 'rs', 'index': '3', 'lanes': '25,26,27,28,29,30,31,32', 'mtu': '9100', 'speed': '800000', 'dhcp_rate_limit': '300', 'link_event_damping_algorithm': 'aied', 'decay_half_life': '25000', 'flap_penalty': '1000', 'max_suppress_time': '20000', 'reuse_threshold': '1200', 'suppress_threshold': '1400', 'port_name': 'Ethernet24', 'asic_id': 0, 'op': 'SET'}
2026 Jun  8 10:51:31.566309 sonic WARNING swss#orchagent: :- setPortLinkEventDampingAiedConfig: Invalid link event damping configuration for port Ethernet24: decay_half_life (25000 ms) must not exceed max_suppress_time (20000 ms)
2. reuse_threshold greater than suppress_threshold:
2026 Jun  8 10:56:40.245543 sonic NOTICE pmon#CmisManagerTask[39]: *** ('Ethernet24', 'CONFIG_DB', 'PORT') handle_port_update_event() fvp {'admin_status': 'up', 'alias': 'et-0/0/3', 'fec': 'rs', 'index': '3', 'lanes': '25,26,27,28,29,30,31,32', 'mtu': '9100', 'speed': '800000', 'dhcp_rate_limit': '300', 'link_event_damping_algorithm': 'aied', 'decay_half_life': '15000', 'flap_penalty': '1000', 'max_suppress_time': '30000', 'reuse_threshold': '1600', 'suppress_threshold': '1500', 'port_name': 'Ethernet24', 'asic_id': 0, 'op': 'SET'}
2026 Jun  8 10:56:40.247985 sonic WARNING swss#orchagent: :- setPortLinkEventDampingAiedConfig: Invalid link event damping configuration for port Ethernet24: suppress_threshold (1500) must be greater than reuse_threshold (1600)
