### PR TITLE
[neighorch]: Retry until inband port is available

### DIFF
--- a/orchagent/mplsrouteorch.cpp
+++ b/orchagent/mplsrouteorch.cpp
@@ -16,6 +16,7 @@ extern sai_object_id_t gSwitchId;
 extern CrmOrch *gCrmOrch;
 extern NhgOrch *gNhgOrch;
 extern CbfNhgOrch *gCbfNhgOrch;
+extern PortsOrch *gPortsOrch;
 
 void RouteOrch::doLabelTask(ConsumerBase& consumer)
 {
@@ -874,6 +875,24 @@ bool RouteOrch::removeLabelRoute(LabelRouteBulkContext& ctx)
         SWSS_LOG_INFO("Failed to find inseg entry, vrf_id 0x%" PRIx64 ", label %u\n",
                       vrf_id, label);
         return true;
+    }
+
+    if (it_route->second.nhg_index.empty())
+    {
+        for (const auto& nexthop : it_route->second.nhg_key.getNextHops())
+        {
+            if (nexthop.isMplsNextHop() &&
+                m_intfsOrch->isRemoteSystemPortIntf(nexthop.alias))
+            {
+                Port inbp;
+                if (!gPortsOrch->getInbandPort(inbp))
+                {
+                    SWSS_LOG_INFO("Inband port is not available for remote MPLS next hop %s",
+                                  nexthop.to_string().c_str());
+                    return false;
+                }
+            }
+        }
     }
 
     auto& object_statuses = ctx.object_statuses;

--- a/orchagent/mplsrouteorch.cpp
+++ b/orchagent/mplsrouteorch.cpp
@@ -879,18 +879,22 @@ bool RouteOrch::removeLabelRoute(LabelRouteBulkContext& ctx)
 
     if (it_route->second.nhg_index.empty())
     {
-        for (const auto& nexthop : it_route->second.nhg_key.getNextHops())
-        {
-            if (nexthop.isMplsNextHop() &&
-                m_intfsOrch->isRemoteSystemPortIntf(nexthop.alias))
+        const auto& nexthops = it_route->second.nhg_key.getNextHops();
+        const auto remote_mpls_nexthop = find_if(nexthops.begin(), nexthops.end(),
+            [this](const auto& nexthop)
             {
-                Port inbp;
-                if (!gPortsOrch->getInbandPort(inbp))
-                {
-                    SWSS_LOG_INFO("Inband port is not available for remote MPLS next hop %s",
-                                  nexthop.to_string().c_str());
-                    return false;
-                }
+                return nexthop.isMplsNextHop() &&
+                       m_intfsOrch->isRemoteSystemPortIntf(nexthop.alias);
+            });
+
+        if (remote_mpls_nexthop != nexthops.end())
+        {
+            Port inbp;
+            if (!gPortsOrch->getInbandPort(inbp))
+            {
+                SWSS_LOG_INFO("Inband port is not available for remote MPLS next hop %s",
+                              remote_mpls_nexthop->to_string().c_str());
+                return false;
             }
         }
     }

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -372,8 +372,11 @@ bool NeighOrch::addNextHop(NeighborContext& ctx)
     {
         //For remote system ports kernel nexthops are always on inband. Change the key
         Port inbp;
-        gPortsOrch->getInbandPort(inbp);
-        assert(inbp.m_alias.length());
+        if (!gPortsOrch->getInbandPort(inbp))
+        {
+            SWSS_LOG_INFO("Inband port is not available for remote next hop %s", nh.to_string().c_str());
+            return false;
+        }
 
         nexthop.alias = inbp.m_alias;
     }
@@ -519,8 +522,11 @@ bool NeighOrch::processBulkAddNextHop(NeighborContext& ctx)
     if (m_intfsOrch->isRemoteSystemPortIntf(nh.alias))
     {
         Port inbp;
-        gPortsOrch->getInbandPort(inbp);
-        assert(inbp.m_alias.length());
+        if (!gPortsOrch->getInbandPort(inbp))
+        {
+            SWSS_LOG_INFO("Inband port is not available for remote next hop %s", nh.to_string().c_str());
+            return false;
+        }
 
         nexthop.alias = inbp.m_alias;
     }
@@ -775,8 +781,11 @@ bool NeighOrch::removeNextHop(const IpAddress &ipAddress, const string &alias)
     {
         //For remote system ports kernel nexthops are always on inband. Change the key
         Port inbp;
-        gPortsOrch->getInbandPort(inbp);
-        assert(inbp.m_alias.length());
+        if (!gPortsOrch->getInbandPort(inbp))
+        {
+            SWSS_LOG_INFO("Inband port is not available for remote next hop %s", nexthop.to_string().c_str());
+            return false;
+        }
 
         nexthop.alias = inbp.m_alias;
     }

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -379,7 +379,7 @@ bool NeighOrch::addNextHop(NeighborContext& ctx)
     }
 
     assert(!hasNextHop(nexthop));
