### PR TITLE
[nbrmgr]: Preserve failed IPv6 neighbors as incomplete

### DIFF
--- a/cfgmgr/nbrmgr.cpp
+++ b/cfgmgr/nbrmgr.cpp
@@ -48,7 +48,7 @@ static bool send_message(struct nl_sock *sk, struct nl_msg *msg)
 
 NbrMgr::NbrMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const vector<string> &tableNames) :
         Orch(cfgDb, tableNames),
-        m_kernelFailedNeighTable(appDb, APP_KERNEL_FAILED_NEIGH_TABLE_NAME),
+        m_kernelFailedNeighTable(appDb, APP_NEIGH_FAILED_TABLE_NAME),
         m_statePortTable(stateDb, STATE_PORT_TABLE_NAME),
         m_stateLagTable(stateDb, STATE_LAG_TABLE_NAME),
         m_stateVlanTable(stateDb, STATE_VLAN_TABLE_NAME),
@@ -73,9 +73,9 @@ NbrMgr::NbrMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, con
     Orch::addExecutor(consumer);
 
     auto failedNeighConsumerStateTable = new swss::ConsumerStateTable(
-        appDb, APP_KERNEL_FAILED_NEIGH_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE, default_orch_pri);
+        appDb, APP_NEIGH_FAILED_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE, default_orch_pri);
     auto failedNeighConsumer = new Consumer(
-        failedNeighConsumerStateTable, this, APP_KERNEL_FAILED_NEIGH_TABLE_NAME);
+        failedNeighConsumerStateTable, this, APP_NEIGH_FAILED_TABLE_NAME);
     Orch::addExecutor(failedNeighConsumer);
 
     /* Reconcile any pending entries in NEIGH_RESOLVE_TABLE from before restart */
@@ -622,7 +622,7 @@ void NbrMgr::doTask(Consumer &consumer)
     } else if (table_name == APP_NEIGH_RESOLVE_TABLE_NAME)
     {
         doResolveNeighTask(consumer);
-    } else if (table_name == APP_KERNEL_FAILED_NEIGH_TABLE_NAME)
+    } else if (table_name == APP_NEIGH_FAILED_TABLE_NAME)
     {
         doKernelFailedNeighTask(consumer);
     } else if(table_name == STATE_SYSTEM_NEIGH_TABLE_NAME)

--- a/cfgmgr/nbrmgr.cpp
+++ b/cfgmgr/nbrmgr.cpp
@@ -46,7 +46,6 @@ static bool send_message(struct nl_sock *sk, struct nl_msg *msg)
 
 NbrMgr::NbrMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const vector<string> &tableNames) :
         Orch(cfgDb, tableNames),
-        m_kernelFailedNeighTable(appDb, APP_NEIGH_FAILED_TABLE_NAME),
         m_statePortTable(stateDb, STATE_PORT_TABLE_NAME),
         m_stateLagTable(stateDb, STATE_LAG_TABLE_NAME),
         m_stateVlanTable(stateDb, STATE_VLAN_TABLE_NAME),
@@ -78,7 +77,6 @@ NbrMgr::NbrMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, con
 
     /* Reconcile any pending entries in NEIGH_RESOLVE_TABLE from before restart */
     reconcileNeighResolveTable(appDb);
-    reconcileKernelFailedNeighTable();
 
     string swtype;
     Table cfgDeviceMetaDataTable(cfgDb, CFG_DEVICE_METADATA_TABLE_NAME);
@@ -296,11 +294,10 @@ bool NbrMgr::sendNeighborSolicitation(const string& alias, const IpAddress& ip)
     return true;
 }
 
-void NbrMgr::processKernelFailedNeighbor(const string& key)
+void NbrMgr::processKernelFailedNeighbor(const string& key, const string& tableSeparator)
 {
     try
     {
-        string tableSeparator = m_kernelFailedNeighTable.getTableNameSeparator();
         if (key.find(tableSeparator) == string::npos)
         {
             SWSS_LOG_ERROR("Invalid failed kernel neighbor entry '%s'", key.c_str());
@@ -408,24 +405,6 @@ void NbrMgr::reconcileNeighResolveTable(DBConnector *appDb)
     }
 }
 
-void NbrMgr::reconcileKernelFailedNeighTable()
-{
-    vector<string> keys;
-    m_kernelFailedNeighTable.getKeys(keys);
-
-    for (const auto& key : keys)
-    {
-        vector<FieldValueTuple> data;
-        if (!m_kernelFailedNeighTable.get(key, data))
-        {
-            SWSS_LOG_ERROR("Failed to read pending kernel neighbor '%s'", key.c_str());
-            continue;
-        }
-
-        processKernelFailedNeighbor(key);
-    }
-}
-
 void NbrMgr::doResolveNeighTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
@@ -457,13 +436,14 @@ void NbrMgr::doResolveNeighTask(Consumer &consumer)
 
 void NbrMgr::doKernelFailedNeighTask(Consumer& consumer)
 {
+    const string tableSeparator = consumer.getConsumerTable()->getTableNameSeparator();
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
     {
         KeyOpFieldsValuesTuple t = it->second;
         if (kfvOp(t) == SET_COMMAND)
         {
-            processKernelFailedNeighbor(kfvKey(t));
+            processKernelFailedNeighbor(kfvKey(t), tableSeparator);
         }
 
         it = consumer.m_toSync.erase(it);

--- a/cfgmgr/nbrmgr.cpp
+++ b/cfgmgr/nbrmgr.cpp
@@ -399,8 +399,6 @@ void NbrMgr::processKernelFailedNeighbor(const string& key, const vector<FieldVa
     {
         SWSS_LOG_ERROR("Failed to process kernel neighbor '%s': %s", key.c_str(), e.what());
     }
-
-    m_kernelFailedNeighTable.del(key);
 }
 
 /**
@@ -487,7 +485,6 @@ void NbrMgr::reconcileKernelFailedNeighTable()
         if (!m_kernelFailedNeighTable.get(key, data))
         {
             SWSS_LOG_ERROR("Failed to read pending kernel neighbor '%s'", key.c_str());
-            m_kernelFailedNeighTable.del(key);
             continue;
         }
 

--- a/cfgmgr/nbrmgr.cpp
+++ b/cfgmgr/nbrmgr.cpp
@@ -3,9 +3,7 @@
 #include <net/if.h>
 #include <unistd.h>
 #include <linux/neighbour.h>
-#include <netlink/addr.h>
-#include <netlink/cache.h>
-#include <netlink/route/neighbour.h>
+#include <netlink/msg.h>
 
 #include "logger.h"
 #include "tokenize.h"
@@ -221,55 +219,6 @@ bool NbrMgr::setNeighbor(const string& alias, const IpAddress& ip, const MacAddr
     return send_message(m_nl_sock, msg);
 }
 
-bool NbrMgr::isFailedNeighbor(const string& alias, const IpAddress& ip)
-{
-    if (!m_nl_sock)
-    {
-        SWSS_LOG_ERROR("Cannot query failed neighbor '%s': netlink socket is unavailable",
-                       ip.to_string().c_str());
-        return false;
-    }
-
-    unsigned int ifindex = if_nametoindex(alias.c_str());
-    if (ifindex == 0)
-    {
-        SWSS_LOG_ERROR("Cannot query failed neighbor '%s': interface '%s' does not exist",
-                       ip.to_string().c_str(), alias.c_str());
-        return false;
-    }
-
-    struct nl_addr *dst = nullptr;
-    int err = nl_addr_parse(ip.to_string().c_str(), AF_INET6, &dst);
-    if (err < 0)
-    {
-        SWSS_LOG_ERROR("Failed to parse IPv6 neighbor '%s': %s",
-                       ip.to_string().c_str(), nl_geterror(err));
-        return false;
-    }
-
-    struct nl_cache *cache = nullptr;
-    err = rtnl_neigh_alloc_cache(m_nl_sock, &cache);
-    if (err < 0 || !cache)
-    {
-        SWSS_LOG_ERROR("Failed to read kernel neighbors for '%s': %s",
-                       ip.to_string().c_str(), nl_geterror(err));
-        nl_addr_put(dst);
-        return false;
-    }
-
-    struct rtnl_neigh *neigh = rtnl_neigh_get(cache, static_cast<int>(ifindex), dst);
-    bool isFailed = neigh && rtnl_neigh_get_state(neigh) == NUD_FAILED;
-
-    if (neigh)
-    {
-        rtnl_neigh_put(neigh);
-    }
-    nl_cache_free(cache);
-    nl_addr_put(dst);
-
-    return isFailed;
-}
-
 bool NbrMgr::setFailedNeighborIncomplete(const string& alias, const IpAddress& ip)
 {
     SWSS_LOG_ENTER();
@@ -347,25 +296,14 @@ bool NbrMgr::sendNeighborSolicitation(const string& alias, const IpAddress& ip)
     return true;
 }
 
-void NbrMgr::processKernelFailedNeighbor(const string& key, const vector<FieldValueTuple>& data)
+void NbrMgr::processKernelFailedNeighbor(const string& key)
 {
     try
     {
-        string family;
-        for (const auto& fieldValue : data)
-        {
-            if (fvField(fieldValue) == "family")
-            {
-                family = fvValue(fieldValue);
-                break;
-            }
-        }
-
         string tableSeparator = m_kernelFailedNeighTable.getTableNameSeparator();
-        if (family != IPV6_NAME || key.find(tableSeparator) == string::npos)
+        if (key.find(tableSeparator) == string::npos)
         {
-            SWSS_LOG_ERROR("Invalid failed kernel neighbor entry '%s' with family '%s'",
-                           key.c_str(), family.c_str());
+            SWSS_LOG_ERROR("Invalid failed kernel neighbor entry '%s'", key.c_str());
         }
         else
         {
@@ -376,10 +314,6 @@ void NbrMgr::processKernelFailedNeighbor(const string& key, const vector<FieldVa
             if (ip.isV4())
             {
                 SWSS_LOG_ERROR("Ignoring non-IPv6 failed kernel neighbor '%s'", key.c_str());
-            }
-            else if (!isFailedNeighbor(alias, ip))
-            {
-                SWSS_LOG_NOTICE("Skipping stale failed kernel neighbor request '%s'", key.c_str());
             }
             else if (!setFailedNeighborIncomplete(alias, ip))
             {
@@ -488,7 +422,7 @@ void NbrMgr::reconcileKernelFailedNeighTable()
             continue;
         }
 
-        processKernelFailedNeighbor(key, data);
+        processKernelFailedNeighbor(key);
     }
 }
 
@@ -529,7 +463,7 @@ void NbrMgr::doKernelFailedNeighTask(Consumer& consumer)
         KeyOpFieldsValuesTuple t = it->second;
         if (kfvOp(t) == SET_COMMAND)
         {
-            processKernelFailedNeighbor(kfvKey(t), kfvFieldsValues(t));
+            processKernelFailedNeighbor(kfvKey(t));
         }
 
         it = consumer.m_toSync.erase(it);

--- a/cfgmgr/nbrmgr.cpp
+++ b/cfgmgr/nbrmgr.cpp
@@ -2,7 +2,10 @@
 #include <netinet/in.h>
 #include <net/if.h>
 #include <unistd.h>
+#include <linux/neighbour.h>
+#include <netlink/addr.h>
 #include <netlink/cache.h>
+#include <netlink/route/neighbour.h>
 
 #include "logger.h"
 #include "tokenize.h"
@@ -14,6 +17,8 @@
 #include "subscriberstatetable.h"
 
 using namespace swss;
+
+static constexpr const char *NDISC6_CMD = "/usr/bin/ndisc6";
 
 static bool send_message(struct nl_sock *sk, struct nl_msg *msg)
 {
@@ -43,6 +48,7 @@ static bool send_message(struct nl_sock *sk, struct nl_msg *msg)
 
 NbrMgr::NbrMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const vector<string> &tableNames) :
         Orch(cfgDb, tableNames),
+        m_kernelFailedNeighTable(appDb, APP_KERNEL_FAILED_NEIGH_TABLE_NAME),
         m_statePortTable(stateDb, STATE_PORT_TABLE_NAME),
         m_stateLagTable(stateDb, STATE_LAG_TABLE_NAME),
         m_stateVlanTable(stateDb, STATE_VLAN_TABLE_NAME),
@@ -66,8 +72,15 @@ NbrMgr::NbrMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, con
     auto consumer = new Consumer(consumerStateTable, this, APP_NEIGH_RESOLVE_TABLE_NAME);
     Orch::addExecutor(consumer);
 
+    auto failedNeighConsumerStateTable = new swss::ConsumerStateTable(
+        appDb, APP_KERNEL_FAILED_NEIGH_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE, default_orch_pri);
+    auto failedNeighConsumer = new Consumer(
+        failedNeighConsumerStateTable, this, APP_KERNEL_FAILED_NEIGH_TABLE_NAME);
+    Orch::addExecutor(failedNeighConsumer);
+
     /* Reconcile any pending entries in NEIGH_RESOLVE_TABLE from before restart */
     reconcileNeighResolveTable(appDb);
+    reconcileKernelFailedNeighTable();
 
     string swtype;
     Table cfgDeviceMetaDataTable(cfgDb, CFG_DEVICE_METADATA_TABLE_NAME);
@@ -208,6 +221,188 @@ bool NbrMgr::setNeighbor(const string& alias, const IpAddress& ip, const MacAddr
     return send_message(m_nl_sock, msg);
 }
 
+bool NbrMgr::isFailedNeighbor(const string& alias, const IpAddress& ip)
+{
+    if (!m_nl_sock)
+    {
+        SWSS_LOG_ERROR("Cannot query failed neighbor '%s': netlink socket is unavailable",
+                       ip.to_string().c_str());
+        return false;
+    }
+
+    unsigned int ifindex = if_nametoindex(alias.c_str());
+    if (ifindex == 0)
+    {
+        SWSS_LOG_ERROR("Cannot query failed neighbor '%s': interface '%s' does not exist",
+                       ip.to_string().c_str(), alias.c_str());
+        return false;
+    }
+
+    struct nl_addr *dst = nullptr;
+    int err = nl_addr_parse(ip.to_string().c_str(), AF_INET6, &dst);
+    if (err < 0)
+    {
+        SWSS_LOG_ERROR("Failed to parse IPv6 neighbor '%s': %s",
+                       ip.to_string().c_str(), nl_geterror(err));
+        return false;
+    }
+
+    struct nl_cache *cache = nullptr;
+    err = rtnl_neigh_alloc_cache(m_nl_sock, &cache);
+    if (err < 0 || !cache)
+    {
+        SWSS_LOG_ERROR("Failed to read kernel neighbors for '%s': %s",
+                       ip.to_string().c_str(), nl_geterror(err));
+        nl_addr_put(dst);
+        return false;
+    }
+
+    struct rtnl_neigh *neigh = rtnl_neigh_get(cache, static_cast<int>(ifindex), dst);
+    bool isFailed = neigh && rtnl_neigh_get_state(neigh) == NUD_FAILED;
+
+    if (neigh)
+    {
+        rtnl_neigh_put(neigh);
+    }
+    nl_cache_free(cache);
+    nl_addr_put(dst);
+
+    return isFailed;
+}
+
+bool NbrMgr::setFailedNeighborIncomplete(const string& alias, const IpAddress& ip)
+{
+    SWSS_LOG_ENTER();
+
+    struct nl_msg *msg = nlmsg_alloc();
+    if (!msg)
+    {
+        SWSS_LOG_ERROR("Netlink message alloc failed for '%s'", ip.to_string().c_str());
+        return false;
+    }
+
+    auto flags = (NLM_F_REQUEST | NLM_F_ACK | NLM_F_REPLACE);
+    struct nlmsghdr *hdr = nlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, RTM_NEWNEIGH, 0, flags);
+    if (!hdr)
+    {
+        SWSS_LOG_ERROR("Netlink message header alloc failed for '%s'", ip.to_string().c_str());
+        nlmsg_free(msg);
+        return false;
+    }
+
+    struct ndmsg *nd_msg = static_cast<struct ndmsg *>(
+        nlmsg_reserve(msg, sizeof(struct ndmsg), NLMSG_ALIGNTO));
+    if (!nd_msg)
+    {
+        SWSS_LOG_ERROR("Netlink ndmsg reserve failed for '%s'", ip.to_string().c_str());
+        nlmsg_free(msg);
+        return false;
+    }
+
+    memset(nd_msg, 0, sizeof(struct ndmsg));
+    nd_msg->ndm_ifindex = static_cast<int>(if_nametoindex(alias.c_str()));
+    if (nd_msg->ndm_ifindex == 0)
+    {
+        SWSS_LOG_ERROR("Interface '%s' does not exist for failed neighbor '%s'",
+                       alias.c_str(), ip.to_string().c_str());
+        nlmsg_free(msg);
+        return false;
+    }
+
+    auto ipAddr = ip.getIp();
+    auto addrLen = sizeof(struct in6_addr);
+    struct rtattr *rta = static_cast<struct rtattr *>(
+        nlmsg_reserve(msg, sizeof(struct rtattr) + addrLen, NLMSG_ALIGNTO));
+    if (!rta)
+    {
+        SWSS_LOG_ERROR("Netlink rtattr (IP) failed for '%s'", ip.to_string().c_str());
+        nlmsg_free(msg);
+        return false;
+    }
+
+    rta->rta_type = NDA_DST;
+    rta->rta_len = static_cast<short>(RTA_LENGTH(addrLen));
+    memcpy(RTA_DATA(rta), &ipAddr.ip_addr.ipv6_addr, addrLen);
+
+    nd_msg->ndm_family = AF_INET6;
+    nd_msg->ndm_type = RTN_UNICAST;
+    nd_msg->ndm_state = NUD_INCOMPLETE;
+
+    return send_message(m_nl_sock, msg);
+}
+
+bool NbrMgr::sendNeighborSolicitation(const string& alias, const IpAddress& ip)
+{
+    string command = string(NDISC6_CMD) + " -q -w 0 -1 " +
+                     shellquote(ip.to_string()) + " " + shellquote(alias);
+    string output;
+    int32_t result = swss::exec(command, output);
+    if (result != 0)
+    {
+        SWSS_LOG_WARN("Failed to send neighbor solicitation for '%s' on '%s', error: %d, output: %s",
+                      ip.to_string().c_str(), alias.c_str(), result, output.c_str());
+        return false;
+    }
+
+    return true;
+}
+
+void NbrMgr::processKernelFailedNeighbor(const string& key, const vector<FieldValueTuple>& data)
+{
+    try
+    {
+        string family;
+        for (const auto& fieldValue : data)
+        {
+            if (fvField(fieldValue) == "family")
+            {
+                family = fvValue(fieldValue);
+                break;
+            }
+        }
+
+        string tableSeparator = m_kernelFailedNeighTable.getTableNameSeparator();
+        if (family != IPV6_NAME || key.find(tableSeparator) == string::npos)
+        {
+            SWSS_LOG_ERROR("Invalid failed kernel neighbor entry '%s' with family '%s'",
+                           key.c_str(), family.c_str());
+        }
+        else
+        {
+            vector<string> parsedKeys = parseAliasIp(key, tableSeparator.c_str());
+            string alias(parsedKeys[0]);
+            IpAddress ip(parsedKeys[1]);
+
+            if (ip.isV4())
+            {
+                SWSS_LOG_ERROR("Ignoring non-IPv6 failed kernel neighbor '%s'", key.c_str());
+            }
+            else if (!isFailedNeighbor(alias, ip))
+            {
+                SWSS_LOG_NOTICE("Skipping stale failed kernel neighbor request '%s'", key.c_str());
+            }
+            else if (!setFailedNeighborIncomplete(alias, ip))
+            {
+                SWSS_LOG_ERROR("Failed to move kernel neighbor '%s' to INCOMPLETE", key.c_str());
+            }
+            else if (sendNeighborSolicitation(alias, ip))
+            {
+                SWSS_LOG_NOTICE("Moved kernel neighbor '%s' to INCOMPLETE and sent one NS", key.c_str());
+            }
+            else
+            {
+                SWSS_LOG_WARN("Moved kernel neighbor '%s' to INCOMPLETE but failed to send NS", key.c_str());
+            }
+        }
+    }
+    catch (const std::invalid_argument& e)
+    {
+        SWSS_LOG_ERROR("Failed to process kernel neighbor '%s': %s", key.c_str(), e.what());
+    }
+
+    m_kernelFailedNeighTable.del(key);
+}
+
 /**
  * Parse APPL_DB neighbors resolve table.
  *
@@ -281,6 +476,25 @@ void NbrMgr::reconcileNeighResolveTable(DBConnector *appDb)
     }
 }
 
+void NbrMgr::reconcileKernelFailedNeighTable()
+{
+    vector<string> keys;
+    m_kernelFailedNeighTable.getKeys(keys);
+
+    for (const auto& key : keys)
+    {
+        vector<FieldValueTuple> data;
+        if (!m_kernelFailedNeighTable.get(key, data))
+        {
+            SWSS_LOG_ERROR("Failed to read pending kernel neighbor '%s'", key.c_str());
+            m_kernelFailedNeighTable.del(key);
+            continue;
+        }
+
+        processKernelFailedNeighbor(key, data);
+    }
+}
+
 void NbrMgr::doResolveNeighTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
@@ -306,6 +520,21 @@ void NbrMgr::doResolveNeighTask(Consumer &consumer)
         {
             SWSS_LOG_ERROR("Neigh entry resolve failed for '%s'", kfvKey(t).c_str());
         }
+        it = consumer.m_toSync.erase(it);
+    }
+}
+
+void NbrMgr::doKernelFailedNeighTask(Consumer& consumer)
+{
+    auto it = consumer.m_toSync.begin();
+    while (it != consumer.m_toSync.end())
+    {
+        KeyOpFieldsValuesTuple t = it->second;
+        if (kfvOp(t) == SET_COMMAND)
+        {
+            processKernelFailedNeighbor(kfvKey(t), kfvFieldsValues(t));
+        }
+
         it = consumer.m_toSync.erase(it);
     }
 }
@@ -393,6 +622,9 @@ void NbrMgr::doTask(Consumer &consumer)
     } else if (table_name == APP_NEIGH_RESOLVE_TABLE_NAME)
     {
         doResolveNeighTask(consumer);
+    } else if (table_name == APP_KERNEL_FAILED_NEIGH_TABLE_NAME)
+    {
+        doKernelFailedNeighTask(consumer);
     } else if(table_name == STATE_SYSTEM_NEIGH_TABLE_NAME)
     {
         doStateSystemNeighTask(consumer);

--- a/cfgmgr/nbrmgr.cpp
+++ b/cfgmgr/nbrmgr.cpp
@@ -126,11 +126,17 @@ NbrMgr::NbrMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, con
     auto consumer = new Consumer(consumerStateTable, this, APP_NEIGH_RESOLVE_TABLE_NAME);
     Orch::addExecutor(consumer);
 
-    auto failedNeighConsumerStateTable = new swss::ConsumerStateTable(
-        appDb, APP_NEIGH_FAILED_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE, default_orch_pri);
-    auto failedNeighConsumer = new Consumer(
-        failedNeighConsumerStateTable, this, APP_NEIGH_FAILED_TABLE_NAME);
-    Orch::addExecutor(failedNeighConsumer);
+    Table cfgPeerSwitchTable(cfgDb, CFG_PEER_SWITCH_TABLE_NAME);
+    vector<string> peerSwitchKeys;
+    cfgPeerSwitchTable.getKeys(peerSwitchKeys);
+    if (!peerSwitchKeys.empty())
+    {
+        auto failedNeighConsumerStateTable = new swss::ConsumerStateTable(
+            appDb, APP_NEIGH_FAILED_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE, default_orch_pri);
+        auto failedNeighConsumer = new Consumer(
+            failedNeighConsumerStateTable, this, APP_NEIGH_FAILED_TABLE_NAME);
+        Orch::addExecutor(failedNeighConsumer);
+    }
 
     /* Reconcile any pending entries in NEIGH_RESOLVE_TABLE from before restart */
     reconcileNeighResolveTable(appDb);

--- a/cfgmgr/nbrmgr.cpp
+++ b/cfgmgr/nbrmgr.cpp
@@ -17,8 +17,9 @@
 using namespace swss;
 
 static constexpr const char *NDISC6_CMD = "/usr/bin/ndisc6";
+static constexpr int NDISC6_NO_RESPONSE = 2;
 
-static bool send_message(struct nl_sock *sk, struct nl_msg *msg)
+static bool send_message_internal(struct nl_sock *sk, struct nl_msg *msg, bool waitForAck)
 {
     bool rc = false;
     int err = 0;
@@ -37,11 +38,36 @@ static bool send_message(struct nl_sock *sk, struct nl_msg *msg)
             break;
         }
 
+        if (waitForAck)
+        {
+            do
+            {
+                err = nl_wait_for_ack(sk);
+            }
+            while (err == -NLE_INTR);
+
+            if (err < 0)
+            {
+                SWSS_LOG_ERROR("Netlink ACK failed, error '%s'", nl_geterror(err));
+                break;
+            }
+        }
+
         rc = true;
     } while(0);
 
     nlmsg_free(msg);
     return rc;
+}
+
+static bool send_message(struct nl_sock *sk, struct nl_msg *msg)
+{
+    return send_message_internal(sk, msg, false);
+}
+
+static bool send_message_with_ack(struct nl_sock *sk, struct nl_msg *msg)
+{
+    return send_message_internal(sk, msg, true);
 }
 
 NbrMgr::NbrMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const vector<string> &tableNames) :
