### PR TITLE
AclOrch: skip default ACL table match fields unsupported by the platform

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -762,9 +762,50 @@ AclTableTypeBuilder& AclTableTypeBuilder::withBindPointType(sai_acl_bind_point_t
     return *this;
 }
 
+/*
+ * Returns true if the platform/SAI implements the given ACL table match field.
+ *
+ * Uses sai_query_attribute_capability() for SAI_OBJECT_TYPE_ACL_TABLE. If the
+ * capability query itself is not implemented (SAI_STATUS_NOT_IMPLEMENTED /
+ * SAI_STATUS_NOT_SUPPORTED) we preserve the historical behavior and assume the
+ * field is supported, so platforms that do not implement the query are
+ * unaffected. Any other (genuine) query failure treats the field as unsupported.
+ */
+static bool isAclTableMatchFieldSupported(sai_acl_table_attr_t matchField)
+{
+    sai_attr_capability_t capability = {};
+    sai_status_t status = sai_query_attribute_capability(
+        gSwitchId, SAI_OBJECT_TYPE_ACL_TABLE, matchField, &capability);
+
+    if (status == SAI_STATUS_SUCCESS)
+    {
+        return capability.create_implemented;
+    }
+
+    // Preserve historical behavior only when the capability query itself is unsupported.
+    if (status == SAI_STATUS_NOT_IMPLEMENTED || status == SAI_STATUS_NOT_SUPPORTED)
+    {
+        SWSS_LOG_INFO("sai_query_attribute_capability(ACL_TABLE, %d) returned %d; "
+                      "assuming match field is supported", matchField, status);
+        return true;
+    }
+
+    SWSS_LOG_WARN("sai_query_attribute_capability(ACL_TABLE, %d) returned %d; "
+                  "treating match field as unsupported", matchField, status);
+    return false;
+}
+
 AclTableTypeBuilder& AclTableTypeBuilder::withMatch(shared_ptr<AclTableMatchInterface> match)
 {
-    m_tableType.m_matches.emplace(match->getId(), match);
+    auto matchField = match->getId();
+    if (!isAclTableMatchFieldSupported(matchField))
+    {
+        const auto *meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_ACL_TABLE, matchField);
+        SWSS_LOG_NOTICE("Skipping ACL table match field %s: not supported by the platform",
+                        meta ? meta->attridname : std::to_string(static_cast<int>(matchField)).c_str());
+        return *this;
+    }
+    m_tableType.m_matches.emplace(matchField, match);
     return *this;
 }
 

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -1,5 +1,8 @@
 #include "ut_helper.h"
 #include "flowcounterrouteorch.h"
+#include "mock_sai_capability_wrap.h"
+
+#include <cstring>
 
 extern sai_object_id_t gSwitchId;
 
