### PR TITLE
orchagent: fix undefined iterator use in IPv6 key parsing

### DIFF
--- a/orchagent/request_parser.cpp
+++ b/orchagent/request_parser.cpp
@@ -1,5 +1,6 @@
 #include <net/ethernet.h>
 #include <cassert>
+#include <cstddef>
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -90,8 +91,9 @@ void Request::parseKey(const KeyOpFieldsValuesTuple& request)
         or request_description_.key_item_types.back() == REQ_T_MAC_ADDRESS or request_description_.key_item_types.back() == REQ_T_STRING))
     {
         // Remove key_items so that key_items.size() is correct, then assemble the removed items into an IPv6 address
-        std::vector<std::string> ip_addr_groups(--key_items.begin() + number_of_key_items_, key_items.end());
-        key_items.erase(--key_items.begin() + number_of_key_items_, key_items.end());
+        const auto ip_key_start = key_items.begin() + static_cast<std::ptrdiff_t>(number_of_key_items_ - 1);
+        std::vector<std::string> ip_addr_groups(ip_key_start, key_items.end());
+        key_items.erase(ip_key_start, key_items.end());
 
         std::string ip_string;
 

--- a/tests/request_parser_ut.cpp
+++ b/tests/request_parser_ut.cpp
@@ -1360,6 +1360,18 @@ public:
     TestRequestIpv6Prefix() : Request(request_description_ipv6_prefix, ':') { }
 };
 
+const request_description_t request_description_ipv6_addr_with_two_prefix_keys = {
+    { REQ_T_STRING, REQ_T_STRING, REQ_T_IP },
+    { },
+    { }
+};
+
+class TestRequestIpv6AddrWithTwoPrefixKeys : public Request
+{
+public:
+    TestRequestIpv6AddrWithTwoPrefixKeys() : Request(request_description_ipv6_addr_with_two_prefix_keys, ':') { }
+};
+
 const request_description_t request_desc_ipv6_addr_only = {
     { REQ_T_IP },
     { },
@@ -1418,6 +1430,37 @@ TEST(request_parser, ipv6_addr_key_item)
         {
             FAIL() << "Got unexpected exception";
         }
+    }
+}
+
+TEST(request_parser, ipv6_addr_key_item_with_two_prefix_keys)
+{
+    const std::string ipv6_addr = "2001:db8::1";
+    const std::string key_string = "prefix1:prefix2:" + ipv6_addr;
+    KeyOpFieldsValuesTuple t {key_string, "SET",
+                                { }
+                            };
+
+    try
+    {
+        TestRequestIpv6AddrWithTwoPrefixKeys request;
+
+        EXPECT_NO_THROW(request.parse(t));
+
+        EXPECT_STREQ(request.getOperation().c_str(), "SET");
+        EXPECT_STREQ(request.getFullKey().c_str(), key_string.c_str());
+        EXPECT_STREQ(request.getKeyString(0).c_str(), "prefix1");
+        EXPECT_STREQ(request.getKeyString(1).c_str(), "prefix2");
+        EXPECT_EQ(request.getKeyIpAddress(2), IpAddress(ipv6_addr));
+        EXPECT_FALSE(request.getKeyIpAddress(2).isV4());
+    }
+    catch (const std::exception& e)
+    {
+        FAIL() << "Got unexpected exception " << e.what();
+    }
+    catch (...)
+    {
+        FAIL() << "Got unexpected exception";
     }
 }
 


### PR DESCRIPTION
Use a valid iterator offset when merging split IPv6 key segments so parsing no longer relies on undefined behavior, and add a regression test covering multi-prefix key parsing.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
1.Fixed undefined iterator arithmetic in orchagent/request_parser.cpp IPv6 key reassembly path.
2.Replaced --key_items.begin()-based range calculation with a valid iterator start.
3.Added regression test request_parser.ipv6_addr_key_item_with_two_prefix_keys in tests/request_parser_ut.cpp.
**Why I did it**
1.Previous logic could trigger undefined behavior when parsing :-separated keys with IPv6 tail segments.
2.This change makes parsing deterministic and safe with minimal code impact.
**How I verified it**
1.Added targeted UT coverage for prefix1:prefix2:2001:db8::1 style keys.
2.Reviewed parsing flow to ensure no behavior change outside the affected path.
3.Test binary is unavailable in this environment, so runtime execution was not performed here.
**Details if related**
1.Scope: orchagent request parser only.
2.Risk: low; no interface or schema changes.