### PR TITLE
[intfsorch]: Retry explicit router interface VRF rehome

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -1199,11 +1199,19 @@ void IntfsOrch::doTask(Consumer &consumer)
 
                 if (vnet_orch->delIntf(alias, vnet_name, ip_prefix_in_key ? &ip_prefix : nullptr))
                 {
+                    if (!ip_prefix_in_key)
+                    {
+                        m_removingIntfses.erase(alias);
+                    }
                     m_vnetInfses.erase(alias);
                     it = consumer.m_toSync.erase(it);
                 }
                 else
                 {
+                    if (!ip_prefix_in_key)
+                    {
+                        m_removingIntfses.insert(alias);
+                    }
                     it++;
                     continue;
                 }

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -1177,6 +1177,11 @@ void IntfsOrch::doTask(Consumer &consumer)
                 }
             }
 
+            if (macIsExplicit && !mac)
+            {
+                mac = gMacAddress;
+            }
+
             // update mac if it is changed
             if (macIsExplicit && m_syncdIntfses.find(alias) != m_syncdIntfses.end())
             {
@@ -2092,4 +2097,3 @@ void IntfsOrch::voqSyncIntfState(string &alias, bool isUp)
     }
 
 }
-

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -117,6 +117,11 @@ sai_object_id_t IntfsOrch::getRouterIntfsId(const string &alias)
     return port.m_rif_id;
 }
 
