### PR TITLE
[aclorch] acl set policer action

### DIFF
--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -651,6 +651,9 @@ Stores rules associated with a specific ACL table on the switch.
     mirror_ingress_action = 1*255VCHAR         ; refer to the mirror session
     mirror_egress_action = 1*255VCHAR          ; refer to the mirror session
 
+    policer_action = 1*255VCHAR                ; name of a POLICER table entry used to
+                                               ; meter/rate-limit packets matching this rule
+
     ether_type    = h16                        ; Ethernet type field
 
     ip_type       = ip_types                   ; options of the l2_protocol_type

--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -652,7 +652,12 @@ Stores rules associated with a specific ACL table on the switch.
     mirror_egress_action = 1*255VCHAR          ; refer to the mirror session
 
     policer_action = 1*255VCHAR                ; name of a POLICER table entry used to
-                                               ; meter/rate-limit packets matching this rule
+                                               ; meter/rate-limit packets matching this rule.
+                                               ; The ACL table's type must advertise POLICER_ACTION
+                                               ; in its ACTIONS -- i.e. use a custom ACL_TABLE_TYPE;
+                                               ; the built-in L3/L3V6 types do not include it.
+                                               ; May compose with a packet/redirect action on the
+                                               ; same rule (e.g. rate-limit + forward).
 
     ether_type    = h16                        ; Ethernet type field
 

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -14,6 +14,7 @@
 #include "sai_serialize.h"
 #include "directory.h"
 #include "saihelper.h"
+#include "policerorch.h"
 
 using namespace std;
 using namespace swss;
@@ -32,6 +33,7 @@ extern sai_object_id_t   gSwitchId;
 extern PortsOrch*        gPortsOrch;
 extern CrmOrch *gCrmOrch;
 extern SwitchOrch *gSwitchOrch;
+extern PolicerOrch *gPolicerOrch;
 extern string gMySwitchType;
 extern Directory<Orch*> gDirectory;
 
@@ -139,6 +141,11 @@ static acl_rule_attr_lookup_t aclDTelActionLookup =
 static acl_rule_attr_lookup_t aclOtherActionLookup =
 {
     { ACTION_COUNTER,                       SAI_ACL_ENTRY_ATTR_ACTION_COUNTER}
+};
+
+static acl_rule_attr_lookup_t aclPolicerActionLookup =
+{
+    { ACTION_POLICER_ACTION,                SAI_ACL_ENTRY_ATTR_ACTION_SET_POLICER}
 };
 
 static acl_packet_action_lookup_t aclPacketActionLookup =
