### PR TITLE
[swss] Support per-VLAN MAC learning disable

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -357,6 +357,7 @@ void VlanMgr::doVlanTask(Consumer &consumer)
             string mtu = DEFAULT_MTU_STR;
             string mac = gMacAddress.to_string();
             string hostif_name = "";
+            string learn_disable = "";
             vector<FieldValueTuple> fvVector;
             string members;
 
@@ -417,7 +418,9 @@ void VlanMgr::doVlanTask(Consumer &consumer)
                 {
                     hostif_name = fvValue(i);
                 }
+                
             }
+            parseLearnDisable(t, learn_disable);
             /* fvVector should not be empty */
             if (fvVector.empty())
             {
@@ -433,6 +436,11 @@ void VlanMgr::doVlanTask(Consumer &consumer)
 
             FieldValueTuple hostif_name_fvt("host_ifname", hostif_name);
             fvVector.push_back(hostif_name_fvt);
+
+            if (!learn_disable.empty())
+            {
+                forwardLearnDisableToApplDb(key, learn_disable, fvVector);
+            }
 
             m_appVlanTableProducer.set(key, fvVector);
             m_vlans.insert(key);
@@ -1004,5 +1012,30 @@ void VlanMgr::doTask(Consumer &consumer)
     {
         SWSS_LOG_ERROR("Unknown config table %s ", table_name.c_str());
         throw runtime_error("VlanMgr doTask failure.");
+    }
+}
+
+// Per-VLAN MAC learning disable support
+void VlanMgr::parseLearnDisable(const KeyOpFieldsValuesTuple& t, string& learn_disable)
+{
+    for (size_t i = 0; i < kfvFieldCount(t); i++)
+    {
+        if (fvField(t, i) == "learn_disable")
+        {
+            learn_disable = fvValue(t, i);
+            SWSS_LOG_INFO("Parsed learn_disable: %s", learn_disable.c_str());
+            break;
+        }
+    }
+}
+
+void VlanMgr::forwardLearnDisableToApplDb(const string& key, const string& learn_disable, vector<FieldValueTuple>& fvVector)
+{
+    if (!learn_disable.empty())
+    {
+        FieldValueTuple ld("learn_disable", learn_disable);
+        fvVector.push_back(ld);
+        SWSS_LOG_NOTICE("Forwarding learn_disable=%s for %s to APPL_DB",
+                learn_disable.c_str(), key.c_str());
     }
 }

--- a/cfgmgr/vlanmgr.h
+++ b/cfgmgr/vlanmgr.h
@@ -51,6 +51,9 @@ private:
     void doVlanPacVlanMemberTask(Consumer &consumer);
     void addPortToVlan(const std::string& port_alias, const std::string& vlan_alias, const std::string& tagging_mode);
     void removePortFromVlan(const std::string& port_alias, const std::string& vlan_alias);
+    void parseLearnDisable(const KeyOpFieldsValuesTuple& t, std::string& learn_disable);
+    void forwardLearnDisableToApplDb(const std::string& key, const std::string& learn_disable, 
+                                     std::vector<FieldValueTuple>& fvVector);
 };
 
 }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -5901,6 +5901,7 @@ void PortsOrch::doVlanTask(Consumer &consumer)
             uint32_t mtu = 0;
             MacAddress mac;
             string hostif_name = "";
