### PR TITLE
tests: harden DVS startup failure handling

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,14 @@ NUM_PORTS = 32
 FABRIC_NUM_PORTS = 16
 
 SINGLE_ASIC_VOQ_FS = "single_asic_voq_fs"
-DEFAULT_DVS_SERVICE_READY_TIMEOUT = int(os.environ.get("DVS_SERVICE_READY_TIMEOUT", "180"))
+
+def get_dvs_service_ready_timeout():
+    try:
+        return int(os.environ.get("DVS_SERVICE_READY_TIMEOUT", "180"))
+    except ValueError:
+        return 180
+
+DEFAULT_DVS_SERVICE_READY_TIMEOUT = get_dvs_service_ready_timeout()
 
 def ensure_system(cmd):
     rc, output = subprocess.getstatusoutput(cmd)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,7 @@ NUM_PORTS = 32
 FABRIC_NUM_PORTS = 16
 
 SINGLE_ASIC_VOQ_FS = "single_asic_voq_fs"
+DEFAULT_DVS_SERVICE_READY_TIMEOUT = int(os.environ.get("DVS_SERVICE_READY_TIMEOUT", "180"))
 
 def ensure_system(cmd):
     rc, output = subprocess.getstatusoutput(cmd)
@@ -564,7 +565,7 @@ class DockerVirtualSwitch:
             self.destroy()
             raise
 
-    def check_services_ready(self, timeout=60) -> None:
+    def check_services_ready(self, timeout=DEFAULT_DVS_SERVICE_READY_TIMEOUT) -> None:
         """Check if all processes in the DVS are ready."""
         service_polling_config = PollingConfig(1, timeout, strict=True)
 
@@ -1951,6 +1952,7 @@ def manage_dvs(request) -> str:
             if dvs is not None:
                 dvs.get_logs()
                 dvs.destroy()
+                dvs = None
 
             vol = {}
             if switch_mode and switch_mode == SINGLE_ASIC_VOQ_FS:
@@ -1958,7 +1960,8 @@ def manage_dvs(request) -> str:
                 voq_configs = cwd + "/single_asic_voq_fs"
                 vol[voq_configs] = {"bind": "/usr/share/sonic/single_asic_voq_fs", "mode": "ro"}
 
-            dvs = DockerVirtualSwitch(name, imgname, keeptb, new_dvs_env, log_path, max_cpu, forcedvs, buffer_model = buffer_model, enable_coverage=enable_coverage, ctnmounts=vol, switch_mode=switch_mode)
+            new_dvs = DockerVirtualSwitch(name, imgname, keeptb, new_dvs_env, log_path, max_cpu, forcedvs, buffer_model = buffer_model, enable_coverage=enable_coverage, ctnmounts=vol, switch_mode=switch_mode)
+            dvs = new_dvs
 
             curr_dvs_env = new_dvs_env
 
@@ -1976,6 +1979,9 @@ def manage_dvs(request) -> str:
         return dvs
 
     yield update_dvs
+
+    if dvs is None:
+        return
 
     if graceful_stop:
         dvs.stop_swss()


### PR DESCRIPTION
### Why

Azure.sonic-sairedis PR CI intermittently fails in VS/DVS setup. The failure pattern tracked in #4728 shows DVS service readiness timing out while most services remain STOPPED and `start.sh`/`syncd` exit. After a failed recreate, follow-on tests can cascade with Redis socket and Docker `No such container` errors.

### What changed

- Increase default DVS service readiness wait from 60s to 180s.
- Allow CI/local override via `DVS_SERVICE_READY_TIMEOUT`.
- Clear the session-scoped DVS object after destroying it before recreation, so a failed constructor does not leave a stale destroyed DVS reference.
- Skip session teardown when no DVS object exists, avoiding secondary `NoneType`/destroyed-container teardown errors after startup failure.

### Validation

- `python -m py_compile tests/conftest.py tests/dvslib/dvs_common.py`
- `git diff --check`

### Related

- Tracks #4728
- Observed while triaging sonic-net/sonic-sairedis#1962 Azure build 1153496.