### PR TITLE
[countersyncd]: fix flaky test_ipfix Arc::try_unwrap ownership race

### DIFF
--- a/crates/countersyncd/src/actor/ipfix.rs
+++ b/crates/countersyncd/src/actor/ipfix.rs
@@ -1533,8 +1533,12 @@ mod test {
 
         let mut received_stats = Vec::new();
         while let Some(stats) = saistats_receiver.recv().await {
-            let unwrapped_stats =
-                Arc::try_unwrap(stats).expect("Failed to unwrap Arc<SAIStatsMessage>");
+            // The actor keeps its own Arc clone of each message until it finishes
+            // the current send batch, so the strong count can still be > 1 when we
+            // receive here. Clone the inner value instead of requiring exclusive
+            // ownership (Arc::try_unwrap), which races on slow/emulated runners
+            // such as armhf under QEMU.
+            let unwrapped_stats = (*stats).clone();
             received_stats.push(unwrapped_stats);
             if received_stats.len() == expected_stats.len() {
                 break;


### PR DESCRIPTION
#### What I did

`actor::ipfix::test::test_ipfix` asserted single ownership of each received message via `Arc::try_unwrap(...).expect(...)`. That assumes the actor has already released its own reference by the time the test dequeues — which is not guaranteed. Replaced it with a plain clone of the inner value, which does not depend on the reference count.

```rust
// before
let unwrapped_stats =
    Arc::try_unwrap(stats).expect("Failed to unwrap Arc<SAIStatsMessage>");
// after
let unwrapped_stats = (*stats).clone();
```

#### Why I did it

The test fails intermittently on the `BuildArm armhf` leg with:

```
thread 'actor::ipfix::test::test_ipfix' panicked at crates/countersyncd/src/actor/ipfix.rs:1537:
Failed to unwrap Arc<SAIStatsMessage>: SAIStats { observation_time: 1, stats: [...] }
test result: FAILED. 91 passed; 1 failed; 0 ignored
```

Root cause is a race between the actor (producer) and the test (consumer):

- `SAIStatsMessage = Arc<SAIStats>`.
- In `IpfixActor::run()` the actor sends a **clone of the `Arc`** to each recipient while still holding its own copies in the local `messages` vector, which is only dropped at the end of the record-handling match arm:
  ```rust
  let messages = actor.handle_record(record);      // actor owns these Arcs
  for recipient in &actor.saistats_recipients {
      for message in &messages {
          let _ = recipient.send(message.clone()).await;   // strong_count becomes 2
      }
  }   // actor's `messages` dropped here
  ```
- `Arc::try_unwrap` only succeeds when `strong_count == 1`. If the consumer dequeues and unwraps **before** the actor task resumes and drops `messages`, the count is still 2, `try_unwrap` returns `Err`, and `.expect(...)` panics.

The actor runs on its own thread/runtime (`spawn_blocking`), so there is no ordering guarantee. On native runners (`amd64`, `amd64+ASAN`, `arm64`) the actor drops its copies fast enough that the race effectively never triggers; under QEMU emulation (`armhf`) the timing window widens and the consumer routinely wins, so the flake reproduces there and ~nowhere else.

This is a test-only assumption — production code never calls `try_unwrap` on these messages. Cloning the inner `SAIStats` removes the reference-count dependency while keeping the assertion identical (`assert_eq!(received_stats, expected_stats)` still validates contents via `SAIStats`'s `PartialEq`).

Surfaced on the `BuildArm armhf` job of #4661.

#### How I verified it

- Built and ran in the `sonic-slave-bookworm` container with `RUSTFLAGS=-Dwarnings`:
  ```
  cargo test -p countersyncd --locked actor::ipfix
  test actor::ipfix::test::test_ipfix ... ok
  test result: ok. 3 passed; 0 failed; 0 ignored
  ```
  Ran 3x consecutively, green each time.
- Compiles clean with `-Dwarnings`.
- Change is scoped to the async `test_ipfix` only; the synchronous `Arc::try_unwrap` in `test_handle_record` is single-owner by construction and left unchanged.

#### Description for the changelog

`[countersyncd]: fix flaky test_ipfix by cloning the received SAIStats instead of asserting sole Arc ownership via try_unwrap, which raced with the actor's in-flight references on emulated (armhf) runners.`
