### PR TITLE
[Mellanox][buffer] Add headroom compensation for Spectrum-6

### DIFF
--- a/cfgmgr/buffer_headroom_mellanox.lua
+++ b/cfgmgr/buffer_headroom_mellanox.lua
@@ -28,6 +28,7 @@ local cable_length = tonumber(string.sub(ARGV[2], 1, -2))
 local port_mtu = tonumber(ARGV[3])
 local gearbox_delay = tonumber(ARGV[4])
 local is_8lane = (ARGV[5] == "8")
+local spectrum6_headroom_compensation = 18 * 1024
 
 local appl_db = "0"
 local config_db = "4"
@@ -60,6 +61,7 @@ end
 -- Fetch ASIC info from ASIC table in STATE_DB
 redis.call('SELECT', state_db)
 local asic_keys = redis.call('KEYS', 'ASIC_TABLE*')
+local is_spectrum6 = asic_keys[1]:sub(-1) == '6'
 
 -- Only one key should exist
 local asic_table_content = redis.call('HGETALL', asic_keys[1])
@@ -164,6 +166,11 @@ propagation_delay = port_mtu + bytes_on_cable + 2 * bytes_on_gearbox + mac_phy_d
 -- Calculate the xoff and xon and then round up at 1024 bytes
 xoff_value = lossless_mtu + propagation_delay * cell_occupancy
 xoff_value = math.ceil(xoff_value / 1024) * 1024
+
+-- Spectrum-6 requires additional headroom for ASIC packet-buffer accounting.
+if is_spectrum6 then
+    xoff_value = xoff_value + spectrum6_headroom_compensation
+end
 
 -- When SHP is disabled, compensate headroom calculated with a reduced small-
 -- packet percentage if it remains more than 2 kB below the worst case.


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
**What I did**

Added 18 KiB of extra XOFF headroom for Spectrum-6 ASICs in the Mellanox dynamic-buffer headroom calculation.

The ASIC generation is identified through `STATE_DB` ASIC metadata. Other Spectrum generations remain unchanged.

**Why I did it**

Spectrum-6 require more headroom than the existing calculation
provides, particularly during traffic startup and for packet sizes near cell boundaries.

The additional headroom helps prevent lossless ingress drops while PFC backpressure takes effect.

**How I verified it**

- Confirmed that Spectrum-6 receives exactly `18 * 1024` additional XOFF bytes.
- Confirmed that other ASIC generations are unaffected.
- Confirmed that with SHP disabled, the private headroom size also increases by 18 KiB.
- Confirmed that with SHP enabled, the additional requirement is accounted for through shared headroom.
- Tested also on 202605

**Details if related**
