### PR TITLE
[neighorch]: Replace VOQ remote nexthop instead of skipping addNeighbor

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -378,7 +378,48 @@ bool NeighOrch::addNextHop(NeighborContext& ctx)
         nexthop.alias = inbp.m_alias;
     }
 
-    assert(!hasNextHop(nexthop));
+    // on VOQ a nexthop could acceptably exist for the remote port, in which case we need to replace it.
+    int starting_ref_count = 0;
+    uint32_t starting_nh_flags = 0;
+    if (hasNextHop(nexthop))
+    {
+        if (m_intfsOrch->isRemoteSystemPortIntf(nh.alias))
+        {
+            // 1. find the current neigh for the nexthop
+            for (const auto &neigh : m_syncdNeighbors)
+            {
+                NeighborEntry entry = neigh.first;
+                if (entry.ip_address == nh.ip_address && entry.alias != nh.alias
+                        && m_intfsOrch->isRemoteSystemPortIntf(entry.alias))
+                {
+                    // 2. attempt to delete it from sai
+                    starting_ref_count = m_syncdNextHops[nexthop].ref_count;
+                    starting_nh_flags = m_syncdNextHops[nexthop].nh_flags;
+                    sai_status_t status = sai_next_hop_api->remove_next_hop(m_syncdNextHops[nexthop].next_hop_id);
+                    if (status == SAI_STATUS_SUCCESS)
+                    {
+                        m_intfsOrch->decreaseRouterIntfsRefCount(entry.alias);
+                        decCrmNextHopCounter(entry.ip_address);
+                    }
+                    else
+                    {
+                        // track the sai nexthop for deletion later
+                        SWSS_LOG_NOTICE("Unable to clear nexthop %s for %s to create for %s, sai rv:%d",
+                            nexthop.to_string().c_str(), entry.alias.c_str(), nh.alias.c_str(), status);
+                        m_staleNextHops[entry] = m_syncdNextHops[nexthop];
+                    }
+
+                    // 3. proceed with clobbering m_syncdNextHops[ (ip, inband port) ]
+                    break;
+                }
+            }
+        }
+        else
+        {
+            assert(false);
+        }
+    }
+
     sai_object_id_t rif_id = m_intfsOrch->getRouterIntfsId(nh.alias);
 
     vector<sai_attribute_t> next_hop_attrs;
@@ -453,8 +494,8 @@ bool NeighOrch::addNextHop(NeighborContext& ctx)
 
     NextHopEntry next_hop_entry;
     next_hop_entry.next_hop_id = next_hop_id;
-    next_hop_entry.ref_count = 0;
-    next_hop_entry.nh_flags = 0;
+    next_hop_entry.ref_count = starting_ref_count;
+    next_hop_entry.nh_flags = starting_nh_flags;
     m_syncdNextHops[nexthop] = next_hop_entry;
 
     m_intfsOrch->increaseRouterIntfsRefCount(nh.alias);
@@ -486,6 +527,15 @@ bool NeighOrch::addNextHop(NeighborContext& ctx)
         if (setNextHopFlag(nexthop, NHFLAGS_IFDOWN) == false)
         {
             SWSS_LOG_WARN("Failed to set NHFLAGS_IFDOWN on nexthop %s for interface %s",
+                nexthop.ip_address.to_string().c_str(), nexthop.alias.c_str());
+        }
+    }
+    // if port has up oper status but the flag is down we need to clear
+    else if (isNextHopFlagSet(nexthop, NHFLAGS_IFDOWN))
+    {
+        if (clearNextHopFlag(nexthop, NHFLAGS_IFDOWN) == false)
+        {
+            SWSS_LOG_WARN("Failed to clear NHFLAGS_IFDOWN on nexthop %s for interface %s",
                 nexthop.ip_address.to_string().c_str(), nexthop.alias.c_str());
         }
     }
@@ -1643,7 +1693,49 @@ bool NeighOrch::removeNeighbor(NeighborContext& ctx, bool disable)
     SWSS_LOG_INFO("Try to remove neighbor %s on %s",
                    ip_address.to_string().c_str(), alias.c_str());
 
