### PR TITLE
[aclorch]: Support SET_PACKET_COLOR ACL action

### DIFF
--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -650,6 +650,11 @@ Stores rules associated with a specific ACL table on the switch.
     mirror_action = 1*255VCHAR                 ; refer to the mirror session (by default it will be ingress mirror action)
     mirror_ingress_action = 1*255VCHAR         ; refer to the mirror session
     mirror_egress_action = 1*255VCHAR          ; refer to the mirror session
+    packet_color_action = "green"/"yellow"/"red"
+                                               ; sets the packet color on matching packets; maps to
+                                               ; SAI_ACL_ENTRY_ATTR_ACTION_SET_PACKET_COLOR (case-insensitive).
+                                               ; Supported only where the platform SAI advertises the action for the
+                                               ; table's ACL stage (ingress and/or egress)
 
     policer_action = 1*255VCHAR                ; name of a POLICER table entry used to
                                                ; meter/rate-limit packets matching this rule.

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -115,7 +115,8 @@ static acl_rule_attr_lookup_t aclL3ActionLookup =
     { ACTION_REDIRECT_ACTION,                  SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT },
     { ACTION_DO_NOT_NAT_ACTION,                SAI_ACL_ENTRY_ATTR_ACTION_NO_NAT },
     { ACTION_DISABLE_TRIM,                     SAI_ACL_ENTRY_ATTR_ACTION_PACKET_TRIM_DISABLE },
-    { ACTION_POLICER_ACTION,                   SAI_ACL_ENTRY_ATTR_ACTION_SET_POLICER }
+    { ACTION_POLICER_ACTION,                   SAI_ACL_ENTRY_ATTR_ACTION_SET_POLICER },
+    { ACTION_PACKET_COLOR_ACTION,              SAI_ACL_ENTRY_ATTR_ACTION_SET_PACKET_COLOR }
 };
 
 static acl_rule_attr_lookup_t aclInnerActionLookup =
@@ -149,6 +150,13 @@ static acl_packet_action_lookup_t aclPacketActionLookup =
     { PACKET_ACTION_FORWARD, SAI_PACKET_ACTION_FORWARD },
     { PACKET_ACTION_DROP,    SAI_PACKET_ACTION_DROP },
     { PACKET_ACTION_COPY,    SAI_PACKET_ACTION_COPY },
+};
+
+static acl_packet_color_lookup_t aclPacketColorLookup =
+{
+    { PACKET_COLOR_GREEN,  SAI_PACKET_COLOR_GREEN },
+    { PACKET_COLOR_YELLOW, SAI_PACKET_COLOR_YELLOW },
+    { PACKET_COLOR_RED,    SAI_PACKET_COLOR_RED },
 };
 
 static acl_rule_attr_lookup_t aclMetadataDscpActionLookup =
@@ -2240,6 +2248,17 @@ bool AclRulePacket::validateAddAction(string attr_name, string _attr_value)
         actionData.parameter.oid = policer_oid;
         m_policerName = _attr_value;
     }
+    else if (attr_name == ACTION_PACKET_COLOR_ACTION)
+    {
+        const auto it = aclPacketColorLookup.find(attr_value);
+        if (it == aclPacketColorLookup.cend())
+        {
+            SWSS_LOG_ERROR("Invalid packet color %s for action %s",
+                           attr_value.c_str(), attr_name.c_str());
+            return false;
+        }
+        actionData.parameter.s32 = it->second;
+    }
     else
     {
         return false;
@@ -2356,16 +2375,23 @@ bool AclRulePacket::validate()
         return false;
     }
 
-    size_t nonPolicerActions = 0;
-    for (const auto& action : m_actions)
+    // SET_POLICER and SET_PACKET_COLOR are composable QoS modifiers, not terminating
+    // actions: SET_POLICER meters the matched packet and SET_PACKET_COLOR sets its
+    // drop-precedence color (consumed downstream by a color-aware policer or WRED).
+    // Either may accompany a single forwarding/terminating action such as
+    // PACKET_ACTION, plus a counter, so only the non-composable actions are capped
+    // at one; SAI applies each as an independent CREATE_AND_SET action.
+    size_t nonComposableActions = 0;
+    for (const auto &action : m_actions)
     {
-        if (action.first != SAI_ACL_ENTRY_ATTR_ACTION_SET_POLICER)
+        if (action.first != SAI_ACL_ENTRY_ATTR_ACTION_SET_POLICER &&
+            action.first != SAI_ACL_ENTRY_ATTR_ACTION_SET_PACKET_COLOR)
         {
-            nonPolicerActions++;
+            nonComposableActions++;
         }
     }
 
