### PR TITLE
 Add fabric port isolate reason isolated link count in the STATE_DB for fabric ports

### DIFF
--- a/orchagent/fabricportsorch.cpp
+++ b/orchagent/fabricportsorch.cpp
@@ -36,9 +36,14 @@ using TimePoint = std::chrono::time_point<Clock>;
 
 // ISOLATE_REASON on FABRIC_PORT_TABLE: current derived cause, refreshed each
 // debug-counter poll. Values: none | config | permanent | crc_errors |
-// fec_uncorrectable | crc_errors & fec_uncorrectable | auto | unknown.
-// link_event_counters_reset and admin_unisolate are written when those events
-// occur and are overwritten on the next poll (e.g. none once the link is healthy).
+// fec_uncorrectable | crc_errors,fec_uncorrectable | auto.
+// Precedence when multiple apply: permanent > config > auto sub-reasons.
+// auto = AUTO_ISOLATED but current poll CRC/FEC counts are below the isolate
+// threshold (hysteresis / recovery window); crc_errors or fec_uncorrectable
+// when the corresponding threshold is met on this poll.
+// link_event_counters_reset and admin_unisolate are written on those events;
+// they are overwritten on the next debug-counter poll when monitoring runs.
+// If monState is disabled, no poll runs and those ephemeral values persist.
 #define STATE_FABRIC_ISOLATE_REASON_FIELD "ISOLATE_REASON"
 
 // constants for link monitoring
