### PR TITLE
[ci]: Pin sonic-buildimage to build 1141167 for vstest docker-sonic-vs

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -135,8 +135,8 @@ jobs:
       project: ${{ parameters.buildimage_artifact_project }}
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/${{ parameters.buildimage_artifact_branch }}'
+      runVersion: 'specific'
+      runId: 1141167
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/${{ parameters.artifact_name }}.gz'
     displayName: "Download sonic-buildimage ${{ parameters.artifact_name }}"
@@ -146,8 +146,8 @@ jobs:
       project: ${{ parameters.buildimage_artifact_project }}
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/${{ parameters.buildimage_artifact_branch }}'
+      runVersion: 'specific'
+      runId: 1141167
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/debs/${{ parameters.debian_version }}/framework_*.deb'
     displayName: "Download sonic-buildimage sonic-framework package"


### PR DESCRIPTION
### What I did

Temporarily pin the **sonic-buildimage** VS artifact consumed by the **vstest** stage to a specific build — **1141167** (`20260617.1`) — instead of `latestFromBranch`. This is the last known-good `master` build of the base `docker-sonic-vs.gz` image before a regression in newer sonic-buildimage broke DVS (vs) tests in sonic-swss CI.

### Why I did it

The `vstest` job (`.azure-pipelines/test-docker-sonic-vs-template.yml`) runs against the `docker-sonic-vs` image produced by the **BuildDocker** stage. That stage (`.azure-pipelines/build-docker-sonic-vs-template.yml`) takes the base `docker-sonic-vs.gz` from the `Azure.sonic-buildimage.official.vs` pipeline and layers the freshly built swss / sairedis / dash debs on top. When that base image floats on `latestFromBranch`, a regression in a newer sonic-buildimage master build flows straight into the swss vstests and breaks them.

Pinning the base image to a known-good build unblocks the vstests while the upstream buildimage regression is sorted out.

### How I did it

In `.azure-pipelines/build-docker-sonic-vs-template.yml`, both `DownloadPipelineArtifact@2` tasks that pull from sonic-buildimage are switched from `latestFromBranch` to a `specific` run:

- `Download sonic-buildimage docker-sonic-vs` (`**/target/docker-sonic-vs.gz`)
- `Download sonic-buildimage sonic-framework package` (`**/target/debs/<debian>/framework_*.deb`)

Both now use:

```yaml
runVersion: 'specific'
runId: 1141167
```

All other artifact downloads (swss-common, sairedis, dash-api, vpp) remain on `latestFromBranch` and are untouched.

### How I verified it

- Confirmed via the Azure DevOps API that build **1141167** is `Azure.sonic-buildimage.official.vs` (definition 142), `20260617.1`, on `refs/heads/master`, completed/succeeded, and that its `sonic-buildimage.vs` pipeline artifact contains `target/docker-sonic-vs.gz` (this is the exact pipeline/artifact the template already references).
- YAML re-validated after the edit; diff limited to the two intended tasks (4 lines changed).

### Notes

- **This is a temporary CI workaround.** Revert both tasks back to `latestFromBranch` once the upstream sonic-buildimage regression is fixed.