+bool IntfsOrch::isIntfRemovalPending(const string &alias) const
+{
+    return m_removingIntfses.find(alias) != m_removingIntfses.end();
+}
+
 bool IntfsOrch::isPrefixSubnet(const IpPrefix &ip_prefix, const string &alias)
 {
     if (m_syncdIntfses.find(alias) == m_syncdIntfses.end())
@@ -1207,12 +1212,18 @@ void IntfsOrch::doTask(Consumer &consumer)
             {
                 if (removeIntf(alias, port.m_vr_id, ip_prefix_in_key ? &ip_prefix : nullptr))
                 {
-                    m_removingIntfses.erase(alias);
+                    if (!ip_prefix_in_key)
+                    {
+                        m_removingIntfses.erase(alias);
+                    }
                     it = consumer.m_toSync.erase(it);
                 }
                 else
                 {
-                    m_removingIntfses.insert(alias);
+                    if (!ip_prefix_in_key)
+                    {
+                        m_removingIntfses.insert(alias);
+                    }
                     it++;
                     continue;
                 }

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -122,6 +122,11 @@ bool IntfsOrch::isIntfRemovalPending(const string &alias) const
     return m_removingIntfses.find(alias) != m_removingIntfses.end();
 }
 
+bool IntfsOrch::isIntfVrfUpdatePending(const string &alias) const
+{
+    return m_pendingVrfUpdates.find(alias) != m_pendingVrfUpdates.end();
+}
+
 bool IntfsOrch::isPrefixSubnet(const IpPrefix &ip_prefix, const string &alias)
 {
     if (m_syncdIntfses.find(alias) == m_syncdIntfses.end())
@@ -483,12 +488,18 @@ set<IpPrefix> IntfsOrch:: getSubnetRoutes()
 }
 
 bool IntfsOrch::setIntf(const string& alias, sai_object_id_t vrf_id, const IpPrefix *ip_prefix,
-                        const bool adminUp, const uint32_t mtu, string loopbackAction)
+                        const bool adminUp, const uint32_t mtu, string loopbackAction,
+                        const bool vrfIdIsExplicit)
 
 {
     SWSS_LOG_ENTER();
 
     if (m_removingIntfses.find(alias) != m_removingIntfses.end())
+    {
+        return false;
+    }
+
+    if (ip_prefix && isIntfVrfUpdatePending(alias))
     {
         return false;
     }
@@ -517,8 +528,10 @@ bool IntfsOrch::setIntf(const string& alias, sai_object_id_t vrf_id, const IpPre
             {
                 intfs_entry.mac = gMacAddress;
             }
+            intfs_entry.loopback_action = loopbackAction;
             m_syncdIntfses[alias] = intfs_entry;
             m_vrfOrch->increaseVrfRefCount(vrf_id);
+            m_pendingVrfUpdates.erase(alias);
         }
         else
         {
@@ -527,30 +540,107 @@ bool IntfsOrch::setIntf(const string& alias, sai_object_id_t vrf_id, const IpPre
     }
     else
     {
-        if (!ip_prefix && port.m_type == Port::SUBPORT)
+        // Treat an explicit VRF change as a RIF replacement and retain the SET
+        // until the old interface has no prefixes or dependent objects.
+        sai_object_id_t old_vrf_id = it_intfs->second.vrf_id;
+        if (!ip_prefix && vrfIdIsExplicit && old_vrf_id != vrf_id)
         {
-            // port represents a sub interface
-            // Change sub interface config at run time
-            bool attrChanged = false;
-            if (mtu && port.m_mtu != mtu)
+            m_pendingVrfUpdates.insert(alias);
+            if (!it_intfs->second.ip_addresses.empty())
             {
-                port.m_mtu = mtu;
-                attrChanged = true;
-
-                setRouterIntfsMtu(port);
+                return false;
             }
 
-            if (port.m_admin_state_up != adminUp)
+            IntfsEntry intfs_entry = it_intfs->second;
+            if (intfs_entry.sag_enabled)
             {
-                port.m_admin_state_up = adminUp;
-                attrChanged = true;
-
-                setRouterIntfsAdminStatus(port);
+                SWSS_LOG_WARN("Cannot move SAG-enabled interface %s between VRFs", alias.c_str());
+                return false;
             }
 
-            if (attrChanged)
+            Port rehome_port = port;
+            rehome_port.m_mac = intfs_entry.mac;
+            if (rehome_port.m_type == Port::SUBPORT)
             {
-                gPortsOrch->setPort(alias, port);
+                rehome_port.m_admin_state_up = adminUp;
+                if (mtu)
+                {
+                    rehome_port.m_mtu = mtu;
+                }
+            }
+            if (!removeRouterIntfs(port))
+            {
+                return false;
+            }
+
+            rehome_port.m_rif_id = SAI_NULL_OBJECT_ID;
+            rehome_port.m_vr_id = SAI_NULL_OBJECT_ID;
+            string rehome_loopback_action = loopbackAction.empty() ?
+                                                intfs_entry.loopback_action :
+                                                loopbackAction;
+            try
+            {
+                if (!addRouterIntfs(vrf_id, rehome_port, rehome_loopback_action))
+                {
+                    return false;
+                }
+            }
+            catch (const std::exception& e)
+            {
+                Port rollback_port = rehome_port;
+                rollback_port.m_rif_id = SAI_NULL_OBJECT_ID;
+                rollback_port.m_vr_id = SAI_NULL_OBJECT_ID;
+                if (!addRouterIntfs(old_vrf_id, rollback_port, intfs_entry.loopback_action))
+                {
+                    SWSS_LOG_ERROR("Failed to restore interface %s after VRF move failed: %s",
+                                   alias.c_str(), e.what());
+                    throw;
+                }
+                SWSS_LOG_ERROR("Failed to move interface %s to VRF %s; restored the old RIF and will retry: %s",
+                               alias.c_str(), m_vrfOrch->getVRFname(vrf_id).c_str(), e.what());
+                return false;
+            }
+
+            m_vrfOrch->decreaseVrfRefCount(old_vrf_id);
+            m_vrfOrch->increaseVrfRefCount(vrf_id);
+            intfs_entry.vrf_id = vrf_id;
+            intfs_entry.loopback_action = rehome_loopback_action;
+            m_syncdIntfses[alias] = intfs_entry;
+
+            m_pendingVrfUpdates.erase(alias);
+        }
+        else if (!ip_prefix)
+        {
+            if (vrfIdIsExplicit)
+            {
+                m_pendingVrfUpdates.erase(alias);
+            }
+
+            if (port.m_type == Port::SUBPORT)
+            {
+                // port represents a sub interface
+                // Change sub interface config at run time
+                bool attrChanged = false;
+                if (mtu && port.m_mtu != mtu)
+                {
+                    port.m_mtu = mtu;
+                    attrChanged = true;
+
+                    setRouterIntfsMtu(port);
+                }
+
+                if (port.m_admin_state_up != adminUp)
+                {
+                    port.m_admin_state_up = adminUp;
+                    attrChanged = true;
+
+                    setRouterIntfsAdminStatus(port);
+                }
+
+                if (attrChanged)
+                {
+                    gPortsOrch->setPort(alias, port);
+                }
             }
         }
     }
@@ -663,6 +753,7 @@ bool IntfsOrch::removeIntf(const string& alias, sai_object_id_t vrf_id, const Ip
 
             m_syncdIntfses.erase(alias);
             m_vrfOrch->decreaseVrfRefCount(vrf_id);
+            m_pendingVrfUpdates.erase(alias);
 
             if (port.m_type == Port::SUBPORT)
             {
@@ -741,6 +832,9 @@ void IntfsOrch::doTask(Consumer &consumer)
 
         const vector<FieldValueTuple>& data = kfvFieldsValues(t);
         string vrf_name = "", vnet_name = "", nat_zone = "";
+        bool vrfNameIsExplicit = false;
+        bool macIsExplicit = false;
+        bool mplsIsExplicit = false;
         MacAddress mac;
 
         uint32_t mtu = 0;
@@ -775,6 +869,7 @@ void IntfsOrch::doTask(Consumer &consumer)
             if (field == "vrf_name")
             {
                 vrf_name = value;
+                vrfNameIsExplicit = true;
             }
             else if (field == "vnet_name")
             {
@@ -785,6 +880,7 @@ void IntfsOrch::doTask(Consumer &consumer)
                 try
                 {
                     mac = MacAddress(value);
+                    macIsExplicit = true;
                 }
                 catch (const std::invalid_argument &e)
                 {
@@ -795,6 +891,7 @@ void IntfsOrch::doTask(Consumer &consumer)
             else if (field == "mpls")
             {
                 mpls = (value == "enable" ? true : false);
+                mplsIsExplicit = true;
             }
             else if (field == "nat_zone")
             {
@@ -1016,7 +1113,8 @@ void IntfsOrch::doTask(Consumer &consumer)
                     adminUp = port.m_admin_state_up;
                 }
 
-                if (!setIntf(alias, vrf_id, ip_prefix_in_key ? &ip_prefix : nullptr, adminUp, mtu, loopbackAction))
+                if (!setIntf(alias, vrf_id, ip_prefix_in_key ? &ip_prefix : nullptr, adminUp, mtu,
+                             loopbackAction, vrfNameIsExplicit))
                 {
                     it++;
                     continue;
@@ -1060,7 +1158,7 @@ void IntfsOrch::doTask(Consumer &consumer)
                         gPortsOrch->setPort(alias, port);
                     }
                     /* Set MPLS */
-                    if ((!ip_prefix_in_key) && (port.m_mpls != mpls))
+                    if (mplsIsExplicit && !ip_prefix_in_key && port.m_mpls != mpls)
                     {
                         port.m_mpls = mpls;
 
@@ -1071,18 +1169,16 @@ void IntfsOrch::doTask(Consumer &consumer)
                     /* Set loopback action */
                     if (!loopbackAction.empty())
                     {
-                        setIntfLoopbackAction(port, loopbackAction);
+                        if (setIntfLoopbackAction(port, loopbackAction))
+                        {
+                            m_syncdIntfses[alias].loopback_action = loopbackAction;
+                        }
                     }
                 }
             }
 
-            if (!mac)
-            {
-                mac = gMacAddress;
-            }
-
             // update mac if it is changed
-            if (m_syncdIntfses.find(alias) != m_syncdIntfses.end())
+            if (macIsExplicit && m_syncdIntfses.find(alias) != m_syncdIntfses.end())
             {
                 if ((!ip_prefix_in_key) && (m_syncdIntfses[alias].mac != mac))
                 {
@@ -1110,6 +1206,8 @@ void IntfsOrch::doTask(Consumer &consumer)
                             SWSS_LOG_NOTICE("Set router interface mac %s for port %s success",
                                                         mac.to_string().c_str(), alias.c_str());
                             m_syncdIntfses[alias].mac = mac;
+                            port.m_mac = mac;
+                            gPortsOrch->setPort(alias, port);
                         }
                     }
                     else

--- a/orchagent/intfsorch.h
+++ b/orchagent/intfsorch.h
@@ -39,6 +39,7 @@ public:
     static const int intfsorch_pri;
 
     sai_object_id_t getRouterIntfsId(const string&);
+    bool isIntfRemovalPending(const string&) const;
     bool isPrefixSubnet(const IpPrefix&, const string&);
     bool isInbandIntfInMgmtVrf(const string& alias);
     string getRouterIntfsAlias(const IpAddress &ip, const string &vrf_name = "");

--- a/orchagent/intfsorch.h
+++ b/orchagent/intfsorch.h
@@ -28,6 +28,7 @@ struct IntfsEntry
     bool                proxy_arp;
     bool                sag_enabled = false;
     MacAddress          mac;
+    std::string         loopback_action;
 };
 
 typedef map<string, IntfsEntry> IntfsTable;
@@ -40,6 +41,7 @@ public:
 
     sai_object_id_t getRouterIntfsId(const string&);
     bool isIntfRemovalPending(const string&) const;
+    bool isIntfVrfUpdatePending(const string&) const;
     bool isPrefixSubnet(const IpPrefix&, const string&);
     bool isInbandIntfInMgmtVrf(const string& alias);
     string getRouterIntfsAlias(const IpAddress &ip, const string &vrf_name = "");
@@ -61,7 +63,7 @@ public:
 
     bool setIntfLoopbackAction(const Port &port, string actionStr);
     bool getSaiLoopbackAction(const string &actionStr, sai_packet_action_t &action);
-    bool setIntf(const string& alias, sai_object_id_t vrf_id = gVirtualRouterId, const IpPrefix *ip_prefix = nullptr, const bool adminUp = true, const uint32_t mtu = 0, string loopbackAction = "");
+    bool setIntf(const string& alias, sai_object_id_t vrf_id = gVirtualRouterId, const IpPrefix *ip_prefix = nullptr, const bool adminUp = true, const uint32_t mtu = 0, string loopbackAction = "", const bool vrfIdIsExplicit = false);
     bool removeIntf(const string& alias, sai_object_id_t vrf_id = gVirtualRouterId, const IpPrefix *ip_prefix = nullptr);
 
     void addIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_prefix);
@@ -100,6 +102,7 @@ private:
     unique_ptr<Table> m_vidToRidTable;
 
     std::set<std::string> m_removingIntfses;
+    std::set<std::string> m_pendingVrfUpdates;
 
     std::string getRifFlexCounterTableKey(std::string s);
 

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -380,9 +380,10 @@ bool NeighOrch::addNextHop(NeighborContext& ctx)
 
     assert(!hasNextHop(nexthop));
     if (!m_intfsOrch->isRemoteSystemPortIntf(nh.alias) &&
-        m_intfsOrch->isIntfRemovalPending(nh.alias))
+        (m_intfsOrch->isIntfRemovalPending(nh.alias) ||
+         m_intfsOrch->isIntfVrfUpdatePending(nh.alias)))
     {
-        SWSS_LOG_INFO("Interface %s is pending removal", nh.alias.c_str());
+        SWSS_LOG_INFO("Interface %s is pending removal or VRF update", nh.alias.c_str());
         return false;
     }
 
@@ -1332,9 +1333,10 @@ bool NeighOrch::addNeighbor(NeighborContext& ctx)
     bool bulk_op = ctx.bulk_op;
 
     if (!m_intfsOrch->isRemoteSystemPortIntf(alias) &&
-        m_intfsOrch->isIntfRemovalPending(alias))
+        (m_intfsOrch->isIntfRemovalPending(alias) ||
+         m_intfsOrch->isIntfVrfUpdatePending(alias)))
     {
-        SWSS_LOG_INFO("Interface %s is pending removal", alias.c_str());
+        SWSS_LOG_INFO("Interface %s is pending removal or VRF update", alias.c_str());
         return false;
     }
 

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -379,6 +379,13 @@ bool NeighOrch::addNextHop(NeighborContext& ctx)
     }
 
     assert(!hasNextHop(nexthop));