@@ -423,22 +428,22 @@ void FabricPortsOrch::updateFabricPortState()
 }
 
 string FabricPortsOrch::computeFabricIsolateReason(int isolated,
-                     int cfgIsolated, int autoIsolated, int permIsolate,
-                     int origPermIsolated, uint64_t consecutivePollsWithErrors,
-                     uint64_t consecutivePollsWithFecErrs, uint64_t isolationPollsCfg,
-                     uint64_t fecIsolatedPolls)
+        int cfgIsolated, int autoIsolated, int permIsolate,
+        uint64_t consecutivePollsWithErrors,
+        uint64_t consecutivePollsWithFecErrs, uint64_t isolationPollsCfg,
+        uint64_t fecIsolatedPolls)
 {
     if (!isolated)
     {
         return "none";
     }
+    if (permIsolate)
+    {
+        return "permanent";
+    }
     if (cfgIsolated)
     {
         return "config";
-    }
-    if (permIsolate || origPermIsolated)
-    {
-        return "permanent";
     }
     if (autoIsolated)
     {
@@ -446,7 +451,7 @@ string FabricPortsOrch::computeFabricIsolateReason(int isolated,
         const bool fecHit = consecutivePollsWithFecErrs >= fecIsolatedPolls;
         if (crcHit && fecHit)
         {
-            return "crc_errors & fec_uncorrectable";
+            return "crc_errors,fec_uncorrectable";
         }
         if (fecHit)
         {
@@ -456,10 +461,9 @@ string FabricPortsOrch::computeFabricIsolateReason(int isolated,
         {
             return "crc_errors";
         }
-        //  still in the auto-isolated state, but the current CRC/FEC
-        //  counters are not at/above the isolate trigger anymore
         return "auto";
     }
+    SWSS_LOG_WARN("ISOLATE_REASON: isolated with no config/auto/permanent cause");
     return "unknown";
 }
 
@@ -984,7 +988,7 @@ void FabricPortsOrch::updateFabricDebugCounters()
         updateStateDbTable(m_stateTable, key, "PRM_ISOLATED", permIsolate);
 
         const string isolateReason = computeFabricIsolateReason(
-            isolated, cfgIsolated, autoIsolated, permIsolate, origPermIsolated,
+            isolated, cfgIsolated, autoIsolated, permIsolate,
             consecutivePollsWithErrors, consecutivePollsWithFecErrs,
             isolationPollsCfg, fecIsolatedPolls);
         m_stateTable->hset(key, STATE_FABRIC_ISOLATE_REASON_FIELD, isolateReason.c_str());
@@ -1075,7 +1079,7 @@ void FabricPortsOrch::clearFabricCnt(int lane, bool clearIsolation)
         // sai call to unisolate the link
         isolateFabricLink(lane, !clearIsolation);
         updateStateDbTable(m_stateTable, key, "ISOLATED", isolated);
-        // Ephemeral: overwritten on the next debug-counter poll.
+        // Ephemeral: overwritten on the next debug-counter poll when monState is enabled.
         m_stateTable->hset(key, STATE_FABRIC_ISOLATE_REASON_FIELD, "link_event_counters_reset");
     }
 
@@ -1579,7 +1583,7 @@ void FabricPortsOrch::doFabricPortTask(Consumer &consumer)
                     updateStateDbTable(m_stateTable, state_key, "ISOLATED", m_defaultIsolated);
                     updateStateDbTable(m_stateTable, state_key, "AUTO_ISOLATED", m_defaultAutoIsolated);
                     updateStateDbTable(m_stateTable, state_key, "PRM_ISOLATED", m_defaultIsolated);
-                    // Ephemeral: overwritten on the next debug-counter poll.
+                    // Ephemeral: overwritten on the next debug-counter poll when monState is enabled.
                     m_stateTable->hset(state_key, STATE_FABRIC_ISOLATE_REASON_FIELD, "admin_unisolate");
                     linkQueues.clear();
 

--- a/orchagent/fabricportsorch.cpp
+++ b/orchagent/fabricportsorch.cpp
@@ -34,10 +34,11 @@ using TimePoint = std::chrono::time_point<Clock>;
 #define FABRIC_SWITCH_DEBUG_COUNTER_POLLING_INTERVAL_MS 60000
 #define SWITCH_STANDARD_DROP_COUNTERS  "SWITCH_ID"
 
-// STATE_DB field on PORT<n> (fabric): isolation cause for operators / telemetry.
-// Values: none | config | permanent | crc_error| fec_uncorrectable |
-//         crc_errors & fec_uncorrectable | auto | unknown |
-//         link_event_counters_reset | admin_unisolate
+// ISOLATE_REASON on FABRIC_PORT_TABLE: current derived cause, refreshed each
+// debug-counter poll. Values: none | config | permanent | crc_errors |
+// fec_uncorrectable | crc_errors & fec_uncorrectable | auto | unknown.
+// link_event_counters_reset and admin_unisolate are written when those events
+// occur and are overwritten on the next poll (e.g. none once the link is healthy).
 #define STATE_FABRIC_ISOLATE_REASON_FIELD "ISOLATE_REASON"
 
 // constants for link monitoring
@@ -934,7 +935,7 @@ void FabricPortsOrch::updateFabricDebugCounters()
         if (cfgIsolated == 1)
         {
             isolated = 1;
-            SWSS_LOG_INFO("port %s keep isolated due to configuation",key.c_str());
+            SWSS_LOG_INFO("port %s keep isolated due to configuration",key.c_str());
         }
         else
         {
@@ -956,7 +957,7 @@ void FabricPortsOrch::updateFabricDebugCounters()
         {
             isolated = 1;
             permIsolate = 1;
-            SWSS_LOG_INFO("port %s permentantly isolated %d",key.c_str(), permIsolate );
+            SWSS_LOG_INFO("port %s permanently isolated %d",key.c_str(), permIsolate );
         }
 
         if (origIsolated != isolated)
@@ -1074,6 +1075,7 @@ void FabricPortsOrch::clearFabricCnt(int lane, bool clearIsolation)
         // sai call to unisolate the link
         isolateFabricLink(lane, !clearIsolation);
         updateStateDbTable(m_stateTable, key, "ISOLATED", isolated);
+        // Ephemeral: overwritten on the next debug-counter poll.
         m_stateTable->hset(key, STATE_FABRIC_ISOLATE_REASON_FIELD, "link_event_counters_reset");
     }
 
@@ -1170,6 +1172,7 @@ void FabricPortsOrch::updateFabricCapacity()
        // Calculate total number of serdes link, number of operational links,
        // total fabric capacity.
         bool linkIssue = false;
+        // Count links isolated by config, SAI ISOLATED, or auto-isolate (includes permanent).
         if (configIsolated == "1" || isolated == "1" || autoIsolated == "1")
         {
             linkIssue = true;
@@ -1576,6 +1579,7 @@ void FabricPortsOrch::doFabricPortTask(Consumer &consumer)
                     updateStateDbTable(m_stateTable, state_key, "ISOLATED", m_defaultIsolated);
                     updateStateDbTable(m_stateTable, state_key, "AUTO_ISOLATED", m_defaultAutoIsolated);
                     updateStateDbTable(m_stateTable, state_key, "PRM_ISOLATED", m_defaultIsolated);
+                    // Ephemeral: overwritten on the next debug-counter poll.
                     m_stateTable->hset(state_key, STATE_FABRIC_ISOLATE_REASON_FIELD, "admin_unisolate");
                     linkQueues.clear();
 

--- a/orchagent/fabricportsorch.cpp
+++ b/orchagent/fabricportsorch.cpp
@@ -34,6 +34,12 @@ using TimePoint = std::chrono::time_point<Clock>;
 #define FABRIC_SWITCH_DEBUG_COUNTER_POLLING_INTERVAL_MS 60000
 #define SWITCH_STANDARD_DROP_COUNTERS  "SWITCH_ID"
 
+// STATE_DB field on PORT<n> (fabric): isolation cause for operators / telemetry.
+// Values: none | config | permanent | crc_error| fec_uncorrectable |
+//         crc_errors & fec_uncorrectable | auto | unknown |
+//         link_event_counters_reset | admin_unisolate
+#define STATE_FABRIC_ISOLATE_REASON_FIELD "ISOLATE_REASON"
+
 // constants for link monitoring
 #define CHECK_TIME 120
 #define MAX_SKIP_CRCERR_ON_LNKUP_POLLS 20
@@ -415,6 +421,47 @@ void FabricPortsOrch::updateFabricPortState()
     }
 }
 
+string FabricPortsOrch::computeFabricIsolateReason(int isolated,
+                     int cfgIsolated, int autoIsolated, int permIsolate,
+                     int origPermIsolated, uint64_t consecutivePollsWithErrors,
+                     uint64_t consecutivePollsWithFecErrs, uint64_t isolationPollsCfg,
+                     uint64_t fecIsolatedPolls)
+{
+    if (!isolated)
+    {
+        return "none";
+    }
+    if (cfgIsolated)
+    {
+        return "config";
+    }
+    if (permIsolate || origPermIsolated)
+    {
+        return "permanent";
+    }
+    if (autoIsolated)
+    {
+        const bool crcHit = consecutivePollsWithErrors >= isolationPollsCfg;
+        const bool fecHit = consecutivePollsWithFecErrs >= fecIsolatedPolls;
+        if (crcHit && fecHit)
+        {
+            return "crc_errors & fec_uncorrectable";
+        }
+        if (fecHit)
+        {
+            return "fec_uncorrectable";
+        }
+        if (crcHit)
+        {
+            return "crc_errors";
+        }
+        //  still in the auto-isolated state, but the current CRC/FEC
+        //  counters are not at/above the isolate trigger anymore
+        return "auto";
+    }
+    return "unknown";
+}
+
 void FabricPortsOrch::updateFabricDebugCounters()
 {
     if (!m_getFabricPortListDone) return;
@@ -491,12 +538,6 @@ void FabricPortsOrch::updateFabricDebugCounters()
         string key = FABRIC_PORT_PREFIX + to_string(lane);
         // so basically port is the oid
         vector<FieldValueTuple> fieldValues;
-        static const array<string, 3> cntNames =
-        {
-            "SAI_PORT_STAT_IF_IN_ERRORS", // cells with crc errors
-            "SAI_PORT_STAT_IF_IN_FABRIC_DATA_UNITS", // rx data cells
-            "SAI_PORT_STAT_IF_IN_FEC_NOT_CORRECTABLE_FRAMES"  // cell with uncorrectable errors
-        };
         if (!m_fabricCounterTable->get(sai_serialize_object_id(port), fieldValues))
         {
            SWSS_LOG_INFO("no port %s", sai_serialize_object_id(port).c_str());
@@ -509,25 +550,22 @@ void FabricPortsOrch::updateFabricDebugCounters()
         {
             const auto field = fvField(fv);
             const auto value = fvValue(fv);
-            for (size_t cnt = 0; cnt != cntNames.size(); cnt++)
+            if (field == "SAI_PORT_STAT_IF_IN_ERRORS") // cells with crc errors
             {
-                if (field == "SAI_PORT_STAT_IF_IN_ERRORS")
-                {
-                    crcErrors = stoull(value);
-                }
-                else if (field == "SAI_PORT_STAT_IF_IN_FABRIC_DATA_UNITS")
-                {
-                    rxCells = stoull(value);
-                }
-                else if (field == "SAI_PORT_STAT_IF_IN_FEC_NOT_CORRECTABLE_FRAMES")
-                {
-                    codeErrors = stoull(value);
-                }
-                SWSS_LOG_INFO("port %s %s %lld %lld %lld at %s",
-                         sai_serialize_object_id(port).c_str(), field.c_str(), (long long)crcErrors,
-                         (long long)rxCells, (long long)codeErrors, asctime(gmtime(&now)));
+                crcErrors = stoull(value);
+            }
+            else if (field == "SAI_PORT_STAT_IF_IN_FABRIC_DATA_UNITS")  // rx data cells
+            {
+                rxCells = stoull(value);
+            }
+            else if (field == "SAI_PORT_STAT_IF_IN_FEC_NOT_CORRECTABLE_FRAMES") // cell with uncorrectable errors
+            {
+                codeErrors = stoull(value);
             }
         }
+        SWSS_LOG_INFO("port %s %lld %lld %lld at %s",
+             sai_serialize_object_id(port).c_str(), (long long)crcErrors,
+             (long long)rxCells, (long long)codeErrors, asctime(gmtime(&now)));
         // now we get the values of:
         // *totalNumCells *cellsWithCrcErrors *cellsWithUncorrectableErrors
         //
@@ -746,7 +784,7 @@ void FabricPortsOrch::updateFabricDebugCounters()
             }
 
             SWSS_LOG_INFO("port %s about to clear counters.", key.c_str());
-            SWSS_LOG_INFO("origIsolated %d isolated %d cfgIsolated %d clearCnt %s", origIsolated, isolated, cfgIsolated, clearCnt ? "true":"flase");
+            SWSS_LOG_INFO("origIsolated %d isolated %d cfgIsolated %d clearCnt %s", origIsolated, isolated, cfgIsolated, clearCnt ? "true":"false");
             clearFabricCnt(lane, clearCnt);
 
             if (linkFlap > 0 )
@@ -912,7 +950,7 @@ void FabricPortsOrch::updateFabricDebugCounters()
             }
         }
         // if "ISOLATED" is true, Call SAI api here to actually isolated the link
