### PR TITLE
[fdborch]: Revert FDB flush-all to dynamic-only flush

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -1758,7 +1758,7 @@ void FdbOrch::updateVlanMember(const VlanMemberUpdate& update)
     {
         swss::Port vlan = update.vlan;
         swss::Port port = update.member;
-        flushAllFDBEntries(port.m_bridge_port_id, vlan.m_vlan_info.vlan_oid);
+        flushFDBEntries(port.m_bridge_port_id, vlan.m_vlan_info.vlan_oid);
         notifyObserversFDBFlush(port, vlan.m_vlan_info.vlan_oid);
         return;
     }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -7483,9 +7483,8 @@ bool PortsOrch::removeBridgePort(Port &port)
     /* Remove STP ports before bridge port deletion*/
     gStpOrch->removeStpPorts(port);
 
-    //Flush all FDB entires corresponding to the port (including static entries
-    //on tunnel/nexthop_group bridge ports)
-    gFdbOrch->flushAllFDBEntries(port.m_bridge_port_id, SAI_NULL_OBJECT_ID);
+    //Flush the FDB entires corresponding to the port
+    gFdbOrch->flushFDBEntries(port.m_bridge_port_id, SAI_NULL_OBJECT_ID);
     SWSS_LOG_INFO("Flush FDB entries for port %s", port.m_alias.c_str());
 
     /* Remove bridge port */

--- a/tests/mock_tests/fdborch/fdborch_vxlan_ut.cpp
+++ b/tests/mock_tests/fdborch/fdborch_vxlan_ut.cpp
@@ -932,7 +932,7 @@ namespace fdborch_vxlan_ut
         attrs.push_back(attr);
 
         attr.id = SAI_FDB_FLUSH_ATTR_ENTRY_TYPE;
-        attr.value.s32 = SAI_FDB_FLUSH_ENTRY_TYPE_ALL;
+        attr.value.s32 = SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC;
         attrs.push_back(attr);
 
         EXPECT_CALL(*mock_sai_fdb_api, flush_fdb_entries(_, _, _))


### PR DESCRIPTION
PR #4615 (EVPN-MH) changed the VLAN member removal and bridge port removal paths to call flushAllFDBEntries(), which issues a SAI flush with SAI_FDB_FLUSH_ENTRY_TYPE_ALL. This flushes static (user configured) FDB entries and fails on vendor SAIs that do not support the ALL entry type, causing bridge port removal to fail.

Restore the previous behavior by calling flushFDBEntries() (dynamic entries only) from updateVlanMember() and removeBridgePort(), and update the corresponding mock test expectation.

Fixes sonic-net/sonic-buildimage#27835

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

## Description

#### What I did
Reverted the VLAN member removal and bridge port removal paths to use
`flushFDBEntries()` (dynamic entries only) instead of `flushAllFDBEntries()`,
which was introduced by PR #4615 (EVPN-MH integration).

`flushAllFDBEntries()` issues a SAI flush with
`SAI_FDB_FLUSH_ATTR_ENTRY_TYPE = SAI_FDB_FLUSH_ENTRY_TYPE_ALL`. This has two
problems:

1. It flushes static (user-configured) FDB entries, which are meant to be
   persistent and should not be removed on VLAN/VLAN-member changes.
2. It fails on vendor SAIs that do not support the `ALL` entry type, e.g.:

   ```
   ERR swss#orchagent: :- flushAllFDBEntries: Flushing all FDB failed. rv:-131070
   ERR syncd#SDK: ... enum value SAI_FDB_FLUSH_ENTRY_TYPE_ALL is not supported
   ERR swss#orchagent: :- removeBridgePort: Failed to remove bridge port
   PortChannel0001 from default 1Q bridge, rv:-17
   ```

#### Why I did it
Fixes sonic-net/sonic-buildimage#27835. Default flush behavior should only
flush dynamic entries, as it did before the EVPN-MH change.

#### How I verified it
Updated the `FlushLocalRemoteMACsOnVlanDelete` mock test to expect
`SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC`. Existing `flushAllFDBEntries` unit tests
remain (function is retained; only the two production call sites are reverted).

#### Details if related
- `orchagent/fdborch.cpp`: `updateVlanMember()` -> `flushFDBEntries()`
- `orchagent/portsorch.cpp`: `removeBridgePort()` -> `flushFDBEntries()`
- `tests/mock_tests/fdborch/fdborch_vxlan_ut.cpp`: expectation updated