@@ -104,6 +107,7 @@ namespace aclorch_test
 
     TEST_F(AclTest, Create_L3_Acl_Table)
     {
+        hftelorch_sai_wrap_ut::HFTelSaiHookGuard guard(hftelorch_sai_wrap_ut::setSaiHookAllSupported);
         AclTable acltable; /* this test shouldn't trigger a call to gAclOrch because it's nullptr */
         AclTableTypeBuilder builder;
         auto l3TableType = builder
@@ -145,6 +149,163 @@ namespace aclorch_test
         SaiAttributeList attr_list(SAI_OBJECT_TYPE_ACL_TABLE, v, false);
 
         ASSERT_TRUE(Check::AttrListEq(SAI_OBJECT_TYPE_ACL_TABLE, res->attr_list, attr_list));
+    }
+
+    /*
+     * The following tests cover AclTableTypeBuilder::withMatch() gating each ACL
+     * table match field on sai_query_attribute_capability(SAI_OBJECT_TYPE_ACL_TABLE,
+     * <field>). A match field is only added when the platform reports it as
+     * supported (create_implemented); when the capability query is unimplemented
+     * the field is assumed supported so existing platforms are unaffected.
+     */
+
+    /*
+     * Field reported unsupported by the platform is dropped from the table type,
+     * while supported fields are retained.
+     */
+    TEST_F(AclTest, MatchFieldCapabilityGate_DropsUnsupportedField)
+    {
+        sai_cap_ut::AttrCapabilityOverrideGuard guard(
+            [](sai_object_type_t objectType, sai_attr_id_t attrId,
+               sai_attr_capability_t *cap, sai_status_t *status) -> bool {
+                if (objectType != SAI_OBJECT_TYPE_ACL_TABLE)
+                {
+                    return false;
+                }
+                std::memset(cap, 0, sizeof(*cap));
+                bool supported = (attrId != SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID);
+                cap->create_implemented = supported;
+                cap->set_implemented = supported;
+                cap->get_implemented = supported;
+                *status = SAI_STATUS_SUCCESS;
+                return true;
+            });
+
+        AclTableTypeBuilder builder;
+        auto tableType = builder
+            .withName("TEST_TABLE_TYPE")
+            .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID))
+            .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_SRC_IP))
+            .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_DST_IP))
+            .build();
+
+        const auto &matches = tableType.getMatches();
+        EXPECT_EQ(matches.count(SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID), 0U);
+        EXPECT_EQ(matches.count(SAI_ACL_TABLE_ATTR_FIELD_SRC_IP), 1U);
+        EXPECT_EQ(matches.count(SAI_ACL_TABLE_ATTR_FIELD_DST_IP), 1U);
+    }
+
+    /*
+     * When the capability query itself is not implemented, the field is assumed
+     * supported (preserves behavior on platforms that do not implement the query).
+     */
+    TEST_F(AclTest, MatchFieldCapabilityGate_QueryUnimplementedKeepsField)
+    {
+        sai_cap_ut::AttrCapabilityOverrideGuard guard(
+            [](sai_object_type_t objectType, sai_attr_id_t /*attrId*/,
+               sai_attr_capability_t * /*cap*/, sai_status_t *status) -> bool {
+                if (objectType != SAI_OBJECT_TYPE_ACL_TABLE)
+                {
+                    return false;
+                }
+                *status = SAI_STATUS_NOT_IMPLEMENTED;
+                return true;
+            });
+
+        AclTableTypeBuilder builder;
+        auto tableType = builder
+            .withName("TEST_TABLE_TYPE")
+            .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID))
+            .build();
+
+        EXPECT_EQ(tableType.getMatches().count(SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID), 1U);
+    }
+
+    /* Field reported supported by the platform is retained. */
+    TEST_F(AclTest, MatchFieldCapabilityGate_SupportedFieldKept)
+    {
+        sai_cap_ut::AttrCapabilityOverrideGuard guard(
+            [](sai_object_type_t objectType, sai_attr_id_t /*attrId*/,
+               sai_attr_capability_t *cap, sai_status_t *status) -> bool {
+                if (objectType != SAI_OBJECT_TYPE_ACL_TABLE)
+                {
+                    return false;
+                }
+                std::memset(cap, 0, sizeof(*cap));
+                cap->create_implemented = true;
+                cap->set_implemented = true;
+                cap->get_implemented = true;
+                *status = SAI_STATUS_SUCCESS;
+                return true;
+            });
+
+        AclTableTypeBuilder builder;
+        auto tableType = builder
+            .withName("TEST_TABLE_TYPE")
+            .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID))
+            .build();
+
+        EXPECT_EQ(tableType.getMatches().count(SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID), 1U);
+    }
+
+    /*
+     * SAI_STATUS_NOT_SUPPORTED is the other "query unavailable" status (besides
+     * NOT_IMPLEMENTED) for which the field must be assumed supported, preserving
+     * behavior on platforms that do not implement the capability query.
+     */
+    TEST_F(AclTest, MatchFieldCapabilityGate_QueryNotSupportedKeepsField)
+    {
+        sai_cap_ut::AttrCapabilityOverrideGuard guard(
+            [](sai_object_type_t objectType, sai_attr_id_t /*attrId*/,
+               sai_attr_capability_t * /*cap*/, sai_status_t *status) -> bool {
+                if (objectType != SAI_OBJECT_TYPE_ACL_TABLE)
+                {
+                    return false;
+                }
+                *status = SAI_STATUS_NOT_SUPPORTED;
+                return true;
+            });
+
+        AclTableTypeBuilder builder;
+        auto tableType = builder
+            .withName("TEST_TABLE_TYPE")
+            .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID))
+            .build();
+
+        EXPECT_EQ(tableType.getMatches().count(SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID), 1U);
+    }
+
+    /*
+     * A genuine capability-query failure (a status that is neither SUCCESS nor
+     * NOT_IMPLEMENTED/NOT_SUPPORTED) must NOT be treated as "assume supported".
+     * The field is treated as unsupported and dropped, so a real error cannot
+     * keep an unsupported field and drive the ACL table create into an endless
+     * fail/retry loop. This is the core behavior of the capability-query error
+     * handling fix.
+     */
+    TEST_F(AclTest, MatchFieldCapabilityGate_GenuineQueryFailureDropsField)
+    {
+        sai_cap_ut::AttrCapabilityOverrideGuard guard(
+            [](sai_object_type_t objectType, sai_attr_id_t /*attrId*/,
+               sai_attr_capability_t * /*cap*/, sai_status_t *status) -> bool {
+                if (objectType != SAI_OBJECT_TYPE_ACL_TABLE)
+                {
+                    return false;
+                }
+                *status = SAI_STATUS_FAILURE;
+                return true;
+            });
+
+        AclTableTypeBuilder builder;
+        auto tableType = builder
+            .withName("TEST_TABLE_TYPE")
+            .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID))
+            .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_SRC_IP))
+            .build();
+
+        // Every field is dropped because the query failed genuinely.
+        EXPECT_EQ(tableType.getMatches().count(SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID), 0U);
+        EXPECT_EQ(tableType.getMatches().count(SAI_ACL_TABLE_ATTR_FIELD_SRC_IP), 0U);
     }
 
     struct MockAclOrch

