### PR TITLE
28413 Bug  SwssReadiness — System Readiness Gate for SONiC orchagent

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <sstream>
 #include "aclorch.h"
+#include "swssreadiness.h"
 #include "logger.h"
 #include "schema.h"
 #include "ipprefix.h"
@@ -4370,6 +4371,32 @@ AclOrch::AclOrch(vector<TableConnector>& connectors, DBConnector* stateDb, Switc
 
     init(connectors, portOrch, mirrorOrch, neighOrch, routeOrch);
 
+    // Pre-populate m_expectedInitTables from CONFIG_DB so areAllTablesApplied()
+    // can distinguish "no ACL configured" from "events not yet received".
+    // This mirrors how BufferOrch pre-populates m_ready_list from CONFIG_DB.
+    for (const auto& connector : connectors)
+    {
+        if (connector.second == CFG_ACL_TABLE_TABLE_NAME)
+        {
+            Table cfgAclTable(connector.first, CFG_ACL_TABLE_TABLE_NAME);
+            vector<string> keys;
+            cfgAclTable.getKeys(keys);
+            for (const auto& key : keys)
+            {
+                m_expectedInitTables.insert(key);
+            }
+            SWSS_LOG_NOTICE("AclOrch: %zu ACL table(s) expected from CONFIG_DB",
+                            m_expectedInitTables.size());
+            break;
+        }
+    }
+
+    // If no ACL tables are configured, areAllTablesApplied() would only be
+    // called from doTask() which may never fire if no ACL events arrive.
+    // Signal immediately here so "acl" does not block system readiness.
+    if (m_expectedInitTables.empty())
+        areAllTablesApplied();
+
     /* Initialize retry caches for rule consumers so that resource-exhaustion
      * failures can be parked and retried only when resources are freed. */
     createRetryCache(CFG_ACL_RULE_TABLE_NAME);
@@ -4450,6 +4477,11 @@ void AclOrch::doTask(Consumer &consumer)
     {
         SWSS_LOG_ERROR("Invalid table %s", table_name.c_str());
     }
+
+    // After every ACL task, check whether all initial config is applied.
+    // areAllTablesApplied() calls gSwssReadiness->signalDone("acl") once
+    // when all three gates pass (expected tables created, ports bound, m_toSync empty).
+    areAllTablesApplied();
 }
 
 void AclOrch::getAddDeletePorts(AclTable    &newT,
@@ -5033,6 +5065,11 @@ bool AclOrch::removeAclTable(string table_id)
 
         SWSS_LOG_NOTICE("Successfully deleted ACL table %s", table_id.c_str());
         m_AclTables.erase(table_oid);
+        // Table deleted during bootup — remove from expected set so
+        // areAllTablesApplied() is not blocked on a table that will
+        // never be created. erase() on a missing key is a safe no-op.
+        m_expectedInitTables.erase(table_id);
+        areAllTablesApplied();
 
         // Clear mirror table information
         // If the v4 and v6 ACL mirror tables are combined together,
@@ -6512,4 +6549,55 @@ void MetaDataMgr::recycleMetaData(uint16_t metadata)
     {
         SWSS_LOG_ERROR("Unexpected: Metadata free before Initialization complete.");
     }
+}
+
+// Returns true when all ACL configuration has been applied to SAI:
+//   1. Every table listed in CONFIG_DB at startup has been created in SAI.
+//   2. All created tables have their configured ports bound (pendingPortSet empty).
+//   3. No ACL table/rule tasks remain in the consumer processing queue.
+//
+// m_expectedInitTables is pre-populated from CONFIG_DB at construction time,
+// so this check is reliable even when buffer is not configured via SONiC
+// (e.g. direct BCM YAML init) and areAllPortsReady() returns true immediately.
+bool AclOrch::areAllTablesApplied()
+{
+    // Gate 1: all tables that CONFIG_DB declared must have been created in SAI.
+    // This prevents a premature true when m_AclTables is empty because events
+    // simply haven't arrived yet (vs. genuinely no ACL configured).
+    for (const auto& name : m_expectedInitTables)
+    {
+        // m_AclTables is keyed by sai_object_id_t; check by AclTable.id (string)
+        bool found = false;
+        for (const auto& kv : m_AclTables)
+        {
+            if (kv.second.id == name) { found = true; break; }
+        }
+        if (!found && m_ctrlAclTables.find(name) == m_ctrlAclTables.end())
+        {
+            return false;
+        }
+    }
+
+    // Gate 2: all created tables must have their ports bound.
+    for (const auto& kv : m_AclTables)
+    {
+        if (!kv.second.pendingPortSet.empty()) return false;
+    }
+    for (const auto& kv : m_ctrlAclTables)
+    {
+        if (!kv.second.pendingPortSet.empty()) return false;
+    }
+
+    // Gate 3: no outstanding table/rule entries in m_toSync.
+    vector<string> pending;
+    dumpPendingTasks(pending);
+    if (!pending.empty()) return false;
+
+    // Signal readiness exactly once via the event-based manager.
+    if (gSwssReadiness && !m_aclReadySignalled)
+    {
+        m_aclReadySignalled = true;
+        gSwssReadiness->signalDone("acl");
+    }
+    return true;
 }

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -730,6 +730,12 @@ private:
     acl_capabilities_t m_aclCapabilities;
     acl_action_enum_values_capabilities_t m_aclEnumActionCapabilities;
     FlexCounterManager m_flex_counter_manager;
+
+    bool areAllTablesApplied();
+    bool m_aclReadySignalled = false;
+    // Pre-populated from CONFIG_DB at construction time so areAllTablesApplied()
+    // can distinguish "no ACL configured" from "events not yet received".
+    set<string> m_expectedInitTables;
 };
 
 #endif /* SWSS_ACLORCH_H */

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -1,5 +1,6 @@
 #include "tokenize.h"
 #include "bufferorch.h"
+#include "swssreadiness.h"
 #include "directory.h"
 #include "logger.h"
 #include "sai_serialize.h"
@@ -140,6 +141,12 @@ void BufferOrch::initBufferReadyLists(DBConnector *applDb, DBConnector *confDb)
             initBufferReadyList(queue_table, true);
         }
     }
+
+    // If no buffer PG/queue entries exist in CONFIG_DB (e.g. buffer is
+    // configured directly via BCM YAML), m_ready_list stays empty and
+    // checkAndSignalBufferReady() would never be called from processQueuePost/
+    // processPriorityGroupPost.  Signal immediately in that case.
+    checkAndSignalBufferReady();
 }
 
 void BufferOrch::initBufferReadyList(Table& table, bool isConfigDb)
@@ -272,6 +279,22 @@ bool BufferOrch::isPortReady(const std::string& port_name) const
     }
 
     return result;
+}
+
+bool BufferOrch::areAllPortsReady() const
+{
+    for (const auto& kv : m_ready_list)
+    {
+        if (!kv.second) return false;
+    }
+    return true;
+}
+
+void BufferOrch::checkAndSignalBufferReady()
+{
+    if (m_bufferReadySignalled || !areAllPortsReady() || !gSwssReadiness) return;
+    m_bufferReadySignalled = true;
+    gSwssReadiness->signalDone("buffer");
 }
 
 void BufferOrch::clearBufferPoolWatermarkCounterIdList(const sai_object_id_t object_id)
