### PR TITLE
[ci] Increase timeout from 60 to 90 minutes

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -18,7 +18,7 @@ parameters:
 
 - name: timeout
   type: number
-  default: 60
+  default: 90
 
 - name: sonic_slave
   type: string


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Increase the timeout for the CI build stage to 90 minutes

**Why I did it**
Compilation time for SWSS has increased and occasionally causes CI stages to time out.

**How I verified it**

**Details if related**
