### PR TITLE
[orchagent]: Clean up dormant consumer priority values

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -48,12 +48,12 @@ IntfMgr::IntfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
         m_appLagTable(appDb, APP_LAG_TABLE_NAME)
 {
     auto subscriberStateTable = new swss::SubscriberStateTable(stateDb,
-            STATE_PORT_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE, 100);
+            STATE_PORT_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE);
     auto stateConsumer = new Consumer(subscriberStateTable, this, STATE_PORT_TABLE_NAME);
     Orch::addExecutor(stateConsumer);
 
     auto subscriberStateLagTable = new swss::SubscriberStateTable(stateDb,
-            STATE_LAG_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE, 200);
+            STATE_LAG_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE);
     auto stateLagConsumer = new Consumer(subscriberStateLagTable, this, STATE_LAG_TABLE_NAME);
     Orch::addExecutor(stateLagConsumer);
 

--- a/cfgmgr/nbrmgr.cpp
+++ b/cfgmgr/nbrmgr.cpp
@@ -62,7 +62,7 @@ NbrMgr::NbrMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, con
     }
 
     auto consumerStateTable = new swss::ConsumerStateTable(appDb, APP_NEIGH_RESOLVE_TABLE_NAME,
-                              TableConsumable::DEFAULT_POP_BATCH_SIZE, default_orch_pri);
+                              TableConsumable::DEFAULT_POP_BATCH_SIZE);
     auto consumer = new Consumer(consumerStateTable, this, APP_NEIGH_RESOLVE_TABLE_NAME);
     Orch::addExecutor(consumer);
 
@@ -78,7 +78,7 @@ NbrMgr::NbrMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, con
         if(swtype == "voq")
         {
             string tableName = STATE_SYSTEM_NEIGH_TABLE_NAME;
-            Orch::addExecutor(new Consumer(new SubscriberStateTable(stateDb, tableName, TableConsumable::DEFAULT_POP_BATCH_SIZE, 0), this, tableName));
+            Orch::addExecutor(new Consumer(new SubscriberStateTable(stateDb, tableName, TableConsumable::DEFAULT_POP_BATCH_SIZE), this, tableName));
             m_cfgVoqInbandInterfaceTable = unique_ptr<Table>(new Table(cfgDb, CFG_VOQ_INBAND_INTERFACE_TABLE_NAME));
         }
     }

--- a/cfgmgr/tunnelmgr.cpp
+++ b/cfgmgr/tunnelmgr.cpp
@@ -148,7 +148,7 @@ TunnelMgr::TunnelMgr(DBConnector *cfgDb, DBConnector *appDb, const std::vector<s
 
 
     auto consumerStateTable = new swss::ConsumerStateTable(appDb, APP_TUNNEL_ROUTE_TABLE_NAME,
-                              TableConsumable::DEFAULT_POP_BATCH_SIZE, default_orch_pri);
+                              TableConsumable::DEFAULT_POP_BATCH_SIZE);
     auto consumer = new Consumer(consumerStateTable, this, APP_TUNNEL_ROUTE_TABLE_NAME);
     Orch::addExecutor(consumer);
 

--- a/orchagent/fabricportsorch.cpp
+++ b/orchagent/fabricportsorch.cpp
@@ -77,7 +77,7 @@ const vector<sai_switch_stat_t> switch_drop_counter_ids =
     SAI_SWITCH_STAT_PACKET_INTEGRITY_DROP
 };
 
