### PR TITLE
teamsyncd: fix VoQ system LAG ID regression after teamdctl gate (#27245)

### DIFF
--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -120,11 +120,9 @@ void TeamSync::onMsg(int nlmsg_type, struct nl_object *obj)
 
     if (nlmsg_type == RTM_DELLINK)
     {
-        if (m_teamSelectables.find(lagName) != m_teamSelectables.end())
-        {
-            /* Remove LAG ports and delete LAG */
-            removeLag(lagName);
-        }
+        /* Always remove APP_LAG (and STATE_LAG if tracked), even when
+         * TeamPortSync was never created because teamdctl failed on add. */
+        removeLag(lagName);
         return;
     }
 
@@ -137,7 +135,6 @@ void TeamSync::onMsg(int nlmsg_type, struct nl_object *obj)
 void TeamSync::addLag(const string &lagName, int ifindex, bool admin_state,
                       bool oper_state, unsigned int mtu)
 {
-    /* Set the LAG */
     std::vector<FieldValueTuple> fvVector;
     FieldValueTuple a("admin_status", admin_state ? "up" : "down");
     FieldValueTuple o("oper_status", oper_state ? "up" : "down");
@@ -145,10 +142,6 @@ void TeamSync::addLag(const string &lagName, int ifindex, bool admin_state,
     fvVector.push_back(a);
     fvVector.push_back(o);
     fvVector.push_back(m);
-    m_lagTable.set(lagName, fvVector);
-
-    SWSS_LOG_INFO("Add %s admin_status:%s oper_status:%s, mtu: %d",
-                   lagName.c_str(), admin_state ? "up" : "down", oper_state ? "up" : "down", mtu);
 
     bool lag_update = true;
     /* Return when the team instance has already been tracked */
@@ -165,6 +158,12 @@ void TeamSync::addLag(const string &lagName, int ifindex, bool admin_state,
 
     FieldValueTuple s("state", "ok");
     fvVector.push_back(s);
+
+    /* Publish APP_LAG immediately so orchagent can allocate and free LAG ids on
+     * rapid add/del; RTM_DELLINK always removes APP_LAG even when TeamPortSync
+     * never succeeded.  STATE_LAG is written only after teamd is ready (#3984). */
+    m_lagTable.set(lagName, fvVector);
+
     if (lag_update)
     {
         /* Create the team instance.
@@ -177,16 +176,17 @@ void TeamSync::addLag(const string &lagName, int ifindex, bool admin_state,
          * which would abort the entire netlink processing loop.  When teamd finishes
          * recreating the device the kernel emits a fresh RTM_NEWLINK with the correct
          * new ifindex and addLag() is called again, at which point initialization
-         * succeeds.
-         * STATE_DB is written only after the team instance is successfully created
-         * to prevent dependent services (e.g. intfmgrd) from acting on a LAG that
-         * teamd has not yet finished setting up. */
+         * succeeds. */
         try
         {
             auto sync = make_shared<TeamPortSync>(lagName, ifindex, &m_lagMemberTable);
             m_stateLagTable.set(lagName, fvVector);
             m_teamSelectables[lagName] = sync;
             m_selectablesToAdd.insert(lagName);
+
+            SWSS_LOG_INFO("Add %s admin_status:%s oper_status:%s, mtu: %d",
+                           lagName.c_str(), admin_state ? "up" : "down",
+                           oper_state ? "up" : "down", mtu);
         }
         catch (const system_error& e)
         {
@@ -203,14 +203,16 @@ void TeamSync::addLag(const string &lagName, int ifindex, bool admin_state,
 
 void TeamSync::removeLag(const string &lagName)
 {
-    /* Delete all members */
-    auto selectable = m_teamSelectables[lagName];
-    for (auto it : selectable->m_lagMembers)
+    auto it = m_teamSelectables.find(lagName);
+    if (it != m_teamSelectables.end())
     {
-        m_lagMemberTable.del(lagName + ":" + it.first);
+        for (auto member : it->second->m_lagMembers)
+        {
+            m_lagMemberTable.del(lagName + ":" + member.first);
 
-        SWSS_LOG_INFO("Remove member %s before removing LAG %s",
-                it.first.c_str(), lagName.c_str());
+            SWSS_LOG_INFO("Remove member %s before removing LAG %s",
+                    member.first.c_str(), lagName.c_str());
+        }
     }
 
     /* Delete the LAG */
@@ -218,9 +220,10 @@ void TeamSync::removeLag(const string &lagName)
 
     SWSS_LOG_INFO("Remove LAG %s", lagName.c_str());
 
-    /* Return when the team instance hasn't been tracked before */
-    if (m_teamSelectables.find(lagName) == m_teamSelectables.end())
+    if (it == m_teamSelectables.end())
+    {
         return;
+    }
 
     m_stateLagTable.del(lagName);
 

--- a/tests/mock_tests/teamsync_ut.cpp
+++ b/tests/mock_tests/teamsync_ut.cpp
@@ -4,6 +4,7 @@
 #include <stdexcept>
 #include <team.h>
 #include <teamdctl.h>
+#include "schema.h"
 #include "teamsync.h"
 #include "mock_table.h"
 
@@ -207,13 +208,13 @@ namespace teamsync_test
         callback_teamdctl_disconnect = cb_teamdctl_disconnect;
     }
 
-    /* Subclass to expose the protected addLag() for unit testing. */
     class TeamSyncUnderTest : public swss::TeamSync
     {
     public:
         TeamSyncUnderTest(swss::DBConnector *db, swss::DBConnector *stateDb, swss::Select *sel)
             : swss::TeamSync(db, stateDb, sel) {}
         using swss::TeamSync::addLag;
+        using swss::TeamSync::removeLag;
     };
 
     struct TeamSyncTest : public ::testing::Test
@@ -269,5 +270,52 @@ namespace teamsync_test
         TeamSyncUnderTest ts(&db, &stateDb, nullptr);
 
         ts.addLag("testLag", 4, true, true, 1500);
+    }
+
+    /* When teamd is not ready, APP_LAG is still published for orchagent but
+     * STATE_LAG is deferred until TeamPortSync succeeds. */
+    TEST_F(TeamSyncTest, AddLagTeamdctlFailsNoStateLag)
+    {
+        callback_team_init = cb_team_init;
+        callback_team_change_handler = cb_team_change_handler;
+        callback_teamdctl_connect = cb_teamdctl_connect;
+        callback_sleep = cb_sleep;
+
+        swss::DBConnector db(0, "localhost", 0, 0);
+        swss::DBConnector stateDb(1, "localhost", 0, 0);
+        TeamSyncUnderTest ts(&db, &stateDb, nullptr);
+
+        ts.addLag("testLag", 4, true, true, 1500);
+
+        swss::Table appLagTable(&db, APP_LAG_TABLE_NAME);
+        std::vector<std::string> appKeys;
+        appLagTable.getKeys(appKeys);
+        EXPECT_EQ(appKeys.size(), 1u);
+        EXPECT_EQ(appKeys[0], "testLag");
+
+        swss::Table stateLagTable(&stateDb, STATE_LAG_TABLE_NAME);
+        std::vector<std::string> stateKeys;
+        stateLagTable.getKeys(stateKeys);
+        EXPECT_TRUE(stateKeys.empty());
+    }
+
+    TEST_F(TeamSyncTest, RemoveLagWithoutTeamPortSync)
+    {
+        callback_team_init = cb_team_init;
+        callback_team_change_handler = cb_team_change_handler;
+        callback_teamdctl_connect = cb_teamdctl_connect;
+        callback_sleep = cb_sleep;
+
+        swss::DBConnector db(0, "localhost", 0, 0);
+        swss::DBConnector stateDb(1, "localhost", 0, 0);
+        TeamSyncUnderTest ts(&db, &stateDb, nullptr);
+
+        ts.addLag("testLag", 4, true, true, 1500);
+        ts.removeLag("testLag");
+
+        swss::Table appLagTable(&db, APP_LAG_TABLE_NAME);
+        std::vector<std::string> keys;
+        appLagTable.getKeys(keys);
+        EXPECT_TRUE(keys.empty());
     }
 }

--- a/tests/mock_tests/teamsync_ut.cpp
+++ b/tests/mock_tests/teamsync_ut.cpp
@@ -5,7 +5,11 @@
 #include <team.h>
 #include <teamdctl.h>
 #include "schema.h"
+#define protected public
+#define private public
 #include "teamsync.h"
+#undef protected
+#undef private
 #include "mock_table.h"
 
 static unsigned int (*callback_sleep)(unsigned int seconds) = NULL;
@@ -317,5 +321,48 @@ namespace teamsync_test
         std::vector<std::string> keys;
         appLagTable.getKeys(keys);
         EXPECT_TRUE(keys.empty());
+    }
+
+    /* When TeamPortSync exists with tracked members, removeLag() must delete
+     * each APP_LAG_MEMBER entry before removing the LAG itself. */
+    TEST_F(TeamSyncTest, RemoveLagWithTeamPortSyncMembers)
+    {
+        setTeamSyncSuccessMocks();
+
+        swss::DBConnector db(0, "localhost", 0, 0);
+        swss::DBConnector stateDb(1, "localhost", 0, 0);
+        TeamSyncUnderTest ts(&db, &stateDb, nullptr);
+
+        ts.addLag("testLag", 4, true, true, 1500);
+
+        ASSERT_NE(ts.m_teamSelectables.find("testLag"), ts.m_teamSelectables.end());
+
+        ts.m_teamSelectables["testLag"]->m_lagMembers["Ethernet0"] = true;
+        ts.m_teamSelectables["testLag"]->m_lagMembers["Ethernet4"] = false;
+
+        std::vector<swss::FieldValueTuple> memberFv;
+        memberFv.emplace_back("status", "enabled");
+        ts.m_lagMemberTable.set("testLag:Ethernet0", memberFv);
+        ts.m_lagMemberTable.set("testLag:Ethernet4", memberFv);
+
+        ts.removeLag("testLag");
+
+        swss::Table appLagMemberTable(&db, APP_LAG_MEMBER_TABLE_NAME);
+        std::vector<std::string> memberKeys;
+        appLagMemberTable.getKeys(memberKeys);
+        EXPECT_TRUE(memberKeys.empty());
+
+        swss::Table appLagTable(&db, APP_LAG_TABLE_NAME);
+        std::vector<std::string> lagKeys;
+        appLagTable.getKeys(lagKeys);
+        EXPECT_TRUE(lagKeys.empty());
+
+        swss::Table stateLagTable(&stateDb, STATE_LAG_TABLE_NAME);
+        std::vector<std::string> stateKeys;
+        stateLagTable.getKeys(stateKeys);
+        EXPECT_TRUE(stateKeys.empty());
+
+        EXPECT_EQ(ts.m_teamSelectables.find("testLag"), ts.m_teamSelectables.end());
+        EXPECT_EQ(ts.m_selectablesToRemove.count("testLag"), 1u);
     }
 }

--- a/tests/mock_tests/teamsync_ut.cpp
+++ b/tests/mock_tests/teamsync_ut.cpp
@@ -362,7 +362,10 @@ namespace teamsync_test
         stateLagTable.getKeys(stateKeys);
         EXPECT_TRUE(stateKeys.empty());
 
-        EXPECT_EQ(ts.m_teamSelectables.find("testLag"), ts.m_teamSelectables.end());
+        /* removeLag() defers erasing TeamPortSync until doSelectableTask().
+         * Do not call doSelectableTask() here: mocked team_init does not yield
+         * a valid team event fd, so epoll registration would fail in unit tests. */
         EXPECT_EQ(ts.m_selectablesToRemove.count("testLag"), 1u);
+        EXPECT_NE(ts.m_teamSelectables.find("testLag"), ts.m_teamSelectables.end());
     }
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixes the issue  https://github.com/sonic-net/sonic-buildimage/issues/27245 introduced by #3984 
Always call removeLag() on RTM_DELLINK
Publish APP_LAG DEL even when TeamPortSync never ran (teamdctl failed on add). Orchagent can then run lagIdDel() and return system LAG IDs to SYSTEM_LAG_IDS_FREE_LIST.

Leave PR #3984  behavior for STATE_LAG
STATE_LAG is still written only after successful TeamPortSync / teamdctl. If teamd is not ready, there is still no STATE_LAG (intfmgrd and other STATE_DB users stay protected).

Publish APP_LAG for orch before teamd setup
After building attributes (including state=ok), m_lagTable.set() runs before attempting TeamPortSync, so orch sees SET on add and can pair it with DEL on delete during rapid port-channel churn. Success logging stays after teamd comes up.

Harden removeLag()
Use find() before walking members; always m_lagTable.del(); clear STATE_LAG and selectables only when the LAG was tracked.
Preserve https://github.com/sonic-net/sonic-swss/pull/3984 for STATE_DB; fix APP_LAG teardown and publish timing for orch.


**Why I did it**
On VoQ T2 chassis, repeated add/delete of a port channel can leave system LAG IDs inconsistent in CHASSIS_APP_DB, failing pc/test_po_update.py::test_po_update_with_higher_lagids.

sonic-swss #3984  correctly defers STATE_LAG until teamd responds via teamdctl, but RTM_DELLINK still skipped removeLag() when TeamPortSync was never created. Orchagent then missed APP_LAG DEL while still seeing APP_LAG SET, so lagIdDel() did not run and IDs leaked or the free list did not advance.

This change keeps #3984’s STATE_DB behavior, always publishes APP_LAG DEL on interface delete, hardens removeLag() for untracked LAGs, and publishes APP_LAG SET (with state=ok) before teamd setup so orch can pair add/del under port-channel churn.

**How I verified it**
teamsync_ut: existing tests + new cases above.
 VoQ T2: pytest tests/pc/test_po_update.py::test_po_update_with_higher_lagids -  Ran the po_update tests multiple times and ensured the test passed. 
 
 ### _Reason for small delay (~0.5sec) required in test_po_update_with_higher_lagids:_
 The teamsync fix makes SET/DEL correct when the kernel and teamsyncd finish each cycle. It does not make orchagent process APP_LAG as fast as the test pushes config. 
increment_lag_id() calls config_portchannel(PortChannel999, "add") and config_portchannel(..., "del") back-to-back, with no wait for:
teammgrd / kernel → netlink → teamsyncd → APP_LAG in Redis
orchagent → lagIdAdd on create and lagIdDel on remove (SAI LAG create/remove, CHASSIS_APP_DB updates)
Orch handles APP_LAG on a single consumer queue. Under hundreds of rapid iterations, config can outrun orch. If delete is applied before create is done, doLagTask can ignore DEL when the LAG is not in m_portList yet, so that loop iteration does not advance the free-list head even when IDs are not leaked.
The test only checks SYSTEM_LAG_IDS_FREE_LIST once at the end and expects ~one successful add→del per iteration. Without a short wait after add (LAG/orch/DB visible) and/or after del (LAG gone / ID returned), the test can fail on timing, while lag_set_sanity() still passes.

**Details if related**
