### PR TITLE
switchorch: add credit_watchdog SWITCH_TABLE knob

### DIFF
--- a/orchagent/p4orch/tests/test_main.cpp
+++ b/orchagent/p4orch/tests/test_main.cpp
@@ -38,6 +38,7 @@ char *gMirrorSession2 = "mirror-session-2";
 sai_object_id_t kMirrorSessionOid2 = 9002;
 sai_object_id_t gUnderlayIfId = 0x101;
 string gMyAsicName = "";
+string gMySwitchType = "switch";
 event_handle_t g_events_handle;
 
 bool gMultiAsicVoq = false;

--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -26,6 +26,7 @@ extern MacAddress gVxlanMacAddress;
 extern CrmOrch *gCrmOrch;
 extern event_handle_t g_events_handle;
 extern string gMyAsicName;
+extern string gMySwitchType;
 
 // defines ------------------------------------------------------------------------------------------------------------
 
@@ -51,7 +52,9 @@ const map<string, sai_switch_attr_t> switch_attribute_map =
     {"vxlan_port",                          SAI_SWITCH_ATTR_VXLAN_DEFAULT_PORT},
     {"vxlan_router_mac",                    SAI_SWITCH_ATTR_VXLAN_DEFAULT_ROUTER_MAC},
     {"ecmp_hash_offset",                    SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_OFFSET},
-    {"lag_hash_offset",                     SAI_SWITCH_ATTR_LAG_DEFAULT_HASH_OFFSET}
+    {"lag_hash_offset",                     SAI_SWITCH_ATTR_LAG_DEFAULT_HASH_OFFSET},
+    {"credit_watchdog",                     SAI_SWITCH_ATTR_CREDIT_WD},
+    {"credit_watchdog_timer",               SAI_SWITCH_ATTR_CREDIT_WD_TIMER}
 };
 
 const map<string, sai_switch_tunnel_attr_t> switch_tunnel_attribute_map =
@@ -699,6 +702,35 @@ void SwitchOrch::doAppSwitchTableTask(Consumer &consumer)
                         else
                         {
                             attr.value.u8 = to_uint<uint8_t>(value);
+                        }
+                        break;
+
+                    case SAI_SWITCH_ATTR_CREDIT_WD:
+                        // SAI gates this attribute to VOQ switches (validonly
+                        // SAI_SWITCH_ATTR_TYPE == SAI_SWITCH_TYPE_VOQ). Skip on
+                        // non-VOQ rather than letting SAI return NOT_SUPPORTED.
+                        if (gMySwitchType != "voq")
+                        {
+                            SWSS_LOG_NOTICE("credit_watchdog is VOQ-only; switch type is '%s', skipping",
+                                            gMySwitchType.c_str());
+                            unsupported_attr = true;
+                        }
+                        else
+                        {
+                            attr.value.booldata = to_uint<bool>(value);
+                        }
+                        break;
+
+                    case SAI_SWITCH_ATTR_CREDIT_WD_TIMER:
+                        if (gMySwitchType != "voq")
+                        {
+                            SWSS_LOG_NOTICE("credit_watchdog_timer is VOQ-only; switch type is '%s', skipping",
+                                            gMySwitchType.c_str());
+                            unsupported_attr = true;
+                        }
+                        else
+                        {
+                            attr.value.u32 = to_uint<uint32_t>(value);
                         }
                         break;
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -87,6 +87,45 @@ def ecmp_lag_hash_offset_test(dvs, oid, lag_offset, ecmp_offset):
     )
 
 