@@ -842,6 +849,7 @@ bool AclTableTypeParser::parseAclTableTypeActions(const std::string& value, AclT
         auto otherAction = aclOtherActionLookup.find(action);
         auto metadataAction = aclMetadataDscpActionLookup.find(action);
         auto innerAction = aclInnerActionLookup.find(action);
+        auto policerAction = aclPolicerActionLookup.find(action);
         if (l3Action != aclL3ActionLookup.end())
         {
             saiActionAttr = l3Action->second;
@@ -865,6 +873,10 @@ bool AclTableTypeParser::parseAclTableTypeActions(const std::string& value, AclT
         else if (metadataAction != aclMetadataDscpActionLookup.end())
         {
             saiActionAttr = metadataAction->second;
+        }
+        else if (policerAction != aclPolicerActionLookup.end())
+        {
+            saiActionAttr = policerAction->second;
         }
         else
         {
@@ -1813,6 +1825,10 @@ shared_ptr<AclRule> AclRule::makeShared(AclOrch *acl, MirrorOrch *mirror, DTelOr
         {
             return make_shared<AclRuleInnerSrcMacRewrite>(acl, rule, table);
         }
+        else if (aclPolicerActionLookup.find(action) != aclPolicerActionLookup.cend())
+        {
+            return make_shared<AclRulePolicer>(acl, rule, table);
+        }
         else if (acl->isUsingEgrSetDscp(table) || table == EGR_SET_DSCP_TABLE_ID)
         {
             return make_shared<AclRuleUnderlaySetDscp>(acl, rule, table, m_metadataMgr);
@@ -2246,6 +2262,104 @@ AclRuleInnerSrcMacRewrite::AclRuleInnerSrcMacRewrite(AclOrch *aclOrch, string ru
  {
     //do nothing
  }
+
+AclRulePolicer::AclRulePolicer(AclOrch *aclOrch, string rule, string table, bool createCounter) :
+        AclRule(aclOrch, rule, table, createCounter)
+{
+}
+
+bool AclRulePolicer::validateAddAction(string attr_name, string attr_value)
+{
+    SWSS_LOG_ENTER();
+
+    if (attr_name != ACTION_POLICER_ACTION)
+    {
+        return false;
+    }
+
+    if (attr_value.empty())
+    {
+        SWSS_LOG_ERROR("Empty policer name for action %s in rule %s", attr_name.c_str(), m_id.c_str());
+        return false;
+    }
+
+    sai_object_id_t policer_oid = SAI_NULL_OBJECT_ID;
+    if (!gPolicerOrch->getPolicerOid(attr_value, policer_oid))
+    {
+        SWSS_LOG_ERROR("Failed to add policer action to rule %s: policer %s does not exist",
+                m_id.c_str(), attr_value.c_str());
+        return false;
+    }
+
+    sai_acl_action_data_t actionData = {};
+    actionData.enable = true;
+    actionData.parameter.oid = policer_oid;
+
+    m_policerName = attr_value;
+
+    return setAction(aclPolicerActionLookup[attr_name], actionData);
+}
+
+bool AclRulePolicer::validate()
+{
+    SWSS_LOG_ENTER();
+
+    if ((m_rangeConfig.empty() && m_matches.empty()) || m_actions.size() != 1)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+void AclRulePolicer::onUpdate(SubjectType, void *)
+{
+    // Do nothing
+}
+
+bool AclRulePolicer::createRule()
+{
+    SWSS_LOG_ENTER();
+
+    if (!AclRule::createRule())
+    {
+        return false;
+    }
+
+    // Hold a reference on the policer so it cannot be removed while this rule
+    // binds it. Bump only once per created rule to keep the count balanced
+    // across recreate cycles.
+    if (!m_policerRefHeld)
+    {
+        if (!gPolicerOrch->increaseRefCount(m_policerName))
+        {
+            SWSS_LOG_ERROR("Failed to increase reference count for policer %s bound by rule %s",
+                    m_policerName.c_str(), m_id.c_str());
+            return false;
+        }
+        m_policerRefHeld = true;
+    }
+
+    return true;
+}
+
+bool AclRulePolicer::removeRule()
+{
+    SWSS_LOG_ENTER();
+
+    if (!AclRule::removeRule())
+    {
+        return false;
+    }
+
+    if (m_policerRefHeld)
+    {
+        gPolicerOrch->decreaseRefCount(m_policerName);
+        m_policerRefHeld = false;
+    }
+
+    return true;
+}
 
 AclRuleMirror::AclRuleMirror(AclOrch *aclOrch, MirrorOrch *mirror, string rule, string table) :
         AclRule(aclOrch, rule, table),
@@ -5573,6 +5687,29 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
                 type = table_id == m_mirrorTableId[stage] ? TABLE_TYPE_MIRROR : TABLE_TYPE_MIRRORV6;
             }
 
+            /* If the rule references a policer that has not been created yet,
+             * defer it and rely on the Consumer m_toSync retry (same pattern as
+             * "Wait for ACL table" above). This covers the case where the
+             * POLICER table is synced after the ACL_RULE table. */
+            bool waitForPolicer = false;
+            for (const auto& itr : kfvFieldsValues(t))
+            {
+                if (to_upper(fvField(itr)) == ACTION_POLICER_ACTION)
+                {
+                    if (!fvValue(itr).empty() && !gPolicerOrch->policerExists(fvValue(itr)))
+                    {
+                        SWSS_LOG_INFO("Wait for policer %s to be created for ACL rule %s",
+                                fvValue(itr).c_str(), key.c_str());
+                        waitForPolicer = true;
+                    }
+                    break;
+                }
+            }
+            if (waitForPolicer)
+            {
+                it++;
+                continue;
+            }
 
             try
             {

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -114,7 +114,8 @@ static acl_rule_attr_lookup_t aclL3ActionLookup =
     { ACTION_PACKET_ACTION,                    SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION },
     { ACTION_REDIRECT_ACTION,                  SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT },
     { ACTION_DO_NOT_NAT_ACTION,                SAI_ACL_ENTRY_ATTR_ACTION_NO_NAT },
-    { ACTION_DISABLE_TRIM,                     SAI_ACL_ENTRY_ATTR_ACTION_PACKET_TRIM_DISABLE }
+    { ACTION_DISABLE_TRIM,                     SAI_ACL_ENTRY_ATTR_ACTION_PACKET_TRIM_DISABLE },
+    { ACTION_POLICER_ACTION,                   SAI_ACL_ENTRY_ATTR_ACTION_SET_POLICER }
 };
 
 static acl_rule_attr_lookup_t aclInnerActionLookup =
@@ -141,11 +142,6 @@ static acl_rule_attr_lookup_t aclDTelActionLookup =
 static acl_rule_attr_lookup_t aclOtherActionLookup =
 {
     { ACTION_COUNTER,                       SAI_ACL_ENTRY_ATTR_ACTION_COUNTER}
-};
-
-static acl_rule_attr_lookup_t aclPolicerActionLookup =
-{
-    { ACTION_POLICER_ACTION,                SAI_ACL_ENTRY_ATTR_ACTION_SET_POLICER}
 };
 
 static acl_packet_action_lookup_t aclPacketActionLookup =
@@ -849,7 +845,6 @@ bool AclTableTypeParser::parseAclTableTypeActions(const std::string& value, AclT
         auto otherAction = aclOtherActionLookup.find(action);
         auto metadataAction = aclMetadataDscpActionLookup.find(action);
         auto innerAction = aclInnerActionLookup.find(action);
-        auto policerAction = aclPolicerActionLookup.find(action);
         if (l3Action != aclL3ActionLookup.end())
         {
             saiActionAttr = l3Action->second;
@@ -873,10 +868,6 @@ bool AclTableTypeParser::parseAclTableTypeActions(const std::string& value, AclT
         else if (metadataAction != aclMetadataDscpActionLookup.end())
         {
             saiActionAttr = metadataAction->second;
-        }
-        else if (policerAction != aclPolicerActionLookup.end())
-        {
-            saiActionAttr = policerAction->second;
         }
         else
         {
@@ -1825,10 +1816,6 @@ shared_ptr<AclRule> AclRule::makeShared(AclOrch *acl, MirrorOrch *mirror, DTelOr
         {
             return make_shared<AclRuleInnerSrcMacRewrite>(acl, rule, table);
         }
-        else if (aclPolicerActionLookup.find(action) != aclPolicerActionLookup.cend())
-        {
-            return make_shared<AclRulePolicer>(acl, rule, table);
-        }
         else if (acl->isUsingEgrSetDscp(table) || table == EGR_SET_DSCP_TABLE_ID)
         {
             return make_shared<AclRuleUnderlaySetDscp>(acl, rule, table, m_metadataMgr);
@@ -2081,6 +2068,26 @@ bool AclRulePacket::validateAddAction(string attr_name, string _attr_value)
         }
         actionData.parameter.oid = param_id;
     }
+    // SET_POLICER attaches a policer (by name -> OID) to the ACL entry.
+    else if (attr_name == ACTION_POLICER_ACTION)
+    {
+        if (_attr_value.empty())
+        {
+            SWSS_LOG_ERROR("Empty policer name for action %s in rule %s", attr_name.c_str(), m_id.c_str());
+            return false;
+        }
+
+        sai_object_id_t policer_oid = SAI_NULL_OBJECT_ID;
+        if (!gPolicerOrch->getPolicerOid(_attr_value, policer_oid))
+        {
+            SWSS_LOG_ERROR("Failed to add policer action to rule %s: policer %s does not exist",
+                    m_id.c_str(), _attr_value.c_str());
+            return false;
+        }
+
+        actionData.parameter.oid = policer_oid;
+        m_policerName = _attr_value;
+    }
     else
     {
         return false;
@@ -2186,7 +2193,27 @@ bool AclRulePacket::validate()
 {
     SWSS_LOG_ENTER();
 
-    if ((m_rangeConfig.empty() && m_matches.empty()) || m_actions.size() != 1)
+    if (m_rangeConfig.empty() && m_matches.empty())
+    {
+        return false;
+    }
+
+    // A packet rule must carry at least one action.
+    if (m_actions.empty())
+    {
+        return false;
+    }
+
+    size_t nonPolicerActions = 0;
+    for (const auto& action : m_actions)
+    {
+        if (action.first != SAI_ACL_ENTRY_ATTR_ACTION_SET_POLICER)
+        {
+            nonPolicerActions++;
+        }
+    }
+
+    if (nonPolicerActions > 1)
     {
         return false;
     }
@@ -2197,6 +2224,57 @@ bool AclRulePacket::validate()
 void AclRulePacket::onUpdate(SubjectType, void *)
 {
     // Do nothing
+}
+
+bool AclRulePacket::createRule()
+{
+    SWSS_LOG_ENTER();
+
+    // When the rule binds a policer, take the policer reference BEFORE creating the
+    // SAI ACL entry (same ordering as AclRuleMirror's session policer). This way a
+    // refcount failure -- only reachable if the policer disappeared after validate()
+    // -- leaves nothing to unwind. m_policerRefHeld keeps the count balanced across
+    // recreate cycles.
+    if (!m_policerName.empty() && !m_policerRefHeld)
+    {
+        if (!gPolicerOrch->increaseRefCount(m_policerName))
+        {
+            SWSS_LOG_ERROR("Failed to increase reference count for policer %s bound by rule %s",
+                    m_policerName.c_str(), m_id.c_str());
+            return false;
+        }
+        m_policerRefHeld = true;
+    }
+
+    if (!AclRule::createRule())
+    {
+        if (m_policerRefHeld)
+        {
+            gPolicerOrch->decreaseRefCount(m_policerName);
+            m_policerRefHeld = false;
+        }
+        return false;
+    }
+
+    return true;
+}
+
+bool AclRulePacket::removeRule()
+{
+    SWSS_LOG_ENTER();
+
+    if (!AclRule::removeRule())
+    {
+        return false;
+    }
+
+    if (m_policerRefHeld)
+    {
+        gPolicerOrch->decreaseRefCount(m_policerName);
+        m_policerRefHeld = false;
+    }
+
+    return true;
 }
 
 AclRuleInnerSrcMacRewrite::AclRuleInnerSrcMacRewrite(AclOrch *aclOrch, string rule, string table, bool createCounter) :
@@ -2262,113 +2340,6 @@ AclRuleInnerSrcMacRewrite::AclRuleInnerSrcMacRewrite(AclOrch *aclOrch, string ru
  {
     //do nothing
  }
-
-AclRulePolicer::AclRulePolicer(AclOrch *aclOrch, string rule, string table, bool createCounter) :
-        AclRule(aclOrch, rule, table, createCounter)
-{
-}
-
-bool AclRulePolicer::validateAddAction(string attr_name, string attr_value)
-{
-    SWSS_LOG_ENTER();
-
-    if (attr_name != ACTION_POLICER_ACTION)
-    {
-        return false;
-    }
-
-    if (attr_value.empty())
-    {
-        SWSS_LOG_ERROR("Empty policer name for action %s in rule %s", attr_name.c_str(), m_id.c_str());
-        return false;
-    }
-
-    sai_object_id_t policer_oid = SAI_NULL_OBJECT_ID;
-    if (!gPolicerOrch->getPolicerOid(attr_value, policer_oid))
-    {
-        SWSS_LOG_ERROR("Failed to add policer action to rule %s: policer %s does not exist",
-                m_id.c_str(), attr_value.c_str());
-        return false;
-    }
-
-    sai_acl_action_data_t actionData = {};
-    actionData.enable = true;
-    actionData.parameter.oid = policer_oid;
-
-    m_policerName = attr_value;
-
-    return setAction(aclPolicerActionLookup[attr_name], actionData);
-}
-
-bool AclRulePolicer::validate()
-{
-    SWSS_LOG_ENTER();
-
-    if ((m_rangeConfig.empty() && m_matches.empty()) || m_actions.size() != 1)
-    {
-        return false;
-    }
-
-    return true;
-}
-
-void AclRulePolicer::onUpdate(SubjectType, void *)
-{
-    // Do nothing
-}
-
-bool AclRulePolicer::createRule()
-{
-    SWSS_LOG_ENTER();
-
-    // Acquire the policer reference before creating the SAI ACL entry. Taking the
-    // reference first means a refcount failure (only if the policer no longer exists --
-    // effectively unreachable, as validate() already confirmed it) leaves nothing to
-    // undo: we never program a rule that points at a policer we could not pin. Bump
-    // only once per created rule to keep the count balanced across recreate cycles.
-    bool tookRef = false;
-    if (!m_policerRefHeld)
-    {
-        if (!gPolicerOrch->increaseRefCount(m_policerName))
-        {
-            SWSS_LOG_ERROR("Failed to increase reference count for policer %s bound by rule %s",
-                    m_policerName.c_str(), m_id.c_str());
-            return false;
-        }
-        m_policerRefHeld = true;
-        tookRef = true;
-    }
-
-    if (!AclRule::createRule())
-    {
-        if (tookRef)
-        {
-            gPolicerOrch->decreaseRefCount(m_policerName);
-            m_policerRefHeld = false;
-        }
-        return false;
-    }
-
-    return true;
-}
-
-bool AclRulePolicer::removeRule()
-{
-    SWSS_LOG_ENTER();
-
-    if (!AclRule::removeRule())
-    {
-        return false;
-    }
-
-    if (m_policerRefHeld)
-    {
-        gPolicerOrch->decreaseRefCount(m_policerName);
-        m_policerRefHeld = false;
-    }
-
-    return true;
-}
 
 AclRuleMirror::AclRuleMirror(AclOrch *aclOrch, MirrorOrch *mirror, string rule, string table) :
         AclRule(aclOrch, rule, table),

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -2321,14 +2321,12 @@ bool AclRulePolicer::createRule()
 {
     SWSS_LOG_ENTER();
 
-    if (!AclRule::createRule())
-    {
-        return false;
-    }
-
-    // Hold a reference on the policer so it cannot be removed while this rule
-    // binds it. Bump only once per created rule to keep the count balanced
-    // across recreate cycles.
+    // Acquire the policer reference before creating the SAI ACL entry. Taking the
+    // reference first means a refcount failure (only if the policer no longer exists --
+    // effectively unreachable, as validate() already confirmed it) leaves nothing to
+    // undo: we never program a rule that points at a policer we could not pin. Bump
+    // only once per created rule to keep the count balanced across recreate cycles.
+    bool tookRef = false;
     if (!m_policerRefHeld)
     {
         if (!gPolicerOrch->increaseRefCount(m_policerName))
@@ -2338,6 +2336,17 @@ bool AclRulePolicer::createRule()
             return false;
         }
         m_policerRefHeld = true;
+        tookRef = true;
+    }
+
+    if (!AclRule::createRule())
+    {
+        if (tookRef)
+        {
+            gPolicerOrch->decreaseRefCount(m_policerName);
+            m_policerRefHeld = false;
+        }
+        return false;
     }
 
     return true;

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -407,7 +407,13 @@ public:
     void onUpdate(SubjectType, void *) override;
 
 protected:
+    bool createRule() override;
+    bool removeRule() override;
+
     sai_object_id_t getRedirectObjectId(const string& redirect_param);
+
+    string m_policerName;
+    bool m_policerRefHeld {false};
 };
 
 class AclRuleInnerSrcMacRewrite: public AclRule
@@ -420,23 +426,6 @@ class AclRuleInnerSrcMacRewrite: public AclRule
      void onUpdate(SubjectType, void *) override;
  };
  
-class AclRulePolicer: public AclRule
-{
-public:
-    AclRulePolicer(AclOrch *m_pAclOrch, string rule, string table, bool createCounter = true);
-
-    bool validateAddAction(string attr_name, string attr_value);
-    bool validate();
-    void onUpdate(SubjectType, void *) override;
-
-protected:
-    bool createRule() override;
-    bool removeRule() override;
-
-    string m_policerName;
-    bool m_policerRefHeld {false};
-};
-
 class AclRuleMirror: public AclRule
 {
 public:

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -80,6 +80,7 @@
 #define ACTION_META_DATA                    "META_DATA_ACTION"
 #define ACTION_DSCP                         "DSCP_ACTION"
 #define ACTION_INNER_SRC_MAC_REWRITE_ACTION "INNER_SRC_MAC_REWRITE_ACTION"
+#define ACTION_POLICER_ACTION               "POLICER_ACTION"
 
 #define PACKET_ACTION_FORWARD      "FORWARD"
 #define PACKET_ACTION_DROP         "DROP"
@@ -419,6 +420,23 @@ class AclRuleInnerSrcMacRewrite: public AclRule
      void onUpdate(SubjectType, void *) override;
  };
  
+class AclRulePolicer: public AclRule
+{
+public:
+    AclRulePolicer(AclOrch *m_pAclOrch, string rule, string table, bool createCounter = true);
+
+    bool validateAddAction(string attr_name, string attr_value);
+    bool validate();
+    void onUpdate(SubjectType, void *) override;
+
+protected:
+    bool createRule() override;
+    bool removeRule() override;
+
+    string m_policerName;
+    bool m_policerRefHeld {false};
+};
+
 class AclRuleMirror: public AclRule
 {
 public:

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -1421,6 +1421,73 @@ namespace aclorch_test
         ASSERT_FALSE(orch->getAclRule(aclTableName, "NOMATCH_POLICER_RULE"));
     }
 
+    // If the SAI ACL entry creation fails after the policer reference has been
+    // acquired, AclRulePolicer::createRule() must roll that reference back so the
+    // policer is not leaked. A still-referenced policer cannot be deleted, so a
+    // successful delete afterwards proves the reference count returned to zero.
+    TEST_F(AclOrchTest, AclRule_Policer_CreateFailureReleasesRef)
+    {
+        const string aclTableTypeName = "TEST_POLICER_FAIL_TYPE";
+        const string aclTableName     = "TEST_POLICER_FAIL_TABLE";
+        const string aclRuleName      = "TEST_POLICER_FAIL_RULE";
+        const string policerName      = "test_policer_fail";
+
+        auto orch = createAclOrch();
+
+        // Create a policer so POLICER_ACTION can resolve its OID.
+        auto policerConsumer = unique_ptr<Consumer>(new Consumer(
+            new swss::ConsumerStateTable(m_config_db.get(), CFG_POLICER_TABLE_NAME, 1, 1),
+            gPolicerOrch, CFG_POLICER_TABLE_NAME));
+        policerConsumer->addToSync(deque<KeyOpFieldsValuesTuple>(
+            { { policerName, SET_COMMAND,
+                { { "METER_TYPE", "packets" }, { "MODE", "sr_tcm" },
+                  { "CIR", "100" }, { "CBS", "100" }, { "RED_PACKET_ACTION", "drop" } } } }));
+        static_cast<Orch *>(gPolicerOrch)->doTask(*policerConsumer);
+        ASSERT_TRUE(gPolicerOrch->policerExists(policerName));
+
+        orch->doAclTableTypeTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableTypeName, SET_COMMAND,
+                    { { ACL_TABLE_TYPE_MATCHES, MATCH_SRC_IP },
+                      { ACL_TABLE_TYPE_ACTIONS, ACTION_POLICER_ACTION },
+                      { ACL_TABLE_TYPE_BPOINT_TYPES, BIND_POINT_TYPE_PORT } } } }));
+
+        orch->doAclTableTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableName, SET_COMMAND,
+                    { { ACL_TABLE_DESCRIPTION, "policer table" },
+                      { ACL_TABLE_TYPE, aclTableTypeName },
+                      { ACL_TABLE_STAGE, STAGE_INGRESS },
+                      { ACL_TABLE_PORTS, "1,2" } } } }));
+        ASSERT_TRUE(orch->getAclTable(aclTableName));
+
+        // Force SAI ACL entry creation to fail so AclRule::createRule() returns
+        // false *after* AclRulePolicer::createRule() has taken the policer ref.
+        {
+            auto spy = SpyOn<SAI_API_ACL, SAI_OBJECT_TYPE_ACL_ENTRY>(&sai_acl_api->create_acl_entry);
+            spy->callFake([&](sai_object_id_t *, sai_object_id_t, uint32_t,
+                              const sai_attribute_t *) -> sai_status_t {
+                return SAI_STATUS_FAILURE;
+            });
+
+            orch->doAclRuleTask(
+                deque<KeyOpFieldsValuesTuple>(
+                    { { aclTableName + "|" + aclRuleName, SET_COMMAND,
+                        { { MATCH_SRC_IP, "1.1.1.1/32" },
+                          { ACTION_POLICER_ACTION, policerName } } } }));
+        }
+
+        // The rule was not created.
+        ASSERT_FALSE(orch->getAclRule(aclTableName, aclRuleName));
+
+        // The policer reference taken before the failed entry creation was
+        // released: deleting the policer now succeeds (it is no longer referenced).
+        policerConsumer->addToSync(deque<KeyOpFieldsValuesTuple>(
+            { { policerName, DEL_COMMAND, {} } }));
+        static_cast<Orch *>(gPolicerOrch)->doTask(*policerConsumer);
+        ASSERT_FALSE(gPolicerOrch->policerExists(policerName));
+    }
+
     // When received ACL table/rule SET_COMMAND, orchagent can create corresponding ACL table/rule
     // When received ACL table/rule DEL_COMMAND, orchagent can delete corresponding ACL table/rule
     //

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -1389,7 +1389,7 @@ namespace aclorch_test
         ASSERT_NE(actions.find(SAI_ACL_ENTRY_ATTR_ACTION_SET_POLICER), actions.end());
 
         // Deleting the rule releases the policer reference it held
-        // (exercises AclRulePolicer::removeRule()).
+        // (exercises AclRulePacket::removeRule()).
         orch->doAclRuleTask(
             deque<KeyOpFieldsValuesTuple>(
                 { { aclTableName + "|" + aclRuleName, DEL_COMMAND, {} } }));
@@ -1404,7 +1404,7 @@ namespace aclorch_test
         ASSERT_FALSE(orch->getAclRule(aclTableName, "MISSING_POLICER_RULE"));
 
         // A POLICER_ACTION with an empty policer name is rejected by
-        // AclRulePolicer::validateAddAction() and the rule is not created.
+        // AclRulePacket::validateAddAction() and the rule is not created.
         orch->doAclRuleTask(
             deque<KeyOpFieldsValuesTuple>(
                 { { aclTableName + "|" + "EMPTY_POLICER_RULE", SET_COMMAND,
@@ -1412,8 +1412,8 @@ namespace aclorch_test
                       { ACTION_POLICER_ACTION, "" } } } }));
         ASSERT_FALSE(orch->getAclRule(aclTableName, "EMPTY_POLICER_RULE"));
 
-        // A POLICER_ACTION rule with no match/range fails AclRulePolicer::
-        // validate() (needs at least one match and exactly one action).
+        // A POLICER_ACTION rule with no match/range fails AclRulePacket::
+        // validate() (needs at least one match).
         orch->doAclRuleTask(
             deque<KeyOpFieldsValuesTuple>(
                 { { aclTableName + "|" + "NOMATCH_POLICER_RULE", SET_COMMAND,
@@ -1421,8 +1421,74 @@ namespace aclorch_test
         ASSERT_FALSE(orch->getAclRule(aclTableName, "NOMATCH_POLICER_RULE"));
     }
 
+    // POLICER_ACTION composes with a packet action on the same rule: SAI allows
+    // SET_POLICER alongside PACKET_ACTION. Verify rate-limit + forward programs
+    // both SET_POLICER *and* PACKET_ACTION on the entry.
+    TEST_F(AclOrchTest, AclRule_Policer_With_Packet_Action)
+    {
+        const string aclTableTypeName = "TEST_POLICER_PKT_TYPE";
+        const string aclTableName     = "TEST_POLICER_PKT_TABLE";
+        const string policerName      = "test_policer_pkt";
+
+        auto orch = createAclOrch();
+
+        // Create a policer so POLICER_ACTION can resolve its OID.
+        auto policerConsumer = unique_ptr<Consumer>(new Consumer(
+            new swss::ConsumerStateTable(m_config_db.get(), CFG_POLICER_TABLE_NAME, 1, 1),
+            gPolicerOrch, CFG_POLICER_TABLE_NAME));
+        policerConsumer->addToSync(deque<KeyOpFieldsValuesTuple>(
+            { { policerName, SET_COMMAND,
+                { { "METER_TYPE", "packets" }, { "MODE", "sr_tcm" },
+                  { "CIR", "100" }, { "CBS", "100" }, { "RED_PACKET_ACTION", "drop" } } } }));
+        static_cast<Orch *>(gPolicerOrch)->doTask(*policerConsumer);
+        ASSERT_TRUE(gPolicerOrch->policerExists(policerName));
+
+        // Table type advertising SRC_IP match plus BOTH the packet and policer actions.
+        orch->doAclTableTypeTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableTypeName, SET_COMMAND,
+                    { { ACL_TABLE_TYPE_MATCHES, MATCH_SRC_IP },
+                      { ACL_TABLE_TYPE_ACTIONS,
+                        string(ACTION_PACKET_ACTION) + "," + ACTION_POLICER_ACTION },
+                      { ACL_TABLE_TYPE_BPOINT_TYPES, BIND_POINT_TYPE_PORT } } } }));
+
+        orch->doAclTableTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableName, SET_COMMAND,
+                    { { ACL_TABLE_DESCRIPTION, "policer+packet table" },
+                      { ACL_TABLE_TYPE, aclTableTypeName },
+                      { ACL_TABLE_STAGE, STAGE_INGRESS },
+                      { ACL_TABLE_PORTS, "1,2" } } } }));
+        ASSERT_TRUE(orch->getAclTable(aclTableName));
+
+        // rate-limit + forward: the rule must carry BOTH SET_POLICER and PACKET_ACTION.
+        orch->doAclRuleTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableName + "|" + "FWD_RULE", SET_COMMAND,
+                    { { MATCH_SRC_IP, "1.1.1.1/32" },
+                      { ACTION_PACKET_ACTION, PACKET_ACTION_FORWARD },
+                      { ACTION_POLICER_ACTION, policerName } } } }));
+        {
+            auto rule = orch->getAclRule(aclTableName, "FWD_RULE");
+            ASSERT_TRUE(rule);
+            const auto &actions = Portal::AclRuleInternal::getActions(rule);
+            ASSERT_NE(actions.find(SAI_ACL_ENTRY_ATTR_ACTION_SET_POLICER), actions.end());
+            ASSERT_NE(actions.find(SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION), actions.end());
+        }
+
+        // Deleting the composed rule releases the policer reference, so the
+        // policer can then be deleted -- proving the refcount stays balanced when
+        // the policer rides alongside a packet action.
+        orch->doAclRuleTask(deque<KeyOpFieldsValuesTuple>(
+            { { aclTableName + "|" + "FWD_RULE", DEL_COMMAND, {} } }));
+        policerConsumer->addToSync(deque<KeyOpFieldsValuesTuple>(
+            { { policerName, DEL_COMMAND, {} } }));
+        static_cast<Orch *>(gPolicerOrch)->doTask(*policerConsumer);
+        ASSERT_FALSE(gPolicerOrch->policerExists(policerName));
+    }
+
     // If the SAI ACL entry creation fails after the policer reference has been
