### PR TITLE
[intfsorch]: Retry loopback action update failures

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -76,6 +76,7 @@ IntfsOrch::IntfsOrch(DBConnector *db, vector<table_name_with_pri_t> tableNames, 
         m_vidToRidTable = unique_ptr<Table>(new Table(m_asic_db.get(), "VIDTORID"));
     }
 
+
     auto intervT = timespec { .tv_sec = UPDATE_MAPS_SEC , .tv_nsec = 0 };
     m_updateMapsTimer = new SelectableTimer(intervT);
     auto executorT = new ExecutableTimer(m_updateMapsTimer, this, "UPDATE_MAPS_TIMER");
@@ -880,6 +881,15 @@ void IntfsOrch::doTask(Consumer &consumer)
         string op = kfvOp(t);
         if (op == SET_COMMAND)
         {
+            if (!loopbackAction.empty())
+            {
+                sai_packet_action_t action;
+                if (!getSaiLoopbackAction(loopbackAction, action))
+                {
+                    loopbackAction.clear();
+                }
+            }
+
             if (is_lo)
             {
                 if (!ip_prefix_in_key)
@@ -1066,7 +1076,11 @@ void IntfsOrch::doTask(Consumer &consumer)
                     /* Set loopback action */
                     if (!loopbackAction.empty())
                     {
-                        setIntfLoopbackAction(port, loopbackAction);
+                        if (!setIntfLoopbackAction(port, loopbackAction))
+                        {
+                            it++;
+                            continue;
+                        }
                     }
                 }
             }
@@ -1975,4 +1989,3 @@ void IntfsOrch::voqSyncIntfState(string &alias, bool isUp)
     }
 
 }
-

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -437,7 +437,7 @@ bool IntfsOrch::setIntfLoopbackAction(const Port &port, string actionStr)
 
     if (!getSaiLoopbackAction(actionStr, action))
     {
-        return false;
+        return true;
     }
 
     attr.id = SAI_ROUTER_INTERFACE_ATTR_LOOPBACK_PACKET_ACTION;
@@ -881,15 +881,6 @@ void IntfsOrch::doTask(Consumer &consumer)
         string op = kfvOp(t);
         if (op == SET_COMMAND)
         {
-            if (!loopbackAction.empty())
-            {
-                sai_packet_action_t action;
-                if (!getSaiLoopbackAction(loopbackAction, action))
-                {
-                    loopbackAction.clear();
-                }
-            }
-
             if (is_lo)
             {
                 if (!ip_prefix_in_key)

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -53,7 +53,8 @@ namespace intfsorch_test
             saw_loopback_action = true;
             last_loopback_action = static_cast<sai_packet_action_t>(attr->value.s32);
         }
-        return SAI_STATUS_SUCCESS;
+        return pold_sai_rif_api->set_router_interface_attribute(
+            router_interface_id, attr);
     }
 
     struct IntfsOrchTest : public ::testing::Test

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -16,6 +16,9 @@ namespace intfsorch_test
 
     int create_rif_count = 0;
     int remove_rif_count = 0;
+    bool saw_loopback_action = false;
+    bool fail_next_rif_set = false;
+    sai_packet_action_t last_loopback_action = SAI_PACKET_ACTION_FORWARD;
     sai_router_interface_api_t *pold_sai_rif_api;
     sai_router_interface_api_t ut_sai_rif_api;
 
@@ -33,6 +36,23 @@ namespace intfsorch_test
             _In_ sai_object_id_t router_interface_id)
     {
         ++remove_rif_count;
+        return SAI_STATUS_SUCCESS;
+    }
+
+    sai_status_t _ut_set_router_interface_attribute(
+            _In_ sai_object_id_t router_interface_id,
+            _In_ const sai_attribute_t *attr)
+    {
+        if (fail_next_rif_set)
+        {
+            fail_next_rif_set = false;
+            return SAI_STATUS_INSUFFICIENT_RESOURCES;
+        }
+        if (attr->id == SAI_ROUTER_INTERFACE_ATTR_LOOPBACK_PACKET_ACTION)
+        {
+            saw_loopback_action = true;
+            last_loopback_action = static_cast<sai_packet_action_t>(attr->value.s32);
+        }
         return SAI_STATUS_SUCCESS;
     }
 