-    sai_object_id_t rif_id = m_intfsOrch->getRouterIntfsId(nh.alias);
+    sai_object_id_t rif_id = m_intfsOrch->getRouterIntfsId(nexthop.alias);
 
     vector<sai_attribute_t> next_hop_attrs;
 
@@ -457,7 +457,7 @@ bool NeighOrch::addNextHop(NeighborContext& ctx)
     next_hop_entry.nh_flags = 0;
     m_syncdNextHops[nexthop] = next_hop_entry;
 
-    m_intfsOrch->increaseRouterIntfsRefCount(nh.alias);
+    m_intfsOrch->increaseRouterIntfsRefCount(nexthop.alias);
 
     if (nexthop.isMplsNextHop())
     {
@@ -516,6 +516,15 @@ bool NeighOrch::processBulkAddNextHop(NeighborContext& ctx)
     }
 
     NextHopKey nexthop(nh);
+    if (m_intfsOrch->isRemoteSystemPortIntf(nh.alias))
+    {
+        Port inbp;
+        gPortsOrch->getInbandPort(inbp);
+        assert(inbp.m_alias.length());
+
+        nexthop.alias = inbp.m_alias;
+    }
+
     if (ctx.next_hop_id == SAI_NULL_OBJECT_ID)
     {
         sai_status_t bulker_status = gNextHopBulker.create_status(ctx.next_hop_id);
@@ -549,7 +558,7 @@ bool NeighOrch::processBulkAddNextHop(NeighborContext& ctx)
     next_hop_entry.nh_flags = 0;
     m_syncdNextHops[nexthop] = next_hop_entry;
 
-    m_intfsOrch->increaseRouterIntfsRefCount(nh.alias);
+    m_intfsOrch->increaseRouterIntfsRefCount(nexthop.alias);
 
     if (nexthop.isMplsNextHop())
     {
@@ -784,7 +793,7 @@ bool NeighOrch::removeNextHop(const IpAddress &ipAddress, const string &alias)
     }
 
     m_syncdNextHops.erase(nexthop);
-    m_intfsOrch->decreaseRouterIntfsRefCount(alias);
+    m_intfsOrch->decreaseRouterIntfsRefCount(nexthop.alias);
     return true;
 }
 

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -1501,9 +1501,12 @@ bool NeighOrch::addNeighbor(NeighborContext& ctx)
         if (bulk_op)
         {
             SWSS_LOG_INFO("Adding neighbor entry %s on %s to bulker.", ip_address.to_string().c_str(), alias.c_str());
+            if (!addNextHop(ctx))
+            {
+                return false;
+            }
             object_statuses.emplace_back();
             gNeighBulker.create_entry(&object_statuses.back(), &neighbor_entry, (uint32_t)neighbor_attrs.size(), neighbor_attrs.data());
-            addNextHop(ctx);
             return true;
         }
 
@@ -1629,6 +1632,12 @@ bool NeighOrch::removeNeighbor(NeighborContext& ctx, bool disable)
     bool bulk_op = ctx.bulk_op;
 
     NextHopKey nexthop = { ip_address, alias };
+    auto neighborIt = m_syncdNeighbors.find(neighborEntry);
+    if (neighborIt == m_syncdNeighbors.end())
+    {
+        return true;
+    }
+
     sai_object_id_t port_vrf_id;
     port_vrf_id = gVirtualRouterId;
 
@@ -1636,8 +1645,11 @@ bool NeighOrch::removeNeighbor(NeighborContext& ctx, bool disable)
     {
         //For remote system ports kernel nexthops are always on inband. Change the key
         Port inbp;
-        gPortsOrch->getInbandPort(inbp);
-        assert(inbp.m_alias.length());
+        if (!gPortsOrch->getInbandPort(inbp))
+        {
+            SWSS_LOG_INFO("Inband port is not available for remote neighbor %s", nexthop.to_string().c_str());
+            return false;
+        }
 
         nexthop.alias = inbp.m_alias;
     }
@@ -1650,12 +1662,6 @@ bool NeighOrch::removeNeighbor(NeighborContext& ctx, bool disable)
     else
     {
         SWSS_LOG_ERROR("Port does not exist for %s!", alias.c_str());
-    }
-
-    auto neighborIt = m_syncdNeighbors.find(neighborEntry);
-    if (neighborIt == m_syncdNeighbors.end())
-    {
-        return true;
     }
 
     SWSS_LOG_INFO("Try to remove neighbor %s on %s",
@@ -1760,7 +1766,10 @@ bool NeighOrch::removeNeighbor(NeighborContext& ctx, bool disable)
                 gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_IPV6_NEIGHBOR);
             }
 
