### PR TITLE
[vrfmgrd][fpmsyncd]: Implement Linux VRF Route Lookup Fallback Control

### DIFF
--- a/cfgmgr/vrfmgr.cpp
+++ b/cfgmgr/vrfmgr.cpp
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <exception>
 #include "logger.h"
 #include "dbconnector.h"
 #include "producerstatetable.h"
@@ -17,14 +18,75 @@
 
 using namespace swss;
 
+namespace
+{
+
+/* Matches the CFG table name generated from the companion YANG model. */
+constexpr auto KERNEL_VRF_FALLBACK_CONFIG_TABLE = "KERNEL_VRF_FALLBACK";
+constexpr auto KERNEL_VRF_FALLBACK_GLOBAL_KEY = "GLOBAL";
+constexpr auto KERNEL_VRF_FALLBACK_STATUS_FIELD = "status";
+constexpr auto KERNEL_VRF_FALLBACK_ENABLED = "enabled";
+constexpr auto KERNEL_VRF_FALLBACK_DISABLED = "disabled";
+constexpr auto KERNEL_VRF_SENTINEL_METRIC = "4278198272";
+
+bool hasManagedKernelVrfSentinel(const string& routes)
+{
+    istringstream routeStream(routes);
+    string line;
+
+    while (getline(routeStream, line))
+    {
+        istringstream lineStream(line);
+        vector<string> fields;
+        string field;
+        while (lineStream >> field)
+        {
+            fields.push_back(field);
+        }
+        if (fields.size() < 4 || fields[0] != "unreachable" || fields[1] != "default")
+        {
+            continue;
+        }
+
+        for (size_t i = 2; i + 1 < fields.size(); ++i)
+        {
+            if (fields[i] == "metric" && fields[i + 1] == KERNEL_VRF_SENTINEL_METRIC)
+            {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+bool executeKernelVrfCommand(const string& command, string& result, int& rc)
+{
+    try
+    {
+        rc = swss::exec(command, result);
+        return true;
+    }
+    catch (const std::exception& e)
+    {
+        SWSS_LOG_ERROR("Command '%s' failed: %s", command.c_str(), e.what());
+        return false;
+    }
+}
+
+} // namespace
+
 VrfMgr::VrfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const vector<string> &tableNames) :
         Orch(cfgDb, tableNames),
+        m_cfgKernelVrfFallbackTable(cfgDb, KERNEL_VRF_FALLBACK_CONFIG_TABLE),
+        m_stateVrfTable(stateDb, STATE_VRF_TABLE_NAME),
+        m_stateVrfObjectTable(stateDb, STATE_VRF_OBJECT_TABLE_NAME),
         m_appVrfTableProducer(appDb, APP_VRF_TABLE_NAME),
         m_appVnetTableProducer(appDb, APP_VNET_TABLE_NAME),
-        m_appVxlanVrfTableProducer(appDb, APP_VXLAN_VRF_TABLE_NAME),
-        m_stateVrfTable(stateDb, STATE_VRF_TABLE_NAME),
-        m_stateVrfObjectTable(stateDb, STATE_VRF_OBJECT_TABLE_NAME)
+        m_appVxlanVrfTableProducer(appDb, APP_VXLAN_VRF_TABLE_NAME)
 {
+    loadKernelVrfFallbackState();
+
     for (uint32_t i = VRF_TABLE_START; i < VRF_TABLE_END; i++)
     {
         m_freeTables.emplace(i);
@@ -109,6 +171,208 @@ VrfMgr::VrfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, con
     {
         WarmStart::setWarmStartState("vrfmgrd", WarmStart::WSDISABLED);
     }
+
+    reconcileAllKernelVrfs();
+}
+
+bool VrfMgr::parseKernelVrfFallbackState(const vector<FieldValueTuple>& values)
+{
+    for (const auto& value : values)
+    {
+        if (fvField(value) != KERNEL_VRF_FALLBACK_STATUS_FIELD)
+        {
+            continue;
+        }
+
+        if (fvValue(value) == KERNEL_VRF_FALLBACK_ENABLED)
+        {
+            return true;
+        }
+        if (fvValue(value) == KERNEL_VRF_FALLBACK_DISABLED)
+        {
+            return false;
+        }
+
+        SWSS_LOG_ERROR("Invalid %s value '%s' in %s|%s; using disabled",
+                       KERNEL_VRF_FALLBACK_STATUS_FIELD, fvValue(value).c_str(),
+                       KERNEL_VRF_FALLBACK_CONFIG_TABLE, KERNEL_VRF_FALLBACK_GLOBAL_KEY);
+        return false;
+    }
+
+    SWSS_LOG_ERROR("Missing %s field in %s|%s; using disabled",
+                   KERNEL_VRF_FALLBACK_STATUS_FIELD, KERNEL_VRF_FALLBACK_CONFIG_TABLE,
+                   KERNEL_VRF_FALLBACK_GLOBAL_KEY);
+    return false;
+}
+
+void VrfMgr::loadKernelVrfFallbackState()
+{
+    vector<FieldValueTuple> values;
+    if (!m_cfgKernelVrfFallbackTable.get(KERNEL_VRF_FALLBACK_GLOBAL_KEY, values))
+    {
+        m_kernelVrfFallbackEnabled = false;
+        return;
+    }
+
+    m_kernelVrfFallbackEnabled = parseKernelVrfFallbackState(values);
+}
+
+void VrfMgr::handleKernelVrfFallbackConfig(const KeyOpFieldsValuesTuple& t)
+{
+    const auto& key = kfvKey(t);
+    const auto& op = kfvOp(t);
+
+    if (key != KERNEL_VRF_FALLBACK_GLOBAL_KEY)
+    {
+        SWSS_LOG_ERROR("Ignore invalid key %s in %s; only %s is supported", key.c_str(),
+                       KERNEL_VRF_FALLBACK_CONFIG_TABLE, KERNEL_VRF_FALLBACK_GLOBAL_KEY);
+        return;
+    }
+
+    if (op == SET_COMMAND)
+    {
+        m_kernelVrfFallbackEnabled = parseKernelVrfFallbackState(kfvFieldsValues(t));
+    }
+    else if (op == DEL_COMMAND)
+    {
+        m_kernelVrfFallbackEnabled = false;
+    }
+    else
+    {
+        SWSS_LOG_ERROR("Unknown operation %s for %s|%s", op.c_str(),
+                       KERNEL_VRF_FALLBACK_CONFIG_TABLE, KERNEL_VRF_FALLBACK_GLOBAL_KEY);
+        return;
+    }
+
+    SWSS_LOG_NOTICE("Kernel VRF fallback is %s",
+                    m_kernelVrfFallbackEnabled ? "enabled" : "disabled");
+    reconcileAllKernelVrfs();
+}
+
+bool VrfMgr::runKernelVrfRouteCommand(uint32_t table, bool ipv6)
+{
+    stringstream cmd;
+    string result;
+
+    cmd << IP_CMD;
+    if (ipv6)
+    {
+        cmd << " -6";
+    }
+
+    if (!m_kernelVrfFallbackEnabled)
+    {
+        cmd << " route replace table " << table << " unreachable default metric "
+            << KERNEL_VRF_SENTINEL_METRIC;
+        int rc;
+        if (!executeKernelVrfCommand(cmd.str(), result, rc))
+        {
+            return false;
+        }
+        if (rc != 0)
+        {
+            SWSS_LOG_ERROR("Command '%s' failed with rc %d", cmd.str().c_str(), rc);
+            return false;
+        }
+        return true;
+    }
+
+    cmd << " route del table " << table << " unreachable default metric "
+        << KERNEL_VRF_SENTINEL_METRIC;
+    int rc;
+    if (!executeKernelVrfCommand(cmd.str(), result, rc))
+    {
+        return false;
+    }
+    if (rc == 0)
+    {
+        return true;
+    }
+
+    cmd.str("");
+    cmd.clear();
+    cmd << IP_CMD;
+    if (ipv6)
+    {
+        cmd << " -6";
+    }
+    cmd << " route show table " << table << " type unreachable";
+    if (!executeKernelVrfCommand(cmd.str(), result, rc))
+    {
+        return false;
+    }
+    if (rc != 0)
+    {
+        SWSS_LOG_ERROR("Command '%s' failed with rc %d", cmd.str().c_str(), rc);
+        return false;
+    }
+
+    if (hasManagedKernelVrfSentinel(result))
+    {
+        SWSS_LOG_ERROR("Managed unreachable route is still present in table %u", table);
+        return false;
+    }
+
+    return true;
+}
+
+bool VrfMgr::reconcileKernelVrf(const string& vrfName)
+{
+    auto table = m_vrfTableMap.find(vrfName);
+    if (table == m_vrfTableMap.end() || vrfName == MGMT_VRF)
+    {
+        m_pendingKernelVrfReconcile.erase(vrfName);
+        return true;
+    }
+
+    bool ipv4Success = runKernelVrfRouteCommand(table->second, false);
+    bool ipv6Success = runKernelVrfRouteCommand(table->second, true);
+    if (ipv4Success && ipv6Success)
+    {
+        m_pendingKernelVrfReconcile.erase(vrfName);
+        return true;
+    }
+
+    m_pendingKernelVrfReconcile.insert(vrfName);
+    SWSS_LOG_ERROR("Failed to reconcile kernel VRF fallback routes for %s", vrfName.c_str());
+    return false;
+}
+
+void VrfMgr::reconcileAllKernelVrfs()
+{
+    for (auto it = m_pendingKernelVrfReconcile.begin(); it != m_pendingKernelVrfReconcile.end();)
+    {
+        if (m_vrfTableMap.find(*it) == m_vrfTableMap.end() || *it == MGMT_VRF)
+        {
+            it = m_pendingKernelVrfReconcile.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    vector<string> vrfs;
+    vrfs.reserve(m_vrfTableMap.size());
+    for (const auto& vrf : m_vrfTableMap)
+    {
+        vrfs.push_back(vrf.first);
+    }
+
+    for (const auto& vrf : vrfs)
+    {
+        reconcileKernelVrf(vrf);
+    }
+}
+
+void VrfMgr::retryPendingKernelVrfs()
+{
+    const vector<string> pending(m_pendingKernelVrfReconcile.begin(),
+                                 m_pendingKernelVrfReconcile.end());
+    for (const auto& vrf : pending)
+    {
+        reconcileKernelVrf(vrf);
+    }
 }
 
 uint32_t VrfMgr::getFreeTable(void)
@@ -149,6 +413,7 @@ bool VrfMgr::delLink(const string& vrfName)
     {
         recycleTable(m_vrfTableMap[vrfName]);
         m_vrfTableMap.erase(vrfName);
+        m_pendingKernelVrfReconcile.erase(vrfName);
         return true;
     }
 
@@ -157,6 +422,7 @@ bool VrfMgr::delLink(const string& vrfName)
 
     recycleTable(m_vrfTableMap[vrfName]);
     m_vrfTableMap.erase(vrfName);
+    m_pendingKernelVrfReconcile.erase(vrfName);
 
     return true;
 }
@@ -217,6 +483,18 @@ bool VrfMgr::isVrfObjExist(const string& vrfName)
 void VrfMgr::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
+    retryPendingKernelVrfs();
+
+    if (consumer.getTableName() == KERNEL_VRF_FALLBACK_CONFIG_TABLE)
+    {
+        auto config = consumer.m_toSync.begin();
+        while (config != consumer.m_toSync.end())
+        {
+            handleKernelVrfFallbackConfig(config->second);
+            config = consumer.m_toSync.erase(config);
+        }
+        return;
+    }
 
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
@@ -281,6 +559,14 @@ void VrfMgr::doTask(Consumer &consumer)
                 if (!setLink(vrfName))
                 {
                     SWSS_LOG_ERROR("Failed to create vrf netdev %s", vrfName.c_str());
+                    it++;
+                    continue;
+                }
+
+                if (!reconcileKernelVrf(vrfName))
+                {
+                    SWSS_LOG_ERROR("Kernel VRF fallback reconciliation pending for %s",
+                                   vrfName.c_str());
                 }
 
                 bool status = true;
@@ -552,4 +838,3 @@ uint32_t VrfMgr::getVRFmappedVNI(const std::string& vrf_name)
         return 0;
     }
 }
-

--- a/cfgmgr/vrfmgr.h
+++ b/cfgmgr/vrfmgr.h
@@ -22,10 +22,17 @@ public:
     std::string m_evpnVxlanTunnel;
 
     uint32_t getVRFmappedVNI(const std::string& vrf_name);
+    void retryPendingKernelVrfs();
 
 private:
     bool delLink(const std::string& vrfName);
     bool setLink(const std::string& vrfName);
+    bool parseKernelVrfFallbackState(const std::vector<FieldValueTuple>& values);
+    void loadKernelVrfFallbackState();
+    void handleKernelVrfFallbackConfig(const KeyOpFieldsValuesTuple& t);
+    bool runKernelVrfRouteCommand(uint32_t table, bool ipv6);
+    bool reconcileKernelVrf(const std::string& vrfName);
+    void reconcileAllKernelVrfs();
     bool isVrfObjExist(const std::string& vrfName);
     void recycleTable(uint32_t table);
     uint32_t getFreeTable(void);
@@ -40,9 +47,11 @@ private:
 
     std::map<std::string, uint32_t> m_vrfTableMap;
     std::set<uint32_t> m_freeTables;
+    std::set<std::string> m_pendingKernelVrfReconcile;
     VRFNameVNIMapTable m_vrfVniMapTable;
+    bool m_kernelVrfFallbackEnabled = false;
 
-    Table m_stateVrfTable, m_stateVrfObjectTable;
+    Table m_cfgKernelVrfFallbackTable, m_stateVrfTable, m_stateVrfObjectTable;
     ProducerStateTable m_appVrfTableProducer, m_appVnetTableProducer, m_appVxlanVrfTableProducer;
 };
 

--- a/cfgmgr/vrfmgrd.cpp
+++ b/cfgmgr/vrfmgrd.cpp
@@ -16,6 +16,9 @@ using namespace swss;
 /* select() function timeout retry time, in millisecond */
 #define SELECT_TIMEOUT 1000
 
+/* Matches the CFG table name generated from the companion YANG model. */
+constexpr auto KERNEL_VRF_FALLBACK_CONFIG_TABLE = "KERNEL_VRF_FALLBACK";
+
 int main(int argc, char **argv)
 {
     Logger::linkToDbNative("vrfmgrd");
@@ -30,7 +33,8 @@ int main(int argc, char **argv)
             CFG_VRF_TABLE_NAME,
             CFG_VNET_TABLE_NAME,
             CFG_VXLAN_EVPN_NVO_TABLE_NAME,
-            CFG_MGMT_VRF_CONFIG_TABLE_NAME
+            CFG_MGMT_VRF_CONFIG_TABLE_NAME,
+            KERNEL_VRF_FALLBACK_CONFIG_TABLE
         };
 
         DBConnector cfgDb("CONFIG_DB", 0);
@@ -68,6 +72,7 @@ int main(int argc, char **argv)
             if (ret == Select::TIMEOUT)
             {
                 vrfmgr.doTask();
+                vrfmgr.retryPendingKernelVrfs();
                 if (isWarmStart && firstReadTimeout)
                 {
                     firstReadTimeout = false;

--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -2542,6 +2542,17 @@ void RouteSync::onMsg(int nlmsg_type, struct nl_object *obj)
         return;
     }
 
+    /* Keep kernel-only policy sentinels out of every APP_DB route table. */
+    if (rtnl_route_get_type(route_obj) == RTN_UNREACHABLE)
+    {
+        if (nlmsg_type == RTM_NEWROUTE && !isSuppressionEnabled())
+        {
+            sendOffloadReply(route_obj);
+        }
+        SWSS_LOG_INFO("Ignore unreachable route notification type %d", nlmsg_type);
+        return;
+    }
+
     /* Get the index of the master device */
     unsigned int master_index = rtnl_route_get_table(route_obj);
     char master_name[IFNAMSIZ] = {0};

--- a/orchagent/vrforch.cpp
+++ b/orchagent/vrforch.cpp
@@ -75,6 +75,12 @@ bool VRFOrch::addOperation(const Request& request)
             vni = static_cast<uint32_t>(request.getAttrUint(name));
             continue;
         }
+        else if (name == "fallback")
+        {
+            SWSS_LOG_WARN("VRF fallback attribute is deprecated and ignored; "
+                          "use KERNEL_VRF_FALLBACK|GLOBAL for temporary compatibility");
+            continue;
+        }
         else if ((name == "mgmtVrfEnabled") || (name == "in_band_mgmt_enabled"))
         {
             SWSS_LOG_INFO("MGMT VRF field: %s ignored", name.c_str());

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -9,9 +9,9 @@ CXXFLAGS = -g -O0
 
 CFLAGS_SAI = -I /usr/include/sai
 
-TESTS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_fdbsyncd tests_response_publisher tests_nbrmgrd tests_teamsyncd
+TESTS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_fdbsyncd tests_response_publisher tests_nbrmgrd tests_teamsyncd tests_vrfmgrd
 
-noinst_PROGRAMS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_fdbsyncd tests_response_publisher tests_nbrmgrd tests_teamsyncd
+noinst_PROGRAMS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_fdbsyncd tests_response_publisher tests_nbrmgrd tests_teamsyncd tests_vrfmgrd
 
 LDADD_SAI = -lsaivs -lsairedis -lsaimeta -lsaimetadata
 
@@ -280,6 +280,27 @@ tests_intfmgrd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/cfgmgr -I$(top_srcdi
 tests_intfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
 tests_intfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_intfmgrd_INCLUDES)
 tests_intfmgrd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
+        -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lgmock_main
+
+## vrfmgrd unit tests
+
+tests_vrfmgrd_SOURCES = vrfmgrd/vrfmgr_ut.cpp \
+                        $(top_srcdir)/cfgmgr/vrfmgr.cpp \
+                        $(top_srcdir)/lib/recorder.cpp \
+                        $(top_srcdir)/orchagent/orch.cpp \
+                        $(top_srcdir)/orchagent/request_parser.cpp \
+                        mock_orchagent_main.cpp \
+                        mock_dbconnector.cpp \
+                        mock_table.cpp \
+                        mock_hiredis.cpp \
+                        fake_response_publisher.cpp \
+                        mock_redisreply.cpp \
+                        common/mock_shell_command.cpp
+
+tests_vrfmgrd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/cfgmgr -I$(top_srcdir)/lib
+tests_vrfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
+tests_vrfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_vrfmgrd_INCLUDES)
+tests_vrfmgrd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
         -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lgmock_main
 
 ## teammgrd unit tests

--- a/tests/mock_tests/fpmsyncd/test_routesync.cpp
+++ b/tests/mock_tests/fpmsyncd/test_routesync.cpp
@@ -1512,6 +1512,19 @@ auto create_route(const char* dst_addr_str)
     return unique_ptr<rtnl_route, decltype(rtnl_route_put)*>(route, rtnl_route_put);
 }
 
+auto create_unreachable_route(const char* dst_addr_str, int family)
+{
+    rtnl_route* route = rtnl_route_alloc();
+    auto dst_addr = create_nl_addr(dst_addr_str);
+    rtnl_route_set_dst(route, dst_addr.get());
+    rtnl_route_set_type(route, RTN_UNREACHABLE);
+    rtnl_route_set_protocol(route, RTPROT_KERNEL);
+    rtnl_route_set_family(route, family);
+    rtnl_route_set_scope(route, RT_SCOPE_UNIVERSE);
+    rtnl_route_set_table(route, RT_TABLE_MAIN);
+    return unique_ptr<rtnl_route, decltype(rtnl_route_put)*>(route, rtnl_route_put);
+}
+
 rtnl_nexthop* create_nexthop(const char* gateway_str)
 {
     static int idx = 1; // interface index
@@ -4550,6 +4563,85 @@ TEST_F(FpmSyncdResponseTest, TestOnRouteMsg_DeleteWithVrf)
 
     // Should be deleted
     EXPECT_FALSE(routeTable.get("Vrf200:10.34.4.0/24", result));
+}
+
+TEST_F(FpmSyncdResponseTest, TestOnMsg_UnreachableIpv4DoesNotMutateRouteTable)
+{
+    Table routeTable(m_db.get(), APP_ROUTE_TABLE_NAME);
+    const string key = "VrfFallback:0.0.0.0/0";
+    const vector<FieldValueTuple> expected = {
+        {"nexthop", "192.0.2.1"},
+        {"ifname", "Ethernet0"},
+        {"protocol", "bgp"},
+    };
+    routeTable.set(key, expected);
+
+    auto route = create_unreachable_route("0.0.0.0/0", AF_INET);
+
+    m_routeSync.onMsg(RTM_NEWROUTE, (nl_object*)route.get());
+    m_routeSync.onMsg(RTM_DELROUTE, (nl_object*)route.get());
+
+    vector<FieldValueTuple> actual;
+    ASSERT_TRUE(routeTable.get(key, actual));
+    EXPECT_EQ(actual, expected);
+}
+
+TEST_F(FpmSyncdResponseTest, TestOnMsg_UnreachableIpv6DoesNotMutateRouteTable)
+{
+    Table routeTable(m_db.get(), APP_ROUTE_TABLE_NAME);
+    const string key = "VrfFallback:::/0";
+    const vector<FieldValueTuple> expected = {
+        {"nexthop", "2001:db8::1"},
+        {"ifname", "Ethernet0"},
+        {"protocol", "bgp"},
+    };
+    routeTable.set(key, expected);
+
+    auto route = create_unreachable_route("::/0", AF_INET6);
+
+    m_routeSync.onMsg(RTM_NEWROUTE, (nl_object*)route.get());
+    m_routeSync.onMsg(RTM_DELROUTE, (nl_object*)route.get());
+
+    vector<FieldValueTuple> actual;
+    ASSERT_TRUE(routeTable.get(key, actual));
+    EXPECT_EQ(actual, expected);
+}
+
+TEST_F(FpmSyncdResponseTest, TestOnMsg_UnreachableVnetRouteDoesNotMutateVnetTables)
+{
+    Table routeTable(m_db.get(), APP_VNET_RT_TABLE_NAME);
+    Table tunnelTable(m_db.get(), APP_VNET_RT_TUNNEL_TABLE_NAME);
+    const string key = "VnetFallback:0.0.0.0/0";
+    const vector<FieldValueTuple> routeExpected = {
+        {"nexthop", "192.0.2.1"},
+        {"ifname", "Ethernet0"},
+    };
+    const vector<FieldValueTuple> tunnelExpected = {
+        {"endpoint", "198.51.100.1"},
+    };
+    routeTable.set(key, routeExpected);
+    tunnelTable.set(key, tunnelExpected);
+
+    auto route = create_unreachable_route("0.0.0.0/0", AF_INET);
+
+    m_routeSync.onMsg(RTM_NEWROUTE, (nl_object*)route.get());
+    m_routeSync.onMsg(RTM_DELROUTE, (nl_object*)route.get());
+
+    vector<FieldValueTuple> actual;
+    ASSERT_TRUE(routeTable.get(key, actual));
+    EXPECT_EQ(actual, routeExpected);
+    ASSERT_TRUE(tunnelTable.get(key, actual));
+    EXPECT_EQ(actual, tunnelExpected);
+}
+
+TEST_F(FpmSyncdResponseTest, TestOnMsg_UnreachableNewRouteKeepsOffloadReply)
+{
+    auto route = create_unreachable_route("0.0.0.0/0", AF_INET);
+    m_routeSync.setSuppressionEnabled(false);
+
+    EXPECT_CALL(m_mockFpm, send(_)).WillOnce(Return(true));
+
+    m_routeSync.onMsg(RTM_NEWROUTE, (nl_object*)route.get());
 }
 
 // Test default route (0.0.0.0/0)

--- a/tests/mock_tests/fpmsyncd/test_routesync.cpp
+++ b/tests/mock_tests/fpmsyncd/test_routesync.cpp
@@ -1512,7 +1512,7 @@ auto create_route(const char* dst_addr_str)
     return unique_ptr<rtnl_route, decltype(rtnl_route_put)*>(route, rtnl_route_put);
 }
 