-    // acquired, AclRulePolicer::createRule() must roll that reference back so the
+    // acquired, AclRulePacket::createRule() must roll that reference back so the
     // policer is not leaked. A still-referenced policer cannot be deleted, so a
     // successful delete afterwards proves the reference count returned to zero.
     TEST_F(AclOrchTest, AclRule_Policer_CreateFailureReleasesRef)
@@ -1462,7 +1528,7 @@ namespace aclorch_test
         ASSERT_TRUE(orch->getAclTable(aclTableName));
 
         // Force SAI ACL entry creation to fail so AclRule::createRule() returns
-        // false *after* AclRulePolicer::createRule() has taken the policer ref.
+        // false *after* AclRulePacket::createRule() has taken the policer ref.
         {
             auto spy = SpyOn<SAI_API_ACL, SAI_OBJECT_TYPE_ACL_ENTRY>(&sai_acl_api->create_acl_entry);
             spy->callFake([&](sai_object_id_t *, sai_object_id_t, uint32_t,
@@ -1486,6 +1552,256 @@ namespace aclorch_test
             { { policerName, DEL_COMMAND, {} } }));
         static_cast<Orch *>(gPolicerOrch)->doTask(*policerConsumer);
         ASSERT_FALSE(gPolicerOrch->policerExists(policerName));
+    }
+
+    // POLICER_ACTION composes on an IPv6 (L3V6) rule: an SRC_IPV6 match plus a
+    // packet action and a policer must program BOTH PACKET_ACTION and SET_POLICER
+    // on the ASIC entry (parity with the IPv4 compose path).
+    TEST_F(AclOrchTest, AclRule_Policer_L3V6_Compose)
+    {
+        const string aclTableTypeName = "TEST_POLICER_V6_TYPE";
+        const string aclTableName     = "TEST_POLICER_V6_TABLE";
+        const string aclRuleName      = "TEST_POLICER_V6_RULE";
+        const string policerName      = "test_policer_v6";
+
+        auto orch = createAclOrch();
+
+        auto policerConsumer = unique_ptr<Consumer>(new Consumer(
+            new swss::ConsumerStateTable(m_config_db.get(), CFG_POLICER_TABLE_NAME, 1, 1),
+            gPolicerOrch, CFG_POLICER_TABLE_NAME));
+        policerConsumer->addToSync(deque<KeyOpFieldsValuesTuple>(
+            { { policerName, SET_COMMAND,
+                { { "METER_TYPE", "packets" }, { "MODE", "sr_tcm" },
+                  { "CIR", "100" }, { "CBS", "100" }, { "RED_PACKET_ACTION", "drop" } } } }));
+        static_cast<Orch *>(gPolicerOrch)->doTask(*policerConsumer);
+        ASSERT_TRUE(gPolicerOrch->policerExists(policerName));
+
+        orch->doAclTableTypeTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableTypeName, SET_COMMAND,
+                    { { ACL_TABLE_TYPE_MATCHES, MATCH_SRC_IPV6 },
+                      { ACL_TABLE_TYPE_ACTIONS,
+                        string(ACTION_PACKET_ACTION) + "," + ACTION_POLICER_ACTION },
+                      { ACL_TABLE_TYPE_BPOINT_TYPES, BIND_POINT_TYPE_PORT } } } }));
+
+        orch->doAclTableTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableName, SET_COMMAND,
+                    { { ACL_TABLE_DESCRIPTION, "v6 policer table" },
+                      { ACL_TABLE_TYPE, aclTableTypeName },
+                      { ACL_TABLE_STAGE, STAGE_INGRESS },
+                      { ACL_TABLE_PORTS, "1,2" } } } }));
+        ASSERT_TRUE(orch->getAclTable(aclTableName));
+
+        orch->doAclRuleTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableName + "|" + aclRuleName, SET_COMMAND,
+                    { { MATCH_SRC_IPV6, "::1.2.3.4" },
+                      { ACTION_PACKET_ACTION, PACKET_ACTION_FORWARD },
+                      { ACTION_POLICER_ACTION, policerName } } } }));
+
+        auto rule = orch->getAclRule(aclTableName, aclRuleName);
+        ASSERT_TRUE(rule);
+        const auto &actions = Portal::AclRuleInternal::getActions(rule);
+        ASSERT_NE(actions.find(SAI_ACL_ENTRY_ATTR_ACTION_SET_POLICER), actions.end());
+        ASSERT_NE(actions.find(SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION), actions.end());
+    }
+
+    // A POLICER_ACTION rule is rejected when the ACL table's type does not
+    // advertise the policer action: setAction() -> AclTable::validateAclRuleAction()
+    // fails before the policer reference is taken, so the rule is not created and
+    // the policer is left unreferenced (still deletable -- no dangling ref).
+    TEST_F(AclOrchTest, AclRule_Policer_TableType_NotAdvertised_Rejected)
+    {
+        const string aclTableTypeName = "TEST_NO_POLICER_TYPE";
+        const string aclTableName     = "TEST_NO_POLICER_TABLE";
+        const string aclRuleName      = "TEST_NO_POLICER_RULE";
+        const string policerName      = "test_policer_gate";
+
+        auto orch = createAclOrch();
+
+        auto policerConsumer = unique_ptr<Consumer>(new Consumer(
+            new swss::ConsumerStateTable(m_config_db.get(), CFG_POLICER_TABLE_NAME, 1, 1),
+            gPolicerOrch, CFG_POLICER_TABLE_NAME));
+        policerConsumer->addToSync(deque<KeyOpFieldsValuesTuple>(
+            { { policerName, SET_COMMAND,
+                { { "METER_TYPE", "packets" }, { "MODE", "sr_tcm" },
+                  { "CIR", "100" }, { "CBS", "100" }, { "RED_PACKET_ACTION", "drop" } } } }));
+        static_cast<Orch *>(gPolicerOrch)->doTask(*policerConsumer);
+        ASSERT_TRUE(gPolicerOrch->policerExists(policerName));
+
+        // Table type advertises only PACKET_ACTION -- NOT POLICER_ACTION.
+        orch->doAclTableTypeTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableTypeName, SET_COMMAND,
+                    { { ACL_TABLE_TYPE_MATCHES, MATCH_SRC_IP },
+                      { ACL_TABLE_TYPE_ACTIONS, ACTION_PACKET_ACTION },
+                      { ACL_TABLE_TYPE_BPOINT_TYPES, BIND_POINT_TYPE_PORT } } } }));
+
+        orch->doAclTableTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableName, SET_COMMAND,
+                    { { ACL_TABLE_DESCRIPTION, "no-policer table" },
+                      { ACL_TABLE_TYPE, aclTableTypeName },
+                      { ACL_TABLE_STAGE, STAGE_INGRESS },
+                      { ACL_TABLE_PORTS, "1,2" } } } }));
+        ASSERT_TRUE(orch->getAclTable(aclTableName));
+
+        orch->doAclRuleTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableName + "|" + aclRuleName, SET_COMMAND,
+                    { { MATCH_SRC_IP, "1.1.1.1/32" },
+                      { ACTION_POLICER_ACTION, policerName } } } }));
+        ASSERT_FALSE(orch->getAclRule(aclTableName, aclRuleName));
+
+        // No reference was leaked onto the policer: it can still be deleted.
+        policerConsumer->addToSync(deque<KeyOpFieldsValuesTuple>(
+            { { policerName, DEL_COMMAND, {} } }));
+        static_cast<Orch *>(gPolicerOrch)->doTask(*policerConsumer);
+        ASSERT_FALSE(gPolicerOrch->policerExists(policerName));
+    }
+
+    // Updating a rule's policer via re-SET (add / change / remove) keeps the
+    // PolicerOrch refcount balanced. A rule re-SET is remove+create in AclTable::add,
+    // so removeRule() releases the old policer ref and createRule() takes the new one.
+    // Each policer is therefore deletable exactly when no rule references it.
+    TEST_F(AclOrchTest, AclRule_Policer_Update_RefcountBalance)
+    {
+        const string aclTableTypeName = "TEST_POLICER_UPD_TYPE";
+        const string aclTableName     = "TEST_POLICER_UPD_TABLE";
+        const string aclRuleName      = "TEST_POLICER_UPD_RULE";
+        const string policer1         = "test_policer_upd1";
+        const string policer2         = "test_policer_upd2";
+
+        auto orch = createAclOrch();
+
+        auto policerConsumer = unique_ptr<Consumer>(new Consumer(
+            new swss::ConsumerStateTable(m_config_db.get(), CFG_POLICER_TABLE_NAME, 1, 1),
+            gPolicerOrch, CFG_POLICER_TABLE_NAME));
+        auto createPolicer = [&](const string &name) {
+            policerConsumer->addToSync(deque<KeyOpFieldsValuesTuple>(
+                { { name, SET_COMMAND,
+                    { { "METER_TYPE", "packets" }, { "MODE", "sr_tcm" },
+                      { "CIR", "100" }, { "CBS", "100" }, { "RED_PACKET_ACTION", "drop" } } } }));
+            static_cast<Orch *>(gPolicerOrch)->doTask(*policerConsumer);
+        };
+        auto deletePolicer = [&](const string &name) {
+            policerConsumer->addToSync(deque<KeyOpFieldsValuesTuple>(
+                { { name, DEL_COMMAND, {} } }));
+            static_cast<Orch *>(gPolicerOrch)->doTask(*policerConsumer);
+        };
+        createPolicer(policer1);
+        createPolicer(policer2);
+        ASSERT_TRUE(gPolicerOrch->policerExists(policer1));
+        ASSERT_TRUE(gPolicerOrch->policerExists(policer2));
+
+        orch->doAclTableTypeTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableTypeName, SET_COMMAND,
+                    { { ACL_TABLE_TYPE_MATCHES, MATCH_SRC_IP },
+                      { ACL_TABLE_TYPE_ACTIONS,
+                        string(ACTION_PACKET_ACTION) + "," + ACTION_POLICER_ACTION },
+                      { ACL_TABLE_TYPE_BPOINT_TYPES, BIND_POINT_TYPE_PORT } } } }));
+        orch->doAclTableTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableName, SET_COMMAND,
+                    { { ACL_TABLE_DESCRIPTION, "policer update table" },
+                      { ACL_TABLE_TYPE, aclTableTypeName },
+                      { ACL_TABLE_STAGE, STAGE_INGRESS },
+                      { ACL_TABLE_PORTS, "1,2" } } } }));
+        ASSERT_TRUE(orch->getAclTable(aclTableName));
+
+        auto setRule = [&](const vector<swss::FieldValueTuple> &fvs) {
+            orch->doAclRuleTask(deque<KeyOpFieldsValuesTuple>(
+                { { aclTableName + "|" + aclRuleName, SET_COMMAND, fvs } }));
+        };
+        auto ruleHasPolicer = [&]() {
+            auto rule = orch->getAclRule(aclTableName, aclRuleName);
+            if (!rule) return false;
+            const auto &actions = Portal::AclRuleInternal::getActions(rule);
+            return actions.find(SAI_ACL_ENTRY_ATTR_ACTION_SET_POLICER) != actions.end();
+        };
+
+        // add-via-update: FORWARD-only rule, then re-SET to add a policer.
+        setRule({ { MATCH_SRC_IP, "1.1.1.1/32" }, { ACTION_PACKET_ACTION, PACKET_ACTION_FORWARD } });
+        ASSERT_TRUE(orch->getAclRule(aclTableName, aclRuleName));
+        ASSERT_FALSE(ruleHasPolicer());
+        setRule({ { MATCH_SRC_IP, "1.1.1.1/32" }, { ACTION_PACKET_ACTION, PACKET_ACTION_FORWARD },
+                  { ACTION_POLICER_ACTION, policer1 } });
+        ASSERT_TRUE(ruleHasPolicer());
+
+        // change-via-update: policer1 -> policer2. policer1 must be released.
+        setRule({ { MATCH_SRC_IP, "1.1.1.1/32" }, { ACTION_PACKET_ACTION, PACKET_ACTION_FORWARD },
+                  { ACTION_POLICER_ACTION, policer2 } });
+        ASSERT_TRUE(ruleHasPolicer());
+        deletePolicer(policer1);
+        ASSERT_FALSE(gPolicerOrch->policerExists(policer1));
+
+        // remove-via-update: drop the policer. policer2 must be released.
+        setRule({ { MATCH_SRC_IP, "1.1.1.1/32" }, { ACTION_PACKET_ACTION, PACKET_ACTION_FORWARD } });
+        ASSERT_TRUE(orch->getAclRule(aclTableName, aclRuleName));
+        ASSERT_FALSE(ruleHasPolicer());
+        deletePolicer(policer2);
+        ASSERT_FALSE(gPolicerOrch->policerExists(policer2));
+    }
+
+    // Ordering: an ACL rule that references a policer created AFTER the rule is
+    // first deferred (m_toSync retry, not created) and then programmed with
+    // SET_POLICER once the policer exists.
+    TEST_F(AclOrchTest, AclRule_Policer_Deferred_Then_Created)
+    {
+        const string aclTableTypeName = "TEST_POLICER_DEFER_TYPE";
+        const string aclTableName     = "TEST_POLICER_DEFER_TABLE";
+        const string aclRuleName      = "TEST_POLICER_DEFER_RULE";
+        const string policerName      = "test_policer_defer";
+
+        auto orch = createAclOrch();
+
+        orch->doAclTableTypeTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableTypeName, SET_COMMAND,
+                    { { ACL_TABLE_TYPE_MATCHES, MATCH_SRC_IP },
+                      { ACL_TABLE_TYPE_ACTIONS, ACTION_POLICER_ACTION },
+                      { ACL_TABLE_TYPE_BPOINT_TYPES, BIND_POINT_TYPE_PORT } } } }));
+        orch->doAclTableTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableName, SET_COMMAND,
+                    { { ACL_TABLE_DESCRIPTION, "policer defer table" },
+                      { ACL_TABLE_TYPE, aclTableTypeName },
+                      { ACL_TABLE_STAGE, STAGE_INGRESS },
+                      { ACL_TABLE_PORTS, "1,2" } } } }));
+        ASSERT_TRUE(orch->getAclTable(aclTableName));
+
+        // Policer does not exist yet -> rule is deferred, not created.
+        ASSERT_FALSE(gPolicerOrch->policerExists(policerName));
+        orch->doAclRuleTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableName + "|" + aclRuleName, SET_COMMAND,
+                    { { MATCH_SRC_IP, "1.1.1.1/32" },
+                      { ACTION_POLICER_ACTION, policerName } } } }));
+        ASSERT_FALSE(orch->getAclRule(aclTableName, aclRuleName));
+
+        // Create the policer, then re-run the rule task: the rule is now programmed.
+        auto policerConsumer = unique_ptr<Consumer>(new Consumer(
+            new swss::ConsumerStateTable(m_config_db.get(), CFG_POLICER_TABLE_NAME, 1, 1),
+            gPolicerOrch, CFG_POLICER_TABLE_NAME));
+        policerConsumer->addToSync(deque<KeyOpFieldsValuesTuple>(
+            { { policerName, SET_COMMAND,
+                { { "METER_TYPE", "packets" }, { "MODE", "sr_tcm" },
+                  { "CIR", "100" }, { "CBS", "100" }, { "RED_PACKET_ACTION", "drop" } } } }));
+        static_cast<Orch *>(gPolicerOrch)->doTask(*policerConsumer);
+        ASSERT_TRUE(gPolicerOrch->policerExists(policerName));
+
+        orch->doAclRuleTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableName + "|" + aclRuleName, SET_COMMAND,
+                    { { MATCH_SRC_IP, "1.1.1.1/32" },
+                      { ACTION_POLICER_ACTION, policerName } } } }));
+
+        auto rule = orch->getAclRule(aclTableName, aclRuleName);
+        ASSERT_TRUE(rule);
+        const auto &actions = Portal::AclRuleInternal::getActions(rule);
+        ASSERT_NE(actions.find(SAI_ACL_ENTRY_ATTR_ACTION_SET_POLICER), actions.end());
     }
 
     // When received ACL table/rule SET_COMMAND, orchagent can create corresponding ACL table/rule

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -15,10 +15,12 @@ extern Srv6Orch  *gSrv6Orch;
 
 extern FdbOrch *gFdbOrch;
 extern MirrorOrch *gMirrorOrch;
