### PR TITLE
[portsorch] Don't abort orchagent on a per-port failure during bulk port creation

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1321,7 +1321,8 @@ bool PortsOrch::addPortBulk(const std::vector<PortConfig> &portList, std::vector
 
     auto portCount = static_cast<std::uint32_t>(portList.size());
     std::vector<sai_object_id_t> oidList(portCount, SAI_NULL_OBJECT_ID);
-    std::vector<sai_status_t> statusList(portCount, SAI_STATUS_SUCCESS);
+    // Default to failure so any port SAI does not explicitly mark success is treated as not-created.
+    std::vector<sai_status_t> statusList(portCount, SAI_STATUS_FAILURE);
 
     for (const auto &cit : portList)
     {
@@ -1500,35 +1501,32 @@ bool PortsOrch::addPortBulk(const std::vector<PortConfig> &portList, std::vector
         SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR,
         oidList.data(), statusList.data()
     );
+
+    // Under IGNORE_ERROR the bulk call returns a non-success aggregate status if ANY port
+    // fails, with per-port results in statusList. Don't abort: keep the ports that were
+    // created and skip the ones that failed (per-port triage below).
     if (status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR("Failed to create ports with bulk operation, rv:%d", status);
-
-        auto handle_status = handleSaiCreateStatus(SAI_API_PORT, status);
-        if (handle_status != task_process_status::task_success)
-        {
-            SWSS_LOG_THROW("PortsOrch bulk create failure");
-        }
-
-        return false;
+        SWSS_LOG_WARN("Bulk port create returned rv:%d; keeping the ports that succeeded", status);
     }
+
+    std::uint32_t failedPortCount = 0;
 
     for (std::uint32_t i = 0; i < portCount; i++)
     {
-        if (statusList.at(i) != SAI_STATUS_SUCCESS)
+        // Skip any port SAI did not create (incl. already-exists / resource errors); one bad port must not fail the bulk.
+        bool created = (status == SAI_STATUS_SUCCESS) || (statusList.at(i) == SAI_STATUS_SUCCESS);
+        if (!created)
         {
             SWSS_LOG_ERROR(
-                "Failed to create port %s with bulk operation, rv:%d",
+                "Failed to create port %s with bulk operation, rv:%d - skipping",
                 portList.at(i).key.c_str(), statusList.at(i)
             );
 
-            auto handle_status = handleSaiCreateStatus(SAI_API_PORT, statusList.at(i));
-            if (handle_status != task_process_status::task_success)
-            {
-                SWSS_LOG_THROW("PortsOrch bulk create failure");
-            }
-
-            return false;
+            // Leave m_port_id at SAI_NULL_OBJECT_ID so this entry is pruned below.
+            addedPorts.at(i).m_port_id = SAI_NULL_OBJECT_ID;
+            failedPortCount++;
+            continue;
         }
 
         Port& p = addedPorts.at(i);
@@ -1544,6 +1542,29 @@ bool PortsOrch::addPortBulk(const std::vector<PortConfig> &portList, std::vector
         m_portCount++;
     }
 
+    // Drop the failed ports so the caller only initializes the ones SAI created.
+    if (failedPortCount > 0)
+    {
+        addedPorts.erase(
+            std::remove_if(
+                addedPorts.begin(), addedPorts.end(),
+                [](const Port &p) { return p.m_port_id == SAI_NULL_OBJECT_ID; }
+            ),
+            addedPorts.end()
+        );
+
+        SWSS_LOG_WARN(
+            "addPortBulk: %u of %u port(s) failed to create and were skipped; continuing with %zu",
+            failedPortCount, portCount, addedPorts.size()
+        );
+
+        // No port could be created: keep the original fail-fast for a total failure.
+        if (addedPorts.empty())
+        {
+            return false;
+        }
+    }
+
     // newly created ports might be put in the default vlan so remove all ports from
     // the default vlan.
     if (gMySwitchType == "voq") {
@@ -1551,7 +1572,13 @@ bool PortsOrch::addPortBulk(const std::vector<PortConfig> &portList, std::vector
         removeDefaultBridgePorts();
     }
 
-    SWSS_LOG_NOTICE("Created ports: %s", swss::join(',', oidList.begin(), oidList.end()).c_str());
+    // Log only the OIDs actually created (addedPorts is pruned of skipped ports).
+    std::vector<sai_object_id_t> createdOids;
+    for (const auto &p : addedPorts)
+    {
+        createdOids.push_back(p.m_port_id);
+    }
+    SWSS_LOG_NOTICE("Created ports: %s", swss::join(',', createdOids.begin(), createdOids.end()).c_str());
 
     return true;
 }

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -424,6 +424,40 @@ namespace portsorch_test
         set_admin_status_failures = 0;
     }
 
+    // Stub: fail (IGNORE_ERROR style) the last _sai_create_ports_fail_count ports of each bulk.
+    uint32_t _sai_create_ports_fail_count = 0;
+
+    sai_status_t _ut_stub_create_ports(
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t object_count,
+        _In_ const uint32_t *attr_count,
+        _In_ const sai_attribute_t **attr_list,
+        _In_ sai_bulk_op_error_mode_t mode,
+        _Out_ sai_object_id_t *object_id,
+        _Out_ sai_status_t *object_statuses)
+    {
+        uint32_t fail = _sai_create_ports_fail_count > object_count ? object_count : _sai_create_ports_fail_count;
+        uint32_t good = object_count - fail;
+
+        // Create only the good ports in VS; never create the failed ones (so no orphan
+        // objects leak into VS), mirroring SAI IGNORE_ERROR where a failed item creates nothing.
+        auto status = pold_sai_port_api->create_ports(
+            switch_id, good, attr_count, attr_list, mode, object_id, object_statuses);
+
+        for (uint32_t i = 0; i < good; i++)
+        {
+            object_statuses[i] = SAI_STATUS_SUCCESS;
+        }
+        for (uint32_t i = good; i < object_count; i++)
+        {
+            object_id[i] = SAI_NULL_OBJECT_ID;
+            object_statuses[i] = SAI_STATUS_INSUFFICIENT_RESOURCES;
+        }
+
+        // Real SAI reports a non-success aggregate when any item fails under IGNORE_ERROR.
+        return fail > 0 ? SAI_STATUS_FAILURE : status;
+    }
+
     void _hook_sai_port_api()
     {
         ut_sai_port_api = *sai_port_api;
@@ -1187,6 +1221,128 @@ namespace portsorch_test
         std::vector<std::string> keys;
         bufferMaxParameterTable.getKeys(keys);
         ASSERT_TRUE(keys.empty());
+    }
+
+    // A per-port bulk create failure must be skipped, not abort orchagent.
+    TEST_F(PortsOrchTest, PortBulkCreatePartialFailureIsSkipped)
+    {
+        auto portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+
+        auto &ports = defaultPortList;
+        ASSERT_TRUE(!ports.empty());
+
+        // Generate port config (same shape as PortBulkCreateRemove).
+        for (std::uint32_t idx1 = 0, idx2 = 1; idx1 < ports.size() * 4; idx1 += 4, idx2++)
+        {
+            std::stringstream key;   key   << FRONT_PANEL_PORT_PREFIX << idx1;
+            std::stringstream alias; alias << "etp" << idx2;
+            std::stringstream index; index << idx2;
+            std::stringstream lanes; lanes << idx1 << "," << idx1 + 1 << "," << idx1 + 2 << "," << idx1 + 3;
+
+            std::vector<FieldValueTuple> fvList = {
+                { "alias",               alias.str() },
+                { "index",               index.str() },
+                { "lanes",               lanes.str() },
+                { "speed",               "100000"    },
+                { "autoneg",             "off"       },
+                { "adv_speeds",          "all"       },
+                { "interface_type",      "none"      },
+                { "adv_interface_types", "all"       },
+                { "fec",                 "rs"        },
+                { "mtu",                 "9100"      },
+                { "tpid",                "0x8100"    },
+                { "pfc_asym",            "off"       },
+                { "admin_status",        "up"        },
+                { "description",         "FP port"   }
+            };
+
+            portTable.set(key.str(), fvList);
+        }
+
+        portTable.set("PortConfigDone", { { "count", std::to_string(ports.size()) } });
+        gPortsOrch->addExistingData(&portTable);
+
+        // Make SAI reject the last port of the bulk (an IGNORE_ERROR partial failure).
+        _hook_sai_port_api();
+        ut_sai_port_api.create_ports = _ut_stub_create_ports;
+        _sai_create_ports_fail_count = 1;
+
+        // With the fix this is graceful; before, it threw "PortsOrch bulk create failure".
+        ASSERT_NO_THROW(static_cast<Orch*>(gPortsOrch)->doTask());
+
+        _sai_create_ports_fail_count = 0;
+        _unhook_sai_port_api();
+
+        // The one rejected port is skipped; the remaining ports (+ CPU) are created.
+        ASSERT_EQ(gPortsOrch->getAllPorts().size(), ports.size());
+
+        // The skipped port's task remains pending and is retried on later doTask cycles;
+        // with the real SAI restored it now succeeds. Drain it so cleanup below removes
+        // every port and leaves the shared VS switch as clean as we found it.
+        static_cast<Orch*>(gPortsOrch)->doTask();
+
+        cleanupPortsBestEffort(gPortsOrch);
+    }
+
+    // A total bulk-create failure creates no ports (addPortBulk returns false).
+    TEST_F(PortsOrchTest, PortBulkCreateTotalFailureCreatesNoPorts)
+    {
+        auto portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+
+        auto &ports = defaultPortList;
+        ASSERT_TRUE(!ports.empty());
+
+        // Generate port config (same shape as PortBulkCreateRemove).
+        for (std::uint32_t idx1 = 0, idx2 = 1; idx1 < ports.size() * 4; idx1 += 4, idx2++)
+        {
+            std::stringstream key;   key   << FRONT_PANEL_PORT_PREFIX << idx1;
+            std::stringstream alias; alias << "etp" << idx2;
+            std::stringstream index; index << idx2;
+            std::stringstream lanes; lanes << idx1 << "," << idx1 + 1 << "," << idx1 + 2 << "," << idx1 + 3;
+
+            std::vector<FieldValueTuple> fvList = {
+                { "alias",               alias.str() },
+                { "index",               index.str() },
+                { "lanes",               lanes.str() },
+                { "speed",               "100000"    },
+                { "autoneg",             "off"       },
+                { "adv_speeds",          "all"       },
+                { "interface_type",      "none"      },
+                { "adv_interface_types", "all"       },
+                { "fec",                 "rs"        },
+                { "mtu",                 "9100"      },
+                { "tpid",                "0x8100"    },
+                { "pfc_asym",            "off"       },
+                { "admin_status",        "up"        },
+                { "description",         "FP port"   }
+            };
+
+            portTable.set(key.str(), fvList);
+        }
+
+        portTable.set("PortConfigDone", { { "count", std::to_string(ports.size()) } });
+        gPortsOrch->addExistingData(&portTable);
+
+        // Make SAI reject every port of the bulk (a total IGNORE_ERROR failure).
+        _hook_sai_port_api();
+        ut_sai_port_api.create_ports = _ut_stub_create_ports;
+        _sai_create_ports_fail_count = static_cast<uint32_t>(ports.size());
+
+        // addPortBulk returns false when nothing is created; the init caller then
+        // fail-fasts (throws) on some trees, so tolerate either outcome here.
+        try
+        {
+            static_cast<Orch*>(gPortsOrch)->doTask();
+        }
+        catch (const std::exception &)
+        {
+        }
+
+        _sai_create_ports_fail_count = 0;
+        _unhook_sai_port_api();
+
+        // The whole bulk was rejected: only the CPU port exists, nothing leaked.
+        ASSERT_EQ(gPortsOrch->getAllPorts().size(), 1);
     }
 
     // Verifies certain port attributes are configured for the port creation flow.


### PR DESCRIPTION
#### Why I did it

Fixes #3981

During initialization, `PortsOrch::addPortBulk()` creates all front-panel ports with a single bulk SAI call using `SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR`. When the bulk create reports a non-success aggregate status (which, under `IGNORE_ERROR`, is how SAI signals that *some* objects failed while others succeeded), orchagent calls `SWSS_LOG_THROW("PortsOrch bulk create failure")`. Because `addPortBulk()` runs from `doPortConfig()` during init and the throw is uncaught, orchagent aborts (SIGABRT), swss/syncd crash-loop, and the device cannot boot.

As a result, a single port the ASIC/SAI rejects (an unsupported lane/speed for the platform, a resource limit, or a stray extra port entry) takes down the entire switch instead of just that one port — which defeats the purpose of requesting `IGNORE_ERROR`. See #3981 for a concrete reproduction (conflicting speeds on breakout sub-ports).

#### How I did it

Honor `IGNORE_ERROR` in `PortsOrch::addPortBulk()`:

- When the bulk create returns a non-success aggregate status, log a warning instead of throwing, then triage per port using the per-object `statusList`.
- Skip the ports that failed (leave their OID as `SAI_NULL_OBJECT_ID` and prune them from the returned list) and continue initializing the ports that succeeded.
- Return `false` only if *no* port could be created, preserving the existing fail-fast for a genuine total failure (the caller still throws in that case).
- Default the per-object status vector to failure so a port SAI does not explicitly mark successful is treated as not-created, guarding against registering a port with a null OID.

#### How to verify it

Added mock test `PortsOrchTest.PortBulkCreatePartialFailureIsSkipped`, which injects a single per-port failure into the bulk create (returning a non-success aggregate with per-object statuses, as SAI does under `IGNORE_ERROR`):

- Without the fix: the whole bulk is discarded — `getAllPorts()` returns `1` (only the CPU port) instead of `32`.
- With the fix: the one bad port is skipped and the rest come up — `getAllPorts()` returns `32`.

The full `PortsOrchTest` suite passes (55/55), including the existing `PortBulkCreateRemove` regression test.
