### PR TITLE
[portsorch]: Set port PVID for priority-tagged VLAN members

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -7756,8 +7756,9 @@ bool PortsOrch::addVlanMember(Port &vlan, Port &port, string &tagging_mode, stri
     SWSS_LOG_NOTICE("Add member %s to VLAN %s vid:%hu pid%" PRIx64,
             port.m_alias.c_str(), vlan.m_alias.c_str(), vlan.m_vlan_info.vlan_id, port.m_port_id);
 
-    /* Use untagged VLAN as pvid of the member port */
-    if (sai_tagging_mode == SAI_VLAN_TAGGING_MODE_UNTAGGED &&
+    /* Use the VLAN as pvid for untagged and priority-tagged member ports */
+    if ((sai_tagging_mode == SAI_VLAN_TAGGING_MODE_UNTAGGED ||
+         sai_tagging_mode == SAI_VLAN_TAGGING_MODE_PRIORITY_TAGGED) &&
         port.m_type != Port::TUNNEL)
     {
         if(!setPortPvid(port, vlan.m_vlan_info.vlan_id))
@@ -8093,8 +8094,9 @@ bool PortsOrch::removeVlanMember(Port &vlan, Port &port, string end_point_ip)
     SWSS_LOG_NOTICE("Remove member %s from VLAN %s lid:%hx vmid:%" PRIx64,
             port.m_alias.c_str(), vlan.m_alias.c_str(), vlan.m_vlan_info.vlan_id, vlan_member_id);
 
-    /* Restore to default pvid if this port joined this VLAN in untagged mode previously */
-    if (sai_tagging_mode == SAI_VLAN_TAGGING_MODE_UNTAGGED &&
+    /* Restore to default pvid if this port joined this VLAN in untagged or priority-tagged mode previously */
+    if ((sai_tagging_mode == SAI_VLAN_TAGGING_MODE_UNTAGGED ||
+         sai_tagging_mode == SAI_VLAN_TAGGING_MODE_PRIORITY_TAGGED) &&
         port.m_type != Port::TUNNEL)
     {
         if (!setPortPvid(port, DEFAULT_PORT_VLAN_ID))

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -386,6 +386,34 @@ class TestVlan(object):
         self.dvs_vlan.remove_vlan(vlan)
         self.dvs_vlan.get_and_verify_vlan_ids(0)
 
+    def test_VlanMemberPriorityTaggedPvid(self, dvs):
+        # A priority-tagged member must get the VLAN as its port PVID, like an untagged member.
+        vlan = "2"
+        interface = "Ethernet0"
+        port_oid = dvs.asic_db.port_name_map[interface]
+
+        self.dvs_vlan.create_vlan(vlan)
+        vlan_oid = self.dvs_vlan.get_and_verify_vlan_ids(1)[0]
+
+        self.dvs_vlan.create_vlan_member(vlan, interface, "priority_tagged")
+        self.dvs_vlan.verify_vlan_member(vlan_oid, interface, "SAI_VLAN_TAGGING_MODE_PRIORITY_TAGGED")
+
+        # PVID is set to the VLAN id, not left at the default.
+        self.dvs_vlan.asic_db.wait_for_field_match(
+            "ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid,
+            {"SAI_PORT_ATTR_PORT_VLAN_ID": vlan})
+
+        self.dvs_vlan.remove_vlan_member(vlan, interface)
+        self.dvs_vlan.get_and_verify_vlan_member_ids(0)
+
+        # PVID is restored to the default VLAN on removal.
+        self.dvs_vlan.asic_db.wait_for_field_match(
+            "ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid,
+            {"SAI_PORT_ATTR_PORT_VLAN_ID": "1"})
+
+        self.dvs_vlan.remove_vlan(vlan)
+        self.dvs_vlan.get_and_verify_vlan_ids(0)
+
     @pytest.mark.skip(reason="AddMaxVlan takes too long to execute")
     def test_AddMaxVlan(self, dvs):
 


### PR DESCRIPTION
**What I did**

`PortsOrch::addVlanMember()` / `removeVlanMember()` set (and restore) the port PVID (`SAI_PORT_ATTR_PORT_VLAN_ID`) only for `SAI_VLAN_TAGGING_MODE_UNTAGGED` members. This extends the guard to also cover `SAI_VLAN_TAGGING_MODE_PRIORITY_TAGGED`, so a `priority_tagged` member gets the VLAN as its PVID (and it is restored to the default on removal), the same as an `untagged` member.

**Why I did it**

Fixes #4831.

A VLAN member configured with `tagging_mode: priority_tagged` receives untagged / priority-tagged (VLAN 0) frames, so it needs a port PVID to classify ingress traffic into the access VLAN. Without it, the member's port PVID stays at the default and its ingress traffic is not assigned to the VLAN.

**How I verified it**

Hardware — Juniper QFX5241 (Broadcom Tomahawk), SONiC 202511:
- Before: a `priority_tagged` member's `SAI_PORT_ATTR_PORT_VLAN_ID` stayed at `1` (default).
- After: it is set to the VLAN id; on member removal it is restored to the default.
- `untagged` / `tagged` behavior is unchanged.

 Complementary to to #4771 (VLAN member `tagging_mode` updates)