-FabricPortsOrch::FabricPortsOrch(DBConnector *appl_db, vector<table_name_with_pri_t> &tableNames,
+FabricPortsOrch::FabricPortsOrch(DBConnector *appl_db, vector<string> &tableNames,
                                  bool fabricPortStatEnabled, bool fabricQueueStatEnabled) :
         Orch(appl_db, tableNames),
         port_stat_manager(FABRIC_PORT_STAT_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ,

--- a/orchagent/fabricportsorch.h
+++ b/orchagent/fabricportsorch.h
@@ -18,7 +18,7 @@ using TimePoint = std::chrono::time_point<Clock>;
 class FabricPortsOrch : public Orch, public Subject
 {
 public:
-    FabricPortsOrch(DBConnector *appl_db, vector<table_name_with_pri_t> &tableNames,
+    FabricPortsOrch(DBConnector *appl_db, vector<string> &tableNames,
                     bool fabricPortStatEnabled=true, bool fabricQueueStatEnabled=true);
     bool allPortsReady();
     void generateQueueStats();

--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -31,9 +31,7 @@ extern Directory<Orch*> gDirectory;
 extern NeighOrch*       gNeighOrch;
 extern L2NhgOrch*       gL2NhgOrch;
 
-const int FdbOrch::fdborch_pri = 20;
-
-FdbOrch::FdbOrch(DBConnector* applDbConnector, vector<table_name_with_pri_t> appFdbTables,
+FdbOrch::FdbOrch(DBConnector* applDbConnector, vector<string> appFdbTables,
     TableConnector stateDbFdbConnector, TableConnector stateDbMclagFdbConnector, PortsOrch *port,
     DBConnector* configDb) :
     Orch(applDbConnector, appFdbTables),
@@ -43,7 +41,7 @@ FdbOrch::FdbOrch(DBConnector* applDbConnector, vector<table_name_with_pri_t> app
 {
     for(auto it: appFdbTables)
     {
-        m_appTables.push_back(new Table(applDbConnector, it.first));
+        m_appTables.push_back(new Table(applDbConnector, it));
     }
 
     m_portsOrch->attach(this);

--- a/orchagent/fdborch.h
+++ b/orchagent/fdborch.h
@@ -124,7 +124,7 @@ class FdbOrch: public Orch, public Subject, public Observer
 
 public:
 
-    FdbOrch(DBConnector* applDbConnector, vector<table_name_with_pri_t> appFdbTables,
+    FdbOrch(DBConnector* applDbConnector, vector<string> appFdbTables,
                 TableConnector stateDbFdbConnector, TableConnector stateDbMclagFdbConnector,
                 PortsOrch *port,
                 DBConnector* configDb);
@@ -139,7 +139,6 @@ public:
     bool is_fdb_programmed_to_vxlan_tunnel(FdbEntry& entry);
     bool removeFdbEntry(const FdbEntry& entry, FdbOrigin origin=FDB_ORIGIN_PROVISIONED);
 
-    static const int fdborch_pri;
     void flushFDBEntries(sai_object_id_t bridge_port_oid,
                          sai_object_id_t vlan_oid);
     void flushAllFDBEntries(sai_object_id_t bridge_port_oid,

--- a/orchagent/fgnhgorch.cpp
+++ b/orchagent/fgnhgorch.cpp
@@ -22,7 +22,7 @@ extern RouteOrch *gRouteOrch;
 extern CrmOrch *gCrmOrch;
 extern PortsOrch *gPortsOrch;
 
-FgNhgOrch::FgNhgOrch(DBConnector *db, DBConnector *appDb, DBConnector *stateDb, vector<table_name_with_pri_t> &tableNames, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch) :
+FgNhgOrch::FgNhgOrch(DBConnector *db, DBConnector *appDb, DBConnector *stateDb, vector<string> &tableNames, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch) :
         Orch(db, tableNames),
         m_zmqClient(create_route_perf_zmq_client()),
         m_neighOrch(neighOrch),

--- a/orchagent/fgnhgorch.h
+++ b/orchagent/fgnhgorch.h
@@ -104,7 +104,7 @@ typedef map<string, NextHopIndexMap> WarmBootRecoveryMap;
 class FgNhgOrch : public Orch, public Observer
 {
 public:
-    FgNhgOrch(DBConnector *db, DBConnector *appDb, DBConnector *stateDb, vector<table_name_with_pri_t> &tableNames, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch);
+    FgNhgOrch(DBConnector *db, DBConnector *appDb, DBConnector *stateDb, vector<string> &tableNames, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch);
 
     void update(SubjectType type, void *cntx);
     bool isRouteFineGrained(sai_object_id_t vrf_id, const IpPrefix &ipPrefix, const NextHopGroupKey &nextHops);

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -41,8 +41,6 @@ extern RouteOrch *gRouteOrch;
 extern bool gTraditionalFlexCounter;
 extern bool isChassisDbInUse();
 
-const int IntfsOrch::intfsorch_pri = 35;
-
 #define UPDATE_MAPS_SEC 1
 
 #define MGMT_VRF            "mgmt"
@@ -59,7 +57,7 @@ static const vector<sai_router_interface_stat_t> rifStatIds =
     SAI_ROUTER_INTERFACE_STAT_OUT_ERROR_OCTETS,
 };
 
-IntfsOrch::IntfsOrch(DBConnector *db, vector<table_name_with_pri_t> tableNames, VRFOrch *vrf_orch, DBConnector *chassisAppDb) :
+IntfsOrch::IntfsOrch(DBConnector *db, vector<string> tableNames, VRFOrch *vrf_orch, DBConnector *chassisAppDb) :
         Orch(db, tableNames), m_vrfOrch(vrf_orch)
 {
     SWSS_LOG_ENTER();
@@ -104,7 +102,7 @@ IntfsOrch::IntfsOrch(DBConnector *db, vector<table_name_with_pri_t> tableNames, 
     {
         //Add subscriber to process VOQ system interface
         string tableName = CHASSIS_APP_SYSTEM_INTERFACE_TABLE_NAME;
-        Orch::addExecutor(new Consumer(new SubscriberStateTable(chassisAppDb, tableName, TableConsumable::DEFAULT_POP_BATCH_SIZE, 0), this, tableName));
+        Orch::addExecutor(new Consumer(new SubscriberStateTable(chassisAppDb, tableName, TableConsumable::DEFAULT_POP_BATCH_SIZE), this, tableName));
         m_tableVoqSystemInterfaceTable = unique_ptr<Table>(new Table(chassisAppDb, CHASSIS_APP_SYSTEM_INTERFACE_TABLE_NAME));
     }
 

--- a/orchagent/intfsorch.h
+++ b/orchagent/intfsorch.h
@@ -35,8 +35,7 @@ typedef map<string, IntfsEntry> IntfsTable;
 class IntfsOrch : public Orch
 {
 public:
-    IntfsOrch(DBConnector *db, vector<table_name_with_pri_t> tableNames, VRFOrch *vrf_orch, DBConnector *chassisAppDb);
-    static const int intfsorch_pri;
+    IntfsOrch(DBConnector *db, vector<string> tableNames, VRFOrch *vrf_orch, DBConnector *chassisAppDb);
 
     sai_object_id_t getRouterIntfsId(const string&);
     bool isPrefixSubnet(const IpPrefix&, const string&);

--- a/orchagent/macmoveguard.cpp
+++ b/orchagent/macmoveguard.cpp
@@ -56,7 +56,7 @@ MacMoveGuard::MacMoveGuard(DBConnector *configDb, DBConnector *stateDb,
     // Register a Consumer for the MAC_MOVE_GUARD CONFIG_DB table on the owning
     // FdbOrch. FdbOrch::doTask(Consumer&) dispatches back into doConfigTask().
     auto *consumerTable = new swss::SubscriberStateTable(
-        configDb, tableName, swss::TableConsumable::DEFAULT_POP_BATCH_SIZE, default_orch_pri);
+        configDb, tableName, swss::TableConsumable::DEFAULT_POP_BATCH_SIZE);
     auto *consumer      = new Consumer(consumerTable, m_fdbOrch, tableName);
     m_fdbOrch->addExecutor(consumer);
 

--- a/orchagent/natorch.cpp
+++ b/orchagent/natorch.cpp
@@ -43,7 +43,7 @@ extern DebugDumpOrch      *gDebugDumpOrch;
 uint32_t  natTimerTickCntr  = 0;
 bool      gNhTrackingSupported = false;
 
-NatOrch::NatOrch(DBConnector *appDb, DBConnector *stateDb, vector<table_name_with_pri_t> &tableNames,
+NatOrch::NatOrch(DBConnector *appDb, DBConnector *stateDb, vector<string> &tableNames,
          RouteOrch *routeOrch, NeighOrch *neighOrch):
          Orch(appDb, tableNames),
          m_neighOrch(neighOrch),

--- a/orchagent/natorch.h
+++ b/orchagent/natorch.h
@@ -180,7 +180,7 @@ class NatOrch: public Orch, public Subject, public Observer
 {
 public:
 
-    NatOrch(DBConnector *appDb, DBConnector *stateDb, vector<table_name_with_pri_t> &tableNames, RouteOrch *routeOrch, NeighOrch *neighOrch);
+    NatOrch(DBConnector *appDb, DBConnector *stateDb, vector<string> &tableNames, RouteOrch *routeOrch, NeighOrch *neighOrch);
 
     ~NatOrch()
     {

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -27,12 +27,10 @@ extern string gMyHostName;
 
 extern bool isChassisDbInUse();
 
-const int neighorch_pri = 30;
-
 NeighOrch::NeighOrch(DBConnector *appDb, string tableName, IntfsOrch *intfsOrch, FdbOrch *fdbOrch, PortsOrch *portsOrch, DBConnector *chassisAppDb) :
         gNeighBulker(sai_neighbor_api, gMaxBulkSize),
         gNextHopBulker(sai_next_hop_api, gSwitchId, gMaxBulkSize),
-        Orch(appDb, tableName, neighorch_pri),
+        Orch(appDb, tableName),
         m_intfsOrch(intfsOrch),
         m_fdbOrch(fdbOrch),
         m_portsOrch(portsOrch),
@@ -52,7 +50,7 @@ NeighOrch::NeighOrch(DBConnector *appDb, string tableName, IntfsOrch *intfsOrch,
     {
         //Add subscriber to process VOQ system neigh
         tableName = CHASSIS_APP_SYSTEM_NEIGH_TABLE_NAME;
-        Orch::addExecutor(new Consumer(new SubscriberStateTable(chassisAppDb, tableName, TableConsumable::DEFAULT_POP_BATCH_SIZE, 0), this, tableName));
+        Orch::addExecutor(new Consumer(new SubscriberStateTable(chassisAppDb, tableName, TableConsumable::DEFAULT_POP_BATCH_SIZE), this, tableName));
         m_tableVoqSystemNeighTable = unique_ptr<Table>(new Table(chassisAppDb, CHASSIS_APP_SYSTEM_NEIGH_TABLE_NAME));
 
         //STATE DB connection for setting state of the remote neighbor SAI programming

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -89,38 +89,30 @@ bool RingBuffer::serves(const std::string& tableName)
     return m_consumerSet.find(tableName) != m_consumerSet.end();  
 }
 
-Orch::Orch(DBConnector *db, const string tableName, int pri)
+Orch::Orch(DBConnector *db, const string tableName)
 {
-    addConsumer(db, tableName, pri);
+    addConsumer(db, tableName);
 }
 
 Orch::Orch(DBConnector *db, const vector<string> &tableNames)
 {
     for (auto it : tableNames)
     {
-        addConsumer(db, it, default_orch_pri);
+        addConsumer(db, it);
     }
 }
 
-Orch::Orch(swss::DBConnector *db1, swss::DBConnector *db2, 
+Orch::Orch(swss::DBConnector *db1, swss::DBConnector *db2,
     const std::vector<std::string> &tableNames_1, const std::vector<std::string> &tableNames_2)
 {
     for(auto it : tableNames_1)
     {
-        addConsumer(db1, it, default_orch_pri);
+        addConsumer(db1, it);
     }
 
     for(auto it : tableNames_2)
     {
-        addConsumer(db2, it, default_orch_pri);
-    }
-}
-
-Orch::Orch(DBConnector *db, const vector<table_name_with_pri_t> &tableNames_with_pri)
-{
-    for (const auto& it : tableNames_with_pri)
-    {
-        addConsumer(db, it.first, it.second);
+        addConsumer(db2, it);
     }
 }
 
@@ -1208,15 +1200,15 @@ bool Orch::isItemIdsMapContinuous(unsigned long idsMap, sai_uint32_t maxId)
     return true;
 }
 
-void Orch::addConsumer(DBConnector *db, string tableName, int pri)
+void Orch::addConsumer(DBConnector *db, string tableName)
 {
     if (db->getDbId() == CONFIG_DB || db->getDbId() == STATE_DB || db->getDbId() == CHASSIS_APP_DB)
     {
-        addExecutor(new Consumer(new SubscriberStateTable(db, tableName, TableConsumable::DEFAULT_POP_BATCH_SIZE, pri), this, tableName));
+        addExecutor(new Consumer(new SubscriberStateTable(db, tableName, TableConsumable::DEFAULT_POP_BATCH_SIZE), this, tableName));
     }
     else
     {
-        addExecutor(new Consumer(new ConsumerStateTable(db, tableName, gBatchSize, pri), this, tableName));
+        addExecutor(new Consumer(new ConsumerStateTable(db, tableName, gBatchSize), this, tableName));
     }
 }
 

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -57,8 +57,6 @@ const char state_db_key_delimiter  = '|';
 #define RING_SIZE 30
 #define SLEEP_MSECONDS 500
 
-const int default_orch_pri = 0;
-
 typedef enum
 {
     task_success,
@@ -91,8 +89,6 @@ typedef std::pair<std::string, sai_object_id_t> object_map_pair;
 // The order of the key-value pairs whose keys compare equivalent is the order of
 // insertion and does not change. (since C++11)
 typedef std::multimap<std::string, swss::KeyOpFieldsValuesTuple> SyncMap;
-
-typedef std::pair<std::string, int> table_name_with_pri_t;
 
 class Orch;
 
@@ -311,11 +307,10 @@ typedef std::pair<swss::DBConnector *, std::vector<std::string>> TablesConnector
 class Orch
 {
 public:
-    Orch(swss::DBConnector *db, const std::string tableName, int pri = default_orch_pri);
+    Orch(swss::DBConnector *db, const std::string tableName);
     Orch(swss::DBConnector *db, const std::vector<std::string> &tableNames);
     Orch(swss::DBConnector *db1, swss::DBConnector *db2,
         const std::vector<std::string> &tableNames_1, const std::vector<std::string> &tableNames_2);
-    Orch(swss::DBConnector *db, const std::vector<table_name_with_pri_t> &tableNameWithPri);
     Orch(const std::vector<TableConnector>& tables);
     virtual ~Orch() = default;
 
@@ -414,7 +409,7 @@ protected:
 
     ResponsePublisher m_publisher{"APPL_STATE_DB"};
 private:
-    void addConsumer(swss::DBConnector *db, std::string tableName, int pri = default_orch_pri);
+    void addConsumer(swss::DBConnector *db, std::string tableName);
 };
 
 #include "request_parser.h"
@@ -422,8 +417,8 @@ private:
 class Orch2 : public Orch
 {
 public:
-    Orch2(swss::DBConnector *db, const std::string& tableName, Request& request, int pri=default_orch_pri)
-        : Orch(db, tableName, pri), request_(request)
+    Orch2(swss::DBConnector *db, const std::string& tableName, Request& request)
+        : Orch(db, tableName), request_(request)
     {
     }
 

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -119,6 +119,9 @@ public:
     bool initializedWithData() override { return m_selectable->initializedWithData(); }
     void updateAfterRead() override { m_selectable->updateAfterRead(); }
 
+    // Executors have priority 0 and are scheduled in least-recently-used order.
+    int getPri() const override { return 0; }
+
     // Disable copying
     Executor(const Executor&) = delete;
     Executor& operator=(const Executor&) = delete;

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -226,21 +226,19 @@ bool OrchDaemon::init()
 
     gSwitchOrch = new SwitchOrch(m_applDb, switch_tables, stateDbSwitchTable);
 
-    const int portsorch_base_pri = 40;
-
-    vector<table_name_with_pri_t> ports_tables = {
-        { APP_PORT_TABLE_NAME,        portsorch_base_pri + 5 },
-        { APP_SEND_TO_INGRESS_PORT_TABLE_NAME,        portsorch_base_pri + 5 },
-        { APP_VLAN_TABLE_NAME,        portsorch_base_pri + 2 },
-        { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri     },
-        { APP_LAG_TABLE_NAME,         portsorch_base_pri + 4 },
-        { APP_LAG_MEMBER_TABLE_NAME,  portsorch_base_pri     }
+    vector<string> ports_tables = {
+        APP_PORT_TABLE_NAME,
+        APP_SEND_TO_INGRESS_PORT_TABLE_NAME,
+        APP_VLAN_TABLE_NAME,
+        APP_VLAN_MEMBER_TABLE_NAME,
+        APP_LAG_TABLE_NAME,
+        APP_LAG_MEMBER_TABLE_NAME
     };
 
-    vector<table_name_with_pri_t> app_fdb_tables = {
-        { APP_FDB_TABLE_NAME,        FdbOrch::fdborch_pri},
-        { APP_VXLAN_FDB_TABLE_NAME,  FdbOrch::fdborch_pri},
-        { APP_MCLAG_FDB_TABLE_NAME,  FdbOrch::fdborch_pri}
+    vector<string> app_fdb_tables = {
+        APP_FDB_TABLE_NAME,
+        APP_VXLAN_FDB_TABLE_NAME,
+        APP_MCLAG_FDB_TABLE_NAME
     };
 
     gPortsOrch = new PortsOrch(m_applDb, m_stateDb, ports_tables, m_chassisAppDb);
@@ -321,9 +319,9 @@ bool OrchDaemon::init()
     ChassisOrch* chassis_frontend_orch = new ChassisOrch(m_configDb, m_applDb, chassis_frontend_tables, vnet_rt_orch);
     gDirectory.set(chassis_frontend_orch);
 
-    vector<table_name_with_pri_t> intf_tables = {
-        { APP_INTF_TABLE_NAME,  IntfsOrch::intfsorch_pri},
-        { APP_SAG_TABLE_NAME,   IntfsOrch::intfsorch_pri}
+    vector<string> intf_tables = {
+        APP_INTF_TABLE_NAME,
+        APP_SAG_TABLE_NAME
     };
 
     gIntfsOrch = new IntfsOrch(m_applDb, intf_tables, vrf_orch, m_chassisAppDb);
@@ -332,12 +330,10 @@ bool OrchDaemon::init()
     gNeighOrch = new NeighOrch(m_applDb, APP_NEIGH_TABLE_NAME, gIntfsOrch, gFdbOrch, gPortsOrch, m_chassisAppDb);
     gDirectory.set(gNeighOrch);
 
-    const int fgnhgorch_pri = 15;
-
-    vector<table_name_with_pri_t> fgnhg_tables = {
-        { CFG_FG_NHG,                 fgnhgorch_pri },
-        { CFG_FG_NHG_PREFIX,          fgnhgorch_pri },
-        { CFG_FG_NHG_MEMBER,          fgnhgorch_pri }
+    vector<string> fgnhg_tables = {
+        CFG_FG_NHG,
+        CFG_FG_NHG_PREFIX,
+        CFG_FG_NHG_MEMBER
     };
 
     gFgNhgOrch = new FgNhgOrch(m_configDb, m_applDb, m_stateDb, fgnhg_tables, gNeighOrch, gIntfsOrch, vrf_orch);
@@ -358,10 +354,9 @@ bool OrchDaemon::init()
     gSrv6Orch = new Srv6Orch(m_configDb, m_applDb, srv6_tables, gSwitchOrch, vrf_orch, gNeighOrch);
     gDirectory.set(gSrv6Orch);
 
-    const int routeorch_pri = 5;
-    vector<table_name_with_pri_t> route_tables = {
-        { APP_ROUTE_TABLE_NAME,        routeorch_pri },
-        { APP_LABEL_ROUTE_TABLE_NAME,  routeorch_pri }
+    vector<string> route_tables = {
+        APP_ROUTE_TABLE_NAME,
+        APP_LABEL_ROUTE_TABLE_NAME
     };
 
     // Enable the fpmsyncd service to send Route events to orchagent via the ZMQ channel.
@@ -485,15 +480,13 @@ bool OrchDaemon::init()
 
     gDebugCounterOrch = new DebugCounterOrch(m_configDb, debug_counter_tables, 1000);
 
-    const int natorch_base_pri = 50;
-
-    vector<table_name_with_pri_t> nat_tables = {
-        { APP_NAT_DNAT_POOL_TABLE_NAME,  natorch_base_pri + 5 },
-        { APP_NAT_TABLE_NAME,            natorch_base_pri + 4 },
-        { APP_NAPT_TABLE_NAME,           natorch_base_pri + 3 },
-        { APP_NAT_TWICE_TABLE_NAME,      natorch_base_pri + 2 },
-        { APP_NAPT_TWICE_TABLE_NAME,     natorch_base_pri + 1 },
-        { APP_NAT_GLOBAL_TABLE_NAME,     natorch_base_pri     }
+    vector<string> nat_tables = {
+        APP_NAT_DNAT_POOL_TABLE_NAME,
+        APP_NAT_TABLE_NAME,
+        APP_NAPT_TABLE_NAME,
+        APP_NAT_TWICE_TABLE_NAME,
+        APP_NAPT_TWICE_TABLE_NAME,
+        APP_NAT_GLOBAL_TABLE_NAME
     };
 
     gNatOrch = new NatOrch(m_applDb, m_stateDb, nat_tables, gRouteOrch, gNeighOrch);
@@ -644,10 +637,9 @@ bool OrchDaemon::init()
     if (m_fabricEnabled)
     {
         // register APP_FABRIC_MONITOR_PORT_TABLE_NAME table
-        const int fabric_portsorch_base_pri = 30;
-        vector<table_name_with_pri_t> fabric_port_tables = {
-           { APP_FABRIC_MONITOR_PORT_TABLE_NAME, fabric_portsorch_base_pri },
-           { APP_FABRIC_MONITOR_DATA_TABLE_NAME, fabric_portsorch_base_pri }
+        vector<string> fabric_port_tables = {
+           APP_FABRIC_MONITOR_PORT_TABLE_NAME,
+           APP_FABRIC_MONITOR_DATA_TABLE_NAME
         };
         gFabricPortsOrch = new FabricPortsOrch(m_applDb, fabric_port_tables, m_fabricPortStatEnabled, m_fabricQueueStatEnabled);
         m_orchList.push_back(gFabricPortsOrch);
@@ -1371,10 +1363,9 @@ bool FabricOrchDaemon::init()
     SWSS_LOG_ENTER();
     SWSS_LOG_NOTICE("FabricOrchDaemon init");
 
-    const int fabric_portsorch_base_pri = 30;
-    vector<table_name_with_pri_t> fabric_port_tables = {
-        { APP_FABRIC_MONITOR_PORT_TABLE_NAME, fabric_portsorch_base_pri },
-        { APP_FABRIC_MONITOR_DATA_TABLE_NAME, fabric_portsorch_base_pri }
+    vector<string> fabric_port_tables = {
+        APP_FABRIC_MONITOR_PORT_TABLE_NAME,
+        APP_FABRIC_MONITOR_DATA_TABLE_NAME
     };
     gFabricPortsOrch = new FabricPortsOrch(m_applDb, fabric_port_tables);
     addOrchList(gFabricPortsOrch);

--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -20,7 +20,7 @@ sai_object_id_t gBridgePortOid;
 #define PG_WATERMARK_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS   60000
 #define PG_DROP_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS   10000
 
-PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_with_pri_t> &tableNames,
+PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<string> &tableNames,
                      DBConnector *chassisAppDb)
     : Orch(db, tableNames),
       m_portStateTable(stateDb, STATE_PORT_TABLE_NAME),

--- a/orchagent/p4orch/tests/fake_routeorch.cpp
+++ b/orchagent/p4orch/tests/fake_routeorch.cpp
@@ -19,7 +19,7 @@ extern sai_mpls_api_t*              sai_mpls_api;
 extern sai_switch_api_t*            sai_switch_api;
 extern size_t gMaxBulkSize;
 
-RouteOrch::RouteOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames, SwitchOrch *switchOrch, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch, FgNhgOrch *fgNhgOrch, Srv6Orch *srv6Orch, swss::ZmqServer *zmqServer) :
+RouteOrch::RouteOrch(DBConnector *db, vector<string> &tableNames, SwitchOrch *switchOrch, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch, FgNhgOrch *fgNhgOrch, Srv6Orch *srv6Orch, swss::ZmqServer *zmqServer) :
         gRouteBulker(sai_route_api, gMaxBulkSize),
         gLabelRouteBulker(sai_mpls_api, gMaxBulkSize),
         gNextHopGroupMemberBulker(sai_next_hop_group_api, gSwitchId, gMaxBulkSize),

--- a/orchagent/p4orch/tests/mock_routeorch.h
+++ b/orchagent/p4orch/tests/mock_routeorch.h
@@ -182,7 +182,7 @@ struct LabelRouteBulkContext
 class RouteOrch : public Orch, public Subject
 {
 public:
-    RouteOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames, SwitchOrch *switchOrch, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch, FgNhgOrch *fgNhgOrch, Srv6Orch *srv6Orch, swss::ZmqServer *zmqServer = nullptr);
+    RouteOrch(DBConnector *db, vector<string> &tableNames, SwitchOrch *switchOrch, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch, FgNhgOrch *fgNhgOrch, Srv6Orch *srv6Orch, swss::ZmqServer *zmqServer = nullptr);
 
     bool hasNextHopGroup(const NextHopGroupKey&) const;
     sai_object_id_t getNextHopGroupId(const NextHopGroupKey&);

--- a/orchagent/p4orch/tests/p4orch_test.cpp
+++ b/orchagent/p4orch/tests/p4orch_test.cpp
@@ -200,7 +200,7 @@ TEST_F(P4OrchTest, ProcessInvalidEntry) {
   DBConnector db("APPL_DB", 0);
   ZmqConsumerStateTable* table =
       new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
-                                TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,
+                                TableConsumable::DEFAULT_POP_BATCH_SIZE, /*pri=*/0,
                                 /*dbPersistence=*/false);
   ZmqConsumer consumer(table, nullptr, APP_P4RT_TABLE_NAME);
   consumer.m_toSyncQueue.push_back(swss::KeyOpFieldsValuesTuple{
@@ -224,7 +224,7 @@ TEST_F(P4OrchTest, ProcessP4Notification) {
   DBConnector db("APPL_DB", 0);
   ZmqConsumerStateTable* table =
       new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
-                                TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,
+                                TableConsumable::DEFAULT_POP_BATCH_SIZE, /*pri=*/0,
                                 /*dbPersistence=*/false);
   ZmqConsumer consumer(table, nullptr, APP_P4RT_TABLE_NAME);
 
@@ -323,7 +323,7 @@ TEST_F(P4OrchTest, ProcessP4NotificationInvalidKey) {
   DBConnector db("APPL_DB", 0);
   ZmqConsumerStateTable* table =
       new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
-                                TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,
+                                TableConsumable::DEFAULT_POP_BATCH_SIZE, /*pri=*/0,
                                 /*dbPersistence=*/false);
   ZmqConsumer consumer(table, nullptr, APP_P4RT_TABLE_NAME);
 
@@ -346,7 +346,7 @@ TEST_F(P4OrchTest, ProcessP4NotificationInOrder) {
   DBConnector db("APPL_DB", 0);
   ZmqConsumerStateTable* table =
       new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
-                                TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,
+                                TableConsumable::DEFAULT_POP_BATCH_SIZE, /*pri=*/0,
                                 /*dbPersistence=*/false);
   ZmqConsumer consumer(table, nullptr, APP_P4RT_TABLE_NAME);
 
@@ -404,7 +404,7 @@ TEST_F(P4OrchTest, ProcessP4NotificationWrongOrder) {
   DBConnector db("APPL_DB", 0);
   ZmqConsumerStateTable* table =
       new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
-                                TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,
+                                TableConsumable::DEFAULT_POP_BATCH_SIZE, /*pri=*/0,
                                 /*dbPersistence=*/false);
   ZmqConsumer consumer(table, nullptr, APP_P4RT_TABLE_NAME);
 
@@ -503,7 +503,7 @@ TEST_F(P4OrchTest, ProcessP4NotificationStopOnFirstFailure) {
   DBConnector db("APPL_DB", 0);
   ZmqConsumerStateTable* table =
       new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
-                                TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,
+                                TableConsumable::DEFAULT_POP_BATCH_SIZE, /*pri=*/0,
                                 /*dbPersistence=*/false);
   ZmqConsumer consumer(table, nullptr, APP_P4RT_TABLE_NAME);
 
@@ -606,7 +606,7 @@ TEST_F(P4OrchTest, ProcessP4NotificationStopOnFirstFailureDifferentTypes) {
   DBConnector db("APPL_DB", 0);
   ZmqConsumerStateTable* table =
       new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
-                                TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,
+                                TableConsumable::DEFAULT_POP_BATCH_SIZE, /*pri=*/0,
                                 /*dbPersistence=*/false);
   ZmqConsumer consumer(table, nullptr, APP_P4RT_TABLE_NAME);
 
@@ -686,7 +686,7 @@ TEST_F(P4OrchTest, TestP4OrchDumpPendingTasks)
   DBConnector db("APPL_DB", 0);
   ZmqConsumerStateTable* table =
       new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
-                                TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,
+                                TableConsumable::DEFAULT_POP_BATCH_SIZE, /*pri=*/0,
                                 /*dbPersistence=*/false);
   ZmqConsumer consumer(table, nullptr, APP_P4RT_TABLE_NAME);
   consumer.setOrderedQueue(/*orderedQueue=*/true);
@@ -735,7 +735,7 @@ TEST_F(P4OrchTest, P4OrchBakeWithAclTableDefinition) {
   DBConnector db("APPL_DB", 0);
   ZmqConsumerStateTable* table =
       new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
-                                TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,
+                                TableConsumable::DEFAULT_POP_BATCH_SIZE, /*pri=*/0,
                                 /*dbPersistence=*/false);
   ZmqConsumer consumer(table, nullptr, APP_P4RT_TABLE_NAME);
   consumer.setOrderedQueue(/*orderedQueue=*/true);
@@ -765,7 +765,7 @@ TEST_F(P4OrchTest, P4OrchBakeWithMultipleAclTables) {
   DBConnector db("APPL_DB", 0);
   ZmqConsumerStateTable* table =
       new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
-                                TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,
+                                TableConsumable::DEFAULT_POP_BATCH_SIZE, /*pri=*/0,
                                 /*dbPersistence=*/false);
   ZmqConsumer consumer(table, nullptr, APP_P4RT_TABLE_NAME);
   consumer.setOrderedQueue(/*orderedQueue=*/true);
@@ -806,7 +806,7 @@ TEST_F(P4OrchTest, P4OrchBakeEmptyConsumer) {
   DBConnector db("APPL_DB", 0);
   ZmqConsumerStateTable* table =
       new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
-                                TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,
+                                TableConsumable::DEFAULT_POP_BATCH_SIZE, /*pri=*/0,
                                 /*dbPersistence=*/false);
   ZmqConsumer consumer(table, nullptr, APP_P4RT_TABLE_NAME);
   consumer.setOrderedQueue(/*orderedQueue=*/true);
@@ -822,7 +822,7 @@ TEST_F(P4OrchTest, P4OrchBakeNonAclTableEntries) {
   DBConnector db("APPL_DB", 0);
   ZmqConsumerStateTable* table =
       new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
-                                TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,
+                                TableConsumable::DEFAULT_POP_BATCH_SIZE, /*pri=*/0,
                                 /*dbPersistence=*/false);
   ZmqConsumer consumer(table, nullptr, APP_P4RT_TABLE_NAME);
   consumer.setOrderedQueue(/*orderedQueue=*/true);
@@ -849,7 +849,7 @@ TEST_F(P4OrchTest, P4OrchBakeMixedAclAndNonAclEntries) {
   DBConnector db("APPL_DB", 0);
   ZmqConsumerStateTable* table =
       new ZmqConsumerStateTable(&db, APP_P4RT_TABLE_NAME, zmq_server,
-                                TableConsumable::DEFAULT_POP_BATCH_SIZE, 0,
+                                TableConsumable::DEFAULT_POP_BATCH_SIZE, /*pri=*/0,
                                 /*dbPersistence=*/false);
   ZmqConsumer consumer(table, nullptr, APP_P4RT_TABLE_NAME);
   consumer.setOrderedQueue(/*orderedQueue=*/true);

--- a/orchagent/p4orch/tests/test_main.cpp
+++ b/orchagent/p4orch/tests/test_main.cpp
@@ -270,7 +270,7 @@ int main(int argc, char *argv[])
     gStateDb = &state_db;
     gConfigDb = &config_db;
     gCountersDb = &counters_db;
-    std::vector<table_name_with_pri_t> ports_tables;
+    std::vector<std::string> ports_tables;
     PortsOrch ports_orch(gAppDb, gStateDb, ports_tables, gAppDb);
     gPortsOrch = &ports_orch;
     CrmOrch crm_orch(gConfigDb, CFG_CRM_TABLE_NAME);
@@ -280,10 +280,9 @@ int main(int argc, char *argv[])
     gVrfOrch = &vrf_orch;
     gDirectory.set(static_cast<VRFOrch *>(&vrf_orch));
 
-    const int routeorch_pri = 5;
-    vector<table_name_with_pri_t> route_tables = {
-        { APP_ROUTE_TABLE_NAME,        routeorch_pri },
-        { APP_LABEL_ROUTE_TABLE_NAME,  routeorch_pri }
+    vector<string> route_tables = {
+        APP_ROUTE_TABLE_NAME,
+        APP_LABEL_ROUTE_TABLE_NAME
     };
     RouteOrch route_orch(gAppDb, route_tables, NULL, NULL, NULL, NULL, NULL, NULL);
     gRouteOrch = &route_orch;

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -755,7 +755,7 @@ PfcWdSwOrch<DropHandler, ForwardHandler>::PfcWdSwOrch(
     timer->start();
 
     auto ssTable = new swss::SubscriberStateTable(
-            m_applDb.get(), APP_PFC_WD_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE, default_orch_pri);
+            m_applDb.get(), APP_PFC_WD_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE);
     auto ssConsumer = new Consumer(ssTable, this, APP_PFC_WD_TABLE_NAME);
     Orch::addExecutor(ssConsumer);
 }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -751,7 +751,7 @@ static bool isMlnxPlatform()
  *    bridge. By design, SONiC switch starts with all bridge ports removed from
  *    default VLAN and all ports removed from .1Q bridge.
  */
-PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_with_pri_t> &tableNames, DBConnector *chassisAppDb) :
+PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<string> &tableNames, DBConnector *chassisAppDb) :
         Orch(db, tableNames),
         m_portStateTable(stateDb, STATE_PORT_TABLE_NAME),
         m_portOpErrTable(stateDb, STATE_PORT_OPER_ERR_TABLE_NAME),
@@ -1012,7 +1012,7 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
             SWSS_LOG_ERROR("PortsOrch failed to set SAI_SWITCH_ATTR_PORT_HOST_TX_READY_NOTIFY attribute");
         }
 
-        Orch::addExecutor(new Consumer(new SubscriberStateTable(stateDb, STATE_TRANSCEIVER_INFO_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE, 0), this, STATE_TRANSCEIVER_INFO_TABLE_NAME));
+        Orch::addExecutor(new Consumer(new SubscriberStateTable(stateDb, STATE_TRANSCEIVER_INFO_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE), this, STATE_TRANSCEIVER_INFO_TABLE_NAME));
     }
 
     if (gMySwitchType != "dpu")
@@ -1136,12 +1136,12 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
         string tableName;
         //Add subscriber to process system LAG (System PortChannel) table
         tableName = CHASSIS_APP_LAG_TABLE_NAME;
-        Orch::addExecutor(new Consumer(new SubscriberStateTable(chassisAppDb, tableName, TableConsumable::DEFAULT_POP_BATCH_SIZE, 0), this, tableName));
+        Orch::addExecutor(new Consumer(new SubscriberStateTable(chassisAppDb, tableName, TableConsumable::DEFAULT_POP_BATCH_SIZE), this, tableName));
         m_tableVoqSystemLagTable = unique_ptr<Table>(new Table(chassisAppDb, CHASSIS_APP_LAG_TABLE_NAME));
 
         //Add subscriber to process system LAG member (System PortChannelMember) table
         tableName = CHASSIS_APP_LAG_MEMBER_TABLE_NAME;
-        Orch::addExecutor(new Consumer(new SubscriberStateTable(chassisAppDb, tableName, TableConsumable::DEFAULT_POP_BATCH_SIZE, 0), this, tableName));
+        Orch::addExecutor(new Consumer(new SubscriberStateTable(chassisAppDb, tableName, TableConsumable::DEFAULT_POP_BATCH_SIZE), this, tableName));
         m_tableVoqSystemLagMemberTable = unique_ptr<Table>(new Table(chassisAppDb, CHASSIS_APP_LAG_MEMBER_TABLE_NAME));
 
         m_lagIdAllocator = unique_ptr<LagIdAllocator> (new LagIdAllocator(chassisAppDb));

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -151,7 +151,7 @@ class PortSerdesAttrTest;
 class PortsOrch : public Orch, public Subject
 {
 public:
-    PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_with_pri_t> &tableNames, DBConnector *chassisAppDb);
+    PortsOrch(DBConnector *db, DBConnector *stateDb, vector<string> &tableNames, DBConnector *chassisAppDb);
 
     bool allPortsReady();
     bool isInitDone();

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -39,7 +39,7 @@ extern bool gRouteStateAsyncPublish;
 #define DEFAULT_NUMBER_OF_ECMP_GROUPS   128
 #define DEFAULT_MAX_ECMP_GROUP_SIZE     32
 
-RouteOrch::RouteOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames, SwitchOrch *switchOrch, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch, FgNhgOrch *fgNhgOrch, Srv6Orch *srv6Orch, swss::ZmqServer *zmqServer) :
+RouteOrch::RouteOrch(DBConnector *db, vector<string> &tableNames, SwitchOrch *switchOrch, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch, FgNhgOrch *fgNhgOrch, Srv6Orch *srv6Orch, swss::ZmqServer *zmqServer) :
         gRouteBulker(sai_route_api, gMaxBulkSize),
         gLabelRouteBulker(sai_mpls_api, gMaxBulkSize),
         gNextHopGroupMemberBulker(sai_next_hop_group_api, gSwitchId, gMaxBulkSize),

--- a/orchagent/routeorch.h
+++ b/orchagent/routeorch.h
@@ -224,7 +224,7 @@ struct LabelRouteBulkContext
 class RouteOrch : public ZmqRouteOrch, public Subject
 {
 public:
-    RouteOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames, SwitchOrch *switchOrch, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch, FgNhgOrch *fgNhgOrch, Srv6Orch *srv6Orch, swss::ZmqServer *zmqServer = nullptr);
+    RouteOrch(DBConnector *db, vector<string> &tableNames, SwitchOrch *switchOrch, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch, FgNhgOrch *fgNhgOrch, Srv6Orch *srv6Orch, swss::ZmqServer *zmqServer = nullptr);
 
     bool hasNextHopGroup(const NextHopGroupKey&) const;
     sai_object_id_t getNextHopGroupId(const NextHopGroupKey&);

--- a/orchagent/tunneldecaporch.cpp
+++ b/orchagent/tunneldecaporch.cpp
@@ -36,7 +36,7 @@ TunnelDecapOrch::TunnelDecapOrch(
 {
     SWSS_LOG_ENTER();
 
-    auto cfgSubnetDecapSubTable = new SubscriberStateTable(configDb, CFG_SUBNET_DECAP_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE, 0);
+    auto cfgSubnetDecapSubTable = new SubscriberStateTable(configDb, CFG_SUBNET_DECAP_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE);
     deque<KeyOpFieldsValuesTuple> entries;
     cfgSubnetDecapSubTable->pops(entries);
     // init subnet decap config

--- a/orchagent/zmqorch.cpp
+++ b/orchagent/zmqorch.cpp
@@ -58,32 +58,24 @@ ZmqOrch::ZmqOrch(DBConnector *db, const vector<string> &tableNames, ZmqServer *z
 {
     for (auto it : tableNames)
     {
-        addConsumer(db, it, default_orch_pri, zmqServer, dbPersistence);
+        addConsumer(db, it, zmqServer, dbPersistence);
     }
 }
 
-
-ZmqOrch::ZmqOrch(DBConnector *db, const vector<table_name_with_pri_t> &tableNames_with_pri, ZmqServer *zmqServer, bool dbPersistence)
-{
-    for (const auto& it : tableNames_with_pri)
-    {
-        addConsumer(db, it.first, it.second, zmqServer, dbPersistence);
-    }
-}
-
-void ZmqOrch::addConsumer(DBConnector *db, string tableName, int pri, ZmqServer *zmqServer, bool dbPersistence)
+void ZmqOrch::addConsumer(DBConnector *db, string tableName, ZmqServer *zmqServer, bool dbPersistence)
 {
     if (db->getDbId() == APPL_DB || db->getDbId() == DPU_APPL_DB)
     {
         if (zmqServer != nullptr)
         {
             SWSS_LOG_DEBUG("ZmqConsumer initialize for: %s", tableName.c_str());
-            addExecutor(new ZmqConsumer(new ZmqConsumerStateTable(db, tableName, *zmqServer, gBatchSize, pri, dbPersistence), this, tableName));
+            // swss-common places pri before dbPersistence; retain its default.
+            addExecutor(new ZmqConsumer(new ZmqConsumerStateTable(db, tableName, *zmqServer, gBatchSize, /*pri=*/0, dbPersistence), this, tableName));
         }
         else
         {
             SWSS_LOG_DEBUG("Consumer initialize for: %s", tableName.c_str());
-            addExecutor(new Consumer(new ConsumerStateTable(db, tableName, gBatchSize, pri), this, tableName));
+            addExecutor(new Consumer(new ConsumerStateTable(db, tableName, gBatchSize), this, tableName));
         }
     }
     else
@@ -103,32 +95,24 @@ ZmqRouteOrch::ZmqRouteOrch(DBConnector *db, const vector<string> &tableNames, Zm
 {
     for (auto it : tableNames)
     {
-        addConsumer(db, it, default_orch_pri, zmqServer, dbPersistence);
+        addConsumer(db, it, zmqServer, dbPersistence);
     }
 }
 
-ZmqRouteOrch::ZmqRouteOrch(DBConnector *db, const vector<table_name_with_pri_t> &tableNames_with_pri, ZmqServer *zmqServer, bool dbPersistence)
-: ZmqOrch()
-{
-    for (const auto& it : tableNames_with_pri)
-    {
-        addConsumer(db, it.first, it.second, zmqServer, dbPersistence);
-    }
-}
-
-void ZmqRouteOrch::addConsumer(DBConnector *db, string tableName, int pri, ZmqServer *zmqServer, bool dbPersistence)
+void ZmqRouteOrch::addConsumer(DBConnector *db, string tableName, ZmqServer *zmqServer, bool dbPersistence)
 {
     if (db->getDbId() == APPL_DB || db->getDbId() == DPU_APPL_DB)
     {
         if (zmqServer != nullptr)
         {
             SWSS_LOG_DEBUG("ZmqRouteConsumer initialize for: %s", tableName.c_str());
-            addExecutor(new ZmqRouteConsumer(new ZmqConsumerStateTable(db, tableName, *zmqServer, gBatchSize, pri, dbPersistence), this, tableName));
+            // swss-common places pri before dbPersistence; retain its default.
+            addExecutor(new ZmqRouteConsumer(new ZmqConsumerStateTable(db, tableName, *zmqServer, gBatchSize, /*pri=*/0, dbPersistence), this, tableName));
         }
         else
         {
             SWSS_LOG_DEBUG("Consumer initialize for: %s", tableName.c_str());
-            addExecutor(new Consumer(new ConsumerStateTable(db, tableName, gBatchSize, pri), this, tableName));
+            addExecutor(new Consumer(new ConsumerStateTable(db, tableName, gBatchSize), this, tableName));
         }
     }
     else

--- a/orchagent/zmqorch.h
+++ b/orchagent/zmqorch.h
@@ -38,7 +38,6 @@ class ZmqOrch : public Orch
 {
 public:
     ZmqOrch(swss::DBConnector *db, const std::vector<std::string> &tableNames, swss::ZmqServer *zmqServer, bool dbPersistence = true);
-    ZmqOrch(swss::DBConnector *db, const std::vector<table_name_with_pri_t> &tableNames_with_pri, swss::ZmqServer *zmqServer, bool dbPersistence = true);
 
     virtual void doTask(ConsumerBase &consumer) { };
     void doTask(Consumer &consumer) override;
@@ -50,15 +49,14 @@ protected:
     ZmqOrch() = default;
 
 private:
-    void addConsumer(swss::DBConnector *db, std::string tableName, int pri, swss::ZmqServer *zmqServer, bool dbPersistence = true);
+    void addConsumer(swss::DBConnector *db, std::string tableName, swss::ZmqServer *zmqServer, bool dbPersistence = true);
 };
 
 class ZmqRouteOrch : public ZmqOrch
 {
 public:
     ZmqRouteOrch(swss::DBConnector *db, const std::vector<std::string> &tableNames, swss::ZmqServer *zmqServer, bool dbPersistence = true);
-    ZmqRouteOrch(swss::DBConnector *db, const std::vector<table_name_with_pri_t> &tableNames_with_pri, swss::ZmqServer *zmqServer, bool dbPersistence = true);
 
 private:
-    void addConsumer(swss::DBConnector *db, std::string tableName, int pri, swss::ZmqServer *zmqServer, bool dbPersistence = true);
+    void addConsumer(swss::DBConnector *db, std::string tableName, swss::ZmqServer *zmqServer, bool dbPersistence = true);
 };

--- a/tests/mock_tests/aclorch_rule_ut.cpp
+++ b/tests/mock_tests/aclorch_rule_ut.cpp
@@ -62,7 +62,7 @@ namespace aclorch_rule_test
             aclMockState = make_unique<SaiMockState>();
             /* Port init done is a pre-req for Aclorch */
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_app_db.get(), APP_PORT_TABLE_NAME, 1, 1), gPortsOrch, APP_PORT_TABLE_NAME));
+                new swss::ConsumerStateTable(m_app_db.get(), APP_PORT_TABLE_NAME, 1), gPortsOrch, APP_PORT_TABLE_NAME));
             consumer->addToSync({ { "PortInitDone", EMPTY_PREFIX, { { "", "" } } } });
             static_cast<Orch *>(gPortsOrch)->doTask(*consumer.get());
         }
@@ -78,7 +78,7 @@ namespace aclorch_rule_test
         void doAclTableTypeTask(const deque<KeyOpFieldsValuesTuple> &entries)
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_config_db.get(), CFG_ACL_TABLE_TYPE_TABLE_NAME, 1, 1), 
+                new swss::ConsumerStateTable(m_config_db.get(), CFG_ACL_TABLE_TYPE_TABLE_NAME, 1),
                     gAclOrch, CFG_ACL_TABLE_TYPE_TABLE_NAME));
             consumer->addToSync(entries);
             static_cast<Orch *>(gAclOrch)->doTask(*consumer);
@@ -87,7 +87,7 @@ namespace aclorch_rule_test
         void doAclTableTask(const deque<KeyOpFieldsValuesTuple> &entries)
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_config_db.get(), CFG_ACL_TABLE_TABLE_NAME, 1, 1), 
+                new swss::ConsumerStateTable(m_config_db.get(), CFG_ACL_TABLE_TABLE_NAME, 1),
                     gAclOrch, CFG_ACL_TABLE_TABLE_NAME));
             consumer->addToSync(entries);
             static_cast<Orch *>(gAclOrch)->doTask(*consumer);
@@ -96,7 +96,7 @@ namespace aclorch_rule_test
         void doAclRuleTask(const deque<KeyOpFieldsValuesTuple> &entries)
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_config_db.get(), CFG_ACL_RULE_TABLE_NAME, 1, 1), 
+                new swss::ConsumerStateTable(m_config_db.get(), CFG_ACL_RULE_TABLE_NAME, 1),
                     gAclOrch, CFG_ACL_RULE_TABLE_NAME));
             consumer->addToSync(entries);
             static_cast<Orch *>(gAclOrch)->doTask(*consumer);
@@ -122,7 +122,7 @@ namespace aclorch_rule_test
 
             /* Create a tunnel */
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_app_db.get(), APP_VXLAN_TUNNEL_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_app_db.get(), APP_VXLAN_TUNNEL_TABLE_NAME, 1),
                                              m_VxlanTunnelOrch, APP_VXLAN_TUNNEL_TABLE_NAME));
 
             consumer->addToSync(
@@ -149,7 +149,7 @@ namespace aclorch_rule_test
 
             /* Delete the Tunnel Object */
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_app_db.get(), APP_VXLAN_TUNNEL_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_app_db.get(), APP_VXLAN_TUNNEL_TABLE_NAME, 1),
                                              m_VxlanTunnelOrch, APP_VXLAN_TUNNEL_TABLE_NAME));
 
             consumer->addToSync(

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -180,7 +180,7 @@ namespace aclorch_test
         void doAclTableTypeTask(const deque<KeyOpFieldsValuesTuple> &entries)
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(config_db, CFG_ACL_TABLE_TYPE_TABLE_NAME, 1, 1), m_aclOrch, CFG_ACL_TABLE_TYPE_TABLE_NAME));
+                new swss::ConsumerStateTable(config_db, CFG_ACL_TABLE_TYPE_TABLE_NAME, 1), m_aclOrch, CFG_ACL_TABLE_TYPE_TABLE_NAME));
 
             consumer->addToSync(entries);
             static_cast<Orch *>(m_aclOrch)->doTask(*consumer);
@@ -189,7 +189,7 @@ namespace aclorch_test
         void doAclTableTask(const deque<KeyOpFieldsValuesTuple> &entries)
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(config_db, CFG_ACL_TABLE_TABLE_NAME, 1, 1), m_aclOrch, CFG_ACL_TABLE_TABLE_NAME));
+                new swss::ConsumerStateTable(config_db, CFG_ACL_TABLE_TABLE_NAME, 1), m_aclOrch, CFG_ACL_TABLE_TABLE_NAME));
 
             consumer->addToSync(entries);
             static_cast<Orch *>(m_aclOrch)->doTask(*consumer);
@@ -198,7 +198,7 @@ namespace aclorch_test
         void doAclRuleTask(const deque<KeyOpFieldsValuesTuple> &entries)
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(config_db, CFG_ACL_RULE_TABLE_NAME, 1, 1), m_aclOrch, CFG_ACL_RULE_TABLE_NAME));
+                new swss::ConsumerStateTable(config_db, CFG_ACL_RULE_TABLE_NAME, 1), m_aclOrch, CFG_ACL_RULE_TABLE_NAME));
 
             consumer->addToSync(entries);
             static_cast<Orch *>(m_aclOrch)->doTask(*consumer);
