### PR TITLE
[intfsorch]: Fence new RIF dependencies during interface removal

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -117,6 +117,11 @@ sai_object_id_t IntfsOrch::getRouterIntfsId(const string &alias)
     return port.m_rif_id;
 }
 
+bool IntfsOrch::isIntfRemovalPending(const string &alias) const
+{
+    return m_removingIntfses.find(alias) != m_removingIntfses.end();
+}
+
 bool IntfsOrch::isPrefixSubnet(const IpPrefix &ip_prefix, const string &alias)
 {
     if (m_syncdIntfses.find(alias) == m_syncdIntfses.end())
@@ -1204,12 +1209,18 @@ void IntfsOrch::doTask(Consumer &consumer)
             {
                 if (removeIntf(alias, port.m_vr_id, ip_prefix_in_key ? &ip_prefix : nullptr))
                 {
-                    m_removingIntfses.erase(alias);
+                    if (!ip_prefix_in_key)
+                    {
+                        m_removingIntfses.erase(alias);
+                    }
                     it = consumer.m_toSync.erase(it);
                 }
                 else
                 {
-                    m_removingIntfses.insert(alias);
+                    if (!ip_prefix_in_key)
+                    {
+                        m_removingIntfses.insert(alias);
+                    }
                     it++;
                     continue;
                 }

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -1196,11 +1196,19 @@ void IntfsOrch::doTask(Consumer &consumer)
 
                 if (vnet_orch->delIntf(alias, vnet_name, ip_prefix_in_key ? &ip_prefix : nullptr))
                 {
+                    if (!ip_prefix_in_key)
+                    {
+                        m_removingIntfses.erase(alias);
+                    }
                     m_vnetInfses.erase(alias);
                     it = consumer.m_toSync.erase(it);
                 }
                 else
                 {
+                    if (!ip_prefix_in_key)
+                    {
+                        m_removingIntfses.insert(alias);
+                    }
                     it++;
                     continue;
                 }

--- a/orchagent/intfsorch.h
+++ b/orchagent/intfsorch.h
@@ -39,6 +39,7 @@ public:
     static const int intfsorch_pri;
 
     sai_object_id_t getRouterIntfsId(const string&);
+    bool isIntfRemovalPending(const string&) const;
     bool isPrefixSubnet(const IpPrefix&, const string&);
     bool isInbandIntfInMgmtVrf(const string& alias);
     string getRouterIntfsAlias(const IpAddress &ip, const string &vrf_name = "");

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -379,6 +379,13 @@ bool NeighOrch::addNextHop(NeighborContext& ctx)
     }
 
     assert(!hasNextHop(nexthop));
+    if (!m_intfsOrch->isRemoteSystemPortIntf(nh.alias) &&
+        m_intfsOrch->isIntfRemovalPending(nh.alias))
+    {
+        SWSS_LOG_INFO("Interface %s is pending removal", nh.alias.c_str());
+        return false;
+    }
+
     sai_object_id_t rif_id = m_intfsOrch->getRouterIntfsId(nh.alias);
 
     vector<sai_attribute_t> next_hop_attrs;
@@ -1324,6 +1331,13 @@ bool NeighOrch::addNeighbor(NeighborContext& ctx)
     string alias = neighborEntry.alias;
     bool bulk_op = ctx.bulk_op;
 
+    if (!m_intfsOrch->isRemoteSystemPortIntf(alias) &&
+        m_intfsOrch->isIntfRemovalPending(alias))
+    {
+        SWSS_LOG_INFO("Interface %s is pending removal", alias.c_str());
+        return false;
+    }
+
     sai_object_id_t rif_id = m_intfsOrch->getRouterIntfsId(alias);
     if (rif_id == SAI_NULL_OBJECT_ID)
     {
@@ -2065,6 +2079,7 @@ bool NeighOrch::enableNeighbors(std::list<NeighborContext>& bulk_ctx_list)
         if(!addNeighbor(*ctx))
         {
             SWSS_LOG_ERROR("Neighbor %s create entry failed.", neighborEntry.ip_address.to_string().c_str());
+            ret = false;
             continue;
         }
     }

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1507,7 +1507,10 @@ bool RouteOrch::addNextHopGroup(const NextHopGroupKey &nexthops)
                  m_neighOrch->hasNextHop(NextHopKey(it.ip_address, it.alias)))
         {
             NeighborContext ctx = NeighborContext(it);
-            m_neighOrch->addNextHop(ctx);
+            if (!m_neighOrch->addNextHop(ctx))
+            {
+                return false;
+            }
             next_hop_id = m_neighOrch->getNextHopId(it);
         }
         else