+extern PolicerOrch *gPolicerOrch;
 extern VRFOrch *gVrfOrch;
 
 extern sai_acl_api_t *sai_acl_api;
 extern sai_switch_api_t *sai_switch_api;
+extern sai_policer_api_t *sai_policer_api;
 extern sai_hash_api_t *sai_hash_api;
 extern sai_port_api_t *sai_port_api;
 extern sai_vlan_api_t *sai_vlan_api;
@@ -325,6 +327,7 @@ namespace aclorch_test
             sai_api_query(SAI_API_MPLS, (void **)&sai_mpls_api);
             sai_api_query(SAI_API_ACL, (void **)&sai_acl_api);
             sai_api_query(SAI_API_NEXT_HOP_GROUP, (void **)&sai_next_hop_group_api);
+            sai_api_query(SAI_API_POLICER, (void **)&sai_policer_api);
 
             sai_attribute_t attr;
 
@@ -447,14 +450,15 @@ namespace aclorch_test
                 TableConnector(m_config_db.get(), CFG_PORT_STORM_CONTROL_TABLE_NAME)
             };
             TableConnector stateDbStorm(m_state_db.get(), "BUM_STORM_CAPABILITY");
-            PolicerOrch *policer_orch = new PolicerOrch(policer_tables, gPortsOrch);
+            ASSERT_EQ(gPolicerOrch, nullptr);
+            gPolicerOrch = new PolicerOrch(policer_tables, gPortsOrch);
 
             TableConnector stateDbMirrorSession(m_state_db.get(), STATE_MIRROR_SESSION_TABLE_NAME);
             TableConnector confDbMirrorSession(m_config_db.get(), CFG_MIRROR_SESSION_TABLE_NAME);
 
             ASSERT_EQ(gMirrorOrch, nullptr);
             gMirrorOrch = new MirrorOrch(stateDbMirrorSession, confDbMirrorSession,
-                                         gPortsOrch, gRouteOrch, gNeighOrch, gFdbOrch, policer_orch, gSwitchOrch);
+                                         gPortsOrch, gRouteOrch, gNeighOrch, gFdbOrch, gPolicerOrch, gSwitchOrch);
 
             auto consumer = unique_ptr<Consumer>(new Consumer(
                 new swss::ConsumerStateTable(m_app_db.get(), APP_PORT_TABLE_NAME, 1, 1), gPortsOrch, APP_PORT_TABLE_NAME));