@@ -370,14 +370,12 @@ namespace aclorch_test
 
             // Create dependencies ...
 
-            const int portsorch_base_pri = 40;
-
-            vector<table_name_with_pri_t> ports_tables = {
-                { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },
-                { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },
-                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
-                { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },
-                { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
+            vector<string> ports_tables = {
+                APP_PORT_TABLE_NAME,
+                APP_VLAN_TABLE_NAME,
+                APP_VLAN_MEMBER_TABLE_NAME,
+                APP_LAG_TABLE_NAME,
+                APP_LAG_MEMBER_TABLE_NAME
             };
 
             ASSERT_EQ(gPortsOrch, nullptr);
@@ -390,20 +388,18 @@ namespace aclorch_test
 
             ASSERT_EQ(gVrfOrch, nullptr);
             gVrfOrch = new VRFOrch(m_app_db.get(), APP_VRF_TABLE_NAME, m_state_db.get(), STATE_VRF_OBJECT_TABLE_NAME);
-            vector<table_name_with_pri_t> intf_tables = {
-                { APP_INTF_TABLE_NAME,  IntfsOrch::intfsorch_pri},
-                { APP_SAG_TABLE_NAME,   IntfsOrch::intfsorch_pri}
+            vector<string> intf_tables = {
+                APP_INTF_TABLE_NAME,
+                APP_SAG_TABLE_NAME
             };
 
             ASSERT_EQ(gIntfsOrch, nullptr);
             gIntfsOrch = new IntfsOrch(m_app_db.get(), intf_tables, gVrfOrch, m_chassis_app_db.get());
 
-            const int fdborch_pri = 20;
-
-            vector<table_name_with_pri_t> app_fdb_tables = {
-                { APP_FDB_TABLE_NAME,        FdbOrch::fdborch_pri},
-                { APP_VXLAN_FDB_TABLE_NAME,  FdbOrch::fdborch_pri},
-                { APP_MCLAG_FDB_TABLE_NAME,  fdborch_pri}
+            vector<string> app_fdb_tables = {
+                APP_FDB_TABLE_NAME,
+                APP_VXLAN_FDB_TABLE_NAME,
+                APP_MCLAG_FDB_TABLE_NAME
             };
 
             TableConnector stateDbFdb(m_state_db.get(), STATE_FDB_TABLE_NAME);
@@ -416,12 +412,11 @@ namespace aclorch_test
             gNeighOrch = new NeighOrch(m_app_db.get(), APP_NEIGH_TABLE_NAME, gIntfsOrch, gFdbOrch, gPortsOrch, m_chassis_app_db.get());
 
             ASSERT_EQ(gFgNhgOrch, nullptr);
-            const int fgnhgorch_pri = 15;
 
-            vector<table_name_with_pri_t> fgnhg_tables = {
-                { CFG_FG_NHG,                 fgnhgorch_pri },
-                { CFG_FG_NHG_PREFIX,          fgnhgorch_pri },
-                { CFG_FG_NHG_MEMBER,          fgnhgorch_pri }
+            vector<string> fgnhg_tables = {
+                CFG_FG_NHG,
+                CFG_FG_NHG_PREFIX,
+                CFG_FG_NHG_MEMBER
             };
             gFgNhgOrch = new FgNhgOrch(m_config_db.get(), m_app_db.get(), m_state_db.get(), fgnhg_tables, gNeighOrch, gIntfsOrch, gVrfOrch);
 
@@ -438,10 +433,9 @@ namespace aclorch_test
             gSrv6Orch = new Srv6Orch(m_config_db.get(), m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
 
             ASSERT_EQ(gRouteOrch, nullptr);
-            const int routeorch_pri = 5;
-            vector<table_name_with_pri_t> route_tables = {
-                { APP_ROUTE_TABLE_NAME,        routeorch_pri },
-                { APP_LABEL_ROUTE_TABLE_NAME,  routeorch_pri }
+            vector<string> route_tables = {
+                APP_ROUTE_TABLE_NAME,
+                APP_LABEL_ROUTE_TABLE_NAME
             };
             gRouteOrch = new RouteOrch(m_app_db.get(), route_tables, gSwitchOrch, gNeighOrch, gIntfsOrch, gVrfOrch, gFgNhgOrch, gSrv6Orch);
 
@@ -461,7 +455,7 @@ namespace aclorch_test
                                          gPortsOrch, gRouteOrch, gNeighOrch, gFdbOrch, gPolicerOrch, gSwitchOrch);
 
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_app_db.get(), APP_PORT_TABLE_NAME, 1, 1), gPortsOrch, APP_PORT_TABLE_NAME));
+                new swss::ConsumerStateTable(m_app_db.get(), APP_PORT_TABLE_NAME, 1), gPortsOrch, APP_PORT_TABLE_NAME));
 
             consumer->addToSync({ { "PortInitDone", EMPTY_PREFIX, { { "", "" } } } });
             static_cast<Orch *>(gPortsOrch)->doTask(*consumer.get());
@@ -1350,7 +1344,7 @@ namespace aclorch_test
 
         // Create a policer so POLICER_ACTION can resolve its OID.
         auto policerConsumer = unique_ptr<Consumer>(new Consumer(
-            new swss::ConsumerStateTable(m_config_db.get(), CFG_POLICER_TABLE_NAME, 1, 1),
+            new swss::ConsumerStateTable(m_config_db.get(), CFG_POLICER_TABLE_NAME, 1),
             gPolicerOrch, CFG_POLICER_TABLE_NAME));
         policerConsumer->addToSync(deque<KeyOpFieldsValuesTuple>(
             { { policerName, SET_COMMAND,
@@ -1434,7 +1428,7 @@ namespace aclorch_test
 
         // Create a policer so POLICER_ACTION can resolve its OID.
         auto policerConsumer = unique_ptr<Consumer>(new Consumer(
-            new swss::ConsumerStateTable(m_config_db.get(), CFG_POLICER_TABLE_NAME, 1, 1),
+            new swss::ConsumerStateTable(m_config_db.get(), CFG_POLICER_TABLE_NAME, 1),
             gPolicerOrch, CFG_POLICER_TABLE_NAME));
         policerConsumer->addToSync(deque<KeyOpFieldsValuesTuple>(
             { { policerName, SET_COMMAND,
@@ -1502,7 +1496,7 @@ namespace aclorch_test
 
         // Create a policer so POLICER_ACTION can resolve its OID.
         auto policerConsumer = unique_ptr<Consumer>(new Consumer(
-            new swss::ConsumerStateTable(m_config_db.get(), CFG_POLICER_TABLE_NAME, 1, 1),
+            new swss::ConsumerStateTable(m_config_db.get(), CFG_POLICER_TABLE_NAME, 1),
             gPolicerOrch, CFG_POLICER_TABLE_NAME));
         policerConsumer->addToSync(deque<KeyOpFieldsValuesTuple>(
             { { policerName, SET_COMMAND,
@@ -1567,7 +1561,7 @@ namespace aclorch_test
         auto orch = createAclOrch();
 
         auto policerConsumer = unique_ptr<Consumer>(new Consumer(
-            new swss::ConsumerStateTable(m_config_db.get(), CFG_POLICER_TABLE_NAME, 1, 1),
+            new swss::ConsumerStateTable(m_config_db.get(), CFG_POLICER_TABLE_NAME, 1),
             gPolicerOrch, CFG_POLICER_TABLE_NAME));
         policerConsumer->addToSync(deque<KeyOpFieldsValuesTuple>(
             { { policerName, SET_COMMAND,
@@ -1621,7 +1615,7 @@ namespace aclorch_test
         auto orch = createAclOrch();
 
         auto policerConsumer = unique_ptr<Consumer>(new Consumer(
-            new swss::ConsumerStateTable(m_config_db.get(), CFG_POLICER_TABLE_NAME, 1, 1),
+            new swss::ConsumerStateTable(m_config_db.get(), CFG_POLICER_TABLE_NAME, 1),
             gPolicerOrch, CFG_POLICER_TABLE_NAME));
         policerConsumer->addToSync(deque<KeyOpFieldsValuesTuple>(
             { { policerName, SET_COMMAND,
@@ -1676,7 +1670,7 @@ namespace aclorch_test
         auto orch = createAclOrch();
 
         auto policerConsumer = unique_ptr<Consumer>(new Consumer(
-            new swss::ConsumerStateTable(m_config_db.get(), CFG_POLICER_TABLE_NAME, 1, 1),
+            new swss::ConsumerStateTable(m_config_db.get(), CFG_POLICER_TABLE_NAME, 1),
             gPolicerOrch, CFG_POLICER_TABLE_NAME));
         auto createPolicer = [&](const string &name) {
             policerConsumer->addToSync(deque<KeyOpFieldsValuesTuple>(
@@ -1783,7 +1777,7 @@ namespace aclorch_test
 
         // Create the policer, then re-run the rule task: the rule is now programmed.
         auto policerConsumer = unique_ptr<Consumer>(new Consumer(
-            new swss::ConsumerStateTable(m_config_db.get(), CFG_POLICER_TABLE_NAME, 1, 1),
+            new swss::ConsumerStateTable(m_config_db.get(), CFG_POLICER_TABLE_NAME, 1),
             gPolicerOrch, CFG_POLICER_TABLE_NAME));
         policerConsumer->addToSync(deque<KeyOpFieldsValuesTuple>(
             { { policerName, SET_COMMAND,

--- a/tests/mock_tests/bufferorch_ut.cpp
+++ b/tests/mock_tests/bufferorch_ut.cpp
@@ -290,14 +290,12 @@ namespace bufferorch_test
 
             // Create dependencies ...
 
-            const int portsorch_base_pri = 40;
-
-            vector<table_name_with_pri_t> ports_tables = {
-                { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },
-                { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },
-                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
-                { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },
-                { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
+            vector<string> ports_tables = {
+                APP_PORT_TABLE_NAME,
+                APP_VLAN_TABLE_NAME,
+                APP_VLAN_MEMBER_TABLE_NAME,
+                APP_LAG_TABLE_NAME,
+                APP_LAG_MEMBER_TABLE_NAME
             };
 
             vector<string> flex_counter_tables = {
@@ -318,20 +316,18 @@ namespace bufferorch_test
 
             ASSERT_EQ(gVrfOrch, nullptr);
             gVrfOrch = new VRFOrch(m_app_db.get(), APP_VRF_TABLE_NAME, m_state_db.get(), STATE_VRF_OBJECT_TABLE_NAME);
-            vector<table_name_with_pri_t> intf_tables = {
-                { APP_INTF_TABLE_NAME,  IntfsOrch::intfsorch_pri},
-                { APP_SAG_TABLE_NAME,   IntfsOrch::intfsorch_pri}
+            vector<string> intf_tables = {
+                APP_INTF_TABLE_NAME,
+                APP_SAG_TABLE_NAME
             };
 
             ASSERT_EQ(gIntfsOrch, nullptr);
             gIntfsOrch = new IntfsOrch(m_app_db.get(), intf_tables, gVrfOrch, m_chassis_app_db.get());
 
-            const int fdborch_pri = 20;
-
-            vector<table_name_with_pri_t> app_fdb_tables = {
-                { APP_FDB_TABLE_NAME,        FdbOrch::fdborch_pri},
-                { APP_VXLAN_FDB_TABLE_NAME,  FdbOrch::fdborch_pri},
-                { APP_MCLAG_FDB_TABLE_NAME,  fdborch_pri}
+            vector<string> app_fdb_tables = {
+                APP_FDB_TABLE_NAME,
+                APP_VXLAN_FDB_TABLE_NAME,
+                APP_MCLAG_FDB_TABLE_NAME
             };
 
             TableConnector stateDbFdb(m_state_db.get(), STATE_FDB_TABLE_NAME);

--- a/tests/mock_tests/consumer_ut.cpp
+++ b/tests/mock_tests/consumer_ut.cpp
@@ -224,6 +224,17 @@ namespace consumer_test
         }
     };
 
+    TEST_F(ConsumerTest, ExecutorPriorityIgnoresWrappedSelectablePriority)
+    {
+        Consumer consumer(
+            new swss::ConsumerStateTable(m_config_db.get(), "CFG_PRIORITY_TEST", 1, 100),
+            gPortsOrch, "CFG_PRIORITY_TEST");
+
+        EXPECT_EQ(consumer.getConsumerTable()->getPri(), 100);
+        const swss::Selectable *selectable = &consumer;
+        EXPECT_EQ(selectable->getPri(), 0);
+    }
+
     TEST_F(ConsumerTest, ConsumerAddToSync_Set)
     {
 

--- a/tests/mock_tests/consumer_ut.cpp
+++ b/tests/mock_tests/consumer_ut.cpp
@@ -226,12 +226,12 @@ namespace consumer_test
 
     TEST_F(ConsumerTest, ExecutorPriorityIgnoresWrappedSelectablePriority)
     {
-        Consumer consumer(
+        Consumer priorityConsumer(
             new swss::ConsumerStateTable(m_config_db.get(), "CFG_PRIORITY_TEST", 1, 100),
             gPortsOrch, "CFG_PRIORITY_TEST");
 
-        EXPECT_EQ(consumer.getConsumerTable()->getPri(), 100);
-        const swss::Selectable *selectable = &consumer;
+        EXPECT_EQ(priorityConsumer.getConsumerTable()->getPri(), 100);
+        const swss::Selectable *selectable = &priorityConsumer;
         EXPECT_EQ(selectable->getPri(), 0);
     }
 

--- a/tests/mock_tests/consumer_ut.cpp
+++ b/tests/mock_tests/consumer_ut.cpp
@@ -160,7 +160,7 @@ namespace consumer_test
             m_config_db = make_shared<swss::DBConnector>("CONFIG_DB", 0);
             m_state_db = make_shared<swss::DBConnector>("STATE_DB", 0);
             consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_config_db.get(), "CFG_TEST_TABLE", 1, 1), gPortsOrch, "CFG_TEST_TABLE"));
+                new swss::ConsumerStateTable(m_config_db.get(), "CFG_TEST_TABLE", 1), gPortsOrch, "CFG_TEST_TABLE"));
         }
 
         virtual void SetUp() override
@@ -480,7 +480,7 @@ namespace consumer_test
         int consumer_pops_batch_size = 10;
         TestOrch test_orch(m_config_db.get(), "CFG_TEST_TABLE");
         Consumer test_consumer(
-                new swss::ConsumerStateTable(m_config_db.get(), "CFG_TEST_TABLE", consumer_pops_batch_size, 1), &test_orch, "CFG_TEST_TABLE");
+                new swss::ConsumerStateTable(m_config_db.get(), "CFG_TEST_TABLE", consumer_pops_batch_size), &test_orch, "CFG_TEST_TABLE");
         swss::ProducerStateTable producer_table(m_config_db.get(), "CFG_TEST_TABLE");
 
         m_config_db->flushdb();

--- a/tests/mock_tests/copporch_ut.cpp
+++ b/tests/mock_tests/copporch_ut.cpp
@@ -25,7 +25,7 @@ namespace copporch_test
         {
             // ConsumerStateTable is used for APP DB
             auto consumer = std::unique_ptr<Consumer>(new Consumer(
-                new ConsumerStateTable(this->appDb.get(), APP_COPP_TABLE_NAME, 1, 1),
+                new ConsumerStateTable(this->appDb.get(), APP_COPP_TABLE_NAME, 1),
                 this->coppOrch.get(), APP_COPP_TABLE_NAME
             ));
 
@@ -37,7 +37,7 @@ namespace copporch_test
         {
             // ConsumerStateTable is used for APP DB
             auto consumer = std::unique_ptr<Consumer>(new Consumer(
-                new ConsumerStateTable(this->appDb.get(), APP_COPP_TABLE_NAME, 1, 1),
+                new ConsumerStateTable(this->appDb.get(), APP_COPP_TABLE_NAME, 1),
                 this->coppOrch.get(), APP_COPP_TABLE_NAME
             ));
 
@@ -158,14 +158,12 @@ namespace copporch_test
             // PortsOrch
             //
 
-            const int portsorchBasePri = 40;
-
-            std::vector<table_name_with_pri_t> portTableList = {
-                { APP_PORT_TABLE_NAME,        portsorchBasePri + 5 },
-                { APP_VLAN_TABLE_NAME,        portsorchBasePri + 2 },
-                { APP_VLAN_MEMBER_TABLE_NAME, portsorchBasePri     },
-                { APP_LAG_TABLE_NAME,         portsorchBasePri + 4 },
-                { APP_LAG_MEMBER_TABLE_NAME,  portsorchBasePri     }
+            std::vector<std::string> portTableList = {
+                APP_PORT_TABLE_NAME,
+                APP_VLAN_TABLE_NAME,
+                APP_VLAN_MEMBER_TABLE_NAME,
+                APP_LAG_TABLE_NAME,
+                APP_LAG_MEMBER_TABLE_NAME
             };
 
             gPortsOrch = new PortsOrch(this->appDb.get(), this->stateDb.get(), portTableList, this->chassisAppDb.get());

--- a/tests/mock_tests/dashenifwdorch_ut.cpp
+++ b/tests/mock_tests/dashenifwdorch_ut.cpp
@@ -125,7 +125,7 @@ namespace dashenifwdorch_ut
               void doDashEniFwdTableTask(DBConnector* applDb, const deque<KeyOpFieldsValuesTuple> &entries)
               {
                      auto consumer = unique_ptr<Consumer>(new Consumer(
-                            new swss::ConsumerStateTable(applDb, APP_DASH_ENI_FORWARD_TABLE, 1, 1), 
+                            new swss::ConsumerStateTable(applDb, APP_DASH_ENI_FORWARD_TABLE, 1),
                             eniOrch.get(), APP_DASH_ENI_FORWARD_TABLE));
 
                      consumer->addToSync(entries);

--- a/tests/mock_tests/dashhafloworch_ut.cpp
+++ b/tests/mock_tests/dashhafloworch_ut.cpp
@@ -75,7 +75,7 @@ namespace dashhafloworch_ut
         void CreateFlowSyncSession(const string &key, const string &ha_set_id, const string &target_server_ip, const string &target_server_port, const string &timeout = "120")
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_FLOW_SYNC_SESSION_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_FLOW_SYNC_SESSION_TABLE_NAME, 1),
                 m_dashHaFlowOrch, APP_DASH_FLOW_SYNC_SESSION_TABLE_NAME));
 
             consumer->addToSync(
@@ -101,7 +101,7 @@ namespace dashhafloworch_ut
         void RemoveFlowSyncSession(const string &key)
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_FLOW_SYNC_SESSION_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_FLOW_SYNC_SESSION_TABLE_NAME, 1),
                 m_dashHaFlowOrch, APP_DASH_FLOW_SYNC_SESSION_TABLE_NAME));
 
             consumer->addToSync(
@@ -121,7 +121,7 @@ namespace dashhafloworch_ut
         void CreateFlowDumpFilter(const string &key, const string &filter_key, const string &filter_op, const string &filter_value)
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_FLOW_DUMP_FILTER_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_FLOW_DUMP_FILTER_TABLE_NAME, 1),
                 m_dashHaFlowOrch, APP_DASH_FLOW_DUMP_FILTER_TABLE_NAME));
 
             consumer->addToSync(
@@ -145,7 +145,7 @@ namespace dashhafloworch_ut
         void RemoveFlowDumpFilter(const string &key)
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_FLOW_DUMP_FILTER_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_FLOW_DUMP_FILTER_TABLE_NAME, 1),
                 m_dashHaFlowOrch, APP_DASH_FLOW_DUMP_FILTER_TABLE_NAME));
 
             consumer->addToSync(
@@ -165,7 +165,7 @@ namespace dashhafloworch_ut
         void CreateFlowDumpSession(const string &key, const string &flow_state = "true", const string &max_flows = "1000", const string &timeout = "300", const vector<string> &filters = {})
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_FLOW_SYNC_SESSION_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_FLOW_SYNC_SESSION_TABLE_NAME, 1),
                 m_dashHaFlowOrch, APP_DASH_FLOW_SYNC_SESSION_TABLE_NAME));
 
             vector<FieldValueTuple> fvs = {
@@ -198,7 +198,7 @@ namespace dashhafloworch_ut
         void RemoveFlowDumpSession(const string &key)
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_FLOW_SYNC_SESSION_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_FLOW_SYNC_SESSION_TABLE_NAME, 1),
                 m_dashHaFlowOrch, APP_DASH_FLOW_SYNC_SESSION_TABLE_NAME));
 
             consumer->addToSync(
@@ -248,7 +248,7 @@ namespace dashhafloworch_ut
 
         // Missing target_server_ip
         auto consumer = unique_ptr<Consumer>(new Consumer(
-            new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_FLOW_SYNC_SESSION_TABLE_NAME, 1, 1),
+            new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_FLOW_SYNC_SESSION_TABLE_NAME, 1),
             m_dashHaFlowOrch, APP_DASH_FLOW_SYNC_SESSION_TABLE_NAME));
 
         consumer->addToSync(
@@ -312,7 +312,7 @@ namespace dashhafloworch_ut
 
         // Create session before filters are available - should return task_need_retry
         auto consumer = unique_ptr<Consumer>(new Consumer(
-            new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_FLOW_SYNC_SESSION_TABLE_NAME, 1, 1),
+            new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_FLOW_SYNC_SESSION_TABLE_NAME, 1),
             m_dashHaFlowOrch, APP_DASH_FLOW_SYNC_SESSION_TABLE_NAME));
 
         vector<FieldValueTuple> fvs = {

--- a/tests/mock_tests/dashhaorch_ut.cpp
+++ b/tests/mock_tests/dashhaorch_ut.cpp
@@ -137,7 +137,7 @@ namespace dashhaorch_ut
         void CreateHaSet()
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1),
                 m_dashHaOrch, APP_DASH_HA_SET_TABLE_NAME));
 
             consumer->addToSync(
@@ -172,7 +172,7 @@ namespace dashhaorch_ut
         void UpdatePeerIp(std::string peer_ip)
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1),
                 m_dashHaOrch, APP_DASH_HA_SET_TABLE_NAME));
 
             std::vector<std::pair<std::string, std::string>> fields = {{"version", "2"}};
@@ -197,7 +197,7 @@ namespace dashhaorch_ut
         void InvalidIpAddresses()
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1),
                 m_dashHaOrch, APP_DASH_HA_SET_TABLE_NAME));
 
             consumer->addToSync(
@@ -232,7 +232,7 @@ namespace dashhaorch_ut
         void InvalidField()
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1),
                 m_dashHaOrch, APP_DASH_HA_SET_TABLE_NAME));
 
             consumer->addToSync(
@@ -268,7 +268,7 @@ namespace dashhaorch_ut
         void CreateEniScopeHaSet()
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1),
                 m_dashHaOrch, APP_DASH_HA_SET_TABLE_NAME));
 
             consumer->addToSync(
@@ -303,7 +303,7 @@ namespace dashhaorch_ut
         void RemoveHaSet()
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1),
                 m_dashHaOrch, APP_DASH_HA_SET_TABLE_NAME));
 
             consumer->addToSync(
@@ -323,7 +323,7 @@ namespace dashhaorch_ut
         void CreateHaScope()
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1),
                 m_dashHaOrch, APP_DASH_HA_SCOPE_TABLE_NAME));
 
             consumer->addToSync(
@@ -350,7 +350,7 @@ namespace dashhaorch_ut
         void CreateHaScopeLessFields()
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1),
                 m_dashHaOrch, APP_DASH_HA_SCOPE_TABLE_NAME));
 
             consumer->addToSync(
@@ -373,7 +373,7 @@ namespace dashhaorch_ut
         void RemoveHaScope()
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1),
                 m_dashHaOrch, APP_DASH_HA_SCOPE_TABLE_NAME));
 
             consumer->addToSync(
@@ -393,7 +393,7 @@ namespace dashhaorch_ut
         void SetHaScopeHaRole(std::string role="active")
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1),
                 m_dashHaOrch, APP_DASH_HA_SCOPE_TABLE_NAME));
 
             consumer->addToSync(
@@ -417,7 +417,7 @@ namespace dashhaorch_ut
         void SetHaScopeActivateRoleRequest()
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1),
                 m_dashHaOrch, APP_DASH_HA_SCOPE_TABLE_NAME));
 
             consumer->addToSync(
@@ -441,7 +441,7 @@ namespace dashhaorch_ut
         void SetHaScopeFlowReconcileRequest()
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1),
                 m_dashHaOrch, APP_DASH_HA_SCOPE_TABLE_NAME));
 
             consumer->addToSync(
@@ -465,7 +465,7 @@ namespace dashhaorch_ut
         void SetHaScopeBrainSplitRecovered()
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1),
                 m_dashHaOrch, APP_DASH_HA_SCOPE_TABLE_NAME));
 
             consumer->addToSync(
@@ -497,7 +497,7 @@ namespace dashhaorch_ut
         void RandomTable()
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), "RANDOM_TABLE", 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), "RANDOM_TABLE", 1),
                 m_dashHaOrch, "RANDOM_TABLE"));
 
             consumer->addToSync(
@@ -519,7 +519,7 @@ namespace dashhaorch_ut
         void InvalidHaScopePbString()
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SCOPE_TABLE_NAME, 1),
                 m_dashHaOrch, APP_DASH_HA_SCOPE_TABLE_NAME));
 
             consumer->addToSync(
@@ -541,7 +541,7 @@ namespace dashhaorch_ut
         void InvalidHaSetPbString()
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1),
                 m_dashHaOrch, APP_DASH_HA_SET_TABLE_NAME));
 
             consumer->addToSync(
@@ -563,7 +563,7 @@ namespace dashhaorch_ut
         void HaSetScopeUnspecified()
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1),
                 m_dashHaOrch, APP_DASH_HA_SET_TABLE_NAME));
 
             dash::ha_set::HaSet ha_set = dash::ha_set::HaSet();