--- a/tests/mock_tests/mock_sai_capability_wrap.cpp
+++ b/tests/mock_tests/mock_sai_capability_wrap.cpp
@@ -57,6 +57,11 @@ namespace
 
         thread_local Hook g_hook = Hook::None;
     }
+
+    // Generic per-attribute capability override (sai_cap_ut), checked first in
+    // __wrap_sai_query_attribute_capability so any orch UT (e.g. the ACL
+    // match-field gate) can inject a result regardless of object type.
+    thread_local sai_cap_ut::AttrCapabilityOverride g_attr_cap_override;
 }
 
 static const sai_attr_metadata_t g_nonEnumMetadataTest{};
@@ -165,6 +170,24 @@ extern "C"
             _In_ sai_attr_id_t attr_id,
             _Out_ sai_attr_capability_t *attr_capability)
     {
+        // Generic per-attribute override (any orch UT). Checked first: when it
+        // handles the query, its status and capability are used verbatim;
+        // otherwise fall through to the per-orch handling below.
+        if (g_attr_cap_override)
+        {
+            sai_attr_capability_t cap;
+            std::memset(&cap, 0, sizeof(cap));
+            sai_status_t st = SAI_STATUS_SUCCESS;
+            if (g_attr_cap_override(object_type, attr_id, &cap, &st))
+            {
+                if (attr_capability)
+                {
+                    *attr_capability = cap;
+                }
+                return st;
+            }
+        }
+
         // ICMP echo session selective-counter capability (IcmpOrch via the shared
         // SaiOffloadSession base). Fail only the ICMP echo session object; any
         // other object type falls through to the HFTel handling / real impl so
@@ -337,5 +360,18 @@ namespace hftelorch_sai_wrap_ut
     HFTelSaiHookGuard::~HFTelSaiHookGuard()
     {
         setSaiHookNone();
+    }
+}
+
+namespace sai_cap_ut
+{
+    void setAttrCapabilityOverride(AttrCapabilityOverride fn)
+    {
+        g_attr_cap_override = std::move(fn);
+    }
+
+    void clearAttrCapabilityOverride()
+    {
+        g_attr_cap_override = nullptr;
     }
 }

