### PR TITLE
[ci]: Pin sonic-buildimage to pre-LLDP build to unblock vstests

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -135,8 +135,8 @@ jobs:
       project: ${{ parameters.buildimage_artifact_project }}
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/${{ parameters.buildimage_artifact_branch }}'
+      runVersion: 'specific'
+      runId: 1141167
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/${{ parameters.artifact_name }}.gz'
     displayName: "Download sonic-buildimage ${{ parameters.artifact_name }}"
@@ -146,8 +146,8 @@ jobs:
       project: ${{ parameters.buildimage_artifact_project }}
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/${{ parameters.buildimage_artifact_branch }}'
+      runVersion: 'specific'
+      runId: 1141167
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/debs/${{ parameters.debian_version }}/framework_*.deb'
     displayName: "Download sonic-buildimage sonic-framework package"


### PR DESCRIPTION
### What I did

Temporarily pin sonic-buildimage artifact to build **1141167** (20260617.1, commit f1d42c1a) ? the last master build before sonic-buildimage PR #26724 merged and broke DVS tests.

### Why I did it

sonic-buildimage [PR #26724](https://github.com/sonic-net/sonic-buildimage/pull/26724) introduced a change that causes DVS test failures in sonic-swss CI. This pin unblocks CI while the upstream issue is resolved.

### How I verified it

CI pipeline will download the pinned artifact and run DVS tests against the known-good buildimage.

### Details

- Both `DownloadPipelineArtifact@2` tasks for sonic-buildimage (docker-sonic-vs.gz and framework deb) are changed from `latestFromBranch` to `specific` with `runId: 1141167`
- Other artifact downloads (swss-common, sairedis, dash-api, libnexthopgroup, vpp) remain on `latestFromBranch`
- **This is a temporary workaround** ? revert once sonic-buildimage PR #26724 is fixed