+    if (!m_intfsOrch->isRemoteSystemPortIntf(nh.alias) &&
+        m_intfsOrch->isIntfRemovalPending(nh.alias))
+    {
+        SWSS_LOG_INFO("Interface %s is pending removal", nh.alias.c_str());
+        return false;
+    }
+
     sai_object_id_t rif_id = m_intfsOrch->getRouterIntfsId(nh.alias);
 
     vector<sai_attribute_t> next_hop_attrs;
@@ -1324,6 +1331,13 @@ bool NeighOrch::addNeighbor(NeighborContext& ctx)
     string alias = neighborEntry.alias;
     bool bulk_op = ctx.bulk_op;
 
+    if (!m_intfsOrch->isRemoteSystemPortIntf(alias) &&
+        m_intfsOrch->isIntfRemovalPending(alias))
+    {
+        SWSS_LOG_INFO("Interface %s is pending removal", alias.c_str());
+        return false;
+    }
+
     sai_object_id_t rif_id = m_intfsOrch->getRouterIntfsId(alias);
     if (rif_id == SAI_NULL_OBJECT_ID)
     {
@@ -2065,6 +2079,7 @@ bool NeighOrch::enableNeighbors(std::list<NeighborContext>& bulk_ctx_list)
         if(!addNeighbor(*ctx))
         {
             SWSS_LOG_ERROR("Neighbor %s create entry failed.", neighborEntry.ip_address.to_string().c_str());
+            ret = false;
             continue;
         }
     }

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -2087,9 +2087,10 @@ bool RouteOrch::addRoute(RouteBulkContext& ctx, const NextHopGroupKey &nextHops)
             }
 
             if (!m_intfsOrch->isRemoteSystemPortIntf(nexthop.alias) &&
-                m_intfsOrch->isIntfRemovalPending(nexthop.alias))
+                (m_intfsOrch->isIntfRemovalPending(nexthop.alias) ||
+                 m_intfsOrch->isIntfVrfUpdatePending(nexthop.alias)))
             {
-                SWSS_LOG_INFO("Interface %s is pending removal", nexthop.alias.c_str());
+                SWSS_LOG_INFO("Interface %s is pending removal or VRF update", nexthop.alias.c_str());
                 return false;
             }
 

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1507,7 +1507,10 @@ bool RouteOrch::addNextHopGroup(const NextHopGroupKey &nexthops)
                  m_neighOrch->hasNextHop(NextHopKey(it.ip_address, it.alias)))
         {
             NeighborContext ctx = NeighborContext(it);
-            m_neighOrch->addNextHop(ctx);
+            if (!m_neighOrch->addNextHop(ctx))
+            {
+                return false;
+            }
             next_hop_id = m_neighOrch->getNextHopId(it);
         }
         else
