### PR TITLE
[orchagent]: Extend syncd response timeout for APPLY_VIEW

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -193,9 +193,30 @@ void syncd_apply_view()
 
     sai_status_t status;
     sai_attribute_t attr;
+    char *platform = getenv("platform");
+
+    /* syncd runs the view comparison and the ASIC_DB rewrite inside this single
+     * notification. Both scale with the number of objects and exceed the default
+     * response timeout at high route scale, so allow the long timeout here. */
+    if (platform && strstr(platform, MLNX_PLATFORM_SUBSTRING))
+    {
+        SWSS_LOG_NOTICE("Set SAI REDIS response timeout to %d for Mellanox platform, to extend the timeout for apply view", SAI_REDIS_SYNC_OPERATION_RESPONSE_TIMEOUT);
+        attr.id = SAI_REDIS_SWITCH_ATTR_SYNC_OPERATION_RESPONSE_TIMEOUT;
+        attr.value.u64 = SAI_REDIS_SYNC_OPERATION_RESPONSE_TIMEOUT;
+        sai_switch_api->set_switch_attribute(gSwitchId, &attr);
+    }
+
     attr.id = SAI_REDIS_SWITCH_ATTR_NOTIFY_SYNCD;
     attr.value.s32 = SAI_REDIS_NOTIFY_SYNCD_APPLY_VIEW;
     status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);
+
+    if (platform && strstr(platform, MLNX_PLATFORM_SUBSTRING))
+    {
+        SWSS_LOG_NOTICE("Set SAI REDIS response timeout to %d for Mellanox platform, to restore the default timeout", SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT);
+        attr.id = SAI_REDIS_SWITCH_ATTR_SYNC_OPERATION_RESPONSE_TIMEOUT;
+        attr.value.u64 = SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT;
+        sai_switch_api->set_switch_attribute(gSwitchId, &attr);
+    }
 
     if (status != SAI_STATUS_SUCCESS)
     {

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -32,11 +32,6 @@ using namespace swss;
 #define STR(s) _STR(s)
 
 #define CONTEXT_CFG_FILE "/usr/share/sonic/hwsku/context_config.json"
-#if defined(__arm__)
-#define SAI_REDIS_SYNC_OPERATION_RESPONSE_TIMEOUT ((480*1000)*2)
-#else
-#define SAI_REDIS_SYNC_OPERATION_RESPONSE_TIMEOUT (480*1000)
-#endif
 
 // hwinfo = "INTERFACE_NAME/PHY ID", mii_ioctl_data->phy_id is a __u16
 #define HWINFO_MAX_SIZE IFNAMSIZ + 1 + 5

--- a/orchagent/saihelper.h
+++ b/orchagent/saihelper.h
@@ -16,6 +16,12 @@ extern "C" {
 #define IS_ATTR_ID_IN_RANGE(attrId, objectType, attrPrefix) \
     ((attrId) >= SAI_ ## objectType ## _ATTR_ ## attrPrefix ## _START && (attrId) <= SAI_ ## objectType ## _ATTR_ ## attrPrefix ## _END)
 
+#if defined(__arm__)
+#define SAI_REDIS_SYNC_OPERATION_RESPONSE_TIMEOUT ((480*1000)*2)
+#else
+#define SAI_REDIS_SYNC_OPERATION_RESPONSE_TIMEOUT (480*1000)
+#endif
+
 void initFlexCounterTables();
 void initSaiApi();
 void initSaiRedis();


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Extended the SAI-Redis sync operation response timeout around `APPLY_VIEW` in `syncd_apply_view()`, matching the existing long timeout used for `INIT_VIEW`, then restored the default 60s timeout afterward.
Moved `SAI_REDIS_SYNC_OPERATION_RESPONSE_TIMEOUT` from `saihelper.cpp` to `saihelper.h` so both `initSaiRedis()` and `syncd_apply_view()` can share it.

**Why I did it**
During warm reboot at large route / full-KVD scale, syncd's `APPLY_VIEW` (view comparison + full ASIC_DB rewrite) can take longer than the default 60s SAI-Redis response timeout (observed ~88s). orchagent then fails the notify and aborts warm reboot even though syncd is still progressing.


**How I verified it**
Warm reboot at high route scale on a build with this change

**Details if related**
