### PR TITLE
fix: replace NULL with nullptr in fake_notificationconsumer constructors

### DIFF
--- a/orchagent/p4orch/tests/fake_notificationconsumer.cpp
+++ b/orchagent/p4orch/tests/fake_notificationconsumer.cpp
@@ -5,7 +5,7 @@ namespace swss
 
 NotificationConsumer::NotificationConsumer(swss::DBConnector *db, const std::string &channel, int pri,
                                            size_t popBatchSize)
-    : Selectable(pri), POP_BATCH_SIZE(popBatchSize), m_db(db), m_subscribe(NULL), m_channel(channel),
+    : Selectable(pri), POP_BATCH_SIZE(popBatchSize), m_db(db), m_subscribe(nullptr), m_channel(channel),
       m_queue(std::make_unique<FifoNotificationQueue>())
 {
     SWSS_LOG_ENTER();
@@ -13,7 +13,7 @@ NotificationConsumer::NotificationConsumer(swss::DBConnector *db, const std::str
 
 NotificationConsumer::NotificationConsumer(swss::DBConnector *db, const std::string &channel, int pri,
                                            size_t popBatchSize, NotificationQueuePolicy policy)
-    : Selectable(pri), POP_BATCH_SIZE(popBatchSize), m_db(db), m_subscribe(NULL), m_channel(channel),
+    : Selectable(pri), POP_BATCH_SIZE(popBatchSize), m_db(db), m_subscribe(nullptr), m_channel(channel),
       m_queue(policy == NotificationQueuePolicy::LruDedup
               ? std::unique_ptr<NotificationQueueBase>(std::make_unique<LruDedupNotificationQueue>(channel))
               : std::unique_ptr<NotificationQueueBase>(std::make_unique<FifoNotificationQueue>()))


### PR DESCRIPTION
## Why

`NULL` is an integer literal (`0`) which is ambiguous when the member type is `std::unique_ptr` — the compiler cannot choose between `unique_ptr(nullptr_t)` and `unique_ptr(pointer)` overloads.

This is a forward-compatibility fix for [sonic-swss-common#1212](https://github.com/sonic-net/sonic-swss-common/pull/1212), which changes `m_subscribe` from a raw `DBConnector*` to `std::unique_ptr<DBConnector>`. Without this change, BuildSwss fails with:
```
fake_notificationconsumer.cpp:8:64: error: call of overloaded unique_ptr(NULL) is ambiguous
```

## What

Replace `m_subscribe(NULL)` with `m_subscribe(nullptr)` in both constructors in `fake_notificationconsumer.cpp`.

`nullptr` has type `std::nullptr_t` and is unambiguous for both raw pointer and `unique_ptr`, making this change safe to merge independently before or after sonic-swss-common#1212.

## How to verify

BuildSwss CI passes.
