### PR TITLE
[ci][202511] replace python3-pip with uv in vs test pipeline (cherry-pick #4761)

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -119,7 +119,7 @@ jobs:
   - script: |
       set -ex
       # install packages for vs test
-      sudo pip3 install pytest flaky exabgp docker lcov_cobertura
+      sudo uv pip install --system pytest flaky exabgp docker lcov_cobertura
 
       # install other dependencies
       sudo apt-get -o DPkg::Lock::Timeout=600 install -y net-tools \


### PR DESCRIPTION
Cherry-pick of #4761 to the 202511 branch.

Only the applicable change from #4761 applies here: the vs-test pip install is switched from `pip3` to `uv pip install --system`.

The libyang-related commits from #4761 (install wheel / python3-dev for building `libyang==3.3.0` from PyPI) were **skipped** because 202511 installs libyang **1.0 via dpkg** and does not build the Python bindings from PyPI, so those hunks do not apply.

Original PR: sonic-net/sonic-swss#4761

Signed-off-by: Yijing Yan <yijingyan@microsoft.com>