### PR TITLE
[ci] replace python3-pip with uv in vs test pipeline

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -146,7 +146,7 @@ jobs:
       # version-mismatch Exception that jammy's pip 22.0.2 build-isolation
       # env otherwise triggers. --no-build-isolation needs wheel present
       # in the environment to provide bdist_wheel, so install it first.
-      sudo apt-get install -y python3-cffi
+      sudo apt-get install -y python3-cffi python3-dev
       sudo uv pip install --system wheel
       sudo uv pip install --system --no-build-isolation 'libyang==3.3.0'
 

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -144,8 +144,10 @@ jobs:
       # from PyPI instead — same fallback as the inline amd64/ubuntu-22.04
       # job. --no-build-isolation + apt's python3-cffi sidesteps a cffi
       # version-mismatch Exception that jammy's pip 22.0.2 build-isolation
-      # env otherwise triggers.
+      # env otherwise triggers. --no-build-isolation needs wheel present
+      # in the environment to provide bdist_wheel, so install it first.
       sudo apt-get install -y python3-cffi
+      sudo uv pip install --system wheel
       sudo uv pip install --system --no-build-isolation 'libyang==3.3.0'
 
       sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libprotobuf*_amd64.deb $(Build.ArtifactStagingDirectory)/download/libprotobuf-lite*_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-protobuf*_amd64.deb

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -118,7 +118,7 @@ jobs:
   - script: |
       set -ex
       # install packages for vs test
-      sudo pip3 install pytest flaky exabgp docker lcov_cobertura
+      sudo uv pip install --system pytest flaky exabgp docker lcov_cobertura
 
       # install other dependencies
       sudo apt-get -o DPkg::Lock::Timeout=600 install -y net-tools \
@@ -146,7 +146,7 @@ jobs:
       # version-mismatch Exception that jammy's pip 22.0.2 build-isolation
       # env otherwise triggers.
       sudo apt-get install -y python3-cffi
-      sudo pip3 install --no-build-isolation 'libyang==3.3.0'
+      sudo uv pip install --system --no-build-isolation 'libyang==3.3.0'
 
       sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libprotobuf*_amd64.deb $(Build.ArtifactStagingDirectory)/download/libprotobuf-lite*_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-protobuf*_amd64.deb
       sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libdashapi*.deb


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Remove usage of `pip3` from the vs test pipeline script following the removal of `python3-pip` from the CI agent. Replace all `pip3 install` calls with `uv pip install --system` to maintain equivalent system-wide package installation behaviour.

**Why I did it**
`python3-pip` was removed from CI agent because S360 flags python3-pip as a security vulnerability

**How I verified it**

**Details if related**
