### PR TITLE
[P4orch] Consolidate L3 admit alias MAC handling, optimize RIF/multicast MyMAC allocation, and support dynamic user-defined trap group updates in P4Orch.

### DIFF
--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -15,6 +15,7 @@ extern "C" {
 #include "directory.h"
 #include "flow_counter_handler.h"
 #include "timer.h"
+#include "p4orch/p4orch.h"
 
 #include <inttypes.h>
 #include <sstream>
@@ -33,6 +34,8 @@ extern PortsOrch*           gPortsOrch;
 extern Directory<Orch*>     gDirectory;
 extern bool                 gIsNatSupported;
 extern bool                 gTraditionalFlexCounter;
+
+extern P4Orch *gP4Orch;
 
 #define FLEX_COUNTER_UPD_INTERVAL 1
 
@@ -849,6 +852,11 @@ task_process_status CoppOrch::processCoppRule(Consumer& consumer)
             {
                 return task_process_status::task_failed;
             }
+            if (gP4Orch &&
+                !gP4Orch->getAclRuleManager()->updateUserDefinedTrap(trap_group_name, /*is_delete=*/false).ok())
+            {
+                return task_process_status::task_failed;
+            }
         }
         if (!trapGroupProcessTrapIdChange(trap_group_name, add_trap_ids, rem_trap_ids))
         {
@@ -864,6 +872,11 @@ task_process_status CoppOrch::processCoppRule(Consumer& consumer)
             return task_process_status::task_ignore;
         }
 
+        if (gP4Orch &&
+            !gP4Orch->getAclRuleManager()->updateUserDefinedTrap(trap_group_name, /*is_delete=*/true).ok())
+        {
+            return task_process_status::task_failed;
+        }
         if (!processTrapGroupDel(trap_group_name))
         {
             return task_process_status::task_failed;

--- a/orchagent/namelabelmapper.cpp
+++ b/orchagent/namelabelmapper.cpp
@@ -29,7 +29,7 @@ NameLabelMapper::NameLabelMapper() : m_db("STATE_DB", 0), m_table(&m_db, "SAI_KE
 {
 }
 
-bool NameLabelMapper::setLabel(_In_ sai_object_type_t object_type, _In_ const std::string &key, _In_ std::string &label)
+bool NameLabelMapper::setLabel(_In_ sai_object_type_t object_type, _In_ const std::string &key, _In_ const std::string& label)
 {
     SWSS_LOG_ENTER();
 

--- a/orchagent/namelabelmapper.cpp
+++ b/orchagent/namelabelmapper.cpp
@@ -59,6 +59,12 @@ bool NameLabelMapper::getLabel(_In_ sai_object_type_t object_type, _In_ const st
     return true;
 }
 
+bool NameLabelMapper::isLabelValid(std::string label) {
+    SWSS_LOG_ENTER();
+    size_t len = label.length();
+    return len >= 16 && len < 32;
+}
+
 bool NameLabelMapper::eraseLabel(_In_ sai_object_type_t object_type, _In_ const std::string &key)
 {
     SWSS_LOG_ENTER();

--- a/orchagent/namelabelmapper.h
+++ b/orchagent/namelabelmapper.h
@@ -28,7 +28,7 @@ class NameLabelMapper
 
     // Sets label for the given key for the specific object_type. Returns false if
     // the key already exists.
-    bool setLabel(_In_ sai_object_type_t object_type, _In_ const std::string &key, _In_ std::string &label);
+    bool setLabel(_In_ sai_object_type_t object_type, _In_ const std::string &key, _In_ const std::string& label);
 
     // Return true if label present in the mapper, and copy the label in the 3rd
     // argument; or false, and a new unique label is allocated and saved in mapper

--- a/orchagent/namelabelmapper.h
+++ b/orchagent/namelabelmapper.h
@@ -38,6 +38,10 @@ class NameLabelMapper
     // Returns true on success.
     bool getLabel(_In_ sai_object_type_t object_type, _In_ const std::string &key, _Out_ std::string &label);
 
+    // Is the label valid. Label is valid if length is between [16, 32)
+    // Returns true if label is valid.
+    bool isLabelValid(std::string label);
+
     // Erases label for the given key for the SAI object_type.
     // Returns true on success.
     bool eraseLabel(_In_ sai_object_type_t object_type, _In_ const std::string &key);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -900,7 +900,7 @@ bool OrchDaemon::init()
 
     vector<string> p4rt_tables = {APP_P4RT_TABLE_NAME};
     m_p4OrchZmqServer = new swss::ZmqServer(m_p4OrchZmqServerEp, "", false, true);
-    gP4Orch = new P4Orch(m_applDb, p4rt_tables, m_p4OrchZmqServer, vrf_orch, gCoppOrch);
+    gP4Orch = new P4Orch(m_applDb, p4rt_tables, m_p4OrchZmqServer, vrf_orch);
     m_orchList.push_back(gP4Orch);
 
     TableConnector confDbTwampTable(m_configDb, CFG_TWAMP_SESSION_TABLE_NAME);

--- a/orchagent/p4orch/acl_rule_manager.cpp
+++ b/orchagent/p4orch/acl_rule_manager.cpp
@@ -7,6 +7,7 @@
 
 #include "SaiAttributeList.h"
 #include "converter.h"
+#include "copporch.h"
 #include "crmorch.h"
 #include "dbconnector.h"
 #include "intfsorch.h"
@@ -32,6 +33,7 @@ extern sai_policer_api_t *sai_policer_api;
 extern sai_hostif_api_t *sai_hostif_api;
 extern CrmOrch *gCrmOrch;
 extern PortsOrch *gPortsOrch;
+extern CoppOrch *gCoppOrch;
 extern P4Orch *gP4Orch;
 extern NameLabelMapper* gLabelMapper;
 
@@ -205,6 +207,93 @@ std::vector<sai_attribute_t> getMeterSaiAttrs(P4AclMeter &p4_acl_meter)
     return meter_attrs;
 }
 
+std::vector<sai_attribute_t> getUserDefinedTrapAttrs(
+    const sai_object_id_t trap_group_oid) {
+  std::vector<sai_attribute_t> trap_attrs;
+  sai_attribute_t attr;
+  attr.id = SAI_HOSTIF_USER_DEFINED_TRAP_ATTR_TRAP_GROUP;
+  attr.value.oid = trap_group_oid;
+  trap_attrs.push_back(attr);
+  attr.id = SAI_HOSTIF_USER_DEFINED_TRAP_ATTR_TYPE;
+  attr.value.s32 = SAI_HOSTIF_USER_DEFINED_TRAP_TYPE_ACL;
+  trap_attrs.push_back(attr);
+  return trap_attrs;
+}
+
+std::vector<sai_attribute_t> getUserDefinedTrapHostIfTableEntryAttrs(
+    const sai_object_id_t user_defined_trap_oid,
+    const sai_object_id_t hostif_oid) {
+  std::vector<sai_attribute_t> sai_host_table_attr;
+  sai_attribute_t attr;
+  attr.id = SAI_HOSTIF_TABLE_ENTRY_ATTR_TYPE;
+  attr.value.s32 = SAI_HOSTIF_TABLE_ENTRY_TYPE_TRAP_ID;
+  sai_host_table_attr.push_back(attr);
+
+  attr.id = SAI_HOSTIF_TABLE_ENTRY_ATTR_TRAP_ID;
+  attr.value.oid = user_defined_trap_oid;
+  sai_host_table_attr.push_back(attr);
+
+  attr.id = SAI_HOSTIF_TABLE_ENTRY_ATTR_CHANNEL_TYPE;
+  attr.value.s32 = SAI_HOSTIF_TABLE_ENTRY_CHANNEL_TYPE_GENETLINK;
+  sai_host_table_attr.push_back(attr);
+
+  attr.id = SAI_HOSTIF_TABLE_ENTRY_ATTR_HOST_IF;
+  attr.value.oid = hostif_oid;
+  sai_host_table_attr.push_back(attr);
+  return sai_host_table_attr;
+}
+
+ReturnCodeOr<P4UserDefinedTrapHostifTableEntry>
+createUserDefinedTrapAndHostIfTableEntry(const sai_object_id_t trap_group_oid,
+                                         const sai_object_id_t hostif_oid) {
+  P4UserDefinedTrapHostifTableEntry udt_hostif;
+  const auto trap_attrs = getUserDefinedTrapAttrs(trap_group_oid);
+  CHECK_ERROR_AND_LOG_AND_RETURN(
+      sai_hostif_api->create_hostif_user_defined_trap(
+          &udt_hostif.user_defined_trap, gSwitchId, (uint32_t)trap_attrs.size(),
+          trap_attrs.data()),
+      "Failed to create trap by calling "
+      "sai_hostif_api->create_hostif_user_defined_trap");
+  const auto sai_host_table_attrs = getUserDefinedTrapHostIfTableEntryAttrs(
+      udt_hostif.user_defined_trap, hostif_oid);
+  auto sai_status = sai_hostif_api->create_hostif_table_entry(
+      &udt_hostif.hostif_table_entry, gSwitchId,
+      (uint32_t)sai_host_table_attrs.size(), sai_host_table_attrs.data());
+  if (sai_status != SAI_STATUS_SUCCESS) {
+    ReturnCode return_code =
+        ReturnCode(sai_status)
+        << "Failed to create hostif table entry by calling "
+           "sai_hostif_api->create_hostif_table_entry";
+    auto recover_sai_status = sai_hostif_api->remove_hostif_user_defined_trap(
+        udt_hostif.user_defined_trap);
+    if (recover_sai_status != SAI_STATUS_SUCCESS) {
+      RETURN_INTERNAL_ERROR_AND_RAISE_CRITICAL(
+          "Failed to remove user defined traps during recovery.");
+    }
+    SWSS_LOG_ERROR("%s SAI_STATUS: %s", return_code.message().c_str(),
+                   sai_serialize_status(sai_status).c_str());
+    return return_code;
+  }
+  return udt_hostif;
+}
+
+ReturnCodeOr<uint32_t> parseQueueNumberFromStr(
+    const std::string& queue_num_str) {
+  uint32_t queue_num = 0;
+  try {
+    queue_num = to_uint<uint32_t>(queue_num_str);
+  } catch (std::exception& e) {
+    LOG_ERROR_AND_RETURN(ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
+                         << "Traps group names should start with "
+                         << GENL_PACKET_TRAP_GROUP_NAME_PREFIX
+                         << " and followed up by an unsigned number. e.g."
+                         << GENL_PACKET_TRAP_GROUP_NAME_PREFIX
+                         << "1. queue number " << QuotedVar(queue_num_str)
+                         << " is invalid.");
+  }
+  return queue_num;
+}
+
 } // namespace
 
 ReturnCode AclRuleManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
@@ -295,101 +384,154 @@ ReturnCode AclRuleManager::drain() {
   return status;
 }
 
-ReturnCode AclRuleManager::setUpUserDefinedTraps()
+ReturnCode AclRuleManager::setUserDefinedTrap(
+    const uint32_t queue_num, const sai_object_id_t trap_group_oid,
+    const sai_object_id_t hostif_oid)
 {
     SWSS_LOG_ENTER();
 
-    const auto trapGroupMap = m_coppOrch->getTrapGroupMap();
-    const auto trapGroupHostIfMap = m_coppOrch->getTrapGroupHostIfMap();
-    for (int queue_num = 1; queue_num <= P4_CPU_QUEUE_MAX_NUM; queue_num++)
-    {
-        auto trap_group_it = trapGroupMap.find(GENL_PACKET_TRAP_GROUP_NAME_PREFIX + std::to_string(queue_num));
-        if (trap_group_it == trapGroupMap.end())
-        {
-	    SWSS_LOG_INFO("Trap group was not found given trap group name: %s%d",
-                    GENL_PACKET_TRAP_GROUP_NAME_PREFIX, queue_num);
-              continue;
+    auto udt_it = m_userDefinedTraps.find(queue_num);
+    if (udt_it != m_userDefinedTraps.end()) {
+      CHECK_ERROR_AND_LOG_AND_RETURN(
+          sai_hostif_api->remove_hostif_table_entry(
+              udt_it->second.hostif_table_entry),
+          "Received trap group update request but "
+          "failed to remove the old hostif table entry.");
+      CHECK_ERROR_AND_LOG_AND_RETURN(
+          sai_hostif_api->remove_hostif_user_defined_trap(
+              udt_it->second.user_defined_trap),
+          "Received trap group update request but "
+          "failed to remove the old user defined trap.");
+      m_p4OidMapper->eraseOID(SAI_OBJECT_TYPE_HOSTIF_USER_DEFINED_TRAP,
+                              std::to_string(queue_num));
+      m_userDefinedTraps.erase(queue_num);
+    }
+    ASSIGN_OR_RETURN(auto udt_hostif, createUserDefinedTrapAndHostIfTableEntry(
+                                          trap_group_oid, hostif_oid));
+    m_p4OidMapper->setOID(SAI_OBJECT_TYPE_HOSTIF_USER_DEFINED_TRAP,
+                          std::to_string(queue_num), udt_hostif.user_defined_trap,
+                          /*ref_count=*/1);
+    m_userDefinedTraps[queue_num] = udt_hostif;
+    SWSS_LOG_NOTICE(
+       "Created user defined trap for QUEUE number %d: %s", queue_num,
+        sai_serialize_object_id(udt_hostif.user_defined_trap).c_str());
+    return ReturnCode();
+}
+
+ReturnCode AclRuleManager::initializeUserDefinedTraps() {
+    SWSS_LOG_ENTER();
+    // User Defined Traps should be initialized only once when an ACL table is
+    // referencing them created.
+    if (m_isAclTableReferencingUserDefinedTrapsAdded) return ReturnCode();
+
+    const auto trapGroupMap = gCoppOrch->getTrapGroupMap();
+    const auto trapGroupHostIfMap = gCoppOrch->getTrapGroupHostIfMap();
+    for (const auto& trap_group_it : trapGroupMap) {
+      const auto trap_group_name = trap_group_it.first;
+      if (trap_group_name.find(GENL_PACKET_TRAP_GROUP_NAME_PREFIX) ==
+          std::string::npos) {
+        SWSS_LOG_INFO("%s is not a trap group for user defined trap creation.",
+                      QuotedVar(trap_group_name).c_str());
+        continue;
         }
+        const auto queue_num_str =
+            trap_group_name.substr(strlen(GENL_PACKET_TRAP_GROUP_NAME_PREFIX));
+        ASSIGN_OR_RETURN(auto queue_num, parseQueueNumberFromStr(queue_num_str));
+        const sai_object_id_t trap_group_oid = trap_group_it.second;
+        auto hostif_oid_it = trapGroupHostIfMap.find(trap_group_oid);
+        if (hostif_oid_it == trapGroupHostIfMap.end()) {
+          LOG_ERROR_AND_RETURN(
+              ReturnCode(StatusCode::SWSS_RC_NOT_FOUND)
+              << "Hostif object id was not found given trap group - "
+              << trap_group_it.first);
+        }
+        // Create user defined trap and add it in hostif table.
+        LOG_AND_RETURN_IF_ERROR(
+            setUserDefinedTrap(queue_num, trap_group_oid, hostif_oid_it->second));
+      }
+      m_isAclTableReferencingUserDefinedTrapsAdded = true;
+      return ReturnCode();
+}
+
+ReturnCode AclRuleManager::updateUserDefinedTrap(
+    const std::string& trap_group_name, bool is_delete) {
+  SWSS_LOG_ENTER();
+
+      if (trap_group_name.find(GENL_PACKET_TRAP_GROUP_NAME_PREFIX) ==
+          std::string::npos) {
+        SWSS_LOG_INFO("%s is not a trap group for user defined trap update.",
+                      QuotedVar(trap_group_name).c_str());
+        return ReturnCode();
+      }
+      // User-defined traps are initially set up when P4Orch adds the first ACL
+      // table that references a user-defined trap as an action.  Subsequent updates
+      // to user-defined traps in the cache and hardware are only permitted after
+      // this initialization.
+      if (!m_isAclTableReferencingUserDefinedTrapsAdded) {
+        SWSS_LOG_INFO(
+            "User defined traps have not been initialized during ACL table "
+            "creation yet. They will not be created until an ACL table is "
+            "referencing them.");
+        return ReturnCode();
+      }
+      // Retrieve trapGroupMap and trapGroupHostIfMap from CoppOrch during runtime,
+      // as new trap groups might be added after the initial setup. This accounts
+      // for situations like CoPP table updates that occur following NSF
+      // reconciliation.
+      const auto trapGroupMap = gCoppOrch->getTrapGroupMap();
+      const auto trapGroupHostIfMap = gCoppOrch->getTrapGroupHostIfMap();
+      const auto queue_num_str =
+          trap_group_name.substr(strlen(GENL_PACKET_TRAP_GROUP_NAME_PREFIX));
+      ASSIGN_OR_RETURN(auto queue_num, parseQueueNumberFromStr(queue_num_str));
+      auto trap_group_it = trapGroupMap.find(trap_group_name);
+      auto udt_it = m_userDefinedTraps.find(queue_num);
+      if (!is_delete) {
+        if (trap_group_it == trapGroupMap.end()) {
+          SWSS_LOG_ERROR("trap_group_name %s was not found in CoppOrch cache.",
+                         QuotedVar(trap_group_name).c_str());
+          return ReturnCode(StatusCode::SWSS_RC_NOT_FOUND);
+        }
+        // trap_group_name has been added to the trapGroupMap,
+        // create user defined trap referencing the trap group and hostif table
+        // entry.
         const sai_object_id_t trap_group_oid = trap_group_it->second;
         auto hostif_oid_it = trapGroupHostIfMap.find(trap_group_oid);
         if (hostif_oid_it == trapGroupHostIfMap.end())
         {
             LOG_ERROR_AND_RETURN(ReturnCode(StatusCode::SWSS_RC_NOT_FOUND)
-                                 << "Hostif object id was not found given trap group - " << trap_group_it->first);
+                                 << "Hostif object id was not found given trap group - "
+         << QuotedVar(trap_group_name));
         }
-        // Create user defined trap
-        std::vector<sai_attribute_t> trap_attrs;
-        sai_attribute_t attr;
-        attr.id = SAI_HOSTIF_USER_DEFINED_TRAP_ATTR_TRAP_GROUP;
-        attr.value.oid = trap_group_oid;
-        trap_attrs.push_back(attr);
-        attr.id = SAI_HOSTIF_USER_DEFINED_TRAP_ATTR_TYPE;
-        attr.value.s32 = SAI_HOSTIF_USER_DEFINED_TRAP_TYPE_ACL;
-        trap_attrs.push_back(attr);
-        P4UserDefinedTrapHostifTableEntry udt_hostif;
-        CHECK_ERROR_AND_LOG_AND_RETURN(
-            sai_hostif_api->create_hostif_user_defined_trap(&udt_hostif.user_defined_trap, gSwitchId,
-                                                            (uint32_t)trap_attrs.size(), trap_attrs.data()),
-            "Failed to create trap by calling "
-            "sai_hostif_api->create_hostif_user_defined_trap");
-        std::vector<sai_attribute_t> sai_host_table_attr;
-
-        attr.id = SAI_HOSTIF_TABLE_ENTRY_ATTR_TYPE;
-        attr.value.s32 = SAI_HOSTIF_TABLE_ENTRY_TYPE_TRAP_ID;
-        sai_host_table_attr.push_back(attr);
-
-        attr.id = SAI_HOSTIF_TABLE_ENTRY_ATTR_TRAP_ID;
-        attr.value.oid = udt_hostif.user_defined_trap;
-        sai_host_table_attr.push_back(attr);
-
-        attr.id = SAI_HOSTIF_TABLE_ENTRY_ATTR_CHANNEL_TYPE;
-        attr.value.s32 = SAI_HOSTIF_TABLE_ENTRY_CHANNEL_TYPE_GENETLINK;
-        sai_host_table_attr.push_back(attr);
-
-        attr.id = SAI_HOSTIF_TABLE_ENTRY_ATTR_HOST_IF;
-        attr.value.oid = hostif_oid_it->second;
-        sai_host_table_attr.push_back(attr);
-
-        auto sai_status =
-            sai_hostif_api->create_hostif_table_entry(&udt_hostif.hostif_table_entry, gSwitchId,
-                                                      (uint32_t)sai_host_table_attr.size(), sai_host_table_attr.data());
-        if (sai_status != SAI_STATUS_SUCCESS)
-        {
-            ReturnCode return_code = ReturnCode(sai_status) << "Failed to create hostif table entry by calling "
-                                                               "sai_hostif_api->remove_hostif_user_defined_trap";
-            sai_hostif_api->remove_hostif_user_defined_trap(udt_hostif.user_defined_trap);
-            SWSS_LOG_ERROR("%s SAI_STATUS: %s", return_code.message().c_str(),
-                           sai_serialize_status(sai_status).c_str());
-            return return_code;
+        // Create user defined trap and add it in hostif table.
+        LOG_AND_RETURN_IF_ERROR(
+            setUserDefinedTrap(queue_num, trap_group_oid, hostif_oid_it->second));
+      } else {
+        // trap_group_name has been deleted from the trapGroupMap,
+        // if no ACL rules are referencing its corresponding user defined trap, then
+        // delete the user defined trap as well.
+        if (udt_it == m_userDefinedTraps.end()) {
+          return ReturnCode();
         }
-        m_p4OidMapper->setOID(SAI_OBJECT_TYPE_HOSTIF_USER_DEFINED_TRAP, std::to_string(queue_num),
-                              udt_hostif.user_defined_trap, /*ref_count=*/1);
-	m_userDefinedTraps[queue_num] = udt_hostif;
-        SWSS_LOG_NOTICE("Created user defined trap for QUEUE number %d: %s", queue_num,
-                        sai_serialize_object_id(udt_hostif.user_defined_trap).c_str());
-    }
-    return ReturnCode();
-}
-
-ReturnCode AclRuleManager::cleanUpUserDefinedTraps()
-{
-    SWSS_LOG_ENTER();
-
-    const auto trapGroupMap = m_coppOrch->getTrapGroupMap();
-    for (const auto& udt_it : m_userDefinedTraps) {
+        uint32_t ref_count = 0;
+        if (!m_p4OidMapper->getRefCount(SAI_OBJECT_TYPE_HOSTIF_USER_DEFINED_TRAP,
+                                        std::to_string(queue_num), &ref_count) ||
+            ref_count > 1) {
+          return ReturnCode(StatusCode::SWSS_RC_IN_USE)
+                 << "User defined trap for queue:" << QuotedVar(queue_num_str)
+                 << " can not be removed as it is in use.";
+        }
         CHECK_ERROR_AND_LOG_AND_RETURN(sai_hostif_api->remove_hostif_table_entry(
-                                       fvValue(udt_it).hostif_table_entry),
+                                       udt_it->second.hostif_table_entry),
                                        "Failed to remove hostif table entry.");
 
         m_p4OidMapper->decreaseRefCount(SAI_OBJECT_TYPE_HOSTIF_USER_DEFINED_TRAP,
-                                        std::to_string(fvField(udt_it)));
+                                        std::to_string(queue_num));
         sai_hostif_api->remove_hostif_user_defined_trap(
-            fvValue(udt_it).user_defined_trap);
+            udt_it->second.user_defined_trap);
         m_p4OidMapper->eraseOID(SAI_OBJECT_TYPE_HOSTIF_USER_DEFINED_TRAP,
-                                std::to_string(fvField(udt_it)));
-    }
-
-    m_userDefinedTraps.clear();
+                                std::to_string(queue_num));
+        m_userDefinedTraps.erase(queue_num);
+      }
     return ReturnCode();
 }
 