-    if (m_syncdNextHops.find(nexthop) != m_syncdNextHops.end() && m_syncdNextHops[nexthop].ref_count > 0)
+    /*
+        on VOQ the nexthop keyed by (ip, inband port) can exist for multiple
+        neighbors, keyed by (ip, system port).
+        We shouldn't delete the orch nexthop in this case, but should clean up
+        the old stale sai nexthop created for this neighbor.
+    */
+    bool nexthop_still_valid = false;
+    if (m_intfsOrch->isRemoteSystemPortIntf(alias))
+    {
+        // 1. find the *other* neigh for the nexthop
+        for (const auto &neigh : m_syncdNeighbors)
+        {
+            NeighborEntry otherEntry = neigh.first;
+            if (otherEntry.ip_address == ip_address && otherEntry.alias != alias &&
+                m_intfsOrch->isRemoteSystemPortIntf(otherEntry.alias))
+            {
+                nexthop_still_valid = true;
+
+                // 2. attempt to delete the stale entry for *this* neigh
+                auto it = m_staleNextHops.find(neighborEntry);
+                if (it != m_staleNextHops.end())
+                {
+                    status = sai_next_hop_api->remove_next_hop(it->second.next_hop_id);
+                    if (status == SAI_STATUS_SUCCESS)
+                    {
+                        m_staleNextHops.erase(it);
+                        m_intfsOrch->decreaseRouterIntfsRefCount(alias);
+                        decCrmNextHopCounter(neighborEntry.ip_address);
+                    }
+                    // if we can't remove it then we need to wait to remove *this* neighbor
+                    else
+                    {
+                        SWSS_LOG_NOTICE("Unable to remove stale nexthop %s on %s during removal of %s, sai rv:%d",
+                            nexthop.to_string().c_str(), otherEntry.alias.c_str(), alias.c_str(), status);
+                        return false;
+                    }
+                }
+                break;
+            }
+        }
+    }
+
+    if (!nexthop_still_valid && m_syncdNextHops.find(nexthop) != m_syncdNextHops.end() && m_syncdNextHops[nexthop].ref_count > 0)
     {
         SWSS_LOG_INFO("Failed to remove still referenced neighbor %s on %s",
                       m_syncdNeighbors[neighborEntry].mac.to_string().c_str(), alias.c_str());
@@ -1675,42 +1767,37 @@ bool NeighOrch::removeNeighbor(NeighborContext& ctx, bool disable)
             gNeighBulker.remove_entry(&object_statuses.back(), &neighbor_entry);
             return true;
         }
-
-        status = sai_next_hop_api->remove_next_hop(next_hop_id);
-        if (status != SAI_STATUS_SUCCESS)
+        if (!nexthop_still_valid)
         {
-            /* When next hop is not found, we continue to remove neighbor entry. */
-            if (status == SAI_STATUS_ITEM_NOT_FOUND)
+            status = sai_next_hop_api->remove_next_hop(next_hop_id);
+            if (status != SAI_STATUS_SUCCESS)
             {
-                SWSS_LOG_NOTICE("Next hop %s on %s doesn't exist, rv:%d",
-                               ip_address.to_string().c_str(), alias.c_str(), status);
-            }
-            else
-            {
-                SWSS_LOG_ERROR("Failed to remove next hop %s on %s, rv:%d",
-                               ip_address.to_string().c_str(), alias.c_str(), status);
-                task_process_status handle_status = handleSaiRemoveStatus(SAI_API_NEXT_HOP, status);
-                if (handle_status != task_success)
+                /* When next hop is not found, we continue to remove neighbor entry. */
+                if (status == SAI_STATUS_ITEM_NOT_FOUND)
                 {
-                    return parseHandleSaiStatusFailure(handle_status);
+                    SWSS_LOG_NOTICE("Next hop %s on %s doesn't exist, rv:%d",
+                                ip_address.to_string().c_str(), alias.c_str(), status);
+                }
+                else
+                {
+                    SWSS_LOG_ERROR("Failed to remove next hop %s on %s, rv:%d",
+                                ip_address.to_string().c_str(), alias.c_str(), status);
+                    task_process_status handle_status = handleSaiRemoveStatus(SAI_API_NEXT_HOP, status);
+                    if (handle_status != task_success)
+                    {
+                        return parseHandleSaiStatusFailure(handle_status);
+                    }
                 }
             }
-        }
 
