### PR TITLE
[dashha]: Acknowledge switch-owned HA `switching_to_active`

### DIFF
--- a/orchagent/dash/dashhaorch.cpp
+++ b/orchagent/dash/dashhaorch.cpp
@@ -770,7 +770,8 @@ void DashHaOrch::updateHaScopeStateForSwitchOwner(const std::string &key, const 
             ha_state = SAI_DASH_HA_STATE_DEAD;
             break;
         case dash::types::HA_ROLE_SWITCHING_TO_ACTIVE:
-            return;
+            ha_state = SAI_DASH_HA_STATE_INITIALIZING_TO_ACTIVE;
+            break;
         default:
             ha_state = SAI_DASH_HA_STATE_DEAD;
     }

--- a/tests/mock_tests/dashhaorch_ut.cpp
+++ b/tests/mock_tests/dashhaorch_ut.cpp
@@ -1255,6 +1255,25 @@ namespace dashhaorch_ut
         RemoveHaSet();
     }
 
+    TEST_F(DashHaOrchTestSwitchOwner, SwitchOwnerSwitchingToActiveInitializesStateAndProcessesBfdSessions)
+    {
+        CreateSwitchOwnerDpuScopeHaSet();
+        CreateHaScope();
+
+        CreateSoftwareBfdSession();
+        EXPECT_EQ(m_mockBfdOrch->createSoftwareBfdSession_invoked_times, 0);
+
+        SetHaScopeHaRole("switching_to_active");
+
+        auto& scope_entry = m_dashHaOrch->getHaScopeEntries().find("HA_SET_1")->second;
+        EXPECT_EQ(scope_entry.ha_state, SAI_DASH_HA_STATE_INITIALIZING_TO_ACTIVE);
+        EXPECT_EQ(to_sai(scope_entry.metadata.ha_role()), SAI_DASH_HA_ROLE_SWITCHING_TO_ACTIVE);
+        EXPECT_EQ(m_mockBfdOrch->createSoftwareBfdSession_invoked_times, 1);
+
+        RemoveHaScope();
+        RemoveHaSet();
+    }
+
     TEST_F(DashHaOrchTest, DpuOwnerSetRoleDoesNotUpdateState)
     {
         // DPU owner (default CreateHaSet uses "dpu" owner)


### PR DESCRIPTION
## What I did

Map `HA_ROLE_SWITCHING_TO_ACTIVE` to `SAI_DASH_HA_STATE_INITIALIZING_TO_ACTIVE` for switch-owned HA scopes.

Keep the existing non-dead transition behavior so cached software BFD sessions are created when the scope starts switching to active. Add focused mock coverage for the state, role, and BFD invocation.

## Why I did it

Switch-owned HA scopes do not rely on HA scope notifications to acknowledge role transitions. The existing code returned without updating `DPU_STATE_DB` or the in-memory state for `HA_ROLE_SWITCHING_TO_ACTIVE`, leaving the transition unacknowledged.

## How I verified it

- Compiled the modified production and mock-test translation units with the project's warning-as-error flags.
- Built and linked the x86-64 `orchagent` binary successfully.
- `git diff --check` passed.