### PR TITLE
[countersyncd]: Fix countersyncd netlink datagram truncation

### DIFF
--- a/crates/countersyncd/src/actor/data_netlink.rs
+++ b/crates/countersyncd/src/actor/data_netlink.rs
@@ -13,7 +13,11 @@ use log::{debug, info, warn};
 use netlink_sys::Socket;
 #[cfg(not(test))]
 use netlink_sys::{protocols::NETLINK_GENERIC, SocketAddr};
-use tokio::{select, sync::mpsc::{Receiver, Sender}, time::{interval, MissedTickBehavior}};
+use tokio::{
+    select,
+    sync::mpsc::{Receiver, Sender},
+    time::{interval, MissedTickBehavior},
+};
 
 use std::io;
 
@@ -21,9 +25,9 @@ use super::super::message::{
     buffer::SocketBufferMessage,
     netlink::{NetlinkCommand, SocketConnect},
 };
-use crate::utilities::{format_hex_lines, record_comm_stats, ChannelLabel};
 #[cfg(not(test))]
 use super::netlink_utils;
+use crate::utilities::{format_hex_lines, record_comm_stats, ChannelLabel};
 
 #[cfg(not(test))]
 type SocketType = Socket;
@@ -34,6 +38,7 @@ type SocketType = test::MockSocket;
 const SONIC_CONSTANTS: &str = "/etc/sonic/constants.yml";
 
 /// Size of the buffer used for receiving netlink messages
+#[cfg(test)]
 const BUFFER_SIZE: usize = 0x1FFFF;
 /// Linux error code for "No buffer space available" (ENOBUFS)
 /// Note: std::io::ErrorKind doesn't have a specific variant for ENOBUFS,
@@ -55,21 +60,17 @@ const DEBUG_TARGET_MS: u64 = 30 * 1000;
 /// Target duration for WouldBlock log (1 minute).
 const WOULDBLOCK_TARGET_MS: u64 = 60 * 1000;
 
-/// Maximum size for buffering incomplete messages (1MB)
-const MAX_INCOMPLETE_MESSAGE_SIZE: usize = 1024 * 1024;
+/// Maximum supported size for a single netlink datagram/message.
+/// This bounds userspace allocation after peeking the datagram length.
+const MAX_NETLINK_DATAGRAM_SIZE: usize = 16 * 1024 * 1024;
 
-/// Netlink message parser for handling multiple messages in one buffer
+/// Netlink message parser for handling multiple messages in one datagram
 #[derive(Debug)]
