### PR TITLE
[orchagent]: Fix syslog noise from CPU port counter check and dhcp_rate_limit field

### DIFF
--- a/orchagent/countercheckorch.cpp
+++ b/orchagent/countercheckorch.cpp
@@ -223,6 +223,12 @@ QueueMcCounters CounterCheckOrch::getQueueMcCounters(
 
 void CounterCheckOrch::addPort(const Port& port)
 {
+    // Skip non-PHY ports (CPU, MGMT, RECYCLE, etc.) as they do not have
+    // PFC frame counters or multicast queue counters on the ASIC
+    if (port.m_type != Port::PHY)
+    {
+        return;
+    }
     m_mcCountersMap.emplace(port.m_port_id, getQueueMcCounters(port));
     m_pfcFrameCountersMap.emplace(port.m_port_id, getPfcFrameCounters(port.m_port_id));
 }

--- a/orchagent/port/porthlpr.cpp
+++ b/orchagent/port/porthlpr.cpp
@@ -1404,6 +1404,12 @@ bool PortHelper::parsePortConfig(PortConfig &port) const
                 return false;
             }
         }
+        else if (field == "dhcp_rate_limit")
+        {
+            /* Placeholder to prevent warning. Handled by dhcp container,
+             * not needed to be parsed here.
+             */
+        }
         else
         {
             SWSS_LOG_WARN("Unknown field(%s): skipping ...", field.c_str());


### PR DESCRIPTION
**What I did**
Fixed two sources of syslog noise in orchagent:
1, countercheckorch.cpp — Added Port::PHY guard in CounterCheckOrch::addPort() to skip non-physical ports (CPU, MGMT, RECYCLE). PFC frame and multicast queue counters only exist on physical ASIC ports.
2, port/porthlpr.cpp — Added dhcp_rate_limit as a recognized field in parsePortConfig() to suppress the Unknown field(dhcp_rate_limit): skipping ... WARNING. This field is present in CONFIG_DB and handled by the DHCP container, not orchagent.

**Why I did it**
Both generate log noise during normal operation with no actionable signal:
1, CPU/MGMT ports added to counter maps cause ERR on every 5-minute counter-poll cycle
2, dhcp_rate_limit WARNING fires 33+ times every boot (once per port)
The Port::PHY guard follows the existing pattern in pfcwdorch.cpp::createEntry() and flexcounterorch.cpp::generateQueueMap(). The placeholder follows the PORT_MODE pattern already in porthlpr.cpp.

**How I verified it**
Tested on sonic-vs (SONiC master, commit 1658c9049):

Before:
2026 Aug 19 06:15:08.341003 sonic WARNING swss#orchagent: :- parsePortConfig: Unknown field(dhcp_rate_limit): skipping ...
2026 Aug 19 06:15:08.343460 sonic WARNING swss#orchagent: :- parsePortConfig: Unknown field(dhcp_rate_limit): skipping ...
2026 Aug 19 06:15:08.346969 sonic WARNING swss#orchagent: :- parsePortConfig: Unknown field(dhcp_rate_limit): skipping ...
After:
show logging | grep "dhcp_rate_limit" | wc -l
0

**Details if related**
No functional change. Callers ignore return values of setPortFDR and parsePortConfig. No new tests required — these are defensive guards following existing community patterns.