### PR TITLE
[neighorch]: Track remote next hops on inband RIF

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -379,7 +379,7 @@ bool NeighOrch::addNextHop(NeighborContext& ctx)
     }
 
     assert(!hasNextHop(nexthop));
-    sai_object_id_t rif_id = m_intfsOrch->getRouterIntfsId(nh.alias);
+    sai_object_id_t rif_id = m_intfsOrch->getRouterIntfsId(nexthop.alias);
 
     vector<sai_attribute_t> next_hop_attrs;
 
@@ -457,7 +457,7 @@ bool NeighOrch::addNextHop(NeighborContext& ctx)
     next_hop_entry.nh_flags = 0;
     m_syncdNextHops[nexthop] = next_hop_entry;
 
-    m_intfsOrch->increaseRouterIntfsRefCount(nh.alias);
+    m_intfsOrch->increaseRouterIntfsRefCount(nexthop.alias);
 
     if (nexthop.isMplsNextHop())
     {
@@ -516,6 +516,15 @@ bool NeighOrch::processBulkAddNextHop(NeighborContext& ctx)
     }
 
     NextHopKey nexthop(nh);
+    if (m_intfsOrch->isRemoteSystemPortIntf(nh.alias))
+    {
+        Port inbp;
+        gPortsOrch->getInbandPort(inbp);
+        assert(inbp.m_alias.length());
+
+        nexthop.alias = inbp.m_alias;
+    }
+
     if (ctx.next_hop_id == SAI_NULL_OBJECT_ID)
     {
         sai_status_t bulker_status = gNextHopBulker.create_status(ctx.next_hop_id);
@@ -549,7 +558,7 @@ bool NeighOrch::processBulkAddNextHop(NeighborContext& ctx)
     next_hop_entry.nh_flags = 0;
     m_syncdNextHops[nexthop] = next_hop_entry;
 
-    m_intfsOrch->increaseRouterIntfsRefCount(nh.alias);
+    m_intfsOrch->increaseRouterIntfsRefCount(nexthop.alias);
 
     if (nexthop.isMplsNextHop())
     {
@@ -784,7 +793,7 @@ bool NeighOrch::removeNextHop(const IpAddress &ipAddress, const string &alias)
     }
 
     m_syncdNextHops.erase(nexthop);
-    m_intfsOrch->decreaseRouterIntfsRefCount(alias);
+    m_intfsOrch->decreaseRouterIntfsRefCount(nexthop.alias);
     return true;
 }
 

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -787,8 +787,8 @@ bool NeighOrch::removeNextHop(const IpAddress &ipAddress, const string &alias)
 
     if (m_syncdNextHops[nexthop].ref_count > 0)
     {
-        SWSS_LOG_ERROR("Failed to remove still referenced next hop %s on %s",
-                       ipAddress.to_string().c_str(), alias.c_str());
+        SWSS_LOG_ERROR("Failed to remove still referenced next hop %s requested on %s, tracked on %s",
+                       ipAddress.to_string().c_str(), alias.c_str(), nexthop.alias.c_str());
         return false;
     }
 

--- a/tests/mock_tests/neighorch_ut.cpp
+++ b/tests/mock_tests/neighorch_ut.cpp
@@ -219,6 +219,15 @@ namespace neighorch_test
     {
         ConfigureRemoteSystemPort(ETHERNET0, ETHERNET4);
 
+        Port remote_port;
+        ASSERT_TRUE(gPortsOrch->getPort(ETHERNET0, remote_port));
+        remote_port.m_oper_status = SAI_PORT_OPER_STATUS_DOWN;
+        gPortsOrch->setPort(ETHERNET0, remote_port);
+
+        Port inband_port;
+        ASSERT_TRUE(gPortsOrch->getPort(ETHERNET4, inband_port));
+        ASSERT_EQ(inband_port.m_oper_status, SAI_PORT_OPER_STATUS_UP);
+
         auto inband_rif = gIntfsOrch->getRouterIntfsId(ETHERNET4);
         ASSERT_NE(inband_rif, SAI_NULL_OBJECT_ID);
         auto remote_ref_count = gIntfsOrch->getSyncdIntfses().at(ETHERNET0).ref_count;
@@ -245,6 +254,7 @@ namespace neighorch_test
         ASSERT_TRUE(gNeighOrch->addNextHop(ctx));
         ASSERT_TRUE(saw_inband_rif);
         ASSERT_EQ(gNeighOrch->m_syncdNextHops.count(inband_nexthop), 1u);
+        ASSERT_TRUE(gNeighOrch->isNextHopFlagSet(inband_nexthop, NHFLAGS_IFDOWN));
         ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at(ETHERNET0).ref_count, remote_ref_count);
         ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at(ETHERNET4).ref_count, inband_ref_count + 1);
 