-struct NetlinkMessageParser {
-    /// Buffer for incomplete messages that span multiple recv operations
-    incomplete_buffer: Vec<u8>,
-}
+struct NetlinkMessageParser;
 
 impl NetlinkMessageParser {
     fn new() -> Self {
-        Self {
-            incomplete_buffer: Vec::new(),
-        }
+        Self
     }
 
     /// Mirrors `NLMSG_ALIGN` from `linux/netlink.h` by rounding lengths up to the next 4-byte boundary.
@@ -77,65 +78,112 @@ impl NetlinkMessageParser {
         (len + 3) & !3
     }
 
-    /// Parse buffer that may contain multiple complete and/or incomplete netlink messages
-    /// Returns a vector of complete message payloads, where each payload represents 
-    /// one complete netlink message (which contains one complete IPFIX message)
-    fn parse_buffer(&mut self, new_data: &[u8]) -> Result<Vec<SocketBufferMessage>, io::Error> {
-        // Combine any incomplete data from previous recv with new data
-        if !self.incomplete_buffer.is_empty() {
-            self.incomplete_buffer.extend_from_slice(new_data);
-            debug!("Combined incomplete buffer ({} bytes) with new data ({} bytes)", 
-                   self.incomplete_buffer.len() - new_data.len(), new_data.len());
-        } else {
-            self.incomplete_buffer.extend_from_slice(new_data);
+    fn is_valid_alignment_padding(data: &[u8]) -> bool {
+        data.len() <= 3 && data.iter().all(|byte| *byte == 0)
+    }
+
+    fn return_parsed_or_error(
+        complete_messages: Vec<SocketBufferMessage>,
+        error: io::Error,
+        offset: usize,
+        remaining: usize,
+    ) -> Result<Vec<SocketBufferMessage>, io::Error> {
+        if complete_messages.is_empty() {
+            return Err(error);
         }
 
+        warn!(
+            "Discarding trailing {} bytes at offset {} after parsing {} message(s): {}",
+            remaining,
+            offset,
+            complete_messages.len(),
+            error
+        );
+        Ok(complete_messages)
+    }
+
+    /// Parse a single netlink datagram that may contain one or more complete netlink messages.
+    ///
+    /// Netlink multicast sockets are datagram-oriented. If a userspace receive buffer is too small,
+    /// the kernel discards the rest of that datagram, so bytes from a later recv must never be
+    /// treated as a continuation of the previous one.
+    /// Returns the generic-netlink payload from each complete netlink message. For IPFIX data,
+    /// each payload can contain multiple IPFIX sets and records.
+    fn parse_buffer(&mut self, new_data: &[u8]) -> Result<Vec<SocketBufferMessage>, io::Error> {
         let mut complete_messages = Vec::new();
         let mut offset = 0;
 
         // Parse all complete messages in the buffer
-        while offset < self.incomplete_buffer.len() {
+        while offset < new_data.len() {
             // Check if we have enough data for a netlink header
-            if offset + 16 > self.incomplete_buffer.len() {
-                debug!("Not enough data for netlink header at offset {}, keeping {} bytes for next recv", 
-                       offset, self.incomplete_buffer.len() - offset);
-                break;
+            if offset + 16 > new_data.len() {
+                if Self::is_valid_alignment_padding(&new_data[offset..]) {
+                    break;
+                }
+
+                let remaining = new_data.len() - offset;
+                let error = io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "Incomplete netlink header at offset {}: have {} bytes",
+                        offset, remaining
+                    ),
+                );
+                return Self::return_parsed_or_error(complete_messages, error, offset, remaining);
             }
 
             // Extract message length from netlink header
             let nl_len = u32::from_le_bytes([
-                self.incomplete_buffer[offset],
-                self.incomplete_buffer[offset + 1], 
-                self.incomplete_buffer[offset + 2],
-                self.incomplete_buffer[offset + 3],
+                new_data[offset],
+                new_data[offset + 1],
+                new_data[offset + 2],
+                new_data[offset + 3],
             ]) as usize;
 
             // Validate message length
             if nl_len < 16 {
-                return Err(io::Error::new(
+                let error = io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!("Invalid netlink message length: {} (too small)", nl_len),
-                ));
+                );
+                return Self::return_parsed_or_error(
+                    complete_messages,
+                    error,
+                    offset,
+                    new_data.len() - offset,
+                );
             }
 
-            if nl_len > MAX_INCOMPLETE_MESSAGE_SIZE {
-                return Err(io::Error::new(
+            if nl_len > MAX_NETLINK_DATAGRAM_SIZE {
+                let error = io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!("Invalid netlink message length: {} (too large)", nl_len),
-                ));
+                );
+                return Self::return_parsed_or_error(
+                    complete_messages,
+                    error,
+                    offset,
+                    new_data.len() - offset,
+                );
             }
 
             // Check if we have the complete message
-            if offset + nl_len > self.incomplete_buffer.len() {
-                debug!("Incomplete message at offset {}: need {} bytes, have {} bytes", 
-                       offset, nl_len, self.incomplete_buffer.len() - offset);
-                break;
+            if offset + nl_len > new_data.len() {
+                let remaining = new_data.len() - offset;
+                let error = io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "Incomplete netlink message at offset {}: need {} bytes, have {} bytes",
+                        offset, nl_len, remaining
+                    ),
+                );
+                return Self::return_parsed_or_error(complete_messages, error, offset, remaining);
             }
 
             let aligned_nl_len = Self::nlmsg_align(nl_len);
 
             // Extract complete message without trailing alignment padding
-            let message_data = self.incomplete_buffer[offset..offset + nl_len].to_vec();
+            let message_data = new_data[offset..offset + nl_len].to_vec();
             debug!(
                 "Found complete message: offset={}, length={}, aligned_length={}",
                 offset, nl_len, aligned_nl_len
@@ -144,27 +192,23 @@ impl NetlinkMessageParser {
             // Extract payload from this message
             match Self::extract_payload_from_slice(&message_data) {
                 Ok(payload) => {
-                    debug!("Successfully extracted payload with {} bytes", payload.len());
+                    debug!(
+                        "Successfully extracted payload with {} bytes",
+                        payload.len()
+                    );
                     complete_messages.push(payload);
                 }
                 Err(e) => {
-                    warn!("Failed to extract payload from message at offset {}: {}", offset, e);
+                    warn!(
+                        "Failed to extract payload from message at offset {}: {}",
+                        offset, e
+                    );
                     // Continue with next message instead of failing completely
                 }
             }
 
-            let remaining = self.incomplete_buffer.len() - offset;
+            let remaining = new_data.len() - offset;
             offset += usize::min(aligned_nl_len, remaining);
-        }
-
-        // Keep remaining incomplete data for next recv
-        if offset < self.incomplete_buffer.len() {
-            let remaining = self.incomplete_buffer[offset..].to_vec();
-            debug!("Keeping {} bytes for next recv operation", remaining.len());
-            self.incomplete_buffer = remaining;
-        } else {
-            // All data was consumed
-            self.incomplete_buffer.clear();
         }
 
         Ok(complete_messages)
@@ -175,45 +219,70 @@ impl NetlinkMessageParser {
         const NLMSG_HDRLEN: usize = 16; // sizeof(struct nlmsghdr)
         const GENL_HDRLEN: usize = 4; // sizeof(struct genlmsghdr)
         const TOTAL_HEADER_SIZE: usize = NLMSG_HDRLEN + GENL_HDRLEN;
+        const NLMSG_LEN: std::ops::Range<usize> = 0..4;
+        const NLMSG_TYPE: std::ops::Range<usize> = 4..6;
+        const NLMSG_FLAGS: std::ops::Range<usize> = 6..8;
+        const NLMSG_SEQ: std::ops::Range<usize> = 8..12;
+        const NLMSG_PID: std::ops::Range<usize> = 12..16;
+        const GENL_CMD: usize = 16;
+        const GENL_VERSION: usize = 17;
+        const GENL_RESERVED: std::ops::Range<usize> = 18..20;
 
         if message_data.len() < TOTAL_HEADER_SIZE {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("Message too small: {} bytes, expected at least {}", 
-                        message_data.len(), TOTAL_HEADER_SIZE),
+                format!(
+                    "Message too small: {} bytes, expected at least {}",
+                    message_data.len(),
+                    TOTAL_HEADER_SIZE
+                ),
             ));
         }
 
         // Extract netlink message length from header
-        let nl_len = u32::from_le_bytes([
-            message_data[0], message_data[1], message_data[2], message_data[3]
-        ]) as usize;
+        let nl_len = u32::from_le_bytes(message_data[NLMSG_LEN].try_into().unwrap()) as usize;
 
         if nl_len != message_data.len() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("Message length mismatch: header says {}, actual {}", 
-                        nl_len, message_data.len()),
+                format!(
+                    "Message length mismatch: header says {}, actual {}",
+                    nl_len,
+                    message_data.len()
+                ),
             ));
         }
 
         // Debug: Print headers only when debug logging is enabled
         if log::log_enabled!(log::Level::Debug) {
-            debug!("Netlink Header (16 bytes): {:02x?}", &message_data[0..16]);
-            let nl_type = u16::from_le_bytes([message_data[4], message_data[5]]);
-            let nl_flags = u16::from_le_bytes([message_data[6], message_data[7]]);
-            let nl_seq = u32::from_le_bytes([message_data[8], message_data[9], message_data[10], message_data[11]]);
-            let nl_pid = u32::from_le_bytes([message_data[12], message_data[13], message_data[14], message_data[15]]);
-            debug!("  nl_len={}, nl_type={}, nl_flags=0x{:04x}, nl_seq={}, nl_pid={}", 
-                   nl_len, nl_type, nl_flags, nl_seq, nl_pid);
+            debug!(
+                "Netlink Header ({} bytes): {:02x?}",
+                NLMSG_HDRLEN,
+                &message_data[..NLMSG_HDRLEN]
+            );
+            let nl_type = u16::from_le_bytes(message_data[NLMSG_TYPE].try_into().unwrap());
+            let nl_flags = u16::from_le_bytes(message_data[NLMSG_FLAGS].try_into().unwrap());
+            let nl_seq = u32::from_le_bytes(message_data[NLMSG_SEQ].try_into().unwrap());
+            let nl_pid = u32::from_le_bytes(message_data[NLMSG_PID].try_into().unwrap());
+            debug!(
+                "  nl_len={}, nl_type={}, nl_flags=0x{:04x}, nl_seq={}, nl_pid={}",
+                nl_len, nl_type, nl_flags, nl_seq, nl_pid
+            );
 
             if message_data.len() >= TOTAL_HEADER_SIZE {
-                debug!("Generic Netlink Header (4 bytes): {:02x?}", &message_data[16..20]);
-                let genl_cmd = message_data[16];
-                let genl_version = message_data[17];
-                let genl_reserved = u16::from_le_bytes([message_data[18], message_data[19]]);
-                debug!("  genl_cmd={}, genl_version={}, genl_reserved=0x{:04x}", 
-                       genl_cmd, genl_version, genl_reserved);
+                debug!(
+                    "Generic Netlink Header ({} bytes): {:02x?}",
+                    GENL_HDRLEN,
+                    &message_data[NLMSG_HDRLEN..TOTAL_HEADER_SIZE]
+                );
+                let genl_cmd = message_data[GENL_CMD];
+                let genl_version = message_data[GENL_VERSION];
+                let genl_reserved =
+                    u16::from_le_bytes(message_data[GENL_RESERVED].try_into().unwrap());
+                debug!(
+                    "  genl_cmd={}, genl_version={}, genl_reserved=0x{:04x}",
+                    genl_cmd, genl_version, genl_reserved
+                );
             }
         }
 