--- a/tests/mock_tests/mock_sai_capability_wrap.h
+++ b/tests/mock_tests/mock_sai_capability_wrap.h
@@ -26,6 +26,46 @@
  * Each orch therefore drives only its own namespace below.
  */
 
+#include <functional>
+#include <utility>
+
+#include <saitypes.h>
+#include <saiobject.h>
+
+/**
+ * Generic per-attribute capability override for the single shared
+ * sai_query_attribute_capability() --wrap. Return true to handle the query
+ * (filling *cap and *status); return false to fall through to the default
+ * per-orch behaviour. Usable by any mock test (e.g. the ACL match-field gate).
+ */
+namespace sai_cap_ut
+{
+    using AttrCapabilityOverride = std::function<bool(
+        sai_object_type_t object_type,
+        sai_attr_id_t attr_id,
+        sai_attr_capability_t *cap,
+        sai_status_t *status)>;
+
+    void setAttrCapabilityOverride(AttrCapabilityOverride fn);
+    void clearAttrCapabilityOverride();
+
+    /** RAII: clears the override on scope exit. */
+    struct AttrCapabilityOverrideGuard
+    {
+        explicit AttrCapabilityOverrideGuard(AttrCapabilityOverride fn)
+        {
+            setAttrCapabilityOverride(std::move(fn));
+        }
+        ~AttrCapabilityOverrideGuard()
+        {
+            clearAttrCapabilityOverride();
+        }
+
+        AttrCapabilityOverrideGuard(const AttrCapabilityOverrideGuard &) = delete;
+        AttrCapabilityOverrideGuard &operator=(const AttrCapabilityOverrideGuard &) = delete;
+    };
+}
+
 /**
  * Test hooks for the SAI calls on the ICMP echo session stats count mode path
  * (orchagent/icmporch.cpp, IcmpOrch::resolve_stats_count_mode).


### PR DESCRIPTION
#### Why I did it

`AclOrch::initDefaultTableTypes()` builds the default ACL table types (L3, L3V6, L3V4V6, MCLAG, MIRROR, MIRRORV6, …) with a fixed set of match fields and assumes every field is supported. `create_acl_table` sets all match fields atomically, so a single field the ASIC/SAI does not implement fails the **whole** table create.

On platforms where VLAN match is not valid for L3 ACLs, `SAI_ACL_TABLE_ATTR_FIELD_OUTER_VLAN_ID` is rejected, the L3 table create fails, and orchagent retries the create indefinitely — ACL bring-up never completes.

Fixes #4660

#### How I did it

Gate `AclTableTypeBuilder::withMatch()` on `sai_query_attribute_capability(SAI_OBJECT_TYPE_ACL_TABLE, <field>)`:

- A match field is added only when the capability query reports `create_implemented`.
- If the capability query itself is not implemented (`SAI_STATUS_NOT_IMPLEMENTED` / `SAI_STATUS_NOT_SUPPORTED`), the field is assumed supported, so platforms that do not implement the query keep their existing behavior.
- Any other (genuine) capability-query failure treats the field as unsupported and drops it, so a real error cannot keep an unsupported field and drive the ACL table create into an endless fail/retry loop.
- Fields the platform reports as unsupported are dropped and logged at `NOTICE`; a genuine query failure is logged at `WARN`.

This reuses the same `sai_query_attribute_capability()` mechanism `AclOrch` already uses for action and metadata capabilities.

**Implementation note:** the gate lives in the universal `withMatch()`, so it also applies to user-defined `ACL_TABLE_TYPE`s, not just the built-in defaults. Fields a user explicitly configures but the platform can't implement are silently dropped (logged at `NOTICE`) rather than failing the create. If reviewers prefer to gate **only** the built-in defaults, this can instead be a `withMatchIfSupported()` variant called solely from `initDefaultTableTypes()`, leaving `withMatch()` strict — happy to refactor either way.

#### How to verify it
Added `mock_tests` coverage in `tests/mock_tests/aclorch_ut.cpp`:

- `MatchFieldCapabilityGate_DropsUnsupportedField` — a field reported unsupported is dropped from the table type, supported fields are retained.
- `MatchFieldCapabilityGate_QueryUnimplementedKeepsField` — when the capability query is unimplemented (`SAI_STATUS_NOT_IMPLEMENTED`), the field is kept (no regression).
- `MatchFieldCapabilityGate_SupportedFieldKept` — a field reported supported is retained.
- `MatchFieldCapabilityGate_QueryNotSupportedKeepsField` — `SAI_STATUS_NOT_SUPPORTED` is also treated as "query unavailable", so the field is kept.
- `MatchFieldCapabilityGate_GenuineQueryFailureDropsField` — a genuine query failure (neither `SUCCESS` nor `NOT_IMPLEMENTED` / `NOT_SUPPORTED`) drops the field instead of assuming it is supported.

`sai_query_attribute_capability()` is a free function (not a SAI api struct member), so it can't be mocked via `SpyOn`. It is already intercepted through a single GNU-ld `--wrap` point in the shared `mock_sai_capability_wrap` helper (the unified wrapper introduced by #4613); I added a generic, test-settable per-attribute capability override there (`sai_cap_ut::AttrCapabilityOverride` plus an RAII `AttrCapabilityOverrideGuard`) so any mock test can program a result without disturbing the existing per-orch hooks.

```
$ make -C tests/mock_tests tests
$ ./tests/mock_tests/tests --gtest_filter='AclTest.Create_L3_Acl_Table:AclTest.MatchFieldCapabilityGate_*'
[ RUN      ] AclTest.Create_L3_Acl_Table
[       OK ] AclTest.Create_L3_Acl_Table (0 ms)
[ RUN      ] AclTest.MatchFieldCapabilityGate_DropsUnsupportedField
[       OK ] AclTest.MatchFieldCapabilityGate_DropsUnsupportedField (0 ms)
[ RUN      ] AclTest.MatchFieldCapabilityGate_QueryUnimplementedKeepsField
[       OK ] AclTest.MatchFieldCapabilityGate_QueryUnimplementedKeepsField (0 ms)
[ RUN      ] AclTest.MatchFieldCapabilityGate_SupportedFieldKept
[       OK ] AclTest.MatchFieldCapabilityGate_SupportedFieldKept (0 ms)
[ RUN      ] AclTest.MatchFieldCapabilityGate_QueryNotSupportedKeepsField
[       OK ] AclTest.MatchFieldCapabilityGate_QueryNotSupportedKeepsField (0 ms)
[ RUN      ] AclTest.MatchFieldCapabilityGate_GenuineQueryFailureDropsField
[       OK ] AclTest.MatchFieldCapabilityGate_GenuineQueryFailureDropsField (0 ms)
[  PASSED  ] 6 tests.
```

The existing `Create_L3_Acl_Table` test confirms no regression on the default L3 table type.

Verified that the ACL table is created without the unsupported field on a HPE SONiC dut.

#### Description for the changelog

AclOrch: skip default ACL table match fields unsupported by the platform (capability-gated `withMatch()`), preventing a single unsupported field from failing the whole ACL table create.