+            string learn_disable = "";
             for (auto i : kfvFieldsValues(t))
             {
                 if (fvField(i) == "mtu")
@@ -5915,6 +5916,11 @@ void PortsOrch::doVlanTask(Consumer &consumer)
                 {
                     hostif_name = fvValue(i);
                 }
+                if (fvField(i) == "learn_disable")
+                {
+                    learn_disable = fvValue(i);
+                }
+                
             }
 
             /*
@@ -5956,6 +5962,13 @@ void PortsOrch::doVlanTask(Consumer &consumer)
                     {
                         gIntfsOrch->setRouterIntfsMac(vl);
                     }
+                }
+                if (!learn_disable.empty())
+                {
+                    sai_object_id_t vlan_oid = vl.m_vlan_oid;
+                    setProgramSaiVlanLearnDisable(learn_disable, vlan_oid);
+                    SWSS_LOG_INFO("Programmed learn_disable=%s for VLAN %s (OID: %" PRIx64 ")",
+                                  learn_disable.c_str(), vlan_alias.c_str(), vlan_oid);
                 }
                 if (!hostif_name.empty())
                 {
@@ -11994,5 +12007,28 @@ void PortsOrch::doTask(swss::SelectableTimer &timer)
     if (m_port_state_poll.size() == 0)
     {
         m_port_state_poller->stop();
+    }
+}
+
+// Per-VLAN MAC learning disable support - SAI programming
+void PortsOrch::setProgramSaiVlanLearnDisable(const string& learn_disable, sai_object_id_t vlan_oid)
+{
+    if (!learn_disable.empty())
+    {
+        sai_attribute_t attr;
+        attr.id = SAI_VLAN_ATTR_LEARN_DISABLE;
+        attr.value.booldata = (learn_disable == "true");
+        
+        sai_status_t status = sai_vlan_api->set_vlan_attribute(vlan_oid, &attr);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to set learn_disable=%s on VLAN OID %" PRIx64 ", rv:%d",
+                    learn_disable.c_str(), vlan_oid, status);
+        }
+        else
+        {
+            SWSS_LOG_NOTICE("Successfully set SAI_VLAN_ATTR_LEARN_DISABLE=%s on VLAN OID %" PRIx64,
+                    learn_disable.c_str(), vlan_oid);
+        }
     }
 }

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -653,6 +653,8 @@ private:
     bool m_isWredPortCounterMapGenerated = false;
     std::unique_ptr<swss::Table> m_queueCounterCapabilitiesTable = nullptr;
     std::unique_ptr<swss::Table> m_portCounterCapabilitiesTable = nullptr;
+    // Per-VLAN MAC Learning Control (NEW)
+    void setProgramSaiVlanLearnDisable(const std::string& learn_disable, sai_object_id_t vlan_oid);
 
 private:
     // Port config aggregator

--- a/tests/test_vlan_mac_learning.py
+++ b/tests/test_vlan_mac_learning.py
@@ -1,0 +1,33 @@
+class TestVlanMacLearning(object):
+    def test_LearnDisableReachesAsicDb(self, dvs, testlog):
+        config_db = dvs.get_config_db()
+        asic_db = dvs.get_asic_db()
+
+        # Create Vlan100 with learning disabled
+        config_db.create_entry("VLAN", "Vlan100",
+                               {"vlanid": "100", "learn_disable": "true"})
+
+        # Wait for VLAN to appear in ASIC_DB
+        vlan_oids = asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_VLAN", 2)
+
+        vlan100_oid = None
+        for oid in vlan_oids:
+            fvs = asic_db.get_entry("ASIC_STATE:SAI_OBJECT_TYPE_VLAN", oid)
+            if fvs.get("SAI_VLAN_ATTR_VLAN_ID") == "100":
+                vlan100_oid = oid
+
+        assert vlan100_oid is not None, "Vlan100 not found in ASIC_DB"
+
+        # Verify learn_disable reached ASIC_DB
+        asic_db.wait_for_field_match("ASIC_STATE:SAI_OBJECT_TYPE_VLAN", vlan100_oid,
+                                     {"SAI_VLAN_ATTR_LEARN_DISABLE": "true"})
+
+        # Toggle to enabled
+        config_db.update_entry("VLAN", "Vlan100",
+                               {"vlanid": "100", "learn_disable": "false"})
+        asic_db.wait_for_field_match("ASIC_STATE:SAI_OBJECT_TYPE_VLAN", vlan100_oid,
+                                     {"SAI_VLAN_ATTR_LEARN_DISABLE": "false"})
+
+        # Cleanup
+        config_db.delete_entry("VLAN", "Vlan100")
+        asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_VLAN", 1)


### PR DESCRIPTION
## Summary
Adds per-VLAN MAC learning control support to SWSS daemon and portsorch agent.

## Changes
- **cfgmgr/vlanmgr.cpp** 
  - parseLearnDisable(): Extract learn_disable from CONFIG_DB
  - forwardLearnDisableToApplDb(): Forward to APPL_DB for portsorch

- **orchagent/portsorch.cpp** 
  - setProgramSaiVlanLearnDisable(): Program SAI_VLAN_ATTR_LEARN_DISABLE
  - Error handling and status verification
  - Success/failure logging

- **tests/test_vlan_mac_learning.py** 
  - DVS regression test for CONFIG_DB → APPL_DB → ASIC_DB flow
  - Verify learn_disable propagation through all layers
  - Test toggle functionality (true/false)

## Related PRs
- sonic-buildimage #28861 (YANG schema)
- sonic-utilities #4770 (CLI commands)