@@ -254,7 +323,7 @@ pub struct DataNetlinkActor {
     buffer_recipients: LinkedList<Sender<SocketBufferMessage>>,
     /// Channel for receiving control commands
     command_recipient: Receiver<NetlinkCommand>,
-    /// Message parser for handling multiple and fragmented netlink messages
+    /// Message parser for handling one or more netlink messages in each datagram
     message_parser: NetlinkMessageParser,
     /// Netlink socket receive buffer size in bytes (0 = OS default). Reduces ENOBUFS when set.
     netlink_rcvbuf_bytes: usize,
@@ -263,6 +332,90 @@ pub struct DataNetlinkActor {
 }
 
 impl DataNetlinkActor {
+    fn recvmsg_into(
+        fd: std::os::unix::io::RawFd,
+        buffer: &mut [u8],
+        flags: i32,
+    ) -> Result<(usize, i32), io::Error> {
+        let mut iov = libc::iovec {
+            iov_base: buffer.as_mut_ptr() as *mut libc::c_void,
+            iov_len: buffer.len(),
+        };
+        let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+        msg.msg_iov = &mut iov;
+        msg.msg_iovlen = 1;
+
+        // Safe on the Tokio worker because the fd is configured as non-blocking by connect().
+        let size = unsafe { libc::recvmsg(fd, &mut msg, flags) };
+        if size < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok((size as usize, msg.msg_flags))
+        }
+    }
+
+    fn recv_datagram_fd(
+        fd: std::os::unix::io::RawFd,
+        max_size: usize,
+    ) -> Result<Vec<u8>, io::Error> {
+        let mut peek_buffer = [0u8; 1];
+        // Peek first to size the receive buffer exactly and to make truncation observable. A fixed
+        // large buffer would either waste memory in the hot path or still silently truncate when a
+        // producer emits a larger datagram than expected.
+        let (needed, peek_flags) =
+            Self::recvmsg_into(fd, &mut peek_buffer, libc::MSG_PEEK | libc::MSG_TRUNC)?;
+
+        if needed == 0 {
+            let _ = Self::recvmsg_into(fd, &mut peek_buffer, 0);
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Received empty netlink datagram",
+            ));
+        }
+
+        if needed > max_size {
+            let mut drain_buffer = [0u8; 1];
+            if let Err(err) = Self::recvmsg_into(fd, &mut drain_buffer, libc::MSG_TRUNC) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "Failed to drain oversized netlink datagram of {} bytes: {}",
+                        needed, err
+                    ),
+                ));
+            }
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "Netlink datagram length {} exceeds maximum supported {} bytes",
+                    needed, max_size
+                ),
+            ));
+        }
+
+        let mut buffer = vec![0u8; needed];
+        let (size, flags) = Self::recvmsg_into(fd, &mut buffer, 0)?;
+        if flags & libc::MSG_TRUNC != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "Truncated netlink datagram: buffer={} bytes, received={} bytes, peek_flags=0x{:x}",
+                    buffer.len(),
+                    size,
+                    peek_flags
+                ),
+            ));
+        }
+
+        buffer.truncate(size);
+        Ok(buffer)
+    }
+
+    #[cfg(not(test))]
+    fn recv_netlink_datagram(socket: &mut SocketType) -> Result<Vec<u8>, io::Error> {
+        Self::recv_datagram_fd(socket.as_raw_fd(), MAX_NETLINK_DATAGRAM_SIZE)
+    }
+
     /// Creates a new DataNetlinkActor instance.
     ///
     /// # Arguments
