### PR TITLE
[tests] Fix FABRIC_PORT_TABLE readiness race in check_swss_ready (20s wait vs 30s fabric poll)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -639,7 +639,7 @@ class DockerVirtualSwitch:
         if metadata.get('switch_type', 'npu') in ['voq', 'fabric']:
             if not self.switch_mode or (self.switch_mode and self.switch_mode != SINGLE_ASIC_VOQ_FS):
                 self.get_state_db()
-                self.state_db.wait_for_n_keys("FABRIC_PORT_TABLE", FABRIC_NUM_PORTS)
+                self.state_db.wait_for_n_keys("FABRIC_PORT_TABLE", FABRIC_NUM_PORTS, polling_config=PollingConfig(polling_interval=0.01, timeout=40, strict=True))
 
     def net_cleanup(self) -> None:
         """Clean up network, remove extra links."""


### PR DESCRIPTION
#### What I did fix

Fixed a pre-existing timing race in the `check_swss_ready()` test fixture that can make voq/fabric chassis vstests error at setup with:

```
AssertionError: Unexpected number of keys: expected=16, received=0 ([]), table="FABRIC_PORT_TABLE"
```

#### Why I did it

`DockerVirtualSwitch.check_swss_ready()` (tests/conftest.py) waits for STATE_DB `FABRIC_PORT_TABLE` to reach `FABRIC_NUM_PORTS` keys with the **default** `PollingConfig` (`timeout=20s`). On voq/fabric chassis, that table is only populated by orchagent's `FabricPortsOrch`, which runs off a `SelectableTimer` whose interval is `FABRIC_POLLING_INTERVAL_DEFAULT = 30` (seconds). The first poll therefore cannot fire before ~30s, so `FABRIC_PORT_TABLE` cannot reach its full key count inside the 20s wait.

Whether setup passes then depends purely on how much wall-time the earlier readiness waits (`PORT_TABLE` `PortInitDone`, ASIC_DB port objects) happen to consume before this fabric wait starts — a coin-flip race. Faster bring-ups lose it; slower ones win. Both the 20s default gate and the 30s poll interval predate this change (they were introduced together years ago), so this is a latent fixture race, not a regression from any recent image/branch.

#### How I verified it

On a voq virtual chassis, `FABRIC_PORT_TABLE` is observed to go from a transient 1 key to the full 16 keys at orchagent uptime ~33–36s (right after the first 30s `FABRIC_POLL` timer fires) — identical timing on a fresh build and a known-good baseline. With the default 20s wait the setup races and can error; widening this single wait past the 30s poll interval makes the first `FabricPortsOrch` poll always land before the wait expires, and the affected test (`test_pfcwd_shared_egress_acl_table`) then passes deterministically (`2 passed`).

The change is platform-agnostic — it only widens the single fabric-readiness wait — and helps all voq/fabric chassis vstests.

#### Which release branch to backport (if applicable)

<!-- N/A / maintainers' discretion -->

#### A picture of a cute animal (not mandatory but encouraged)

🦦