-        if (status != SAI_STATUS_ITEM_NOT_FOUND)
-        {
-            if (neighbor_entry.ip_address.addr_family == SAI_IP_ADDR_FAMILY_IPV4)
+            if (status != SAI_STATUS_ITEM_NOT_FOUND)
             {
-                gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_IPV4_NEXTHOP);
+                decCrmNextHopCounter(ip_address);
             }
-            else
-            {
-                gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_IPV6_NEXTHOP);
-            }
-        }
 
-        SWSS_LOG_NOTICE("Removed next hop %s on %s",
-                        ip_address.to_string().c_str(), alias.c_str());
+            SWSS_LOG_NOTICE("Removed next hop %s on %s",
+                            ip_address.to_string().c_str(), alias.c_str());
+        }
 
         status = sai_neighbor_api->remove_neighbor_entry(&neighbor_entry);
         if (status != SAI_STATUS_SUCCESS)
@@ -1742,7 +1829,11 @@ bool NeighOrch::removeNeighbor(NeighborContext& ctx, bool disable)
                 gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_IPV6_NEIGHBOR);
             }
 
-            removeNextHop(ip_address, alias);
+            if (!nexthop_still_valid)
+            {
+                removeNextHop(ip_address, alias);
+            }
+
             m_intfsOrch->decreaseRouterIntfsRefCount(alias);
             SWSS_LOG_NOTICE("Removed neighbor %s on %s",
                     m_syncdNeighbors[neighborEntry].mac.to_string().c_str(), alias.c_str());
@@ -1930,14 +2021,7 @@ bool NeighOrch::processBulkDisableNeighbor(NeighborContext& ctx)
 
         if (ctx.nexthop_status != SAI_STATUS_ITEM_NOT_FOUND)
         {
-            if (neighbor_entry.ip_address.addr_family == SAI_IP_ADDR_FAMILY_IPV4)
-            {
-                gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_IPV4_NEXTHOP);
-            }
-            else
-            {
-                gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_IPV6_NEXTHOP);
-            }
+            decCrmNextHopCounter(ip_address);
         }
 
         SWSS_LOG_NOTICE("Bulk removed next hop %s on %s", ip_address.to_string().c_str(), alias.c_str());
@@ -2299,15 +2383,6 @@ void NeighOrch::doVoqSystemNeighTask(Consumer &consumer)
                 //Encap index is made available either by dynamic syncing or by static config
                 it++;
                 continue;
-            }
-            if (m_syncdNeighbors.find(neighbor_entry) == m_syncdNeighbors.end())
-            {
-                NextHopKey nexthop = { ip_address, ibif.m_alias};
-                if (hasNextHop(nexthop))
-                {
-                    it++;
-                    continue;
-                }
             }
 
             if (m_syncdNeighbors.find(neighbor_entry) == m_syncdNeighbors.end() ||
@@ -2955,4 +3030,16 @@ void NeighOrch::clearBulkers()
 {
     gNeighBulker.clear();
     gNextHopBulker.clear();
+}
+
+void NeighOrch::decCrmNextHopCounter(const IpAddress& addr)
+{
+    if (addr.isV4())
+    {
+        gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_IPV4_NEXTHOP);
+    }
+    else
+    {
+        gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_IPV6_NEXTHOP);
+    }
 }

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -395,9 +395,15 @@ bool NeighOrch::addNextHop(NeighborContext& ctx)
                     // 2. attempt to delete it from sai
                     starting_ref_count = m_syncdNextHops[nexthop].ref_count;
                     starting_nh_flags = m_syncdNextHops[nexthop].nh_flags;
+
                     sai_status_t status = sai_next_hop_api->remove_next_hop(m_syncdNextHops[nexthop].next_hop_id);
-                    if (status == SAI_STATUS_SUCCESS)
+                    if (status == SAI_STATUS_SUCCESS || status == SAI_STATUS_ITEM_NOT_FOUND)
                     {
+                        if (status == SAI_STATUS_ITEM_NOT_FOUND)
+                        {
+                            SWSS_LOG_NOTICE("Next hop %s for %s doesn't exist while replacing for %s, rv:%d",
+                                nexthop.to_string().c_str(), entry.alias.c_str(), nh.alias.c_str(), status);
+                        }
                         m_intfsOrch->decreaseRouterIntfsRefCount(entry.alias);
                         decCrmNextHopCounter(entry.ip_address);
                     }
