### PR TITLE
[routeorch] Remove Mellanox ECMP group count divisor workaround

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -71,21 +71,6 @@ RouteOrch::RouteOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames,
     else
     {
         m_maxNextHopGroupCount = attr.value.s32;
-
-        /*
-         * ASIC specific workaround to re-calculate maximum ECMP groups
-         * according to different ECMP mode used.
-         *
-         * On Mellanox platform, the maximum ECMP groups returned is the value
-         * under the condition that the ECMP group size is 1. Dividing this
-         * number by DEFAULT_MAX_ECMP_GROUP_SIZE gets the maximum number of
-         * ECMP groups when the maximum ECMP group size is 32.
-         */
-        char *platform = getenv("platform");
-        if (platform && strstr(platform, MLNX_PLATFORM_SUBSTRING))
-        {
-            m_maxNextHopGroupCount /= DEFAULT_MAX_ECMP_GROUP_SIZE;
-        }
     }
     vector<FieldValueTuple> fvTuple;
     fvTuple.emplace_back("MAX_NEXTHOP_GROUP_COUNT", to_string(m_maxNextHopGroupCount));


### PR DESCRIPTION
## Summary
- Remove the Mellanox-specific workaround in `routeorch.cpp` that divided `SAI_SWITCH_ATTR_NUMBER_OF_ECMP_GROUPS` by 32
- The vendor SDK now returns the true hardware ECMP group limit (4200) directly, making the divisor unnecessary
- With the divisor still applied, `m_maxNextHopGroupCount` is incorrectly set to 131 (4200/32), preventing the system from utilizing the full 4200 ECMP groups

## Background
The SDK previously returned the KVD size (~512K) for `SAI_SWITCH_ATTR_NUMBER_OF_ECMP_GROUPS`, assuming each ECMP group has only 1 member. The `/= 32` workaround compensated for this by estimating the real limit when the max group size is 32.

The SDK has since been fixed to return the actual hardware limit (4200) directly. With this fix applied, the `/= 32` workaround produces an artificially low value of 131, which causes:
- `MAX_NEXTHOP_GROUP_COUNT` in STATE_DB to be 131
- CRM test `test_crm_nexthop_group(group_member=True)` to fail because the system cannot create enough NHG entries during the pre-warm phase


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed platform-specific ECMP scaling so routing uses a single, consistent default ECMP group capacity across all platforms.
  * Increased the fallback ECMP group capacity used when hardware-reported values are unavailable, improving default path capacity and making behavior more predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->