-            removeNextHop(ip_address, alias);
+            if (!removeNextHop(ip_address, nexthop.alias))
+            {
+                return false;
+            }
             m_intfsOrch->decreaseRouterIntfsRefCount(alias);
             SWSS_LOG_NOTICE("Removed neighbor %s on %s",
                     m_syncdNeighbors[neighborEntry].mac.to_string().c_str(), alias.c_str());
@@ -1909,10 +1918,23 @@ bool NeighOrch::processBulkDisableNeighbor(NeighborContext& ctx)
     const NeighborEntry neighborEntry = ctx.neighborEntry;
     string alias = neighborEntry.alias;
     IpAddress ip_address = neighborEntry.ip_address;
+    NextHopKey nexthop = { ip_address, alias };
 
     if (m_syncdNeighbors.find(neighborEntry) == m_syncdNeighbors.end())
     {
         return true;
+    }
+
+    if (m_intfsOrch->isRemoteSystemPortIntf(alias))
+    {
+        Port inbp;
+        if (!gPortsOrch->getInbandPort(inbp))
+        {
+            SWSS_LOG_INFO("Inband port is not available for remote neighbor %s", nexthop.to_string().c_str());
+            return false;
+        }
+
+        nexthop.alias = inbp.m_alias;
     }
 
     SWSS_LOG_INFO("Checking neighbor remove entry status %s on %s.", ip_address.to_string().c_str(), m_syncdNeighbors[neighborEntry].mac.to_string().c_str());
@@ -1990,7 +2012,10 @@ bool NeighOrch::processBulkDisableNeighbor(NeighborContext& ctx)
                 gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_IPV6_NEIGHBOR);
             }
 
-            removeNextHop(ip_address, alias);
+            if (!removeNextHop(ip_address, nexthop.alias))
+            {
+                return false;
+            }
             m_intfsOrch->decreaseRouterIntfsRefCount(alias);
             SWSS_LOG_NOTICE("Removed neighbor %s on %s",
                     m_syncdNeighbors[neighborEntry].mac.to_string().c_str(), alias.c_str());

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -815,8 +815,12 @@ bool NeighOrch::removeMplsNextHop(const NextHopKey& nh)
     {
         //For remote system ports kernel nexthops are always on inband. Change the key
         Port inbp;
-        gPortsOrch->getInbandPort(inbp);
-        assert(inbp.m_alias.length());
+        if (!gPortsOrch->getInbandPort(inbp))
+        {
+            SWSS_LOG_INFO("Inband port is not available for remote MPLS next hop %s",
+                          nexthop.to_string().c_str());
+            return false;
+        }
 
         nexthop.alias = inbp.m_alias;
     }

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -787,8 +787,8 @@ bool NeighOrch::removeNextHop(const IpAddress &ipAddress, const string &alias)
 
     if (m_syncdNextHops[nexthop].ref_count > 0)
     {
-        SWSS_LOG_ERROR("Failed to remove still referenced next hop %s on %s",
-                       ipAddress.to_string().c_str(), alias.c_str());
+        SWSS_LOG_ERROR("Failed to remove still referenced next hop %s requested on %s, tracked on %s",
+                       ipAddress.to_string().c_str(), alias.c_str(), nexthop.alias.c_str());
         return false;
     }
 

--- a/orchagent/nhgorch.cpp
+++ b/orchagent/nhgorch.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <random>
 #include "nhgorch.h"
 #include "neighorch.h"
@@ -879,19 +880,22 @@ bool NextHopGroup::remove()
         return true;
     }
 
