### PR TITLE
Fix race condition between LAG and VLAN

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -5969,7 +5969,6 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
         vlan_alias = VLAN_PREFIX + to_string(vlan_id);
         string op = kfvOp(t);
 
-        assert(m_portList.find(vlan_alias) != m_portList.end());
         Port vlan, port;
 
         /* When VLAN member is to be created before VLAN is created */

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -5975,6 +5975,12 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
         /* When VLAN member is to be created before VLAN is created */
         if (!getPort(vlan_alias, vlan))
         {
+            if (op == DEL_COMMAND)
+            {
+                it = consumer.m_toSync.erase(it);
+                continue;
+            }
+
             SWSS_LOG_INFO("Failed to locate VLAN %s", vlan_alias.c_str());
             it++;
             continue;
@@ -6010,6 +6016,15 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
             if (vlan.m_members.find(port_alias) != vlan.m_members.end())
             {
                 it = consumer.m_toSync.erase(it);
+                continue;
+            }
+
+            /* Defer vlan member add while port is still a LAG member in orchagent */
+            if (isValidPortTypeForLagMember(port) && port.m_lag_member_id != SAI_NULL_OBJECT_ID)
+            {
+                SWSS_LOG_INFO("Port %s is still a LAG member (lmid:%" PRIx64 "), delaying vlan member add",
+                               port.m_alias.c_str(), port.m_lag_member_id);
+                it++;
                 continue;
             }
 

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -5226,6 +5226,8 @@ namespace portsorch_test
      * Test: LAG member on port first, then VLAN member SET only (no LAG DEL in same
      * batch). Uses a distinct port/LAG/VLAN from VlanMemberSucceedsAfterLagMemberRemoved
      * because saivs state persists across tests in one process.
+     * Then removes the VLAN and queues member DEL to cover the erase path when the
+     * vlan is already gone (!getPort + DEL_COMMAND).
      */
     TEST_F(VlanLagRaceTest, VlanMemberAddDeferredWhileLagMemberActive)
     {
@@ -5310,6 +5312,32 @@ namespace portsorch_test
 
         gPortsOrch->getPort(testPort, port);
         ASSERT_NE(port.m_lag_member_id, SAI_NULL_OBJECT_ID) << "Port should still be a LAG member";
+
+        // Deferred SET is replaced by DEL via consumer coalescing; after Vlan51 is
+        // removed, doVlanMemberTask must erase the DEL (member never existed in vlan).
+        std::deque<KeyOpFieldsValuesTuple> vlanDelEntries;
+        vlanDelEntries.push_back({"Vlan51", DEL_COMMAND, {}});
+        auto vlanConsumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_VLAN_TABLE_NAME));
+        vlanConsumer->addToSync(vlanDelEntries);
+
+        std::deque<KeyOpFieldsValuesTuple> vlanMemberDelEntries;
+        vlanMemberDelEntries.push_back({vlanMemberKey, DEL_COMMAND, {}});
+        auto vlanMemberConsumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_VLAN_MEMBER_TABLE_NAME));
+        vlanMemberConsumer->addToSync(vlanMemberDelEntries);
+
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        Port vlanAfterDel;
+        ASSERT_FALSE(gPortsOrch->getPort("Vlan51", vlanAfterDel)) << "Vlan51 should be removed";
+
+        for (auto tableName : {APP_VLAN_TABLE_NAME, APP_VLAN_MEMBER_TABLE_NAME})
+        {
+            vector<string> ts;
+            auto exec = gPortsOrch->getExecutor(tableName);
+            auto consumer = static_cast<Consumer *>(exec);
+            consumer->dumpPendingTasks(ts);
+            ASSERT_TRUE(ts.empty()) << "VLAN teardown should complete with no pending tasks: " << tableName;
+        }
     }
 
     TEST_F(VlanLagRaceTest, VlanMemberSucceedsAfterLagMemberRemoved)

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -5236,6 +5236,7 @@ namespace portsorch_test
         Table vlanMemberTable = Table(m_app_db.get(), APP_VLAN_MEMBER_TABLE_NAME);
 
         auto ports = ut_helper::getInitialSaiPorts();
