### PR TITLE
[portsorch] Fix invalid LAG field handling in doLagTask

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -6181,6 +6181,7 @@ void PortsOrch::doLagTask(Consumer &consumer)
             int32_t switch_id = -1;
             string tpid_string;
             uint16_t tpid = 0;
+            bool invalid_field = false;
 
             for (auto i : kfvFieldsValues(t))
             {
@@ -6196,8 +6197,8 @@ void PortsOrch::doLagTask(Consumer &consumer)
                     if (cit == learn_mode_map.cend())
                     {
                         SWSS_LOG_ERROR("Invalid MAC learn mode: %s", learn_mode_str.c_str());
-                        it++;
-                        continue;
+                        invalid_field = true;
+                        break;
                     }
 
                     learn_mode = cit->second;
@@ -6208,8 +6209,8 @@ void PortsOrch::doLagTask(Consumer &consumer)
                     if (!string_oper_status.count(operation_status))
                     {
                         SWSS_LOG_ERROR("Invalid operation status value:%s", operation_status.c_str());
-                        it++;
-                        continue;
+                        invalid_field = true;
+                        break;
                     }
                 }
                 else if (fvField(i) == "lag_id")
@@ -6228,6 +6229,12 @@ void PortsOrch::doLagTask(Consumer &consumer)
                     tpid = (uint16_t)stoi(tpid_string, 0, 16);
                     SWSS_LOG_DEBUG("reading TPID string:%s to uint16: 0x%x", tpid_string.c_str(), tpid);
                  }
+            }
+
+            if (invalid_field)
+            {
+                it = consumer.m_toSync.erase(it);
+                continue;
             }
 
             if (table_name == CHASSIS_APP_LAG_TABLE_NAME)

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -4582,6 +4582,148 @@ namespace portsorch_test
         ts.clear();
     }
 
+    /*
+     * This test checks that invalid LAG field validation happens on orchagent level
+     * and no SAI LAG create call is executed when learn_mode is invalid.
+     * It also verifies that the invalid task is removed from the pending task list.
+     */
+    TEST_F(PortsOrchTest, LagIsNotCreatedWhenLearnModeIsInvalid)
+    {
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        Table lagTable = Table(m_app_db.get(), APP_LAG_TABLE_NAME);
+
+        // Get SAI default ports to populate DB
+        auto ports = ut_helper::getInitialSaiPorts();
+
+        /*
+         * Next we will prepare some configuration data to be consumed by PortsOrch
+         * 32 Ports, 1 LAG with invalid learn_mode.
+         */
+
+        // Populate pot table with SAI ports
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+
+        // Set PortConfigDone
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+        portTable.set("PortInitDone", { { } });
+
+        lagTable.set("PortChannel0001",
+            {
+                {"admin_status", "up"},
+                {"mtu", "9100"},
+                {"learn_mode", "111"}
+            }
+        );
+
+        // refill consumer
+        gPortsOrch->addExistingData(&portTable);
+        gPortsOrch->addExistingData(&lagTable);
+
+        // save original api since we will spy
+        auto orig_lag_api = sai_lag_api;
+        sai_lag_api = new sai_lag_api_t();
+        memcpy(sai_lag_api, orig_lag_api, sizeof(*sai_lag_api));
+
+        bool lagCreateCalled = false;
+
+        auto lagSpy = SpyOn<SAI_API_LAG, SAI_OBJECT_TYPE_LAG>(&sai_lag_api->create_lag);
+        lagSpy->callFake([&](sai_object_id_t *oid, sai_object_id_t swoid, uint32_t count, const sai_attribute_t * attrs) -> sai_status_t
+            {
+                lagCreateCalled = true;
+                return orig_lag_api->create_lag(oid, swoid, count, attrs);
+            }
+        );
+
+        static_cast<Orch *>(gPortsOrch)->doTask();
+        sai_lag_api = orig_lag_api;
+
+        // verify there was no SAI call executed.
+        ASSERT_FALSE(lagCreateCalled);
+
+        vector<string> ts;
+
+        // check was processed
+        auto exec = gPortsOrch->getExecutor(APP_LAG_TABLE_NAME);
+        auto consumer = static_cast<Consumer*>(exec);
+        ts.clear();
+        consumer->dumpPendingTasks(ts);
+        ASSERT_TRUE(ts.empty());
+    }
+
+    /*
+     * This test checks that invalid LAG field validation happens on orchagent level
+     * and no SAI LAG create call is executed when oper_status is invalid.
+     * It also verifies that the invalid task is removed from the pending task list.
+     */
+    TEST_F(PortsOrchTest, LagIsNotCreatedWhenOperStatusIsInvalid)
+    {
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        Table lagTable = Table(m_app_db.get(), APP_LAG_TABLE_NAME);
+
+        // Get SAI default ports to populate DB
+        auto ports = ut_helper::getInitialSaiPorts();
+
+        /*
+         * Next we will prepare some configuration data to be consumed by PortsOrch
+         * 32 Ports, 1 LAG with invalid oper_status.
+         */
+
+        // Populate pot table with SAI ports
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+
+        // Set PortConfigDone
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+        portTable.set("PortInitDone", { { } });
+
+        lagTable.set("PortChannel0001",
+            {
+                {"admin_status", "up"},
+                {"mtu", "9100"},
+                {"oper_status", "111"}
+            }
+        );
+
+        // refill consumer
+        gPortsOrch->addExistingData(&portTable);
+        gPortsOrch->addExistingData(&lagTable);
+
+        // save original api since we will spy
+        auto orig_lag_api = sai_lag_api;
+        sai_lag_api = new sai_lag_api_t();
+        memcpy(sai_lag_api, orig_lag_api, sizeof(*sai_lag_api));
+
+        bool lagCreateCalled = false;
+
+        auto lagSpy = SpyOn<SAI_API_LAG, SAI_OBJECT_TYPE_LAG>(&sai_lag_api->create_lag);
+        lagSpy->callFake([&](sai_object_id_t *oid, sai_object_id_t swoid, uint32_t count, const sai_attribute_t * attrs) -> sai_status_t
+            {
+                lagCreateCalled = true;
+                return orig_lag_api->create_lag(oid, swoid, count, attrs);
+            }
+        );
+
+        static_cast<Orch *>(gPortsOrch)->doTask();
+        sai_lag_api = orig_lag_api;
+
+        // verify there was no SAI call executed.
+        ASSERT_FALSE(lagCreateCalled);
+
+        vector<string> ts;
+
+        // check was processed
+        auto exec = gPortsOrch->getExecutor(APP_LAG_TABLE_NAME);
+        auto consumer = static_cast<Consumer*>(exec);
+        ts.clear();
+        consumer->dumpPendingTasks(ts);
+        ASSERT_TRUE(ts.empty());
+    }
+
     /* This test passes an incorrect LAG entry and verifies that this entry is not
      * erased from the consumer table.
      */


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
Fixes #4655

**What I did**
Fixed invalid LAG field handling in `PortsOrch::doLagTask()`.
Previously, when an invalid `learn_mode` or `oper_status` value was detected, the code incremented the outer `m_toSync` iterator inside the inner field parsing loop. However, the following `continue` only applied to the inner loop, so the current task could still be processed while the iterator already pointed to the next task.
This change uses an `invalid_field` flag to stop field parsing and handles the current task explicitly in the outer loop.

**Why I did it**
The previous logic could make the current task and the outer iterator inconsistent. This may cause the invalid task to continue being processed, or cause a later erase/increment operation to affect the wrong pending task.
