### PR TITLE
[tests] mirror_ipv6_separate: skip on combined-mirror platforms (VS)

### DIFF
--- a/tests/test_mirror_ipv6_separate.py
+++ b/tests/test_mirror_ipv6_separate.py
@@ -1,9 +1,80 @@
 # This test suite covers the functionality of mirror feature in SwSS
 import time
 
+import pytest
+
 from swsscommon import swsscommon
 
 DVS_ENV = ["HWSKU=Mellanox-SN2700"]
+
+# Platforms on which aclorch keeps the v4 and v6 ACL mirror tables SEPARATE
+# (a v4-only MIRROR table + a distinct MIRRORV6 table). This mirrors the
+# m_isCombinedMirrorV6Table=false branch in AclOrch::setMirrorTableCapabilities():
+#   mellanox | cisco-8000 | marvell-prestera | xsight | clounix
+#   | (broadcom && sub_platform==broadcom-dnx)
+# Every other platform (including the default Virtual Switch, platform=vs) uses a
+# single COMBINED v4+v6 MIRROR table, for which test_mirror_ipv6_combined.py is
+# the correct coverage.
+SEPARATE_MIRROR_PLATFORMS = {
+    "mellanox",
+    "cisco-8000",
+    "marvell-prestera",
+    "xsight",
+    "clounix",
+}
+
+
+def _read_orchagent_env(dvs, name):
+    # aclorch reads the lowercase `platform`/`sub_platform` env via getenv(); that
+    # env is injected into the orchagent process (not the default container
+    # shell), so read it straight from the running orchagent's environment.
+    res = dvs.ctn.exec_run(
+        ["sh", "-c",
+         'p=$(pgrep -x orchagent | head -1); '
+         f'tr "\\0" "\\n" < /proc/$p/environ 2>/dev/null | sed -n "s/^{name}=//p" | head -1'])
+    return res.output.decode("utf-8").strip() if res.output else ""
+
+
+def get_orchagent_platform(dvs):
+    platform = _read_orchagent_env(dvs, "platform")
+    if not platform:
+        # Fall back to the orchagent init NOTICE: "<platform> switch capability:".
+        res = dvs.ctn.exec_run(
+            ["sh", "-c",
+             'grep -hoE "[a-z0-9_-]+ switch capability:" /var/log/syslog 2>/dev/null '
+             '| tail -1 | sed "s/ switch capability://"'])
+        platform = res.output.decode("utf-8").strip() if res.output else ""
+    return platform
+
+
+def uses_combined_mirror_table(dvs):
+    # True when the image programs a single combined v4+v6 MIRROR table (i.e. the
+    # separate-mode assertions in this module do not apply). Default VS images
+    # report platform=vs -> combined. Mellanox/Cisco/Marvell/etc. report their
+    # vendor platform -> separate. Mirrors aclorch's m_isCombinedMirrorV6Table.
+    platform = get_orchagent_platform(dvs)
+    if not platform:
+        # Could not determine platform; do not skip so a real misconfig surfaces.
+        return False
+    sub_platform = _read_orchagent_env(dvs, "sub_platform")
+    if platform == "broadcom" and sub_platform == "broadcom-dnx":
+        return False
+    return platform not in SEPARATE_MIRROR_PLATFORMS
+
+
+@pytest.fixture(scope="class", autouse=True)
+def skip_if_combined_mirror(dvs):
+    # Guard the whole separate-mode suite: skip when the image programs a
+    # combined v4+v6 mirror table (e.g. the default VS SAI image, platform=vs).
+    # This keeps the suite meaningful on split-table platforms while preventing
+    # false failures on combined-capability images. Combined-mode coverage lives
+    # in test_mirror_ipv6_combined.py.
+    if uses_combined_mirror_table(dvs):
+        platform = get_orchagent_platform(dvs)
+        pytest.skip(
+            f"platform={platform!r} programs a combined v4+v6 mirror table; "
+            "separate-mode mirror tests do not apply. "
+            "See test_mirror_ipv6_combined.py.")
 
 
 class TestMirror(object):


### PR DESCRIPTION
#### What I did

`tests/test_mirror_ipv6_separate.py` is hardcoded to the Mellanox **separate** mirror-table layout: it forces `DVS_ENV=["HWSKU=Mellanox-SN2700"]` and asserts a v4-only `MIRROR` ACL table (16 SAI attributes) plus a distinct `MIRRORV6` table.

But aclorch does **not** choose combined-vs-separate mirror tables based on HWSKU. `AclOrch::setMirrorTableCapabilities()` keys off the lowercase `platform`/`sub_platform` env (`getenv("platform")`). Only `mellanox`, `cisco-8000`, `marvell-prestera`, `xsight`, `clounix` (and `broadcom` + `sub_platform=broadcom-dnx`) program **separate** v4/v6 tables. Every other platform — including the Virtual Switch (`platform=vs`) — programs a single **combined** v4+v6 `MIRROR` table (21 attributes, adding `SRC_IPV6`/`ICMPV6_*`). Combined-mode coverage already exists in `test_mirror_ipv6_combined.py`.

This makes the separate-mode suite **platform-aware**: a `class`-scoped `autouse` fixture reads the running orchagent's `platform`/`sub_platform` (from the orchagent process `environ`, falling back to the orchagent init `"<platform> switch capability:"` NOTICE in syslog) and **skips** the suite when the image programs a combined mirror table. Split-table coverage is preserved on mellanox/cisco/marvell/etc.; false failures on combined-capability images (VS) are prevented. If the platform can't be determined, the suite is **not** skipped, so genuine misconfigurations still surface.

#### Why I did it

On the Virtual Switch image, `docker-orchagent/orchagent.sh` used to special-case `HWSKU=Mellanox-SN2700 -> export platform=mellanox`, which silently made this Mellanox-pinned suite pass on VS. Now that `orchagent.sh` derives `platform` from `asic_type` (`=vs`), the SN2700 HWSKU no longer changes the platform, the VS DUT programs the **combined** table, and all 5 separate-mode cases fail:

```
test_MirrorTableCreation          assert 21 == ((13+2)+1)   # combined table carries v6 fields
test_MirrorV6TableCreation        assert False              # no separate v6 table in combined mode
test_CreateMirrorIngressAndEgress expected=1 received=2     # leaked table from prior failed case
test_AclBindMirrorSeparated       assert 1 == 2
test_AclBindMirrorV6WrongConfig   assert 1 == 0
```

The combined layout is the **intended** VS behavior (aclorch builds it when both `MIRROR` and `MIRRORV6` are supported), so the right fix is to scope the separate-mode suite to the platforms that actually program separate tables — not to revert the platform derivation.

The `SEPARATE_MIRROR_PLATFORMS` set mirrors `AclOrch::setMirrorTableCapabilities()` exactly.

#### How I verified it

Ran the modified suite on the same VS DUT and a Mellanox-platform DUT:

- **VS image** (`platform=vs`, combined 21-attr table): suite **skips** — `8 skipped, 0 failed` (previously 5 failed).
- **Mellanox platform** (`platform=mellanox`, separate 16-attr table): suite still **runs and passes** — `8 passed, 0 skipped` (no over-skip; real split-table coverage retained).

The `platform`-env discriminator (not a STATE_DB `MIRRORV6` flag) is deliberate: Mellanox also reports `MIRRORV6=true`, so a capability flag would wrongly over-skip genuine split-table coverage; `platform` is the only correct discriminator and matches aclorch.