+        ASSERT_GE(ports.size(), 2u) << "Need at least two ports for this test";
         auto portIt = ports.begin();
         ++portIt;
         string testPort = portIt->first;
@@ -5344,6 +5345,20 @@ namespace portsorch_test
         gPortsOrch->addExistingData(&lagTable);
         gPortsOrch->addExistingData(&lagMemberTable);
         static_cast<Orch *>(gPortsOrch)->doTask();
+
+        for (auto tableName : {APP_LAG_TABLE_NAME, APP_LAG_MEMBER_TABLE_NAME})
+        {
+            vector<string> ts;
+            auto exec = gPortsOrch->getExecutor(tableName);
+            auto consumer = static_cast<Consumer *>(exec);
+            consumer->dumpPendingTasks(ts);
+            ASSERT_TRUE(ts.empty()) << "LAG setup should complete: " << tableName;
+        }
+        {
+            Port port;
+            ASSERT_TRUE(gPortsOrch->getPort(testPort, port));
+            ASSERT_NE(port.m_lag_member_id, SAI_NULL_OBJECT_ID) << "Port should be a LAG member before VLAN add";
+        }
 
         vlanTable.set("Vlan50",
             {

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -5215,6 +5215,197 @@ namespace portsorch_test
         ASSERT_NE(port.m_lag_id, SAI_NULL_OBJECT_ID) << "Port should be a LAG member after second doTask";
     }
 
+    /*
+     * Regression test for LAG/VLAN race (inverse of issue #23635).
+     *
+     * Issue: When a port is added to a LAG and a VLAN member SET is queued while
+     * orchagent still has m_lag_member_id set, addBridgePort/addVlanMember must not
+     * call SAI (SAI_STATUS_INVALID_PORT_NUMBER on some platforms).
+     *
+     * Fix: PortsOrch defers VLAN member SET when a physical port's m_lag_member_id
+     * Test: LAG member on port first, then VLAN member SET only (no LAG DEL in same
+     * batch). Uses a distinct port/LAG/VLAN from VlanMemberSucceedsAfterLagMemberRemoved
+     * because saivs state persists across tests in one process.
+     */
+    TEST_F(VlanLagRaceTest, VlanMemberAddDeferredWhileLagMemberActive)
+    {
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        Table lagTable = Table(m_app_db.get(), APP_LAG_TABLE_NAME);
+        Table lagMemberTable = Table(m_app_db.get(), APP_LAG_MEMBER_TABLE_NAME);
+        Table vlanTable = Table(m_app_db.get(), APP_VLAN_TABLE_NAME);
+        Table vlanMemberTable = Table(m_app_db.get(), APP_VLAN_MEMBER_TABLE_NAME);
+
+        auto ports = ut_helper::getInitialSaiPorts();
+        auto portIt = ports.begin();
+        ++portIt;
+        string testPort = portIt->first;
+
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+        portTable.set("PortInitDone", { { } });
+
+        gPortsOrch->addExistingData(&portTable);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        lagTable.set("PortChannel2",
+            {
+                {"admin_status", "up"},
+                {"mtu", "9100"}
+            }
+        );
+        string lagMemberKey = string("PortChannel2") + lagMemberTable.getTableNameSeparator() + testPort;
+        lagMemberTable.set(lagMemberKey, { {"status", "enabled"} });
+
+        gPortsOrch->addExistingData(&lagTable);
+        gPortsOrch->addExistingData(&lagMemberTable);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        for (auto tableName : {APP_LAG_TABLE_NAME, APP_LAG_MEMBER_TABLE_NAME})
+        {
+            vector<string> ts;
+            auto exec = gPortsOrch->getExecutor(tableName);
+            auto consumer = static_cast<Consumer *>(exec);
+            consumer->dumpPendingTasks(ts);
+            ASSERT_TRUE(ts.empty()) << "LAG setup should complete: " << tableName;
+        }
+
+        Port port;
+        gPortsOrch->getPort(testPort, port);
+        ASSERT_NE(port.m_lag_member_id, SAI_NULL_OBJECT_ID) << "Port should be a LAG member before VLAN add";
+
+        vlanTable.set("Vlan51",
+            {
+                {"admin_status", "up"},
+                {"mtu", "9100"}
+            }
+        );
+        string vlanMemberKey = string("Vlan51") + vlanMemberTable.getTableNameSeparator() + testPort;
+        vlanMemberTable.set(vlanMemberKey, { {"tagging_mode", "untagged"} });
+
+        gPortsOrch->addExistingData(&vlanTable);
+        gPortsOrch->addExistingData(&vlanMemberTable);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        Port vlan;
+        ASSERT_TRUE(gPortsOrch->getPort("Vlan51", vlan));
+        ASSERT_EQ(vlan.m_members.find(testPort), vlan.m_members.end())
+            << "VLAN member add must defer while port is LAG member";
+
+        {
+            vector<string> ts;
+            auto exec = gPortsOrch->getExecutor(APP_VLAN_MEMBER_TABLE_NAME);
+            auto consumer = static_cast<Consumer *>(exec);
+            consumer->dumpPendingTasks(ts);
+            ASSERT_EQ(ts.size(), 1) << "Exactly one VLAN member task should be pending";
+
+            string expectedSubstr = vlanMemberKey + "|SET";
+            ASSERT_NE(ts[0].find(expectedSubstr), string::npos)
+                << "Pending task should be the SET for " << vlanMemberKey
+                << ", got: " << ts[0];
+        }
+
+        gPortsOrch->getPort(testPort, port);
+        ASSERT_NE(port.m_lag_member_id, SAI_NULL_OBJECT_ID) << "Port should still be a LAG member";
+    }
+
+    TEST_F(VlanLagRaceTest, VlanMemberSucceedsAfterLagMemberRemoved)
+    {
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        Table lagTable = Table(m_app_db.get(), APP_LAG_TABLE_NAME);
+        Table lagMemberTable = Table(m_app_db.get(), APP_LAG_MEMBER_TABLE_NAME);
+        Table vlanTable = Table(m_app_db.get(), APP_VLAN_TABLE_NAME);
+        Table vlanMemberTable = Table(m_app_db.get(), APP_VLAN_MEMBER_TABLE_NAME);
+
+        auto ports = ut_helper::getInitialSaiPorts();
+        string testPort = ports.begin()->first;
+
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+        portTable.set("PortInitDone", { { } });
+
+        gPortsOrch->addExistingData(&portTable);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        lagTable.set("PortChannel1",
+            {
+                {"admin_status", "up"},
+                {"mtu", "9100"}
+            }
+        );
+        string lagMemberKey = string("PortChannel1") + lagMemberTable.getTableNameSeparator() + testPort;
+        lagMemberTable.set(lagMemberKey, { {"status", "enabled"} });
+
+        gPortsOrch->addExistingData(&lagTable);
+        gPortsOrch->addExistingData(&lagMemberTable);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        vlanTable.set("Vlan50",
+            {
+                {"admin_status", "up"},
+                {"mtu", "9100"}
+            }
+        );
+        string vlanMemberKey = string("Vlan50") + vlanMemberTable.getTableNameSeparator() + testPort;
+        vlanMemberTable.set(vlanMemberKey, { {"tagging_mode", "untagged"} });
+
+        gPortsOrch->addExistingData(&vlanTable);
+        gPortsOrch->addExistingData(&vlanMemberTable);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        {
+            vector<string> ts;
+            auto exec = gPortsOrch->getExecutor(APP_VLAN_MEMBER_TABLE_NAME);
+            auto consumer = static_cast<Consumer *>(exec);
+            consumer->dumpPendingTasks(ts);
+            ASSERT_EQ(ts.size(), 1) << "VLAN member SET should be deferred while LAG member is active";
+        }
+
+        std::deque<KeyOpFieldsValuesTuple> lagMemberDelEntries;
+        lagMemberDelEntries.push_back({lagMemberKey, DEL_COMMAND, {}});
+        auto lagMemberConsumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_LAG_MEMBER_TABLE_NAME));
+        lagMemberConsumer->addToSync(lagMemberDelEntries);
+
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        Port port;
+        gPortsOrch->getPort(testPort, port);
+        ASSERT_EQ(port.m_lag_member_id, SAI_NULL_OBJECT_ID) << "LAG member should be removed";
+
+        {
+            vector<string> ts;
+            auto exec = gPortsOrch->getExecutor(APP_LAG_MEMBER_TABLE_NAME);
+            auto consumer = static_cast<Consumer *>(exec);
+            consumer->dumpPendingTasks(ts);
+            ASSERT_TRUE(ts.empty()) << "LAG member DEL should complete";
+        }
+
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        gPortsOrch->getPort(testPort, port);
+        ASSERT_NE(port.m_bridge_port_id, SAI_NULL_OBJECT_ID)
+            << "Bridge port should be created after LAG member removal";
+
+        for (auto tableName : {APP_VLAN_TABLE_NAME, APP_VLAN_MEMBER_TABLE_NAME})
+        {
+            vector<string> ts;
+            auto exec = gPortsOrch->getExecutor(tableName);
+            auto consumer = static_cast<Consumer *>(exec);
+            consumer->dumpPendingTasks(ts);
+            ASSERT_TRUE(ts.empty()) << "All VLAN tasks should complete: " << tableName;
+        }
+
+        Port vlan;
+        ASSERT_TRUE(gPortsOrch->getPort("Vlan50", vlan));
+        ASSERT_NE(vlan.m_members.find(testPort), vlan.m_members.end())
+            << "Port should be a VLAN member after deferred SET completes";
+    }
+
     struct PostPortInitTests : PortsOrchTest
     {
     };


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
**What I did**