@@ -62,6 +88,10 @@ NbrMgr::NbrMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, con
     else if ((err = nl_connect(m_nl_sock, NETLINK_ROUTE)) < 0)
     {
         SWSS_LOG_ERROR("Netlink socket connect failed, error '%s'", nl_geterror(err));
+    }
+    else
+    {
+        nl_socket_disable_auto_ack(m_nl_sock);
     }
 
     auto consumerStateTable = new swss::ConsumerStateTable(appDb, APP_NEIGH_RESOLVE_TABLE_NAME,
@@ -130,7 +160,7 @@ bool NbrMgr::setNeighbor(const string& alias, const IpAddress& ip, const MacAddr
         return false;
     }
 
-    auto flags = (NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_REPLACE);
+    auto flags = (NLM_F_REQUEST | NLM_F_CREATE | NLM_F_REPLACE);
 
     struct nlmsghdr *hdr = nlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, RTM_NEWNEIGH, 0, flags);
     if (!hdr)
@@ -275,60 +305,70 @@ bool NbrMgr::setFailedNeighborIncomplete(const string& alias, const IpAddress& i
     nd_msg->ndm_type = RTN_UNICAST;
     nd_msg->ndm_state = NUD_INCOMPLETE;
 
-    return send_message(m_nl_sock, msg);
+    return send_message_with_ack(m_nl_sock, msg);
 }
 
 bool NbrMgr::sendNeighborSolicitation(const string& alias, const IpAddress& ip)
 {
-    string command = string(NDISC6_CMD) + " -q -w 0 -1 " +
+    string command = string(NDISC6_CMD) + " -q -r 1 -w 0 " +
                      shellquote(ip.to_string()) + " " + shellquote(alias);
     string output;
     int32_t result = swss::exec(command, output);
-    if (result != 0)
+    if (result == 0 || result == NDISC6_NO_RESPONSE)
     {
-        SWSS_LOG_WARN("Failed to send neighbor solicitation for '%s' on '%s', error: %d, output: %s",
-                      ip.to_string().c_str(), alias.c_str(), result, output.c_str());
-        return false;
+        return true;
     }
 
-    return true;
+    SWSS_LOG_WARN("Failed to execute neighbor solicitation for '%s' on '%s', error: %d, output: %s",
+                  ip.to_string().c_str(), alias.c_str(), result, output.c_str());
+    return false;
 }
 