-    for (const auto& member : m_members)
-    {
-        const auto& nh_key = member.first;
-        if (nh_key.isMplsNextHop() &&
-            gIntfsOrch->isRemoteSystemPortIntf(nh_key.alias))
+    const auto remote_mpls_member = find_if(m_members.begin(), m_members.end(),
+        [](const auto& member)
         {
-            Port inbp;
-            if (!gPortsOrch->getInbandPort(inbp))
-            {
-                SWSS_LOG_INFO("Inband port is not available for remote MPLS next hop %s",
-                              nh_key.to_string().c_str());
-                return false;
-            }
+            const auto& nh_key = member.first;
+            return nh_key.isMplsNextHop() &&
+                   gIntfsOrch->isRemoteSystemPortIntf(nh_key.alias);
+        });
+
+    if (remote_mpls_member != m_members.end())
+    {
+        Port inbp;
+        if (!gPortsOrch->getInbandPort(inbp))
+        {
+            SWSS_LOG_INFO("Inband port is not available for remote MPLS next hop %s",
+                          remote_mpls_member->first.to_string().c_str());
+            return false;
         }
     }
 

--- a/orchagent/nhgorch.cpp
+++ b/orchagent/nhgorch.cpp
@@ -878,6 +878,23 @@ bool NextHopGroup::remove()
     {
         return true;
     }
+
+    for (const auto& member : m_members)
+    {
+        const auto& nh_key = member.first;
+        if (nh_key.isMplsNextHop() &&
+            gIntfsOrch->isRemoteSystemPortIntf(nh_key.alias))
+        {
+            Port inbp;
+            if (!gPortsOrch->getInbandPort(inbp))
+            {
+                SWSS_LOG_INFO("Inband port is not available for remote MPLS next hop %s",
+                              nh_key.to_string().c_str());
+                return false;
+            }
+        }
+    }
+
     //  If the group is temporary or non-recursive, update the neigh or rif ref-count and reset the ID.
     if (m_is_temp ||
         (!isRecursive() && m_members.size() == 1))

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -2800,18 +2800,22 @@ bool RouteOrch::removeRoute(RouteBulkContext& ctx)
 
     if (it_route != it_route_table->second.end() && it_route->second.nhg_index.empty())
     {
-        for (const auto& nexthop : it_route->second.nhg_key.getNextHops())
-        {
-            if (nexthop.isMplsNextHop() &&
-                m_intfsOrch->isRemoteSystemPortIntf(nexthop.alias))
+        const auto& nexthops = it_route->second.nhg_key.getNextHops();
+        const auto remote_mpls_nexthop = find_if(nexthops.begin(), nexthops.end(),
+            [this](const auto& nexthop)
             {
-                Port inbp;
-                if (!gPortsOrch->getInbandPort(inbp))
-                {
-                    SWSS_LOG_INFO("Inband port is not available for remote MPLS next hop %s",
-                                  nexthop.to_string().c_str());
-                    return false;
-                }
+                return nexthop.isMplsNextHop() &&
+                       m_intfsOrch->isRemoteSystemPortIntf(nexthop.alias);
+            });
+
+        if (remote_mpls_nexthop != nexthops.end())
+        {
+            Port inbp;
+            if (!gPortsOrch->getInbandPort(inbp))
+            {
+                SWSS_LOG_INFO("Inband port is not available for remote MPLS next hop %s",
+                              remote_mpls_nexthop->to_string().c_str());
+                return false;
             }
         }
     }

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -2798,6 +2798,24 @@ bool RouteOrch::removeRoute(RouteBulkContext& ctx)
         return true;
     }
 
+    if (it_route != it_route_table->second.end() && it_route->second.nhg_index.empty())
+    {
+        for (const auto& nexthop : it_route->second.nhg_key.getNextHops())
+        {
+            if (nexthop.isMplsNextHop() &&
+                m_intfsOrch->isRemoteSystemPortIntf(nexthop.alias))
+            {
+                Port inbp;
+                if (!gPortsOrch->getInbandPort(inbp))
+                {
+                    SWSS_LOG_INFO("Inband port is not available for remote MPLS next hop %s",
+                                  nexthop.to_string().c_str());
+                    return false;
+                }
+            }
+        }
+    }
+
     auto& object_statuses = ctx.object_statuses;
 
     // set to blackhole for default route

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1507,7 +1507,10 @@ bool RouteOrch::addNextHopGroup(const NextHopGroupKey &nexthops)
                  m_neighOrch->hasNextHop(NextHopKey(it.ip_address, it.alias)))
         {
             NeighborContext ctx = NeighborContext(it);
-            m_neighOrch->addNextHop(ctx);
+            if (!m_neighOrch->addNextHop(ctx))
+            {
+                return false;
+            }
             next_hop_id = m_neighOrch->getNextHopId(it);
         }
         else
@@ -2118,7 +2121,10 @@ bool RouteOrch::addRoute(RouteBulkContext& ctx, const NextHopGroupKey &nextHops)
             {
                 /* since IP neighbor NH exists, neighbor is resolved, add MPLS NH */
                 NeighborContext ctx = NeighborContext(nexthop);
-                m_neighOrch->addNextHop(ctx);
+                if (!m_neighOrch->addNextHop(ctx))
+                {
+                    return false;
+                }
                 next_hop_id = m_neighOrch->getNextHopId(nexthop);
             }
             /* IP neighbor is not yet resolved */

