### PR TITLE
neighsyncd: support link-local IPv6 on VLAN subinterfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ tests/mock_tests/tests_fpmsyncd
 tests/mock_tests/tests_intfmgrd
 tests/mock_tests/tests_teammgrd
 tests/mock_tests/tests_portsyncd
+tests/mock_tests/tests_neighsyncd
 
 
 # Test Files #

--- a/neighsyncd/Makefile.am
+++ b/neighsyncd/Makefile.am
@@ -1,4 +1,4 @@
-INCLUDES = -I $(top_srcdir) -I $(top_srcdir)/warmrestart
+INCLUDES = -I $(top_srcdir) -I $(top_srcdir)/lib -I $(top_srcdir)/warmrestart
 
 bin_PROGRAMS = neighsyncd
 
@@ -8,7 +8,7 @@ else
 DBGFLAGS = -g
 endif
 
-neighsyncd_SOURCES = neighsyncd.cpp neighsync.cpp $(top_srcdir)/warmrestart/warmRestartAssist.cpp
+neighsyncd_SOURCES = neighsyncd.cpp neighsync.cpp $(top_srcdir)/lib/subintf.cpp $(top_srcdir)/warmrestart/warmRestartAssist.cpp
 
 neighsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
 neighsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)

--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -14,6 +14,7 @@
 
 #include "neighsync.h"
 #include "warm_restart.h"
+#include "subintf.h"
 #include <algorithm>
 #include <linux/neighbour.h>
 
