### PR TITLE
[orchagent] Enable MirrorV6 capability for VPP platform

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3742,7 +3742,8 @@ void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, Mirr
             platform == NPS_PLATFORM_SUBSTRING ||
             platform == XS_PLATFORM_SUBSTRING ||
             platform == CLX_PLATFORM_SUBSTRING ||
-            platform == VS_PLATFORM_SUBSTRING)
+            platform == VS_PLATFORM_SUBSTRING ||
+            platform == VPP_PLATFORM_SUBSTRING)
     {
         m_mirrorTableCapabilities =
         {
@@ -3761,7 +3762,8 @@ void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, Mirr
 
     if ( platform == MRVL_PRST_PLATFORM_SUBSTRING ||
 	    platform == MRVL_TL_PLATFORM_SUBSTRING ||
-            platform == VS_PLATFORM_SUBSTRING)
+            platform == VS_PLATFORM_SUBSTRING ||
+            platform == VPP_PLATFORM_SUBSTRING)
     {
 	m_L3V4V6Capability =
         {

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -50,6 +50,7 @@ const char state_db_key_delimiter  = '|';
 #define CISCO_8000_PLATFORM_SUBSTRING "cisco-8000"
 #define XS_PLATFORM_SUBSTRING   "xsight"
 #define CLX_PLATFORM_SUBSTRING  "clounix"
+#define VPP_PLATFORM_SUBSTRING "vpp"
 
 #define CONFIGDB_KEY_SEPARATOR "|"
 #define DEFAULT_KEY_SEPARATOR  ":"


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
- Add VPP platform substring to orch.h
- Add VPP platform to the MirrorV6 allowlist in aclorch.cpp
- Enable acl ingress/egress in L3V4V6 capability to match VS platform capability

**Why I did it**
MirrorV6 capability is required for enabling everflow test cases testing for ipv6-addressed mirror sessions. The feature is currently in progress (issue here: sonic-net/sonic-buildimage#25780)

**How I verified it**

**Details if related**
