### PR TITLE
[hftorch]: Fixbug skip commit for unrelated counter map updates

### DIFF
--- a/orchagent/high_frequency_telemetry/hftelorch.cpp
+++ b/orchagent/high_frequency_telemetry/hftelorch.cpp
@@ -151,11 +151,17 @@ void HFTelOrch::locallyNotify(const CounterNameMapUpdater::Message &msg)
 
         if (msg.m_operation == CounterNameMapUpdater::SET)
         {
-            profile->setObjectSAIID(counter_itr->second, counter_name.c_str(), msg.m_oid);
+            if (!profile->setObjectSAIID(counter_itr->second, counter_name.c_str(), msg.m_oid))
+            {
+                continue;
+            }
         }
         else if (msg.m_operation == CounterNameMapUpdater::DEL)
         {
-            profile->delObjectSAIID(counter_itr->second, counter_name.c_str());
+            if (!profile->delObjectSAIID(counter_itr->second, counter_name.c_str()))
+            {
+                continue;
+            }
         }
         else
         {

--- a/orchagent/high_frequency_telemetry/hftelprofile.cpp
+++ b/orchagent/high_frequency_telemetry/hftelprofile.cpp
@@ -373,7 +373,13 @@ bool HFTelProfile::delObjectSAIID(sai_object_type_t object_type, const char *obj
         return false;
     }
 
-    auto &objs = m_name_sai_map[object_type];
+    auto objs_itr = m_name_sai_map.find(object_type);
+    if (objs_itr == m_name_sai_map.end())
+    {
+        return false;
+    }
+
+    auto &objs = objs_itr->second;
     auto itr = objs.find(object_name);
     if (itr == objs.end())
     {

--- a/orchagent/high_frequency_telemetry/hftelprofile.cpp
+++ b/orchagent/high_frequency_telemetry/hftelprofile.cpp
@@ -333,13 +333,13 @@ void HFTelProfile::setStatsIDs(const string &group_name, const set<string> &obje
     deployCounterSubscriptions(sai_object_type);
 }
 
-void HFTelProfile::setObjectSAIID(sai_object_type_t object_type, const char *object_name, sai_object_id_t object_id)
+bool HFTelProfile::setObjectSAIID(sai_object_type_t object_type, const char *object_name, sai_object_id_t object_id)
 {
     SWSS_LOG_ENTER();
 
     if (!isObjectTypeInProfile(object_type, object_name))
     {
-        return;
+        return false;
     }
 
     auto &objs = m_name_sai_map[object_type];
@@ -348,7 +348,7 @@ void HFTelProfile::setObjectSAIID(sai_object_type_t object_type, const char *obj
     {
         if (itr->second == object_id)
         {
-            return;
+            return false;
         }
     }
     objs[object_name] = object_id;
@@ -360,22 +360,24 @@ void HFTelProfile::setObjectSAIID(sai_object_type_t object_type, const char *obj
 
     // Update the counter subscription
     deployCounterSubscriptions(object_type, object_id, m_groups.at(object_type).getObjects().at(object_name));
+
+    return true;
 }
 
-void HFTelProfile::delObjectSAIID(sai_object_type_t object_type, const char *object_name)
+bool HFTelProfile::delObjectSAIID(sai_object_type_t object_type, const char *object_name)
 {
     SWSS_LOG_ENTER();
 
     if (!isObjectTypeInProfile(object_type, object_name))
     {
-        return;
+        return false;
     }
 
     auto &objs = m_name_sai_map[object_type];
     auto itr = objs.find(object_name);
     if (itr == objs.end())
     {
-        return;
+        return false;
     }
 
     // TODO: In the phase 2, we don't need to stop the stream before removing the object
@@ -398,6 +400,8 @@ void HFTelProfile::delObjectSAIID(sai_object_type_t object_type, const char *obj
         m_name_sai_map.erase(object_type);
         SWSS_LOG_DEBUG("Delete object %s from the name sai map", object_name);
     }
+
+    return true;
 }
 
 bool HFTelProfile::canBeUpdated() const

--- a/orchagent/high_frequency_telemetry/hftelprofile.h
+++ b/orchagent/high_frequency_telemetry/hftelprofile.h
@@ -46,8 +46,8 @@ public:
     void setBulkSize(std::uint32_t bulk_size);
     void setObjectNames(const std::string &group_name, std::set<std::string> &&object_names);
     void setStatsIDs(const std::string &group_name, const std::set<std::string> &object_counters);
-    void setObjectSAIID(sai_object_type_t object_type, const char *object_name, sai_object_id_t object_id);
-    void delObjectSAIID(sai_object_type_t object_type, const char *object_name);
+    bool setObjectSAIID(sai_object_type_t object_type, const char *object_name, sai_object_id_t object_id);
+    bool delObjectSAIID(sai_object_type_t object_type, const char *object_name);
     bool canBeUpdated() const;
     bool canBeUpdated(sai_object_type_t object_type) const;
     bool isEmpty() const;

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -35,6 +35,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 qosorch_ut.cpp \
                 bufferorch_ut.cpp \
                 buffermgrdyn_ut.cpp \
+                hftelprofile_ut.cpp \
                 fdborch/flush_syncd_notif_ut.cpp \
                 macmoveguard/macmoveguard_ut.cpp \
                 fdborch/fdborch_vxlan_ut.cpp \

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -35,7 +35,6 @@ tests_SOURCES = aclorch_ut.cpp \
                 qosorch_ut.cpp \
                 bufferorch_ut.cpp \
                 buffermgrdyn_ut.cpp \
-                hftelprofile_ut.cpp \
                 fdborch/flush_syncd_notif_ut.cpp \
                 macmoveguard/macmoveguard_ut.cpp \
                 fdborch/fdborch_vxlan_ut.cpp \

--- a/tests/mock_tests/hftelprofile_ut.cpp
+++ b/tests/mock_tests/hftelprofile_ut.cpp
@@ -368,6 +368,21 @@ namespace hftelprofile_ut
                   set<sai_stat_id_t>({SAI_PORT_STAT_IF_OUT_OCTETS}));
     }
 
+    TEST_F(SetStatsIDsTest, DelObjectSAIIDMissingTypeDoesNotInsertMap)
+    {
+        SetStatsIDsStub s;
+        s.init();
+
+        HFTelGroup group("port");
+        group.updateObjects({"Ethernet0"});
+        group.updateStatsIDs({SAI_PORT_STAT_IF_IN_OCTETS});
+        s.p->m_groups.emplace(SAI_OBJECT_TYPE_PORT, move(group));
+
+        EXPECT_TRUE(s.p->m_name_sai_map.empty());
+        EXPECT_FALSE(s.p->delObjectSAIID(SAI_OBJECT_TYPE_PORT, "Ethernet0"));
+        EXPECT_TRUE(s.p->m_name_sai_map.empty());
+    }
+
     struct SaiAttrTest : public ::testing::Test
     {
         sai_tam_api_t ut_api;

--- a/tests/mock_tests/hftelprofile_ut.cpp
+++ b/tests/mock_tests/hftelprofile_ut.cpp
@@ -630,4 +630,29 @@ namespace hftelprofile_ut
         EXPECT_EQ(orchStub.p->m_counter_name_cache[SAI_OBJECT_TYPE_PORT]["Ethernet4"], msg.m_oid);
         EXPECT_EQ(profileStub.p->getStreamState(SAI_OBJECT_TYPE_PORT), SAI_TAM_TEL_TYPE_STATE_START_STREAM);
     }
+
+    TEST_F(LocallyNotifyStartedProfileTest, UnrelatedObjectDeleteDoesNotRecommitStartedProfile)
+    {
+        ProfileStub profileStub;
+        profileStub.init();
+
+        ASSERT_EQ(profileStub.p->getStreamState(SAI_OBJECT_TYPE_PORT), SAI_TAM_TEL_TYPE_STATE_START_STREAM);
+        ASSERT_TRUE(profileStub.p->isMonitoringObjectReady(SAI_OBJECT_TYPE_PORT));
+        ASSERT_TRUE(profileStub.p->canBeUpdated(SAI_OBJECT_TYPE_PORT));
+        ASSERT_THROW(profileStub.p->tryCommitConfig(SAI_OBJECT_TYPE_PORT), runtime_error);
+
+        shared_ptr<HFTelProfile> profile(profileStub.p, [](HFTelProfile *) {});
+        OrchStub orchStub;
+        orchStub.init(profile);
+        orchStub.p->m_counter_name_cache[SAI_OBJECT_TYPE_PORT]["Ethernet4"] = 0x1000000000002ULL;
+
+        CounterNameMapUpdater::Message msg;
+        msg.m_table_name = "COUNTERS_PORT_NAME_MAP";
+        msg.m_operation = CounterNameMapUpdater::DEL;
+        msg.m_counter_name = "Ethernet4";
+
+        EXPECT_NO_THROW(orchStub.p->locallyNotify(msg));
+        EXPECT_EQ(orchStub.p->m_counter_name_cache[SAI_OBJECT_TYPE_PORT].count("Ethernet4"), 0);
+        EXPECT_EQ(profileStub.p->getStreamState(SAI_OBJECT_TYPE_PORT), SAI_TAM_TEL_TYPE_STATE_START_STREAM);
+    }
 }

--- a/tests/mock_tests/hftelprofile_ut.cpp
+++ b/tests/mock_tests/hftelprofile_ut.cpp
@@ -505,10 +505,8 @@ namespace hftelprofile_ut
         EXPECT_EQ(itr->value.u32, static_cast<uint32_t>(SAI_PORT_STAT_IF_IN_OCTETS));
     }
 