-        // if "ISOLATED" is false, Call SAP api to actually unisolate the link
+        // if "ISOLATED" is false, Call SAI api to actually unisolate the link
 
         if (permIsolate == 1 || origPermIsolated == 1)
         {
@@ -943,6 +981,13 @@ void FabricPortsOrch::updateFabricDebugCounters()
         updateStateDbTable(m_stateTable, key, "CONFIG_ISOLATED", cfgIsolated);
         updateStateDbTable(m_stateTable, key, "ISOLATED", isolated);
         updateStateDbTable(m_stateTable, key, "PRM_ISOLATED", permIsolate);
+
+        const string isolateReason = computeFabricIsolateReason(
+            isolated, cfgIsolated, autoIsolated, permIsolate, origPermIsolated,
+            consecutivePollsWithErrors, consecutivePollsWithFecErrs,
+            isolationPollsCfg, fecIsolatedPolls);
+        m_stateTable->hset(key, STATE_FABRIC_ISOLATE_REASON_FIELD, isolateReason.c_str());
+        SWSS_LOG_INFO("port %s %s %s", key.c_str(), STATE_FABRIC_ISOLATE_REASON_FIELD, isolateReason.c_str());
 
         // Update state_db with error rate
         valuePt = to_string(rxCells);
@@ -996,7 +1041,7 @@ void FabricPortsOrch::isolateFabricLink(int lane, bool isolate)
         sai_status_t status = sai_port_api->set_port_attribute(m_fabricLanePortMap[lane], &attr);
         if (status != SAI_STATUS_SUCCESS)
         {
-            SWSS_LOG_ERROR("Failed to set admin status");
+            SWSS_LOG_ERROR("Failed to Isolate the Port %d", lane);
         }
         SWSS_LOG_NOTICE("Set fabric port %d state isolated %s done", lane, isolate? "true" : "false");
     }