@@ -61,6 +81,10 @@ namespace intfsorch_test
 
             sai_router_intfs_api->create_router_interface = _ut_create_router_interface;
             sai_router_intfs_api->remove_router_interface = _ut_remove_router_interface;
+            sai_router_intfs_api->set_router_interface_attribute = _ut_set_router_interface_attribute;
+            saw_loopback_action = false;
+            fail_next_rif_set = false;
+            last_loopback_action = SAI_PACKET_ACTION_FORWARD;
 
             m_app_db = make_shared<swss::DBConnector>("APPL_DB", 0);
             m_config_db = make_shared<swss::DBConnector>("CONFIG_DB", 0);
@@ -488,5 +512,55 @@ namespace intfsorch_test
         syncd = gIntfsOrch->getSyncdIntfses();
         ASSERT_EQ(syncd["Loopback6"].vrf_id, gVrfOrch->getVRFid("Vrf-Blue"));
         ASSERT_EQ(gVrfOrch->getVrfRefCount("Vrf-Blue"), base_vrf_ref + 1);
+    TEST_F(IntfsOrchTest, IntfsOrchRetriesLoopbackActionSetFailure)
+    {
+        std::deque<KeyOpFieldsValuesTuple> entries{
+            {"Ethernet0", "SET", {{"mtu", "9100"}}}
+        };
+        auto consumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+
+        fail_next_rif_set = true;
+        entries = {
+            {"Ethernet0", "SET", {{"loopback_action", "drop"}}}
+        };
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+
+        ASSERT_EQ(consumer->m_toSync.size(), 1u);
+        ASSERT_FALSE(saw_loopback_action);
+
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+
+        ASSERT_TRUE(consumer->m_toSync.empty());
+        ASSERT_TRUE(saw_loopback_action);
+        ASSERT_EQ(last_loopback_action, SAI_PACKET_ACTION_DROP);
+    }
+
+    TEST_F(IntfsOrchTest, IntfsOrchIgnoresInvalidLoopbackActionField)
+    {
+        std::deque<KeyOpFieldsValuesTuple> entries{
+            {"Ethernet0", "SET", {{"mtu", "9100"}}}
+        };
+        auto consumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+
+        entries = {
+            {"Ethernet0", "SET", {
+                {"loopback_action", "invalid"},
+                {"mtu", "1500"}
+            }}
+        };
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+
+        ASSERT_TRUE(consumer->m_toSync.empty());
+        ASSERT_FALSE(saw_loopback_action);
+
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+        ASSERT_EQ(port.m_mtu, 1500u);
     }
 }

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -518,6 +518,7 @@ namespace intfsorch_test
             {"Ethernet0", "SET", {{"mtu", "9100"}}}
         };
         auto consumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
+        ASSERT_NE(consumer, nullptr);
         consumer->addToSync(entries);
         static_cast<Orch *>(gIntfsOrch)->doTask();
 
@@ -544,6 +545,7 @@ namespace intfsorch_test
             {"Ethernet0", "SET", {{"mtu", "9100"}}}
         };
         auto consumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
+        ASSERT_NE(consumer, nullptr);
         consumer->addToSync(entries);
         static_cast<Orch *>(gIntfsOrch)->doTask();
 

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -512,13 +512,14 @@ namespace intfsorch_test
         syncd = gIntfsOrch->getSyncdIntfses();
         ASSERT_EQ(syncd["Loopback6"].vrf_id, gVrfOrch->getVRFid("Vrf-Blue"));
         ASSERT_EQ(gVrfOrch->getVrfRefCount("Vrf-Blue"), base_vrf_ref + 1);