- Fixed a LAG/VLAN race in `PortsOrch::doVlanMemberTask` (`orchagent/portsorch.cpp`):
  - Defer `VLAN_MEMBER` SET when the target port is a valid LAG member type (`isValidPortTypeForLagMember`: PHY or SYSTEM) and still has `m_lag_member_id` set in orchagent (symmetric to the existing guard that defers LAG member add while a VLAN member is pending — issue #23635).
  - Drop a pending `VLAN_MEMBER` DEL when the VLAN no longer exists in `m_portList` (avoids retrying a stale delete).
- Added two mock regression tests under `VlanLagRaceTest` in `tests/mock_tests/portsorch_ut.cpp`:
  - `VlanMemberAddDeferredWhileLagMemberActive` — LAG member add completes first; VLAN member SET is deferred (asserts VLAN exists via `getPort`, port not in `vlan.m_members`, one pending SET).
  - `VlanMemberSucceedsAfterLagMemberRemoved` — after LAG member removal, the deferred VLAN member SET completes.

**Why I did it**

When a port is added to a LAG and a VLAN member SET is processed while orchagent still has `m_lag_member_id` set, `addBridgePort`/`addVlanMember` can call SAI too early. For some vendor this surfaces as `SAI_STATUS_INVALID_PORT_NUMBER` (rv:-9) and can leave a deferred SET retrying indefinitely. This is the inverse of #23635 (VLAN membership blocking LAG add); both come from table ordering and overlapping config during test teardown or fast config churn.

**How I verified it**

In the sonic-slave docker:

```bash
cd /sonic/src/sonic-swss/tests/mock_tests
make -j
./tests --gtest_filter=PortsOrchTest.LagMemberIsCreatedBeforeOtherObjectsAreCreatedOnLag:VlanLagRaceTest.*
```

All four tests pass, including the existing `LagMemberIsCreatedBeforeOtherObjectsAreCreatedOnLag` and `LagMemberAddDeferredWhileVlanMemberPending` cases.

**Details if related**

- The defer guard uses `isValidPortTypeForLagMember(port)` so only PHY/SYSTEM ports that can be LAG members are deferred. LAG interfaces (`PortChannel*`) are not LAG member types and remain addable as VLAN members even though they have `m_lag_id` set.
- The DEL-on-missing-VLAN path handles cleanup when a VLAN is removed while a member task is still queued; a coalesced `VLAN_MEMBER` DEL from vlanmgr remains the normal production path.
- `VlanMemberAddDeferredWhileLagMemberActive` uses a distinct port/LAG/VLAN (`PortChannel2` / `Vlan51`) from the success test because saivs state persists across tests in one gtest process.