@@ -1625,13 +1767,6 @@ ReturnCode AclRuleManager::setActionValue(const sai_acl_entry_attr_t attr_name,
         try
         {
             uint32_t queue_num = to_uint<uint32_t>(attr_value);
-            if (queue_num < 1 || queue_num > m_userDefinedTraps.size())
-            {
-                return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                       << "Invalid CPU queue number " << QuotedVar(attr_value) << " for "
-                       << QuotedVar(acl_rule->acl_table_name)
-                       << ". Queue number should >= 1 and <= " << m_userDefinedTraps.size();
-            }
 	    const auto udt_it = m_userDefinedTraps.find(queue_num);
             if (udt_it == m_userDefinedTraps.end()) {
           	return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)

--- a/orchagent/p4orch/acl_rule_manager.cpp
+++ b/orchagent/p4orch/acl_rule_manager.cpp
@@ -176,7 +176,6 @@ std::vector<sai_attribute_t> getMeterSaiAttrs(P4AclMeter &p4_acl_meter)
             meter_attrs.push_back(meter_attr);
         }
 
-        /* TBD
         if (gLabelMapper->isLabelValid(p4_acl_meter.policer_label)) {
           meter_attr.id = SAI_POLICER_ATTR_LABEL;
           auto size = sizeof(meter_attr.value.chardata);
@@ -184,7 +183,6 @@ std::vector<sai_attribute_t> getMeterSaiAttrs(P4AclMeter &p4_acl_meter)
                    p4_acl_meter.policer_label.c_str());
           meter_attrs.push_back(meter_attr);
         }
-       */
     }
 
     for (const auto &packet_color_action : p4_acl_meter.packet_color_actions)

--- a/orchagent/p4orch/acl_rule_manager.h
+++ b/orchagent/p4orch/acl_rule_manager.h
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "dbconnector.h"
-#include "copporch.h"
 #include "orch.h"
 #include "p4orch/acl_util.h"
 #include "p4orch/object_manager_interface.h"