@@ -471,6 +475,8 @@ namespace aclorch_test
             gSwitchOrch = nullptr;
             delete gMirrorOrch;
             gMirrorOrch = nullptr;
+            delete gPolicerOrch;
+            gPolicerOrch = nullptr;
             delete gRouteOrch;
             gRouteOrch = nullptr;
             delete gFlowCounterRouteOrch;
@@ -1328,6 +1334,91 @@ namespace aclorch_test
             ASSERT_EQ(it_rule, acl_table.rules.end());
             ASSERT_TRUE(validateLowerLayerDb(orch.get()));
         }
+    }
+
+    // An ACL rule with POLICER_ACTION referencing a POLICER entry is realized as
+    // SAI_ACL_ENTRY_ATTR_ACTION_SET_POLICER. A rule referencing a policer that
+    // does not exist yet is deferred (relies on the m_toSync retry) and not created.
+    TEST_F(AclOrchTest, AclRule_Policer_Action)
+    {
+        const string aclTableTypeName = "TEST_POLICER_TYPE";
+        const string aclTableName     = "TEST_POLICER_TABLE";
+        const string aclRuleName      = "TEST_POLICER_RULE";
+        const string policerName      = "test_policer";
+
+        auto orch = createAclOrch();
+
+        // Create a policer so POLICER_ACTION can resolve its OID.
+        auto policerConsumer = unique_ptr<Consumer>(new Consumer(
+            new swss::ConsumerStateTable(m_config_db.get(), CFG_POLICER_TABLE_NAME, 1, 1),
+            gPolicerOrch, CFG_POLICER_TABLE_NAME));
+        policerConsumer->addToSync(deque<KeyOpFieldsValuesTuple>(
+            { { policerName, SET_COMMAND,
+                { { "METER_TYPE", "packets" }, { "MODE", "sr_tcm" },
+                  { "CIR", "100" }, { "CBS", "100" }, { "RED_PACKET_ACTION", "drop" } } } }));
+        static_cast<Orch *>(gPolicerOrch)->doTask(*policerConsumer);
+        ASSERT_TRUE(gPolicerOrch->policerExists(policerName));
+
+        // Custom table type advertising the SRC_IP match and the policer action.
+        orch->doAclTableTypeTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableTypeName, SET_COMMAND,
+                    { { ACL_TABLE_TYPE_MATCHES, MATCH_SRC_IP },
+                      { ACL_TABLE_TYPE_ACTIONS, ACTION_POLICER_ACTION },
+                      { ACL_TABLE_TYPE_BPOINT_TYPES, BIND_POINT_TYPE_PORT } } } }));
+
+        orch->doAclTableTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableName, SET_COMMAND,
+                    { { ACL_TABLE_DESCRIPTION, "policer table" },
+                      { ACL_TABLE_TYPE, aclTableTypeName },
+                      { ACL_TABLE_STAGE, STAGE_INGRESS },
+                      { ACL_TABLE_PORTS, "1,2" } } } }));
+        ASSERT_TRUE(orch->getAclTable(aclTableName));
+
+        // Rule referencing the existing policer is created and carries SET_POLICER.
+        orch->doAclRuleTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableName + "|" + aclRuleName, SET_COMMAND,
+                    { { MATCH_SRC_IP, "1.1.1.1/32" },
+                      { ACTION_POLICER_ACTION, policerName } } } }));
+
+        auto rule = orch->getAclRule(aclTableName, aclRuleName);
+        ASSERT_TRUE(rule);
+        const auto &actions = Portal::AclRuleInternal::getActions(rule);
+        ASSERT_NE(actions.find(SAI_ACL_ENTRY_ATTR_ACTION_SET_POLICER), actions.end());
+
+        // Deleting the rule releases the policer reference it held
+        // (exercises AclRulePolicer::removeRule()).
+        orch->doAclRuleTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableName + "|" + aclRuleName, DEL_COMMAND, {} } }));
+        ASSERT_FALSE(orch->getAclRule(aclTableName, aclRuleName));
+
+        // Rule referencing a non-existent policer is deferred, not created.
+        orch->doAclRuleTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableName + "|" + "MISSING_POLICER_RULE", SET_COMMAND,
+                    { { MATCH_SRC_IP, "2.2.2.2/32" },
+                      { ACTION_POLICER_ACTION, "no_such_policer" } } } }));
+        ASSERT_FALSE(orch->getAclRule(aclTableName, "MISSING_POLICER_RULE"));
+
+        // A POLICER_ACTION with an empty policer name is rejected by
+        // AclRulePolicer::validateAddAction() and the rule is not created.
+        orch->doAclRuleTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableName + "|" + "EMPTY_POLICER_RULE", SET_COMMAND,
+                    { { MATCH_SRC_IP, "3.3.3.3/32" },
+                      { ACTION_POLICER_ACTION, "" } } } }));
+        ASSERT_FALSE(orch->getAclRule(aclTableName, "EMPTY_POLICER_RULE"));
+
+        // A POLICER_ACTION rule with no match/range fails AclRulePolicer::
+        // validate() (needs at least one match and exactly one action).
+        orch->doAclRuleTask(
+            deque<KeyOpFieldsValuesTuple>(
+                { { aclTableName + "|" + "NOMATCH_POLICER_RULE", SET_COMMAND,
+                    { { ACTION_POLICER_ACTION, policerName } } } }));
+        ASSERT_FALSE(orch->getAclRule(aclTableName, "NOMATCH_POLICER_RULE"));
     }
 
     // When received ACL table/rule SET_COMMAND, orchagent can create corresponding ACL table/rule