@@ -1029,6 +1074,7 @@ void FabricPortsOrch::clearFabricCnt(int lane, bool clearIsolation)
         // sai call to unisolate the link
         isolateFabricLink(lane, !clearIsolation);
         updateStateDbTable(m_stateTable, key, "ISOLATED", isolated);
+        m_stateTable->hset(key, STATE_FABRIC_ISOLATE_REASON_FIELD, "link_event_counters_reset");
     }
 
     // update state_db
@@ -1049,6 +1095,7 @@ void FabricPortsOrch::updateFabricCapacity()
     int downCapacity = 0;
     int operating_links = 0;
     int total_links = 0;
+    int isolated_links = 0;
     int threshold = 100;
     std::vector<FieldValueTuple> constValues;
     string applKey = FABRIC_MONITOR_DATA;
@@ -1126,6 +1173,7 @@ void FabricPortsOrch::updateFabricCapacity()
         if (configIsolated == "1" || isolated == "1" || autoIsolated == "1")
         {
             linkIssue = true;
+            isolated_links += 1;
         }
 
         if (lnkStatus == "down" || linkIssue == true)
@@ -1226,6 +1274,7 @@ void FabricPortsOrch::updateFabricCapacity()
     m_fabricCapacityTable->hset("FABRIC_CAPACITY_DATA", "missing_capacity", to_string(downCapacity));
     m_fabricCapacityTable->hset("FABRIC_CAPACITY_DATA", "operating_links", to_string(operating_links));
     m_fabricCapacityTable->hset("FABRIC_CAPACITY_DATA", "number_of_links", to_string(total_links));