@@ -589,7 +589,7 @@ namespace dashhaorch_ut
         void CreateSoftwareBfdSession(string bfd_session_key = "default:default:192.168.1.100")
         {
             auto bfd_consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_BFD_SESSION_TABLE_NAME , 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_BFD_SESSION_TABLE_NAME , 1),
                 m_dashHaOrch, APP_BFD_SESSION_TABLE_NAME ));
 
             vector<FieldValueTuple> bfd_session_data = {
@@ -619,7 +619,7 @@ namespace dashhaorch_ut
         void deleteSoftwareBfdSession(string bfd_session_key = "default:default:192.168.1.100")
         {
             auto bfd_consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_BFD_SESSION_TABLE_NAME , 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_BFD_SESSION_TABLE_NAME , 1),
                 m_dashHaOrch, APP_BFD_SESSION_TABLE_NAME ));
 
             bfd_consumer->addToSync(
@@ -1159,7 +1159,7 @@ namespace dashhaorch_ut
         void CreateSwitchOwnerDpuScopeHaSet()
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
-                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1, 1),
+                new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1),
                 m_dashHaOrch, APP_DASH_HA_SET_TABLE_NAME));
 
             consumer->addToSync(

--- a/tests/mock_tests/evpnmhorch_ut.cpp
+++ b/tests/mock_tests/evpnmhorch_ut.cpp
@@ -159,14 +159,12 @@ namespace evpnmhorch_test
             gDirectory.set(m_FlexCounterOrch);
             ut_orch_list.push_back((Orch **)&m_FlexCounterOrch);
 
-            const int portsorch_base_pri = 40;
-
-            vector<table_name_with_pri_t> ports_tables = {
-                { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },
-                { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },
-                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
-                { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },
-                { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
+            vector<string> ports_tables = {
+                APP_PORT_TABLE_NAME,
+                APP_VLAN_TABLE_NAME,
+                APP_VLAN_MEMBER_TABLE_NAME,
+                APP_LAG_TABLE_NAME,
+                APP_LAG_MEMBER_TABLE_NAME
             };
 
             ASSERT_EQ(gPortsOrch, nullptr);

--- a/tests/mock_tests/fdborch/fdborch_vxlan_ut.cpp
+++ b/tests/mock_tests/fdborch/fdborch_vxlan_ut.cpp
@@ -161,13 +161,12 @@ namespace fdborch_vxlan_ut
             gDirectory.set(gSwitchOrch);
 
             // 2) Portsorch
-            const int portsorch_base_pri = 40;
-            vector<table_name_with_pri_t> ports_tables = {
-                { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },
-                { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },
-                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
-                { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },
-                { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
+            vector<string> ports_tables = {
+                APP_PORT_TABLE_NAME,
+                APP_VLAN_TABLE_NAME,
+                APP_VLAN_MEMBER_TABLE_NAME,
+                APP_LAG_TABLE_NAME,
+                APP_LAG_MEMBER_TABLE_NAME
             };
             m_portsOrch = std::make_shared<PortsOrch>(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
             gDirectory.set(m_portsOrch.get());
@@ -189,10 +188,10 @@ namespace fdborch_vxlan_ut
             gBufferOrch = new BufferOrch(m_app_db.get(), m_config_db.get(), m_state_db.get(), buffer_tables);
 
              // Construct fdborch
-            vector<table_name_with_pri_t> app_fdb_tables = {
-                { APP_FDB_TABLE_NAME,        FdbOrch::fdborch_pri},
-                { APP_VXLAN_FDB_TABLE_NAME,  FdbOrch::fdborch_pri},
-                { APP_MCLAG_FDB_TABLE_NAME,  FdbOrch::fdborch_pri}
+            vector<string> app_fdb_tables = {
+                APP_FDB_TABLE_NAME,
+                APP_VXLAN_FDB_TABLE_NAME,
+                APP_MCLAG_FDB_TABLE_NAME
             };
 
             TableConnector stateDbFdb(m_state_db.get(), STATE_FDB_TABLE_NAME);
@@ -218,8 +217,8 @@ namespace fdborch_vxlan_ut
 
             ASSERT_EQ(gIntfsOrch, nullptr);
 
-            vector<table_name_with_pri_t> intf_tables = {
-                { APP_INTF_TABLE_NAME,  IntfsOrch::intfsorch_pri}
+            vector<string> intf_tables = {
+                APP_INTF_TABLE_NAME
             };
             gIntfsOrch = new IntfsOrch(m_app_db.get(), intf_tables, gVrfOrch, m_chassis_app_db.get());
             ASSERT_EQ(gNeighOrch, nullptr);
@@ -246,11 +245,10 @@ namespace fdborch_vxlan_ut
             gDirectory.set(m_EvpnNvoOrch);
 
             gPortsOrch = m_portsOrch.get();
-            const int fgnhgorch_pri = 15;
-            vector<table_name_with_pri_t> fgnhg_tables = {
-                { CFG_FG_NHG, fgnhgorch_pri },
-                { CFG_FG_NHG_PREFIX, fgnhgorch_pri },
-                { CFG_FG_NHG_MEMBER, fgnhgorch_pri }
+            vector<string> fgnhg_tables = {
+                CFG_FG_NHG,
+                CFG_FG_NHG_PREFIX,
+                CFG_FG_NHG_MEMBER
             };
             gFgNhgOrch = new FgNhgOrch(m_config_db.get(), m_app_db.get(), m_state_db.get(), fgnhg_tables, gNeighOrch, gIntfsOrch, gVrfOrch);
             gDirectory.set(gFgNhgOrch);
@@ -264,10 +262,9 @@ namespace fdborch_vxlan_ut
             gSrv6Orch = new Srv6Orch(m_config_db.get(), m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
             gDirectory.set(gSrv6Orch);
 
-            const int routeorch_pri = 5;
-            vector<table_name_with_pri_t> route_tables = {
-                { APP_ROUTE_TABLE_NAME, routeorch_pri },
-                { APP_LABEL_ROUTE_TABLE_NAME, routeorch_pri }
+            vector<string> route_tables = {
+                APP_ROUTE_TABLE_NAME,
+                APP_LABEL_ROUTE_TABLE_NAME
             };
             gRouteOrch = new RouteOrch(m_app_db.get(), route_tables, gSwitchOrch, gNeighOrch, gIntfsOrch, gVrfOrch, gFgNhgOrch, gSrv6Orch);
             gDirectory.set(gRouteOrch);

--- a/tests/mock_tests/fdborch/flush_syncd_notif_ut.cpp
+++ b/tests/mock_tests/fdborch/flush_syncd_notif_ut.cpp
@@ -108,14 +108,12 @@ namespace fdb_syncd_flush_test
             gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
 
             // 2) Portsorch
-            const int portsorch_base_pri = 40;
-
-            vector<table_name_with_pri_t> ports_tables = {
-                { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },
-                { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },
-                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
-                { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },
-                { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
+            vector<string> ports_tables = {
+                APP_PORT_TABLE_NAME,
+                APP_VLAN_TABLE_NAME,
+                APP_VLAN_MEMBER_TABLE_NAME,
+                APP_LAG_TABLE_NAME,
+                APP_LAG_MEMBER_TABLE_NAME
             };
 
             m_portsOrch = std::make_shared<PortsOrch>(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
@@ -127,10 +125,10 @@ namespace fdb_syncd_flush_test
             gDirectory.set(m_vxlanTunnelOrch);
 
             // Construct fdborch
-            vector<table_name_with_pri_t> app_fdb_tables = {
-                { APP_FDB_TABLE_NAME,        FdbOrch::fdborch_pri},
-                { APP_VXLAN_FDB_TABLE_NAME,  FdbOrch::fdborch_pri},
-                { APP_MCLAG_FDB_TABLE_NAME,  FdbOrch::fdborch_pri}
+            vector<string> app_fdb_tables = {
+                APP_FDB_TABLE_NAME,
+                APP_VXLAN_FDB_TABLE_NAME,
+                APP_MCLAG_FDB_TABLE_NAME
             };
 
             TableConnector stateDbFdb(m_state_db.get(), STATE_FDB_TABLE_NAME);
@@ -147,8 +145,8 @@ namespace fdb_syncd_flush_test
             gVrfOrch = new VRFOrch(m_app_db.get(), APP_VRF_TABLE_NAME, m_state_db.get(), STATE_VRF_OBJECT_TABLE_NAME);
 
             ASSERT_EQ(gIntfsOrch, nullptr);
-            vector<table_name_with_pri_t> intf_tables = {
-                { APP_INTF_TABLE_NAME, IntfsOrch::intfsorch_pri }
+            vector<string> intf_tables = {
+                APP_INTF_TABLE_NAME
             };
             gIntfsOrch = new IntfsOrch(m_app_db.get(), intf_tables, gVrfOrch, m_chassis_app_db.get());
 

--- a/tests/mock_tests/flexcounter_ut.cpp
+++ b/tests/mock_tests/flexcounter_ut.cpp
@@ -345,15 +345,13 @@ namespace flexcounter_test
             ASSERT_EQ(gSwitchOrch, nullptr);
             gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
 
-            const int portsorch_base_pri = 40;
-
-            vector<table_name_with_pri_t> ports_tables = {
-                { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },
-                { APP_SEND_TO_INGRESS_PORT_TABLE_NAME, portsorch_base_pri + 5 },
-                { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },
-                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
-                { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },
-                { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
+            vector<string> ports_tables = {
+                APP_PORT_TABLE_NAME,
+                APP_SEND_TO_INGRESS_PORT_TABLE_NAME,
+                APP_VLAN_TABLE_NAME,
+                APP_VLAN_MEMBER_TABLE_NAME,
+                APP_LAG_TABLE_NAME,
+                APP_LAG_MEMBER_TABLE_NAME
             };
 
             ASSERT_EQ(gPortsOrch, nullptr);
@@ -409,9 +407,9 @@ namespace flexcounter_test
             static_cast<Orch *>(gPortsOrch)->doTask();
 
 
-            vector<table_name_with_pri_t> intf_tables = {
-                { APP_INTF_TABLE_NAME,  IntfsOrch::intfsorch_pri},
-                { APP_SAG_TABLE_NAME,   IntfsOrch::intfsorch_pri}
+            vector<string> intf_tables = {
+                APP_INTF_TABLE_NAME,
+                APP_SAG_TABLE_NAME
             };
 
             ASSERT_EQ(gIntfsOrch, nullptr);
@@ -1118,7 +1116,7 @@ namespace flexcounter_test
         m_dashHaOrch = new DashHaOrch(m_dpu_app_db.get(), dash_ha_tables, m_DashOrch, nullptr, m_dpu_app_state_db.get(), nullptr);
 
         auto consumer = unique_ptr<Consumer>(new Consumer(
-            new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1, 1),
+            new swss::ConsumerStateTable(m_dpu_app_db.get(), APP_DASH_HA_SET_TABLE_NAME, 1),
             m_dashHaOrch, APP_DASH_HA_SET_TABLE_NAME));
 
         consumer->addToSync(

--- a/tests/mock_tests/flowcounterrouteorch_ut.cpp
+++ b/tests/mock_tests/flowcounterrouteorch_ut.cpp
@@ -118,13 +118,12 @@ namespace flowcounterrouteorch_test
             TableConnector stateDbBfdSessionTable(m_state_db.get(), STATE_BFD_SESSION_TABLE_NAME);
             gBfdOrch = new BfdOrch(m_app_db.get(), APP_BFD_SESSION_TABLE_NAME, stateDbBfdSessionTable);
 
-            const int portsorch_base_pri = 40;
-            vector<table_name_with_pri_t> ports_tables = {
-                { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },
-                { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },
-                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
-                { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },
-                { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
+            vector<string> ports_tables = {
+                APP_PORT_TABLE_NAME,
+                APP_VLAN_TABLE_NAME,
+                APP_VLAN_MEMBER_TABLE_NAME,
+                APP_LAG_TABLE_NAME,
+                APP_LAG_MEMBER_TABLE_NAME
             };
 
             vector<string> flex_counter_tables = {
@@ -157,20 +156,18 @@ namespace flowcounterrouteorch_test
             gVrfOrch = new VRFOrch(m_app_db.get(), APP_VRF_TABLE_NAME, m_state_db.get(), STATE_VRF_OBJECT_TABLE_NAME);
             gDirectory.set(gVrfOrch);
 
-            vector<table_name_with_pri_t> intf_tables = {
-                { APP_INTF_TABLE_NAME,  IntfsOrch::intfsorch_pri},
-                { APP_SAG_TABLE_NAME,   IntfsOrch::intfsorch_pri}
+            vector<string> intf_tables = {
+                APP_INTF_TABLE_NAME,
+                APP_SAG_TABLE_NAME
             };
 
             ASSERT_EQ(gIntfsOrch, nullptr);
             gIntfsOrch = new IntfsOrch(m_app_db.get(), intf_tables, gVrfOrch, m_chassis_app_db.get());
 
-            const int fdborch_pri = 20;
-
-            vector<table_name_with_pri_t> app_fdb_tables = {
-                { APP_FDB_TABLE_NAME,        FdbOrch::fdborch_pri},
-                { APP_VXLAN_FDB_TABLE_NAME,  FdbOrch::fdborch_pri},
-                { APP_MCLAG_FDB_TABLE_NAME,  fdborch_pri}
+            vector<string> app_fdb_tables = {
+                APP_FDB_TABLE_NAME,
+                APP_VXLAN_FDB_TABLE_NAME,
+                APP_MCLAG_FDB_TABLE_NAME
             };
 
             TableConnector stateDbFdb(m_state_db.get(), STATE_FDB_TABLE_NAME);
@@ -197,12 +194,11 @@ namespace flowcounterrouteorch_test
             gDirectory.set(mux_orch);
 
             ASSERT_EQ(gFgNhgOrch, nullptr);
-            const int fgnhgorch_pri = 15;
 
-            vector<table_name_with_pri_t> fgnhg_tables = {
-                { CFG_FG_NHG,                 fgnhgorch_pri },
-                { CFG_FG_NHG_PREFIX,          fgnhgorch_pri },
-                { CFG_FG_NHG_MEMBER,          fgnhgorch_pri }
+            vector<string> fgnhg_tables = {
+                CFG_FG_NHG,
+                CFG_FG_NHG_PREFIX,
+                CFG_FG_NHG_MEMBER
             };
             gFgNhgOrch = new FgNhgOrch(m_config_db.get(), m_app_db.get(), m_state_db.get(), fgnhg_tables, gNeighOrch, gIntfsOrch, gVrfOrch);
 
@@ -225,10 +221,9 @@ namespace flowcounterrouteorch_test
             gFlowCounterRouteOrch = new FlowCounterRouteOrch(m_config_db.get(), route_pattern_tables);
 
             ASSERT_EQ(gRouteOrch, nullptr);
-            const int routeorch_pri = 5;
-            vector<table_name_with_pri_t> route_tables = {
-                { APP_ROUTE_TABLE_NAME,        routeorch_pri },
-                { APP_LABEL_ROUTE_TABLE_NAME,  routeorch_pri }
+            vector<string> route_tables = {
+                APP_ROUTE_TABLE_NAME,
+                APP_LABEL_ROUTE_TABLE_NAME
             };
             gRouteOrch = new RouteOrch(m_app_db.get(), route_tables, gSwitchOrch, gNeighOrch, gIntfsOrch, gVrfOrch, gFgNhgOrch, gSrv6Orch);
             gNhgOrch = new NhgOrch(m_app_db.get(), APP_NEXTHOP_GROUP_TABLE_NAME);

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -110,13 +110,12 @@ namespace intfsorch_test
             TableConnector stateDbBfdSessionTable(m_state_db.get(), STATE_BFD_SESSION_TABLE_NAME);
             gBfdOrch = new BfdOrch(m_app_db.get(), APP_BFD_SESSION_TABLE_NAME, stateDbBfdSessionTable);
 
-            const int portsorch_base_pri = 40;
-            vector<table_name_with_pri_t> ports_tables = {
-                { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },
-                { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },
-                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
-                { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },
-                { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
+            vector<string> ports_tables = {
+                APP_PORT_TABLE_NAME,
+                APP_VLAN_TABLE_NAME,
+                APP_VLAN_MEMBER_TABLE_NAME,
+                APP_LAG_TABLE_NAME,
+                APP_LAG_MEMBER_TABLE_NAME
             };
 
             vector<string> flex_counter_tables = {
@@ -148,20 +147,18 @@ namespace intfsorch_test
             gVrfOrch = new VRFOrch(m_app_db.get(), APP_VRF_TABLE_NAME, m_state_db.get(), STATE_VRF_OBJECT_TABLE_NAME);
             gDirectory.set(gVrfOrch);
 
-            vector<table_name_with_pri_t> intf_tables = {
-                { APP_INTF_TABLE_NAME,  IntfsOrch::intfsorch_pri},
-                { APP_SAG_TABLE_NAME,   IntfsOrch::intfsorch_pri}
+            vector<string> intf_tables = {
+                APP_INTF_TABLE_NAME,
+                APP_SAG_TABLE_NAME
             };
 
             ASSERT_EQ(gIntfsOrch, nullptr);
             gIntfsOrch = new IntfsOrch(m_app_db.get(), intf_tables, gVrfOrch, m_chassis_app_db.get());
 
-            const int fdborch_pri = 20;
-
-            vector<table_name_with_pri_t> app_fdb_tables = {
-                { APP_FDB_TABLE_NAME,        FdbOrch::fdborch_pri},
-                { APP_VXLAN_FDB_TABLE_NAME,  FdbOrch::fdborch_pri},
-                { APP_MCLAG_FDB_TABLE_NAME,  fdborch_pri}
+            vector<string> app_fdb_tables = {
+                APP_FDB_TABLE_NAME,
+                APP_VXLAN_FDB_TABLE_NAME,
+                APP_MCLAG_FDB_TABLE_NAME
             };
 
             TableConnector stateDbFdb(m_state_db.get(), STATE_FDB_TABLE_NAME);
@@ -186,12 +183,11 @@ namespace intfsorch_test
             gDirectory.set(mux_orch);
 
             ASSERT_EQ(gFgNhgOrch, nullptr);
-            const int fgnhgorch_pri = 15;
 
-            vector<table_name_with_pri_t> fgnhg_tables = {
-                { CFG_FG_NHG,                 fgnhgorch_pri },
-                { CFG_FG_NHG_PREFIX,          fgnhgorch_pri },
-                { CFG_FG_NHG_MEMBER,          fgnhgorch_pri }
+            vector<string> fgnhg_tables = {
+                CFG_FG_NHG,
+                CFG_FG_NHG_PREFIX,
+                CFG_FG_NHG_MEMBER
             };
             gFgNhgOrch = new FgNhgOrch(m_config_db.get(), m_app_db.get(), m_state_db.get(), fgnhg_tables, gNeighOrch, gIntfsOrch, gVrfOrch);
 
@@ -214,10 +210,9 @@ namespace intfsorch_test
             gFlowCounterRouteOrch = new FlowCounterRouteOrch(m_config_db.get(), route_pattern_tables);
 
             ASSERT_EQ(gRouteOrch, nullptr);
-            const int routeorch_pri = 5;
-            vector<table_name_with_pri_t> route_tables = {
-                { APP_ROUTE_TABLE_NAME,        routeorch_pri },
-                { APP_LABEL_ROUTE_TABLE_NAME,  routeorch_pri }
+            vector<string> route_tables = {
+                APP_ROUTE_TABLE_NAME,
+                APP_LABEL_ROUTE_TABLE_NAME
             };
             gRouteOrch = new RouteOrch(m_app_db.get(), route_tables, gSwitchOrch, gNeighOrch, gIntfsOrch, gVrfOrch, gFgNhgOrch, gSrv6Orch);
             gNhgOrch = new NhgOrch(m_app_db.get(), APP_NEXTHOP_GROUP_TABLE_NAME);

--- a/tests/mock_tests/macmoveguard/macmoveguard_ut.cpp
+++ b/tests/mock_tests/macmoveguard/macmoveguard_ut.cpp
@@ -326,13 +326,12 @@ namespace macmoveguard_test
             ASSERT_EQ(gSwitchOrch, nullptr);
             gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
 
-            const int portsorch_base_pri = 40;
-            vector<table_name_with_pri_t> ports_tables = {
-                { APP_PORT_TABLE_NAME,        portsorch_base_pri + 5 },
-                { APP_VLAN_TABLE_NAME,        portsorch_base_pri + 2 },
-                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
-                { APP_LAG_TABLE_NAME,         portsorch_base_pri + 4 },
-                { APP_LAG_MEMBER_TABLE_NAME,  portsorch_base_pri }
+            vector<string> ports_tables = {
+                APP_PORT_TABLE_NAME,
+                APP_VLAN_TABLE_NAME,
+                APP_VLAN_MEMBER_TABLE_NAME,
+                APP_LAG_TABLE_NAME,
+                APP_LAG_MEMBER_TABLE_NAME
             };
             m_portsOrch = make_shared<PortsOrch>(m_app_db.get(), m_state_db.get(),
                                                  ports_tables, m_chassis_app_db.get());
@@ -372,10 +371,10 @@ namespace macmoveguard_test
         // post-construction state as before.
         void buildOrch()
         {
-            vector<table_name_with_pri_t> app_fdb_tables = {
-                { APP_FDB_TABLE_NAME,        FdbOrch::fdborch_pri },
-                { APP_VXLAN_FDB_TABLE_NAME,  FdbOrch::fdborch_pri },
-                { APP_MCLAG_FDB_TABLE_NAME,  FdbOrch::fdborch_pri }
+            vector<string> app_fdb_tables = {
+                APP_FDB_TABLE_NAME,
+                APP_VXLAN_FDB_TABLE_NAME,
+                APP_MCLAG_FDB_TABLE_NAME
             };
             TableConnector stateDbFdb(m_state_db.get(), STATE_FDB_TABLE_NAME);
             TableConnector stateMclagDbFdb(m_state_db.get(), STATE_MCLAG_REMOTE_FDB_TABLE_NAME);
@@ -421,7 +420,7 @@ namespace macmoveguard_test
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
                 new swss::ConsumerStateTable(m_config_db.get(),
-                                             CFG_MAC_MOVE_GUARD_TABLE_NAME, 1, 1),
+                                             CFG_MAC_MOVE_GUARD_TABLE_NAME, 1),
                 m_fdbOrch.get(), CFG_MAC_MOVE_GUARD_TABLE_NAME));
 
             KeyOpFieldsValuesTuple kfv;
@@ -437,7 +436,7 @@ namespace macmoveguard_test
         {
             auto consumer = unique_ptr<Consumer>(new Consumer(
                 new swss::ConsumerStateTable(m_config_db.get(),
-                                             CFG_MAC_MOVE_GUARD_TABLE_NAME, 1, 1),
+                                             CFG_MAC_MOVE_GUARD_TABLE_NAME, 1),
                 m_fdbOrch.get(), CFG_MAC_MOVE_GUARD_TABLE_NAME));
             KeyOpFieldsValuesTuple kfv;
             kfvKey(kfv) = key;

--- a/tests/mock_tests/mock_orch_test.cpp
+++ b/tests/mock_tests/mock_orch_test.cpp
@@ -99,13 +99,12 @@ void MockOrchTest::SetUp()
 
     PrepareSai();
 
-    const int portsorch_base_pri = 40;
-    vector<table_name_with_pri_t> ports_tables = {
-        { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },
-        { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },
-        { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
-        { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },
-        { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
+    vector<string> ports_tables = {
+        APP_PORT_TABLE_NAME,
+        APP_VLAN_TABLE_NAME,
+        APP_VLAN_MEMBER_TABLE_NAME,
+        APP_LAG_TABLE_NAME,
+        APP_LAG_MEMBER_TABLE_NAME
     };
 
     TableConnector stateDbSwitchTable(m_state_db.get(), STATE_SWITCH_CAPABILITY_TABLE_NAME);
@@ -143,8 +142,8 @@ void MockOrchTest::SetUp()
     ut_orch_list.push_back((Orch **)&gVrfOrch);
     global_orch_list.insert((Orch **)&gVrfOrch);
 
-    vector<table_name_with_pri_t> intf_tables = {
-        { APP_INTF_TABLE_NAME, IntfsOrch::intfsorch_pri }
+    vector<string> intf_tables = {
+        APP_INTF_TABLE_NAME
     };
     gIntfsOrch = new IntfsOrch(m_app_db.get(), intf_tables, gVrfOrch, m_chassis_app_db.get());
     gDirectory.set(gIntfsOrch);
@@ -169,12 +168,10 @@ void MockOrchTest::SetUp()
     ut_orch_list.push_back((Orch **)&gEvpnMhOrch);
     global_orch_list.insert((Orch **)&gEvpnMhOrch);
 
-    const int fgnhgorch_pri = 15;
-
-    vector<table_name_with_pri_t> fgnhg_tables = {
-        { CFG_FG_NHG, fgnhgorch_pri },
-        { CFG_FG_NHG_PREFIX, fgnhgorch_pri },
-        { CFG_FG_NHG_MEMBER, fgnhgorch_pri }
+    vector<string> fgnhg_tables = {
+        CFG_FG_NHG,
+        CFG_FG_NHG_PREFIX,
+        CFG_FG_NHG_MEMBER
     };
 
     gFgNhgOrch = new FgNhgOrch(m_config_db.get(), m_app_db.get(), m_state_db.get(), fgnhg_tables, gNeighOrch, gIntfsOrch, gVrfOrch);
@@ -182,12 +179,10 @@ void MockOrchTest::SetUp()
     ut_orch_list.push_back((Orch **)&gFgNhgOrch);
     global_orch_list.insert((Orch **)&gFgNhgOrch);
 
-    const int fdborch_pri = 20;
-
-    vector<table_name_with_pri_t> app_fdb_tables = {
-        { APP_FDB_TABLE_NAME, FdbOrch::fdborch_pri },
-        { APP_VXLAN_FDB_TABLE_NAME, FdbOrch::fdborch_pri },
-        { APP_MCLAG_FDB_TABLE_NAME, fdborch_pri }
+    vector<string> app_fdb_tables = {
+        APP_FDB_TABLE_NAME,
+        APP_VXLAN_FDB_TABLE_NAME,
+        APP_MCLAG_FDB_TABLE_NAME
     };
 
     TableConnector stateDbFdb(m_state_db.get(), STATE_FDB_TABLE_NAME);
@@ -262,10 +257,9 @@ void MockOrchTest::SetUp()
     ut_orch_list.push_back((Orch **)&gCrmOrch);
     global_orch_list.insert((Orch **)&gCrmOrch);
 
-    const int routeorch_pri = 5;
-    vector<table_name_with_pri_t> route_tables = {
-        { APP_ROUTE_TABLE_NAME, routeorch_pri },
-        { APP_LABEL_ROUTE_TABLE_NAME, routeorch_pri }
+    vector<string> route_tables = {
+        APP_ROUTE_TABLE_NAME,
+        APP_LABEL_ROUTE_TABLE_NAME
     };
     gRouteOrch = new RouteOrch(m_app_db.get(), route_tables, gSwitchOrch, gNeighOrch, gIntfsOrch, gVrfOrch, gFgNhgOrch, gSrv6Orch);
     gDirectory.set(gRouteOrch);

--- a/tests/mock_tests/orchdaemon_ut.cpp
+++ b/tests/mock_tests/orchdaemon_ut.cpp
@@ -9,6 +9,7 @@
 #include "saihelper.h"
 
 #include <csignal>
+#include <type_traits>
 
 extern sai_switch_api_t* sai_switch_api;
 sai_switch_api_t test_sai_switch;
@@ -27,6 +28,9 @@ namespace orchdaemon_test
     DBConnector state_db("STATE_DB", 0);
     DBConnector config_db("CONFIG_DB", 0);
     DBConnector counters_db("COUNTERS_DB", 0);
+
+    static_assert(!std::is_constructible<Orch, DBConnector *, std::string, int>::value,
+                  "Orch must not expose a consumer priority constructor");
 
     class OrchDaemonTest : public ::testing::Test
     {

--- a/tests/mock_tests/portphyattr_ut.cpp
+++ b/tests/mock_tests/portphyattr_ut.cpp
@@ -101,14 +101,13 @@ namespace portphyattr_test
             gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
 
             // Create PortsOrch with all required table dependencies
-            const int portsorch_base_pri = 40;
-            vector<table_name_with_pri_t> port_tables = {
-                { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },                // Physical port config (highest priority)
-                { APP_SEND_TO_INGRESS_PORT_TABLE_NAME, portsorch_base_pri + 5 }, // Ingress port forwarding
-                { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },                // VLAN configuration
-                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },             // VLAN membership (lowest priority)
-                { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },                 // Link aggregation groups
-                { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }               // LAG membership
+            vector<string> port_tables = {
+                APP_PORT_TABLE_NAME,                 // Physical port config
+                APP_SEND_TO_INGRESS_PORT_TABLE_NAME, // Ingress port forwarding
+                APP_VLAN_TABLE_NAME,                 // VLAN configuration
+                APP_VLAN_MEMBER_TABLE_NAME,          // VLAN membership
+                APP_LAG_TABLE_NAME,                  // Link aggregation groups
+                APP_LAG_MEMBER_TABLE_NAME            // LAG membership
             };
 
             ASSERT_EQ(gPortsOrch, nullptr);

--- a/tests/mock_tests/portphyserdesattr_ut.cpp
+++ b/tests/mock_tests/portphyserdesattr_ut.cpp
@@ -207,14 +207,13 @@ namespace portphyserdesattr_test
             gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
 
             // Create PortsOrch with all required table dependencies
-            const int portsorch_base_pri = 40;
-            vector<table_name_with_pri_t> port_tables = {
-                { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },                // Physical port config (highest priority)
-                { APP_SEND_TO_INGRESS_PORT_TABLE_NAME, portsorch_base_pri + 5 }, // Ingress port forwarding
-                { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },                // VLAN configuration
-                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },             // VLAN membership (lowest priority)
-                { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },                 // Link aggregation groups
-                { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }               // LAG membership
+            vector<string> port_tables = {
+                APP_PORT_TABLE_NAME,                 // Physical port config
+                APP_SEND_TO_INGRESS_PORT_TABLE_NAME, // Ingress port forwarding
+                APP_VLAN_TABLE_NAME,                 // VLAN configuration
+                APP_VLAN_MEMBER_TABLE_NAME,          // VLAN membership
+                APP_LAG_TABLE_NAME,                  // Link aggregation groups
+                APP_LAG_MEMBER_TABLE_NAME            // LAG membership
             };
 
             ASSERT_EQ(gPortsOrch, nullptr);

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -660,15 +660,13 @@ namespace portsorch_test
             ASSERT_EQ(gSwitchOrch, nullptr);
             gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
 
-            const int portsorch_base_pri = 40;
-
-            vector<table_name_with_pri_t> ports_tables = {
-                { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },
-                { APP_SEND_TO_INGRESS_PORT_TABLE_NAME, portsorch_base_pri + 5 },
-                { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },
-                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
-                { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },
-                { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
+            vector<string> ports_tables = {
+                APP_PORT_TABLE_NAME,
+                APP_SEND_TO_INGRESS_PORT_TABLE_NAME,
+                APP_VLAN_TABLE_NAME,
+                APP_VLAN_MEMBER_TABLE_NAME,
+                APP_LAG_TABLE_NAME,
+                APP_LAG_MEMBER_TABLE_NAME
             };
 
             ASSERT_EQ(gPortsOrch, nullptr);
@@ -702,18 +700,16 @@ namespace portsorch_test
             gBufferOrch = new BufferOrch(m_app_db.get(), m_config_db.get(), m_state_db.get(), buffer_tables);
 
             ASSERT_EQ(gIntfsOrch, nullptr);
-            vector<table_name_with_pri_t> intf_tables = {
-                { APP_INTF_TABLE_NAME,  IntfsOrch::intfsorch_pri},
-                { APP_SAG_TABLE_NAME,   IntfsOrch::intfsorch_pri}
+            vector<string> intf_tables = {
+                APP_INTF_TABLE_NAME,
+                APP_SAG_TABLE_NAME
             };
             gIntfsOrch = new IntfsOrch(m_app_db.get(), intf_tables, gVrfOrch, m_chassis_app_db.get());
 
-            const int fdborch_pri = 20;
-
-            vector<table_name_with_pri_t> app_fdb_tables = {
-                { APP_FDB_TABLE_NAME,        FdbOrch::fdborch_pri},
-                { APP_VXLAN_FDB_TABLE_NAME,  FdbOrch::fdborch_pri},
-                { APP_MCLAG_FDB_TABLE_NAME,  fdborch_pri}
+            vector<string> app_fdb_tables = {
+                APP_FDB_TABLE_NAME,
+                APP_VXLAN_FDB_TABLE_NAME,
+                APP_MCLAG_FDB_TABLE_NAME
             };
 
             TableConnector stateDbFdb(m_state_db.get(), STATE_FDB_TABLE_NAME);

--- a/tests/mock_tests/qosorch_ut.cpp
+++ b/tests/mock_tests/qosorch_ut.cpp
@@ -384,14 +384,12 @@ namespace qosorch_test
 
             // Create dependencies ...
 
-            const int portsorch_base_pri = 40;
-
-            vector<table_name_with_pri_t> ports_tables = {
-                { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },
-                { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },
-                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
-                { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },
-                { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
+            vector<string> ports_tables = {
+                APP_PORT_TABLE_NAME,
+                APP_VLAN_TABLE_NAME,
+                APP_VLAN_MEMBER_TABLE_NAME,
+                APP_LAG_TABLE_NAME,
+                APP_LAG_MEMBER_TABLE_NAME
             };
 
             vector<string> flex_counter_tables = {
@@ -406,20 +404,18 @@ namespace qosorch_test
             ASSERT_EQ(gVrfOrch, nullptr);
             gVrfOrch = new VRFOrch(m_app_db.get(), APP_VRF_TABLE_NAME, m_state_db.get(), STATE_VRF_OBJECT_TABLE_NAME);
 
-            vector<table_name_with_pri_t> intf_tables = {
-                { APP_INTF_TABLE_NAME,  IntfsOrch::intfsorch_pri},
-                { APP_SAG_TABLE_NAME,   IntfsOrch::intfsorch_pri}
+            vector<string> intf_tables = {
+                APP_INTF_TABLE_NAME,
+                APP_SAG_TABLE_NAME
             };
 
             ASSERT_EQ(gIntfsOrch, nullptr);
             gIntfsOrch = new IntfsOrch(m_app_db.get(), intf_tables, gVrfOrch, m_chassis_app_db.get());
 
-            const int fdborch_pri = 20;
-
-            vector<table_name_with_pri_t> app_fdb_tables = {
-                { APP_FDB_TABLE_NAME,        FdbOrch::fdborch_pri},
-                { APP_VXLAN_FDB_TABLE_NAME,  FdbOrch::fdborch_pri},
-                { APP_MCLAG_FDB_TABLE_NAME,  fdborch_pri}
+            vector<string> app_fdb_tables = {
+                APP_FDB_TABLE_NAME,
+                APP_VXLAN_FDB_TABLE_NAME,
+                APP_MCLAG_FDB_TABLE_NAME
             };
 
             TableConnector stateDbFdb(m_state_db.get(), STATE_FDB_TABLE_NAME);

--- a/tests/mock_tests/routeorch_ut.cpp
+++ b/tests/mock_tests/routeorch_ut.cpp
@@ -224,14 +224,12 @@ namespace routeorch_test
 
             // Create dependencies ...
 
-            const int portsorch_base_pri = 40;
-
-            vector<table_name_with_pri_t> ports_tables = {
-                { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },
-                { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },
-                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
-                { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },
-                { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
+            vector<string> ports_tables = {
+                APP_PORT_TABLE_NAME,
+                APP_VLAN_TABLE_NAME,
+                APP_VLAN_MEMBER_TABLE_NAME,
+                APP_LAG_TABLE_NAME,
+                APP_LAG_MEMBER_TABLE_NAME
             };
 
             ASSERT_EQ(gPortsOrch, nullptr);
@@ -268,19 +266,17 @@ namespace routeorch_test
             m_evpnNvoOrch = new EvpnNvoOrch(m_app_db.get(), APP_VXLAN_EVPN_NVO_TABLE_NAME);
             gDirectory.set(m_evpnNvoOrch);
 
-            vector<table_name_with_pri_t> intf_tables = {
-                { APP_INTF_TABLE_NAME,  IntfsOrch::intfsorch_pri},
-                { APP_SAG_TABLE_NAME,   IntfsOrch::intfsorch_pri}
+            vector<string> intf_tables = {
+                APP_INTF_TABLE_NAME,
+                APP_SAG_TABLE_NAME
             };
             ASSERT_EQ(gIntfsOrch, nullptr);
             gIntfsOrch = new IntfsOrch(m_app_db.get(), intf_tables, gVrfOrch, m_chassis_app_db.get());
 
-            const int fdborch_pri = 20;
-
-            vector<table_name_with_pri_t> app_fdb_tables = {
-                { APP_FDB_TABLE_NAME,        FdbOrch::fdborch_pri},
-                { APP_VXLAN_FDB_TABLE_NAME,  FdbOrch::fdborch_pri},
-                { APP_MCLAG_FDB_TABLE_NAME,  fdborch_pri}
+            vector<string> app_fdb_tables = {
+                APP_FDB_TABLE_NAME,
+                APP_VXLAN_FDB_TABLE_NAME,
+                APP_MCLAG_FDB_TABLE_NAME
             };
 
             TableConnector stateDbFdb(m_state_db.get(), STATE_FDB_TABLE_NAME);
@@ -307,12 +303,11 @@ namespace routeorch_test
             gDirectory.set(m_muxOrch);
 
             ASSERT_EQ(gFgNhgOrch, nullptr);
-            const int fgnhgorch_pri = 15;
 
-            vector<table_name_with_pri_t> fgnhg_tables = {
-                { CFG_FG_NHG,                 fgnhgorch_pri },
-                { CFG_FG_NHG_PREFIX,          fgnhgorch_pri },
-                { CFG_FG_NHG_MEMBER,          fgnhgorch_pri }
+            vector<string> fgnhg_tables = {
+                CFG_FG_NHG,
+                CFG_FG_NHG_PREFIX,
+                CFG_FG_NHG_MEMBER
             };
             gFgNhgOrch = new FgNhgOrch(m_config_db.get(), m_app_db.get(), m_state_db.get(), fgnhg_tables, gNeighOrch, gIntfsOrch, gVrfOrch);
 
@@ -329,10 +324,9 @@ namespace routeorch_test
             gSrv6Orch = new Srv6Orch(m_config_db.get(), m_app_db.get(), srv6_tables, gSwitchOrch, gVrfOrch, gNeighOrch);
 
             ASSERT_EQ(gRouteOrch, nullptr);
-            const int routeorch_pri = 5;
-            vector<table_name_with_pri_t> route_tables = {
-                { APP_ROUTE_TABLE_NAME,        routeorch_pri },
-                { APP_LABEL_ROUTE_TABLE_NAME,  routeorch_pri }
+            vector<string> route_tables = {
+                APP_ROUTE_TABLE_NAME,
+                APP_LABEL_ROUTE_TABLE_NAME
             };
             gRouteOrch = new RouteOrch(m_app_db.get(), route_tables, gSwitchOrch, gNeighOrch, gIntfsOrch, gVrfOrch, gFgNhgOrch, gSrv6Orch);
             gNhgOrch = new NhgOrch(m_app_db.get(), APP_NEXTHOP_GROUP_TABLE_NAME);

--- a/tests/mock_tests/sfloworh_ut.cpp
+++ b/tests/mock_tests/sfloworh_ut.cpp
@@ -31,7 +31,7 @@ namespace sflow_test
         {
             // ConsumerStateTable is used for APP DB
             auto consumer = std::unique_ptr<Consumer>(new Consumer(
-                new ConsumerStateTable(this->appDb.get(), APP_SFLOW_TABLE_NAME, 1, 1),
+                new ConsumerStateTable(this->appDb.get(), APP_SFLOW_TABLE_NAME, 1),
                 this->sflowOrch.get(), APP_SFLOW_TABLE_NAME
             ));
 
@@ -43,7 +43,7 @@ namespace sflow_test
         {
             // ConsumerStateTable is used for APP DB
             auto consumer = std::unique_ptr<Consumer>(new Consumer(
-                new ConsumerStateTable(this->appDb.get(), APP_SFLOW_SESSION_TABLE_NAME, 1, 1),
+                new ConsumerStateTable(this->appDb.get(), APP_SFLOW_SESSION_TABLE_NAME, 1),
                 this->sflowOrch.get(), APP_SFLOW_SESSION_TABLE_NAME
             ));
 
@@ -55,7 +55,7 @@ namespace sflow_test
         {
             // ConsumerStateTable is used for APP DB
             auto consumer = std::unique_ptr<Consumer>(new Consumer(
-                new ConsumerStateTable(this->appDb.get(), APP_SFLOW_SAMPLE_RATE_TABLE_NAME, 1, 1),
+                new ConsumerStateTable(this->appDb.get(), APP_SFLOW_SAMPLE_RATE_TABLE_NAME, 1),
                 this->sflowOrch.get(), APP_SFLOW_SAMPLE_RATE_TABLE_NAME
             ));
 
@@ -176,14 +176,12 @@ namespace sflow_test
             // PortsOrch
             //
 
-            const int portsorchBasePri = 40;
-
-            std::vector<table_name_with_pri_t> portTableList = {
-                { APP_PORT_TABLE_NAME,        portsorchBasePri + 5 },
-                { APP_VLAN_TABLE_NAME,        portsorchBasePri + 2 },
-                { APP_VLAN_MEMBER_TABLE_NAME, portsorchBasePri     },
-                { APP_LAG_TABLE_NAME,         portsorchBasePri + 4 },
-                { APP_LAG_MEMBER_TABLE_NAME,  portsorchBasePri     }
+            std::vector<std::string> portTableList = {
+                APP_PORT_TABLE_NAME,
+                APP_VLAN_TABLE_NAME,
+                APP_VLAN_MEMBER_TABLE_NAME,
+                APP_LAG_TABLE_NAME,
+                APP_LAG_MEMBER_TABLE_NAME
             };
 
             gPortsOrch = new PortsOrch(this->appDb.get(), this->stateDb.get(), portTableList, this->chassisAppDb.get());

--- a/tests/mock_tests/shlorch_ut.cpp
+++ b/tests/mock_tests/shlorch_ut.cpp
@@ -312,13 +312,12 @@ namespace shlorch_test
 
             PrepareSai();
 
-            const int portsorch_base_pri = 40;
-            vector<table_name_with_pri_t> ports_tables = {
-                { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },
-                { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },
-                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
-                { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },
-                { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
+            vector<string> ports_tables = {
+                APP_PORT_TABLE_NAME,
+                APP_VLAN_TABLE_NAME,
+                APP_VLAN_MEMBER_TABLE_NAME,
+                APP_LAG_TABLE_NAME,
+                APP_LAG_MEMBER_TABLE_NAME
             };
 
             vector<string> flex_counter_tables = {
@@ -340,8 +339,8 @@ namespace shlorch_test
             gDirectory.set(gVrfOrch);
             ut_orch_list.push_back((Orch **)&gVrfOrch);
 
-            vector<table_name_with_pri_t> intf_tables = {
-                { APP_INTF_TABLE_NAME, IntfsOrch::intfsorch_pri }
+            vector<string> intf_tables = {
+                APP_INTF_TABLE_NAME
             };
             gIntfsOrch = new IntfsOrch(m_app_db.get(), intf_tables, gVrfOrch, m_chassis_app_db.get());
             gDirectory.set(gIntfsOrch);
@@ -377,24 +376,20 @@ namespace shlorch_test
             gDirectory.set(gEvpnMhOrch);
             ut_orch_list.push_back((Orch **)&gEvpnMhOrch);
 
-            const int fgnhgorch_pri = 15;
-
-            vector<table_name_with_pri_t> fgnhg_tables = {
-                { CFG_FG_NHG, fgnhgorch_pri },
-                { CFG_FG_NHG_PREFIX, fgnhgorch_pri },
-                { CFG_FG_NHG_MEMBER, fgnhgorch_pri }
+            vector<string> fgnhg_tables = {
+                CFG_FG_NHG,
+                CFG_FG_NHG_PREFIX,
+                CFG_FG_NHG_MEMBER
             };
 
             gFgNhgOrch = new FgNhgOrch(m_config_db.get(), m_app_db.get(), m_state_db.get(), fgnhg_tables, gNeighOrch, gIntfsOrch, gVrfOrch);
             gDirectory.set(gFgNhgOrch);
             ut_orch_list.push_back((Orch **)&gFgNhgOrch);
 
-            const int fdborch_pri = 20;
-
-            vector<table_name_with_pri_t> app_fdb_tables = {
-                { APP_FDB_TABLE_NAME, FdbOrch::fdborch_pri },
-                { APP_VXLAN_FDB_TABLE_NAME, FdbOrch::fdborch_pri },
-                { APP_MCLAG_FDB_TABLE_NAME, fdborch_pri }
+            vector<string> app_fdb_tables = {
+                APP_FDB_TABLE_NAME,
+                APP_VXLAN_FDB_TABLE_NAME,
+                APP_MCLAG_FDB_TABLE_NAME
             };
 
             TableConnector stateDbFdb(m_state_db.get(), STATE_FDB_TABLE_NAME);
@@ -460,10 +455,9 @@ namespace shlorch_test
             gDirectory.set(gCrmOrch);
             ut_orch_list.push_back((Orch **)&gCrmOrch);
 
-            const int routeorch_pri = 5;
-            vector<table_name_with_pri_t> route_tables = {
-                { APP_ROUTE_TABLE_NAME, routeorch_pri },
-                { APP_LABEL_ROUTE_TABLE_NAME, routeorch_pri }
+            vector<string> route_tables = {
+                APP_ROUTE_TABLE_NAME,
+                APP_LABEL_ROUTE_TABLE_NAME
             };
             gRouteOrch = new RouteOrch(m_app_db.get(), route_tables, gSwitchOrch, gNeighOrch, gIntfsOrch, gVrfOrch, gFgNhgOrch, gSrv6Orch);
             gDirectory.set(gRouteOrch);

--- a/tests/mock_tests/twamporch_ut.cpp
+++ b/tests/mock_tests/twamporch_ut.cpp
@@ -262,14 +262,12 @@ namespace twamporch_test
             //
             // PortsOrch
             //
-            const int portsorch_base_pri = 40;
-
-            vector<table_name_with_pri_t> ports_tables = {
-                { APP_PORT_TABLE_NAME,        portsorch_base_pri + 5 },
-                { APP_VLAN_TABLE_NAME,        portsorch_base_pri + 2 },
-                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri     },
-                { APP_LAG_TABLE_NAME,         portsorch_base_pri + 4 },
-                { APP_LAG_MEMBER_TABLE_NAME,  portsorch_base_pri     }
+            vector<string> ports_tables = {
+                APP_PORT_TABLE_NAME,
+                APP_VLAN_TABLE_NAME,
+                APP_VLAN_MEMBER_TABLE_NAME,
+                APP_LAG_TABLE_NAME,
+                APP_LAG_MEMBER_TABLE_NAME
             };
 
             ASSERT_EQ(gPortsOrch, nullptr);

--- a/tests/mock_tests/vxlanorch_ut.cpp
+++ b/tests/mock_tests/vxlanorch_ut.cpp
@@ -167,14 +167,12 @@ namespace vxlanorch_test
                 gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
 
                 // Create dependencies ...
-                const int portsorch_base_pri = 40;
-
-                vector<table_name_with_pri_t> ports_tables = {
-                    { APP_PORT_TABLE_NAME, portsorch_base_pri + 5 },
-                    { APP_VLAN_TABLE_NAME, portsorch_base_pri + 2 },
-                    { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri },
-                    { APP_LAG_TABLE_NAME, portsorch_base_pri + 4 },
-                    { APP_LAG_MEMBER_TABLE_NAME, portsorch_base_pri }
+                vector<string> ports_tables = {
+                    APP_PORT_TABLE_NAME,
+                    APP_VLAN_TABLE_NAME,
+                    APP_VLAN_MEMBER_TABLE_NAME,
+                    APP_LAG_TABLE_NAME,
+                    APP_LAG_MEMBER_TABLE_NAME
                 };
 
                 ASSERT_EQ(gPortsOrch, nullptr);

--- a/tests/mock_tests/zmq_orch_ut.cpp
+++ b/tests/mock_tests/zmq_orch_ut.cpp
@@ -19,10 +19,10 @@ using namespace std;
 
 TEST(ZmqOrchTest, CreateZmqOrchWitTableNames)
 {   
-    vector<table_name_with_pri_t> tables = {
-        { "TABLE_1", 1 },
-        { "TABLE_2", 2 },
-        { "TABLE_3", 3 }
+    vector<string> tables = {
+        "TABLE_1",
+        "TABLE_2",
+        "TABLE_3"
     };
 
     auto app_db = make_shared<swss::DBConnector>("APPL_DB", 0);
@@ -65,14 +65,14 @@ TEST(ZmqOrchTest, ZmqRouteConsumerExecuteEmpty)
     // Hosting ZmqRouteOrch — used only as the parent Orch pointer for the
     // ZmqRouteConsumer below (nullptr server so it doesn't register a real
     // ZMQ consumer of its own).
-    vector<table_name_with_pri_t> empty_tables;
+    vector<string> empty_tables;
     auto host_orch = make_shared<ZmqRouteOrch>(app_db.get(), empty_tables, nullptr);
 
     // Construct ZmqConsumerStateTable with dbPersistence=false so no
     // AsyncDBUpdater / Redis activity happens.
     auto* cst = new swss::ZmqConsumerStateTable(
         app_db.get(), "ROUTE_TABLE_E", *zmq_server,
-        /*popBatchSize=*/128, /*pri=*/1, /*dbPersistence=*/false);
+        /*popBatchSize=*/128, /*pri=*/0, /*dbPersistence=*/false);
     auto* consumer = new ZmqRouteConsumer(cst, host_orch.get(), "ROUTE_TABLE_E");
 
     // With no messages received, pops() returns empty, addToSync returns 0,

--- a/tests/mock_tests/zmq_orch_ut.cpp
+++ b/tests/mock_tests/zmq_orch_ut.cpp
@@ -31,20 +31,6 @@ TEST(ZmqOrchTest, CreateZmqOrchWitTableNames)
     EXPECT_EQ(zmq_orch->getSelectables().size(), tables.size());
 }
 
-TEST(ZmqOrchTest, CreateZmqRouteOrchWithTableNamesAndPri)
-{
-    vector<table_name_with_pri_t> tables = {
-        { "ROUTE_TABLE_1", 1 },
-        { "ROUTE_TABLE_2", 2 },
-        { "ROUTE_TABLE_3", 3 }
-    };
-
-    auto app_db = make_shared<swss::DBConnector>("APPL_DB", 0);
-    auto zmq_route_orch = make_shared<ZmqRouteOrch>(app_db.get(), tables, nullptr);
-
-    EXPECT_EQ(zmq_route_orch->getSelectables().size(), tables.size());
-}
-
 TEST(ZmqOrchTest, CreateZmqRouteOrchWithTableNames)
 {
     vector<string> tables = { "ROUTE_TABLE_A", "ROUTE_TABLE_B" };


### PR DESCRIPTION
#### Why I did it
`sonic-swss` assigns priorities to inner consumers, while orchagent schedules their outer `Executor` wrappers. Since `Executor` retains priority zero, those values do not affect orchagent dispatch.

Removing the dormant configuration makes that mechanism explicit without changing the current scheduler behavior.

Fix https://github.com/sonic-net/sonic-buildimage/issues/28626

#### How I did it
* The first commit removes unused priority values from orchagent, cfgmgr, and mock call sites.
* The second removes priority-bearing `Orch`/ZMQ table interfaces, preserves the positional ZMQ default before `dbPersistence`, and leaves `sonic-swss-common` unchanged.
* The third makes Executor's priority-zero policy explicit and covers the inner/outer priority boundary.

#### How to verify it
1. Run the GitHub CI build and mock-test jobs for this branch.
2. Confirm the mock-test target compiles with the no-priority `Orch` constructor guard and Executor priority-boundary test.
3. Confirm `Executor` still does not forward its wrapped selectable's priority.

#### Description for the changelog
Remove unused orchagent consumer-priority configuration while preserving existing dispatch behavior.