### PR TITLE
[tests]: Remove mirror destination route correctly

### DIFF
--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -618,7 +618,7 @@ class TestMirror(object):
         self.remove_vlan("9")
 
         # remove route; remove neighbor; remove ip; bring down port
-        self.remove_route(dvs, vlan_intf_addr)
+        self.remove_route(dvs, port_ip_prefix)
         self.remove_neighbor("Ethernet32", port_nhop_ip)
         self.remove_ip_address("Ethernet32", port_intf_addr)
         self.set_interface_status(dvs, "Ethernet32", "down")


### PR DESCRIPTION
**What I did**

Corrected `test_MirrorDestMoveVlan` cleanup to remove `port_ip_prefix`, the static route installed by the test, instead of attempting to remove the unrelated VLAN interface prefix.

**Why I did it**

The stale route keeps the `Ethernet32` router interface referenced after the IPv4 case. The following IPv6 case can then inherit stale mirror-session state or fail interface recreation, especially when removal retry fencing is enabled.

**How I verified it**

- Master head: `5d43f7dc14665582f47d26b4de6804660884076b`
- Master PR build: [1173264](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1173264)
- All applicable architecture, ASAN, Docker, Trixie, `Test vstest`, and `TestAsan vstest` lanes passed.
- The existing test covers both IPv4 and IPv6 paths and now removes the exact prefix each path installs.
- The equivalent cleanup was included in the exact combined 202605 validation stack as commit `253e3009fc42ccc1671715ab4a7797f6b1559b37`.
- Validation PR: [#4747](https://github.com/sonic-net/sonic-swss/pull/4747)
- Validation build: [1175840](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1175840)
- Result: all applicable build, regular VSTest, and ASAN VSTest lanes passed.

**Details if related**

Observed while investigating repeated `test_MirrorDestMoveVlan` failures in #4746. This cleanup defect predates and is separate from that product change.

### Which release branch to backport

- [x] 202605

The same incorrect cleanup exists on 202605 and must be corrected so dependent interface-removal validation does not retain the stale route.

### Tested branch

- [x] 202605

### Test result

- 202605: The equivalent cleanup passed in the exact combined validation stack in [PR #4747](https://github.com/sonic-net/sonic-swss/pull/4747), head `253e3009fc42ccc1671715ab4a7797f6b1559b37`, build [1175840](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1175840).



##### Work item tracking
- Microsoft ADO (number only): 39058195
