### PR TITLE
[macsecorch]: Default-initialize m_enable_post to false

### DIFF
--- a/orchagent/macsecorch.h
+++ b/orchagent/macsecorch.h
@@ -62,7 +62,7 @@ private:
     DBConnector * m_state_db;
     shared_ptr<DBConnector> m_notificationsDb;
     NotificationConsumer* m_postCompletionNotificationConsumer;
-    bool m_enable_post;
+    bool m_enable_post = false;
 
     PortsOrch * m_port_orch;
 


### PR DESCRIPTION
MACsecOrch::m_enable_post is declared without an initializer and is only assigned (= true) on the "macsec-level-post-in-progress" state path. On every other path (e.g. POST/FIPS disabled) it is read as an indeterminate bool at the SAI_MACSEC_ATTR_ENABLE_POST push sites (macsecorch.cpp:1246, 1278) and the guard at 807. That can push ENABLE_POST=true on hardware that does not support POST, causing MACsec SAI object creation to fail with SAI_STATUS_ATTR_NOT_SUPPORTED and MACsec to never initialize.

This would tear down orchagent and wedge the entire LC

Default-initialize the member to false so POST is only enabled when explicitly requested by the state machine.

seen on arista 7800 with 202511

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**
on local 202511 build on arista 7800 hw
**Details if related**
