### PR TITLE
orchagent_restart_check: report the specific failure reason

### DIFF
--- a/orchagent/orchagent_restart_check.cpp
+++ b/orchagent/orchagent_restart_check.cpp
@@ -149,13 +149,13 @@ int main(int argc, char **argv)
         }
         else if (result == swss::Select::TIMEOUT)
         {
-            SWSS_LOG_NOTICE("RESTARTCHECK for %s timed out", op_ret.c_str());
+            SWSS_LOG_NOTICE("RESTARTCHECK for %s timed out", op.c_str());
             failReason = "timed out waiting for orchagent to respond; it may be busy processing tasks "
                     "(e.g. large-scale routes), try increasing the wait time (-w) or retry count (-r)";
         }
         else
         {
-            SWSS_LOG_NOTICE("RESTARTCHECK for %s error", op_ret.c_str());
+            SWSS_LOG_NOTICE("RESTARTCHECK for %s error", op.c_str());
             failReason = "error while waiting for a response from orchagent";
         }
         retries++;

--- a/orchagent/orchagent_restart_check.cpp
+++ b/orchagent/orchagent_restart_check.cpp
@@ -121,6 +121,7 @@ int main(int argc, char **argv)
     std::string op = "orchagent";
 
     int retries = 0;
+    std::string failReason = "orchagent did not respond";
 
     while (retries <= retryCount)
     {
@@ -143,19 +144,23 @@ int main(int argc, char **argv)
             {
                 SWSS_LOG_NOTICE("RESTARTCHECK failed, %s is not ready for warm restart with status %s",
                         op_ret.c_str(), data.c_str());
+                failReason = "orchagent is not ready for warm restart, pending tasks remain (status: " + data + ")";
             }
         }
         else if (result == swss::Select::TIMEOUT)
         {
             SWSS_LOG_NOTICE("RESTARTCHECK for %s timed out", op_ret.c_str());
+            failReason = "timed out waiting for orchagent to respond; it may be busy processing tasks "
+                    "(e.g. large-scale routes), try increasing the wait time (-w) or retry count (-r)";
         }
         else
         {
             SWSS_LOG_NOTICE("RESTARTCHECK for %s error", op_ret.c_str());
+            failReason = "error while waiting for a response from orchagent";
         }
         retries++;
         values_ret.clear();
     }
-    std::cout << "RESTARTCHECK failed" << std::endl;
+    std::cout << "RESTARTCHECK failed: " << failReason << std::endl;
     return EXIT_FAILURE;
 }

--- a/orchagent/orchagent_restart_check.cpp
+++ b/orchagent/orchagent_restart_check.cpp
@@ -121,7 +121,7 @@ int main(int argc, char **argv)
     std::string op = "orchagent";
 
     int retries = 0;
