### PR TITLE
[fpmsyncd]: Add ZMQ route-drop telemetry to STATE_DB

### DIFF
--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -13,8 +13,12 @@
 #include "fpmsyncd/fpm/fpm.h"
 #include "macaddress.h"
 #include "converter.h"
+#include "table.h"
 #include <string.h>
 #include <arpa/inet.h>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
 #include <linux/pkt_cls.h>
 #include <linux/nexthop.h>
 #include <linux/lwtunnel.h>
@@ -23,6 +27,16 @@
 
 using namespace std;
 using namespace swss;
+
+/* ZMQ route-drop telemetry — STATE_DB surface. */
+#define STATE_FPMSYNCD_ROUTE_STAT_TABLE_NAME "FPMSYNCD_ROUTE_STAT_TABLE"
+#define FPMSYNCD_ROUTE_STAT_KEY              "global"
+/* Throttle the drop ERROR log to at most once per this many seconds under a sustained burst. */
+#define ZMQ_ROUTE_DROP_LOG_THROTTLE_SECS     5
+/* Publish the running route stats to STATE_DB at most once per this many seconds on the
+ * success path (drops publish immediately). Keeps the hot path off per-route STATE_DB writes
+ * while still giving a fresh throughput denominator for the drop rate. */
+#define ZMQ_ROUTE_STAT_PUBLISH_INTERVAL_SECS 10
 
 #if BYTE_ORDER == LITTLE_ENDIAN
 #define ntohll(x) (((uint64_t)ntohl((x)&0xFFFFFFFF) << 32) | ntohl((uint32_t)(((x)>>32) & 0xFFFFFFFFU)))
@@ -188,6 +202,135 @@ RouteSync::RouteSync(RedisPipeline *pipeline) :
     rtnl_link_alloc_cache(m_nl_sock, AF_UNSPEC, &m_link_cache);
 }
 