--- a/tests/mock_tests/neighorch_ut.cpp
+++ b/tests/mock_tests/neighorch_ut.cpp
@@ -293,6 +293,14 @@ namespace neighorch_test
         EXPECT_EQ(gNeighOrch->m_syncdNeighbors.count(ctx.neighborEntry), 1u);
         EXPECT_FALSE(gNeighOrch->processBulkDisableNeighbor(ctx));
         EXPECT_EQ(gNeighOrch->m_syncdNeighbors.count(ctx.neighborEntry), 1u);
+
+        NextHopKey remote_mpls_nexthop("push100+" + TEST_IP + "@" + ETHERNET0);
+        NextHopKey inband_mpls_nexthop(remote_mpls_nexthop);
+        inband_mpls_nexthop.alias = ETHERNET4;
+        gNeighOrch->m_syncdNextHops[inband_mpls_nexthop] = {0x200002, 0, 0};
+
+        EXPECT_FALSE(gNeighOrch->removeMplsNextHop(remote_mpls_nexthop));
+        EXPECT_EQ(gNeighOrch->m_syncdNextHops.count(inband_mpls_nexthop), 1u);
     }
 
     TEST_F(NeighOrchTest, MultiVlanDuplicateNeighbor)

--- a/tests/mock_tests/neighorch_ut.cpp
+++ b/tests/mock_tests/neighorch_ut.cpp
@@ -273,6 +273,19 @@ namespace neighorch_test
         ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at(ETHERNET4).ref_count, inband_ref_count);
     }
 
+    TEST_F(NeighOrchTest, RemoteSystemPortNextHopRetriesWithoutInbandPort)
+    {
+        ConfigureRemoteSystemPort(ETHERNET0, ETHERNET4);
+        gPortsOrch->m_inbandPortName.clear();
+
+        NeighborContext ctx(NeighborEntry(TEST_IP, ETHERNET0), true);
+        ctx.next_hop_id = 0x200001;
+
+        EXPECT_FALSE(gNeighOrch->addNextHop(ctx));
+        EXPECT_FALSE(gNeighOrch->processBulkAddNextHop(ctx));
+        EXPECT_FALSE(gNeighOrch->removeNextHop(IpAddress(TEST_IP), ETHERNET0));
+    }
+
     TEST_F(NeighOrchTest, MultiVlanDuplicateNeighbor)
     {
         EXPECT_CALL(*mock_sai_neighbor_api, create_neighbor_entry);

--- a/tests/mock_tests/neighorch_ut.cpp
+++ b/tests/mock_tests/neighorch_ut.cpp
@@ -219,6 +219,15 @@ namespace neighorch_test
     {
         ConfigureRemoteSystemPort(ETHERNET0, ETHERNET4);
 
+        Port remote_port;
+        ASSERT_TRUE(gPortsOrch->getPort(ETHERNET0, remote_port));
+        remote_port.m_oper_status = SAI_PORT_OPER_STATUS_DOWN;
+        gPortsOrch->setPort(ETHERNET0, remote_port);
+
+        Port inband_port;
+        ASSERT_TRUE(gPortsOrch->getPort(ETHERNET4, inband_port));
+        ASSERT_EQ(inband_port.m_oper_status, SAI_PORT_OPER_STATUS_UP);
+
         auto inband_rif = gIntfsOrch->getRouterIntfsId(ETHERNET4);
         ASSERT_NE(inband_rif, SAI_NULL_OBJECT_ID);
         auto remote_ref_count = gIntfsOrch->getSyncdIntfses().at(ETHERNET0).ref_count;
@@ -245,6 +254,7 @@ namespace neighorch_test
         ASSERT_TRUE(gNeighOrch->addNextHop(ctx));
         ASSERT_TRUE(saw_inband_rif);
         ASSERT_EQ(gNeighOrch->m_syncdNextHops.count(inband_nexthop), 1u);
+        ASSERT_TRUE(gNeighOrch->isNextHopFlagSet(inband_nexthop, NHFLAGS_IFDOWN));
         ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at(ETHERNET0).ref_count, remote_ref_count);
         ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at(ETHERNET4).ref_count, inband_ref_count + 1);
 
@@ -255,6 +265,7 @@ namespace neighorch_test
         bulk_ctx.next_hop_id = 0x200001;
         ASSERT_TRUE(gNeighOrch->processBulkAddNextHop(bulk_ctx));
         ASSERT_EQ(gNeighOrch->m_syncdNextHops.count(inband_nexthop), 1u);
+        ASSERT_TRUE(gNeighOrch->isNextHopFlagSet(inband_nexthop, NHFLAGS_IFDOWN));
         ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at(ETHERNET0).ref_count, remote_ref_count);
         ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at(ETHERNET4).ref_count, inband_ref_count + 1);
 