-    std::string failReason = "orchagent did not respond";
+    std::string failReason = "";
 
     while (retries <= retryCount)
     {
@@ -150,8 +150,7 @@ int main(int argc, char **argv)
         else if (result == swss::Select::TIMEOUT)
         {
             SWSS_LOG_NOTICE("RESTARTCHECK for %s timed out", op.c_str());
-            failReason = "timed out waiting for orchagent to respond; it may be busy processing tasks "
-                    "(e.g. large-scale routes), try increasing the wait time (-w) or retry count (-r)";
+            failReason = "timed out waiting for orchagent to respond; try increasing the wait time (-w) or retry count (-r)";
         }
         else
         {

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -933,7 +933,7 @@ class TestWarmReboot(object):
         time.sleep(1)
         # Should fail, since neighbor for next 20.0.0.1 has not been not resolved yet
         (exitcode, result) =  dvs.runcmd("/usr/bin/orchagent_restart_check", include_stderr=False)
-        assert result == "RESTARTCHECK failed\n"
+        assert result == "RESTARTCHECK failed: orchagent is not ready for warm restart, pending tasks remain (status: NOT_READY)\n"
 
         # Should succeed, the option for skipPendingTaskCheck -s and noFreeze -n have been provided.
         # Wait up to 500 milliseconds for response from orchagent. Default wait time is 1000 milliseconds.
@@ -949,7 +949,7 @@ class TestWarmReboot(object):
 
         # Should fail since orchagent has been frozen at last step.
         (exitcode, result) =  dvs.runcmd("/usr/bin/orchagent_restart_check -n -s -w 500", include_stderr=False)
-        assert result == "RESTARTCHECK failed\n"
+        assert result == "RESTARTCHECK failed: timed out waiting for orchagent to respond; it may be busy processing tasks (e.g. large-scale routes), try increasing the wait time (-w) or retry count (-r)\n"
 
         # Cleaning previously pushed route-entry to ease life of subsequent testcases.
         ps._del("2.2.2.0/24")

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -932,7 +932,8 @@ class TestWarmReboot(object):
 
         time.sleep(1)
         # Should fail, since neighbor for next 20.0.0.1 has not been not resolved yet
-        (exitcode, result) =  dvs.runcmd("/usr/bin/orchagent_restart_check", include_stderr=False)
+        # Allow a longer wait so a slow orchagent reports NOT_READY rather than timing out.
+        (exitcode, result) =  dvs.runcmd("/usr/bin/orchagent_restart_check -w 5000", include_stderr=False)
         assert result == "RESTARTCHECK failed: orchagent is not ready for warm restart, pending tasks remain (status: NOT_READY)\n"
 
         # Should succeed, the option for skipPendingTaskCheck -s and noFreeze -n have been provided.
@@ -949,7 +950,7 @@ class TestWarmReboot(object):
 
         # Should fail since orchagent has been frozen at last step.
         (exitcode, result) =  dvs.runcmd("/usr/bin/orchagent_restart_check -n -s -w 500", include_stderr=False)
-        assert result == "RESTARTCHECK failed: timed out waiting for orchagent to respond; it may be busy processing tasks (e.g. large-scale routes), try increasing the wait time (-w) or retry count (-r)\n"
+        assert result == "RESTARTCHECK failed: timed out waiting for orchagent to respond; try increasing the wait time (-w) or retry count (-r)\n"
 
         # Cleaning previously pushed route-entry to ease life of subsequent testcases.
         ps._del("2.2.2.0/24")


### PR DESCRIPTION
#### What I did
`orchagent_restart_check` logs the specific reason a warm-restart readiness check failed to syslog (pending tasks, timeout, or select error), but always prints the same bare `RESTARTCHECK failed` to stdout. An operator (or the warm-reboot test) who only sees stdout cannot tell *why* the check failed — the most common real cause being a timeout when orchagent is still busy processing large-scale routes on a slower CPU.

This tracks the failure reason and appends it to the stdout line, e.g.:
- `RESTARTCHECK failed: timed out waiting for orchagent to respond; it may be busy processing tasks (e.g. large-scale routes), try increasing the wait time (-w) or retry count (-r)`
- `RESTARTCHECK failed: orchagent is not ready for warm restart, pending tasks remain (status: NOT_READY)`
- `RESTARTCHECK failed: error while waiting for a response from orchagent`

The `RESTARTCHECK failed` prefix and the `EXIT_FAILURE` return code are preserved, so existing callers keyed off the exit code are unaffected.

Fixes sonic-net/sonic-buildimage#21841

#### Why I did it
`RESTARTCHECK failed` alone gives no actionable information. Surfacing the reason (already known internally and logged to syslog) on stdout lets a user immediately see whether to raise the wait time / retry count or investigate pending tasks.

#### How I verified it
- Built `orchagent_restart_check` and ran it against redis with no orchagent responding → it prints the new timeout message and returns exit code 1.
- Updated `tests/test_warm_reboot.py`: its two failure assertions now exercise the two distinct messages — the pending-task path (unresolved neighbor → `NOT_READY`) and the frozen-orchagent path (→ timeout).
- On a QFX5241, confirmed the current bare `RESTARTCHECK failed` on a failing check while syslog held the actual reason (`RESTARTCHECK for orchagent timed out`), and that the success path (`RESTARTCHECK succeeded`) is unchanged.
