### PR TITLE
Clear DASH HA brainsplit recovery pending flag

### DIFF
--- a/orchagent/dash/dashhaorch.cpp
+++ b/orchagent/dash/dashhaorch.cpp
@@ -817,6 +817,17 @@ bool DashHaOrch::setHaScopeFlowReconcileRequest(const std::string &key)
     return true;
 }
 
+bool DashHaOrch::clearHaScopeBrainSplitRecoverPending(const std::string &key)
+{
+    SWSS_LOG_ENTER();
+
+    std::vector<FieldValueTuple> fvs = {{"brainsplit_recover_pending", "false"}};
+    m_dpuStateDbHaScopeTable->set(key, fvs);
+    SWSS_LOG_NOTICE("Cleared HA Scope brainsplit recover pending flag for %s", key.c_str());
+
+    return true;
+}
+
 bool DashHaOrch::setHaScopeActivateRoleRequest(const std::string &key)
 {
     SWSS_LOG_ENTER();
@@ -952,6 +963,16 @@ void DashHaOrch::doTaskHaScopeTable(ConsumerBase &consumer)
         if (op == SET_COMMAND)
         {
             dash::ha_scope::HaScope entry;
+            bool brainSplitRecovered = false;
+
+            for (const auto &fieldValue : kfvFieldsValues(tuple))
+            {
+                if (fvField(fieldValue) == "brainsplit_recovered")
+                {
+                    brainSplitRecovered = fvValue(fieldValue) == "true" || fvValue(fieldValue) == "1";
+                    break;
+                }
+            }
 
             auto existing_it = m_ha_scope_entries.find(key);
             if (existing_it != m_ha_scope_entries.end())
@@ -982,6 +1003,10 @@ void DashHaOrch::doTaskHaScopeTable(ConsumerBase &consumer)
 
             if (addHaScopeEntry(key, entry))
             {
+                if (brainSplitRecovered)
+                {
+                    clearHaScopeBrainSplitRecoverPending(key);
+                }
                 it = consumer.m_toSync.erase(it);
             }
             else

--- a/orchagent/dash/dashhaorch.h
+++ b/orchagent/dash/dashhaorch.h
@@ -78,6 +78,7 @@ protected:
     bool setHaScopeHaRole(const std::string &key, const dash::ha_scope::HaScope &entry);
     void updateHaScopeStateForSwitchOwner(const std::string &key, const dash::ha_scope::HaScope &entry);
     bool setHaScopeFlowReconcileRequest(const  std::string &key);
+    bool clearHaScopeBrainSplitRecoverPending(const std::string &key);
     bool setHaScopeActivateRoleRequest(const std::string &key);
     bool setHaScopeDisabled(const std::string &key, bool disabled);
     virtual bool isHaScopeAdminStateAttrSupported();

--- a/tests/mock_tests/dashhaorch_ut.cpp
+++ b/tests/mock_tests/dashhaorch_ut.cpp
@@ -73,6 +73,7 @@ namespace dashhaorch_ut
     {
     protected:
         std::unique_ptr<MockBfdOrch> m_mockBfdOrch;
+        shared_ptr<swss::DBConnector> m_dpu_state_db;
 
         virtual DashHaOrch* CreateDashHaOrch(const vector<string>& dash_ha_tables)
         {
@@ -82,6 +83,7 @@ namespace dashhaorch_ut
         void PostSetUp() override
         {
             m_mockBfdOrch = std::make_unique<MockBfdOrch>(m_app_db.get(), m_state_db.get());
+            m_dpu_state_db = make_shared<swss::DBConnector>("DPU_STATE_DB", 0);
 
             vector<string> dash_ha_tables = {
                 APP_DASH_HA_SET_TABLE_NAME,
@@ -458,6 +460,38 @@ namespace dashhaorch_ut
                 )
             );
             static_cast<Orch *>(m_dashHaOrch)->doTask(*consumer.get());
+        }
+
+        void SetHaScopeBrainSplitRecovered()
+        {
+            auto consumer = unique_ptr<Consumer>(new Consumer(
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1, 1),
+                m_dashHaOrch, APP_DASH_HA_SCOPE_TABLE_NAME));
+
+            consumer->addToSync(
+                deque<KeyOpFieldsValuesTuple>(
+                    {
+                        {
+                            "HA_SET_1",
+                            SET_COMMAND,
+                            {
+                                {"version", "1"},
+                                {"ha_role", "active"},
+                                {"brainsplit_recovered", "true"}
+                            }
+                        }
+                    }
+                )
+            );
+            static_cast<Orch *>(m_dashHaOrch)->doTask(*consumer.get());
+        }
+
+        void ExpectHaScopeStateField(const std::string &field, const std::string &expected)
+        {
+            swss::Table state_table(m_dpu_state_db.get(), STATE_DASH_HA_SCOPE_STATE_TABLE_NAME);
+            std::string value;
+            ASSERT_TRUE(state_table.hget("HA_SET_1", field, value));
+            EXPECT_EQ(value, expected);
         }
 
         void RandomTable()
@@ -993,6 +1027,11 @@ namespace dashhaorch_ut
 
         HaScopeEvent(SAI_HA_SCOPE_EVENT_SPLIT_BRAIN_DETECTED,
             SAI_DASH_HA_ROLE_ACTIVE, SAI_DASH_HA_STATE_ACTIVE);
+        ExpectHaScopeStateField("brainsplit_recover_pending", "true");
+
+        SetHaScopeBrainSplitRecovered();
+
+        ExpectHaScopeStateField("brainsplit_recover_pending", "false");
 
         RemoveHaScope();
         RemoveHaSet();


### PR DESCRIPTION
Clear the DASH HA `brainsplit_recover_pending` DPU state flag when hamgrd writes `brainsplit_recovered=true` to `DASH_HA_SCOPE_TABLE`.

This aligns the brainsplit recovery acknowledgement path with the existing requested-flag handling for `flow_reconcile_requested` and `activate_role_requested`, where dashhaorch clears the corresponding pending flag after processing the request.

Changes:
- Detect `brainsplit_recovered=true` or `1` while processing HA scope table updates.
- Clear `brainsplit_recover_pending=false` in `DPU_STATE_DB:DASH_HA_SCOPE_STATE` after successful HA scope entry processing.
- Add `DashHaOrchTest.HaScopeSplitBrain` gtest coverage for split-brain pending set and recovery clear.

Validation:
- Built `orchagent` in refreshed `swss-bookworm-master` build container.
- Passed `./tests --gtest_filter=DashHaOrchTest.HaScopeSplitBrain`.
- Passed `./tests --gtest_filter="DashHaOrchTest*"` with 23 tests.
- `git diff --check` clean.