### PR TITLE
neighsyncd, orchagent: fix strncpy truncation; enable FORTIFY_SOURCE=3

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -10,6 +10,10 @@ include /usr/share/dpkg/default.mk
 # see FEATURE AREAS in dpkg-buildflags(1)
 #export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
+# Upgrade FORTIFY_SOURCE to level 3 (dpkg default is =2).
+# -U clears the existing =2 set by dpkg before setting =3.
+export DEB_CPPFLAGS_MAINT_APPEND = -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3
+
 # see ENVIRONMENT in dpkg-buildflags(1)
 # package maintainers to append CFLAGS
 #export DEB_CFLAGS_MAINT_APPEND  = -Wall -pedantic

--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -290,6 +290,7 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     {
         std::string zero_mac = "00:00:00:00:00:00";
         strncpy(macStr, zero_mac.c_str(), zero_mac.length());
+        macStr[zero_mac.length()] = '\0';
     }
     else
     {

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -557,6 +557,7 @@ sai_status_t initSaiPhyApi(swss::gearbox_phy_t *phy)
        SWSS_LOG_ERROR( "hwinfo string attribute is too long." );
        return SAI_STATUS_FAILURE;
     }
+    memset(hwinfo, 0, HWINFO_MAX_SIZE + 1);
     strncpy(hwinfo, phy->hwinfo.c_str(), phy->hwinfo.length());
 
     attr.id = SAI_SWITCH_ATTR_SWITCH_HARDWARE_INFO;


### PR DESCRIPTION
**What I did**

Fix two instances where `strncpy(dst, str.c_str(), str.length())` was used without ensuring null termination, and enable `FORTIFY_SOURCE=3` in `debian/rules` so the package is built with the stronger check going forward.

- `neighsyncd/neighsync.cpp:292`: append `macStr[zero_mac.length()] = '\0'` after the strncpy
- `orchagent/saihelper.cpp:560`: restore `memset(hwinfo, 0, HWINFO_MAX_SIZE + 1)` before strncpy (was removed in #2383; adding it back does not change the SAI attribute payload since `s8list.count` remains `phy->hwinfo.length()`)

**Why I did it**

`strncpy(dst, src.c_str(), src.length())` copies exactly `src.length()` bytes without a null terminator. With `_FORTIFY_SOURCE=3`, GCC detects this at compile time and errors on the pattern.

**How I verified it**

Compiled both code paths against GCC 14 (Debian trixie) with `-Wall -Werror -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -O2`. Both exit 0.

**Details if related**

Part of enabling `FORTIFY_SOURCE=3` across SONiC packages (sonic-buildimage slave.mk PR #28153).