### PR TITLE
Cache dual-ToR PEER_SWITCH role at startup to avoid per-netlink-messa…

### DIFF
--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -42,6 +42,11 @@ NeighSync::NeighSync(RedisPipeline *pipelineAppDB, DBConnector *stateDb, DBConne
         m_AppRestartAssist->registerAppTable(APP_NEIGH_TABLE_NAME, &m_neighTable);
     }
 
+    std::vector<std::string> peerSwitchKeys;
+    m_cfgPeerSwitchTable.getKeys(peerSwitchKeys);
+    m_isDualToR = peerSwitchKeys.size() > 0;
+    SWSS_LOG_NOTICE("neighsyncd: dualtor=%s", m_isDualToR ? "true" : "false");
+
     m_nl_sock = nl_socket_alloc();
     if (!m_nl_sock)
     {
@@ -156,9 +161,7 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     string key;
     string family;
     string intfName;
-    std::vector<std::string> peerSwitchKeys;
-    m_cfgPeerSwitchTable.getKeys(peerSwitchKeys);
-    bool is_dualtor = peerSwitchKeys.size() > 0;
+    bool is_dualtor = m_isDualToR;
 
     if ((nlmsg_type != RTM_NEWNEIGH) && (nlmsg_type != RTM_GETNEIGH) &&
         (nlmsg_type != RTM_DELNEIGH))

--- a/neighsyncd/neighsync.h
+++ b/neighsyncd/neighsync.h
@@ -55,6 +55,7 @@ private:
     struct nl_sock     *m_nl_sock;
     AppRestartAssist  *m_AppRestartAssist;
     Table m_cfgVlanInterfaceTable, m_cfgLagInterfaceTable, m_cfgInterfaceTable;
+    bool m_isDualToR = false;
     bool m_isEvpnNvoExist = false;
 
     bool isLinkLocalEnabled(const std::string &port);

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -1499,19 +1499,44 @@ class TestMuxTunnelBase():
             self.DEFAULT_TUNNEL_PARAMS
         )
 
-    @pytest.fixture
+    @pytest.fixture(scope='class')
     def setup_peer_switch(self, dvs):
+        # Add PEER_SWITCH once per class and restart neighsyncd so it re-reads the
+        # dual-ToR role (neighsyncd caches it at startup).
         config_db = dvs.get_config_db()
         config_db.create_entry(
             self.CONFIG_PEER_SWITCH,
             self.PEER_SWITCH_HOST,
             self.DEFAULT_PEER_SWITCH_PARAMS
         )
+        self._restart_neighsyncd(dvs)
 
         yield
 
         config_db = dvs.get_config_db()
         config_db.delete_entry(self.CONFIG_PEER_SWITCH, self.PEER_SWITCH_HOST)
+        self._restart_neighsyncd(dvs)
+
+    @pytest.fixture
+    def remove_peer_switch(self, dvs, setup_peer_switch):
+        # Drop PEER_SWITCH and restart neighsyncd for a true no-peer state; restore on teardown.
+        config_db = dvs.get_config_db()
+        config_db.delete_entry(self.CONFIG_PEER_SWITCH, self.PEER_SWITCH_HOST)
+        self._restart_neighsyncd(dvs)
+
+        yield
+
+        config_db.create_entry(
+            self.CONFIG_PEER_SWITCH,
+            self.PEER_SWITCH_HOST,
+            self.DEFAULT_PEER_SWITCH_PARAMS
+        )
+        self._restart_neighsyncd(dvs)
+
+    def _restart_neighsyncd(self, dvs):
+        # Restart neighsyncd so it re-reads the PEER_SWITCH (dual-ToR) role.
+        dvs.runcmd(['sh', '-c', 'supervisorctl restart neighsyncd'])
+        time.sleep(3)
 
     @pytest.fixture(params=['IPv4', 'IPv6'])
     def ip_version(self, request):
