### PR TITLE
[aclorch] Query SAI for MIRRORV6 ACL table capability

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3633,37 +3633,17 @@ void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, Mirr
     removeAllAclTableStatus();
     removeAllAclRuleStatus();
 
-    // TODO: Query SAI to get mirror table capabilities
-    // Right now, verified platforms that support mirroring IPv6 packets are
-    // Broadcom and Mellanox. Virtual switch is also supported for testing
-    // purposes.
     string platform = getenv("platform") ? getenv("platform") : "";
     string sub_platform = getenv("sub_platform") ? getenv("sub_platform") : "";
-    if (platform == BRCM_PLATFORM_SUBSTRING ||
-            platform == CISCO_8000_PLATFORM_SUBSTRING ||
-            platform == MLNX_PLATFORM_SUBSTRING ||
-            platform == BFN_PLATFORM_SUBSTRING  ||
-            platform == MRVL_PRST_PLATFORM_SUBSTRING ||
-            platform == MRVL_TL_PLATFORM_SUBSTRING ||
-            platform == NPS_PLATFORM_SUBSTRING ||
-            platform == XS_PLATFORM_SUBSTRING ||
-            platform == CLX_PLATFORM_SUBSTRING ||
-            platform == VS_PLATFORM_SUBSTRING)
+
+    // MIRRORV6 (IPv6 mirror) ACL table support: query SAI rather than relying
+    // on a hardcoded platform list (see queryAclMirrorV6Capability()).
+    m_mirrorTableCapabilities =
     {
-        m_mirrorTableCapabilities =
-        {
-            { TABLE_TYPE_MIRROR, true },
-            { TABLE_TYPE_MIRRORV6, true },
-        };
-    }
-    else
-    {
-        m_mirrorTableCapabilities =
-        {
-            { TABLE_TYPE_MIRROR, true },
-            { TABLE_TYPE_MIRRORV6, false },
-        };
-    }
+        // IPv4 mirror was never platform-gated; only MIRRORV6 is queried.
+        { TABLE_TYPE_MIRROR, true },
+        { TABLE_TYPE_MIRRORV6, queryAclMirrorV6Capability(platform) },
+    };
 
     if ( platform == MRVL_PRST_PLATFORM_SUBSTRING ||
 	    platform == MRVL_TL_PLATFORM_SUBSTRING ||
@@ -5371,6 +5351,60 @@ bool AclOrch::isAclMirrorV4Supported() const
 bool AclOrch::isAclMirrorV6Supported() const
 {
     return isAclMirrorTableSupported(TABLE_TYPE_MIRRORV6);
+}
+
+bool AclOrch::queryAclMirrorV6Capability(const string &platform) const
+{
+    // No real ASIC on the virtual switch; assume supported so VS tests run.
+    if (platform == VS_PLATFORM_SUBSTRING)
+    {
+        return true;
+    }
+
+    // The IPv6 match field distinguishes the MIRRORV6 table, so its create
+    // capability gates the table.
+    sai_attr_capability_t capability = {};
+    sai_status_t status = sai_query_attribute_capability(
+            gSwitchId, SAI_OBJECT_TYPE_ACL_TABLE,
+            SAI_ACL_TABLE_ATTR_FIELD_SRC_IPV6, &capability);
+    if (status == SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_NOTICE("Queried SAI ACL IPv6 match-field capability: MIRRORV6 %s",
+                capability.create_implemented ? "supported" : "not supported");
+        return capability.create_implemented;
+    }
+
+    // Query unavailable (older SAI): fall back to the historical platform list
+    // so those platforms behave as before.
+    static const set<string> mirrorV6SupportedPlatforms =
+    {
+        BRCM_PLATFORM_SUBSTRING,
+        CISCO_8000_PLATFORM_SUBSTRING,
+        MLNX_PLATFORM_SUBSTRING,
+        BFN_PLATFORM_SUBSTRING,
+        MRVL_PRST_PLATFORM_SUBSTRING,
+        MRVL_TL_PLATFORM_SUBSTRING,
+        NPS_PLATFORM_SUBSTRING,
+        XS_PLATFORM_SUBSTRING,
+        CLX_PLATFORM_SUBSTRING,
+    };
+    bool supported = mirrorV6SupportedPlatforms.count(platform) != 0;
+
+    // NOT_IMPLEMENTED/NOT_SUPPORTED just means the SAI lacks the query (expected
+    // on older SAI) -> NOTICE; any other status is an unexpected error -> WARN.
+    if (status == SAI_STATUS_NOT_IMPLEMENTED || status == SAI_STATUS_NOT_SUPPORTED)
+    {
+        SWSS_LOG_NOTICE("SAI ACL IPv6 match-field capability query not implemented "
+                "(status %d); using platform default for '%s': MIRRORV6 %s",
+                status, platform.c_str(), supported ? "supported" : "not supported");
+    }
+    else
+    {
+        SWSS_LOG_WARN("SAI ACL IPv6 match-field capability query failed (status %d); "
+                "using platform default for '%s': MIRRORV6 %s",
+                status, platform.c_str(), supported ? "supported" : "not supported");
+    }
+    return supported;
 }
 
 bool AclOrch::isAclActionListMandatoryOnTableCreation(acl_stage_type_t stage) const

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -624,6 +624,7 @@ public:
     bool isCombinedMirrorV6Table();
     bool isAclMirrorV6Supported() const;
     bool isAclMirrorV4Supported() const;
+    bool queryAclMirrorV6Capability(const string &platform) const;
     bool isAclMirrorTableSupported(string type) const;
     bool isAclL3V4V6TableSupported(acl_stage_type_t stage) const;
     bool isAclActionListMandatoryOnTableCreation(acl_stage_type_t stage) const;

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -1,5 +1,6 @@
 #include "ut_helper.h"
 #include "flowcounterrouteorch.h"
+#include "mock_sai_capability_wrap.h"
 
 extern sai_object_id_t gSwitchId;
 
@@ -1993,6 +1994,65 @@ namespace aclorch_test
 
         // Restore sai_switch_api.
         sai_switch_api = old_sai_switch_api;
+    }
+
+    // SAI reports the IPv6 match field supported: MIRRORV6 enabled even on a
+    // platform absent from the legacy hardcoded list.
+    TEST_F(AclOrchTest, MirrorV6Capability_FollowsSaiQueryWhenSupported)
+    {
+        hftelorch_sai_wrap_ut::HFTelSaiHookGuard guard(
+            hftelorch_sai_wrap_ut::setSaiHookAllSupported);
+
+        // A platform that is NOT in the legacy hardcoded MIRRORV6 platform list.
+        setenv("platform", "acl_ut_unknown_platform", 1);
+
+        auto orch = createAclOrch();
+        EXPECT_TRUE(orch->m_aclOrch->isAclMirrorV6Supported());
+
+        unsetenv("platform");
+    }
+
+    // Query unavailable: fall back to the historical list (platform on it -> supported).
+    TEST_F(AclOrchTest, MirrorV6Capability_FallbackSupportedPlatform)
+    {
+        hftelorch_sai_wrap_ut::HFTelSaiHookGuard guard(
+            hftelorch_sai_wrap_ut::setSaiHookAttributeCapabilityQueryFail);
+
+        setenv("platform", BRCM_PLATFORM_SUBSTRING, 1);
+
+        auto orch = createAclOrch();
+        EXPECT_TRUE(orch->m_aclOrch->isAclMirrorV6Supported());
+
+        unsetenv("platform");
+    }
+
+    // Query unavailable and platform not on the historical list -> unsupported.
+    TEST_F(AclOrchTest, MirrorV6Capability_FallbackUnsupportedPlatform)
+    {
+        hftelorch_sai_wrap_ut::HFTelSaiHookGuard guard(
+            hftelorch_sai_wrap_ut::setSaiHookAttributeCapabilityQueryFail);
+
+        setenv("platform", "acl_ut_unknown_platform", 1);
+
+        auto orch = createAclOrch();
+        EXPECT_FALSE(orch->m_aclOrch->isAclMirrorV6Supported());
+
+        unsetenv("platform");
+    }
+
+    // Query succeeds but reports the field not implemented: MIRRORV6 disabled,
+    // overriding the platform default (BRCM is on the legacy list).
+    TEST_F(AclOrchTest, MirrorV6Capability_SaiQuerySupportedButFieldUnimplemented)
+    {
+        hftelorch_sai_wrap_ut::HFTelSaiHookGuard guard(
+            hftelorch_sai_wrap_ut::setSaiHookAttributeCapabilitySuccessUnsupported);
+
+        setenv("platform", BRCM_PLATFORM_SUBSTRING, 1);
+
+        auto orch = createAclOrch();
+        EXPECT_FALSE(orch->m_aclOrch->isAclMirrorV6Supported());
+
+        unsetenv("platform");
     }
 
     TEST_F(AclOrchTest, Match_Inner_Mac)

