### PR TITLE
[macsecmgr] Fix macsecmgrd crash on invalid Type-7 CAK

### DIFF
--- a/cfgmgr/macsecmgr.cpp
+++ b/cfgmgr/macsecmgr.cpp
@@ -132,7 +132,15 @@ static std::string decodeKey(const std::string &cipher_str, const MACsecMgr::MAC
     }
 
     // Get the salt index from the cipher_str
-    saltIdx = (unsigned int) stoi(cipher_str.substr(0,2));
+    try
+    {
+        saltIdx = static_cast<unsigned int>(stoi(cipher_str.substr(0, 2)));
+    }
+    catch (const std::exception &)
+    {
+        throw std::invalid_argument(
+            "Invalid Type-7 CAK: salt prefix must be two decimal digits");
+    }
 
     // Convert the hex string (eg: "aabbcc") to hex integers (eg: 0xaa, 0xbb, 0xcc) taking a substring of 2 chars at a time
     // and do xor with the magic salt string
@@ -832,6 +840,11 @@ bool MACsecMgr::configureMACsec(
             "",
             "enable_network",
             network_id);
+    }
+    catch(const std::invalid_argument & e)
+    {
+        SWSS_LOG_WARN("Enable MACsec fail due to invalid CAK : %s", e.what());
+        return false;
     }
     catch(const std::runtime_error & e)
     {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Make `macsecmgr` survive a malformed Type-7 CAK instead of taking the whole `macsec` container down with it.

- `decodeKey()`: wrap the salt-prefix `stoi()` in try/catch and rethrow a descriptive `std::invalid_argument` ("Invalid Type-7 CAK: salt prefix must be two decimal digits") rather than letting the raw `stoi` exception escape, whose `what()` is just `"stoi"`.
- `configureMACsec()`: add a `catch(const std::invalid_argument & e)` ahead of the existing `runtime_error` handler, so the port is skipped with `SWSS_LOG_WARN("Enable MACsec fail due to invalid CAK : %s", ...)` and `return false`.

The CONFIG_DB format, the YANG model, and the wpa_supplicant interaction are all unchanged. The new handler also covers the two `throw std::invalid_argument` length-check sites already present at the top of `decodeKey()`, which had the same escape problem.

**Why I did it**

A `MACSEC_PROFILE` whose `primary_cak` is the right length and valid hex but whose two-character Type-7 salt prefix is not decimal (for example `B0`) kills `macsecmgrd` when a port is bound to it.

Hit in production on a Cisco 8223 running a 202511-based image, with 32 MACsec sessions to an IOS-XR 8808:

```
2026 Jul  2 17:33:41.107765 NOTICE macsec#macsecmgrd: :- loadProfile: The MACsec profile 'MSP1-AES-256-KEYMISMATCH' is loaded
2026 Jul  2 17:33:44.193464 NOTICE macsec#macsecmgrd: :- disableMACsec: The MACsec profile 'MSP1-AES-256' on the port 'Ethernet88' is removed
[snip]
2026 Jul  2 17:33:45.653160 NOTICE macsec#macsecmgrd: :- disableMACsec: The MACsec profile 'MSP1-AES-128' on the port 'Ethernet0' is removed
[snip - remaining ports]
2026 Jul  2 17:33:50.553619 ERR   macsec#macsecmgrd: :- main: Runtime error: stoi
2026 Jul  2 17:33:50.555366 INFO  macsec#supervisord WARN exited: macsecmgrd (exit status 255; not expected)
2026 Jul  2 17:33:51.557602 INFO  macsec#supervisor-proc-exit-listener-rs[26]: Process 'macsecmgrd' exited unexpectedly. Terminating supervisor 'macsec'
```

The failure chain:

1. `loadProfile()` accepts the profile — `MACsecProfile::update()` only reads the fields and never calls `decodeKey()`, so its `catch(const std::invalid_argument &)` is not on this path. The profile logs as loaded and the problem is deferred to the port bind, which makes it look unrelated to the profile that caused it.
2. On the bind, `enableMACsec()` → `configureMACsec()` → `decodeKey()` → `stoi("B0")` throws `std::invalid_argument`, whose `what()` is `"stoi"`.
3. `configureMACsec()` only caught `std::runtime_error`. `std::invalid_argument` derives from `std::logic_error`, so it escapes to `main()`'s `catch(const std::exception &)`, which logs `Runtime error: stoi` and returns `-1` (exit 255).

Two things make the impact much worse than a single failed port:

- **All ports lose MACsec, not just the one being configured.** `MACsecMgr` is a stack object declared inside `main()`'s `try` block, so unwinding destroys it and `~MACsecMgr()` calls `disableMACsec()` on every port — before the error is even logged. That is why the `disableMACsec` lines for unrelated ports above appear roughly five seconds *ahead* of `Runtime error: stoi`; the gap is the destructor walking all 32 ports. All 32 sessions dropped.
- **It does not recover on its own.** The offending profile persists in CONFIG_DB, so each restart replays the same `PORT` SET event and crashes again. `macsec.service` is `Restart=always`/`RestartSec=30` but also carries `StartLimitIntervalSec=1200` and `StartLimitBurst=3`, so three crashes exhaust the start limit and the container sits in `Exited (0)` — 35 minutes in our case, until manual intervention.

With this change the same configuration fails only the port it applies to, `macsecmgrd` stays up, and the other sessions are untouched.

Input-side validation is being tightened separately in sonic-net/sonic-buildimage#28864 (YANG), but neither removes the need for this fix: a CAK can still reach CONFIG_DB via `redis-cli`, `sonic-cfggen`, a restored `config_db.json`, or an image upgrade of a device that already holds such a profile, and `macsecmgrd` must not die when it does.

**How I verified it**

On-device, before — binding a port to a profile with a `B0` salt prefix:

```
2026 Jul  2 17:33:50.553619 ERR  macsec#macsecmgrd: :- main: Runtime error: stoi
2026 Jul  2 17:33:50.555366 INFO macsec#supervisord WARN exited: macsecmgrd (exit status 255; not expected)
2026 Jul  2 17:33:51.557602 INFO macsec#supervisor-proc-exit-listener-rs[26]: Process 'macsecmgrd' exited unexpectedly. Terminating supervisor 'macsec'

admin@sonic:~$ docker ps -a | grep macsec
c45a8ce54f89   docker-macsec:latest   "/usr/local/bin/supe..."   Exited (0) 35 minutes ago   macsec
```

On-device, after :

```
<< The four things worth
   capturing, matching the before block above:

   1. Bind a port to the bad profile:
        sudo config macsec profile add --cipher_suite GCM-AES-256 \
          --primary_cak B06D2A3A...0908 --primary_ckn CCC256 BADSALT
        sudo config macsec port add Ethernet88 BADSALT

      Expected: syslog shows
        WARNING macsec#macsecmgrd: :- configureMACsec: Enable MACsec fail due to
        invalid CAK : Invalid Type-7 CAK: salt prefix must be two decimal digits

   2. macsecmgrd still running:
        docker exec macsec supervisorctl status macsecmgrd
        docker ps | grep macsec          # Up, not Exited

   3. Other ports unaffected:
        show macsec                      # remaining sessions still established

   4. Valid CAK still works end to end:
        sudo config macsec port add Ethernet88 <good-profile>
        show macsec                      # MKA establishes as before
>>
```

**Details if related**

- SONiC expects MACsec CAKs in Cisco Type-7 encoding (sonic-net/sonic-swss#2892): two decimal salt characters followed by the hex-encoded key material. sonic-net/sonic-buildimage#16388 later made the CLI require the encoded length.
- YANG-side validation of the salt prefix: sonic-net/sonic-buildimage#28864.
