### PR TITLE
Revert "[ci]: Pin sonic-buildimage artifact to build 1141167 (#4700)"

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -135,8 +135,8 @@ jobs:
       project: ${{ parameters.buildimage_artifact_project }}
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
-      runVersion: 'specific'
-      runId: 1141167
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/${{ parameters.buildimage_artifact_branch }}'
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/${{ parameters.artifact_name }}.gz'
     displayName: "Download sonic-buildimage ${{ parameters.artifact_name }}"
@@ -146,8 +146,8 @@ jobs:
       project: ${{ parameters.buildimage_artifact_project }}
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
-      runVersion: 'specific'
-      runId: 1141167
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/${{ parameters.buildimage_artifact_branch }}'
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/debs/${{ parameters.debian_version }}/framework_*.deb'
     displayName: "Download sonic-buildimage sonic-framework package"


### PR DESCRIPTION
#### Why I did it

Revert the temporary VS `docker-sonic-vs` artifact pin (#4700) once the upstream `sonic-buildimage` regression is fixed, so the vstest stage consumes `latestFromBranch` again.

#### Background

#4700 pinned the VS base image to build `1141167` (`f1d42c1a`) — the last master build before `sonic-buildimage` **#26724** broke DVS tests in sonic-swss CI.

Root cause (confirmed locally, A/B against the broken vs known-good images):
- The ASAN-linked VS `syncd` could not load `libasan.so.8` — the VS Dockerfile installed `libasan6` (buster/gcc-10) under `ENABLE_ASAN`, but bookworm/gcc-12 ships `libasan8`. `syncd` went `FATAL` → no `ASIC_DB` → the whole DVS/vstest suite aborted.
- The newer image also renamed the supervisor program `start.sh` → `start`, which `tests/conftest.py` (`check_services_ready`, waits for `start.sh == EXITED`) does not accept.

Both are fixed upstream in **sonic-buildimage [#28108](https://github.com/sonic-net/sonic-buildimage/pull/28108)** (libasan8 + restore `start.sh` supervisor contract). Verified locally: with the combined fix, `syncd` is `RUNNING`, `ASIC_DB DBSIZE=1480`, and `test_vlan.py::TestVlan::test_VlanAddRemove` passes.

#### How to verify

Once #28108 has merged and a green master `docker-sonic-vs` build exists, the vstest stage will pull `latestFromBranch` and DVS tests should remain green.

Candidate artifact checked: **sonic-buildimage build `1150673`** (`master-28108`, commit `86bec0a0a`). ⚠️ Local validation shows this build still carries **both** regressions — `syncd` is `FATAL` (`ldd /usr/bin/syncd` → `libasan.so.8 => not found`, `ASIC_DB DBSIZE=1`) and `/usr/bin/buffermgrd.sh` is still missing `export ASIC_VENDOR=vs`. `test_buffer_dynamic.py` = 0 passed / 12 errored (vs 11 passed on the 1141167 baseline). So `1150673` is **not** a safe unpin target. Keep the 1141167 pin until a `latestFromBranch` VS build clears all gates (syncd RUNNING + `ldd` clean, `ASIC_VENDOR=vs` present, `NOSCRIPT=0`, buffer_dynamic 11 passing).

#### ⚠️ Do not merge yet

**Blocked on sonic-buildimage #28108.** Keep this as a draft until #28108 is merged and a fixed master VS image build is green. Merging earlier will re-break vstest.

