### PR TITLE
[tunnelmgr]: Make kernel tunnel creation optional

### DIFF
--- a/cfgmgr/tunnelmgr.cpp
+++ b/cfgmgr/tunnelmgr.cpp
@@ -381,7 +381,7 @@ bool TunnelMgr::doTunnelRouteTask(const KeyOpFieldsValuesTuple & t)
     const std::string & prefix = kfvKey(t);;
     const std::string & op = kfvOp(t);
 
-    if (!hasKernelEnabledTunnel())
+    if (op == SET_COMMAND && !hasKernelEnabledTunnel())
     {
         SWSS_LOG_INFO("Kernel tunnel route update skipped for %s, op %s", prefix.c_str(), op.c_str());
         return true;

--- a/cfgmgr/tunnelmgr.cpp
+++ b/cfgmgr/tunnelmgr.cpp
@@ -17,6 +17,7 @@ using namespace swss;
 #define IPINIP "IPINIP"
 #define TUNIF "tun0"
 #define LOOPBACK_SRC "Loopback3"
+#define KERNEL_TUNNEL_ENABLED "kernel_tunnel_enabled"
 
 static int cmdIpTunnelIfCreate(const swss::TunnelInfo & info, std::string & res)
 {
@@ -243,6 +244,10 @@ bool TunnelMgr::doTunnelTask(const KeyOpFieldsValuesTuple & t)
         {
             src_ip = value;
         }
+        else if (field == KERNEL_TUNNEL_ENABLED)
+        {
+            tunInfo.kernelTunnelEnabled = value != "false";
+        }
     }
 
     if (op == SET_COMMAND)
@@ -251,13 +256,17 @@ bool TunnelMgr::doTunnelTask(const KeyOpFieldsValuesTuple & t)
         {
             tunInfo.remote_ip = m_peerIp;
 
-            if (!m_peerIp.empty() && !configIpTunnel(tunInfo))
+            if (tunInfo.kernelTunnelEnabled && !m_peerIp.empty() && !configIpTunnel(tunInfo))
             {
                 return false;
             }
-            else if (m_peerIp.empty())
+            else if (tunInfo.kernelTunnelEnabled && m_peerIp.empty())
             {
                 SWSS_LOG_NOTICE("Peer/Remote IP not configured");
+            }
+            else if (!tunInfo.kernelTunnelEnabled)
+            {
+                SWSS_LOG_NOTICE("Kernel tunnel creation is disabled for tunnel %s", tunnelName.c_str());
             }
 
             /* If the tunnel is already in hardware (i.e. present in the replay),
@@ -271,7 +280,7 @@ bool TunnelMgr::doTunnelTask(const KeyOpFieldsValuesTuple & t)
                 std::copy_if(kfvFieldsValues(t).cbegin(), kfvFieldsValues(t).cend(),
                              std::back_inserter(fvs),
                              [](const FieldValueTuple & fv) {
-                                 return fvField(fv) != "dst_ip";
+                                 return fvField(fv) != "dst_ip" && fvField(fv) != KERNEL_TUNNEL_ENABLED;
                              });
                 m_appIpInIpTunnelTable.set(tunnelName, fvs);
 

--- a/cfgmgr/tunnelmgr.cpp
+++ b/cfgmgr/tunnelmgr.cpp
@@ -246,7 +246,20 @@ bool TunnelMgr::doTunnelTask(const KeyOpFieldsValuesTuple & t)
         }
         else if (field == KERNEL_TUNNEL_ENABLED)
         {
-            tunInfo.kernelTunnelEnabled = value != "false";
+            if (value == "true")
+            {
+                tunInfo.kernelTunnelEnabled = true;
+            }
+            else if (value == "false")
+            {
+                tunInfo.kernelTunnelEnabled = false;
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Invalid %s value '%s' for tunnel %s; expected 'true' or 'false'",
+                               KERNEL_TUNNEL_ENABLED, value.c_str(), tunnelName.c_str());
+                return false;
+            }
         }
     }
 
@@ -345,7 +358,7 @@ bool TunnelMgr::doLpbkIntfTask(const KeyOpFieldsValuesTuple & t)
 
     m_intfCache[alias] = ipPrefix;
 
-    if (alias == LOOPBACK_SRC && !m_tunnelCache.empty())
+    if (alias == LOOPBACK_SRC && hasKernelEnabledTunnel())
     {
         int ret = 0;
         std::string res;
@@ -367,6 +380,12 @@ bool TunnelMgr::doTunnelRouteTask(const KeyOpFieldsValuesTuple & t)
 
     const std::string & prefix = kfvKey(t);;
     const std::string & op = kfvOp(t);
+
+    if (!hasKernelEnabledTunnel())
+    {
+        SWSS_LOG_INFO("Kernel tunnel route update skipped for %s, op %s", prefix.c_str(), op.c_str());
+        return true;
+    }
 
     int ret = 0;
     std::string res;
@@ -423,6 +442,12 @@ bool TunnelMgr::configIpTunnel(const TunnelInfo& tunInfo)
     }
 
     return true;
+}
+
+bool TunnelMgr::hasKernelEnabledTunnel() const
+{
+    return std::any_of(m_tunnelCache.cbegin(), m_tunnelCache.cend(),
+                       [](const auto &tunnel) { return tunnel.second.kernelTunnelEnabled; });
 }
 
 

--- a/cfgmgr/tunnelmgr.h
+++ b/cfgmgr/tunnelmgr.h
@@ -30,6 +30,7 @@ private:
     bool doLpbkIntfTask(const KeyOpFieldsValuesTuple & t);
 
     bool configIpTunnel(const TunnelInfo& info);
+    bool hasKernelEnabledTunnel() const;
 
     void finalizeWarmReboot();
 

--- a/cfgmgr/tunnelmgr.h
+++ b/cfgmgr/tunnelmgr.h
@@ -13,6 +13,7 @@ struct TunnelInfo
     std::string type;
     std::string dst_ip;
     std::string remote_ip;
+    bool kernelTunnelEnabled = true;
 };
 
 class TunnelMgr : public Orch

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -44,6 +44,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 consumer_ut.cpp \
                 sfloworh_ut.cpp \
                 tunneldecaporch_ut.cpp \
+                tunnelmgr_ut.cpp \
                 ut_saihelper.cpp \
                 mock_orchagent_main.cpp \
                 mock_dbconnector.cpp \
@@ -179,6 +180,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 $(top_srcdir)/orchagent/nvgreorch.cpp \
                 $(top_srcdir)/cfgmgr/portmgr.cpp \
                 $(top_srcdir)/cfgmgr/sflowmgr.cpp \
+                $(top_srcdir)/cfgmgr/tunnelmgr.cpp \
                 $(top_srcdir)/orchagent/zmqorch.cpp \
                 $(top_srcdir)/orchagent/namelabelmapper.cpp \
                 $(top_srcdir)/orchagent/dash/dashenifwdorch.cpp \

--- a/tests/mock_tests/tunnelmgr_ut.cpp
+++ b/tests/mock_tests/tunnelmgr_ut.cpp
@@ -62,12 +62,20 @@ protected:
     std::unique_ptr<swss::TunnelMgr> m_tunnelMgr;
 };
 
+TEST_F(TunnelMgrTest, ConstructorRemovesStaleKernelTunnel)
+{
+    EXPECT_TRUE(commandWasIssued("tunnel del tun0"));
+}
+
 TEST_F(TunnelMgrTest, KernelTunnelSettingIsPerEntry)
 {
     const swss::KeyOpFieldsValuesTuple enabledTunnelConfig{
         "MuxTunnelWithKernelEntry",
         SET_COMMAND,
-        {{"tunnel_type", "IPINIP"}, {"dst_ip", "10.1.0.32"}, {"src_ip", "10.1.0.33"}}};
+        {{"tunnel_type", "IPINIP"},
+         {"dst_ip", "10.1.0.32"},
+         {"src_ip", "10.1.0.33"},
+         {"kernel_tunnel_enabled", "true"}}};
     const swss::KeyOpFieldsValuesTuple disabledTunnelConfig{
         "MuxTunnelWithoutKernelEntry",
         SET_COMMAND,
@@ -77,8 +85,8 @@ TEST_F(TunnelMgrTest, KernelTunnelSettingIsPerEntry)
          {"dscp_mode", "pipe"},
          {"kernel_tunnel_enabled", "false"}}};
 
+    mockCallArgs.clear();
     EXPECT_TRUE(m_tunnelMgr->doTunnelTask(enabledTunnelConfig));
-    EXPECT_TRUE(commandWasIssued("tunnel del tun0"));
     EXPECT_TRUE(commandWasIssued("tunnel add tun0"));
     EXPECT_TRUE(commandWasIssued("link set dev tun0 up"));
 
@@ -94,6 +102,9 @@ TEST_F(TunnelMgrTest, KernelTunnelSettingIsPerEntry)
     EXPECT_FALSE(hasField(appTunnelValues, "dst_ip"));
     EXPECT_FALSE(hasField(appTunnelValues, "kernel_tunnel_enabled"));
 
+    swss::Table appTunnelTermTable(m_appDb.get(), APP_TUNNEL_DECAP_TERM_TABLE_NAME);
+    ASSERT_TRUE(appTunnelTermTable.get("MuxTunnelWithoutKernelEntry:10.1.0.34", appTunnelValues));
+
     mockCallArgs.clear();
     EXPECT_TRUE(m_tunnelMgr->doLpbkIntfTask(
         {"Loopback3|10.1.0.32/32", SET_COMMAND, {}}));
@@ -103,6 +114,51 @@ TEST_F(TunnelMgrTest, KernelTunnelSettingIsPerEntry)
     EXPECT_TRUE(m_tunnelMgr->doTunnelRouteTask(
         {"192.0.2.1/32", SET_COMMAND, {}}));
     EXPECT_TRUE(commandWasIssued("route replace \"192.0.2.1/32\" dev tun0"));
+
+    mockCallArgs.clear();
+    EXPECT_TRUE(m_tunnelMgr->doTunnelTask(
+        {"MuxTunnelWithoutKernelEntry", DEL_COMMAND, {}}));
+    EXPECT_TRUE(mockCallArgs.empty());
+    EXPECT_EQ(m_tunnelMgr->m_tunnelCache.count("MuxTunnelWithoutKernelEntry"), 0u);
+    EXPECT_FALSE(appTunnelTable.get("MuxTunnelWithoutKernelEntry", appTunnelValues));
+    EXPECT_FALSE(appTunnelTermTable.get("MuxTunnelWithoutKernelEntry:10.1.0.34", appTunnelValues));
+}
+
+TEST_F(TunnelMgrTest, DisabledOnlySkipsDependentKernelOperations)
+{
+    mockCallArgs.clear();
+    EXPECT_TRUE(m_tunnelMgr->doTunnelTask(
+        {"MuxTunnelWithoutKernelEntry",
+         SET_COMMAND,
+         {{"tunnel_type", "IPINIP"},
+          {"dst_ip", "10.1.0.34"},
+          {"src_ip", "10.1.0.33"},
+          {"kernel_tunnel_enabled", "false"}}}));
+    EXPECT_TRUE(mockCallArgs.empty());
+
+    EXPECT_TRUE(m_tunnelMgr->doLpbkIntfTask(
+        {"Loopback3|10.1.0.32/32", SET_COMMAND, {}}));
+    EXPECT_TRUE(m_tunnelMgr->doTunnelRouteTask(
+        {"192.0.2.1/32", SET_COMMAND, {}}));
+    EXPECT_TRUE(mockCallArgs.empty());
+}
+
+TEST_F(TunnelMgrTest, InvalidKernelTunnelSettingIsRejected)
+{
+    mockCallArgs.clear();
+    EXPECT_FALSE(m_tunnelMgr->doTunnelTask(
+        {"MuxTunnel0",
+         SET_COMMAND,
+         {{"tunnel_type", "IPINIP"},
+          {"dst_ip", "10.1.0.32"},
+          {"src_ip", "10.1.0.33"},
+          {"kernel_tunnel_enabled", "False"}}}));
+    EXPECT_TRUE(mockCallArgs.empty());
+    EXPECT_EQ(m_tunnelMgr->m_tunnelCache.count("MuxTunnel0"), 0u);
+
+    std::vector<swss::FieldValueTuple> appTunnelValues;
+    swss::Table appTunnelTable(m_appDb.get(), APP_TUNNEL_DECAP_TABLE_NAME);
+    EXPECT_FALSE(appTunnelTable.get("MuxTunnel0", appTunnelValues));
 }
 
 TEST_F(TunnelMgrTest, KernelTunnelRemainsEnabledByDefault)
@@ -112,8 +168,8 @@ TEST_F(TunnelMgrTest, KernelTunnelRemainsEnabledByDefault)
         SET_COMMAND,
         {{"tunnel_type", "IPINIP"}, {"dst_ip", "10.1.0.32"}, {"src_ip", "10.1.0.33"}}};
 
+    mockCallArgs.clear();
     EXPECT_TRUE(m_tunnelMgr->doTunnelTask(tunnelConfig));
-    EXPECT_TRUE(commandWasIssued("tunnel del tun0"));
     EXPECT_TRUE(commandWasIssued("tunnel add tun0"));
     EXPECT_TRUE(commandWasIssued("link set dev tun0 up"));
 

--- a/tests/mock_tests/tunnelmgr_ut.cpp
+++ b/tests/mock_tests/tunnelmgr_ut.cpp
@@ -177,6 +177,14 @@ TEST_F(TunnelMgrTest, KernelTunnelRemainsEnabledByDefault)
     EXPECT_TRUE(m_tunnelMgr->doTunnelRouteTask(
         {"192.0.2.1/32", SET_COMMAND, {}}));
     EXPECT_TRUE(commandWasIssued("route replace \"192.0.2.1/32\" dev tun0"));
+
+    EXPECT_TRUE(m_tunnelMgr->doTunnelTask(
+        {"MuxTunnel0", DEL_COMMAND, {}}));
+
+    mockCallArgs.clear();
+    EXPECT_TRUE(m_tunnelMgr->doTunnelRouteTask(
+        {"192.0.2.1/32", DEL_COMMAND, {}}));
+    EXPECT_TRUE(commandWasIssued("route del \"192.0.2.1/32\" dev tun0"));
 }
 
 } // namespace tunnelmgr_ut

--- a/tests/mock_tests/tunnelmgr_ut.cpp
+++ b/tests/mock_tests/tunnelmgr_ut.cpp
@@ -1,0 +1,126 @@
+#include "gtest/gtest.h"
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "mock_table.h"
+#include "schema.h"
+#include "warm_restart.h"
+
+#define private public
+#include "tunnelmgr.h"
+#undef private
+
+extern int (*callback)(const std::string &cmd, std::string &stdout);
+extern std::vector<std::string> mockCallArgs;
+
+namespace tunnelmgr_ut
+{
+
+class TunnelMgrTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        testing_db::reset();
+        m_configDb = std::make_shared<swss::DBConnector>("CONFIG_DB", 0);
+        m_appDb = std::make_shared<swss::DBConnector>("APPL_DB", 0);
+
+        swss::Table peerTable(m_configDb.get(), CFG_PEER_SWITCH_TABLE_NAME);
+        peerTable.set("peer_switch", {{"address_ipv4", "10.1.0.33"}});
+
+        callback = nullptr;
+        mockCallArgs.clear();
+        swss::WarmStart::initialize("tunnelmgrd", "swss");
+        m_tunnelMgr = std::make_unique<swss::TunnelMgr>(
+            m_configDb.get(),
+            m_appDb.get(),
+            std::vector<std::string>{CFG_TUNNEL_TABLE_NAME, CFG_LOOPBACK_INTERFACE_TABLE_NAME});
+    }
+
+    void TearDown() override
+    {
+        callback = nullptr;
+    }
+
+    static bool commandWasIssued(const std::string &needle)
+    {
+        return std::any_of(mockCallArgs.begin(), mockCallArgs.end(),
+                           [&needle](const std::string &cmd) { return cmd.find(needle) != std::string::npos; });
+    }
+
+    static bool hasField(const std::vector<swss::FieldValueTuple> &values, const std::string &field)
+    {
+        return std::any_of(values.begin(), values.end(),
+                           [&field](const swss::FieldValueTuple &fv) { return fvField(fv) == field; });
+    }
+
+    std::shared_ptr<swss::DBConnector> m_configDb;
+    std::shared_ptr<swss::DBConnector> m_appDb;
+    std::unique_ptr<swss::TunnelMgr> m_tunnelMgr;
+};
+
+TEST_F(TunnelMgrTest, KernelTunnelSettingIsPerEntry)
+{
+    const swss::KeyOpFieldsValuesTuple enabledTunnelConfig{
+        "MuxTunnelWithKernelEntry",
+        SET_COMMAND,
+        {{"tunnel_type", "IPINIP"}, {"dst_ip", "10.1.0.32"}, {"src_ip", "10.1.0.33"}}};
+    const swss::KeyOpFieldsValuesTuple disabledTunnelConfig{
+        "MuxTunnelWithoutKernelEntry",
+        SET_COMMAND,
+        {{"tunnel_type", "IPINIP"},
+         {"dst_ip", "10.1.0.34"},
+         {"src_ip", "10.1.0.33"},
+         {"dscp_mode", "pipe"},
+         {"kernel_tunnel_enabled", "false"}}};
+
+    EXPECT_TRUE(m_tunnelMgr->doTunnelTask(enabledTunnelConfig));
+    EXPECT_TRUE(commandWasIssued("tunnel del tun0"));
+    EXPECT_TRUE(commandWasIssued("tunnel add tun0"));
+    EXPECT_TRUE(commandWasIssued("link set dev tun0 up"));
+
+    mockCallArgs.clear();
+    EXPECT_TRUE(m_tunnelMgr->doTunnelTask(disabledTunnelConfig));
+    EXPECT_FALSE(commandWasIssued("tunnel add tun0"));
+    EXPECT_FALSE(commandWasIssued("link set dev tun0 up"));
+
+    std::vector<swss::FieldValueTuple> appTunnelValues;
+    swss::Table appTunnelTable(m_appDb.get(), APP_TUNNEL_DECAP_TABLE_NAME);
+    ASSERT_TRUE(appTunnelTable.get("MuxTunnelWithoutKernelEntry", appTunnelValues));
+    EXPECT_TRUE(hasField(appTunnelValues, "tunnel_type"));
+    EXPECT_FALSE(hasField(appTunnelValues, "dst_ip"));
+    EXPECT_FALSE(hasField(appTunnelValues, "kernel_tunnel_enabled"));
+
+    mockCallArgs.clear();
+    EXPECT_TRUE(m_tunnelMgr->doLpbkIntfTask(
+        {"Loopback3|10.1.0.32/32", SET_COMMAND, {}}));
+    EXPECT_TRUE(commandWasIssued("addr add \"10.1.0.32/32\" dev tun0"));
+
+    mockCallArgs.clear();
+    EXPECT_TRUE(m_tunnelMgr->doTunnelRouteTask(
+        {"192.0.2.1/32", SET_COMMAND, {}}));
+    EXPECT_TRUE(commandWasIssued("route replace \"192.0.2.1/32\" dev tun0"));
+}
+
+TEST_F(TunnelMgrTest, KernelTunnelRemainsEnabledByDefault)
+{
+    const swss::KeyOpFieldsValuesTuple tunnelConfig{
+        "MuxTunnel0",
+        SET_COMMAND,
+        {{"tunnel_type", "IPINIP"}, {"dst_ip", "10.1.0.32"}, {"src_ip", "10.1.0.33"}}};
+
+    EXPECT_TRUE(m_tunnelMgr->doTunnelTask(tunnelConfig));
+    EXPECT_TRUE(commandWasIssued("tunnel del tun0"));
+    EXPECT_TRUE(commandWasIssued("tunnel add tun0"));
+    EXPECT_TRUE(commandWasIssued("link set dev tun0 up"));
+
+    mockCallArgs.clear();
+    EXPECT_TRUE(m_tunnelMgr->doTunnelRouteTask(
+        {"192.0.2.1/32", SET_COMMAND, {}}));
+    EXPECT_TRUE(commandWasIssued("route replace \"192.0.2.1/32\" dev tun0"));
+}
+
+} // namespace tunnelmgr_ut


### PR DESCRIPTION
**What I did**

Added a per-entry `kernel_tunnel_enabled` attribute to the CONFIG_DB TUNNEL table handling. The attribute defaults to `true` for backward compatibility and accepts only literal `true` or `false`. When set to `false`, tunnelmgr continues publishing tunnel and decap-term entries to APPL_DB but skips creating and enabling the kernel IP-in-IP interface for that tunnel entry.

Kept startup cleanup of stale `tun0` unchanged. Loopback3 and TUNNEL_ROUTE kernel programming now run only when at least one cached tunnel entry has kernel creation enabled, preserving shared `tun0` behavior for mixed configurations. The cfgmgr-only attribute is filtered from APPL_DB.

Added focused mock tests for constructor cleanup, mixed enabled/disabled entries, all-disabled handling, invalid values, deletion, and default-enabled behavior.

**Why I did it**

Some dual-ToR deployments have multiple TUNNEL entries but require kernel tunnel creation for only one entry. Per-entry control avoids recreating the shared kernel interface while preserving ASIC programming through APPL_DB.

**How I verified it**

- Built the TunnelMgr production and unit-test translation units with `-Werror`
- Ran `TunnelMgrTest.*`: 5/5 tests passed
- Ran `git diff --check`

**Details if related**

A corresponding CONFIG_DB schema update may be required in the SONiC YANG model repository.