### PR TITLE
portsorch: drop port from pending set on parse failure

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4778,12 +4778,19 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
                 if (!parsePortFvs(fvMap))
                 {
+                    // Invalid config for this port: drop the task and stop
+                    // tracking it as pending, so one bad port can't keep
+                    // allPortsReady() false and block every other port.
+                    SWSS_LOG_ERROR("Failed to parse configuration for port %s, skipping it", key.c_str());
+                    m_pendingPortSet.erase(key);
                     it = taskMap.erase(it);
                     continue;
                 }
 
                 if (!m_portHlpr.validatePortConfig(pCfg))
                 {
+                    SWSS_LOG_ERROR("Invalid configuration for port %s, skipping it", key.c_str());
+                    m_pendingPortSet.erase(key);
                     it = taskMap.erase(it);
                     continue;
                 }
@@ -4798,6 +4805,8 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
                 if (!parsePortFvs(fvMap))
                 {
+                    SWSS_LOG_ERROR("Failed to parse configuration update for port %s, skipping it", key.c_str());
+                    m_pendingPortSet.erase(key);
                     it = taskMap.erase(it);
                     continue;
                 }

--- a/tests/mock_tests/portphyserdesattr_ut.cpp
+++ b/tests/mock_tests/portphyserdesattr_ut.cpp
@@ -522,5 +522,97 @@ namespace portphyserdesattr_test
 
         gPortsOrch->clearPortPhySerdesAttrCounterMap();
     }
+
+    /*
+     * Regression test for sonic-buildimage#25165: if a port's configuration
+     * fails to parse (here, a serdes value missing the "0x" prefix), the port
+     * must not be left stranded in m_pendingPortSet. Otherwise allPortsReady()
+     * stays false forever and orchagent stops making progress on every other
+     * port.
+     */
+    TEST_F(PortSerdesAttrTest, ParseFailureDoesNotStrandPendingPort)
+    {
+        ASSERT_NE(gPortsOrch, nullptr);
+
+        const std::string alias = "Ethernet0";
+
+        Port p;
+        ASSERT_TRUE(gPortsOrch->getPort(alias, p));
+
+        // Emulate the warm-reboot bake() path, which pre-loads every port into
+        // m_pendingPortSet; allPortsReady() (and thus all further processing)
+        // is gated on this set draining.
+        gPortsOrch->m_pendingPortSet.emplace(alias);
+        ASSERT_EQ(gPortsOrch->m_pendingPortSet.count(alias), 1u);
+
+        // Push an update carrying an unparseable serdes value, which makes
+        // PortHelper::parsePortConfig() fail for this port.
+        auto consumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_PORT_TABLE_NAME));
+        ASSERT_NE(consumer, nullptr);
+
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({ alias, "SET", { { "idriver", "0" } } });
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        // The bad port must be dropped from the pending set instead of being
+        // stranded there forever.
+        EXPECT_EQ(gPortsOrch->m_pendingPortSet.count(alias), 0u);
+    }
+
+    /*
+     * Same regression (sonic-buildimage#25165) for the not-yet-created port
+     * path: a parse failure in the !portExists branch of doPortTask must also
+     * drop the port from m_pendingPortSet.
+     */
+    TEST_F(PortSerdesAttrTest, ParseFailureNewPortDropsPending)
+    {
+        ASSERT_NE(gPortsOrch, nullptr);
+
+        const std::string alias = "Ethernet512";
+        ASSERT_EQ(gPortsOrch->m_portList.count(alias), 0u); // not yet created
+
+        gPortsOrch->m_pendingPortSet.emplace(alias);
+        ASSERT_EQ(gPortsOrch->m_pendingPortSet.count(alias), 1u);
+
+        auto consumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_PORT_TABLE_NAME));
+        ASSERT_NE(consumer, nullptr);
+
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({ alias, "SET", { { "idriver", "0" } } });
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        EXPECT_EQ(gPortsOrch->m_pendingPortSet.count(alias), 0u);
+    }
+
+    /*
+     * Same regression (sonic-buildimage#25165) for the validation-failure
+     * path: a not-yet-created port whose config parses but fails
+     * validatePortConfig (missing mandatory lanes/speed) must also be dropped
+     * from m_pendingPortSet.
+     */
+    TEST_F(PortSerdesAttrTest, ValidateFailureNewPortDropsPending)
+    {
+        ASSERT_NE(gPortsOrch, nullptr);
+
+        const std::string alias = "Ethernet513";
+        ASSERT_EQ(gPortsOrch->m_portList.count(alias), 0u); // not yet created
+
+        gPortsOrch->m_pendingPortSet.emplace(alias);
+        ASSERT_EQ(gPortsOrch->m_pendingPortSet.count(alias), 1u);
+
+        auto consumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_PORT_TABLE_NAME));
+        ASSERT_NE(consumer, nullptr);
+
+        // Parses fine but misses mandatory lanes/speed, so validatePortConfig()
+        // returns false.
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({ alias, "SET", { { "admin_status", "up" } } });
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        EXPECT_EQ(gPortsOrch->m_pendingPortSet.count(alias), 0u);
+    }
 } // namespace portphyserdesattr_test
 


### PR DESCRIPTION
#### What I did

In `PortsOrch::doPortTask`, a port whose configuration fails to parse or
validate has its task erased but is left in `m_pendingPortSet`. Because
`allPortsReady()` is gated on that set draining, a single bad port (for
example an unparsable serdes value pushed from a bad `media_setting.json`)
keeps `allPortsReady()` false forever and stalls orchagent for every other
port — the busy loop reported in the issue, which can brick the device on
warm reboot.

This removes the affected port from `m_pendingPortSet` on parse/validate
failure so the impact stays isolated to that port.

Fixes sonic-net/sonic-buildimage#25165

#### Why I did it

As the issue notes, on a bad `media_setting.json` "only the port with bad
parameters should be impacted". The three failure paths in `doPortTask`
(the `!portExists` parse and validate failures, and the `portExists` update
parse failure) erase the task but never clear the pending entry, so one bad
port blocks all of them.

#### How I verified it

Unit tests in `tests/mock_tests/portphyserdesattr_ut.cpp`, one per failure
branch:

- `ParseFailureDoesNotStrandPendingPort` — existing port, bad serdes update
- `ParseFailureNewPortDropsPending` — not-yet-created port, parse failure
- `ValidateFailureNewPortDropsPending` — not-yet-created port, validation
  failure (missing mandatory fields)

Each passes with the fix and fails without it; the full `PortSerdesAttrTest`
fixture passes (8/8, no regressions).

I also reproduced the busy loop on a hardware switch: injecting a bad serdes
value and warm-restarting swss yields `bake()` →
`parsePortSerdes: Failed to parse field(...): Invalid argument: '0'` →
`WARM_RESTART_TABLE|orchagent` stuck at `initialized` (never `reconciled`).
With the port dropped from the pending set, reconciliation is no longer
blocked.
