### PR TITLE
Revert "[fpmsyncd]: add libnexthopgroup in Makefile.am to support rib/fib"

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -154,17 +154,6 @@ jobs:
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
-      project: ${{ parameters.buildimage_artifact_project }}
-      pipeline: Azure.sonic-buildimage.common_libs
-      artifact: common-lib
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/${{ parameters.buildimage_artifact_branch }}'
-      path: $(Build.ArtifactStagingDirectory)/download
-      patterns: '**/target/debs/${{ parameters.debian_version }}/libnexthopgroup_*.deb'
-    displayName: "Download sonic-buildimage libnexthopgroup package"
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      source: specific
       project: build
       pipeline: sonic-net.sonic-platform-vpp
       artifact: ${{ parameters.vpp_artifact_name }}
@@ -183,7 +172,6 @@ jobs:
       mkdir -p .azure-pipelines/docker-sonic-vs/debs
 
       find $(Build.ArtifactStagingDirectory)/download/sairedis -name '*.deb' -exec cp "{}" .azure-pipelines/docker-sonic-vs/debs \;
-      find $(Build.ArtifactStagingDirectory)/download -name 'libnexthopgroup_*.deb' -exec cp "{}" .azure-pipelines/docker-sonic-vs/debs \;
       cp -v $(Build.ArtifactStagingDirectory)/download/*.deb .azure-pipelines/docker-sonic-vs/debs
       if [ -f $(Build.ArtifactStagingDirectory)/download/coverage.info ]; then
         cp -v $(Build.ArtifactStagingDirectory)/download/coverage.info $(Build.ArtifactStagingDirectory)/

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -176,8 +176,6 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libnl-nf-3-200_*.deb
         target/debs/${{ parameters.debian_version }}/libnl-nf-3-dev_*.deb
         target/debs/${{ parameters.debian_version }}/libyang3_*.deb
-        target/debs/${{ parameters.debian_version }}/libnexthopgroup_*.deb
-        target/debs/${{ parameters.debian_version }}/libnexthopgroup-dev_*.deb
     displayName: "Download common libs"
   - task: DownloadPipelineArtifact@2
     inputs:

--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -13,7 +13,7 @@ COPY ["debs", "/debs"]
 # same, even though contents have changed) are checked between the previous and current layer.
 RUN dpkg --remove --force-all libswsscommon
 RUN apt --fix-broken install -y
-RUN dpkg --purge python3-swsscommon sonic-db-cli libsaimetadata libsairedis libsaivs syncd-vs swss sonic-eventd libdashapi framework libnexthopgroup
+RUN dpkg --purge python3-swsscommon sonic-db-cli libsaimetadata libsairedis libsaivs syncd-vs swss sonic-eventd libdashapi framework
 
 RUN apt-get update
 
@@ -43,8 +43,7 @@ RUN apt install -y /debs/libdashapi_1.0.0_amd64.deb \
             /debs/libsairedis_1.0.0_amd64.deb \
             /debs/libsaivs_1.0.0_amd64.deb \
             /debs/syncd-vs_1.0.0_amd64.deb \
-            /debs/swss_1.0.0_amd64.deb \
-            /debs/libnexthopgroup_1.0.0_amd64.deb
+            /debs/swss_1.0.0_amd64.deb
 
 RUN if [ "$need_dbg" = "y" ] ; then dpkg -i /debs/swss-dbg_1.0.0_amd64.deb ; fi
 

--- a/fpmsyncd/Makefile.am
+++ b/fpmsyncd/Makefile.am
@@ -13,7 +13,7 @@ fpmsyncd_SOURCES = fpmsyncd.cpp fpmlink.cpp routesync.cpp $(top_srcdir)/warmrest
 
 fpmsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
 fpmsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
-fpmsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon -lnexthopgroup
+fpmsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon
 
 if GCOV_ENABLED
 fpmsyncd_SOURCES += ../gcovpreload/gcovpreload.cpp


### PR DESCRIPTION
This reverts https://github.com/sonic-net/sonic-swss/pull/4394.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Remove build dependency on libnexthopgroup to unblock CI failures. This lib is not actively used in SWSS at the moment.

**Why I did it**
https://github.com/sonic-net/sonic-buildimage/pull/27629 is part of the libyang1 to libyang3 migration and causes libnexthopgroup to not be built as part of the common-libs pipeline. Previously when the migration was in progress, both libyang1 and 3 were being built. All packages which were dependent on libyang3 (including libnexthopgroup transitively via FRR)  were built as part of common-libs due to some serialization logic to prevent libyang1 and 3 from conflicting in sonic-buildimage at build time. Now that libyang1 is completely removed, this serialization logic doesn't exist anymore and libnexthopgroup is not built as part of common-libs, which causes the SWSS build to fail since libnexthopgroup is missing.

**How I verified it**

**Details if related**