-    struct LocallyNotifyTest : public ::testing::Test
+    struct LocallyNotifyStartedProfileTest : public ::testing::Test
     {
-        static constexpr sai_object_id_t PORT_OID = 0x1000000000001ULL;
-
         struct ProfileStub
         {
             alignas(HFTelProfile) unsigned char buf[sizeof(HFTelProfile)];
@@ -535,8 +533,9 @@ namespace hftelprofile_ut
                 group.updateObjects({"Ethernet0"});
                 group.updateStatsIDs({SAI_PORT_STAT_IF_IN_OCTETS});
                 p->m_groups.emplace(SAI_OBJECT_TYPE_PORT, move(group));
-                p->m_name_sai_map[SAI_OBJECT_TYPE_PORT]["Ethernet0"] = PORT_OID;
-                p->m_sai_tam_counter_subscription_objs[SAI_OBJECT_TYPE_PORT][PORT_OID][SAI_PORT_STAT_IF_IN_OCTETS] =
+                constexpr sai_object_id_t port_oid = 0x1000000000001ULL;
+                p->m_name_sai_map[SAI_OBJECT_TYPE_PORT]["Ethernet0"] = port_oid;
+                p->m_sai_tam_counter_subscription_objs[SAI_OBJECT_TYPE_PORT][port_oid][SAI_PORT_STAT_IF_IN_OCTETS] =
                     make_shared<sai_object_id_t>(0x300);
 
                 auto guard = make_shared<sai_object_id_t>(0x200);
@@ -547,12 +546,19 @@ namespace hftelprofile_ut
             ~ProfileStub()
             {
                 if (!p) return;
-                p->m_profile_name.~basic_string();
-                p->m_groups.~map();
-                p->m_name_sai_map.~unordered_map();
-                p->m_sai_tam_counter_subscription_objs.~unordered_map();
-                p->m_sai_tam_tel_type_objs.~unordered_map();
-                p->m_sai_tam_tel_type_states.~unordered_map();
+                using ProfileName = decay_t<decltype(p->m_profile_name)>;
+                using Groups = decay_t<decltype(p->m_groups)>;
+                using NameSaiMap = decay_t<decltype(p->m_name_sai_map)>;
+                using CounterSubscriptionObjs = decay_t<decltype(p->m_sai_tam_counter_subscription_objs)>;
+                using TelTypeObjs = decay_t<decltype(p->m_sai_tam_tel_type_objs)>;
+                using TelTypeStates = decay_t<decltype(p->m_sai_tam_tel_type_states)>;
+
+                p->m_profile_name.~ProfileName();
+                p->m_groups.~Groups();
+                p->m_name_sai_map.~NameSaiMap();
+                p->m_sai_tam_counter_subscription_objs.~CounterSubscriptionObjs();
+                p->m_sai_tam_tel_type_objs.~TelTypeObjs();
+                p->m_sai_tam_tel_type_states.~TelTypeStates();
                 p = nullptr;
             }
         };
@@ -575,14 +581,17 @@ namespace hftelprofile_ut
             ~OrchStub()
             {
                 if (!p) return;
-                p->m_type_profile_mapping.~unordered_map();
-                p->m_counter_name_cache.~unordered_map();
+                using TypeProfileMapping = decay_t<decltype(p->m_type_profile_mapping)>;
+                using CounterNameCacheType = decay_t<decltype(p->m_counter_name_cache)>;
+
+                p->m_type_profile_mapping.~TypeProfileMapping();
+                p->m_counter_name_cache.~CounterNameCacheType();
                 p = nullptr;
             }
         };
     };
 
