### PR TITLE
[aclorch]: Make ACL table group member priority configurable

### DIFF
--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -606,6 +606,11 @@ Stores information about ACL tables on the switch.  Port names are defined in [p
     ports         = [0-max_ports]*port_name ; the ports to which this ACL
                                             ; table is applied, can be emtry
                                             ; value annotations
+    priority      = 1*10DIGIT               ; optional ACL table group-member priority
+                                            ; within a bind point; higher value takes
+                                            ; precedence. Valid range is platform-dependent
+                                            ; (queried from SAI). Ignored for table types
+                                            ; that are not bound as group members.
     port_name     = 1*64VCHAR               ; name of the port, must be unique
     max_ports     = 1*5DIGIT                ; number of ports supported on the chip
 

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -2918,7 +2918,7 @@ bool AclTable::bind(sai_object_id_t portOid)
     assert(ports.find(portOid) != ports.end());
 
     sai_object_id_t group_member_oid;
-    if (!gPortsOrch->bindAclTable(portOid, m_oid, group_member_oid, stage))
+    if (!gPortsOrch->bindAclTable(portOid, m_oid, group_member_oid, stage, priority))
     {
         SWSS_LOG_ERROR("Failed to bind port oid: %" PRIx64 "", portOid);
         return false;
@@ -3704,6 +3704,26 @@ void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, Mirr
             {
                 throw "AclOrch initialization failure";
             }
+        }
+
+        // Query the switch-reported ACL table group member priority range. This
+        // is best-effort: if the SAI implementation does not support it, table
+        // priority range validation is simply skipped (see processAclTablePriority).
+        sai_attribute_t tbl_prio_attrs[2] = {};
+        tbl_prio_attrs[0].id = SAI_SWITCH_ATTR_ACL_TABLE_MINIMUM_PRIORITY;
+        tbl_prio_attrs[1].id = SAI_SWITCH_ATTR_ACL_TABLE_MAXIMUM_PRIORITY;
+        status = sai_switch_api->get_switch_attribute(gSwitchId, 2, tbl_prio_attrs);
+        if (status == SAI_STATUS_SUCCESS)
+        {
+            m_aclTableMinPriority = tbl_prio_attrs[0].value.u32;
+            m_aclTableMaxPriority = tbl_prio_attrs[1].value.u32;
+            SWSS_LOG_NOTICE("Get ACL table priority values, min: %u, max: %u",
+                            m_aclTableMinPriority, m_aclTableMaxPriority);
+        }
+        else
+        {
+            SWSS_LOG_NOTICE("ACL table priority min/max query not supported (rv:%d); "
+                            "ACL table priority range validation disabled", status);
         }
 
         queryAclActionCapability();
@@ -5398,6 +5418,16 @@ void AclOrch::doAclTableTask(Consumer &consumer)
                         break;
                     }
                 }
