### PR TITLE
build: enable full gcc hardening flags (hardening=+all)

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -8,7 +8,7 @@ DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
 
 # see FEATURE AREAS in dpkg-buildflags(1)
-#export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 # Upgrade FORTIFY_SOURCE to level 3 (dpkg default is =2).
 # -U clears the existing =2 set by dpkg before setting =3.


### PR DESCRIPTION
#### Why I did it

`DEB_BUILD_MAINT_OPTIONS = hardening=+all` was present in `debian/rules` but commented out. This enables the full Debian gcc hardening profile: PIE, full RELRO, stack-protector-strong, and bindnow. `FORTIFY_SOURCE=3` was already active; this adds the remaining flags.

##### Work item tracking
- Microsoft ADO:

#### How I did it

Uncomment the existing `DEB_BUILD_MAINT_OPTIONS = hardening=+all` line in `debian/rules`.

#### How to verify it

Build the package and inspect a binary:

```
dpkg-buildpackage -rfakeroot -b -us -uc
hardening-check debian/sonic-swss/usr/bin/orchagent
```

Expected output: all hardening features enabled (PIE, stack-protected, FORTIFY, RELRO, bindnow).

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type:

#### Tested branch

- [ ] master

#### Test result

#### Description for the changelog

Enable full gcc hardening flags for sonic-swss binaries.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)
