### PR TITLE
[aclorch]: Support SET_TC (traffic class) ACL rule action

### DIFF
--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -651,6 +651,11 @@ Stores rules associated with a specific ACL table on the switch.
     mirror_ingress_action = 1*255VCHAR         ; refer to the mirror session
     mirror_egress_action = 1*255VCHAR          ; refer to the mirror session
 
+    tc_action     = 1*3DIGIT                   ; sets the traffic class (CoS) on matching packets; decimal uint8 [0..255].
+                                               ; Maps to SAI_ACL_ENTRY_ATTR_ACTION_SET_TC.
+                                               ; Supported only where the platform SAI advertises the action for the
+                                               ; table's ACL stage (ingress and/or egress)
+
     ether_type    = h16                        ; Ethernet type field
 
     ip_type       = ip_types                   ; options of the l2_protocol_type

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -112,7 +112,8 @@ static acl_rule_attr_lookup_t aclL3ActionLookup =
     { ACTION_PACKET_ACTION,                    SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION },
     { ACTION_REDIRECT_ACTION,                  SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT },
     { ACTION_DO_NOT_NAT_ACTION,                SAI_ACL_ENTRY_ATTR_ACTION_NO_NAT },
-    { ACTION_DISABLE_TRIM,                     SAI_ACL_ENTRY_ATTR_ACTION_PACKET_TRIM_DISABLE }
+    { ACTION_DISABLE_TRIM,                     SAI_ACL_ENTRY_ATTR_ACTION_PACKET_TRIM_DISABLE },
+    { ACTION_TC,                               SAI_ACL_ENTRY_ATTR_ACTION_SET_TC }
 };
 
 static acl_rule_attr_lookup_t aclInnerActionLookup =
@@ -2217,6 +2218,19 @@ bool AclRulePacket::validateAddAction(string attr_name, string _attr_value)
         }
         actionData.parameter.oid = param_id;
     }