@@ -350,11 +351,18 @@ bool NeighSync::isLinkLocalEnabled(const string &port)
 {
     vector<FieldValueTuple> values;
 
-    bool isSubIntf = (port.find('.') != string::npos);
-
-    if (isSubIntf &&
-        (!port.compare(0, strlen("Ethernet"), "Ethernet") ||
-         !port.compare(0, strlen("PortChannel"), "PortChannel")))
+    /*
+     * VLAN sub-interfaces appear in the kernel with either a long-name
+     * (e.g. "Ethernet0.10", "PortChannel1.10") or a short-name
+     * (e.g. "Eth0.10", "Po1.10") format. Both forms are valid CONFIG_DB
+     * keys for VLAN_SUB_INTERFACE, and the kernel ifname matches whatever
+     * was used when "ip link add link <parent> name <subintf>" was invoked
+     * by intfmgrd. Use the same swss::subIntf parser that intfmgr /
+     * portsorch use, so any name those modules accept is also accepted
+     * here (and nothing more).
+     */
+    subIntf subif(port);
+    if (subif.isValid())
     {
         if (!m_cfgVlanSubInterfaceTable.get(port, values))
         {

--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -32,6 +32,7 @@ NeighSync::NeighSync(RedisPipeline *pipelineAppDB, DBConnector *stateDb, DBConne
     m_cfgInterfaceTable(cfgDb, CFG_INTF_TABLE_NAME),
     m_cfgLagInterfaceTable(cfgDb, CFG_LAG_INTF_TABLE_NAME),
     m_cfgVlanInterfaceTable(cfgDb, CFG_VLAN_INTF_TABLE_NAME),
+    m_cfgVlanSubInterfaceTable(cfgDb, CFG_VLAN_SUB_INTF_TABLE_NAME),
     m_cfgPeerSwitchTable(cfgDb, CFG_PEER_SWITCH_TABLE_NAME),
     m_cfgEvpnNvoTable(cfgDb, CFG_VXLAN_EVPN_NVO_TABLE_NAME),
     m_nl_sock(NULL), m_link_cache(NULL)
@@ -349,7 +350,19 @@ bool NeighSync::isLinkLocalEnabled(const string &port)
 {
     vector<FieldValueTuple> values;
 
-    if (!port.compare(0, strlen("Vlan"), "Vlan"))
+    bool isSubIntf = (port.find('.') != string::npos);
+
+    if (isSubIntf &&
+        (!port.compare(0, strlen("Ethernet"), "Ethernet") ||
+         !port.compare(0, strlen("PortChannel"), "PortChannel")))
+    {
+        if (!m_cfgVlanSubInterfaceTable.get(port, values))
+        {
+            SWSS_LOG_INFO("IPv6 Link local is not enabled on %s", port.c_str());
+            return false;
+        }
+    }
+    else if (!port.compare(0, strlen("Vlan"), "Vlan"))
     {
         if (!m_cfgVlanInterfaceTable.get(port, values))
         {

--- a/neighsyncd/neighsync.h
+++ b/neighsyncd/neighsync.h
@@ -54,7 +54,7 @@ private:
     struct nl_cache    *m_link_cache;
     struct nl_sock     *m_nl_sock;
     AppRestartAssist  *m_AppRestartAssist;
-    Table m_cfgVlanInterfaceTable, m_cfgLagInterfaceTable, m_cfgInterfaceTable;
+    Table m_cfgVlanInterfaceTable, m_cfgLagInterfaceTable, m_cfgInterfaceTable, m_cfgVlanSubInterfaceTable;
     bool m_isEvpnNvoExist = false;
 
     bool isLinkLocalEnabled(const std::string &port);

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -355,8 +355,7 @@ tests_fdbsyncd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhired
 
 ## neighsyncd unit tests
 
-tests_neighsyncd_SOURCES = swss_ut_main.cpp \
-                           neighsyncd/neighsync_ut.cpp \
+tests_neighsyncd_SOURCES = neighsyncd/neighsync_ut.cpp \
                            mock_dbconnector.cpp \
                            mock_table.cpp \
                            mock_hiredis.cpp \
@@ -370,7 +369,7 @@ tests_neighsyncd_INCLUDES = -I$(top_srcdir)/neighsyncd -I$(top_srcdir)/lib -I$(t
 tests_neighsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST)
 tests_neighsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(tests_neighsyncd_INCLUDES)
 tests_neighsyncd_LDADD = $(LDADD_GTEST) -lnl-genl-3 -lhiredis -lhiredis \
-        -lswsscommon -lswsscommon -lgtest -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lboost_program_options
+        -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lgmock_main -lboost_program_options
 
 ## response publisher unit tests
 

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -9,9 +9,9 @@ CXXFLAGS = -g -O0
 
 CFLAGS_SAI = -I /usr/include/sai
 
-TESTS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_fdbsyncd tests_response_publisher tests_nbrmgrd tests_teamsyncd
+TESTS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_fdbsyncd tests_neighsyncd tests_response_publisher tests_nbrmgrd tests_teamsyncd
 
-noinst_PROGRAMS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_fdbsyncd tests_response_publisher tests_nbrmgrd tests_teamsyncd
+noinst_PROGRAMS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_fdbsyncd tests_neighsyncd tests_response_publisher tests_nbrmgrd tests_teamsyncd
 
 LDADD_SAI = -lsaivs -lsairedis -lsaimeta -lsaimetadata
 
@@ -352,6 +352,25 @@ tests_fdbsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST
 tests_fdbsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_fdbsyncd_INCLUDES)
 tests_fdbsyncd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
         -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lgmock_main
+
+## neighsyncd unit tests
+
+tests_neighsyncd_SOURCES = swss_ut_main.cpp \
+                           neighsyncd/neighsync_ut.cpp \
+                           mock_dbconnector.cpp \
+                           mock_table.cpp \
+                           mock_hiredis.cpp \
+                           mock_redisreply.cpp \
+                           $(top_srcdir)/neighsyncd/neighsync.cpp \
+                           $(top_srcdir)/lib/subintf.cpp \
+                           $(top_srcdir)/warmrestart/warmRestartHelper.cpp \
+                           $(top_srcdir)/warmrestart/warmRestartAssist.cpp
+
+tests_neighsyncd_INCLUDES = -I$(top_srcdir)/neighsyncd -I$(top_srcdir)/lib -I$(top_srcdir)/warmrestart
+tests_neighsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST)
+tests_neighsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(tests_neighsyncd_INCLUDES)
+tests_neighsyncd_LDADD = $(LDADD_GTEST) -lnl-genl-3 -lhiredis -lhiredis \
+        -lswsscommon -lswsscommon -lgtest -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lboost_program_options
 
 ## response publisher unit tests
 

--- a/tests/mock_tests/neighsyncd/neighsync_ut.cpp
+++ b/tests/mock_tests/neighsyncd/neighsync_ut.cpp
@@ -1,0 +1,203 @@
+#include "gtest/gtest.h"
+
+#include "../mock_table.h"
+#include "schema.h"
+#include "warm_restart.h"
+
+#define private public
+#include "neighsync.h"
+#undef private
+
+namespace neighsync_ut
+{
+    using namespace swss;
+
+    struct NeighSyncTest : public ::testing::Test
+    {
+        std::shared_ptr<DBConnector> m_app_db;
+        std::shared_ptr<DBConnector> m_state_db;
+        std::shared_ptr<DBConnector> m_config_db;
+        std::shared_ptr<RedisPipeline> m_app_db_pipeline;
+        std::shared_ptr<NeighSync> m_neighSync;
+
+        void SetUp() override
+        {
+            testing_db::reset();
+            WarmStart::initialize("neighsyncd", "swss");
+
+            m_app_db = std::make_shared<DBConnector>("APPL_DB", 0);
+            m_state_db = std::make_shared<DBConnector>("STATE_DB", 0);
+            m_config_db = std::make_shared<DBConnector>("CONFIG_DB", 0);
+            m_app_db_pipeline = std::make_shared<RedisPipeline>(m_app_db.get());
+
+            m_neighSync = std::make_shared<NeighSync>(
+                m_app_db_pipeline.get(), m_state_db.get(),
+                m_config_db.get(), m_app_db.get());
+        }
+
+        void TearDown() override
+        {
+            m_neighSync.reset();
+            testing_db::reset();
+        }
+
+        /*
+         * Helper: write {ipv6_use_link_local_only: enable} to the requested
+         * CONFIG_DB table under the given key.
+         */
+        void enableLinkLocal(const std::string &table, const std::string &key)
+        {
+            Table t(m_config_db.get(), table);
+            std::vector<FieldValueTuple> fv;
+            fv.emplace_back("ipv6_use_link_local_only", "enable");
+            t.set(key, fv);
+        }
+    };
+
+    /*
+     * Bare interface coverage: Ethernet, PortChannel, Vlan all continue to
+     * resolve to their respective CONFIG_DB tables.
+     */
+    TEST_F(NeighSyncTest, BareEthernetEnabled)
+    {
+        enableLinkLocal(CFG_INTF_TABLE_NAME, "Ethernet0");
+        EXPECT_TRUE(m_neighSync->isLinkLocalEnabled("Ethernet0"));
+    }
+
+    TEST_F(NeighSyncTest, BarePortChannelEnabled)
+    {
+        enableLinkLocal(CFG_LAG_INTF_TABLE_NAME, "PortChannel10");
+        EXPECT_TRUE(m_neighSync->isLinkLocalEnabled("PortChannel10"));
+    }
+
+    TEST_F(NeighSyncTest, BareVlanEnabled)
+    {
+        enableLinkLocal(CFG_VLAN_INTF_TABLE_NAME, "Vlan100");
+        EXPECT_TRUE(m_neighSync->isLinkLocalEnabled("Vlan100"));
+    }
+
+    /*
+     * Long-name VLAN sub-interfaces (Ethernet0.10, PortChannel1.20) must look
+     * up VLAN_SUB_INTERFACE and not the bare-interface tables. This is the
+     * long-name VLAN sub-interface case.
+     */
+    TEST_F(NeighSyncTest, LongNameEthernetSubIntfEnabled)
+    {
+        enableLinkLocal(CFG_VLAN_SUB_INTF_TABLE_NAME, "Ethernet0.10");
+        EXPECT_TRUE(m_neighSync->isLinkLocalEnabled("Ethernet0.10"));
+    }
+
+    TEST_F(NeighSyncTest, LongNamePortChannelSubIntfEnabled)
+    {
+        enableLinkLocal(CFG_VLAN_SUB_INTF_TABLE_NAME, "PortChannel1.20");
+        EXPECT_TRUE(m_neighSync->isLinkLocalEnabled("PortChannel1.20"));
+    }
+
+    /*
+     * Short-name VLAN sub-interfaces (Eth0.10, Po1.20) must also resolve to
+     * VLAN_SUB_INTERFACE. Without this, neighsyncd silently drops IPv6
+     * link-local neighbors learnt from BGP unnumbered on short-name
+     * sub-interfaces.
+     */
+    TEST_F(NeighSyncTest, ShortNameEthernetSubIntfEnabled)
+    {
+        enableLinkLocal(CFG_VLAN_SUB_INTF_TABLE_NAME, "Eth0.10");
+        EXPECT_TRUE(m_neighSync->isLinkLocalEnabled("Eth0.10"));
+    }
+
+    TEST_F(NeighSyncTest, ShortNamePortChannelSubIntfEnabled)
+    {
+        enableLinkLocal(CFG_VLAN_SUB_INTF_TABLE_NAME, "Po1.20");
+        EXPECT_TRUE(m_neighSync->isLinkLocalEnabled("Po1.20"));
+    }
+
+    /*
+     * A sub-interface present in CONFIG_DB but without ipv6_use_link_local_only
+     * set to "enable" must return false. This guards against regressions where
+     * the mere presence of a VLAN_SUB_INTERFACE entry might unconditionally
+     * enable link-local processing.
+     */
+    TEST_F(NeighSyncTest, SubIntfWithoutLinkLocalDisabled)
+    {
+        Table t(m_config_db.get(), CFG_VLAN_SUB_INTF_TABLE_NAME);
+        std::vector<FieldValueTuple> fv;
+        fv.emplace_back("admin_status", "up");
+        fv.emplace_back("vlan", "10");
+        t.set("Eth0.10", fv);
+
+        EXPECT_FALSE(m_neighSync->isLinkLocalEnabled("Eth0.10"));
+    }
+
+    TEST_F(NeighSyncTest, SubIntfWithDisableValueDisabled)
+    {
+        Table t(m_config_db.get(), CFG_VLAN_SUB_INTF_TABLE_NAME);
+        std::vector<FieldValueTuple> fv;
+        fv.emplace_back("ipv6_use_link_local_only", "disable");
+        t.set("Eth0.10", fv);
+
+        EXPECT_FALSE(m_neighSync->isLinkLocalEnabled("Eth0.10"));
+    }
+
+    /*
+     * A sub-interface not present in CONFIG_DB at all must return false (the
+     * lookup misses and we drop the link-local neighbor).
+     */
+    TEST_F(NeighSyncTest, SubIntfNotConfiguredDisabled)
+    {
+        EXPECT_FALSE(m_neighSync->isLinkLocalEnabled("Eth0.10"));
+        EXPECT_FALSE(m_neighSync->isLinkLocalEnabled("Ethernet0.10"));
+        EXPECT_FALSE(m_neighSync->isLinkLocalEnabled("Po1.20"));
+        EXPECT_FALSE(m_neighSync->isLinkLocalEnabled("PortChannel1.20"));
+    }
+
+    /*
+     * Make sure a sub-interface lookup does NOT accidentally fall through to
+     * the bare-interface tables. If we configure only the bare-port entry
+     * (e.g. INTERFACE|Ethernet0), the sub-interface must still report
+     * link-local as disabled.
+     */
+    TEST_F(NeighSyncTest, SubIntfDoesNotFallThroughToBareInterface)
+    {
+        enableLinkLocal(CFG_INTF_TABLE_NAME, "Ethernet0");
+        EXPECT_FALSE(m_neighSync->isLinkLocalEnabled("Ethernet0.10"));
+        EXPECT_FALSE(m_neighSync->isLinkLocalEnabled("Eth0.10"));
+
+        enableLinkLocal(CFG_LAG_INTF_TABLE_NAME, "PortChannel1");
+        EXPECT_FALSE(m_neighSync->isLinkLocalEnabled("PortChannel1.20"));
+        EXPECT_FALSE(m_neighSync->isLinkLocalEnabled("Po1.20"));
+    }
+
+    /*
+     * Unsupported interface names must continue to return false.
+     */
+    TEST_F(NeighSyncTest, UnsupportedInterfaceDisabled)
+    {
+        EXPECT_FALSE(m_neighSync->isLinkLocalEnabled("lo"));
+        EXPECT_FALSE(m_neighSync->isLinkLocalEnabled("eth0"));
+        EXPECT_FALSE(m_neighSync->isLinkLocalEnabled("Bridge"));
+        EXPECT_FALSE(m_neighSync->isLinkLocalEnabled("Loopback0"));
+    }
+
+    /*
+     * Dotted names that look like sub-interfaces but are NOT SONiC sub-intfs
+     * (lowercase eth, loopback, Vlan, etc.) must not be treated as
+     * sub-interfaces. Using the swss::subIntf parser (the same one
+     * intfmgr / portsorch use) makes the accepted set explicit and
+     * keeps it in sync with the rest of swss.
+     *
+     * Pre-populate VLAN_SUB_INTERFACE with these keys to make sure that
+     * even if such a key were configured, the parser still rejects the
+     * NAME (so we never even look it up), and that even when we DO fall
+     * through to the bare-port tables, the lookup misses.
+     */
+    TEST_F(NeighSyncTest, NonSonicDottedNamesRejected)
+    {
+        enableLinkLocal(CFG_VLAN_SUB_INTF_TABLE_NAME, "eth0.10");      // lowercase
+        enableLinkLocal(CFG_VLAN_SUB_INTF_TABLE_NAME, "lo.10");        // loopback
+        enableLinkLocal(CFG_VLAN_SUB_INTF_TABLE_NAME, "Vlan100.10");   // Vlan sub-intf (unsupported)
+
+        EXPECT_FALSE(m_neighSync->isLinkLocalEnabled("eth0.10"));
+        EXPECT_FALSE(m_neighSync->isLinkLocalEnabled("lo.10"));
+        EXPECT_FALSE(m_neighSync->isLinkLocalEnabled("Vlan100.10"));
+    }
+}


### PR DESCRIPTION
## Summary

Update `neighsyncd` so IPv6 link-local-only mode is honored for VLAN subinterfaces. The change also uses the common subinterface parser so canonical and short subinterface names are handled consistently.

## Why

Neighbor sync already checks link-local-only mode for routed interfaces. VLAN subinterfaces need the same lookup path so their IPv6 link-local behavior is reflected correctly.

## Changes

- Check VLAN subinterface configuration when evaluating link-local-only mode.
- Reuse the shared subinterface parser for subinterface name handling.
- Add mock test coverage for VLAN subinterface link-local behavior.

## Related

- Design proposal: https://github.com/sonic-net/SONiC/pull/2414

## Validation

- `git diff --check upstream/master..HEAD`
- Reviewed the diff for unintended references.
