### PR TITLE
[dualtor][intfsorch] Preserve port MAC when updating router interface MAC

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -1078,7 +1078,10 @@ void IntfsOrch::doTask(Consumer &consumer)
 
             if (!mac)
             {
-                mac = gMacAddress;
+                // Prefer the port's own MAC (e.g. a VLAN SVI's gateway MAC populated
+                // from VLAN_TABLE) and only fall back to the switch MAC when the port
+                // has none.
+                mac = port.m_mac ? port.m_mac : gMacAddress;
             }
 
             // update mac if it is changed

--- a/tests/evpn_tunnel.py
+++ b/tests/evpn_tunnel.py
@@ -448,6 +448,28 @@ class VxlanTunnel(object):
 
         return mac
 
+    def get_rif_mac(self, dvs, vlan_oid):
+        # IntfsOrch programs a router interface with the MAC of the underlying port.
+        # For a VLAN that is the VLAN's own MAC (APP_DB VLAN_TABLE|mac, which vlanmgrd
+        # defaults to the DEVICE_METADATA MAC); only a VLAN without a MAC falls back to
+        # the switch MAC.
+        if not vlan_oid:
+            return self.switch_mac
+
+        asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
+        status, fvs = swsscommon.Table(asic_db, "ASIC_STATE:SAI_OBJECT_TYPE_VLAN").get(vlan_oid)
+        assert status, "Failed to read VLAN %s from ASIC_DB" % vlan_oid
+
+        vlan_id = dict(fvs).get("SAI_VLAN_ATTR_VLAN_ID")
+        assert vlan_id, "VLAN %s has no SAI_VLAN_ATTR_VLAN_ID" % vlan_oid
+
+        app_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        status, fvs = swsscommon.Table(app_db, "VLAN_TABLE").get("Vlan%s" % vlan_id)
+        mac = dict(fvs).get("mac") if status else None
+
+        # ASIC_DB stores MACs upper case, APP_DB lower case
+        return mac.upper() if mac else self.switch_mac
+
     def fetch_exist_entries(self, dvs):
         self.tunnel_ids = self.helper.get_exist_entries(dvs, self.ASIC_TUNNEL_TABLE)
         self.tunnel_map_ids = self.helper.get_exist_entries(dvs, self.ASIC_TUNNEL_MAP)
@@ -945,7 +967,7 @@ class VxlanTunnel(object):
 
         expected_attr = {
             "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": self.vr_map[name].get('ing'),
-            "SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS": self.switch_mac,
+            "SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS": self.get_rif_mac(dvs, vlan_oid),
         }
 
         if vlan_oid:


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Made `IntfsOrch::doTask()` prefer the port's own MAC (`port.m_mac`) when reconciling a router interface's `SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS`, only falling back to the switch MAC (`gMacAddress`) when the port has no MAC — mirroring what the create path in `setIntf()` already does.

**Why I did it**

#4615 ([EVPN-MH] Integrate EVPN-MH with existing modules, f0c53b94) added an "update mac if it is changed" block to IntfsOrch::doTask() that reconciles the RIF's SRC_MAC on every interface update. When the MAC parsed from INTF_TABLE is empty (the 00:00:00:00:00:00 sentinel that intfmgr writes for interfaces without a per-interface MAC), it falls back to gMacAddress and, if that differs from the tracked MAC, issues a set_router_interface_attribute(SRC_MAC).

The problem is an asymmetry between the create and update paths:

- Create (setIntf() → intfs_entry.mac): port.m_mac ? port.m_mac : gMacAddress — so the RIF is created with the port's MAC (line 514/518).
- Update (doTask()): fell back straight to gMacAddress (line 1080).

For a VLAN SVI whose gateway MAC is configured on the VLAN (populated into port.m_mac from VLAN_TABLE), the two never agree:

1. The RIF is created with the VLAN's gateway MAC (e.g. dual-ToR shared MAC 00:aa:bb:cc:dd:ee).
2. The update path immediately recomputes the MAC as gMacAddress (the per-device switch MAC) because INTF_TABLE.mac_addr is the zero sentinel.
3. m_syncdIntfses[alias].mac (shared) != mac (device) → a spurious SET SRC_MAC = <device MAC> is issued, overwriting the shared gateway MAC.

On dual-ToR, replacing the shared VLAN gateway MAC with a per-device MAC breaks seamless mux failover (each ToR would answer the server's gateway ARP with a different MAC, so a switchover stales the server's ARP cache). This is a regression introduced in #4615; releases predating it never issued the set (the old code was guarded by if (mac), so the zero sentinel simply meant "don't touch the MAC").

The fix makes the update path fall back exactly like the create path, so the reconciliation MAC matches what the RIF was created with and no spurious set is generated.

**How I verified it**
Build and validate on dualtor device.

**Details if related**

Fixes #4823
