### PR TITLE
[vxlanorch]: set default VXLAN decap TTL mode to pipe

### DIFF
--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -369,18 +369,13 @@ create_tunnel(
         tunnel_attrs.push_back(attr);
     }
 
-    if (decap_ttl_mode == VxlanTunnelTTLMode::PIPE)
-    {
-        attr.id = SAI_TUNNEL_ATTR_DECAP_TTL_MODE;
-        attr.value.s32 = SAI_TUNNEL_TTL_MODE_PIPE_MODEL;
-        tunnel_attrs.push_back(attr);
-    }
-    else if (decap_ttl_mode == VxlanTunnelTTLMode::UNIFORM)
-    {
-        attr.id = SAI_TUNNEL_ATTR_DECAP_TTL_MODE;
-        attr.value.s32 = SAI_TUNNEL_TTL_MODE_UNIFORM_MODEL;
-        tunnel_attrs.push_back(attr);
-    }
+    // Set the default VXLAN decapsulation mode to pipe to match the encapsulation mode.
+    // Uniform mode remains available through explicit configuration.
+    attr.id = SAI_TUNNEL_ATTR_DECAP_TTL_MODE;
+    attr.value.s32 = decap_ttl_mode == VxlanTunnelTTLMode::UNIFORM ?
+                         SAI_TUNNEL_TTL_MODE_UNIFORM_MODEL :
+                         SAI_TUNNEL_TTL_MODE_PIPE_MODEL;
+    tunnel_attrs.push_back(attr);
 
     if (encap_ttl != 0)
     {

--- a/orchagent/vxlanorch.h
+++ b/orchagent/vxlanorch.h
@@ -241,7 +241,8 @@ private:
     TunnelUsers tnl_users_;
     VxlanTunnel* vtep_ptr=NULL;
     tunnel_creation_src_t src_creation_;
-    VxlanTunnelTTLMode decap_ttl_mode_; // Decap TTL mode: NOT_SET, PIPE, or UNIFORM (default is NOT_SET)
+    // NOT_SET is programmed as PIPE; UNIFORM must be requested explicitly.
+    VxlanTunnelTTLMode decap_ttl_mode_;
     uint8_t encap_dedicated_mappers_ = 0;
     uint8_t decap_dedicated_mappers_ = 0;
 };

--- a/tests/test_vxlan_tunnel.py
+++ b/tests/test_vxlan_tunnel.py
@@ -122,7 +122,7 @@ def create_vlan(dvs, vlan_name, vlan_ids):
     return
 
 
-def check_vxlan_tunnel(dvs, src_ip, dst_ip, tunnel_map_ids, tunnel_map_entry_ids, tunnel_ids, tunnel_term_ids, lo_id, decap_ttl_mode="not_set"):
+def check_vxlan_tunnel(dvs, src_ip, dst_ip, tunnel_map_ids, tunnel_map_entry_ids, tunnel_ids, tunnel_term_ids, lo_id, decap_ttl_mode="pipe"):
     asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
     tunnel_map_id  = get_created_entry_mapid(asic_db, "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL_MAP", tunnel_map_ids)
     tunnel_id      = get_created_entry(asic_db, "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL", tunnel_ids)


### PR DESCRIPTION
**What I did**

Defaulted the VXLAN decapsulation TTL mode to `PIPE` when `ttl_mode` is not provided. Explicit `ttl_mode: uniform` and `ttl_mode: pipe` settings continue to be honored.

Updated the VXLAN DVS test expectation to verify that an omitted `ttl_mode` produces `SAI_TUNNEL_ATTR_DECAP_TTL_MODE=SAI_TUNNEL_TTL_MODE_PIPE_MODEL`.

**Why I did it**

The `VXLAN_TUNNEL` configuration parameter:

```json
"ttl_mode": "pipe|uniform"
```

controls the VXLAN **decapsulation** TTL mode. 
VXLAN **encapsulation** is hard-coded to `SAI_TUNNEL_TTL_MODE_PIPE_MODEL`.

Previously, omitting `ttl_mode` caused SWSS to omit `SAI_TUNNEL_ATTR_DECAP_TTL_MODE`, falling through to the SAI default of `SAI_TUNNEL_TTL_MODE_UNIFORM_MODEL`. So the implicit decapsulation mode differ from the pipe encapsulation mode.

The new implicit behavior matches the existing encapsulation mode. Deployments that require uniform decapsulation can still configure `ttl_mode: uniform` explicitly.

**How I verified it**

- Updated `tests/test_vxlan_tunnel.py` so tunnels created without `ttl_mode` require decap `PIPE` in ASIC DB.
- Ran `git diff --check` successfully.
- Ran Python syntax compilation for the updated DVS test successfully.
- The focused DVS test was not executed locally because the host test environment does not provide the `swsscommon` Python module required by the DVS harness.

**Details if related**

The last change was done in https://github.com/sonic-net/sonic-swss/pull/3963

```text
encap TTL mode: PIPE (programmed explicitly by SWSS)
decap TTL mode: UNIFORM (implicit SAI default when ttl_mode was omitted)
```

After this change, an omitted `ttl_mode` results in `PIPE/PIPE`. Explicit `uniform` remains supported for decapsulation.