@@ -255,6 +265,7 @@ namespace neighorch_test
         bulk_ctx.next_hop_id = 0x200001;
         ASSERT_TRUE(gNeighOrch->processBulkAddNextHop(bulk_ctx));
         ASSERT_EQ(gNeighOrch->m_syncdNextHops.count(inband_nexthop), 1u);
+        ASSERT_TRUE(gNeighOrch->isNextHopFlagSet(inband_nexthop, NHFLAGS_IFDOWN));
         ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at(ETHERNET0).ref_count, remote_ref_count);
         ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at(ETHERNET4).ref_count, inband_ref_count + 1);
 

--- a/tests/mock_tests/neighorch_ut.cpp
+++ b/tests/mock_tests/neighorch_ut.cpp
@@ -17,7 +17,9 @@ EXTERN_MOCK_FNS
 namespace neighorch_test
 {
     DEFINE_SAI_API_MOCK(neighbor);
+    DEFINE_SAI_GENERIC_API_MOCK(next_hop, next_hop);
     using namespace std;
+    using ::testing::Invoke;
     using namespace mock_orch_test;
     using ::testing::Return;
     using ::testing::Throw;
@@ -47,6 +49,27 @@ namespace neighorch_test
             gNeighOrch->addExistingData(&neigh_table);
             static_cast<Orch *>(gNeighOrch)->doTask();
             neigh_table.del(key);
+        }
+
+        void ConfigureRemoteSystemPort(const string& remote_alias, const string& inband_alias)
+        {
+            Table intf_table = Table(m_app_db.get(), APP_INTF_TABLE_NAME);
+            intf_table.set(remote_alias, {{"NULL", "NULL"}});
+            intf_table.set(inband_alias, {{"NULL", "NULL"}});
+            gIntfsOrch->addExistingData(&intf_table);
+            static_cast<Orch *>(gIntfsOrch)->doTask();
+
+            Port remote_port;
+            ASSERT_TRUE(gPortsOrch->getPort(remote_alias, remote_port));
+            remote_port.m_system_port_info.type = SAI_SYSTEM_PORT_TYPE_REMOTE;
+            remote_port.m_oper_status = SAI_PORT_OPER_STATUS_UP;
+            gPortsOrch->setPort(remote_alias, remote_port);
+
+            Port inband_port;
+            ASSERT_TRUE(gPortsOrch->getPort(inband_alias, inband_port));
+            inband_port.m_oper_status = SAI_PORT_OPER_STATUS_UP;
+            gPortsOrch->setPort(inband_alias, inband_port);
+            gPortsOrch->m_inbandPortName = inband_alias;
         }
 
         void ApplyInitialConfigs()
@@ -180,14 +203,64 @@ namespace neighorch_test
         void PostSetUp() override
         {
             INIT_SAI_API_MOCK(neighbor);
+            INIT_SAI_API_MOCK(next_hop);
             MockSaiApis();
         }
 
         void PreTearDown() override
         {
             RestoreSaiApis();
+            DEINIT_SAI_API_MOCK(next_hop);
+            DEINIT_SAI_API_MOCK(neighbor);
         }
     };
