### PR TITLE
orchagent: query ACL table group type capability instead of hardcoding PARALLEL

### DIFF
--- a/orchagent/p4orch/tests/test_main.cpp
+++ b/orchagent/p4orch/tests/test_main.cpp
@@ -122,6 +122,11 @@ bool parseHandleSaiStatusFailure(task_process_status status)
     return true;
 }
 
+sai_acl_table_group_type_t querySupportedAclTableGroupType(sai_object_id_t switch_id)
+{
+    return SAI_ACL_TABLE_GROUP_TYPE_PARALLEL;
+}
+
 namespace
 {
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2896,7 +2896,7 @@ bool PortsOrch::createBindAclTableGroup(sai_object_id_t  port_oid,
         group_attrs.push_back(group_attr);
 
         group_attr.id = SAI_ACL_TABLE_GROUP_ATTR_TYPE;
-        group_attr.value.s32 = SAI_ACL_TABLE_GROUP_TYPE_PARALLEL;
+        group_attr.value.s32 = querySupportedAclTableGroupType(gSwitchId);
         group_attrs.push_back(group_attr);
 
         status = sai_acl_api->create_acl_table_group(&group_oid_ref, gSwitchId,

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -1268,3 +1268,91 @@ bool getSaiFailureStatus(std::string& error)
     return true;
 }
 
+/*
+ * Determine the ACL table group lookup type the platform actually supports.
+ *
+ * Historically orchagent hardcodes SAI_ACL_TABLE_GROUP_TYPE_PARALLEL. The only
+ * case in which we deviate from that is when a *successful* enum-values
+ * capability query for SAI_ACL_TABLE_GROUP_ATTR_TYPE tells us PARALLEL is not
+ * supported but SEQUENTIAL is. For every other outcome we keep the historical
+ * PARALLEL default so existing platforms are never regressed:
+ *   - query SUCCESS, PARALLEL listed            -> PARALLEL (unchanged)
+ *   - query SUCCESS, only SEQUENTIAL listed     -> SEQUENTIAL
+ *   - query NOT_IMPLEMENTED / NOT_SUPPORTED     -> PARALLEL (query not available)
+ *   - any other (genuine) query failure         -> PARALLEL (preserve historical)
+ *
+ * Note: unlike a "must this field be dropped" gate, choosing PARALLEL on a
+ * non-definitive result cannot introduce a new create/retry loop here because
+ * PARALLEL is exactly what is programmed today; it is the safe, no-change path.
+ */
+sai_acl_table_group_type_t querySupportedAclTableGroupType(sai_object_id_t switch_id)
+{
+    const auto *meta = sai_metadata_get_attr_metadata(
+        SAI_OBJECT_TYPE_ACL_TABLE_GROUP, SAI_ACL_TABLE_GROUP_ATTR_TYPE);
+    if (meta == nullptr || !meta->isenum || meta->enummetadata == nullptr)
+    {
+        return SAI_ACL_TABLE_GROUP_TYPE_PARALLEL;
+    }
+
+    std::vector<int32_t> values_list(meta->enummetadata->valuescount, 0);
+    sai_s32_list_t values;
+    values.count = static_cast<uint32_t>(values_list.size());
+    values.list = values_list.data();
+
+    sai_status_t status = sai_query_attribute_enum_values_capability(
+        switch_id, SAI_OBJECT_TYPE_ACL_TABLE_GROUP,
+        SAI_ACL_TABLE_GROUP_ATTR_TYPE, &values);
+
+    if (status == SAI_STATUS_SUCCESS)
+    {
+        bool parallel_supported = false;
+        bool sequential_supported = false;
+        for (uint32_t i = 0; i < values.count; i++)
+        {
+            if (values.list[i] == SAI_ACL_TABLE_GROUP_TYPE_PARALLEL)
+            {
+                parallel_supported = true;
+            }
+            else if (values.list[i] == SAI_ACL_TABLE_GROUP_TYPE_SEQUENTIAL)
+            {
+                sequential_supported = true;
+            }
+        }
+
+        if (parallel_supported)
+        {
+            return SAI_ACL_TABLE_GROUP_TYPE_PARALLEL;
+        }
+        if (sequential_supported)
+        {
+            SWSS_LOG_NOTICE("PARALLEL ACL table group lookup not supported by the "
+                            "platform; using SEQUENTIAL");
+            return SAI_ACL_TABLE_GROUP_TYPE_SEQUENTIAL;
+        }
+
+        SWSS_LOG_WARN("ACL table group TYPE capability query returned no usable "
+                      "values; preserving historical PARALLEL default");
+        return SAI_ACL_TABLE_GROUP_TYPE_PARALLEL;
+    }
+
+    /*
+     * The capability query did not succeed. Only treat NOT_IMPLEMENTED /
+     * NOT_SUPPORTED as the expected "query unavailable" case; log any other
+     * status as a genuine failure. In both cases keep the historical PARALLEL
+     * default so behavior is identical to before this change.
+     */
+    if (status == SAI_STATUS_NOT_IMPLEMENTED || status == SAI_STATUS_NOT_SUPPORTED)
+    {
+        SWSS_LOG_INFO("sai_query_attribute_enum_values_capability(ACL_TABLE_GROUP, "
+                      "TYPE) not available (status:%d); using historical PARALLEL "
+                      "default", status);
+    }
+    else
+    {
+        SWSS_LOG_WARN("sai_query_attribute_enum_values_capability(ACL_TABLE_GROUP, "
+                      "TYPE) failed (status:%d); preserving historical PARALLEL "
+                      "default", status);
+    }
+    return SAI_ACL_TABLE_GROUP_TYPE_PARALLEL;
+}
+

--- a/orchagent/saihelper.h
+++ b/orchagent/saihelper.h
@@ -72,3 +72,12 @@ void stopFlexCounterPolling(sai_object_id_t switch_oid,
                             const std::string &key);
 
 std::vector<sai_stat_id_t> queryAvailableCounterStats(const sai_object_type_t);
+
+/*
+ * Query the ACL table group lookup type (PARALLEL/SEQUENTIAL) supported by the
+ * platform for SAI_ACL_TABLE_GROUP_ATTR_TYPE. Returns the historical PARALLEL
+ * default on every non-definitive result so existing platforms are never
+ * regressed; only a *successful* query that reports PARALLEL unsupported (and
+ * SEQUENTIAL supported) yields SEQUENTIAL. See saihelper.cpp for details.
+ */
+sai_acl_table_group_type_t querySupportedAclTableGroupType(sai_object_id_t switch_id);

--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -339,7 +339,7 @@ ReturnCode SwitchOrch::createAclGroup(const sai_acl_stage_t &group_stage, refere
     acl_grp_attrs.push_back(acl_grp_attr);
 
     acl_grp_attr.id = SAI_ACL_TABLE_GROUP_ATTR_TYPE;
-    acl_grp_attr.value.s32 = SAI_ACL_TABLE_GROUP_TYPE_PARALLEL;
+    acl_grp_attr.value.s32 = querySupportedAclTableGroupType(gSwitchId);
     acl_grp_attrs.push_back(acl_grp_attr);
 
     acl_grp_attr.id = SAI_ACL_TABLE_ATTR_ACL_BIND_POINT_TYPE_LIST;

--- a/tests/mock_tests/mock_sai_capability_wrap.cpp
+++ b/tests/mock_tests/mock_sai_capability_wrap.cpp
@@ -18,6 +18,7 @@
 
 #include <cstddef>
 #include <cstring>
+#include <utility>
 
 namespace
 {
@@ -41,6 +42,11 @@ namespace
         // (sai_query_attribute_capability) fails, forcing native FlexCounter.
         thread_local bool g_fail_session_capability = false;
     }
+
+    // Generic per-attribute enum-values-capability override (sai_enum_cap_ut),
+    // consulted first in __wrap_sai_query_attribute_enum_values_capability so any
+    // orch UT (e.g. the ACL table group type query) can inject a result.
+    thread_local sai_enum_cap_ut::EnumValuesCapabilityOverride g_enumValuesOverride;
 
     // HFTel capability discovery path (HFTelOrch::isSupportedHFTel).
     namespace hftel
@@ -109,6 +115,14 @@ extern "C"
             _In_ sai_attr_id_t attr_id,
             _Inout_ sai_s32_list_t* enum_values_capability)
     {
+        // Generic per-attribute override (any orch UT). Checked first: when set,
+        // its result is used verbatim; otherwise fall through to the icmp hooks.
+        if (g_enumValuesOverride)
+        {
+            return g_enumValuesOverride(switch_id, object_type, attr_id,
+                                        enum_values_capability);
+        }
+
         const bool is_icmp_stats_mode = (object_type == SAI_OBJECT_TYPE_ICMP_ECHO_SESSION)
                 && (attr_id == SAI_ICMP_ECHO_SESSION_ATTR_STATS_COUNT_MODE);
 
@@ -337,5 +351,29 @@ namespace hftelorch_sai_wrap_ut
     HFTelSaiHookGuard::~HFTelSaiHookGuard()
     {
         setSaiHookNone();
+    }
+}
+
+namespace sai_enum_cap_ut
+{
+    void setEnumValuesCapabilityOverride(EnumValuesCapabilityOverride fn)
+    {
+        g_enumValuesOverride = std::move(fn);
+    }
+
+    void clearEnumValuesCapabilityOverride()
+    {
+        g_enumValuesOverride = nullptr;
+    }
+
+    EnumValuesCapabilityOverrideGuard::EnumValuesCapabilityOverrideGuard(
+            EnumValuesCapabilityOverride fn)
+    {
+        setEnumValuesCapabilityOverride(std::move(fn));
+    }
+
+    EnumValuesCapabilityOverrideGuard::~EnumValuesCapabilityOverrideGuard()
+    {
+        clearEnumValuesCapabilityOverride();
     }
 }

--- a/tests/mock_tests/mock_sai_capability_wrap.h
+++ b/tests/mock_tests/mock_sai_capability_wrap.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#include <functional>
+
+extern "C"
+{
+#include "saitypes.h"
+}
+
 /*
  * GNU ld --wrap hooks for free-standing SAI capability/metadata functions
  * exercised by the orchagent unit tests.
@@ -82,5 +89,34 @@ namespace hftelorch_sai_wrap_ut
 
         HFTelSaiHookGuard(const HFTelSaiHookGuard&) = delete;
         HFTelSaiHookGuard& operator=(const HFTelSaiHookGuard&) = delete;
+    };
+}
+
+/*
+ * Generic, test-settable override for the shared --wrap of
+ * sai_query_attribute_enum_values_capability. Any mock test can program a
+ * per-attribute enum-values result (status + value list) without disturbing the
+ * icmp-specific hooks above. The override is consulted first; if unset, the wrap
+ * falls back to the icmp hooks / __real_*.
+ */
+namespace sai_enum_cap_ut
+{
+    using EnumValuesCapabilityOverride = std::function<sai_status_t(
+        sai_object_id_t switch_id,
+        sai_object_type_t object_type,
+        sai_attr_id_t attr_id,
+        sai_s32_list_t *enum_values_capability)>;
+
+    void setEnumValuesCapabilityOverride(EnumValuesCapabilityOverride fn);
+    void clearEnumValuesCapabilityOverride();
+
+    /** RAII: clears the override on scope exit. */
+    struct EnumValuesCapabilityOverrideGuard
+    {
+        explicit EnumValuesCapabilityOverrideGuard(EnumValuesCapabilityOverride fn);
+        ~EnumValuesCapabilityOverrideGuard();
+
+        EnumValuesCapabilityOverrideGuard(const EnumValuesCapabilityOverrideGuard&) = delete;
+        EnumValuesCapabilityOverrideGuard& operator=(const EnumValuesCapabilityOverrideGuard&) = delete;
     };
 }

--- a/tests/mock_tests/saihelper_ut.cpp
+++ b/tests/mock_tests/saihelper_ut.cpp
@@ -1,9 +1,12 @@
 #include "ut_helper.h"
 #include "saihelper.h"
 #include "mock_table.h"
+#include "mock_sai_capability_wrap.h"
 
+#include <cstdint>
 #include <memory>
 #include <sstream>
+#include <vector>
 
 extern std::unique_ptr<swss::DBConnector> gHealthStateDb;
 extern std::unique_ptr<swss::Table> gOrchHealthTable;
@@ -199,5 +202,114 @@ namespace sai_failure_status_test
 
         // Re-init for TearDown safety
         initSaiFailureTable();
+    }
+
+    /*
+     * querySupportedAclTableGroupType() must preserve the historical PARALLEL
+     * default on every outcome except a *successful* enum-values query that
+     * reports PARALLEL unsupported while SEQUENTIAL is supported. The enum-values
+     * SAI call is driven through the shared --wrap override (sai_enum_cap_ut).
+     */
+    namespace
+    {
+        sai_enum_cap_ut::EnumValuesCapabilityOverride makeAclGroupTypeOverride(
+            sai_status_t status, std::vector<int32_t> supported_values)
+        {
+            return [status, supported_values](
+                       sai_object_id_t /*switch_id*/,
+                       sai_object_type_t object_type,
+                       sai_attr_id_t attr_id,
+                       sai_s32_list_t *cap) -> sai_status_t
+            {
+                // Only intercept the ACL table group TYPE query.
+                if (object_type != SAI_OBJECT_TYPE_ACL_TABLE_GROUP ||
+                    attr_id != SAI_ACL_TABLE_GROUP_ATTR_TYPE)
+                {
+                    if (cap)
+                    {
+                        cap->count = 0;
+                    }
+                    return SAI_STATUS_SUCCESS;
+                }
+
+                if (status != SAI_STATUS_SUCCESS)
+                {
+                    if (cap)
+                    {
+                        cap->count = 0;
+                    }
+                    return status;
+                }
+
+                // The helper pre-sizes the buffer to the enum's total value
+                // count, so a supported subset always fits.
+                if (!cap || !cap->list ||
+                    cap->count < supported_values.size())
+                {
+                    if (cap)
+                    {
+                        cap->count = static_cast<uint32_t>(supported_values.size());
+                    }
+                    return SAI_STATUS_BUFFER_OVERFLOW;
+                }
+                for (size_t i = 0; i < supported_values.size(); i++)
+                {
+                    cap->list[i] = supported_values[i];
+                }
+                cap->count = static_cast<uint32_t>(supported_values.size());
+                return SAI_STATUS_SUCCESS;
+            };
+        }
+    }
+
+    TEST(QuerySupportedAclTableGroupType, ParallelSupportedReturnsParallel)
+    {
+        sai_enum_cap_ut::EnumValuesCapabilityOverrideGuard guard(
+            makeAclGroupTypeOverride(SAI_STATUS_SUCCESS,
+                {SAI_ACL_TABLE_GROUP_TYPE_SEQUENTIAL,
+                 SAI_ACL_TABLE_GROUP_TYPE_PARALLEL}));
+        EXPECT_EQ(SAI_ACL_TABLE_GROUP_TYPE_PARALLEL,
+                  querySupportedAclTableGroupType(SAI_NULL_OBJECT_ID));
+    }
+
+    TEST(QuerySupportedAclTableGroupType, OnlySequentialReturnsSequential)
+    {
+        sai_enum_cap_ut::EnumValuesCapabilityOverrideGuard guard(
+            makeAclGroupTypeOverride(SAI_STATUS_SUCCESS,
+                {SAI_ACL_TABLE_GROUP_TYPE_SEQUENTIAL}));
+        EXPECT_EQ(SAI_ACL_TABLE_GROUP_TYPE_SEQUENTIAL,
+                  querySupportedAclTableGroupType(SAI_NULL_OBJECT_ID));
+    }
+
+    TEST(QuerySupportedAclTableGroupType, EmptyListPreservesParallel)
+    {
+        sai_enum_cap_ut::EnumValuesCapabilityOverrideGuard guard(
+            makeAclGroupTypeOverride(SAI_STATUS_SUCCESS, {}));
+        EXPECT_EQ(SAI_ACL_TABLE_GROUP_TYPE_PARALLEL,
+                  querySupportedAclTableGroupType(SAI_NULL_OBJECT_ID));
+    }
+
+    TEST(QuerySupportedAclTableGroupType, NotSupportedPreservesParallel)
+    {
+        sai_enum_cap_ut::EnumValuesCapabilityOverrideGuard guard(
+            makeAclGroupTypeOverride(SAI_STATUS_NOT_SUPPORTED, {}));
+        EXPECT_EQ(SAI_ACL_TABLE_GROUP_TYPE_PARALLEL,
+                  querySupportedAclTableGroupType(SAI_NULL_OBJECT_ID));
+    }
+
+    TEST(QuerySupportedAclTableGroupType, NotImplementedPreservesParallel)
+    {
+        sai_enum_cap_ut::EnumValuesCapabilityOverrideGuard guard(
+            makeAclGroupTypeOverride(SAI_STATUS_NOT_IMPLEMENTED, {}));
+        EXPECT_EQ(SAI_ACL_TABLE_GROUP_TYPE_PARALLEL,
+                  querySupportedAclTableGroupType(SAI_NULL_OBJECT_ID));
+    }
+
+    TEST(QuerySupportedAclTableGroupType, GenuineFailurePreservesParallel)
+    {
+        sai_enum_cap_ut::EnumValuesCapabilityOverrideGuard guard(
+            makeAclGroupTypeOverride(SAI_STATUS_FAILURE, {}));
+        EXPECT_EQ(SAI_ACL_TABLE_GROUP_TYPE_PARALLEL,
+                  querySupportedAclTableGroupType(SAI_NULL_OBJECT_ID));
     }
 }