@@ -459,7 +612,10 @@ impl DataNetlinkActor {
             "Successfully connected to family '{}', group '{}' with group_id: {}",
             family, group, group_id
         );
-        debug!("Socket created successfully, ready to receive multicast messages on group_id: {}", group_id);
+        debug!(
+            "Socket created successfully, ready to receive multicast messages on group_id: {}",
+            group_id
+        );
         Some(socket)
     }
 
@@ -511,7 +667,8 @@ impl DataNetlinkActor {
             "Temporary socket created, resolving group ID for family '{}', group '{}'",
             family, group
         );
-        let group_id = match netlink_utils::resolve_multicast_group(&mut temp_socket, family, group) {
+        let group_id = match netlink_utils::resolve_multicast_group(&mut temp_socket, family, group)
+        {
             Ok(id) => {
                 debug!(
                     "Resolved group ID {} for family '{}', group '{}'",
@@ -574,14 +731,17 @@ impl DataNetlinkActor {
             "Successfully connected to family '{}', group '{}' with group_id: {}",
             family, group, group_id
         );
-        debug!("Socket created successfully, ready to receive multicast messages on group_id: {}", group_id);
+        debug!(
+            "Socket created successfully, ready to receive multicast messages on group_id: {}",
+            group_id
+        );
         Some(socket)
     }
 
     /// Attempts to establish a connection on demand.
     ///
     /// This will be called when receiving a Reconnect or SoftReconnect command from ControlNetlinkActor.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `force` - If true, always reconnect regardless of socket health status.
@@ -600,9 +760,9 @@ impl DataNetlinkActor {
                     warn!(
                         "Socket unhealthy - no data received for {} seconds, forcing reconnection",
                         time_since_last_data.as_secs()
-                        );
-                        // Close the unhealthy socket
-                        self.socket = None;
+                    );
+                    // Close the unhealthy socket
+                    self.socket = None;
                 } else {
                     info!(
                         "Socket healthy - data received {} seconds ago, skipping reconnect",
@@ -676,82 +836,60 @@ impl DataNetlinkActor {
     ///
     /// Returns immediately with WouldBlock if no data is available, allowing
     /// the event loop to handle other operations concurrently.
-    /// 
+    ///
     /// This function handles multiple scenarios:
     /// 1. Single complete message in one recv
-    /// 2. Multiple complete messages in one recv  
-    /// 3. Incomplete message that needs to be combined with future recv data
+    /// 2. Multiple complete messages in one recv
+    /// 3. Truncated or malformed datagrams, which are rejected without splicing future recv data
     async fn try_recv(
-        socket: Option<&mut SocketType>, 
-        message_parser: &mut NetlinkMessageParser
+        socket: Option<&mut SocketType>,
+        message_parser: &mut NetlinkMessageParser,
     ) -> Result<Vec<SocketBufferMessage>, io::Error> {
         let socket = socket
             .ok_or_else(|| io::Error::new(io::ErrorKind::NotConnected, "No socket available"))?;
 
-        let mut buffer = vec![0; BUFFER_SIZE];
-
         // Try to receive with non-blocking mode (socket should already be set to non-blocking)
         debug!("Attempting to receive netlink message...");
         #[cfg(not(test))]
-        let result = {
-            let fd = socket.as_raw_fd();
-            // Safe on the Tokio worker because the fd is already configured as non-blocking.
-            unsafe {
-                libc::recv(
-                    fd,
-                    buffer.as_mut_ptr() as *mut libc::c_void,
-                    buffer.len(),
-                    0
-                )
-            }
-        };
+        let recv_result = Self::recv_netlink_datagram(socket);
 
         #[cfg(test)]
-        let result = match socket.recv(&mut buffer, 0) {
-            Ok(size) => size as isize,
-            Err(e) => {
-                return Err(e);
-            }
+        let recv_result = {
+            let mut buffer = vec![0; BUFFER_SIZE];
+            socket.recv(&mut buffer, 0).map(|size| {
+                buffer.truncate(size);
+                buffer
+            })
         };
 
-        match result {
-            size if size > 0 => {
-                let size = size as usize;
+        match recv_result {
+            Ok(buffer) => {
+                let size = buffer.len();
                 debug!("Received netlink data, size: {} bytes", size);
 
                 if size == 0 {
                     return Err(io::Error::new(
-                        io::ErrorKind::UnexpectedEof,
-                        "No more data to receive",
+                        io::ErrorKind::InvalidData,
+                        "Received empty netlink datagram",
                     ));
                 }
 
-                // Resize buffer to actual received size
-                buffer.resize(size, 0);
-
                 if log::log_enabled!(log::Level::Debug) {
                     let hex_dump = format_hex_lines(&buffer);
-                    debug!(
-                        "Raw netlink recv buffer ({} bytes):\n{}",
-                        size, hex_dump
-                    );
+                    debug!("Raw netlink recv buffer ({} bytes):\n{}", size, hex_dump);
                 }
 
                 // Parse buffer which may contain multiple messages and/or incomplete messages
                 let messages = message_parser.parse_buffer(&buffer)?;
-                debug!("Parsed {} complete messages from {} bytes of data", messages.len(), size);
+                debug!(
+                    "Parsed {} complete messages from {} bytes of data",
+                    messages.len(),
+                    size
+                );
 
                 Ok(messages)
             }
-            size if size == 0 => {
-                Err(io::Error::new(
-                    io::ErrorKind::UnexpectedEof,
-                    "Connection closed",
-                ))
-            }
-            _ => {
-                // size < 0, errno is set
-                let err = io::Error::last_os_error();
+            Err(err) => {
                 // WouldBlock is expected for non-blocking sockets with no data
                 // Only log other errors
                 if err.kind() != io::ErrorKind::WouldBlock {
@@ -842,7 +980,7 @@ impl DataNetlinkActor {
                                 actor.last_data_time = Instant::now();
 
                                 if messages.is_empty() {
-                                    debug!("Received data but no complete messages yet (partial message)");
+                                    debug!("Received netlink datagram but no complete payload was extracted");
                                 } else {
                                     debug!("Successfully parsed {} complete netlink messages", messages.len());
 
@@ -893,6 +1031,8 @@ impl DataNetlinkActor {
                                     if heartbeat_counter % wouldblock_interval == 0 {
                                         debug!("No netlink data available (WouldBlock) - socket is connected but no messages from kernel");
                                     }
+                                } else if e.kind() == io::ErrorKind::InvalidData {
+                                    warn!("Dropping invalid netlink datagram: {:?}", e);
                                 } else {
                                     warn!("Failed to receive message: {:?}", e);
                                     actor.disconnect();
@@ -943,7 +1083,17 @@ pub mod test {
         msg[..actual_len].to_vec()
     }
 
-    // Test constants for simulating different message scenarios  
+    fn create_large_mock_netlink_message(payload: &[u8]) -> Vec<u8> {
+        let total_len = 20 + payload.len();
+        let mut msg = vec![0u8; total_len];
+        msg[0..4].copy_from_slice(&(total_len as u32).to_le_bytes());
+        msg[4..6].copy_from_slice(&0x10u16.to_le_bytes());
+        msg[16] = 0x01;
+        msg[20..].copy_from_slice(payload);
+        msg
+    }
+
+    // Test constants for simulating different message scenarios
     fn get_partially_valid_messages() -> Vec<Vec<u8>> {
         vec![
             create_test_message(b"PARTIALLY_VALID1"),
@@ -1216,11 +1366,8 @@ pub mod test {
         let mut parser = NetlinkMessageParser::new();
 
         let result = parser.parse_buffer(&buffer);
-        assert!(result.is_ok());
-
-        // Should have no complete messages due to insufficient data
-        let messages = result.unwrap();
-        assert!(messages.is_empty());
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::InvalidData);
     }
 
     /// Tests handling multiple messages in one buffer.
@@ -1270,34 +1417,54 @@ pub mod test {
         assert_eq!(String::from_utf8(messages[1].to_vec()).unwrap(), "SECOND");
     }
 
-    /// Tests handling fragmented messages across multiple recv operations.
     #[test]
-    fn test_fragmented_message() {
-        let msg = create_mock_netlink_message(b"FRAGMENTED_MESSAGE");
-        let msg_len = 20 + b"FRAGMENTED_MESSAGE".len();
+    fn test_trailing_zero_bytes_larger_than_alignment_padding_are_discarded() {
+        let mut buffer = create_mock_netlink_message(b"COMPLETE").to_vec();
+        buffer.truncate(20 + b"COMPLETE".len());
+        buffer.extend_from_slice(&[0; 4]);
+
+        let mut parser = NetlinkMessageParser::new();
+        let messages = parser.parse_buffer(&buffer).unwrap();
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].as_ref(), b"COMPLETE");
+    }
+
+    #[test]
+    fn test_zero_bytes_larger_than_alignment_padding_are_rejected() {
+        let mut parser = NetlinkMessageParser::new();
+        let result = parser.parse_buffer(&[0; 4]);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// Tests that a truncated datagram is never spliced with the next datagram.
+    ///
+    /// Without the fix, parse_buffer() keeps the first truncated datagram in an
+    /// incomplete buffer and combines it with the next recv, producing one
+    /// corrupted payload instead of dropping the truncated datagram.
+    #[test]
+    fn test_truncated_datagram_is_not_spliced_with_next_datagram() {
+        let first_payload = vec![b'A'; BUFFER_SIZE + 3200];
+        let first_datagram = create_large_mock_netlink_message(&first_payload);
+        let second_datagram = create_large_mock_netlink_message(b"SECOND_DATAGRAM");
         let mut parser = NetlinkMessageParser::new();
 
-        // Simulate first recv getting only part of the message
-        let first_part = &msg[..15]; // Less than header size
-        let result1 = parser.parse_buffer(first_part);
-        assert!(result1.is_ok());
-        let messages1 = result1.unwrap();
-        assert!(messages1.is_empty()); // No complete messages yet
+        let result1 = parser.parse_buffer(&first_datagram[..BUFFER_SIZE]);
+        assert!(result1.is_err());
+        assert_eq!(result1.unwrap_err().kind(), io::ErrorKind::InvalidData);
 
-        // Simulate second recv getting the rest
-        let second_part = &msg[15..msg_len];
-        let result2 = parser.parse_buffer(second_part);
+        let result2 = parser.parse_buffer(&second_datagram);
         assert!(result2.is_ok());
         let messages2 = result2.unwrap();
         assert_eq!(messages2.len(), 1);
-
-        let payload_str = String::from_utf8(messages2[0].to_vec()).unwrap();
-        assert_eq!(payload_str, "FRAGMENTED_MESSAGE");
+        assert_eq!(messages2[0].as_ref(), b"SECOND_DATAGRAM");
     }
 
-    /// Tests handling mixed scenario: complete message + partial message.
+    /// Tests handling a datagram with a complete message followed by a truncated message.
     #[test]
-    fn test_mixed_complete_and_partial() {
+    fn test_complete_message_followed_by_truncated_message_is_rejected() {
         let mut combined_buffer = Vec::new();
 
         // First complete message
@@ -1311,25 +1478,100 @@ pub mod test {
         combined_buffer.extend_from_slice(&msg2[..25]); // Only part of second message
 
         let mut parser = NetlinkMessageParser::new();
-        let result1 = parser.parse_buffer(&combined_buffer);
-        assert!(result1.is_ok());
+        let result = parser.parse_buffer(&combined_buffer);
+        assert!(result.is_ok());
+        let messages = result.unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].as_ref(), b"COMPLETE");
 
-        let messages1 = result1.unwrap();
-        assert_eq!(messages1.len(), 1); // Only first complete message
+        // The next datagram must be parsed independently, not as a continuation.
+        let result = parser.parse_buffer(&msg2[..msg2_len]);
+        assert!(result.is_ok());
+        let messages = result.unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].as_ref(), b"PARTIAL_MSG");
+    }
 
-        let payload1_str = String::from_utf8(messages1[0].to_vec()).unwrap();
-        assert_eq!(payload1_str, "COMPLETE");
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_recv_datagram_larger_than_default_buffer() {
+        use std::os::unix::net::UnixDatagram;
 
-        // Send remaining part of second message
-        let remaining_part = &msg2[25..msg2_len];
-        let result2 = parser.parse_buffer(remaining_part);
-        assert!(result2.is_ok());
+        let (tx, rx) = UnixDatagram::pair().unwrap();
+        let payload = vec![0xab; BUFFER_SIZE + 4096];
+        tx.send(&payload).unwrap();
 
-        let messages2 = result2.unwrap();
-        assert_eq!(messages2.len(), 1); // Second message now complete
+        let received =
+            DataNetlinkActor::recv_datagram_fd(rx.as_raw_fd(), MAX_NETLINK_DATAGRAM_SIZE).unwrap();
 
-        let payload2_str = String::from_utf8(messages2[0].to_vec()).unwrap();
-        assert_eq!(payload2_str, "PARTIAL_MSG");
+        assert_eq!(received, payload);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_recv_datagram_larger_than_max_size_is_drained() {
+        use std::os::unix::net::UnixDatagram;
+
+        let (tx, rx) = UnixDatagram::pair().unwrap();
+        let payload = vec![0xef; BUFFER_SIZE + 4096];
+        let next_payload = b"NEXT";
+        tx.send(&payload).unwrap();
+        tx.send(next_payload).unwrap();
+
+        let result = DataNetlinkActor::recv_datagram_fd(rx.as_raw_fd(), BUFFER_SIZE);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::InvalidData);
+
+        let received = DataNetlinkActor::recv_datagram_fd(rx.as_raw_fd(), BUFFER_SIZE).unwrap();
+        assert_eq!(received, next_payload);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_recv_datagram_empty_is_invalid_and_drained() {
+        use std::os::unix::net::UnixDatagram;
+
+        let (tx, rx) = UnixDatagram::pair().unwrap();
+        let next_payload = b"NEXT";
+        tx.send(&[]).unwrap();
+        tx.send(next_payload).unwrap();
+
+        let result = DataNetlinkActor::recv_datagram_fd(rx.as_raw_fd(), BUFFER_SIZE);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::InvalidData);
+
+        let received = DataNetlinkActor::recv_datagram_fd(rx.as_raw_fd(), BUFFER_SIZE).unwrap();
+        assert_eq!(received, next_payload);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_plain_recvmsg_reports_truncation() {
+        use std::os::unix::net::UnixDatagram;
+
+        let (tx, rx) = UnixDatagram::pair().unwrap();
+        let payload = vec![0xcd; BUFFER_SIZE + 4096];
+        tx.send(&payload).unwrap();
+
+        let mut buffer = vec![0u8; BUFFER_SIZE];
+        let (size, flags) = DataNetlinkActor::recvmsg_into(rx.as_raw_fd(), &mut buffer, 0).unwrap();
+
+        assert_eq!(size, BUFFER_SIZE);
+        assert_ne!(flags & libc::MSG_TRUNC, 0);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_recv_datagram_fd_propagates_wouldblock() {
+        use std::os::unix::net::UnixDatagram;
+
+        let (_tx, rx) = UnixDatagram::pair().unwrap();
+        rx.set_nonblocking(true).unwrap();
+
+        let result = DataNetlinkActor::recv_datagram_fd(rx.as_raw_fd(), BUFFER_SIZE);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::WouldBlock);
     }
 
     /// Tests the get_genl_family_group function with a valid constants file.
@@ -1404,12 +1646,21 @@ pub mod test {
             let heartbeat = (HEARTBEAT_TARGET_MS / poll_ms).max(1);
             let debug = (DEBUG_TARGET_MS / poll_ms).max(1);
             let wouldblock = (WOULDBLOCK_TARGET_MS / poll_ms).max(1);
-            assert_eq!(heartbeat * poll_ms, HEARTBEAT_TARGET_MS, "poll_ms={}", poll_ms);
+            assert_eq!(
+                heartbeat * poll_ms,
+                HEARTBEAT_TARGET_MS,
+                "poll_ms={}",
+                poll_ms
+            );
             assert_eq!(debug * poll_ms, DEBUG_TARGET_MS, "poll_ms={}", poll_ms);
-            assert_eq!(wouldblock * poll_ms, WOULDBLOCK_TARGET_MS, "poll_ms={}", poll_ms);
+            assert_eq!(
+                wouldblock * poll_ms,
+                WOULDBLOCK_TARGET_MS,
+                "poll_ms={}",
+                poll_ms
+            );
         }
     }
-
 }
 
 /// Reads the Generic Netlink family and group names from the configuration file.

--- a/crates/countersyncd/src/actor/data_netlink.rs
+++ b/crates/countersyncd/src/actor/data_netlink.rs
@@ -589,6 +589,8 @@ impl DataNetlinkActor {
             return None;
         }
 
+        netlink_utils::set_socket_rcvbuf(&socket, self.netlink_rcvbuf_bytes);
+
         debug!("Adding multicast membership for group_id {}", group_id);
         if let Err(e) = socket.add_membership(group_id) {
             warn!(
@@ -605,8 +607,6 @@ impl DataNetlinkActor {
             warn!("Failed to set non-blocking mode: {:?}", e);
             return None;
         }
-
-        netlink_utils::set_socket_rcvbuf(&socket, self.netlink_rcvbuf_bytes);
 
         info!(
             "Successfully connected to family '{}', group '{}' with group_id: {}",
@@ -710,6 +710,8 @@ impl DataNetlinkActor {
             return None;
         }
 
+        netlink_utils::set_socket_rcvbuf(&socket, netlink_rcvbuf_bytes);
+
         debug!("Adding multicast membership for group_id {}", group_id);
         if let Err(e) = socket.add_membership(group_id) {
             warn!(
@@ -724,8 +726,6 @@ impl DataNetlinkActor {
             warn!("Failed to set non-blocking mode: {:?}", e);
             return None;
         }
-
-        netlink_utils::set_socket_rcvbuf(&socket, netlink_rcvbuf_bytes);
 
         info!(
             "Successfully connected to family '{}', group '{}' with group_id: {}",


### PR DESCRIPTION
**What I did**

Fix `countersyncd` IPFIX data netlink receive handling for oversized datagrams:

- Receive generic netlink multicast data as atomic datagrams with `recvmsg`.
- Use `MSG_PEEK | MSG_TRUNC` to determine the real datagram length before consuming it.
- Allocate the receive buffer from the probed datagram length instead of relying on the fixed 128 KB buffer.
- Configure data socket `SO_RCVBUF` before joining the multicast group, avoiding a startup race where early multicast datagrams used the kernel default receive buffer.
- Stop carrying incomplete parser state across receives, so a truncated datagram cannot be spliced with the next datagram.
- Drop invalid, empty, or oversized datagrams without reconnecting the socket.
- Preserve already-parsed messages from the same datagram if only a malformed trailing portion is found.
- Add parser regression tests, fd-level `UnixDatagram` tests, and a startup-burst regression test covering the receive-buffer/membership ordering.

**Why I did it**

Fixes sonic-net/sonic-buildimage#27372.

That issue reports silent IPFIX counter data corruption and reconnect loops when an IPFIX netlink datagram exceeds the old userspace receive buffer size (`BUFFER_SIZE = 0x1FFFF`).

The old code used `recv(..., flags = 0)` and then let `NetlinkMessageParser` keep incomplete bytes for the next recv. On a datagram socket, an undersized receive discards the rest of that datagram. The next recv is a new datagram, not a continuation. This allowed `countersyncd` to splice the truncated head of one datagram with bytes from the next datagram and send corrupted IPFIX payloads downstream.

This change makes truncation observable and keeps parsing scoped to a single datagram. It also ensures the enlarged kernel receive buffer is applied before multicast delivery can begin on the data socket.

**How I verified it**

Verified in `swss-bookworm-master` container on commits `824881f` and `6d9bbc7`.

Commands:

```bash
RUSTFLAGS=-Dwarnings cargo test -p countersyncd test_data_socket_rcvbuf_before_membership_prevents_startup_burst_corruption -- --nocapture
RUSTFLAGS=-Dwarnings cargo check -p countersyncd --all-targets
RUSTFLAGS=-Dwarnings cargo test -p countersyncd
```

TDD check:

```text
Temporarily changed configure_data_socket_steps() to old order:
bind -> add_membership -> set_non_blocking -> set_rcvbuf

test_data_socket_rcvbuf_before_membership_prevents_startup_burst_corruption failed with:
Invalid netlink message length: 0 (too small)

Restored fixed order:
bind -> set_rcvbuf -> add_membership -> set_non_blocking

The same test passed.
```

Final committed result:

```text
cargo check -p countersyncd --all-targets: passed
src/lib.rs: 100 passed
src/main.rs: 106 passed
tests/integration_test.rs: 2 passed
tests/ipfix_helpers_integration.rs: 1 passed
doc-tests: 0 passed
```

Redis was started on `/var/run/redis/redis.sock` for the `swss` actor tests.

**Details if related**

Related issue: sonic-net/sonic-buildimage#27372

The receive path intentionally uses a peek-first flow instead of a fixed large reusable buffer. This adds one extra syscall per datagram, but it guarantees correct sizing and prevents future silent truncation if producer datagrams grow beyond any fixed buffer value.