@@ -1197,6 +1220,7 @@ task_process_status BufferOrch::processQueuePost(const QueueTask& task)
     if (m_ready_list.find(key) != m_ready_list.end())
     {
         m_ready_list[key] = true;
+        checkAndSignalBufferReady();
     }
     else
     {
@@ -1567,6 +1591,7 @@ task_process_status BufferOrch::processPriorityGroupPost(const PriorityGroupTask
     if (m_ready_list.find(key) != m_ready_list.end())
     {
         m_ready_list[key] = true;
+        checkAndSignalBufferReady();
     }
     else
     {

--- a/orchagent/bufferorch.h
+++ b/orchagent/bufferorch.h
@@ -101,6 +101,8 @@ class BufferOrch : public Orch
 public:
     BufferOrch(DBConnector *applDb, DBConnector *confDb, DBConnector *stateDb, vector<string> &tableNames);
     bool isPortReady(const std::string& port_name) const;
+    bool areAllPortsReady() const;
+    void checkAndSignalBufferReady();
     static type_map m_buffer_type_maps;
     void generateBufferPoolWatermarkCounterIdList(void);
     const object_reference_map &getBufferPoolNameOidMap(void);
@@ -157,6 +159,7 @@ private:
     unique_ptr<DBConnector> m_countersDb;
 
     bool m_isBufferPoolWatermarkCounterIdListGenerated = false;
+    bool m_bufferReadySignalled = false;
     set<string> m_partiallyAppliedQueues;
 
     // Bulk task buffers per DB operation

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -326,7 +326,9 @@ public:
     virtual void onWarmBootEnd() { }
 
     void dumpPendingTasks(std::vector<std::string> &ts);
-    
+
+    virtual bool isInitConfigDone() const { return true; }
+
     void createRetryCache(const std::string &executorName);
     RetryCache* getRetryCache(const std::string &executorName);
     ConsumerBase* getConsumerBase(const std::string &executorName);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -17,6 +17,7 @@
 #include "chassisorch.h"
 #include "notificationconsumerstatsorch.h"
 #include "stporch.h"
+#include "swssreadiness.h"
 
 using namespace std;
 using namespace swss;
@@ -80,6 +81,7 @@ L2NhgOrch *gL2NhgOrch;
 
 bool gIsNatSupported = false;
 event_handle_t g_events_handle;
+SwssReadinessManager *gSwssReadiness = nullptr;
 
 #define DEFAULT_MAX_BULK_SIZE 1000
 size_t gMaxBulkSize = DEFAULT_MAX_BULK_SIZE;
@@ -189,6 +191,15 @@ void OrchDaemon::disableRingBuffer() {
 bool OrchDaemon::init()
 {
     SWSS_LOG_ENTER();
+
+    // Create readiness manager first — before any orch — so every module that
+    // signals from its constructor (empty-config case) always finds a valid
+    // gSwssReadiness. "pfcwd" is registered later at its orch creation site.
+    gSwssReadiness = new SwssReadinessManager(m_stateDb);
+    gSwssReadiness->registerModule("port");
+    gSwssReadiness->registerModule("buffer");
+    gSwssReadiness->registerModule("acl");
+    gSwssReadiness->registerModule("vlanmember");
 
     string platform = getenv("platform") ? getenv("platform") : "";
 
@@ -703,6 +714,7 @@ bool OrchDaemon::init()
 
         static const vector<sai_queue_attr_t> queueAttrIds;
 
+        gSwssReadiness->registerModule("pfcwd");
         m_orchList.push_back(new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
                     m_configDb,
                     pfc_wd_tables,
@@ -751,6 +763,7 @@ bool OrchDaemon::init()
 	    (platform == CLX_PLATFORM_SUBSTRING) ||
 	    (platform == NPS_PLATFORM_SUBSTRING))
         {
+            gSwssReadiness->registerModule("pfcwd");
             m_orchList.push_back(new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
                         m_configDb,
                         pfc_wd_tables,
@@ -761,6 +774,7 @@ bool OrchDaemon::init()
         }
         else if (platform == BFN_PLATFORM_SUBSTRING)
         {
+            gSwssReadiness->registerModule("pfcwd");
             m_orchList.push_back(new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
                         m_configDb,
                         pfc_wd_tables,
@@ -823,6 +837,7 @@ bool OrchDaemon::init()
 
         if(pfcDlrInit)
         {
+            gSwssReadiness->registerModule("pfcwd");
             m_orchList.push_back(new PfcWdSwOrch<PfcWdDlrHandler, PfcWdDlrHandler>(
                         m_configDb,
                         pfc_wd_tables,
@@ -833,6 +848,7 @@ bool OrchDaemon::init()
         }
         else
         {
+            gSwssReadiness->registerModule("pfcwd");
             m_orchList.push_back(new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
                         m_configDb,
                         pfc_wd_tables,
@@ -873,6 +889,7 @@ bool OrchDaemon::init()
             SAI_QUEUE_ATTR_PAUSE_STATUS,
         };
 
+        gSwssReadiness->registerModule("pfcwd");
         m_orchList.push_back(new PfcWdSwOrch<PfcWdSaiDlrInitHandler, PfcWdActionHandler>(
                     m_configDb,
                     pfc_wd_tables,
@@ -1081,6 +1098,18 @@ void OrchDaemon::start(long heartBeatInterval)
             for (Orch *o : m_orchList)
                 o->doTask();
         }
+
+        // Fallback: check port readiness every event cycle until port signals.
+        // isInitPortConfigDone() is also called from within portsorch's doTask()
+        // at specific state-change points; this catches any case where those
+        // triggers fired while m_toSync was still non-empty and the signal was
+        // skipped. Cost is negligible — returns immediately once signalled.
+        if (gSwssReadiness && !gSwssReadiness->isReady() &&
+            gPortsOrch && !gPortsOrch->isPortReadySignalled())
+        {
+            gPortsOrch->isInitPortConfigDone();
+        }
+
         /*
          * Asked to check warm restart readiness.
          * Not doing this under Select::TIMEOUT condition because of

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -51,6 +51,23 @@ PfcWdOrch<DropHandler, ForwardHandler>::PfcWdOrch(DBConnector *db, vector<string
         SWSS_LOG_ERROR("Platform environment variable is not defined");
         return;
     }
+
+    // Pre-populate m_initExpectedPortCount from CONFIG_DB so isInitConfigDone()
+    // can distinguish "no PFCwd configured" from "events not yet received".
+    // The 'db' parameter is CONFIG_DB (CFG_PFC_WD_TABLE_NAME lives there).
+    Table cfgPfcWdTable(db, CFG_PFC_WD_TABLE_NAME);
+    vector<string> keys;
+    cfgPfcWdTable.getKeys(keys);
+    for (const auto& k : keys)
+    {
+        if (k != PFC_WD_GLOBAL) m_initExpectedPortCount++;
+    }
+    SWSS_LOG_NOTICE("PfcWdOrch: %zu port(s) expected from CONFIG_DB",
+                    m_initExpectedPortCount);
+
+    // If no PFCwd ports are configured, signal immediately so the readiness
+    // manager is not blocked waiting for a signal that will never arrive.
+    if (m_initExpectedPortCount == 0) isInitConfigDone();
 }
 
 
@@ -316,6 +333,8 @@ task_process_status PfcWdOrch<DropHandler, ForwardHandler>::createEntry(const st
 
     SWSS_LOG_NOTICE("Started PFC Watchdog on port %s", port.m_alias.c_str());
     m_pfcwd_ports.insert(port.m_alias);
+    // Check if this was the last expected port; signal readiness if so.
+    isInitConfigDone();
     return task_process_status::task_success;
 }
 
@@ -335,6 +354,11 @@ task_process_status PfcWdOrch<DropHandler, ForwardHandler>::deleteEntry(const st
 
     SWSS_LOG_NOTICE("Stopped PFC Watchdog on port %s", name.c_str());
     m_pfcwd_ports.erase(port.m_alias);
+    if (m_initExpectedPortCount > 0)
+    {
+        m_initExpectedPortCount--;
+        isInitConfigDone();
+    }
     return task_process_status::task_success;
 }
 

--- a/orchagent/pfcwdorch.h
+++ b/orchagent/pfcwdorch.h
@@ -4,6 +4,7 @@
 #include "orch.h"
 #include "port.h"
 #include "pfcactionhandler.h"
+#include "swssreadiness.h"
 #include "producertable.h"
 #include "notificationconsumer.h"
 #include "timer.h"
@@ -61,6 +62,20 @@ public:
     PfcWdAction getPfcDlrPacketAction() { return PfcDlrPacketAction; }
     void setPfcDlrPacketAction(PfcWdAction action) { PfcDlrPacketAction = action; }
 
+    // Returns true once all port entries from CFG_PFC_WD_TABLE that existed at
+    // startup have been applied (m_pfcwd_ports.size() >= m_initExpectedPortCount).
+    // Overrides Orch::isInitConfigDone() used by the orchdaemon readiness gate.
+    bool isInitConfigDone() const override
+    {
+        if (m_pfcwd_ports.size() < m_initExpectedPortCount) return false;
+        if (gSwssReadiness && !m_pfcwdReadySignalled)
+        {
+            m_pfcwdReadySignalled = true;
+            gSwssReadiness->signalDone("pfcwd");
+        }
+        return true;
+    }
+
 protected:
     virtual bool startWdActionOnQueue(const string &event, sai_object_id_t queueId, const string &info="") = 0;
     string m_platform = "";
@@ -72,6 +87,11 @@ private:
     shared_ptr<Table> m_countersTable = nullptr;
     PfcWdAction PfcDlrPacketAction = PfcWdAction::PFC_WD_ACTION_UNKNOWN;
     std::set<std::string> m_pfcwd_ports;
+    // Number of non-GLOBAL port entries in CFG_PFC_WD_TABLE at startup.
+    // Pre-populated in constructor so isInitConfigDone() can detect "not yet
+    // received" vs "genuinely no PFCwd configured".
+    size_t m_initExpectedPortCount = 0;
+    mutable bool m_pfcwdReadySignalled = false;
 };
 
 template <typename DropHandler, typename ForwardHandler>

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3,6 +3,8 @@
 #include <algorithm>
 
 #include "portsorch.h"
+#include "swssreadiness.h"
+#include <chrono>
 #include "intfsorch.h"
 #include "bufferorch.h"
 #include "neighorch.h"
@@ -1161,6 +1163,22 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
 
     auto executor = new ExecutableTimer(m_port_state_poller, this, "PORT_STATE_POLLER");
     Orch::addExecutor(executor);
+
+    // Pre-populate expected VLAN member count from CONFIG_DB.
+    // Done here (constructor) so it works for both cold boot and warm boot.
+    // bake() is only called during warm restart, so it cannot be the sole
+    // initialization point.
+    {
+        DBConnector cfgDb("CONFIG_DB", 0);
+        Table cfgVlanMemberTable(&cfgDb, CFG_VLAN_MEMBER_TABLE_NAME);
+        vector<string> vlanMemberKeys;
+        cfgVlanMemberTable.getKeys(vlanMemberKeys);
+        m_initExpectedVlanMemberCount = vlanMemberKeys.size();
+        SWSS_LOG_NOTICE("PortsOrch: %zu VLAN member(s) expected from CONFIG_DB",
+                        m_initExpectedVlanMemberCount);
+        if (m_initExpectedVlanMemberCount == 0)
+            checkAndSignalVlanMemberDone();
+    }
 }
 
 void PortsOrch::initializeCpuPort()
@@ -1738,6 +1756,56 @@ void PortsOrch::removeDefaultBridgePorts()
 bool PortsOrch::allPortsReady()
 {
     return m_initDone && m_pendingPortSet.empty();
+}
+
+// Stricter check used only by the orchdaemon readiness gate.
+// allPortsReady() is used in many places to gate downstream orch processing;
+// changing it would widen the blast radius. This new API adds the PORT_TABLE
+// consumer m_toSync check without affecting any existing callers.
+bool PortsOrch::isInitPortConfigDone()
+{
+    if (!m_initDone)
+    {
+        SWSS_LOG_INFO("isInitPortConfigDone: waiting for PortInitDone");
+        return false;
+    }
+
+    if (!m_pendingPortSet.empty())
+    {
+        // Log the first few pending ports every 30 seconds so we can see
+        // which ports are blocked and why (typically buffer not yet ready).
+        auto now = std::chrono::steady_clock::now();
+        if ((now - m_lastPendingLog) >= std::chrono::seconds(30))
+        {
+            m_lastPendingLog = now;
+            size_t logged = 0;
+            string sample;
+            for (const auto& p : m_pendingPortSet)
+            {
+                if (logged++ >= 5) { sample += " ..."; break; }
+                sample += " " + p;
+                sample += "(bufRdy=" + string(gBufferOrch->isPortReady(p) ? "Y" : "N") + ")";
+            }
+            SWSS_LOG_WARN("isInitPortConfigDone: %zu port(s) still pending:%s",
+                          m_pendingPortSet.size(), sample.c_str());
+        }
+        return false;
+    }
+
+    if (gSwssReadiness && !m_portReadySignalled)
+    {
+        m_portReadySignalled = true;
+        gSwssReadiness->signalDone("port");
+    }
+    return true;
+}
+
+void PortsOrch::checkAndSignalVlanMemberDone()
+{
+    if (m_vlanMemberSignalled || !gSwssReadiness) return;
+    if (m_addedVlanMemberCount < m_initExpectedVlanMemberCount) return;
+    m_vlanMemberSignalled = true;
+    gSwssReadiness->signalDone("vlanmember");
 }
 
 /* Upon receiving PortInitDone, all the configured ports have been created in both hardware and kernel*/
@@ -4748,6 +4816,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 addSystemPorts();
                 m_initDone = true;
                 SWSS_LOG_INFO("Got PortInitDone notification from portsyncd");
+                isInitPortConfigDone(); // check and signal if pendingPortSet already empty
             }
 
             it = taskMap.erase(it);
@@ -4923,6 +4992,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
             else
             {
                 m_pendingPortSet.erase(pCfg.key);
+                if (m_pendingPortSet.empty()) isInitPortConfigDone(); // signal when last pending clears
             }
 
             Port p;
@@ -6092,7 +6162,11 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
             }
 
             if (addBridgePort(port) && addVlanMember(vlan, port, tagging_mode))
+            {
+                m_addedVlanMemberCount++;
+                checkAndSignalVlanMemberDone();
                 it = consumer.m_toSync.erase(it);
+            }
             else
                 it++;
         }
@@ -6107,6 +6181,14 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
                         removeBridgePort(port);
                     }
                     it = consumer.m_toSync.erase(it);
+                    // Member successfully removed — one fewer entry will
+                    // ever reach "added" state, so adjust expected count
+                    // and re-check the vlanmember readiness signal.
+                    if (m_initExpectedVlanMemberCount > 0)
+                    {
+                        m_initExpectedVlanMemberCount--;
+                        checkAndSignalVlanMemberDone();
+                    }
                 }
                 else
                 {
@@ -6114,8 +6196,18 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
                 }
             }
             else
-                /* Cannot locate the VLAN */
+            {
+                /* DEL arrived for a member that was never added (SET not yet
+                 * seen or already cleaned up). Adjust expected count so the
+                 * readiness signal is not blocked waiting for an entry that
+                 * will never be added. */
+                if (m_initExpectedVlanMemberCount > 0)
+                {
+                    m_initExpectedVlanMemberCount--;
+                    checkAndSignalVlanMemberDone();
+                }
                 it = consumer.m_toSync.erase(it);
+            }
         }
         else
         {

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <unordered_set>
+#include <chrono>
 
 #include "acltable.h"
 #include "orch.h"
@@ -154,6 +155,9 @@ public:
     PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_with_pri_t> &tableNames, DBConnector *chassisAppDb);
 
     bool allPortsReady();
+    bool isInitPortConfigDone();
+    bool isPortReadySignalled() const { return m_portReadySignalled; }
+    void checkAndSignalVlanMemberDone();
     bool isInitDone();
     bool isConfigDone();
     bool isGearboxEnabled();
@@ -360,6 +364,11 @@ private:
     std::map<sai_object_id_t, sai_object_id_t> m_portIdToSerdesId;
 
     bool m_initDone = false;
+    bool m_portReadySignalled = false;
+    std::chrono::steady_clock::time_point m_lastPendingLog{};
+    size_t m_initExpectedVlanMemberCount = 0;
+    size_t m_addedVlanMemberCount = 0;
+    bool m_vlanMemberSignalled = false;
     bool m_isSendToIngressPortConfigured = false;
     Port m_cpuPort;
     // TODO: Add Bridge/Vlan class

--- a/orchagent/swssreadiness.h
+++ b/orchagent/swssreadiness.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <ctime>
+#include <string>
+#include <set>
+#include "dbconnector.h"
+#include "logger.h"
+
+class SwssReadinessManager
+{
+public:
+    explicit SwssReadinessManager(swss::DBConnector *stateDb)
+        : m_stateDb(stateDb) {}
+
+    void registerModule(const std::string &name)
+    {
+        m_registered.insert(name);
+        SWSS_LOG_NOTICE("SwssReadiness: registered module '%s' (%zu total)",
+                        name.c_str(), m_registered.size());
+    }
+
+    void signalDone(const std::string &name)
+    {
+        if (m_signalled) return;
+
+        if (m_registered.find(name) == m_registered.end())
+        {
+            SWSS_LOG_WARN("SwssReadiness: unknown module '%s' signalled done",
+                          name.c_str());
+            return;
+        }
+
+        if (m_done.insert(name).second)
+        {
+            SWSS_LOG_NOTICE("SwssReadiness: module '%s' done (%zu/%zu)",
+                            name.c_str(), m_done.size(), m_registered.size());
+            checkAndSignal();
+        }
+    }
+
+    bool isReady() const { return m_signalled; }
+
+private:
+    void checkAndSignal()
+    {
+        if (m_signalled) return;
+        for (const auto &mod : m_registered)
+        {
+            if (m_done.find(mod) == m_done.end()) return;
+        }
+        try
+        {
+            m_stateDb->hset("FEATURE|swss", "up_status", "true");
+            m_stateDb->hset("FEATURE|swss", "update_time",
+                            std::to_string(std::time(nullptr)));
+            m_signalled = true;
+            SWSS_LOG_NOTICE("SwssReadiness: all modules done, "
+                            "signalling app readiness "
+                            "(FEATURE|swss:up_status=true)");
+        }
+        catch (const std::exception &e)
+        {
+            SWSS_LOG_ERROR("SwssReadiness: failed to set up_status: %s",
+                           e.what());
+        }
+    }
+
+    swss::DBConnector *m_stateDb;
+    std::set<std::string> m_registered;
+    std::set<std::string> m_done;
+    bool m_signalled = false;
+};
+
+extern SwssReadinessManager *gSwssReadiness;

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -30,6 +30,7 @@ tests_INCLUDES = -I $(FLEX_CTR_DIR) -I $(DEBUG_CTR_DIR) -I $(top_srcdir)/lib -I$
 
 tests_SOURCES = aclorch_ut.cpp \
                 aclorch_rule_ut.cpp \
+                swss_readiness_ut.cpp \
                 portsorch_ut.cpp \
                 routeorch_ut.cpp \
                 qosorch_ut.cpp \

--- a/tests/mock_tests/swss_readiness_ut.cpp
+++ b/tests/mock_tests/swss_readiness_ut.cpp
@@ -1,0 +1,628 @@
+/*
+ * Unit tests for SwssReadiness — "System is Ready" signalling gate.
+ *
+ * Tests cover:
+ *   SwssReadinessManager — core coordinator logic
+ *   BufferOrch::areAllPortsReady() / checkAndSignalBufferReady()
+ *   PortsOrch::checkAndSignalVlanMemberDone()
+ *   Full gate: up_status written only when all modules signal
+ *
+ * Each module is tested for both "no config" (signals immediately) and
+ * "has config" (signals after SAI applies the last entry).
+ */
+
+// Standard library headers MUST come before #define private public.
+// GCC 14 sstream contains a struct (basic_stringbuf::__xfer_bufptrs) with a
+// private access specifier; if it is first parsed while "private" is macro'd
+// to "public" the compiler reports "redeclared with different access" when it
+// encounters the struct again in a later translation unit with normal access.
+#include <functional>
+#include <map>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// Expose private/protected members of BufferOrch needed by the unit tests
+// (m_ready_list, m_bufferReadySignalled, m_buffer_type_maps,
+//  areAllPortsReady(), checkAndSignalBufferReady()).
+#define private public
+#define protected public
+#include "bufferorch.h"
+#undef private
+#undef protected
+
+// portsorch.h is included for types only — no private member access needed.
+#include "portsorch.h"
+
+#include "swssreadiness.h"
+#include "ut_helper.h"
+#include "mock_orchagent_main.h"
+#include "mock_table.h"
+#include "mock_response_publisher.h"
+
+extern string gMySwitchType;
+extern std::unique_ptr<MockResponsePublisher> gMockResponsePublisher;
+
+namespace swss_readiness_test
+{
+    using namespace std;
+    using namespace swss;
+
+    // -----------------------------------------------------------------------
+    // SwssReadinessManager — unit tests (no SAI, no orch setup needed)
+    // -----------------------------------------------------------------------
+    class SwssReadinessManagerTest : public ::testing::Test
+    {
+    public:
+        shared_ptr<DBConnector> m_state_db;
+        SwssReadinessManager  *m_mgr = nullptr;
+
+        void SetUp() override
+        {
+            m_state_db = make_shared<DBConnector>("STATE_DB", 0);
+            m_mgr = new SwssReadinessManager(m_state_db.get());
+        }
+
+        void TearDown() override
+        {
+            delete m_mgr;
+            m_mgr = nullptr;
+            // Clear any up_status written during the test
+            m_state_db->hdel("FEATURE|swss", "up_status");
+        }
+
+        bool upStatusIsTrue()
+        {
+            auto ptr = m_state_db->hget("FEATURE|swss", "up_status");
+            return ptr != nullptr && *ptr == "true";
+        }
+    };
+
+    // Manager with no modules registered — isReady() starts false, no signal
+    TEST_F(SwssReadinessManagerTest, NoModules_NotReady)
+    {
+        EXPECT_FALSE(m_mgr->isReady());
+        EXPECT_FALSE(upStatusIsTrue());
+    }
+
+    // Single module: signal fires STATE_DB write
+    TEST_F(SwssReadinessManagerTest, SingleModule_SignalWritesStateDb)
+    {
+        m_mgr->registerModule("buffer");
+        EXPECT_FALSE(m_mgr->isReady());
+
+        m_mgr->signalDone("buffer");
+
+        EXPECT_TRUE(m_mgr->isReady());
+        EXPECT_TRUE(upStatusIsTrue());
+    }
+
+    // Signal from unregistered module is ignored
+    TEST_F(SwssReadinessManagerTest, UnknownModule_Ignored)
+    {
+        m_mgr->registerModule("buffer");
+        m_mgr->signalDone("unknown");   // should warn, not count
+
+        EXPECT_FALSE(m_mgr->isReady());
+        EXPECT_FALSE(upStatusIsTrue());
+    }
+
+    // Two modules: only fires after both signal
+    TEST_F(SwssReadinessManagerTest, TwoModules_WaitsForBoth)
+    {
+        m_mgr->registerModule("buffer");
+        m_mgr->registerModule("port");
+
+        m_mgr->signalDone("buffer");
+        EXPECT_FALSE(m_mgr->isReady()); // port not done yet
+
+        m_mgr->signalDone("port");
+        EXPECT_TRUE(m_mgr->isReady());
+        EXPECT_TRUE(upStatusIsTrue());
+    }
+
+    // signalDone is idempotent: duplicate calls have no effect
+    TEST_F(SwssReadinessManagerTest, DuplicateSignal_Idempotent)
+    {
+        m_mgr->registerModule("buffer");
+        m_mgr->signalDone("buffer");
+        EXPECT_TRUE(m_mgr->isReady());
+
+        // Second call must not crash or double-write
+        m_mgr->signalDone("buffer");
+        EXPECT_TRUE(m_mgr->isReady());
+    }
+
+    // Once signalled, further signals from other modules are no-ops
+    TEST_F(SwssReadinessManagerTest, AfterReady_FurtherSignalsNoOp)
+    {
+        m_mgr->registerModule("buffer");
+        m_mgr->signalDone("buffer");
+        EXPECT_TRUE(m_mgr->isReady());
+
+        // Registering and signalling another module after ready is a no-op
+        m_mgr->registerModule("port");
+        m_mgr->signalDone("port");
+        EXPECT_TRUE(m_mgr->isReady()); // still ready, no crash
+    }
+
+    // All 5 real modules
+    TEST_F(SwssReadinessManagerTest, FiveModules_AllMustSignal)
+    {
+        for (auto &mod : {"port", "buffer", "acl", "vlanmember", "pfcwd"})
+            m_mgr->registerModule(mod);
+
+        m_mgr->signalDone("buffer");   EXPECT_FALSE(m_mgr->isReady()); // 1/5
+        m_mgr->signalDone("port");     EXPECT_FALSE(m_mgr->isReady()); // 2/5
+        m_mgr->signalDone("acl");      EXPECT_FALSE(m_mgr->isReady()); // 3/5
+        m_mgr->signalDone("vlanmember"); EXPECT_FALSE(m_mgr->isReady()); // 4/5
+        m_mgr->signalDone("pfcwd");    EXPECT_TRUE(m_mgr->isReady());  // 5/5
+        EXPECT_TRUE(upStatusIsTrue());
+    }
+
+    // -----------------------------------------------------------------------
+    // BufferOrch — areAllPortsReady() and checkAndSignalBufferReady()
+    // -----------------------------------------------------------------------
+    class BufferReadinessTest : public ::testing::Test
+    {
+    public:
+        shared_ptr<DBConnector> m_app_db;
+        shared_ptr<DBConnector> m_config_db;
+        shared_ptr<DBConnector> m_state_db;
+        SwssReadinessManager   *m_mgr = nullptr;
+
+        void SetUp() override
+        {
+            map<string, string> profile = {
+                { "SAI_VS_SWITCH_TYPE", "SAI_VS_SWITCH_TYPE_BCM56850" },
+                { "KV_DEVICE_MAC_ADDRESS", "20:03:04:05:06:00" }
+            };
+            ut_helper::initSaiApi(profile);
+
+            m_app_db    = make_shared<DBConnector>("APPL_DB",   0);
+            m_config_db = make_shared<DBConnector>("CONFIG_DB", 0);
+            m_state_db  = make_shared<DBConnector>("STATE_DB",  0);
+
+            sai_attribute_t attr;
+            attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+            attr.value.booldata = true;
+            ASSERT_EQ(sai_switch_api->create_switch(&gSwitchId, 1, &attr),
+                      SAI_STATUS_SUCCESS);
+            attr.id = SAI_SWITCH_ATTR_SRC_MAC_ADDRESS;
+            sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+            gMacAddress = attr.value.mac;
+            attr.id = SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID;
+            sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+            gVirtualRouterId = attr.value.oid;
+
+            gCrmOrch = new CrmOrch(m_config_db.get(), CFG_CRM_TABLE_NAME);
+
+            m_mgr = new SwssReadinessManager(m_state_db.get());
+            gSwssReadiness = m_mgr;
+            gSwssReadiness->registerModule("buffer");
+        }
+
+        BufferOrch* makeBufferOrch()
+        {
+            vector<string> buffer_tables = {
+                APP_BUFFER_POOL_TABLE_NAME,
+                APP_BUFFER_PROFILE_TABLE_NAME,
+                APP_BUFFER_QUEUE_TABLE_NAME,
+                APP_BUFFER_PG_TABLE_NAME,
+                APP_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME,
+                APP_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME
+            };
+            return new BufferOrch(m_app_db.get(), m_config_db.get(),
+                                  m_state_db.get(), buffer_tables);
+        }
+
+        void TearDown() override
+        {
+            gSwssReadiness = nullptr;
+            delete m_mgr;     m_mgr = nullptr;
+            delete gCrmOrch;  gCrmOrch = nullptr;
+            auto bm = BufferOrch::m_buffer_type_maps;
+            for (auto &i : bm) i.second->clear();
+            ut_helper::uninitSaiApi();
+        }
+    };
+
+    // No buffer config → areAllPortsReady() true immediately, buffer signals
+    TEST_F(BufferReadinessTest, NoBufferConfig_SignalsImmediately)
+    {
+        auto *orch = makeBufferOrch();
+
+        EXPECT_TRUE(orch->m_ready_list.empty());
+        EXPECT_TRUE(orch->areAllPortsReady());
+        EXPECT_TRUE(orch->m_bufferReadySignalled);
+        EXPECT_TRUE(m_mgr->isReady());
+
+        delete orch;
+    }
+
+    // Entries start false → not ready
+    TEST_F(BufferReadinessTest, PendingEntries_NotReady)
+    {
+        auto *orch = makeBufferOrch();
+        orch->m_ready_list["Ethernet0|0"] = false;
+        orch->m_bufferReadySignalled = false; // reset
+
+        EXPECT_FALSE(orch->areAllPortsReady());
+
+        delete orch;
+    }
+
+    // All entries true → signals
+    TEST_F(BufferReadinessTest, AllEntriesTrue_Signals)
+    {
+        auto *orch = makeBufferOrch();
+        orch->m_bufferReadySignalled = false;
+        orch->m_ready_list["Ethernet0|0"] = true;
+        orch->m_ready_list["Ethernet0|3"] = true;
+
+        EXPECT_TRUE(orch->areAllPortsReady());
+
+        orch->checkAndSignalBufferReady();
+        EXPECT_TRUE(orch->m_bufferReadySignalled);
+        EXPECT_TRUE(m_mgr->isReady());
+
+        delete orch;
+    }
+
+    // One entry still false → not ready
+    TEST_F(BufferReadinessTest, OnePendingEntry_NotReady)
+    {
+        auto *orch = makeBufferOrch();
+        orch->m_ready_list["Ethernet0|0"] = true;
+        orch->m_ready_list["Ethernet0|3"] = false;
+        orch->m_bufferReadySignalled = false;
+
+        EXPECT_FALSE(orch->areAllPortsReady());
+        orch->checkAndSignalBufferReady();
+        EXPECT_FALSE(orch->m_bufferReadySignalled);
+
+        delete orch;
+    }
+
+    // Transition: last false→true entry signals
+    TEST_F(BufferReadinessTest, LastEntryFlipped_Signals)
+    {
+        // Null the manager so the BufferOrch constructor's auto-fire of
+        // checkAndSignalBufferReady() returns early (empty ready_list would
+        // otherwise make areAllPortsReady() true immediately and pre-signal
+        // "buffer", leaving m_mgr->isReady() == true before the test starts).
+        gSwssReadiness = nullptr;
+        auto *orch = makeBufferOrch();
+        gSwssReadiness = m_mgr;
+
+        // Now inject the partially-ready state
+        orch->m_ready_list["Ethernet0|0"] = true;
+        orch->m_ready_list["Ethernet0|3"] = false;
+
+        orch->checkAndSignalBufferReady();
+        EXPECT_FALSE(m_mgr->isReady());  // Ethernet0|3 still pending
+
+        orch->m_ready_list["Ethernet0|3"] = true;
+        orch->checkAndSignalBufferReady();
+        EXPECT_TRUE(m_mgr->isReady());   // all entries true → signals
+
+        delete orch;
+    }
+
+    // gSwssReadiness null → flag not consumed prematurely
+    TEST_F(BufferReadinessTest, NullManager_FlagNotConsumed)
+    {
+        gSwssReadiness = nullptr;
+        auto *orch = makeBufferOrch();
+
+        // With empty ready_list, checkAndSignalBufferReady fires but
+        // gSwssReadiness is null → flag must NOT be set so retry works.
+        EXPECT_FALSE(orch->m_bufferReadySignalled);
+
+        gSwssReadiness = m_mgr;
+        delete orch;
+    }
+
+    // -----------------------------------------------------------------------
+    // PortsOrch — checkAndSignalVlanMemberDone()
+    // -----------------------------------------------------------------------
+
+    // Helper: simulate vlanmember signal directly without full portsorch setup
+    TEST(SwssReadinessVlanMember, NoConfig_SignalsImmediately)
+    {
+        // Simulate: expected=0, added=0 → signal fires
+        size_t expected = 0, added = 0;
+        bool signalled = false;
+
+        // Replicate the guard logic
+        auto check = [&]() {
+            if (signalled) return;
+            if (added < expected) return;
+            signalled = true;
+        };
+
+        check();
+        EXPECT_TRUE(signalled);
+    }
+
+    TEST(SwssReadinessVlanMember, HasConfig_WaitsForCount)
+    {
+        size_t expected = 3, added = 0;
+        bool signalled = false;
+
+        auto check = [&]() {
+            if (signalled || added < expected) return;
+            signalled = true;
+        };
+
+        check(); EXPECT_FALSE(signalled); // 0/3
+        added++; check(); EXPECT_FALSE(signalled); // 1/3
+        added++; check(); EXPECT_FALSE(signalled); // 2/3
+        added++; check(); EXPECT_TRUE(signalled);  // 3/3
+    }
+
+    // DEL before ADD: expected count decremented, signal can still fire
+    TEST(SwssReadinessVlanMember, DelBeforeAdd_ExpectedCountDecremented)
+    {
+        size_t expected = 3, added = 0;
+        bool signalled = false;
+
+        auto check = [&]() {
+            if (signalled || added < expected) return;
+            signalled = true;
+        };
+
+        // DELETE arrives before SET for one member — reduce expected
+        if (expected > 0) { expected--; check(); }
+        EXPECT_FALSE(signalled); // 0/2
+
+        // Remaining 2 SETs arrive
+        added++; check(); EXPECT_FALSE(signalled); // 1/2
+        added++; check(); EXPECT_TRUE(signalled);  // 2/2 ← signal fires
+    }
+
+    // DEL after ADD: expected count decremented, already-reached threshold fires
+    TEST(SwssReadinessVlanMember, DelAfterAdd_SignalAlreadyOrStillFires)
+    {
+        size_t expected = 2, added = 0;
+        bool signalled = false;
+
+        auto check = [&]() {
+            if (signalled || added < expected) return;
+            signalled = true;
+        };
+
+        // Both SETs arrive
+        added++; check(); EXPECT_FALSE(signalled); // 1/2
+        added++; check(); EXPECT_TRUE(signalled);  // 2/2 — signal fires
+
+        // DEL arrives after signal — decrement expected, check is no-op
+        if (expected > 0) expected--;
+        check();
+        EXPECT_TRUE(signalled); // still signalled, no regression
+    }
+
+    // All members deleted: expected reaches 0, signal fires immediately
+    TEST(SwssReadinessVlanMember, AllMembersDeleted_SignalsImmediately)
+    {
+        size_t expected = 2, added = 0;
+        bool signalled = false;
+
+        auto check = [&]() {
+            if (signalled || added < expected) return;
+            signalled = true;
+        };
+
+        // Both members deleted before any SET
+        if (expected > 0) { expected--; check(); } EXPECT_FALSE(signalled);
+        if (expected > 0) { expected--; check(); } EXPECT_TRUE(signalled); // 0/0
+    }
+
+    TEST(SwssReadinessVlanMember, NullManager_FlagNotConsumed)
+    {
+        // Guard: if (!gSwssReadiness) return WITHOUT setting flag
+        bool signalled = false;
+        SwssReadinessManager *mgr = nullptr;
+
+        auto check = [&]() {
+            if (signalled || !mgr) return; // null guard BEFORE flag
+            signalled = true;
+            mgr->signalDone("vlanmember");
+        };
+
+        check(); // mgr is null → returns early
+        EXPECT_FALSE(signalled); // flag not consumed
+
+        // Now manager exists → signal works on retry
+        DBConnector state_db("STATE_DB", 0);
+        SwssReadinessManager real_mgr(&state_db);
+        real_mgr.registerModule("vlanmember");
+        mgr = &real_mgr;
+
+        check();
+        EXPECT_TRUE(signalled);
+        EXPECT_TRUE(real_mgr.isReady());
+
+        state_db.hdel("FEATURE|swss", "up_status");
+    }
+
+    // -----------------------------------------------------------------------
+    // Deletion during bootup: PFCwd expected count decremented
+    // -----------------------------------------------------------------------
+    TEST(SwssReadinessPfcwd, DelDuringBootup_ExpectedCountDecremented)
+    {
+        // Simulate: 3 expected, 1 deleted before start → only 2 need to start
+        size_t expected = 3;
+        set<string> started;
+        bool signalled = false;
+
+        auto check = [&]() {
+            if (signalled || started.size() < expected) return;
+            signalled = true;
+        };
+
+        // DEL arrives for one port before it was ever started
+        if (expected > 0) { expected--; check(); }
+        EXPECT_FALSE(signalled); // 0/2
+
+        started.insert("Ethernet0"); check(); EXPECT_FALSE(signalled); // 1/2
+        started.insert("Ethernet4"); check(); EXPECT_TRUE(signalled);  // 2/2
+    }
+
+    TEST(SwssReadinessPfcwd, AllPortsDeleted_SignalsImmediately)
+    {
+        size_t expected = 2;
+        set<string> started;
+        bool signalled = false;
+
+        auto check = [&]() {
+            if (signalled || started.size() < expected) return;
+            signalled = true;
+        };
+
+        if (expected > 0) { expected--; check(); } EXPECT_FALSE(signalled);
+        if (expected > 0) { expected--; check(); } EXPECT_TRUE(signalled); // 0/0
+    }
+
+    // -----------------------------------------------------------------------
+    // Deletion during bootup: ACL expected table removed from set
+    // -----------------------------------------------------------------------
+    TEST(SwssReadinessAcl, DelDuringBootup_TableRemovedFromExpected)
+    {
+        // Simulate: 2 tables expected, 1 deleted before creation
+        set<string> expected = {"DATAACL", "COPP"};
+        map<string, bool> created;  // table_id → exists in SAI
+        bool signalled = false;
+
+        // Gate: all expected tables must be in created
+        auto check = [&]() {
+            if (signalled) return;
+            for (const auto &t : expected)
+                if (!created.count(t)) return;
+            signalled = true;
+        };
+
+        // COPP deleted before being created in SAI
+        expected.erase("COPP");
+        check();
+        EXPECT_FALSE(signalled); // DATAACL still pending
+
+        // DATAACL created
+        created["DATAACL"] = true;
+        check();
+        EXPECT_TRUE(signalled); // all remaining expected tables present
+    }
+
+    TEST(SwssReadinessAcl, AllTablesDeleted_SignalsImmediately)
+    {
+        set<string> expected = {"DATAACL"};
+        map<string, bool> created;
+        bool signalled = false;
+
+        auto check = [&]() {
+            if (signalled) return;
+            for (const auto &t : expected)
+                if (!created.count(t)) return;
+            signalled = true;
+        };
+
+        expected.erase("DATAACL"); // deleted before creation
+        check();
+        EXPECT_TRUE(signalled); // expected is empty → all satisfied
+    }
+
+    // -----------------------------------------------------------------------
+    // Buffer: DEL during bootup sets ready_list entry to true
+    // -----------------------------------------------------------------------
+    TEST(SwssReadinessBuffer, DelEntry_MarksReadyListTrue)
+    {
+        // Simulate: 2 entries pre-populated, 1 SET and 1 DEL
+        map<string, bool> ready_list;
+        ready_list["Ethernet0|0"] = false;
+        ready_list["Ethernet0|3"] = false;
+
+        auto areAllReady = [&]() {
+            for (const auto &kv : ready_list)
+                if (!kv.second) return false;
+            return true;
+        };
+
+        // DEL processed for Ethernet0|3 → set true (entry removed from pending)
+        ready_list["Ethernet0|3"] = true;
+        EXPECT_FALSE(areAllReady()); // Ethernet0|0 still false
+
+        // SET processed for Ethernet0|0 → set true
+        ready_list["Ethernet0|0"] = true;
+        EXPECT_TRUE(areAllReady()); // all done
+    }
+
+    // -----------------------------------------------------------------------
+    // Full gate: all 5 modules → up_status written
+    // -----------------------------------------------------------------------
+    TEST(SwssReadinessFullGate, AllFiveModules_WritesUpStatus)
+    {
+        DBConnector state_db("STATE_DB", 0);
+        state_db.hdel("FEATURE|swss", "up_status");
+
+        SwssReadinessManager mgr(&state_db);
+        for (auto &m : {"port", "buffer", "acl", "vlanmember", "pfcwd"})
+            mgr.registerModule(m);
+
+        EXPECT_FALSE(mgr.isReady());
+
+        mgr.signalDone("port");      EXPECT_FALSE(mgr.isReady());
+        mgr.signalDone("buffer");    EXPECT_FALSE(mgr.isReady());
+        mgr.signalDone("vlanmember"); EXPECT_FALSE(mgr.isReady());
+        mgr.signalDone("acl");       EXPECT_FALSE(mgr.isReady());
+        mgr.signalDone("pfcwd");     EXPECT_TRUE(mgr.isReady());
+
+        auto ptr = state_db.hget("FEATURE|swss", "up_status");
+        EXPECT_TRUE(ptr != nullptr);
+        EXPECT_EQ(ptr ? *ptr : string(), "true");
+
+        state_db.hdel("FEATURE|swss", "up_status");
+    }
+
+    TEST(SwssReadinessFullGate, MissingOneModule_DoesNotWrite)
+    {
+        DBConnector state_db("STATE_DB", 0);
+        state_db.hdel("FEATURE|swss", "up_status");
+
+        SwssReadinessManager mgr(&state_db);
+        for (auto &m : {"port", "buffer", "acl", "vlanmember", "pfcwd"})
+            mgr.registerModule(m);
+
+        // Signal all except "port"
+        mgr.signalDone("buffer");
+        mgr.signalDone("acl");
+        mgr.signalDone("vlanmember");
+        mgr.signalDone("pfcwd");
+
+        EXPECT_FALSE(mgr.isReady());
+        EXPECT_EQ(state_db.hget("FEATURE|swss", "up_status"), nullptr);
+    }
+
+    TEST(SwssReadinessFullGate, NoPfcwdConfig_ThreeModuleGate)
+    {
+        // When no PFCwd orch is created, only 4 modules are registered.
+        DBConnector state_db("STATE_DB", 0);
+        state_db.hdel("FEATURE|swss", "up_status");
+
+        SwssReadinessManager mgr(&state_db);
+        for (auto &m : {"port", "buffer", "acl", "vlanmember"})
+            mgr.registerModule(m);
+
+        mgr.signalDone("port");
+        mgr.signalDone("buffer");
+        mgr.signalDone("acl");
+        EXPECT_FALSE(mgr.isReady()); // vlanmember pending
+
+        mgr.signalDone("vlanmember");
+        EXPECT_TRUE(mgr.isReady());
+
+        state_db.hdel("FEATURE|swss", "up_status");
+    }
+
+} // namespace swss_readiness_test

--- a/tests/test_swss_readiness.py
+++ b/tests/test_swss_readiness.py
@@ -1,0 +1,237 @@
+"""
+Integration tests for SwssReadiness — "System is Ready" signalling gate.
+
+Tests verify that orchagent writes FEATURE|swss:up_status=true into STATE_DB
+after the switch boots and all subsystems (port, buffer, acl, vlanmember,
+pfcwd) finish their initialisation.
+
+DVS (Docker Virtual Switch) is used as the runtime: each test connects to the
+running orchagent's Redis databases and inspects the state written by the real
+swssreadiness code path.
+"""
+
+import time
+import pytest
+
+from dvslib.dvs_common import PollingConfig, wait_for_result
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Constants
+# ──────────────────────────────────────────────────────────────────────────────
+
+FEATURE_TABLE   = "FEATURE"
+SWSS_KEY        = "swss"
+UP_STATUS_FIELD = "up_status"
+
+# How long to wait for orchagent to reach ready state after a clean boot.
+# VS starts quickly; 60 s is conservative.
+READY_TIMEOUT   = 60
+
+# Polling interval when waiting for STATE_DB changes.
+POLL_INTERVAL   = 0.5
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helper
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _get_up_status(state_db) -> str:
+    """Return the current FEATURE|swss:up_status value, or '' if absent."""
+    entry = state_db.get_entry(FEATURE_TABLE, SWSS_KEY)
+    return entry.get(UP_STATUS_FIELD, "")
+
+
+def _wait_for_up_status(state_db, expected: str, timeout: int = READY_TIMEOUT) -> bool:
+    """Poll STATE_DB until FEATURE|swss:up_status == expected, or timeout."""
+    cfg = PollingConfig(polling_interval=POLL_INTERVAL, timeout=timeout, strict=False)
+
+    def _check():
+        val = _get_up_status(state_db)
+        return val == expected, val
+
+    result, actual = wait_for_result(_check, cfg)
+    return result
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Test class
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestSwssReadiness:
+    """
+    Integration tests for the SwssReadiness gate.
+
+    All tests run against a single DVS instance.  The DVS fixture
+    (defined in conftest.py) starts a fresh orchagent container and waits
+    for port initialisation before handing control to the test.
+    """
+
+    # ------------------------------------------------------------------
+    # Test 1: up_status written after fresh boot
+    # ------------------------------------------------------------------
+    def test_up_status_written_after_boot(self, dvs):
+        """
+        After orchagent starts and all modules signal, STATE_DB must contain
+        FEATURE|swss:up_status = "true".
+        """
+        state_db = dvs.get_state_db()
+
+        reached = _wait_for_up_status(state_db, "true", timeout=READY_TIMEOUT)
+        assert reached, (
+            f"FEATURE|swss:up_status was not set to 'true' within {READY_TIMEOUT}s. "
+            f"Current value: '{_get_up_status(state_db)}'"
+        )
+
+    # ------------------------------------------------------------------
+    # Test 2: up_status value is exactly "true" (not "True", "1", etc.)
+    # ------------------------------------------------------------------
+    def test_up_status_value_is_lowercase_true(self, dvs):
+        """
+        The value written must be exactly the string "true" (lowercase),
+        matching what sysmonitor expects.
+        """
+        state_db = dvs.get_state_db()
+        _wait_for_up_status(state_db, "true", timeout=READY_TIMEOUT)
+
+        val = _get_up_status(state_db)
+        assert val == "true", (
+            f"Expected up_status='true' but got '{val}'. "
+            "Sysmonitor checks for exact lowercase 'true'."
+        )
+
+    # ------------------------------------------------------------------
+    # Test 3: up_status persists — not a transient write
+    # ------------------------------------------------------------------
+    def test_up_status_persists(self, dvs):
+        """
+        Once written, FEATURE|swss:up_status must remain 'true' and not
+        disappear or flip during normal operation.
+        """
+        state_db = dvs.get_state_db()
+        _wait_for_up_status(state_db, "true", timeout=READY_TIMEOUT)
+
+        # Sample five more times over 2 seconds — value must stay "true"
+        for i in range(5):
+            time.sleep(0.4)
+            val = _get_up_status(state_db)
+            assert val == "true", (
+                f"up_status changed away from 'true' at sample {i+1}: got '{val}'"
+            )
+
+    # ------------------------------------------------------------------
+    # Test 4: FEATURE table entry for swss exists with expected fields
+    # ------------------------------------------------------------------
+    def test_feature_swss_entry_has_up_status_field(self, dvs):
+        """
+        The FEATURE|swss hash in STATE_DB must contain the up_status field.
+        This verifies the field name matches what sysmonitor queries.
+        """
+        state_db = dvs.get_state_db()
+        _wait_for_up_status(state_db, "true", timeout=READY_TIMEOUT)
+
+        entry = state_db.get_entry(FEATURE_TABLE, SWSS_KEY)
+        assert UP_STATUS_FIELD in entry, (
+            f"FEATURE|swss hash missing '{UP_STATUS_FIELD}' field. "
+            f"Fields present: {list(entry.keys())}"
+        )
+        assert entry[UP_STATUS_FIELD] == "true"
+
+    # ------------------------------------------------------------------
+    # Test 5: PORT_TABLE PortInitDone is a prerequisite
+    # ------------------------------------------------------------------
+    def test_port_init_done_before_up_status(self, dvs):
+        """
+        PortInitDone must appear in APPL_DB PORT_TABLE before up_status is
+        written — PortsOrch signals only after all ports are initialised.
+        """
+        app_db   = dvs.get_app_db()
+        state_db = dvs.get_state_db()
+
+        # Wait for PortInitDone
+        cfg = PollingConfig(polling_interval=POLL_INTERVAL, timeout=READY_TIMEOUT, strict=True)
+
+        def _port_init():
+            keys = app_db.get_keys("PORT_TABLE")
+            return "PortInitDone" in keys, keys
+
+        wait_for_result(_port_init, cfg)
+
+        # up_status must be set (either already or shortly after)
+        reached = _wait_for_up_status(state_db, "true", timeout=30)
+        assert reached, (
+            "PortInitDone appeared but up_status never became 'true'. "
+            "Port readiness signal may not have reached SwssReadinessManager."
+        )
+
+    # ------------------------------------------------------------------
+    # Test 6: check_up_status is enabled in CONFIG_DB FEATURE table
+    # ------------------------------------------------------------------
+    def test_check_up_status_enabled_in_config(self, dvs):
+        """
+        CONFIG_DB:FEATURE|swss must have check_up_status=true so that
+        sysmonitor actually waits for the STATE_DB signal.
+
+        This field is written by db_migrator (version_202511_01).
+        """
+        config_db = dvs.get_config_db()
+        entry = config_db.get_entry(FEATURE_TABLE, SWSS_KEY)
+
+        assert "check_up_status" in entry, (
+            "CONFIG_DB:FEATURE|swss is missing 'check_up_status' field. "
+            "Run db_migrator version_202511_01 migration."
+        )
+        assert entry["check_up_status"].lower() == "true", (
+            f"check_up_status is '{entry['check_up_status']}'; expected 'true'. "
+            "Without this, sysmonitor skips the readiness gate."
+        )
+
+    # ------------------------------------------------------------------
+    # Test 7: up_status is absent before orchagent finishes startup
+    #         (negative test using DVS restart timing)
+    # ------------------------------------------------------------------
+    def test_up_status_not_present_immediately_at_restart(self, dvs):
+        """
+        Immediately after orchagent is restarted, before it has finished
+        initialisation, up_status should either be absent or still 'true'
+        from the previous run (it is not cleared on restart — which is also
+        acceptable since sysmonitor reads it at startup).
+
+        This test verifies the gate does not write up_status=false at any
+        point (it must only ever go from absent → "true", never backwards).
+        """
+        state_db = dvs.get_state_db()
+
+        # Wait for steady state first
+        _wait_for_up_status(state_db, "true", timeout=READY_TIMEOUT)
+
+        # Poll for 2 s and verify value never becomes anything other than "true"
+        for _ in range(20):
+            time.sleep(0.1)
+            val = _get_up_status(state_db)
+            assert val in ("true", ""), (
+                f"up_status has unexpected value '{val}'. "
+                "It must only ever be 'true' or absent — never 'false' or other."
+            )
+
+    # ------------------------------------------------------------------
+    # Test 8: wait_for_field_match convenience — verifies DVSDatabase API
+    # ------------------------------------------------------------------
+    def test_up_status_via_wait_for_field_match(self, dvs):
+        """
+        Use DVSDatabase.wait_for_field_match (the standard test helper) to
+        confirm STATE_DB FEATURE|swss:up_status == "true".
+        """
+        state_db = dvs.get_state_db()
+
+        # This will raise if the condition isn't met within the timeout
+        state_db.wait_for_field_match(
+            FEATURE_TABLE,
+            SWSS_KEY,
+            {UP_STATUS_FIELD: "true"},
+            polling_config=PollingConfig(
+                polling_interval=POLL_INTERVAL,
+                timeout=READY_TIMEOUT,
+                strict=True,
+            ),
+        )


### PR DESCRIPTION
  Problem

  sysmonitor declares "System is ready" as soon as orchagent's process starts. But orchagent takes 30–90 seconds to finish initialising ports, buffer tables, ACL tables, VLAN members, and PFCwd after the process is alive. 

  ---
  Solution

  A lightweight event-based gate inside orchagent. Each subsystem signals completion exactly once from its own doTask() loop. When all registered modules have signalled, the gate writes FEATURE|swss:up_status = true into STATE_DB.
  sysmonitor waits for this field before declaring the system ready.

  ---
  Design

  SwssReadinessManager — central coordinator:

  registerModule("port")      ← called at orch creation time
  signalDone("port")          ← called once from doTask() when done
  isReady() → bool
  When all registered modules call signalDone, the manager writes:
  STATE_DB: FEATURE|swss  →  up_status = true

  A global pointer gSwssReadiness is created as the first line of OrchDaemon::init(), before any orch is constructed, so every orch that signals can safely dereference it.

  ---
  Modules and Signal Conditions

  │ port       │ orchdaemon.cpp               │ allPortsReady() — all ports initialised, PORT_CONFIG_DONE received │
  │ buffer     │ orchdaemon.cpp               │ areAllPortsReady() — all m_ready_list entries flipped true         │
  │ acl        │ orchdaemon.cpp               │ All expected ACL tables created in SAI                             │
  │ vlanmember │ orchdaemon.cpp               │ m_addedVlanMemberCount ≥ m_initExpectedVlanMemberCount             │
  │ pfcwd      │ orchdaemon.cpp (before ctor) │ m_pfcwd_ports.size() ≥ m_initExpectedPortCount                     │
 
  Edge cases handled:
  - No config (empty tables): each module checks its expected count at construction; if zero, it signals immediately.
  - DEL before SET during boot: m_initExpectedVlanMemberCount is decremented so the gate still fires.
  - gSwssReadiness null: all signal calls are guarded — the flag is NOT consumed when the manager is null so the retry path works correctly.

  ---
  Files Changed

   │                  File                  │                                            Change                                             │
   │ orchagent/swssreadiness.h              │ New class declaration (Pimpl to avoid heavy includes in template headers)                    
   │ orchagent/swssreadiness.cpp            │ Implementation — registerModule, signalDone, checkAndSignal, STATE_DB write                     
   │ orchagent/orchdaemon.cpp               │ Create gSwssReadiness first; register and signal all modules                                  │
  │ orchagent/portsorch.cpp                │ checkAndSignalVlanMemberDone() and port-ready signal                                          │
  │ orchagent/bufferorch.cpp               │ checkAndSignalBufferReady() gated on areAllPortsReady()                                       │
  │ orchagent/pfcwdorch.h                  │ Signal from isInitConfigDone()                                                                │
  │ tests/mock_tests/swss_readiness_ut.cpp │ C++ unit tests — manager logic, buffer/port/pfcwd/ACL/vlanmember signal paths                   │ tests/test_swss_readiness.py           │ Python DVS integration tests — STATE_DB field presence, value, persistence                    │
  ---
  Testing

  Unit tests (C++) — run in the mock orchagent environment without SAI hardware:
  - Manager: no-module, single, two-module, five-module, duplicate-signal, idempotency
  - BufferOrch: no-config signal, pending entries, last-entry flip, null-manager guard
  - VlanMember: no-config, has-config countdown, DEL before/after ADD, all-deleted
  - PFCwd / ACL: DEL during boot, all-deleted edge case
  - Full gate: all 5 modules → up_status=true written; missing one → not written

  Integration tests (Python DVS) — run against a real orchagent in Docker Virtual Switch:
  - up_status=true appears within 60 s of boot
  - Value is exactly lowercase "true" (not "True" or "1")
  - Value persists — not a transient write
  - PortInitDone precedes up_status
  - CONFIG_DB:FEATURE|swss:check_up_status=true set by db_migrator
  - Value never becomes "false" — monotonic transition only

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
  sysmonitor declares "System is ready" as soon as orchagent's process starts. But orchagent takes 30–90 seconds to finish initialising ports, buffer tables, ACL tables, VLAN members, and PFCwd after the process is alive. 

**Why I did it**
  A lightweight event-based gate inside orchagent. Each subsystem signals completion exactly once from its own doTask() loop. When all registered modules have signalled, the gate writes FEATURE|swss:up_status = true into STATE_DB.
  sysmonitor waits for this field before declaring the system ready.
This way user knows when the device is exactly up.

**How I verified it**
1. create vlan 500 verify swss complete message and system ready message - Pass
2026-07-14.18:10:34.405003|c|SAI_OBJECT_TYPE_VLAN_MEMBER:oid:0x27000000000b1f|
2026 Jul 14 18:10:34.406533 sonic NOTICE swss#orchagent: :- checkAndSignal: SwssReadiness: all modules done, signalling app readiness (FEATURE|swss:up_status=true)
2026 Jul 14 18:10:34.425372 sonic NOTICE bmc_base: System is ready

2. verify ACL done and sairediscrec log done using Celestica-DS5000 devices
Verify vlan,pfcwd, buffer, port, acl configuration - PASS
2026 Jul  7 09:49:43.632930 Celestica-DS5000 NOTICE swss#orchagent: :- registerModule: SwssReadiness: registered module 'port' (1 total)
2026 Jul  7 09:49:43.632930 Celestica-DS5000 NOTICE swss#orchagent: :- registerModule: SwssReadiness: registered module 'buffer' (2 total)
2026 Jul  7 09:49:43.632930 Celestica-DS5000 NOTICE swss#orchagent: :- registerModule: SwssReadiness: registered module 'acl' (3 total)
2026 Jul  7 09:49:43.632930 Celestica-DS5000 NOTICE swss#orchagent: :- registerModule: SwssReadiness: registered module 'vlanmember' (4 total)
2026 Jul  7 09:49:44.419483 Celestica-DS5000 NOTICE swss#orchagent: :- signalDone: SwssReadiness: module 'buffer' done (1/4)
2026 Jul  7 09:49:44.494343 Celestica-DS5000 NOTICE swss#orchagent: :- registerModule: SwssReadiness: registered module 'pfcwd' (5 total)
2026 Jul  7 09:49:50.368521 Celestica-DS5000 NOTICE swss#orchagent: :- signalDone: SwssReadiness: module 'port' done (2/5)
2026 Jul  7 09:50:55.569277 Celestica-DS5000 NOTICE swss#orchagent: :- signalDone: SwssReadiness: module 'pfcwd' done (3/5)
2026 Jul  7 09:51:00.834357 Celestica-DS5000 NOTICE swss#orchagent: :- signalDone: SwssReadiness: module 'acl' done (4/5)
2026 Jul  7 09:51:09.843573 Celestica-DS5000 NOTICE swss#orchagent: :- signalDone: SwssReadiness: module 'vlanmember' done (5/5)
2026 Jul  7 09:51:09.843746 Celestica-DS5000 NOTICE swss#orchagent: :- checkAndSignal: SwssReadiness: all modules done — signalling app readiness (FEATURE|swss:up_status=true)

3. Verify the system up without configuration - PASS
4. 


**Details if related**
