### PR TITLE
[fdbsyncd]: Ignore deletes for untracked L2 nexthops

### DIFF
--- a/fdbsyncd/fdbsync.cpp
+++ b/fdbsyncd/fdbsync.cpp
@@ -1290,6 +1290,14 @@ void FdbSync::onMsgNhg(struct nlmsghdr *msg)
     }
     else if (msg->nlmsg_type == RTM_DELNEXTHOP)
     {
+        if (m_l2NhgMap.find(nhid) == m_l2NhgMap.end())
+        {
+            SWSS_LOG_DEBUG(
+                "L2_NEXTHOP_GROUP_TABLE: DEL nhid=%u ignored; entry is not present in L2 NHG cache",
+                nhid);
+            return;
+        }
+
         /* Delete from L2_NEXTHOP_GROUP_TABLE */
         m_l2NhgTable.del(to_string(nhid));
         m_l2NhgMap.erase(nhid);

--- a/tests/mock_tests/fdbsyncd/fdbsyncd_ut.cpp
+++ b/tests/mock_tests/fdbsyncd/fdbsyncd_ut.cpp
@@ -1234,6 +1234,35 @@ TEST_F(FdbSyncdEvpnMhTest, NhgRefcounting)
     free(nhg_del);
 }
 
+// Regression test for sonic-net/sonic-swss#4842. The fake ProducerStateTable
+// (mock_table.cpp) backs onto a plain std::map, so a DEL of an already-absent
+// key is indistinguishable from never calling DEL at all. To make an
+// unguarded DEL observable, pre-seed a sentinel row at the ignored nhid's
+// key: an unguarded del() would wipe it out, while the fix leaves it intact.
+TEST_F(FdbSyncdEvpnMhTest, IgnoredOifNextHopDelete)
+{
+    uint32_t nhid = 9000;
+
+    std::vector<FieldValueTuple> sentinel = { FieldValueTuple("remote_vtep", "192.0.2.1") };
+    getNhgTable().set(std::to_string(nhid), sentinel);
+
+    struct nlmsghdr *create = create_l2_nhg_member_msg(nhid, "10.0.0.50", 300);
+    m_mockFdbSync.onMsgRaw(create);
+    free(create);
+
+    EXPECT_EQ(m_mockFdbSync.m_l2NhgMap.count(nhid), 0u);
+
+    struct nlmsghdr *del = delete_nhg_msg(nhid);
+    m_mockFdbSync.onMsgRaw(del);
+    free(del);
+
+    std::vector<FieldValueTuple> values;
+    ASSERT_TRUE(getNhgTable().get(std::to_string(nhid), values));
+    ASSERT_EQ(values.size(), 1u);
+    EXPECT_EQ(fvField(values[0]), "remote_vtep");
+    EXPECT_EQ(fvValue(values[0]), "192.0.2.1");
+}
+
 TEST_F(FdbSyncdEvpnMhTest, TestMclagRemoteFdb)
 {
     // Test MCLAG remote FDB processing


### PR DESCRIPTION
**What I did**

- Guard `RTM_DELNEXTHOP` processing with `m_l2NhgMap` so `fdbsyncd` only publishes a DEL for L2 nexthops it previously accepted.
- Add `FdbSyncdEvpnMhTest.IgnoredOifNextHopDelete` regression coverage for an `NHA_OIF` nexthop whose create is intentionally ignored.

**Why I did it**

An `RTM_NEWNEXTHOP` containing `NHA_OIF` is intentionally dropped by `fdbsyncd`, but its corresponding `RTM_DELNEXTHOP` was still publishing an unmatched DEL to `L2_NEXTHOP_GROUP_TABLE`.

That caused orchagent to receive a delete for an L2 nexthop group that did not exist and log an error.

Fixes #4842.

**How I verified it**

- `git diff --check` passes.
- Added a focused regression test that makes an unmatched DEL observable and verifies that an ignored OIF nexthop does not generate the delete.
- The full `tests_fdbsyncd` binary could not be built locally because the WSL environment does not have the matching SONiC build dependencies (`libswsscommon`, `libsairedis`, `libsaivs`, and related packages). Repository CI will provide the full build/test validation.

**Details if related**

No schema or configuration changes.
