### PR TITLE
[flexcounterorch] Make warm/fast-reboot port-counter deferral observable and diagnosable

### DIFF
--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -142,6 +142,36 @@ FlexCounterOrch::~FlexCounterOrch(void)
     SWSS_LOG_ENTER();
 }
 
+// Log (throttled) why port flex counter processing is deferred at the
+// allPortsReady() gate, so the otherwise silent, unbounded wait is diagnosable.
+void FlexCounterOrch::warnPortsNotReady()
+{
+    // Log once per not-ready episode; re-armed in doTask() when ports are ready.
+    if (m_portsNotReadyWarned)
+    {
+        return;
+    }
+    m_portsNotReadyWarned = true;
+
+    if (!gPortsOrch->isInitDone())
+    {
+        SWSS_LOG_WARN("Port flex counters deferred: port init not complete "
+                      "(PortInitDone not received). Counters unavailable until it finishes.");
+        return;
+    }
+
+    auto pendingPorts = gPortsOrch->getPendingInitPorts();
+    string pendingStr;
+    for (const auto &alias : pendingPorts)
+    {
+        pendingStr += (pendingStr.empty() ? "" : ", ") + alias;
+    }
+    SWSS_LOG_WARN("Port flex counters deferred: %zu port(s) not initialized "
+                  "(e.g. buffer config not applied) block counters for ALL ports: [%s]. "
+                  "\"show interfaces counters\" stays empty until they are ready.",
+                  pendingPorts.size(), pendingStr.c_str());
+}
+
 void FlexCounterOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
@@ -163,6 +193,8 @@ void FlexCounterOrch::doTask(Consumer &consumer)
     DashHaOrch* dash_ha_orch = gDirectory.get<DashHaOrch*>();
     if (gPortsOrch && !gPortsOrch->allPortsReady())
     {
+        // Deferral is by design; warn (throttled) so the wait is not silent.
+        warnPortsNotReady();
         return;
     }
 
@@ -170,6 +202,9 @@ void FlexCounterOrch::doTask(Consumer &consumer)
     {
         return;
     }
+
+    // Ports are ready; re-arm the diagnostic for any future deferral.
+    m_portsNotReadyWarned = false;
 
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())

--- a/orchagent/flexcounterorch.h
+++ b/orchagent/flexcounterorch.h
@@ -63,6 +63,7 @@ public:
 
 private:
     void handleDeviceMetadataTable(Consumer &consumer);
+    void warnPortsNotReady();
     bool m_port_counter_enabled = false;
     bool m_port_phy_attr_enabled = false;
     bool m_port_phy_serdes_attr_enabled = false;
@@ -74,6 +75,7 @@ private:
     bool m_hostif_trap_counter_enabled = false;
     bool m_route_flow_counter_enabled = false;
     bool m_delayTimerExpired = false;
+    bool m_portsNotReadyWarned = false;
     bool m_wred_queue_counter_enabled = false;
     bool m_wred_port_counter_enabled = false;
     Table m_bufferQueueConfigTable;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1730,6 +1730,11 @@ bool PortsOrch::allPortsReady()
     return m_initDone && m_pendingPortSet.empty();
 }
 
+std::set<std::string> PortsOrch::getPendingInitPorts() const
+{
+    return std::set<std::string>(m_pendingPortSet.begin(), m_pendingPortSet.end());
+}
+
 /* Upon receiving PortInitDone, all the configured ports have been created in both hardware and kernel*/
 bool PortsOrch::isInitDone()
 {

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -154,6 +154,9 @@ public:
     PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_with_pri_t> &tableNames, DBConnector *chassisAppDb);
 
     bool allPortsReady();
+    // Ports created but not yet fully initialized (e.g. buffers not applied);
+    // while non-empty, allPortsReady() returns false.
+    std::set<std::string> getPendingInitPorts() const;
     bool isInitDone();
     bool isConfigDone();
     bool isGearboxEnabled();

--- a/tests/mock_tests/flexcounter_ut.cpp
+++ b/tests/mock_tests/flexcounter_ut.cpp
@@ -1049,6 +1049,57 @@ namespace flexcounter_test
         ASSERT_TRUE(ts.empty());
     }
 