+    else if (attr_name == ACTION_TC)
+    {
+        try
+        {
+            actionData.parameter.u8 = to_uint<uint8_t>(attr_value);
+        }
+        catch (const std::exception& e)
+        {
+            SWSS_LOG_ERROR("Invalid traffic class value '%s' for action %s: %s",
+                           attr_value.c_str(), attr_name.c_str(), e.what());
+            return false;
+        }
+    }
     else
     {
         return false;
@@ -2322,7 +2336,31 @@ bool AclRulePacket::validate()
 {
     SWSS_LOG_ENTER();
 
-    if ((m_rangeConfig.empty() && m_matches.empty()) || m_actions.size() != 1)
+    if (m_rangeConfig.empty() && m_matches.empty())
+    {
+        return false;
+    }
+
+    // A packet rule must carry at least one action.
+    if (m_actions.empty())
+    {
+        return false;
+    }
+
+    // SET_TC is a composable QoS action: it assigns the traffic class of a matched packet and
+    // may accompany a single forwarding/terminating action (e.g. FORWARD/DROP/REDIRECT) rather
+    // than being exclusive. Exclude it from the single exclusive-action check so a rule may both
+    // forward and set the traffic class. (COUNTER is tracked separately and always composes.)
+    size_t nonComposableActions = 0;
+    for (const auto& action : m_actions)
+    {
+        if (action.first != SAI_ACL_ENTRY_ATTR_ACTION_SET_TC)
+        {
+            nonComposableActions++;
+        }
+    }
+
+    if (nonComposableActions > 1)
     {
         return false;
     }

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -83,6 +83,7 @@
 #define ACTION_COUNTER                      "COUNTER"
 #define ACTION_META_DATA                    "META_DATA_ACTION"
 #define ACTION_DSCP                         "DSCP_ACTION"
+#define ACTION_TC                           "TC_ACTION"
 #define ACTION_INNER_SRC_MAC_REWRITE_ACTION "INNER_SRC_MAC_REWRITE_ACTION"
 
 #define PACKET_ACTION_FORWARD      "FORWARD"

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -2061,6 +2061,307 @@ namespace aclorch_test
         ASSERT_TRUE(validateAclRuleByConfOp(*it_rule->second, kfvFieldsValues(kvfAclRule.front())));
     }
 
+    sai_switch_api_t *old_sai_switch_api_set_tc;
+
+    // Override SAI get_switch_attribute so that the ASIC reports SET_TC
+    // (and PACKET_ACTION) as supported ACL actions for both stages.
+    sai_status_t getSwitchAttributeSetTc(_In_ sai_object_id_t switch_id, _In_ uint32_t attr_count,
+                                         _Inout_ sai_attribute_t *attr_list)
+    {
+        if (attr_count == 1)
+        {
+            switch (attr_list[0].id)
+            {
+            case SAI_SWITCH_ATTR_MAX_ACL_ACTION_COUNT:
+                attr_list[0].value.u32 = 2;
+                return SAI_STATUS_SUCCESS;
+            case SAI_SWITCH_ATTR_ACL_STAGE_INGRESS:
+            case SAI_SWITCH_ATTR_ACL_STAGE_EGRESS:
+                attr_list[0].value.aclcapability.action_list.count = 2;
+                attr_list[0].value.aclcapability.action_list.list[0] = SAI_ACL_ACTION_TYPE_PACKET_ACTION;
+                attr_list[0].value.aclcapability.action_list.list[1] = SAI_ACL_ACTION_TYPE_SET_TC;
+                attr_list[0].value.aclcapability.is_action_list_mandatory = false;
+                return SAI_STATUS_SUCCESS;
+            }
+        }
+        return old_sai_switch_api_set_tc->get_switch_attribute(switch_id, attr_count, attr_list);
+    }
+
+    // Verify that the generic (CONFIG_DB) ACL path programs
+    // SAI_ACL_ENTRY_ATTR_ACTION_SET_TC with the right uint8 traffic class value
+    // for the TC_ACTION rule action, and that invalid values are rejected.
+    TEST_F(AclOrchTest, AclRuleSetTcAction)
+    {
+        // Report SET_TC as a supported ACL action.
+        old_sai_switch_api_set_tc = sai_switch_api;
+        sai_switch_api_t new_sai_switch_api = *sai_switch_api;
+        sai_switch_api = &new_sai_switch_api;
+        sai_switch_api->get_switch_attribute = getSwitchAttributeSetTc;
+
+        // Restore the global SAI switch API on every exit path (including an
+        // early return from a failed ASSERT_* below) so TearDown() never
+        // dereferences the stack-allocated override above.
+        struct SaiSwitchApiRestore {
+            ~SaiSwitchApiRestore() { sai_switch_api = old_sai_switch_api_set_tc; }
+        } saiSwitchApiRestore;
+
+        auto orch = createAclOrch();
+
+        const string aclTableTypeName = "TC_TABLE_TYPE";
+        const string aclTableName = "TC_TABLE";
+
+        orch->doAclTableTypeTask(
+            deque<KeyOpFieldsValuesTuple>(
+            {
+                {
+                    aclTableTypeName,
+                    SET_COMMAND,
+                    {
+                        { ACL_TABLE_TYPE_MATCHES, MATCH_SRC_IP },
+                        { ACL_TABLE_TYPE_ACTIONS, ACTION_TC }
+                    }
+                }
+            })
+        );
+
+        orch->doAclTableTask(
+            deque<KeyOpFieldsValuesTuple>(
+            {
+                {
+                    aclTableName,
+                    SET_COMMAND,
+                    {
+                        { ACL_TABLE_TYPE, aclTableTypeName },
+                        { ACL_TABLE_STAGE, STAGE_INGRESS }
+                    }
+                }
+            })
+        );
+        ASSERT_TRUE(orch->getAclTable(aclTableName));
+
+        const vector<pair<string, uint8_t>> tcValues = {
+            { "0",   0   },
+            { "1",   1   },
+            { "7",   7   },
+            { "255", 255 }
+        };
+
+        for (const auto &tc : tcValues)
+        {
+            const string aclRuleName = "TC_RULE_" + tc.first;
+            orch->doAclRuleTask(
+                deque<KeyOpFieldsValuesTuple>(
+                {
+                    {
+                        aclTableName + "|" + aclRuleName,
+                        SET_COMMAND,
+                        {
+                            { RULE_PRIORITY, "999" },
+                            { MATCH_SRC_IP, "1.2.3.4/32" },
+                            { ACTION_TC, tc.first }
+                        }
+                    }
+                })
+            );
+
+            auto rule = orch->getAclRule(aclTableName, aclRuleName);
+            ASSERT_NE(rule, nullptr);
+
+            const auto &actions = Portal::AclRuleInternal::getActions(rule);
+            auto it = actions.find(SAI_ACL_ENTRY_ATTR_ACTION_SET_TC);
+            ASSERT_NE(it, actions.end());
+            ASSERT_TRUE(it->second.getSaiAttr().value.aclaction.enable);
+            ASSERT_EQ(it->second.getSaiAttr().value.aclaction.parameter.u8, tc.second);
+        }
+
+        // Invalid traffic class values must be rejected (rule not created):
+        // out-of-range (> 255) and non-numeric.
+        for (const string &badTc : { string("256"), string("ABC") })
+        {
+            const string aclRuleName = "TC_RULE_INVALID_" + badTc;
+            orch->doAclRuleTask(
+                deque<KeyOpFieldsValuesTuple>(
+                {
+                    {
+                        aclTableName + "|" + aclRuleName,
+                        SET_COMMAND,
+                        {
+                            { RULE_PRIORITY, "998" },
+                            { MATCH_SRC_IP, "1.2.3.5/32" },
+                            { ACTION_TC, badTc }
+                        }
+                    }
+                })
+            );
+            ASSERT_EQ(orch->getAclRule(aclTableName, aclRuleName), nullptr);
+        }
+    }
+
+    // Verify that TC_ACTION composes with a forwarding action: a rule carrying both
+    // PACKET_ACTION (FORWARD) and TC_ACTION is created, and BOTH SAI actions are programmed.
+    // Regression for AclRulePacket::validate() treating SET_TC as an exclusive action (which
+    // would reject a rule that both forwards a packet and sets its traffic class).
+    TEST_F(AclOrchTest, AclRuleSetTcActionComposeForward)
+    {
+        // Report SET_TC and PACKET_ACTION as supported ACL actions.
+        old_sai_switch_api_set_tc = sai_switch_api;
+        sai_switch_api_t new_sai_switch_api = *sai_switch_api;
+        sai_switch_api = &new_sai_switch_api;
+        sai_switch_api->get_switch_attribute = getSwitchAttributeSetTc;
+
+        struct SaiSwitchApiRestore {
+            ~SaiSwitchApiRestore() { sai_switch_api = old_sai_switch_api_set_tc; }
+        } saiSwitchApiRestore;
+
+        auto orch = createAclOrch();
+
+        const string aclTableTypeName = "TC_TABLE_TYPE";
+        const string aclTableName = "TC_TABLE";
+
+        orch->doAclTableTypeTask(
+            deque<KeyOpFieldsValuesTuple>(
+            {
+                {
+                    aclTableTypeName,
+                    SET_COMMAND,
+                    {
+                        { ACL_TABLE_TYPE_MATCHES, MATCH_SRC_IP },
+                        { ACL_TABLE_TYPE_ACTIONS, string(ACTION_PACKET_ACTION) + comma + ACTION_TC }
+                    }
+                }
+            })
+        );
+
+        orch->doAclTableTask(
+            deque<KeyOpFieldsValuesTuple>(
+            {
+                {
+                    aclTableName,
+                    SET_COMMAND,
+                    {
+                        { ACL_TABLE_TYPE, aclTableTypeName },
+                        { ACL_TABLE_STAGE, STAGE_INGRESS }
+                    }
+                }
+            })
+        );
+        ASSERT_TRUE(orch->getAclTable(aclTableName));
+
+        const string aclRuleName = "TC_RULE_FORWARD";
+        orch->doAclRuleTask(
+            deque<KeyOpFieldsValuesTuple>(
+            {
+                {
+                    aclTableName + "|" + aclRuleName,
+                    SET_COMMAND,
+                    {
+                        { RULE_PRIORITY, "999" },
+                        { MATCH_SRC_IP, "1.2.3.4/32" },
+                        { ACTION_PACKET_ACTION, PACKET_ACTION_FORWARD },
+                        { ACTION_TC, "3" }
+                    }
+                }
+            })
+        );
+
+        // The composed rule must be created (validate() must not treat SET_TC as exclusive).
+        auto rule = orch->getAclRule(aclTableName, aclRuleName);
+        ASSERT_NE(rule, nullptr);
+
+        const auto &actions = Portal::AclRuleInternal::getActions(rule);
+
+        // Both actions are programmed: SET_TC with the configured traffic class ...
+        auto tcIt = actions.find(SAI_ACL_ENTRY_ATTR_ACTION_SET_TC);
+        ASSERT_NE(tcIt, actions.end());
+        ASSERT_TRUE(tcIt->second.getSaiAttr().value.aclaction.enable);
+        ASSERT_EQ(tcIt->second.getSaiAttr().value.aclaction.parameter.u8, 3);
+
+        // ... and PACKET_ACTION set to FORWARD.
+        auto paIt = actions.find(SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION);
+        ASSERT_NE(paIt, actions.end());
+        ASSERT_TRUE(paIt->second.getSaiAttr().value.aclaction.enable);
+        ASSERT_EQ(paIt->second.getSaiAttr().value.aclaction.parameter.s32, SAI_PACKET_ACTION_FORWARD);
+    }
+
+    sai_switch_api_t *old_sai_switch_api_no_set_tc;
+
+    // Override SAI get_switch_attribute so that the ASIC does NOT advertise
+    // SET_TC (only PACKET_ACTION is supported).
+    sai_status_t getSwitchAttributeNoSetTc(_In_ sai_object_id_t switch_id, _In_ uint32_t attr_count,
+                                           _Inout_ sai_attribute_t *attr_list)
+    {
+        if (attr_count == 1)
+        {
+            switch (attr_list[0].id)
+            {
+            case SAI_SWITCH_ATTR_MAX_ACL_ACTION_COUNT:
+                attr_list[0].value.u32 = 1;
+                return SAI_STATUS_SUCCESS;
+            case SAI_SWITCH_ATTR_ACL_STAGE_INGRESS:
+            case SAI_SWITCH_ATTR_ACL_STAGE_EGRESS:
+                attr_list[0].value.aclcapability.action_list.count = 1;
+                attr_list[0].value.aclcapability.action_list.list[0] = SAI_ACL_ACTION_TYPE_PACKET_ACTION;
+                attr_list[0].value.aclcapability.is_action_list_mandatory = false;
+                return SAI_STATUS_SUCCESS;
+            }
+        }
+        return old_sai_switch_api_no_set_tc->get_switch_attribute(switch_id, attr_count, attr_list);
+    }
+
+    // When the ASIC does not advertise SET_TC, an ACL table whose type lists
+    // TC_ACTION must be rejected: AclOrch validates every table action against
+    // the queried switch capability on table creation.
+    TEST_F(AclOrchTest, AclTableSetTcActionNotSupported)
+    {
+        old_sai_switch_api_no_set_tc = sai_switch_api;
+        sai_switch_api_t new_sai_switch_api = *sai_switch_api;
+        sai_switch_api = &new_sai_switch_api;
+        sai_switch_api->get_switch_attribute = getSwitchAttributeNoSetTc;
+
+        // Restore the global SAI switch API on every exit path (including an
+        // early return from a failed ASSERT_* below) so TearDown() never
+        // dereferences the stack-allocated override above.
+        struct SaiSwitchApiRestore {
+            ~SaiSwitchApiRestore() { sai_switch_api = old_sai_switch_api_no_set_tc; }
+        } saiSwitchApiRestore;
+
+        auto orch = createAclOrch();
+
+        const string aclTableTypeName = "TC_UNSUP_TABLE_TYPE";
+        const string aclTableName = "TC_UNSUP_TABLE";
+
+        orch->doAclTableTypeTask(
+            deque<KeyOpFieldsValuesTuple>(
+            {
+                {
+                    aclTableTypeName,
+                    SET_COMMAND,
+                    {
+                        { ACL_TABLE_TYPE_MATCHES, MATCH_SRC_IP },
+                        { ACL_TABLE_TYPE_ACTIONS, string(ACTION_PACKET_ACTION) + comma + ACTION_TC }
+                    }
+                }
+            })
+        );
+
+        orch->doAclTableTask(
+            deque<KeyOpFieldsValuesTuple>(
+            {
+                {
+                    aclTableName,
+                    SET_COMMAND,
+                    {
+                        { ACL_TABLE_TYPE, aclTableTypeName },
+                        { ACL_TABLE_STAGE, STAGE_INGRESS }
+                    }
+                }
+            })
+        );
+
+        // The table is rejected because SET_TC is not a supported action.
+        ASSERT_EQ(orch->getAclTable(aclTableName), nullptr);
+    }
+
     TEST_F(AclOrchTest, AclInnerSourceMacRewriteTableValidation)
     {
         const string aclTableTypeName = "INNER_SRC_MAC_REWRITE_TABLE_TYPE";


### PR DESCRIPTION
#### Why I did it
SONiC ACL rules can already *match* on traffic class (TC) but cannot *set* it. This adds the `TC_ACTION` ACL rule action, mapping to `SAI_ACL_ENTRY_ATTR_ACTION_SET_TC`, closing a capability gap parallel to the existing `SET_POLICER` / `SET_PACKET_COLOR` actions. Previously `SAI_ACL_ENTRY_ATTR_ACTION_SET_TC` was only reachable via the P4Orch/P4RT path.

#### How I did it
- Add `ACTION_TC` (`"TC_ACTION"`) to `aclL3ActionLookup`, mapping to `SAI_ACL_ENTRY_ATTR_ACTION_SET_TC`.
- Parse the 8-bit value (0-255) in `AclRulePacket::validateAddAction` into `parameter.u8`, with error handling for invalid / out-of-range input.
- Treat `SET_TC` as a composable (additive) QoS action: relax `AclRulePacket::validate()` to exclude `SAI_ACL_ENTRY_ATTR_ACTION_SET_TC` from the single exclusive-action check, so a rule may set the traffic class alone or alongside a single forwarding action (`FORWARD`/`DROP`/`REDIRECT`) and/or a counter.
- Capability-gated through the existing `setAction` / capability-query path: a table or rule that uses it is rejected on platforms whose SAI does not advertise the action for the ACL stage, so there is no behavior change for existing platforms.
- `TC_ACTION` is validated as a `uint8` (0-255) matching the SAI type; the platform-specific valid range (the ASIC's traffic-class count) is enforced by SAI at program time, consistent with how `SET_DSCP` is handled.

#### How to verify it
- Unit tests (`tests/mock_tests/aclorch_ut.cpp`):
  - `AclOrchTest.AclRuleSetTcAction` — values 0/1/7/255 verify `parameter.u8`; invalid 256/ABC rejected.
  - `AclOrchTest.AclRuleSetTcActionComposeForward` — a `FORWARD` + `TC_ACTION` rule programs both `SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION` and `SAI_ACL_ENTRY_ATTR_ACTION_SET_TC`.
  - `AclOrchTest.AclTableSetTcActionNotSupported` — a `TC_ACTION` table is rejected where SAI does not advertise the action.
- Hardware (Broadcom TH5): STATE_DB advertises `TC_ACTION` on ingress; a composed `FORWARD` + `TC_ACTION` rule goes Active and its ASIC_DB entry carries both `SAI_PACKET_ACTION_FORWARD` and `SAI_ACL_ENTRY_ATTR_ACTION_SET_TC = 3` (Broadcom field processor: `act=PrioIntNew param0=3`); matched IPv4/IPv6 traffic egresses on the TC-mapped unicast queue UC3.

---
Related PRs:

| Repo | PR title | State |
| ---- | -------- | ----- |
| SONiC | [doc/acl: Add TC_ACTION (set traffic class) ACL rule action](https://github.com/sonic-net/SONiC/pull/2432) | ![state](https://img.shields.io/github/pulls/detail/state/sonic-net/SONiC/2432) |
| sonic-buildimage | [sonic-yang-models: Add TC_ACTION to sonic-acl](https://github.com/sonic-net/sonic-buildimage/pull/28193) | ![state](https://img.shields.io/github/pulls/detail/state/sonic-net/sonic-buildimage/28193) |
| sonic-mgmt | [tests: SET_TC (TC_ACTION) ACL rule action](https://github.com/sonic-net/sonic-mgmt/pull/26099) | ![state](https://img.shields.io/github/pulls/detail/state/sonic-net/sonic-mgmt/26099) |

