### PR TITLE
[ci] Pin GitHub Actions to commit SHAs to fix Semgrep master failures

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,11 +29,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2.1.29
+      uses: github/codeql-action/init@ec3cf9c605b848da5f1e41e8452719eb1ccfb9a6 # v2.1.29
       with:
         config-file: ./.github/codeql/codeql-config.yml
         languages: ${{ matrix.language }}
@@ -154,6 +154,6 @@ jobs:
         --with-libnl-3.0-inc=$(dirname $GITHUB_WORKSPACE)/usr/include/libnl3
 
     - name: Perform CodeQL analysis
-      uses: github/codeql-action/analyze@v2.1.29
+      uses: github/codeql-action/analyze@ec3cf9c605b848da5f1e41e8452719eb1ccfb9a6 # v2.1.29
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -16,7 +16,7 @@ jobs:
     container:
       image: returntocorp/semgrep
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - run: semgrep ci
         env:
            SEMGREP_RULES: p/default


### PR DESCRIPTION
#### What I did

Pinned the GitHub Actions in `semgrep.yml` and `codeql-analysis.yml` to full 40-character commit SHAs, keeping the original tag in a trailing comment:

| Action | Was | Now |
|--------|-----|-----|
| `actions/checkout` | `@v3` | `@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3` |
| `github/codeql-action/init` | `@v2.1.29` | `@ec3cf9c605b848da5f1e41e8452719eb1ccfb9a6 # v2.1.29` |
| `github/codeql-action/analyze` | `@v2.1.29` | `@ec3cf9c605b848da5f1e41e8452719eb1ccfb9a6 # v2.1.29` |

These are the exact commits the tags currently resolve to, so there is no version or behavior change (and it stays Dependabot-compatible).

#### Root cause

Semgrep (`SEMGREP_RULES: p/default`) began failing on every push to `master` on **June 30, 2026**, while PRs stayed green. The raw CI logs for the two runs on either side of the transition show the `p/default` YAML rules growing under an otherwise-identical build (same engine `v1.168.0`, same 500 targets, no repo change):

| Run | Time (UTC) | YAML rules | Total rules | Findings |
|-----|-----------|:---:|:---:|:---:|
| `a32b585` (last green) | Jun 30 17:01 | **31** | 1059 | **0** |
| `de7a1d6` (first red)  | Jun 30 18:43 | **35** | 1074 | **4 blocking** |

All 4 findings are the newly-added rule `yaml.github-actions.security.github-actions-mutable-action-tag`, which flags Actions pinned to mutable tags/branches instead of a commit SHA. It fires on the workflow files here (including `semgrep.yml` itself). `semgrep ci` runs a full scan on push to `master` but a diff-only scan on PRs, so master blocks on these pre-existing files while PRs don't.

(The exact server-side registry event that added the rule to `p/default` isn't publicly logged, but the CI logs make the effect a fact: the pack composition changed, not this repo.)

#### Verification

Reproduced locally with Semgrep 1.169.0 against master `HEAD`: **before** -> exit 1, 4 blocking findings; **after this change** -> exit 0, 0 findings. The fix is also the exact remediation the rule asks for.

Also, since PRs only run semgrep on the diff, created a dummy PR to verify that touching the semgrep workflow file without the fix will fail: https://github.com/sonic-net/sonic-swss/actions/runs/29362069261/job/87184395388?pr=4754

#### Follow-up (not in this PR)

`semgrep.yml` uses an unpinned, deprecated container image (`returntocorp/semgrep`). Pinning it to a versioned `semgrep/semgrep:<tag>` would prevent similar drift, but it isn't flagged by the rule, so it's left out of this minimal fix.