+    }
+
     TEST_F(IntfsOrchTest, IntfsOrchRetriesLoopbackActionSetFailure)
     {
         std::deque<KeyOpFieldsValuesTuple> entries{
             {"Ethernet0", "SET", {{"mtu", "9100"}}}
         };
         auto consumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
-        ASSERT_NE(consumer, nullptr);
         consumer->addToSync(entries);
         static_cast<Orch *>(gIntfsOrch)->doTask();
 
@@ -545,14 +546,13 @@ namespace intfsorch_test
             {"Ethernet0", "SET", {{"mtu", "9100"}}}
         };
         auto consumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
-        ASSERT_NE(consumer, nullptr);
         consumer->addToSync(entries);
         static_cast<Orch *>(gIntfsOrch)->doTask();
 
         entries = {
             {"Ethernet0", "SET", {
                 {"loopback_action", "invalid"},
-                {"nat_zone", "7"}
+                {"mtu", "1500"}
             }}
         };
         consumer->addToSync(entries);
@@ -563,6 +563,6 @@ namespace intfsorch_test
 
         Port port;
         ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
-        ASSERT_EQ(port.m_nat_zone_id, 7u);
+        ASSERT_EQ(port.m_mtu, 1500u);
     }
 }

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -520,6 +520,7 @@ namespace intfsorch_test
             {"Ethernet0", "SET", {{"mtu", "9100"}}}
         };
         auto consumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
+        ASSERT_NE(consumer, nullptr);
         consumer->addToSync(entries);
         static_cast<Orch *>(gIntfsOrch)->doTask();
 
@@ -546,13 +547,14 @@ namespace intfsorch_test
             {"Ethernet0", "SET", {{"mtu", "9100"}}}
         };
         auto consumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
+        ASSERT_NE(consumer, nullptr);
         consumer->addToSync(entries);
         static_cast<Orch *>(gIntfsOrch)->doTask();
 
         entries = {
             {"Ethernet0", "SET", {
                 {"loopback_action", "invalid"},
-                {"mtu", "1500"}
+                {"nat_zone", "7"}
             }}
         };
         consumer->addToSync(entries);
@@ -563,6 +565,6 @@ namespace intfsorch_test
 
         Port port;
         ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
-        ASSERT_EQ(port.m_mtu, 1500u);
+        ASSERT_EQ(port.m_nat_zone_id, 7u);
     }
 }

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -43,13 +43,13 @@ namespace intfsorch_test
             _In_ sai_object_id_t router_interface_id,
             _In_ const sai_attribute_t *attr)
     {
-        if (fail_next_rif_set)
-        {
-            fail_next_rif_set = false;
-            return SAI_STATUS_INSUFFICIENT_RESOURCES;
-        }
         if (attr->id == SAI_ROUTER_INTERFACE_ATTR_LOOPBACK_PACKET_ACTION)
         {
+            if (fail_next_rif_set)
+            {
+                fail_next_rif_set = false;
+                return SAI_STATUS_INSUFFICIENT_RESOURCES;
+            }
             saw_loopback_action = true;
             last_loopback_action = static_cast<sai_packet_action_t>(attr->value.s32);
         }

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -552,7 +552,7 @@ namespace intfsorch_test
         entries = {
             {"Ethernet0", "SET", {
                 {"loopback_action", "invalid"},
-                {"mtu", "1500"}
+                {"nat_zone", "7"}
             }}
         };
         consumer->addToSync(entries);
@@ -563,6 +563,6 @@ namespace intfsorch_test
 
         Port port;
         ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
-        ASSERT_EQ(port.m_mtu, 1500u);
+        ASSERT_EQ(port.m_nat_zone_id, 7u);
     }
 }

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -52,6 +52,7 @@ namespace intfsorch_test
             }
             saw_loopback_action = true;
             last_loopback_action = static_cast<sai_packet_action_t>(attr->value.s32);