-void NbrMgr::processKernelFailedNeighbor(const string& key, const string& tableSeparator)
+task_process_status NbrMgr::processKernelFailedNeighbor(const string& key, const string& tableSeparator)
 {
     try
     {
         if (key.find(tableSeparator) == string::npos)
         {
             SWSS_LOG_ERROR("Invalid failed kernel neighbor entry '%s'", key.c_str());
+            return task_invalid_entry;
         }
-        else
-        {
-            vector<string> parsedKeys = parseAliasIp(key, tableSeparator.c_str());
-            string alias(parsedKeys[0]);
-            IpAddress ip(parsedKeys[1]);
 
-            if (ip.isV4())
-            {
-                SWSS_LOG_ERROR("Ignoring non-IPv6 failed kernel neighbor '%s'", key.c_str());
-            }
-            else if (!setFailedNeighborIncomplete(alias, ip))
-            {
-                SWSS_LOG_ERROR("Failed to move kernel neighbor '%s' to INCOMPLETE", key.c_str());
-            }
-            else if (sendNeighborSolicitation(alias, ip))
-            {
-                SWSS_LOG_NOTICE("Moved kernel neighbor '%s' to INCOMPLETE and sent one NS", key.c_str());
-            }
-            else
-            {
-                SWSS_LOG_WARN("Moved kernel neighbor '%s' to INCOMPLETE but failed to send NS", key.c_str());
-            }
+        vector<string> parsedKeys = parseAliasIp(key, tableSeparator.c_str());
+        string alias(parsedKeys[0]);
+        IpAddress ip(parsedKeys[1]);
+
+        if (alias.empty())
+        {
+            SWSS_LOG_ERROR("Invalid empty interface in failed kernel neighbor entry '%s'", key.c_str());
+            return task_invalid_entry;
         }
+
+        if (ip.isV4())
+        {
+            SWSS_LOG_ERROR("Ignoring non-IPv6 failed kernel neighbor '%s'", key.c_str());
+            return task_invalid_entry;
+        }
+
+        if (!setFailedNeighborIncomplete(alias, ip))
+        {
+            SWSS_LOG_ERROR("Failed to move kernel neighbor '%s' to INCOMPLETE, retrying", key.c_str());
+            return task_need_retry;
+        }
+
+        if (!sendNeighborSolicitation(alias, ip))
+        {
+            SWSS_LOG_WARN("Moved kernel neighbor '%s' to INCOMPLETE but failed to execute ndisc6", key.c_str());
+            return task_failed;
+        }
+
+        SWSS_LOG_NOTICE("Moved kernel neighbor '%s' to INCOMPLETE and sent one NS", key.c_str());
+        return task_success;
     }
     catch (const std::invalid_argument& e)
     {
         SWSS_LOG_ERROR("Failed to process kernel neighbor '%s': %s", key.c_str(), e.what());
+        return task_invalid_entry;
     }
 }
 
@@ -443,7 +483,12 @@ void NbrMgr::doKernelFailedNeighTask(Consumer& consumer)
         KeyOpFieldsValuesTuple t = it->second;
         if (kfvOp(t) == SET_COMMAND)
         {
-            processKernelFailedNeighbor(kfvKey(t), tableSeparator);
+            task_process_status status = processKernelFailedNeighbor(kfvKey(t), tableSeparator);
+            if (status == task_need_retry)
+            {
+                it++;
+                continue;
+            }
         }
 
         it = consumer.m_toSync.erase(it);

--- a/cfgmgr/nbrmgr.cpp
+++ b/cfgmgr/nbrmgr.cpp
@@ -19,7 +19,7 @@ using namespace swss;
 static constexpr const char *NDISC6_CMD = "/usr/bin/ndisc6";
 static constexpr int NDISC6_NO_RESPONSE = 2;
 
-static bool send_message_internal(struct nl_sock *sk, struct nl_msg *msg, bool waitForAck)
+static bool send_message(struct nl_sock *sk, struct nl_msg *msg, bool waitForAck = false)
 {
     bool rc = false;
     int err = 0;
@@ -58,16 +58,6 @@ static bool send_message_internal(struct nl_sock *sk, struct nl_msg *msg, bool w
 
     nlmsg_free(msg);
     return rc;
-}
-
-static bool send_message(struct nl_sock *sk, struct nl_msg *msg)
-{
-    return send_message_internal(sk, msg, false);
-}
-
-static bool send_message_with_ack(struct nl_sock *sk, struct nl_msg *msg)
-{
-    return send_message_internal(sk, msg, true);
 }
 
 NbrMgr::NbrMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const vector<string> &tableNames) :
@@ -305,7 +295,7 @@ bool NbrMgr::setFailedNeighborIncomplete(const string& alias, const IpAddress& i
     nd_msg->ndm_type = RTN_UNICAST;
     nd_msg->ndm_state = NUD_INCOMPLETE;
 
-    return send_message_with_ack(m_nl_sock, msg);
+    return send_message(m_nl_sock, msg, true);
 }
 
 bool NbrMgr::sendNeighborSolicitation(const string& alias, const IpAddress& ip)

--- a/cfgmgr/nbrmgr.cpp
+++ b/cfgmgr/nbrmgr.cpp
@@ -385,8 +385,9 @@ task_process_status NbrMgr::processKernelFailedNeighbor(const string& key, const
 
         if (!sendNeighborSolicitation(alias, ip))
         {
-            SWSS_LOG_WARN("Moved kernel neighbor '%s' to INCOMPLETE but failed to execute ndisc6", key.c_str());
-            return task_failed;
+            SWSS_LOG_WARN("Moved kernel neighbor '%s' to INCOMPLETE but failed to execute ndisc6, retrying",
+                          key.c_str());
+            return task_need_retry;
         }
 
         SWSS_LOG_NOTICE("Moved kernel neighbor '%s' to INCOMPLETE and sent one NS", key.c_str());

--- a/cfgmgr/nbrmgr.cpp
+++ b/cfgmgr/nbrmgr.cpp
@@ -1,6 +1,8 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <net/if.h>
+#include <sys/socket.h>
+#include <sys/time.h>
 #include <unistd.h>
 #include <linux/neighbour.h>
 #include <netlink/msg.h>
@@ -18,21 +20,52 @@ using namespace swss;
 
 static constexpr const char *NDISC6_CMD = "/usr/bin/ndisc6";
 static constexpr int NDISC6_NO_RESPONSE = 2;
+static constexpr time_t NETLINK_ACK_TIMEOUT_SEC = 1;
 
 static bool send_message(struct nl_sock *sk, struct nl_msg *msg, bool waitForAck = false)
 {
     bool rc = false;
     int err = 0;
+    struct nl_sock *ackSock = nullptr;
+    struct nl_sock *sendSock = sk;
 
     do
     {
-        if (!sk)
+        if (waitForAck)
+        {
+            ackSock = nl_socket_alloc();
+            if (!ackSock)
+            {
+                SWSS_LOG_ERROR("Netlink ACK socket alloc failed");
+                break;
+            }
+
+            if ((err = nl_connect(ackSock, NETLINK_ROUTE)) < 0)
+            {
+                SWSS_LOG_ERROR("Netlink ACK socket connect failed, error '%s'", nl_geterror(err));
+                break;
+            }
+
+            struct timeval timeout = {};
+            timeout.tv_sec = NETLINK_ACK_TIMEOUT_SEC;
+            if (setsockopt(nl_socket_get_fd(ackSock), SOL_SOCKET, SO_RCVTIMEO,
+                           &timeout, sizeof(timeout)) < 0)
+            {
+                SWSS_LOG_ERROR("Netlink ACK socket timeout configuration failed: %s",
+                               strerror(errno));
+                break;
+            }
+
+            sendSock = ackSock;
+        }
+
+        if (!sendSock)
         {
             SWSS_LOG_ERROR("Netlink socket null pointer");
             break;
         }
 
-        if ((err = nl_send_auto(sk, msg)) < 0)
+        if ((err = nl_send_auto(sendSock, msg)) < 0)
         {
             SWSS_LOG_ERROR("Netlink send message failed, error '%s'", nl_geterror(err));
             break;
@@ -42,7 +75,7 @@ static bool send_message(struct nl_sock *sk, struct nl_msg *msg, bool waitForAck
         {
             do
             {
-                err = nl_wait_for_ack(sk);
+                err = nl_wait_for_ack(sendSock);
             }
             while (err == -NLE_INTR);
 
@@ -57,6 +90,10 @@ static bool send_message(struct nl_sock *sk, struct nl_msg *msg, bool waitForAck
     } while(0);
 
     nlmsg_free(msg);
+    if (ackSock)
+    {
+        nl_socket_free(ackSock);
+    }
     return rc;
 }
 

--- a/cfgmgr/nbrmgr.h
+++ b/cfgmgr/nbrmgr.h
@@ -24,12 +24,11 @@ public:
 
 private:
     void reconcileNeighResolveTable(DBConnector *appDb);
-    void reconcileKernelFailedNeighTable();
     bool isIntfStateOk(const std::string &alias);
     bool setNeighbor(const std::string& alias, const IpAddress& ip, const MacAddress& mac);
     bool setFailedNeighborIncomplete(const std::string& alias, const IpAddress& ip);
     bool sendNeighborSolicitation(const std::string& alias, const IpAddress& ip);
-    void processKernelFailedNeighbor(const std::string& key);
+    void processKernelFailedNeighbor(const std::string& key, const std::string& tableSeparator);
 
     vector<string> parseAliasIp(const string &app_db_nbr_tbl_key, const char *delimiter);
 
@@ -46,7 +45,6 @@ private:
     bool isIntfOperUp(const std::string &alias);
     unique_ptr<Table> m_cfgVoqInbandInterfaceTable;
 
-    Table m_kernelFailedNeighTable;
     Table m_statePortTable, m_stateLagTable, m_stateVlanTable, m_stateIntfTable, m_stateNeighRestoreTable;
     struct nl_sock *m_nl_sock;
 };

--- a/cfgmgr/nbrmgr.h
+++ b/cfgmgr/nbrmgr.h
@@ -27,10 +27,9 @@ private:
     void reconcileKernelFailedNeighTable();
     bool isIntfStateOk(const std::string &alias);
     bool setNeighbor(const std::string& alias, const IpAddress& ip, const MacAddress& mac);
-    bool isFailedNeighbor(const std::string& alias, const IpAddress& ip);
     bool setFailedNeighborIncomplete(const std::string& alias, const IpAddress& ip);
     bool sendNeighborSolicitation(const std::string& alias, const IpAddress& ip);
-    void processKernelFailedNeighbor(const std::string& key, const std::vector<FieldValueTuple>& data);
+    void processKernelFailedNeighbor(const std::string& key);
 
     vector<string> parseAliasIp(const string &app_db_nbr_tbl_key, const char *delimiter);
 

--- a/cfgmgr/nbrmgr.h
+++ b/cfgmgr/nbrmgr.h
@@ -24,12 +24,18 @@ public:
 
 private:
     void reconcileNeighResolveTable(DBConnector *appDb);
+    void reconcileKernelFailedNeighTable();
     bool isIntfStateOk(const std::string &alias);
     bool setNeighbor(const std::string& alias, const IpAddress& ip, const MacAddress& mac);
+    bool isFailedNeighbor(const std::string& alias, const IpAddress& ip);
+    bool setFailedNeighborIncomplete(const std::string& alias, const IpAddress& ip);
+    bool sendNeighborSolicitation(const std::string& alias, const IpAddress& ip);
+    void processKernelFailedNeighbor(const std::string& key, const std::vector<FieldValueTuple>& data);
 
     vector<string> parseAliasIp(const string &app_db_nbr_tbl_key, const char *delimiter);
 
     void doResolveNeighTask(Consumer &consumer);
+    void doKernelFailedNeighTask(Consumer &consumer);
     void doSetNeighTask(Consumer &consumer);
     void doTask(Consumer &consumer);
     void doStateSystemNeighTask(Consumer &consumer);
@@ -41,6 +47,7 @@ private:
     bool isIntfOperUp(const std::string &alias);
     unique_ptr<Table> m_cfgVoqInbandInterfaceTable;
 
+    Table m_kernelFailedNeighTable;
     Table m_statePortTable, m_stateLagTable, m_stateVlanTable, m_stateIntfTable, m_stateNeighRestoreTable;
     struct nl_sock *m_nl_sock;
 };

--- a/cfgmgr/nbrmgr.h
+++ b/cfgmgr/nbrmgr.h
@@ -28,7 +28,7 @@ private:
     bool setNeighbor(const std::string& alias, const IpAddress& ip, const MacAddress& mac);
     bool setFailedNeighborIncomplete(const std::string& alias, const IpAddress& ip);
     bool sendNeighborSolicitation(const std::string& alias, const IpAddress& ip);
-    void processKernelFailedNeighbor(const std::string& key, const std::string& tableSeparator);
+    task_process_status processKernelFailedNeighbor(const std::string& key, const std::string& tableSeparator);
 
     vector<string> parseAliasIp(const string &app_db_nbr_tbl_key, const char *delimiter);
 

--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -26,7 +26,7 @@ using namespace swss;
 
 NeighSync::NeighSync(RedisPipeline *pipelineAppDB, DBConnector *stateDb, DBConnector *cfgDb, DBConnector *appDb) :
     m_neighTable(pipelineAppDB, APP_NEIGH_TABLE_NAME),
-    m_kernelFailedNeighTable(pipelineAppDB, APP_KERNEL_FAILED_NEIGH_TABLE_NAME),
+    m_kernelFailedNeighTable(pipelineAppDB, APP_NEIGH_FAILED_TABLE_NAME),
     m_routeTable(pipelineAppDB, APP_ROUTE_TABLE_NAME, false),
     m_routeCheckTable(appDb, APP_ROUTE_TABLE_NAME),
     m_stateNeighRestoreTable(stateDb, STATE_NEIGH_RESTORE_TABLE_NAME),

--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -24,11 +24,15 @@ using namespace swss;
 #define TENMS                   10000
 #define MAX_ROUTE_DEL_RETRY     100
 
+static constexpr int RESOLVED_NEIGH_STATES =
+    NUD_PERMANENT | NUD_NOARP | NUD_REACHABLE | NUD_PROBE | NUD_STALE | NUD_DELAY;
+
 NeighSync::NeighSync(RedisPipeline *pipelineAppDB, DBConnector *stateDb, DBConnector *cfgDb, DBConnector *appDb) :
     m_neighTable(pipelineAppDB, APP_NEIGH_TABLE_NAME),
     m_kernelFailedNeighTable(pipelineAppDB, APP_NEIGH_FAILED_TABLE_NAME),
     m_routeTable(pipelineAppDB, APP_ROUTE_TABLE_NAME, false),
     m_routeCheckTable(appDb, APP_ROUTE_TABLE_NAME),
+    m_kernelFailedNeighCheckTable(appDb, APP_NEIGH_FAILED_TABLE_NAME),
     m_stateNeighRestoreTable(stateDb, STATE_NEIGH_RESTORE_TABLE_NAME),
     m_cfgInterfaceTable(cfgDb, CFG_INTF_TABLE_NAME),
     m_cfgLagInterfaceTable(cfgDb, CFG_LAG_INTF_TABLE_NAME),
@@ -232,6 +236,30 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     key+= ipStr;
 
     int state = rtnl_neigh_get_state(neigh);
+    if (family == IPV6_NAME)
+    {
+        if (is_dualtor && nlmsg_type == RTM_NEWNEIGH && state == NUD_FAILED)
+        {
+            std::vector<FieldValueTuple> failedNeighFields = {
+                FieldValueTuple("family", family),
+            };
+            m_kernelFailedNeighTable.set(key, failedNeighFields);
+            SWSS_LOG_NOTICE("Published failed kernel neighbor '%s' for nbrmgrd processing", key.c_str());
+        }
+        else if (nlmsg_type == RTM_DELNEIGH ||
+                 ((nlmsg_type == RTM_NEWNEIGH || nlmsg_type == RTM_GETNEIGH) &&
+                  (state & RESOLVED_NEIGH_STATES)))
+        {
+            std::vector<FieldValueTuple> failedNeighFields;
+            if (m_kernelFailedNeighCheckTable.get(key, failedNeighFields))
+            {
+                m_kernelFailedNeighTable.del(key);
+                SWSS_LOG_NOTICE("Removed resolved or deleted kernel neighbor '%s' from failed neighbor table",
+                                key.c_str());
+            }
+        }
+    }
+
     /* Ignore probe msg (EVPN only) */
     if (m_isEvpnNvoExist && (nlmsg_type == RTM_NEWNEIGH) && (state == NUD_PROBE))
     {
@@ -250,15 +278,6 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     }
 
     SWSS_LOG_INFO("Get neighbor msg %s, state %d, type %d", ipStr, state, nlmsg_type);
-
-    if (is_dualtor && family == IPV6_NAME && state == NUD_FAILED && nlmsg_type == RTM_NEWNEIGH)
-    {
-        std::vector<FieldValueTuple> failedNeighFields = {
-            FieldValueTuple("family", family),
-        };
-        m_kernelFailedNeighTable.set(key, failedNeighFields);
-        SWSS_LOG_NOTICE("Published failed kernel neighbor '%s' for nbrmgrd processing", key.c_str());
-    }
 
     bool delete_key = false;
     bool use_zero_mac = false;

--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -26,6 +26,7 @@ using namespace swss;
 
 NeighSync::NeighSync(RedisPipeline *pipelineAppDB, DBConnector *stateDb, DBConnector *cfgDb, DBConnector *appDb) :
     m_neighTable(pipelineAppDB, APP_NEIGH_TABLE_NAME),
+    m_kernelFailedNeighTable(pipelineAppDB, APP_KERNEL_FAILED_NEIGH_TABLE_NAME),
     m_routeTable(pipelineAppDB, APP_ROUTE_TABLE_NAME, false),
     m_routeCheckTable(appDb, APP_ROUTE_TABLE_NAME),
     m_stateNeighRestoreTable(stateDb, STATE_NEIGH_RESTORE_TABLE_NAME),
@@ -249,6 +250,15 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     }
 
     SWSS_LOG_INFO("Get neighbor msg %s, state %d, type %d", ipStr, state, nlmsg_type);
+
+    if (is_dualtor && family == IPV6_NAME && state == NUD_FAILED && nlmsg_type == RTM_NEWNEIGH)
+    {
+        std::vector<FieldValueTuple> failedNeighFields = {
+            FieldValueTuple("family", family),
+        };
+        m_kernelFailedNeighTable.set(key, failedNeighFields);
+        SWSS_LOG_NOTICE("Published failed kernel neighbor '%s' for nbrmgrd processing", key.c_str());
+    }
 
     bool delete_key = false;
     bool use_zero_mac = false;

--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -236,9 +236,9 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     key+= ipStr;
 
     int state = rtnl_neigh_get_state(neigh);
-    if (family == IPV6_NAME)
+    if (is_dualtor && family == IPV6_NAME)
     {
-        if (is_dualtor && nlmsg_type == RTM_NEWNEIGH && state == NUD_FAILED)
+        if (nlmsg_type == RTM_NEWNEIGH && state == NUD_FAILED)
         {
             std::vector<FieldValueTuple> failedNeighFields = {
                 FieldValueTuple("NULL", "NULL"),

--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -241,7 +241,7 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
         if (is_dualtor && nlmsg_type == RTM_NEWNEIGH && state == NUD_FAILED)
         {
             std::vector<FieldValueTuple> failedNeighFields = {
-                FieldValueTuple("family", family),
+                FieldValueTuple("NULL", "NULL"),
             };
             m_kernelFailedNeighTable.set(key, failedNeighFields);
             SWSS_LOG_NOTICE("Published failed kernel neighbor '%s' for nbrmgrd processing", key.c_str());

--- a/neighsyncd/neighsync.h
+++ b/neighsyncd/neighsync.h
@@ -49,6 +49,7 @@ public:
 private:
     Table m_stateNeighRestoreTable, m_cfgPeerSwitchTable, m_routeCheckTable;
     ProducerStateTable m_neighTable;
+    ProducerStateTable m_kernelFailedNeighTable;
     ProducerStateTable m_routeTable;
     SubscriberStateTable m_cfgEvpnNvoTable;
     struct nl_cache    *m_link_cache;

--- a/neighsyncd/neighsync.h
+++ b/neighsyncd/neighsync.h
@@ -47,7 +47,7 @@ public:
     void processCfgEvpnNvo();
 
 private:
-    Table m_stateNeighRestoreTable, m_cfgPeerSwitchTable, m_routeCheckTable;
+    Table m_stateNeighRestoreTable, m_cfgPeerSwitchTable, m_routeCheckTable, m_kernelFailedNeighCheckTable;
     ProducerStateTable m_neighTable;
     ProducerStateTable m_kernelFailedNeighTable;
     ProducerStateTable m_routeTable;

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -416,8 +416,7 @@ tests_nbrmgrd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/cfgmgr -I$(top_srcdir
 tests_nbrmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
 tests_nbrmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_nbrmgrd_INCLUDES)
 tests_nbrmgrd_CXXFLAGS = -Wl,-wrap,nl_socket_alloc -Wl,-wrap,nl_connect -Wl,-wrap,nl_send_auto \
-        -Wl,-wrap,if_nametoindex -Wl,-wrap,nlmsg_alloc -Wl,-wrap,rtnl_neigh_alloc_cache \
-        -Wl,-wrap,rtnl_neigh_get -Wl,-wrap,nl_cache_free
+        -Wl,-wrap,if_nametoindex -Wl,-wrap,nlmsg_alloc
 tests_nbrmgrd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
         -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lgmock_main
 

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -9,9 +9,9 @@ CXXFLAGS = -g -O0
 
 CFLAGS_SAI = -I /usr/include/sai
 
-TESTS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_fdbsyncd tests_response_publisher tests_nbrmgrd tests_teamsyncd
+TESTS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_fdbsyncd tests_neighsyncd tests_response_publisher tests_nbrmgrd tests_teamsyncd
 
-noinst_PROGRAMS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_fdbsyncd tests_response_publisher tests_nbrmgrd tests_teamsyncd
+noinst_PROGRAMS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_fdbsyncd tests_neighsyncd tests_response_publisher tests_nbrmgrd tests_teamsyncd
 
 LDADD_SAI = -lsaivs -lsairedis -lsaimeta -lsaimetadata
 
@@ -360,6 +360,24 @@ tests_fdbsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTE
 tests_fdbsyncd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
         -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lgmock_main
 
+## neighsyncd unit tests
+
+tests_neighsyncd_SOURCES = neighsyncd/neighsync_ut.cpp \
+                           fdbsyncd/fake_warmstartassist.cpp \
+                           fdbsyncd/fake_producerstatetable.cpp \
+                           fdbsyncd/fake_subscriberstatetable.cpp \
+                           mock_dbconnector.cpp \
+                           mock_table.cpp \
+                           mock_hiredis.cpp \
+                           mock_redisreply.cpp \
+                           $(top_srcdir)/neighsyncd/neighsync.cpp
+
+tests_neighsyncd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/neighsyncd
+tests_neighsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST)
+tests_neighsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(tests_neighsyncd_INCLUDES)
+tests_neighsyncd_LDADD = $(LDADD_GTEST) -lnl-genl-3 -lhiredis \
+        -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lgmock_main
+
 ## response publisher unit tests
 
 tests_response_publisher_SOURCES = response_publisher/response_publisher_ut.cpp \
@@ -397,7 +415,9 @@ tests_nbrmgrd_SOURCES = nbrmgrd/nbrmgr_ut.cpp \
 tests_nbrmgrd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/cfgmgr -I$(top_srcdir)/lib
 tests_nbrmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
 tests_nbrmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_nbrmgrd_INCLUDES)
-tests_nbrmgrd_CXXFLAGS = -Wl,-wrap,nl_socket_alloc -Wl,-wrap,nl_connect -Wl,-wrap,nl_send_auto -Wl,-wrap,if_nametoindex -Wl,-wrap,nlmsg_alloc
+tests_nbrmgrd_CXXFLAGS = -Wl,-wrap,nl_socket_alloc -Wl,-wrap,nl_connect -Wl,-wrap,nl_send_auto \
+        -Wl,-wrap,if_nametoindex -Wl,-wrap,nlmsg_alloc -Wl,-wrap,rtnl_neigh_alloc_cache \
+        -Wl,-wrap,rtnl_neigh_get -Wl,-wrap,nl_cache_free
 tests_nbrmgrd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
         -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lgmock_main
 

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -416,6 +416,7 @@ tests_nbrmgrd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/cfgmgr -I$(top_srcdir
 tests_nbrmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
 tests_nbrmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_nbrmgrd_INCLUDES)
 tests_nbrmgrd_CXXFLAGS = -Wl,-wrap,nl_socket_alloc -Wl,-wrap,nl_connect -Wl,-wrap,nl_send_auto \
+        -Wl,-wrap,nl_wait_for_ack -Wl,-wrap,nl_socket_disable_auto_ack \
         -Wl,-wrap,if_nametoindex -Wl,-wrap,nlmsg_alloc
 tests_nbrmgrd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
         -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lgmock_main

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -418,7 +418,8 @@ tests_nbrmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTES
 tests_nbrmgrd_CXXFLAGS = -Wl,-wrap,nl_socket_alloc -Wl,-wrap,nl_socket_free \
         -Wl,-wrap,nl_connect -Wl,-wrap,nl_send_auto -Wl,-wrap,nl_wait_for_ack \
         -Wl,-wrap,nl_socket_disable_auto_ack -Wl,-wrap,nl_socket_get_fd \
-        -Wl,-wrap,setsockopt -Wl,-wrap,if_nametoindex -Wl,-wrap,nlmsg_alloc
+        -Wl,-wrap,setsockopt -Wl,-wrap,__setsockopt64 \
+        -Wl,-wrap,if_nametoindex -Wl,-wrap,nlmsg_alloc
 tests_nbrmgrd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
         -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lgmock_main
 

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -415,9 +415,10 @@ tests_nbrmgrd_SOURCES = nbrmgrd/nbrmgr_ut.cpp \
 tests_nbrmgrd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/cfgmgr -I$(top_srcdir)/lib
 tests_nbrmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
 tests_nbrmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_nbrmgrd_INCLUDES)
-tests_nbrmgrd_CXXFLAGS = -Wl,-wrap,nl_socket_alloc -Wl,-wrap,nl_connect -Wl,-wrap,nl_send_auto \
-        -Wl,-wrap,nl_wait_for_ack -Wl,-wrap,nl_socket_disable_auto_ack \
-        -Wl,-wrap,if_nametoindex -Wl,-wrap,nlmsg_alloc
+tests_nbrmgrd_CXXFLAGS = -Wl,-wrap,nl_socket_alloc -Wl,-wrap,nl_socket_free \
+        -Wl,-wrap,nl_connect -Wl,-wrap,nl_send_auto -Wl,-wrap,nl_wait_for_ack \
+        -Wl,-wrap,nl_socket_disable_auto_ack -Wl,-wrap,nl_socket_get_fd \
+        -Wl,-wrap,setsockopt -Wl,-wrap,if_nametoindex -Wl,-wrap,nlmsg_alloc
 tests_nbrmgrd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
         -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lgmock_main
 

--- a/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
+++ b/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
@@ -143,13 +143,13 @@ namespace nbrmgr_ut
 
         void addFailedNeighborRequest(const std::string &key, const std::string &family = IPV6_NAME)
         {
-            swss::Table failedNeighTable(m_app_db.get(), APP_KERNEL_FAILED_NEIGH_TABLE_NAME);
+            swss::Table failedNeighTable(m_app_db.get(), APP_NEIGH_FAILED_TABLE_NAME);
             failedNeighTable.set(key, {{"family", family}});
         }
 
         void expectFailedNeighborTableEmpty()
         {
-            swss::Table failedNeighTable(m_app_db.get(), APP_KERNEL_FAILED_NEIGH_TABLE_NAME);
+            swss::Table failedNeighTable(m_app_db.get(), APP_NEIGH_FAILED_TABLE_NAME);
             std::vector<std::string> keys;
             failedNeighTable.getKeys(keys);
             EXPECT_TRUE(keys.empty());

--- a/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
+++ b/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
@@ -147,12 +147,11 @@ namespace nbrmgr_ut
             failedNeighTable.set(key, {{"family", family}});
         }
 
-        void expectFailedNeighborTableEmpty()
+        void expectFailedNeighborEntry(const std::string& key)
         {
             swss::Table failedNeighTable(m_app_db.get(), APP_NEIGH_FAILED_TABLE_NAME);
-            std::vector<std::string> keys;
-            failedNeighTable.getKeys(keys);
-            EXPECT_TRUE(keys.empty());
+            std::vector<swss::FieldValueTuple> values;
+            EXPECT_TRUE(failedNeighTable.get(key, values));
         }
     };
 
@@ -285,10 +284,10 @@ namespace nbrmgr_ut
         ASSERT_EQ(mockCallArgs.size(), 1u);
         EXPECT_EQ(mockCallArgs[0], "/usr/bin/ndisc6 -q -w 0 -1 \"2001:db8::1\" \"Vlan1000\"");
         EXPECT_EQ(operationOrder, (std::vector<std::string>{"netlink", "ndisc6"}));
-        expectFailedNeighborTableEmpty();
+        expectFailedNeighborEntry("Vlan1000:2001:db8::1");
     }
 
-    TEST_F(NbrMgrTest, NetlinkFailureSkipsSolicitationAndDeletesRequest)
+    TEST_F(NbrMgrTest, NetlinkFailureSkipsSolicitationAndKeepsRequest)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
         swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
@@ -300,10 +299,10 @@ namespace nbrmgr_ut
         ASSERT_EQ(capturedNeighborRequests.size(), 1u);
         EXPECT_TRUE(mockCallArgs.empty());
         EXPECT_EQ(operationOrder, (std::vector<std::string>{"netlink"}));
-        expectFailedNeighborTableEmpty();
+        expectFailedNeighborEntry("Vlan1000:2001:db8::2");
     }
 
-    TEST_F(NbrMgrTest, SolicitationFailureDeletesRequest)
+    TEST_F(NbrMgrTest, SolicitationFailureKeepsRequest)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
         swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
@@ -314,10 +313,10 @@ namespace nbrmgr_ut
 
         EXPECT_EQ(capturedNeighborRequests.size(), 1u);
         EXPECT_EQ(mockCallArgs.size(), 1u);
-        expectFailedNeighborTableEmpty();
+        expectFailedNeighborEntry("Vlan1000:2001:db8::3");
     }
 
