### PR TITLE
Re-add the libnexthopgroup to Azure pipeline build and swss Makefile.am

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -154,6 +154,17 @@ jobs:
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
+      project: ${{ parameters.buildimage_artifact_project }}
+      pipeline: Azure.sonic-buildimage.common_libs
+      artifact: common-lib
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/${{ parameters.buildimage_artifact_branch }}'
+      path: $(Build.ArtifactStagingDirectory)/download
+      patterns: '**/target/debs/${{ parameters.debian_version }}/libnexthopgroup_*.deb'
+    displayName: "Download sonic-buildimage libnexthopgroup package"
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: specific
       project: build
       pipeline: sonic-net.sonic-platform-vpp
       artifact: ${{ parameters.vpp_artifact_name }}

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -176,6 +176,8 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libnl-nf-3-200_*.deb
         target/debs/${{ parameters.debian_version }}/libnl-nf-3-dev_*.deb
         target/debs/${{ parameters.debian_version }}/libyang3_*.deb
+        target/debs/${{ parameters.debian_version }}/libnexthopgroup_*.deb
+        target/debs/${{ parameters.debian_version }}/libnexthopgroup-dev_*.deb
     displayName: "Download common libs"
   - task: DownloadPipelineArtifact@2
     inputs:

--- a/fpmsyncd/Makefile.am
+++ b/fpmsyncd/Makefile.am
@@ -13,7 +13,7 @@ fpmsyncd_SOURCES = fpmsyncd.cpp fpmlink.cpp routesync.cpp $(top_srcdir)/warmrest
 
 fpmsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
 fpmsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
-fpmsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon
+fpmsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon -lnexthopgroup
 
 if GCOV_ENABLED
 fpmsyncd_SOURCES += ../gcovpreload/gcovpreload.cpp


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Re-add the  libnexthopgroup  to  Azure pipeline build and Makefile.am to support rib/fib feature.
This pr was added before, but it was reverted for some reasons, and now it is added again. 

The reasons for reverting can be found in PR: https://github.com/sonic-net/sonic-swss/pull/4657
Previous PR: https://github.com/sonic-net/sonic-swss/pull/4394

**Why I did it**

In the RIB/FIB design, we need the libnexthopgroup compiled from sonic-fib to communicate with Zebra.
More details please refer the documents following:

**How I verified it**

Unit tests for libnexthopgroup.
Unit tests for nhg mgr.
Daily vsonic tests.

**Details if related**
