### PR TITLE
[ci]: Restore master-branch docker-sonic-vs image for vstest

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -135,8 +135,8 @@ jobs:
       project: ${{ parameters.buildimage_artifact_project }}
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
-      runVersion: 'specific'
-      runId: 1141167
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/${{ parameters.buildimage_artifact_branch }}'
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/${{ parameters.artifact_name }}.gz'
     displayName: "Download sonic-buildimage ${{ parameters.artifact_name }}"
@@ -146,8 +146,8 @@ jobs:
       project: ${{ parameters.buildimage_artifact_project }}
       pipeline: ${{ parameters.buildimage_artifact_pipeline }}
       artifact: ${{ parameters.buildimage_artifact_name }}
-      runVersion: 'specific'
-      runId: 1141167
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/${{ parameters.buildimage_artifact_branch }}'
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: '**/target/debs/${{ parameters.debian_version }}/framework_*.deb'
     displayName: "Download sonic-buildimage sonic-framework package"


### PR DESCRIPTION
#### Why I did it

Revert the temporary `sonic-buildimage` artifact pin added in #4700 (`[ci]: Pin sonic-buildimage artifact to build 1141167`).

That pin was a workaround for the DVS-test breakage introduced by sonic-buildimage PR #26724, and it kept the vstest `docker-sonic-vs` base on an old build (1141167 / 20260617.1) while the ASAN VS image was being repaired.

Those fixes have now merged in sonic-buildimage #28108 (merge commit `e5835501`), and the official VS pipeline (`Azure.sonic-buildimage.official.vs`) master build **1154584** has succeeded carrying them (libasan8, start.sh supervisor contract, `ASIC_VENDOR=vs`, VS orchagent shims, and the `ENABLE_ASAN` cache-key fix). So master `docker-sonic-vs` is a healthy vstest base again.

#### How I did it

In `.azure-pipelines/build-docker-sonic-vs-template.yml`, switch both `sonic-buildimage` downloads (the `docker-sonic-vs.gz` image and the `framework` deb) back from a hardcoded pin to tracking the branch:

- `runVersion: 'specific'` / `runId: 1141167` → `runVersion: 'latestFromBranch'` / `runBranch: 'refs/heads/$(BUILD_BRANCH)'`

This is an exact mirror-revert of #4700 and matches every other artifact download in the template (swss-common, sairedis, vpp), so vstest tracks the latest master VS image again. The pipeline default is already `Azure.sonic-buildimage.official.vs`, so it is unchanged.

#### How I verified it

- Confirmed sonic-buildimage #28108 merged to master (`e5835501`).
- Confirmed the official VS pipeline master build **1154584** (commit `e5835501`) **succeeded**, so `latestFromBranch` on `refs/heads/master` resolves to an image that contains the fix.
- `yaml.safe_load` parses the edited template successfully.
- The resulting file is byte-identical to the pre-#4700 state (blob reverts to `e76d4c56`).

CI on this PR will download the latest master VS artifact and run the DVS tests against it.