### PR TITLE
Fix EVPN neighbor-first remote MAC race

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -2086,10 +2086,12 @@ bool FdbOrch::addFdbEntry(const FdbEntry& entry, const string& port_name,
             attrs.push_back(attr);
         }
 
-        if (fdbData.dest_type == FdbDest::VTEP || fdbData.dest_type == FdbDest::NEXTHOPGROUP) {
-            /* Try to remvoe local neighbor entry if exists
-            * Since this mac is at the remote vxlan side now
-            */
+        if ((fdbData.dest_type == FdbDest::VTEP || fdbData.dest_type == FdbDest::NEXTHOPGROUP) &&
+            macUpdate && (oldOrigin != FDB_ORIGIN_VXLAN_ADVERTIZED) &&
+            (oldOrigin != FDB_ORIGIN_MCLAG_ADVERTIZED)) {
+            /* Try to remove the local neighbor entry if a local MAC moved to
+             * the remote VXLAN side now.
+             */
             gNeighOrch->processFDBDelete(entry);
         }
     }

--- a/tests/mock_tests/fdborch/fdborch_vxlan_ut.cpp
+++ b/tests/mock_tests/fdborch/fdborch_vxlan_ut.cpp
@@ -32,6 +32,10 @@ namespace fdborch_vxlan_ut
 
     sai_route_api_t ut_sai_route_api;
     sai_route_api_t *pold_sai_route_api;
