### PR TITLE
[lib]: Add shared interface name validator

### DIFF
--- a/lib/ifname.h
+++ b/lib/ifname.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <net/if.h>
+#include <string>
+
+namespace swss
+{
+
+// This validates interface-name syntax only. Category semantics remain in the
+// YANG models and component-specific parsers. IFNAMSIZ includes the
+// terminating NUL.
+inline bool isValidIfname(const std::string &name)
+{
+    if (
+        name.empty() ||
+        name == "." ||
+        name == ".." ||
+        name.size() >= IFNAMSIZ ||
+        name.front() == '-'
+    )
+    {
+        return false;
+    }
+
+    for (unsigned char character : name)
+    {
+        if (!(
+            (character >= 'A' && character <= 'Z') ||
+            (character >= 'a' && character <= 'z') ||
+            (character >= '0' && character <= '9') ||
+            character == '.' ||
+            character == '_' ||
+            character == '-'
+        ))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -20,7 +20,7 @@ CFLAGS_GTEST =
 LDADD_GTEST = -L/usr/src/gtest
 
 tests_SOURCES = swssnet_ut.cpp request_parser_ut.cpp ../orchagent/request_parser.cpp            \
-        quoted_ut.cpp ../lib/recorder.cpp
+        ifname_ut.cpp ../lib/ifname.h quoted_ut.cpp ../lib/recorder.cpp
 
 tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
 tests_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) -I../orchagent

--- a/tests/ifname_ut.cpp
+++ b/tests/ifname_ut.cpp
@@ -1,0 +1,27 @@
+#include "gtest/gtest.h"
+
+#include "ifname.h"
+
+TEST(IfnameTest, AcceptsKernelInterfaceNames)
+{
+    EXPECT_TRUE(swss::isValidIfname("Ethernet0"));
+    EXPECT_TRUE(swss::isValidIfname("PortChannel1"));
+    EXPECT_TRUE(swss::isValidIfname("Eth0.100"));
+    EXPECT_TRUE(swss::isValidIfname("Ethernet-BP0"));
+    EXPECT_TRUE(swss::isValidIfname("1Ethernet"));
+    EXPECT_TRUE(swss::isValidIfname("_eth0"));
+    EXPECT_TRUE(swss::isValidIfname(".eth0"));
+}
+
+TEST(IfnameTest, RejectsInvalidKernelInterfaceNames)
+{
+    EXPECT_FALSE(swss::isValidIfname(""));
+    EXPECT_FALSE(swss::isValidIfname("."));
+    EXPECT_FALSE(swss::isValidIfname(".."));
+    EXPECT_FALSE(swss::isValidIfname("-Ethernet0"));
+    EXPECT_FALSE(swss::isValidIfname("Port Channel"));
+    EXPECT_FALSE(swss::isValidIfname("Ethernet0/1"));
+    EXPECT_FALSE(swss::isValidIfname("Ethernet0:1"));
+    EXPECT_FALSE(swss::isValidIfname("Ethernet0@1"));
+    EXPECT_FALSE(swss::isValidIfname("PortChannel1.100"));
+}


### PR DESCRIPTION
**What I did**

Added a header-only `swss::isValidIfname` helper and focused unit tests for shared interface-name syntax validation.

The exact accepted format is:

- Length is 1 through 15 bytes (`< IFNAMSIZ`).
- Every byte is an ASCII letter, digit, underscore, period, or hyphen: `[A-Za-z0-9_.-]`.
- The complete name is not `.` or `..`.
- The first character is not a hyphen.

There is no letter-first rule and no SONiC prefix requirement. Names such as `1Ethernet`, `_eth0`, and `.eth0` match the format. Interface category, parent existence, and naming conventions remain the responsibility of YANG and component-specific parsers.

Implementation and coverage: [`lib/ifname.h`](https://github.com/sonic-net/sonic-swss/blob/ae4e2d1dbaaa45fadac5f0c24e42a1d335e83f44/lib/ifname.h) and [`tests/ifname_ut.cpp`](https://github.com/sonic-net/sonic-swss/blob/ae4e2d1dbaaa45fadac5f0c24e42a1d335e83f44/tests/ifname_ut.cpp).

**Why I did it**

A shared helper gives SWSS components one interface-name syntax rule while leaving interface-category rules to the existing YANG models and component parsers.

Linux [`dev_valid_name`](https://github.com/torvalds/linux/blob/master/net/core/dev.c#L1339-L1363) and SONiC's YANG [`interface_name` typedef](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/yang-templates/sonic-types.yang.j2#L393-L401) provide the underlying length and naming constraints. Physical-interface and VLAN-subinterface semantics remain defined by [`sonic-interface.yang`](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/yang-models/sonic-interface.yang#L45-L60) and [`sonic-vlan-sub-interface.yang`](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang#L43-L78).

**How I verified it**

Built and ran the focused tests in the Bookworm build environment:

```text
[==========] 2 tests from 1 test suite ran.
[  PASSED  ] 2 tests.
```

The tests cover names that match the exact format and each nonmatching length, character, whole-name, and first-character case.

**Details if related**

Dependent draft PRs #4845, #4846, and #4847 are intentionally paused. After this helper merges, each consumer branch will be rebuilt from current `master` so its review diff contains only the dependent integration.