--- a/tests/mock_tests/neighorch_ut.cpp
+++ b/tests/mock_tests/neighorch_ut.cpp
@@ -280,10 +280,19 @@ namespace neighorch_test
 
         NeighborContext ctx(NeighborEntry(TEST_IP, ETHERNET0), true);
         ctx.next_hop_id = 0x200001;
+        ctx.mac = MacAddress(MAC1);
 
         EXPECT_FALSE(gNeighOrch->addNextHop(ctx));
         EXPECT_FALSE(gNeighOrch->processBulkAddNextHop(ctx));
         EXPECT_FALSE(gNeighOrch->removeNextHop(IpAddress(TEST_IP), ETHERNET0));
+        EXPECT_FALSE(gNeighOrch->addNeighbor(ctx));
+        EXPECT_TRUE(ctx.object_statuses.empty());
+
+        gNeighOrch->m_syncdNeighbors[ctx.neighborEntry] = {ctx.mac, true};
+        EXPECT_FALSE(gNeighOrch->removeNeighbor(ctx));
+        EXPECT_EQ(gNeighOrch->m_syncdNeighbors.count(ctx.neighborEntry), 1u);
+        EXPECT_FALSE(gNeighOrch->processBulkDisableNeighbor(ctx));
+        EXPECT_EQ(gNeighOrch->m_syncdNeighbors.count(ctx.neighborEntry), 1u);
     }
 
     TEST_F(NeighOrchTest, MultiVlanDuplicateNeighbor)

--- a/tests/mock_tests/neighorch_ut.cpp
+++ b/tests/mock_tests/neighorch_ut.cpp
@@ -17,7 +17,9 @@ EXTERN_MOCK_FNS
 namespace neighorch_test
 {
     DEFINE_SAI_API_MOCK(neighbor);
+    DEFINE_SAI_GENERIC_API_MOCK(next_hop, next_hop);
     using namespace std;
+    using ::testing::Invoke;
     using namespace mock_orch_test;
     using ::testing::Return;
     using ::testing::Throw;
@@ -47,6 +49,27 @@ namespace neighorch_test
             gNeighOrch->addExistingData(&neigh_table);
             static_cast<Orch *>(gNeighOrch)->doTask();
             neigh_table.del(key);
+        }
+
+        void ConfigureRemoteSystemPort(const string& remote_alias, const string& inband_alias)
+        {
+            Table intf_table = Table(m_app_db.get(), APP_INTF_TABLE_NAME);
+            intf_table.set(remote_alias, {{"NULL", "NULL"}});
+            intf_table.set(inband_alias, {{"NULL", "NULL"}});
+            gIntfsOrch->addExistingData(&intf_table);
+            static_cast<Orch *>(gIntfsOrch)->doTask();
+
+            Port remote_port;
+            ASSERT_TRUE(gPortsOrch->getPort(remote_alias, remote_port));
+            remote_port.m_system_port_info.type = SAI_SYSTEM_PORT_TYPE_REMOTE;
+            remote_port.m_oper_status = SAI_PORT_OPER_STATUS_UP;
+            gPortsOrch->setPort(remote_alias, remote_port);
+
+            Port inband_port;
+            ASSERT_TRUE(gPortsOrch->getPort(inband_alias, inband_port));
+            inband_port.m_oper_status = SAI_PORT_OPER_STATUS_UP;
+            gPortsOrch->setPort(inband_alias, inband_port);
+            gPortsOrch->m_inbandPortName = inband_alias;
         }
 
         void ApplyInitialConfigs()
@@ -180,14 +203,64 @@ namespace neighorch_test
         void PostSetUp() override
         {
             INIT_SAI_API_MOCK(neighbor);
+            INIT_SAI_API_MOCK(next_hop);
             MockSaiApis();
         }
 
         void PreTearDown() override
         {
             RestoreSaiApis();
+            DEINIT_SAI_API_MOCK(next_hop);
+            DEINIT_SAI_API_MOCK(neighbor);
         }
     };
