### PR TITLE
[ci][DO-NOT-MERGE]: Validate against sonic-swss-common migration (#1222, build 1164874)

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -87,8 +87,12 @@ jobs:
       project: build
       pipeline: Azure.sonic-swss-common
       artifact: ${{ parameters.swss_common_artifact_name }}
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/${{ parameters.swss_common_branch }}'
+      # PINNED to sonic-swss-common PR #1222 build 1164874 (CI-unification migration
+      # validation): build against the migration swss-common (stock apt libnl,
+      # published build-env/). Revert to latestFromBranch / runBranch:
+      # refs/heads/${{ parameters.swss_common_branch }} before merge.
+      runVersion: 'specific'
+      runId: '1164874'
       path: $(Build.ArtifactStagingDirectory)/download
       allowPartiallySucceededBuilds: true
     displayName: "Download sonic swss common deb packages"

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -131,8 +131,12 @@ jobs:
       project: build
       pipeline: Azure.sonic-swss-common
       artifact: ${{ parameters.swss_common_artifact_name }}
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/${{ parameters.swss_common_branch }}'
+      # PINNED to sonic-swss-common PR #1222 build 1164874 (CI-unification migration
+      # validation): build against the migration swss-common (stock apt libnl,
+      # published build-env/). Revert to latestFromBranch / runBranch:
+      # refs/heads/${{ parameters.swss_common_branch }} before merge.
+      runVersion: 'specific'
+      runId: '1164874'
       allowPartiallySucceededBuilds: true
       path: $(Build.ArtifactStagingDirectory)/download/swsscommon
       patterns: |

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -75,8 +75,12 @@ jobs:
       project: build
       pipeline: Azure.sonic-swss-common
       artifact: sonic-swss-common.amd64.ubuntu22_04
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/${{ parameters.swss_common_branch }}'
+      # PINNED to sonic-swss-common PR #1222 build 1164874 (CI-unification migration
+      # validation): build against the migration swss-common (stock apt libnl,
+      # published build-env/). Revert to latestFromBranch / runBranch:
+      # refs/heads/${{ parameters.swss_common_branch }} before merge.
+      runVersion: 'specific'
+      runId: '1164874'
       path: $(Build.ArtifactStagingDirectory)/download
       allowPartiallySucceededBuilds: true
     displayName: "Download sonic swss common deb packages"


### PR DESCRIPTION
## DO NOT MERGE — CI validation only

Draft PR to validate that **sonic-swss** builds and tests green against the
sonic-swss-common **CI-unification migration** PR (sonic-net/sonic-swss-common#1222).

This draft pins sonic-swss's swss-common download to **#1222's green build `1164874`** so its
whole pipeline (build + docker + VS test) is exercised against the migration artifact (produced
by `buildenv_setup`, which also publishes `build-env/`).

### Changes
Pin every `Download sonic swss common` step (`build-template`, `build-docker`, `test-docker`) to
`runVersion: specific` / `runId: 1164874` instead of `latestFromBranch` on the
`swss_common_branch` parameter.

**No libnl companion changes** — #1222's swss-common builds against **stock apt libnl**, so
`libswsscommon` Depends on the stock libnl already present in every sonic-swss build/test/docker
environment (the build stage installs it from common-lib; the test host resolves it via apt).

### Not for merge
The `runId` pin is temporary; revert to `latestFromBranch` / `runBranch: refs/heads/${{ parameters.swss_common_branch }}`
before merge.
