### PR TITLE
[doc]: Add HLD for migrating VS tests to C++ mock tests

### DIFF
--- a/doc/vs-to-mock-test-migration.md
+++ b/doc/vs-to-mock-test-migration.md
@@ -1,0 +1,162 @@
+# Migrating VS tests to C++ mock tests in sonic-swss
+
+## Scope
+
+This proposal covers the test suite in sonic-swss `tests/`. It does not include any changes to production SONiC code, the `docker-sonic-vs` image, or the orchagent/daemon logic being tested - only which tests we run and how.
+
+## 1. TL;DR
+
+sonic-swss has two test suites that cover a lot of the same ground: VS tests (`tests/test_*.py` plus the `tests/dash/` suite, ~114 modules) which spin up a full `docker-sonic-vs` container and poll Redis to check behavior, and C++ mock tests (`tests/mock_tests/*_ut.cpp`) which run orchagent in-process against an in-memory Redis and a virtual SAI. VS tests are slow, flaky, and need Docker + root, but the majority of them are really just checking how orchagent reacts to a DB change - which is exactly what a mock test does, except in under a second and deterministically. This proposal is to port two groups over to mock tests - the tests that don't depend on kernel or tooling behavior at all, plus the kernel-dependent ones whose kernel behavior is already covered by a test we're keeping - and keep a small, deliberately chosen set of VS tests around, including a seven-test core-functionality set, for the things a mock test genuinely can't cover or that are worth keeping end-to-end. Based on the analysis below, that works out to ~81% of modules moving to mock tests, with ~21 kept as VS.
+
+## 2. Background
+
+A VS test works by writing to CONFIG_DB or APPL_DB (the application DB, sometimes written APP_DB in code), letting the whole SONiC stack churn, and then polling ASIC_DB (or STATE_DB, etc.) to confirm the expected end state. To do this it boots the full `docker-sonic-vs` image: orchagent, syncd, redis, every cfgmgr/syncd daemon, and whatever kernel the host happens to be running. It's a real integration test, which is great for confidence but expensive to run and painful to debug when it fails.
+
+A mock test lives in `tests/mock_tests` and links the orchagent Orch classes directly into a gtest binary. Redis calls are intercepted by an in-memory stub (`mock_table.cpp`), SAI calls are served in-process by `libsaivs`, and the test drives `Orch::doTask()` synchronously and inspects the result. There is no syncd, so SAI objects are **not** round-tripped into a readable `ASIC_DB` (unlike a VS run). No Docker, no other daemons, no kernel.
+
+The key thing that makes migration feasible: a mock test can intercept the SAI API and capture the exact `sai_attribute_t` lists orchagent programs (attribute IDs and values like `SAI_POLICER_ATTR_CIR` / `SAI_POLICER_MODE_SR_TCM`), which is the same orchagent→SAI output a VS test observes indirectly through `ASIC_DB`. So a VS assertion against ASIC_DB content is reproduced by asserting on the captured SAI call instead - the *assertion mechanism* changes (SAI-API mocking via the shared `tests/mock_tests/mock_sai_api.h` framework, not an `ASIC_DB` read), but the verified content is equivalent. The only thing we lose is everything that happens *before* orchagent - the kernel and the daemons that feed it.
+
+It helps to think of any VS test as exercising three stages:
+
+1. Kernel - a real action (`ip route add`, an ARP reply, a link flap) makes the kernel install state and emit a netlink.
+2. Daemon translation - a syncd/cfgmgr (fpmsyncd, neighsyncd, intfmgrd, vlanmgrd, etc.) parses that message and writes a row into APPL_DB.
+3. Orchagent - an Orch reads APPL_DB or CONFIG_DB, calls SAI, and ASIC_DB updates.
+
+A mock test can only reproduce stage 3. When we port a test, we substitute the stage-2 APPL_DB write directly (or inject a SAI notification for the notification-driven paths), then run `doTask()` and assert on the SAI calls orchagent makes (the same orchagent→SAI output the VS test observed through ASIC_DB). Every `time.sleep`/poll in the original collapses into a synchronous call.
+
+## 3. Problems
+
+1. VS tests are slow - the VS stage is ~69% of total pipeline wall-clock (section 4), and each module still pays ~30s of Docker startup before it even begins, plus per-test polling.
+2. They're flaky - lots of `time.sleep()` and cross-test state, so failures often aren't reproducible; section 4 breaks the failure modes down.
+3. They're hard to debug and need a specific environment (Docker, root, the `team` kernel module, a particular Ubuntu version), which discourages people from running them locally and pushes debugging onto CI.
+4. Most of that cost buys us nothing extra - a test that just writes CONFIG_DB and checks ASIC_DB is exercising orchagent, not the kernel, and could run as a mock test instead.
+
+## 4. What the VS suite costs today
+
+VS test runs on the master branch were analyzed between 2026-06-09 and 2026-07-08, totalling 40 successful runs. (Runs where all tests failed due to unrelated infra/DVS image issues were excluded)
+
+The VS test stage is the pipeline's critical path - it's 68.9% of total wall-clock. The `Run vs tests` task alone averages 143.6 min (ranging 115.8–174.6 across runs), the whole Test stage 151.6 min, out of a 228.4 min build. So most of what we take out of the VS stage comes more or less straight off the pipeline's critical path.
+
+| Metric | Value |
+|--------|-------|
+| `Run vs tests` task (avg) | 143.6 min (115.8–174.6) |
+| VS Test stage wall-clock (avg) | 151.6 min |
+| Full pipeline (avg) | 228.4 min |
+| VS stage share of pipeline | 68.9% |
+
+Longest-running files (avg per build, retries included) - this is what drives the migration order in section 9. The `Portable?` column is the section 6 / section 7 classification, since that's what decides whether a given cost is actually ours to reclaim.
+
+| File | Avg / build | Flaky builds (of 40) | Portable? |
+|------|------------:|---------------------:|-----------|
+| test_vnet | 52.5 min | 365 occ. | Yes |
+| test_fabric_port_isolation | 40.4 min | 13 | Yes |
+| test_virtual_chassis | 34.9 min | 22 | No - kept |
+| test_fabric_capacity | 29.8 min | 0 | Yes |
+| test_mux_prefixroute | 28.5 min | 113 | No - kernel |
+| test_fabric_rate | 26.5 min | 0 | Yes |
+| test_mux | 25.1 min | 0 | No - kept (core) |
+| test_fabric_switch_id | 24.6 min | 0 | Yes |
+| test_fabric | 24.0 min | 0 | Yes |
+| test_fabric_port | 23.8 min | 0 | Yes |
+| test_buffer_dynamic | 23.1 min | 12 | Yes |
+| test_pfcwd_shared_egress_acl_table | 17.9 min | 0 | Yes |
+| test_fips_macsec_post | 13.3 min | 0 | Yes |
+| test_nhg | 12.7 min | 0 | No - kernel |
+| dash/test_dash_acl | 12.5 min | 53 occ. | Yes - dash |
+| test_warm_reboot | 12.2 min | 7 | No - kept |
+| test_sub_port_intf | 11.4 min | 0 | Borderline |
+
+(The `dash/` suite is in scope for this pass - see section 7 - and shows up in the ranking as `test_dash_acl`. The `p4rt/` folder is heavy too - `test_p4rt_l3_multicast` alone is ~19.5 min - but it stays a follow-on, since P4Orch has no mock harness yet.)
+
+The biggest single sink, `test_vnet` (52.5 min, and the flakiest module at 365 occurrences), turns out to be portable: its 38 methods are almost all CONFIG_DB/APPL_DB-driven (VNET tunnels are DB/SAI-only, BFD arrives as a SAI notification), and its only two kernel touchpoints - a `proxy_arp_pvlan` `/proc` read and one FRR-route method (`test_vnet_orch_24`) - are both owned by kept tests (`test_vlan` and `test_route`; see section 7), so it ports by dropping that one assertion and substituting that one method (an APPL_DB `ROUTE_TABLE` write in place of the FRR route) - no part of it stays VS. That makes it the single highest-value target in the migration - biggest runtime and worst flakiness, both reclaimed. The only heavy thing the migration genuinely can't take is the `p4rt/` folder, a follow-on until P4Orch has a mock harness. The clean bulk win beyond test_vnet is the `test_fabric_*` family: six portable files, each 24–40 min and essentially non-flaky, slow purely because of inherent convergence waits (the report's phrase) that a mock test collapses into a synchronous `doTask()` - so they fill out Phase 0's top-10 (section 9), just behind test_vnet itself.
+
+Flakiness - 1209 first-failure records across the 40 runs, by root cause:
+
+| Root cause | Category | Share | Distinct tests |
+|------------|----------|------:|---------------:|
+| Redis socket not ready | Infrastructure (p4rt/dash) | 30% | 40 |
+| VNET VR objects not created in time | Timing / convergence (test_vnet) | 27% | 19 |
+| State poll timeout / entry missing | Timing / convergence | 18% | 63 |
+| Assorted AssertionError | Value/identity checks | 16% | 55 |
+| ASIC_STATE key-count mismatch | Cross-test race / leak | 6% | 57 |
+| orchagent startup race | Cross-test race / leak | 2% | 1 |
+
+Two things stand out. The heaviest execution units are also the flakiest - test_vnet (VNET-VR convergence) and p4rt/ (redis-socket) are the top two categories, and folder-level reruns amplify them (a ~4-min p4rt flake re-runs the entire ~25-min p4rt folder). But since test_vnet is portable, porting it eliminates the 27% VNET-VR-convergence category outright, and porting the dash suite removes dash's share of the redis-socket failures - which leaves p4rt (a follow-on, section 11) as the main flakiness the migration doesn't touch. More broadly, for every portable test moved in-process the whole timing/convergence and cross-test-leak class (poll timeouts, ASIC_STATE key-count races) disappears by construction - a mock test has no polling, no cross-container state, and no convergence wait, so those failure modes can't occur.
+
+
+## 5. Goals
+
+1. Move the bulk of orchagent regression coverage to fast, deterministic, Docker-free mock tests, without losing any assertion coverage.
+2. Keep a minimal set of VS tests for the coverage that genuinely needs a live kernel or the real SONiC tooling, and be explicit about why each one stays.
+3. Don't touch orchagent or any production code - this is a test-only change.
+
+## 6. Criteria: can a given test be ported?
+
+The rule is simple: a test is portable in isolation if and only if it does not depend on kernel or tooling behavior to pass. In practice a test is NOT portable if it either:
+
+- runs a kernel/dataplane command as stimulus that its assertions depend on (`ip route/neigh/link/addr`, `arp`, `bridge fdb`, `ping`, `sysctl`, `ethtool`, `teamdctl`, `vtysh`, a `dvs.servers[N]` command, or a `config` CLI that drives a kernel pipeline), or
+- reads kernel/tool state and asserts on it (e.g. `ip link show ... | grep Vrf`, `bridge fdb show`, `teamdctl ... state dump`, `ip macsec show`, a `/proc` read).
+
+The one exception is kernel commands used only in cleanup/teardown - those don't touch the assertion path, so they don't disqualify a test.
+
+We decide which bucket a test lands in with a full transitive call-graph trace, not just a file-level grep - kernel commands hide in helper modules (e.g. `test_macsec`'s `MACsecInspector` shells out to `ip macsec show`) and in list-form `runcmd(["ip","link","show"])` calls that a naive scan walks straight past.
+
+When considering the test suite as a whole, we don't actually need to keep every test that depends on the kernel. Many exercise the same underlying kernel behavior (e.g. dozens of tests each do a plain `ip neigh add`). So we enumerate the distinct kernel behaviors - splitting strictly, e.g. IPv4 vs IPv6, add vs replace vs change vs del vs flush, MPLS vs SRv6 vs plain routes, each SRv6 `seg6local` action, reading a VXLAN netdev vs reading a VRF - and then pick the minimum set of VS tests whose kept behaviors are a superset of everything the suite exercises. Any test whose behaviors are all covered by that kept set is then safe to port. This is a straightforward set-cover: force-keep every test that's the sole owner of a behavior, then greedily cover whatever's left.
+
+So two kinds of test get ported: the *intrinsically portable* ones (no kernel dependency in the first place) and the *substitution-eligible* ones (kernel-dependent, but every behavior they touch is still exercised by a kept VS test, so we can substitute the DB write for the kernel stimulus). Everything else stays VS. Where this doc calls a test "portable", it means one of those two - not necessarily that it has no kernel dependency.
+
+On top of that pure set-cover result we also deliberately keep seven tests as a core-functionality set - `test_port`, `test_route`, `test_neighbor`, `test_fdb`, `test_interface`, `test_portchannel`, and `test_mux`. These are the highest-traffic paths in SWSS (ports, routes, neighbors, FDB, interfaces, LAGs, mux), and it's worth having one real end-to-end test for each even where the set-cover math alone wouldn't demand it. Their breadth is tempting to lean on - you'd assume `test_route` subsumes `test_ipv6_link_local` and `test_interface` subsumes `test_sub_port_intf` - but a close trace shows it doesn't: the IPv6 link-local-only path and the sub-interface-to-VRF enslavement check are behaviors neither core test exercises, so `test_ipv6_link_local` stays kept and `test_sub_port_intf` ports only as a split. (Verifying subsumption by trace instead of assuming it from breadth is exactly the section 10, risk 2 guard.)
+
+Porting a test also skips the daemon that used to translate kernel input to APPL_DB, so we also have to confirm that translation stays covered - either by a dedicated daemon C++ test (intfmgrd, portsyncd, fpmsyncd, teammgrd, teamsyncd, fdbsyncd, nbrmgrd, etc. all have one) or by a VS test we're keeping anyway.
+
+## 7. Why keep some VS tests at all
+
+1. Daemons that program the kernel and then read it back. Some cfgmgr/syncd daemons (vrfmgr, vxlanmgr, macsecmgr, natmgr/natsyncd) take config and create real kernel objects - a VRF device, a VXLAN netdev, a MACsec SA, a conntrack entry - and the test verifies the result by reading the kernel (`ip link show Vxlan1`, `ip macsec show`, `conntrack -L`). A mock test has no kernel to program or read, so there's nothing to substitute here. This is the one category that's fundamentally un-portable, e.g. `test_vxlan_tunnel`, `test_macsec`, `test_nat` (`test_inband_intf_mgmt_vrf` and `test_vrf` are close cousins, but now borderline - `test_interface` covers the VRF-device create/read, so they can move once we sort out the substitution).
+2. The real iproute2/libnl/libteam tooling. `docker-sonic-vs` is built from the same feature dockers, so its `ip`/`bridge`/`teamdctl` binaries are the same packages SONiC builds from - the VS base image is pinned to a specific build, so it's a snapshot of that lineage rather than today's exact release, but it's the real tooling, not a lookalike. Keeping a test that runs them catches things a mock or fixture test never could: SONiC code that shells out and parses tool output, tests that assert on tool output, and tooling regressions from a package bump.
+3. Feeding realistic netlink into the daemon parsers with no extra development overhead. A VS test lets neighsyncd/routesync/fdbsyncd parse real, kernel-produced netlink for free, which means we don't need to worry about implementing a way to inject/mock netlink messages in the C++ unittest context.
+4. A small, deliberate core set for end-to-end confidence. Separate from the behavior/tool/daemon accounting above, we keep one live integration test for each of the handful of features that basically everything else leans on - ports, routes, neighbors, FDB, interfaces, portchannels, mux. If one of those breaks end-to-end, a lot breaks with it, and a mock test that only drives orchagent won't tell us the whole kernel-to-SAI path still hangs together. This is the one place we accept a bit of redundancy on purpose.
+
+The important nuance is that reasons 1-3 only justify keeping a *representative* test per behavior/tool/daemon, not the whole redundant pile - one test running `ip neigh` catches an `ip neigh` tooling regression, thirty of them don't add anything. Reason 4 is the deliberate exception, and it's deliberately small. Between the two, that's what the set-cover in section 6 produces.
+
+## 8. What this works out to
+
+Running the classification over the ~114 modules (108 top-level `tests/test_*.py` plus the six `tests/dash/` modules; `test_setro` is a libsaivs-mode skip, not counted as portable or kept):
+
+| Bucket | Count | What happens |
+|--------|:-----:|--------------|
+| No kernel/tool dependency at all | ~74 | Port to mock tests - includes the six `tests/dash/` modules (one no-dep test, `test_neighbor`, we keep anyway as part of the core set) |
+| Kernel-dependent, but every behavior is already covered by the kept set | ~17 | Port (kernel behavior, tooling, and daemon translation are all retained by the kept VS tests) - notably `test_vnet`/`test_vnet2`, whose only kernel touchpoints (proxy-arp, one FRR route) are owned by kept `test_vlan`/`test_route` |
+| Kept as VS - the core set plus the minimum owners of every remaining kernel behavior | ~21 | Keep (some are splittable - port the DB-only methods, keep the kernel ones - e.g. `test_sub_port_intf`) |
+
+(These buckets classify by kernel-dependence; `test_neighbor` is the one test counted in the top row yet kept as VS, so it's the single overlap between "ported" and "kept" - the net ported count is one below the no-dependency total.)
+
+So roughly 81% of modules move to mock tests, with ~21 kept as VS: the seven-test core set, thirteen tests that solely own some kernel behavior (MPLS, SRv6, bridge-fdb/vxlan, conntrack, macsec, IPv6 link-local, and so on), and one borderline case - `test_inband_intf_mgmt_vrf`, whose mgmt-VRF creation is now covered by `test_interface` but which needs a substitution plan before it can move. (`test_sub_port_intf` is a split: its sub-interface-to-VRF enslavement isn't covered by `test_interface`, so those methods stay VS while the DB-only methods port.) Keeping the core set permanently has a nice side effect: the three translators without a dedicated C++ test yet - neighsyncd, vlanmgrd, vrfmgrd - are now anchored to `test_route`/`test_mux`, `test_interface`/`test_vlan`, and `test_interface`/`test_srv6`, so their translation coverage no longer hangs on some incidental test we might later want to retire. It stops being a thing to worry about, and writing those daemon C++ tests becomes a nice-to-have rather than a prerequisite.
+
+## 9. Migration plan
+
+The migration is incremental - one test module per PR (roughly one new `*_ut.cpp` plus one line in `Makefile.am`), so each PR is easy to review and revert, and nothing is half-migrated across a merge boundary. We order the work by payoff - longest-running VS modules first (section 4's ranking) - so the CI time we save comes back as early as possible.
+
+| Phase | What |
+|-------|------|
+| 0 (POC) | Two jobs. First, port the simplest possible test - `test_policer.py` → `policerorch_ut.cpp` - to shake out the template (the SAI-mock verification pattern - the harness has no readable ASIC_DB, so verification captures the `sai_attribute_t` lists orchagent programs via `mock_sai_api.h`; the CONFIG_DB delete-replay pattern - which Phase 0 has to prove end-to-end, since a mock delete needs an explicit `DEL_COMMAND` and not just removing the row - reusing the existing `MockOrchTest` fixture). PR #1 adds one reusable framework macro (`DEFINE_SAI_GENERIC_API_MOCK_WITH_SET`, for object APIs with `set` but no bulk ops like `sai_policer_api`) and the mock-first policy in `tests/README.md`, but no orchagent changes. Then port the ten longest-running *portable* modules (section 4's ranking), one PR each, so Phase 0 also proves the CI-time payoff, not just that the mechanics work. `test_vnet` (52.5 min, flakiest) now tops that list - it's mostly clean CONFIG_DB→ASIC, so do it right after the template PR, carrying its one substituted method (`test_vnet_orch_24`, an APPL_DB `ROUTE_TABLE` write in place of the FRR route) and the dropped proxy-arp assertion (owned by kept `test_vlan`) - it ports whole, no VS remnant. (`test_vnet` is also the largest, most complex module and the one that extracts the shared SAI-mock helpers, so consider slotting a smaller port ahead of it to de-risk that extraction.) The rest are the six `test_fabric_*` files (each 24–40 min) plus `test_buffer_dynamic`, `test_pfcwd_shared_egress_acl_table`, and `test_fips_macsec_post` - all clean, near-non-flaky ports. Each deletes its VS test in the same PR. |
+| 1 | Work through the rest of the no-dependency modules (the ~73 portable ones - now including the six `tests/dash/` modules - less the Phase 0 batch and `test_neighbor`, which we keep), ordered longest-running first so the biggest CI-time savings land earliest. The second migration pulls the shared assertion helpers out into `common/mock_test_helpers`. DASH is low-risk here: `DashOrch` already has a mock fixture (`mock_dash_orch_test`) and nine `dash*orch_ut.cpp`, so porting its VS tests is mostly filling in scenarios against infra that already exists. |
+| 2 | Port the rest of the freed set - ~16, with `test_vnet` already done in Phase 0. These substitute the APPL_DB write for their kernel stimulus, adding small kernel-substitute / log-capture / flex-counter helpers on first use. |
+
+Each port deletes the VS test it replaces in the same PR, rather than in a separate cleanup pass later. The reason is the coverage report the PR checks already produce: if you add the mock test and remove the VS test in one PR, the coverage delta tells you directly whether the port kept the orchagent lines the VS test used to hit - if it didn't, coverage drops and the check flags it before merge. Keep the two running in parallel instead and you lose that signal, because the old VS test keeps those lines green. It's one guardrail, not a proof - covering the same lines isn't the same as making the same assertions, so the PR description still has to spell out the per-method mapping from old test to new - but it's a cheap, automatic one, and one-module-per-PR keeps a bad port trivial to revert.
+
+A few things to pin down so this doesn't drift over ~80 PRs. *Done* means every portable and substitution-eligible module has a mock equivalent and its VS file (or, for a split, the ported methods) is deleted, leaving the documented ~21-test VS residue and nothing half-migrated. Each PR is gated on three things: the new mock test green in CI, no per-PR diff-coverage regression on the orchagent files it touches, and a per-method VS→`TEST_F` assertion map in the description. If mock-suite flakiness or coverage starts regressing across a run of PRs, the stop condition is to pause and re-baseline rather than push through. Splits are self-documenting - the trimmed VS file keeps a header comment listing which methods stayed and why - and the seven-test core set is revisited whenever a genuinely new core feature lands.
+
+## 10. Risks
+
+| # | Risk | Mitigation |
+|:-:|------|------------|
+| 1 | A test we called portable actually has a hidden kernel dependency, so porting silently drops coverage. | The call-graph trace (section 6) is the guard, and it's conservative; every newly-ported test gets re-traced, and the PR has to show the stimulus is DB/notification-only. |
+| 2 | The set-cover is too coarse and merges two behaviors that are actually different, hiding a gap. | We split behaviors strictly (address family, operation, feature) and flag the genuinely borderline/split tests (e.g. `test_vrf`, `test_sub_port_intf`, `test_inband_intf_mgmt_vrf`) for a closer look at migration time. |
+| 3 | Deleting the VS test in the same PR gives up the old parallel-validation cycle, so a subtly-incomplete port could slip through. | The mock test has to pass CI before merge, the coverage delta is reviewed as a no-loss check, and each PR is one module so a bad port is trivial to revert. Coverage parity is necessary but not sufficient, so we still require the per-method scenario mapping. |
+
+## 11. Follow-up opportunities
+
+- A netns single-daemon harness: run one daemon in a network namespace against a real kernel and the real tools, without the full `docker-sonic-vs` stack. That covers stages 1 and 2 for a fraction of the cost of a VS run, and is the natural home for the neighsyncd/vlanmgrd/vrfmgrd translation coverage that today rides along on the kept core tests.
+- Writing the missing daemon C++ tests (`tests_neighsyncd`, `tests_vlanmgrd`, `tests_vrfmgrd`) and a substitution plan for the mgmt VRF, either of which would let the kept set shrink a little further.
+- Folding in the `p4rt/` suite: P4Orch is kernel-free and DB-driven, but over a ZMQ channel (`ZmqProducerStateTable`) and with no mock fixture yet, so it needs a small ZMQ-ingest harness and a P4Orch test fixture before its VS tests can port the way dash's do.
+- The main flakiness the migration leaves untouched is the `p4rt/` suite's redis-socket infra failures (much of the 30% infra category) - test_vnet's VNET-VR convergence (27%) and dash's share both get resolved by porting those tests in this pass. The p4rt infra still wants its own fixes: gating on redis-socket readiness, and making the runner rerun only the failed test rather than the whole `p4rt/` folder (the report pins ~14 min of avoidable retry time on that folder-rerun behavior alone).

--- a/doc/vs-to-mock-test-migration.md
+++ b/doc/vs-to-mock-test-migration.md
@@ -46,9 +46,9 @@ The VS test stage is the pipeline's critical path - it's 68.9% of total wall-clo
 
 Longest-running files (avg per build, retries included) - this is what drives the migration order in section 9. The `Portable?` column is the section 6 / section 7 classification, since that's what decides whether a given cost is actually ours to reclaim.
 
-| File | Avg / build | Flaky builds (of 40) | Portable? |
-|------|------------:|---------------------:|-----------|
-| test_vnet | 52.5 min | 365 occ. | Yes |
+| File | Avg / build | Flaky occurrences (across 40 runs) | Portable? |
+|------|------------:|----------------------------------:|-----------|
+| test_vnet | 52.5 min | 365 | Yes |
 | test_fabric_port_isolation | 40.4 min | 13 | Yes |
 | test_virtual_chassis | 34.9 min | 22 | No - kept |
 | test_fabric_capacity | 29.8 min | 0 | Yes |


### PR DESCRIPTION
## Summary

Draft HLD proposing migration of the pytest VS (Docker Virtual Switch) integration tests in `tests/` to C++/gtest mock unit tests in `tests/mock_tests/`.

Doc: `doc/vs-to-mock-test-migration.md`

Highlights:
- **Criteria** - a test is portable unless it depends on kernel/tooling behavior to pass; a set-cover picks the minimum VS tests to keep so no kernel behavior loses coverage.
- **Core set** - seven end-to-end VS tests kept deliberately (port/route/neighbor/fdb/interface/portchannel/mux).
- **Baseline** - 30-day VS runtime/flakiness data (the VS stage is ~69% of pipeline wall-clock).
- **Plan** - incremental, one module per PR, deleting each VS test in the same PR that ports it, longest-running modules first.

Documentation-only; no production or test code changes.

_Opened as a draft for review._