-    TEST_F(NbrMgrTest, StaleNeighborDeletesRequestWithoutUpdate)
+    TEST_F(NbrMgrTest, StaleNeighborKeepsRequestWithoutUpdate)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
         swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
@@ -328,7 +327,7 @@ namespace nbrmgr_ut
 
         EXPECT_TRUE(capturedNeighborRequests.empty());
         EXPECT_TRUE(mockCallArgs.empty());
-        expectFailedNeighborTableEmpty();
+        expectFailedNeighborEntry("Vlan1000:2001:db8::4");
     }
 
     TEST_F(NbrMgrTest, RejectsIpv4FailedNeighborRequest)
@@ -341,7 +340,7 @@ namespace nbrmgr_ut
 
         EXPECT_TRUE(capturedNeighborRequests.empty());
         EXPECT_TRUE(mockCallArgs.empty());
-        expectFailedNeighborTableEmpty();
+        expectFailedNeighborEntry("Vlan1000:192.0.2.1");
     }
 
     TEST_F(NbrMgrTest, RejectsMalformedFailedNeighborRequest)
@@ -354,7 +353,7 @@ namespace nbrmgr_ut
 
         EXPECT_TRUE(capturedNeighborRequests.empty());
         EXPECT_TRUE(mockCallArgs.empty());
-        expectFailedNeighborTableEmpty();
+        expectFailedNeighborEntry("invalid-key");
     }
 
     TEST_F(NbrMgrTest, ReconcilesPendingFailedNeighborRequest)
@@ -366,7 +365,7 @@ namespace nbrmgr_ut
 
         EXPECT_EQ(capturedNeighborRequests.size(), 1u);
         EXPECT_EQ(mockCallArgs.size(), 1u);
-        expectFailedNeighborTableEmpty();
+        expectFailedNeighborEntry("Vlan1000:2001:db8::5");
     }
 
     TEST_F(NbrMgrTest, ExistingResolvePathStillUsesNtfUse)

--- a/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
+++ b/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
@@ -6,9 +6,7 @@
 #include <net/if.h>
 #include "../mock_table.h"
 #include "warm_restart.h"
-#define private public
 #include "nbrmgr.h"
-#undef private
 
 extern int (*callback)(const std::string &cmd, std::string &stdout);
 extern std::vector<std::string> mockCallArgs;
@@ -86,6 +84,13 @@ int noop_cb(const std::string &cmd, std::string &out){
 
 namespace nbrmgr_ut
 {
+    class TestableNbrMgr : public swss::NbrMgr
+    {
+    public:
+        using swss::NbrMgr::NbrMgr;
+        using Orch::getExecutor;
+    };
+
     struct NbrMgrTest : public ::testing::Test
     {
         std::shared_ptr<swss::DBConnector> m_config_db;
@@ -110,17 +115,16 @@ namespace nbrmgr_ut
             callback = noop_cb;
         }
 
-        void addFailedNeighborRequest(const std::string &key)
+        void processFailedNeighborRequest(TestableNbrMgr& nbrmgr, const std::string& key)
         {
             swss::Table failedNeighTable(m_app_db.get(), APP_NEIGH_FAILED_TABLE_NAME);
             failedNeighTable.set(key, {{"NULL", "NULL"}});
-        }
-
-        void expectFailedNeighborEntry(const std::string& key)
-        {
-            swss::Table failedNeighTable(m_app_db.get(), APP_NEIGH_FAILED_TABLE_NAME);
             std::vector<swss::FieldValueTuple> values;
-            EXPECT_TRUE(failedNeighTable.get(key, values));
+            ASSERT_TRUE(failedNeighTable.get(key, values));
+
+            auto executor = nbrmgr.getExecutor(APP_NEIGH_FAILED_TABLE_NAME);
+            ASSERT_NE(executor, nullptr);
+            executor->execute();
         }
     };
 
@@ -237,10 +241,8 @@ namespace nbrmgr_ut
     TEST_F(NbrMgrTest, ProcessFailedIpv6Neighbor)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
-        swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
-        addFailedNeighborRequest("Vlan1000:2001:db8::1");
-
-        nbrmgr.processKernelFailedNeighbor("Vlan1000:2001:db8::1", ":");
+        TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
+        processFailedNeighborRequest(nbrmgr, "Vlan1000:2001:db8::1");
 
         ASSERT_EQ(capturedNeighborRequests.size(), 1u);
         EXPECT_EQ(capturedNeighborRequests[0].state, NUD_INCOMPLETE);
@@ -253,86 +255,48 @@ namespace nbrmgr_ut
         ASSERT_EQ(mockCallArgs.size(), 1u);
         EXPECT_EQ(mockCallArgs[0], "/usr/bin/ndisc6 -q -w 0 -1 \"2001:db8::1\" \"Vlan1000\"");
         EXPECT_EQ(operationOrder, (std::vector<std::string>{"netlink", "ndisc6"}));
-        expectFailedNeighborEntry("Vlan1000:2001:db8::1");
     }
 
-    TEST_F(NbrMgrTest, NetlinkFailureSkipsSolicitationAndKeepsRequest)
+    TEST_F(NbrMgrTest, NetlinkFailureSkipsSolicitation)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
-        swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
-        addFailedNeighborRequest("Vlan1000:2001:db8::2");
+        TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
         mockNlSendResult = -NLE_FAILURE;
-
-        nbrmgr.processKernelFailedNeighbor("Vlan1000:2001:db8::2", ":");
+        processFailedNeighborRequest(nbrmgr, "Vlan1000:2001:db8::2");
 
         ASSERT_EQ(capturedNeighborRequests.size(), 1u);
         EXPECT_TRUE(mockCallArgs.empty());
         EXPECT_EQ(operationOrder, (std::vector<std::string>{"netlink"}));
-        expectFailedNeighborEntry("Vlan1000:2001:db8::2");
     }
 
-    TEST_F(NbrMgrTest, SolicitationFailureKeepsRequest)
+    TEST_F(NbrMgrTest, SolicitationFailureAfterNetlinkUpdate)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
-        swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
-        addFailedNeighborRequest("Vlan1000:2001:db8::3");
+        TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
         mockExecResult = 1;
-
-        nbrmgr.processKernelFailedNeighbor("Vlan1000:2001:db8::3", ":");
+        processFailedNeighborRequest(nbrmgr, "Vlan1000:2001:db8::3");
 
         EXPECT_EQ(capturedNeighborRequests.size(), 1u);
         EXPECT_EQ(mockCallArgs.size(), 1u);
-        expectFailedNeighborEntry("Vlan1000:2001:db8::3");
     }
 
     TEST_F(NbrMgrTest, RejectsIpv4FailedNeighborRequest)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
-        swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
-        addFailedNeighborRequest("Vlan1000:192.0.2.1");
-
-        nbrmgr.processKernelFailedNeighbor("Vlan1000:192.0.2.1", ":");
+        TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
+        processFailedNeighborRequest(nbrmgr, "Vlan1000:192.0.2.1");
 
         EXPECT_TRUE(capturedNeighborRequests.empty());
         EXPECT_TRUE(mockCallArgs.empty());
-        expectFailedNeighborEntry("Vlan1000:192.0.2.1");
     }
 
     TEST_F(NbrMgrTest, RejectsMalformedFailedNeighborRequest)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
-        swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
-        addFailedNeighborRequest("invalid-key");
-
-        nbrmgr.processKernelFailedNeighbor("invalid-key", ":");
+        TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
+        processFailedNeighborRequest(nbrmgr, "invalid-key");
 
         EXPECT_TRUE(capturedNeighborRequests.empty());
         EXPECT_TRUE(mockCallArgs.empty());
