### PR TITLE
[tests]: Fix DVS readiness check after start.sh supervisor program rename

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -585,7 +585,12 @@ class DockerVirtualSwitch:
                 if process_status.get(pname, None) != "RUNNING":
                     return (False, process_status)
 
-            return (process_status.get("start.sh", None) == "EXITED", process_status)
+            # The docker-sonic-vs supervisor program that runs start.sh was
+            # renamed from "start.sh" to "start" in sonic-buildimage
+            # (commit 0f59ce19bc). Accept either name so the readiness check
+            # works against both old and new base images.
+            start_status = process_status.get("start", process_status.get("start.sh", None))
+            return (start_status == "EXITED", process_status)
 
         wait_for_result(_polling_function, service_polling_config)
 


### PR DESCRIPTION
### What I did

* Microsoft ADO (number only): 38615544

Fix the DVS readiness check in `tests/conftest.py` (`DockerVirtualSwitch.check_services_ready()`) to tolerate the supervisor program rename in docker-sonic-vs.

The readiness poll required the supervisor program `start.sh` to be `EXITED`. sonic-buildimage commit `0f59ce19bc` ("Add lldpd and _DOCKER += feature composition to docker-sonic-vs") renamed that program from `start.sh` to `start` in `platform/vs/docker-sonic-vs/supervisord.conf.j2`.

With the new image, `process_status.get("start.sh")` returns `None`, so the poll never succeeds and **every** DVS spin-up times out after 60s in `check_services_ready` (`dvslib/dvs_common.py:60`). All vs test modules then error at setup, and teardown fails with `'NoneType' object has no attribute 'get_logs'` because the DVS object was never assigned.

### How I did it
Accept either `start` (new) or `start.sh` (legacy) program name:

```python
start_status = process_status.get("start", process_status.get("start.sh", None))
return (start_status == "EXITED", process_status)
```

This is backward-compatible so vs tests keep working against both old and new docker-sonic-vs base images.

### How I verified it
- `python3 -c "import ast; ast.parse(...)"` — syntax OK.
- Logic validated against four supervisor snapshots:
  - new image (`start=EXITED`, all required RUNNING) -> ready ✅
  - legacy image (`start.sh=EXITED`, all required RUNNING) -> ready ✅
  - still booting (`start=STARTING`) -> not ready ✅
  - required service down (`orchagent=STOPPED`) -> not ready ✅

### Why
Symptom seen in CI: 60+ vs test modules erroring at setup with 60s `check_services_ready` timeouts and ~297 `'NoneType' object has no attribute 'get_logs'` teardown errors. All required services were `RUNNING`; only the `start.sh`-vs-`start` name mismatch caused the failure.