+                else if (attr_name == ACL_TABLE_PRIORITY)
+                {
+                    if (!processAclTablePriority(attr_value, newTable))
+                    {
+                        SWSS_LOG_ERROR("Failed to process ACL table %s priority",
+                                table_id.c_str());
+                        bAllAttributesOk = false;
+                        break;
+                    }
+                }
                 else if (attr_name == ACL_TABLE_STAGE)
                 {
                    if (!processAclTableStage(attr_value, newTable.stage))
@@ -5440,6 +5470,21 @@ void AclOrch::doAclTableTask(Consumer &consumer)
             newTable.validateAddType(*tableType);
             // Add mandatory ACL action if not present
             newTable.addMandatoryActions();
+
+            // 'priority' maps to the ACL table group member attribute, which only
+            // exists for PORT/LAG-bound tables; warn if set on a type that can't use it.
+            if (newTable.priority != ACL_TABLE_GROUP_MEMBER_DEFAULT_PRIORITY)
+            {
+                const auto &bpTypes = newTable.type.getBindPointTypes();
+                if (bpTypes.find(SAI_ACL_BIND_POINT_TYPE_PORT) == bpTypes.end() &&
+                    bpTypes.find(SAI_ACL_BIND_POINT_TYPE_LAG) == bpTypes.end())
+                {
+                    SWSS_LOG_WARN("ACL table %s: 'priority' is ignored for table type %s "
+                                  "(only effective for port/LAG-bound tables)",
+                                  table_id.c_str(), newTable.type.getName().c_str());
+                }
+            }
+
             // validate and create/update ACL Table
             if (bAllAttributesOk && newTable.validate())
             {
@@ -5452,7 +5497,9 @@ void AclOrch::doAclTableTask(Consumer &consumer)
                     !isAclTableTypeUpdated(newTable.type.getName(),
                                            m_AclTables[table_oid]) &&
                     !isAclTableStageUpdated(newTable.stage,
-                                            m_AclTables[table_oid]))
+                                            m_AclTables[table_oid]) &&
+                    !isAclTablePriorityUpdated(newTable.priority,
+                                               m_AclTables[table_oid]))
                 {
                     // Update the existing table using the info in newTable
                     if (updateAclTable(table_id, newTable, orignalTableTypeName))
@@ -5834,6 +5881,39 @@ bool AclOrch::processAclTableType(string type, string &out_table_type)
 bool AclOrch::isAclTableStageUpdated(acl_stage_type_t acl_stage, AclTable &t)
 {
     return (acl_stage != t.stage);
+}
+
+bool AclOrch::isAclTablePriorityUpdated(sai_uint32_t priority, AclTable &t)
+{
+    return (priority != t.priority);
+}
+
+bool AclOrch::processAclTablePriority(const string &priority, AclTable &aclTable)
+{
+    SWSS_LOG_ENTER();
+
+    char *endp = nullptr;
+    errno = 0;
+    auto value = (sai_uint32_t)strtoul(priority.c_str(), &endp, 0);
+    if (errno != 0 || endp != priority.c_str() + priority.size())
+    {
+        SWSS_LOG_ERROR("Invalid ACL table priority value %s", priority.c_str());
+        return false;
+    }
+
+    // Enforce the switch-reported priority range only when it was discovered.
+    // When unavailable (e.g. Vendor SAI does not implement the query), fall back to
+    // accepting the configured value for backward compatibility.
+    if (m_aclTableMaxPriority != 0 &&
+        (value < m_aclTableMinPriority || value > m_aclTableMaxPriority))
+    {
+        SWSS_LOG_ERROR("ACL table priority %u is out of supported range %u-%u",
+                       value, m_aclTableMinPriority, m_aclTableMaxPriority);
+        return false;
+    }
+
+    aclTable.priority = value;
+    return true;
 }
 
 bool AclOrch::processAclTableStage(string stage, acl_stage_type_t &acl_stage)

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -543,6 +543,10 @@ public:
     AclTableType type;
     acl_stage_type_t stage = ACL_STAGE_INGRESS;
 
+    // ACL table group member priority. Drives table lookup order (SEQUENTIAL
+    // groups) and action-conflict resolution (PARALLEL groups).
+    sai_uint32_t priority = ACL_TABLE_GROUP_MEMBER_DEFAULT_PRIORITY;
+
     // Map port oid to group member oid
     std::map<sai_object_id_t, sai_object_id_t> ports;
     // Map rule name to rule data
@@ -673,9 +677,11 @@ private:
 
     bool isAclTableTypeUpdated(string table_type, AclTable &aclTable);
     bool isAclTableStageUpdated(acl_stage_type_t acl_stage, AclTable &aclTable);
+    bool isAclTablePriorityUpdated(sai_uint32_t priority, AclTable &aclTable);
     bool processAclTableStage(string stage, acl_stage_type_t &acl_stage);
     bool processAclTableType(string type, string &out_table_type);
     bool processAclTablePorts(string portList, AclTable &aclTable);
+    bool processAclTablePriority(const string &priority, AclTable &aclTable);
     bool validateAclTable(AclTable &aclTable);
     bool updateAclTablePorts(AclTable &newTable, AclTable &curTable);
     void getAddDeletePorts(AclTable    &newT,
@@ -719,6 +725,11 @@ private:
     acl_capabilities_t m_aclCapabilities;
     acl_action_enum_values_capabilities_t m_aclEnumActionCapabilities;
     FlexCounterManager m_flex_counter_manager;
+
+    // Switch-reported ACL table group member priority range. Both 0 means the
+    // range is unknown (SAI query unsupported) and validation is skipped.
+    sai_uint32_t m_aclTableMinPriority = 0;
+    sai_uint32_t m_aclTableMaxPriority = 0;
 };
 
 #endif /* SWSS_ACLORCH_H */

--- a/orchagent/acltable.h
+++ b/orchagent/acltable.h
@@ -14,6 +14,11 @@ extern "C" {
 #define ACL_TABLE_TYPE         "TYPE"
 #define ACL_TABLE_PORTS        "PORTS"
 #define ACL_TABLE_SERVICES     "SERVICES"
+#define ACL_TABLE_PRIORITY     "PRIORITY"
+
+// Default ACL table group member priority, used when no PRIORITY is configured.
+// Preserves the historical hardcoded value for backward compatibility.
+#define ACL_TABLE_GROUP_MEMBER_DEFAULT_PRIORITY 100
 
 #define ACL_TABLE_TYPE_MATCHES      "MATCHES"
 #define ACL_TABLE_TYPE_BPOINT_TYPES "BIND_POINTS"

--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -171,7 +171,7 @@ bool PortsOrch::unbindRemoveAclTableGroup(sai_object_id_t port_oid, sai_object_i
 }
 
 bool PortsOrch::bindAclTable(sai_object_id_t id, sai_object_id_t table_oid, sai_object_id_t &group_member_oid,
-                             acl_stage_type_t acl_stage)
+                             acl_stage_type_t acl_stage, sai_uint32_t group_member_priority)
 {
     return true;
 }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2965,7 +2965,8 @@ bool PortsOrch::unbindAclTable(sai_object_id_t  port_oid,
 bool PortsOrch::bindAclTable(sai_object_id_t  port_oid,
                              sai_object_id_t  table_oid,
                              sai_object_id_t  &group_member_oid,
-                             acl_stage_type_t acl_stage)
+                             acl_stage_type_t acl_stage,
+                             sai_uint32_t     group_member_priority)
 {
     SWSS_LOG_ENTER();
     /*
@@ -3004,7 +3005,7 @@ bool PortsOrch::bindAclTable(sai_object_id_t  port_oid,
     member_attrs.push_back(member_attr);
 
     member_attr.id = SAI_ACL_TABLE_GROUP_MEMBER_ATTR_PRIORITY;
-    member_attr.value.u32 = 100;
+    member_attr.value.u32 = group_member_priority;
     member_attrs.push_back(member_attr);
 
     status = sai_acl_api->create_acl_table_group_member(&group_member_oid, gSwitchId, (uint32_t)member_attrs.size(), member_attrs.data());

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -198,7 +198,8 @@ public:
     bool bindAclTable(sai_object_id_t  id,
                       sai_object_id_t  table_oid,
                       sai_object_id_t  &group_member_oid,
-                      acl_stage_type_t acl_stage = ACL_STAGE_INGRESS);
+                      acl_stage_type_t acl_stage = ACL_STAGE_INGRESS,
+                      sai_uint32_t     group_member_priority = ACL_TABLE_GROUP_MEMBER_DEFAULT_PRIORITY);
     bool unbindAclTable(sai_object_id_t  port_oid,
                         sai_object_id_t  acl_table_oid,
                         sai_object_id_t  acl_group_member_oid,

--- a/tests/dvslib/dvs_acl.py
+++ b/tests/dvslib/dvs_acl.py
@@ -81,7 +81,8 @@ class DVSAcl:
             table_name: str,
             table_type: str,
             ports: List[str],
-            stage: str = None
+            stage: str = None,
+            priority: str = None
     ) -> None:
         """Create a new ACL table in Config DB.
 
@@ -90,6 +91,7 @@ class DVSAcl:
             table_type: The type of table to create.
             ports: A list of ports to bind to the ACL table.
             stage: The stage for the ACL table. {ingress, egress}
+            priority: The ACL table group member priority for the table.
         """
         table_attrs = {
             "policy_desc": table_name,
@@ -99,6 +101,9 @@ class DVSAcl:
 
         if stage:
             table_attrs["stage"] = stage
+
+        if priority:
+            table_attrs["priority"] = priority
 
         self.config_db.create_entry(self.CDB_ACL_TABLE_NAME, table_name, table_attrs)
 
@@ -249,6 +254,31 @@ class DVSAcl:
                 member_groups.append(group_id)
 
         assert set(member_groups) == set(acl_table_group_ids)
+
+    def verify_acl_table_group_member_priority(
+            self,
+            acl_table_id: str,
+            priority: str,
+            num_members: int
+    ) -> None:
+        """Verify that the ACL table group members for the given table carry the
+        expected SAI_ACL_TABLE_GROUP_MEMBER_ATTR_PRIORITY value.
+
+        Args:
+            acl_table_id: The ACL table whose group members to check.
+            priority: The expected group member priority value.
+            num_members: The number of ACL table group members in ASIC DB.
+        """
+        members = self.asic_db.wait_for_n_keys(self.ADB_ACL_GROUP_MEMBER_TABLE_NAME, num_members)
+
+        checked = 0
+        for member in members:
+            fvs = self.asic_db.wait_for_entry(self.ADB_ACL_GROUP_MEMBER_TABLE_NAME, member)
+            if fvs.get("SAI_ACL_TABLE_GROUP_MEMBER_ATTR_ACL_TABLE_ID") == acl_table_id:
+                assert fvs.get("SAI_ACL_TABLE_GROUP_MEMBER_ATTR_PRIORITY") == str(priority)
+                checked += 1
+
+        assert checked > 0
 
     def verify_acl_table_portchannel_binding(
             self,

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -1150,6 +1150,185 @@ namespace aclorch_test
         }
     }
 
+    // An ACL table with no PRIORITY field inherits the default group member
+    // priority, and a configured PRIORITY is parsed and stored on the table.
+    TEST_F(AclOrchTest, AclTableGroupMemberPriority)
+    {
+        auto orch = createAclOrch();
+
+        // No PRIORITY configured -> default is used.
+        {
+            string acl_table_id = "acl_table_default_prio";
+            auto kvfAclTable = deque<KeyOpFieldsValuesTuple>(
+                { { acl_table_id,
+                    SET_COMMAND,
+                    { { ACL_TABLE_DESCRIPTION, "default priority" },
+                      { ACL_TABLE_TYPE, TABLE_TYPE_L3 },
+                      { ACL_TABLE_STAGE, STAGE_INGRESS },
+                      { ACL_TABLE_PORTS, "1,2" } } } });
+
+            orch->doAclTableTask(kvfAclTable);
+
+            const auto *acl_table = orch->getAclTable(acl_table_id);
+            ASSERT_NE(acl_table, nullptr);
+            ASSERT_EQ(acl_table->priority, (sai_uint32_t)ACL_TABLE_GROUP_MEMBER_DEFAULT_PRIORITY);
+        }
+
+        // PRIORITY configured -> the configured value is stored on the table.
+        {
+            string acl_table_id = "acl_table_custom_prio";
+            auto kvfAclTable = deque<KeyOpFieldsValuesTuple>(
+                { { acl_table_id,
+                    SET_COMMAND,
+                    { { ACL_TABLE_DESCRIPTION, "custom priority" },
+                      { ACL_TABLE_TYPE, TABLE_TYPE_L3 },
+                      { ACL_TABLE_STAGE, STAGE_INGRESS },
+                      { ACL_TABLE_PRIORITY, "200" },
+                      { ACL_TABLE_PORTS, "1,2" } } } });
+
+            orch->doAclTableTask(kvfAclTable);
+
+            const auto *acl_table = orch->getAclTable(acl_table_id);
+            ASSERT_NE(acl_table, nullptr);
+            ASSERT_EQ(acl_table->priority, (sai_uint32_t)200);
+        }
+    }
+
+    // Helpers to force a known ACL table group member priority range so that the
+    // range-validation path in AclOrch::processAclTablePriority can be exercised.
+    static sai_status_t (*g_orig_get_switch_attribute_fn)(sai_object_id_t, uint32_t, sai_attribute_t *) = nullptr;
+
+    static sai_status_t _ut_acl_table_prio_get_switch_attribute(
+        sai_object_id_t switch_id, uint32_t attr_count, sai_attribute_t *attr_list)
+    {
+        if (attr_count == 2 && attr_list != nullptr &&
+            attr_list[0].id == SAI_SWITCH_ATTR_ACL_TABLE_MINIMUM_PRIORITY &&
+            attr_list[1].id == SAI_SWITCH_ATTR_ACL_TABLE_MAXIMUM_PRIORITY)
+        {
+            attr_list[0].value.u32 = 100;
+            attr_list[1].value.u32 = 10000;
+            return SAI_STATUS_SUCCESS;
+        }
+        return g_orig_get_switch_attribute_fn(switch_id, attr_count, attr_list);
+    }
+
+    // RAII guard so the original SAI switch API is restored even if an assertion
+    // returns early from the test.
+    struct AclTablePriorityRangeStub
+    {
+        AclTablePriorityRangeStub()
+        {
+            g_orig_get_switch_attribute_fn = sai_switch_api->get_switch_attribute;
+            sai_switch_api->get_switch_attribute = _ut_acl_table_prio_get_switch_attribute;
+        }
+        ~AclTablePriorityRangeStub()
+        {
+            sai_switch_api->get_switch_attribute = g_orig_get_switch_attribute_fn;
+        }
+    };
+
+    // An invalid (non-numeric) priority is rejected and the table is not created.
+    TEST_F(AclOrchTest, AclTableGroupMemberPriorityInvalid)
+    {
+        auto orch = createAclOrch();
+
+        string acl_table_id = "acl_table_invalid_prio";
+        auto kvfAclTable = deque<KeyOpFieldsValuesTuple>(
+            { { acl_table_id,
+                SET_COMMAND,
+                { { ACL_TABLE_DESCRIPTION, "invalid priority" },
+                  { ACL_TABLE_TYPE, TABLE_TYPE_L3 },
+                  { ACL_TABLE_STAGE, STAGE_INGRESS },
+                  { ACL_TABLE_PRIORITY, "not_a_number" },
+                  { ACL_TABLE_PORTS, "1,2" } } } });
+
+        orch->doAclTableTask(kvfAclTable);
+
+        ASSERT_EQ(orch->getAclTable(acl_table_id), nullptr);
+    }
+
+    // Changing the priority of an existing table recreates it with the new value.
+    TEST_F(AclOrchTest, AclTableGroupMemberPriorityUpdate)
+    {
+        auto orch = createAclOrch();
+        string acl_table_id = "acl_table_upd_prio";
+
+        auto setPriority = [&](const string &prio) {
+            auto kvf = deque<KeyOpFieldsValuesTuple>(
+                { { acl_table_id,
+                    SET_COMMAND,
+                    { { ACL_TABLE_DESCRIPTION, "update priority" },
+                      { ACL_TABLE_TYPE, TABLE_TYPE_L3 },
+                      { ACL_TABLE_STAGE, STAGE_INGRESS },
+                      { ACL_TABLE_PRIORITY, prio },
+                      { ACL_TABLE_PORTS, "1,2" } } } });
+            orch->doAclTableTask(kvf);
+        };
+
+        setPriority("200");
+        const auto *acl_table = orch->getAclTable(acl_table_id);
+        ASSERT_NE(acl_table, nullptr);
+        ASSERT_EQ(acl_table->priority, (sai_uint32_t)200);
+
+        setPriority("300");
+        acl_table = orch->getAclTable(acl_table_id);
+        ASSERT_NE(acl_table, nullptr);
+        ASSERT_EQ(acl_table->priority, (sai_uint32_t)300);
+    }
+
+    // With a switch-reported priority range, out-of-range values are rejected.
+    TEST_F(AclOrchTest, AclTableGroupMemberPriorityRange)
+    {
+        AclTablePriorityRangeStub stub;
+
+        auto orch = createAclOrch();
+
+        auto setPriority = [&](const string &id, const string &prio) {
+            auto kvf = deque<KeyOpFieldsValuesTuple>(
+                { { id,
+                    SET_COMMAND,
+                    { { ACL_TABLE_DESCRIPTION, "range" },
+                      { ACL_TABLE_TYPE, TABLE_TYPE_L3 },
+                      { ACL_TABLE_STAGE, STAGE_INGRESS },
+                      { ACL_TABLE_PRIORITY, prio },
+                      { ACL_TABLE_PORTS, "1,2" } } } });
+            orch->doAclTableTask(kvf);
+        };
+
+        // In range -> accepted.
+        setPriority("acl_in_range", "200");
+        const auto *acl_table = orch->getAclTable("acl_in_range");
+        ASSERT_NE(acl_table, nullptr);
+        ASSERT_EQ(acl_table->priority, (sai_uint32_t)200);
+
+        // Below minimum and above maximum -> rejected.
+        setPriority("acl_below_min", "5");
+        ASSERT_EQ(orch->getAclTable("acl_below_min"), nullptr);
+
+        setPriority("acl_above_max", "20000");
+        ASSERT_EQ(orch->getAclTable("acl_above_max"), nullptr);
+    }
+
+    // Priority on a non port/LAG-bound table type (CTRLPLANE) is accepted but
+    // ignored; the table is tracked as a control plane table, not a SAI ACL table.
+    TEST_F(AclOrchTest, AclTableGroupMemberPriorityIgnoredForCtrlPlane)
+    {
+        auto orch = createAclOrch();
+        string acl_table_id = "acl_table_ctrl_prio";
+
+        auto kvfAclTable = deque<KeyOpFieldsValuesTuple>(
+            { { acl_table_id,
+                SET_COMMAND,
+                { { ACL_TABLE_DESCRIPTION, "ctrlplane" },
+                  { ACL_TABLE_TYPE, TABLE_TYPE_CTRLPLANE },
+                  { ACL_TABLE_STAGE, STAGE_INGRESS },
+                  { ACL_TABLE_PRIORITY, "200" } } } });
+
+        orch->doAclTableTask(kvfAclTable);
+
+        ASSERT_EQ(orch->getTableById(acl_table_id), SAI_NULL_OBJECT_ID);
+    }
+
     // When received ACL rule SET_COMMAND, orchagent can create corresponding ACL rule.
     // When received ACL rule DEL_COMMAND, orchagent can delete corresponding ACL rule.
     //

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -109,6 +109,31 @@ class TestAcl:
             # Verify the STATE_DB entry is removed
             dvs_acl.verify_acl_table_status(L3_TABLE_NAME, None)
 
+    def test_AclTableGroupMemberPriority(self, dvs_acl):
+        # Omitting priority yields the default group member priority of 100.
+        try:
+            dvs_acl.create_acl_table(L3_TABLE_NAME, L3_TABLE_TYPE, L3_BIND_PORTS)
+
+            acl_table_id = dvs_acl.get_acl_table_ids(1)[0]
+            acl_table_group_ids = dvs_acl.get_acl_table_group_ids(len(L3_BIND_PORTS))
+
+            dvs_acl.verify_acl_table_group_member_priority(acl_table_id, "100", len(acl_table_group_ids))
+        finally:
+            dvs_acl.remove_acl_table(L3_TABLE_NAME)
+            dvs_acl.verify_acl_table_count(0)
+
+        # A configured priority is programmed as the group member priority.
+        try:
+            dvs_acl.create_acl_table(L3_TABLE_NAME, L3_TABLE_TYPE, L3_BIND_PORTS, priority="555")
+
+            acl_table_id = dvs_acl.get_acl_table_ids(1)[0]
+            acl_table_group_ids = dvs_acl.get_acl_table_group_ids(len(L3_BIND_PORTS))
+
+            dvs_acl.verify_acl_table_group_member_priority(acl_table_id, "555", len(acl_table_group_ids))
+        finally:
+            dvs_acl.remove_acl_table(L3_TABLE_NAME)
+            dvs_acl.verify_acl_table_count(0)
+
     def test_InvalidAclTableCreationDeletion(self, dvs_acl):
         try:
             dvs_acl.create_acl_table("INVALID_ACL_TABLE", L3_TABLE_TYPE, "dummy_port", "invalid_stage")


### PR DESCRIPTION
#### Why I did it

Fixes #4687

`PortsOrch::bindAclTable()` hardcoded `SAI_ACL_TABLE_GROUP_MEMBER_ATTR_PRIORITY` to `100` for every ACL table group member. This priority is the "ACL table priority" that governs table lookup order (SEQUENTIAL groups) and action-conflict resolution (PARALLEL groups), so a fixed value makes the relative behavior of multiple ACL tables on a shared port + stage uncontrollable and non-deterministic.

#### How I did it

Expose the value as an optional CONFIG_DB `ACL_TABLE` `priority` field, mirroring the P4Orch ACL path which already drives this attribute from configuration:

- New `ACL_TABLE_PRIORITY` schema key and `AclTable::priority` member, defaulting to `100` (`ACL_TABLE_GROUP_MEMBER_DEFAULT_PRIORITY`) for backward compatibility.
- Plumb the value through `AclTable::bind()` → `PortsOrch::bindAclTable()` into the group member priority attribute.
- Query the switch-reported range (`SAI_SWITCH_ATTR_ACL_TABLE_MINIMUM/MAXIMUM_PRIORITY`) and validate the configured value against it when available; validation is skipped when the query is unsupported.
- Recreate the table group member when the priority changes, since the attribute is `CREATE_ONLY`.

Absent the field, behavior is identical to before (`100`).

**Applicability by table type:** `ACL_TABLE.priority` is realized as `SAI_ACL_TABLE_GROUP_MEMBER_ATTR_PRIORITY` at port/LAG bind time. Like the existing `ports` leaf, the orchagent translates this table-level input into the per-bind-point SAI attribute. It is therefore a no-op for table types that are not port/LAG-bound — i.e. switch-bound tables and CTRLPLANE tables, which have no ACL table group member. Setting `priority` on those logs a `SWSS_LOG_WARN`.

**Companion YANG PR:** sonic-net/sonic-buildimage (adds the `priority` leaf to `ACL_TABLE_LIST` in `sonic-acl.yang`).

#### How I verified it

- New `aclorch_ut` gtests (`AclTableGroupMemberPriority*`) covering: default value, configured value, invalid value rejection, priority-update/recreate, switch-reported range rejection, and the no-op WARN path for CTRLPLANE. All pass.
- New virtual switch test (`test_AclTableGroupMemberPriority`) asserting the configured priority reaches the ACL table group member attribute in ASIC DB.
- Built orchagent and `mock_tests` on a bookworm slave; all ACL priority tests green.
-  Validated end-to-end on a **SONiC** DUT running this PR's image


HLD: sonic-net/SONiC#2430
YANG: sonic-net/sonic-buildimage#28006
