### PR TITLE
[portsorch] Handle stale PortConfigDone count=0 on warm reboot

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4476,12 +4476,29 @@ bool PortsOrch::bake()
     SWSS_LOG_NOTICE("portCount = %" PRIuMAX ", m_portCount = %u", portCount, m_portCount);
     if (portCount != keys.size() - 2)
     {
-        // Invalid port table
-        SWSS_LOG_ERROR("Invalid port table: portCount, expecting %" PRIuMAX ", got %zu",
-                portCount, keys.size() - 2);
+        /*
+         * A stale PortConfigDone:count==0 can be left over from a cold start
+         * that ran before CONFIG_DB was populated, while the actual port rows
+         * still survive in APPL_DB across the warm restart. In that case the
+         * port table is valid (PortInitDone is set and ports are present);
+         * fall back to the real surviving key count instead of treating it as
+         * an invalid table and destructively wiping it.
+         */
+        if (portCount == 0 && keys.size() > 2)
+        {
+            SWSS_LOG_WARN("PortConfigDone count is 0 but %zu port keys survived; "
+                    "using surviving key count for warm reboot", keys.size() - 2);
+            portCount = keys.size() - 2;
+        }
+        else
+        {
+            // Invalid port table
+            SWSS_LOG_ERROR("Invalid port table: portCount, expecting %" PRIuMAX ", got %zu",
+                    portCount, keys.size() - 2);
 
-        cleanPortTable(keys);
-        return false;
+            cleanPortTable(keys);
+            return false;
+        }
     }
 
     for (const auto& alias: keys)


### PR DESCRIPTION
### What I did
On warm restart, portsyncd skips `notifyPortConfigDone()` (guarded by `if(!warm)`). If the prior cold boot wrote `PortConfigDone:count=0` to APPL_DB before CONFIG_DB was populated, that stale count survives into the warm boot while the real port rows are still present. `PortsOrch::bake()` then rejects the table ("expecting 0, got 32"), runs `cleanPortTable()`, and `warmRestoreValidation` fails -> orchagent FATAL, breaking warm-reboot.

When `portCount==0` but port keys survived, trust the surviving key count instead of destructively wiping the table. Genuinely truncated tables (portCount>0 mismatch) are still rejected.

### Why I did it
Fixes deterministic orchagent FATAL on VS warm reboot; unblocks fgnhg/warm-reboot DVS tests.

### How I verified it
`test_fgnhg.py::TestFineGrainedNextHopGroup::test_fgnhg_matchmode_route` flips FAIL/FATAL -> **1 passed** on the VS image. New WARN: `bake: PortConfigDone count is 0 but 32 port keys survived`; orchagent RUNNING, FG_ROUTE_TABLE populated.