+
+    TEST_F(NeighOrchTest, RemoteSystemPortNextHopUsesInbandRif)
+    {
+        ConfigureRemoteSystemPort(ETHERNET0, ETHERNET4);
+
+        auto inband_rif = gIntfsOrch->getRouterIntfsId(ETHERNET4);
+        ASSERT_NE(inband_rif, SAI_NULL_OBJECT_ID);
+        auto remote_ref_count = gIntfsOrch->getSyncdIntfses().at(ETHERNET0).ref_count;
+        auto inband_ref_count = gIntfsOrch->getSyncdIntfses().at(ETHERNET4).ref_count;
+        NextHopKey inband_nexthop(TEST_IP, ETHERNET4);
+
+        bool saw_inband_rif = false;
+        EXPECT_CALL(*mock_sai_next_hop_api, create_next_hop)
+            .WillOnce(Invoke([&](sai_object_id_t *next_hop_id, sai_object_id_t, uint32_t attr_count,
+                                 const sai_attribute_t *attr_list) {
+                *next_hop_id = 0x200000;
+                for (uint32_t i = 0; i < attr_count; ++i)
+                {
+                    if (attr_list[i].id == SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID)
+                    {
+                        EXPECT_EQ(attr_list[i].value.oid, inband_rif);
+                        saw_inband_rif = true;
+                    }
+                }
+                return SAI_STATUS_SUCCESS;
+            }));
+
+        NeighborContext ctx(NeighborEntry(TEST_IP, ETHERNET0));
+        ASSERT_TRUE(gNeighOrch->addNextHop(ctx));
+        ASSERT_TRUE(saw_inband_rif);
+        ASSERT_EQ(gNeighOrch->m_syncdNextHops.count(inband_nexthop), 1u);
+        ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at(ETHERNET0).ref_count, remote_ref_count);
+        ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at(ETHERNET4).ref_count, inband_ref_count + 1);
+
+        ASSERT_TRUE(gNeighOrch->removeNextHop(IpAddress(TEST_IP), ETHERNET0));
+        ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at(ETHERNET4).ref_count, inband_ref_count);
+
+        NeighborContext bulk_ctx(NeighborEntry(TEST_IP, ETHERNET0), true);
+        bulk_ctx.next_hop_id = 0x200001;
+        ASSERT_TRUE(gNeighOrch->processBulkAddNextHop(bulk_ctx));
+        ASSERT_EQ(gNeighOrch->m_syncdNextHops.count(inband_nexthop), 1u);
+        ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at(ETHERNET0).ref_count, remote_ref_count);
+        ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at(ETHERNET4).ref_count, inband_ref_count + 1);
+
+        ASSERT_TRUE(gNeighOrch->removeNextHop(IpAddress(TEST_IP), ETHERNET0));
+        ASSERT_EQ(gIntfsOrch->getSyncdIntfses().at(ETHERNET4).ref_count, inband_ref_count);
+    }
 
     TEST_F(NeighOrchTest, MultiVlanDuplicateNeighbor)
     {

--- a/tests/mock_tests/routeorch_ut.cpp
+++ b/tests/mock_tests/routeorch_ut.cpp
@@ -1733,4 +1733,36 @@ namespace routeorch_test
         (void)gRouteOrch->removeRoutePrefix(IpPrefix("7.7.7.0/24"));
         ASSERT_TRUE(gRouteOrch->removeRoutePrefix(IpPrefix("7.7.7.0/24")));
     }
+
+    TEST_F(RouteOrchTest, RemoteMplsRouteRemovalRetriesWithoutInbandPort)
+    {
+        Port remote_port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", remote_port));
+        remote_port.m_system_port_info.type = SAI_SYSTEM_PORT_TYPE_REMOTE;
+        gPortsOrch->setPort("Ethernet0", remote_port);
+        gPortsOrch->m_inbandPortName.clear();
+
+        NextHopGroupKey nhg(
+            "push100+10.0.0.2@Ethernet0,push200+10.0.0.3@Ethernet0");
+
+        IpPrefix prefix("8.8.8.0/24");
+        gRouteOrch->m_syncdRoutes[gVirtualRouterId][prefix] = RouteNhg(nhg, "");
+
+        RouteBulkContext route_ctx(prefix.to_string(), false);
+        route_ctx.vrf_id = gVirtualRouterId;
+        route_ctx.ip_prefix = prefix;
+
+        EXPECT_FALSE(gRouteOrch->removeRoute(route_ctx));
+        EXPECT_TRUE(route_ctx.object_statuses.empty());
+
+        Label label = 1000;
+        gRouteOrch->m_syncdLabelRoutes[gVirtualRouterId][label] = RouteNhg(nhg, "");
+
+        LabelRouteBulkContext label_ctx;
+        label_ctx.vrf_id = gVirtualRouterId;
+        label_ctx.label = label;
+
+        EXPECT_FALSE(gRouteOrch->removeLabelRoute(label_ctx));
+        EXPECT_TRUE(label_ctx.object_statuses.empty());
+    }
 }

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -1370,7 +1370,7 @@ class TestVirtualChassis(object):
         nexthop_entry = asic_db.get_entry("ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP", nexthop_keys[0])
         print("3:nexthop_entrty:",nexthop_entry)
         rif3 = nexthop_entry.get("SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID")