@@ -2083,6 +2086,13 @@ bool RouteOrch::addRoute(RouteBulkContext& ctx, const NextHopGroupKey &nextHops)
                 return true;
             }
 
+            if (!m_intfsOrch->isRemoteSystemPortIntf(nexthop.alias) &&
+                m_intfsOrch->isIntfRemovalPending(nexthop.alias))
+            {
+                SWSS_LOG_INFO("Interface %s is pending removal", nexthop.alias.c_str());
+                return false;
+            }
+
             next_hop_id = m_intfsOrch->getRouterIntfsId(nexthop.alias);
             /* rif is not created yet */
             if (next_hop_id == SAI_NULL_OBJECT_ID)
@@ -2118,7 +2128,10 @@ bool RouteOrch::addRoute(RouteBulkContext& ctx, const NextHopGroupKey &nextHops)
             {
                 /* since IP neighbor NH exists, neighbor is resolved, add MPLS NH */
                 NeighborContext ctx = NeighborContext(nexthop);
-                m_neighOrch->addNextHop(ctx);
+                if (!m_neighOrch->addNextHop(ctx))
+                {
+                    return false;
+                }
                 next_hop_id = m_neighOrch->getNextHopId(nexthop);
             }
             /* IP neighbor is not yet resolved */

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -591,6 +591,30 @@ namespace intfsorch_test
                   MacAddress("00:11:22:33:44:55"));
     }
 