### PR DESCRIPTION
**What I did**

`PortsOrch::createBindAclTableGroup()` and `SwitchOrch::createAclGroup()` hardcoded
`SAI_ACL_TABLE_GROUP_TYPE_PARALLEL` when creating ACL table groups. This replaces both with a new
`saihelper` free function `querySupportedAclTableGroupType()` that discovers the platform-supported
group type via `sai_query_attribute_enum_values_capability(SAI_OBJECT_TYPE_ACL_TABLE_GROUP,
SAI_ACL_TABLE_GROUP_ATTR_TYPE)`.

The helper returns the historical `PARALLEL` default on every non-definitive result and only returns
`SEQUENTIAL` when the platform *successfully* reports SEQUENTIAL as the only supported type:

| Capability query result | Returned type |
|---|---|
| SUCCESS, PARALLEL listed | PARALLEL (unchanged) |
| SUCCESS, only SEQUENTIAL listed | SEQUENTIAL |
| SUCCESS, empty / unusable list | PARALLEL |
| `SAI_STATUS_NOT_IMPLEMENTED` / `SAI_STATUS_NOT_SUPPORTED` | PARALLEL |
| any other genuine query failure | PARALLEL |

**Why I did it**

Fixes #4671. The SAI spec default for `SAI_ACL_TABLE_GROUP_ATTR_TYPE` is `SEQUENTIAL`, so the hardcoded
`PARALLEL` is an orchagent-imposed override. On a platform whose SAI implementation does not realize
PARALLEL ACL table groups, `create_acl_table_group()` fails and the ACL never binds, with no graceful
fallback. This mirrors the capability-gating already done for ACL table match fields in #4661.