+    sai_router_interface_api_t ut_sai_router_intfs_api;
+    sai_router_interface_api_t *pold_sai_router_intfs_api;
+    sai_next_hop_api_t ut_sai_next_hop_api;
+    sai_next_hop_api_t *pold_sai_next_hop_api;
 
     sai_status_t _ut_stub_sai_create_route_entry(
         _In_ const sai_route_entry_t *route_entry,
@@ -43,6 +47,39 @@ namespace fdborch_vxlan_ut
 
     sai_status_t _ut_stub_sai_remove_route_entry(
         _In_ const sai_route_entry_t *route_entry)
+    {
+        return SAI_STATUS_SUCCESS;
+    }
+
+    sai_status_t _ut_stub_sai_create_router_interface(
+        _Out_ sai_object_id_t *router_interface_id,
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list)
+    {
+        *router_interface_id = 0x6000000000040;
+        return SAI_STATUS_SUCCESS;
+    }
+
+    sai_status_t _ut_stub_sai_remove_router_interface(
+        _In_ sai_object_id_t router_interface_id)
+    {
+        return SAI_STATUS_SUCCESS;
+    }
+
+    sai_status_t _ut_stub_sai_create_next_hop(
+        _Out_ sai_object_id_t *next_hop_id,
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list)
+    {
+        static sai_object_id_t nh_id_counter = 0x6000000000041;
+        *next_hop_id = nh_id_counter++;
+        return SAI_STATUS_SUCCESS;
+    }
+
+    sai_status_t _ut_stub_sai_remove_next_hop(
+        _In_ sai_object_id_t next_hop_id)
     {
         return SAI_STATUS_SUCCESS;
     }
@@ -78,11 +115,33 @@ namespace fdborch_vxlan_ut
             auto status = sai_switch_api->create_switch(&gSwitchId, 1, &attr);
             ASSERT_EQ(status, SAI_STATUS_SUCCESS);
 
+            attr.id = SAI_SWITCH_ATTR_SRC_MAC_ADDRESS;
+            status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+            gMacAddress = attr.value.mac;
+
+            attr.id = SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID;
+            status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+            gVirtualRouterId = attr.value.oid;
+
             ut_sai_route_api = *sai_route_api;
             pold_sai_route_api = sai_route_api;
             ut_sai_route_api.create_route_entry = _ut_stub_sai_create_route_entry;
             ut_sai_route_api.remove_route_entry = _ut_stub_sai_remove_route_entry;
             sai_route_api = &ut_sai_route_api;
+
+            ut_sai_router_intfs_api = *sai_router_intfs_api;
+            pold_sai_router_intfs_api = sai_router_intfs_api;
+            ut_sai_router_intfs_api.create_router_interface = _ut_stub_sai_create_router_interface;
+            ut_sai_router_intfs_api.remove_router_interface = _ut_stub_sai_remove_router_interface;
+            sai_router_intfs_api = &ut_sai_router_intfs_api;
+
+            ut_sai_next_hop_api = *sai_next_hop_api;
+            pold_sai_next_hop_api = sai_next_hop_api;
+            ut_sai_next_hop_api.create_next_hop = _ut_stub_sai_create_next_hop;
+            ut_sai_next_hop_api.remove_next_hop = _ut_stub_sai_remove_next_hop;
+            sai_next_hop_api = &ut_sai_next_hop_api;
 
             m_config_db = std::make_shared<swss::DBConnector>("CONFIG_DB", 0);
             m_app_db = std::make_shared<swss::DBConnector>("APPL_DB", 0);
@@ -111,6 +170,7 @@ namespace fdborch_vxlan_ut
                 { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
             };
             m_portsOrch = std::make_shared<PortsOrch>(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
+            gDirectory.set(m_portsOrch.get());
 
             // 3) Crmorch
             ASSERT_EQ(gCrmOrch, nullptr);
@@ -271,6 +331,8 @@ namespace fdborch_vxlan_ut
 
             gDirectory.m_values.clear();
             sai_route_api = pold_sai_route_api;
+            sai_router_intfs_api = pold_sai_router_intfs_api;
+            sai_next_hop_api = pold_sai_next_hop_api;
             RestoreSaiApis();
             ut_helper::uninitSaiApi();
         }
@@ -534,9 +596,10 @@ namespace fdborch_vxlan_ut
 
         const string ip = "100.1.1.47";
         const string mac = "00:11:01:00:00:2e";
-        NeighborEntry neighbor(ip, VLAN40);
+        NeighborEntry neighbor(ip, string(VLAN40));
 
-        EXPECT_CALL(*mock_sai_neighbor_api, create_neighbor_entry);
+        EXPECT_CALL(*mock_sai_neighbor_api, create_neighbor_entry)
+            .WillOnce(testing::Return(SAI_STATUS_SUCCESS));
         learnNeighbor(m_app_db.get(), VLAN40, ip, mac);
         ASSERT_EQ(gNeighOrch->m_syncdNeighbors.count(neighbor), 1);
         ASSERT_TRUE(gNeighOrch->isHwConfigured(neighbor));
@@ -544,9 +607,9 @@ namespace fdborch_vxlan_ut
         EXPECT_CALL(*mock_sai_neighbor_api, remove_neighbor_entry).Times(0);
         Table vxlanFdbTable = Table(m_app_db.get(), APP_VXLAN_FDB_TABLE_NAME);
         vxlanFdbTable.set(VLAN40 + vxlanFdbTable.getTableNameSeparator() + mac, {
-            { "vni", "40" },
-            { "type", "dynamic" },
-            { "remote_vtep", "1.1.1.1" }
+            { string("vni"), string("40") },
+            { string("type"), string("dynamic") },
+            { string("remote_vtep"), string("1.1.1.1") }
         });
 
         gFdbOrch->addExistingData(&vxlanFdbTable);

--- a/tests/mock_tests/fdborch/fdborch_vxlan_ut.cpp
+++ b/tests/mock_tests/fdborch/fdborch_vxlan_ut.cpp
@@ -28,6 +28,8 @@ extern redisReply *mockReply;
 
 namespace fdborch_vxlan_ut
 {
+    DEFINE_SAI_API_MOCK(neighbor);
+
     sai_route_api_t ut_sai_route_api;
     sai_route_api_t *pold_sai_route_api;
 
@@ -211,6 +213,7 @@ namespace fdborch_vxlan_ut
             gDirectory.set(gRouteOrch);
 
             INIT_SAI_API_MOCK(fdb);
+            INIT_SAI_API_MOCK(neighbor);
             MockSaiApis();
         }
 
@@ -351,6 +354,16 @@ namespace fdborch_vxlan_ut
         m_portsOrch->m_portList[NHG_REMOTE].m_bridge_port_id = bridge_port_id;
         m_portsOrch->saiOidToAlias[bridge_port_id] = NHG_REMOTE;
         m_portsOrch->m_portList[VLAN40].m_members.insert(VXLAN_REMOTE);
+    }
+
+    void learnNeighbor(DBConnector *appDb, const string &vlan, const string &ip, const string &mac)
+    {
+        Table neigh_table = Table(appDb, APP_NEIGH_TABLE_NAME);
+        string key = vlan + neigh_table.getTableNameSeparator() + ip;
+        neigh_table.set(key, { { "neigh", mac }, { "family", "IPv4" } });
+        gNeighOrch->addExistingData(&neigh_table);
+        static_cast<Orch *>(gNeighOrch)->doTask();
+        neigh_table.del(key);
     }
 
 
