### PR TITLE
Ecn acl marking

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -112,7 +112,8 @@ static acl_rule_attr_lookup_t aclL3ActionLookup =
     { ACTION_PACKET_ACTION,                    SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION },
     { ACTION_REDIRECT_ACTION,                  SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT },
     { ACTION_DO_NOT_NAT_ACTION,                SAI_ACL_ENTRY_ATTR_ACTION_NO_NAT },
-    { ACTION_DISABLE_TRIM,                     SAI_ACL_ENTRY_ATTR_ACTION_PACKET_TRIM_DISABLE }
+    { ACTION_DISABLE_TRIM,                     SAI_ACL_ENTRY_ATTR_ACTION_PACKET_TRIM_DISABLE },
+    { ACTION_ECN,                              SAI_ACL_ENTRY_ATTR_ACTION_SET_ECN }
 };
 
 static acl_rule_attr_lookup_t aclInnerActionLookup =
@@ -2064,6 +2065,28 @@ bool AclRulePacket::validateAddAction(string attr_name, string _attr_value)
             return false;
         }
         actionData.parameter.oid = param_id;
+    }
+    else if (attr_name == ACTION_ECN)
+    {
+        sai_uint8_t val;
+        try
+        {
+            val = to_uint<sai_uint8_t>(attr_value);
+        }
+        catch (const std::exception& e)
+        {
+            SWSS_LOG_ERROR("Failed to parse %s value %s", attr_name.c_str(), attr_value.c_str());
+            return false;
+        }
+
+        // ECN field is 2 bits (RFC 3168): 0=Non-ECT, 1=ECT(1), 2=ECT(0), 3=CE
+        if (val > 3)
+        {
+            SWSS_LOG_ERROR("ECN_ACTION value %u is out of range (0-3)", val);
+            return false;
+        }
+
+        actionData.parameter.u8 = val;
     }
     else
     {

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -205,14 +205,16 @@ static acl_table_action_list_lookup_t defaultAclActionList =
                 ACL_STAGE_INGRESS,
                 {
                     SAI_ACL_ACTION_TYPE_PACKET_ACTION,
-                    SAI_ACL_ACTION_TYPE_REDIRECT
+                    SAI_ACL_ACTION_TYPE_REDIRECT,
+                    SAI_ACL_ACTION_TYPE_SET_ECN
                 }
             },
             {
                 ACL_STAGE_EGRESS,
                 {
                     SAI_ACL_ACTION_TYPE_PACKET_ACTION,
-                    SAI_ACL_ACTION_TYPE_REDIRECT
+                    SAI_ACL_ACTION_TYPE_REDIRECT,
+                    SAI_ACL_ACTION_TYPE_SET_ECN
                 }
             }
         }
@@ -225,14 +227,16 @@ static acl_table_action_list_lookup_t defaultAclActionList =
                 ACL_STAGE_INGRESS,
                 {
                     SAI_ACL_ACTION_TYPE_PACKET_ACTION,
-                    SAI_ACL_ACTION_TYPE_REDIRECT
+                    SAI_ACL_ACTION_TYPE_REDIRECT,
+                    SAI_ACL_ACTION_TYPE_SET_ECN
                 }
             },
             {
                 ACL_STAGE_EGRESS,
                 {
                     SAI_ACL_ACTION_TYPE_PACKET_ACTION,
-                    SAI_ACL_ACTION_TYPE_REDIRECT
+                    SAI_ACL_ACTION_TYPE_REDIRECT,
+                    SAI_ACL_ACTION_TYPE_SET_ECN
                 }
             }
         }
@@ -245,14 +249,16 @@ static acl_table_action_list_lookup_t defaultAclActionList =
                 ACL_STAGE_INGRESS,
                 {
                     SAI_ACL_ACTION_TYPE_PACKET_ACTION,
-                    SAI_ACL_ACTION_TYPE_REDIRECT
+                    SAI_ACL_ACTION_TYPE_REDIRECT,
+                    SAI_ACL_ACTION_TYPE_SET_ECN
                 }
             },
             {
                 ACL_STAGE_EGRESS,
                 {
                     SAI_ACL_ACTION_TYPE_PACKET_ACTION,
-                    SAI_ACL_ACTION_TYPE_REDIRECT
+                    SAI_ACL_ACTION_TYPE_REDIRECT,
+                    SAI_ACL_ACTION_TYPE_SET_ECN
                 }
             }
         }

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -2088,7 +2088,7 @@ bool AclRulePacket::validateAddAction(string attr_name, string _attr_value)
         // ECN field is 2 bits (RFC 3168): 0=Non-ECT, 1=ECT(1), 2=ECT(0), 3=CE
         if (val > 3)
         {
-            SWSS_LOG_ERROR("ECN_ACTION value %u is out of range (0-3)", val);
+            SWSS_LOG_ERROR("ECN_ACTION value %u is out of range (0-3)", (unsigned int)val);
             return false;
         }
 

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -79,6 +79,7 @@
 #define ACTION_COUNTER                      "COUNTER"
 #define ACTION_META_DATA                    "META_DATA_ACTION"
 #define ACTION_DSCP                         "DSCP_ACTION"