+    // When a port is not ready, port flex counters are deferred; verify the
+    // deferral is observable and that it recovers once the port is ready.
+    // See sonic-net/sonic-swss#4694.
+    TEST_P(FlexCounterTest, PortNotReadyDeferralIsObservable)
+    {
+        auto flexCounterOrch = gDirectory.get<FlexCounterOrch*>();
+
+        // Delay timer expired, so doTask() reaches the allPortsReady() gate.
+        flexCounterOrch->m_delayTimerExpired = true;
+        flexCounterOrch->m_portsNotReadyWarned = false;
+
+        // A port stuck in init keeps allPortsReady() false.
+        const std::string stuckPort = "Ethernet0";
+        gPortsOrch->m_pendingPortSet.insert(stuckPort);
+
+        ASSERT_FALSE(gPortsOrch->allPortsReady());
+        auto pending = gPortsOrch->getPendingInitPorts();
+        ASSERT_NE(pending.find(stuckPort), pending.end());
+
+        // PORT enable while not ready: counters deferred, warning fired once.
+        Table flexCounterCfg(m_config_db.get(), CFG_FLEX_COUNTER_TABLE_NAME);
+        const std::vector<FieldValueTuple> values({ {FLEX_COUNTER_STATUS_FIELD, "enable"} });
+        flexCounterCfg.set("PORT", values);
+        flexCounterOrch->addExistingData(&flexCounterCfg);
+        static_cast<Orch *>(flexCounterOrch)->doTask();
+
+        ASSERT_TRUE(flexCounterOrch->m_portsNotReadyWarned);
+        ASSERT_FALSE(flexCounterOrch->getPortCountersState());
+
+        // Port becomes ready: diagnostic re-arms and counters are enabled.
+        gPortsOrch->m_pendingPortSet.erase(stuckPort);
+        ASSERT_TRUE(gPortsOrch->allPortsReady());
+        ASSERT_TRUE(gPortsOrch->getPendingInitPorts().empty());
+
+        static_cast<Orch *>(flexCounterOrch)->doTask();
+        ASSERT_FALSE(flexCounterOrch->m_portsNotReadyWarned);
+        ASSERT_TRUE(flexCounterOrch->getPortCountersState());
+
+        // Also cover the "PortInitDone not received" path: when port init is
+        // not done, allPortsReady() is false and the diagnostic reports it.
+        bool savedInitDone = gPortsOrch->m_initDone;
+        flexCounterOrch->m_portsNotReadyWarned = false;
+        gPortsOrch->m_initDone = false;
+        flexCounterCfg.set("PORT", values);
+        flexCounterOrch->addExistingData(&flexCounterCfg);
+        ASSERT_FALSE(gPortsOrch->allPortsReady());
+        static_cast<Orch *>(flexCounterOrch)->doTask();
+        ASSERT_TRUE(flexCounterOrch->m_portsNotReadyWarned);
+        gPortsOrch->m_initDone = savedInitDone;
+    }
+
     INSTANTIATE_TEST_CASE_P(
         FlexCounterTests,
         FlexCounterTest,


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contributing guidelines.
-->

#### What I did

Make the warm/fast-reboot **port-counter deferral observable and diagnosable** in `FlexCounterOrch`.

On warm/fast-reboot, flex counter setup is intentionally deferred until all ports are ready — counters are processed only after `APPLY_VIEW` so they don't slow data-plane restoration (#3326, #3562). `FlexCounterOrch::doTask()` gates on `gPortsOrch->allPortsReady()` and **silently returns** until every port has finished initialization.

The problem: this wait has **no timeout and is silent**. If a port is slow to become ready after an inconsistent warm-boot snapshot (a forced `fast-reboot -f` past a failed `RESTARTCHECK` under scale) — a single stuck port in `PortsOrch::m_pendingPortSet` can keep `allPortsReady()` false. Flex counter polling is then not enabled for **any** port, so `COUNTERS_PORT_NAME_MAP` stays unpolled and `show interfaces counters` returns nothing, with **no log**, until that port becomes ready. The reporter observed counters missing for an extended period after reboot.

This change **keeps the deferral** (the optimization is preserved) but makes it observable:
- Once the delay timer has expired and ports are still not ready, emit a **throttled warning** naming the ports still pending (or noting `PortInitDone` has not been received). Logged once per not-ready episode and re-armed once all ports become ready, so it doesn't spam.
- Adds `PortsOrch::getPendingInitPorts()` to expose the ports created but not yet finished initializing.

No functional change to the counter pipeline itself; this only adds diagnostics around the existing readiness gate.

Fixes #4694

#### Why I did it

When this readiness gate blocks, **all** port counters disappear with no indication of the cause, making the condition hard to root-cause in the field (data plane and BGP look healthy; only counters are gone). Naming the blocking port(s) turns a silent, no-timeout wait into an actionable log message.

This change focuses on observability. Based on maintainer feedback, follow-up work can build on it to (a) enable counters per-ready-port so one stuck port does not suppress counters for all ports, and (b) ensure a port cannot remain in m_pendingPortSet after a forced warm-boot.

#### How I verified it

- Mock tests
``` 
[ RUN/OK ] FlexCounterTests/FlexCounterTest.PortNotReadyDeferralIsObservable/0 .. /7
:test-result: PASS  PortNotReadyDeferralIsObservable/0 .. /7
```
#### Which release branch to backport (provide reason below if selected)

- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

Same readiness-gate logic is present and identical on 202505, 202511, and master, so the diagnostic is useful on all three.

#### Tested branch (Please provide the tested image version)

- master