-    if (nonPolicerActions > 1)
+    if (nonComposableActions > 1)
     {
         return false;
     }
@@ -2383,10 +2409,9 @@ bool AclRulePacket::createRule()
     SWSS_LOG_ENTER();
 
     // When the rule binds a policer, take the policer reference BEFORE creating the
-    // SAI ACL entry (same ordering as AclRuleMirror's session policer). This way a
-    // refcount failure -- only reachable if the policer disappeared after validate()
-    // -- leaves nothing to unwind. m_policerRefHeld keeps the count balanced across
-    // recreate cycles.
+    // SAI ACL entry. This way a refcount failure -- only reachable if the policer
+    // disappeared after validate() -- leaves nothing to unwind. m_policerRefHeld
+    // keeps the count balanced across recreate cycles.
     if (!m_policerName.empty() && !m_policerRefHeld)
     {
         if (!gPolicerOrch->increaseRefCount(m_policerName))
@@ -4296,6 +4321,9 @@ void AclOrch::queryAclActionCapability()
     queryAclActionAttrEnumValues(ACTION_PACKET_ACTION,
                                  aclL3ActionLookup,
                                  aclPacketActionLookup);
+    queryAclActionAttrEnumValues(ACTION_PACKET_COLOR_ACTION,
+                                 aclL3ActionLookup,
+                                 aclPacketColorLookup);
     queryAclActionAttrEnumValues(ACTION_DTEL_FLOW_OP,
                                  aclDTelActionLookup,
                                  aclDTelFlowOpTypeLookup);

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -85,6 +85,7 @@
 #define ACTION_DSCP                         "DSCP_ACTION"
 #define ACTION_INNER_SRC_MAC_REWRITE_ACTION "INNER_SRC_MAC_REWRITE_ACTION"
 #define ACTION_POLICER_ACTION               "POLICER_ACTION"
+#define ACTION_PACKET_COLOR_ACTION          "PACKET_COLOR_ACTION"
 
 #define PACKET_ACTION_FORWARD      "FORWARD"
 #define PACKET_ACTION_DROP         "DROP"
@@ -92,6 +93,10 @@
 #define PACKET_ACTION_REDIRECT     "REDIRECT"
 #define PACKET_ACTION_DO_NOT_NAT   "DO_NOT_NAT"
 #define PACKET_ACTION_DISABLE_TRIM "DISABLE_TRIM"
+
+#define PACKET_COLOR_GREEN  "GREEN"
+#define PACKET_COLOR_YELLOW "YELLOW"
+#define PACKET_COLOR_RED    "RED"
 
 #define DTEL_FLOW_OP_NOP        "NOP"
 #define DTEL_FLOW_OP_POSTCARD   "POSTCARD"
@@ -155,6 +160,7 @@ typedef map<string, sai_acl_bind_point_type_t> acl_bind_point_type_lookup_t;
 typedef map<string, sai_acl_ip_type_t> acl_ip_type_lookup_t;
 typedef map<string, sai_acl_dtel_flow_op_t> acl_dtel_flow_op_type_lookup_t;
 typedef map<string, sai_packet_action_t> acl_packet_action_lookup_t;
+typedef map<string, sai_packet_color_t> acl_packet_color_lookup_t;
 typedef tuple<sai_acl_range_type_t, int, int> acl_range_properties_t;
 typedef map<acl_stage_type_t, AclActionCapabilities> acl_capabilities_t;
 typedef map<sai_acl_action_type_t, set<int32_t>> acl_action_enum_values_capabilities_t;

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -2535,6 +2535,300 @@ namespace aclorch_test
         ASSERT_TRUE(validateAclRuleByConfOp(*it_rule->second, kfvFieldsValues(kvfAclRule.front())));
     }
 