+    m_fabricCapacityTable->hset("FABRIC_CAPACITY_DATA", "isolated_links", to_string(isolated_links));
     m_fabricCapacityTable->hset("FABRIC_CAPACITY_DATA", "warning_threshold", to_string(threshold));
     m_fabricCapacityTable->hset("FABRIC_CAPACITY_DATA", "last_event", event);
     m_fabricCapacityTable->hset("FABRIC_CAPACITY_DATA", "last_event_time", lastTime);
@@ -1297,11 +1346,7 @@ void FabricPortsOrch::updateFabricRate()
         // get the newData and newTime for this poll
         vector<FieldValueTuple> fieldValues;
         sai_object_id_t port = p.second;
-        static const array<string, 2> cntNames =
-        {
-            "SAI_PORT_STAT_IF_OUT_OCTETS", // snmpBcmTxDataBytes
-            "SAI_PORT_STAT_IF_IN_OCTETS", // snmpBcmRxDataBytes
-        };
+
         if (!m_fabricCounterTable->get(sai_serialize_object_id(port), fieldValues))
         {
             SWSS_LOG_INFO("no port %s", sai_serialize_object_id(port).c_str());
@@ -1312,16 +1357,13 @@ void FabricPortsOrch::updateFabricRate()
         {
             const auto field = fvField(fv);
             const auto value = fvValue(fv);
-            for (size_t cnt = 0; cnt != cntNames.size(); cnt++)
+            if (field == "SAI_PORT_STAT_IF_OUT_OCTETS") // snmpBcmTxDataBytes
             {
-                if (field == "SAI_PORT_STAT_IF_OUT_OCTETS")
-                {
-                    txBytes = stoull(value);
-                }
-                else if (field == "SAI_PORT_STAT_IF_IN_OCTETS")
-                {
-                    rxBytes = stoull(value);
-                }
+                txBytes = stoull(value);
+            }
+            else if (field == "SAI_PORT_STAT_IF_IN_OCTETS") // snmpBcmRxDataBytes
+            {
+                rxBytes = stoull(value);
             }
         }
         // This is for testing purpose
@@ -1534,6 +1576,7 @@ void FabricPortsOrch::doFabricPortTask(Consumer &consumer)
                     updateStateDbTable(m_stateTable, state_key, "ISOLATED", m_defaultIsolated);
                     updateStateDbTable(m_stateTable, state_key, "AUTO_ISOLATED", m_defaultAutoIsolated);
                     updateStateDbTable(m_stateTable, state_key, "PRM_ISOLATED", m_defaultIsolated);
+                    m_stateTable->hset(state_key, STATE_FABRIC_ISOLATE_REASON_FIELD, "admin_unisolate");
                     linkQueues.clear();
 
                     // unisolate the link

--- a/orchagent/fabricportsorch.h
+++ b/orchagent/fabricportsorch.h
@@ -86,7 +86,7 @@ private:
     void isolateFabricLink(int lane, bool isolate);
     string computeFabricIsolateReason(int isolated,
         int cfgIsolated, int autoIsolated, int permIsolate,
-        int origPermIsolated, uint64_t consecutivePollsWithErrors,
+        uint64_t consecutivePollsWithErrors,
         uint64_t consecutivePollsWithFecErrs, uint64_t isolationPollsCfg,
         uint64_t fecIsolatedPolls);
 

--- a/orchagent/fabricportsorch.h
+++ b/orchagent/fabricportsorch.h
@@ -84,6 +84,11 @@ private:
         const string& field,
         uint64_t value);
     void isolateFabricLink(int lane, bool isolate);
+    string computeFabricIsolateReason(int isolated,
+        int cfgIsolated, int autoIsolated, int permIsolate,
+        int origPermIsolated, uint64_t consecutivePollsWithErrors,
+        uint64_t consecutivePollsWithFecErrs, uint64_t isolationPollsCfg,
+        uint64_t fecIsolatedPolls);
 
     void doTask() override;
     void doTask(Consumer &consumer);

--- a/tests/test_fabric_capacity.py
+++ b/tests/test_fabric_capacity.py
@@ -58,6 +58,7 @@ class TestVirtualChassis(object):
                        # isolate the link from config_db
                        config_db.update_entry("FABRIC_PORT", cdb_port, {"isolateStatus": "True"})
                        sdb.wait_for_field_match("FABRIC_PORT_TABLE", sdb_port, {"ISOLATED": "1"}, polling_config=max_poll)
