### PR TITLE
[ci] Use sonic-buildimage build 1154037 for docker-sonic-vs in vstest

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -136,7 +136,7 @@ jobs:
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
       runVersion: 'specific'
-      runId: 1152313
+      runId: 1152802
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/${{ parameters.artifact_name }}.gz'
     displayName: "Download sonic-buildimage ${{ parameters.artifact_name }}"
@@ -147,7 +147,7 @@ jobs:
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
       runVersion: 'specific'
-      runId: 1152313
+      runId: 1152802
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/debs/${{ parameters.debian_version }}/framework_*.deb'
     displayName: "Download sonic-buildimage sonic-framework package"

--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -136,7 +136,7 @@ jobs:
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
       runVersion: 'specific'
-      runId: 1153151
+      runId: 1153324
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/${{ parameters.artifact_name }}.gz'
     displayName: "Download sonic-buildimage ${{ parameters.artifact_name }}"
@@ -147,7 +147,7 @@ jobs:
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
       runVersion: 'specific'
-      runId: 1153151
+      runId: 1153324
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/debs/${{ parameters.debian_version }}/framework_*.deb'
     displayName: "Download sonic-buildimage sonic-framework package"

--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -136,7 +136,7 @@ jobs:
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
       runVersion: 'specific'
-      runId: 1152802
+      runId: 1153151
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/${{ parameters.artifact_name }}.gz'
     displayName: "Download sonic-buildimage ${{ parameters.artifact_name }}"
@@ -147,7 +147,7 @@ jobs:
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
       runVersion: 'specific'
-      runId: 1152802
+      runId: 1153151
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/debs/${{ parameters.debian_version }}/framework_*.deb'
     displayName: "Download sonic-buildimage sonic-framework package"

--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -136,7 +136,7 @@ jobs:
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
       runVersion: 'specific'
-      runId: 1150712
+      runId: 1151458
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/${{ parameters.artifact_name }}.gz'
     displayName: "Download sonic-buildimage ${{ parameters.artifact_name }}"
@@ -147,7 +147,7 @@ jobs:
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
       runVersion: 'specific'
-      runId: 1150712
+      runId: 1151458
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/debs/${{ parameters.debian_version }}/framework_*.deb'
     displayName: "Download sonic-buildimage sonic-framework package"

--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -41,7 +41,7 @@ parameters:
 
 - name: buildimage_artifact_pipeline
   type: string
-  default: 'Azure.sonic-buildimage.official.vs'
+  default: 'Azure.sonic-buildimage'
 
 - name: buildimage_artifact_branch
   type: string
@@ -136,7 +136,7 @@ jobs:
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
       runVersion: 'specific'
-      runId: 1141167
+      runId: 1150712
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/${{ parameters.artifact_name }}.gz'
     displayName: "Download sonic-buildimage ${{ parameters.artifact_name }}"
@@ -147,7 +147,7 @@ jobs:
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
       runVersion: 'specific'
-      runId: 1141167
+      runId: 1150712
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/debs/${{ parameters.debian_version }}/framework_*.deb'
     displayName: "Download sonic-buildimage sonic-framework package"

--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -136,7 +136,7 @@ jobs:
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
       runVersion: 'specific'
-      runId: 1153632
+      runId: 1154037
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/${{ parameters.artifact_name }}.gz'
     displayName: "Download sonic-buildimage ${{ parameters.artifact_name }}"
@@ -147,7 +147,7 @@ jobs:
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
       runVersion: 'specific'
-      runId: 1153632
+      runId: 1154037
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/debs/${{ parameters.debian_version }}/framework_*.deb'
     displayName: "Download sonic-buildimage sonic-framework package"

--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -136,7 +136,7 @@ jobs:
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
       runVersion: 'specific'
-      runId: 1153324
+      runId: 1153632
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/${{ parameters.artifact_name }}.gz'
     displayName: "Download sonic-buildimage ${{ parameters.artifact_name }}"
@@ -147,7 +147,7 @@ jobs:
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
       runVersion: 'specific'
-      runId: 1153324
+      runId: 1153632
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/debs/${{ parameters.debian_version }}/framework_*.deb'
     displayName: "Download sonic-buildimage sonic-framework package"

--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -136,7 +136,7 @@ jobs:
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
       runVersion: 'specific'
-      runId: 1151458
+      runId: 1152313
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/${{ parameters.artifact_name }}.gz'
     displayName: "Download sonic-buildimage ${{ parameters.artifact_name }}"
@@ -147,7 +147,7 @@ jobs:
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
       runVersion: 'specific'
-      runId: 1151458
+      runId: 1152313
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/debs/${{ parameters.debian_version }}/framework_*.deb'
     displayName: "Download sonic-buildimage sonic-framework package"


### PR DESCRIPTION
### What I did

Pin the vstest `docker-sonic-vs` base image to **sonic-buildimage build `1150712`**.

- `1150712` = `Azure.sonic-buildimage`, source `refs/pull/28108/merge`, sourceVersion `8c4babb3` — the **merge of #28108 head `aeb134d0` into master `098ce6a8`**, build **succeeded**.
- Both `DownloadPipelineArtifact@2` tasks (the `docker-sonic-vs.gz` image and the `framework_*.deb`) now pull from `runId: 1150712` in `.azure-pipelines/build-docker-sonic-vs-template.yml`.

### Why `1150712` (and why not the earlier `1150673`)

This pin carries the sonic-buildimage **#28108** docker-sonic-vs fixes:
- `libasan8` is shipped, so the ASAN-linked `syncd` starts (no more `libasan.so.8 => not found` → `syncd` FATAL).
- `ASIC_VENDOR=vs` is set in the image env, so `buffermgrd`/BufferMgrDynamic loads the lossless headroom Lua (no more `NOSCRIPT` → missing `pg_lossless_*` profiles).

The previously-pinned **`1150673`** was built from an *older* push of #28108 and, due to stale Docker layers, shipped **neither** fix — its `syncd` was FATAL and `buffer_dynamic` ran 0 passed / 12 errored.

### Validation

The exact tree `1150712` is built from (#28108 head `aeb134d0`) was built cleanly and validated locally:
- gates: `syncd` RUNNING, `ldd /usr/bin/syncd` clean (`libasan8` present), `ASIC_VENDOR=vs`, ASIC_DB alive, `NOSCRIPT=0`.
- `test_buffer_dynamic.py`: **11 passed / 2 skipped / 0 failed** (matches the known-good `1141167` baseline).
- Full vstest sweep of the prior failing set: every image-caused failure flips green; remaining reds are pre-existing non-#28108 issues (warm-restart reconcile, FGNHG ECMP), known test-side schema drift, or local-harness limits.

> Note: this is a temporary explicit pin to unblock vstest while #28108 lands on master. Once #28108 is merged and a master VS build carries it, the companion PR can drop the pin and return to `latestFromBranch`.