+def credit_watchdog_non_voq_test(dvs, oid):
+    """Verify credit watchdog fields are skipped on non-VOQ switches.
+
+    credit_watchdog and credit_watchdog_timer are valid only for VOQ switches
+    (validonly SAI_SWITCH_ATTR_TYPE == SAI_SWITCH_TYPE_VOQ). On a non-VOQ
+    switch, orchagent must skip them without blocking the rest of the batch.
+    """
+    app_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+    create_entry_pst(
+        app_db,
+        "SWITCH_TABLE", ':', "switch",
+        [
+            ("credit_watchdog", "0"),
+            ("credit_watchdog_timer", "600"),
+            ("fdb_aging_time", "777"),
+        ],
+    )
+    time.sleep(2)
+
+    asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
+
+    # The supported attribute from the same batch must still be applied
+    check_object(asic_db, "ASIC_STATE:SAI_OBJECT_TYPE_SWITCH", oid,
+        {
+            'SAI_SWITCH_ATTR_FDB_AGING_TIME': "777",
+        }
+    )
+
+    # The VOQ-only attributes must not have been programmed
+    tbl = swsscommon.Table(asic_db, "ASIC_STATE:SAI_OBJECT_TYPE_SWITCH")
+    status, fvs = tbl.get(oid)
+    assert status, "Got an error when get a key"
+    attr_names = {fv[0] for fv in fvs}
+    assert "SAI_SWITCH_ATTR_CREDIT_WD" not in attr_names, \
+        "credit_watchdog was programmed on a non-VOQ switch"
+    assert "SAI_SWITCH_ATTR_CREDIT_WD_TIMER" not in attr_names, \
+        "credit_watchdog_timer was programmed on a non-VOQ switch"
+
+
 class TestSwitch(object):
     '''
     Test- Check switch attributes
@@ -102,6 +141,13 @@ class TestSwitch(object):
         vxlan_switch_test(dvs, switch_oid, "56789", "00:0A:0B:0C:0D:0E", "15", "56789", "invalid")
 
         ecmp_lag_hash_offset_test(dvs, switch_oid, "10", "10")
+
+    def test_credit_watchdog_non_voq(self, dvs, testlog):
+        '''
+        Test credit watchdog fields are skipped on a non-VOQ switch
+        '''
+        switch_oid = get_exist_entry(dvs, "ASIC_STATE:SAI_OBJECT_TYPE_SWITCH")
+        credit_watchdog_non_voq_test(dvs, switch_oid)
 
 
 # Add Dummy always-pass test at end as workaroud

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -205,6 +205,54 @@ class TestVirtualChassis(object):
                 spcfg = ast.literal_eval(value)
                 assert spcfg['count'] == sp_count, "Number of systems ports configured is invalid"
 
+    def test_voq_switch_credit_watchdog(self, vct):
+        """Test credit watchdog SWITCH_TABLE configuration on VOQ switches.
+
+        The credit_watchdog and credit_watchdog_timer fields of SWITCH_TABLE:switch
+        in APPL_DB map to SAI_SWITCH_ATTR_CREDIT_WD and SAI_SWITCH_ATTR_CREDIT_WD_TIMER,
+        which are valid only for VOQ switches. This test verifies that on the line
+        cards (switch_type voq) the sets are programmed in the asic db.
+        """
+
+        if vct is None:
+            return
+
+        dvss = vct.dvss
+        for name in dvss.keys():
+            dvs = dvss[name]
+            # Get the config info
+            config_db = dvs.get_config_db()
+            metatbl = config_db.get_entry("DEVICE_METADATA", "localhost")
+
+            cfg_switch_type = metatbl.get("switch_type")
+
+            # Test only for line cards
+            if cfg_switch_type == "voq":
+                print("VOQ credit watchdog test for {}".format(name))
+
+                asic_db = dvs.get_asic_db()
+                switch_oid_key = asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_SWITCH")[0]
+
+                app_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+                switch_tbl = swsscommon.ProducerStateTable(app_db, "SWITCH_TABLE")
+
+                # Disable the credit watchdog and set the watchdog timer, then
+                # verify both sets reach the asic db
+                fvs = swsscommon.FieldValuePairs([("credit_watchdog", "0"),
+                                                  ("credit_watchdog_timer", "600")])
+                switch_tbl.set("switch", fvs)
+                asic_db.wait_for_field_match("ASIC_STATE:SAI_OBJECT_TYPE_SWITCH",
+                                             switch_oid_key,
+                                             {"SAI_SWITCH_ATTR_CREDIT_WD": "false",
+                                              "SAI_SWITCH_ATTR_CREDIT_WD_TIMER": "600"})
+
+                # Re-enable the credit watchdog (hardware default) and verify the update
+                fvs = swsscommon.FieldValuePairs([("credit_watchdog", "1")])
+                switch_tbl.set("switch", fvs)
+                asic_db.wait_for_field_match("ASIC_STATE:SAI_OBJECT_TYPE_SWITCH",
+                                             switch_oid_key,
+                                             {"SAI_SWITCH_ATTR_CREDIT_WD": "true"})
+
     def test_chassis_app_db_sync(self, vct):
         """Test chassis app db syncing.
 


### PR DESCRIPTION
**What I did**

Added `credit_watchdog` and `credit_watchdog_timer` to the SwitchOrch `SWITCH_TABLE` attribute map. These map to the SAI attributes `SAI_SWITCH_ATTR_CREDIT_WD` and `SAI_SWITCH_ATTR_CREDIT_WD_TIMER` respectively.

This allows the VOQ credit watchdog for supported platforms to be controlled through the standard SAI switch-attribute path driven via APPL_DB.

Both attributes are gated by `SAI_SWITCH_ATTR_TYPE == SAI_SWITCH_TYPE_VOQ` so setting them on non-VOQ switches will be skipped with a log notice. We also define `gMySwitchType` in p4orch test main to fix linker errors.

**Why I did it**

There is currently no vendor-neutral way to disable the VOQ hardware credit watchdog. Today, [for example in Snappi](https://github.com/nexthop-ai/sonic-mgmt/blob/master/tests/common/snappi_tests/common_helpers.py#L833-L860), the only method is via a bcmcmd, which is not supported on latest BCM platforms.

The alternatives are using platform shell commands to write explicit registers, exposing vendor-specific implementation details, or `sai_thrift`, introducing a dependency on the syncd RPC swap image which snappi tests today have no reason to rely on.

Exposing the attribute via `SWITCH_TABLE` makes the knob available to tests and tooling on any VOQ platform.

**How I verified it**

- New DVS test `test_switch.py::TestSwitch::test_credit_watchdog_non_voq` verifies the fields are skipped on a non-VOQ switch without blocking other attributes in the same batch.
- New DVS test `test_virtual_chassis.py::TestVirtualChassis::test_voq_switch_credit_watchdog` verifies the attributes are programmed on a VOQ switch.
- Verified on Broadcom DNX VOQ hardware: writing `credit_watchdog=0` via `SWITCH_TABLE` (using `swssconfig`) disables the credit watchdog and writing `1` restores it.

**Details if related**

Requires SAI headers with `SAI_SWITCH_ATTR_CREDIT_WD` / `SAI_SWITCH_ATTR_CREDIT_WD_TIMER` (added in [opencomputeproject/SAI#1779](https://github.com/opencomputeproject/SAI/pull/1779), first released in SAI v1.12.0).

Changes validated on SAI 14.1.

Related to sonic-net/sonic-mgmt#25152

Fixes #4705 