+/* ZMQ route-drop telemetry: lazily open the STATE_DB stat table on
+ * first use. Only reached from the record* path, which is gated on isNbZmqEnabled(),
+ * so no STATE_DB connector/table is created when northbound ZMQ is disabled. */
+void RouteSync::ensureRouteStatTable()
+{
+    if (!m_zmqRouteStatTable)
+    {
+        m_stateDb = std::make_unique<DBConnector>("STATE_DB", 0);
+        m_zmqRouteStatTable = std::make_unique<Table>(m_stateDb.get(),
+                                                      STATE_FPMSYNCD_ROUTE_STAT_TABLE_NAME);
+    }
+}
+
+void RouteSync::trySetRoute(ProducerStateTable & table,
+                            const std::vector<KeyOpFieldsValuesTuple> & kcos)
+{
+    try
+    {
+        table.set(kcos);
+    }
+    catch (const std::exception &)
+    {
+        const std::string key = kcos.empty() ? "<unknown>" : kfvKey(kcos.front());
+        recordRouteDrop(key, kcos.size());
+        throw;
+    }
+    recordRouteSuccess(kcos.size());
+}
+
+void RouteSync::trySetRoute(ProducerStateTable & table,
+                            const std::string & key,
+                            const std::vector<FieldValueTuple> & fvs)
+{
+    try
+    {
+        table.set(key, fvs);
+    }
+    catch (const std::exception &)
+    {
+        recordRouteDrop(key, 1);
+        throw;
+    }
+    recordRouteSuccess(1);
+}
+
+void RouteSync::recordRouteSuccess(uint64_t routeCount)
+{
+    /* Telemetry is scoped to the northbound ZMQ producer path only. When ZMQ is
+     * disabled the same set() sites reach Redis directly; counting them would
+     * mislabel non-ZMQ activity as zmq_route_* stats. */
+    if (!isNbZmqEnabled())
+    {
+        return;
+    }
+    ensureRouteStatTable();
+    m_zmqRouteProcessed += routeCount;
+    time_t now = time(nullptr);
+    m_lastSuccessTime = now;
+    /* Off the hot path: publish at most once per interval on success (drops publish
+     * immediately). Provides the throughput denominator for the drop rate without a
+     * STATE_DB write per route. */
+    if (now - m_lastStatPublishTime >= ZMQ_ROUTE_STAT_PUBLISH_INTERVAL_SECS)
+    {
+        publishRouteStats();
+        m_lastStatPublishTime = now;
+    }
+}
+
+void RouteSync::recordRouteDrop(const std::string & routeKey, uint64_t routeCount)
+{
+    /* Telemetry is scoped to the northbound ZMQ producer path only (see
+     * recordRouteSuccess). A failure on the non-ZMQ Redis path is not a ZMQ drop. */
+    if (!isNbZmqEnabled())
+    {
+        return;
+    }
+    ensureRouteStatTable();
+    m_zmqRouteDropMsgs   += 1;
+    m_zmqRouteDropRoutes += routeCount;
+    m_lastDropPrefix      = routeKey;
+    m_lastDropTime        = time(nullptr);
+
+    /* Rate-limit the ERROR log so a sustained burst does not flood syslog. */
+    if (m_lastDropTime - m_lastDropLogTime >= ZMQ_ROUTE_DROP_LOG_THROTTLE_SECS)
+    {
+        SWSS_LOG_ERROR("fpmsyncd dropped route update over ZMQ: prefix=%s, "
+                       "dropped_msgs_total=%s, dropped_routes_total=%s",
+                       routeKey.c_str(),
+                       std::to_string(m_zmqRouteDropMsgs).c_str(),
+                       std::to_string(m_zmqRouteDropRoutes).c_str());
+        m_lastDropLogTime = m_lastDropTime;
+    }
+
+    /* A drop publishes immediately (unthrottled) so the loss is visible at once. */
+    m_lastStatPublishTime = m_lastDropTime;
+    publishRouteStats();
+}
+
+std::string RouteSync::formatUtcTime(time_t t)
+{
+    if (t == 0)
+    {
+        return "";
+    }
+    struct tm tm_utc;
+    gmtime_r(&t, &tm_utc);
+    std::ostringstream oss;
+    oss << std::put_time(&tm_utc, "%Y-%m-%d %H:%M:%S");
+    return oss.str();
+}
+
+void RouteSync::publishRouteStats()
+{
+    if (!m_zmqRouteStatTable)
+    {
+        return;
+    }
+
+    std::vector<FieldValueTuple> fvs = {
+        {"zmq_route_processed_total",   std::to_string(m_zmqRouteProcessed)},
+        {"zmq_route_drop_msgs_total",   std::to_string(m_zmqRouteDropMsgs)},
+        {"zmq_route_drop_routes_total", std::to_string(m_zmqRouteDropRoutes)},
+        {"zmq_route_last_drop_prefix",  m_lastDropPrefix},
+        {"zmq_route_last_drop_time",    formatUtcTime(m_lastDropTime)},
+        {"zmq_route_last_success_time", formatUtcTime(m_lastSuccessTime)},
+    };
+    m_zmqRouteStatTable->set(FPMSYNCD_ROUTE_STAT_KEY, fvs);
+}
+
 void RouteSync::setRouteWithWarmRestart(FieldValueTupleWrapperBase & fvw,
                                         ProducerStateTable & table )
 {
@@ -195,7 +338,7 @@ void RouteSync::setRouteWithWarmRestart(FieldValueTupleWrapperBase & fvw,
 
     if (!warmRestartInProgress)
     {
-        table.set(fvw.KeyOpFieldsValuesTupleVector());
+        trySetRoute(table, fvw.KeyOpFieldsValuesTupleVector());
     }
     else
     {
@@ -1946,7 +2089,7 @@ void RouteSync::onSrv6VpnRouteMsg(struct nlmsghdr *h, int len)
                 FieldValueTuple wg("weight", weights.c_str());
                 fvVector.push_back(wg);
             }
-            m_routeTable->set(routeTableKey, fvVector);
+            trySetRoute(*m_routeTable, routeTableKey, fvVector);
 
             SWSS_LOG_DEBUG("NextHop group id %d is a single nexthop address. Filling the route table %s with nexthop and ifname", nhg_id, destipprefix);
         }
@@ -1974,7 +2117,7 @@ void RouteSync::onSrv6VpnRouteMsg(struct nlmsghdr *h, int len)
             fvVectorVpnRoute.push_back(vpn_sid);
             fvVectorVpnRoute.push_back(seg_srcs_route);
             fvVectorVpnRoute.push_back(intf);
-            m_routeTable->set(routeTableKey, fvVectorVpnRoute);
+            trySetRoute(*m_routeTable, routeTableKey, fvVectorVpnRoute);
         }
     }
 