@@ -2083,6 +2086,13 @@ bool RouteOrch::addRoute(RouteBulkContext& ctx, const NextHopGroupKey &nextHops)
                 return true;
             }
 
+            if (!m_intfsOrch->isRemoteSystemPortIntf(nexthop.alias) &&
+                m_intfsOrch->isIntfRemovalPending(nexthop.alias))
+            {
+                SWSS_LOG_INFO("Interface %s is pending removal", nexthop.alias.c_str());
+                return false;
+            }
+
             next_hop_id = m_intfsOrch->getRouterIntfsId(nexthop.alias);
             /* rif is not created yet */
             if (next_hop_id == SAI_NULL_OBJECT_ID)
@@ -2118,7 +2128,10 @@ bool RouteOrch::addRoute(RouteBulkContext& ctx, const NextHopGroupKey &nextHops)
             {
                 /* since IP neighbor NH exists, neighbor is resolved, add MPLS NH */
                 NeighborContext ctx = NeighborContext(nexthop);
-                m_neighOrch->addNextHop(ctx);
+                if (!m_neighOrch->addNextHop(ctx))
+                {
+                    return false;
+                }
                 next_hop_id = m_neighOrch->getNextHopId(nexthop);
             }
             /* IP neighbor is not yet resolved */

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -313,17 +313,30 @@ namespace intfsorch_test
         static_cast<Orch *>(gIntfsOrch)->doTask();
         ASSERT_EQ(current_create_count + 1, create_rif_count);
 
+        // Add a prefix so the whole-interface DEL is processed before its dependency DEL.
+        entries.clear();
+        entries.push_back({"Ethernet0:10.0.0.1/24", "SET", {
+            {"scope", "global"},
+            {"family", "IPv4"}
+        }});
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+
         // create dependency to the interface
         gIntfsOrch->increaseRouterIntfsRefCount("Ethernet0");
 
-        // delete the interface, expect retry because dependency exists
+        // Delete the interface and prefix in lexical order. The successful prefix
+        // DEL must not clear the whole-interface removal fence.
         entries.clear();
         entries.push_back({"Ethernet0", "DEL", { {} }});
+        entries.push_back({"Ethernet0:10.0.0.1/24", "DEL", { {} }});
         consumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
         consumer->addToSync(entries);
         auto current_remove_count = remove_rif_count;
         static_cast<Orch *>(gIntfsOrch)->doTask();
         ASSERT_EQ(current_remove_count, remove_rif_count);
+        ASSERT_EQ(consumer->m_toSync.size(), 1u);
+        ASSERT_TRUE(gIntfsOrch->isIntfRemovalPending("Ethernet0"));
 
         // create the interface again, expect retry because interface is in removing
         entries.clear();

--- a/tests/mock_tests/neighorch_ut.cpp
+++ b/tests/mock_tests/neighorch_ut.cpp
@@ -189,6 +189,20 @@ namespace neighorch_test
         }
     };
 
