### PR TITLE
[portsorch]: Do not let an optional DF attribute fail object creation

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -7430,14 +7430,6 @@ bool PortsOrch::addBridgePort(Port &port)
     attr.value.s32 = port.m_learn_mode;
     attrs.push_back(attr);
 
-    /* If the interface is associated with an ethernet segment, set the DF role */
-    if (gEvpnMhOrch && gEvpnMhOrch->isPortInterfaceAssociatedToEs(port.m_alias)) {
-        /* TODO FIXME: sridsant : Use proper attribute once its available in SAI */
-        attr.id = SAI_BRIDGE_PORT_ATTR_EGRESS_FILTERING;
-        attr.value.booldata = gEvpnMhOrch->isInterfaceDF(port.m_alias, DEFAULT_PORT_VLAN_ID);
-        attrs.push_back(attr);
-    }
-
     sai_status_t status = sai_bridge_api->create_bridge_port(&port.m_bridge_port_id, gSwitchId, (uint32_t)attrs.size(), attrs.data());
     if (status != SAI_STATUS_SUCCESS)
     {
@@ -7449,6 +7441,28 @@ bool PortsOrch::addBridgePort(Port &port)
             return parseHandleSaiStatusFailure(handle_status);
         }
         return false;
+    }
+
+    /* Set after create: the DF role is optional, and a platform that does not
+     * implement it must not lose the bridge port along with it. */
+    if (gEvpnMhOrch && gEvpnMhOrch->isPortInterfaceAssociatedToEs(port.m_alias)) {
+        /* TODO FIXME: sridsant : Use proper attribute once its available in SAI */
+        sai_attribute_t df_attr;
+        df_attr.id = SAI_BRIDGE_PORT_ATTR_EGRESS_FILTERING;
+        df_attr.value.booldata = gEvpnMhOrch->isInterfaceDF(port.m_alias, DEFAULT_PORT_VLAN_ID);
+
+        sai_status_t df_status = sai_bridge_api->set_bridge_port_attribute(port.m_bridge_port_id, &df_attr);
+        if (df_status == SAI_STATUS_NOT_SUPPORTED || df_status == SAI_STATUS_NOT_IMPLEMENTED ||
+            SAI_STATUS_IS_ATTR_NOT_SUPPORTED(df_status) || SAI_STATUS_IS_ATTR_NOT_IMPLEMENTED(df_status))
+        {
+            SWSS_LOG_WARN("Bridge port %s: DF role attribute unavailable on this platform, "
+                          "non-DF BUM suppression not applied", port.m_alias.c_str());
+        }
+        else if (df_status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Bridge port %s: failed to set DF role, rv:%d",
+                           port.m_alias.c_str(), df_status);
+        }
     }
 
     if (!setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_KEEP))
