### PR TITLE
[202605][intfsorch]Fix race condition between VRF bind and ip address removal

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -857,7 +857,10 @@ void IntfsOrch::doTask(Consumer &consumer)
                         }
                         else
                         {
-                            SWSS_LOG_ERROR("Failed to set interface '%s' to VRF ID '%d' because it has IP addresses associated with it.", alias.c_str(), vrf_id);
+                            SWSS_LOG_NOTICE("Interface '%s' still has %zu IP address(es); deferring VRF '%s' bind until pending IP removals are processed.",
+                                          alias.c_str(), m_syncdIntfses[alias].ip_addresses.size(), vrf_name.c_str());
+                            it++;
+                            continue;
                         }
                     }
                 }

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -395,4 +395,57 @@ namespace intfsorch_test
         m_syncdIntfses = gIntfsOrch->getSyncdIntfses();
         ASSERT_EQ(m_syncdIntfses["Loopback3"].vrf_id, gVirtualRouterId);    
     }
+
+    // Regression test for the batched IP-removal + VRF-bind race.
+    // m_toSync is an ordered multimap, so within a single drain the bare interface
+    // key ("Loopback6") is processed before the per-IP key ("Loopback6:6.6.6.6/32").
+    // When a config sequence removes the loopback IPs and rebinds the interface to a
+    // VRF back-to-back, both land in one batch and the VRF-change SET is evaluated
+    // while the IP is still present. The fix defers (retains) that SET instead of
+    // logging an error and dropping it, so the bind converges on a later drain.
+    TEST_F(IntfsOrchTest, IntfsOrchVrfBindDeferredUntilIpRemoved)
+    {
+        // create a new vrf
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({"Vrf-Blue", "SET", { {"NULL", "NULL"}}});
+        auto vrfConsumer = dynamic_cast<Consumer *>(gVrfOrch->getExecutor(APP_VRF_TABLE_NAME));
+        vrfConsumer->addToSync(entries);
+        static_cast<Orch *>(gVrfOrch)->doTask();
+        ASSERT_TRUE(gVrfOrch->isVRFexists("Vrf-Blue"));
+        auto base_vrf_ref = gVrfOrch->getVrfRefCount("Vrf-Blue");
+
+        auto intfConsumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
+
+        // create a loopback in the default vrf and give it an IP address
+        entries.clear();
+        entries.push_back({"Loopback6", "SET", {}});
+        entries.push_back({"Loopback6:6.6.6.6/32", "SET", {{"scope", "global"}, {"family", "IPv4"}}});
+        intfConsumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+        auto syncd = gIntfsOrch->getSyncdIntfses();
+        ASSERT_EQ(syncd["Loopback6"].vrf_id, gVirtualRouterId);
+        ASSERT_EQ(syncd["Loopback6"].ip_addresses.size(), static_cast<size_t>(1));
+
+        // Single batch: remove the IP AND rebind the interface to Vrf-Blue.
+        // The bare "Loopback6" SET sorts before "Loopback6:6.6.6.6/32" DEL, so the
+        // bind is evaluated first (IP still present) and must be deferred, not dropped.
+        entries.clear();
+        entries.push_back({"Loopback6", "SET", { {"vrf_name", "Vrf-Blue"}}});
+        entries.push_back({"Loopback6:6.6.6.6/32", "DEL", {}});
+        intfConsumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+
+        // After the first drain: IP removed, interface still present and still in the
+        // default vrf (the bind is pending, not lost).
+        syncd = gIntfsOrch->getSyncdIntfses();
+        ASSERT_NE(syncd.find("Loopback6"), syncd.end());
+        ASSERT_EQ(syncd["Loopback6"].ip_addresses.size(), static_cast<size_t>(0));
+        ASSERT_EQ(syncd["Loopback6"].vrf_id, gVirtualRouterId);
+
+        // The deferred bind is retried on the next drain and now succeeds.
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+        syncd = gIntfsOrch->getSyncdIntfses();
+        ASSERT_EQ(syncd["Loopback6"].vrf_id, gVrfOrch->getVRFid("Vrf-Blue"));
+        ASSERT_EQ(gVrfOrch->getVrfRefCount("Vrf-Blue"), base_vrf_ref + 1);
+    }
 }


### PR DESCRIPTION
Manual cherry-pick of https://github.com/sonic-net/sonic-swss/pull/4758

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
#### Why I did it
When loopback IP removal and VRF rebind arrive in the same `m_toSync` batch, the bare
interface key is processed before per-IP keys. The VRF bind is attempted while IPs remain,
logged as an error, and dropped, leaving the interface stuck in the wrong VRF.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
- **orchagent/intfsorch.cpp**: Defer VRF bind (retain sync entry) instead of error+log+drop
  when IPs are still present on the interface.
- **tests/mock_tests/intfsorch_ut.cpp**: Add `IntfsOrchVrfBindDeferredUntilIpRemoved`
  regression test for the batched IP-removal + VRF-bind race (Redmine #5108427).

#### How to verify it
- Run mock UT `IntfsOrchVrfBindDeferredUntilIpRemoved` in `intfsorch_ut.cpp`.

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

#### Description for the changelog
[intfsorch]Fix race condition between VRF bind and ip address removal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loopback interface VRF reassignment when IP address changes are still pending.
  * VRF reassignment is now deferred until pending IP removals complete, preventing the update from being dropped.
  * Added a regression test covering the batched “interface IP removal + VRF rebind” race to ensure correct post-drain behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->