### PR TITLE
[vrfmgr] Backport management VRF reboot rule fix to 202605

### DIFF
--- a/cfgmgr/vrfmgr.cpp
+++ b/cfgmgr/vrfmgr.cpp
@@ -93,21 +93,24 @@ VrfMgr::VrfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, con
         }
     }
 
-    cmd.str("");
-    cmd.clear();
-    // Get local table pref
-    cmd << IP_CMD << " rule | grep 'from all lookup local' | awk -F'[^0-9]+' '{ print $1 }'";
-    swss::exec(cmd.str(), res);
-    table = static_cast<uint32_t>(stoul(res));
-    // If local table pref is not expected, set it to be expected
-    if (table != TABLE_LOCAL_PREF)
+    for (const char *family : {" -4", " -6"})
     {
         cmd.str("");
         cmd.clear();
-        cmd << IP_CMD << " rule add pref " << TABLE_LOCAL_PREF << " table local && " << IP_CMD << " rule del pref "
-            << table << " && " << IP_CMD << " -6 rule add pref " << TABLE_LOCAL_PREF << " table local && " << IP_CMD
-            << " -6 rule del pref " << table;
+        res.clear();
+        cmd << IP_CMD << family << " rule show table local | grep 'from all lookup local'";
         EXEC_WITH_ERROR_THROW(cmd.str(), res);
+        table = static_cast<uint32_t>(stoul(res));
+
+        if (table != TABLE_LOCAL_PREF)
+        {
+            cmd.str("");
+            cmd.clear();
+            res.clear();
+            cmd << IP_CMD << family << " rule add pref " << TABLE_LOCAL_PREF << " table local && "
+                << IP_CMD << family << " rule del pref " << table << " table local";
+            EXEC_WITH_ERROR_THROW(cmd.str(), res);
+        }
     }
 
     if (!WarmStart::isWarmStart())
@@ -557,4 +560,3 @@ uint32_t VrfMgr::getVRFmappedVNI(const std::string& vrf_name)
         return 0;
     }
 }
-

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -163,6 +163,55 @@ class TestVrf(object):
         r = random.choice(values)
         return r[0], r[1]
 
+    @pytest.mark.parametrize("family", ["-4", "-6"])
+    def test_VRFMgr_LocalRulePriority(self, dvs, testlog, family):
+        other_family = "-6" if family == "-4" else "-4"
+
+        def get_local_rule_pref(rule_family):
+            status, output = dvs.runcmd(["ip", rule_family, "rule", "show", "table", "local"])
+            assert status == 0, output
+            for rule in output.splitlines():
+                preference, selector = rule.split(":", 1)
+                if selector.strip() == "from all lookup local":
+                    return int(preference.strip())
+            assert False, "Missing {} canonical local rule".format(rule_family)
+
+        original_pref = get_local_rule_pref(family)
+        assert original_pref == 1001
+        assert get_local_rule_pref(other_family) == 1001
+        try:
+            status, output = dvs.runcmd(
+                ["ip", family, "rule", "add", "pref", "32765", "table", "local"]
+            )
+            assert status == 0, output
+            status, output = dvs.runcmd(
+                ["ip", family, "rule", "del", "pref", str(original_pref), "table", "local"]
+            )
+            assert status == 0, output
+
+            status, output = dvs.runcmd(["supervisorctl", "restart", "vrfmgrd"])
+            assert status == 0, output
+
+            for _ in range(10):
+                if get_local_rule_pref(family) == 1001:
+                    break
+                time.sleep(1)
+            assert get_local_rule_pref(family) == 1001
+            assert get_local_rule_pref(other_family) == 1001
+        finally:
+            current_pref = get_local_rule_pref(family)
+            if current_pref != 1001:
+                status, output = dvs.runcmd(
+                    ["ip", family, "rule", "add", "pref", "1001", "table", "local"]
+                )
+                assert status == 0, output
+                status, output = dvs.runcmd(
+                    ["ip", family, "rule", "del", "pref", str(current_pref), "table", "local"]
+                )
+                assert status == 0, output
+            status, output = dvs.runcmd(["supervisorctl", "restart", "vrfmgrd"])
+            assert status == 0, output
+
     def test_VRFMgr_Comprehensive(self, dvs, testlog):
         self.setup_db(dvs)
 


### PR DESCRIPTION
**What I did**

Cherry-picked the two patches from https://github.com/sonic-net/sonic-swss/pull/3584 onto the `202605` branch:

- Normalize the canonical `from all lookup local` rule to preference `1001` during `VrfMgr` startup.
- Handle IPv4 and IPv6 independently.
- Add DVS regression coverage for stale local-rule preferences.

The `202605` commits are patch-identical to the source commits:

- `6d8477829` corresponds to `60efcc5f`
- `42c21c102` corresponds to `98134129`

**Why I did it**

Without the fix, a reboot after management VRF use can leave the canonical local lookup rule at preference `32765`, where it conflicts with the management source rule and can make the management interface unreachable.

This PR provides the requested branch-specific backport and validation for https://github.com/sonic-net/sonic-swss/pull/3584.

**How I verified it**

- Azure build and VS tests passed, including normal and ASAN VSTest lanes:
  https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1171731
- Downloaded the exact `sonic-swss-trixie` artifact from build `1171731`.
- Deployed its `vrfmgrd` to physical DUT `bjw2-can-7050-1` on `SONiC.20260510.06`, Debian 13/Trixie.
- Verified the deployed candidate SHA-256:
  `b85628d5bda90c6bd75b9b6e4eef591b217c8a3391f0cc03edf4272d5864982d`.
- Ran:

  ```text
  ./run_tests.sh \
    -n testbed-bjw2-can-t0-7050-1 \
    -c "mvrf/test_mgmtvrf.py::TestReboot::test_reboot" \
    -i ../ansible/veos,../ansible/bjw2 \
    -u -x -a False \
    -e "--ignore-conditional-mark --skip-yang"
  ```

- Result: `1 passed in 1051.68s`.
- Proved that a real reboot occurred: DUT boot time changed to `2026-07-22 17:07:23 UTC` / `2026-07-23 03:07:23 Sydney`.
- Verified after reboot:
  - management SSH remained reachable;
  - IPv4 `from all lookup local` was at preference `1001`;
  - IPv6 `from all lookup local` was at preference `1001`;
  - the exact candidate checksum remained active;
  - `vrfmgrd` was `RUNNING`;
  - system state was `running`;
  - management VRF was disabled after test cleanup.
- Restored the stock `vrfmgrd` with SHA-256
  `a031378563fa4d2e22b11c3c11c4c34200cec4787200e717e9a52778a9617b2e`
  and re-verified daemon, system, IPv4/IPv6 rules, and management-VRF state.

**Details if related**

The first attempt stopped before the reboot body because the branch's module-level YANG empty-patch precheck rejected unrelated pre-existing `EVERFLOW|RULE_8` data. The successful run used the branch-supported `--skip-yang` option, which skips only that pre/post module fixture; the management-VRF reboot test body and its connectivity/rule assertions remained enabled.

This PR remains a draft until the source PR https://github.com/sonic-net/sonic-swss/pull/3584 is merged.