--- a/tests/mock_tests/mock_sai_capability_wrap.cpp
+++ b/tests/mock_tests/mock_sai_capability_wrap.cpp
@@ -53,6 +53,7 @@ namespace
             CollectorCreateNotImplemented,
             SwitchNotifySetNotImplemented,
             AllSupported,
+            AttributeCapabilitySuccessUnsupported,
         };
 
         thread_local Hook g_hook = Hook::None;
@@ -193,6 +194,17 @@ extern "C"
             return SAI_STATUS_SUCCESS;
         }
 
+        if (hftel::g_hook == hftel::Hook::AttributeCapabilitySuccessUnsupported)
+        {
+            if (!attr_capability)
+            {
+                return SAI_STATUS_INVALID_PARAMETER;
+            }
+            // Query succeeds but the attribute is not implemented (create_implemented false).
+            std::memset(attr_capability, 0, sizeof(*attr_capability));
+            return SAI_STATUS_SUCCESS;
+        }
+
         if (hftel::g_hook == hftel::Hook::AttributeCapabilityQueryFail)
         {
             return SAI_STATUS_NOT_SUPPORTED;
@@ -327,6 +339,11 @@ namespace hftelorch_sai_wrap_ut
     void setSaiHookAllSupported()
     {
         hftel::g_hook = hftel::Hook::AllSupported;
+    }
+
+    void setSaiHookAttributeCapabilitySuccessUnsupported()
+    {
+        hftel::g_hook = hftel::Hook::AttributeCapabilitySuccessUnsupported;
     }
 
     HFTelSaiHookGuard::HFTelSaiHookGuard(void (*apply)())

--- a/tests/mock_tests/mock_sai_capability_wrap.h
+++ b/tests/mock_tests/mock_sai_capability_wrap.h
@@ -73,6 +73,8 @@ namespace hftelorch_sai_wrap_ut
     void setSaiHookCollectorCreateNotImplemented();
     void setSaiHookSwitchNotifySetNotImplemented();
     void setSaiHookAllSupported();
+    /** Query returns SUCCESS but the attribute reports create_implemented false. */
+    void setSaiHookAttributeCapabilitySuccessUnsupported();
 
     /** RAII: restores the HFTel hook to None on scope exit. */
     struct HFTelSaiHookGuard


### PR DESCRIPTION
#### What I did
`AclOrch::init()` decided whether the `MIRRORV6` (IPv6 mirror) ACL table type is supported from a hardcoded list of platform strings, with a standing `// TODO: Query SAI to get mirror table capabilities`. A new ASIC whose SAI supports IPv6 ACL match fields therefore had no `MIRRORV6` table until its platform string was manually added.

Derive the capability from SAI instead: query `sai_query_attribute_capability(SAI_OBJECT_TYPE_ACL_TABLE, SAI_ACL_TABLE_ATTR_FIELD_SRC_IPV6)` and use `create_implemented` (the IPv6 match field is what distinguishes the `MIRRORV6` table).

#### Why I did it
Removes a hardcoded platform allow-list so any platform whose SAI reports IPv6 ACL match-field support can use `MIRRORV6`, independent of a static list — consistent with the other capability-query cleanups in `AclOrch`.

Fixes #4692

#### How I verified it
Mock unit tests in `tests/mock_tests/aclorch_ut.cpp` (using the consolidated `mock_sai_capability_wrap` SAI `--wrap` harness) cover every branch of the decision:
- SAI reports the field supported (on a platform not in the legacy list) → `MIRRORV6` enabled;
- SAI reports the field not implemented → `MIRRORV6` disabled even on a legacy-list platform;
- capability query unavailable → fallback to the platform list (both a supported and an unsupported platform);
- software platforms (virtual switch, VPP) short-circuit to supported, independent of the query.

Built and run on a build host after rebasing onto latest `master`:
- `AclOrchTest.MirrorV6Capability_*`: 5/5 pass (incl. the VPP software-platform case);
- full `AclOrchTest` suite: 33/33 pass (no regression).

#### Details if related to the issue
The SAI query is authoritative on success: `SAI_STATUS_SUCCESS` with `create_implemented=false` reports `MIRRORV6` unsupported **even for a platform on the legacy list** (creating the table would fail regardless) — an intentional shift away from the static allow-list. Where the query is unavailable (`NOT_IMPLEMENTED`/`NOT_SUPPORTED`/other failure) it falls back to the original platform list, so existing platforms are unaffected; the software platforms (virtual switch and VPP) short-circuit to supported, so their behavior is unchanged. IPv4 mirror (`TABLE_TYPE_MIRROR`) was never platform-gated and stays unconditional. `NOT_IMPLEMENTED`/`NOT_SUPPORTED` are logged at NOTICE (expected on older SAI); other failures log at WARN.