+
+    TEST_F(NeighOrchTest, RemoteSystemPortNextHopUsesInbandRif)
+    {
+        ConfigureRemoteSystemPort(ETHERNET0, ETHERNET4);
+
+        auto inband_rif = gIntfsOrch->getRouterIntfsId(ETHERNET4);
+        ASSERT_NE(inband_rif, SAI_NULL_OBJECT_ID);
+        auto remote_ref_count = gIntfsOrch->getSyncdIntfses().at(ETHERNET0).ref_count;
+        auto inband_ref_count = gIntfsOrch->getSyncdIntfses().at(ETHERNET4).ref_count;
+        NextHopKey inband_nexthop(TEST_IP, ETHERNET4);
+
+        bool saw_inband_rif = false;
+        EXPECT_CALL(*mock_sai_next_hop_api, create_next_hop)
+            .WillOnce(Invoke([&](sai_object_id_t *next_hop_id, sai_object_id_t, uint32_t attr_count,
+                                 const sai_attribute_t *attr_list) {
+                *next_hop_id = 0x200000;
+                for (uint32_t i = 0; i < attr_count; ++i)
+                {
+                    if (attr_list[i].id == SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID)
+                    {
+                        EXPECT_EQ(attr_list[i].value.oid, inband_rif);
+                        saw_inband_rif = true;
+                    }
+                }
+                return SAI_STATUS_SUCCESS;
+            }));
+
+        NeighborContext ctx(NeighborEntry(TEST_IP, ETHERNET0));
+        ASSERT_TRUE(gNeighOrch->addNextHop(ctx));
+        ASSERT_TRUE(saw_inband_rif);
+        ASSERT_EQ(gNeighOrch->m_syncdNextHops.count(inband_nexthop), 1u);
+        ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at(ETHERNET0).ref_count, remote_ref_count);
+        ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at(ETHERNET4).ref_count, inband_ref_count + 1);
+
+        ASSERT_TRUE(gNeighOrch->removeNextHop(IpAddress(TEST_IP), ETHERNET0));
+        ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at(ETHERNET4).ref_count, inband_ref_count);
+
+        NeighborContext bulk_ctx(NeighborEntry(TEST_IP, ETHERNET0), true);
+        bulk_ctx.next_hop_id = 0x200001;
+        ASSERT_TRUE(gNeighOrch->processBulkAddNextHop(bulk_ctx));
+        ASSERT_EQ(gNeighOrch->m_syncdNextHops.count(inband_nexthop), 1u);
+        ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at(ETHERNET0).ref_count, remote_ref_count);
+        ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at(ETHERNET4).ref_count, inband_ref_count + 1);
+
+        ASSERT_TRUE(gNeighOrch->removeNextHop(IpAddress(TEST_IP), ETHERNET0));
+        ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at(ETHERNET4).ref_count, inband_ref_count);
+    }
 
     TEST_F(NeighOrchTest, MultiVlanDuplicateNeighbor)
     {

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -1370,7 +1370,7 @@ class TestVirtualChassis(object):
         nexthop_entry = asic_db.get_entry("ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP", nexthop_keys[0])
         print("3:nexthop_entrty:",nexthop_entry)
         rif3 = nexthop_entry.get("SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID")
-        assert rif1 != rif3, "Neighbor is not replaced with new rif"
+        assert rif1 == rif3, "Remote neighbor next hop moved off the inband rif"
 
         #del the neighbor
         self.configure_neighbor(local_lc_dvs, "del", test_neigh_ip_1, test_neigh_mac_1, test_neigh_dev_2)


### PR DESCRIPTION
**What I did**

Remote-system-port next hops are represented through the local inband interface, but NeighOrch previously used two different interface identities for the same object.

### Root cause

`addNextHop()` already rewrote the next-hop key from the remote system port to the inband interface:

```text
remote system port alias
→ local inband alias
→ m_syncdNextHops key
```

The rest of the bookkeeping did not consistently follow that normalized key:

- the SAI next hop used the remote system port's RIF;
- the non-bulk path incremented the remote interface refcount;
- the bulk completion path stored the original remote key and incremented the remote refcount;
- removal searched with the inband key but decremented the original remote alias.

This produced three mismatches:

1. The SAI object could reference a different RIF than the key used to track it.
2. Normal add/remove updated different interface refcounts.
3. Bulk add stored a key that the existing removal path could not find.

### Fix

This PR makes the normalized inband next-hop key authoritative:

```text
remote alias
→ resolve inband alias once
→ use inband RIF
→ store inband key
→ increment inband refcount
→ remove inband key
→ decrement inband refcount
```

The changes are limited to remote-system-port next-hop identity and bookkeeping:

- `addNextHop()` obtains the RIF from `nexthop.alias` after remote-to-inband normalization.
- Normal and bulk completion increment the refcount for `nexthop.alias`.
- Bulk completion performs the same remote-to-inband key normalization as the non-bulk path.
- Removal decrements the refcount for the normalized alias.

**Why I did it**

The next-hop key, SAI RIF, sync map entry, and interface refcount describe one logical dependency. Using different aliases across those surfaces can leak references, prevent deletion, or leave bulk-created next hops unreachable by the removal path.

This defect predates the interface deletion and VRF-rehome work. It is therefore isolated from PRs #4746 and #4764 rather than being included as incidental hardening.

### Scope

This PR does not change boot-order handling when the inband port is not yet available. The existing assertion behavior is handled in a separate follow-up so identity/bookkeeping and retry semantics remain independently reviewable.

**How I verified it**

Focused mock coverage configures a remote system port and local inband interface, then verifies:

- the SAI next hop receives the inband RIF ID;
- the next hop is stored under the inband key;
- the remote interface refcount is unchanged;
- the inband interface refcount increments on normal add and balances on removal;
- bulk completion stores the same inband key and balances the same refcount on removal.

The available single-ASIC hardware testbed cannot exercise remote system ports, so this path is covered with focused unit tests and exact-head CI.

### Current exact-head master PR build

- Head: `df387c75cabd5ec325682a1304d1b6ac74882a1a`
- Azure PR build: [1171076](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1171076)
- All architecture, ASAN, Docker, Trixie, `Test vstest`, and `TestAsan vstest` lanes passed.
- CodeQL, Semgrep, DCO, EasyCLA, and the exact-head Copilot review are clean.
- No local build was used; validation is PR-build only.

### 202605 PR-build validation

- Validation-only PR: [#4747](https://github.com/sonic-net/sonic-swss/pull/4747)
- Master head validated: `df387c75cabd5ec325682a1304d1b6ac74882a1a`
- Exact target-branch commits: `c15c06fb88be426d2844c2418c925e87142b7ad6`, `d4831bd21f39b760fad9d475d961fb2ae090e975`, and `964650651ec5750b85b4898cebcb78150d74d113`
- Exact validation head: `253e3009fc42ccc1671715ab4a7797f6b1559b37`
- Azure PR build: [1175840](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1175840)
- Result: all applicable architecture, ASAN, Docker, Trixie, `Test vstest`, and `TestAsan vstest` lanes passed.

### Tested branch

- [x] 202605

### Test result

- 202605: The exact combined validation stack passed in [PR #4747](https://github.com/sonic-net/sonic-swss/pull/4747), head `253e3009fc42ccc1671715ab4a7797f6b1559b37`, build [1175840](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1175840).

**Details if related**

- Microsoft ADO: [38864631](https://msazure.visualstudio.com/One/_workitems/edit/38864631)
- Follow-up: [PR #4770](https://github.com/sonic-net/sonic-swss/pull/4770), retry instead of asserting when the inband port is not yet available.
- This is a pre-existing remote-system-port defect and is independent of PRs #4746 and #4764.
- Merge batch 1. PR #4770 must follow this PR.