+#define ACTION_ECN                          "ECN_ACTION"
 #define ACTION_INNER_SRC_MAC_REWRITE_ACTION "INNER_SRC_MAC_REWRITE_ACTION"
 
 #define PACKET_ACTION_FORWARD      "FORWARD"

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -1995,6 +1995,122 @@ namespace aclorch_test
         sai_switch_api = old_sai_switch_api;
     }
 
+    // Advertise SET_ECN (with COUNTER and PACKET_ACTION) as supported ACL actions so the
+    // capability gate accepts an ECN rule in the mock environment. The mandatory flag is
+    // driven by g_ecnActionListMandatory so the single mock serves both ECN tests.
+    static bool g_ecnActionListMandatory = false;
+
+    sai_status_t getSwitchAttributeEcn(_In_ sai_object_id_t switch_id, _In_ uint32_t attr_count,
+                                       _Inout_ sai_attribute_t *attr_list)
+    {
+        if (attr_count == 1)
+        {
+            switch (attr_list[0].id)
+            {
+            case SAI_SWITCH_ATTR_MAX_ACL_ACTION_COUNT:
+                attr_list[0].value.u32 = 16;
+                return SAI_STATUS_SUCCESS;
+            case SAI_SWITCH_ATTR_ACL_STAGE_INGRESS:
+            case SAI_SWITCH_ATTR_ACL_STAGE_EGRESS:
+                attr_list[0].value.aclcapability.action_list.count = 3;
+                attr_list[0].value.aclcapability.action_list.list[0] = SAI_ACL_ACTION_TYPE_COUNTER;
+                attr_list[0].value.aclcapability.action_list.list[1] = SAI_ACL_ACTION_TYPE_PACKET_ACTION;
+                attr_list[0].value.aclcapability.action_list.list[2] = SAI_ACL_ACTION_TYPE_SET_ECN;
+                attr_list[0].value.aclcapability.is_action_list_mandatory = g_ecnActionListMandatory;
+                return SAI_STATUS_SUCCESS;
+            }
+        }
+        return old_sai_switch_api->get_switch_attribute(switch_id, attr_count, attr_list);
+    }
+
+    // When the ACL action list is mandatory at table creation, a built-in L3 table must seed
+    // SET_ECN from defaultAclActionList so that ECN rules are accepted on a standard L3 table.
+    TEST_F(AclOrchTest, AclTableL3EcnDefaultAction)
+    {
+        old_sai_switch_api = sai_switch_api;
+        sai_switch_api_t new_sai_switch_api = *sai_switch_api;
+        sai_switch_api = &new_sai_switch_api;
+        sai_switch_api->get_switch_attribute = getSwitchAttributeEcn;
+        g_ecnActionListMandatory = true;
+
+        auto orch = createAclOrch();
+
+        string acl_table_id = "ecn_l3_table";
+        auto kvfAclTable = deque<KeyOpFieldsValuesTuple>(
+            { { acl_table_id,
+                SET_COMMAND,
+                { { ACL_TABLE_DESCRIPTION, "ECN" },
+                  { ACL_TABLE_TYPE, TABLE_TYPE_L3 },
+                  { ACL_TABLE_STAGE, STAGE_INGRESS },
+                  { ACL_TABLE_PORTS, "1,2" } } } });
+        orch->doAclTableTask(kvfAclTable);
+
+        auto acl_table = orch->getAclTable(acl_table_id);
+        ASSERT_NE(acl_table, nullptr);
+
+        auto acl_actions = acl_table->type.getActions();
+        ASSERT_NE(acl_actions.find(SAI_ACL_ACTION_TYPE_SET_ECN), acl_actions.end());
+
+        g_ecnActionListMandatory = false;
+        sai_switch_api = old_sai_switch_api;
+    }
+
+    // An ECN_ACTION rule is routed to AclRulePacket, its value is range-checked (RFC 3168,
+    // 0..3), and a valid value is programmed as SAI_ACL_ENTRY_ATTR_ACTION_SET_ECN. An
+    // out-of-range value is rejected and no rule is created.
+    TEST_F(AclOrchTest, AclRuleSetEcnAction)
+    {
+        old_sai_switch_api = sai_switch_api;
+        sai_switch_api_t new_sai_switch_api = *sai_switch_api;
+        sai_switch_api = &new_sai_switch_api;
+        sai_switch_api->get_switch_attribute = getSwitchAttributeEcn;
+        g_ecnActionListMandatory = false;
+
+        auto orch = createAclOrch();
+
+        string acl_table_id = "ecn_acl_table";
+        string acl_rule_id = "ecn_acl_rule";
+
+        auto kvfAclTable = deque<KeyOpFieldsValuesTuple>(
+            { { acl_table_id,
+                SET_COMMAND,
+                { { ACL_TABLE_DESCRIPTION, "ECN" },
+                  { ACL_TABLE_TYPE, TABLE_TYPE_L3 },
+                  { ACL_TABLE_STAGE, STAGE_INGRESS },
+                  { ACL_TABLE_PORTS, "1,2" } } } });
+        orch->doAclTableTask(kvfAclTable);
+
+        auto acl_table_oid = orch->getTableById(acl_table_id);
+        ASSERT_NE(acl_table_oid, SAI_NULL_OBJECT_ID);
+        const auto &acl_tables = orch->getAclTables();
+        const auto &acl_table = acl_tables.at(acl_table_oid);
+
+        // Valid ECN value: the rule is created and programs SET_ECN = 3.
+        auto kvfAclRule = deque<KeyOpFieldsValuesTuple>(
+            { { acl_table_id + "|" + acl_rule_id,
+                SET_COMMAND,
+                { { ACTION_ECN, "3" },
+                  { MATCH_SRC_IP, "1.2.3.4" } } } });
+        orch->doAclRuleTask(kvfAclRule);
+
+        auto it_rule = acl_table.rules.find(acl_rule_id);
+        ASSERT_NE(it_rule, acl_table.rules.end());
+        ASSERT_EQ(getAclRuleSaiAttribute(*it_rule->second, SAI_ACL_ENTRY_ATTR_ACTION_SET_ECN), "3");
+
+        // Out-of-range ECN value (> 3) is rejected: no rule is created.
+        string bad_rule_id = "ecn_acl_rule_bad";
+        auto kvfBadRule = deque<KeyOpFieldsValuesTuple>(
+            { { acl_table_id + "|" + bad_rule_id,
+                SET_COMMAND,
+                { { ACTION_ECN, "4" },
+                  { MATCH_SRC_IP, "5.6.7.8" } } } });
+        orch->doAclRuleTask(kvfBadRule);
+        ASSERT_EQ(acl_table.rules.find(bad_rule_id), acl_table.rules.end());
+
+        sai_switch_api = old_sai_switch_api;
+    }
+
+
     TEST_F(AclOrchTest, Match_Inner_Mac)
     {
         string aclTableTypeName = "MAC_MATCH_TABLE_TYPE";


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add a new ACL action  ECN_ACTION  (value  0..3 ) that marks the packet's 2-bit ECN field in hardware, mapping to the SAI action  SAI_ACL_ENTRY_ATTR_ACTION_SET_ECN .

•  orchagent/aclorch.h  — define  ACTION_ECN "ECN_ACTION" .
•  orchagent/aclorch.cpp 
• add  { ACTION_ECN, SAI_ACL_ENTRY_ATTR_ACTION_SET_ECN }  to  aclL3ActionLookup  (routes the rule to  AclRulePacket  and maps the string to the SAI attribute);
• add the  ACTION_ECN  branch in  AclRulePacket::validateAddAction()  — parse to  sai_uint8_t , reject values outside  0..3 , set  actionData.parameter.u8 ;
• add  SAI_ACL_ACTION_TYPE_SET_ECN  to  defaultAclActionList  for  L3  /  L3V6  /  L3V4V6  (both stages).
•  tests/mock_tests/aclorch_ut.cpp  — add mock unit tests.

**Why I did it**
Enable ECN marking of selected traffic via ACLs (e.g. match a UDP source port and set ECN=CE) through the standard SONiC configuration model instead of direct SDK programming, keeping SWSS/SAI/ASIC state in sync.

The  defaultAclActionList  addition is required on platforms where the ACL action list is mandatory at table creation:  AclTable::addMandatoryActions()  seeds a built-in L3 table's action list from this map, and  validateAclRuleAction()  rejects any action not in it. Without  SET_ECN  there, an  ECN_ACTION  rule on a standard  L3 / L3V6  table is rejected on those platforms (it already worked where the list is not mandatory).

**How I verified it**

• Unit ( make check ): the new gtests pass —
•  AclRuleSetEcnAction  — an  ECN_ACTION  rule is routed to  AclRulePacket  and programmed as  SET_ECN=3 ; an out-of-range value ( 4 ) creates no rule.
•  AclTableL3EcnDefaultAction  — with a mandatory action list, a built-in  L3  table seeds  SET_ECN  from  defaultAclActionList .
• Hardware: validated on two independent ASIC vendor platforms (IPv4 and IPv6) via the companion sonic-mgmt test — control plane ( show acl rule  Active, ASIC entry  SET_ECN=3 ) and data plane (injected ECN  00  → egress ECN  11 /CE).

**Details if related**
• ECN codepoints (RFC 3168, low 2 bits of IPv4 TOS / IPv6 Traffic-Class):  0  Non-ECT,  1  ECT(1),  2  ECT(0),  3  CE.
•  SET_ECN  is a  sai_uint8_t  action (not an enum), handled on the ingress  AclRulePacket  path alongside  PACKET_ACTION / REDIRECT  — deliberately not the DSCP mark-meta path. It is gated by the SAI capability query ( isAclActionSupported ); if the platform SAI does not advertise  SET_ECN , the rule is reported Inactive (no crash).
• The unit tests mock the SAI switch capability to advertise  SET_ECN , since the permissive fallback set ( defaultAclActionsSupported ) intentionally does not include it.
• Companion PRs: YANG leaf ( sonic-buildimage ),  show acl rule  display ( sonic-utilities ), integration test ( sonic-mgmt ).