-auto create_unreachable_route(const char* dst_addr_str, int family)
+auto create_unreachable_route(const char* dst_addr_str, uint8_t family)
 {
     rtnl_route* route = rtnl_route_alloc();
     auto dst_addr = create_nl_addr(dst_addr_str);

--- a/tests/mock_tests/vrfmgrd/vrfmgr_ut.cpp
+++ b/tests/mock_tests/vrfmgrd/vrfmgr_ut.cpp
@@ -1,0 +1,486 @@
+#include "gtest/gtest.h"
+
+#include <algorithm>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "../mock_table.h"
+
+#define private public
+#include "warm_restart.h"
+#include "vrfmgr.h"
+#undef private
+
+extern int (*callback)(const std::string &cmd, std::string &stdout);
+extern std::vector<std::string> mockCallArgs;
+
+namespace
+{
+
+    constexpr auto KERNEL_VRF_FALLBACK_TABLE = "KERNEL_VRF_FALLBACK";
+    constexpr auto KERNEL_VRF_FALLBACK_KEY = "GLOBAL";
+    constexpr auto SENTINEL_METRIC = "4278198272";
+
+    std::string existingVrfOutput;
+    std::string failingCommand;
+    std::string throwingCommand;
+    int remainingFailures;
+    std::string routeShowOutput;
+    int routeShowReturnCode;
+
+    int commandCallback(const std::string &cmd, std::string &output)
+    {
+        mockCallArgs.push_back(cmd);
+        output.clear();
+
+        if (cmd == "/sbin/ip -d link show type vrf")
+        {
+            output = existingVrfOutput;
+            return 0;
+        }
+        if (cmd == "/sbin/ip rule | grep '^0:'")
+        {
+            return 1;
+        }
+        if (cmd.find(" route show table ") != std::string::npos)
+        {
+            output = routeShowOutput;
+            return routeShowReturnCode;
+        }
+        if (!throwingCommand.empty() && cmd == throwingCommand)
+        {
+            throw std::runtime_error("injected command failure");
+        }
+        if (remainingFailures > 0 && cmd == failingCommand)
+        {
+            --remainingFailures;
+            return 2;
+        }
+
+        return 0;
+    }
+
+    bool commandWasIssued(const std::string &command)
+    {
+        return std::find(mockCallArgs.begin(), mockCallArgs.end(), command) != mockCallArgs.end();
+    }
+
+    class TestableVrfMgr : public swss::VrfMgr
+    {
+    public:
+        using VrfMgr::VrfMgr;
+
+        swss::Consumer *getConsumer(const std::string &tableName)
+        {
+            return dynamic_cast<swss::Consumer *>(getExecutor(tableName));
+        }
+    };
+
+    class VrfMgrFallbackTest : public ::testing::Test
+    {
+    protected:
+        void SetUp() override
+        {
+            testing_db::reset();
+            mockCallArgs.clear();
+            existingVrfOutput.clear();
+            failingCommand.clear();
+            throwingCommand.clear();
+            remainingFailures = 0;
+            routeShowOutput.clear();
+            routeShowReturnCode = 0;
+            callback = commandCallback;
+            swss::WarmStart::getInstance().m_enabled = false;
+
+            configDb = std::make_shared<swss::DBConnector>("CONFIG_DB", 0);
+            appDb = std::make_shared<swss::DBConnector>("APPL_DB", 0);
+            stateDb = std::make_shared<swss::DBConnector>("STATE_DB", 0);
+            swss::WarmStart::initialize("vrfmgrd", "swss");
+        }
+
+        void TearDown() override
+        {
+            swss::WarmStart::getInstance().m_enabled = false;
+            callback = nullptr;
+            testing_db::reset();
+        }
+
+        std::unique_ptr<TestableVrfMgr> makeManager()
+        {
+            const std::vector<std::string> tables = {
+                CFG_VRF_TABLE_NAME,
+                CFG_VNET_TABLE_NAME,
+                CFG_VXLAN_EVPN_NVO_TABLE_NAME,
+                CFG_MGMT_VRF_CONFIG_TABLE_NAME,
+                KERNEL_VRF_FALLBACK_TABLE,
+            };
+            return std::make_unique<TestableVrfMgr>(configDb.get(), appDb.get(), stateDb.get(), tables);
+        }
+
+        void setFallbackConfig(const std::string &status)
+        {
+            swss::Table table(configDb.get(), KERNEL_VRF_FALLBACK_TABLE);
+            table.set(KERNEL_VRF_FALLBACK_KEY, { { "status", status } });
+        }
+
+        void enqueueFallbackEvent(TestableVrfMgr &manager, const std::string &op,
+                                  const std::vector<swss::FieldValueTuple> &values = {},
+                                  const std::string &key = KERNEL_VRF_FALLBACK_KEY)
+        {
+            auto *consumer = manager.getConsumer(KERNEL_VRF_FALLBACK_TABLE);
+            ASSERT_NE(consumer, nullptr);
+            consumer->m_toSync[key] = swss::KeyOpFieldsValuesTuple(key, op, values);
+            manager.doTask();
+        }
+
+        std::shared_ptr<swss::DBConnector> configDb;
+        std::shared_ptr<swss::DBConnector> appDb;
+        std::shared_ptr<swss::DBConnector> stateDb;
+    };
+
+    TEST_F(VrfMgrFallbackTest, AbsentConfigInstallsDualStackSentinels)
+    {
+        auto manager = makeManager();
+        manager->m_vrfTableMap["VrfBlue"] = 1001;
+        mockCallArgs.clear();
+
+        EXPECT_TRUE(manager->reconcileKernelVrf("VrfBlue"));
+
+        EXPECT_TRUE(commandWasIssued("/sbin/ip route replace table 1001 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+        EXPECT_TRUE(commandWasIssued("/sbin/ip -6 route replace table 1001 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+    }
+
+    TEST_F(VrfMgrFallbackTest, EnabledConfigDeletesOnlyExactDualStackSentinels)
+    {
+        setFallbackConfig("enabled");
+        auto manager = makeManager();
+        manager->m_vrfTableMap["VrfBlue"] = 1001;
+        mockCallArgs.clear();
+
+        EXPECT_TRUE(manager->reconcileKernelVrf("VrfBlue"));
+
+        EXPECT_TRUE(commandWasIssued("/sbin/ip route del table 1001 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+        EXPECT_TRUE(commandWasIssued("/sbin/ip -6 route del table 1001 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+        EXPECT_FALSE(commandWasIssued("/sbin/ip route del table 1001 default"));
+    }
+
+    TEST_F(VrfMgrFallbackTest, ConfigDeleteRestoresDefaultDisabledState)
+    {
+        setFallbackConfig("enabled");
+        auto manager = makeManager();
+        manager->m_vrfTableMap["VrfBlue"] = 1001;
+        mockCallArgs.clear();
+
+        enqueueFallbackEvent(*manager, DEL_COMMAND);
+
+        EXPECT_FALSE(manager->m_kernelVrfFallbackEnabled);
+        EXPECT_TRUE(commandWasIssued("/sbin/ip route replace table 1001 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+        EXPECT_TRUE(commandWasIssued("/sbin/ip -6 route replace table 1001 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+    }
+
+    TEST_F(VrfMgrFallbackTest, ExplicitDisabledConfigReconcilesAllVrfs)
+    {
+        auto manager = makeManager();
+        manager->m_vrfTableMap["VrfBlue"] = 1001;
+        mockCallArgs.clear();
+
+        enqueueFallbackEvent(*manager, SET_COMMAND, { { "status", "disabled" } });
+
+        EXPECT_FALSE(manager->m_kernelVrfFallbackEnabled);
+        EXPECT_TRUE(commandWasIssued("/sbin/ip route replace table 1001 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+        EXPECT_TRUE(commandWasIssued("/sbin/ip -6 route replace table 1001 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+    }
+
+    TEST_F(VrfMgrFallbackTest, ExplicitEnabledConfigRemovesSentinelsFromAllVrfs)
+    {
+        auto manager = makeManager();
+        manager->m_vrfTableMap["VrfBlue"] = 1001;
+        mockCallArgs.clear();
+
+        enqueueFallbackEvent(*manager, SET_COMMAND, { { "status", "enabled" } });
+
+        EXPECT_TRUE(manager->m_kernelVrfFallbackEnabled);
+        EXPECT_TRUE(commandWasIssued("/sbin/ip route del table 1001 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+        EXPECT_TRUE(commandWasIssued("/sbin/ip -6 route del table 1001 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+    }
+
+    TEST_F(VrfMgrFallbackTest, InvalidConfigUsesDefaultDisabledState)
+    {
+        auto manager = makeManager();
+        manager->m_vrfTableMap["VrfBlue"] = 1001;
+        mockCallArgs.clear();
+
+        enqueueFallbackEvent(*manager, SET_COMMAND, { { "status", "invalid" } });
+
+        EXPECT_FALSE(manager->m_kernelVrfFallbackEnabled);
+        EXPECT_TRUE(commandWasIssued("/sbin/ip route replace table 1001 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+    }
+
+    TEST_F(VrfMgrFallbackTest, MissingStatusUsesDefaultDisabledState)
+    {
+        setFallbackConfig("enabled");
+        auto manager = makeManager();
+        manager->m_vrfTableMap["VrfBlue"] = 1001;
+        mockCallArgs.clear();
+
+        enqueueFallbackEvent(*manager, SET_COMMAND, { { "other", "value" } });
+
+        EXPECT_FALSE(manager->m_kernelVrfFallbackEnabled);
+        EXPECT_TRUE(commandWasIssued("/sbin/ip route replace table 1001 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+    }
+
+    TEST_F(VrfMgrFallbackTest, NonGlobalKeyIsIgnored)
+    {
+        setFallbackConfig("enabled");
+        auto manager = makeManager();
+        manager->m_vrfTableMap["VrfBlue"] = 1001;
+        mockCallArgs.clear();
+
+        enqueueFallbackEvent(*manager, SET_COMMAND, { { "status", "disabled" } }, "NOT_GLOBAL");
+
+        EXPECT_TRUE(manager->m_kernelVrfFallbackEnabled);
+        EXPECT_TRUE(mockCallArgs.empty());
+    }
+
+    TEST_F(VrfMgrFallbackTest, GlobalReconciliationSkipsManagementVrf)
+    {
+        auto manager = makeManager();
+        manager->m_vrfTableMap["mgmt"] = 6000;
+        manager->m_vrfTableMap["VrfBlue"] = 1001;
+        mockCallArgs.clear();
+
+        manager->reconcileAllKernelVrfs();
+
+        EXPECT_TRUE(commandWasIssued("/sbin/ip route replace table 1001 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+        for (const auto &command : mockCallArgs)
+        {
+            EXPECT_EQ(command.find("table 6000"), std::string::npos);
+        }
+    }
+
+    TEST_F(VrfMgrFallbackTest, NewVrfReceivesSentinelsInDefaultState)
+    {
+        auto manager = makeManager();
+        auto *consumer = manager->getConsumer(CFG_VRF_TABLE_NAME);
+        ASSERT_NE(consumer, nullptr);
+        mockCallArgs.clear();
+        consumer->m_toSync["VrfNew"] =
+            swss::KeyOpFieldsValuesTuple("VrfNew", SET_COMMAND, { { "empty", "empty" } });
+
+        manager->doTask();
+
+        EXPECT_TRUE(commandWasIssued("/sbin/ip route replace table 1001 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+        EXPECT_TRUE(commandWasIssued("/sbin/ip -6 route replace table 1001 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+    }
+
+    TEST_F(VrfMgrFallbackTest, NewVnetReceivesSentinelsInDefaultState)
+    {
+        auto manager = makeManager();
+        auto *consumer = manager->getConsumer(CFG_VNET_TABLE_NAME);
+        ASSERT_NE(consumer, nullptr);
+        mockCallArgs.clear();
+        consumer->m_toSync["VnetNew"] =
+            swss::KeyOpFieldsValuesTuple("VnetNew", SET_COMMAND, { { "empty", "empty" } });
+
+        manager->doTask();
+
+        EXPECT_TRUE(commandWasIssued("/sbin/ip route replace table 1001 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+        EXPECT_TRUE(commandWasIssued("/sbin/ip -6 route replace table 1001 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+    }
+
+    TEST_F(VrfMgrFallbackTest, RepeatedDisabledReconciliationIsIdempotent)
+    {
+        auto manager = makeManager();
+        manager->m_vrfTableMap["VrfBlue"] = 1001;
+        const std::string ipv4Command =
+            "/sbin/ip route replace table 1001 unreachable default metric " +
+            std::string(SENTINEL_METRIC);
+        const std::string ipv6Command =
+            "/sbin/ip -6 route replace table 1001 unreachable default metric " +
+            std::string(SENTINEL_METRIC);
+        mockCallArgs.clear();
+
+        EXPECT_TRUE(manager->reconcileKernelVrf("VrfBlue"));
+        EXPECT_TRUE(manager->reconcileKernelVrf("VrfBlue"));
+
+        EXPECT_EQ(std::count(mockCallArgs.begin(), mockCallArgs.end(), ipv4Command), 2);
+        EXPECT_EQ(std::count(mockCallArgs.begin(), mockCallArgs.end(), ipv6Command), 2);
+        EXPECT_TRUE(manager->m_pendingKernelVrfReconcile.empty());
+    }
+
+    TEST_F(VrfMgrFallbackTest, StartupReadsEnabledConfigBeforeReconcilingRetainedVrf)
+    {
+        setFallbackConfig("enabled");
+        existingVrfOutput =
+            "5: VrfRetained: <NOARP,MASTER,UP> mtu 65536 qdisc noqueue state UP mode DEFAULT\n"
+            "    link/ether 02:42:ac:11:00:02 brd ff:ff:ff:ff:ff:ff\n"
+            "    vrf table 1007 addrgenmode eui64 numtxqueues 1 numrxqueues 1\n";
+        swss::WarmStart::getInstance().m_enabled = true;
+
+        auto manager = makeManager();
+
+        EXPECT_EQ(manager->m_vrfTableMap.at("VrfRetained"), 1007u);
+        EXPECT_TRUE(commandWasIssued("/sbin/ip route del table 1007 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+        EXPECT_TRUE(commandWasIssued("/sbin/ip -6 route del table 1007 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+        EXPECT_FALSE(commandWasIssued("/sbin/ip route replace table 1007 unreachable default metric " +
+                                      std::string(SENTINEL_METRIC)));
+    }
+
+    TEST_F(VrfMgrFallbackTest, StartupUsesDefaultDisabledForRetainedVrfWhenConfigAbsent)
+    {
+        existingVrfOutput =
+            "5: VrfRetained: <NOARP,MASTER,UP> mtu 65536 qdisc noqueue state UP mode DEFAULT\n"
+            "    link/ether 02:42:ac:11:00:02 brd ff:ff:ff:ff:ff:ff\n"
+            "    vrf table 1007 addrgenmode eui64 numtxqueues 1 numrxqueues 1\n";
+        swss::WarmStart::getInstance().m_enabled = true;
+
+        auto manager = makeManager();
+
+        EXPECT_FALSE(manager->m_kernelVrfFallbackEnabled);
+        EXPECT_TRUE(commandWasIssued("/sbin/ip route replace table 1007 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+        EXPECT_TRUE(commandWasIssued("/sbin/ip -6 route replace table 1007 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+    }
+
+    TEST_F(VrfMgrFallbackTest, FailedRouteOperationIsRetried)
+    {
+        auto manager = makeManager();
+        manager->m_vrfTableMap["VrfBlue"] = 1001;
+        failingCommand = "/sbin/ip -6 route replace table 1001 unreachable default metric " +
+                         std::string(SENTINEL_METRIC);
+        remainingFailures = 1;
+        mockCallArgs.clear();
+
+        EXPECT_FALSE(manager->reconcileKernelVrf("VrfBlue"));
+        EXPECT_EQ(manager->m_pendingKernelVrfReconcile.count("VrfBlue"), 1u);
+
+        manager->retryPendingKernelVrfs();
+
+        EXPECT_TRUE(manager->m_pendingKernelVrfReconcile.empty());
+        EXPECT_EQ(std::count(mockCallArgs.begin(), mockCallArgs.end(), failingCommand), 2);
+    }
+
+    TEST_F(VrfMgrFallbackTest, RetryUsesCurrentTableAndDesiredState)
+    {
+        auto manager = makeManager();
+        manager->m_vrfTableMap["VrfBlue"] = 1001;
+        failingCommand = "/sbin/ip -6 route replace table 1001 unreachable default metric " +
+                         std::string(SENTINEL_METRIC);
+        remainingFailures = 1;
+
+        EXPECT_FALSE(manager->reconcileKernelVrf("VrfBlue"));
+        manager->m_vrfTableMap["VrfBlue"] = 1002;
+        manager->m_kernelVrfFallbackEnabled = true;
+        mockCallArgs.clear();
+
+        manager->retryPendingKernelVrfs();
+
+        EXPECT_TRUE(commandWasIssued("/sbin/ip route del table 1002 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+        EXPECT_TRUE(commandWasIssued("/sbin/ip -6 route del table 1002 unreachable default metric " +
+                                     std::string(SENTINEL_METRIC)));
+        EXPECT_TRUE(manager->m_pendingKernelVrfReconcile.empty());
+    }
+
+    TEST_F(VrfMgrFallbackTest, MissingExactSentinelIsSuccessfulDuringDelete)
+    {
+        setFallbackConfig("enabled");
+        auto manager = makeManager();
+        manager->m_vrfTableMap["VrfBlue"] = 1001;
+        failingCommand = "/sbin/ip route del table 1001 unreachable default metric " +
+                         std::string(SENTINEL_METRIC);
+        remainingFailures = 1;
+        mockCallArgs.clear();
+
+        EXPECT_TRUE(manager->reconcileKernelVrf("VrfBlue"));
+
+        EXPECT_TRUE(commandWasIssued("/sbin/ip route show table 1001 type unreachable"));
+        EXPECT_TRUE(manager->m_pendingKernelVrfReconcile.empty());
+    }
+
+    TEST_F(VrfMgrFallbackTest, DifferentMetricUnreachableRouteIsNotManaged)
+    {
+        setFallbackConfig("enabled");
+        auto manager = makeManager();
+        manager->m_vrfTableMap["VrfBlue"] = 1001;
+        failingCommand = "/sbin/ip route del table 1001 unreachable default metric " +
+                         std::string(SENTINEL_METRIC);
+        remainingFailures = 1;
+        routeShowOutput = "unreachable default metric 1234\n";
+        mockCallArgs.clear();
+
+        EXPECT_TRUE(manager->reconcileKernelVrf("VrfBlue"));
+
+        EXPECT_TRUE(manager->m_pendingKernelVrfReconcile.empty());
+    }
+
+    TEST_F(VrfMgrFallbackTest, RouteShowFailureLeavesVrfPendingForRetry)
+    {
+        setFallbackConfig("enabled");
+        auto manager = makeManager();
+        manager->m_vrfTableMap["VrfBlue"] = 1001;
+        failingCommand = "/sbin/ip route del table 1001 unreachable default metric " +
+                         std::string(SENTINEL_METRIC);
+        remainingFailures = 1;
+        routeShowReturnCode = 2;
+        mockCallArgs.clear();
+
+        EXPECT_FALSE(manager->reconcileKernelVrf("VrfBlue"));
+
+        EXPECT_EQ(manager->m_pendingKernelVrfReconcile.count("VrfBlue"), 1u);
+    }
+
+    TEST_F(VrfMgrFallbackTest, ExactSentinelStillPresentLeavesVrfPendingForRetry)
+    {
+        setFallbackConfig("enabled");
+        auto manager = makeManager();
+        manager->m_vrfTableMap["VrfBlue"] = 1001;
+        failingCommand = "/sbin/ip route del table 1001 unreachable default metric " +
+                         std::string(SENTINEL_METRIC);
+        remainingFailures = 1;
+        routeShowOutput = "unreachable default metric 4278198272\n";
+        mockCallArgs.clear();
+
+        EXPECT_FALSE(manager->reconcileKernelVrf("VrfBlue"));
+
+        EXPECT_EQ(manager->m_pendingKernelVrfReconcile.count("VrfBlue"), 1u);
+    }
+
+    TEST_F(VrfMgrFallbackTest, CommandExceptionLeavesVrfPendingForTimerRetry)
+    {
+        auto manager = makeManager();
+        manager->m_vrfTableMap["VrfBlue"] = 1001;
+        throwingCommand = "/sbin/ip route replace table 1001 unreachable default metric " +
+                          std::string(SENTINEL_METRIC);
+        mockCallArgs.clear();
+
+        bool result = true;
+        EXPECT_NO_THROW(result = manager->reconcileKernelVrf("VrfBlue"));
+
+        EXPECT_FALSE(result);
+        EXPECT_EQ(manager->m_pendingKernelVrfReconcile.count("VrfBlue"), 1u);
+    }
+
+} // namespace

--- a/tests/mock_tests/vrfmgrd/vrfmgr_ut.cpp
+++ b/tests/mock_tests/vrfmgrd/vrfmgr_ut.cpp
@@ -72,9 +72,9 @@ namespace
     public:
         using VrfMgr::VrfMgr;
 
-        swss::Consumer *getConsumer(const std::string &tableName)
+        Consumer *getConsumer(const std::string &tableName)
         {
-            return dynamic_cast<swss::Consumer *>(getExecutor(tableName));
+            return dynamic_cast<Consumer *>(getExecutor(tableName));
         }
     };
 
@@ -131,7 +131,7 @@ namespace
         {
             auto *consumer = manager.getConsumer(KERNEL_VRF_FALLBACK_TABLE);
             ASSERT_NE(consumer, nullptr);
-            consumer->m_toSync[key] = swss::KeyOpFieldsValuesTuple(key, op, values);
+            consumer->addToSync(swss::KeyOpFieldsValuesTuple(key, op, values));
             manager.doTask();
         }
 
@@ -279,8 +279,8 @@ namespace
         auto *consumer = manager->getConsumer(CFG_VRF_TABLE_NAME);
         ASSERT_NE(consumer, nullptr);
         mockCallArgs.clear();
-        consumer->m_toSync["VrfNew"] =
-            swss::KeyOpFieldsValuesTuple("VrfNew", SET_COMMAND, { { "empty", "empty" } });
+        consumer->addToSync(
+            swss::KeyOpFieldsValuesTuple("VrfNew", SET_COMMAND, { { "empty", "empty" } }));
 
         manager->doTask();
 
@@ -296,8 +296,8 @@ namespace
         auto *consumer = manager->getConsumer(CFG_VNET_TABLE_NAME);
         ASSERT_NE(consumer, nullptr);
         mockCallArgs.clear();
-        consumer->m_toSync["VnetNew"] =
-            swss::KeyOpFieldsValuesTuple("VnetNew", SET_COMMAND, { { "empty", "empty" } });
+        consumer->addToSync(
+            swss::KeyOpFieldsValuesTuple("VnetNew", SET_COMMAND, { { "empty", "empty" } }));
 
         manager->doTask();
 

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -5,9 +5,12 @@ import pytest
 
 from swsscommon import swsscommon
 from pprint import pprint
+from dvslib.dvs_common import wait_for_result
 
 
 class TestVrf(object):
+    SENTINEL_METRIC = "4278198272"
+
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)
         self.adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
@@ -52,6 +55,105 @@ class TestVrf(object):
         for name, value in fvs:
             assert expected_attributes[name] == value, "Wrong value %s for the attribute %s = %s" % \
                                                    (value, name, expected_attributes[name])
+
+    def wait_for_kernel_link(self, dvs, vrf_name, present=True):
+        def _access_function():
+            status, output = dvs.runcmd(["ip", "link", "show", vrf_name])
+            return (status == 0) == present, output
+
+        wait_for_result(
+            _access_function,
+            failure_message="Kernel VRF {} was not {}".format(
+                vrf_name, "created" if present else "removed"
+            ),
+        )
+
+    def wait_for_sentinel(self, dvs, vrf_name, ipv6=False, present=True):
+        command = ["ip"]
+        if ipv6:
+            command.append("-6")
+        command.extend(["route", "show", "vrf", vrf_name])
+
+        def _access_function():
+            status, output = dvs.runcmd(command)
+            found = False
+            if status == 0:
+                for line in output.splitlines():
+                    fields = line.split()
+                    if fields[:2] != ["unreachable", "default"]:
+                        continue
+                    found = any(
+                        fields[index:index + 2] == ["metric", self.SENTINEL_METRIC]
+                        for index in range(len(fields) - 1)
+                    )
+                    if found:
+                        break
+            return found == present, output
+
+        wait_for_result(
+            _access_function,
+            failure_message="{} sentinel for {} was not {}".format(
+                "IPv6" if ipv6 else "IPv4",
+                vrf_name,
+                "installed" if present else "removed",
+            ),
+        )
+
+    def wait_for_unicast_default(self, dvs, vrf_name, interface, ipv6=False):
+        command = ["ip"]
+        if ipv6:
+            command.append("-6")
+        command.extend(["route", "show", "vrf", vrf_name])
+
+        def _access_function():
+            status, output = dvs.runcmd(command)
+            if status == 0:
+                for line in output.splitlines():
+                    fields = line.split()
+                    has_interface = any(
+                        fields[index:index + 2] == ["dev", interface]
+                        for index in range(len(fields) - 1)
+                    )
+                    has_metric = any(
+                        fields[index:index + 2] == ["metric", "100"]
+                        for index in range(len(fields) - 1)
+                    )
+                    if fields and fields[0] == "default" and \
+                            has_interface and has_metric:
+                        return True, output
+            return False, output
+
+        wait_for_result(
+            _access_function,
+            failure_message="{} unicast default for {} was not preserved".format(
+                "IPv6" if ipv6 else "IPv4", vrf_name
+            ),
+        )
+
+    def count_asic_link_local_routes(self):
+        route_table = swsscommon.Table(
+            self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY"
+        )
+        count = 0
+        for key in route_table.getKeys():
+            try:
+                if json.loads(key).get("dest") == "fe80::/10":
+                    count += 1
+            except (TypeError, ValueError):
+                continue
+        return count
+
+    def wait_for_asic_link_local_routes(self, expected_count):
+        def _access_function():
+            count = self.count_asic_link_local_routes()
+            return count == expected_count, count
+
+        wait_for_result(
+            _access_function,
+            failure_message="ASIC link-local route count did not reach {}".format(
+                expected_count
+            ),
+        )
 
 
     def vrf_create(self, dvs, vrf_name, attributes, expected_attributes):
@@ -215,6 +317,122 @@ class TestVrf(object):
             }
         )
         self.vrf_remove(dvs, "Vrf1", state)
+
+    def test_kernel_vrf_fallback_lifecycle(self, dvs, testlog):
+        self.setup_db(dvs)
+        fallback_table = swsscommon.Table(self.cdb, "KERNEL_VRF_FALLBACK")
+        vrf_table = swsscommon.Table(self.cdb, "VRF")
+        app_route_table = swsscommon.Table(self.pdb, "ROUTE_TABLE")
+        asic_route_table = swsscommon.Table(
+            self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY"
+        )
+        vrfs = ["VrfFallback", "VrfFallbackNew"]
+        initial_link_local_routes = self.count_asic_link_local_routes()
+
+        fallback_table._del("GLOBAL")
+        try:
+            vrf_table.set(
+                vrfs[0], swsscommon.FieldValuePairs([("fallback", "true")])
+            )
+            self.wait_for_kernel_link(dvs, vrfs[0])
+            self.wait_for_sentinel(dvs, vrfs[0])
+            self.wait_for_sentinel(dvs, vrfs[0], ipv6=True)
+            self.wait_for_asic_link_local_routes(initial_link_local_routes + 1)
+
+            app_routes_with_sentinels = set(app_route_table.getKeys())
+            asic_routes_with_sentinels = set(asic_route_table.getKeys())
+
+            fallback_table.set(
+                "GLOBAL", swsscommon.FieldValuePairs([("status", "enabled")])
+            )
+            self.wait_for_sentinel(dvs, vrfs[0], present=False)
+            self.wait_for_sentinel(dvs, vrfs[0], ipv6=True, present=False)
+            assert set(app_route_table.getKeys()) == app_routes_with_sentinels
+            assert set(asic_route_table.getKeys()) == asic_routes_with_sentinels
+
+            vrf_table.set(
+                vrfs[1], swsscommon.FieldValuePairs([("fallback", "false")])
+            )
+            self.wait_for_kernel_link(dvs, vrfs[1])
+            self.wait_for_sentinel(dvs, vrfs[1], present=False)
+            self.wait_for_sentinel(dvs, vrfs[1], ipv6=True, present=False)
+            self.wait_for_asic_link_local_routes(initial_link_local_routes + 2)
+
+            app_routes_without_sentinels = set(app_route_table.getKeys())
+            asic_routes_without_sentinels = set(asic_route_table.getKeys())
+
+            fallback_table._del("GLOBAL")
+            for vrf_name in vrfs:
+                self.wait_for_sentinel(dvs, vrf_name)
+                self.wait_for_sentinel(dvs, vrf_name, ipv6=True)
+            assert set(app_route_table.getKeys()) == app_routes_without_sentinels
+            assert set(asic_route_table.getKeys()) == asic_routes_without_sentinels
+        finally:
+            fallback_table._del("GLOBAL")
+            for vrf_name in reversed(vrfs):
+                vrf_table._del(vrf_name)
+            for vrf_name in vrfs:
+                self.wait_for_kernel_link(dvs, vrf_name, present=False)
+            self.wait_for_asic_link_local_routes(initial_link_local_routes)
+
+    def test_kernel_vrf_fallback_preserves_unicast_defaults(self, dvs, testlog):
+        self.setup_db(dvs)
+        fallback_table = swsscommon.Table(self.cdb, "KERNEL_VRF_FALLBACK")
+        vrf_table = swsscommon.Table(self.cdb, "VRF")
+        vrf_name = "VrfFallbackRt"
+        interface = "VrfFbDummy"
+        initial_link_local_routes = self.count_asic_link_local_routes()
+
+        fallback_table._del("GLOBAL")
+        try:
+            vrf_table.set(
+                vrf_name, swsscommon.FieldValuePairs([("fallback", "false")])
+            )
+            self.wait_for_kernel_link(dvs, vrf_name)
+            self.wait_for_sentinel(dvs, vrf_name)
+            self.wait_for_sentinel(dvs, vrf_name, ipv6=True)
+            self.wait_for_asic_link_local_routes(initial_link_local_routes + 1)
+
+            commands = [
+                ["ip", "link", "add", interface, "type", "dummy"],
+                ["ip", "link", "set", interface, "master", vrf_name],
+                ["sysctl", "-w", "net.ipv6.conf.{}.disable_ipv6=0".format(interface)],
+                ["ip", "link", "set", interface, "up"],
+                ["ip", "address", "replace", "192.0.2.1/24", "dev", interface],
+                ["ip", "-6", "address", "replace", "2001:db8:ffff::1/64", "dev", interface],
+                ["ip", "route", "replace", "vrf", vrf_name, "default", "dev", interface,
+                 "metric", "100"],
+                ["ip", "-6", "route", "replace", "vrf", vrf_name, "default", "dev",
+                 interface, "metric", "100"],
+            ]
+            for command in commands:
+                status, output = dvs.runcmd(command)
+                assert status == 0, "Command failed: {}: {}".format(command, output)
+
+            self.wait_for_unicast_default(dvs, vrf_name, interface)
+            self.wait_for_unicast_default(dvs, vrf_name, interface, ipv6=True)
+
+            fallback_table.set(
+                "GLOBAL", swsscommon.FieldValuePairs([("status", "enabled")])
+            )
+            self.wait_for_sentinel(dvs, vrf_name, present=False)
+            self.wait_for_sentinel(dvs, vrf_name, ipv6=True, present=False)
+            self.wait_for_unicast_default(dvs, vrf_name, interface)
+            self.wait_for_unicast_default(dvs, vrf_name, interface, ipv6=True)
+
+            fallback_table.set(
+                "GLOBAL", swsscommon.FieldValuePairs([("status", "disabled")])
+            )
+            self.wait_for_sentinel(dvs, vrf_name)
+            self.wait_for_sentinel(dvs, vrf_name, ipv6=True)
+            self.wait_for_unicast_default(dvs, vrf_name, interface)
+            self.wait_for_unicast_default(dvs, vrf_name, interface, ipv6=True)
+        finally:
+            fallback_table._del("GLOBAL")
+            dvs.runcmd(["ip", "link", "del", interface])
+            vrf_table._del(vrf_name)
+            self.wait_for_kernel_link(dvs, vrf_name, present=False)
+            self.wait_for_asic_link_local_routes(initial_link_local_routes)
 
     def test_VRFMgr_Update(self, dvs, testlog):
         self.setup_db(dvs)


### PR DESCRIPTION
**What I did**

- Implemented Linux VRF Route Lookup Fallback Control in `vrfmgrd` through `KERNEL_VRF_FALLBACK|GLOBAL`, with legacy fallback disabled by default.
- Installed/adopted exact IPv4 and IPv6 unreachable defaults with metric `4278198272` for applicable regular VRF and VNET Linux tables; management VRF is excluded.
- Made `status=enabled` remove only those exact sentinels, and made absent, deleted, malformed, invalid, or explicit `disabled` state restore them.
- Reconciled retained and newly created VRFs and retried failed route operations on normal events and the existing daemon timeout.
- Filtered `RTN_UNREACHABLE` before regular or VNET APP_DB dispatch while preserving the prior FPM offload reply for route additions.
- Explicitly warned and ignored the deprecated per-VRF `fallback` attribute.
- Added focused vrfmgrd mock tests, fpmsyncd add/delete regressions, and DVS lifecycle, APP_DB/ASIC_DB isolation, VNET, retry, and real dual-stack unicast-default preservation coverage.

**Why I did it**

Vanilla Linux permits an unmatched lookup in a VRF table to continue through later RPDB rules. The related [Linux VRF Route Lookup Fallback Control HLD](https://github.com/sonic-net/SONiC/pull/2067) proposes intentionally changing the upstream default so Linux kernel behavior aligns with ASICs that terminate a VRF miss, without changing SAI or hardware programming. Explicit `status=enabled` remains a temporary compatibility state.

This PR supersedes the non-normative, IPv4-only prototype in https://github.com/sonic-net/sonic-swss/pull/2943.

**How I verified it**

Static checks:

```text
git diff HEAD^ --check
python3 -m py_compile tests/test_vrf.py
clang-format --dry-run --Werror --style=file tests/mock_tests/vrfmgrd/vrfmgr_ut.cpp
```

Linux build and test validation was completed on `vxr-slurm-577` using both SONiC distro environments:

- Trixie SWSS package build: three test suites completed with `770 passed / 3 skipped`, `1211 passed / 1 skipped`, and `70 passed`; zero failures or errors.
- Bookworm SWSS package build: the same three suites completed with zero failures or errors.
- Focused `tests_vrfmgrd`: `21/21` passed.
- Bookworm `docker-sonic-vs.gz` built successfully.
- Focused DVS validation: `2 passed` in 46.51 seconds:
  - `test_kernel_vrf_fallback_lifecycle`
  - `test_kernel_vrf_fallback_preserves_unicast_defaults`

Reproduction commands from a configured `sonic-buildimage` workspace:

```bash
make NOBOOKWORM=1 \
  SONIC_BUILD_VARS='INCLUDE_VS_DASH_SAI=n' \
  target/debs/trixie/swss_1.0.0_amd64.deb

make NOTRIXIE=1 SONIC_BUILD_JOBS=32 \
  SONIC_BUILD_VARS='INCLUDE_VS_DASH_SAI=n' \
  target/docker-sonic-vs.gz

docker load -i target/docker-sonic-vs.gz
cd src/sonic-swss/tests
sudo -E python3 -m pytest -sv --max_cpu=2 \
  --imgname=docker-sonic-vs:latest \
  test_vrf.py::TestVrf::test_kernel_vrf_fallback_lifecycle \
  test_vrf.py::TestVrf::test_kernel_vrf_fallback_preserves_unicast_defaults
```

**Details if related**

- HLD: https://github.com/sonic-net/SONiC/pull/2067
- CONFIG_DB YANG/documentation: https://github.com/sonic-net/sonic-buildimage/pull/28226
- Prior prototype: https://github.com/sonic-net/sonic-swss/pull/2943

Merge/build order: the companion schema PR should merge and make its generated CONFIG_DB artifacts available before this SWSS implementation merges. Both PRs can be reviewed concurrently. The SWSS code uses a local table-name constant until the generated header is published; no manual `CFG_*` macro is added to sonic-swss-common.

On multi-ASIC systems each `vrfmgrd` intentionally consumes its namespace-local CONFIG_DB. Persistent configuration must place the same explicit value in every applicable data-ASIC namespace; a host-only row is not replicated automatically. The absent default needs no row and remains `disabled` in each namespace.

Maintainer action requested: apply the `Enhancement :heavy_plus_sign:`, `Testing`, and `DVS :star:` labels. The author account does not have upstream label permissions.