+    TEST_F(IntfsOrchTest, IntfsOrchExplicitZeroMacRestoresSystemMac)
+    {
+        std::deque<KeyOpFieldsValuesTuple> entries{
+            {"Ethernet0", "SET", {{"mac_addr", "00:11:22:33:44:55"}}}
+        };
+        auto consumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+
+        ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at("Ethernet0").mac,
+                  MacAddress("00:11:22:33:44:55"));
+
+        entries = {
+            {"Ethernet0", "SET", {{"mac_addr", "00:00:00:00:00:00"}}}
+        };
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+        ASSERT_EQ(port.m_mac, gMacAddress);
+        ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at("Ethernet0").mac, gMacAddress);
+    }
+
     TEST_F(IntfsOrchTest, IntfsOrchPartialUpdatePreservesVrf)
     {
         std::deque<KeyOpFieldsValuesTuple> entries{

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -16,6 +16,9 @@ namespace intfsorch_test
 
     int create_rif_count = 0;
     int remove_rif_count = 0;
+    bool saw_loopback_action = false;
+    bool fail_next_rif_create = false;
+    sai_packet_action_t last_loopback_action = SAI_PACKET_ACTION_FORWARD;
     sai_router_interface_api_t *pold_sai_rif_api;
     sai_router_interface_api_t ut_sai_rif_api;
 
@@ -26,14 +29,28 @@ namespace intfsorch_test
             _In_ const sai_attribute_t *attr_list)
     {
         ++create_rif_count;
-        return SAI_STATUS_SUCCESS;
+        if (fail_next_rif_create)
+        {
+            fail_next_rif_create = false;
+            return SAI_STATUS_INSUFFICIENT_RESOURCES;
+        }
+        for (uint32_t i = 0; i < attr_count; ++i)
+        {
+            if (attr_list[i].id == SAI_ROUTER_INTERFACE_ATTR_LOOPBACK_PACKET_ACTION)
+            {
+                saw_loopback_action = true;
+                last_loopback_action = static_cast<sai_packet_action_t>(attr_list[i].value.s32);
+            }
+        }
+        return pold_sai_rif_api->create_router_interface(
+            router_interface_id, switch_id, attr_count, attr_list);
     }
 
     sai_status_t _ut_remove_router_interface(
             _In_ sai_object_id_t router_interface_id)
     {
         ++remove_rif_count;
-        return SAI_STATUS_SUCCESS;
+        return pold_sai_rif_api->remove_router_interface(router_interface_id);
     }
 
     struct IntfsOrchTest : public ::testing::Test
@@ -61,6 +78,10 @@ namespace intfsorch_test
 
             sai_router_intfs_api->create_router_interface = _ut_create_router_interface;
             sai_router_intfs_api->remove_router_interface = _ut_remove_router_interface;
+            create_rif_count = 0;
+            remove_rif_count = 0;
+            saw_loopback_action = false;
+            fail_next_rif_create = false;
 
             m_app_db = make_shared<swss::DBConnector>("APPL_DB", 0);
             m_config_db = make_shared<swss::DBConnector>("CONFIG_DB", 0);
@@ -501,5 +522,173 @@ namespace intfsorch_test
         syncd = gIntfsOrch->getSyncdIntfses();
         ASSERT_EQ(syncd["Loopback6"].vrf_id, gVrfOrch->getVRFid("Vrf-Blue"));
         ASSERT_EQ(gVrfOrch->getVrfRefCount("Vrf-Blue"), base_vrf_ref + 1);
+    TEST_F(IntfsOrchTest, IntfsOrchVrfUpdateWaitsForDrain)
+    {
+        std::deque<KeyOpFieldsValuesTuple> entries{
+            {"Vrf-Blue", "SET", {{"NULL", "NULL"}}}
+        };
+        auto consumer = dynamic_cast<Consumer *>(gVrfOrch->getExecutor(APP_VRF_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gVrfOrch)->doTask();
+
+        entries = {
+            {"Ethernet0", "SET", {
+                {"mtu", "9100"},
+                {"loopback_action", "drop"},
+                {"mpls", "enable"},
+                {"mac_addr", "00:11:22:33:44:55"}
+            }},
+            {"Ethernet0:10.0.0.1/24", "SET", {{"scope", "global"}, {"family", "IPv4"}}}
+        };
+        consumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+        gIntfsOrch->increaseRouterIntfsRefCount("Ethernet0");
+
+        entries = {
+            {"Ethernet0", "SET", {{"vrf_name", "Vrf-Blue"}}},
+            {"Ethernet0:10.0.0.1/24", "DEL", {}},
+            {"Ethernet0:10.0.0.1/24", "SET", {{"scope", "global"}, {"family", "IPv4"}}}
+        };
+        saw_loopback_action = false;
+        consumer->addToSync(entries);
+
+        auto create_count = create_rif_count;
+        auto remove_count = remove_rif_count;
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+        ASSERT_EQ(consumer->m_toSync.size(), 2u);
+        ASSERT_EQ(create_count, create_rif_count);
+        ASSERT_EQ(remove_count, remove_rif_count);
+        ASSERT_TRUE(gIntfsOrch->isIntfVrfUpdatePending("Ethernet0"));
+        ASSERT_NE(gIntfsOrch->getRouterIntfsId("Ethernet0"), SAI_NULL_OBJECT_ID);
+
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+        ASSERT_EQ(consumer->m_toSync.size(), 2u);
+        ASSERT_EQ(remove_count, remove_rif_count);
+
+        gIntfsOrch->decreaseRouterIntfsRefCount("Ethernet0");
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+
+        ASSERT_TRUE(consumer->m_toSync.empty());
+        ASSERT_EQ(create_count + 1, create_rif_count);
+        ASSERT_EQ(remove_count + 1, remove_rif_count);
+        ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at("Ethernet0").vrf_id,
+                  gVrfOrch->getVRFid("Vrf-Blue"));
+        ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at("Ethernet0").ip_addresses.count(
+                      IpPrefix("10.0.0.1/24")),
+                  1u);
+        ASSERT_TRUE(saw_loopback_action);
+        ASSERT_EQ(last_loopback_action, SAI_PACKET_ACTION_DROP);
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+        ASSERT_TRUE(port.m_mpls);
+        ASSERT_EQ(port.m_mac, MacAddress("00:11:22:33:44:55"));
+        ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at("Ethernet0").mac,
+                  MacAddress("00:11:22:33:44:55"));
+    }
+
+    TEST_F(IntfsOrchTest, IntfsOrchPartialUpdatePreservesVrf)
+    {
+        std::deque<KeyOpFieldsValuesTuple> entries{
+            {"Vrf-Blue", "SET", {{"NULL", "NULL"}}}
+        };
+        auto consumer = dynamic_cast<Consumer *>(gVrfOrch->getExecutor(APP_VRF_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gVrfOrch)->doTask();
+
+        entries = {
+            {"Ethernet0.10", "SET", {
+                {"vlan", "10"},
+                {"admin_status", "up"},
+                {"mtu", "9100"}
+            }}
+        };
+        consumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+
+        auto create_count = create_rif_count;
+        auto remove_count = remove_rif_count;
+        entries = {
+            {"Ethernet0.10", "SET", {
+                {"vrf_name", "Vrf-Blue"},
+                {"admin_status", "down"},
+                {"mtu", "1500"}
+            }}
+        };
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+
+        ASSERT_EQ(create_count + 1, create_rif_count);
+        ASSERT_EQ(remove_count + 1, remove_rif_count);
+        ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at("Ethernet0.10").vrf_id,
+                  gVrfOrch->getVRFid("Vrf-Blue"));
+
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0.10", port));
+        ASSERT_FALSE(port.m_admin_state_up);
+        ASSERT_EQ(port.m_mtu, 1500u);
+
+        create_count = create_rif_count;
+        remove_count = remove_rif_count;
+        entries = {
+            {"Ethernet0.10", "SET", {{"admin_status", "up"}}}
+        };
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+
+        ASSERT_EQ(create_count, create_rif_count);
+        ASSERT_EQ(remove_count, remove_rif_count);
+        ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at("Ethernet0.10").vrf_id,
+                  gVrfOrch->getVRFid("Vrf-Blue"));
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0.10", port));
+        ASSERT_TRUE(port.m_admin_state_up);
+    }
+
+    TEST_F(IntfsOrchTest, IntfsOrchVrfUpdateRollsBackCreateFailure)
+    {
+        std::deque<KeyOpFieldsValuesTuple> entries{
+            {"Vrf-Blue", "SET", {{"NULL", "NULL"}}}
+        };
+        auto consumer = dynamic_cast<Consumer *>(gVrfOrch->getExecutor(APP_VRF_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gVrfOrch)->doTask();
+
+        entries = {
+            {"Ethernet0", "SET", {{"mtu", "9100"}, {"loopback_action", "drop"}}}
+        };
+        consumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+
+        auto create_count = create_rif_count;
+        auto remove_count = remove_rif_count;
+        fail_next_rif_create = true;
+        entries = {
+            {"Ethernet0", "SET", {{"vrf_name", "Vrf-Blue"}}},
+            {"Ethernet4", "SET", {{"loopback_action", "drop"}}}
+        };
+        consumer->addToSync(entries);
+        EXPECT_NO_THROW(gIntfsOrch->doTask(*consumer));
+
+        ASSERT_EQ(consumer->m_toSync.size(), 1u);
+        ASSERT_EQ(consumer->m_toSync.begin()->first, "Ethernet0");
+        ASSERT_EQ(create_count + 3, create_rif_count);
+        ASSERT_EQ(remove_count + 1, remove_rif_count);
+        ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at("Ethernet0").vrf_id, gVirtualRouterId);
+        ASSERT_TRUE(gIntfsOrch->isIntfVrfUpdatePending("Ethernet0"));
+        ASSERT_NE(gIntfsOrch->getRouterIntfsId("Ethernet0"), SAI_NULL_OBJECT_ID);
+        ASSERT_NE(gIntfsOrch->getSyncdIntfses().find("Ethernet4"),
+                  gIntfsOrch->getSyncdIntfses().end());
+
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+
+        ASSERT_TRUE(consumer->m_toSync.empty());
+        ASSERT_EQ(create_count + 4, create_rif_count);
+        ASSERT_EQ(remove_count + 2, remove_rif_count);
+        ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at("Ethernet0").vrf_id,
+                  gVrfOrch->getVRFid("Vrf-Blue"));
     }
 }

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -313,17 +313,30 @@ namespace intfsorch_test
         static_cast<Orch *>(gIntfsOrch)->doTask();
         ASSERT_EQ(current_create_count + 1, create_rif_count);
 
+        // Add a prefix so the whole-interface DEL is processed before its dependency DEL.
+        entries.clear();
+        entries.push_back({"Ethernet0:10.0.0.1/24", "SET", {
+            {"scope", "global"},
+            {"family", "IPv4"}
+        }});
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+
         // create dependency to the interface
         gIntfsOrch->increaseRouterIntfsRefCount("Ethernet0");
 