+                       sdb.wait_for_field_match("FABRIC_PORT_TABLE", sdb_port, {"ISOLATE_REASON": "config"}, polling_config=max_poll)
                        # check if capacity reduced
                        sdb.wait_for_field_negative_match("FABRIC_CAPACITY_TABLE", "FABRIC_CAPACITY_DATA", {'operating_links': capacity}, polling_config=max_poll)
                        sdb.wait_for_field_negative_match("FABRIC_CAPACITY_TABLE", "FABRIC_CAPACITY_DATA", {'isolated_links': iso_links}, polling_config=max_poll)

--- a/tests/test_fabric_capacity.py
+++ b/tests/test_fabric_capacity.py
@@ -1,5 +1,4 @@
 import random
-from dvslib.dvs_database import DVSDatabase
 from dvslib.dvs_common import PollingConfig
 
 
@@ -8,8 +7,8 @@ class TestVirtualChassis(object):
         """Test basic fabric capacity infrastructure in VOQ switchs.
 
         This test validates that when fabric links get isolated, the fabric capacity
-        get updated in the state_db.
-        When the link get unisolated, the fabric capacity get set back as well.
+        and isolated links get updated in the state_db.
+        When the link get unisolated, the fabric capacity and isolated links get set back as well.
         """
 
         dvss = vst.dvss
@@ -42,8 +41,9 @@ class TestVirtualChassis(object):
                sdb.update_entry("FABRIC_PORT_TABLE", sdb_port, {"TEST": "TEST"})
 
                # get current fabric capacity
-               fvs = sdb.wait_for_fields("FABRIC_CAPACITY_TABLE", "FABRIC_CAPACITY_DATA",['operating_links'], polling_config=max_poll)
+               fvs = sdb.wait_for_fields("FABRIC_CAPACITY_TABLE", "FABRIC_CAPACITY_DATA",['operating_links', 'isolated_links'], polling_config=max_poll)
                capacity = fvs['operating_links']
+               iso_links = fvs['isolated_links']
 
                fvs = sdb.wait_for_fields("FABRIC_PORT_TABLE", sdb_port, ['STATUS'], polling_config=max_poll)
                link_status = fvs['STATUS']
@@ -60,10 +60,12 @@ class TestVirtualChassis(object):
                        sdb.wait_for_field_match("FABRIC_PORT_TABLE", sdb_port, {"ISOLATED": "1"}, polling_config=max_poll)
                        # check if capacity reduced
                        sdb.wait_for_field_negative_match("FABRIC_CAPACITY_TABLE", "FABRIC_CAPACITY_DATA", {'operating_links': capacity}, polling_config=max_poll)
+                       sdb.wait_for_field_negative_match("FABRIC_CAPACITY_TABLE", "FABRIC_CAPACITY_DATA", {'isolated_links': iso_links}, polling_config=max_poll)
                        # unisolate the link from config_db
                        config_db.update_entry("FABRIC_PORT", cdb_port, {"isolateStatus": "False"})
                        sdb.wait_for_field_match("FABRIC_PORT_TABLE", sdb_port, {"ISOLATED": "0"}, polling_config=max_poll)
                        sdb.wait_for_field_match("FABRIC_CAPACITY_TABLE", "FABRIC_CAPACITY_DATA", {'operating_links': capacity}, polling_config=max_poll)
+                       sdb.wait_for_field_match("FABRIC_CAPACITY_TABLE", "FABRIC_CAPACITY_DATA", {'isolated_links': iso_links}, polling_config=max_poll)
 
                        # now disable fabric link monitor
                        config_db.update_entry("FABRIC_MONITOR", "FABRIC_MONITOR_DATA",{'monState': 'disable'})
@@ -75,6 +77,7 @@ class TestVirtualChassis(object):
                           sdb.wait_for_field_match("FABRIC_PORT_TABLE", sdb_port, {"ISOLATED": "1"}, polling_config=max_poll)
                           # check if capacity reduced
                           sdb.wait_for_field_negative_match("FABRIC_CAPACITY_TABLE", "FABRIC_CAPACITY_DATA", {'operating_links': capacity}, polling_config=max_poll)
+                          sdb.wait_for_field_negative_match("FABRIC_CAPACITY_TABLE", "FABRIC_CAPACITY_DATA", {'isolated_links': iso_links}, polling_config=max_poll)
                           assert False, "Expecting no change here"
                        except Exception as e:
                           # Expect field not change here
