### PR TITLE
[dashha]: Skip duplicate HA set peer IP updates

### DIFF
--- a/orchagent/dash/dashhaorch.cpp
+++ b/orchagent/dash/dashhaorch.cpp
@@ -13,6 +13,8 @@
 #include "pbutils.h"
 #include "converter.h"
 
+#include <google/protobuf/util/message_differencer.h>
+
 #include "chrono"
 
 using namespace std;
@@ -244,13 +246,21 @@ bool DashHaOrch::updateExistingHaSetEntry(const std::string &key, const dash::ha
 {
     SWSS_LOG_ENTER();
 
-    if (entry.owner() != m_ha_set_entries[key].metadata.owner())
+    auto &metadata = m_ha_set_entries[key].metadata;
+
+    if (entry.owner() != metadata.owner())
     {
         SWSS_LOG_NOTICE("HA Set owner updated for %s from %s to %s",
                         key.c_str(),
-                        dash::types::HaOwner_Name(m_ha_set_entries[key].metadata.owner()).c_str(),
+                        dash::types::HaOwner_Name(metadata.owner()).c_str(),
                         dash::types::HaOwner_Name(entry.owner()).c_str());
-        m_ha_set_entries[key].metadata.set_owner(entry.owner());
+        metadata.set_owner(entry.owner());
+    }
+
+    if (google::protobuf::util::MessageDifferencer::Equals(entry.peer_ip(), metadata.peer_ip()))
+    {
+        SWSS_LOG_DEBUG("HA Set peer IP is unchanged for %s", key.c_str());
+        return true;
     }
 
     sai_status_t status;
@@ -281,7 +291,7 @@ bool DashHaOrch::updateExistingHaSetEntry(const std::string &key, const dash::ha
                     key.c_str(),
                     to_string(entry.peer_ip()).c_str());
 
-    *m_ha_set_entries[key].metadata.mutable_peer_ip() = entry.peer_ip();
+    *metadata.mutable_peer_ip() = entry.peer_ip();
 
     return true;
 }

--- a/tests/mock_tests/dashhaorch_ut.cpp
+++ b/tests/mock_tests/dashhaorch_ut.cpp
@@ -765,6 +765,10 @@ namespace dashhaorch_ut
     TEST_F(DashHaOrchTest, UpdatePeerIp)
     {
         CreateHaSet();
+
+        EXPECT_CALL(*mock_sai_dash_ha_api, set_ha_set_attribute)
+        .Times(1);
+
         UpdatePeerIp("192.168.2.100");
 
         auto ha_set_entry = m_dashHaOrch->getHaSetEntries().find("HA_SET_1");
@@ -800,6 +804,8 @@ namespace dashhaorch_ut
         CreateHaSet();
 
         EXPECT_CALL(*mock_sai_dash_ha_api, create_ha_set)
+        .Times(0);
+        EXPECT_CALL(*mock_sai_dash_ha_api, set_ha_set_attribute)
         .Times(0);
 
         CreateHaSet();


### PR DESCRIPTION
**What I did**

Skip redundant SAI peer IP updates when an unchanged HA set entry is replayed. Added mock test coverage for unchanged and changed peer IP updates.

**Why I did it**

Repeated HA set messages were issuing duplicate SAI requests even when the peer IP was unchanged.

**How I verified it**

- Native ARM64 mock tests passed:
  - `DashHaOrchTest.HaSetAlreadyExists`
  - `DashHaOrchTest.UpdatePeerIp`
- Deployed the ARM64 orchagent to two DPUs and ran `test_privatelink_basic_transform[vxlan]` successfully
- Both deployed orchagents remained healthy with zero SWSS/syncd/GNMI restarts and no cores after the test.
- Azure Pipeline builds, including ARM64 and Trixie ARM64, passed.

**Details if related**

N/A