-        assert rif1 != rif3, "Neighbor is not replaced with new rif"
+        assert rif1 == rif3, "Remote neighbor next hop moved off the inband rif"
 
         #del the neighbor
         self.configure_neighbor(local_lc_dvs, "del", test_neigh_ip_1, test_neigh_mac_1, test_neigh_dev_2)


### PR DESCRIPTION
**What I did**

NeighOrch previously asserted that an inband port always existed whenever it processed a remote-system-port next hop. This PR converts that boot-order assumption into the normal SWSS retain-and-retry behavior.

### Root cause

Remote-system-port next hops must be normalized to the local inband interface. The original implementation called `getInbandPort()` and then asserted that the returned alias was non-empty.

That assumption has existed since the remote-system-port path was introduced in 2021. It is not guaranteed during initialization: a remote next-hop update can be processed before the local inband port has been configured.

The old behavior was:

```text
remote next-hop event
→ inband port not ready
→ assert
→ terminate orchagent
```

An unavailable prerequisite is transient state, not an invariant violation.

### Fix

Each remote next-hop path now checks the boolean result from `getInbandPort()`:

```text
remote next-hop event
→ inband port not ready
→ return false
→ retain work
→ retry after inband configuration is available
```

The check covers:

- normal next-hop creation;
- bulk next-hop completion;
- IP next-hop removal;
- MPLS next-hop removal.

No fallback alias or synthetic success is used. The operation reports retry and leaves the existing state machine responsible for reprocessing it.

**Why I did it**

SWSS orchagents routinely return `false` when a required object is not available yet. Treating inband-port boot order the same way avoids a process abort without hiding the missing dependency or programming an object against the wrong interface.

This defect predates the interface deletion and VRF-rehome work. It is kept separate from the inband RIF identity/bookkeeping fix because the two changes address different failure modes:

- identity/bookkeeping determines which RIF, key, and refcount represent a remote next hop;
- this PR determines what happens when that required inband interface does not exist yet.

### Dependency

This branch is stacked on [PR #4769](https://github.com/sonic-net/sonic-swss/pull/4769) because that PR adds the bulk normalization path containing the third inband lookup. Until #4769 merges, GitHub's **Files changed** tab includes the prerequisite commit. The final upstream merge order is #4769 first, then this retry change.

**How I verified it**

Focused mock coverage configures a remote system port, removes the inband-port designation, and verifies that next-hop operations return `false` rather than asserting:

- `addNextHop()`;
- `processBulkAddNextHop()`;
- `removeNextHop()`;
- `removeMplsNextHop()`.

Route and label-route removal coverage also verifies that missing-inband MPLS dependencies are detected before any bulk SAI operation is queued. NhgOrch performs the same preflight before changing group or member state.

The available single-ASIC hardware testbed cannot exercise remote system ports, so this path is covered with focused unit tests and exact-head CI.

### Current exact-head master PR build

- Head: `b7c61bb6e2a9ef0b7af97a003b850b061439fa94`
- Azure PR build: [1171077](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1171077)
- All architecture, ASAN, Docker, Trixie, `Test vstest`, and `TestAsan vstest` lanes passed.
- CodeQL, Semgrep, DCO, EasyCLA, all review threads, and the exact-head Copilot review are clean.
- No local build was used; validation is PR-build only.

### 202605 PR-build validation

- Validation-only PR: [#4747](https://github.com/sonic-net/sonic-swss/pull/4747)
- The complete current-`202605` stack applies PR #4769 first, includes batch-1 PR #4772, and applies this retry change last.
- Exact validation head: `d4b0502ecdac76d56fdf063a633045c0fb0de977`
- Azure PR build: [1171672](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1171672) — in progress.
- The `Tested for 202605 branch` label must remain absent until that exact result is complete.

**Details if related**

- Microsoft ADO: [38864639](https://msazure.visualstudio.com/One/_workitems/edit/38864639)
- Required predecessor: [PR #4769](https://github.com/sonic-net/sonic-swss/pull/4769), remote-system-port inband RIF identity and bookkeeping.
- The assertion-to-retry issue is pre-existing and independent of PRs #4746 and #4764.
- Merge batch 2, after batch-1 PRs #4769 and #4772.

### Review follow-up
- Bulk neighbor creation and both RouteOrch MPLS helper paths now propagate `addNextHop()` retry before advancing dependent work.
- Non-bulk and bulk neighbor deletion propagate `removeNextHop()` retry before refcount/cache progression.
- MPLS next-hop removal now returns retry instead of asserting when the inband port is unavailable.
- Route, label-route, and NhgOrch deletion preflight remote MPLS dependencies before submitting SAI operations or changing refcounts.
- Focused coverage verifies missing-inband add and deletion paths preserve retry state.