-        // delete the interface, expect retry because dependency exists
+        // Delete the interface and prefix in lexical order. The successful prefix
+        // DEL must not clear the whole-interface removal fence.
         entries.clear();
         entries.push_back({"Ethernet0", "DEL", { {} }});
+        entries.push_back({"Ethernet0:10.0.0.1/24", "DEL", { {} }});
         consumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
         consumer->addToSync(entries);
         auto current_remove_count = remove_rif_count;
         static_cast<Orch *>(gIntfsOrch)->doTask();
         ASSERT_EQ(current_remove_count, remove_rif_count);
+        ASSERT_EQ(consumer->m_toSync.size(), 1u);
+        ASSERT_TRUE(gIntfsOrch->isIntfRemovalPending("Ethernet0"));
 
         // create the interface again, expect retry because interface is in removing
         entries.clear();

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -522,6 +522,8 @@ namespace intfsorch_test
         syncd = gIntfsOrch->getSyncdIntfses();
         ASSERT_EQ(syncd["Loopback6"].vrf_id, gVrfOrch->getVRFid("Vrf-Blue"));
         ASSERT_EQ(gVrfOrch->getVrfRefCount("Vrf-Blue"), base_vrf_ref + 1);
+    }
+
     TEST_F(IntfsOrchTest, IntfsOrchVrfUpdateWaitsForDrain)
     {
         std::deque<KeyOpFieldsValuesTuple> entries{

--- a/tests/mock_tests/neighorch_ut.cpp
+++ b/tests/mock_tests/neighorch_ut.cpp
@@ -189,6 +189,20 @@ namespace neighorch_test
         }
     };
 
+    TEST_F(NeighOrchTest, LocalNeighborDependenciesRetryWhileInterfaceRemovalPending)
+    {
+        gIntfsOrch->m_removingIntfses.insert(VLAN_1000);
+
+        NeighborContext neighbor_ctx(VLAN1000_NEIGH);
+        neighbor_ctx.mac = MacAddress(MAC1);
+        EXPECT_FALSE(gNeighOrch->addNeighbor(neighbor_ctx));
+
+        NeighborContext next_hop_ctx(VLAN1000_NEIGH);
+        EXPECT_FALSE(gNeighOrch->addNextHop(next_hop_ctx));
+
+        gIntfsOrch->m_removingIntfses.erase(VLAN_1000);
+    }
+
     TEST_F(NeighOrchTest, MultiVlanDuplicateNeighbor)
     {
         EXPECT_CALL(*mock_sai_neighbor_api, create_neighbor_entry);

--- a/tests/mock_tests/neighorch_ut.cpp
+++ b/tests/mock_tests/neighorch_ut.cpp
@@ -203,6 +203,20 @@ namespace neighorch_test
         gIntfsOrch->m_removingIntfses.erase(VLAN_1000);
     }
 