+    TEST_F(NeighOrchTest, LocalNeighborDependenciesRetryWhileInterfaceRemovalPending)
+    {
+        gIntfsOrch->m_removingIntfses.insert(VLAN_1000);
+
+        NeighborContext neighbor_ctx(VLAN1000_NEIGH);
+        neighbor_ctx.mac = MacAddress(MAC1);
+        EXPECT_FALSE(gNeighOrch->addNeighbor(neighbor_ctx));
+
+        NeighborContext next_hop_ctx(VLAN1000_NEIGH);
+        EXPECT_FALSE(gNeighOrch->addNextHop(next_hop_ctx));
+
+        gIntfsOrch->m_removingIntfses.erase(VLAN_1000);
+    }
+
     TEST_F(NeighOrchTest, MultiVlanDuplicateNeighbor)
     {
         EXPECT_CALL(*mock_sai_neighbor_api, create_neighbor_entry);


### PR DESCRIPTION
**How to read this two-PR fix**

The easiest place to start is the externally visible failure in [PR #4764](https://github.com/sonic-net/sonic-swss/pull/4764): an explicit VRF-changing interface `SET` could be consumed while old prefixes still existed, so the RIF remained in the old VRF.

Retaining that `SET` is necessary but not sufficient. While the move waits for old dependencies to drain, RouteOrch and NeighOrch must not attach new work to the old RIF. This PR fixes that prerequisite dependency-drain race.

The required implementation and merge order remains **this PR first, then PR #4764**, because the VRF-rehome fix builds on the explicit removal-state predicate introduced here.

**What I did**

Once deletion of an interface has started, new route and neighbor dependencies must not attach to the RIF being removed.

### Root cause

Whole-interface deletion already had the correct retry model.

For these independent APP_DB keys:

```text
Vlan1000                 DEL
Vlan1000:10.0.0.1/24     DEL
```

the bare interface key is normally visited first because the consumer stores pending work in a key-ordered multimap. That ordering was safe:

```text
attempt Vlan1000 DEL
→ prefix still exists
→ return false
→ retain the interface DEL in m_toSync

process Vlan1000:10.0.0.1/24 DEL
→ remove the prefix and IP2Me route

retry Vlan1000 DEL
→ remove the RIF
```

This is why interface `DEL` arriving before prefix `DEL` had worked historically: deletion already checked its dependencies and retried.

The deletion fence was incomplete, however:

1. A failed whole-interface `DEL` inserted the alias into `m_removingIntfses`.
2. A later successful **prefix** `DEL` also erased that marker, even though the whole-interface `DEL` was still queued.
3. RouteOrch and NeighOrch obtained the old RIF through the unrestricted `getRouterIntfsId()` accessor.
4. A new route, neighbor, or neighbor next hop could therefore attach to the RIF while IntfsOrch was trying to remove it.
5. The new dependency incremented the RIF reference count, so the retained interface `DEL` remained blocked and could repeatedly lose the race to new work.

The problem was not that deletion lacked retry. The problem was that other orchagents could refill the dependency count during that retry.

### Fix

This PR completes the existing deletion state machine:

```text
OLD/STABLE
    new dependencies allowed
        |
        | whole-interface DEL starts
        v
REMOVING
    existing dependency DELs allowed
    new dependency SETs blocked and retained
        |
        | prefixes and references reach zero
        v
REMOVED
```

The implementation has three parts:

1. **The whole-interface `DEL` owns the removal marker.**

   Prefix deletion no longer clears `m_removingIntfses`. The marker is cleared only when the whole-interface deletion succeeds.

2. **Addition paths explicitly check removal state.**

   Standard local route, neighbor, and neighbor-next-hop creation calls `isIntfRemovalPending()` before obtaining the RIF. If removal is pending, the addition returns `false`, leaving the original APP_DB operation in that orchagent's `m_toSync` queue.

   The existing `getRouterIntfsId()` accessor is unchanged. Existing dependencies and deletion paths must still find the old RIF so they can remove themselves and release its reference count. Guarding the getter itself would block both additions and deletions and deadlock the drain.

3. **RouteOrch honors deferred neighbor-next-hop creation.**

   Callers no longer request a next-hop ID immediately after `NeighOrch::addNextHop()` reports that creation was deferred.

The resulting execution is:

```text
attempt interface DEL → retained; removal fence established
prefix/dependency DELs → allowed to drain old state
new route/neighbor SETs → retained, not attached to old RIF
retry interface DEL → succeeds
retained additions → retry only after an interface is available again
```

**Why I did it**

### Why not enforce one global APP_DB order?

APP_DB StateTable is primarily a **latest desired-state transport**, not a durable transactional command log.

Even if one producer emits operations in the desired order, that does not create a global execution order because:

- IntfsOrch keeps interface keys in a key-sorted multimap.
- Interface, route, neighbor, and next-hop work use different APP_DB tables and different consumers.
- A blocked operation remains queued while other work continues.
- Multiple producers operate independently.
- After restart, orchagent reconstructs work from current database state, not the original event history.

Replacing one multimap with a FIFO or priority queue would therefore order only one table. It would not order IntfsOrch against RouteOrch and NeighOrch, and a single blocked entry could introduce head-of-line blocking for unrelated interfaces.

The established SWSS design is instead:

```text
recognize an unmet dependency
→ return false
→ retain the operation
→ let prerequisite deletions proceed
→ retry later
```

This PR follows that design and adds a **local per-interface admission fence**. It does not claim to provide a transaction or generation protocol across all orchagents.

### Scope

The guarded creation paths are the standard local interface route, neighbor, and neighbor-next-hop paths involved in the traced failure. Remote-system-port behavior is explicitly unchanged; its pre-existing inband RIF identity, bookkeeping, and boot-order issues are being handled independently.

**How I verified it**

- Extended `IntfsOrchDeleteCreateRetry` with the real lexical sequence: whole-interface `DEL`, then prefix `DEL`.
- The regression verifies that:
  - the whole-interface `DEL` remains queued;
  - prefix deletion does not clear the removal fence;
  - old references can drain;
  - the retained whole-interface deletion then succeeds.
- Added `LocalNeighborDependenciesRetryWhileInterfaceRemovalPending` to verify that local neighbor and next-hop additions return retry while the fence is active.
- The earlier combined branches containing this fence completed the amd64, ARM, ASAN, Docker, and Trixie compile stages in Azure builds `1168368` (master) and `1168367` (202605). Their `vstest` jobs stopped before executing tests because those workers lacked `pip3`.
- An earlier combined candidate, hardware build `1167872`, passed traced and production 1x/5x runs and all ten production 10x test bodies. This PR is the smaller local deletion-fence subset; exact split-commit validation is provided by this PR's CI.

**Historical teardown clarification:** The 10x run was not fully green: all ten test bodies passed, but pytest reported two LogAnalyzer teardown errors (iterations 9 and 10).

1. The recorded message is already globally suppressed by https://github.com/sonic-net/sonic-mgmt/pull/24642 (master) and https://github.com/sonic-net/sonic-mgmt/pull/26997 (202605).
2. Even without that global suppression, the fixture correction proposed in https://github.com/sonic-net/sonic-mgmt/pull/27830 would retain the intended per-test ignores through the LogAnalyzer scan. That PR is draft; validation and review remain pending.

See the [teardown explanation](https://github.com/sonic-net/sonic-swss/pull/4746#issuecomment-5606086268) for the historical evidence and distinction between suppression and fixture correction.

### Current exact-head master PR build

- Head: `4c38411af466f770e8eb7282423443eed43fe872`
- Fresh Azure PR build: [1171673](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1171673) — in progress.
- Prior exact-head build [1171069](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1171069) passed amd64, arm64, armhf, ASAN, Docker, Docker-ASAN, Trixie, and `TestAsan vstest`.
- Its regular `Test vstest` lane was not green after unrelated VNET, P4RT, and ACL full-suite flakes across retries. No failure in the focused interface-removal coverage was observed.
- CodeQL, Semgrep, DCO, EasyCLA, and the exact-head Copilot review are clean.
- No local build was used; validation is PR-build only.

### 202605 PR-build validation

- Validation-only PR: [#4747](https://github.com/sonic-net/sonic-swss/pull/4747)
- The validation branch is being rebuilt from current `202605`, which already contains the shared PR-CI dependency fix.
- The complete dependency-ordered stack contains merged PR #4758 followed by user PRs #4746, #4766, #4769, #4772, #4764, and #4770.
- Exact validation head: `d4b0502ecdac76d56fdf063a633045c0fb0de977`
- Azure PR build: [1171672](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1171672) — in progress.
- The `Tested for 202605 branch` label must remain absent until that exact full-stack build is complete.

**Details if related**

- Follow-up VRF rehome retry: [PR #4764](https://github.com/sonic-net/sonic-swss/pull/4764)
- Microsoft ADO: [38514061](https://msazure.visualstudio.com/One/_workitems/edit/38514061)
- Merge batch 1. PR #4764 must follow this PR.
