### PR TITLE
[orchagent]: Forward selectable priority through Executor

### DIFF
--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -118,6 +118,7 @@ public:
 
     // Decorating Selectable
     int getFd() override { return m_selectable->getFd(); }
+    int getPri() const override { return m_selectable->getPri(); }
     uint64_t readData() override { return m_selectable->readData(); }
     bool hasCachedData() override { return m_selectable->hasCachedData(); }
     bool initializedWithData() override { return m_selectable->initializedWithData(); }

--- a/tests/mock_tests/orchdaemon_ut.cpp
+++ b/tests/mock_tests/orchdaemon_ut.cpp
@@ -23,6 +23,26 @@ namespace orchdaemon_test
     using ::testing::StrictMock;
     using ::testing::InSequence;
 
+    class PrioritySelectable : public swss::Selectable
+    {
+    public:
+        explicit PrioritySelectable(int priority) : Selectable(priority) {}
+
+        int getFd() override { return -1; }
+        uint64_t readData() override { return 0; }
+    };
+
+    TEST(ExecutorPriorityTest, ForwardsWrappedSelectablePriority)
+    {
+        Executor intfsExecutor(new PrioritySelectable(35), nullptr, "INTF_TABLE");
+        Executor routeExecutor(new PrioritySelectable(5), nullptr, "ROUTE_TABLE");
+        swss::Selectable *intfsSelectable = &intfsExecutor;
+        swss::Selectable *routeSelectable = &routeExecutor;
+
+        EXPECT_EQ(intfsSelectable->getPri(), 35);
+        EXPECT_EQ(routeSelectable->getPri(), 5);
+    }
+
     DBConnector appl_db("APPL_DB", 0);
     DBConnector state_db("STATE_DB", 0);
     DBConnector config_db("CONFIG_DB", 0);


### PR DESCRIPTION
#### Why I did it
Orch table consumers are created with configured priorities, but the `Executor` wrapper reports its inherited default priority of zero to `Select`. This makes the configured ordering ineffective and leaves dispatch to the equal-priority last-used-time fallback.

Fix https://github.com/sonic-net/sonic-buildimage/issues/28626

#### How I did it
* Delegate `Executor::getPri()` to the wrapped `Selectable`
* Add a unit test covering configured interface and route priorities

#### How to verify it
1. Run `tests --gtest_filter=ExecutorPriorityTest.*` in the mock-test environment
2. Run the full sonic-swss VS and ASAN test suites
3. Verify concurrent ready consumers follow configured priorities without starving lower-priority work

#### Description for the changelog
Make orchagent Executors expose their configured consumer priorities.