@@ -496,6 +509,50 @@ namespace fdborch_vxlan_ut
         /* Make sure fdb_count is decremented as expected */
         ASSERT_EQ(m_portsOrch->m_portList[VLAN40].m_fdb_count, 0);
         ASSERT_EQ(m_portsOrch->m_portList[VXLAN_REMOTE].m_fdb_count, 0);
+    }
+
+    TEST_F(VxlanFdbOrchTest, RemoteMacAddAfterNeighborDoesNotDisableNeighbor)
+    {
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        auto ports = ut_helper::getInitialSaiPorts();
+
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+        portTable.set("PortInitDone", { { "lanes", "0" } });
+
+        m_portsOrch.get()->addExistingData(&portTable);
+        static_cast<Orch *>(m_portsOrch.get())->doTask();
+
+        ASSERT_NE(m_portsOrch, nullptr);
+        setUpVlan(m_portsOrch.get());
+        setUpVxlanPort(m_portsOrch.get());
+        setUpVxlanMember(m_portsOrch.get());
+        ASSERT_TRUE(gIntfsOrch->setIntf(VLAN40));
+
+        const string ip = "100.1.1.47";
+        const string mac = "00:11:01:00:00:2e";
+        NeighborEntry neighbor(ip, VLAN40);
+
+        EXPECT_CALL(*mock_sai_neighbor_api, create_neighbor_entry);
+        learnNeighbor(m_app_db.get(), VLAN40, ip, mac);
+        ASSERT_EQ(gNeighOrch->m_syncdNeighbors.count(neighbor), 1);
+        ASSERT_TRUE(gNeighOrch->isHwConfigured(neighbor));
+
+        EXPECT_CALL(*mock_sai_neighbor_api, remove_neighbor_entry).Times(0);
+        Table vxlanFdbTable = Table(m_app_db.get(), APP_VXLAN_FDB_TABLE_NAME);
+        vxlanFdbTable.set(VLAN40 + vxlanFdbTable.getTableNameSeparator() + mac, {
+            { "vni", "40" },
+            { "type", "dynamic" },
+            { "remote_vtep", "1.1.1.1" }
+        });
+
+        gFdbOrch->addExistingData(&vxlanFdbTable);
+        static_cast<Orch *>(gFdbOrch)->doTask();
+
+        EXPECT_TRUE(gNeighOrch->isHwConfigured(neighbor));
     }
 
     TEST_F(VxlanFdbOrchTest, DISABLED_RemoteMacLearnAddDeleteForNhg)


### PR DESCRIPTION
Fixes #4736

## Summary
- Restrict the EVPN remote-FDB neighbor delete path to actual local-to-remote MAC moves.
- Avoid disabling an already-programmed neighbor when a neighbor is programmed before its remote VXLAN FDB entry.
- Add a VXLAN FDB mock regression for the neighbor-first, MAC-second sequence.

## Why I did it
When the neighbor is programmed before the remote EVPN MAC, `FdbOrch::addFdbEntry()` currently treats the first remote FDB add like a MAC move and calls `processFDBDelete()`. That removes the neighbor from hardware even though there was no local-to-remote MAC move, leaving software and hardware neighbor state out of sync.

## How I did it
The fix gates `processFDBDelete()` on `macUpdate` and the previous FDB origin, so it only runs when an existing local entry moves to the remote VXLAN/NHG side. The regression test programs the neighbor first, then adds the remote VXLAN FDB entry, and verifies the neighbor remove path is not called.

## How to verify it
Validated through the SONiC buildimage Trixie SWSS package path in `sbi0`:

```bash
make PLATFORM=vs NOJESSIE=1 NOSTRETCH=1 NOBUSTER=1 NOBULLSEYE=1 NOBOOKWORM=1 NOTRIXIE=0 \
     SONIC_BUILD_JOBS=4 SONIC_CONFIG_MAKE_JOBS=32 \
     target/debs/trixie/swss_1.0.0_amd64.deb
```

A/B result:
- With this fix: `A_WITH_FIX_PACKAGE_RC=0`
- With only `orchagent/fdborch.cpp` reverted to the pre-fix behavior while keeping the regression test: `B_WITHOUT_FIX_PACKAGE_RC=2`
- No-fix failure: `VxlanFdbOrchTest.RemoteMacAddAfterNeighborDoesNotDisableNeighbor` failed because `remove_neighbor_entry(...)` was called once despite the test expecting it never to be called.

Also checked:

```bash
git diff --check github/master..HEAD
```