### PR TITLE
Delete stale dhcp trap entries from state db

### DIFF
--- a/cfgmgr/coppmgr.cpp
+++ b/cfgmgr/coppmgr.cpp
@@ -419,6 +419,9 @@ CoppMgr::CoppMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
             m_appCoppTable.del(it);
         }
     }
+
+    /* Reconcile STATE_DB COPP_TRAP_TABLE: remove stale entries not in m_coppTrapConfMap */
+    cleanupStateDb();
 }
 
 void CoppMgr::setCoppGroupStateOk(string alias)
@@ -449,6 +452,31 @@ void CoppMgr::delCoppTrapStateOk(string alias)
 {
     m_stateCoppTrapTable.del(alias);
     SWSS_LOG_NOTICE("Delete %s(ok) from state db", alias.c_str());
+}
+
+void CoppMgr::cleanupStateDb()
+{
+    SWSS_LOG_ENTER();
+
+    // Reconcile STATE_COPP_TRAP_TABLE: remove only stale entries not in m_coppTrapConfMap
+    vector<string> state_trap_keys;
+    m_stateCoppTrapTable.getKeys(state_trap_keys);
+    SWSS_LOG_DEBUG("cleanupStateDb: Found %zu STATE_DB COPP_TRAP_TABLE entries",
+                    state_trap_keys.size());
+
+    size_t removed_count = 0;
+    for (const auto& key : state_trap_keys)
+    {
+        // Only delete if this trap is NOT in the current configuration
+        if (m_coppTrapConfMap.find(key) == m_coppTrapConfMap.end())
+        {
+            m_stateCoppTrapTable.del(key);
+            removed_count++;
+            SWSS_LOG_NOTICE("cleanupStateDb: Removed stale STATE_DB COPP trap: %s", key.c_str());
+        }
+    }
+    SWSS_LOG_DEBUG("cleanupStateDb: Removed %zu stale entries, kept %zu valid entries",
+                    removed_count, state_trap_keys.size() - removed_count);
 }
 
 void CoppMgr::addTrapIdsToTrapGroup(string trap_group, string trap_ids)

--- a/cfgmgr/coppmgr.h
+++ b/cfgmgr/coppmgr.h
@@ -93,6 +93,8 @@ private:
     void setCoppGroupStateOk(std::string alias);
     void delCoppGroupStateOk(std::string alias);
 
+    void cleanupStateDb();
+
     void setCoppTrapStateOk(std::string alias);
     void delCoppTrapStateOk(std::string alias);
     void coppGroupGetModifiedFvs(std::string key, std::vector<FieldValueTuple> &trap_group_fvs,


### PR DESCRIPTION

**What I did**
Removed stale state db entries in COPP_TRAP_TABLE.

**Why I did it**
"show copp configuration" is showing dhcp traps as installed even when the hardware does not have them installed.
Scenario:

enable dhcp relay feature
verify "show copp config" has dhcp traps installed
do config reload verify dhcp relay feature is disabled but "show copp config" has dhcp traps installed.
This is due to state db having stale enties in COPP_TRAP_TABLE for dhcp.

**How I verified it**
- enable dhcp relay feature
- verify dhcp traps are installed
- do config reload
- verify dhcp traps are not installed
Also run test_copp.py

**Details if related**
Failure in test_copp.py (below) will be fixed.

 testcase classname="tests.copp.test_copp.TestCOPP" name="test_policer[humm109-DHCP]"
            failure message="Failed: Trap dhcp for protocol DHCP is unexpectedly installed"
            