@@ -85,7 +88,7 @@ class TestVirtualChassis(object):
                        sdb.update_entry("FABRIC_PORT_TABLE", sdb_port, {"TEST_CODE_ERRORS": "0"})
                        sdb.update_entry("FABRIC_PORT_TABLE", sdb_port, {"TEST": "product"})
                else:
-                   print("The link ", port, " is down")
+                   print("The link ", sdb_port, " is down")
             else:
                print("We do not check switch type:", cfg_switch_type)
 

--- a/tests/test_fabric_port_isolation.py
+++ b/tests/test_fabric_port_isolation.py
@@ -97,6 +97,26 @@ class TestVirtualChassis(object):
                        sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"ISOLATE_REASON": "none"}, polling_config=max_poll,
                                                  comparator=lambda field, actual, expected: actual in ("admin_unisolate", "none"))
 
+                       # FEC-only auto isolate
+                       sdb.update_entry("FABRIC_PORT_TABLE", port, {"TEST_CRC_ERRORS": "0"})
+                       sdb.update_entry("FABRIC_PORT_TABLE", port, {"TEST_CODE_ERRORS": "2"})
+                       sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"AUTO_ISOLATED": "1"}, polling_config=max_poll)
+                       sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"ISOLATE_REASON": "fec_uncorrectable"}, polling_config=max_poll)
+                       sdb.update_entry("FABRIC_PORT_TABLE", port, {"TEST_CODE_ERRORS": "0"})
+                       sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"AUTO_ISOLATED": "0"}, polling_config=max_poll)
+                       sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"ISOLATE_REASON": "none"}, polling_config=max_poll)
+
+                       # CRC and FEC combined auto isolate
+                       sdb.update_entry("FABRIC_PORT_TABLE", port, {"TEST_CRC_ERRORS": "2"})
+                       sdb.update_entry("FABRIC_PORT_TABLE", port, {"TEST_CODE_ERRORS": "2"})
+                       sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"AUTO_ISOLATED": "1"}, polling_config=max_poll)
+                       sdb.wait_for_field_match("FABRIC_PORT_TABLE", port,
+                                                 {"ISOLATE_REASON": "crc_errors & fec_uncorrectable"}, polling_config=max_poll)
+                       sdb.update_entry("FABRIC_PORT_TABLE", port, {"TEST_CRC_ERRORS": "0"})
+                       sdb.update_entry("FABRIC_PORT_TABLE", port, {"TEST_CODE_ERRORS": "0"})
+                       sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"AUTO_ISOLATED": "0"}, polling_config=max_poll)
+                       sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"ISOLATE_REASON": "none"}, polling_config=max_poll)
+
                    finally:
                        # cleanup
                        sdb.update_entry("FABRIC_PORT_TABLE", port, {"TEST_CRC_ERRORS": "0"})

--- a/tests/test_fabric_port_isolation.py
+++ b/tests/test_fabric_port_isolation.py
@@ -111,7 +111,7 @@ class TestVirtualChassis(object):
                        sdb.update_entry("FABRIC_PORT_TABLE", port, {"TEST_CODE_ERRORS": "2"})
                        sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"AUTO_ISOLATED": "1"}, polling_config=max_poll)
                        sdb.wait_for_field_match("FABRIC_PORT_TABLE", port,
-                                                 {"ISOLATE_REASON": "crc_errors & fec_uncorrectable"}, polling_config=max_poll)
+                                                 {"ISOLATE_REASON": "crc_errors,fec_uncorrectable"}, polling_config=max_poll)
                        sdb.update_entry("FABRIC_PORT_TABLE", port, {"TEST_CRC_ERRORS": "0"})
                        sdb.update_entry("FABRIC_PORT_TABLE", port, {"TEST_CODE_ERRORS": "0"})
                        sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"AUTO_ISOLATED": "0"}, polling_config=max_poll)

--- a/tests/test_fabric_port_isolation.py
+++ b/tests/test_fabric_port_isolation.py
@@ -1,5 +1,4 @@
 import random
-from dvslib.dvs_database import DVSDatabase
 from dvslib.dvs_common import PollingConfig
 
 
@@ -7,7 +6,8 @@ class TestVirtualChassis(object):
     def test_voq_switch_fabric_link(self, vst):
         """Test basic fabric link monitoring infrastructure in VOQ switchs.
 
-        This test validates that fabric links get isolated if they experienced some errors.
+        This test validates that fabric links get isolated and records the correct reason for isolation
+        if they experienced some errors.
         And the link get unisolated if it clears the error for several consecutive polls.
         """
 