+            return SAI_STATUS_SUCCESS;
         }
         return pold_sai_rif_api->set_router_interface_attribute(
             router_interface_id, attr);

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -18,6 +18,7 @@ namespace intfsorch_test
     int remove_rif_count = 0;
     bool saw_loopback_action = false;
     bool fail_next_rif_set = false;
+    int loopback_action_set_count = 0;
     sai_packet_action_t last_loopback_action = SAI_PACKET_ACTION_FORWARD;
     sai_router_interface_api_t *pold_sai_rif_api;
     sai_router_interface_api_t ut_sai_rif_api;
@@ -29,14 +30,15 @@ namespace intfsorch_test
             _In_ const sai_attribute_t *attr_list)
     {
         ++create_rif_count;
-        return SAI_STATUS_SUCCESS;
+        return pold_sai_rif_api->create_router_interface(
+            router_interface_id, switch_id, attr_count, attr_list);
     }
 
     sai_status_t _ut_remove_router_interface(
             _In_ sai_object_id_t router_interface_id)
     {
         ++remove_rif_count;
-        return SAI_STATUS_SUCCESS;
+        return pold_sai_rif_api->remove_router_interface(router_interface_id);
     }
 
     sai_status_t _ut_set_router_interface_attribute(
@@ -45,13 +47,14 @@ namespace intfsorch_test
     {
         if (attr->id == SAI_ROUTER_INTERFACE_ATTR_LOOPBACK_PACKET_ACTION)
         {
+            ++loopback_action_set_count;
+            last_loopback_action = static_cast<sai_packet_action_t>(attr->value.s32);
             if (fail_next_rif_set)
             {
                 fail_next_rif_set = false;
                 return SAI_STATUS_INSUFFICIENT_RESOURCES;
             }
             saw_loopback_action = true;
-            last_loopback_action = static_cast<sai_packet_action_t>(attr->value.s32);
             return SAI_STATUS_SUCCESS;
         }
         return pold_sai_rif_api->set_router_interface_attribute(
@@ -86,6 +89,7 @@ namespace intfsorch_test
             sai_router_intfs_api->set_router_interface_attribute = _ut_set_router_interface_attribute;
             saw_loopback_action = false;
             fail_next_rif_set = false;
+            loopback_action_set_count = 0;
             last_loopback_action = SAI_PACKET_ACTION_FORWARD;
 
             m_app_db = make_shared<swss::DBConnector>("APPL_DB", 0);
@@ -534,11 +538,13 @@ namespace intfsorch_test
         static_cast<Orch *>(gIntfsOrch)->doTask();
 
         ASSERT_EQ(consumer->m_toSync.size(), 1u);
+        ASSERT_EQ(loopback_action_set_count, 1);
         ASSERT_FALSE(saw_loopback_action);
 
         static_cast<Orch *>(gIntfsOrch)->doTask();
 
         ASSERT_TRUE(consumer->m_toSync.empty());
+        ASSERT_EQ(loopback_action_set_count, 2);
         ASSERT_TRUE(saw_loopback_action);
         ASSERT_EQ(last_loopback_action, SAI_PACKET_ACTION_DROP);
     }
@@ -563,6 +569,7 @@ namespace intfsorch_test
         static_cast<Orch *>(gIntfsOrch)->doTask();
 
         ASSERT_TRUE(consumer->m_toSync.empty());
+        ASSERT_EQ(loopback_action_set_count, 0);
         ASSERT_FALSE(saw_loopback_action);
 
         Port port;


### PR DESCRIPTION
**What I did**

Fixed dynamic `loopback_action` updates on an existing router interface so retryable SAI failures retain the APP_DB task instead of silently losing the requested action.

Historically, `loopback_action` was normally supplied while creating a RIF. `setIntf()` passed it to `addRouterIntfs()`, which included `SAI_ROUTER_INTERFACE_ATTR_LOOPBACK_PACKET_ACTION` in the CREATE attributes.

The operation exposing this bug changes an existing RIF dynamically between `DROP` and `FORWARD` without recreating it. That path calls `setIntfLoopbackAction()` from `IntfsOrch::doTask()`.

Before:

```text
setIntfLoopbackAction()
    -> transient SAI SET failure
    -> helper returns false: retry needed
    -> caller ignores false
    -> final m_toSync.erase()
    -> requested action is lost
```

After:

```text
setIntfLoopbackAction()
    -> transient SAI SET failure
    -> helper returns false
    -> caller skips the final erase
    -> original APP_DB row remains queued
    -> complete update is retried on the next drain
```

The helper follows the existing `IntfsOrch` boolean-setter convention: `false` means retry is required; `true` means processing is terminal and should not be retried. Therefore an invalid action logs a warning and returns `true` without issuing a SAI call, allowing unrelated fields in the same row to converge.

The change remains surgical: `setIntf()` still owns the RIF lifecycle, and `setIntfLoopbackAction()` remains the single-attribute SAI setter.

**Why I did it**

A transient SAI resource condition must not silently discard desired state. Dynamic loopback packet-action updates need the same retain-and-retry behavior used by other retryable SAI operations.

Invalid input is different: it cannot converge on a later drain and must not leave the whole row queued forever. For example:

```text
SET Ethernet0
    loopback_action = invalid
    nat_zone        = 7
```

The invalid action is ignored, while `nat_zone=7` is still applied and the task is consumed.

This issue is independent of the interface-removal and VRF-rehome state machines in PRs #4746 and #4764.

**How I verified it**

Focused mock coverage verifies:

- `IntfsOrchRetriesLoopbackActionSetFailure`
  - injects one `SAI_STATUS_INSUFFICIENT_RESOURCES` result for the loopback-action attribute;
  - verifies the task remains in `m_toSync`;
  - retries the drain;
  - verifies the task is consumed and `SAI_PACKET_ACTION_DROP` is applied.
- `IntfsOrchIgnoresInvalidLoopbackActionField`
  - submits an invalid action with `nat_zone=7`;
  - verifies no loopback action is sent to SAI;
  - verifies the NAT-zone update is applied and the task is consumed.
- The test hook creates and removes real RIF objects through the original SAI implementation, intercepts only the loopback-action attribute, and delegates every unrelated RIF SET. It also counts both the failed first SET attempt and the successful retry.

Current head: `d1ef1b1`

- Exact-head Azure PR build [1182055](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1182055) passed all architecture, ASAN, Docker, Trixie, regular VSTest, ASAN VSTest, and coverage lanes.
- Exact-head Copilot review completed with no unresolved findings.
- DCO, EasyCLA, CodeQL, and Semgrep passed on the current head.

**Details if related**

- Backport request: `202605`.
- The current branch has an automated `Cherry Pick Conflict_202605` label.
- Combined 202605 validation passed in [PR #4747](https://github.com/sonic-net/sonic-swss/pull/4747), head `253e3009fc42ccc1671715ab4a7797f6b1559b37`, build [1175840](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1175840).
- That validation is reused for the current head because `5481ae09` preserves all externally observable outcomes while removing a duplicate parse, and the later commits change only mock-test fidelity.

### Tested branch

- [x] 202605

### Test result

- 202605: The exact combined validation stack passed in [PR #4747](https://github.com/sonic-net/sonic-swss/pull/4747), head `253e3009fc42ccc1671715ab4a7797f6b1559b37`, build [1175840](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1175840). The current #4766 head reuses this result because its post-validation production change is behavior-preserving and all subsequent changes are test-only.
- Microsoft ADO:
  https://msazure.visualstudio.com/One/_workitems/edit/38514061
- Merge batch 1.
- Recheck PR #4764 after this PR merges because both touch the same `IntfsOrch` paths.