+    TEST_F(NeighOrchTest, LocalNeighborDependenciesRetryWhileVrfUpdatePending)
+    {
+        gIntfsOrch->m_pendingVrfUpdates.insert(VLAN_1000);
+
+        NeighborContext neighbor_ctx(VLAN1000_NEIGH);
+        neighbor_ctx.mac = MacAddress(MAC1);
+        EXPECT_FALSE(gNeighOrch->addNeighbor(neighbor_ctx));
+
+        NeighborContext next_hop_ctx(VLAN1000_NEIGH);
+        EXPECT_FALSE(gNeighOrch->addNextHop(next_hop_ctx));
+
+        gIntfsOrch->m_pendingVrfUpdates.erase(VLAN_1000);
+    }
+
     TEST_F(NeighOrchTest, MultiVlanDuplicateNeighbor)
     {
         EXPECT_CALL(*mock_sai_neighbor_api, create_neighbor_entry);


### PR DESCRIPTION
**How to read this two-PR fix**

Start here for the externally visible failure: an explicit VRF-changing interface `SET` could be consumed while old prefixes still existed, so the RIF and its IP2Me routes remained in the old VRF.

Then read [PR #4746](https://github.com/sonic-net/sonic-swss/pull/4746) for the prerequisite: retaining the `SET` cannot complete reliably if RouteOrch and NeighOrch can keep attaching new dependencies to the old RIF during the drain.

The required implementation and merge order remains **PR #4746 first, then this PR**, because this PR extends its explicit addition-side removal checks with a separate pending-VRF predicate.

Until #4746 merges, GitHub's **Files changed** tab includes that prerequisite commit. This PR's own changes implement the rehome state machine in IntfsOrch and extend the standard local route, neighbor, and next-hop admission checks to the pending-VRF state.

**What I did**

This PR fixes the **lost VRF-transition request** by making an explicit `vrf_name` update use the same retain-and-retry model that whole-interface deletion already uses.

### Observed failure

The DHCP relay test configured `Vlan1000` in `Vrf01`, but hardware tracing showed:

```text
CONFIG_DB / intended interface VRF:  Vrf01
ASIC RIF virtual router:             default VRF
192.168.0.1/32 IP2Me route VR:       default VRF
fc02:1000::1/128 IP2Me route VR:     default VRF
```

The returning DHCP OFFER was addressed to the relay interface in `Vrf01`. Because the corresponding IP2Me trap route existed in the default virtual router instead, the packet did not reach the relay process.

### Root cause 1: a VRF-changing `SET` was consumed instead of retried

`intfmgrd` intends a VRF move to occur as a delete/recreate sequence:

```text
remove old prefixes
→ unbind the Linux interface
→ bind it to Vrf01
→ recreate the interface and prefixes
```

However, its Linux-side checks do not acknowledge orchagent or ASIC completion. `getIntfIpCount() == 0` means only that Linux no longer has addresses; APP_DB prefix deletions may still be waiting for IntfsOrch.

There are two additional ordering effects:

1. ProducerStateTable/ConsumerStateTable communicates the latest state of a key. If interface `DEL` and replacement interface `SET` occur before the consumer pops that key, the intermediate interface `DEL` can be represented to orchagent as only:

   ```text
   Vlan1000 SET vrf_name=Vrf01
   ```

2. The interface row and prefix rows are different APP_DB keys. When they overlap in IntfsOrch's pending multimap, the bare key sorts first:

   ```text
   Vlan1000                         SET vrf_name=Vrf01
   Vlan1000:192.168.0.1/21         DEL
   Vlan1000:fc02:1000::1/64        DEL
   ```

The trace confirmed that the explicit interface `SET` was processed before the final IPv6 prefix `DEL`.

At that point the old RIF still had prefixes and could not safely be replaced. The critical bug was an asymmetry between `DEL` and `SET`:

| Operation | Dependencies remain | Previous behavior |
|---|---:|---|
| Whole-interface `DEL` | Yes | Return `false`; keep the command queued and retry |
| Explicit VRF-changing interface `SET` | Yes | Return `true`; erase the command without moving the RIF |

After the later prefix deletions drained, the explicit VRF request was gone. Nothing remained in `m_toSync` to retry the move, so the RIF and later IP2Me routes stayed in the old virtual router.

The preserved trace from [build 1167684](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1167684), head `e4e29d85004a50ec0d535eb2676ef94af7274bb5`, distinguishes this from ordinary convergence delay. After the final old VLAN IPv6 prefix was removed, PortChannel101 was recreated in Vrf01 approximately 4 seconds later, but the replacement `192.168.0.1/32` IP2Me route was created in the default VRF approximately 8.2 seconds later. Vlan1000 was not removed until test cleanup approximately 29.9 seconds after the prefix deletion. SWSS was processing other work while the missed VLAN transition persisted.

The [exact failing source](https://github.com/Xichen96/sonic-swss/blob/e4e29d85004a50ec0d535eb2676ef94af7274bb5/orchagent/intfsorch.cpp#L531-L566) records pending VRF intent only when no prefixes remain; otherwise the bare interface SET [returns true](https://github.com/Xichen96/sonic-swss/blob/e4e29d85004a50ec0d535eb2676ef94af7274bb5/orchagent/intfsorch.cpp#L597-L600) and [is erased from the queue](https://github.com/Xichen96/sonic-swss/blob/e4e29d85004a50ec0d535eb2676ef94af7274bb5/orchagent/intfsorch.cpp#L1100-L1105). Its direct child, [d219d1c](https://github.com/Xichen96/sonic-swss/commit/d219d1c994b10f419e96a4cd35dd0c8b4e6e3edb), makes a focused production correction: record the pending intent first and return false while prefixes remain. The accompanying regression checks that the SET remains queued after prefix deletion and completes the rehome on the next processing pass.

This is the central root cause:

> Interface deletion was designed to tolerate dependency reordering; explicit RIF VRF rehome was not.

### Root cause 2: the old RIF could refill while the move waited

Preserving the VRF `SET` is necessary but not sufficient. The RIF cannot be removed while routes, neighbors, or next hops still reference it.

The hardware trace observed new references admitted after the VRF transition had already been seen:

| New dependency on the old RIF | Count |
|---|---:|
| Standard routes | 108 |
| Neighbors | 60 |
| Neighbor next hops | 60 |
| **Total** | **228** |

Without a transition fence, the rehome could repeatedly wait for `ref_count == 0` while other orchagents continued attaching work to the old RIF.

PR #4746 introduces an explicit removal-state predicate checked only by addition paths. This PR adds a separate pending-VRF predicate and makes those same addition paths check both states.

### Fix

The fix turns VRF rehome into an explicit per-interface state machine:

```text
OLD/STABLE
    old RIF is authoritative
        |
        | explicit vrf_name change observed
        v
TRANSITION
    retain VRF SET
    allow old prefix/route/neighbor DELs
    block and retain new prefix/route/neighbor SETs
        |
        | prefixes and RIF references reach zero
        v
RECREATE
    remove old RIF
    create RIF in requested VRF
        |
        v
NEW/STABLE
    release retained additions against new RIF
```

#### 1. Distinguish explicit VRF intent

APP_DB `SET` is a partial update. These are not equivalent:

```text
SET vrf_name=Vrf01
SET admin_status=down
```

Without remembering whether `vrf_name` was actually present, a later MTU or admin-only update could be mistaken for a request to move the interface back to the default VRF.

The consumer therefore records `vrfNameIsExplicit` and enters the rehome path only when:

```text
this is the interface key
AND vrf_name was explicitly present
AND requested VRF differs from the current RIF VRF
```

#### 2. Retain the unresolved VRF `SET`

When prefixes or references remain:

```text
mark Vlan1000 as pending VRF rehome
→ return false
→ leave the original SET, including its target vrf_name, in m_toSync
```

`m_pendingVrfUpdates` is only the transition marker; it does not duplicate the requested VRF. The retained APP_DB tuple remains authoritative.

#### 3. Drain old work and retain new work

During the pending transition:

- Old prefix, route, and neighbor deletions continue using the old RIF.
- New prefix additions return `false`.
- Standard local route, neighbor, and neighbor-next-hop additions explicitly check `isIntfVrfUpdatePending()` and return `false` before obtaining the old RIF ID.
- Those original additions remain queued; no new producer notification is required.

For the processing order discussed during review:

```text
Vlan1000                         SET vrf_name=Vrf01
Vlan1000:192.168.0.1/21         DEL
Vlan1000:192.168.0.1/21         SET   # add replacement prefix
```

the effective execution becomes:

```text
first pass:
    interface SET → retained; transition fence established
    prefix DEL    → old prefix removed
    prefix SET    → retained because transition is pending

next pass:
    interface SET → old RIF removed; new RIF created in Vrf01
    prefix SET    → added using the new RIF and Vrf01
```

The multimap may visit `SET → DEL → ADD`, but dependency checks produce the required semantic order:

```text
delete old state → replace RIF → add new state
```

#### 4. Recreate safely

The replacement preserves the existing interface state used to create the RIF, including:

- custom RIF MAC;
- loopback action;
- MTU and admin state;
- MPLS state;
- NAT zone;
- proxy ARP and other `IntfsEntry` state.

Simultaneous subinterface MTU/admin changes are applied during the rehome. A later partial `SET` without `vrf_name` does not trigger another move.

Logical VRF/refcount state changes only after the replacement RIF is created successfully. If creation fails:

```text
recreate the old RIF
→ keep the VRF SET queued
→ retry later without aborting the rest of the consumer drain
```

If SAG is enabled, the task remains pending rather than attempting to migrate shared SAG link-local accounting as part of this targeted fix.

**Why I did it**

### Why not require APP_DB to deliver `DEL → SET → ADD`?

APP_DB StateTable is a latest desired-state synchronization mechanism, not a durable transactional event log. Preserving one producer's call order is insufficient because:

- same-key updates can be coalesced before a consumer sees them;
- differently keyed interface and prefix rows are sorted by the consumer;
- routes and neighbors are handled by different tables and orchagents;
- retained operations retry in later drain cycles;
- multiple producers run independently;
- restart recovery reconstructs current state rather than replaying the original command sequence.

A FIFO or priority queue inside IntfsOrch would address only one table and could cause head-of-line blocking. It would not order IntfsOrch against RouteOrch or NeighOrch.

A producer-side barrier or Redis transaction would also be insufficient by itself. Atomic publication does not guarantee ordered execution across consumers, retries, dependencies, or restarts.

The fully general solution would require an interface generation or transaction protocol, for example:

```text
interface_generation=42
transition_state=draining
```

with every dependent route and neighbor carrying the same generation. That would allow orchagent to classify an addition intended for a future interface even if it arrived before the transition signal. Such a design requires coordinated schema and behavior changes across `intfmgrd`, IntfsOrch, RouteOrch, NeighOrch, producers, and recovery logic.

This PR instead follows the existing SWSS model:

```text
recognize missing prerequisites
→ retain work by returning false
→ allow dependencies to drain
→ retry when local state permits
```

### Boundary of this fix

Once the interface transition is visible:

```text
later additions are retained
old deletions are allowed
retained additions retry on the new RIF
```

Before any transition signal is visible, an operation naming `Vlan1000` must be interpreted against the currently active old interface. Without generation metadata, orchagent cannot know that an early addition belongs to a future `Vlan1000`.

That means a true `ADD(new) → SET transition → DEL(old)` inversion cannot be classified perfectly. The old dependency will safely block the move until it receives a deletion; the code does not remove a still-referenced RIF.

The traced hardware failure is within the solved boundary: the explicit VRF `SET` had already been processed, but the old code did not retain it or establish a transition fence, so 228 later additions were admitted to the old RIF.

This PR also does not reconstruct a prefix `DEL` that ProducerStateTable may have coalesced with a same-key replacement prefix `SET` before either operation reached IntfsOrch. A priority queue cannot restore an operation that is no longer present.

**How I verified it**

Focused mock coverage verifies:

- the explicit VRF `SET` remains queued across prefix and reference drain;
- same-prefix `DEL` followed by replacement `SET` is applied to the new RIF;
- new prefix, local neighbor, and local neighbor-next-hop dependencies are blocked while the move is pending;
- loopback action, MPLS state, custom MAC, and other RIF creation attributes survive replacement;
- simultaneous subinterface VRF/MTU/admin changes are applied;
- later partial updates without `vrf_name` preserve the current VRF;
- replacement creation failure restores the old RIF and retains the move without aborting the remaining drain pass.

The earlier combined branches containing this implementation completed the amd64, ARM, ASAN, Docker, and Trixie compile stages in Azure builds `1168368` (master) and `1168367` (202605). Their `vstest` jobs stopped before executing tests because those workers lacked `pip3`.

An earlier combined candidate, hardware build `1167872`, passed traced and production 1x/5x runs and all ten production 10x test bodies. This smaller stacked PR adds state-preservation and rollback hardening after that run, so exact-commit validation is provided by this PR's CI.

**Historical teardown clarification:** The 10x run was not fully green: all ten test bodies passed, but pytest reported two LogAnalyzer teardown errors (iterations 9 and 10).

1. The recorded message is already globally suppressed by https://github.com/sonic-net/sonic-mgmt/pull/24642 (master) and https://github.com/sonic-net/sonic-mgmt/pull/26997 (202605).
2. Even without that global suppression, the fixture correction proposed in https://github.com/sonic-net/sonic-mgmt/pull/27830 would retain the intended per-test ignores through the LogAnalyzer scan. That PR is draft; validation and review remain pending.

See the [teardown explanation](https://github.com/sonic-net/sonic-swss/pull/4764#issuecomment-5606087583) for the historical evidence and distinction between suppression and fixture correction.

### Current exact-head master PR build

- Head: `ae4666cadab9015ca2533f5f7ce2c2ef380fd490`
- Azure PR build: [1171658](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1171658)
- This head is the current-master restack that preserves merged PR #4758 and its regression coverage.
- The fresh exact-head PR build is in progress. The previous build `1171071` is superseded because its retry could not merge current master after PR #4758 landed.
- DCO, EasyCLA, and Semgrep are already green on the restacked head; final build, test, and exact-head review results will be recorded when complete.
- No local build was used; validation is PR-build only.

### 202605 PR-build validation

- Validation-only PR: [#4747](https://github.com/sonic-net/sonic-swss/pull/4747)
- The complete current-`202605` stack includes merged PR #4758 and all six user PRs in final dependency order: #4746, #4766, #4769, #4772, this PR, then #4770.
- The target-branch conflict resolution preserves both the #4766 loopback-action retry and this PR's RIF state tracking.
- Current master head validated: `ae6b4c25cab230503a0e193b93930164a445ad79`
- Exact target-branch commits include `0c3a96d3f7a0c89906dda5ca8490dd312b563d61`, `d4b0502ecdac76d56fdf063a633045c0fb0de977`, and `d9033e7019d52a422fd2e2bb04d19c35110c805c`.
- Exact validation head: `253e3009fc42ccc1671715ab4a7797f6b1559b37`
- Azure PR build: [1175840](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1175840)
- Result: all applicable architecture, ASAN, Docker, Trixie, `Test vstest`, and `TestAsan vstest` lanes passed.
- The result remains reusable after the later #4766 changes because its production change is behavior-preserving and the remaining changes are test-only.

### Tested branch

- [x] 202605

### Test result

- 202605: The exact combined validation stack passed in [PR #4747](https://github.com/sonic-net/sonic-swss/pull/4747), head `253e3009fc42ccc1671715ab4a7797f6b1559b37`, build [1175840](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1175840). The later #4766 production adjustment preserves behavior, so the validation remains applicable to this dependent stack.

**Details if related**

- Required prerequisite: [PR #4746](https://github.com/sonic-net/sonic-swss/pull/4746)
- Microsoft ADO: [38514061](https://msazure.visualstudio.com/One/_workitems/edit/38514061)
- Merge batch 2: merge PR #4746 first, merge/recheck batch-1 PR #4766, then merge this PR.
