### PR TITLE
[portsorch] Skip default VLAN and bridge port removal during warm restart

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1077,8 +1077,11 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
         // Get System ports
         getSystemPorts();
 
-        removeDefaultVlanMembers();
-        removeDefaultBridgePorts();
+        if (!WarmStart::isWarmStart())
+        {
+            removeDefaultVlanMembers();
+            removeDefaultBridgePorts();
+        }
     }
 
     // Enable fdb event notifications after all ports are removed from default 1Q bridge


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Skipped removeDefaultVlanMembers() and removeDefaultBridgePorts() during warm restart in the PortsOrch constructor.

**Why I did it**
During a warm restart, the underlying ASIC state is preserved, and these ports have already been removed from the default VLAN and bridge during the initial cold boot. Redundantly calling these remove functions causes SAI validation errors (e.g., reference count is 1, can't remove).

**How I verified it**
Performed warm reboot.

**Details if related**
<img width="1378" height="276" alt="img_v3_02143_51f3be9b-2786-4bb6-bbef-2686f78de00g" src="https://github.com/user-attachments/assets/7b0c217f-b46b-491a-b3d2-4498535a29c6" />
<img width="1875" height="194" alt="img_v3_02143_61d00956-d071-45be-9b8c-344b320de0bg" src="https://github.com/user-attachments/assets/7b2193ac-3ce0-40fd-b5b0-78e256902336" />