-    TEST_F(LocallyNotifyTest, UnrelatedObjectUpdateDoesNotRecommitStartedProfile)
+    TEST_F(LocallyNotifyStartedProfileTest, UnrelatedObjectUpdateDoesNotRecommitStartedProfile)
     {
         ProfileStub profileStub;
         profileStub.init();

--- a/tests/mock_tests/hftelprofile_ut.cpp
+++ b/tests/mock_tests/hftelprofile_ut.cpp
@@ -13,6 +13,7 @@
 
 #define private public
 #define protected public
+#include "high_frequency_telemetry/hftelorch.h"
 #include "high_frequency_telemetry/hftelprofile.h"
 #undef private
 #undef protected
@@ -502,5 +503,107 @@ namespace hftelprofile_ut
         });
         ASSERT_NE(itr, counter_attrs.end());
         EXPECT_EQ(itr->value.u32, static_cast<uint32_t>(SAI_PORT_STAT_IF_IN_OCTETS));
+    }
+
+    struct LocallyNotifyTest : public ::testing::Test
+    {
+        static constexpr sai_object_id_t PORT_OID = 0x1000000000001ULL;
+
+        struct ProfileStub
+        {
+            alignas(HFTelProfile) unsigned char buf[sizeof(HFTelProfile)];
+            HFTelProfile *p = nullptr;
+
+            void init()
+            {
+                memset(buf, 0, sizeof(buf));
+                p = reinterpret_cast<HFTelProfile *>(static_cast<void *>(buf));
+
+                new (const_cast<string*>(&p->m_profile_name)) string("test_profile");
+                p->m_setting_state = SAI_TAM_TEL_TYPE_STATE_START_STREAM;
+                p->m_poll_interval = 0;
+                new (&p->m_groups) decay_t<decltype(p->m_groups)>();
+                new (&p->m_name_sai_map) decay_t<decltype(p->m_name_sai_map)>();
+                new (&p->m_sai_tam_counter_subscription_objs)
+                    decay_t<decltype(p->m_sai_tam_counter_subscription_objs)>();
+                new (&p->m_sai_tam_tel_type_objs)
+                    decay_t<decltype(p->m_sai_tam_tel_type_objs)>();
+                new (&p->m_sai_tam_tel_type_states)
+                    decay_t<decltype(p->m_sai_tam_tel_type_states)>();
+
+                HFTelGroup group("port");
+                group.updateObjects({"Ethernet0"});
+                group.updateStatsIDs({SAI_PORT_STAT_IF_IN_OCTETS});
+                p->m_groups.emplace(SAI_OBJECT_TYPE_PORT, move(group));
+                p->m_name_sai_map[SAI_OBJECT_TYPE_PORT]["Ethernet0"] = PORT_OID;
+                p->m_sai_tam_counter_subscription_objs[SAI_OBJECT_TYPE_PORT][PORT_OID][SAI_PORT_STAT_IF_IN_OCTETS] =
+                    make_shared<sai_object_id_t>(0x300);
+
+                auto guard = make_shared<sai_object_id_t>(0x200);
+                p->m_sai_tam_tel_type_objs[SAI_OBJECT_TYPE_PORT] = guard;
+                p->m_sai_tam_tel_type_states[guard] = SAI_TAM_TEL_TYPE_STATE_START_STREAM;
+            }
+
+            ~ProfileStub()
+            {
+                if (!p) return;
+                p->m_profile_name.~basic_string();
+                p->m_groups.~map();
+                p->m_name_sai_map.~unordered_map();
+                p->m_sai_tam_counter_subscription_objs.~unordered_map();
+                p->m_sai_tam_tel_type_objs.~unordered_map();
+                p->m_sai_tam_tel_type_states.~unordered_map();
+                p = nullptr;
+            }
+        };
+
+        struct OrchStub
+        {
+            alignas(HFTelOrch) unsigned char buf[sizeof(HFTelOrch)];
+            HFTelOrch *p = nullptr;
+
+            void init(const shared_ptr<HFTelProfile> &profile)
+            {
+                memset(buf, 0, sizeof(buf));
+                p = reinterpret_cast<HFTelOrch *>(static_cast<void *>(buf));
+
+                new (&p->m_type_profile_mapping) decay_t<decltype(p->m_type_profile_mapping)>();
+                new (&p->m_counter_name_cache) decay_t<decltype(p->m_counter_name_cache)>();
+                p->m_type_profile_mapping[SAI_OBJECT_TYPE_PORT].insert(profile);
+            }
+
+            ~OrchStub()
+            {
+                if (!p) return;
+                p->m_type_profile_mapping.~unordered_map();
+                p->m_counter_name_cache.~unordered_map();
+                p = nullptr;
+            }
+        };
+    };
+
+    TEST_F(LocallyNotifyTest, UnrelatedObjectUpdateDoesNotRecommitStartedProfile)
+    {
+        ProfileStub profileStub;
+        profileStub.init();
+
+        ASSERT_EQ(profileStub.p->getStreamState(SAI_OBJECT_TYPE_PORT), SAI_TAM_TEL_TYPE_STATE_START_STREAM);
+        ASSERT_TRUE(profileStub.p->isMonitoringObjectReady(SAI_OBJECT_TYPE_PORT));
+        ASSERT_TRUE(profileStub.p->canBeUpdated(SAI_OBJECT_TYPE_PORT));
+        ASSERT_THROW(profileStub.p->tryCommitConfig(SAI_OBJECT_TYPE_PORT), runtime_error);
+
+        shared_ptr<HFTelProfile> profile(profileStub.p, [](HFTelProfile *) {});
+        OrchStub orchStub;
+        orchStub.init(profile);
+
+        CounterNameMapUpdater::Message msg;
+        msg.m_table_name = "COUNTERS_PORT_NAME_MAP";
+        msg.m_operation = CounterNameMapUpdater::SET;
+        msg.m_counter_name = "Ethernet4";
+        msg.m_oid = 0x1000000000002ULL;
+
+        EXPECT_NO_THROW(orchStub.p->locallyNotify(msg));
+        EXPECT_EQ(orchStub.p->m_counter_name_cache[SAI_OBJECT_TYPE_PORT]["Ethernet4"], msg.m_oid);
+        EXPECT_EQ(profileStub.p->getStreamState(SAI_OBJECT_TYPE_PORT), SAI_TAM_TEL_TYPE_STATE_START_STREAM);
     }
 }