-        expectFailedNeighborEntry("invalid-key");
-    }
-
-    TEST_F(NbrMgrTest, DoesNotReprocessExistingFailedNeighborAtStartup)
-    {
-        std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
-        addFailedNeighborRequest("Vlan1000:2001:db8::5");
-
-        swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
-
-        EXPECT_TRUE(capturedNeighborRequests.empty());
-        EXPECT_TRUE(mockCallArgs.empty());
-        expectFailedNeighborEntry("Vlan1000:2001:db8::5");
-    }
-
-    TEST_F(NbrMgrTest, ExistingResolvePathStillUsesNtfUse)
-    {
-        std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
-        swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
-        swss::MacAddress mac;
-
-        ASSERT_TRUE(nbrmgr.setNeighbor("Vlan1000", swss::IpAddress("2001:db8::6"), mac));
-
-        ASSERT_EQ(capturedNeighborRequests.size(), 1u);
-        EXPECT_EQ(capturedNeighborRequests[0].state, NUD_DELAY);
-        EXPECT_NE(capturedNeighborRequests[0].neighborFlags & NTF_USE, 0u);
     }
 }

--- a/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
+++ b/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
@@ -2,6 +2,8 @@
 #include <iostream>
 #include <netlink/netlink.h>
 #include <netlink/msg.h>
+#include <netlink/route/neighbour.h>
+#include <linux/neighbour.h>
 #include <net/if.h>
 #include "../mock_table.h"
 #include "warm_restart.h"
@@ -12,8 +14,21 @@
 extern int (*callback)(const std::string &cmd, std::string &stdout);
 extern std::vector<std::string> mockCallArgs;
 
-/* Track netlink neighbor resolve calls */
-static std::vector<std::string> neighResolvedKeys;
+struct CapturedNeighborRequest
+{
+    int state;
+    unsigned int neighborFlags;
+    int family;
+    int messageFlags;
+};
+
+static std::vector<CapturedNeighborRequest> capturedNeighborRequests;
+static std::vector<std::string> operationOrder;
+static int mockNlSendResult;
+static int mockKernelNeighborState;
+static bool mockKernelNeighborExists;
+static int mockNeighCacheResult;
+static int mockExecResult;
 
 /*
  * Wrap netlink and interface functions to avoid real kernel interaction.
@@ -37,8 +52,12 @@ int __wrap_nl_connect(struct nl_sock *sk, int protocol)
 
 int __wrap_nl_send_auto(struct nl_sock *sk, struct nl_msg *msg)
 {
-    /* Record that a neighbor resolve was attempted */
-    return 0;
+    struct nlmsghdr *hdr = nlmsg_hdr(msg);
+    struct ndmsg *nd = static_cast<struct ndmsg *>(NLMSG_DATA(hdr));
+    capturedNeighborRequests.push_back(
+        {nd->ndm_state, nd->ndm_flags, nd->ndm_family, hdr->nlmsg_flags});
+    operationOrder.push_back("netlink");
+    return mockNlSendResult;
 }
 
 /* Control whether nlmsg_alloc returns NULL to simulate setNeighbor failure */
@@ -61,11 +80,36 @@ unsigned int __wrap_if_nametoindex(const char *ifname)
     return 1;
 }
 
+int __wrap_rtnl_neigh_alloc_cache(struct nl_sock *sk, struct nl_cache **result)
+{
+    static char fake_cache_mem[256];
+    *result = reinterpret_cast<struct nl_cache *>(fake_cache_mem);
+    return mockNeighCacheResult;
+}
+
+struct rtnl_neigh *__wrap_rtnl_neigh_get(struct nl_cache *cache, int ifindex, struct nl_addr *dst)
+{
+    if (!mockKernelNeighborExists)
+    {
+        return nullptr;
+    }
+
+    struct rtnl_neigh *neigh = rtnl_neigh_alloc();
+    rtnl_neigh_unset_state(neigh, -1);
+    rtnl_neigh_set_state(neigh, mockKernelNeighborState);
+    return neigh;
+}
+
+void __wrap_nl_cache_free(struct nl_cache *cache)
+{
+}
+
 }
 
 int noop_cb(const std::string &cmd, std::string &out){
     mockCallArgs.push_back(cmd);
-    return 0;
+    operationOrder.push_back("ndisc6");
+    return mockExecResult;
 }
 
 namespace nbrmgr_ut
@@ -86,9 +130,29 @@ namespace nbrmgr_ut
             swss::WarmStart::initialize("nbrmgrd", "swss");
 
             mockCallArgs.clear();
-            neighResolvedKeys.clear();
+            capturedNeighborRequests.clear();
+            operationOrder.clear();
             mock_nlmsg_alloc_fail = false;
+            mockNlSendResult = 0;
+            mockKernelNeighborState = NUD_FAILED;
+            mockKernelNeighborExists = true;
+            mockNeighCacheResult = 0;
+            mockExecResult = 0;
             callback = noop_cb;
+        }
+
+        void addFailedNeighborRequest(const std::string &key, const std::string &family = IPV6_NAME)
+        {
+            swss::Table failedNeighTable(m_app_db.get(), APP_KERNEL_FAILED_NEIGH_TABLE_NAME);
+            failedNeighTable.set(key, {{"family", family}});
+        }
+
+        void expectFailedNeighborTableEmpty()
+        {
+            swss::Table failedNeighTable(m_app_db.get(), APP_KERNEL_FAILED_NEIGH_TABLE_NAME);
+            std::vector<std::string> keys;
+            failedNeighTable.getKeys(keys);
+            EXPECT_TRUE(keys.empty());
         }
     };
 
@@ -200,5 +264,121 @@ namespace nbrmgr_ut
 
         /* Should not crash; failures are logged as warnings */
         swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
+    }
+
+    TEST_F(NbrMgrTest, ProcessFailedIpv6Neighbor)
+    {
+        std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+        swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
+        addFailedNeighborRequest("Vlan1000:2001:db8::1");
+
+        nbrmgr.processKernelFailedNeighbor("Vlan1000:2001:db8::1", {{"family", IPV6_NAME}});
+
+        ASSERT_EQ(capturedNeighborRequests.size(), 1u);
+        EXPECT_EQ(capturedNeighborRequests[0].state, NUD_INCOMPLETE);
+        EXPECT_EQ(capturedNeighborRequests[0].neighborFlags, 0u);
+        EXPECT_EQ(capturedNeighborRequests[0].family, AF_INET6);
+        EXPECT_EQ(capturedNeighborRequests[0].messageFlags & NLM_F_CREATE, 0);
+        EXPECT_NE(capturedNeighborRequests[0].messageFlags & NLM_F_REPLACE, 0);
+        EXPECT_NE(capturedNeighborRequests[0].messageFlags & NLM_F_ACK, 0);
+
+        ASSERT_EQ(mockCallArgs.size(), 1u);
+        EXPECT_EQ(mockCallArgs[0], "/usr/bin/ndisc6 -q -w 0 -1 \"2001:db8::1\" \"Vlan1000\"");
+        EXPECT_EQ(operationOrder, (std::vector<std::string>{"netlink", "ndisc6"}));
+        expectFailedNeighborTableEmpty();
+    }
+
+    TEST_F(NbrMgrTest, NetlinkFailureSkipsSolicitationAndDeletesRequest)
+    {
+        std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+        swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
+        addFailedNeighborRequest("Vlan1000:2001:db8::2");
+        mockNlSendResult = -NLE_FAILURE;
+
+        nbrmgr.processKernelFailedNeighbor("Vlan1000:2001:db8::2", {{"family", IPV6_NAME}});
+
+        ASSERT_EQ(capturedNeighborRequests.size(), 1u);
+        EXPECT_TRUE(mockCallArgs.empty());
+        EXPECT_EQ(operationOrder, (std::vector<std::string>{"netlink"}));
+        expectFailedNeighborTableEmpty();
+    }
+
+    TEST_F(NbrMgrTest, SolicitationFailureDeletesRequest)
+    {
+        std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+        swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
+        addFailedNeighborRequest("Vlan1000:2001:db8::3");
+        mockExecResult = 1;
+
+        nbrmgr.processKernelFailedNeighbor("Vlan1000:2001:db8::3", {{"family", IPV6_NAME}});
+
+        EXPECT_EQ(capturedNeighborRequests.size(), 1u);
+        EXPECT_EQ(mockCallArgs.size(), 1u);
+        expectFailedNeighborTableEmpty();
+    }
+
+    TEST_F(NbrMgrTest, StaleNeighborDeletesRequestWithoutUpdate)
+    {
+        std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+        swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
+        addFailedNeighborRequest("Vlan1000:2001:db8::4");
+        mockKernelNeighborState = NUD_REACHABLE;
+
+        nbrmgr.processKernelFailedNeighbor("Vlan1000:2001:db8::4", {{"family", IPV6_NAME}});
+
+        EXPECT_TRUE(capturedNeighborRequests.empty());
+        EXPECT_TRUE(mockCallArgs.empty());
+        expectFailedNeighborTableEmpty();
+    }
+
+    TEST_F(NbrMgrTest, RejectsIpv4FailedNeighborRequest)
+    {
+        std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+        swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
+        addFailedNeighborRequest("Vlan1000:192.0.2.1", IPV4_NAME);
+
+        nbrmgr.processKernelFailedNeighbor("Vlan1000:192.0.2.1", {{"family", IPV4_NAME}});
+
+        EXPECT_TRUE(capturedNeighborRequests.empty());
+        EXPECT_TRUE(mockCallArgs.empty());
+        expectFailedNeighborTableEmpty();
+    }
+
+    TEST_F(NbrMgrTest, RejectsMalformedFailedNeighborRequest)
+    {
+        std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+        swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
+        addFailedNeighborRequest("invalid-key");
+
+        nbrmgr.processKernelFailedNeighbor("invalid-key", {{"family", IPV6_NAME}});
+
+        EXPECT_TRUE(capturedNeighborRequests.empty());
+        EXPECT_TRUE(mockCallArgs.empty());
+        expectFailedNeighborTableEmpty();
+    }
+
+    TEST_F(NbrMgrTest, ReconcilesPendingFailedNeighborRequest)
+    {
+        std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+        addFailedNeighborRequest("Vlan1000:2001:db8::5");
+
+        swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
+
+        EXPECT_EQ(capturedNeighborRequests.size(), 1u);
+        EXPECT_EQ(mockCallArgs.size(), 1u);
+        expectFailedNeighborTableEmpty();
+    }
+
+    TEST_F(NbrMgrTest, ExistingResolvePathStillUsesNtfUse)
+    {
+        std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+        swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
+        swss::MacAddress mac;
+
+        ASSERT_TRUE(nbrmgr.setNeighbor("Vlan1000", swss::IpAddress("2001:db8::6"), mac));
+
+        ASSERT_EQ(capturedNeighborRequests.size(), 1u);
+        EXPECT_EQ(capturedNeighborRequests[0].state, NUD_DELAY);
+        EXPECT_NE(capturedNeighborRequests[0].neighborFlags & NTF_USE, 0u);
     }
 }

--- a/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
+++ b/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <netlink/netlink.h>
 #include <netlink/msg.h>
-#include <netlink/route/neighbour.h>
 #include <linux/neighbour.h>
 #include <net/if.h>
 #include "../mock_table.h"
@@ -25,9 +24,6 @@ struct CapturedNeighborRequest
 static std::vector<CapturedNeighborRequest> capturedNeighborRequests;
 static std::vector<std::string> operationOrder;
 static int mockNlSendResult;
-static int mockKernelNeighborState;
-static bool mockKernelNeighborExists;
-static int mockNeighCacheResult;
 static int mockExecResult;
 
 /*
@@ -80,30 +76,6 @@ unsigned int __wrap_if_nametoindex(const char *ifname)
     return 1;
 }
 
-int __wrap_rtnl_neigh_alloc_cache(struct nl_sock *sk, struct nl_cache **result)
-{
-    static char fake_cache_mem[256];
-    *result = reinterpret_cast<struct nl_cache *>(fake_cache_mem);
-    return mockNeighCacheResult;
-}
-
-struct rtnl_neigh *__wrap_rtnl_neigh_get(struct nl_cache *cache, int ifindex, struct nl_addr *dst)
-{
-    if (!mockKernelNeighborExists)
-    {
-        return nullptr;
-    }
-
-    struct rtnl_neigh *neigh = rtnl_neigh_alloc();
-    rtnl_neigh_unset_state(neigh, -1);
-    rtnl_neigh_set_state(neigh, mockKernelNeighborState);
-    return neigh;
-}
-
-void __wrap_nl_cache_free(struct nl_cache *cache)
-{
-}
-
 }
 
 int noop_cb(const std::string &cmd, std::string &out){
@@ -134,17 +106,14 @@ namespace nbrmgr_ut
             operationOrder.clear();
             mock_nlmsg_alloc_fail = false;
             mockNlSendResult = 0;
-            mockKernelNeighborState = NUD_FAILED;
-            mockKernelNeighborExists = true;
-            mockNeighCacheResult = 0;
             mockExecResult = 0;
             callback = noop_cb;
         }
 
-        void addFailedNeighborRequest(const std::string &key, const std::string &family = IPV6_NAME)
+        void addFailedNeighborRequest(const std::string &key)
         {
             swss::Table failedNeighTable(m_app_db.get(), APP_NEIGH_FAILED_TABLE_NAME);
-            failedNeighTable.set(key, {{"family", family}});
+            failedNeighTable.set(key, {{"NULL", "NULL"}});
         }
 
         void expectFailedNeighborEntry(const std::string& key)
@@ -271,7 +240,7 @@ namespace nbrmgr_ut
         swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
         addFailedNeighborRequest("Vlan1000:2001:db8::1");
 
-        nbrmgr.processKernelFailedNeighbor("Vlan1000:2001:db8::1", {{"family", IPV6_NAME}});
+        nbrmgr.processKernelFailedNeighbor("Vlan1000:2001:db8::1");
 
         ASSERT_EQ(capturedNeighborRequests.size(), 1u);
         EXPECT_EQ(capturedNeighborRequests[0].state, NUD_INCOMPLETE);
@@ -294,7 +263,7 @@ namespace nbrmgr_ut
         addFailedNeighborRequest("Vlan1000:2001:db8::2");
         mockNlSendResult = -NLE_FAILURE;
 
-        nbrmgr.processKernelFailedNeighbor("Vlan1000:2001:db8::2", {{"family", IPV6_NAME}});
+        nbrmgr.processKernelFailedNeighbor("Vlan1000:2001:db8::2");
 
         ASSERT_EQ(capturedNeighborRequests.size(), 1u);
         EXPECT_TRUE(mockCallArgs.empty());
@@ -309,34 +278,20 @@ namespace nbrmgr_ut
         addFailedNeighborRequest("Vlan1000:2001:db8::3");
         mockExecResult = 1;
 
-        nbrmgr.processKernelFailedNeighbor("Vlan1000:2001:db8::3", {{"family", IPV6_NAME}});
+        nbrmgr.processKernelFailedNeighbor("Vlan1000:2001:db8::3");
 
         EXPECT_EQ(capturedNeighborRequests.size(), 1u);
         EXPECT_EQ(mockCallArgs.size(), 1u);
         expectFailedNeighborEntry("Vlan1000:2001:db8::3");
     }
 
-    TEST_F(NbrMgrTest, StaleNeighborKeepsRequestWithoutUpdate)
-    {
-        std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
-        swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
-        addFailedNeighborRequest("Vlan1000:2001:db8::4");
-        mockKernelNeighborState = NUD_REACHABLE;
-
-        nbrmgr.processKernelFailedNeighbor("Vlan1000:2001:db8::4", {{"family", IPV6_NAME}});
-
-        EXPECT_TRUE(capturedNeighborRequests.empty());
-        EXPECT_TRUE(mockCallArgs.empty());
-        expectFailedNeighborEntry("Vlan1000:2001:db8::4");
-    }
-
     TEST_F(NbrMgrTest, RejectsIpv4FailedNeighborRequest)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
         swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
-        addFailedNeighborRequest("Vlan1000:192.0.2.1", IPV4_NAME);
+        addFailedNeighborRequest("Vlan1000:192.0.2.1");
 
-        nbrmgr.processKernelFailedNeighbor("Vlan1000:192.0.2.1", {{"family", IPV4_NAME}});
+        nbrmgr.processKernelFailedNeighbor("Vlan1000:192.0.2.1");
 
         EXPECT_TRUE(capturedNeighborRequests.empty());
         EXPECT_TRUE(mockCallArgs.empty());
@@ -349,7 +304,7 @@ namespace nbrmgr_ut
         swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
         addFailedNeighborRequest("invalid-key");
 
-        nbrmgr.processKernelFailedNeighbor("invalid-key", {{"family", IPV6_NAME}});
+        nbrmgr.processKernelFailedNeighbor("invalid-key");
 
         EXPECT_TRUE(capturedNeighborRequests.empty());
         EXPECT_TRUE(mockCallArgs.empty());

--- a/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
+++ b/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
@@ -240,7 +240,7 @@ namespace nbrmgr_ut
         swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
         addFailedNeighborRequest("Vlan1000:2001:db8::1");
 
-        nbrmgr.processKernelFailedNeighbor("Vlan1000:2001:db8::1");
+        nbrmgr.processKernelFailedNeighbor("Vlan1000:2001:db8::1", ":");
 
         ASSERT_EQ(capturedNeighborRequests.size(), 1u);
         EXPECT_EQ(capturedNeighborRequests[0].state, NUD_INCOMPLETE);
@@ -263,7 +263,7 @@ namespace nbrmgr_ut
         addFailedNeighborRequest("Vlan1000:2001:db8::2");
         mockNlSendResult = -NLE_FAILURE;
 
-        nbrmgr.processKernelFailedNeighbor("Vlan1000:2001:db8::2");
+        nbrmgr.processKernelFailedNeighbor("Vlan1000:2001:db8::2", ":");
 
         ASSERT_EQ(capturedNeighborRequests.size(), 1u);
         EXPECT_TRUE(mockCallArgs.empty());
@@ -278,7 +278,7 @@ namespace nbrmgr_ut
         addFailedNeighborRequest("Vlan1000:2001:db8::3");
         mockExecResult = 1;
 
-        nbrmgr.processKernelFailedNeighbor("Vlan1000:2001:db8::3");
+        nbrmgr.processKernelFailedNeighbor("Vlan1000:2001:db8::3", ":");
 
         EXPECT_EQ(capturedNeighborRequests.size(), 1u);
         EXPECT_EQ(mockCallArgs.size(), 1u);
@@ -291,7 +291,7 @@ namespace nbrmgr_ut
         swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
         addFailedNeighborRequest("Vlan1000:192.0.2.1");
 
-        nbrmgr.processKernelFailedNeighbor("Vlan1000:192.0.2.1");
+        nbrmgr.processKernelFailedNeighbor("Vlan1000:192.0.2.1", ":");
 
         EXPECT_TRUE(capturedNeighborRequests.empty());
         EXPECT_TRUE(mockCallArgs.empty());
@@ -304,22 +304,22 @@ namespace nbrmgr_ut
         swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
         addFailedNeighborRequest("invalid-key");
 
-        nbrmgr.processKernelFailedNeighbor("invalid-key");
+        nbrmgr.processKernelFailedNeighbor("invalid-key", ":");
 
         EXPECT_TRUE(capturedNeighborRequests.empty());
         EXPECT_TRUE(mockCallArgs.empty());
         expectFailedNeighborEntry("invalid-key");
     }
 
-    TEST_F(NbrMgrTest, ReconcilesPendingFailedNeighborRequest)
+    TEST_F(NbrMgrTest, DoesNotReprocessExistingFailedNeighborAtStartup)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
         addFailedNeighborRequest("Vlan1000:2001:db8::5");
 
         swss::NbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
 
-        EXPECT_EQ(capturedNeighborRequests.size(), 1u);
-        EXPECT_EQ(mockCallArgs.size(), 1u);
+        EXPECT_TRUE(capturedNeighborRequests.empty());
+        EXPECT_TRUE(mockCallArgs.empty());
         expectFailedNeighborEntry("Vlan1000:2001:db8::5");
     }
 

--- a/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
+++ b/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
@@ -1,9 +1,12 @@
 #include "gtest/gtest.h"
+#include <cstddef>
 #include <iostream>
 #include <netlink/netlink.h>
 #include <netlink/msg.h>
 #include <linux/neighbour.h>
 #include <net/if.h>
+#include <sys/socket.h>
+#include <sys/time.h>
 #include "../mock_table.h"
 #include "warm_restart.h"
 #include "nbrmgr.h"
@@ -25,6 +28,18 @@ static int mockNlSendResult;
 static int mockNlAckResult;
 static int mockExecResult;
 static bool mockAutoAckDisabled;
+static int mockNlSocketAllocCount;
+static int mockNlSocketFreeCount;
+static int mockNlConnectCount;
+static bool mockAckTimeoutConfigured;
+static struct timeval mockAckTimeout;
+static struct nl_sock *mockPersistentSocket;
+static std::vector<struct nl_sock *> mockAckSockets;
+static std::vector<struct nl_sock *> mockSendSockets;
+static std::vector<struct nl_sock *> mockAckWaitSockets;
+static struct nl_sock *mockAutoAckDisabledSocket;
+static const struct nl_sock *mockTimeoutSocket;
+static std::vector<struct nl_sock *> mockFreedSockets;
 
 /*
  * Wrap netlink and interface functions to avoid real kernel interaction.
@@ -36,13 +51,30 @@ extern "C" {
 
 struct nl_sock *__wrap_nl_socket_alloc(void)
 {
-    /* Return a non-null fake pointer; nl_sock is opaque so cast from raw memory */
-    static char fake_sock_mem[256];
-    return reinterpret_cast<struct nl_sock *>(fake_sock_mem);
+    static std::max_align_t fakeSockets[8];
+    struct nl_sock *sock = reinterpret_cast<struct nl_sock *>(
+        &fakeSockets[mockNlSocketAllocCount]);
+    if (mockNlSocketAllocCount == 0)
+    {
+        mockPersistentSocket = sock;
+    }
+    else
+    {
+        mockAckSockets.push_back(sock);
+    }
+    mockNlSocketAllocCount++;
+    return sock;
+}
+
+void __wrap_nl_socket_free(struct nl_sock *sk)
+{
+    mockNlSocketFreeCount++;
+    mockFreedSockets.push_back(sk);
 }
 
 int __wrap_nl_connect(struct nl_sock *sk, int protocol)
 {
+    mockNlConnectCount++;
     return 0;
 }
 
