### PR TITLE
fpmsyncd high cpu when interfaces are created in kernel.

### DIFF
--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -2520,9 +2520,20 @@ void RouteSync::onMsgRaw(struct nlmsghdr *h)
 
 void RouteSync::onMsg(int nlmsg_type, struct nl_object *obj)
 {
-    if (nlmsg_type == RTM_NEWLINK || nlmsg_type == RTM_DELLINK)
+    if (nlmsg_type == RTM_NEWLINK)
     {
-        nl_cache_refill(m_nl_sock, m_link_cache);
+        nl_cache_include(m_link_cache, obj, NULL, NULL);
+        return;
+    }
+    if (nlmsg_type == RTM_DELLINK)
+    {
+        struct rtnl_link *cached = rtnl_link_get(m_link_cache,
+                                        rtnl_link_get_ifindex((struct rtnl_link *)obj));
+        if (cached)
+        {
+            nl_cache_remove((struct nl_object *)cached);
+            rtnl_link_put(cached);
+        }
         return;
     }
 

--- a/tests/mock_tests/fpmsyncd/test_routesync.cpp
+++ b/tests/mock_tests/fpmsyncd/test_routesync.cpp
@@ -15,6 +15,8 @@
 #include <netlink/route/link.h>
 #include <netlink/route/nexthop.h>
 #include <linux/nexthop.h>
+
+#include <chrono>
 #include <linux/lwtunnel.h>
 #include <linux/seg6_iptunnel.h>
 #include <sys/stat.h>
@@ -50,6 +52,8 @@ public:
                                std::string& , std::string&,
                                std::string&), (override));
     MOCK_METHOD(bool, getIfName, (int, char *, size_t), (override));