### PR DESCRIPTION
**What I did**

Added a `POLICER_ACTION` ACL rule action so a `CONFIG_DB` `ACL_RULE` can attach a policer
(`SAI_ACL_ENTRY_ATTR_ACTION_SET_POLICER`) and compose it with a packet/redirect action on the same
rule (rate-limit + forward/redirect). `POLICER_ACTION` must be advertised in a custom `ACL_TABLE_TYPE`'s
`ACTIONS` (it is not part of the built-in `L3`/`L3V6` types); the rule then references a `POLICER` by name:

```json
{
  "ACL_TABLE_TYPE": { "POLICER_L3": {
      "MATCHES": ["SRC_IP", "DST_IP", "L4_SRC_PORT", "L4_DST_PORT", "IP_PROTOCOL"],
      "ACTIONS": ["PACKET_ACTION", "POLICER_ACTION", "COUNTER"],
      "BIND_POINTS": ["PORT"] } },
  "ACL_TABLE": { "DATAACL": {
      "type": "POLICER_L3", "stage": "ingress", "ports": ["Ethernet0"] } },
  "ACL_RULE": { "DATAACL|RULE_1": {
      "PRIORITY": "9999", "SRC_IP": "10.0.0.1/32",
      "PACKET_ACTION": "FORWARD", "POLICER_ACTION": "test_policer" } }
}
```