@@ -52,12 +84,14 @@ int __wrap_nl_send_auto(struct nl_sock *sk, struct nl_msg *msg)
     struct ndmsg *nd = static_cast<struct ndmsg *>(NLMSG_DATA(hdr));
     capturedNeighborRequests.push_back(
         {nd->ndm_state, nd->ndm_flags, nd->ndm_family, hdr->nlmsg_flags});
+    mockSendSockets.push_back(sk);
     operationOrder.push_back("netlink");
     return mockNlSendResult;
 }
 
 int __wrap_nl_wait_for_ack(struct nl_sock *sk)
 {
+    mockAckWaitSockets.push_back(sk);
     operationOrder.push_back("ack");
     return mockNlAckResult;
 }
@@ -65,6 +99,25 @@ int __wrap_nl_wait_for_ack(struct nl_sock *sk)
 void __wrap_nl_socket_disable_auto_ack(struct nl_sock *sk)
 {
     mockAutoAckDisabled = true;
+    mockAutoAckDisabledSocket = sk;
+}
+
+int __wrap_nl_socket_get_fd(const struct nl_sock *sk)
+{
+    mockTimeoutSocket = sk;
+    return 42;
+}
+
+int __wrap_setsockopt(int socket, int level, int optionName,
+                      const void *optionValue, socklen_t optionLength)
+{
+    if (level == SOL_SOCKET && optionName == SO_RCVTIMEO &&
+        optionLength == sizeof(struct timeval))
+    {
+        mockAckTimeout = *static_cast<const struct timeval *>(optionValue);
+        mockAckTimeoutConfigured = true;
+    }
+    return 0;
 }
 
 /* Control whether nlmsg_alloc returns NULL to simulate setNeighbor failure */
@@ -127,6 +180,18 @@ namespace nbrmgr_ut
             mockNlAckResult = 0;
             mockExecResult = 0;
             mockAutoAckDisabled = false;
+            mockNlSocketAllocCount = 0;
+            mockNlSocketFreeCount = 0;
+            mockNlConnectCount = 0;
+            mockAckTimeoutConfigured = false;
+            memset(&mockAckTimeout, 0, sizeof(mockAckTimeout));
+            mockPersistentSocket = nullptr;
+            mockAckSockets.clear();
+            mockSendSockets.clear();
+            mockAckWaitSockets.clear();
+            mockAutoAckDisabledSocket = nullptr;
+            mockTimeoutSocket = nullptr;
+            mockFreedSockets.clear();
             callback = noop_cb;
         }
 
@@ -267,6 +332,22 @@ namespace nbrmgr_ut
         processFailedNeighborRequest(nbrmgr, "Vlan1000:2001:db8::1");
 
         EXPECT_TRUE(mockAutoAckDisabled);
+        EXPECT_EQ(mockNlSocketAllocCount, 2);
+        EXPECT_EQ(mockNlSocketFreeCount, 1);
+        EXPECT_EQ(mockNlConnectCount, 2);
+        EXPECT_TRUE(mockAckTimeoutConfigured);
+        EXPECT_EQ(mockAckTimeout.tv_sec, 1);
+        EXPECT_EQ(mockAckTimeout.tv_usec, 0);
+        ASSERT_EQ(mockAckSockets.size(), 1u);
+        ASSERT_EQ(mockSendSockets.size(), 1u);
+        ASSERT_EQ(mockAckWaitSockets.size(), 1u);
+        ASSERT_EQ(mockFreedSockets.size(), 1u);
+        EXPECT_NE(mockAckSockets[0], mockPersistentSocket);
+        EXPECT_EQ(mockAutoAckDisabledSocket, mockPersistentSocket);
+        EXPECT_EQ(mockSendSockets[0], mockAckSockets[0]);
+        EXPECT_EQ(mockAckWaitSockets[0], mockAckSockets[0]);
+        EXPECT_EQ(mockTimeoutSocket, mockAckSockets[0]);
+        EXPECT_EQ(mockFreedSockets[0], mockAckSockets[0]);
         ASSERT_EQ(capturedNeighborRequests.size(), 1u);
         EXPECT_EQ(capturedNeighborRequests[0].state, NUD_INCOMPLETE);
         EXPECT_EQ(capturedNeighborRequests[0].neighborFlags, 0u);
@@ -301,16 +382,18 @@ namespace nbrmgr_ut
         EXPECT_FALSE(hasPendingFailedNeighborTask(nbrmgr));
     }
 
-    TEST_F(NbrMgrTest, NetlinkAckFailureRetries)
+    TEST_F(NbrMgrTest, NetlinkAckTimeoutRetries)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
         TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
-        mockNlAckResult = -NLE_FAILURE;
+        mockNlAckResult = -NLE_AGAIN;
         processFailedNeighborRequest(nbrmgr, "Vlan1000:2001:db8::3");
 
         EXPECT_EQ(operationOrder, (std::vector<std::string>{"netlink", "ack"}));
         EXPECT_TRUE(mockCallArgs.empty());
         EXPECT_TRUE(hasPendingFailedNeighborTask(nbrmgr));
+        EXPECT_EQ(mockNlSocketAllocCount, 2);
+        EXPECT_EQ(mockNlSocketFreeCount, 1);
 
         mockNlAckResult = 0;
         nbrmgr.doTask();
@@ -318,6 +401,8 @@ namespace nbrmgr_ut
         EXPECT_EQ(operationOrder,
                   (std::vector<std::string>{"netlink", "ack", "netlink", "ack", "ndisc6"}));
         EXPECT_FALSE(hasPendingFailedNeighborTask(nbrmgr));
+        EXPECT_EQ(mockNlSocketAllocCount, 3);
+        EXPECT_EQ(mockNlSocketFreeCount, 2);
     }
 
     TEST_F(NbrMgrTest, NoSolicitationResponseIsSuccess)

--- a/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
+++ b/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
@@ -22,7 +22,9 @@ struct CapturedNeighborRequest
 static std::vector<CapturedNeighborRequest> capturedNeighborRequests;
 static std::vector<std::string> operationOrder;
 static int mockNlSendResult;
+static int mockNlAckResult;
 static int mockExecResult;
+static bool mockAutoAckDisabled;
 
 /*
  * Wrap netlink and interface functions to avoid real kernel interaction.
@@ -52,6 +54,17 @@ int __wrap_nl_send_auto(struct nl_sock *sk, struct nl_msg *msg)
         {nd->ndm_state, nd->ndm_flags, nd->ndm_family, hdr->nlmsg_flags});
     operationOrder.push_back("netlink");
     return mockNlSendResult;
+}
+
+int __wrap_nl_wait_for_ack(struct nl_sock *sk)
+{
+    operationOrder.push_back("ack");
+    return mockNlAckResult;
+}
+
+void __wrap_nl_socket_disable_auto_ack(struct nl_sock *sk)
+{
+    mockAutoAckDisabled = true;
 }
 
 /* Control whether nlmsg_alloc returns NULL to simulate setNeighbor failure */
@@ -111,7 +124,9 @@ namespace nbrmgr_ut
             operationOrder.clear();
             mock_nlmsg_alloc_fail = false;
             mockNlSendResult = 0;
+            mockNlAckResult = 0;
             mockExecResult = 0;
+            mockAutoAckDisabled = false;
             callback = noop_cb;
         }
 
@@ -125,6 +140,13 @@ namespace nbrmgr_ut
             auto executor = nbrmgr.getExecutor(APP_NEIGH_FAILED_TABLE_NAME);
             ASSERT_NE(executor, nullptr);
             executor->execute();
+        }
+
+        bool hasPendingFailedNeighborTask(TestableNbrMgr& nbrmgr)
+        {
+            auto consumer = dynamic_cast<Consumer *>(nbrmgr.getExecutor(APP_NEIGH_FAILED_TABLE_NAME));
+            EXPECT_NE(consumer, nullptr);
+            return consumer && !consumer->m_toSync.empty();
         }
     };
 
@@ -244,6 +266,7 @@ namespace nbrmgr_ut
         TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
         processFailedNeighborRequest(nbrmgr, "Vlan1000:2001:db8::1");
 
+        EXPECT_TRUE(mockAutoAckDisabled);
         ASSERT_EQ(capturedNeighborRequests.size(), 1u);
         EXPECT_EQ(capturedNeighborRequests[0].state, NUD_INCOMPLETE);
         EXPECT_EQ(capturedNeighborRequests[0].neighborFlags, 0u);
@@ -253,11 +276,12 @@ namespace nbrmgr_ut
         EXPECT_NE(capturedNeighborRequests[0].messageFlags & NLM_F_ACK, 0);
 
         ASSERT_EQ(mockCallArgs.size(), 1u);
-        EXPECT_EQ(mockCallArgs[0], "/usr/bin/ndisc6 -q -w 0 -1 \"2001:db8::1\" \"Vlan1000\"");
-        EXPECT_EQ(operationOrder, (std::vector<std::string>{"netlink", "ndisc6"}));
+        EXPECT_EQ(mockCallArgs[0], "/usr/bin/ndisc6 -q -r 1 -w 0 \"2001:db8::1\" \"Vlan1000\"");
+        EXPECT_EQ(operationOrder, (std::vector<std::string>{"netlink", "ack", "ndisc6"}));
+        EXPECT_FALSE(hasPendingFailedNeighborTask(nbrmgr));
     }
 
-    TEST_F(NbrMgrTest, NetlinkFailureSkipsSolicitation)
+    TEST_F(NbrMgrTest, NetlinkSendFailureRetries)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
         TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
@@ -267,17 +291,57 @@ namespace nbrmgr_ut
         ASSERT_EQ(capturedNeighborRequests.size(), 1u);
         EXPECT_TRUE(mockCallArgs.empty());
         EXPECT_EQ(operationOrder, (std::vector<std::string>{"netlink"}));
+        EXPECT_TRUE(hasPendingFailedNeighborTask(nbrmgr));
+
+        mockNlSendResult = 0;
+        nbrmgr.doTask();
+
+        EXPECT_EQ(operationOrder,
+                  (std::vector<std::string>{"netlink", "netlink", "ack", "ndisc6"}));
+        EXPECT_FALSE(hasPendingFailedNeighborTask(nbrmgr));
     }
 
-    TEST_F(NbrMgrTest, SolicitationFailureAfterNetlinkUpdate)
+    TEST_F(NbrMgrTest, NetlinkAckFailureRetries)
+    {
+        std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+        TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
+        mockNlAckResult = -NLE_FAILURE;
+        processFailedNeighborRequest(nbrmgr, "Vlan1000:2001:db8::3");
+
+        EXPECT_EQ(operationOrder, (std::vector<std::string>{"netlink", "ack"}));
+        EXPECT_TRUE(mockCallArgs.empty());
+        EXPECT_TRUE(hasPendingFailedNeighborTask(nbrmgr));
+
+        mockNlAckResult = 0;
+        nbrmgr.doTask();
+
+        EXPECT_EQ(operationOrder,
+                  (std::vector<std::string>{"netlink", "ack", "netlink", "ack", "ndisc6"}));
+        EXPECT_FALSE(hasPendingFailedNeighborTask(nbrmgr));
+    }
+
+    TEST_F(NbrMgrTest, NoSolicitationResponseIsSuccess)
+    {
+        std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+        TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
+        mockExecResult = 2;
+        processFailedNeighborRequest(nbrmgr, "Vlan1000:2001:db8::4");
+
+        EXPECT_EQ(capturedNeighborRequests.size(), 1u);
+        EXPECT_EQ(mockCallArgs.size(), 1u);
+        EXPECT_FALSE(hasPendingFailedNeighborTask(nbrmgr));
+    }
+
+    TEST_F(NbrMgrTest, SolicitationExecutionFailureIsTerminal)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
         TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
         mockExecResult = 1;