The change is backward compatible by construction: `PARALLEL` is preserved on every path except an
explicit, successful "SEQUENTIAL-only" answer — so platforms that don't implement the enum-values
query (i.e. today's behavior) are unaffected, and no new create/retry loop is introduced because
PARALLEL is exactly what is programmed today.

**How I verified it**

- **Unit tests** (`tests/mock_tests/saihelper_ut.cpp`): 6 new gtest cases in the
  `QuerySupportedAclTableGroupType` suite cover all outcomes — PARALLEL supported, SEQUENTIAL-only,
  empty list, `NOT_SUPPORTED`, `NOT_IMPLEMENTED`, and a genuine `SAI_STATUS_FAILURE` — each asserting
  the documented result. The enum-values SAI call is driven through a generic, registrable `--wrap`
  override (`sai_enum_cap_ut`) in the shared unified capability wrap `mock_sai_capability_wrap` (the
  wrapper introduced by #4613), so no test reaches real hardware.

```
$ ./tests --gtest_filter='QuerySupportedAclTableGroupType.*'
[----------] 6 tests from QuerySupportedAclTableGroupType
[ RUN      ] QuerySupportedAclTableGroupType.ParallelSupportedReturnsParallel
[       OK ] QuerySupportedAclTableGroupType.ParallelSupportedReturnsParallel (0 ms)
[ RUN      ] QuerySupportedAclTableGroupType.OnlySequentialReturnsSequential
[       OK ] QuerySupportedAclTableGroupType.OnlySequentialReturnsSequential (0 ms)
[ RUN      ] QuerySupportedAclTableGroupType.EmptyListPreservesParallel
[       OK ] QuerySupportedAclTableGroupType.EmptyListPreservesParallel (0 ms)
[ RUN      ] QuerySupportedAclTableGroupType.NotSupportedPreservesParallel
[       OK ] QuerySupportedAclTableGroupType.NotSupportedPreservesParallel (0 ms)
[ RUN      ] QuerySupportedAclTableGroupType.NotImplementedPreservesParallel
[       OK ] QuerySupportedAclTableGroupType.NotImplementedPreservesParallel (0 ms)
[ RUN      ] QuerySupportedAclTableGroupType.GenuineFailurePreservesParallel
[       OK ] QuerySupportedAclTableGroupType.GenuineFailurePreservesParallel (0 ms)
[----------] 6 tests from QuerySupportedAclTableGroupType (0 ms total)
[  PASSED  ] 6 tests.
```

- **Build**: orchagent compiles clean with the change.
- **Hardware E2E**: with a companion libsai that implements the enum-values query for
  `ACL_TABLE_GROUP/TYPE`): after deploy the ingress ACL table group is created as `PARALLEL` via the
  capability path (`createBindAclTableGroup` → `querySupportedAclTableGroupType` → SUCCESS+{PARALLEL}),
  ASIC ACL table/group/member/entry counts are unchanged, and existing ACL programming is unaffected.
  A direct probe of the deployed libsai confirms `sai_query_attribute_enum_values_capability(
  ACL_TABLE_GROUP, TYPE)` returns `SAI_STATUS_SUCCESS` with `{PARALLEL}`.

**Details if related**
- Related: #4661 (ACL table match-field capability gating).
