### PR TITLE
[azp]: Merge latest target branch before PR validation builds

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -79,6 +79,8 @@ jobs:
     vmImage: 'ubuntu-22.04'
 
   steps:
+  - checkout: self
+  - template: merge-target-branch.yml
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -107,6 +107,7 @@ jobs:
   - checkout: self
     clean: true
     submodules: true
+  - template: merge-target-branch.yml
   - script: |
       set -xe
       sudo apt-get update

--- a/.azure-pipelines/merge-target-branch.yml
+++ b/.azure-pipelines/merge-target-branch.yml
@@ -1,0 +1,46 @@
+# Reusable step template for PR validation builds.
+#
+# When a pipeline runs as part of pull request validation it fetches and merges
+# the tip of the target branch ($(BUILD_BRANCH)) into the checked-out sources.
+# This guarantees the PR is always built and tested against the latest version
+# of the target branch, catching integration issues even when the PR branch is
+# stale. Merge conflicts fail the step, signalling that the PR needs a rebase.
+#
+# For non-PR builds (CI, scheduled, manual) the template expands to no steps.
+#
+# Usage - add immediately after the "checkout: self" step of a job:
+#   steps:
+#   - checkout: self
+#   - template: merge-target-branch.yml
+
+steps:
+- ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+  - script: |
+      set -ex
+      git config user.name "SONiC CI"
+      git config user.email "sonic-ci@users.noreply.github.com"
+
+      # PR source branch head - the commit under review. Sourced from a pipeline
+      # runtime variable so it is pinned to the commit that triggered this build
+      # (no extra fetch, no risk of racing a newer push to the PR branch).
+      echo "PR source branch head: $(System.PullRequest.SourceCommitId)"
+
+      # Currently checked-out commit. For a PR build this is the auto-generated
+      # merge ref (PR source merged with the target branch at queue time).
+      echo "Checked-out HEAD before merge:"
+      git --no-pager log -1 --format='%H %s'
+
+      # Deepen a shallow checkout so a merge base with the target branch exists.
+      git fetch --unshallow 2>/dev/null || true
+      git fetch origin $(BUILD_BRANCH)
+
+      # Tip of the target branch that is about to be merged in.
+      echo "Fetched $(BUILD_BRANCH) tip:"
+      git --no-pager log -1 --format='%H %s' FETCH_HEAD
+
+      git merge --no-edit FETCH_HEAD
+
+      # Resulting merge commit that will actually be built and tested.
+      echo "Resulting HEAD after merge:"
+      git --no-pager log -1 --format='%H %s'
+    displayName: "Merge latest $(BUILD_BRANCH) into PR"

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -63,6 +63,7 @@ jobs:
       ls -A1 | xargs -I{} sudo rm -rf {}
     displayName: "Clean workspace"
   - checkout: self
+  - template: merge-target-branch.yml
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: ${{ parameters.docker_sonic_vs_name }}


### PR DESCRIPTION
### What I did
Added a reusable Azure Pipelines step template, `.azure-pipelines/merge-target-branch.yml`, that fetches and merges the tip of the target branch (`$(BUILD_BRANCH)`) into the sources immediately after the automatic checkout — **only for PR validation builds** (`Build.Reason == PullRequest`). For non-PR builds (CI, scheduled, manual) it expands to zero steps.

Wired it in right after `checkout: self` in:
- `build-template.yml` → Build, BuildAsan, BuildArm, BuildTrixie
- `test-docker-sonic-vs-template.yml` → Test, TestAsan
- `build-docker-sonic-vs-template.yml` → BuildDocker, BuildDockerAsan (added an explicit `checkout: self`, which previously relied on the implicit checkout)

### Why
PRs are currently built/tested against the target-branch state captured when the PR ref was last updated, which can be stale. Merging the latest target branch ensures every PR is validated against the current tip, catching integration issues early. Merge conflicts fail the step, signalling that the PR needs a rebase.

### Notes
- The step logs the PR source head (`$(System.PullRequest.SourceCommitId)`), the pre-merge HEAD, the fetched target tip, and the resulting merge commit for traceability.
- `git fetch --unshallow` deepens the shallow CI checkout so a merge base exists; `FETCH_HEAD` is used because the PR checkout configures a narrow refspec that doesn't reliably populate `origin/<target>`.
- `gcov.yml` is intentionally left out — that stage is disabled (`condition: false`) and its checkout is itself conditional.

### How to verify
On a PR build, the "Merge latest ... into PR" step runs and logs the merged SHAs; on non-PR builds the step is absent.

The first CI run triggered when this PR was opened was merged into master branch commit ab38ffc642521a63f5bf80d7dbda85afd1a70954: https://dev.azure.com/mssonic/build/_build/results?buildId=1153368&view=logs&j=83516c17-6666-5250-abde-63983ce72a49&t=7528e926-38ee-5af1-00ef-256f59c3c1f4&l=916

Retriggering the CI after new commits were added to master branch shows that the CI run is pulling the latest master branch commit cb266094ac4bb42424f08fd1bab3b8555c591849: https://dev.azure.com/mssonic/build/_build/results?buildId=1154976&view=logs&j=83516c17-6666-5250-abde-63983ce72a49&t=6135b38d-96c0-5932-8da0-4571a0c51203&l=390



Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>