+
+    int getLinkCacheCount() const { return nl_cache_nitems(m_link_cache); }
 };
 class MockFpm : public FpmInterface
 {
@@ -5096,4 +5100,182 @@ TEST_F(FpmSyncdResponseTest, TestVnetRouteMsgWithZmqDisabled_OnlyNonEmptyFields)
 
     rtnl_route_put(test_route);
 
+}
+
+/*
+ * Helper: walk m_link_cache and return the highest ifindex currently present.
+ * Returns 0 if the cache is null or empty.
+ * Used to derive a collision-free ifindex range for synthetic test links:
+ * the host kernel cache already contains real interfaces (lo, eth0, …) at
+ * low ifindexes.  nl_cache_include() matches by ifindex, so using the same
+ * ifindexes would silently replace those baseline entries and make count /
+ * delete assertions host-dependent.  Starting above the current maximum
+ * guarantees the synthetic links are always new entries.
+ */
+static int getCacheMaxIfindex(struct nl_cache *cache)
+{
+    int max_idx = 0;
+    if (!cache)
+        return max_idx;
+    for (struct nl_object *obj = nl_cache_get_first(cache);
+         obj != nullptr;
+         obj = nl_cache_get_next(obj))
+    {
+        int idx = rtnl_link_get_ifindex((struct rtnl_link *)obj);
+        if (idx > max_idx)
+            max_idx = idx;
+    }
+    return max_idx;
+}
+
+TEST_F(FpmSyncdResponseTest, OnMsg_BulkNewDel_1kVlan_1kVXLAN_NoRouteProcessing)
+{
+    using clock = std::chrono::steady_clock;
+    using ms    = std::chrono::milliseconds;
+    using us    = std::chrono::microseconds;
+
+    EXPECT_CALL(m_mockRouteSync, getIfName(_, _, _)).Times(0);
+
+    /*
+     * Derive a collision-free ifindex base.
+     * Vlan  links: base + 0    .. base + 999   (1000 entries)
+     * VXLAN links: base + 1000 .. base + 1999  (1000 entries)
+     */
+    const int base = getCacheMaxIfindex(m_mockRouteSync.m_link_cache) + 1;
+
+    /*
+     * Seed one dummy link entry first, then clone from it. This avoids
+     * dependency on pre-existing kernel cache content while still using a
+     * fully-parsed object with valid libnl metadata for nl_cache_include().
+     */
+    const int dummy_ifindex = base + 5000;
+    {
+        struct rtnl_link *dummy = rtnl_link_alloc();
+        ASSERT_NE(dummy, nullptr);
+        rtnl_link_set_ifindex(dummy, dummy_ifindex);
+        rtnl_link_set_name(dummy, "VlanTemplate");
+
+        struct nl_msg *msg = nullptr;
+        ASSERT_EQ(rtnl_link_build_add_request(dummy, NLM_F_CREATE, &msg), 0);
+        ASSERT_EQ(nl_cache_parse_and_add(m_mockRouteSync.m_link_cache, msg), 0);
+        nlmsg_free(msg);
+        rtnl_link_put(dummy);
+    }
+
+    struct rtnl_link *template_link = rtnl_link_get(m_mockRouteSync.m_link_cache, dummy_ifindex);
+    ASSERT_NE(template_link, nullptr);
+    struct nl_object *template_obj = (struct nl_object *)template_link;
+
+    const int initial_count = m_mockRouteSync.getLinkCacheCount();
+
+    /* ------------------------------------------------------------------ */
+    /* Phase 1: RTM_NEWLINK                                                */
+    /* ------------------------------------------------------------------ */
+    auto t_add_vlan_start = clock::now();
+
+    for (int i = 0; i < 1000; i++)
+    {
+        struct nl_object *obj = nl_object_clone(template_obj);
+        ASSERT_NE(obj, nullptr);
+        struct rtnl_link *link = (struct rtnl_link *)obj;
+        rtnl_link_set_ifindex(link, base + i);
+        string name = "Vlan" + to_string(i + 2);
+        rtnl_link_set_name(link, name.c_str());
+        m_mockRouteSync.onMsg(RTM_NEWLINK, obj);
+        rtnl_link_put(link);
+    }
+
+    auto t_add_vlan_end = clock::now();
+    auto add_vlan_us    = std::chrono::duration_cast<us>(t_add_vlan_end - t_add_vlan_start).count();
+
+    auto t_add_vxlan_start = clock::now();
+
+    for (int i = 0; i < 1000; i++)
+    {
+        struct nl_object *obj = nl_object_clone(template_obj);
+        ASSERT_NE(obj, nullptr);
+        struct rtnl_link *link = (struct rtnl_link *)obj;
+        rtnl_link_set_ifindex(link, base + 1000 + i);
+        string name = "VXLAN-" + to_string(i + 2);
+        rtnl_link_set_name(link, name.c_str());
+        m_mockRouteSync.onMsg(RTM_NEWLINK, obj);
+        rtnl_link_put(link);
+    }
+
+    auto t_add_vxlan_end = clock::now();
+    auto add_vxlan_us    = std::chrono::duration_cast<us>(t_add_vxlan_end - t_add_vxlan_start).count();
+    auto add_total_us    = add_vlan_us + add_vxlan_us;
+    auto add_total_ms    = std::chrono::duration_cast<ms>(t_add_vxlan_end - t_add_vlan_start).count();
+
+    EXPECT_EQ(m_mockRouteSync.getLinkCacheCount(), initial_count + 2000)
+        << "Expected cache to grow by 2000 after RTM_NEWLINK phase.";
+
+    /* ------------------------------------------------------------------ */
+    /* Phase 2: RTM_DELLINK                                                */
+    /* ------------------------------------------------------------------ */
+    auto t_del_vlan_start = clock::now();
+
+    for (int i = 0; i < 1000; i++)
+    {
+        struct rtnl_link *link = rtnl_link_alloc();
+        ASSERT_NE(link, nullptr);
+        rtnl_link_set_ifindex(link, base + i);
+        string name = "Vlan" + to_string(i + 2);
+        rtnl_link_set_name(link, name.c_str());
+        m_mockRouteSync.onMsg(RTM_DELLINK, (struct nl_object *)link);
+        rtnl_link_put(link);
+    }
+
+    auto t_del_vlan_end = clock::now();
+    auto del_vlan_us    = std::chrono::duration_cast<us>(t_del_vlan_end - t_del_vlan_start).count();
+
+    auto t_del_vxlan_start = clock::now();
+
+    for (int i = 0; i < 1000; i++)
+    {
+        struct rtnl_link *link = rtnl_link_alloc();
+        ASSERT_NE(link, nullptr);
+        rtnl_link_set_ifindex(link, base + 1000 + i);
+        string name = "VXLAN-" + to_string(i + 2);
+        rtnl_link_set_name(link, name.c_str());
+        m_mockRouteSync.onMsg(RTM_DELLINK, (struct nl_object *)link);
+        rtnl_link_put(link);
+    }
+
+    auto t_del_vxlan_end = clock::now();
+    auto del_vxlan_us    = std::chrono::duration_cast<us>(t_del_vxlan_end - t_del_vxlan_start).count();
+    auto del_total_us    = del_vlan_us + del_vxlan_us;
+    auto del_total_ms    = std::chrono::duration_cast<ms>(t_del_vxlan_end - t_del_vlan_start).count();
+
+    EXPECT_EQ(m_mockRouteSync.getLinkCacheCount(), initial_count)
+        << "Expected cache to return to initial count after RTM_DELLINK phase.";
+
+    std::cout << "onMsg RTM_NEWLINK bulk performance\n"
+              << "  1000 Vlan  events (Vlan2..Vlan1001)    : "
+              << add_vlan_us  << " us  (" << (add_vlan_us  / 1000) << " us/event avg)\n"
+              << "  1000 VXLAN events (VXLAN-2..VXLAN-1001): "
+              << add_vxlan_us << " us  (" << (add_vxlan_us / 1000) << " us/event avg)\n"
+              << "  Total 2000 events                      : "
+              << add_total_us << " us  (" << add_total_ms << " ms)\n";
+
+    std::cout << "onMsg RTM_DELLINK bulk performance\n"
+              << "  1000 Vlan  events (Vlan2..Vlan1001)    : "
+              << del_vlan_us  << " us  (" << (del_vlan_us  / 1000) << " us/event avg)\n"
+              << "  1000 VXLAN events (VXLAN-2..VXLAN-1001): "
+              << del_vxlan_us << " us  (" << (del_vxlan_us / 1000) << " us/event avg)\n"
+              << "  Total 2000 events                      : "
+              << del_total_us << " us  (" << del_total_ms << " ms)\n";
+
+    EXPECT_LT(add_total_ms, 10000)
+        << "RTM_NEWLINK: 2000 events took " << add_total_ms << " ms, expected < 10000 ms.";
+    EXPECT_LT(del_total_ms, 10000)
+        << "RTM_DELLINK: 2000 events took " << del_total_ms << " ms, expected < 10000 ms.";
+
+    Table route_table(m_db.get(), APP_ROUTE_TABLE_NAME);
+    vector<string> keys;
+    route_table.getKeys(keys);
+    EXPECT_TRUE(keys.empty())
+        << "RTM_NEWLINK/DELLINK events must not write any route to APP_DB.";
+
+    rtnl_link_put(template_link);
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Replaced the unconditional nl_cache_refill() call in RouteSync::onMsg() with incremental O(1) cache operations:

RTM_NEWLINK → nl_cache_include(m_link_cache, obj) — inserts only the new link RTM_DELLINK → nl_cache_remove(cached) — removes only the deleted link Added a bulk performance mock test OnMsg_BulkNewDel_1kVlan_1kVXLAN_NoRouteProcessing in tests/mock_tests/fpmsyncd/test_routesync.cpp that simulates 1000 Vlan + 1000 VXLAN interface add and delete events (2000 each) and asserts:

getIfName() is never called for any RTM_NEWLINK / RTM_DELLINK event Cache count is initial + 2000 after the add phase
No routes are written to APP_DB
Both phases complete within 10 seconds

**Why I did it**
Every RTM_NEWLINK or RTM_DELLINK event was triggering nl_cache_refill(), which issues a full RTM_GETLINK dump to the kernel and rebuilds the entire link cache from scratch. With 1000 Vlan + 1000 VXLAN interfaces (2000 total events), this results in:

2000 events × 2000 links = 4,000,000 kernel operations  O(N²) This caused fpmsyncd to pin at 100% CPU for ~10 minutes during bulk interface configuration.

The fix reduces this to:

2000 events × 1 operation = 2000 cache operations  O(N) nl_cache_refill is retained as a fallback safety net inside getIfName() and getLinkByName() for the rare case where a route event arrives before its corresponding RTM_NEWLINK — the full dump only fires on-demand on a cache miss, not proactively on every interface event.

**How I verified it**
Ran ./tests_fpmsyncd --gtest_filter="FpmSyncdResponseTest.*"
— all 26 tests passed

    onMsg RTM_NEWLINK bulk performance
      1000 Vlan  events (Vlan2..Vlan1001)    : 799 us  (0 us/event avg)
      1000 VXLAN events (VXLAN-2..VXLAN-1001): 857 us  (0 us/event avg)
      Total 2000 events                      : 1656 us  (1 ms)
    onMsg RTM_DELLINK bulk performance
      1000 Vlan  events (Vlan2..Vlan1001)    : 491 us  (0 us/event avg)
      1000 VXLAN events (VXLAN-2..VXLAN-1001): 422 us  (0 us/event avg)
      Total 2000 events                      : 913 us  (0 ms)
    [       OK ] FpmSyncdResponseTest.OnMsg_BulkNewDel_1kVlan_1kVXLAN_NoRouteProcessing (3 ms)


Both RTM_NEWLINK and RTM_DELLINK well within the 10-second hard bound.
Confirmed fpmsyncd CPU drops from 100% sustained (~10 minutes) to normal within seconds on device after deploying the fix

**Details if related**