-        processFailedNeighborRequest(nbrmgr, "Vlan1000:2001:db8::3");
+        processFailedNeighborRequest(nbrmgr, "Vlan1000:2001:db8::5");
 
         EXPECT_EQ(capturedNeighborRequests.size(), 1u);
         EXPECT_EQ(mockCallArgs.size(), 1u);
+        EXPECT_FALSE(hasPendingFailedNeighborTask(nbrmgr));
     }
 
     TEST_F(NbrMgrTest, RejectsIpv4FailedNeighborRequest)
@@ -298,5 +362,16 @@ namespace nbrmgr_ut
 
         EXPECT_TRUE(capturedNeighborRequests.empty());
         EXPECT_TRUE(mockCallArgs.empty());
+    }
+
+    TEST_F(NbrMgrTest, RejectsEmptyInterfaceFailedNeighborRequest)
+    {
+        std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+        TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
+        processFailedNeighborRequest(nbrmgr, ":2001:db8::6");
+
+        EXPECT_TRUE(capturedNeighborRequests.empty());
+        EXPECT_TRUE(mockCallArgs.empty());
+        EXPECT_FALSE(hasPendingFailedNeighborTask(nbrmgr));
     }
 }

--- a/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
+++ b/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
@@ -108,8 +108,8 @@ int __wrap_nl_socket_get_fd(const struct nl_sock *sk)
     return 42;
 }
 
-int __wrap_setsockopt(int socket, int level, int optionName,
-                      const void *optionValue, socklen_t optionLength)
+static int mockSetsockopt(int socket, int level, int optionName,
+                          const void *optionValue, socklen_t optionLength)
 {
     if (level == SOL_SOCKET && optionName == SO_RCVTIMEO &&
         optionLength == sizeof(struct timeval))
@@ -118,6 +118,18 @@ int __wrap_setsockopt(int socket, int level, int optionName,
         mockAckTimeoutConfigured = true;
     }
     return 0;
+}
+
+int __wrap_setsockopt(int socket, int level, int optionName,
+                      const void *optionValue, socklen_t optionLength)
+{
+    return mockSetsockopt(socket, level, optionName, optionValue, optionLength);
+}
+
+int __wrap___setsockopt64(int socket, int level, int optionName,
+                          const void *optionValue, socklen_t optionLength)
+{
+    return mockSetsockopt(socket, level, optionName, optionValue, optionLength);
 }
 
 /* Control whether nlmsg_alloc returns NULL to simulate setNeighbor failure */

--- a/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
+++ b/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
@@ -417,7 +417,7 @@ namespace nbrmgr_ut
         EXPECT_FALSE(hasPendingFailedNeighborTask(nbrmgr));
     }
 
-    TEST_F(NbrMgrTest, SolicitationExecutionFailureIsTerminal)
+    TEST_F(NbrMgrTest, SolicitationExecutionFailureRetries)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
         TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
@@ -426,6 +426,18 @@ namespace nbrmgr_ut
 
         EXPECT_EQ(capturedNeighborRequests.size(), 1u);
         EXPECT_EQ(mockCallArgs.size(), 1u);
+        EXPECT_TRUE(hasPendingFailedNeighborTask(nbrmgr));
+
+        mockExecResult = 0;
+        nbrmgr.doTask();
+
+        EXPECT_EQ(capturedNeighborRequests.size(), 2u);
+        EXPECT_EQ(mockCallArgs.size(), 2u);
+        EXPECT_EQ(operationOrder,
+                  (std::vector<std::string>{
+                      "netlink", "ack", "ndisc6",
+                      "netlink", "ack", "ndisc6",
+                  }));
         EXPECT_FALSE(hasPendingFailedNeighborTask(nbrmgr));
     }
 

--- a/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
+++ b/tests/mock_tests/nbrmgrd/nbrmgr_ut.cpp
@@ -207,6 +207,12 @@ namespace nbrmgr_ut
             executor->execute();
         }
 
+        void enableDualTor()
+        {
+            swss::Table peerSwitchTable(m_config_db.get(), CFG_PEER_SWITCH_TABLE_NAME);
+            peerSwitchTable.set("peer_switch_hostname", {{"address_ipv4", "10.0.0.1"}});
+        }
+
         bool hasPendingFailedNeighborTask(TestableNbrMgr& nbrmgr)
         {
             auto consumer = dynamic_cast<Consumer *>(nbrmgr.getExecutor(APP_NEIGH_FAILED_TABLE_NAME));
@@ -328,6 +334,7 @@ namespace nbrmgr_ut
     TEST_F(NbrMgrTest, ProcessFailedIpv6Neighbor)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+        enableDualTor();
         TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
         processFailedNeighborRequest(nbrmgr, "Vlan1000:2001:db8::1");
 
@@ -365,6 +372,7 @@ namespace nbrmgr_ut
     TEST_F(NbrMgrTest, NetlinkSendFailureRetries)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+        enableDualTor();
         TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
         mockNlSendResult = -NLE_FAILURE;
         processFailedNeighborRequest(nbrmgr, "Vlan1000:2001:db8::2");
@@ -385,6 +393,7 @@ namespace nbrmgr_ut
     TEST_F(NbrMgrTest, NetlinkAckTimeoutRetries)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+        enableDualTor();
         TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
         mockNlAckResult = -NLE_AGAIN;
         processFailedNeighborRequest(nbrmgr, "Vlan1000:2001:db8::3");
@@ -408,6 +417,7 @@ namespace nbrmgr_ut
     TEST_F(NbrMgrTest, NoSolicitationResponseIsSuccess)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+        enableDualTor();
         TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
         mockExecResult = 2;
         processFailedNeighborRequest(nbrmgr, "Vlan1000:2001:db8::4");
@@ -420,6 +430,7 @@ namespace nbrmgr_ut
     TEST_F(NbrMgrTest, SolicitationExecutionFailureRetries)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+        enableDualTor();
         TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
         mockExecResult = 1;
         processFailedNeighborRequest(nbrmgr, "Vlan1000:2001:db8::5");
@@ -444,6 +455,7 @@ namespace nbrmgr_ut
     TEST_F(NbrMgrTest, RejectsIpv4FailedNeighborRequest)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+        enableDualTor();
         TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
         processFailedNeighborRequest(nbrmgr, "Vlan1000:192.0.2.1");
 
@@ -454,6 +466,7 @@ namespace nbrmgr_ut
     TEST_F(NbrMgrTest, RejectsMalformedFailedNeighborRequest)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+        enableDualTor();
         TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
         processFailedNeighborRequest(nbrmgr, "invalid-key");
 
@@ -464,11 +477,20 @@ namespace nbrmgr_ut
     TEST_F(NbrMgrTest, RejectsEmptyInterfaceFailedNeighborRequest)
     {
         std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+        enableDualTor();
         TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
         processFailedNeighborRequest(nbrmgr, ":2001:db8::6");
 
         EXPECT_TRUE(capturedNeighborRequests.empty());
         EXPECT_TRUE(mockCallArgs.empty());
         EXPECT_FALSE(hasPendingFailedNeighborTask(nbrmgr));
+    }
+
+    TEST_F(NbrMgrTest, DoesNotSubscribeToFailedNeighborTableOnNonDualTor)
+    {
+        std::vector<std::string> cfg_nbr_tables = {CFG_NEIGH_TABLE_NAME};
+        TestableNbrMgr nbrmgr(m_config_db.get(), m_app_db.get(), m_state_db.get(), cfg_nbr_tables);
+
+        EXPECT_EQ(nbrmgr.getExecutor(APP_NEIGH_FAILED_TABLE_NAME), nullptr);
     }
 }

--- a/tests/mock_tests/neighsyncd/neighsync_ut.cpp
+++ b/tests/mock_tests/neighsyncd/neighsync_ut.cpp
@@ -190,24 +190,6 @@ TEST_F(NeighSyncTest, RemovesFailedNeighborEntryWhenResolved)
     EXPECT_FALSE(failedNeighborExists("2001:db8::4"));
 }
 