@@ -53,25 +53,30 @@ class TestVirtualChassis(object):
                        config_db.wait_for_field_match("FABRIC_PORT", configKey, {'forceUnisolateStatus': str(curForceStatus)},
                                                       polling_config=max_poll)
                        sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"AUTO_ISOLATED": "0"}, polling_config=max_poll)
+                       sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"ISOLATE_REASON": "none"}, polling_config=max_poll)
 
                        # ======
                        # inject testing errors and wait for link get isolated.
                        sdb.update_entry("FABRIC_PORT_TABLE", port, {"TEST_CRC_ERRORS": "2"})
                        sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"AUTO_ISOLATED": "1"}, polling_config=max_poll)
+                       sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"ISOLATE_REASON": "crc_errors"}, polling_config=max_poll)
 
                        # clear the testing errors and wait for link get unisolated.
                        sdb.update_entry("FABRIC_PORT_TABLE", port, {"TEST_CRC_ERRORS": "0"})
                        sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"AUTO_ISOLATED": "0"}, polling_config=max_poll)
+                       sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"ISOLATE_REASON": "none"}, polling_config=max_poll)
 
                        # inject testing errors and wait for link get isolated.
                        sdb.update_entry("FABRIC_PORT_TABLE", port, {"TEST_CRC_ERRORS": "2"})
                        sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"AUTO_ISOLATED": "1"}, polling_config=max_poll)
+                       sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"ISOLATE_REASON": "crc_errors"}, polling_config=max_poll)
 
                        lnkDownCnt = 2
                        sdb.update_entry("FABRIC_PORT_TABLE", port, {'PORT_DOWN_COUNT': str(lnkDownCnt)})
                        sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"PORT_DOWN_COUNT_handled": str(lnkDownCnt)}, polling_config=max_poll)
                        sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"AUTO_ISOLATED": "0"}, polling_config=max_poll)
-
+                       sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"ISOLATE_REASON": "link_event_counters_reset"}, polling_config=max_poll,
+                                                 comparator=lambda field, actual, expected: actual in ("link_event_counters_reset", "none"))
 
                        # inject testing errors and wait for link get isolated again.
                        sdb.update_entry("FABRIC_PORT_TABLE", port, {"TEST_CRC_ERRORS": "2"})
@@ -79,16 +84,18 @@ class TestVirtualChassis(object):
 
                        # check if the link get permanently isolated as the link get isolate/unisolated more than 3 times
                        sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"PRM_ISOLATED": "1"}, polling_config=max_poll)
+                       sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"ISOLATE_REASON": "permanent"}, polling_config=max_poll)
 
 
                        # now test force unisolate this link
-                       configKey = "Fabric"+str(portNum)
                        curForceStatus = int( config_db.get_entry( "FABRIC_PORT", configKey)['forceUnisolateStatus'] )
                        curForceStatus += 1
                        config_db.update_entry("FABRIC_PORT", configKey, {'forceUnisolateStatus': str(curForceStatus)})
                        config_db.wait_for_field_match("FABRIC_PORT", configKey, {'forceUnisolateStatus': str(curForceStatus)},
                                                       polling_config=max_poll)
                        sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"AUTO_ISOLATED": "0"}, polling_config=max_poll)
+                       sdb.wait_for_field_match("FABRIC_PORT_TABLE", port, {"ISOLATE_REASON": "none"}, polling_config=max_poll,
+                                                 comparator=lambda field, actual, expected: actual in ("admin_unisolate", "none"))
 
                    finally:
                        # cleanup


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Added ISOLATE_REASON on each FABRIC_PORT_TABLE entry in STATE_DB so operators and CLI can see why a link is isolated (config, CRC/FEC auto-isolate, permanent, link-down counter reset, admin unisolate, etc.).
Added computeFabricIsolateReason() to derive the reason from isolation
state and error poll counters during fabric debug monitoring.
Added FABRIC_CAPACITY_DATA.isolated_links alongside existing
capacity fields for chassis-wide isolated link telemetry.
Also simplify (unnecessary) fabric counter parsing loops and fix minor log/comment
typos in FabricPortsOrch.
The corresponding sonic-utilities PR https://github.com/sonic-net/sonic-utilities/pull/4641
sonic-mgmt PR : https://github.com/sonic-net/sonic-mgmt/pull/25637

**Why I did it**
 To make the debugging easier in the field when the crc/fec errors are seen and ports gets isolated
**How I verified it**
   Induced the crc and fec errors in COUNTERS_DB and verified the fields are updated correctly in STATE_DB. Also updated the sonic-mgmt test and verified the tests are passing.
**Details if related**