### PR DESCRIPTION
**What I did**

Avoid re-committing HFT configuration when a counter name map update is for an object outside the HFT group.

Changed `HFTelProfile::setObjectSAIID()` and `HFTelProfile::delObjectSAIID()` to return whether the profile was actually modified. `HFTelOrch::locallyNotify()` now calls `tryCommitConfig()` only when the counter name map update applies to an object in the profile.

Added a mock unit test that calls `HFTelOrch::locallyNotify()` with an unrelated `COUNTERS_PORT_NAME_MAP` update while the HFT profile is already streaming. The old behavior would continue into `tryCommitConfig()` and hit the unsupported `START_STREAM -> CREATE_CONFIG` path; the fixed behavior returns without committing.

**Why I did it**

Fixes sonic-net/sonic-buildimage#27897.

After reload, an HFT profile may already be in `START_STREAM`. `HFTelOrch::locallyNotify()` previously called `tryCommitConfig()` for every profile of the updated SAI object type, even if the updated counter name map entry was unrelated to that HFT group. That unrelated object update caused an unnecessary second commit and hit the existing unsupported `START_STREAM -> CREATE_CONFIG` transition.

**How I verified it**

Used the `sonic-swss-verify` flow and checked the relevant CI files:

- `.azure-pipelines/build-template.yml`
- `.azure-pipelines/test-docker-sonic-vs-template.yml`

Downloaded CI artifacts with `latestFromBranch` strategy:

- swss-common build 1142984
- sairedis build 1142386
- common-lib build 1144430
- VPP build 1139157 from `sonic-net.sonic-platform-vpp` main

Ran the updated unit test compilation in `sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:master-amd64`:

- `make -C tests/mock_tests tests-hftelprofile_ut.o -j$(nproc)`

Result: passed. The updated test object compiled successfully in the CI container.

Also ran:

- `git diff --check`

**Details if related**

The fix intentionally does not implement `START_STREAM -> CREATE_CONFIG`. It prevents unrelated object updates from entering that transition path in the first place.