### PR TITLE
[202605] Backport VPP artifact rename (#4639) + revert libnexthopgroup (#4657) to fix branch CI

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -24,6 +24,10 @@ parameters:
 - name: debian_version
   type: string
 
+- name: vpp_artifact_name
+  type: string
+  default: 'vpp-bookworm'
+
 - name: artifact_name
   type: string
 
@@ -163,7 +167,7 @@ jobs:
       source: specific
       project: build
       pipeline: sonic-net.sonic-platform-vpp
-      artifact: vpp
+      artifact: ${{ parameters.vpp_artifact_name }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/master'
       allowPartiallySucceededBuilds: true

--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -154,17 +154,6 @@ jobs:
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
-      project: ${{ parameters.buildimage_artifact_project }}
-      pipeline: Azure.sonic-buildimage.common_libs
-      artifact: common-lib
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/${{ parameters.buildimage_artifact_branch }}'
-      path: $(Build.ArtifactStagingDirectory)/download
-      patterns: '**/target/debs/${{ parameters.debian_version }}/libnexthopgroup_*.deb'
-    displayName: "Download sonic-buildimage libnexthopgroup package"
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      source: specific
       project: build
       pipeline: sonic-net.sonic-platform-vpp
       artifact: ${{ parameters.vpp_artifact_name }}
@@ -183,7 +172,6 @@ jobs:
       mkdir -p .azure-pipelines/docker-sonic-vs/debs
 
       find $(Build.ArtifactStagingDirectory)/download/sairedis -name '*.deb' -exec cp "{}" .azure-pipelines/docker-sonic-vs/debs \;
-      find $(Build.ArtifactStagingDirectory)/download -name 'libnexthopgroup_*.deb' -exec cp "{}" .azure-pipelines/docker-sonic-vs/debs \;
       cp -v $(Build.ArtifactStagingDirectory)/download/*.deb .azure-pipelines/docker-sonic-vs/debs
       if [ -f $(Build.ArtifactStagingDirectory)/download/coverage.info ]; then
         cp -v $(Build.ArtifactStagingDirectory)/download/coverage.info $(Build.ArtifactStagingDirectory)/

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -176,8 +176,6 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libnl-nf-3-200_*.deb
         target/debs/${{ parameters.debian_version }}/libnl-nf-3-dev_*.deb
         target/debs/${{ parameters.debian_version }}/libyang3_*.deb
-        target/debs/${{ parameters.debian_version }}/libnexthopgroup_*.deb
-        target/debs/${{ parameters.debian_version }}/libnexthopgroup-dev_*.deb
     displayName: "Download common libs"
   - task: DownloadPipelineArtifact@2
     inputs:

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -85,6 +85,10 @@ parameters:
 - name: debian_version
   type: string
 
+- name: vpp_artifact_name
+  type: string
+  default: 'vpp-bookworm'
+
 jobs:
 - job:
   displayName: ${{ parameters.arch }}
@@ -212,7 +216,7 @@ jobs:
       source: specific
       project: build
       pipeline: sonic-net.sonic-platform-vpp
-      artifact: vpp
+      artifact: ${{ parameters.vpp_artifact_name }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/master'
       allowPartiallySucceededBuilds: true

--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -13,7 +13,7 @@ COPY ["debs", "/debs"]
 # same, even though contents have changed) are checked between the previous and current layer.
 RUN dpkg --remove --force-all libswsscommon
 RUN apt --fix-broken install -y
-RUN dpkg --purge python3-swsscommon sonic-db-cli libsaimetadata libsairedis libsaivs syncd-vs swss sonic-eventd libdashapi framework libnexthopgroup
+RUN dpkg --purge python3-swsscommon sonic-db-cli libsaimetadata libsairedis libsaivs syncd-vs swss sonic-eventd libdashapi framework
 
 RUN apt-get update
 
@@ -43,8 +43,7 @@ RUN apt install -y /debs/libdashapi_1.0.0_amd64.deb \
             /debs/libsairedis_1.0.0_amd64.deb \
             /debs/libsaivs_1.0.0_amd64.deb \
             /debs/syncd-vs_1.0.0_amd64.deb \
-            /debs/swss_1.0.0_amd64.deb \
-            /debs/libnexthopgroup_1.0.0_amd64.deb
+            /debs/swss_1.0.0_amd64.deb
 
 RUN if [ "$need_dbg" = "y" ] ; then dpkg -i /debs/swss-dbg_1.0.0_amd64.deb ; fi
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,6 +54,7 @@ stages:
       dash_artifact_name: sonic-dash-api
       artifact_name: sonic-swss-${{ parameters.debian_version }}
       debian_version: ${{ parameters.debian_version }}
+      vpp_artifact_name: vpp-${{ parameters.debian_version }}
       archive_pytests: true
       archive_gcov: true
 
@@ -71,6 +72,7 @@ stages:
       dash_artifact_name: sonic-dash-api
       artifact_name: sonic-swss-asan-${{ parameters.debian_version }}
       debian_version: ${{ parameters.debian_version }}
+      vpp_artifact_name: vpp-${{ parameters.debian_version }}
       asan: true
 
 - stage: BuildArm
@@ -89,6 +91,7 @@ stages:
       dash_artifact_name: sonic-dash-api.armhf
       artifact_name: sonic-swss-${{ parameters.debian_version }}.armhf
       debian_version: ${{ parameters.debian_version }}
+      vpp_artifact_name: vpp-${{ parameters.debian_version }}
       archive_gcov: false
 
   - template: .azure-pipelines/build-template.yml
@@ -103,6 +106,7 @@ stages:
       dash_artifact_name: sonic-dash-api.arm64
       artifact_name: sonic-swss-${{ parameters.debian_version }}.arm64
       debian_version: ${{ parameters.debian_version }}
+      vpp_artifact_name: vpp-${{ parameters.debian_version }}
       archive_gcov: false
 
 - stage: BuildTrixie
@@ -120,6 +124,7 @@ stages:
       dash_artifact_name: sonic-dash-api-trixie
       artifact_name: sonic-swss-trixie
       debian_version: trixie
+      vpp_artifact_name: vpp-trixie
       archive_gcov: false
 
   - template: .azure-pipelines/build-template.yml
@@ -134,6 +139,7 @@ stages:
       dash_artifact_name: sonic-dash-api-trixie.armhf
       artifact_name: sonic-swss-trixie.armhf
       debian_version: trixie
+      vpp_artifact_name: vpp-trixie
       archive_gcov: false
 
   - template: .azure-pipelines/build-template.yml
@@ -148,6 +154,7 @@ stages:
       dash_artifact_name: sonic-dash-api-trixie.arm64
       artifact_name: sonic-swss-trixie.arm64
       debian_version: trixie
+      vpp_artifact_name: vpp-trixie
       archive_gcov: false
 
 - stage: BuildDocker
@@ -160,6 +167,7 @@ stages:
       sairedis_artifact_name: sonic-sairedis-${{ parameters.debian_version }}
       swss_artifact_name: sonic-swss-${{ parameters.debian_version }}
       debian_version: ${{ parameters.debian_version }}
+      vpp_artifact_name: vpp-${{ parameters.debian_version }}
       artifact_name: docker-sonic-vs
 
 - stage: BuildDockerAsan
@@ -173,6 +181,7 @@ stages:
       swss_artifact_name: sonic-swss-asan-${{ parameters.debian_version }}
       artifact_name: docker-sonic-vs-asan
       debian_version: ${{ parameters.debian_version }}
+      vpp_artifact_name: vpp-${{ parameters.debian_version }}
       asan: true
 
 - stage: Test

--- a/fpmsyncd/Makefile.am
+++ b/fpmsyncd/Makefile.am
@@ -13,7 +13,7 @@ fpmsyncd_SOURCES = fpmsyncd.cpp fpmlink.cpp routesync.cpp $(top_srcdir)/warmrest
 
 fpmsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
 fpmsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
-fpmsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon -lnexthopgroup
+fpmsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon
 
 if GCOV_ENABLED
 fpmsyncd_SOURCES += ../gcovpreload/gcovpreload.cpp


### PR DESCRIPTION
**What I did**

Backport two already-merged master fixes to `202605` together, because **neither passes CI on `202605` without the other** — they unblock different stages of the same build:

1. **#4639** — `[azp] Download VPP artifact 'vpp-<debian version>'` (commit 8a9362f9)
   The `sonic-net/sonic-platform-vpp` pipeline renamed its artifact (`vpp` → `vpp-bookworm`/`vpp-trixie`) when the Trixie build was added (sonic-platform-vpp#248). On `202605`, `build-template.yml` still hardcodes `artifact: vpp`, so the dep download fails with *"Artifact vpp was not found"* and the swss compile never runs. This parametrizes the VPP artifact name per Debian version.

2. **#4657** — `Revert "[fpmsyncd]: add libnexthopgroup in Makefile.am (#4394)"` (commit a87a1bcd)
   `fpmsyncd` on `202605` links `-lnexthopgroup`, but `libnexthopgroup` is no longer published by the `common_libs` pipeline after the libyang1→libyang3 migration (see #4657 / sonic-buildimage#27629). This makes the `fpmsyncd` link step fail with *"cannot find -lnexthopgroup"*. master already reverted this; `202605` did not. Reverting removes the build dependency (the lib is not actively used in SWSS at the moment), matching master.

**Why combine them in one PR**

- With only #4639: compile runs, but `fpmsyncd` fails to link `-lnexthopgroup` (common_libs on `202605` has no such deb).
- With only #4657: build still dies earlier at the `vpp` artifact download.
- Both are required for a green `202605` swss build.

**Why I did it**

The `202605` `sonic-swss` branch CI is currently red for all PRs (e.g. the swss-common downstream build buildId 1138029 and the baseline branch build 1137885) due to these two issues. This unblocks the branch.

**How I verified it**

- Both cherry-picks apply cleanly to `origin/202605` with no conflicts.
- Confirmed resulting `fpmsyncd_LDADD` no longer references `-lnexthopgroup`.
- Confirmed `vpp_artifact_name` is parameterized (`vpp-${{ debian_version }}`) in `azure-pipelines.yml` / `build-template.yml`.
- Relying on this PR's own CI for full build validation.

**Notes**

- Opened as **draft** for CI validation. The RIB/FIB feature that originally needed `libnexthopgroup` (#4394) can be re-landed on `202605` later once `common_libs` publishes the lib again (the same path master is taking via sonic-buildimage#27807).
- Both commits are DCO signed-off.

cc: backport of #4639 and #4657 to 202605.