--- a/fpmsyncd/routesync.h
+++ b/fpmsyncd/routesync.h
@@ -233,6 +233,35 @@ public:
         FieldValueTupleWrapperBase & fvw,
         ProducerStateTable & table);
 
+    /*
+     * ZMQ route-drop telemetry.
+     * When swss_zmq is enabled, a ProducerStateTable::set() on a route table can throw
+     * (ZmqClient::sendMsg exhausts its retries under a route burst and throws io_error),
+     * which is silently swallowed by Select::poll_descriptors and the route update is
+     * permanently lost. These helpers wrap the ZMQ route set() sites to attribute and
+     * count the drop and publish counters to STATE_DB, then re-throw so the existing
+     * control flow is unchanged (telemetry-only, no behavior change).
+     */
+    void trySetRoute(
+        ProducerStateTable & table,
+        const std::vector<swss::KeyOpFieldsValuesTuple> & kcos);
+    void trySetRoute(
+        ProducerStateTable & table,
+        const std::string & key,
+        const std::vector<swss::FieldValueTuple> & fvs);
+    /* Record a dropped route update and publish updated counters to STATE_DB. */
+    void recordRouteDrop(const std::string & routeKey, uint64_t routeCount);
+    /* Record a successfully-produced route op (the throughput denominator) and publish
+     * the running stats to STATE_DB on a throttled cadence (off the per-route hot path). */
+    void recordRouteSuccess(uint64_t routeCount);
+    /* Lazily open the STATE_DB stat table on first use (ZMQ-enabled path only). */
+    void ensureRouteStatTable();
+    /* Publish the current route stats (processed + drop counters + last drop/success) to STATE_DB. */
+    void publishRouteStats();
+    /* Format a time_t as a UTC "YYYY-MM-DD HH:MM:SS" string ("" when unset), matching the
+     * human-readable timestamp convention used elsewhere in SONiC STATE_DB. */
+    static std::string formatUtcTime(time_t t);
+
     void setTable(
         FieldValueTupleWrapperBase & fvw,
         ProducerStateTable & table);
@@ -295,6 +324,18 @@ private:
     map<uint32_t,NextHopGroup> m_nh_groups;
     /* SID list to refcount */
     map<string, uint32_t> m_srv6_sidlist_refcnt;
+
+    /* ZMQ route-drop telemetry — published to STATE_DB. */
+    std::unique_ptr<swss::DBConnector> m_stateDb;
+    std::unique_ptr<swss::Table>       m_zmqRouteStatTable;
+    uint64_t    m_zmqRouteDropMsgs{0};
+    uint64_t    m_zmqRouteDropRoutes{0};
+    uint64_t    m_zmqRouteProcessed{0};
+    std::string m_lastDropPrefix;
+    time_t      m_lastDropTime{0};
+    time_t      m_lastDropLogTime{0};
+    time_t      m_lastSuccessTime{0};
+    time_t      m_lastStatPublishTime{0};
 
     WarmStartHelper  m_warmStartHelper;
 

--- a/tests/mock_tests/fpmsyncd/test_routesync.cpp
+++ b/tests/mock_tests/fpmsyncd/test_routesync.cpp
@@ -5097,3 +5097,133 @@ TEST_F(FpmSyncdResponseTest, TestVnetRouteMsgWithZmqDisabled_OnlyNonEmptyFields)
     rtnl_route_put(test_route);
 
 }
