### PR TITLE
orchagent: support independent WRED ECN marking thresholds

### DIFF
--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -444,15 +444,15 @@ and reflects the LAG ports into the redis under: `LAG_TABLE:<team0>:port`
     wred_red_enable         = "true" / "false"
     ; optional independent ECN marking thresholds ("mark before drop"), applied best-effort where the
     ; platform supports them; each color requires that color enabled in "ecn"
-    ecn_green_min_threshold     = byte_count
-    ecn_green_max_threshold     = byte_count
-    ecn_green_mark_probability  = percentage
-    ecn_yellow_min_threshold    = byte_count
-    ecn_yellow_max_threshold    = byte_count
-    ecn_yellow_mark_probability = percentage
-    ecn_red_min_threshold       = byte_count
-    ecn_red_max_threshold       = byte_count
-    ecn_red_mark_probability    = percentage
+    green_ect_min_threshold     = byte_count
+    green_ect_max_threshold     = byte_count
+    green_ect_mark_probability  = percentage
+    yellow_ect_min_threshold    = byte_count
+    yellow_ect_max_threshold    = byte_count
+    yellow_ect_mark_probability = percentage
+    red_ect_min_threshold       = byte_count
+    red_ect_max_threshold       = byte_count
+    red_ect_mark_probability    = percentage
     percentage                  = 1*DIGIT     ; 0..100 (percent)
 
     Example:

--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -442,6 +442,18 @@ and reflects the LAG ports into the redis under: `LAG_TABLE:<team0>:port`
     wred_green_enable       = "true" / "false"
     wred_yellow_enable      = "true" / "false"
     wred_red_enable         = "true" / "false"
+    ; optional independent ECN marking thresholds ("mark before drop"), applied best-effort where the
+    ; platform supports them; each color requires that color enabled in "ecn"
+    ecn_green_min_threshold     = byte_count
+    ecn_green_max_threshold     = byte_count
+    ecn_green_mark_probability  = percentage
+    ecn_yellow_min_threshold    = byte_count
+    ecn_yellow_max_threshold    = byte_count
+    ecn_yellow_mark_probability = percentage
+    ecn_red_min_threshold       = byte_count
+    ecn_red_max_threshold       = byte_count
+    ecn_red_mark_probability    = percentage
+    percentage                  = 1*DIGIT     ; 0..100 (percent)
 
     Example:
     127.0.0.1:6379> hgetall "WRED_PROFILE_TABLE:AZURE"

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -829,31 +829,31 @@ bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tupl
             }
             attribs.push_back(attr);
         }
-        else if (fvField(*i) == ecn_green_min_threshold_field_name)
+        else if (fvField(*i) == green_ect_min_threshold_field_name)
         {
             if (!ecn_supported) { continue; }
             threshold = stoi(fvValue(*i));
             appendThresholdToAttributeList(SAI_WRED_ATTR_ECN_GREEN_MIN_THRESHOLD,
                                            threshold,
-                                           (storedProfile.ecn_green_max_threshold < threshold),
+                                           (storedProfile.green_ect_max_threshold < threshold),
                                            attribs,
                                            deferred_attributes,
-                                           currentProfile.ecn_green_min_threshold);
+                                           currentProfile.green_ect_min_threshold);
             has_ecn_threshold = true;
         }
-        else if (fvField(*i) == ecn_green_max_threshold_field_name)
+        else if (fvField(*i) == green_ect_max_threshold_field_name)
         {
             if (!ecn_supported) { continue; }
             threshold = stoi(fvValue(*i));
             appendThresholdToAttributeList(SAI_WRED_ATTR_ECN_GREEN_MAX_THRESHOLD,
                                            threshold,
-                                           (storedProfile.ecn_green_min_threshold > threshold),
+                                           (storedProfile.green_ect_min_threshold > threshold),
                                            attribs,
                                            deferred_attributes,
-                                           currentProfile.ecn_green_max_threshold);
+                                           currentProfile.green_ect_max_threshold);
             has_ecn_threshold = true;
         }
-        else if (fvField(*i) == ecn_green_mark_probability_field_name)
+        else if (fvField(*i) == green_ect_mark_probability_field_name)
         {
             if (!ecn_supported) { continue; }
             attr.id = SAI_WRED_ATTR_ECN_GREEN_MARK_PROBABILITY;
@@ -861,31 +861,31 @@ bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tupl
             attribs.push_back(attr);
             has_ecn_threshold = true;
         }
-        else if (fvField(*i) == ecn_yellow_min_threshold_field_name)
+        else if (fvField(*i) == yellow_ect_min_threshold_field_name)
         {
             if (!ecn_supported) { continue; }
             threshold = stoi(fvValue(*i));
             appendThresholdToAttributeList(SAI_WRED_ATTR_ECN_YELLOW_MIN_THRESHOLD,
                                            threshold,
-                                           (storedProfile.ecn_yellow_max_threshold < threshold),
+                                           (storedProfile.yellow_ect_max_threshold < threshold),
                                            attribs,
                                            deferred_attributes,
-                                           currentProfile.ecn_yellow_min_threshold);
+                                           currentProfile.yellow_ect_min_threshold);
             has_ecn_threshold = true;
         }
-        else if (fvField(*i) == ecn_yellow_max_threshold_field_name)
+        else if (fvField(*i) == yellow_ect_max_threshold_field_name)
         {
             if (!ecn_supported) { continue; }
             threshold = stoi(fvValue(*i));
             appendThresholdToAttributeList(SAI_WRED_ATTR_ECN_YELLOW_MAX_THRESHOLD,
                                            threshold,
-                                           (storedProfile.ecn_yellow_min_threshold > threshold),
+                                           (storedProfile.yellow_ect_min_threshold > threshold),
                                            attribs,
                                            deferred_attributes,
-                                           currentProfile.ecn_yellow_max_threshold);
+                                           currentProfile.yellow_ect_max_threshold);
             has_ecn_threshold = true;
         }
-        else if (fvField(*i) == ecn_yellow_mark_probability_field_name)
+        else if (fvField(*i) == yellow_ect_mark_probability_field_name)
         {
             if (!ecn_supported) { continue; }
             attr.id = SAI_WRED_ATTR_ECN_YELLOW_MARK_PROBABILITY;
@@ -893,31 +893,31 @@ bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tupl
             attribs.push_back(attr);
             has_ecn_threshold = true;
         }
-        else if (fvField(*i) == ecn_red_min_threshold_field_name)
+        else if (fvField(*i) == red_ect_min_threshold_field_name)
         {
             if (!ecn_supported) { continue; }
             threshold = stoi(fvValue(*i));
             appendThresholdToAttributeList(SAI_WRED_ATTR_ECN_RED_MIN_THRESHOLD,
                                            threshold,
-                                           (storedProfile.ecn_red_max_threshold < threshold),
+                                           (storedProfile.red_ect_max_threshold < threshold),
                                            attribs,
                                            deferred_attributes,
-                                           currentProfile.ecn_red_min_threshold);
+                                           currentProfile.red_ect_min_threshold);
             has_ecn_threshold = true;
         }
-        else if (fvField(*i) == ecn_red_max_threshold_field_name)
+        else if (fvField(*i) == red_ect_max_threshold_field_name)
         {
             if (!ecn_supported) { continue; }
             threshold = stoi(fvValue(*i));
             appendThresholdToAttributeList(SAI_WRED_ATTR_ECN_RED_MAX_THRESHOLD,
                                            threshold,
-                                           (storedProfile.ecn_red_min_threshold > threshold),
+                                           (storedProfile.red_ect_min_threshold > threshold),
                                            attribs,
                                            deferred_attributes,
-                                           currentProfile.ecn_red_max_threshold);
+                                           currentProfile.red_ect_max_threshold);
             has_ecn_threshold = true;
         }
-        else if (fvField(*i) == ecn_red_mark_probability_field_name)
+        else if (fvField(*i) == red_ect_mark_probability_field_name)
         {
             if (!ecn_supported) { continue; }
             attr.id = SAI_WRED_ATTR_ECN_RED_MARK_PROBABILITY;
@@ -946,9 +946,9 @@ bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tupl
         return false;
     }
 
