### PR TITLE
[Mellanox] PFC WD: Allow 1% deviation in accumulated detection time

### DIFF
--- a/orchagent/pfc_detect_mellanox.lua
+++ b/orchagent/pfc_detect_mellanox.lua
@@ -116,7 +116,9 @@ for i = n, 1, -1 do
                             (debug_storm == "enabled")
                             -- DEBUG CODE END.
                             then
-                            if time_left <= effective_poll_time then
+                            -- Allow up to 1% deviation from the configured detection time.
+                            local accumulated_detection_time = detection_time - time_left + effective_poll_time
+                            if accumulated_detection_time > detection_time * 0.99 then
                                 redis.call('HDEL', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key .. '_last')
                                 redis.call('HDEL', counters_table_name .. ':' .. port_id, pfc_duration_key .. '_last')
                                 local occupancy_string = '"occupancy","' .. tostring(occupancy_bytes) .. '",'


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Relaxed the Mellanox PFC watchdog accumulated detection-time threshold from 100% to 99% of the configured detection time.

**Why I did it**

PFC WD uses the actual polling interval when accumulating detection time. When an effective polling interval is slightly shorter than the configured detection time because of normal timing jitter, the 100% threshold requires another complete polling round.

For a 400 ms polling and detection interval, this can delay storm detection by approximately 400 ms and make the reported detection-to-restoration duration shorter than the actual storm duration.

Allowing a 1% deviation avoids this extra-round delay while retaining the existing requirement that PFC pause duration exceed 99% of the effective polling interval.

**How I verified it**

Tested with:

- Polling interval: 400 ms
- Detection time: 400 ms
- Restoration time: 400 ms
- PFC storm: 2000 ms ON and 2000 ms OFF

Before the change, 6 of 17 samples required an additional detection round, resulting in an average detection-to-restoration interval of 1860.711 ms.

After the change, 255 samples from the follow-up runs averaged 2005.724 ms. All identified run averages were within the expected 1900–2100 ms range.

The follow-up data included 23 terminal effective polling intervals below 400 ms, with a minimum of 396.527 ms. These intervals triggered detection without waiting for another polling round.

Test is also done on 202605 branches

**Details if related**