### PR TITLE
Fix duplicate/leaked SAI nhgrp member from getNhId

### DIFF
--- a/orchagent/nhgorch.cpp
+++ b/orchagent/nhgorch.cpp
@@ -943,6 +943,28 @@ bool NextHopGroup::syncMembers(const std::set<NextHopKey>& nh_keys)
             continue;
         }
 
+        /*
+         * getNhId() can have the side effect of creating the underlying next
+         * hop over NeighOrch (e.g. for labeled/MPLS next hops whose neighbor
+         * is already resolved but whose SAI next hop does not exist yet).
+         * NeighOrch::addNextHop() in turn calls NhgOrch::validateNextHop(),
+         * which re-enters this same group and, since this member is already
+         * present in m_members (just not yet synced), syncs it there and
+         * creates the real SAI next hop group member.
+         *
+         * Without re-checking here, this loop would go on to unconditionally
+         * create a second, duplicate SAI next hop group member for the same
+         * key using the OID just returned by getNhId(). That duplicate member
+         * is never tracked by m_members (which still only knows about the
+         * first, reentrantly-synced member), so it can never be removed by
+         * this group again, leaking a SAI object and permanently pinning the
+         * group's reference count.
+         */
+        if (nhgm.isSynced())
+        {
+            continue;
+        }
+
         /* If the neighbor's interface is down, skip from being syncd. */
         if (gNeighOrch->isNextHopFlagSet(nh_key, NHFLAGS_IFDOWN))
         {

--- a/tests/test_nhg.py
+++ b/tests/test_nhg.py
@@ -1409,6 +1409,30 @@ class TestNextHopGroup(TestNextHopGroupBase):
         mainline_labeled_nhs_test()
         routeorch_nhgorch_interop_test()
 
+    def test_nhgorch_reentrant_sync_no_duplicate_member(self, dvs, testlog):
+        # Verify a NHG with labeled (MPLS) NHs -- whose SAI next hop creation
+        # reenters syncMembers() for the same group -- ends up with exactly
+        # one SAI NHG member per NH (no duplicates/leaks), and that the
+        # group can still be cleanly removed afterwards.
+        self.init_test(dvs, 2)
+
+        fvs = swsscommon.FieldValuePairs([('nexthop', '10.0.0.1,10.0.0.3'),
+                                        ('mpls_nh', 'push1,push3'),
+                                        ('ifname', 'Ethernet0,Ethernet4')])
+        self.nhg_ps.set('group1', fvs)
+
+        # Exactly 2 NHG members should exist, one per next hop.
+        self.asic_db.wait_for_n_keys(self.ASIC_NHG_STR, self.asic_nhgs_count + 1)
+        self.asic_db.wait_for_n_keys(self.ASIC_NHGM_STR, self.asic_nhgms_count + 2)
+        self.asic_db.wait_for_n_keys(self.ASIC_NHS_STR, self.asic_nhs_count + 2)
+        assert len(self.get_nhgm_ids('group1')) == 2
+
+        # The group and its members should be fully removable.
+        self.nhg_ps._del('group1')
+        self.asic_db.wait_for_n_keys(self.ASIC_NHG_STR, self.asic_nhgs_count)
+        self.asic_db.wait_for_n_keys(self.ASIC_NHGM_STR, self.asic_nhgms_count)
+        self.asic_db.wait_for_n_keys(self.ASIC_NHS_STR, self.asic_nhs_count)
+
     def test_nhgorch_excp_group_cases(self, dvs, testlog):
         # Test scenario:
         # - remove a NHG that does not exist and assert the number of NHGs in ASIC DB remains the same


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixed a reentrancy bug in NextHopGroup::syncMembers() that can create a duplicate SAI SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER for the same member key, permanently leaking a SAI object and pinning the owning next hop group's reference count so it can never be removed.

orchagent/nhgorch.cpp: in NextHopGroup::syncMembers(), re-check nhgm.isSynced() immediately after calling nhgm.getNhId(), before adding the member to the create bulker.

**Why I did it**
syncMembers() checks isSynced() once per member, then calls getNhId() to resolve the SAI OID. For a labeled (MPLS) next hop, getNhId() has a side effect: it calls NeighOrch::addNextHop() on demand, which calls back into NhgOrch::validateNextHop() — reentering the same group and syncing this very member before the original call returns. The original loop then unconditionally creates a second duplicate member, which is never tracked and can never be removed, leaking a SAI object and stranding the group at refcount ≥1 (meta_generic_validation_remove: object 0x... reference count is 1, can't remove).

**How I verified it**
Reproduced via sairedis.rec tracing during a next hop group update; rebuilt swss and confirmed mock_tests (1027/1027) and tests/test_nhg.py (15/15, including the previously-failing test_nhgorch_labeled_nhs) all pass.

**Details if related**
This is a pre-existing, timing-sensitive race on `master`, not specific to
any feature branch. Found while validating #4646 (Register IPinIP tunnel next hops in NeighOrch): that PR shifts NeighOrch's next hop resolution timing just enough to hit this race, turning it into a consistent `test_nhgorch_labeled_nhs`
failure (passes on clean `master`, fails with only #4646 applied). This fix stands on its own and does not
depend on #4646.