+    sai_switch_api_t *old_sai_switch_api_packet_color;
+
+    // Override SAI get_switch_attribute so that the ASIC reports SET_PACKET_COLOR
+    // (and PACKET_ACTION) as supported ACL actions for both stages.
+    sai_status_t getSwitchAttributePacketColor(_In_ sai_object_id_t switch_id, _In_ uint32_t attr_count,
+                                               _Inout_ sai_attribute_t *attr_list)
+    {
+        if (attr_count == 1)
+        {
+            switch (attr_list[0].id)
+            {
+            case SAI_SWITCH_ATTR_MAX_ACL_ACTION_COUNT:
+                attr_list[0].value.u32 = 2;
+                return SAI_STATUS_SUCCESS;
+            case SAI_SWITCH_ATTR_ACL_STAGE_INGRESS:
+            case SAI_SWITCH_ATTR_ACL_STAGE_EGRESS:
+                attr_list[0].value.aclcapability.action_list.count = 2;
+                attr_list[0].value.aclcapability.action_list.list[0] = SAI_ACL_ACTION_TYPE_PACKET_ACTION;
+                attr_list[0].value.aclcapability.action_list.list[1] = SAI_ACL_ACTION_TYPE_SET_PACKET_COLOR;
+                attr_list[0].value.aclcapability.is_action_list_mandatory = false;
+                return SAI_STATUS_SUCCESS;
+            }
+        }
+        return old_sai_switch_api_packet_color->get_switch_attribute(switch_id, attr_count, attr_list);
+    }
+
+    // Verify that the generic (CONFIG_DB) ACL path programs SAI_ACL_ENTRY_ATTR_ACTION_SET_PACKET_COLOR
+    // with the right sai_packet_color_t value for the PACKET_COLOR_ACTION rule action.
+    TEST_F(AclOrchTest, AclRuleSetPacketColorAction)
+    {
+        // Report SET_PACKET_COLOR as a supported ACL action.
+        old_sai_switch_api_packet_color = sai_switch_api;
+        sai_switch_api_t new_sai_switch_api = *sai_switch_api;
+        sai_switch_api = &new_sai_switch_api;
+        sai_switch_api->get_switch_attribute = getSwitchAttributePacketColor;
+
+        // Restore the global SAI switch API on every exit path (including an
+        // early return from a failed ASSERT_* below) so TearDown() never
+        // dereferences the stack-allocated override above.
+        struct SaiSwitchApiRestore {
+            ~SaiSwitchApiRestore() { sai_switch_api = old_sai_switch_api_packet_color; }
+        } saiSwitchApiRestore;
+
+        auto orch = createAclOrch();
+
+        const string aclTableTypeName = "PACKET_COLOR_TABLE_TYPE";
+        const string aclTableName = "PACKET_COLOR_TABLE";
+
+        orch->doAclTableTypeTask(
+            deque<KeyOpFieldsValuesTuple>(
+            {
+                {
+                    aclTableTypeName,
+                    SET_COMMAND,
+                    {
+                        { ACL_TABLE_TYPE_MATCHES, MATCH_SRC_IP },
+                        { ACL_TABLE_TYPE_ACTIONS, ACTION_PACKET_COLOR_ACTION }
+                    }
+                }
+            })
+        );
+
+        orch->doAclTableTask(
+            deque<KeyOpFieldsValuesTuple>(
+            {
+                {
+                    aclTableName,
+                    SET_COMMAND,
+                    {
+                        { ACL_TABLE_TYPE, aclTableTypeName },
+                        { ACL_TABLE_STAGE, STAGE_INGRESS }
+                    }
+                }
+            })
+        );
+        ASSERT_TRUE(orch->getAclTable(aclTableName));
+
+        const vector<pair<string, sai_packet_color_t>> colors = {
+            { PACKET_COLOR_GREEN,  SAI_PACKET_COLOR_GREEN },
+            { PACKET_COLOR_YELLOW, SAI_PACKET_COLOR_YELLOW },
+            { PACKET_COLOR_RED,    SAI_PACKET_COLOR_RED }
+        };
+
+        for (const auto &color : colors)
+        {
+            const string aclRuleName = "PACKET_COLOR_RULE_" + color.first;
+            orch->doAclRuleTask(
+                deque<KeyOpFieldsValuesTuple>(
+                {
+                    {
+                        aclTableName + "|" + aclRuleName,
+                        SET_COMMAND,
+                        {
+                            { RULE_PRIORITY, "999" },
+                            { MATCH_SRC_IP, "1.2.3.4/32" },
+                            { ACTION_PACKET_COLOR_ACTION, color.first }
+                        }
+                    }
+                })
+            );
+
+            auto rule = orch->getAclRule(aclTableName, aclRuleName);
+            ASSERT_NE(rule, nullptr);
+
+            const auto &actions = Portal::AclRuleInternal::getActions(rule);
+            auto it = actions.find(SAI_ACL_ENTRY_ATTR_ACTION_SET_PACKET_COLOR);
+            ASSERT_NE(it, actions.end());
+            ASSERT_TRUE(it->second.getSaiAttr().value.aclaction.enable);
+            ASSERT_EQ(it->second.getSaiAttr().value.aclaction.parameter.s32, color.second);
+        }
+
+        // An invalid packet color must be rejected (rule not created).
+        orch->doAclRuleTask(
+            deque<KeyOpFieldsValuesTuple>(
+            {
+                {
+                    aclTableName + "|PACKET_COLOR_RULE_INVALID",
+                    SET_COMMAND,
+                    {
+                        { RULE_PRIORITY, "998" },
+                        { MATCH_SRC_IP, "1.2.3.5/32" },
+                        { ACTION_PACKET_COLOR_ACTION, "PURPLE" }
+                    }
+                }
+            })
+        );
+        ASSERT_EQ(orch->getAclRule(aclTableName, "PACKET_COLOR_RULE_INVALID"), nullptr);
+    }
+
+    // A single rule that combines PACKET_ACTION (FORWARD) with PACKET_COLOR_ACTION
+    // must be created -- validate() must not treat SET_PACKET_COLOR as an exclusive
+    // action -- and BOTH SAI actions must be programmed on the entry. This is the
+    // "classify, pre-color, then forward" pattern whose color feeds a downstream
+    // color-aware policer/WRED.
+    TEST_F(AclOrchTest, AclRuleSetPacketColorActionComposeForward)
+    {
+        // Report SET_PACKET_COLOR and PACKET_ACTION as supported ACL actions.
+        old_sai_switch_api_packet_color = sai_switch_api;
+        sai_switch_api_t new_sai_switch_api = *sai_switch_api;
+        sai_switch_api = &new_sai_switch_api;
+        sai_switch_api->get_switch_attribute = getSwitchAttributePacketColor;
+
+        struct SaiSwitchApiRestore {
+            ~SaiSwitchApiRestore() { sai_switch_api = old_sai_switch_api_packet_color; }
+        } saiSwitchApiRestore;
+
+        auto orch = createAclOrch();
+
+        const string aclTableTypeName = "PACKET_COLOR_FWD_TABLE_TYPE";
+        const string aclTableName = "PACKET_COLOR_FWD_TABLE";
+        const string aclRuleName = "PACKET_COLOR_FWD_RULE";
+        const string comma = ",";
+
+        orch->doAclTableTypeTask(
+            deque<KeyOpFieldsValuesTuple>(
+            {
+                {
+                    aclTableTypeName,
+                    SET_COMMAND,
+                    {
+                        { ACL_TABLE_TYPE_MATCHES, MATCH_SRC_IP },
+                        { ACL_TABLE_TYPE_ACTIONS, string(ACTION_PACKET_ACTION) + comma + ACTION_PACKET_COLOR_ACTION }
+                    }
+                }
+            })
+        );
+
+        orch->doAclTableTask(
+            deque<KeyOpFieldsValuesTuple>(
+            {
+                {
+                    aclTableName,
+                    SET_COMMAND,
+                    {
+                        { ACL_TABLE_TYPE, aclTableTypeName },
+                        { ACL_TABLE_STAGE, STAGE_INGRESS }
+                    }
+                }
+            })
+        );
+        ASSERT_TRUE(orch->getAclTable(aclTableName));
+
+        orch->doAclRuleTask(
+            deque<KeyOpFieldsValuesTuple>(
+            {
+                {
+                    aclTableName + "|" + aclRuleName,
+                    SET_COMMAND,
+                    {
+                        { RULE_PRIORITY, "999" },
+                        { MATCH_SRC_IP, "1.2.3.4/32" },
+                        { ACTION_PACKET_ACTION, PACKET_ACTION_FORWARD },
+                        { ACTION_PACKET_COLOR_ACTION, PACKET_COLOR_GREEN }
+                    }
+                }
+            })
+        );
+
+        // The composed rule must be created (validate() must not treat SET_PACKET_COLOR
+        // as exclusive).
+        auto rule = orch->getAclRule(aclTableName, aclRuleName);
+        ASSERT_NE(rule, nullptr);
+
+        // Both actions are programmed: SET_PACKET_COLOR with the configured color ...
+        const auto &actions = Portal::AclRuleInternal::getActions(rule);
+        auto colorIt = actions.find(SAI_ACL_ENTRY_ATTR_ACTION_SET_PACKET_COLOR);
+        ASSERT_NE(colorIt, actions.end());
+        ASSERT_TRUE(colorIt->second.getSaiAttr().value.aclaction.enable);
+        ASSERT_EQ(colorIt->second.getSaiAttr().value.aclaction.parameter.s32, SAI_PACKET_COLOR_GREEN);
+
+        // ... and PACKET_ACTION set to FORWARD.
+        auto paIt = actions.find(SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION);
+        ASSERT_NE(paIt, actions.end());
+        ASSERT_TRUE(paIt->second.getSaiAttr().value.aclaction.enable);
+        ASSERT_EQ(paIt->second.getSaiAttr().value.aclaction.parameter.s32, SAI_PACKET_ACTION_FORWARD);
+    }
+
+    sai_switch_api_t *old_sai_switch_api_no_packet_color;
+
+    // Override SAI get_switch_attribute so that the ASIC does NOT advertise
+    // SET_PACKET_COLOR (only PACKET_ACTION is supported).
+    sai_status_t getSwitchAttributeNoPacketColor(_In_ sai_object_id_t switch_id, _In_ uint32_t attr_count,
+                                                 _Inout_ sai_attribute_t *attr_list)
+    {
+        if (attr_count == 1)
+        {
+            switch (attr_list[0].id)
+            {
+            case SAI_SWITCH_ATTR_MAX_ACL_ACTION_COUNT:
+                attr_list[0].value.u32 = 1;
+                return SAI_STATUS_SUCCESS;
+            case SAI_SWITCH_ATTR_ACL_STAGE_INGRESS:
+            case SAI_SWITCH_ATTR_ACL_STAGE_EGRESS:
+                attr_list[0].value.aclcapability.action_list.count = 1;
+                attr_list[0].value.aclcapability.action_list.list[0] = SAI_ACL_ACTION_TYPE_PACKET_ACTION;
+                attr_list[0].value.aclcapability.is_action_list_mandatory = false;
+                return SAI_STATUS_SUCCESS;
+            }
+        }
+        return old_sai_switch_api_no_packet_color->get_switch_attribute(switch_id, attr_count, attr_list);
+    }
+
+    // When the ASIC does not advertise SET_PACKET_COLOR, an ACL table whose type
+    // lists PACKET_COLOR_ACTION must be rejected: AclOrch validates every table
+    // action against the queried switch capability on table creation.
+    TEST_F(AclOrchTest, AclTableSetPacketColorActionNotSupported)
+    {
+        old_sai_switch_api_no_packet_color = sai_switch_api;
+        sai_switch_api_t new_sai_switch_api = *sai_switch_api;
+        sai_switch_api = &new_sai_switch_api;
+        sai_switch_api->get_switch_attribute = getSwitchAttributeNoPacketColor;
+
+        auto orch = createAclOrch();
+
+        const string aclTableTypeName = "PACKET_COLOR_UNSUP_TABLE_TYPE";
+        const string aclTableName = "PACKET_COLOR_UNSUP_TABLE";
+
+        orch->doAclTableTypeTask(
+            deque<KeyOpFieldsValuesTuple>(
+            {
+                {
+                    aclTableTypeName,
+                    SET_COMMAND,
+                    {
+                        { ACL_TABLE_TYPE_MATCHES, MATCH_SRC_IP },
+                        { ACL_TABLE_TYPE_ACTIONS, string(ACTION_PACKET_ACTION) + comma + ACTION_PACKET_COLOR_ACTION }
+                    }
+                }
+            })
+        );
+
+        orch->doAclTableTask(
+            deque<KeyOpFieldsValuesTuple>(
+            {
+                {
+                    aclTableName,
+                    SET_COMMAND,
+                    {
+                        { ACL_TABLE_TYPE, aclTableTypeName },
+                        { ACL_TABLE_STAGE, STAGE_INGRESS }
+                    }
+                }
+            })
+        );
+
+        // Restore the SAI switch API before asserting so that a failed
+        // expectation does not leave TearDown's remove_switch dereferencing
+        // the temporary stack override.
+        sai_switch_api = old_sai_switch_api_no_packet_color;
+
+        // The table is rejected because SET_PACKET_COLOR is not a supported action.
+        ASSERT_EQ(orch->getAclTable(aclTableName), nullptr);
+    }
+
     TEST_F(AclOrchTest, AclInnerSourceMacRewriteTableValidation)
     {
         const string aclTableTypeName = "INNER_SRC_MAC_REWRITE_TABLE_TYPE";


### PR DESCRIPTION
#### What I did
Add `PACKET_COLOR_ACTION` (GREEN/YELLOW/RED) to the generic CONFIG_DB `AclOrch` pipeline, mapping it to `SAI_ACL_ENTRY_ATTR_ACTION_SET_PACKET_COLOR`. `SAI_ACL_ENTRY_ATTR_ACTION_SET_PACKET_COLOR` was only reachable via the P4Orch/P4RT path; the standard CONFIG_DB AclOrch pipeline had no mapping.

#### Details
- `aclL3ActionLookup`: map `PACKET_COLOR_ACTION` -> `SAI_ACL_ENTRY_ATTR_ACTION_SET_PACKET_COLOR`
- `aclPacketColorLookup`: `GREEN`/`YELLOW`/`RED` -> `SAI_PACKET_COLOR_*` (value is case-insensitive)
- `AclRulePacket::validateAddAction`: parse the color value, reject invalid values
- `AclRulePacket::validate`: `SET_PACKET_COLOR` is a composable QoS marking (a drop-precedence color consumed downstream by a color-aware policer/WRED), so a rule may set the color and still carry a single forwarding/terminating action (e.g. `PACKET_ACTION`) plus a counter. Only actions that are neither SET_PACKET_COLOR nor SET_POLICER are capped at one, so a policer, a color, and one packet/redirect action can coexist. SAI applies SET_PACKET_COLOR as an independent CREATE_AND_SET action.
- `queryAclActionCapability`: query the enum-value capability so the action is capability-gated (platforms that don't advertise it simply reject the table — no behavior change for anyone else)

#### How I verified
- Unit tests: `AclRuleSetPacketColorAction` (positive — programs the right `sai_packet_color_t`, rejects invalid color), `AclTableSetPacketColorActionNotSupported` (negative — table rejected when the platform does not advertise the action), and `AclRuleSetPacketColorActionComposeForward` (`PACKET_ACTION=FORWARD` + `PACKET_COLOR_ACTION` in one rule is created and programs **both** SAI actions). Full swss mock unit-test suite passes (922/922).
- Hardware (Broadcom TH5): a rule with GREEN/YELLOW/RED programs `SAI_ACL_ENTRY_ATTR_ACTION_SET_PACKET_COLOR` in ASIC_DB and the corresponding field-processor action (verified via `bcmcmd`).

Requires the YANG model addition: sonic-net/sonic-buildimage#28151

HLD: sonic-net/SONiC#2429

Fixes #4716