@@ -2066,7 +2091,7 @@ class TestMuxTunnel(TestMuxTunnelBase):
 
     def test_neighbor_miss_no_peer(
             self, dvs, dvs_route, setup_vlan, setup_mux_cable, setup_tunnel,
-            neighbor_cleanup, testlog
+            remove_peer_switch, neighbor_cleanup, testlog
     ):
         """
         test neighbor miss with no peer switch configured

--- a/tests/test_mux_prefixroute.py
+++ b/tests/test_mux_prefixroute.py
@@ -1666,19 +1666,44 @@ class TestMuxTunnelBase():
             self.DEFAULT_TUNNEL_PARAMS
         )
 
-    @pytest.fixture
+    @pytest.fixture(scope='class')
     def setup_peer_switch(self, dvs):
+        # Add PEER_SWITCH once per class and restart neighsyncd so it re-reads the
+        # dual-ToR role (neighsyncd caches it at startup).
         config_db = dvs.get_config_db()
         config_db.create_entry(
             self.CONFIG_PEER_SWITCH,
             self.PEER_SWITCH_HOST,
             self.DEFAULT_PEER_SWITCH_PARAMS
         )
+        self._restart_neighsyncd(dvs)
 
         yield
 
         config_db = dvs.get_config_db()
         config_db.delete_entry(self.CONFIG_PEER_SWITCH, self.PEER_SWITCH_HOST)
+        self._restart_neighsyncd(dvs)
+
+    @pytest.fixture
+    def remove_peer_switch(self, dvs, setup_peer_switch):
+        # Drop PEER_SWITCH and restart neighsyncd for a true no-peer state; restore on teardown.
+        config_db = dvs.get_config_db()
+        config_db.delete_entry(self.CONFIG_PEER_SWITCH, self.PEER_SWITCH_HOST)
+        self._restart_neighsyncd(dvs)
+
+        yield
+
+        config_db.create_entry(
+            self.CONFIG_PEER_SWITCH,
+            self.PEER_SWITCH_HOST,
+            self.DEFAULT_PEER_SWITCH_PARAMS
+        )
+        self._restart_neighsyncd(dvs)
+
+    def _restart_neighsyncd(self, dvs):
+        # Restart neighsyncd so it re-reads the PEER_SWITCH (dual-ToR) role.
+        dvs.runcmd(['sh', '-c', 'supervisorctl restart neighsyncd'])
+        time.sleep(3)
 
     @pytest.fixture(params=['IPv4', 'IPv6'])
     def ip_version(self, request):
@@ -2018,7 +2043,7 @@ class TestMuxTunnel(TestMuxTunnelBase):
 
     def test_neighbor_miss_no_peer(
             self, dvs, dvs_route, setup_vlan, setup_mux_cable, setup_tunnel,
-            neighbor_cleanup, testlog
+            remove_peer_switch, neighbor_cleanup, testlog
     ):
         """
         test neighbor miss with no peer switch configured

--- a/tests/test_neighbor.py
+++ b/tests/test_neighbor.py
@@ -517,12 +517,25 @@ class TestNeighbor(object):
 
     @pytest.fixture
     def setup_peer_switch(self, dvs):
+        # Add PEER_SWITCH and restart neighsyncd so it re-reads the dual-ToR
+        # role (neighsyncd caches it at startup). Restore on teardown.
         config_db = dvs.get_config_db()
         config_db.create_entry(
             self.CONFIG_PEER_SWITCH,
             self.PEER_SWITCH_HOST,
             self.DEFAULT_PEER_SWITCH_PARAMS
         )
+        self._restart_neighsyncd(dvs)
+
+        yield
+
+        config_db.delete_entry(self.CONFIG_PEER_SWITCH, self.PEER_SWITCH_HOST)
+        self._restart_neighsyncd(dvs)
+
+    def _restart_neighsyncd(self, dvs):
+        # Restart neighsyncd so it re-reads the PEER_SWITCH (dual-ToR) role.
+        dvs.runcmd(['sh', '-c', 'supervisorctl restart neighsyncd'])
+        time.sleep(3)
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying


### PR DESCRIPTION
…ge Redis KEYS

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
- Cache the dual-ToR (`PEER_SWITCH`) role once in the `NeighSync` constructor (`m_isDualToR`) instead of calling `m_cfgPeerSwitchTable.getKeys()` on every netlink message in `onMsg()`.

**Why I did it**
- `getKeys()` runs a Redis `KEYS` scan; doing it per netlink message dominated `onMsg()` (avg ~4–11 ms, max 50+ ms — almost entirely the `getKeys` call).
- The added latency filled the neighsyncd netlink socket receive buffer, causing netlink message drops (rising drop counter in `/proc/<pid>/net/netlink`) in scaled scenarios.
- Dropped `RTM_*NEIGH` messages left stale `NEIGH_RESOLVE_TABLE` entries in APPL_DB, so no nexthop was programmed in ASIC_DB even though the kernel had the neighbor resolved (`REACHABLE`).

**How I verified it**
- Confirmed `onMsg` time drops sharply once the per-message `getKeys` is removed (Redis no longer in the hot path).
- Verified the netlink socket drop counter in `/proc/<pid>/net/netlink` stops incrementing under neighbor churn.
- Verified resolved neighbors now create the corresponding nexthop in ASIC_DB and `NEIGH_RESOLVE_TABLE` entries are cleared.
- Updated `tests/test_mux.py` to restart neighsyncd when toggling `PEER_SWITCH`, since the role is read at startup.

**Details if related**
- Reading the role once at startup is safe by the startup flow and code flow:
  - **Config is loaded before the daemon starts.** In the swss container start sequence, CONFIG_DB is fully populated (`configdb-load.sh` / `config load_minigraph` on cold boot) *before* `supervisorctl start neighsyncd`. Daemon startup is gated behind config load, not run concurrently with it, so `PEER_SWITCH` (a minigraph-derived key) is present in CONFIG_DB by the time the `NeighSync` constructor runs.
  - **Role is cached before the first message.** In `neighsyncd.cpp` `main()`, the `NeighSync` object is fully constructed before any netlink handler is registered or the select loop runs, so `m_isDualToR` is always set before the first `onMsg()`. No path processes a neighbor message before the role is cached.
  - **Role changes go through a restart.** A dual-ToR role change is a topology/minigraph change applied via `config reload`, which restarts swss and re-runs the constructor (re-reading the role). Warm restart follows the same path.