+
+// ---------------------------------------------------------------------------
+// ZMQ route-drop telemetry
+// ---------------------------------------------------------------------------
+
+// recordRouteDrop() must accumulate the msg/route counters, remember the last
+// dropped prefix, and publish the running totals to STATE_DB.
+TEST_F(FpmSyncdResponseTest, ZmqRouteDropTelemetryRecordsAndPublishes)
+{
+    // Telemetry is gated on isNbZmqEnabled(); simulate NB ZMQ enabled on this instance.
+    m_routeSync.m_zmqClient = shared_ptr<swss::ZmqClient>(reinterpret_cast<swss::ZmqClient*>(1), [](swss::ZmqClient*){});
+    // Two drops: a 3-route batch, then a single-route batch.
+    m_routeSync.recordRouteDrop("10.1.0.0/24", 3);
+    m_routeSync.recordRouteDrop("10.2.0.1/32", 1);
+
+    DBConnector stateDb("STATE_DB", 0);
+    Table statTable(&stateDb, "FPMSYNCD_ROUTE_STAT_TABLE");
+    vector<FieldValueTuple> result;
+    ASSERT_TRUE(statTable.get("global", result));
+
+    map<string, string> f;
+    for (const auto& fv : result) {
+        f[fvField(fv)] = fvValue(fv);
+    }
+
+    EXPECT_EQ(f["zmq_route_drop_msgs_total"], "2");
+    EXPECT_EQ(f["zmq_route_drop_routes_total"], "4");
+    EXPECT_EQ(f["zmq_route_last_drop_prefix"], "10.2.0.1/32");
+    EXPECT_FALSE(f["zmq_route_last_drop_time"].empty());
+    // No successful sets happened, so the throughput denominator stays 0
+    // and the last-success timestamp is unset (empty).
+    EXPECT_EQ(f["zmq_route_processed_total"], "0");
+    EXPECT_TRUE(f["zmq_route_last_success_time"].empty());
+
+    EXPECT_EQ(m_routeSync.m_zmqRouteDropMsgs, 2u);
+    EXPECT_EQ(m_routeSync.m_zmqRouteDropRoutes, 4u);
+}
+
+// trySetRoute() success path: the route is programmed, NO drop is recorded, and
+// the processed-total denominator is incremented and published to STATE_DB.
+TEST_F(FpmSyncdResponseTest, ZmqRouteProcessedTelemetryOnSuccessfulSet)
+{
+    // Telemetry is gated on isNbZmqEnabled(); simulate NB ZMQ enabled on this instance.
+    m_routeSync.m_zmqClient = shared_ptr<swss::ZmqClient>(reinterpret_cast<swss::ZmqClient*>(1), [](swss::ZmqClient*){});
+    vector<FieldValueTuple> fvs = {
+        {"nexthop", "1.1.1.1"},
+        {"ifname", "Ethernet0"},
+    };
+    m_routeSync.trySetRoute(*m_routeSync.m_routeTable, "192.0.2.0/24", fvs);
+
+    Table routeTable(m_db.get(), APP_ROUTE_TABLE_NAME);
+    vector<FieldValueTuple> result;
+    EXPECT_TRUE(routeTable.get("192.0.2.0/24", result));
+
+    // The success path publishes the running stats: processed incremented, drops still zero.
+    DBConnector stateDb("STATE_DB", 0);
+    Table statTable(&stateDb, "FPMSYNCD_ROUTE_STAT_TABLE");
+    vector<FieldValueTuple> stat;
+    ASSERT_TRUE(statTable.get("global", stat));
+
+    map<string, string> f;
+    for (const auto& fv : stat) {
+        f[fvField(fv)] = fvValue(fv);
+    }
+    EXPECT_EQ(f["zmq_route_processed_total"], "1");
+    EXPECT_EQ(f["zmq_route_drop_msgs_total"], "0");
+    EXPECT_EQ(f["zmq_route_drop_routes_total"], "0");
+    EXPECT_FALSE(f["zmq_route_last_success_time"].empty());
+
+    EXPECT_EQ(m_routeSync.m_zmqRouteProcessed, 1u);
+    EXPECT_EQ(m_routeSync.m_zmqRouteDropMsgs, 0u);
+    EXPECT_EQ(m_routeSync.m_zmqRouteDropRoutes, 0u);
+}
+
+// A drop rate is computable from the published totals: drop_routes / processed.
+TEST_F(FpmSyncdResponseTest, ZmqRouteDropRateDenominatorIsComputable)
+{
+    // Telemetry is gated on isNbZmqEnabled(); simulate NB ZMQ enabled on this instance.
+    m_routeSync.m_zmqClient = shared_ptr<swss::ZmqClient>(reinterpret_cast<swss::ZmqClient*>(1), [](swss::ZmqClient*){});
+    vector<FieldValueTuple> fvs = {
+        {"nexthop", "1.1.1.1"},
+        {"ifname", "Ethernet0"},
+    };
+    // Three successful route ops, then one dropped batch of 2 routes.
+    m_routeSync.trySetRoute(*m_routeSync.m_routeTable, "192.0.2.0/24", fvs);
+    m_routeSync.trySetRoute(*m_routeSync.m_routeTable, "192.0.2.1/32", fvs);
+    m_routeSync.trySetRoute(*m_routeSync.m_routeTable, "192.0.2.2/32", fvs);
+    m_routeSync.recordRouteDrop("198.51.100.0/24", 2);
+
+    DBConnector stateDb("STATE_DB", 0);
+    Table statTable(&stateDb, "FPMSYNCD_ROUTE_STAT_TABLE");
+    vector<FieldValueTuple> stat;
+    ASSERT_TRUE(statTable.get("global", stat));
+
+    map<string, string> f;
+    for (const auto& fv : stat) {
+        f[fvField(fv)] = fvValue(fv);
+    }
+    // processed=3, drop_routes=2 → the consumer can compute a 2/3 drop rate.
+    EXPECT_EQ(f["zmq_route_processed_total"], "3");
+    EXPECT_EQ(f["zmq_route_drop_routes_total"], "2");
+    EXPECT_EQ(m_routeSync.m_zmqRouteProcessed, 3u);
+    EXPECT_EQ(m_routeSync.m_zmqRouteDropRoutes, 2u);
+}
+
+// When northbound ZMQ is disabled (m_zmqClient == nullptr) the same route set()
+// sites reach Redis directly and are NOT ZMQ drops. The telemetry must stay
+// completely inert: no counters move, and no STATE_DB stat table is created.
+TEST_F(FpmSyncdResponseTest, ZmqRouteTelemetrySuppressedWhenZmqDisabled)
+{
+    ASSERT_FALSE(m_routeSync.isNbZmqEnabled());
+
+    vector<FieldValueTuple> fvs = {
+        {"nexthop", "1.1.1.1"},
+        {"ifname", "Ethernet0"},
+    };
+    m_routeSync.trySetRoute(*m_routeSync.m_routeTable, "203.0.113.0/24", fvs);
+    m_routeSync.recordRouteDrop("203.0.113.7/32", 5);
+
+    // Counters untouched.
+    EXPECT_EQ(m_routeSync.m_zmqRouteProcessed, 0u);
+    EXPECT_EQ(m_routeSync.m_zmqRouteDropMsgs, 0u);
+    EXPECT_EQ(m_routeSync.m_zmqRouteDropRoutes, 0u);
+
+    // No STATE_DB stat table was ever opened.
+    DBConnector stateDb("STATE_DB", 0);
+    Table statTable(&stateDb, "FPMSYNCD_ROUTE_STAT_TABLE");
+    vector<FieldValueTuple> stat;
+    EXPECT_FALSE(statTable.get("global", stat));
+}