**Why I did it**

`AclOrch` (the `CONFIG_DB` path) had no way to attach a policer to an ACL rule: none of the action maps in
`orchagent/aclorch.cpp` (`aclL3ActionLookup`, `aclMirrorStageLookup`, `aclDTelActionLookup`,
`aclOtherActionLookup`, `aclInnerActionLookup`) contained `SAI_ACL_ENTRY_ATTR_ACTION_SET_POLICER`, and
`AclRulePacket::validateAddAction()` rejects any unrecognized action. The only producer of
`SAI_ACL_ACTION_TYPE_SET_POLICER` today is P4Orch (driven by P4RT, not `CONFIG_DB`). A `POLICER` table
already exists in `CONFIG_DB` (managed by `PolicerOrch`) but only mirror sessions, port storm-control, and
CoPP trap groups consume it; ACL rules could not.

**How it is implemented**

- New `POLICER_ACTION` -> `SAI_ACL_ENTRY_ATTR_ACTION_SET_POLICER` entry in `aclL3ActionLookup`, so it is
  parsed by `parseAclTableTypeActions` (table-type capability), advertised in the ACL action capability, and
  dispatched on the L3 packet-rule path.
- The policer action is handled on the **L3 packet-rule path (`AclRulePacket`)** so it composes with a
  packet action. `AclRulePacket::createRule()` acquires the policer reference (`gPolicerOrch->increaseRefCount`)
  **before** the SAI ACL entry is created and rolls it back on failure; `removeRule()` releases it.
  `validate()` caps the number of **non-policer** actions at one (a policer may accompany a single
  packet/redirect action).
