### PR TITLE
Revert "cherry-pick-202511: Disable bulk requests for PORT counters"

### DIFF
--- a/orchagent/flex_counter/flex_counter_manager.h
+++ b/orchagent/flex_counter/flex_counter_manager.h
@@ -196,28 +196,14 @@ struct CachedObjects
             auto counter_ids = FlexCounterManager::serializeCounterStats(counter_stats);
             auto counter_type_it = FlexCounterManager::counter_id_field_lookup.find(counter_type);
 
-            // Temporary fix for SNMP PFC counter issue: disable bulk init requests for PORT counters
-            // This forces each port to be processed individually, avoiding capability mismatch
-            // for different ports in bulk requests
-            if (counter_type == CounterType::PORT)
+            auto counter_keys = group_name + ":";
+            for (const auto& oid: pending_sai_objects)
             {
-                for (const auto& oid: pending_sai_objects)
-                {
-                    auto counter_key = group_name + ":" + sai_serialize_object_id(oid);
-                    startFlexCounterPolling(switch_id, counter_key, counter_ids, counter_type_it->second);
-                }
+                counter_keys += sai_serialize_object_id(oid) + ",";
             }
-            else
-            {
-                auto counter_keys = group_name + ":";
-                for (const auto& oid: pending_sai_objects)
-                {
-                    counter_keys += sai_serialize_object_id(oid) + ",";
-                }
-                counter_keys.pop_back();
+            counter_keys.pop_back();
 
-                startFlexCounterPolling(switch_id, counter_keys, counter_ids, counter_type_it->second);
-            }
+            startFlexCounterPolling(switch_id, counter_keys, counter_ids, counter_type_it->second);
         }
 
         /* Clear all cached entries after flush */

--- a/tests/mock_tests/flexcounter_ut.cpp
+++ b/tests/mock_tests/flexcounter_ut.cpp
@@ -1127,9 +1127,7 @@ namespace flexcounter_test
         port_stat_manager.flush();
 
         /* SAIREDIS channel should have been called thrice, once for port1&port2&port5, port3&port4 and port6*/
-        // ASSERT_EQ(mockFlexCounterOperationCallCount, 3);
-        // Temporary fix for SNMP PFC counter issue: disabled bulk init requests for PORT counters
-        ASSERT_EQ(mockFlexCounterOperationCallCount, 6);
+        ASSERT_EQ(mockFlexCounterOperationCallCount, 3);
 
         ASSERT_TRUE(checkFlexCounter(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, port6_oid,
                                      {


### PR DESCRIPTION
Reverts sonic-net/sonic-swss#4115

Issue caused : https://github.com/sonic-net/sonic-buildimage/issues/28066

Also, this PR is not present in master. please raise a master pr first before requesting porting for release branches.