@@ -7733,14 +7747,6 @@ bool PortsOrch::addVlanMember(Port &vlan, Port &port, string &tagging_mode, stri
     attr.value.s32 = sai_tagging_mode;
     attrs.push_back(attr);
 
-    /* If the interface is associated with an ethernet segment, send the SAI vlan DF attribute */
-    if (gEvpnMhOrch && gEvpnMhOrch->isPortAndVlanAssociatedToEs(port.m_alias, vlan.m_vlan_info.vlan_id)) {
-        /* TODO: Use proper attribute once its available in SAI */
-        attr.id = SAI_VLAN_MEMBER_ATTR_TUNNEL_TERM_BUM_TX_DROP;
-        attr.value.booldata = gEvpnMhOrch->isInterfaceDF(port.m_alias, vlan.m_vlan_info.vlan_id);
-        attrs.push_back(attr);
-    }
-
     sai_object_id_t vlan_member_id;
     sai_status_t status = sai_vlan_api->create_vlan_member(&vlan_member_id, gSwitchId, (uint32_t)attrs.size(), attrs.data());
     if (status != SAI_STATUS_SUCCESS)
@@ -7751,6 +7757,27 @@ bool PortsOrch::addVlanMember(Port &vlan, Port &port, string &tagging_mode, stri
         if (handle_status != task_success)
         {
             return parseHandleSaiStatusFailure(handle_status);
+        }
+    }
+
+    /* Set after create, for the same reason as the bridge port DF role above. */
+    if (gEvpnMhOrch && gEvpnMhOrch->isPortAndVlanAssociatedToEs(port.m_alias, vlan.m_vlan_info.vlan_id)) {
+        /* TODO: Use proper attribute once its available in SAI */
+        sai_attribute_t df_attr;
+        df_attr.id = SAI_VLAN_MEMBER_ATTR_TUNNEL_TERM_BUM_TX_DROP;
+        df_attr.value.booldata = gEvpnMhOrch->isInterfaceDF(port.m_alias, vlan.m_vlan_info.vlan_id);
+
+        sai_status_t df_status = sai_vlan_api->set_vlan_member_attribute(vlan_member_id, &df_attr);
+        if (df_status == SAI_STATUS_NOT_SUPPORTED || df_status == SAI_STATUS_NOT_IMPLEMENTED ||
+            SAI_STATUS_IS_ATTR_NOT_SUPPORTED(df_status) || SAI_STATUS_IS_ATTR_NOT_IMPLEMENTED(df_status))
+        {
+            SWSS_LOG_WARN("VLAN member %s on %s: DF role attribute unavailable on this platform, "
+                          "non-DF BUM suppression not applied", port.m_alias.c_str(), vlan.m_alias.c_str());
+        }
+        else if (df_status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("VLAN member %s on %s: failed to set DF role, rv:%d",
+                           port.m_alias.c_str(), vlan.m_alias.c_str(), df_status);
         }
     }
     SWSS_LOG_NOTICE("Add member %s to VLAN %s vid:%hu pid%" PRIx64,

--- a/tests/mock_tests/evpnmhorch_ut.cpp
+++ b/tests/mock_tests/evpnmhorch_ut.cpp
@@ -414,25 +414,38 @@ namespace evpnmhorch_test
         gEvpnMhOrch->addExistingData(&evpnEsIntfTable);
         static_cast<Orch *>(gEvpnMhOrch)->doTask();
 
-        bool df_attr_found;
-        bool df_attr_value;
+        bool df_attr_found = false;
+        bool df_attr_value = false;
+        bool df_attr_in_create = false;
 
         auto vlanSpy = SpyOn<SAI_API_VLAN, SAI_OBJECT_TYPE_VLAN_MEMBER>(&sai_vlan_api->create_vlan_member);
         vlanSpy->callFake([&](sai_object_id_t *oid, sai_object_id_t swoid, uint32_t count, const sai_attribute_t *attrs) -> sai_status_t {
             uint32_t i;
 
-            for (i = 0; i < count && !df_attr_found; i++)
+            for (i = 0; i < count && !df_attr_in_create; i++)
             {
                 // TODO: Use the correct attribute once its available in SAI
                 if (attrs[i].id == SAI_VLAN_MEMBER_ATTR_TUNNEL_TERM_BUM_TX_DROP)
                 {
-                    df_attr_found = true;
-                    // This is inverted from the currently proposed NON_DF SAI attribute
-                    df_attr_value = attrs[i].value.booldata;
+                    df_attr_in_create = true;
                 }
             }
 
             return org_sai_vlan_api->create_vlan_member(oid, swoid, count, attrs);
+        });
+
+        auto vlanMemberAttrSpy = SpyOn<SAI_API_VLAN, SAI_OBJECT_TYPE_VLAN>(&sai_vlan_api->set_vlan_member_attribute);
+        vlanMemberAttrSpy->callFake([&](sai_object_id_t oid, const sai_attribute_t *attr) -> sai_status_t {
+            // TODO: Use the correct attribute once its available in SAI
+            if (attr->id == SAI_VLAN_MEMBER_ATTR_TUNNEL_TERM_BUM_TX_DROP)
+            {
+                df_attr_found = true;
+                df_attr_received = attr->id;
+                // This is inverted from the currently proposed NON_DF SAI attribute
+                df_attr_value = attr->value.booldata;
+            }
+
+            return org_sai_vlan_api->set_vlan_member_attribute(oid, attr);
         });
 
         ApplyDualTorConfigsForSingleVlan();
@@ -440,16 +453,11 @@ namespace evpnmhorch_test
         ASSERT_TRUE(gEvpnMhOrch->isPortInterfaceAssociatedToEs("Ethernet1"));
         ASSERT_TRUE(gEvpnMhOrch->isPortAndVlanAssociatedToEs("Ethernet1", 10));
         ASSERT_FALSE(gEvpnMhOrch->isInterfaceDF("Ethernet1", 10));
+        /* The DF role is applied after create so an unimplemented attribute cannot
+         * fail the VLAN member itself. */
+        ASSERT_FALSE(df_attr_in_create);
         ASSERT_TRUE(df_attr_found);
         ASSERT_FALSE(df_attr_value);
-
-        auto vlanMemberAttrSpy = SpyOn<SAI_API_VLAN, SAI_OBJECT_TYPE_VLAN>(&sai_vlan_api->set_vlan_member_attribute);
-        vlanMemberAttrSpy->callFake([&](sai_object_id_t oid, const sai_attribute_t *attr) -> sai_status_t {
-            df_attr_received = attr->id;
-            df_attr_value = attr->value.booldata;
-
-            return org_sai_vlan_api->set_vlan_member_attribute(oid, attr);
-        });
 
         std::deque<KeyOpFieldsValuesTuple> entries;
         entries.clear();


### PR DESCRIPTION
### What I did

EVPN multihoming marks the Designated Forwarder role by appending an attribute
to object creation:

- `SAI_BRIDGE_PORT_ATTR_EGRESS_FILTERING` on `create_bridge_port()`
- `SAI_VLAN_MEMBER_ATTR_TUNNEL_TERM_BUM_TX_DROP` on `create_vlan_member()`

Both stand in for an attribute SAI does not define yet, and both are flagged as
such in tree (`TODO FIXME: Use proper attribute once its available in SAI`).

Because they are passed to `create`, a platform that does not implement them
fails the entire create, not just the optional part:

```
|c|SAI_OBJECT_TYPE_BRIDGE_PORT:...|SAI_BRIDGE_PORT_ATTR_EGRESS_FILTERING=false
|E|SAI_STATUS_ATTR_NOT_IMPLEMENTED_4
```

On Tomahawk 5 this leaves an Ethernet Segment port with no bridge port, so it
never becomes a VLAN member, hardware learning never starts and the FDB stays
empty. Configuring an Ethernet Segment silently removes the port from the data
plane. Nothing is logged by `addBridgePort` in that path either, because
`handleSaiCreateStatus` absorbs the failure; only `sairedis.rec` shows it.

### How I did it

Create the object with the attributes every platform implements, then set the
DF role separately and tolerate `NOT_IMPLEMENTED` / `NOT_SUPPORTED`, which is
what `vlanMembersApplyNonDF()` already does for the same attribute. Where the
attribute is unavailable the port forwards normally and only non-DF BUM
suppression is lost, which is a much better failure mode than losing the port.

The behaviour is unchanged on platforms that do implement the attribute.

### How to verify it

`EvpnMhOrchTest.ESProgramAndAddVlanMember` is updated to pin the new contract:
the DF attribute must not appear in the create argument list, and must arrive
via the follow-up set. It also initialises `df_attr_found` / `df_attr_value`,
which were previously read uninitialised.

Verified in hardware on a 7060X6-64PE-B with two Ethernet Segments configured.

Before:

```
BRIDGE_PORT : 1
VLAN_MEMBER : 1
MACs        : 0
```

After:

```
BRIDGE_PORT : 3
VLAN_MEMBER : 3
MACs        : 2
DF warnings : 4   (graceful, one per bridge port and VLAN member)
BP create failures : 0
```

with the local MACs present in the kernel FDB:

```
02:00:00:00:10:22 dev PortChannel122 vlan 100 extern_learn master Bridge proto hw
```

A control unit with no Ethernet Segments configured was unaffected in both
cases, which is what isolated the DF attribute as the cause.

### Note

This is a mitigation, not a fix for the underlying gap. SAI still has no
attribute that expresses the DF role, so there is no portable way to request
non-DF BUM suppression. I intend to raise that separately.
