### PR TITLE
[vxlanorch]: Downgrade L3 VNI remote VNI retry log (#4707)

### DIFF
--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -2550,7 +2550,7 @@ bool EvpnRemoteVnip2pOrch::addOperation(const Request& request)
     VRFOrch* vrf_orch = gDirectory.get<VRFOrch*>();
     if (vrf_orch->isL3VniVlan(vni_id))
     {
-        SWSS_LOG_WARN("Ignoring remote VNI add for L3 VNI:%d, remote:%s", vni_id, remote_vtep.c_str());
+        SWSS_LOG_INFO("Ignoring remote VNI add for L3 VNI:%d, remote:%s", vni_id, remote_vtep.c_str());
         return false;
     }
 
@@ -2712,7 +2712,7 @@ bool EvpnRemoteVnip2mpOrch::addOperation(const Request& request)
     VRFOrch* vrf_orch = gDirectory.get<VRFOrch*>();
     if (vrf_orch->isL3VniVlan(vni_id))
     {
-        SWSS_LOG_WARN("Ignoring remote VNI add for L3 VNI:%d, remote:%s", vni_id, end_point_ip.c_str());
+        SWSS_LOG_INFO("Ignoring remote VNI add for L3 VNI:%d, remote:%s", vni_id, end_point_ip.c_str());
         return false;
     }
 


### PR DESCRIPTION
**What I did**
Updated `vxlanorch` to treat remote VNI add events for L3 VNI VLANs as an expected retryable no-op.

Updated `EvpnRemoteVnip2pOrch::addOperation()` and `EvpnRemoteVnip2mpOrch::addOperation()` so the expected L3 VNI skip is logged at INFO level instead of WARNING.

The change:
- keeps returning `false` when the VNI is identified as an L3 VNI VLAN
- changes the log level from `SWSS_LOG_WARN` to `SWSS_LOG_INFO`

**Why I did it**
Remote VNI add events for L3 VNI VLANs are intentionally ignored by `vxlanorch` while the VNI is classified as L3.

Keeping `return false` preserves the existing retry/replay behavior. If the VNI is later unmapped from the VRF and becomes a valid L2 VNI again, the pending remote VNI task can be processed and the VLAN extension can be created.

The issue was that this expected skip was logged as a warning on every retry. Downgrading it to INFO avoids repeated warning logs while preserving the replay behavior.

**How I verified it**
Verified through code inspection that both EVPN remote VNI add paths now treat L3 VNI VLAN entries as expected retryable no-op cases:
- P2P remote VNI add still returns retry status after detecting an L3 VNI VLAN
- P2MP remote VNI add still returns retry status after detecting an L3 VNI VLAN
- both paths now log the ignored event at INFO level instead of WARN level