### PR TITLE
[Mellanox] [buffer] Compensate reduced small packet headroom

### DIFF
--- a/cfgmgr/buffer_headroom_mellanox.lua
+++ b/cfgmgr/buffer_headroom_mellanox.lua
@@ -118,6 +118,7 @@ end
 -- Calculate the headroom information
 local speed_of_light = 198000000
 local minimal_packet_size = 64
+local headroom_compensation = 2 * 1024
 local cell_occupancy
 local worst_case_factor
 local propagation_delay
@@ -163,6 +164,17 @@ propagation_delay = port_mtu + bytes_on_cable + 2 * bytes_on_gearbox + mac_phy_d
 -- Calculate the xoff and xon and then round up at 1024 bytes
 xoff_value = lossless_mtu + propagation_delay * cell_occupancy
 xoff_value = math.ceil(xoff_value / 1024) * 1024
+
+-- When SHP is disabled, compensate headroom calculated with a reduced small-
+-- packet percentage if it remains more than 2 kB below the worst case.
+if not shp_enabled and small_packet_percentage ~= 100 then
+    local full_small_packet_xoff = lossless_mtu + propagation_delay * worst_case_factor
+    full_small_packet_xoff = math.ceil(full_small_packet_xoff / 1024) * 1024
+    if xoff_value + headroom_compensation < full_small_packet_xoff then
+        xoff_value = xoff_value + headroom_compensation
+    end
+end
+
 xon_value = pipeline_latency
 xon_value = math.ceil(xon_value / 1024) * 1024
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
#### Why I did it

Reducing the small-packet percentage from 100% can occasionally produce insufficient lossless headroom when the shared headroom pool (SHP) is disabled.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

When SHP is disabled and the configured small-packet percentage is below 100%:

- Calculate the rounded XOFF headroom using the configured percentage.
- Calculate the rounded worst-case XOFF using 100% small packets.
- Add 2 KiB of compensation when the configured XOFF plus 2 KiB is still less than the worst-case XOFF.

The compensation is not applied when SHP is enabled or when the small-packet percentage is 100%.

#### How to verify it

Executed the Lua calculation with mocked Redis inputs and verified:

- A qualifying reduced-percentage calculation receives 2 KiB of compensation when SHP is disabled.
- No compensation is applied when SHP is enabled.
- The SHP private headroom size remains XON-only.
- The Lua script passes syntax and Git whitespace checks.

Also tested on 202605 branch.