- `doAclRuleTask`: a rule that references a `POLICER` not yet created is deferred and retried via the
  Consumer `m_toSync` mechanism — same pattern as the existing "wait for ACL table" handling.

The policer supports two modes on a rule:
- **Compose (enforce):** `POLICER_ACTION` with a `PACKET_ACTION`/`REDIRECT_ACTION` — rate-limit + forward/redirect; the policer's red action drops out-of-profile traffic at ingress (the `RULE_1` example above).
- **Meter/mark-only:** `POLICER_ACTION` alone (no packet action) — forwarding is unchanged; the rule only meters and color-marks the matched flow (e.g. a trTCM marker whose green/yellow/red actions are `FORWARD`) so a downstream **color-aware WRED** can preferentially drop out-of-profile (yellow/red) packets under congestion. `validate()` therefore caps only the number of **non-policer** actions at one. *(Whether the meter color propagates to egress WRED is platform-dependent.)*

```json
"POLICER": { "mark_policer": {
    "METER_TYPE": "bytes", "MODE": "tr_tcm", "COLOR_SOURCE": "BLIND",
    "CIR": "1000000", "CBS": "20000", "PIR": "2000000", "PBS": "40000",
    "GREEN_PACKET_ACTION": "FORWARD", "YELLOW_PACKET_ACTION": "FORWARD", "RED_PACKET_ACTION": "FORWARD" } },
"ACL_RULE": { "DATAACL|RULE_MARK": {
    "PRIORITY": "9999", "SRC_IP": "10.0.0.1/32",
    "POLICER_ACTION": "mark_policer" } }
```
*(Contrast the compose `RULE_1` above, which also carries `PACKET_ACTION: FORWARD`; a mark-only rule omits the packet action and uses a non-dropping policer.)*


**How I verified it**

- swss mock_tests (`AclOrchTest.*Policer*`): compose (forward + policer),
  refcount rollback on SAI create failure, refcount balance across add/change/remove-policer-via-update,
  rule-before-policer deferral, IPv6 (L3V6) compose, and table-type gating (policer rejected when the type
  does not advertise it).
- Hardware (Broadcom TH5, QFX5241, SONiC 202511): FORWARD / REDIRECT compose program both
  `PACKET_ACTION` and `SET_POLICER` on one ASIC entry; dataplane rate-limit to CIR (200,000 offered @ 1 Mbps
  -> 1,354 forwarded, precise to CBS + CIR·duration); the ACL rule counter counts matched packets
  (pre-policer, = offered); one `POLICER` shared by two ACL rules resolves to a single
  refcounted SAI policer OID; a bound policer cannot be deleted; the rule survives `config reload`; no
  refcount leak across the full lifecycle.

Policer sharing is handled uniformly by `gPolicerOrch` reference counting, so a `POLICER` shared by an ACL
rule and a **mirror session** behaves the same way — a single refcounted SAI policer OID.

**Depends on**: sonic-buildimage YANG PR https://github.com/sonic-net/sonic-buildimage/pull/27859 for the `config_db.json` validation path. 
**HLD**: https://github.com/sonic-net/SONiC/pull/2423.