-TEST_F(NeighSyncTest, DoesNotRemoveFailedNeighborEntryWithoutDualTor)
-{
-    enableDualTor();
-    auto failed = createNeighbor(AF_INET6, "2001:db8::7", NUD_FAILED);
-    ASSERT_TRUE(failed.get() != nullptr);
-    m_sync->onMsg(RTM_NEWNEIGH, reinterpret_cast<struct nl_object *>(failed.get()));
-    ASSERT_TRUE(failedNeighborExists("2001:db8::7"));
-
-    Table peerSwitchTable(m_configDb.get(), CFG_PEER_SWITCH_TABLE_NAME);
-    peerSwitchTable.del("peer_switch_hostname");
-
-    auto reachable = createNeighbor(AF_INET6, "2001:db8::7", NUD_REACHABLE);
-    ASSERT_TRUE(reachable.get() != nullptr);
-    m_sync->onMsg(RTM_NEWNEIGH, reinterpret_cast<struct nl_object *>(reachable.get()));
-
-    EXPECT_TRUE(failedNeighborExists("2001:db8::7"));
-}
-
 TEST_F(NeighSyncTest, RemovesFailedNeighborEntryWhenDeleted)
 {
     enableDualTor();

--- a/tests/mock_tests/neighsyncd/neighsync_ut.cpp
+++ b/tests/mock_tests/neighsyncd/neighsync_ut.cpp
@@ -3,9 +3,12 @@
 #include <arpa/inet.h>
 #include <cstring>
 #include <linux/neighbour.h>
+#include <memory>
 #include <net/if.h>
 #include <netlink/addr.h>
 #include <netlink/route/neighbour.h>
+#include <string>
+#include <vector>
 
 #include "../mock_table.h"
 #include "neighsyncd/neighsync.h"

--- a/tests/mock_tests/neighsyncd/neighsync_ut.cpp
+++ b/tests/mock_tests/neighsyncd/neighsync_ut.cpp
@@ -92,7 +92,7 @@ class NeighSyncTest : public ::testing::Test
 
     bool failedNeighborExists(const std::string& ip)
     {
-        Table failedNeighborTable(m_appDb.get(), APP_KERNEL_FAILED_NEIGH_TABLE_NAME);
+        Table failedNeighborTable(m_appDb.get(), APP_NEIGH_FAILED_TABLE_NAME);
         std::vector<std::string> keys;
         failedNeighborTable.getKeys(keys);
         const std::string suffix = ":" + ip;

--- a/tests/mock_tests/neighsyncd/neighsync_ut.cpp
+++ b/tests/mock_tests/neighsyncd/neighsync_ut.cpp
@@ -1,0 +1,171 @@
+#include "gtest/gtest.h"
+
+#include <arpa/inet.h>
+#include <cstring>
+#include <linux/neighbour.h>
+#include <net/if.h>
+#include <netlink/addr.h>
+#include <netlink/route/neighbour.h>
+
+#include "../mock_table.h"
+#include "neighsyncd/neighsync.h"
+#include "redisutility.h"
+
+using namespace swss;
+
+namespace
+{
+
+struct RtnlNeighDeleter
+{
+    void operator()(struct rtnl_neigh *neigh) const
+    {
+        rtnl_neigh_put(neigh);
+    }
+};
+
+using RtnlNeighPtr = std::unique_ptr<struct rtnl_neigh, RtnlNeighDeleter>;
+
+RtnlNeighPtr createNeighbor(int family, const std::string& ip, int state)
+{
+    char buffer[512] = {};
+    struct nlmsghdr *hdr = reinterpret_cast<struct nlmsghdr *>(buffer);
+    hdr->nlmsg_type = RTM_NEWNEIGH;
+    hdr->nlmsg_flags = NLM_F_REQUEST;
+    hdr->nlmsg_len = NLMSG_LENGTH(sizeof(struct ndmsg));
+
+    struct ndmsg *nd = static_cast<struct ndmsg *>(NLMSG_DATA(hdr));
+    nd->ndm_family = static_cast<unsigned char>(family);
+    nd->ndm_ifindex = static_cast<int>(if_nametoindex("lo"));
+    nd->ndm_state = static_cast<unsigned short>(state);
+    nd->ndm_type = RTN_UNICAST;
+
+    struct rtattr *dst = reinterpret_cast<struct rtattr *>(
+        buffer + NLMSG_ALIGN(hdr->nlmsg_len));
+    size_t addressLength = family == AF_INET ? sizeof(struct in_addr) : sizeof(struct in6_addr);
+    dst->rta_type = NDA_DST;
+    dst->rta_len = static_cast<unsigned short>(RTA_LENGTH(addressLength));
+    if (inet_pton(family, ip.c_str(), RTA_DATA(dst)) != 1)
+    {
+        return nullptr;
+    }
+    hdr->nlmsg_len = static_cast<unsigned int>(
+        NLMSG_ALIGN(hdr->nlmsg_len) + RTA_ALIGN(dst->rta_len));
+
+    const unsigned char mac[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55};
+    struct rtattr *lladdr = reinterpret_cast<struct rtattr *>(
+        buffer + NLMSG_ALIGN(hdr->nlmsg_len));
+    lladdr->rta_type = NDA_LLADDR;
+    lladdr->rta_len = static_cast<unsigned short>(RTA_LENGTH(sizeof(mac)));
+    memcpy(RTA_DATA(lladdr), mac, sizeof(mac));
+    hdr->nlmsg_len = static_cast<unsigned int>(
+        NLMSG_ALIGN(hdr->nlmsg_len) + RTA_ALIGN(lladdr->rta_len));
+
+    struct rtnl_neigh *neigh = nullptr;
+    if (rtnl_neigh_parse(hdr, &neigh) < 0)
+    {
+        return nullptr;
+    }
+
+    return RtnlNeighPtr(neigh);
+}
+
+class NeighSyncTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        testing_db::reset();
+        m_appDb = std::make_shared<DBConnector>("APPL_DB", 0);
+        m_stateDb = std::make_shared<DBConnector>("STATE_DB", 0);
+        m_configDb = std::make_shared<DBConnector>("CONFIG_DB", 0);
+        m_pipeline = std::make_shared<RedisPipeline>(m_appDb.get());
+        m_sync = std::make_unique<NeighSync>(
+            m_pipeline.get(), m_stateDb.get(), m_configDb.get(), m_appDb.get());
+    }
+
+    void enableDualTor()
+    {
+        Table peerSwitchTable(m_configDb.get(), CFG_PEER_SWITCH_TABLE_NAME);
+        peerSwitchTable.set("peer_switch_hostname", {{"address_ipv4", "10.0.0.1"}});
+    }
+
+    bool failedNeighborExists(const std::string& ip)
+    {
+        Table failedNeighborTable(m_appDb.get(), APP_KERNEL_FAILED_NEIGH_TABLE_NAME);
+        std::vector<std::string> keys;
+        failedNeighborTable.getKeys(keys);
+        const std::string suffix = ":" + ip;
+
+        for (const auto& key : keys)
+        {
+            std::vector<FieldValueTuple> values;
+            if (key.size() >= suffix.size() &&
+                key.compare(key.size() - suffix.size(), suffix.size(), suffix) == 0 &&
+                failedNeighborTable.get(key, values) &&
+                fvsGetValue(values, "family", true).get() == IPV6_NAME)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    std::shared_ptr<DBConnector> m_appDb;
+    std::shared_ptr<DBConnector> m_stateDb;
+    std::shared_ptr<DBConnector> m_configDb;
+    std::shared_ptr<RedisPipeline> m_pipeline;
+    std::unique_ptr<NeighSync> m_sync;
+};
+
+TEST_F(NeighSyncTest, PublishesDualTorFailedIpv6Neighbor)
+{
+    enableDualTor();
+    auto neigh = createNeighbor(AF_INET6, "2001:db8::1", NUD_FAILED);
+    ASSERT_TRUE(neigh.get() != nullptr);
+    EXPECT_EQ(rtnl_neigh_get_family(neigh.get()), AF_INET6);
+    EXPECT_EQ(rtnl_neigh_get_state(neigh.get()), NUD_FAILED);
+
+    Table peerSwitchTable(m_configDb.get(), CFG_PEER_SWITCH_TABLE_NAME);
+    std::vector<std::string> peerSwitchKeys;
+    peerSwitchTable.getKeys(peerSwitchKeys);
+    ASSERT_EQ(peerSwitchKeys.size(), 1u);
+
+    m_sync->onMsg(RTM_NEWNEIGH, reinterpret_cast<struct nl_object *>(neigh.get()));
+
+    EXPECT_TRUE(failedNeighborExists("2001:db8::1"));
+}
+
+TEST_F(NeighSyncTest, FiltersUnsupportedFailedNeighborEvents)
+{
+    enableDualTor();
+
+    auto ipv4 = createNeighbor(AF_INET, "192.0.2.1", NUD_FAILED);
+    ASSERT_TRUE(ipv4.get() != nullptr);
+    m_sync->onMsg(RTM_NEWNEIGH, reinterpret_cast<struct nl_object *>(ipv4.get()));
+
+    auto incomplete = createNeighbor(AF_INET6, "2001:db8::2", NUD_INCOMPLETE);
+    ASSERT_TRUE(incomplete.get() != nullptr);
+    m_sync->onMsg(RTM_NEWNEIGH, reinterpret_cast<struct nl_object *>(incomplete.get()));
+
+    auto deleted = createNeighbor(AF_INET6, "2001:db8::3", NUD_FAILED);
+    ASSERT_TRUE(deleted.get() != nullptr);
+    m_sync->onMsg(RTM_DELNEIGH, reinterpret_cast<struct nl_object *>(deleted.get()));
+
+    EXPECT_FALSE(failedNeighborExists("192.0.2.1"));
+    EXPECT_FALSE(failedNeighborExists("2001:db8::2"));
+    EXPECT_FALSE(failedNeighborExists("2001:db8::3"));
+}
+
+TEST_F(NeighSyncTest, DoesNotPublishFailedIpv6NeighborWithoutDualTor)
+{
+    auto neigh = createNeighbor(AF_INET6, "2001:db8::4", NUD_FAILED);
+    ASSERT_TRUE(neigh.get() != nullptr);
+
+    m_sync->onMsg(RTM_NEWNEIGH, reinterpret_cast<struct nl_object *>(neigh.get()));
+
+    EXPECT_FALSE(failedNeighborExists("2001:db8::4"));
+}
+
+} // namespace

--- a/tests/mock_tests/neighsyncd/neighsync_ut.cpp
+++ b/tests/mock_tests/neighsyncd/neighsync_ut.cpp
@@ -183,14 +183,29 @@ TEST_F(NeighSyncTest, RemovesFailedNeighborEntryWhenResolved)
     m_sync->onMsg(RTM_NEWNEIGH, reinterpret_cast<struct nl_object *>(failed.get()));
     ASSERT_TRUE(failedNeighborExists("2001:db8::4"));
 
-    Table peerSwitchTable(m_configDb.get(), CFG_PEER_SWITCH_TABLE_NAME);
-    peerSwitchTable.del("peer_switch_hostname");
-
     auto reachable = createNeighbor(AF_INET6, "2001:db8::4", NUD_REACHABLE);
     ASSERT_TRUE(reachable.get() != nullptr);
     m_sync->onMsg(RTM_NEWNEIGH, reinterpret_cast<struct nl_object *>(reachable.get()));
 
     EXPECT_FALSE(failedNeighborExists("2001:db8::4"));
+}
+
+TEST_F(NeighSyncTest, DoesNotRemoveFailedNeighborEntryWithoutDualTor)
+{
+    enableDualTor();
+    auto failed = createNeighbor(AF_INET6, "2001:db8::7", NUD_FAILED);
+    ASSERT_TRUE(failed.get() != nullptr);
+    m_sync->onMsg(RTM_NEWNEIGH, reinterpret_cast<struct nl_object *>(failed.get()));
+    ASSERT_TRUE(failedNeighborExists("2001:db8::7"));
+
+    Table peerSwitchTable(m_configDb.get(), CFG_PEER_SWITCH_TABLE_NAME);
+    peerSwitchTable.del("peer_switch_hostname");
+
+    auto reachable = createNeighbor(AF_INET6, "2001:db8::7", NUD_REACHABLE);
+    ASSERT_TRUE(reachable.get() != nullptr);
+    m_sync->onMsg(RTM_NEWNEIGH, reinterpret_cast<struct nl_object *>(reachable.get()));
+
+    EXPECT_TRUE(failedNeighborExists("2001:db8::7"));
 }
 
 TEST_F(NeighSyncTest, RemovesFailedNeighborEntryWhenDeleted)

--- a/tests/mock_tests/neighsyncd/neighsync_ut.cpp
+++ b/tests/mock_tests/neighsyncd/neighsync_ut.cpp
@@ -149,23 +149,66 @@ TEST_F(NeighSyncTest, FiltersUnsupportedFailedNeighborEvents)
     ASSERT_TRUE(incomplete.get() != nullptr);
     m_sync->onMsg(RTM_NEWNEIGH, reinterpret_cast<struct nl_object *>(incomplete.get()));
 
-    auto deleted = createNeighbor(AF_INET6, "2001:db8::3", NUD_FAILED);
+    EXPECT_FALSE(failedNeighborExists("192.0.2.1"));
+    EXPECT_FALSE(failedNeighborExists("2001:db8::2"));
+}
+
+TEST_F(NeighSyncTest, KeepsFailedNeighborEntryWhileIncomplete)
+{
+    enableDualTor();
+    auto failed = createNeighbor(AF_INET6, "2001:db8::3", NUD_FAILED);
+    ASSERT_TRUE(failed.get() != nullptr);
+    m_sync->onMsg(RTM_NEWNEIGH, reinterpret_cast<struct nl_object *>(failed.get()));
+    ASSERT_TRUE(failedNeighborExists("2001:db8::3"));
+
+    auto incomplete = createNeighbor(AF_INET6, "2001:db8::3", NUD_INCOMPLETE);
+    ASSERT_TRUE(incomplete.get() != nullptr);
+    m_sync->onMsg(RTM_NEWNEIGH, reinterpret_cast<struct nl_object *>(incomplete.get()));
+
+    EXPECT_TRUE(failedNeighborExists("2001:db8::3"));
+}
+
+TEST_F(NeighSyncTest, RemovesFailedNeighborEntryWhenResolved)
+{
+    enableDualTor();
+    auto failed = createNeighbor(AF_INET6, "2001:db8::4", NUD_FAILED);
+    ASSERT_TRUE(failed.get() != nullptr);
+    m_sync->onMsg(RTM_NEWNEIGH, reinterpret_cast<struct nl_object *>(failed.get()));
+    ASSERT_TRUE(failedNeighborExists("2001:db8::4"));
+
+    Table peerSwitchTable(m_configDb.get(), CFG_PEER_SWITCH_TABLE_NAME);
+    peerSwitchTable.del("peer_switch_hostname");
+
+    auto reachable = createNeighbor(AF_INET6, "2001:db8::4", NUD_REACHABLE);
+    ASSERT_TRUE(reachable.get() != nullptr);
+    m_sync->onMsg(RTM_NEWNEIGH, reinterpret_cast<struct nl_object *>(reachable.get()));
+
+    EXPECT_FALSE(failedNeighborExists("2001:db8::4"));
+}
+
+TEST_F(NeighSyncTest, RemovesFailedNeighborEntryWhenDeleted)
+{
+    enableDualTor();
+    auto failed = createNeighbor(AF_INET6, "2001:db8::5", NUD_FAILED);
+    ASSERT_TRUE(failed.get() != nullptr);
+    m_sync->onMsg(RTM_NEWNEIGH, reinterpret_cast<struct nl_object *>(failed.get()));
+    ASSERT_TRUE(failedNeighborExists("2001:db8::5"));
+
+    auto deleted = createNeighbor(AF_INET6, "2001:db8::5", NUD_FAILED);
     ASSERT_TRUE(deleted.get() != nullptr);
     m_sync->onMsg(RTM_DELNEIGH, reinterpret_cast<struct nl_object *>(deleted.get()));
 
-    EXPECT_FALSE(failedNeighborExists("192.0.2.1"));
-    EXPECT_FALSE(failedNeighborExists("2001:db8::2"));
-    EXPECT_FALSE(failedNeighborExists("2001:db8::3"));
+    EXPECT_FALSE(failedNeighborExists("2001:db8::5"));
 }
 
 TEST_F(NeighSyncTest, DoesNotPublishFailedIpv6NeighborWithoutDualTor)
 {
-    auto neigh = createNeighbor(AF_INET6, "2001:db8::4", NUD_FAILED);
+    auto neigh = createNeighbor(AF_INET6, "2001:db8::6", NUD_FAILED);
     ASSERT_TRUE(neigh.get() != nullptr);
 
     m_sync->onMsg(RTM_NEWNEIGH, reinterpret_cast<struct nl_object *>(neigh.get()));
 
-    EXPECT_FALSE(failedNeighborExists("2001:db8::4"));
+    EXPECT_FALSE(failedNeighborExists("2001:db8::6"));
 }
 
 } // namespace

--- a/tests/mock_tests/neighsyncd/neighsync_ut.cpp
+++ b/tests/mock_tests/neighsyncd/neighsync_ut.cpp
@@ -90,7 +90,7 @@ class NeighSyncTest : public ::testing::Test
         peerSwitchTable.set("peer_switch_hostname", {{"address_ipv4", "10.0.0.1"}});
     }
 
-    bool failedNeighborExists(const std::string& ip)
+    bool failedNeighborExists(const std::string& ip, std::vector<FieldValueTuple>* fields = nullptr)
     {
         Table failedNeighborTable(m_appDb.get(), APP_NEIGH_FAILED_TABLE_NAME);
         std::vector<std::string> keys;
@@ -102,9 +102,12 @@ class NeighSyncTest : public ::testing::Test
             std::vector<FieldValueTuple> values;
             if (key.size() >= suffix.size() &&
                 key.compare(key.size() - suffix.size(), suffix.size(), suffix) == 0 &&
-                failedNeighborTable.get(key, values) &&
-                fvsGetValue(values, "family", true).get() == IPV6_NAME)
+                failedNeighborTable.get(key, values))
             {
+                if (fields)
+                {
+                    *fields = values;
+                }
                 return true;
             }
         }
@@ -134,7 +137,11 @@ TEST_F(NeighSyncTest, PublishesDualTorFailedIpv6Neighbor)
 
     m_sync->onMsg(RTM_NEWNEIGH, reinterpret_cast<struct nl_object *>(neigh.get()));
 
-    EXPECT_TRUE(failedNeighborExists("2001:db8::1"));
+    std::vector<FieldValueTuple> fields;
+    ASSERT_TRUE(failedNeighborExists("2001:db8::1", &fields));
+    ASSERT_EQ(fields.size(), 1u);
+    EXPECT_EQ(fvField(fields[0]), "NULL");
+    EXPECT_EQ(fvValue(fields[0]), "NULL");
 }
 
 TEST_F(NeighSyncTest, FiltersUnsupportedFailedNeighborEvents)

--- a/tests/mock_tests/neighsyncd/neighsync_ut.cpp
+++ b/tests/mock_tests/neighsyncd/neighsync_ut.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <net/if.h>
 #include <netlink/addr.h>
+#include <netlink/msg.h>
 #include <netlink/route/neighbour.h>
 #include <string>
 #include <vector>
@@ -29,43 +30,67 @@ struct RtnlNeighDeleter
 
 using RtnlNeighPtr = std::unique_ptr<struct rtnl_neigh, RtnlNeighDeleter>;
 
+struct NlMsgDeleter
+{
+    void operator()(struct nl_msg *msg) const
+    {
+        nlmsg_free(msg);
+    }
+};
+
+using NlMsgPtr = std::unique_ptr<struct nl_msg, NlMsgDeleter>;
+
 RtnlNeighPtr createNeighbor(int family, const std::string& ip, int state)
 {
-    char buffer[512] = {};
-    struct nlmsghdr *hdr = reinterpret_cast<struct nlmsghdr *>(buffer);
-    hdr->nlmsg_type = RTM_NEWNEIGH;
-    hdr->nlmsg_flags = NLM_F_REQUEST;
-    hdr->nlmsg_len = NLMSG_LENGTH(sizeof(struct ndmsg));
+    NlMsgPtr msg(nlmsg_alloc());
+    if (!msg)
+    {
+        return nullptr;
+    }
+
+    struct nlmsghdr *hdr = nlmsg_put(
+        msg.get(), NL_AUTO_PORT, NL_AUTO_SEQ, RTM_NEWNEIGH, sizeof(struct ndmsg), NLM_F_REQUEST);
+    if (!hdr)
+    {
+        return nullptr;
+    }
 
     struct ndmsg *nd = static_cast<struct ndmsg *>(NLMSG_DATA(hdr));
+    memset(nd, 0, sizeof(*nd));
     nd->ndm_family = static_cast<unsigned char>(family);
     nd->ndm_ifindex = static_cast<int>(if_nametoindex("lo"));
     nd->ndm_state = static_cast<unsigned short>(state);
     nd->ndm_type = RTN_UNICAST;
 
-    struct rtattr *dst = reinterpret_cast<struct rtattr *>(
-        buffer + NLMSG_ALIGN(hdr->nlmsg_len));
     size_t addressLength = family == AF_INET ? sizeof(struct in_addr) : sizeof(struct in6_addr);
+    struct rtattr *dst = static_cast<struct rtattr *>(
+        nlmsg_reserve(msg.get(), RTA_LENGTH(addressLength), NLMSG_ALIGNTO));
+    if (!dst)
+    {
+        return nullptr;
+    }
+
     dst->rta_type = NDA_DST;
     dst->rta_len = static_cast<unsigned short>(RTA_LENGTH(addressLength));
     if (inet_pton(family, ip.c_str(), RTA_DATA(dst)) != 1)
     {
         return nullptr;
     }
-    hdr->nlmsg_len = static_cast<unsigned int>(
-        NLMSG_ALIGN(hdr->nlmsg_len) + RTA_ALIGN(dst->rta_len));
 
     const unsigned char mac[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55};
-    struct rtattr *lladdr = reinterpret_cast<struct rtattr *>(
-        buffer + NLMSG_ALIGN(hdr->nlmsg_len));
+    struct rtattr *lladdr = static_cast<struct rtattr *>(
+        nlmsg_reserve(msg.get(), RTA_LENGTH(sizeof(mac)), NLMSG_ALIGNTO));
+    if (!lladdr)
+    {
+        return nullptr;
+    }
+
     lladdr->rta_type = NDA_LLADDR;
     lladdr->rta_len = static_cast<unsigned short>(RTA_LENGTH(sizeof(mac)));
     memcpy(RTA_DATA(lladdr), mac, sizeof(mac));
-    hdr->nlmsg_len = static_cast<unsigned int>(
-        NLMSG_ALIGN(hdr->nlmsg_len) + RTA_ALIGN(lladdr->rta_len));
 
     struct rtnl_neigh *neigh = nullptr;
-    if (rtnl_neigh_parse(hdr, &neigh) < 0)
+    if (rtnl_neigh_parse(nlmsg_hdr(msg.get()), &neigh) < 0)
     {
         return nullptr;
     }


### PR DESCRIPTION
**What I did**

Added event-driven, best-effort handling for failed IPv6 kernel neighbors on dual-ToR systems. `neighsyncd` records failed neighbors in `NEIGH_FAILED_TABLE`, and `nbrmgrd` subscribes to that table only on dual-ToR devices, attempts to move each entry to `INCOMPLETE` through the existing fire-and-forget netlink send path, and sends one Neighbor Solicitation. Each notification is processed once. The table entry remains while the neighbor is unresolved and is removed when the kernel neighbor reaches a valid state or is deleted.

**Why I did it**

Failed IPv6 neighbors must remain in `INCOMPLETE` state so they can be resolved by a later Neighbor Advertisement, rather than returning to `FAILED` through the kernel retry timer. Sending one Neighbor Solicitation provides an immediate resolution attempt without enabling recurring kernel probes.

**How I verified it**

Added C++ mock tests covering the neighsyncd table lifecycle and the complete nbrmgrd APPL_DB consumer path, including dual-ToR-only subscription, fire-and-forget netlink sends, one-attempt Neighbor Solicitation behavior, best-effort failures, validation, and error handling.

- `tests_nbrmgrd`: 13 tests passed
- `tests_neighsyncd`: 6 tests passed

I have also added new sonic-mgmt tests and modified existing ones to account for this behavior change, and have run them with 100% passing rate against the 202605 version of this PR.

- sonic-mgmt PR: https://github.com/sonic-net/sonic-mgmt/pull/27988
- 202605 backport for this PR: https://github.com/sonic-net/sonic-swss/pull/4882

**Details if related**

Depends on https://github.com/sonic-net/sonic-swss-common/pull/1241 for `APP_NEIGH_FAILED_TABLE_NAME`.