@@ -1716,8 +1722,13 @@ bool NeighOrch::removeNeighbor(NeighborContext& ctx, bool disable)
                 if (it != m_staleNextHops.end())
                 {
                     status = sai_next_hop_api->remove_next_hop(it->second.next_hop_id);
-                    if (status == SAI_STATUS_SUCCESS)
+                    if (status == SAI_STATUS_SUCCESS || status == SAI_STATUS_ITEM_NOT_FOUND)
                     {
+                        if (status == SAI_STATUS_ITEM_NOT_FOUND)
+                        {
+                            SWSS_LOG_NOTICE("Stale next hop %s on %s doesn't exist, rv:%d",
+                                nexthop.to_string().c_str(), alias.c_str(), status);
+                        }
                         m_staleNextHops.erase(it);
                         m_intfsOrch->decreaseRouterIntfsRefCount(alias);
                         decCrmNextHopCounter(neighborEntry.ip_address);
@@ -1725,8 +1736,8 @@ bool NeighOrch::removeNeighbor(NeighborContext& ctx, bool disable)
                     // if we can't remove it then we need to wait to remove *this* neighbor
                     else
                     {
-                        SWSS_LOG_NOTICE("Unable to remove stale nexthop %s on %s during removal of %s, sai rv:%d",
-                            nexthop.to_string().c_str(), otherEntry.alias.c_str(), alias.c_str(), status);
+                        SWSS_LOG_NOTICE("Failed to remove stale nexthop %s during removal of stale neighbor %s, sai rv:%d",
+                            nexthop.to_string().c_str(), alias.c_str(), status);
                         return false;
                     }
                 }

--- a/orchagent/neighorch.h
+++ b/orchagent/neighorch.h
@@ -134,6 +134,7 @@ private:
 
     NeighborTable m_syncdNeighbors;
     NextHopTable m_syncdNextHops;
+    NextHopTable m_staleNextHops;
 
     std::set<NextHopKey> m_neighborToResolve;
 
@@ -142,6 +143,7 @@ private:
 
     bool removeNextHop(const IpAddress&, const string&);
     bool processBulkAddNextHop(NeighborContext&);
+    void decCrmNextHopCounter(const IpAddress&);
 
     bool addNeighbor(NeighborContext& ctx);
     bool removeNeighbor(NeighborContext& ctx, bool disable = false);

--- a/tests/mock_tests/fdborch/fdborch_vxlan_ut.cpp
+++ b/tests/mock_tests/fdborch/fdborch_vxlan_ut.cpp
@@ -96,6 +96,8 @@ namespace fdborch_vxlan_ut
         FlexCounterOrch *m_flexCounterOrch = nullptr;
         VxlanTunnelOrch *m_vxlanTunnelOrch = nullptr;
         FlowCounterRouteOrch *m_flowCounterRouteOrch = nullptr;
+        TunnelDecapOrch *m_tunnelDecapOrch = nullptr;
+        MuxOrch *m_muxOrch = nullptr;
 
         virtual void SetUp() override
         {
@@ -272,6 +274,20 @@ namespace fdborch_vxlan_ut
             gRouteOrch = new RouteOrch(m_app_db.get(), route_tables, gSwitchOrch, gNeighOrch, gIntfsOrch, gVrfOrch, gFgNhgOrch, gSrv6Orch);
             gDirectory.set(gRouteOrch);
 
+            vector<string> tunnel_tables = {
+                APP_TUNNEL_DECAP_TABLE_NAME,
+                APP_TUNNEL_DECAP_TERM_TABLE_NAME
+            };
+            m_tunnelDecapOrch = new TunnelDecapOrch(m_app_db.get(), m_state_db.get(), m_config_db.get(), tunnel_tables);
+            gDirectory.set(m_tunnelDecapOrch);
+
+            vector<string> mux_tables = {
+                CFG_MUX_CABLE_TABLE_NAME,
+                CFG_PEER_SWITCH_TABLE_NAME
+            };
+            m_muxOrch = new MuxOrch(m_config_db.get(), mux_tables, m_tunnelDecapOrch, gNeighOrch, gFdbOrch);
+            gDirectory.set(m_muxOrch);
+
             INIT_SAI_API_MOCK(fdb);
             INIT_SAI_API_MOCK(neighbor);
             MockSaiApis();
@@ -328,6 +344,12 @@ namespace fdborch_vxlan_ut
 
             delete m_flexCounterOrch;
             m_flexCounterOrch = nullptr;
+
+            delete m_muxOrch;
+            m_muxOrch = nullptr;
+
+            delete m_tunnelDecapOrch;
+            m_tunnelDecapOrch = nullptr;
 
             gDirectory.m_values.clear();
             sai_route_api = pold_sai_route_api;

--- a/tests/mock_tests/neighorch_ut.cpp
+++ b/tests/mock_tests/neighorch_ut.cpp
@@ -6,6 +6,7 @@
 #undef protected
 #define private public
 #include "routeorch.h"
+#include "intfsorch.h"
 #undef private
 #include "ut_helper.h"
 #include "mock_orchagent_main.h"
@@ -17,10 +18,14 @@ EXTERN_MOCK_FNS
 namespace neighorch_test
 {
     DEFINE_SAI_API_MOCK(neighbor);
+    DEFINE_SAI_GENERIC_APIS_MOCK(next_hop, next_hop)
     using namespace std;
     using namespace mock_orch_test;
     using ::testing::Return;
     using ::testing::Throw;
+    using ::testing::DoAll;
+    using ::testing::SetArgPointee;
+    using ::testing::_;
 
     static const string TEST_IP = "10.10.10.10";
     static const string VRF_3000 = "Vrf3000";
@@ -28,6 +33,14 @@ namespace neighorch_test
     static const NeighborEntry VLAN2000_NEIGH = NeighborEntry(TEST_IP, VLAN_2000);
     static const NeighborEntry VLAN3000_NEIGH = NeighborEntry(TEST_IP, VLAN_3000);
     static const NeighborEntry VLAN4000_NEIGH = NeighborEntry(TEST_IP, VLAN_4000);
+
+    static const string REMOTE_PORT_A = "lc1|Asic0|Ethernet0";
+    static const string REMOTE_PORT_B = "lc2|Asic0|Ethernet0";
+    static const string INBAND_PORT = "Ethernet-IB0";
+    static const sai_object_id_t NH_OID_A = 0x2001;
+    static const sai_object_id_t NH_OID_B = 0x2002;
+    static const NeighborEntry NEIGH_A = NeighborEntry(TEST_IP, REMOTE_PORT_A);
+    static const NeighborEntry NEIGH_B = NeighborEntry(TEST_IP, REMOTE_PORT_B);
 
     class NeighOrchTest : public MockOrchTest
     {
@@ -177,15 +190,56 @@ namespace neighorch_test
             static_cast<Orch *>(gFdbOrch)->doTask();
         }
 
+        bool AddNeighbor(const string &alias, const string &ip, const string &mac)
+        {
+            NeighborEntry ne(ip, alias);
+            NeighborContext ctx(ne);
+            ctx.mac = MacAddress(mac);
+            return gNeighOrch->addNeighbor(ctx);
+        }
+
+        bool RemoveNeighbor(const string &alias, const string &ip)
+        {
+            NeighborEntry ne(ip, alias);
+            NeighborContext ctx(ne);
+            return gNeighOrch->removeNeighbor(ctx);
+        }
+
+        void AddRemotePort(const string &alias, sai_object_id_t rif_id)
+        {
+            Port p(alias, Port::PHY);
+            p.m_rif_id = rif_id;
+            p.m_oper_status = SAI_PORT_OPER_STATUS_UP;
+            p.m_system_port_info.type = SAI_SYSTEM_PORT_TYPE_REMOTE;
+            gPortsOrch->m_portList[alias] = p;
+            gIntfsOrch->m_syncdIntfses[alias] = { {}, 0, gVirtualRouterId, false };
+        }
+
+        void SetUpVoqPorts()
+        {
+            AddRemotePort(REMOTE_PORT_A, 0x1001);
+            AddRemotePort(REMOTE_PORT_B, 0x1002);
+
+            Port inb(INBAND_PORT, Port::PHY);
+            inb.m_rif_id = 0x1003;
+            inb.m_oper_status = SAI_PORT_OPER_STATUS_UP;
+            gPortsOrch->m_portList[INBAND_PORT] = inb;
+            gPortsOrch->m_inbandPortName = INBAND_PORT;
+            gIntfsOrch->m_syncdIntfses[INBAND_PORT] = { {}, 0, gVirtualRouterId, false };
+        }
+
         void PostSetUp() override
         {
             INIT_SAI_API_MOCK(neighbor);
+            INIT_SAI_API_MOCK(next_hop);
             MockSaiApis();
         }
 
         void PreTearDown() override
         {
             RestoreSaiApis();
+            DEINIT_SAI_API_MOCK(next_hop);
+            DEINIT_SAI_API_MOCK(neighbor);
         }
     };
 
@@ -473,5 +527,77 @@ namespace neighorch_test
         // Verify only VLAN_1000 neighbor is disabled, VLAN_2000 remains enabled
         EXPECT_FALSE(gNeighOrch->isHwConfigured(VLAN1000_NEIGH));
         EXPECT_TRUE(gNeighOrch->isHwConfigured(VLAN2000_NEIGH));
+    }
+
+    TEST_F(NeighOrchTest, VoqRemoteNeighborReplaceAndRemove)
+    {
+        SetUpVoqPorts();
+        // (ip, Ethernet-IB0) is shared across remote ports
+        NextHopKey inband_nh(TEST_IP, INBAND_PORT);
+
+        // create neighbor and nexthop on remote port A
+        EXPECT_CALL(*mock_sai_neighbor_api, create_neighbor_entry(_, _, _))
+            .WillOnce(Return(SAI_STATUS_SUCCESS));
+        EXPECT_CALL(*mock_sai_next_hop_api, create_next_hop(_, _, _, _))
+            .WillOnce(DoAll(SetArgPointee<0>(NH_OID_A), Return(SAI_STATUS_SUCCESS)));
+        ASSERT_TRUE(AddNeighbor(REMOTE_PORT_A, TEST_IP, MAC1));
+
+        ASSERT_EQ(gNeighOrch->m_syncdNeighbors.count(NEIGH_A), 1);
+        ASSERT_EQ(gNeighOrch->m_syncdNextHops[inband_nh].next_hop_id, NH_OID_A);
+
+        // simulate 3 routes referencing nexthop on A
+        // set NHFLAGS_IFDOWN, since mocking scenario where A is being taken down
+        gNeighOrch->m_syncdNextHops[inband_nh].ref_count = 3;
+        gNeighOrch->m_syncdNextHops[inband_nh].nh_flags = NHFLAGS_IFDOWN;
+
+        // now add neighbor and nexthop on remote port B
+        EXPECT_CALL(*mock_sai_next_hop_api, remove_next_hop(NH_OID_A))
+            .WillOnce(Return(SAI_STATUS_OBJECT_IN_USE));
+        EXPECT_CALL(*mock_sai_neighbor_api, create_neighbor_entry(_, _, _))
+            .WillOnce(Return(SAI_STATUS_SUCCESS));
+        EXPECT_CALL(*mock_sai_next_hop_api, create_next_hop(_, _, _, _))
+            .WillOnce(DoAll(SetArgPointee<0>(NH_OID_B), Return(SAI_STATUS_SUCCESS)));
+        ASSERT_TRUE(AddNeighbor(REMOTE_PORT_B, TEST_IP, MAC2));
+
+        // nexthop replaces the nexthop originally made for A
+        ASSERT_EQ(gNeighOrch->m_syncdNeighbors.count(NEIGH_B), 1);
+        ASSERT_EQ(gNeighOrch->m_syncdNextHops[inband_nh].next_hop_id, NH_OID_B);
+        // ref count will carry over but flags will be reset since port B is UP
+        ASSERT_EQ(gNeighOrch->m_syncdNextHops[inband_nh].ref_count, 3);
+        ASSERT_EQ(gNeighOrch->m_syncdNextHops[inband_nh].nh_flags, 0u);
+        // Old SAI nexthop removal failed, so it is tracked as stale.
+        ASSERT_EQ(gNeighOrch->m_staleNextHops.count(NEIGH_A), 1);
+        ASSERT_EQ(gNeighOrch->m_staleNextHops[NEIGH_A].next_hop_id, NH_OID_A);
+
+        // simulate first attempt to remove neighbor on A but nexthop still in use
+        EXPECT_CALL(*mock_sai_next_hop_api, remove_next_hop(NH_OID_A))
+            .WillOnce(Return(SAI_STATUS_OBJECT_IN_USE));
+        EXPECT_CALL(*mock_sai_neighbor_api, remove_neighbor_entry(_)).Times(0);
+        ASSERT_FALSE(RemoveNeighbor(REMOTE_PORT_A, TEST_IP));
+
+        // Everything unchanged, neighbor A and stale entry still present
+        ASSERT_EQ(gNeighOrch->m_syncdNeighbors.count(NEIGH_A), 1);
+        ASSERT_EQ(gNeighOrch->m_staleNextHops.count(NEIGH_A), 1);
+
+        // Second attempt to remove neigh on A, routes have been reprogrammed on asic
+        // nexthop_still_valid is true
+        EXPECT_CALL(*mock_sai_next_hop_api, remove_next_hop(NH_OID_A))
+            .WillOnce(Return(SAI_STATUS_SUCCESS));
+        EXPECT_CALL(*mock_sai_neighbor_api, remove_neighbor_entry(_))
+            .WillOnce(Return(SAI_STATUS_SUCCESS));
+        ASSERT_TRUE(RemoveNeighbor(REMOTE_PORT_A, TEST_IP));
+
+        ASSERT_EQ(gNeighOrch->m_syncdNeighbors.count(NEIGH_A), 0);
+        ASSERT_TRUE(gNeighOrch->m_staleNextHops.empty());
+        ASSERT_TRUE(gNeighOrch->hasNextHop(inband_nh));
+
+        // now remove neighbor on B, where nexthop_still_valid is false
+        gNeighOrch->m_syncdNextHops[inband_nh].ref_count = 0;
+        EXPECT_CALL(*mock_sai_next_hop_api, remove_next_hop(NH_OID_B))
+            .WillOnce(Return(SAI_STATUS_SUCCESS));
+        EXPECT_CALL(*mock_sai_neighbor_api, remove_neighbor_entry(_))
+            .WillOnce(Return(SAI_STATUS_SUCCESS));
+        ASSERT_TRUE(RemoveNeighbor(REMOTE_PORT_B, TEST_IP));
+        ASSERT_FALSE(gNeighOrch->hasNextHop(inband_nh));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/sonic-net/sonic-buildimage/issues/27585 (issue)

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
This fix removes the skip from [PR3329](https://github.com/sonic-net/sonic-swss/pull/3329
) and lets addNeighbor handle the case where a nexthop already exists for a remote port.
It removes the old SAI nexthop (or tracks it as stale for later cleanup if still in use), then creates a new one which preserves the existing ref_count and nh_flags.

**Why I did it**

The issue seen was that when we remove the ip address from lag A and add it to lag B, then attempt to delete lag A, we can not do so because the routes are added and converge for lag B before lag A is removed. On the remote asic the system ports both use Ethernet-IBX as the alias for the nexthops, meaning that lag A fails to delete when it sees that there are still references to it.

removeLag fails because removeRouterIntfs has not completed. 
removeRouterIntfs fails because removeNeighbor has not completed. 
removeNeighbor fails because nexthop "10.0.0.1 on Ethernet-IB1" exists

This nexthop was never deleted because [PR3329](https://github.com/sonic-net/sonic-swss/pull/3329
) added a skip that prevents doVoqSystemNeighTask from calling addNeighbor if there is already a nexthop associated to (10.0.0.1, Ethernet-IB1), which there is from lag B.

In the past, before [PR3329](https://github.com/sonic-net/sonic-swss/pull/3329
), when addNeighbor was called it would simply clobber the current nexthop with a new one. This effectively reset the ref count to 0 and allowing the lag to be deleted

m_syncdNextHops[nexthop] = next_hop_entry

[PR3329](https://github.com/sonic-net/sonic-swss/pull/3329
) results in 2 issues,
1. removeLag becomes impossible on the remote asic for a remote port that uses the same ip as another remote port.
2. the stale neighbor and nexthop remains for lag A and is never created for lag B.

**How I verified it**

I reran the pc/ sonic-mgmt test suite on my multi-asic fixed testbeds to see they no longer failed. Ran the entire sonic-mgmt suite on these boxes as well without regression.

I also used custom scripting that could replicate the issue consistently to verify that the lag id discrepancy between asics was solved by my fix.

I added a `VoqRemoteNeighborReplaceAndRemove` unit test case as well.

**Details if related**