-    if ((currentProfile.ecn_green_min_threshold > currentProfile.ecn_green_max_threshold)
-        || (currentProfile.ecn_yellow_min_threshold > currentProfile.ecn_yellow_max_threshold)
-        || (currentProfile.ecn_red_min_threshold > currentProfile.ecn_red_max_threshold))
+    if ((currentProfile.green_ect_min_threshold > currentProfile.green_ect_max_threshold)
+        || (currentProfile.yellow_ect_min_threshold > currentProfile.yellow_ect_max_threshold)
+        || (currentProfile.red_ect_min_threshold > currentProfile.red_ect_max_threshold))
     {
         SWSS_LOG_ERROR("Wrong wred profile: ECN min threshold is greater than ECN max threshold");
         return false;

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -582,6 +582,95 @@ void WredMapHandler::appendThresholdToAttributeList(sai_attr_id_t type,
 
 WredMapHandler::qos_wred_thresholds_store_t WredMapHandler::m_wredProfiles;
 
+bool WredMapHandler::enableEcnEctThreshold()
+{
+    SWSS_LOG_ENTER();
+
+    // Enable only once. SAI_SWITCH_ATTR_ECN_ECT_THRESHOLD_ENABLE makes ECT traffic honor the
+    // independent ECN marking thresholds instead of the WRED drop thresholds. Its default is
+    // false, so platforms/profiles that do not configure ECN thresholds keep the legacy behavior.
+    static bool ect_threshold_enabled = false;
+    if (ect_threshold_enabled)
+    {
+        return true;
+    }
+
+    // Query the capability directly so we can distinguish "not supported" from "capability query
+    // not implemented". Some platforms (e.g. Broadcom XGS) do not implement the attribute
+    // capability query but do support setting the attribute; treat that case as supported and let
+    // the SAI set validate it, matching the convention used elsewhere in SONiC.
+    sai_attr_capability_t capability;
+    sai_status_t query_status = sai_query_attribute_capability(gSwitchId, SAI_OBJECT_TYPE_SWITCH,
+                                    SAI_SWITCH_ATTR_ECN_ECT_THRESHOLD_ENABLE, &capability);
+    if (query_status == SAI_STATUS_SUCCESS && !capability.set_implemented)
+    {
+        SWSS_LOG_NOTICE("SAI_SWITCH_ATTR_ECN_ECT_THRESHOLD_ENABLE is not supported; "
+                        "ECN marking thresholds will follow the WRED drop thresholds");
+        return false;
+    }
+
+    sai_attribute_t attr;
+    attr.id = SAI_SWITCH_ATTR_ECN_ECT_THRESHOLD_ENABLE;
+    attr.value.booldata = true;
+    sai_status_t status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to enable SAI_SWITCH_ATTR_ECN_ECT_THRESHOLD_ENABLE, status:%d", status);
+        return false;
+    }
+
+    ect_threshold_enabled = true;
+    SWSS_LOG_NOTICE("Enabled SAI_SWITCH_ATTR_ECN_ECT_THRESHOLD_ENABLE for independent ECN marking thresholds");
+    return true;
+}
+
+bool WredMapHandler::ecnThresholdSupported()
+{
+    SWSS_LOG_ENTER();
+
+    // Query once and cache. The per-WRED ECN threshold/mark attributes are optional in SAI; on
+    // platforms that do not implement them, programming them would fail the WRED create/set. So
+    // we gate on capability and silently ignore the ECN fields where unsupported, leaving the
+    // existing WRED drop-threshold behavior intact.
+    static bool queried = false;
+    static bool supported = false;
+    if (!queried)
+    {
+        queried = true;
+
+        // Query the per-WRED ECN threshold capability directly. A successful query reports whether
+        // the attribute can be set; if the platform does not implement the capability query at all
+        // (e.g. Broadcom XGS returns SAI_STATUS_NOT_IMPLEMENTED), assume the attributes are
+        // supported and let the WRED create/set validate them, as is the convention in SONiC.
+        sai_attr_capability_t capability;
+        sai_status_t query_status = sai_query_attribute_capability(gSwitchId, SAI_OBJECT_TYPE_WRED,
+                                        SAI_WRED_ATTR_ECN_GREEN_MIN_THRESHOLD, &capability);
+        if (query_status == SAI_STATUS_SUCCESS)
+        {
+            supported = capability.set_implemented;
+        }
+        else if (query_status == SAI_STATUS_NOT_IMPLEMENTED)
+        {
+            supported = true;
+            SWSS_LOG_NOTICE("Per-WRED ECN marking threshold capability query is not implemented "
+                            "(status:%d); assuming supported", query_status);
+        }
+        else
+        {
+            supported = true;
+            SWSS_LOG_NOTICE("Per-WRED ECN marking threshold capability query failed "
+                            "(status:%d); assuming supported", query_status);
+        }
+
+        if (!supported)
+        {
+            SWSS_LOG_NOTICE("Per-WRED ECN marking thresholds are not supported on this platform; "
+                            "ECN threshold fields will be ignored");
+        }
+    }
+    return supported;
+}
+
 bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tuple, vector<sai_attribute_t> &attribs)
 {
     SWSS_LOG_ENTER();
@@ -591,6 +680,8 @@ bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tupl
     auto &storedProfile = WredMapHandler::m_wredProfiles[key];
     qos_wred_thresholds_t currentProfile = storedProfile;
     sai_uint32_t threshold;
+    bool has_ecn_threshold = false;
+    bool ecn_supported = ecnThresholdSupported();
 
     /*
      * Setting WRED profile can fail in case
@@ -738,6 +829,102 @@ bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tupl
             }
             attribs.push_back(attr);
         }
+        else if (fvField(*i) == ecn_green_min_threshold_field_name)
+        {
+            if (!ecn_supported) { continue; }
+            threshold = stoi(fvValue(*i));
+            appendThresholdToAttributeList(SAI_WRED_ATTR_ECN_GREEN_MIN_THRESHOLD,
+                                           threshold,
+                                           (storedProfile.ecn_green_max_threshold < threshold),
+                                           attribs,
+                                           deferred_attributes,
+                                           currentProfile.ecn_green_min_threshold);
+            has_ecn_threshold = true;
+        }
+        else if (fvField(*i) == ecn_green_max_threshold_field_name)
+        {
+            if (!ecn_supported) { continue; }
+            threshold = stoi(fvValue(*i));
+            appendThresholdToAttributeList(SAI_WRED_ATTR_ECN_GREEN_MAX_THRESHOLD,
+                                           threshold,
+                                           (storedProfile.ecn_green_min_threshold > threshold),
+                                           attribs,
+                                           deferred_attributes,
+                                           currentProfile.ecn_green_max_threshold);
+            has_ecn_threshold = true;
+        }
+        else if (fvField(*i) == ecn_green_mark_probability_field_name)
+        {
+            if (!ecn_supported) { continue; }
+            attr.id = SAI_WRED_ATTR_ECN_GREEN_MARK_PROBABILITY;
+            attr.value.s32 = stoi(fvValue(*i));
+            attribs.push_back(attr);
+            has_ecn_threshold = true;
+        }
+        else if (fvField(*i) == ecn_yellow_min_threshold_field_name)
+        {
+            if (!ecn_supported) { continue; }
+            threshold = stoi(fvValue(*i));
+            appendThresholdToAttributeList(SAI_WRED_ATTR_ECN_YELLOW_MIN_THRESHOLD,
+                                           threshold,
+                                           (storedProfile.ecn_yellow_max_threshold < threshold),
+                                           attribs,
+                                           deferred_attributes,
+                                           currentProfile.ecn_yellow_min_threshold);
+            has_ecn_threshold = true;
+        }
+        else if (fvField(*i) == ecn_yellow_max_threshold_field_name)
+        {
+            if (!ecn_supported) { continue; }
+            threshold = stoi(fvValue(*i));
+            appendThresholdToAttributeList(SAI_WRED_ATTR_ECN_YELLOW_MAX_THRESHOLD,
+                                           threshold,
+                                           (storedProfile.ecn_yellow_min_threshold > threshold),
+                                           attribs,
+                                           deferred_attributes,
+                                           currentProfile.ecn_yellow_max_threshold);
+            has_ecn_threshold = true;
+        }
+        else if (fvField(*i) == ecn_yellow_mark_probability_field_name)
+        {
+            if (!ecn_supported) { continue; }
+            attr.id = SAI_WRED_ATTR_ECN_YELLOW_MARK_PROBABILITY;
+            attr.value.s32 = stoi(fvValue(*i));
+            attribs.push_back(attr);
+            has_ecn_threshold = true;
+        }
+        else if (fvField(*i) == ecn_red_min_threshold_field_name)
+        {
+            if (!ecn_supported) { continue; }
+            threshold = stoi(fvValue(*i));
+            appendThresholdToAttributeList(SAI_WRED_ATTR_ECN_RED_MIN_THRESHOLD,
+                                           threshold,
+                                           (storedProfile.ecn_red_max_threshold < threshold),
+                                           attribs,
+                                           deferred_attributes,
+                                           currentProfile.ecn_red_min_threshold);
+            has_ecn_threshold = true;
+        }
+        else if (fvField(*i) == ecn_red_max_threshold_field_name)
+        {
+            if (!ecn_supported) { continue; }
+            threshold = stoi(fvValue(*i));
+            appendThresholdToAttributeList(SAI_WRED_ATTR_ECN_RED_MAX_THRESHOLD,
+                                           threshold,
+                                           (storedProfile.ecn_red_min_threshold > threshold),
+                                           attribs,
+                                           deferred_attributes,
+                                           currentProfile.ecn_red_max_threshold);
+            has_ecn_threshold = true;
+        }
+        else if (fvField(*i) == ecn_red_mark_probability_field_name)
+        {
+            if (!ecn_supported) { continue; }
+            attr.id = SAI_WRED_ATTR_ECN_RED_MARK_PROBABILITY;
+            attr.value.s32 = stoi(fvValue(*i));
+            attribs.push_back(attr);
+            has_ecn_threshold = true;
+        }
         else if (fvField(*i) == ecn_field_name)
         {
             attr.id = SAI_WRED_ATTR_ECN_MARK_MODE;
@@ -759,24 +946,100 @@ bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tupl
         return false;
     }
 
+    if ((currentProfile.ecn_green_min_threshold > currentProfile.ecn_green_max_threshold)
+        || (currentProfile.ecn_yellow_min_threshold > currentProfile.ecn_yellow_max_threshold)
+        || (currentProfile.ecn_red_min_threshold > currentProfile.ecn_red_max_threshold))
+    {
+        SWSS_LOG_ERROR("Wrong wred profile: ECN min threshold is greater than ECN max threshold");
+        return false;
+    }
+
+    // Record whether this profile carries any independent ECN marking threshold. The switch-level
+    // ECT control is enabled later, from add/modifyQosItem(), once the profile has been programmed.
+    m_ecnThresholdConfigured = has_ecn_threshold;
+
     attribs.insert(attribs.end(), deferred_attributes.begin(), deferred_attributes.end());
     storedProfile = currentProfile;
 
     return true;
 }
 
+// The per-WRED ECN marking attributes (independent threshold/probability per color) are optional
+// and capability-dependent. They are kept out of the base WRED create/set and applied separately
+// as best-effort by applyEcnThresholdAttributes(), so the base WRED profile (drop behaviour) is
+// always programmed.
+static bool isEcnThresholdAttribute(sai_attr_id_t id)
+{
+    switch (id)
+    {
+    case SAI_WRED_ATTR_ECN_GREEN_MIN_THRESHOLD:
+    case SAI_WRED_ATTR_ECN_GREEN_MAX_THRESHOLD:
+    case SAI_WRED_ATTR_ECN_GREEN_MARK_PROBABILITY:
+    case SAI_WRED_ATTR_ECN_YELLOW_MIN_THRESHOLD:
+    case SAI_WRED_ATTR_ECN_YELLOW_MAX_THRESHOLD:
+    case SAI_WRED_ATTR_ECN_YELLOW_MARK_PROBABILITY:
+    case SAI_WRED_ATTR_ECN_RED_MIN_THRESHOLD:
+    case SAI_WRED_ATTR_ECN_RED_MAX_THRESHOLD:
+    case SAI_WRED_ATTR_ECN_RED_MARK_PROBABILITY:
+        return true;
+    default:
+        return false;
+    }
+}
+
+void WredMapHandler::applyEcnThresholdAttributes(sai_object_id_t sai_object,
+                                                 const vector<sai_attribute_t> &ecn_attributes)
+{
+    SWSS_LOG_ENTER();
+
+    if (ecn_attributes.empty())
+    {
+        return;
+    }
+
+    // The independent ECN marking thresholds only take effect once the switch-level ECT control is
+    // enabled, so enable it before programming the per-WRED ECN attributes.
+    enableEcnEctThreshold();
+
+    // Best-effort: the ECN marking attributes are optional. A platform that does not support a
+    // given attribute (even if its capability query did not report it) must not fail the WRED
+    // profile, so a failed set is logged and skipped, leaving the base drop behaviour intact. This
+    // mirrors how PortsOrch applies optional port attributes (FEC/autoneg/PFC).
+    for (const auto &attr : ecn_attributes)
+    {
+        sai_status_t status = sai_wred_api->set_wred_attribute(sai_object, &attr);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_WARN("Failed to set ECN marking attribute id:%d (status:%d); "
+                          "ignoring the ECN marking threshold for this wred profile", attr.id, status);
+        }
+    }
+}
+
 bool WredMapHandler::modifyQosItem(sai_object_id_t sai_object, vector<sai_attribute_t> &attribs)
 {
     SWSS_LOG_ENTER();
     sai_status_t sai_status;
+    vector<sai_attribute_t> ecn_attributes;
     for (auto attr : attribs)
     {
+        // Defer the optional ECN marking attributes; apply them best-effort after the mandatory
+        // attributes so an unsupported ECN attribute cannot fail the WRED profile update.
+        if (isEcnThresholdAttribute(attr.id))
+        {
+            ecn_attributes.push_back(attr);
+            continue;
+        }
         sai_status = sai_wred_api->set_wred_attribute(sai_object, &attr);
         if (sai_status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to set wred profile attribute, id:%d, status:%d", attr.id, sai_status);
             return false;
         }
+    }
+    if (m_ecnThresholdConfigured)
+    {
+        applyEcnThresholdAttributes(sai_object, ecn_attributes);
     }
     return true;
 }
@@ -788,6 +1051,7 @@ sai_object_id_t WredMapHandler::addQosItem(const vector<sai_attribute_t> &attrib
     sai_object_id_t sai_object;
     sai_attribute_t attr;
     vector<sai_attribute_t> attrs;
+    vector<sai_attribute_t> ecn_attributes;
     uint8_t drop_prob_set = 0;
     uint8_t wred_enable_set = 0;
 
@@ -797,6 +1061,14 @@ sai_object_id_t WredMapHandler::addQosItem(const vector<sai_attribute_t> &attrib
 
     for(auto attrib : attribs)
     {
+        // Defer the optional ECN marking attributes. They are applied best-effort after the base
+        // WRED profile is created so an unsupported ECN attribute cannot fail the create.
+        if (isEcnThresholdAttribute(attrib.id))
+        {
+            ecn_attributes.push_back(attrib);
+            continue;
+        }
+
         attrs.push_back(attrib);
 
         switch (attrib.id)
@@ -857,6 +1129,12 @@ sai_object_id_t WredMapHandler::addQosItem(const vector<sai_attribute_t> &attrib
     {
         SWSS_LOG_ERROR("Failed to create wred profile: %d", sai_status);
         return false;
+    }
+    // The base WRED profile exists. Apply the optional ECN marking attributes best-effort so an
+    // unsupported platform cannot fail the profile (mirrors PortsOrch optional port attributes).
+    if (m_ecnThresholdConfigured)
+    {
+        applyEcnThresholdAttributes(sai_object, ecn_attributes);
     }
     return sai_object;
 }

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <string>
 #include <climits>
+#include <algorithm>
 #include <boost/algorithm/string.hpp>
 
 using namespace std;
@@ -671,6 +672,43 @@ bool WredMapHandler::ecnThresholdSupported()
     return supported;
 }
 
+// Parse a WRED threshold; reject malformed input.
+static bool parseWredThreshold(const std::string &value, sai_uint32_t &out)
+{
+    try
+    {
+        out = static_cast<sai_uint32_t>(stoi(value));
+    }
+    catch (const std::exception &e)
+    {
+        SWSS_LOG_ERROR("Invalid wred threshold value '%s': %s", value.c_str(), e.what());
+        return false;
+    }
+    return true;
+}
+
+// ECN mark probability is a 0..100 percentage. Reject malformed input; clamp out-of-range values.
+static bool parseEcnMarkProbability(const std::string &value, sai_uint32_t &out)
+{
+    int prob;
+    try
+    {
+        prob = stoi(value);
+    }
+    catch (const std::exception &e)
+    {
+        SWSS_LOG_ERROR("Invalid ECN mark probability '%s': %s", value.c_str(), e.what());
+        return false;
+    }
+    if (prob < 0 || prob > 100)
+    {
+        SWSS_LOG_WARN("ECN mark probability %d out of range [0,100]; clamping to range", prob);
+        prob = (prob < 0) ? 0 : 100;
+    }
+    out = static_cast<sai_uint32_t>(prob);
+    return true;
+}
+
 bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tuple, vector<sai_attribute_t> &attribs)
 {
     SWSS_LOG_ENTER();
@@ -832,7 +870,7 @@ bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tupl
         else if (fvField(*i) == green_ect_min_threshold_field_name)
         {
             if (!ecn_supported) { continue; }
-            threshold = stoi(fvValue(*i));
+            if (!parseWredThreshold(fvValue(*i), threshold)) { return false; }
             appendThresholdToAttributeList(SAI_WRED_ATTR_ECN_GREEN_MIN_THRESHOLD,
                                            threshold,
                                            (storedProfile.green_ect_max_threshold < threshold),
@@ -844,7 +882,7 @@ bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tupl
         else if (fvField(*i) == green_ect_max_threshold_field_name)
         {
             if (!ecn_supported) { continue; }
-            threshold = stoi(fvValue(*i));
+            if (!parseWredThreshold(fvValue(*i), threshold)) { return false; }
             appendThresholdToAttributeList(SAI_WRED_ATTR_ECN_GREEN_MAX_THRESHOLD,
                                            threshold,
                                            (storedProfile.green_ect_min_threshold > threshold),
@@ -857,14 +895,14 @@ bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tupl
         {
             if (!ecn_supported) { continue; }
             attr.id = SAI_WRED_ATTR_ECN_GREEN_MARK_PROBABILITY;
-            attr.value.s32 = stoi(fvValue(*i));
+            if (!parseEcnMarkProbability(fvValue(*i), attr.value.u32)) { return false; }
             attribs.push_back(attr);
             has_ecn_threshold = true;
         }
         else if (fvField(*i) == yellow_ect_min_threshold_field_name)
         {
             if (!ecn_supported) { continue; }
-            threshold = stoi(fvValue(*i));
+            if (!parseWredThreshold(fvValue(*i), threshold)) { return false; }
             appendThresholdToAttributeList(SAI_WRED_ATTR_ECN_YELLOW_MIN_THRESHOLD,
                                            threshold,
                                            (storedProfile.yellow_ect_max_threshold < threshold),
@@ -876,7 +914,7 @@ bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tupl
         else if (fvField(*i) == yellow_ect_max_threshold_field_name)
         {
             if (!ecn_supported) { continue; }
-            threshold = stoi(fvValue(*i));
+            if (!parseWredThreshold(fvValue(*i), threshold)) { return false; }
             appendThresholdToAttributeList(SAI_WRED_ATTR_ECN_YELLOW_MAX_THRESHOLD,
                                            threshold,
                                            (storedProfile.yellow_ect_min_threshold > threshold),
@@ -889,14 +927,14 @@ bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tupl
         {
             if (!ecn_supported) { continue; }
             attr.id = SAI_WRED_ATTR_ECN_YELLOW_MARK_PROBABILITY;
-            attr.value.s32 = stoi(fvValue(*i));
+            if (!parseEcnMarkProbability(fvValue(*i), attr.value.u32)) { return false; }
             attribs.push_back(attr);
             has_ecn_threshold = true;
         }
         else if (fvField(*i) == red_ect_min_threshold_field_name)
         {
             if (!ecn_supported) { continue; }
-            threshold = stoi(fvValue(*i));
+            if (!parseWredThreshold(fvValue(*i), threshold)) { return false; }
             appendThresholdToAttributeList(SAI_WRED_ATTR_ECN_RED_MIN_THRESHOLD,
                                            threshold,
                                            (storedProfile.red_ect_max_threshold < threshold),
@@ -908,7 +946,7 @@ bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tupl
         else if (fvField(*i) == red_ect_max_threshold_field_name)
         {
             if (!ecn_supported) { continue; }
-            threshold = stoi(fvValue(*i));
+            if (!parseWredThreshold(fvValue(*i), threshold)) { return false; }
             appendThresholdToAttributeList(SAI_WRED_ATTR_ECN_RED_MAX_THRESHOLD,
                                            threshold,
                                            (storedProfile.red_ect_min_threshold > threshold),
@@ -921,7 +959,7 @@ bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tupl
         {
             if (!ecn_supported) { continue; }
             attr.id = SAI_WRED_ATTR_ECN_RED_MARK_PROBABILITY;
-            attr.value.s32 = stoi(fvValue(*i));
+            if (!parseEcnMarkProbability(fvValue(*i), attr.value.u32)) { return false; }
             attribs.push_back(attr);
             has_ecn_threshold = true;
         }
@@ -946,12 +984,42 @@ bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tupl
         return false;
     }
 
-    if ((currentProfile.green_ect_min_threshold > currentProfile.green_ect_max_threshold)
-        || (currentProfile.yellow_ect_min_threshold > currentProfile.yellow_ect_max_threshold)
-        || (currentProfile.red_ect_min_threshold > currentProfile.red_ect_max_threshold))
+    // ECN thresholds are optional/best-effort and per-color. If a color's min > max, skip only that
+    // color's ECN threshold (keep the base profile and other colors) rather than failing the profile.
+    auto skipColorEcnThreshold = [&](sai_attr_id_t minId, sai_attr_id_t maxId,
+                                     sai_uint32_t &curMin, sai_uint32_t &curMax,
+                                     sai_uint32_t storedMin, sai_uint32_t storedMax,
+                                     const char *color)
     {
-        SWSS_LOG_ERROR("Wrong wred profile: ECN min threshold is greater than ECN max threshold");
-        return false;
+        SWSS_LOG_WARN("Wred profile ECN %s min threshold (%u) is greater than max (%u); skipping "
+                      "this color's ECN marking threshold and keeping the rest of the profile",
+                      color, curMin, curMax);
+        auto isColorEcn = [&](const sai_attribute_t &a) { return a.id == minId || a.id == maxId; };
+        attribs.erase(std::remove_if(attribs.begin(), attribs.end(), isColorEcn), attribs.end());
+        deferred_attributes.erase(
+            std::remove_if(deferred_attributes.begin(), deferred_attributes.end(), isColorEcn),
+            deferred_attributes.end());
+        curMin = storedMin;
+        curMax = storedMax;
+    };
+
+    if (currentProfile.green_ect_min_threshold > currentProfile.green_ect_max_threshold)
+    {
+        skipColorEcnThreshold(SAI_WRED_ATTR_ECN_GREEN_MIN_THRESHOLD, SAI_WRED_ATTR_ECN_GREEN_MAX_THRESHOLD,
+                              currentProfile.green_ect_min_threshold, currentProfile.green_ect_max_threshold,
+                              storedProfile.green_ect_min_threshold, storedProfile.green_ect_max_threshold, "green");
+    }
+    if (currentProfile.yellow_ect_min_threshold > currentProfile.yellow_ect_max_threshold)
+    {
+        skipColorEcnThreshold(SAI_WRED_ATTR_ECN_YELLOW_MIN_THRESHOLD, SAI_WRED_ATTR_ECN_YELLOW_MAX_THRESHOLD,
+                              currentProfile.yellow_ect_min_threshold, currentProfile.yellow_ect_max_threshold,
+                              storedProfile.yellow_ect_min_threshold, storedProfile.yellow_ect_max_threshold, "yellow");
+    }
+    if (currentProfile.red_ect_min_threshold > currentProfile.red_ect_max_threshold)
+    {
+        skipColorEcnThreshold(SAI_WRED_ATTR_ECN_RED_MIN_THRESHOLD, SAI_WRED_ATTR_ECN_RED_MAX_THRESHOLD,
+                              currentProfile.red_ect_min_threshold, currentProfile.red_ect_max_threshold,
+                              storedProfile.red_ect_min_threshold, storedProfile.red_ect_max_threshold, "red");
     }
 
     // Record whether this profile carries any independent ECN marking threshold. The switch-level
@@ -959,7 +1027,18 @@ bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tupl
     m_ecnThresholdConfigured = has_ecn_threshold;
 
     attribs.insert(attribs.end(), deferred_attributes.begin(), deferred_attributes.end());
+
+    // Commit drop thresholds now, but hold ECN thresholds at their prior values: they are committed
+    // to the cache by applyEcnThresholdAttributes() only after each best-effort SAI set succeeds.
+    qos_wred_thresholds_t priorEcn = storedProfile;
+    m_pendingWredKey = key;
     storedProfile = currentProfile;
+    storedProfile.green_ect_min_threshold  = priorEcn.green_ect_min_threshold;
+    storedProfile.green_ect_max_threshold  = priorEcn.green_ect_max_threshold;
+    storedProfile.yellow_ect_min_threshold = priorEcn.yellow_ect_min_threshold;
+    storedProfile.yellow_ect_max_threshold = priorEcn.yellow_ect_max_threshold;
+    storedProfile.red_ect_min_threshold    = priorEcn.red_ect_min_threshold;
+    storedProfile.red_ect_max_threshold    = priorEcn.red_ect_max_threshold;
 
     return true;
 }
@@ -987,6 +1066,27 @@ static bool isEcnThresholdAttribute(sai_attr_id_t id)
     }
 }
 
+// Commit a successfully-set ECN threshold to the in-flight profile's cache (m_pendingWredKey), so the
+// cache never records a threshold the best-effort SAI set dropped.
+void WredMapHandler::commitEcnThresholdToCache(sai_attr_id_t id, sai_uint32_t value)
+{
+    if (m_pendingWredKey.empty())
+    {
+        return;
+    }
+    auto &profile = m_wredProfiles[m_pendingWredKey];
+    switch (id)
+    {
+    case SAI_WRED_ATTR_ECN_GREEN_MIN_THRESHOLD:  profile.green_ect_min_threshold  = value; break;
+    case SAI_WRED_ATTR_ECN_GREEN_MAX_THRESHOLD:  profile.green_ect_max_threshold  = value; break;
+    case SAI_WRED_ATTR_ECN_YELLOW_MIN_THRESHOLD: profile.yellow_ect_min_threshold = value; break;
+    case SAI_WRED_ATTR_ECN_YELLOW_MAX_THRESHOLD: profile.yellow_ect_max_threshold = value; break;
+    case SAI_WRED_ATTR_ECN_RED_MIN_THRESHOLD:    profile.red_ect_min_threshold    = value; break;
+    case SAI_WRED_ATTR_ECN_RED_MAX_THRESHOLD:    profile.red_ect_max_threshold    = value; break;
+    default: break;  // mark-probability attributes are not cached
+    }
+}
+
 void WredMapHandler::applyEcnThresholdAttributes(sai_object_id_t sai_object,
                                                  const vector<sai_attribute_t> &ecn_attributes)
 {
@@ -997,9 +1097,14 @@ void WredMapHandler::applyEcnThresholdAttributes(sai_object_id_t sai_object,
         return;
     }
 
-    // The independent ECN marking thresholds only take effect once the switch-level ECT control is
-    // enabled, so enable it before programming the per-WRED ECN attributes.
-    enableEcnEctThreshold();
+    // Enable the switch-level ECT control first; if it fails the per-WRED ECN thresholds can't take
+    // effect, so skip them rather than proceeding as if ECN marking were active.
+    if (!enableEcnEctThreshold())
+    {
+        SWSS_LOG_WARN("SAI_SWITCH_ATTR_ECN_ECT_THRESHOLD_ENABLE not enabled; skipping ECN marking "
+                      "threshold programming for this wred profile");
+        return;
+    }
 
     // Best-effort: the ECN marking attributes are optional. A platform that does not support a
     // given attribute (even if its capability query did not report it) must not fail the WRED
@@ -1012,7 +1117,10 @@ void WredMapHandler::applyEcnThresholdAttributes(sai_object_id_t sai_object,
         {
             SWSS_LOG_WARN("Failed to set ECN marking attribute id:%d (status:%d); "
                           "ignoring the ECN marking threshold for this wred profile", attr.id, status);
+            continue;
         }
+        // SAI set succeeded: reflect this threshold in the cache (mark-probability isn't cached).
+        commitEcnThresholdToCache(attr.id, attr.value.u32);
     }
 }
 

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -132,6 +132,8 @@ protected:
     // control and sets each ECN attribute, logging and skipping any the platform rejects so the
     // base WRED profile is never failed by an unsupported ECN attribute.
     void applyEcnThresholdAttributes(sai_object_id_t sai_object, const vector<sai_attribute_t> &ecn_attributes);
+    // Commit a successfully-set ECN threshold attribute to the cached profile (m_pendingWredKey).
+    void commitEcnThresholdToCache(sai_attr_id_t id, sai_uint32_t value);
     // Capability-gated (queried once, cached) check for the per-WRED ECN threshold/mark
     // attributes. When unsupported, the ECN threshold fields are ignored so that WRED profile
     // creation keeps working unchanged on platforms that do not implement them.
@@ -165,6 +167,10 @@ private:
     // marking configuration (thresholds and/or probabilities); consumed by add/modifyQosItem()
     // to apply the optional ECN marking attributes (which also enables the switch-level ECT control).
     bool m_ecnThresholdConfigured = false;
+
+    // Key of the WRED profile currently being processed (set in convertFieldValuesToAttributes()).
+    // Used by commitEcnThresholdToCache() to update the cache after a successful best-effort ECN set.
+    string m_pendingWredKey;
 };
 
 

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -62,6 +62,16 @@ const string ecn_green_red                      = "ecn_green_red";
 const string ecn_green_yellow                   = "ecn_green_yellow";
 const string ecn_all                            = "ecn_all";
 
+const string ecn_green_min_threshold_field_name     = "ecn_green_min_threshold";
+const string ecn_green_max_threshold_field_name     = "ecn_green_max_threshold";
+const string ecn_green_mark_probability_field_name  = "ecn_green_mark_probability";
+const string ecn_yellow_min_threshold_field_name    = "ecn_yellow_min_threshold";
+const string ecn_yellow_max_threshold_field_name    = "ecn_yellow_max_threshold";
+const string ecn_yellow_mark_probability_field_name = "ecn_yellow_mark_probability";
+const string ecn_red_min_threshold_field_name       = "ecn_red_min_threshold";
+const string ecn_red_max_threshold_field_name       = "ecn_red_max_threshold";
+const string ecn_red_mark_probability_field_name    = "ecn_red_mark_probability";
+
 class QosMapHandler
 {
 public:
@@ -113,6 +123,19 @@ public:
 protected:
     bool convertEcnMode(string str, sai_ecn_mark_mode_t &ecn_val);
     bool convertBool(string str, bool &val);
+    // Enable SAI_SWITCH_ATTR_ECN_ECT_THRESHOLD_ENABLE (capability-gated, idempotent) so that
+    // the independent ECN marking thresholds take effect for ECT traffic on platforms that
+    // support it. Platforms without the capability are left untouched.
+    bool enableEcnEctThreshold();
+    // Apply the optional per-WRED ECN marking attributes (independent thresholds/probabilities)
+    // best-effort after the base WRED profile has been programmed: enables the switch-level ECT
+    // control and sets each ECN attribute, logging and skipping any the platform rejects so the
+    // base WRED profile is never failed by an unsupported ECN attribute.
+    void applyEcnThresholdAttributes(sai_object_id_t sai_object, const vector<sai_attribute_t> &ecn_attributes);
+    // Capability-gated (queried once, cached) check for the per-WRED ECN threshold/mark
+    // attributes. When unsupported, the ECN threshold fields are ignored so that WRED profile
+    // creation keeps working unchanged on platforms that do not implement them.
+    bool ecnThresholdSupported();
 private:
     void appendThresholdToAttributeList(sai_attr_id_t type,
                                         sai_uint32_t threshold,
@@ -127,10 +150,21 @@ private:
         sai_uint32_t yellow_min_threshold;
         sai_uint32_t red_max_threshold;
         sai_uint32_t red_min_threshold;
+        sai_uint32_t ecn_green_max_threshold;
+        sai_uint32_t ecn_green_min_threshold;
+        sai_uint32_t ecn_yellow_max_threshold;
+        sai_uint32_t ecn_yellow_min_threshold;
+        sai_uint32_t ecn_red_max_threshold;
+        sai_uint32_t ecn_red_min_threshold;
     } qos_wred_thresholds_t;
     typedef map<string, qos_wred_thresholds_t> qos_wred_thresholds_store_t;
 
     static qos_wred_thresholds_store_t m_wredProfiles;
+
+    // Set by convertFieldValuesToAttributes() when a WRED profile carries any independent ECN
+    // marking configuration (thresholds and/or probabilities); consumed by add/modifyQosItem()
+    // to apply the optional ECN marking attributes (which also enables the switch-level ECT control).
+    bool m_ecnThresholdConfigured = false;
 };
 
 

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -62,15 +62,15 @@ const string ecn_green_red                      = "ecn_green_red";
 const string ecn_green_yellow                   = "ecn_green_yellow";
 const string ecn_all                            = "ecn_all";
 
-const string ecn_green_min_threshold_field_name     = "ecn_green_min_threshold";
-const string ecn_green_max_threshold_field_name     = "ecn_green_max_threshold";
-const string ecn_green_mark_probability_field_name  = "ecn_green_mark_probability";
-const string ecn_yellow_min_threshold_field_name    = "ecn_yellow_min_threshold";
-const string ecn_yellow_max_threshold_field_name    = "ecn_yellow_max_threshold";
-const string ecn_yellow_mark_probability_field_name = "ecn_yellow_mark_probability";
-const string ecn_red_min_threshold_field_name       = "ecn_red_min_threshold";
-const string ecn_red_max_threshold_field_name       = "ecn_red_max_threshold";
-const string ecn_red_mark_probability_field_name    = "ecn_red_mark_probability";
+const string green_ect_min_threshold_field_name     = "green_ect_min_threshold";
+const string green_ect_max_threshold_field_name     = "green_ect_max_threshold";
+const string green_ect_mark_probability_field_name  = "green_ect_mark_probability";
+const string yellow_ect_min_threshold_field_name    = "yellow_ect_min_threshold";
+const string yellow_ect_max_threshold_field_name    = "yellow_ect_max_threshold";
+const string yellow_ect_mark_probability_field_name = "yellow_ect_mark_probability";
+const string red_ect_min_threshold_field_name       = "red_ect_min_threshold";
+const string red_ect_max_threshold_field_name       = "red_ect_max_threshold";
+const string red_ect_mark_probability_field_name    = "red_ect_mark_probability";
 
 class QosMapHandler
 {
@@ -150,12 +150,12 @@ private:
         sai_uint32_t yellow_min_threshold;
         sai_uint32_t red_max_threshold;
         sai_uint32_t red_min_threshold;
-        sai_uint32_t ecn_green_max_threshold;
-        sai_uint32_t ecn_green_min_threshold;
-        sai_uint32_t ecn_yellow_max_threshold;
-        sai_uint32_t ecn_yellow_min_threshold;
-        sai_uint32_t ecn_red_max_threshold;
-        sai_uint32_t ecn_red_min_threshold;
+        sai_uint32_t green_ect_max_threshold;
+        sai_uint32_t green_ect_min_threshold;
+        sai_uint32_t yellow_ect_max_threshold;
+        sai_uint32_t yellow_ect_min_threshold;
+        sai_uint32_t red_ect_max_threshold;
+        sai_uint32_t red_ect_min_threshold;
     } qos_wred_thresholds_t;
     typedef map<string, qos_wred_thresholds_t> qos_wred_thresholds_store_t;
 

--- a/tests/mock_tests/qosorch_ut.cpp
+++ b/tests/mock_tests/qosorch_ut.cpp
@@ -131,28 +131,28 @@ namespace qosorch_test
             saiMaxDropProbabilities.red_max_drop_probability = attr.value.u32;
             break;
         case SAI_WRED_ATTR_ECN_GREEN_MAX_THRESHOLD:
-            ASSERT_TRUE(!saiThresholds.ecn_green_min_threshold || saiThresholds.ecn_green_min_threshold < attr.value.u32);
-            saiThresholds.ecn_green_max_threshold = attr.value.u32;
+            ASSERT_TRUE(!saiThresholds.green_ect_min_threshold || saiThresholds.green_ect_min_threshold < attr.value.u32);
+            saiThresholds.green_ect_max_threshold = attr.value.u32;
             break;
         case SAI_WRED_ATTR_ECN_GREEN_MIN_THRESHOLD:
-            ASSERT_TRUE(!saiThresholds.ecn_green_max_threshold || saiThresholds.ecn_green_max_threshold > attr.value.u32);
-            saiThresholds.ecn_green_min_threshold = attr.value.u32;
+            ASSERT_TRUE(!saiThresholds.green_ect_max_threshold || saiThresholds.green_ect_max_threshold > attr.value.u32);
+            saiThresholds.green_ect_min_threshold = attr.value.u32;
             break;
         case SAI_WRED_ATTR_ECN_YELLOW_MAX_THRESHOLD:
-            ASSERT_TRUE(!saiThresholds.ecn_yellow_min_threshold || saiThresholds.ecn_yellow_min_threshold < attr.value.u32);
-            saiThresholds.ecn_yellow_max_threshold = attr.value.u32;
+            ASSERT_TRUE(!saiThresholds.yellow_ect_min_threshold || saiThresholds.yellow_ect_min_threshold < attr.value.u32);
+            saiThresholds.yellow_ect_max_threshold = attr.value.u32;
             break;
         case SAI_WRED_ATTR_ECN_YELLOW_MIN_THRESHOLD:
-            ASSERT_TRUE(!saiThresholds.ecn_yellow_max_threshold || saiThresholds.ecn_yellow_max_threshold > attr.value.u32);
-            saiThresholds.ecn_yellow_min_threshold = attr.value.u32;
+            ASSERT_TRUE(!saiThresholds.yellow_ect_max_threshold || saiThresholds.yellow_ect_max_threshold > attr.value.u32);
+            saiThresholds.yellow_ect_min_threshold = attr.value.u32;
             break;
         case SAI_WRED_ATTR_ECN_RED_MAX_THRESHOLD:
-            ASSERT_TRUE(!saiThresholds.ecn_red_min_threshold || saiThresholds.ecn_red_min_threshold < attr.value.u32);
-            saiThresholds.ecn_red_max_threshold = attr.value.u32;
+            ASSERT_TRUE(!saiThresholds.red_ect_min_threshold || saiThresholds.red_ect_min_threshold < attr.value.u32);
+            saiThresholds.red_ect_max_threshold = attr.value.u32;
             break;
         case SAI_WRED_ATTR_ECN_RED_MIN_THRESHOLD:
-            ASSERT_TRUE(!saiThresholds.ecn_red_max_threshold || saiThresholds.ecn_red_max_threshold > attr.value.u32);
-            saiThresholds.ecn_red_min_threshold = attr.value.u32;
+            ASSERT_TRUE(!saiThresholds.red_ect_max_threshold || saiThresholds.red_ect_max_threshold > attr.value.u32);
+            saiThresholds.red_ect_min_threshold = attr.value.u32;
             break;
         case SAI_WRED_ATTR_ECN_GREEN_MARK_PROBABILITY:
             saiEcnMarkProbabilities.green_max_drop_probability = attr.value.u32;
@@ -178,12 +178,12 @@ namespace qosorch_test
         ASSERT_EQ(oaThresholds.yellow_max_threshold, thresholds.yellow_max_threshold);
         ASSERT_EQ(oaThresholds.red_min_threshold, thresholds.red_min_threshold);
         ASSERT_EQ(oaThresholds.red_max_threshold, thresholds.red_max_threshold);
-        ASSERT_EQ(oaThresholds.ecn_green_min_threshold, thresholds.ecn_green_min_threshold);
-        ASSERT_EQ(oaThresholds.ecn_green_max_threshold, thresholds.ecn_green_max_threshold);
-        ASSERT_EQ(oaThresholds.ecn_yellow_min_threshold, thresholds.ecn_yellow_min_threshold);
-        ASSERT_EQ(oaThresholds.ecn_yellow_max_threshold, thresholds.ecn_yellow_max_threshold);
-        ASSERT_EQ(oaThresholds.ecn_red_min_threshold, thresholds.ecn_red_min_threshold);
-        ASSERT_EQ(oaThresholds.ecn_red_max_threshold, thresholds.ecn_red_max_threshold);
+        ASSERT_EQ(oaThresholds.green_ect_min_threshold, thresholds.green_ect_min_threshold);
+        ASSERT_EQ(oaThresholds.green_ect_max_threshold, thresholds.green_ect_max_threshold);
+        ASSERT_EQ(oaThresholds.yellow_ect_min_threshold, thresholds.yellow_ect_min_threshold);
+        ASSERT_EQ(oaThresholds.yellow_ect_max_threshold, thresholds.yellow_ect_max_threshold);
+        ASSERT_EQ(oaThresholds.red_ect_min_threshold, thresholds.red_ect_min_threshold);
+        ASSERT_EQ(oaThresholds.red_ect_max_threshold, thresholds.red_ect_max_threshold);
     }
 
     void updateWredProfileAndCheck(vector<FieldValueTuple> &thresholdsVector, WredMapHandler::qos_wred_thresholds_t &thresholdsValue)
@@ -1613,15 +1613,15 @@ namespace qosorch_test
             {"yellow_max_threshold", "2097153"},
             {"red_min_threshold", "1048578"},
             {"red_max_threshold", "2097154"},
-            {"ecn_green_min_threshold", "524288"},
-            {"ecn_green_max_threshold", "1048576"},
-            {"ecn_green_mark_probability", "50"},
-            {"ecn_yellow_min_threshold", "524289"},
-            {"ecn_yellow_max_threshold", "1048577"},
-            {"ecn_yellow_mark_probability", "50"},
-            {"ecn_red_min_threshold", "524290"},
-            {"ecn_red_max_threshold", "1048578"},
-            {"ecn_red_mark_probability", "100"}
+            {"green_ect_min_threshold", "524288"},
+            {"green_ect_max_threshold", "1048576"},
+            {"green_ect_mark_probability", "50"},
+            {"yellow_ect_min_threshold", "524289"},
+            {"yellow_ect_max_threshold", "1048577"},
+            {"yellow_ect_mark_probability", "50"},
+            {"red_ect_min_threshold", "524290"},
+            {"red_ect_max_threshold", "1048578"},
+            {"red_ect_mark_probability", "100"}
         };
         WredMapHandler::qos_wred_thresholds_t ecnThresholds = {
             2097152, //green_max_threshold
@@ -1630,12 +1630,12 @@ namespace qosorch_test
             1048577, //yellow_min_threshold
             2097154, //red_max_threshold
             1048578, //red_min_threshold
-            1048576, //ecn_green_max_threshold
-            524288,  //ecn_green_min_threshold
-            1048577, //ecn_yellow_max_threshold
-            524289,  //ecn_yellow_min_threshold
-            1048578, //ecn_red_max_threshold
-            524290   //ecn_red_min_threshold
+            1048576, //green_ect_max_threshold
+            524288,  //green_ect_min_threshold
+            1048577, //yellow_ect_max_threshold
+            524289,  //yellow_ect_min_threshold
+            1048578, //red_ect_max_threshold
+            524290   //red_ect_min_threshold
         };
 
         updateWredProfileAndCheck(ecnSetVector, ecnThresholds);
@@ -1663,9 +1663,9 @@ namespace qosorch_test
             {"wred_green_enable", "true"},
             {"green_min_threshold", "1048576"},
             {"green_max_threshold", "2097152"},
-            {"ecn_green_min_threshold", "524288"},
-            {"ecn_green_max_threshold", "1048576"},
-            {"ecn_green_mark_probability", "50"}
+            {"green_ect_min_threshold", "524288"},
+            {"green_ect_max_threshold", "1048576"},
+            {"green_ect_mark_probability", "50"}
         };
 
         std::deque<KeyOpFieldsValuesTuple> entries;
@@ -1683,8 +1683,8 @@ namespace qosorch_test
         ASSERT_EQ(saiThresholds.green_max_threshold, 2097152u);
         // The unsupported ECN marking attributes were skipped, not programmed, and did not fail
         // the WRED profile creation.
-        ASSERT_EQ(saiThresholds.ecn_green_min_threshold, 0u);
-        ASSERT_EQ(saiThresholds.ecn_green_max_threshold, 0u);
+        ASSERT_EQ(saiThresholds.green_ect_min_threshold, 0u);
+        ASSERT_EQ(saiThresholds.green_ect_max_threshold, 0u);
         ASSERT_EQ(saiEcnMarkProbabilities.green_max_drop_probability, 0u);
 
         testing_wred_thresholds = false;
@@ -1708,15 +1708,15 @@ namespace qosorch_test
             {"yellow_max_threshold", "2097153"},
             {"red_min_threshold", "1048578"},
             {"red_max_threshold", "2097154"},
-            {"ecn_green_min_threshold", "524288"},
-            {"ecn_green_max_threshold", "1048576"},
-            {"ecn_green_mark_probability", "50"},
-            {"ecn_yellow_min_threshold", "524289"},
-            {"ecn_yellow_max_threshold", "1048577"},
-            {"ecn_yellow_mark_probability", "50"},
-            {"ecn_red_min_threshold", "524290"},
-            {"ecn_red_max_threshold", "1048578"},
-            {"ecn_red_mark_probability", "100"}
+            {"green_ect_min_threshold", "524288"},
+            {"green_ect_max_threshold", "1048576"},
+            {"green_ect_mark_probability", "50"},
+            {"yellow_ect_min_threshold", "524289"},
+            {"yellow_ect_max_threshold", "1048577"},
+            {"yellow_ect_mark_probability", "50"},
+            {"red_ect_min_threshold", "524290"},
+            {"red_ect_max_threshold", "1048578"},
+            {"red_ect_mark_probability", "100"}
         };
         WredMapHandler::qos_wred_thresholds_t afterCreate = {
             2097152, 1048576, 2097153, 1048577, 2097154, 1048578,
@@ -1737,15 +1737,15 @@ namespace qosorch_test
             {"yellow_max_threshold", "2097153"},
             {"red_min_threshold", "1048578"},
             {"red_max_threshold", "2097154"},
-            {"ecn_green_min_threshold", "786432"},
-            {"ecn_green_max_threshold", "1572864"},
-            {"ecn_green_mark_probability", "60"},
-            {"ecn_yellow_min_threshold", "786433"},
-            {"ecn_yellow_max_threshold", "1572865"},
-            {"ecn_yellow_mark_probability", "60"},
-            {"ecn_red_min_threshold", "786434"},
-            {"ecn_red_max_threshold", "1572866"},
-            {"ecn_red_mark_probability", "100"}
+            {"green_ect_min_threshold", "786432"},
+            {"green_ect_max_threshold", "1572864"},
+            {"green_ect_mark_probability", "60"},
+            {"yellow_ect_min_threshold", "786433"},
+            {"yellow_ect_max_threshold", "1572865"},
+            {"yellow_ect_mark_probability", "60"},
+            {"red_ect_min_threshold", "786434"},
+            {"red_ect_max_threshold", "1572866"},
+            {"red_ect_mark_probability", "100"}
         };
         WredMapHandler::qos_wred_thresholds_t afterModify = {
             2097152, 1048576, 2097153, 1048577, 2097154, 1048578,
@@ -1769,8 +1769,8 @@ namespace qosorch_test
             {"wred_green_enable", "true"},
             {"green_min_threshold", "1048576"},
             {"green_max_threshold", "2097152"},
-            {"ecn_green_min_threshold", "2097152"},
-            {"ecn_green_max_threshold", "1048576"}
+            {"green_ect_min_threshold", "2097152"},
+            {"green_ect_max_threshold", "1048576"}
         };
         updateWrongWredProfileAndCheck(invalidVector);
         testing_wred_thresholds = false;

--- a/tests/mock_tests/qosorch_ut.cpp
+++ b/tests/mock_tests/qosorch_ut.cpp
@@ -65,6 +65,29 @@ namespace qosorch_test
     bool testing_wred_thresholds;
     WredMapHandler::qos_wred_thresholds_t saiThresholds;
     qos_wred_max_drop_probability_t saiMaxDropProbabilities;
+    qos_wred_max_drop_probability_t saiEcnMarkProbabilities;
+    // When set, the WRED set-attribute stub rejects the optional ECN marking attributes to emulate
+    // a platform that does not support them, so a test can assert the base WRED is still created.
+    bool failEcnThresholdSet;
+    // Identifies the optional ECN marking attributes (mirrors the orchagent's file-local helper).
+    static bool isEcnThresholdAttrUt(sai_attr_id_t id)
+    {
+        switch (id)
+        {
+        case SAI_WRED_ATTR_ECN_GREEN_MIN_THRESHOLD:
+        case SAI_WRED_ATTR_ECN_GREEN_MAX_THRESHOLD:
+        case SAI_WRED_ATTR_ECN_GREEN_MARK_PROBABILITY:
+        case SAI_WRED_ATTR_ECN_YELLOW_MIN_THRESHOLD:
+        case SAI_WRED_ATTR_ECN_YELLOW_MAX_THRESHOLD:
+        case SAI_WRED_ATTR_ECN_YELLOW_MARK_PROBABILITY:
+        case SAI_WRED_ATTR_ECN_RED_MIN_THRESHOLD:
+        case SAI_WRED_ATTR_ECN_RED_MAX_THRESHOLD:
+        case SAI_WRED_ATTR_ECN_RED_MARK_PROBABILITY:
+            return true;
+        default:
+            return false;
+        }
+    }
     void _ut_stub_sai_check_wred_attributes(const sai_attribute_t &attr)
     {
         if (!testing_wred_thresholds)
@@ -107,6 +130,39 @@ namespace qosorch_test
         case SAI_WRED_ATTR_RED_DROP_PROBABILITY:
             saiMaxDropProbabilities.red_max_drop_probability = attr.value.u32;
             break;
+        case SAI_WRED_ATTR_ECN_GREEN_MAX_THRESHOLD:
+            ASSERT_TRUE(!saiThresholds.ecn_green_min_threshold || saiThresholds.ecn_green_min_threshold < attr.value.u32);
+            saiThresholds.ecn_green_max_threshold = attr.value.u32;
+            break;
+        case SAI_WRED_ATTR_ECN_GREEN_MIN_THRESHOLD:
+            ASSERT_TRUE(!saiThresholds.ecn_green_max_threshold || saiThresholds.ecn_green_max_threshold > attr.value.u32);
+            saiThresholds.ecn_green_min_threshold = attr.value.u32;
+            break;
+        case SAI_WRED_ATTR_ECN_YELLOW_MAX_THRESHOLD:
+            ASSERT_TRUE(!saiThresholds.ecn_yellow_min_threshold || saiThresholds.ecn_yellow_min_threshold < attr.value.u32);
+            saiThresholds.ecn_yellow_max_threshold = attr.value.u32;
+            break;
+        case SAI_WRED_ATTR_ECN_YELLOW_MIN_THRESHOLD:
+            ASSERT_TRUE(!saiThresholds.ecn_yellow_max_threshold || saiThresholds.ecn_yellow_max_threshold > attr.value.u32);
+            saiThresholds.ecn_yellow_min_threshold = attr.value.u32;
+            break;
+        case SAI_WRED_ATTR_ECN_RED_MAX_THRESHOLD:
+            ASSERT_TRUE(!saiThresholds.ecn_red_min_threshold || saiThresholds.ecn_red_min_threshold < attr.value.u32);
+            saiThresholds.ecn_red_max_threshold = attr.value.u32;
+            break;
+        case SAI_WRED_ATTR_ECN_RED_MIN_THRESHOLD:
+            ASSERT_TRUE(!saiThresholds.ecn_red_max_threshold || saiThresholds.ecn_red_max_threshold > attr.value.u32);
+            saiThresholds.ecn_red_min_threshold = attr.value.u32;
+            break;
+        case SAI_WRED_ATTR_ECN_GREEN_MARK_PROBABILITY:
+            saiEcnMarkProbabilities.green_max_drop_probability = attr.value.u32;
+            break;
+        case SAI_WRED_ATTR_ECN_YELLOW_MARK_PROBABILITY:
+            saiEcnMarkProbabilities.yellow_max_drop_probability = attr.value.u32;
+            break;
+        case SAI_WRED_ATTR_ECN_RED_MARK_PROBABILITY:
+            saiEcnMarkProbabilities.red_max_drop_probability = attr.value.u32;
+            break;
         default:
             break;
         }
@@ -122,6 +178,12 @@ namespace qosorch_test
         ASSERT_EQ(oaThresholds.yellow_max_threshold, thresholds.yellow_max_threshold);
         ASSERT_EQ(oaThresholds.red_min_threshold, thresholds.red_min_threshold);
         ASSERT_EQ(oaThresholds.red_max_threshold, thresholds.red_max_threshold);
+        ASSERT_EQ(oaThresholds.ecn_green_min_threshold, thresholds.ecn_green_min_threshold);
+        ASSERT_EQ(oaThresholds.ecn_green_max_threshold, thresholds.ecn_green_max_threshold);
+        ASSERT_EQ(oaThresholds.ecn_yellow_min_threshold, thresholds.ecn_yellow_min_threshold);
+        ASSERT_EQ(oaThresholds.ecn_yellow_max_threshold, thresholds.ecn_yellow_max_threshold);
+        ASSERT_EQ(oaThresholds.ecn_red_min_threshold, thresholds.ecn_red_min_threshold);
+        ASSERT_EQ(oaThresholds.ecn_red_max_threshold, thresholds.ecn_red_max_threshold);
     }
 
     void updateWredProfileAndCheck(vector<FieldValueTuple> &thresholdsVector, WredMapHandler::qos_wred_thresholds_t &thresholdsValue)
@@ -197,6 +259,12 @@ namespace qosorch_test
         _In_ sai_object_id_t wred_id,
         _In_ const sai_attribute_t *attr)
     {
+        if (failEcnThresholdSet && isEcnThresholdAttrUt(attr->id))
+        {
+            // Emulate a platform that does not support this ECN marking attribute.
+            sai_set_wred_attribute_count++;
+            return SAI_STATUS_NOT_IMPLEMENTED;
+        }
         auto rc = old_set_wred_attribute(wred_id, attr);
         if (rc == SAI_STATUS_SUCCESS)
         {
@@ -1522,6 +1590,189 @@ namespace qosorch_test
         redProbabilities.red_max_drop_probability = 5;
         updateMaxDropProbabilityAndCheck("red", redProfile, redProbabilities);
 
+        testing_wred_thresholds = false;
+    }
+
+    TEST_F(QosOrchTest, QosOrchTestWredEcnThresholds)
+    {
+        testing_wred_thresholds = true;
+        saiThresholds = {};
+        saiEcnMarkProbabilities = {};
+
+        // A profile carrying both WRED drop thresholds and independent ECN marking thresholds.
+        // The ECN thresholds sit below the drop thresholds ("mark before drop"). The orchagent
+        // must defer min/max ordering for the ECN thresholds just like the drop thresholds.
+        vector<FieldValueTuple> ecnSetVector = {
+            {"ecn", "ecn_all"},
+            {"wred_green_enable", "true"},
+            {"wred_yellow_enable", "true"},
+            {"wred_red_enable", "true"},
+            {"green_min_threshold", "1048576"},
+            {"green_max_threshold", "2097152"},
+            {"yellow_min_threshold", "1048577"},
+            {"yellow_max_threshold", "2097153"},
+            {"red_min_threshold", "1048578"},
+            {"red_max_threshold", "2097154"},
+            {"ecn_green_min_threshold", "524288"},
+            {"ecn_green_max_threshold", "1048576"},
+            {"ecn_green_mark_probability", "50"},
+            {"ecn_yellow_min_threshold", "524289"},
+            {"ecn_yellow_max_threshold", "1048577"},
+            {"ecn_yellow_mark_probability", "50"},
+            {"ecn_red_min_threshold", "524290"},
+            {"ecn_red_max_threshold", "1048578"},
+            {"ecn_red_mark_probability", "100"}
+        };
+        WredMapHandler::qos_wred_thresholds_t ecnThresholds = {
+            2097152, //green_max_threshold
+            1048576, //green_min_threshold
+            2097153, //yellow_max_threshold
+            1048577, //yellow_min_threshold
+            2097154, //red_max_threshold
+            1048578, //red_min_threshold
+            1048576, //ecn_green_max_threshold
+            524288,  //ecn_green_min_threshold
+            1048577, //ecn_yellow_max_threshold
+            524289,  //ecn_yellow_min_threshold
+            1048578, //ecn_red_max_threshold
+            524290   //ecn_red_min_threshold
+        };
+
+        updateWredProfileAndCheck(ecnSetVector, ecnThresholds);
+
+        // ECN mark probabilities are programmed to SAI as well.
+        ASSERT_EQ(saiEcnMarkProbabilities.green_max_drop_probability, 50u);
+        ASSERT_EQ(saiEcnMarkProbabilities.yellow_max_drop_probability, 50u);
+        ASSERT_EQ(saiEcnMarkProbabilities.red_max_drop_probability, 100u);
+
+        testing_wred_thresholds = false;
+    }
+
+    TEST_F(QosOrchTest, QosOrchTestWredEcnThresholdsUnsupported)
+    {
+        // A platform that accepts the base WRED profile but does not support the per-WRED ECN
+        // marking attributes must still get a working WRED profile with its drop thresholds; the
+        // ECN marking attributes are best-effort and are skipped without failing the profile.
+        testing_wred_thresholds = true;
+        saiThresholds = {};
+        saiEcnMarkProbabilities = {};
+        failEcnThresholdSet = true;
+
+        vector<FieldValueTuple> ecnSetVector = {
+            {"ecn", "ecn_all"},
+            {"wred_green_enable", "true"},
+            {"green_min_threshold", "1048576"},
+            {"green_max_threshold", "2097152"},
+            {"ecn_green_min_threshold", "524288"},
+            {"ecn_green_max_threshold", "1048576"},
+            {"ecn_green_mark_probability", "50"}
+        };
+
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({"AZURE", "SET", ecnSetVector});
+        auto consumer = dynamic_cast<Consumer *>(gQosOrch->getExecutor(CFG_WRED_PROFILE_TABLE_NAME));
+        consumer->addToSync(entries);
+        entries.clear();
+        static_cast<Orch *>(gQosOrch)->doTask();
+        // Reset before the assertions so a failed assertion cannot leak the flag to other tests.
+        failEcnThresholdSet = false;
+
+        // The base WRED profile (drop thresholds) is programmed even though the ECN marking
+        // attributes were rejected by SAI.
+        ASSERT_EQ(saiThresholds.green_min_threshold, 1048576u);
+        ASSERT_EQ(saiThresholds.green_max_threshold, 2097152u);
+        // The unsupported ECN marking attributes were skipped, not programmed, and did not fail
+        // the WRED profile creation.
+        ASSERT_EQ(saiThresholds.ecn_green_min_threshold, 0u);
+        ASSERT_EQ(saiThresholds.ecn_green_max_threshold, 0u);
+        ASSERT_EQ(saiEcnMarkProbabilities.green_max_drop_probability, 0u);
+
+        testing_wred_thresholds = false;
+    }
+
+    TEST_F(QosOrchTest, QosOrchTestWredEcnThresholdsModify)
+    {
+        // Create a WRED profile with independent ECN thresholds, then re-set it with raised ECN
+        // thresholds. The second update modifies the existing WRED profile, exercising the modify
+        // path that applies the ECN marking attributes via set_wred_attribute.
+        testing_wred_thresholds = true;
+
+        vector<FieldValueTuple> createVector = {
+            {"ecn", "ecn_all"},
+            {"wred_green_enable", "true"},
+            {"wred_yellow_enable", "true"},
+            {"wred_red_enable", "true"},
+            {"green_min_threshold", "1048576"},
+            {"green_max_threshold", "2097152"},
+            {"yellow_min_threshold", "1048577"},
+            {"yellow_max_threshold", "2097153"},
+            {"red_min_threshold", "1048578"},
+            {"red_max_threshold", "2097154"},
+            {"ecn_green_min_threshold", "524288"},
+            {"ecn_green_max_threshold", "1048576"},
+            {"ecn_green_mark_probability", "50"},
+            {"ecn_yellow_min_threshold", "524289"},
+            {"ecn_yellow_max_threshold", "1048577"},
+            {"ecn_yellow_mark_probability", "50"},
+            {"ecn_red_min_threshold", "524290"},
+            {"ecn_red_max_threshold", "1048578"},
+            {"ecn_red_mark_probability", "100"}
+        };
+        WredMapHandler::qos_wred_thresholds_t afterCreate = {
+            2097152, 1048576, 2097153, 1048577, 2097154, 1048578,
+            1048576, 524288, 1048577, 524289, 1048578, 524290
+        };
+        saiThresholds = {};
+        saiEcnMarkProbabilities = {};
+        updateWredProfileAndCheck(createVector, afterCreate);
+
+        vector<FieldValueTuple> modifyVector = {
+            {"ecn", "ecn_all"},
+            {"wred_green_enable", "true"},
+            {"wred_yellow_enable", "true"},
+            {"wred_red_enable", "true"},
+            {"green_min_threshold", "1048576"},
+            {"green_max_threshold", "2097152"},
+            {"yellow_min_threshold", "1048577"},
+            {"yellow_max_threshold", "2097153"},
+            {"red_min_threshold", "1048578"},
+            {"red_max_threshold", "2097154"},
+            {"ecn_green_min_threshold", "786432"},
+            {"ecn_green_max_threshold", "1572864"},
+            {"ecn_green_mark_probability", "60"},
+            {"ecn_yellow_min_threshold", "786433"},
+            {"ecn_yellow_max_threshold", "1572865"},
+            {"ecn_yellow_mark_probability", "60"},
+            {"ecn_red_min_threshold", "786434"},
+            {"ecn_red_max_threshold", "1572866"},
+            {"ecn_red_mark_probability", "100"}
+        };
+        WredMapHandler::qos_wred_thresholds_t afterModify = {
+            2097152, 1048576, 2097153, 1048577, 2097154, 1048578,
+            1572864, 786432, 1572865, 786433, 1572866, 786434
+        };
+        saiThresholds = {};
+        saiEcnMarkProbabilities = {};
+        updateWredProfileAndCheck(modifyVector, afterModify);
+        ASSERT_EQ(saiEcnMarkProbabilities.green_max_drop_probability, 60u);
+
+        testing_wred_thresholds = false;
+    }
+
+    TEST_F(QosOrchTest, QosOrchTestWredEcnThresholdsInvalid)
+    {
+        // An ECN min threshold greater than the ECN max threshold is rejected by the handler and
+        // no WRED attribute is programmed.
+        testing_wred_thresholds = true;
+        vector<FieldValueTuple> invalidVector = {
+            {"ecn", "ecn_all"},
+            {"wred_green_enable", "true"},
+            {"green_min_threshold", "1048576"},
+            {"green_max_threshold", "2097152"},
+            {"ecn_green_min_threshold", "2097152"},
+            {"ecn_green_max_threshold", "1048576"}
+        };
+        updateWrongWredProfileAndCheck(invalidVector);
         testing_wred_thresholds = false;
     }
 

--- a/tests/mock_tests/qosorch_ut.cpp
+++ b/tests/mock_tests/qosorch_ut.cpp
@@ -1761,18 +1761,92 @@ namespace qosorch_test
 
     TEST_F(QosOrchTest, QosOrchTestWredEcnThresholdsInvalid)
     {
-        // An ECN min threshold greater than the ECN max threshold is rejected by the handler and
-        // no WRED attribute is programmed.
+        // An inverted ECN min/max for one color skips only that color's ECN threshold; the base
+        // profile and the other colors' ECN thresholds are still programmed (not a whole-profile fail).
         testing_wred_thresholds = true;
+        saiThresholds = {};
+        saiEcnMarkProbabilities = {};
         vector<FieldValueTuple> invalidVector = {
             {"ecn", "ecn_all"},
             {"wred_green_enable", "true"},
             {"green_min_threshold", "1048576"},
             {"green_max_threshold", "2097152"},
-            {"green_ect_min_threshold", "2097152"},
+            {"green_ect_min_threshold", "2097152"},   // green ECN min > max => invalid, skip green
+            {"green_ect_max_threshold", "1048576"},
+            {"yellow_ect_min_threshold", "524289"},    // yellow ECN valid => still programmed
+            {"yellow_ect_max_threshold", "1048577"}
+        };
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({"AZURE", "SET", invalidVector});
+        auto consumer = dynamic_cast<Consumer *>(gQosOrch->getExecutor(CFG_WRED_PROFILE_TABLE_NAME));
+        consumer->addToSync(entries);
+        entries.clear();
+        vector<string> ts;
+        static_cast<Orch *>(gQosOrch)->doTask();
+
+        // Base drop thresholds are programmed (profile not rejected).
+        ASSERT_EQ(saiThresholds.green_min_threshold, 1048576u);
+        ASSERT_EQ(saiThresholds.green_max_threshold, 2097152u);
+        // The offending color's (green) ECN threshold was skipped, not programmed.
+        ASSERT_EQ(saiThresholds.green_ect_min_threshold, 0u);
+        ASSERT_EQ(saiThresholds.green_ect_max_threshold, 0u);
+        // A valid color's (yellow) ECN threshold is still programmed.
+        ASSERT_EQ(saiThresholds.yellow_ect_min_threshold, 524289u);
+        ASSERT_EQ(saiThresholds.yellow_ect_max_threshold, 1048577u);
+        // The task completed (not deferred/retried).
+        static_cast<Orch *>(gQosOrch)->dumpPendingTasks(ts);
+        ASSERT_TRUE(ts.empty());
+        testing_wred_thresholds = false;
+    }
+
+    TEST_F(QosOrchTest, QosOrchTestWredEcnThresholdsBestEffortNoStaleCache)
+    {
+        // A failed best-effort ECN set must not record the threshold in the cache -- otherwise a
+        // later identical SET is a no-op and the threshold never reaches hardware. Verify the cache
+        // stays clean on failure and that a subsequent (supported) set re-attempts and lands.
+        testing_wred_thresholds = true;
+        saiThresholds = {};
+        saiEcnMarkProbabilities = {};
+
+        vector<FieldValueTuple> ecnSetVector = {
+            {"ecn", "ecn_all"},
+            {"wred_green_enable", "true"},
+            {"green_min_threshold", "1048576"},
+            {"green_max_threshold", "2097152"},
+            {"green_ect_min_threshold", "524288"},
             {"green_ect_max_threshold", "1048576"}
         };
-        updateWrongWredProfileAndCheck(invalidVector);
+        auto consumer = dynamic_cast<Consumer *>(gQosOrch->getExecutor(CFG_WRED_PROFILE_TABLE_NAME));
+        std::deque<KeyOpFieldsValuesTuple> entries;
+
+        // 1) ECN set fails (unsupported): base profile programmed, ECN not in SAI, cache not updated.
+        // Unique profile name: m_wredProfiles is a static cache that persists across tests.
+        const string profileName = "ECN_BESTEFFORT";
+        failEcnThresholdSet = true;
+        entries.push_back({profileName, "SET", ecnSetVector});
+        consumer->addToSync(entries);
+        entries.clear();
+        static_cast<Orch *>(gQosOrch)->doTask();
+        failEcnThresholdSet = false;
+
+        ASSERT_EQ(saiThresholds.green_ect_min_threshold, 0u);   // never reached SAI
+        ASSERT_EQ(saiThresholds.green_ect_max_threshold, 0u);
+        auto &cached = WredMapHandler::m_wredProfiles[profileName];
+        ASSERT_EQ(cached.green_ect_min_threshold, 0u);          // cache not falsely recorded
+        ASSERT_EQ(cached.green_ect_max_threshold, 0u);
+
+        // 2) Re-SET the identical config now that ECN is supported: the ECN set is re-attempted
+        //    (not skipped as a stale-cache no-op) and now reaches SAI and updates the cache.
+        entries.push_back({profileName, "SET", ecnSetVector});
+        consumer->addToSync(entries);
+        entries.clear();
+        static_cast<Orch *>(gQosOrch)->doTask();
+
+        ASSERT_EQ(saiThresholds.green_ect_min_threshold, 524288u);    // now programmed
+        ASSERT_EQ(saiThresholds.green_ect_max_threshold, 1048576u);
+        ASSERT_EQ(cached.green_ect_min_threshold, 524288u);           // cache now reflects hardware
+        ASSERT_EQ(cached.green_ect_max_threshold, 1048576u);
+
         testing_wred_thresholds = false;
     }
 


### PR DESCRIPTION
#### Why I did it
A `WRED_PROFILE` exposes only the WRED drop thresholds per color, and ECN marking reuses those same thresholds — there is no way to ECN-mark at a lower queue depth than where WRED starts dropping ("mark before drop"). This adds independent per-WRED ECN marking thresholds.

Fixes #4718

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
`WredMapHandler` programs the optional ECN marking attributes when the new `ecn_*_threshold` / `ecn_*_mark_probability` fields are present in the CONFIG_DB `WRED_PROFILE`:
- `SAI_WRED_ATTR_ECN_{GREEN,YELLOW,RED}_{MIN,MAX}_THRESHOLD` and `_MARK_PROBABILITY`
- enables `SAI_SWITCH_ATTR_ECN_ECT_THRESHOLD_ENABLE` so ECT traffic honours the independent ECN thresholds.

The feature is capability-driven (queries `sai_query_attribute_capability`; an unimplemented query is treated as supported, per existing SONiC convention) and best-effort: the ECN attributes are applied via `set_wred_attribute` after the base WRED profile is created, so a platform that does not support them logs and skips rather than failing the profile — mirroring how `PortsOrch` handles optional port attributes. Absent ECN fields keep behaviour byte-identical to today.

YANG: sonic-net/sonic-buildimage#28164.
HLD: https://github.com/sonic-net/SONiC/pull/2433

#### How to verify it
- New mock unit tests in `tests/mock_tests/qosorch_ut.cpp`: create and modify with independent ECN thresholds, ECN mark-probability programming, an unsupported-platform path (WRED still created, ECN skipped), and an invalid (min>max) path.
- Validated on a Broadcom Tomahawk5 (TH5) testbed: the ECN marking curve is programmed below the WRED drop curve in the ASIC (verified via `saidump` and the SDK WRED drop-curve-set profile table), bound to forwarding queues.

#### Description for the changelog
orchagent: support independent WRED ECN marking thresholds (mark before drop).