@@ -31,9 +30,9 @@ class AclManagerTest;
 class AclRuleManager : public ObjectManagerInterface
 {
   public:
-    explicit AclRuleManager(P4OidMapper *p4oidMapper, VRFOrch *vrfOrch, CoppOrch *coppOrch,
+    explicit AclRuleManager(P4OidMapper *p4oidMapper, VRFOrch *vrfOrch,
                             ResponsePublisherInterface *publisher)
-        : m_p4OidMapper(p4oidMapper), m_vrfOrch(vrfOrch), m_asic_db("ASIC_DB", 0), m_asic_state_table(&m_asic_db, "ASIC_STATE"), m_publisher(publisher), m_coppOrch(coppOrch),
+        : m_p4OidMapper(p4oidMapper), m_vrfOrch(vrfOrch), m_asic_db("ASIC_DB", 0), m_asic_state_table(&m_asic_db, "ASIC_STATE"), m_publisher(publisher),
           m_countersDb(std::make_unique<swss::DBConnector>("COUNTERS_DB", 0)),
           m_countersTable(std::make_unique<swss::Table>(
               m_countersDb.get(), std::string(COUNTERS_TABLE) + DEFAULT_KEY_SEPARATOR + APP_P4RT_TABLE_NAME))
@@ -53,6 +52,15 @@ class AclRuleManager : public ObjectManagerInterface
     // Update counters stats for every rule in each ACL table in COUNTERS_DB, if
     // counters are enabled in rules.
     void doAclCounterStatsTask();
+
+    // Create user defined trap for new cpu queue/trap group and program the user
+    // defined trap in hostif table if it is a new trap group.
+    // Save the user defined trap oid in m_p4OidMapper and default ref count is 1.
+    // Remove and create user defined trap if trap group is being updated.
+    // Remove user defined trap and its hostif entry if trap group is going to be
+    // deleted.
+    ReturnCode updateUserDefinedTrap(const std::string& trap_group_name,
+                                     bool is_delete = false);
 
   private:
     // Deserializes an entry in a dynamically created ACL table.
@@ -147,12 +155,13 @@ class AclRuleManager : public ObjectManagerInterface
     // Create user defined trap for each cpu queue/trap group and program user
     // defined traps in hostif. Save the user defined trap oids in m_p4OidMapper
     // and default ref count is 1.
-    ReturnCode setUpUserDefinedTraps();
+    ReturnCode initializeUserDefinedTraps();
 
-    // Clean up user defined traps created for cpu queues. Callers need to make
-    // sure ref count on user defined traps in m_userDefinedTraps are ones before
-    // clean up.
-    ReturnCode cleanUpUserDefinedTraps();
+    // Create or update(remove then create) user defined traps and its hostif
+    // table entry and update cache.
+    ReturnCode setUserDefinedTrap(const uint32_t queue_num,
+                                  const sai_object_id_t trap_group_oid,
+                                  const sai_object_id_t hostif_oid);
 
     // Verifies internal cache for an entry.
     std::string verifyStateCache(const P4AclRuleAppDbEntry &app_db_entry, const P4AclRule *acl_rule);
@@ -166,11 +175,13 @@ class AclRuleManager : public ObjectManagerInterface
     ResponsePublisherInterface *m_publisher;
     P4AclRuleTables m_aclRuleTables;
     VRFOrch *m_vrfOrch;
-    CoppOrch *m_coppOrch;
     std::deque<swss::KeyOpFieldsValuesTuple> m_entries;
     std::unique_ptr<swss::DBConnector> m_countersDb;
     std::unique_ptr<swss::Table> m_countersTable;
-    std::map<int, P4UserDefinedTrapHostifTableEntry> m_userDefinedTraps;
+    std::unordered_map<uint32_t, P4UserDefinedTrapHostifTableEntry>
+        m_userDefinedTraps;
+
+    bool m_isAclTableReferencingUserDefinedTrapsAdded = false;
 
     friend class AclTableManager;
     friend class p4orch::test::AclManagerTest;

--- a/orchagent/p4orch/acl_table_manager.cpp
+++ b/orchagent/p4orch/acl_table_manager.cpp
@@ -1,5 +1,4 @@
 #include "p4orch/acl_table_manager.h"
-#include "namelabelmapper.h"
 
 #include <nlohmann/json.hpp>
 #include <sstream>
@@ -11,6 +10,7 @@
 #include "crmorch.h"
 #include "dbconnector.h"
 #include "logger.h"
+#include "namelabelmapper.h"
 #include "orchagent/aclorch.h"
 #include "orchagent/crmorch.h"
 #include "orch.h"
@@ -79,9 +79,8 @@ std::vector<sai_attribute_t> getUdfGroupSaiAttrs(const P4UdfField& udf_field,
     // Add label to uniquely identify udf group.
     std::string mapper_key;
     label_present = gLabelMapper->addLabelToAttr(
-                                                 SAI_OBJECT_TYPE_UDF_GROUP, APP_P4RT_TABLE_NAME,
-                                                 udf_field.group_id, udf_group_attr, SAI_UDF_GROUP_ATTR_LABEL,
-                                                 mapper_key, group_label);
+        SAI_OBJECT_TYPE_UDF_GROUP, APP_P4RT_TABLE_NAME, udf_field.group_id,
+        udf_group_attr, SAI_UDF_GROUP_ATTR_LABEL, mapper_key, group_label);
     udf_group_attrs.push_back(udf_group_attr);
 
     return udf_group_attrs;
@@ -488,12 +487,8 @@ ReturnCode AclTableManager::processAddTableRequest(const P4AclTableDefinitionApp
         isSetUserTrapActionInAclTableDefinition(acl_table_definition.rule_action_field_lookup))
     {
         // Set up User Defined Traps for QOS_QUEUE action
-        auto status = gP4Orch->getAclRuleManager()->setUpUserDefinedTraps();
-        if (!status.ok())
-        {
-            gP4Orch->getAclRuleManager()->cleanUpUserDefinedTraps();
-            LOG_ERROR_AND_RETURN(status);
-        }
+        LOG_AND_RETURN_IF_ERROR(
+        gP4Orch->getAclRuleManager()->initializeUserDefinedTraps());
     }
 
     auto build_action_color_rc = buildAclTableDefinitionActionColorFieldValues(
@@ -641,7 +636,7 @@ ReturnCode AclTableManager::createUdfGroup(const P4UdfField &udf_field)
                                                                              APP_P4RT_TABLE_NAME, udf_field.group_id);
     if (!label_present)
     {
-        gLabelMapper->setLabel(SAI_OBJECT_TYPE_UDF_GROUP, mapper_key, group_label);
+      gLabelMapper->setLabel(SAI_OBJECT_TYPE_UDF_GROUP, mapper_key, group_label);
     }
 
     SWSS_LOG_INFO("Suceeded to create UDF group %s with object ID %s ", QuotedVar(udf_field.group_id).c_str(),
@@ -675,10 +670,9 @@ ReturnCode AclTableManager::removeUdfGroup(const std::string &udf_group_id)
     CHECK_ERROR_AND_LOG_AND_RETURN(sai_udf_api->remove_udf_group(group_oid),
                                    "Failed to remove UDF group with id " << QuotedVar(udf_group_id));
     m_p4OidMapper->eraseOID(SAI_OBJECT_TYPE_UDF_GROUP, udf_group_id);
-    gLabelMapper->eraseLabel(
-                SAI_OBJECT_TYPE_UDF_GROUP,
-                gLabelMapper->generateKeyFromTableAndObjectName(
-                     APP_P4RT_TABLE_NAME, udf_group_id));
+    gLabelMapper->eraseLabel(SAI_OBJECT_TYPE_UDF_GROUP,
+                             gLabelMapper->generateKeyFromTableAndObjectName(
+                                 APP_P4RT_TABLE_NAME, udf_group_id));
 
     SWSS_LOG_NOTICE("Suceeded to remove UDF group %s: %s", QuotedVar(udf_group_id).c_str(),
                     sai_serialize_object_id(group_oid).c_str());

--- a/orchagent/p4orch/acl_util.h
+++ b/orchagent/p4orch/acl_util.h
@@ -522,9 +522,6 @@ using P4AclRuleTables = std::map<std::string, std::map<std::string, P4AclRule>>;
 
 #define EMPTY_STRING ""
 
-#define P4_CPU_QUEUE_MIN_NUM 0
-#define P4_CPU_QUEUE_MAX_NUM 47
-
 #define IPV6_SINGLE_WORD_BYTES_LENGTH 4
 #define BYTE_BITWIDTH 8
 

--- a/orchagent/p4orch/ext_tables_manager.cpp
+++ b/orchagent/p4orch/ext_tables_manager.cpp
@@ -1,5 +1,7 @@
 #include "p4orch/ext_tables_manager.h"
 
+#include <inttypes.h>
+
 #include <boost/algorithm/string.hpp>
 #include <memory>
 #include <nlohmann/json.hpp>
@@ -221,7 +223,7 @@ ReturnCodeOr<P4ExtTableAppDbEntry> ExtTablesManager::deserializeP4ExtTableEntry(
             continue;
         }
 
-        const auto &tokenized_fields = tokenize(field, p4orch::kFieldDelimiter);
+        const auto& tokenized_fields = swss::tokenize(field, p4orch::kFieldDelimiter);
         if (tokenized_fields.size() <= 1)
         {
             SWSS_LOG_ERROR("Unknown extension entry field");

--- a/orchagent/p4orch/l3_admit_manager.cpp
+++ b/orchagent/p4orch/l3_admit_manager.cpp
@@ -403,6 +403,7 @@ std::string L3AdmitManager::verifyState(const std::string &key, const std::vecto
     auto &app_db_entry = *app_db_entry_or;
     const std::string l3_admit_key = KeyGenerator::generateL3AdmitKey(
         app_db_entry.mac_address_data, app_db_entry.mac_address_mask, app_db_entry.port_name, app_db_entry.priority);
+
     auto *l3_admit_entry = getL3AdmitEntry(l3_admit_key);
     if (l3_admit_entry == nullptr)
     {

--- a/orchagent/p4orch/l3_multicast_manager.cpp
+++ b/orchagent/p4orch/l3_multicast_manager.cpp
@@ -201,14 +201,14 @@ std::vector<sai_attribute_t> prepareNextHopSaiAttrs(
                         p4orch::kMulticastSetSrcMacAndDstMacAndVlanId;
   attrs.push_back(attr);
 
-  bool write_vlan = multicast_router_interface_entry.action ==
-                        p4orch::kMulticastSetSrcMacAndVlanId ||
-                    multicast_router_interface_entry.action ==
-                        p4orch::kMulticastSetSrcMacAndDstMacAndVlanId ||
-                    // In P4, this action is expected to write the internal
-                    // VLAN value (not provided from P4).
-                    multicast_router_interface_entry.action ==
-                        p4orch::kMulticastSetSrcMac;
+  bool write_vlan =
+      multicast_router_interface_entry.action ==
+          p4orch::kMulticastSetSrcMacAndVlanId ||
+      multicast_router_interface_entry.action ==
+          p4orch::kMulticastSetSrcMacAndDstMacAndVlanId ||
+      // In P4, this action is expected to write the internal
+      // VLAN value (not provided from P4).
+      multicast_router_interface_entry.action == p4orch::kMulticastSetSrcMac;
 
   attr.id = SAI_NEXT_HOP_ATTR_DISABLE_VLAN_REWRITE;
   attr.value.booldata = !write_vlan;

--- a/orchagent/p4orch/l3_multicast_manager.h
+++ b/orchagent/p4orch/l3_multicast_manager.h
@@ -204,8 +204,8 @@ class L3MulticastManager : public ObjectManagerInterface {
   ReturnCode createNextHop(P4MulticastRouterInterfaceEntry& entry,
                            const sai_object_id_t rif_oid,
                            sai_object_id_t* next_hop_oid);
-  ReturnCode createNeighborEntry(
-    P4MulticastRouterInterfaceEntry& entry, const sai_object_id_t rif_oid);
+  ReturnCode createNeighborEntry(P4MulticastRouterInterfaceEntry& entry,
+                                 const sai_object_id_t rif_oid);
 
   ReturnCode deleteRouterInterface(const std::string& rif_key,
                                    sai_object_id_t rif_oid);

--- a/orchagent/p4orch/p4orch.cpp
+++ b/orchagent/p4orch/p4orch.cpp
@@ -6,7 +6,6 @@
 #include <string>
 #include <vector>
 
-#include "copporch.h"
 #include "eventexecutor.h"
 #include "logger.h"
 #include "namelabelmapper.h"
@@ -38,7 +37,7 @@ extern PortsOrch *gPortsOrch;
 #define APP_P4RT_EXT_TABLES_MANAGER "EXT_TABLES_MANAGER"
 
 P4Orch::P4Orch(swss::DBConnector* db, std::vector<std::string> tableNames,
-               ZmqServer* zmqServer, VRFOrch* vrfOrch, CoppOrch* coppOrch)
+               ZmqServer* zmqServer, VRFOrch* vrfOrch)
     : ZmqOrch(db, tableNames, zmqServer, /*dbPersistence=*/false),
       m_zmqServer(zmqServer),
       m_publisher("APPL_DB", /*bool buffered=*/true,
@@ -68,7 +67,7 @@ P4Orch::P4Orch(swss::DBConnector* db, std::vector<std::string> tableNames,
     m_routeManager = std::make_unique<RouteManager>(&m_p4OidMapper, vrfOrch, &m_publisher);
     m_mirrorSessionManager = std::make_unique<p4orch::MirrorSessionManager>(&m_p4OidMapper, &m_publisher);
     m_aclTableManager = std::make_unique<p4orch::AclTableManager>(&m_p4OidMapper, &m_publisher);
-    m_aclRuleManager = std::make_unique<p4orch::AclRuleManager>(&m_p4OidMapper, vrfOrch, coppOrch, &m_publisher);
+    m_aclRuleManager = std::make_unique<p4orch::AclRuleManager>(&m_p4OidMapper, vrfOrch, &m_publisher);
     m_wcmpManager = std::make_unique<p4orch::WcmpManager>(
         &m_p4OidMapper, &m_publisher, m_watchportEvent);
     m_l3AdmitManager = std::make_unique<L3AdmitManager>(&m_p4OidMapper, &m_publisher);

--- a/orchagent/p4orch/p4orch.h
+++ b/orchagent/p4orch/p4orch.h
@@ -6,7 +6,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "copporch.h"
 #include "notificationconsumer.h"
 #include "notifier.h"
 #include "orch.h"
@@ -48,7 +47,7 @@ class P4Orch : public ZmqOrch
 {
   public:
     P4Orch(swss::DBConnector *db, std::vector<std::string> tableNames,
-        swss::ZmqServer* zmqServer, VRFOrch *vrfOrch, CoppOrch *coppOrch);
+        swss::ZmqServer* zmqServer, VRFOrch *vrfOrch);
     // Add ACL table to ACLRuleManager mapping in P4Orch.
     bool addAclTableToManagerMapping(const std::string &acl_table_name);
     // Remove the ACL table name to AclRuleManager mapping in P4Orch

--- a/orchagent/p4orch/p4orch_util.h
+++ b/orchagent/p4orch/p4orch_util.h
@@ -54,6 +54,9 @@ constexpr char *kSetWcmpGroupId = "set_wcmp_group_id";
 constexpr char* kSetMulticastGroupId = "set_multicast_group_id";
 constexpr char* kSetSrcMac = "set_src_mac";
 constexpr char* kSetMulticastSrcMac = "set_multicast_src_mac";
+constexpr char* kSetPortAndSrcMac = "set_port_and_src_mac";
+constexpr char* kSetPortAndSrcMacAndVlanId =
+    "set_port_and_src_mac_and_vlan_id";
 constexpr char *kSetNexthopIdAndMetadata = "set_nexthop_id_and_metadata";
 constexpr char *kSetWcmpGroupIdAndMetadata = "set_wcmp_group_id_and_metadata";
 constexpr char *kSetMetadataAndDrop = "set_metadata_and_drop";
@@ -68,6 +71,9 @@ constexpr char* kMulticastSetSrcMac = "multicast_set_src_mac";
 constexpr char* kMulticastSetSrcMacAndVlanId = "multicast_set_src_mac_and_vlan_id";
 constexpr char* kMulticastSetSrcMacAndDstMacAndVlanId = "multicast_set_src_mac_and_dst_mac_and_vlan_id";
 constexpr char* kMulticastSetSrcMacAndPreserveIngressVlanId = "multicast_set_src_mac_and_preserve_ingress_vlan_id";
+constexpr char* kUnicastSetPortAndSrcMac = "unicast_set_port_and_src_mac";
+constexpr char* kUnicastSetPortAndSrcMacAndVlanId =
+    "unicast_set_port_and_src_mac_and_vlan_id";
 constexpr char *kDrop = "drop";
 constexpr char *kTrap = "trap";
 constexpr char *kStage = "stage";
@@ -201,6 +207,8 @@ struct P4RouterInterfaceAppDbEntry
     bool is_set_port_name = false;
     bool is_set_src_mac = false;
     bool is_set_vlan_id = false;
+    bool creates_my_mac = true;
+    std::string action;
 };
 
 struct P4NeighborAppDbEntry

--- a/orchagent/p4orch/router_interface_manager.cpp
+++ b/orchagent/p4orch/router_interface_manager.cpp
@@ -175,7 +175,20 @@ ReturnCodeOr<P4RouterInterfaceAppDbEntry> RouterInterfaceManager::deserializeRou
       }
       app_db_entry.is_set_vlan_id = true;
         }
-        else if (field != p4orch::kAction && field != p4orch::kControllerMetadata)
+        else if (field == p4orch::kAction) {
+        if (value == p4orch::kUnicastSetPortAndSrcMac ||
+            value == p4orch::kUnicastSetPortAndSrcMacAndVlanId ||
+            value == p4orch::kSetPortAndSrcMacAndVlanId) {
+          app_db_entry.creates_my_mac = false;
+        } else if (value == p4orch::kSetPortAndSrcMac) {
+          app_db_entry.creates_my_mac = true;
+        } else {
+          return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
+                 << "Unexpected action " << QuotedVar(value) << " in "
+                 << APP_P4RT_ROUTER_INTERFACE_TABLE_NAME;
+        }
+        app_db_entry.action = value;
+      } else if (field != p4orch::kControllerMetadata)
         {
             return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
                    << "Unexpected field " << QuotedVar(field) << " in table entry";
@@ -189,6 +202,24 @@ ReturnCode RouterInterfaceManager::validateRouterInterfaceAppDbEntry(
     const P4RouterInterfaceAppDbEntry& app_db_entry) {
   // Perform generic APP DB entry validations. Operation specific validations
   // will be done by the respective request process methods.
+
+  if (app_db_entry.action == p4orch::kSetPortAndSrcMac ||
+      app_db_entry.action == p4orch::kUnicastSetPortAndSrcMac) {
+    if (!app_db_entry.is_set_port_name || !app_db_entry.is_set_src_mac ||
+        app_db_entry.is_set_vlan_id) {
+      return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
+             << "Action " << QuotedVar(app_db_entry.action)
+             << " should set port and source mac, but not vlan id";
+    }
+  } else if (app_db_entry.action == p4orch::kSetPortAndSrcMacAndVlanId ||
+             app_db_entry.action == p4orch::kUnicastSetPortAndSrcMacAndVlanId) {
+    if (!app_db_entry.is_set_port_name || !app_db_entry.is_set_src_mac ||
+        !app_db_entry.is_set_vlan_id) {
+      return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
+             << "Action " << QuotedVar(app_db_entry.action)
+             << " should set port, source mac, and vlan id";
+    }
+  }
 
   if (app_db_entry.is_set_port_name) {
     Port port;
@@ -329,7 +360,7 @@ std::vector<ReturnCode> RouterInterfaceManager::createRouterInterfaces(
         router_intf_entries[i].router_interface_id,
         router_intf_entries[i].port_name,
         router_intf_entries[i].src_mac_address, router_intf_entries[i].vlan_id,
-        router_intf_entries[i].is_set_vlan_id);
+        router_intf_entries[i].is_set_vlan_id, router_intf_entries[i].creates_my_mac);
     auto attrs = prepareSaiAttrs(entries[i]);
     if (!attrs.ok()) {
       statuses[i] = ReturnCode(attrs.status());
@@ -732,6 +763,13 @@ std::string RouterInterfaceManager::verifyStateCache(const P4RouterInterfaceAppD
             << " does not match internal cache " << router_intf_entry->vlan_id
             << " in router interface manager.";
         return msg.str();
+    }
+    if (router_intf_entry->creates_my_mac != app_db_entry.creates_my_mac) {
+      std::stringstream msg;
+      msg << "Creating a My MAC entry " << app_db_entry.creates_my_mac
+          << " does not match internal cache "
+          << router_intf_entry->creates_my_mac << " in router interface manager.";
+      return msg.str();
     }
 
     return m_p4OidMapper->verifyOIDMapping(SAI_OBJECT_TYPE_ROUTER_INTERFACE, router_intf_key,

--- a/orchagent/p4orch/router_interface_manager.h
+++ b/orchagent/p4orch/router_interface_manager.h
@@ -27,16 +27,18 @@ struct P4RouterInterfaceEntry
     swss::MacAddress src_mac_address;
     uint16_t vlan_id = 0;
     bool has_vlan_id = false;
+    bool creates_my_mac = true;
     sai_object_id_t router_interface_oid = 0;
 
     P4RouterInterfaceEntry() = default;
     P4RouterInterfaceEntry(const std::string &router_intf_id, const std::string &port,
                            const swss::MacAddress& mac_address,
-                           uint16_t vlan_id, bool has_vlan)
-        : router_interface_id(router_intf_id), port_name(port), 
+                           uint16_t vlan_id, bool has_vlan, bool creates_my_mac)
+        : router_interface_id(router_intf_id), port_name(port),
           src_mac_address(mac_address),
           vlan_id(vlan_id),
-          has_vlan_id(has_vlan) {}
+          has_vlan_id(has_vlan),
+          creates_my_mac(creates_my_mac) {}
 };
 
 // P4RouterInterfaceTable: Router Interface key, P4RouterInterfaceEntry

--- a/orchagent/p4orch/tests/acl_manager_test.cpp
+++ b/orchagent/p4orch/tests/acl_manager_test.cpp
@@ -10,6 +10,7 @@
 #include "acl_util.h"
 #include "aclorch.h"
 #include "acltable.h"
+#include "copporch.h"
 #include "mock_response_publisher.h"
 #include "mock_sai_acl.h"
 #include "mock_sai_hostif.h"
@@ -44,6 +45,7 @@ extern P4Orch *gP4Orch;
 extern std::unique_ptr<MockResponsePublisher> gMockResponsePublisher;
 extern SwitchOrch *gSwitchOrch;
 extern AclOrch* gAclOrch;
+extern CoppOrch* gCoppOrch;
 extern sai_object_id_t gSwitchId;
 extern sai_object_id_t gVrfOid;
 extern sai_object_id_t gTrapGroupStartOid;
@@ -90,19 +92,22 @@ constexpr sai_object_id_t kUdfMatchOid1 = 5001;
 constexpr sai_object_id_t kUdfOid1 = 6001;
 constexpr char *kAclIngressTableName = "ACL_PUNT_TABLE";
 
-std::string kUdfGroupMapperKey = "P4RT_TABLE:ACL_PUNT_TABLE-udf2-0";
-std::string kUdfGroupMapperLabel = "1706901078193258";
-std::string kAclCounterMapperKey1 =
+constexpr char* kUdfGroupMapperKey = "P4RT_TABLE:ACL_PUNT_TABLE-udf2-0";
+constexpr char* kUdfGroupMapperLabel = "1706901078193258";
+constexpr char* kAclCounterMapperKey1 =
     "P4RT_TABLE:ACL_PUNT_TABLE:match/ether_type=0x0800:match/"
     "ipv6_dst=fdf8:f53b:82e4::53 & fdf8:f53b:82e4::53:priority=15";
-std::string kAclCounterLabel1 = "1707179015354132";
+constexpr char* kAclCounterLabel1 = "1707179015354132";
 constexpr char* kAclCounterMapperKey2 =
     "P4RT_TABLE:ACL_PUNT_TABLE:match/arp_tpa=0xff112231:match/"
     "ether_type=0x0800:match/in_ports=Ethernet1,Ethernet2:match/"
     "ipmc_table_hit=0x1:match/ipv6_dst=fdf8:f53b:82e4::53 & "
     "fdf8:f53b:82e4::53:match/out_ports=Ethernet4,Ethernet5:match/"
     "route_table_hit=0x1:match/vrf_id=b4-traffic:priority=15";
-std::string kAclCounterLabel2 = "1708458300499045";
+constexpr char* kAclCounterLabel2 = "1708458300499045";
+
+constexpr uint32_t kP4CpuQueueMinNum = 0;
+constexpr uint32_t kP4CpuQueueMaxNum = 47;
 
 // Matches the policer sai_attribute_t[] argument.
 bool MatchSaiPolicerAttributeInStormMode(const int attrs_size,
@@ -270,6 +275,35 @@ bool MatchSaiSwitchAttrByAclStage(const sai_switch_attr_t expected_switch_attr, 
         return false;
     }
     return true;
+}
+
+bool GetQueueNumberFromTrapGroupSaiAttributes(
+    sai_uint32_t* queue_num, const uint32_t attr_size,
+    const sai_attribute_t* attr_list) {
+  if (attr_list == nullptr) {
+    return false;
+  }
+  for (uint32_t i = 0; i < attr_size; i++) {
+    if (attr_list[i].id == SAI_HOSTIF_TRAP_GROUP_ATTR_QUEUE) {
+      *queue_num = attr_list[i].value.u32;
+      return true;
+    }
+  }
+  return false;
+}
+
+bool GetQueueNumberFromUserDefinedTrapSaiAttributes(
+    sai_object_id_t* queue_num, const sai_attribute_t* attr_list) {
+  if (attr_list == nullptr) {
+    return false;
+  }
+  for (int i = 0; i < 2; i++) {
+    if (attr_list[i].id == SAI_HOSTIF_USER_DEFINED_TRAP_ATTR_TRAP_GROUP) {
+      *queue_num = attr_list[i].value.oid - gTrapGroupStartOid - 1;
+      return true;
+    }
+  }
+  return false;
 }
 
 std::string BuildMatchFieldJsonStrKindSaiField(std::string sai_field, std::string format = P4_FORMAT_HEX_STRING,
@@ -969,9 +1003,10 @@ class AclManagerTest : public ::testing::Test
     AclManagerTest()
     {
         setUpMockApi();
-        setUpCoppOrch();
         setUpSwitchOrch();
+        initCoppOrch();
         setUpP4Orch();
+        setUpCoppOrch();
         // const auto& acl_groups = gSwitchOrch->getAclGroupsBindingToSwitch();
         // EXPECT_EQ(3, acl_groups.size());
         // EXPECT_NE(acl_groups.end(), acl_groups.find(SAI_ACL_STAGE_INGRESS));
@@ -998,7 +1033,7 @@ class AclManagerTest : public ::testing::Test
     {
         EXPECT_CALL(mock_sai_udf_, remove_udf_match(_)).WillRepeatedly(Return(SAI_STATUS_SUCCESS));
         delete gP4Orch;
-        delete copp_orch_;
+        delete gCoppOrch;
         delete gSwitchOrch;
         gMockResponsePublisher.reset();
     }
@@ -1030,6 +1065,7 @@ class AclManagerTest : public ::testing::Test
         sai_hostif_api->create_hostif_table_entry = mock_create_hostif_table_entry;
         sai_hostif_api->remove_hostif_table_entry = mock_remove_hostif_table_entry;
         sai_hostif_api->create_hostif_trap_group = mock_create_hostif_trap_group;
+        sai_hostif_api->set_hostif_trap_group_attribute = mock_set_hostif_trap_group_attribute;
         sai_hostif_api->create_hostif_trap = mock_create_hostif_trap;
         sai_hostif_api->create_hostif = mock_create_hostif;
         sai_hostif_api->remove_hostif = mock_remove_hostif;
@@ -1050,42 +1086,49 @@ class AclManagerTest : public ::testing::Test
                                kAclCounterLabel1);
         gLabelMapper->setLabel(SAI_OBJECT_TYPE_ACL_COUNTER, kAclCounterMapperKey2,
                                kAclCounterLabel2);
-    }
+        EXPECT_CALL(mock_sai_switch_, get_switch_attribute(_, _, _))
+            .WillRepeatedly(Return(SAI_STATUS_SUCCESS));
+      }
 
-    void setUpCoppOrch()
-    {
+      void initCoppOrch() {
         // init copp orch
         EXPECT_CALL(mock_sai_hostif_, create_hostif_table_entry(_, _, _, _)).WillRepeatedly(Return(SAI_STATUS_SUCCESS));
         EXPECT_CALL(mock_sai_hostif_, create_hostif_trap(_, _, _, _)).WillOnce(Return(SAI_STATUS_SUCCESS));
-        EXPECT_CALL(mock_sai_switch_, get_switch_attribute(_, _, _)).WillRepeatedly(Return(SAI_STATUS_SUCCESS));
-        copp_orch_ = new CoppOrch(gAppDb, APP_COPP_TABLE_NAME);
+        gCoppOrch = new CoppOrch(gAppDb, APP_COPP_TABLE_NAME);
+      }
+
+      void setUpCoppOrch() {
         // add trap group and genetlink for each CPU queue
         swss::Table app_copp_table(gAppDb, APP_COPP_TABLE_NAME);
-        for (uint64_t queue_num = 1; queue_num <= P4_CPU_QUEUE_MAX_NUM; queue_num++)
-        {
+         for (auto queue_num = kP4CpuQueueMinNum; queue_num <= kP4CpuQueueMaxNum;
+              queue_num++) {
             std::vector<swss::FieldValueTuple> attrs;
             attrs.push_back({"queue", std::to_string(queue_num)});
             attrs.push_back({"genetlink_name", "genl_packet"});
             attrs.push_back({"genetlink_mcgrp_name", "packets"});
             app_copp_table.set(GENL_PACKET_TRAP_GROUP_NAME_PREFIX + std::to_string(queue_num), attrs);
         }
-        sai_object_id_t trap_group_oid = gTrapGroupStartOid;
         sai_object_id_t hostif_oid = gHostifStartOid;
         EXPECT_CALL(mock_sai_hostif_, create_hostif_trap_group(_, _, _, _))
-            .Times(P4_CPU_QUEUE_MAX_NUM)
+            .Times(kP4CpuQueueMaxNum - kP4CpuQueueMinNum + 1)
             .WillRepeatedly(
-                DoAll(Invoke([&trap_group_oid](sai_object_id_t *oid, sai_object_id_t switch_id, uint32_t attr_count,
-                                               const sai_attribute_t *attr_list) { *oid = ++trap_group_oid; }),
+                DoAll(Invoke([](sai_object_id_t* oid, sai_object_id_t switch_id,
+                      uint32_t attr_count, const sai_attribute_t* attr_list) {
+              sai_uint32_t queue_num = 0;
+              EXPECT_TRUE(GetQueueNumberFromTrapGroupSaiAttributes(
+                  &queue_num, attr_count, attr_list));
+              *oid = gTrapGroupStartOid + (uint64_t)queue_num + 1;
+                      }),
                       Return(SAI_STATUS_SUCCESS)));
         EXPECT_CALL(mock_sai_hostif_, create_hostif(_, _, _, _))
-            .Times(P4_CPU_QUEUE_MAX_NUM)
+            .Times(kP4CpuQueueMaxNum - kP4CpuQueueMinNum + 1)
             .WillRepeatedly(
                 DoAll(Invoke([&hostif_oid](sai_object_id_t *oid, sai_object_id_t switch_id, uint32_t attr_count,
                                            const sai_attribute_t *attr_list) { *oid = ++hostif_oid; }),
                       Return(SAI_STATUS_SUCCESS)));
 
-        copp_orch_->addExistingData(&app_copp_table);
-        static_cast<Orch *>(copp_orch_)->doTask();
+        gCoppOrch->addExistingData(&app_copp_table);
+        static_cast<Orch*>(gCoppOrch)->doTask();
     }
 
     void setUpSwitchOrch()
@@ -1132,20 +1175,23 @@ class AclManagerTest : public ::testing::Test
                                                          kAclGroupLookupOid, std::placeholders::_1))))
             .WillRepeatedly(Return(SAI_STATUS_SUCCESS));
         std::vector<std::string> p4_tables;
-        gP4Orch = new P4Orch(gAppDb, p4_tables, nullptr, gVrfOrch, copp_orch_);
+        gP4Orch = new P4Orch(gAppDb, p4_tables, nullptr, gVrfOrch);
         acl_table_manager_ = gP4Orch->getAclTableManager();
         acl_rule_manager_ = gP4Orch->getAclRuleManager();
         p4_oid_mapper_ = acl_table_manager_->m_p4OidMapper;
         gMockResponsePublisher = std::make_unique<MockResponsePublisher>();
     }
 
-    void AddDefaultUserTrapsSaiCalls(sai_object_id_t *user_defined_trap_oid)
+    void AddDefaultUserTrapsSaiCalls()
     {
         EXPECT_CALL(mock_sai_hostif_, create_hostif_user_defined_trap(_, _, _, _))
-            .Times(P4_CPU_QUEUE_MAX_NUM)
-            .WillRepeatedly(DoAll(Invoke([user_defined_trap_oid](
-                                             sai_object_id_t *oid, sai_object_id_t switch_id, uint32_t attr_count,
-                                             const sai_attribute_t *attr_list) { *oid = ++(*user_defined_trap_oid); }),
+            .Times(kP4CpuQueueMaxNum - kP4CpuQueueMinNum + 1)
+            .WillRepeatedly(DoAll(Invoke([](sai_object_id_t* oid, sai_object_id_t switch_id,
+                      uint32_t attr_count, const sai_attribute_t* attr_list) {
+              sai_object_id_t queue_num = 0;
+              EXPECT_TRUE(GetQueueNumberFromUserDefinedTrapSaiAttributes(
+                  &queue_num, attr_list));
+              *oid = gUserDefinedTrapStartOid + queue_num + 1; }),
                                   Return(SAI_STATUS_SUCCESS)));
     }
 
@@ -1164,8 +1210,7 @@ class AclManagerTest : public ::testing::Test
         EXPECT_CALL(mock_sai_udf_, create_udf(_, _, _, _))
             .Times(3)
             .WillRepeatedly(DoAll(SetArgPointee<0>(kUdfOid1), Return(SAI_STATUS_SUCCESS)));
-        sai_object_id_t user_defined_trap_oid = gUserDefinedTrapStartOid;
-        AddDefaultUserTrapsSaiCalls(&user_defined_trap_oid);
+        AddDefaultUserTrapsSaiCalls();
         ASSERT_EQ(StatusCode::SWSS_RC_SUCCESS, ProcessAddTableRequest(app_db_entry));
         ASSERT_NO_FATAL_FAILURE(
             IsExpectedAclTableDefinitionMapping(*GetAclTable(app_db_entry.acl_table_name), app_db_entry));
@@ -1263,6 +1308,11 @@ class AclManagerTest : public ::testing::Test
         return acl_table_manager_->createAclGroupMember(acl_table, acl_grp_mem_oid);
     }
 
+    ReturnCode UpdateUserDefinedTrap(const std::string& trap_group_name,
+                                     bool is_delete) {
+        return acl_rule_manager_->updateUserDefinedTrap(trap_group_name, is_delete);
+    }
+
     StrictMock<MockSaiAcl> mock_sai_acl_;
     StrictMock<MockSaiSerialize> mock_sai_serialize_;
     StrictMock<MockSaiPolicer> mock_sai_policer_;
@@ -1270,7 +1320,6 @@ class AclManagerTest : public ::testing::Test
     StrictMock<MockSaiSwitch> mock_sai_switch_;
     StrictMock<MockSaiUdf> mock_sai_udf_;
     // StrictMock<MockResponsePublisher> *gMockResponsePublisher;
-    CoppOrch *copp_orch_;
     P4OidMapper *p4_oid_mapper_;
     p4orch::AclTableManager *acl_table_manager_;
     p4orch::AclRuleManager *acl_rule_manager_;
@@ -1566,23 +1615,8 @@ TEST_F(AclManagerTest, CreatePuntTableFailsWhenUserTrapsSaiCallFails)
 {
     auto app_db_entry = getDefaultAclTableDefAppDbEntry();
     EXPECT_CALL(mock_sai_hostif_, create_hostif_user_defined_trap(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<0>(gUserDefinedTrapStartOid + 1), Return(SAI_STATUS_SUCCESS)))
-        .WillOnce(Return(SAI_STATUS_INSUFFICIENT_RESOURCES));
-    EXPECT_CALL(mock_sai_hostif_, create_hostif_table_entry(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<0>(gHostifStartOid + 1), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_hostif_, remove_hostif_table_entry(Eq(gHostifStartOid + 1)))
-        .WillOnce(Return(SAI_STATUS_SUCCESS));
-    EXPECT_CALL(mock_sai_hostif_, remove_hostif_user_defined_trap(Eq(gUserDefinedTrapStartOid + 1)))
-        .WillOnce(Return(SAI_STATUS_SUCCESS));
-    // The user defined traps fail to create
-    EXPECT_EQ(StatusCode::SWSS_RC_FULL, ProcessAddTableRequest(app_db_entry));
-    EXPECT_EQ(nullptr, GetAclTable(app_db_entry.acl_table_name));
-    sai_object_id_t oid;
-    EXPECT_FALSE(p4_oid_mapper_->getOID(SAI_OBJECT_TYPE_HOSTIF_USER_DEFINED_TRAP,
-                                        std::to_string(gUserDefinedTrapStartOid + 1), &oid));
-
-    EXPECT_CALL(mock_sai_hostif_, create_hostif_user_defined_trap(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<0>(gUserDefinedTrapStartOid + 1), Return(SAI_STATUS_SUCCESS)));
+        .WillOnce(DoAll(SetArgPointee<0>(gUserDefinedTrapStartOid + 1),
+            Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_hostif_, create_hostif_table_entry(_, _, _, _))
         .WillOnce(Return(SAI_STATUS_INSUFFICIENT_RESOURCES));
     EXPECT_CALL(mock_sai_hostif_, remove_hostif_user_defined_trap(Eq(gUserDefinedTrapStartOid + 1)))
@@ -1595,30 +1629,77 @@ TEST_F(AclManagerTest, CreatePuntTableFailsWhenUserTrapsSaiCallFails)
         .WillOnce(DoAll(SetArgPointee<0>(gUserDefinedTrapStartOid + 1), Return(SAI_STATUS_SUCCESS)))
         .WillOnce(Return(SAI_STATUS_INSUFFICIENT_RESOURCES));
     EXPECT_CALL(mock_sai_hostif_, create_hostif_table_entry(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<0>(gHostifStartOid + 1), Return(SAI_STATUS_SUCCESS)));
-    EXPECT_CALL(mock_sai_hostif_, remove_hostif_table_entry(Eq(gHostifStartOid + 1)))
-        .WillOnce(Return(SAI_STATUS_OBJECT_IN_USE));
-    // The 2nd user defined trap fails to create, the 1st hostif table entry fails
-    // to remove
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    // The 2nd user defined trap fails to create.
     EXPECT_EQ(StatusCode::SWSS_RC_FULL, ProcessAddTableRequest(app_db_entry));
+     EXPECT_EQ(nullptr, GetAclTable(app_db_entry.acl_table_name));
+}
+
+TEST_F(AclManagerTest, UpdateUserDefinedTrapSucceeds) {
+  ASSERT_NO_FATAL_FAILURE(AddDefaultIngressTable());
+
+  const std::string trap_group =
+      GENL_PACKET_TRAP_GROUP_NAME_PREFIX + std::to_string(kP4CpuQueueMinNum);
+
+  EXPECT_CALL(mock_sai_hostif_,
+              remove_hostif_user_defined_trap(Eq(gUserDefinedTrapStartOid + 1)))
+      .WillOnce(Return(SAI_STATUS_SUCCESS));
+  EXPECT_CALL(mock_sai_hostif_, remove_hostif_table_entry(_))
+      .WillOnce(Return(SAI_STATUS_SUCCESS));
+  EXPECT_CALL(mock_sai_hostif_, create_hostif_user_defined_trap(_, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<0>(gUserDefinedTrapStartOid + 1),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_CALL(mock_sai_hostif_, create_hostif_table_entry(_, _, _, _))
+      .WillOnce(Return(SAI_STATUS_SUCCESS));
+
+  EXPECT_TRUE(UpdateUserDefinedTrap(trap_group, /*is_delete=*/false).ok());
+}
+
+TEST_F(
+    AclManagerTest,
+    UpdateUserDefinedTrapFailsRaisesCriticalStateWhenUserDefinedTrapRecoveryFails) {
+  ASSERT_NO_FATAL_FAILURE(AddDefaultIngressTable());
+  const std::string out_of_band_trap_group =
+      GENL_PACKET_TRAP_GROUP_NAME_PREFIX +
+      std::to_string(kP4CpuQueueMaxNum + 10);
+  EXPECT_EQ(StatusCode::SWSS_RC_NOT_FOUND,
+            UpdateUserDefinedTrap(out_of_band_trap_group, /*is_delete=*/false));
+
+  const std::string trap_group =
+      GENL_PACKET_TRAP_GROUP_NAME_PREFIX + std::to_string(kP4CpuQueueMinNum);
+
+  EXPECT_CALL(mock_sai_hostif_,
+              remove_hostif_user_defined_trap(Eq(gUserDefinedTrapStartOid + 1)))
+      .WillOnce(Return(SAI_STATUS_SUCCESS))
+      .WillOnce(Return(SAI_STATUS_FAILURE));
+  EXPECT_CALL(mock_sai_hostif_, remove_hostif_table_entry(_))
+      .WillOnce(Return(SAI_STATUS_SUCCESS));
+  EXPECT_CALL(mock_sai_hostif_, create_hostif_user_defined_trap(_, _, _, _))
+      .WillOnce(DoAll(SetArgPointee<0>(gUserDefinedTrapStartOid + 1),
+                      Return(SAI_STATUS_SUCCESS)));
+  EXPECT_CALL(mock_sai_hostif_, create_hostif_table_entry(_, _, _, _))
+      .WillOnce(Return(SAI_STATUS_INSUFFICIENT_RESOURCES));
+
+  EXPECT_EQ(StatusCode::SWSS_RC_INTERNAL,
+            UpdateUserDefinedTrap(trap_group, /*is_delete=*/false));
 }
 
 TEST_F(AclManagerTest, DISABLED_CreatePuntTableFailsWhenUserTrapGroupOrHostifNotFound)
 {
     auto app_db_entry = getDefaultAclTableDefAppDbEntry();
-    const auto skip_cpu_queue = 1;
+    const auto skip_cpu_queue = kP4CpuQueueMinNum;
     // init copp orch
     EXPECT_CALL(mock_sai_hostif_, create_hostif_table_entry(_, _, _, _)).WillRepeatedly(Return(SAI_STATUS_SUCCESS));
     EXPECT_CALL(mock_sai_hostif_, create_hostif_trap(_, _, _, _)).WillOnce(Return(SAI_STATUS_SUCCESS));
     EXPECT_CALL(mock_sai_switch_, get_switch_attribute(_, _, _)).WillRepeatedly(Return(SAI_STATUS_SUCCESS));
     swss::Table app_copp_table(gAppDb, APP_COPP_TABLE_NAME);
     // Clean up APP_COPP_TABLE_NAME table entries
-    for (int queue_num = 1; queue_num <= P4_CPU_QUEUE_MAX_NUM; queue_num++)
+    for (uint32_t queue_num = kP4CpuQueueMinNum; queue_num <= kP4CpuQueueMaxNum; queue_num++)
     {
         app_copp_table.del(GENL_PACKET_TRAP_GROUP_NAME_PREFIX + std::to_string(queue_num));
     }
     cleanupAclManagerTest();
-    copp_orch_ = new CoppOrch(gAppDb, APP_COPP_TABLE_NAME);
+    gCoppOrch = new CoppOrch(gAppDb, APP_COPP_TABLE_NAME);
     setUpSwitchOrch();
     // Update p4orch to use new copp orch
     setUpP4Orch();
@@ -1629,10 +1710,10 @@ TEST_F(AclManagerTest, DISABLED_CreatePuntTableFailsWhenUserTrapGroupOrHostifNot
     attrs.push_back({"queue", std::to_string(skip_cpu_queue)});
     // Add one COPP_TABLE entry with trap group info, without hostif info
     app_copp_table.set(GENL_PACKET_TRAP_GROUP_NAME_PREFIX + std::to_string(skip_cpu_queue), attrs);
-    copp_orch_->addExistingData(&app_copp_table);
+    gCoppOrch = new CoppOrch(gAppDb, APP_COPP_TABLE_NAME);
     EXPECT_CALL(mock_sai_hostif_, create_hostif_trap_group(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<0>(gTrapGroupStartOid + skip_cpu_queue), Return(SAI_STATUS_SUCCESS)));
-    static_cast<Orch *>(copp_orch_)->doTask();
+        .WillOnce(DoAll(SetArgPointee<0>(gTrapGroupStartOid + skip_cpu_queue - kP4CpuQueueMinNum), Return(SAI_STATUS_SUCCESS)));
+    static_cast<Orch*>(gCoppOrch)->doTask();
     // Fail to create ACL table because the host interface is absent
     EXPECT_EQ("Hostif object id was not found given trap group - " + std::string(GENL_PACKET_TRAP_GROUP_NAME_PREFIX) +
                   std::to_string(skip_cpu_queue),
@@ -1643,8 +1724,7 @@ TEST_F(AclManagerTest, DISABLED_CreatePuntTableFailsWhenUserTrapGroupOrHostifNot
 TEST_F(AclManagerTest, CreateIngressPuntTableFailsWhenCapabilityExceeds)
 {
     auto app_db_entry = getDefaultAclTableDefAppDbEntry();
-    sai_object_id_t user_defined_trap_oid = gUserDefinedTrapStartOid;
-    AddDefaultUserTrapsSaiCalls(&user_defined_trap_oid);
+    AddDefaultUserTrapsSaiCalls();
     EXPECT_CALL(mock_sai_udf_, create_udf_match(_, _, _, _))
         .WillOnce(DoAll(SetArgPointee<0>(kUdfMatchOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_udf_, create_udf_group(_, _, _, _))
@@ -1671,8 +1751,7 @@ TEST_F(AclManagerTest, CreateIngressTableFailsWhenRedirectObjectTypeUnknown) {
 TEST_F(AclManagerTest, CreateIngressPuntTableFailsWhenFailedToCreateTableGroupMember)
 {
     auto app_db_entry = getDefaultAclTableDefAppDbEntry();
-    sai_object_id_t user_defined_trap_oid = gUserDefinedTrapStartOid;
-    AddDefaultUserTrapsSaiCalls(&user_defined_trap_oid);
+    AddDefaultUserTrapsSaiCalls();
     EXPECT_CALL(mock_sai_udf_, create_udf_match(_, _, _, _))
         .WillOnce(DoAll(SetArgPointee<0>(kUdfMatchOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_udf_, create_udf_group(_, _, _, _))
@@ -1692,8 +1771,7 @@ TEST_F(AclManagerTest, CreateIngressPuntTableFailsWhenFailedToCreateTableGroupMe
 TEST_F(AclManagerTest, CreateIngressPuntTableRaisesCriticalStateWhenAclTableRecoveryFails)
 {
     auto app_db_entry = getDefaultAclTableDefAppDbEntry();
-    sai_object_id_t user_defined_trap_oid = gUserDefinedTrapStartOid;
-    AddDefaultUserTrapsSaiCalls(&user_defined_trap_oid);
+    AddDefaultUserTrapsSaiCalls();
     EXPECT_CALL(mock_sai_udf_, create_udf_match(_, _, _, _))
         .WillOnce(DoAll(SetArgPointee<0>(kUdfMatchOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_udf_, create_udf_group(_, _, _, _))
@@ -1714,8 +1792,7 @@ TEST_F(AclManagerTest, CreateIngressPuntTableRaisesCriticalStateWhenAclTableReco
 TEST_F(AclManagerTest, CreateIngressPuntTableRaisesCriticalStateWhenUdfGroupRecoveryFails)
 {
     auto app_db_entry = getDefaultAclTableDefAppDbEntry();
-    sai_object_id_t user_defined_trap_oid = gUserDefinedTrapStartOid;
-    AddDefaultUserTrapsSaiCalls(&user_defined_trap_oid);
+    AddDefaultUserTrapsSaiCalls();
     EXPECT_CALL(mock_sai_udf_, create_udf_match(_, _, _, _))
         .WillOnce(DoAll(SetArgPointee<0>(kUdfMatchOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_udf_, create_udf_group(_, _, _, _))
@@ -1736,8 +1813,7 @@ TEST_F(AclManagerTest, CreateIngressPuntTableRaisesCriticalStateWhenUdfGroupReco
 TEST_F(AclManagerTest, CreateIngressPuntTableRaisesCriticalStateWhenUdfRecoveryFails)
 {
     auto app_db_entry = getDefaultAclTableDefAppDbEntry();
-    sai_object_id_t user_defined_trap_oid = gUserDefinedTrapStartOid;
-    AddDefaultUserTrapsSaiCalls(&user_defined_trap_oid);
+    AddDefaultUserTrapsSaiCalls();
     EXPECT_CALL(mock_sai_udf_, create_udf_match(_, _, _, _))
         .WillOnce(DoAll(SetArgPointee<0>(kUdfMatchOid1), Return(SAI_STATUS_SUCCESS)));
     EXPECT_CALL(mock_sai_udf_, create_udf_group(_, _, _, _))
@@ -1759,8 +1835,7 @@ TEST_F(AclManagerTest, CreateIngressPuntTableRaisesCriticalStateWhenUdfRecoveryF
 TEST_F(AclManagerTest, CreateIngressPuntTableFailsWhenFailedToCreateUdf)
 {
     auto app_db_entry = getDefaultAclTableDefAppDbEntry();
-    sai_object_id_t user_defined_trap_oid = gUserDefinedTrapStartOid;
-    AddDefaultUserTrapsSaiCalls(&user_defined_trap_oid);
+    AddDefaultUserTrapsSaiCalls();
     // Fail to create the first UDF, and success to remove the first UDF
     // group
     EXPECT_CALL(mock_sai_udf_, create_udf_match(_, _, _, _))
@@ -2149,8 +2224,7 @@ TEST_F(AclManagerTest, CreatePuntTableWithInvalidActionFieldFails)
 TEST_F(AclManagerTest, CreatePuntTableWithInvalidPacketColorFieldFails)
 {
     auto app_db_entry = getDefaultAclTableDefAppDbEntry();
-    sai_object_id_t user_defined_trap_oid = gUserDefinedTrapStartOid;
-    AddDefaultUserTrapsSaiCalls(&user_defined_trap_oid);
+    AddDefaultUserTrapsSaiCalls();
 
     // Invalid packet_color field
     app_db_entry.packet_action_color_lookup["invalid_packet_color"].push_back(
@@ -2749,8 +2823,7 @@ TEST_F(AclManagerTest, DrainRuleTuplesToProcessSetRequestSucceeds)
     EXPECT_CALL(mock_sai_udf_, create_udf(_, _, _, _))
         .Times(3)
         .WillRepeatedly(DoAll(SetArgPointee<0>(kUdfOid1), Return(SAI_STATUS_SUCCESS)));
-    sai_object_id_t user_defined_trap_oid = gUserDefinedTrapStartOid;
-    AddDefaultUserTrapsSaiCalls(&user_defined_trap_oid);
+    AddDefaultUserTrapsSaiCalls();
     ASSERT_EQ(StatusCode::SWSS_RC_SUCCESS, ProcessAddTableRequest(app_db_entry));
     ASSERT_NO_FATAL_FAILURE(
         IsExpectedAclTableDefinitionMapping(*GetAclTable(app_db_entry.acl_table_name), app_db_entry));
@@ -2946,7 +3019,8 @@ TEST_F(AclManagerTest, DeserializeAclRuleAppDbWithInvalidMeterFieldFails)
 
     // ACL rule has invalid cir value in meter field
     attributes.pop_back();
-    attributes.push_back(swss::FieldValueTuple{"meter/cir", "18446744073709551616"});
+    attributes.push_back(
+      swss::FieldValueTuple{"meter/cir", "18446744073709551616"});
     EXPECT_FALSE(DeserializeAclRuleAppDbEntry(acl_table_name, acl_rule_json_key, attributes).ok());
 
     // ACL rule has max uint64 cir value in meter field
@@ -3479,7 +3553,7 @@ TEST_F(AclManagerTest, AclRuleWithColorPacketActionsButNoRateLimit)
     auto acl_rule = GetAclRule(kAclIngressTableName, acl_rule_key);
     ASSERT_NE(nullptr, acl_rule);
     // Check action field value
-    EXPECT_EQ(gUserDefinedTrapStartOid + queue_num,
+    EXPECT_EQ(gUserDefinedTrapStartOid + queue_num - kP4CpuQueueMinNum + 1,
               acl_rule->action_fvs[SAI_ACL_ENTRY_ATTR_ACTION_SET_USER_TRAP_ID].aclaction.parameter.oid);
 }
 
@@ -3536,7 +3610,7 @@ TEST_F(AclManagerTest, AclRuleWithColorPacketActionsButWithRateLimit) {
   auto acl_rule = GetAclRule(kAclIngressTableName, acl_rule_key);
   ASSERT_NE(nullptr, acl_rule);
   // Check action field value
-  EXPECT_EQ(gUserDefinedTrapStartOid + queue_num - P4_CPU_QUEUE_MIN_NUM ,
+  EXPECT_EQ(gUserDefinedTrapStartOid + queue_num - kP4CpuQueueMinNum + 1,
             acl_rule->action_fvs[SAI_ACL_ENTRY_ATTR_ACTION_SET_USER_TRAP_ID]
                 .aclaction.parameter.oid);
 }
@@ -4064,7 +4138,7 @@ TEST_F(AclManagerTest, AclRuleWithValidAction)
     EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ProcessDeleteRuleRequest(kAclIngressTableName, acl_rule_key));
 
     // Set user defined trap for QOS_QUEUE
-    int queue_num = 2;
+    uint32_t queue_num = 8;
     app_db_entry.action = "qos_queue";
     app_db_entry.action_param_fvs["cpu_queue"] = std::to_string(queue_num);
     // Install rule
@@ -4077,7 +4151,7 @@ TEST_F(AclManagerTest, AclRuleWithValidAction)
     acl_rule = GetAclRule(kAclIngressTableName, acl_rule_key);
     ASSERT_NE(nullptr, acl_rule);
     // Check action field value
-    EXPECT_EQ(gUserDefinedTrapStartOid + queue_num,
+    EXPECT_EQ(gUserDefinedTrapStartOid + queue_num - kP4CpuQueueMinNum + 1,
               acl_rule->action_fvs[SAI_ACL_ENTRY_ATTR_ACTION_SET_USER_TRAP_ID].aclaction.parameter.oid);
     // Remove rule
     EXPECT_CALL(mock_sai_acl_, remove_acl_entry(Eq(kAclIngressRuleOid1))).WillOnce(Return(SAI_STATUS_SUCCESS));
@@ -4085,6 +4159,84 @@ TEST_F(AclManagerTest, AclRuleWithValidAction)
     EXPECT_CALL(mock_sai_policer_, remove_policer(Eq(kAclMeterOid1))).WillOnce(Return(SAI_STATUS_SUCCESS));
     EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, ProcessDeleteRuleRequest(kAclIngressTableName, acl_rule_key));
     EXPECT_EQ(nullptr, GetAclRule(kAclIngressTableName, acl_rule_key));
+
+    // Set new user defined trap for QOS_QUEUE
+    queue_num = kP4CpuQueueMaxNum + 1;
+    // add trap group and genetlink for the new CPU queue
+    swss::Table app_copp_table(gAppDb, APP_COPP_TABLE_NAME);
+
+    std::vector<swss::FieldValueTuple> attrs;
+    attrs.push_back({"queue", std::to_string(queue_num)});
+    attrs.push_back({"genetlink_name", "genl_packet"});
+    attrs.push_back({"genetlink_mcgrp_name", "packets"});
+    for (uint32_t queue_num = kP4CpuQueueMinNum; queue_num <= kP4CpuQueueMaxNum;
+         queue_num++) {
+      app_copp_table.del(GENL_PACKET_TRAP_GROUP_NAME_PREFIX +
+                         std::to_string(queue_num));
+    }
+    app_copp_table.set(
+        GENL_PACKET_TRAP_GROUP_NAME_PREFIX + std::to_string(queue_num), attrs);
+    EXPECT_CALL(mock_sai_hostif_, set_hostif_trap_group_attribute(_, _))
+        .WillRepeatedly(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_hostif_, create_hostif_trap_group(_, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<0>(gTrapGroupStartOid + queue_num -
+                                         kP4CpuQueueMinNum + 1),
+                        Return(SAI_STATUS_SUCCESS)));
+    EXPECT_CALL(mock_sai_hostif_, create_hostif(_, _, _, _))
+        .WillOnce(DoAll(
+            SetArgPointee<0>(gHostifStartOid + queue_num - kP4CpuQueueMinNum + 1),
+            Return(SAI_STATUS_SUCCESS)));
+    EXPECT_CALL(mock_sai_hostif_, create_hostif_user_defined_trap(_, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<0>(gUserDefinedTrapStartOid + queue_num -
+                                         kP4CpuQueueMinNum + 1),
+                        Return(SAI_STATUS_SUCCESS)));
+    EXPECT_CALL(mock_sai_hostif_, create_hostif_table_entry(_, _, _, _))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    gCoppOrch->addExistingData(&app_copp_table);
+    static_cast<Orch*>(gCoppOrch)->doTask();
+
+    app_db_entry.action = "qos_queue";
+    app_db_entry.action_param_fvs["cpu_queue"] = std::to_string(queue_num);
+    // Install rule
+    EXPECT_CALL(mock_sai_acl_, create_acl_entry(_, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<0>(kAclIngressRuleOid1),
+                        Return(SAI_STATUS_SUCCESS)));
+    EXPECT_CALL(mock_sai_acl_, create_acl_counter(_, _, _, _))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_policer_, create_policer(_, _, _, _))
+        .WillOnce(
+            DoAll(SetArgPointee<0>(kAclMeterOid1), Return(SAI_STATUS_SUCCESS)));
+    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
+              ProcessAddRuleRequest(acl_rule_key, app_db_entry));
+    acl_rule = GetAclRule(kAclIngressTableName, acl_rule_key);
+    ASSERT_NE(nullptr, acl_rule);
+    // Check action field value
+    EXPECT_EQ(gUserDefinedTrapStartOid + queue_num - kP4CpuQueueMinNum + 1,
+              acl_rule->action_fvs[SAI_ACL_ENTRY_ATTR_ACTION_SET_USER_TRAP_ID]
+                  .aclaction.parameter.oid);
+    // Remove rule
+    EXPECT_CALL(mock_sai_acl_, remove_acl_entry(Eq(kAclIngressRuleOid1)))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_acl_, remove_acl_counter(_))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_policer_, remove_policer(Eq(kAclMeterOid1)))
+        .WillOnce(Return(SAI_STATUS_SUCCESS));
+    EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS,
+              ProcessDeleteRuleRequest(kAclIngressTableName, acl_rule_key));
+    EXPECT_EQ(nullptr, GetAclRule(kAclIngressTableName, acl_rule_key));
+
+    EXPECT_CALL(mock_sai_hostif_, remove_hostif_trap_group(_))
+        .WillRepeatedly(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_hostif_, remove_hostif(_))
+        .WillRepeatedly(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_hostif_, remove_hostif_user_defined_trap(_))
+        .WillRepeatedly(Return(SAI_STATUS_SUCCESS));
+    EXPECT_CALL(mock_sai_hostif_, remove_hostif_table_entry(_))
+        .WillRepeatedly(Return(SAI_STATUS_SUCCESS));
+    app_copp_table.del(GENL_PACKET_TRAP_GROUP_NAME_PREFIX +
+                       std::to_string(queue_num));
+    gCoppOrch->addExistingData(&app_copp_table);
+    static_cast<Orch*>(gCoppOrch)->doTask();
 }
 
 #pragma GCC diagnostic pop
@@ -4922,7 +5074,7 @@ TEST_F(AclManagerTest, UpdateAclRuleWithActionMeterChange)
     // Check action field value
     EXPECT_EQ(1, acl_rule->action_fvs.size());
     EXPECT_TRUE(acl_rule->action_fvs[SAI_ACL_ENTRY_ATTR_ACTION_SET_USER_TRAP_ID].aclaction.enable);
-    EXPECT_EQ(gUserDefinedTrapStartOid + queue_num,
+    EXPECT_EQ(gUserDefinedTrapStartOid + queue_num - kP4CpuQueueMinNum + 1,
               acl_rule->action_fvs[SAI_ACL_ENTRY_ATTR_ACTION_SET_USER_TRAP_ID].aclaction.parameter.oid);
 
     // QOS_QUEUE action to set user defined trap CPU queue number 4
@@ -4937,7 +5089,7 @@ TEST_F(AclManagerTest, UpdateAclRuleWithActionMeterChange)
     // Check action field value
     EXPECT_EQ(1, acl_rule->action_fvs.size());
     EXPECT_TRUE(acl_rule->action_fvs[SAI_ACL_ENTRY_ATTR_ACTION_SET_USER_TRAP_ID].aclaction.enable);
-    EXPECT_EQ(gUserDefinedTrapStartOid + queue_num,
+    EXPECT_EQ(gUserDefinedTrapStartOid + queue_num - kP4CpuQueueMinNum + 1,
               acl_rule->action_fvs[SAI_ACL_ENTRY_ATTR_ACTION_SET_USER_TRAP_ID].aclaction.parameter.oid);
 }
 
@@ -5791,7 +5943,8 @@ TEST_F(AclManagerTest, CreateAclRuleWithInvalidActionFails) {
     app_db_entry.action_param_fvs.erase("target");
     // Invalid cpu queue number
     app_db_entry.action = "qos_queue";
-    app_db_entry.action_param_fvs["cpu_queue"] = "48";
+    app_db_entry.action_param_fvs["cpu_queue"] =
+        std::to_string(kP4CpuQueueMaxNum + 1);
     EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ProcessAddRuleRequest(acl_rule_key, app_db_entry));
     app_db_entry.action_param_fvs["cpu_queue"] = "invalid";
     EXPECT_EQ(StatusCode::SWSS_RC_INVALID_PARAM, ProcessAddRuleRequest(acl_rule_key, app_db_entry));
@@ -5984,8 +6137,7 @@ TEST_F(AclManagerTest, DoAclCounterStatsTaskSucceeds)
     EXPECT_CALL(mock_sai_udf_, create_udf(_, _, _, _))
         .Times(3)
         .WillRepeatedly(DoAll(SetArgPointee<0>(kUdfOid1), Return(SAI_STATUS_SUCCESS)));
-    sai_object_id_t user_defined_trap_oid = gUserDefinedTrapStartOid;
-    AddDefaultUserTrapsSaiCalls(&user_defined_trap_oid);
+    AddDefaultUserTrapsSaiCalls();
     ASSERT_EQ(StatusCode::SWSS_RC_SUCCESS, ProcessAddTableRequest(app_db_def_entry));
     auto counters_table = std::make_unique<swss::Table>(gCountersDb, std::string(COUNTERS_TABLE) +
                                                                          DEFAULT_KEY_SEPARATOR + APP_P4RT_TABLE_NAME);
@@ -6204,8 +6356,7 @@ TEST_F(AclManagerTest, CreatePreIngressTableWillCreateDefaultRule) {
       .WillRepeatedly(
           DoAll(SetArgPointee<0>(kUdfOid1), Return(SAI_STATUS_SUCCESS)));
   EXPECT_CALL(mock_sai_acl_, create_acl_entry(_, _, _, _)).Times(0);
-  sai_object_id_t user_defined_trap_oid = gUserDefinedTrapStartOid;
-  AddDefaultUserTrapsSaiCalls(&user_defined_trap_oid);
+  AddDefaultUserTrapsSaiCalls();
   ASSERT_EQ(StatusCode::SWSS_RC_SUCCESS, ProcessAddTableRequest(app_db_entry));
   ASSERT_NO_FATAL_FAILURE(IsExpectedAclTableDefinitionMapping(
       *GetAclTable(app_db_entry.acl_table_name), app_db_entry));

--- a/orchagent/p4orch/tests/acl_manager_test.cpp
+++ b/orchagent/p4orch/tests/acl_manager_test.cpp
@@ -6830,6 +6830,12 @@ TEST_F(AclManagerTest, AclRuleVerifyStateTest)
         "\"Ethernet4,Ethernet5\", \"priority\":15,\"match/ipmc_table_hit\":"
         "\"0x1\",\"match/route_table_hit\":\"0x1\",\"match/"
         "vrf_id\":\"b4-traffic\"}";
+    std::string mapper_key =
+        "P4RT_TABLE:ACL_PUNT_TABLE:match/arp_tpa=0xff112231:match/"
+        "ether_type=0x0800:match/in_ports=Ethernet1,Ethernet2:match/"
+        "ipmc_table_hit=0x1:match/ipv6_dst=fdf8:f53b:82e4::53 & "
+        "fdf8:f53b:82e4::53:match/out_ports=Ethernet4,Ethernet5:match/"
+        "route_table_hit=0x1:match/vrf_id=b4-traffic:priority=15";
     const auto &rule_tuple_key = std::string(kAclIngressTableName) + kTableKeyDelimiter + acl_rule_json_key;
     EnqueueRuleTuple(std::string(kAclIngressTableName),
                      swss::KeyOpFieldsValuesTuple({rule_tuple_key, SET_COMMAND, attributes}));
@@ -6891,12 +6897,16 @@ TEST_F(AclManagerTest, AclRuleVerifyStateTest)
                   swss::FieldValueTuple{"SAI_ACL_COUNTER_ATTR_ENABLE_PACKET_COUNT", "true"},
                   swss::FieldValueTuple{"SAI_ACL_COUNTER_ATTR_LABEL",
                                         kAclCounterLabel2}});
+    std::string label;
+    EXPECT_TRUE(
+        gLabelMapper->getLabel(SAI_OBJECT_TYPE_POLICER, mapper_key, label));
     table.set(
         "SAI_OBJECT_TYPE_POLICER:oid:0x7d1",
         std::vector<swss::FieldValueTuple>{
             swss::FieldValueTuple{"SAI_POLICER_ATTR_MODE", "SAI_POLICER_MODE_STORM_CONTROL"},
             swss::FieldValueTuple{"SAI_POLICER_ATTR_METER_TYPE", "SAI_METER_TYPE_BYTES"},
             swss::FieldValueTuple{"SAI_POLICER_ATTR_CBS", "80"}, swss::FieldValueTuple{"SAI_POLICER_ATTR_CIR", "80"},
+            swss::FieldValueTuple{"SAI_POLICER_ATTR_LABEL", label.c_str()},
             swss::FieldValueTuple{"SAI_POLICER_ATTR_GREEN_PACKET_ACTION", "SAI_PACKET_ACTION_COPY"}});
 
     // Verification should succeed with vaild key and value.
@@ -7392,6 +7402,9 @@ TEST_F(AclManagerTest, AclRuleVerifyStateAsicDbTest)
     const auto &acl_rule_json_key = "{\"match/ether_type\":\"0x0800\",\"match/"
                                     "ipv6_dst\":\"fdf8:f53b:82e4::53 & "
                                     "fdf8:f53b:82e4::53\",\"priority\":15}";
+    std::string mapper_key =
+        "P4RT_TABLE:ACL_PUNT_TABLE:match/ether_type=0x0800:match/"
+        "ipv6_dst=fdf8:f53b:82e4::53 & fdf8:f53b:82e4::53:priority=15";
     const auto &rule_tuple_key = std::string(kAclIngressTableName) + kTableKeyDelimiter + acl_rule_json_key;
     EnqueueRuleTuple(std::string(kAclIngressTableName),
                      swss::KeyOpFieldsValuesTuple({rule_tuple_key, SET_COMMAND, attributes}));
@@ -7430,12 +7443,16 @@ TEST_F(AclManagerTest, AclRuleVerifyStateAsicDbTest)
                   swss::FieldValueTuple{"SAI_ACL_COUNTER_ATTR_ENABLE_PACKET_COUNT", "true"},
                   swss::FieldValueTuple{"SAI_ACL_COUNTER_ATTR_LABEL",
                                         kAclCounterLabel1}});
+    std::string label;
+    EXPECT_TRUE(
+        gLabelMapper->getLabel(SAI_OBJECT_TYPE_POLICER, mapper_key, label));
     table.set(
         "SAI_OBJECT_TYPE_POLICER:oid:0x7d1",
         std::vector<swss::FieldValueTuple>{
             swss::FieldValueTuple{"SAI_POLICER_ATTR_MODE", "SAI_POLICER_MODE_STORM_CONTROL"},
             swss::FieldValueTuple{"SAI_POLICER_ATTR_METER_TYPE", "SAI_METER_TYPE_BYTES"},
             swss::FieldValueTuple{"SAI_POLICER_ATTR_CBS", "80"}, swss::FieldValueTuple{"SAI_POLICER_ATTR_CIR", "80"},
+            swss::FieldValueTuple{"SAI_POLICER_ATTR_LABEL", label.c_str()},
             swss::FieldValueTuple{"SAI_POLICER_ATTR_GREEN_PACKET_ACTION", "SAI_PACKET_ACTION_COPY"}});
 
     // Verification should succeed with correct ASIC DB values.

--- a/orchagent/p4orch/tests/l3_admit_manager_test.cpp
+++ b/orchagent/p4orch/tests/l3_admit_manager_test.cpp
@@ -34,6 +34,7 @@ extern sai_my_mac_api_t *sai_my_mac_api;
 extern MockSaiMyMac *mock_sai_my_mac;
 
 namespace
+
 {
 // A physical port set up in test_main.cpp
 constexpr char *kPortName1 = "Ethernet1";
@@ -170,6 +171,7 @@ bool MatchCreateL3AdmitArgAttrList(const sai_attribute_t *attr_list,
 
     return true;
 }
+
 } // namespace
 
 class L3AdmitManagerTest : public ::testing::Test

--- a/orchagent/p4orch/tests/l3_multicast_manager_test.cpp
+++ b/orchagent/p4orch/tests/l3_multicast_manager_test.cpp
@@ -788,6 +788,19 @@ class L3MulticastManagerTest : public ::testing::Test {
     EXPECT_EQ(x.controller_metadata, y.controller_metadata);
   }
 
+  void SetMyMacOid() {
+    swss::Table table(nullptr, APP_SWITCH_TABLE_NAME);
+    std::vector<swss::FieldValueTuple> values;
+    values.push_back(swss::FieldValueTuple{"alias_mac", kClusterMac1});
+    table.set("switch", values);
+    gSwitchOrch->addExistingData(&table);
+    EXPECT_CALL(mock_sai_my_mac_, create_my_mac(_, _, _, _))
+        .WillOnce(DoAll(SetArgPointee<0>(kDefaultMyMacOid),
+                        Return(SAI_STATUS_SUCCESS)));
+    Orch* switch_orch = gSwitchOrch;
+    switch_orch->doTask();
+  }
+
   void SetUp() override {
     mock_sai_router_intf = &mock_sai_router_intf_;
     sai_router_intfs_api->create_router_interface =
@@ -1712,7 +1725,7 @@ TEST_F(L3MulticastManagerTest, CreateRouterInterfaceMyMacFailure) {
       .WillOnce(Return(SAI_STATUS_FAILURE));
 
   EXPECT_EQ(StatusCode::SWSS_RC_UNKNOWN,
-            CreateRouterInterface(entry, &rif_oid));
+      CreateRouterInterface(entry, &rif_oid));
 }
 
 TEST_F(L3MulticastManagerTest, CreateRouterInterfaceAttributeFailures) {

--- a/orchagent/p4orch/tests/l3_multicast_manager_test.cpp
+++ b/orchagent/p4orch/tests/l3_multicast_manager_test.cpp
@@ -788,19 +788,6 @@ class L3MulticastManagerTest : public ::testing::Test {
     EXPECT_EQ(x.controller_metadata, y.controller_metadata);
   }
 
-  void SetMyMacOid() {
-    swss::Table table(nullptr, APP_SWITCH_TABLE_NAME);
-    std::vector<swss::FieldValueTuple> values;
-    values.push_back(swss::FieldValueTuple{"alias_mac", kClusterMac1});
-    table.set("switch", values);
-    gSwitchOrch->addExistingData(&table);
-    EXPECT_CALL(mock_sai_my_mac_, create_my_mac(_, _, _, _))
-        .WillOnce(DoAll(SetArgPointee<0>(kDefaultMyMacOid),
-                        Return(SAI_STATUS_SUCCESS)));
-    Orch* switch_orch = gSwitchOrch;
-    switch_orch->doTask();
-  }
-
   void SetUp() override {
     mock_sai_router_intf = &mock_sai_router_intf_;
     sai_router_intfs_api->create_router_interface =

--- a/orchagent/p4orch/tests/next_hop_manager_test.cpp
+++ b/orchagent/p4orch/tests/next_hop_manager_test.cpp
@@ -329,20 +329,16 @@ class NextHopManagerTest : public ::testing::Test
         mock_sai_hostif = &mock_sai_hostif_;
         mock_sai_switch = &mock_sai_switch_;
         sai_switch_api->get_switch_attribute = mock_get_switch_attribute;
-        sai_hostif_api->create_hostif_trap = mock_create_hostif_trap;
         sai_hostif_api->create_hostif_table_entry = mock_create_hostif_table_entry;
         EXPECT_CALL(mock_sai_hostif_, create_hostif_table_entry(_, _, _, _)).WillRepeatedly(Return(SAI_STATUS_SUCCESS));
-        EXPECT_CALL(mock_sai_hostif_, create_hostif_trap(_, _, _, _)).WillOnce(Return(SAI_STATUS_SUCCESS));
         EXPECT_CALL(mock_sai_switch_, get_switch_attribute(_, _, _)).WillRepeatedly(Return(SAI_STATUS_SUCCESS));
-        copp_orch_ = new CoppOrch(gAppDb, APP_COPP_TABLE_NAME);
         std::vector<std::string> p4_tables;
-        gP4Orch = new P4Orch(gAppDb, p4_tables, nullptr, gVrfOrch, copp_orch_);
+        gP4Orch = new P4Orch(gAppDb, p4_tables, nullptr, gVrfOrch);
     }
 
     ~NextHopManagerTest()
     {
         delete gP4Orch;
-        delete copp_orch_;
     }
 
     void SetUp() override
@@ -449,7 +445,6 @@ class NextHopManagerTest : public ::testing::Test
     NextHopManager next_hop_manager_;
     StrictMock<MockSaiHostif> mock_sai_hostif_;
     StrictMock<MockSaiSwitch> mock_sai_switch_;
-    CoppOrch *copp_orch_;
 };
 
 bool NextHopManagerTest::ResolveNextHopEntryDependency(const P4NextHopAppDbEntry &app_db_entry,

--- a/orchagent/p4orch/tests/p4orch_test.cpp
+++ b/orchagent/p4orch/tests/p4orch_test.cpp
@@ -20,6 +20,7 @@
 #include "mock_sai_switch.h"
 
 using ::p4orch::kTableKeyDelimiter;
+using namespace swss;
 
 extern P4Orch* gP4Orch;
 extern VRFOrch* gVrfOrch;
@@ -165,15 +166,13 @@ class P4OrchTest : public ::testing::Test {
     sai_bridge_api->get_bridge_port_stats_ext = mock_get_bridge_port_stats_ext;
     sai_bridge_api->clear_bridge_port_stats = mock_clear_bridge_port_stats;
 
-    copp_orch_ = new CoppOrch(gAppDb, APP_COPP_TABLE_NAME);
     std::vector<std::string> p4_tables{APP_P4RT_TABLE_NAME};
-    gP4Orch = new P4Orch(gAppDb, p4_tables, nullptr, gVrfOrch, copp_orch_);
+    gP4Orch = new P4Orch(gAppDb, p4_tables, nullptr, gVrfOrch);
     gMockResponsePublisher = std::make_unique<MockResponsePublisher>();
   }
 
   ~P4OrchTest() {
     delete gP4Orch;
-    delete copp_orch_;
     gMockResponsePublisher.reset();
   }
 
@@ -191,7 +190,6 @@ class P4OrchTest : public ::testing::Test {
   NiceMock<MockSaiBridge> mock_sai_bridge_;
   NiceMock<MockSaiL2mc> mock_sai_l2mc_;
   NiceMock<MockSaiL2mcGroup> mock_sai_l2mc_group_;
-  CoppOrch* copp_orch_;
 };
 
 TEST_F(P4OrchTest, ProcessInvalidEntry) {

--- a/orchagent/p4orch/tests/router_interface_manager_test.cpp
+++ b/orchagent/p4orch/tests/router_interface_manager_test.cpp
@@ -306,6 +306,7 @@ class RouterInterfaceManagerTest : public ::testing::Test
       const sai_object_id_t ritf_oid, const sai_object_id_t port_oid,
       const uint32_t mtu, const bool sub_port = false,
       const uint16_t vlan_id = 0) {
+
     auto attrs = CreateRouterInterfaceAttributeList(
         gVirtualRouterId, router_intf_entry.src_mac_address, port_oid, mtu,
         sub_port, vlan_id);
@@ -343,13 +344,15 @@ TEST_F(RouterInterfaceManagerTest, CreateRouterInterfaceValidAttributes) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
   AddRouterInterfaceEntry(router_intf_entry, kRouterInterfaceOid1, kPortOid1,
                           kMtu1);
 
   P4RouterInterfaceEntry entry(kRouterInterfaceId1, kPortName1, kMacAddress1,
                                kVlanId0,
-                               /*has_vlan=*/false);
+                               /*has_vlan=*/false, /*creates_my_mac*/true);
   entry.router_interface_oid = kRouterInterfaceOid1;
   ValidateRouterInterfaceEntry(entry);
 }
@@ -363,13 +366,15 @@ TEST_F(RouterInterfaceManagerTest, CreateRouterInterfaceWithSubport) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = ""
   };
   AddRouterInterfaceEntry(router_intf_entry, kRouterInterfaceOid1, kPortOid10,
                           kMtu10, true, kVlanId2);
 
   P4RouterInterfaceEntry entry(kRouterInterfaceId1, kPortName10, kMacAddress1,
                                kVlanId0,
-                               /*has_vlan=*/false);
+                               /*has_vlan=*/false, /*creates_my_mac*/true);
   entry.router_interface_oid = kRouterInterfaceOid1;
   ValidateRouterInterfaceEntry(entry);
 }
@@ -388,10 +393,62 @@ TEST_F(RouterInterfaceManagerTest,
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
 
   EXPECT_EQ(StatusCode::SWSS_RC_INTERNAL, ValidateRouterInterfaceEntryOperation(
                                               router_intf_entry, SET_COMMAND));
+}
+
+TEST_F(RouterInterfaceManagerTest, ValidateRouterInterfaceActionParamsMismatch) {
+  P4RouterInterfaceAppDbEntry router_intf_entry{
+      .router_interface_id = kRouterInterfaceId1,
+      .port_name = kPortName1,
+      .src_mac_address = kMacAddress1,
+      .vlan_id = kVlanId0,
+      .is_set_port_name = true,
+      .is_set_src_mac = true,
+      .is_set_vlan_id = false,
+      .creates_my_mac = false,
+      .action = ""
+  };
+
+  router_intf_entry.action = p4orch::kUnicastSetPortAndSrcMac;
+  router_intf_entry.is_set_port_name = false;
+  EXPECT_EQ(
+      StatusCode::SWSS_RC_INVALID_PARAM,
+      ValidateRouterInterfaceEntryOperation(router_intf_entry, SET_COMMAND));
+
+  router_intf_entry.is_set_port_name = true;
+  router_intf_entry.is_set_port_name = false;
+  EXPECT_EQ(
+      StatusCode::SWSS_RC_INVALID_PARAM,
+      ValidateRouterInterfaceEntryOperation(router_intf_entry, SET_COMMAND));
+
+  router_intf_entry.is_set_port_name = true;
+  router_intf_entry.is_set_vlan_id = true;
+  EXPECT_EQ(
+      StatusCode::SWSS_RC_INVALID_PARAM,
+      ValidateRouterInterfaceEntryOperation(router_intf_entry, SET_COMMAND));
+
+  router_intf_entry.action = p4orch::kUnicastSetPortAndSrcMacAndVlanId;
+  router_intf_entry.is_set_port_name = false;
+  EXPECT_EQ(
+      StatusCode::SWSS_RC_INVALID_PARAM,
+      ValidateRouterInterfaceEntryOperation(router_intf_entry, SET_COMMAND));
+
+  router_intf_entry.is_set_port_name = true;
+  router_intf_entry.is_set_port_name = false;
+  EXPECT_EQ(
+      StatusCode::SWSS_RC_INVALID_PARAM,
+      ValidateRouterInterfaceEntryOperation(router_intf_entry, SET_COMMAND));
+
+  router_intf_entry.is_set_port_name = true;
+  router_intf_entry.is_set_vlan_id = false;
+  EXPECT_EQ(
+      StatusCode::SWSS_RC_INVALID_PARAM,
+      ValidateRouterInterfaceEntryOperation(router_intf_entry, SET_COMMAND));
 }
 
 TEST_F(RouterInterfaceManagerTest, ValidateRouterInterfacePortNameNotSet) {
@@ -403,6 +460,8 @@ TEST_F(RouterInterfaceManagerTest, ValidateRouterInterfacePortNameNotSet) {
       .is_set_port_name = false,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = ""
   };
   EXPECT_EQ(
       StatusCode::SWSS_RC_INVALID_PARAM,
@@ -419,6 +478,8 @@ TEST_F(RouterInterfaceManagerTest, CreateRouterInterfaceInvalidPort) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
 
   EXPECT_THAT(CreateRouterInterfaces(
@@ -437,6 +498,8 @@ TEST_F(RouterInterfaceManagerTest, CreateRouterInterfaceNoMacAddress) {
       .is_set_port_name = true,
       .is_set_src_mac = false,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = ""
   };
 
   auto attrs = CreateRouterInterfaceAttributeList(
@@ -473,6 +536,8 @@ TEST_F(RouterInterfaceManagerTest, CreateRouterInterfaceSaiApiFails) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
   auto attrs = CreateRouterInterfaceAttributeList(
       gVirtualRouterId, router_intf_entry.src_mac_address, kPortOid1, kMtu1);
@@ -502,6 +567,8 @@ TEST_F(RouterInterfaceManagerTest, RemoveRouterInterfaceExistingInterface) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
   AddRouterInterfaceEntry(router_intf_entry, kRouterInterfaceOid2, kPortOid2,
                           kMtu2);
@@ -531,6 +598,8 @@ TEST_F(RouterInterfaceManagerTest,
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
   EXPECT_EQ(
       StatusCode::SWSS_RC_NOT_FOUND,
@@ -546,6 +615,8 @@ TEST_F(RouterInterfaceManagerTest, ValideDelRouterInterfaceNonZeroRefCount) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
   AddRouterInterfaceEntry(router_intf_entry, kRouterInterfaceOid2, kPortOid2,
                           kMtu2);
@@ -561,7 +632,7 @@ TEST_F(RouterInterfaceManagerTest, ValideDelRouterInterfaceNonZeroRefCount) {
 
   P4RouterInterfaceEntry entry(kRouterInterfaceId2, kPortName2, kMacAddress2,
                                kVlanId0,
-                               /*has_vlan=*/false);
+                               /*has_vlan=*/false, /*creates_my_mac*/true);
   entry.router_interface_oid = kRouterInterfaceOid2;
   ValidateRouterInterfaceEntry(entry);
 }
@@ -575,6 +646,8 @@ TEST_F(RouterInterfaceManagerTest, RemoveRouterInterfaceSaiApiFails) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
   AddRouterInterfaceEntry(router_intf_entry, kRouterInterfaceOid2, kPortOid2,
                           kMtu2);
@@ -593,7 +666,7 @@ TEST_F(RouterInterfaceManagerTest, RemoveRouterInterfaceSaiApiFails) {
 
   P4RouterInterfaceEntry entry(kRouterInterfaceId2, kPortName2, kMacAddress2,
                                kVlanId0,
-                               /*has_vlan=*/false);
+                               /*has_vlan=*/false, /*creates_my_mac*/true);
   entry.router_interface_oid = kRouterInterfaceOid2;
   ValidateRouterInterfaceEntry(entry);
 }
@@ -607,6 +680,8 @@ TEST_F(RouterInterfaceManagerTest, SetSourceMacAddressModifyMacAddress) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
   AddRouterInterfaceEntry(router_intf_entry, kRouterInterfaceOid1, kPortOid1,
                           kMtu1);
@@ -644,6 +719,8 @@ TEST_F(RouterInterfaceManagerTest, SetSourceMacAddressIdempotent) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
   AddRouterInterfaceEntry(router_intf_entry, kRouterInterfaceOid1, kPortOid1,
                           kMtu1);
@@ -669,6 +746,8 @@ TEST_F(RouterInterfaceManagerTest, SetSourceMacAddressSaiApiFails) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
   AddRouterInterfaceEntry(router_intf_entry, kRouterInterfaceOid1, kPortOid1,
                           kMtu1);
@@ -703,7 +782,10 @@ TEST_F(RouterInterfaceManagerTest, ProcessAddRequestValidAppDbParams) {
       .port_name = kPortName1,
       .src_mac_address = kMacAddress1,
       .is_set_port_name = true,
-      .is_set_src_mac = true};
+      .is_set_src_mac = true,
+      .creates_my_mac = true,
+      .action = ""
+  };
 
   auto attrs = CreateRouterInterfaceAttributeList(
       gVirtualRouterId, app_db_entry.src_mac_address, kPortOid1, kMtu1);
@@ -741,7 +823,7 @@ TEST_F(RouterInterfaceManagerTest, ProcessAddRequestValidAppDbParams) {
 
   P4RouterInterfaceEntry router_intf_entry(
       app_db_entry.router_interface_id, app_db_entry.port_name,
-      app_db_entry.src_mac_address, kVlanId0, /*has_vlan=*/false);
+      app_db_entry.src_mac_address, kVlanId0, /*has_vlan=*/false, /*creates_my_mac*/true);
   router_intf_entry.router_interface_oid = kRouterInterfaceOid1;
   ValidateRouterInterfaceEntry(router_intf_entry);
 }
@@ -755,6 +837,8 @@ TEST_F(RouterInterfaceManagerTest, ProcessUpdateRequestSetSourceMacAddress) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
   AddRouterInterfaceEntry(router_intf_entry, kRouterInterfaceOid1, kPortOid1,
                           kMtu1);
@@ -796,7 +880,7 @@ TEST_F(RouterInterfaceManagerTest, ProcessUpdateRequestSetSourceMacAddress) {
   // MacAddress.
   P4RouterInterfaceEntry entry(kRouterInterfaceId1, kPortName1, kMacAddress2,
                                kVlanId0,
-                               /*has_vlan=*/false);
+                               /*has_vlan=*/false, /*creates_my_mac*/true);
   entry.router_interface_oid = kRouterInterfaceOid1;
   ValidateRouterInterfaceEntry(entry);
 }
@@ -810,6 +894,8 @@ TEST_F(RouterInterfaceManagerTest, ProcessUpdateRequestSetPortNameIdempotent) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
   AddRouterInterfaceEntry(router_intf_entry, kRouterInterfaceOid1, kPortOid1,
                           kMtu1);
@@ -837,7 +923,7 @@ TEST_F(RouterInterfaceManagerTest, ProcessUpdateRequestSetPortNameIdempotent) {
   // changed.
   P4RouterInterfaceEntry entry(kRouterInterfaceId1, kPortName1, kMacAddress1,
                                kVlanId0,
-                               /*has_vlan=*/false);
+                               /*has_vlan=*/false, /*creates_my_mac*/true);
   entry.router_interface_oid = kRouterInterfaceOid1;
   ValidateRouterInterfaceEntry(entry);
 }
@@ -851,6 +937,8 @@ TEST_F(RouterInterfaceManagerTest, ValidateUpdateRequestSetPortName) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
   AddRouterInterfaceEntry(router_intf_entry, kRouterInterfaceOid1, kPortOid1,
                           kMtu1);
@@ -870,6 +958,8 @@ TEST_F(RouterInterfaceManagerTest, ValidateUpdateRequestMacAddrAndPort) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
   AddRouterInterfaceEntry(router_intf_entry, kRouterInterfaceOid1, kPortOid1,
                           kMtu1);
@@ -890,12 +980,15 @@ TEST_F(RouterInterfaceManagerTest, ValidateUpdateRequestVlanId) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
   AddRouterInterfaceEntry(router_intf_entry, kRouterInterfaceOid1, kPortOid1,
                           kMtu1);
 
   router_intf_entry.vlan_id = kVlanId1;
   router_intf_entry.is_set_vlan_id = true;
+  router_intf_entry.action = p4orch::kSetPortAndSrcMacAndVlanId;
   EXPECT_EQ(
       StatusCode::SWSS_RC_UNIMPLEMENTED,
       ValidateRouterInterfaceEntryOperation(router_intf_entry, SET_COMMAND));
@@ -910,6 +1003,8 @@ TEST_F(RouterInterfaceManagerTest, ProcessDeleteRequestExistingInterface) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
   AddRouterInterfaceEntry(router_intf_entry, kRouterInterfaceOid1, kPortOid1,
                           kMtu1);
@@ -950,6 +1045,8 @@ TEST_F(RouterInterfaceManagerTest, ValidateDeleteRequestNonExistingInterface) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = ""
   };
   EXPECT_EQ(
       StatusCode::SWSS_RC_NOT_FOUND,
@@ -966,6 +1063,8 @@ TEST_F(RouterInterfaceManagerTest,
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
   AddRouterInterfaceEntry(router_intf_entry, kRouterInterfaceOid1, kPortOid1,
                           kMtu1);
@@ -980,7 +1079,7 @@ TEST_F(RouterInterfaceManagerTest,
 TEST_F(RouterInterfaceManagerTest, DeserializeRouterIntfEntryValidAttributes)
 {
     const std::vector<swss::FieldValueTuple> attributes = {
-        swss::FieldValueTuple(p4orch::kAction, "set_port_and_src_mac"),
+        swss::FieldValueTuple(p4orch::kAction, p4orch::kSetPortAndSrcMac),
         swss::FieldValueTuple(prependParamField(p4orch::kPort), kPortName1),
         swss::FieldValueTuple(prependParamField(p4orch::kSrcMac), kMacAddress1.to_string()),
     };
@@ -994,13 +1093,15 @@ TEST_F(RouterInterfaceManagerTest, DeserializeRouterIntfEntryValidAttributes)
     EXPECT_TRUE(app_db_entry.is_set_port_name);
     EXPECT_TRUE(app_db_entry.is_set_src_mac);
     EXPECT_FALSE(app_db_entry.is_set_vlan_id);
+    EXPECT_TRUE(app_db_entry.creates_my_mac);
+    EXPECT_EQ(app_db_entry.action, p4orch::kSetPortAndSrcMac);
 }
 
 TEST_F(RouterInterfaceManagerTest,
        DeserializeRouterIntfEntryWithVlanValidAttributes) {
   const std::vector<swss::FieldValueTuple> attributes = {
       swss::FieldValueTuple(p4orch::kAction,
-                            "set_port_and_src_mac_and_vlan_id"),
+                            p4orch::kSetPortAndSrcMacAndVlanId),
       swss::FieldValueTuple(prependParamField(p4orch::kPort), kPortName1),
       swss::FieldValueTuple(prependParamField(p4orch::kSrcMac),
                             kMacAddress1.to_string()),
@@ -1018,6 +1119,55 @@ TEST_F(RouterInterfaceManagerTest,
   EXPECT_TRUE(app_db_entry.is_set_port_name);
   EXPECT_TRUE(app_db_entry.is_set_src_mac);
   EXPECT_TRUE(app_db_entry.is_set_vlan_id);
+  EXPECT_FALSE(app_db_entry.creates_my_mac);
+  EXPECT_EQ(app_db_entry.action, p4orch::kSetPortAndSrcMacAndVlanId);
+}
+
+TEST_F(RouterInterfaceManagerTest, DeserializeRouterIntfEntryNoMyMacAction) {
+  const std::vector<swss::FieldValueTuple> attributes = {
+      swss::FieldValueTuple(p4orch::kAction, p4orch::kUnicastSetPortAndSrcMac),
+      swss::FieldValueTuple(prependParamField(p4orch::kPort), kPortName1),
+      swss::FieldValueTuple(prependParamField(p4orch::kSrcMac),
+                            kMacAddress1.to_string()),
+  };
+
+  auto app_db_entry_or =
+      DeserializeRouterIntfEntry(kRouterIntfAppDbKey, attributes);
+  EXPECT_TRUE(app_db_entry_or.ok());
+  auto& app_db_entry = *app_db_entry_or;
+  EXPECT_EQ(app_db_entry.router_interface_id, kRouterInterfaceId1);
+  EXPECT_EQ(app_db_entry.port_name, kPortName1);
+  EXPECT_EQ(app_db_entry.src_mac_address, kMacAddress1);
+  EXPECT_TRUE(app_db_entry.is_set_port_name);
+  EXPECT_TRUE(app_db_entry.is_set_src_mac);
+  EXPECT_FALSE(app_db_entry.is_set_vlan_id);
+  EXPECT_FALSE(app_db_entry.creates_my_mac);
+  EXPECT_EQ(app_db_entry.action, p4orch::kUnicastSetPortAndSrcMac);
+}
+
+TEST_F(RouterInterfaceManagerTest,
+       DeserializeRouterIntfEntryNoMyMacActionWithVlan) {
+  const std::vector<swss::FieldValueTuple> attributes = {
+      swss::FieldValueTuple(p4orch::kAction,
+                            p4orch::kUnicastSetPortAndSrcMacAndVlanId),
+      swss::FieldValueTuple(prependParamField(p4orch::kPort), kPortName1),
+      swss::FieldValueTuple(prependParamField(p4orch::kSrcMac),
+                            kMacAddress1.to_string()),
+      swss::FieldValueTuple(prependParamField(p4orch::kVlanId), "0x123"),
+  };
+
+  auto app_db_entry_or =
+      DeserializeRouterIntfEntry(kRouterIntfAppDbKey, attributes);
+  EXPECT_TRUE(app_db_entry_or.ok());
+  auto& app_db_entry = *app_db_entry_or;
+  EXPECT_EQ(app_db_entry.router_interface_id, kRouterInterfaceId1);
+  EXPECT_EQ(app_db_entry.port_name, kPortName1);
+  EXPECT_EQ(app_db_entry.src_mac_address, kMacAddress1);
+  EXPECT_TRUE(app_db_entry.is_set_port_name);
+  EXPECT_TRUE(app_db_entry.is_set_src_mac);
+  EXPECT_TRUE(app_db_entry.is_set_vlan_id);
+  EXPECT_FALSE(app_db_entry.creates_my_mac);
+  EXPECT_EQ(app_db_entry.action, p4orch::kUnicastSetPortAndSrcMacAndVlanId);
 }
 
 TEST_F(RouterInterfaceManagerTest, DeserializeRouterIntfEntryWithInvalidVlan) {
@@ -1064,6 +1214,19 @@ TEST_F(RouterInterfaceManagerTest, DeserializeRouterIntfEntryInvalidKeyFormat)
     EXPECT_FALSE(app_db_entry_or.ok());
 }
 
+TEST_F(RouterInterfaceManagerTest, DeserializeRouterIntfEntryWithInvalidAction) {
+  const std::vector<swss::FieldValueTuple> attributes = {
+      swss::FieldValueTuple(p4orch::kAction, "invalid_set_port_and_src_mac"),
+      swss::FieldValueTuple(prependParamField(p4orch::kPort), kPortName1),
+      swss::FieldValueTuple(prependParamField(p4orch::kSrcMac),
+                            kMacAddress1.to_string()),
+  };
+
+  auto app_db_entry_or =
+      DeserializeRouterIntfEntry(kRouterIntfAppDbKey, attributes);
+  EXPECT_FALSE(app_db_entry_or.ok());
+}
+
 TEST_F(RouterInterfaceManagerTest, DeserializeRouterIntfEntryMissingAction)
 {
     const std::vector<swss::FieldValueTuple> attributes = {
@@ -1079,6 +1242,8 @@ TEST_F(RouterInterfaceManagerTest, DeserializeRouterIntfEntryMissingAction)
     EXPECT_EQ(app_db_entry.src_mac_address, kMacAddress1);
     EXPECT_TRUE(app_db_entry.is_set_port_name);
     EXPECT_TRUE(app_db_entry.is_set_src_mac);
+    EXPECT_TRUE(app_db_entry.creates_my_mac);
+    EXPECT_TRUE(app_db_entry.action.empty());
 }
 
 TEST_F(RouterInterfaceManagerTest, DeserializeRouterIntfEntryOnlyPortNameAttribute)
@@ -1094,6 +1259,8 @@ TEST_F(RouterInterfaceManagerTest, DeserializeRouterIntfEntryOnlyPortNameAttribu
     EXPECT_EQ(app_db_entry.src_mac_address, kZeroMacAddress);
     EXPECT_TRUE(app_db_entry.is_set_port_name);
     EXPECT_FALSE(app_db_entry.is_set_src_mac);
+    EXPECT_TRUE(app_db_entry.creates_my_mac);
+    EXPECT_TRUE(app_db_entry.action.empty());
 }
 
 TEST_F(RouterInterfaceManagerTest, DeserializeRouterIntfEntryOnlyMacAddrAttribute)
@@ -1109,6 +1276,8 @@ TEST_F(RouterInterfaceManagerTest, DeserializeRouterIntfEntryOnlyMacAddrAttribut
     EXPECT_EQ(app_db_entry.src_mac_address, kMacAddress1);
     EXPECT_FALSE(app_db_entry.is_set_port_name);
     EXPECT_TRUE(app_db_entry.is_set_src_mac);
+    EXPECT_TRUE(app_db_entry.creates_my_mac);
+    EXPECT_TRUE(app_db_entry.action.empty());
 }
 
 TEST_F(RouterInterfaceManagerTest, DeserializeRouterIntfEntryNoAttributes)
@@ -1123,6 +1292,8 @@ TEST_F(RouterInterfaceManagerTest, DeserializeRouterIntfEntryNoAttributes)
     EXPECT_EQ(app_db_entry.src_mac_address, kZeroMacAddress);
     EXPECT_FALSE(app_db_entry.is_set_port_name);
     EXPECT_FALSE(app_db_entry.is_set_src_mac);
+    EXPECT_TRUE(app_db_entry.creates_my_mac);
+    EXPECT_TRUE(app_db_entry.action.empty());
 }
 
 TEST_F(RouterInterfaceManagerTest, DeserializeRouterIntfEntryInvalidField)
@@ -1164,9 +1335,9 @@ TEST_F(RouterInterfaceManagerTest, DrainValidAttributes)
                       Eq(StatusCode::SWSS_RC_SUCCESS), Eq(true)));
     EXPECT_EQ(StatusCode::SWSS_RC_SUCCESS, Drain(/*failure_before=*/false));
 
-    P4RouterInterfaceEntry router_intf_entry(kRouterInterfaceId1, kPortName1,
-                                             kMacAddress1, kVlanId0,
-                                             /*has_vlan=*/false);
+    P4RouterInterfaceEntry router_intf_entry(
+        kRouterInterfaceId1, kPortName1, kMacAddress1, kVlanId0,
+        /*has_vlan=*/false, /*creates_my_mac*/ true);
     router_intf_entry.router_interface_oid = kRouterInterfaceOid1;
     ValidateRouterInterfaceEntry(router_intf_entry);
 
@@ -1232,7 +1403,7 @@ TEST_F(RouterInterfaceManagerTest, DrainValidAttributesWithVlan) {
 
   P4RouterInterfaceEntry router_intf_entry(kRouterInterfaceId1, kPortName1,
                                            kMacAddress1, kVlanId1,
-                                           /*has_vlan=*/true);
+                                           /*has_vlan=*/true, /*creates_my_mac*/true);
   router_intf_entry.router_interface_oid = kRouterInterfaceOid1;
   ValidateRouterInterfaceEntry(router_intf_entry);
 
@@ -1464,6 +1635,8 @@ TEST_F(RouterInterfaceManagerTest, VerifyStateTest) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
   AddRouterInterfaceEntry(router_intf_entry, kRouterInterfaceOid1, kPortOid1,
                           kMtu1);
@@ -1544,6 +1717,8 @@ TEST_F(RouterInterfaceManagerTest, VerifyStateWithVlanTest) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = true,
+      .creates_my_mac = false,
+      .action = p4orch::kSetPortAndSrcMacAndVlanId
   };
   AddRouterInterfaceEntry(router_intf_entry, kRouterInterfaceOid1, kPortOid1,
                           kMtu1, /*subport=*/true, kVlanId1);
@@ -1567,7 +1742,7 @@ TEST_F(RouterInterfaceManagerTest, VerifyStateWithVlanTest) {
                                 "true"},
           swss::FieldValueTuple{"SAI_ROUTER_INTERFACE_ATTR_V6_MCAST_ENABLE",
                                 "true"},
-          swss::FieldValueTuple{"SAI_ROUTER_INTERFACE_ATTR_MTU", "1500"}});
+           swss::FieldValueTuple{"SAI_ROUTER_INTERFACE_ATTR_MTU", "1500"}});
 
   const std::string db_key = std::string(APP_P4RT_TABLE_NAME) +
                              kTableKeyDelimiter +
@@ -1576,6 +1751,8 @@ TEST_F(RouterInterfaceManagerTest, VerifyStateWithVlanTest) {
   std::vector<swss::FieldValueTuple> attributes;
 
   // Verification should succeed with vaild key and value.
+  attributes.push_back(swss::FieldValueTuple{
+      p4orch::kAction, p4orch::kUnicastSetPortAndSrcMacAndVlanId});
   attributes.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kPort), kPortName1});
   attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kSrcMac),
@@ -1608,6 +1785,8 @@ TEST_F(RouterInterfaceManagerTest, VerifyStateWithVlanTest) {
 
   // Missing VLAN ID should fail verification.
   attributes.clear();
+  attributes.push_back(swss::FieldValueTuple{
+      p4orch::kAction, p4orch::kUnicastSetPortAndSrcMacAndVlanId});
   attributes.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kPort), kPortName1});
   attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kSrcMac),
@@ -1616,6 +1795,8 @@ TEST_F(RouterInterfaceManagerTest, VerifyStateWithVlanTest) {
 
   // Different VLAN ID should fail verification.
   attributes.clear();
+  attributes.push_back(swss::FieldValueTuple{
+      p4orch::kAction, p4orch::kUnicastSetPortAndSrcMacAndVlanId});
   attributes.push_back(
       swss::FieldValueTuple{prependParamField(p4orch::kPort), kPortName1});
   attributes.push_back(swss::FieldValueTuple{prependParamField(p4orch::kSrcMac),
@@ -1636,6 +1817,8 @@ TEST_F(RouterInterfaceManagerTest, VerifyStateAsicDbTest) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
   AddRouterInterfaceEntry(router_intf_entry, kRouterInterfaceOid1, 0x1234,
                           9100);
@@ -1697,6 +1880,8 @@ TEST_F(RouterInterfaceManagerTest, UpdateRifMtuWhenPortMtuChanges) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
   AddRouterInterfaceEntry(router_intf_entry1, kRouterInterfaceOid1, kPortOid1,
                           kMtu1);
@@ -1709,6 +1894,8 @@ TEST_F(RouterInterfaceManagerTest, UpdateRifMtuWhenPortMtuChanges) {
       .is_set_port_name = true,
       .is_set_src_mac = true,
       .is_set_vlan_id = false,
+      .creates_my_mac = true,
+      .action = p4orch::kSetPortAndSrcMac
   };
   AddRouterInterfaceEntry(router_intf_entry2, kRouterInterfaceOid2, kPortOid2,
                           kMtu2);

--- a/orchagent/p4orch/tests/test_main.cpp
+++ b/orchagent/p4orch/tests/test_main.cpp
@@ -64,6 +64,7 @@ VRFOrch *gVrfOrch;
 RouteOrch *gRouteOrch;
 FlowCounterRouteOrch *gFlowCounterRouteOrch;
 SwitchOrch *gSwitchOrch;
+CoppOrch *gCoppOrch;
 Directory<Orch *> gDirectory;
 swss::DBConnector *gAppDb;
 swss::DBConnector *gStateDb;

--- a/orchagent/p4orch/tests/wcmp_manager_test.cpp
+++ b/orchagent/p4orch/tests/wcmp_manager_test.cpp
@@ -174,7 +174,6 @@ class WcmpManagerTest : public ::testing::Test
             .WillRepeatedly(Return(SAI_STATUS_SUCCESS));
         EXPECT_CALL(mock_sai_acl_, remove_acl_table_group(_)).WillRepeatedly(Return(SAI_STATUS_SUCCESS));
         delete gP4Orch;
-        delete copp_orch_;
         gMockResponsePublisher.reset();
     }
 
@@ -197,7 +196,6 @@ class WcmpManagerTest : public ::testing::Test
             set_next_hop_group_member_attribute;
 
         sai_hostif_api->create_hostif_table_entry = mock_create_hostif_table_entry;
-        sai_hostif_api->create_hostif_trap = mock_create_hostif_trap;
         sai_switch_api->get_switch_attribute = mock_get_switch_attribute;
         sai_switch_api->set_switch_attribute = mock_set_switch_attribute;
         sai_acl_api->create_acl_table_group = create_acl_table_group;
@@ -208,12 +206,11 @@ class WcmpManagerTest : public ::testing::Test
     {
         // init copp orch
         EXPECT_CALL(mock_sai_hostif_, create_hostif_table_entry(_, _, _, _)).WillRepeatedly(Return(SAI_STATUS_SUCCESS));
-        EXPECT_CALL(mock_sai_hostif_, create_hostif_trap(_, _, _, _)).WillOnce(Return(SAI_STATUS_SUCCESS));
-        EXPECT_CALL(mock_sai_switch_, get_switch_attribute(_, _, _)).WillOnce(Return(SAI_STATUS_SUCCESS));
-        copp_orch_ = new CoppOrch(gAppDb, APP_COPP_TABLE_NAME);
+        EXPECT_CALL(mock_sai_switch_, get_switch_attribute(_, _, _))
+            .WillRepeatedly(Return(SAI_STATUS_SUCCESS));
 
         std::vector<std::string> p4_tables{APP_P4RT_TABLE_NAME};
-        gP4Orch = new P4Orch(gAppDb, p4_tables, nullptr, gVrfOrch, copp_orch_);
+        gP4Orch = new P4Orch(gAppDb, p4_tables, nullptr, gVrfOrch);
         gMockResponsePublisher = std::make_unique<MockResponsePublisher>();
     }
 
@@ -331,7 +328,6 @@ class WcmpManagerTest : public ::testing::Test
     StrictMock<MockSaiAcl> mock_sai_acl_;
     P4OidMapper *p4_oid_mapper_;
     WcmpManager *wcmp_group_manager_;
-    CoppOrch *copp_orch_;
 };
 
 P4WcmpGroupEntry WcmpManagerTest::getDefaultWcmpGroupEntryForTest()

--- a/tests/p4rt/test_p4rt_acl.py
+++ b/tests/p4rt/test_p4rt_acl.py
@@ -415,6 +415,12 @@ class TestP4RTAcl(object):
         ]
         util.verify_attr(fvs, attr_list)
 
+        # Allow unused trap group removal
+        copp_app_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+        copp_tbl = swsscommon.ProducerStateTable(copp_app_db, self._p4rt_trap_group_obj.APP_DB_TBL_NAME)
+        copp_trap_group = self._p4rt_trap_group_obj.TBL_NAME_PREFIX + str(10)
+        copp_tbl._del(copp_trap_group)
+
         # maintain list of original Application and ASIC DB ACL entries before adding
         # new ACL rule
         original_appl_acl_rules = util.get_keys(
@@ -762,32 +768,12 @@ class TestP4RTAcl(object):
         ]
         util.verify_attr(fvs, attr_list)
 
-        # First attempt failed since cpu queue is out of range
+        # create ACL rule 2 with QOS_QUEUE action
         rule_json_key2 = '{"match/is_ip":"0x1","match/ether_type":"0x0800 & 0xFFFF","match/ether_dst":"AA:BB:CC:DD:EE:FF & FF:FF:FF:FF:FF:FF","priority":100}'
         action = "qos_queue"
         meter_cir = "80"
         meter_cbs = "80"
         table_name_with_rule_key2 = table_name + ":" + rule_json_key2
-
-    # First attempt failed since no UserDefinedTrap is created for the CPU queue    
-        attr_list = [
-            (self._p4rt_acl_rule_obj.ACTION, action),
-            # No UserDefinedTrap created for the queue.
-            ("param/cpu_queue", "48"),
-            (self._p4rt_acl_rule_obj.METER_CIR, meter_cir),
-            (self._p4rt_acl_rule_obj.METER_CBURST, meter_cbs),
-            (self._p4rt_acl_rule_obj.METER_PIR, meter_pir),
-            (self._p4rt_acl_rule_obj.METER_PBURST, meter_pbs),
-        ]
-
-        self._p4rt_acl_rule_obj.set_app_db_entry(
-            table_name_with_rule_key2, attr_list)
-        self._p4rt_acl_rule_obj.verify_response(
-            table_name_with_rule_key2,
-            attr_list,
-            "SWSS_RC_INVALID_PARAM",
-            "[OrchAgent] Invalid CPU queue number '48' for 'ACL_PUNT_TABLE_RULE_TEST'. Queue number should >= 0 and <= 47",
-        )
 
         # Second attempt failed since no UserDefinedTrap is created for the CPU queue
         attr_list = [


### PR DESCRIPTION
**What I did**

- Programmed a centralized alias_mac L3 admit entry in SwitchOrch, allowing L3AdmitManager to treat matching requests as no-ops and enabling RIFs and multicast interfaces to reuse this global My MAC OID instead of creating redundant dummy entries.

- Added support and validation for creating RIFs without dedicated MyStation entries across unicast and VLAN actions (kUnicastSetPortAndSrcMac, kUnicastSetPortAndSrcMacAndVlanId, kSetPortAndSrcMacAndVlanId).

- Replaced hardcoded CPU queue limits with dynamic user-defined trap creation/deletion, hooking CoppOrch directly to P4Orch to synchronize runtime genetlink trap group updates.

- Enabled SAI_POLICER_ATTR_LABEL checks during state verification with length validation in NameLabelMapper, and updated corresponding unit/P4RT test suites.

**Why I did it**

- To eliminate TCAM/hardware resource waste caused by creating duplicate or dummy My MAC entries across every individual unicast and multicast router interface.

- To prevent state desynchronization and static queue limit bottlenecks between CoppOrch and P4Orch during dynamic runtime trap configuration or post-NSF reconciliation.

- To enforce strict state verification and input validation across ASIC/APP DBs, ensuring policer labels, RIF actions, and My MAC references cleanly reflect the underlying switch hardware state.

**How I verified it**
Added and updated C++ unit test cases across AclManagerTest, L3AdmitManagerTest, L3MulticastManagerTest, and RouterInterfaceManagerTest to validate global alias_mac resolution, dynamic trap group creation/recovery, and RIF attribute verification without dedicated My MAC entries.

**Details if related**