### PR DESCRIPTION
**What I did**

Added drop telemetry to fpmsyncd's ZMQ route-producer path so a silent route loss becomes observable, **without changing control flow**. The ZMQ route-table `set()` sites now go through a `trySetRoute()` funnel that, on exception, records the dropped prefix and route count and then **re-throws** (the success path and the existing `Select::ERROR` path are unchanged). The success path also increments an in-memory processed counter so the drop count becomes a computable rate.

Stats are published to STATE_DB `FPMSYNCD_ROUTE_STAT_TABLE|global`:

| Field | Meaning |
|---|---|
| `zmq_route_processed_total` | successfully-produced route ops (throughput denominator) |
| `zmq_route_drop_msgs_total` | dropped ZMQ messages |
| `zmq_route_drop_routes_total` | dropped route ops (blast radius) |
| `zmq_route_last_drop_prefix` | most recent dropped prefix |
| `zmq_route_last_drop_time` | time of last drop |
| `zmq_route_last_success_time` | time of last successful produce |

Sample on a DUT after a drop (real capture from the LC1/asic0 A/B row below — `drop_rate` is operator-computed from `drop_routes_total / processed_total`, not stored). `last_drop_time` and `last_success_time` are independent last-event timestamps: once the ZMQ channel saturates near the burst tail (sends block/retry and stop succeeding), successes stop while drops continue to the end, so the last success typically **predates** the last drop:

```
admin@sonic:~$ sonic-db-cli STATE_DB HGETALL "FPMSYNCD_ROUTE_STAT_TABLE|global"
zmq_route_processed_total    9999
zmq_route_drop_msgs_total    2
zmq_route_drop_routes_total  2
zmq_route_last_drop_prefix   193.118.67.0/25
zmq_route_last_success_time  2026-07-14 07:50:18
zmq_route_last_drop_time     2026-07-14 07:51:40
```

A drop publishes immediately and emits a rate-limited (1/5s) `SWSS_LOG_ERROR` naming the prefix; the success path publishes at most once per 10s to keep the per-route hot path off STATE_DB. Scope is limited to the 3 ZMQ route-table producer sites (`setRouteWithWarmRestart` covering route+label, plus the 2 VPN sites); the non-ZMQ VNET producer is left untouched so redis errors are not mislabelled as ZMQ drops. The recording path is additionally gated on NB ZMQ actually being enabled (`isNbZmqEnabled()`) and the STATE_DB stat table is created lazily on first record, so when `swss_zmq` is off the counters never populate and no STATE_DB table is created — a route-table `set()` that fails in plain-Redis mode is not counted as a ZMQ drop. Pure sonic-swss change (table name defined locally) — no libswsscommon dependency.

**Why I did it**

When `swss_zmq` is enabled, fpmsyncd sends route updates to orchagent over ZMQ. Under a burst the ZMQ send can exhaust its retry/backoff budget and throw `system_error(io_error)`; that exception unwinds through `ProducerStateTable::set()` and is swallowed in `Select::poll_descriptors`, so the route is **silently lost** — present in neither ZMQ nor APP_DB — with no crash and no signal. Operators have no way to detect or size the loss. This change makes the loss visible, counted, prefix-named, and per-ASIC.

This is **observability-only** — it makes the existing silent drop visible; the drop itself is addressed by follow-up bulking/backpressure changes tracked in the issue.

Fixes sonic-net/sonic-buildimage#28369 (observability portion).

**How I verified it**

**Unit tests** — `tests/mock_tests/tests_fpmsyncd`: adds `ZmqRouteDropTelemetryRecordsAndPublishes`, `ZmqRouteProcessedTelemetryOnSuccessfulSet`, `ZmqRouteDropRateDenominatorIsComputable`, and `ZmqRouteTelemetrySuppressedWhenZmqDisabled` (proves the counters + STATE_DB table stay inert when NB ZMQ is disabled). Full suite **189/189, 0 regressions**.

**KVM T2 multi-ASIC A/B** (2 line-cards × 2 ASICs = 4 ASIC instances; DUT = master nightly; AFTER = hot-swap of the `docker-fpm-frr` container only, DUT not re-imaged so NUM_ASIC=2 preserved). Bug activated on all 4 ASICs via `SYSTEM_DEFAULTS|swss_zmq=enabled`; identical burst both arms (40 000-route `sharpd` bulk-inject per ASIC).

| LC / ASIC | `FPMSYNCD_ROUTE_STAT_TABLE\|global` — **BEFORE** | **AFTER** (processed / drop_routes / last_drop_prefix / drop_rate) |
|---|---|---|
| LC1 / asic0 | `<EMPTY>` — operator **blind** | 9999 / 2 / `193.118.67.0/25` / **0.020 %** |
| LC1 / asic1 | `<EMPTY>` — **blind** | 9992 / 3 / `100.0.35.145` / **0.030 %** |
| LC2 / asic0 | `<EMPTY>` — **blind** | 9992 / 3 / `100.0.32.155` / **0.030 %** |
| LC2 / asic1 | `<EMPTY>` — **blind** | 9992 / 3 / `100.0.35.110` / **0.030 %** |

Independent per-ASIC copies verified 4/4 (distinct last-drop prefix, distinct timestamps, differing counters, physically separate line-cards). **Stuck-route correlation confirmed:** the named `last_drop_prefix` (e.g. `100.0.35.145/32`) is present in zebra RIB but **absent from APPL_DB** — the exact silently-dropped route pinpointed. Syslog now carries the rate-limited `recordRouteDrop … (issue #28369): prefix=…` ERROR.

**Details if related**

Follow-up work tracked in sonic-net/sonic-buildimage#28369: send-path pressure counters (swss-common), transport bulking (the actual drop fix — batches route updates per netlink drain so the ZMQ per-message HWM is no longer hit), and same-key coalescing.
