### PR TITLE
[Hw PFCWD feature] Counter handling for hardware PFC watchdog

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -701,6 +701,7 @@ bool OrchDaemon::init()
         static const vector<sai_queue_stat_t> queueStatIds =
         {
             SAI_QUEUE_STAT_PACKETS,
+            SAI_QUEUE_STAT_DROPPED_PACKETS,
             SAI_QUEUE_STAT_CURR_OCCUPANCY_BYTES,
         };
 

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -24,7 +24,6 @@ using namespace swss;
 
 /* select() function timeout retry time */
 #define SELECT_TIMEOUT 1000
-#define PFC_WD_POLL_MSECS 100
 
 #define APP_FABRIC_MONITOR_PORT_TABLE_NAME      "FABRIC_PORT_TABLE"
 #define APP_FABRIC_MONITOR_DATA_TABLE_NAME      "FABRIC_MONITOR_TABLE"
@@ -799,6 +798,7 @@ bool OrchDaemon::init()
         static const vector<sai_queue_stat_t> queueStatIds =
         {
             SAI_QUEUE_STAT_PACKETS,
+            SAI_QUEUE_STAT_DROPPED_PACKETS,
             SAI_QUEUE_STAT_CURR_OCCUPANCY_BYTES,
         };
 

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -827,13 +827,20 @@ bool OrchDaemon::init()
 
         // Complete hardware recovery needs deadlock detection and recovery in
         // hardware, which SAI_QUEUE_ATTR_ENABLE_PFC_DLDR reports. A hybrid
-        // platform only advertises SAI_QUEUE_ATTR_PFC_DLR_INIT.
+        // platform only advertises SAI_QUEUE_ATTR_PFC_DLR_INIT, and a platform
+        // that reports DLDR may report DLR init too, so DLDR is checked first:
+        // starting a software handler there would duplicate the hardware.
         if (gSwitchOrch->checkPfcDldrEnable())
         {
-            SWSS_LOG_NOTICE("Switch supports PFC hardware watchdog");
+            SWSS_LOG_NOTICE("Starting hardware-based pfc watchdog");
+            m_orchList.push_back(new PfcWdHwOrch(
+                        m_configDb,
+                        pfc_wd_tables,
+                        portStatIds,
+                        queueStatIds,
+                        queueAttrIds));
         }
-
-        if(pfcDlrInit)
+        else if(pfcDlrInit)
         {
             SWSS_LOG_NOTICE("Starting dlr init handler for pfc watchdog");
             m_orchList.push_back(new PfcWdSwOrch<PfcWdDlrHandler, PfcWdDlrHandler>(

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -798,7 +798,6 @@ bool OrchDaemon::init()
         static const vector<sai_queue_stat_t> queueStatIds =
         {
             SAI_QUEUE_STAT_PACKETS,
-            SAI_QUEUE_STAT_DROPPED_PACKETS,
             SAI_QUEUE_STAT_CURR_OCCUPANCY_BYTES,
         };
 

--- a/orchagent/pfcwdhworch.cpp
+++ b/orchagent/pfcwdhworch.cpp
@@ -4,16 +4,17 @@
 #include "portsorch.h"
 #include "saiextensions.h"
 #include "sai_serialize.h"
-#include "converter.h"
 #include <algorithm>
 #include <set>
+
+#define PFC_WD_COUNTER_POLL_TIMEOUT_SEC  1
+#define PFC_HW_WD_POLL_MSECS 50
 
 extern sai_object_id_t gSwitchId;
 extern sai_switch_api_t* sai_switch_api;
 extern sai_port_api_t* sai_port_api;
 extern sai_queue_api_t* sai_queue_api;
 extern sai_buffer_api_t* sai_buffer_api;
-extern event_handle_t g_events_handle;
 extern SwitchOrch *gSwitchOrch;
 extern PortsOrch *gPortsOrch;
 
@@ -21,7 +22,6 @@ extern PortsOrch *gPortsOrch;
 static PfcWdHwOrch* g_pfcWdHwOrch = nullptr;
 
 // SAI callback wrapper
-__attribute__((unused))
 static void on_queue_pfc_deadlock(
         _In_ uint32_t count,
         _In_ sai_queue_deadlock_notification_data_t *data)
@@ -31,6 +31,14 @@ static void on_queue_pfc_deadlock(
         g_pfcWdHwOrch->onQueuePfcDeadlock(count, data);
     }
 }
+
+namespace {
+
+// Maximum tick count for hardware timers.
+// TODO: Hard-coded value, replace with SAI query when API support is available.
+constexpr uint32_t MAX_TICK_COUNT = 15;
+
+} // anonymous namespace
 
 PfcWdHwOrch::PfcWdHwOrch(DBConnector *db, vector<string> &tableNames,
                          const vector<sai_port_stat_t> &portStatIds,
@@ -139,61 +147,282 @@ void PfcWdHwOrch::registerCallbacks()
 {
     SWSS_LOG_ENTER();
 
-    // Register SAI callback for PFC deadlock notifications
-    // This will be invoked when hardware detects or restores from PFC storms
-    sai_attribute_t attr;
-    attr.id = SAI_SWITCH_ATTR_PFC_TC_DLD_INTERVAL;
+    // FlexCounter manager for PFC_WD queue statistics
+    m_pfcwdFlexCounterManager = make_shared<FlexCounterTaggedCachedManager<sai_object_type_t>>(
+        PFC_WD_FLEX_COUNTER_GROUP,
+        StatsMode::READ,
+        PFC_HW_WD_POLL_MSECS,
+        true,
+        make_pair("", ""));
 
-    // Note: The actual callback registration happens via SAI switch attribute
-    // SAI_SWITCH_ATTR_QUEUE_PFC_DEADLOCK_NOTIFY which should be set during
-    // switch initialization. The callback function is on_queue_pfc_deadlock()
-    // which calls this->onQueuePfcDeadlock()
+    SWSS_LOG_NOTICE("Initialized FlexCounter for hardware PFC watchdog with %d ms poll interval",
+                   PFC_HW_WD_POLL_MSECS);
 
-    SWSS_LOG_NOTICE("PFC watchdog hardware callbacks registered");
+    // Create timer for periodic counter updates
+    auto interv = timespec { .tv_sec = PFC_WD_COUNTER_POLL_TIMEOUT_SEC, .tv_nsec = 0 };
+    auto timer = new SelectableTimer(interv);
+    auto executor = new ExecutableTimer(timer, this, "PFC_WD_HW_COUNTERS_POLL");
+    Orch::addExecutor(executor);
+    timer->start();
+    SWSS_LOG_NOTICE("Started periodic counter update timer with %d second interval",
+                   PFC_WD_COUNTER_POLL_TIMEOUT_SEC);
+
+    // Register PFC deadlock notification callback
+    bool supported = gSwitchOrch->querySwitchCapability(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_QUEUE_PFC_DEADLOCK_NOTIFY);
+    if (supported)
+    {
+        sai_attribute_t attr;
+        attr.id = SAI_SWITCH_ATTR_QUEUE_PFC_DEADLOCK_NOTIFY;
+        attr.value.ptr = (void *)on_queue_pfc_deadlock;
+
+        sai_status_t status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to register PFC deadlock notification callback (status: %d)", status);
+        }
+        else
+        {
+            SWSS_LOG_NOTICE("Registered PFC deadlock notification callback");
+        }
+    }
+    else
+    {
+        SWSS_LOG_NOTICE("PFC deadlock notification not supported by hardware");
+    }
 }
 
 void PfcWdHwOrch::recoverWarmReboot(DBConnector *db)
 {
     SWSS_LOG_ENTER();
 
-    // During warm reboot, we need to restore the hardware watchdog state
-    // from STATE_DB and re-enable monitoring on ports that had it configured
-    // before the reboot.
+    // Re-apply existing CONFIG_DB entries after warm reboot
+    Table cfgPfcWdTable(db, CFG_PFC_WD_TABLE_NAME);
+    vector<string> keys;
+    cfgPfcWdTable.getKeys(keys);
 
-    // This is a placeholder for warm reboot recovery logic.
-    // The full implementation will:
-    // 1. Read STATE_DB to find ports with active hardware watchdog
-    // 2. Re-enable flex counters for those ports
-    // 3. Re-register queue monitoring
-
-    SWSS_LOG_NOTICE("PFC watchdog warm reboot recovery completed");
+    if (!keys.empty())
+    {
+        SWSS_LOG_NOTICE("Found %zu existing PFC watchdog configuration(s), will re-apply after ports are ready",
+                       keys.size());
+        addExistingData(&cfgPfcWdTable);
+    }
+    else
+    {
+        SWSS_LOG_INFO("No existing PFC watchdog configuration found");
+    }
 }
 
 void PfcWdHwOrch::onQueuePfcDeadlock(uint32_t count, sai_queue_deadlock_notification_data_t *data)
 {
     SWSS_LOG_ENTER();
-    // TODO: Implementation
+
+    for (uint32_t i = 0; i < count; i++)
+    {
+        auto& notification = data[i];
+
+        // Look up port information for this queue
+        sai_object_id_t port_id = 0;
+        string port_alias;
+        uint8_t queue_index = 0;
+        bool port_found = false;
+
+        auto it = m_queueToPortMap.find(notification.queue_id);
+        if (it != m_queueToPortMap.end())
+        {
+            port_id = it->second.port_id;
+            port_alias = it->second.port_alias;
+            queue_index = it->second.queue_index;
+            port_found = true;
+        }
+
+        if (notification.event == SAI_QUEUE_PFC_DEADLOCK_EVENT_TYPE_DETECTED)
+        {
+            // Initialize counters on storm detection
+            if (port_found)
+            {
+                string queueIdStr = sai_serialize_object_id(notification.queue_id);
+                initQueueCounters(queueIdStr, notification.queue_id, queue_index);
+                SWSS_LOG_DEBUG("PfcWdHwOrch: Initialized counters for queue 0x%" PRIx64 " on storm detection",
+                              notification.queue_id);
+
+                this->report_pfc_storm(notification.queue_id, port_id,
+                                      queue_index, port_alias, "");
+            }
+            else
+            {
+                SWSS_LOG_WARN("PFC deadlock DETECTED on queue 0x%" PRIx64 " (no port info)", notification.queue_id);
+            }
+
+            // Let SAI/SDK manage recovery automatically
+            notification.app_managed_recovery = false;
+        }
+        else if (notification.event == SAI_QUEUE_PFC_DEADLOCK_EVENT_TYPE_RECOVERED)
+        {
+            // Update counters on recovery
+            if (port_found)
+            {
+                string queueIdStr = sai_serialize_object_id(notification.queue_id);
+                updateQueueCounters(queueIdStr, notification.queue_id, queue_index, false);  // false = not periodic (recovery)
+                SWSS_LOG_DEBUG("PfcWdHwOrch: Updated counters for queue 0x%" PRIx64 " on storm restoration",
+                              notification.queue_id);
+
+                // Remove baseline stats
+                m_queueBaselineStats.erase(notification.queue_id);
+
+                this->report_pfc_restored(notification.queue_id, port_id,
+                                         queue_index, port_alias);
+            }
+            else
+            {
+                SWSS_LOG_NOTICE("PFC deadlock RECOVERED on queue 0x%" PRIx64 " (no port info)", notification.queue_id);
+            }
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Unknown PFC deadlock event type %d on queue 0x%" PRIx64,
+                          notification.event, notification.queue_id);
+        }
+    }
 }
 
 PfcWdHwOrch::PfcWdQueueStats PfcWdHwOrch::getQueueStats(const string &queueIdStr)
 {
     SWSS_LOG_ENTER();
-    // TODO: Implementation
+
     PfcWdQueueStats stats;
     memset(&stats, 0, sizeof(PfcWdQueueStats));
+    stats.operational = true;
+    vector<FieldValueTuple> fieldValues;
+
+    if (!this->getCountersTable()->get(queueIdStr, fieldValues))
+    {
+        // Return zeros if entry doesn't exist
+        return stats;
+    }
+
+    for (const auto& fv : fieldValues)
+    {
+        const auto field = fvField(fv);
+        const auto value = fvValue(fv);
+
+        if (field == "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED")
+        {
+            stats.detectCount = stoul(value);
+        }
+        else if (field == "PFC_WD_QUEUE_STATS_DEADLOCK_RESTORED")
+        {
+            stats.restoreCount = stoul(value);
+        }
+        else if (field == "PFC_WD_STATUS")
+        {
+            stats.operational = (value == "operational");
+        }
+        else if (field == "PFC_WD_QUEUE_STATS_TX_PACKETS")
+        {
+            stats.txPkt = stoul(value);
+        }
+        else if (field == "PFC_WD_QUEUE_STATS_TX_DROPPED_PACKETS")
+        {
+            stats.txDropPkt = stoul(value);
+        }
+        else if (field == "PFC_WD_QUEUE_STATS_RX_PACKETS")
+        {
+            stats.rxPkt = stoul(value);
+        }
+        else if (field == "PFC_WD_QUEUE_STATS_RX_DROPPED_PACKETS")
+        {
+            stats.rxDropPkt = stoul(value);
+        }
+        else if (field == "PFC_WD_QUEUE_STATS_TX_PACKETS_LAST")
+        {
+            stats.txPktLast = stoul(value);
+        }
+        else if (field == "PFC_WD_QUEUE_STATS_TX_DROPPED_PACKETS_LAST")
+        {
+            stats.txDropPktLast = stoul(value);
+        }
+        else if (field == "PFC_WD_QUEUE_STATS_RX_PACKETS_LAST")
+        {
+            stats.rxPktLast = stoul(value);
+        }
+        else if (field == "PFC_WD_QUEUE_STATS_RX_DROPPED_PACKETS_LAST")
+        {
+            stats.rxDropPktLast = stoul(value);
+        }
+    }
+
     return stats;
 }
 
 void PfcWdHwOrch::updateQueueStats(const string &queueIdStr, const PfcWdQueueStats &stats)
 {
     SWSS_LOG_ENTER();
-    // TODO: Implementation
+
+    vector<FieldValueTuple> resultFvValues;
+
+    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED", to_string(stats.detectCount));
+    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_DEADLOCK_RESTORED", to_string(stats.restoreCount));
+
+    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_TX_PACKETS", to_string(stats.txPkt));
+    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_TX_DROPPED_PACKETS", to_string(stats.txDropPkt));
+    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_RX_PACKETS", to_string(stats.rxPkt));
+    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_RX_DROPPED_PACKETS", to_string(stats.rxDropPkt));
+
+    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_TX_PACKETS_LAST", to_string(stats.txPktLast));
+    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_TX_DROPPED_PACKETS_LAST", to_string(stats.txDropPktLast));
+    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_RX_PACKETS_LAST", to_string(stats.rxPktLast));
+    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_RX_DROPPED_PACKETS_LAST", to_string(stats.rxDropPktLast));
+
+    resultFvValues.emplace_back("PFC_WD_STATUS", stats.operational ? "operational" : "stormed");
+
+    this->getCountersTable()->set(queueIdStr, resultFvValues);
 }
+
+
+
+
 
 bool PfcWdHwOrch::determineTimerGranularity(uint32_t timeValue, uint32_t hwMin, uint32_t hwMax, uint32_t& granularity)
 {
     SWSS_LOG_ENTER();
-    // TODO: Implementation
+
+    // Fixed granularity options: 1ms, 10ms, 100ms
+    // TODO: Query supported granularities from hardware
+    const vector<uint32_t> granularities = {1, 10, 100};
+
+    // Find granularity where timeValue fits in range [gran*1, gran*MAX_TICK_COUNT]
+    for (uint32_t gran : granularities)
+    {
+        uint32_t minTime = gran * 1;
+        uint32_t maxTime = gran * MAX_TICK_COUNT;
+
+        // Skip if not in hardware range
+        if (gran < hwMin || minTime > hwMax)
+        {
+            SWSS_LOG_DEBUG("Skipping granularity %u ms (not in hardware range [%u, %u] ms)",
+                          gran, hwMin, hwMax);
+            continue;
+        }
+
+        if (timeValue < minTime)
+        {
+            SWSS_LOG_ERROR("Time value %u ms is less than minimum supported time %u ms for granularity %u ms",
+                          timeValue, minTime, gran);
+            return false;
+        }
+
+        if (timeValue <= maxTime)
+        {
+            granularity = gran;
+            uint32_t ticks = (timeValue + gran - 1) / gran; // Round up to nearest tick
+            SWSS_LOG_DEBUG("Time %u ms can be represented with granularity %u ms (range: %u-%u ms, ticks: %u)",
+                          timeValue, gran, minTime, maxTime, ticks);
+            return true;
+        }
+    }
+
+    SWSS_LOG_ERROR("Time value %u ms exceeds maximum supported time %u ms",
+                  timeValue, 100 * MAX_TICK_COUNT);
     return false;
 }
 
@@ -439,15 +668,39 @@ bool PfcWdHwOrch::stopWdOnPort(const Port& port)
 void PfcWdHwOrch::doTask(SelectableTimer &timer)
 {
     SWSS_LOG_ENTER();
-    // TODO: Implementation
+
+    // Update counters for queues in storm
+    for (auto& entry : m_queueBaselineStats)
+    {
+        sai_object_id_t queueId = entry.first;
+        auto it = m_queueToPortMap.find(queueId);
+        if (it != m_queueToPortMap.end())
+        {
+            string queueIdStr = sai_serialize_object_id(queueId);
+            updateQueueCounters(queueIdStr, queueId, it->second.queue_index, true);  // true = periodic
+            SWSS_LOG_DEBUG("Periodic counter update for queue 0x%" PRIx64, queueId);
+        }
+        else
+        {
+            SWSS_LOG_WARN("Queue 0x%" PRIx64 " has baseline stats but no port mapping", queueId);
+        }
+    }
 }
 
 bool PfcWdHwOrch::startWdActionOnQueue(const string &event, sai_object_id_t queueId, const string &info)
 {
     SWSS_LOG_ENTER();
-    // TODO: Implementation
+
+    // Not used - hardware watchdog reports storms via SAI notifications
+
+    SWSS_LOG_ERROR("startWdActionOnQueue is not supported for hardware-based PFC watchdog. "
+                  "Queue 0x%" PRIx64 ", event: %s. Hardware handles actions automatically.",
+                  queueId, event.c_str());
+
     return false;
 }
+
+
 
 bool PfcWdHwOrch::readBackTimerValue(const Port& port, sai_port_attr_t attrId,
                                      const set<uint8_t>& losslessTc, uint32_t expected,
@@ -671,7 +924,7 @@ bool PfcWdHwOrch::configureTimerGranularity(const Port& port, uint32_t detection
     sai_status_t status = sai_port_api->set_port_attribute(port.m_port_id, &attr_granularity);
     if (status != SAI_STATUS_SUCCESS)
     {
-        return handleFailure("Failed to set PFC DLR timer granularity to " + to_string(timerGranularity) +
+        return handleFailure("Failed to set PFC DLD timer granularity to " + to_string(timerGranularity) +
                            " ms on port " + port.m_alias + ": " + to_string(status));
     }
 
@@ -680,6 +933,8 @@ bool PfcWdHwOrch::configureTimerGranularity(const Port& port, uint32_t detection
 
     return true;
 }
+
+
 
 bool PfcWdHwOrch::configureTimerIntervals(const Port& port, const set<uint8_t>& losslessTc,
                                           uint32_t detectionTime, uint32_t restorationTime,
@@ -863,12 +1118,11 @@ void PfcWdHwOrch::initializeQueueStats(const Port& port, const set<uint8_t>& los
         stats.rxDropPktLast = 0;
         updateQueueStats(queueIdStr, stats);
 
-        SWSS_LOG_DEBUG("Initialized PFC watchdog stats for port %s queue TC%d (0x%" PRIx64 ")",
-                      port.m_alias.c_str(), tc, queueId);
-    }
+        // Baseline stats will be created on-demand when storm is detected.
 
-    SWSS_LOG_NOTICE("Initialized PFC watchdog flex counters and stats for %zu lossless queues on port %s",
-                   losslessTc.size(), port.m_alias.c_str());
+        SWSS_LOG_NOTICE("Initialized PFC watchdog for queue 0x%" PRIx64 " on port %s TC %d",
+                       queueId, port.m_alias.c_str(), tc);
+    }
 }
 
 bool PfcWdHwOrch::disableHwWatchdog(const Port& port)
@@ -1030,26 +1284,205 @@ bool PfcWdHwOrch::isPortInStormedState(const Port& port)
 bool PfcWdHwOrch::readHwCounters(sai_object_id_t queueId, uint8_t queueIndex, PfcWdHwStats& counters)
 {
     SWSS_LOG_ENTER();
-    // TODO: Implementation
-    return false;
+
+    // For HW PFC watchdog, read queue/PG counters from COUNTERS_DB (via FlexCounter)
+    // instead of querying SAI directly.
+
+    string queueIdStr = sai_serialize_object_id(queueId);
+    vector<FieldValueTuple> fieldValues;
+
+    auto countersTable = getCountersTable();
+    if (!countersTable || !countersTable->get(queueIdStr, fieldValues))
+    {
+        SWSS_LOG_DEBUG("No counter entry found for queue 0x%" PRIx64, queueId);
+        memset(&counters, 0, sizeof(PfcWdHwStats));
+        return true;
+    }
+
+    // Initialize to zero
+    counters.txPkt = 0;
+    counters.txDropPkt = 0;
+    counters.rxPkt = 0;
+    counters.rxDropPkt = 0;
+
+    // Read TX counters (queue stats)
+    for (const auto& fv : fieldValues)
+    {
+        const auto field = fvField(fv);
+        const auto value = fvValue(fv);
+
+        if (field == "SAI_QUEUE_STAT_PACKETS")
+        {
+            counters.txPkt = stoull(value);
+        }
+        else if (field == "SAI_QUEUE_STAT_DROPPED_PACKETS")
+        {
+            counters.txDropPkt = stoull(value);
+        }
+    }
+
+    // Read RX counters from the priority group mapped to this queue.
+    Port portInstance;
+    auto it = m_queueToPortMap.find(queueId);
+    if (it == m_queueToPortMap.end())
+    {
+        SWSS_LOG_ERROR("Queue 0x%" PRIx64 " not found in queue-to-port map", queueId);
+        return false;
+    }
+
+    if (!gPortsOrch->getPort(it->second.port_id, portInstance))
+    {
+        SWSS_LOG_ERROR("Cannot get port by ID 0x%" PRIx64, it->second.port_id);
+        return false;
+    }
+
+    if (queueIndex >= portInstance.m_priority_group_ids.size())
+    {
+        SWSS_LOG_ERROR("Invalid queue index %u for port 0x%" PRIx64, queueIndex, it->second.port_id);
+        return false;
+    }
+
+    sai_object_id_t pg = portInstance.m_priority_group_ids[static_cast<size_t>(queueIndex)];
+    string pgIdStr = sai_serialize_object_id(pg);
+
+    fieldValues.clear();
+    if (countersTable->get(pgIdStr, fieldValues))
+    {
+        for (const auto& fv : fieldValues)
+        {
+            const auto field = fvField(fv);
+            const auto value = fvValue(fv);
+
+            if (field == "SAI_INGRESS_PRIORITY_GROUP_STAT_PACKETS")
+            {
+                counters.rxPkt = stoull(value);
+            }
+            else if (field == "SAI_INGRESS_PRIORITY_GROUP_STAT_DROPPED_PACKETS")
+            {
+                counters.rxDropPkt = stoull(value);
+            }
+        }
+    }
+
+    SWSS_LOG_DEBUG("Read HW counters for queue 0x%" PRIx64 ": txPkt=%" PRIu64 ", txDropPkt=%" PRIu64 ", rxPkt=%" PRIu64 ", rxDropPkt=%" PRIu64,
+                   queueId, counters.txPkt, counters.txDropPkt, counters.rxPkt, counters.rxDropPkt);
+
+    return true;
 }
 
 void PfcWdHwOrch::initQueueCounters(const string& queueIdStr, sai_object_id_t queueId, uint8_t queueIndex)
 {
     SWSS_LOG_ENTER();
-    // TODO: Implementation
+
+    PfcWdHwStats hwStats;
+    if (!readHwCounters(queueId, queueIndex, hwStats))
+    {
+        return;
+    }
+
+    // Read current stats from COUNTERS_DB
+    auto wdQueueStats = getQueueStats(queueIdStr);
+
+    // Only bump detectCount for a new storm; if storm persisted across
+    // warm-reboot (detectCount > restoreCount), keep counters as-is.
+    if (!(wdQueueStats.detectCount > wdQueueStats.restoreCount))
+    {
+        wdQueueStats.detectCount++;
+        wdQueueStats.txPktLast = 0;
+        wdQueueStats.txDropPktLast = 0;
+        wdQueueStats.rxPktLast = 0;
+        wdQueueStats.rxDropPktLast = 0;
+    }
+    wdQueueStats.operational = false;
+
+    // Store baseline for delta calculation
+    m_queueBaselineStats[queueId] = hwStats;
+
+    // Write to COUNTERS_DB
+    updateQueueStats(queueIdStr, wdQueueStats);
 }
 
 void PfcWdHwOrch::updateQueueCounters(const string& queueIdStr, sai_object_id_t queueId,
                                       uint8_t queueIndex, bool periodic)
 {
     SWSS_LOG_ENTER();
-    // TODO: Implementation
-}
 
-uint32_t PfcWdHwOrch::roundUpToValidInterval(uint32_t requestedTime, const vector<uint32_t>& validIntervals)
-{
-    SWSS_LOG_ENTER();
-    // TODO: Implementation
-    return 0;
+    PfcWdHwStats hwStats;
+    if (!readHwCounters(queueId, queueIndex, hwStats))
+    {
+        return;
+    }
+
+    auto finalStats = getQueueStats(queueIdStr);
+
+    if (!periodic)
+    {
+        finalStats.restoreCount++;
+    }
+    finalStats.operational = !periodic;
+
+    // Get baseline (stored in initQueueCounters or previous update)
+    auto it = m_queueBaselineStats.find(queueId);
+    if (it == m_queueBaselineStats.end())
+    {
+        SWSS_LOG_WARN("No baseline stats found for queue 0x%" PRIx64 ", initializing", queueId);
+        m_queueBaselineStats[queueId] = hwStats;
+        updateQueueStats(queueIdStr, finalStats);
+        return;
+    }
+
+    auto& baseline = it->second;
+
+    // Calculate deltas with underflow protection
+    // If hardware counters are less than baseline, it means counters were reset
+    // In this case, skip the update to avoid huge negative values
+    if (hwStats.txPkt >= baseline.txPkt)
+    {
+        finalStats.txPktLast += hwStats.txPkt - baseline.txPkt;
+        finalStats.txPkt += hwStats.txPkt - baseline.txPkt;
+    }
+    else
+    {
+        SWSS_LOG_WARN("Counter reset detected for queue 0x%" PRIx64 ": txPkt went from %" PRIu64 " to %" PRIu64,
+                     queueId, baseline.txPkt, hwStats.txPkt);
+    }
+
+    if (hwStats.txDropPkt >= baseline.txDropPkt)
+    {
+        finalStats.txDropPktLast += hwStats.txDropPkt - baseline.txDropPkt;
+        finalStats.txDropPkt += hwStats.txDropPkt - baseline.txDropPkt;
+    }
+    else
+    {
+        SWSS_LOG_WARN("Counter reset detected for queue 0x%" PRIx64 ": txDropPkt went from %" PRIu64 " to %" PRIu64,
+                     queueId, baseline.txDropPkt, hwStats.txDropPkt);
+    }
+
+    if (hwStats.rxPkt >= baseline.rxPkt)
+    {
+        finalStats.rxPktLast += hwStats.rxPkt - baseline.rxPkt;
+        finalStats.rxPkt += hwStats.rxPkt - baseline.rxPkt;
+    }
+    else
+    {
+        SWSS_LOG_WARN("Counter reset detected for queue 0x%" PRIx64 ": rxPkt went from %" PRIu64 " to %" PRIu64,
+                     queueId, baseline.rxPkt, hwStats.rxPkt);
+    }
+
+    if (hwStats.rxDropPkt >= baseline.rxDropPkt)
+    {
+        finalStats.rxDropPktLast += hwStats.rxDropPkt - baseline.rxDropPkt;
+        finalStats.rxDropPkt += hwStats.rxDropPkt - baseline.rxDropPkt;
+    }
+    else
+    {
+        SWSS_LOG_WARN("Counter reset detected for queue 0x%" PRIx64 ": rxDropPkt went from %" PRIu64 " to %" PRIu64,
+                     queueId, baseline.rxDropPkt, hwStats.rxDropPkt);
+    }
+
+    // Update baseline
+    baseline = hwStats;
+
+    // Write to COUNTERS_DB
+    updateQueueStats(queueIdStr, finalStats);
 }

--- a/orchagent/pfcwdhworch.cpp
+++ b/orchagent/pfcwdhworch.cpp
@@ -32,14 +32,6 @@ static void on_queue_pfc_deadlock(
     }
 }
 
-namespace {
-
-// Maximum tick count for hardware timers.
-// TODO: Hard-coded value, replace with SAI query when API support is available.
-constexpr uint32_t MAX_TICK_COUNT = 15;
-
-} // anonymous namespace
-
 PfcWdHwOrch::PfcWdHwOrch(DBConnector *db, vector<string> &tableNames,
                          const vector<sai_port_stat_t> &portStatIds,
                          const vector<sai_queue_stat_t> &queueStatIds,
@@ -53,8 +45,7 @@ PfcWdHwOrch::PfcWdHwOrch(DBConnector *db, vector<string> &tableNames,
     m_restorationTimeMin(0),
     m_restorationTimeMax(0),
     m_stateDb(make_shared<DBConnector>("STATE_DB", 0)),
-    m_pfcWdHwStateTable(make_shared<Table>(m_stateDb.get(), STATE_PFC_WD_HW_STATE_TABLE_NAME)),
-    m_portLevelGranularitySupported(false)
+    m_pfcWdHwStateTable(make_shared<Table>(m_stateDb.get(), STATE_PFC_WD_HW_STATE_TABLE_NAME))
 {
     SWSS_LOG_ENTER();
 
@@ -66,7 +57,6 @@ PfcWdHwOrch::PfcWdHwOrch(DBConnector *db, vector<string> &tableNames,
 
     SWSS_LOG_NOTICE("Initializing hardware-based PFC watchdog");
 
-    initializeCapabilities();
     initializeTimerRanges();
     registerCallbacks();
     recoverWarmReboot(db);
@@ -79,32 +69,6 @@ PfcWdHwOrch::~PfcWdHwOrch(void)
     SWSS_LOG_ENTER();
 
     g_pfcWdHwOrch = nullptr;
-}
-
-void PfcWdHwOrch::initializeCapabilities()
-{
-    SWSS_LOG_ENTER();
-
-    // Detect platform capability for port-level timer granularity
-    sai_attr_capability_t attr_capability;
-    sai_status_t cap_status = sai_query_attribute_capability(
-        gSwitchId,
-        SAI_OBJECT_TYPE_PORT,
-        SAI_PORT_ATTR_PFC_TC_DLD_TIMER_INTERVAL,
-        &attr_capability);
-
-    if (cap_status == SAI_STATUS_SUCCESS &&
-        attr_capability.set_implemented &&
-        attr_capability.get_implemented)
-    {
-        m_portLevelGranularitySupported = true;
-        SWSS_LOG_NOTICE("Port-level PFC DLD timer granularity supported");
-    }
-    else
-    {
-        m_portLevelGranularitySupported = false;
-        SWSS_LOG_NOTICE("Port-level PFC DLD timer granularity not supported, using default 100ms");
-    }
 }
 
 void PfcWdHwOrch::initializeTimerRanges()
@@ -376,54 +340,6 @@ void PfcWdHwOrch::updateQueueStats(const string &queueIdStr, const PfcWdQueueSta
     resultFvValues.emplace_back("PFC_WD_STATUS", stats.operational ? "operational" : "stormed");
 
     this->getCountersTable()->set(queueIdStr, resultFvValues);
-}
-
-
-
-
-
-bool PfcWdHwOrch::determineTimerGranularity(uint32_t timeValue, uint32_t hwMin, uint32_t hwMax, uint32_t& granularity)
-{
-    SWSS_LOG_ENTER();
-
-    // Fixed granularity options: 1ms, 10ms, 100ms
-    // TODO: Query supported granularities from hardware
-    const vector<uint32_t> granularities = {1, 10, 100};
-
-    // Find granularity where timeValue fits in range [gran*1, gran*MAX_TICK_COUNT]
-    for (uint32_t gran : granularities)
-    {
-        uint32_t minTime = gran * 1;
-        uint32_t maxTime = gran * MAX_TICK_COUNT;
-
-        // Skip if not in hardware range
-        if (gran < hwMin || minTime > hwMax)
-        {
-            SWSS_LOG_DEBUG("Skipping granularity %u ms (not in hardware range [%u, %u] ms)",
-                          gran, hwMin, hwMax);
-            continue;
-        }
-
-        if (timeValue < minTime)
-        {
-            SWSS_LOG_ERROR("Time value %u ms is less than minimum supported time %u ms for granularity %u ms",
-                          timeValue, minTime, gran);
-            return false;
-        }
-
-        if (timeValue <= maxTime)
-        {
-            granularity = gran;
-            uint32_t ticks = (timeValue + gran - 1) / gran; // Round up to nearest tick
-            SWSS_LOG_DEBUG("Time %u ms can be represented with granularity %u ms (range: %u-%u ms, ticks: %u)",
-                          timeValue, gran, minTime, maxTime, ticks);
-            return true;
-        }
-    }
-
-    SWSS_LOG_ERROR("Time value %u ms exceeds maximum supported time %u ms",
-                  timeValue, 100 * MAX_TICK_COUNT);
-    return false;
 }
 
 task_process_status PfcWdHwOrch::createEntry(const string& key, const vector<FieldValueTuple>& data)
@@ -777,13 +693,6 @@ bool PfcWdHwOrch::configureHwWatchdog(const Port& port, uint32_t detectionTime,
         return false;
     }
 
-    // Configure timer granularity if supported
-    uint32_t timerGranularity = 0;
-    if (!configureTimerGranularity(port, detectionTime, timerGranularity, handleFailure))
-    {
-        return false;
-    }
-
     // Configure detection and restoration intervals
     if (!configureTimerIntervals(port, losslessTc, detectionTime, restorationTime, handleFailure))
     {
@@ -822,12 +731,6 @@ bool PfcWdHwOrch::configureHwWatchdog(const Port& port, uint32_t detectionTime,
     fvs.emplace_back("hw_restoration_time", to_string(actualHwRestorationTime));
     fvs.emplace_back("configured_detection_time", to_string(detectionTime));
     fvs.emplace_back("configured_restoration_time", to_string(restorationTime));
-
-    // Add granularity field if port-level granularity is supported
-    if (m_portLevelGranularitySupported && timerGranularity > 0)
-    {
-        fvs.emplace_back("detection_granularity", to_string(timerGranularity));
-    }
 
     fvs.emplace_back("action", serializeAction(action));
     m_pfcWdHwStateTable->set(port.m_alias, fvs);
@@ -880,61 +783,6 @@ bool PfcWdHwOrch::configureSwitchAction(const Port& port, PfcWdAction action,
 
     return true;
 }
-
-bool PfcWdHwOrch::configureTimerGranularity(const Port& port, uint32_t detectionTime,
-                                            uint32_t& timerGranularity,
-                                            const function<bool(const string&)>& handleFailure)
-{
-    SWSS_LOG_ENTER();
-
-    // SAI_PORT_ATTR_PFC_TC_DLD_TIMER_INTERVAL only applies to detection timer
-    if (!m_portLevelGranularitySupported)
-    {
-        SWSS_LOG_INFO("Port-level granularity not supported on port %s, ASIC will configure best available granularity",
-                     port.m_alias.c_str());
-        timerGranularity = 0;
-        return true;
-    }
-
-    // Find granularity that supports the detection time
-    if (!determineTimerGranularity(detectionTime, m_detectionTimeMin, m_detectionTimeMax, timerGranularity))
-    {
-        return handleFailure("Failed to determine suitable timer granularity for detection time " +
-                           to_string(detectionTime) + " ms on port " + port.m_alias);
-    }
-
-    SWSS_LOG_INFO("Using timer granularity %u ms for detection time %u ms on port %s",
-                 timerGranularity, detectionTime, port.m_alias.c_str());
-
-    // Build map with granularity for all TCs (0-7)
-    std::vector<sai_map_t> granularity_map_list;
-    for (uint8_t tc = 0; tc < PFC_WD_TC_MAX; tc++)
-    {
-        sai_map_t gran_map;
-        gran_map.key = tc;
-        gran_map.value = timerGranularity;
-        granularity_map_list.push_back(gran_map);
-    }
-
-    sai_attribute_t attr_granularity;
-    attr_granularity.id = SAI_PORT_ATTR_PFC_TC_DLD_TIMER_INTERVAL;
-    attr_granularity.value.maplist.count = static_cast<uint32_t>(granularity_map_list.size());
-    attr_granularity.value.maplist.list = granularity_map_list.data();
-
-    sai_status_t status = sai_port_api->set_port_attribute(port.m_port_id, &attr_granularity);
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        return handleFailure("Failed to set PFC DLD timer granularity to " + to_string(timerGranularity) +
-                           " ms on port " + port.m_alias + ": " + to_string(status));
-    }
-
-    SWSS_LOG_NOTICE("Set PFC DLD timer granularity to %u ms for detection timer on port %s",
-                   timerGranularity, port.m_alias.c_str());
-
-    return true;
-}
-
-
 
 bool PfcWdHwOrch::configureTimerIntervals(const Port& port, const set<uint8_t>& losslessTc,
                                           uint32_t detectionTime, uint32_t restorationTime,

--- a/orchagent/pfcwdhworch.cpp
+++ b/orchagent/pfcwdhworch.cpp
@@ -200,7 +200,190 @@ bool PfcWdHwOrch::determineTimerGranularity(uint32_t timeValue, uint32_t hwMin, 
 task_process_status PfcWdHwOrch::createEntry(const string& key, const vector<FieldValueTuple>& data)
 {
     SWSS_LOG_ENTER();
-    // TODO: Implementation
+
+    // GLOBAL configuration not supported for hardware watchdog
+    if (key == PFC_WD_GLOBAL)
+    {
+        SWSS_LOG_WARN("GLOBAL configuration is not supported for hardware-based PFC watchdog");
+
+        for (const auto& field : data)
+        {
+            SWSS_LOG_WARN("Field '%s' with value '%s' is not supported for hardware-based PFC watchdog",
+                         fvField(field).c_str(), fvValue(field).c_str());
+        }
+
+        return task_process_status::task_invalid_entry;
+    }
+
+    uint32_t detectionTime = 0;
+    uint32_t restorationTime = 0;
+    // Default action is drop
+    PfcWdAction action = PfcWdAction::PFC_WD_ACTION_DROP;
+    string pfcStatHistory = "disable";
+    Port port;
+
+    if (!gPortsOrch->getPort(key, port))
+    {
+        SWSS_LOG_ERROR("Invalid port interface %s", key.c_str());
+        return task_process_status::task_invalid_entry;
+    }
+
+    if (port.m_type != Port::PHY)
+    {
+        SWSS_LOG_ERROR("Interface %s is not physical port", key.c_str());
+        return task_process_status::task_invalid_entry;
+    }
+
+    // Parse configuration fields
+    for (auto i : data)
+    {
+        const auto &field = fvField(i);
+        const auto &value = fvValue(i);
+
+        try
+        {
+            if (field == PFC_WD_DETECTION_TIME)
+            {
+                detectionTime = static_cast<uint32_t>(stoul(value));
+
+                // Check detection time is within supported range
+                if (m_detectionTimeMin > 0 && m_detectionTimeMax > 0)
+                {
+                    if (detectionTime < m_detectionTimeMin)
+                    {
+                        SWSS_LOG_ERROR("Detection time %u ms is below minimum supported value %u ms on port %s",
+                                      detectionTime, m_detectionTimeMin, key.c_str());
+                        return task_process_status::task_invalid_entry;
+                    }
+
+                    if (detectionTime > m_detectionTimeMax)
+                    {
+                        SWSS_LOG_ERROR("Detection time %u ms exceeds maximum supported value %u ms on port %s",
+                                      detectionTime, m_detectionTimeMax, key.c_str());
+                        return task_process_status::task_invalid_entry;
+                    }
+                }
+            }
+            else if (field == PFC_WD_RESTORATION_TIME)
+            {
+                restorationTime = static_cast<uint32_t>(stoul(value));
+
+                // Check restoration time is within supported range
+                if (m_restorationTimeMin > 0 && m_restorationTimeMax > 0)
+                {
+                    if (restorationTime < m_restorationTimeMin)
+                    {
+                        SWSS_LOG_ERROR("Restoration time %u ms is below minimum supported value %u ms on port %s",
+                                      restorationTime, m_restorationTimeMin, key.c_str());
+                        return task_process_status::task_invalid_entry;
+                    }
+
+                    if (restorationTime > m_restorationTimeMax)
+                    {
+                        SWSS_LOG_ERROR("Restoration time %u ms exceeds maximum supported value %u ms on port %s",
+                                      restorationTime, m_restorationTimeMax, key.c_str());
+                        return task_process_status::task_invalid_entry;
+                    }
+                }
+            }
+            else if (field == PFC_WD_ACTION)
+            {
+                action = deserializeAction(value);
+                if (action == PfcWdAction::PFC_WD_ACTION_UNKNOWN)
+                {
+                    SWSS_LOG_ERROR("Invalid PFC Watchdog action %s", value.c_str());
+                    return task_process_status::task_invalid_entry;
+                }
+            }
+            else if (field == PFC_STAT_HISTORY)
+            {
+                pfcStatHistory = value;
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Unknown PFC Watchdog configuration field %s", field.c_str());
+                return task_process_status::task_invalid_entry;
+            }
+        }
+        catch (const invalid_argument& e)
+        {
+            SWSS_LOG_ERROR("Failed to parse PFC Watchdog %s attribute %s invalid argument error",
+                          key.c_str(), field.c_str());
+            return task_process_status::task_invalid_entry;
+        }
+        catch (const out_of_range& e)
+        {
+            SWSS_LOG_ERROR("Failed to parse PFC Watchdog %s attribute %s out of range error",
+                          key.c_str(), field.c_str());
+            return task_process_status::task_invalid_entry;
+        }
+        catch (...)
+        {
+            SWSS_LOG_ERROR("Failed to parse PFC Watchdog %s attribute %s. Unknown error has been occurred",
+                          key.c_str(), field.c_str());
+            return task_process_status::task_invalid_entry;
+        }
+    }
+
+    // Validation
+    if (detectionTime == 0)
+    {
+        SWSS_LOG_ERROR("%s missing", PFC_WD_DETECTION_TIME);
+        return task_process_status::task_invalid_entry;
+    }
+    if (pfcStatHistory != "enable" && pfcStatHistory != "disable")
+    {
+        SWSS_LOG_ERROR("%s is invalid value for %s", pfcStatHistory.c_str(), PFC_STAT_HISTORY);
+        return task_process_status::task_invalid_entry;
+    }
+
+    // All ports must use the same switch-level PFC DLR packet action.
+    // Action can only change when no ports are configured, or when
+    // reconfiguring the single existing port.
+    PfcWdAction currentAction = this->getPfcDlrPacketAction();
+
+    bool isSinglePortReconfiguration = (m_hwWdPorts.size() == 1 &&
+                                        m_hwWdPorts.find(port.m_alias) != m_hwWdPorts.end());
+
+    if (currentAction != PfcWdAction::PFC_WD_ACTION_UNKNOWN &&
+        currentAction != action &&
+        !isSinglePortReconfiguration)
+    {
+        SWSS_LOG_ERROR("PFC DLR packet action mismatch on port %s: current=%s, requested=%s. "
+                      "All ports must use the same action. "
+                      "Action can only be changed when no ports are configured or when reconfiguring the only configured port.",
+                      port.m_alias.c_str(),
+                      serializeAction(currentAction).c_str(),
+                      serializeAction(action).c_str());
+        return task_process_status::task_invalid_entry;
+    }
+
+    // Check if port is already configured and has any queue in stormed state
+    if (m_hwWdPorts.find(port.m_alias) != m_hwWdPorts.end())
+    {
+        if (isPortInStormedState(port))
+        {
+            SWSS_LOG_ERROR("Cannot modify PFC watchdog configuration on port %s: port is in stormed state. "
+                          "Wait for storm to pass before making changes.",
+                          port.m_alias.c_str());
+            return task_process_status::task_invalid_entry;
+        }
+    }
+
+    // Hardware watchdog doesn't support in-place updates, so stop
+    // existing configuration before applying new one
+    SWSS_LOG_INFO("Attempting to disable any existing hardware PFC watchdog on port %s before applying new configuration",
+                  port.m_alias.c_str());
+    stopWdOnPort(port);
+
+    if (!startWdOnPort(port, detectionTime, restorationTime, action, pfcStatHistory))
+    {
+        SWSS_LOG_ERROR("Failed to start PFC Watchdog on port %s", port.m_alias.c_str());
+        return task_process_status::task_need_retry;
+    }
+
+    SWSS_LOG_NOTICE("Started PFC Watchdog on port %s", port.m_alias.c_str());
+    // Port is tracked in m_hwWdPorts by configureHwWatchdog
     return task_process_status::task_success;
 }
 
@@ -235,11 +418,15 @@ task_process_status PfcWdHwOrch::deleteEntry(const string& key)
 }
 
 bool PfcWdHwOrch::startWdOnPort(const Port& port,
-        uint32_t detectionTime, uint32_t restorationTime, PfcWdAction action, string pfcStatHistory)
+	    uint32_t detectionTime, uint32_t restorationTime, PfcWdAction action, string pfcStatHistory)
 {
-    SWSS_LOG_ENTER();
-    // TODO: Implementation
-    return false;
+	SWSS_LOG_ENTER();
+
+	// For hardware-based watchdog, all hardware programming and flex counter
+	// registration are handled in configureHwWatchdog()/initializeQueueStats().
+	// Any existing configuration is cleaned up via stopWdOnPort() before this
+	// function is invoked from createEntry().
+	return configureHwWatchdog(port, detectionTime, restorationTime, action);
 }
 
 bool PfcWdHwOrch::stopWdOnPort(const Port& port)
@@ -266,25 +453,179 @@ bool PfcWdHwOrch::readBackTimerValue(const Port& port, sai_port_attr_t attrId,
                                      const set<uint8_t>& losslessTc, uint32_t expected,
                                      uint32_t& actual, const string& timerName)
 {
-    SWSS_LOG_ENTER();
-    // TODO: Implementation
-    return false;
+    vector<sai_map_t> readBack(PFC_WD_TC_MAX);
+    for (uint32_t i = 0; i < PFC_WD_TC_MAX; i++)
+    {
+        readBack[i].key = i;
+        readBack[i].value = 0;
+    }
+
+    sai_attribute_t attr;
+    attr.id = attrId;
+    attr.value.maplist.count = PFC_WD_TC_MAX;
+    attr.value.maplist.list = readBack.data();
+
+    sai_status_t status = sai_port_api->get_port_attribute(port.m_port_id, 1, &attr);
+    if (status == SAI_STATUS_SUCCESS && attr.value.maplist.count > 0)
+    {
+        for (uint32_t i = 0; i < attr.value.maplist.count; i++)
+        {
+            uint8_t tcKey = static_cast<uint8_t>(attr.value.maplist.list[i].key);
+            if (losslessTc.find(tcKey) != losslessTc.end())
+            {
+                actual = attr.value.maplist.list[i].value;
+                break;
+            }
+        }
+
+        if (actual != expected)
+        {
+            SWSS_LOG_WARN("%s time mismatch on port %s: sent %u, hardware has %u",
+                          timerName.c_str(), port.m_alias.c_str(), expected, actual);
+        }
+        return true;
+    }
+    else
+    {
+        SWSS_LOG_WARN("Failed to read back %s time on port %s (status: %d)",
+                      timerName.c_str(), port.m_alias.c_str(), status);
+        return false;
+    }
 }
 
 bool PfcWdHwOrch::configureHwWatchdog(const Port& port, uint32_t detectionTime,
                                       uint32_t restorationTime, PfcWdAction action)
 {
     SWSS_LOG_ENTER();
-    // TODO: Implementation
-    return false;
+
+    SWSS_LOG_NOTICE("Configuring hardware watchdog on port %s: detection=%ums, restoration=%ums, action=%s",
+                    port.m_alias.c_str(), detectionTime, restorationTime, serializeAction(action).c_str());
+
+    // Validate port has lossless TCs before configuring hardware
+    set<uint8_t> losslessTc;
+    if (!getLosslessTcsForPort(port, losslessTc))
+    {
+        SWSS_LOG_NOTICE("No lossless TC found on port %s", port.m_alias.c_str());
+        writeFailureStatus(port);
+        return false;
+    }
+
+    // Cleanup handler called on configuration failure
+    auto handleFailure = [this, &port](const string& errorMsg) -> bool {
+        SWSS_LOG_ERROR("%s", errorMsg.c_str());
+        disableHwWatchdog(port);
+        writeFailureStatus(port);
+        return false;
+    };
+
+    // Configure switch-level action if needed
+    if (!configureSwitchAction(port, action, handleFailure))
+    {
+        return false;
+    }
+
+    // Configure timer granularity if supported
+    uint32_t timerGranularity = 0;
+    if (!configureTimerGranularity(port, detectionTime, timerGranularity, handleFailure))
+    {
+        return false;
+    }
+
+    // Configure detection and restoration intervals
+    if (!configureTimerIntervals(port, losslessTc, detectionTime, restorationTime, handleFailure))
+    {
+        return false;
+    }
+
+    // Enable deadlock detection/recovery on queues
+    if (!enableDldrOnLosslessQueues(port, losslessTc, detectionTime, restorationTime, handleFailure))
+    {
+        return false;
+    }
+
+    // Initialize queue statistics in COUNTERS_DB
+    initializeQueueStats(port, losslessTc);
+
+    // Track this port
+    m_hwWdPorts.insert(port.m_alias);
+
+    SWSS_LOG_NOTICE("Successfully configured hardware PFC watchdog on port %s with %zu lossless TCs",
+                   port.m_alias.c_str(), losslessTc.size());
+
+    // Read back and verify timer values from hardware
+    uint32_t actualHwDetectionTime = detectionTime;
+    uint32_t actualHwRestorationTime = restorationTime;
+
+    readBackTimerValue(port, SAI_PORT_ATTR_PFC_TC_DLD_INTERVAL, losslessTc,
+                      detectionTime, actualHwDetectionTime, "Detection");
+    readBackTimerValue(port, SAI_PORT_ATTR_PFC_TC_DLR_INTERVAL, losslessTc,
+                      restorationTime, actualHwRestorationTime, "Restoration");
+
+    // Write success to STATE_DB
+    vector<FieldValueTuple> fvs;
+    fvs.emplace_back("recovery_type", "hardware");
+    fvs.emplace_back("status", "configured");
+    fvs.emplace_back("hw_detection_time", to_string(actualHwDetectionTime));
+    fvs.emplace_back("hw_restoration_time", to_string(actualHwRestorationTime));
+    fvs.emplace_back("configured_detection_time", to_string(detectionTime));
+    fvs.emplace_back("configured_restoration_time", to_string(restorationTime));
+
+    // Add granularity field if port-level granularity is supported
+    if (m_portLevelGranularitySupported && timerGranularity > 0)
+    {
+        fvs.emplace_back("detection_granularity", to_string(timerGranularity));
+    }
+
+    fvs.emplace_back("action", serializeAction(action));
+    m_pfcWdHwStateTable->set(port.m_alias, fvs);
+
+    return true;
 }
 
 bool PfcWdHwOrch::configureSwitchAction(const Port& port, PfcWdAction action,
                                         const function<bool(const string&)>& handleFailure)
 {
     SWSS_LOG_ENTER();
-    // TODO: Implementation
-    return false;
+
+    // Only set action if not already configured
+    if (this->getPfcDlrPacketAction() != PfcWdAction::PFC_WD_ACTION_UNKNOWN)
+    {
+        return true;
+    }
+
+    sai_packet_action_t sai_action;
+    if (action == PfcWdAction::PFC_WD_ACTION_DROP)
+    {
+        sai_action = SAI_PACKET_ACTION_DROP;
+    }
+    else if (action == PfcWdAction::PFC_WD_ACTION_FORWARD || action == PfcWdAction::PFC_WD_ACTION_ALERT)
+    {
+        sai_action = SAI_PACKET_ACTION_FORWARD;
+    }
+    else
+    {
+        return handleFailure("Unsupported PFC DLR packet action: " + serializeAction(action));
+    }
+
+    sai_attribute_t attr;
+    attr.id = SAI_SWITCH_ATTR_PFC_DLR_PACKET_ACTION;
+    attr.value.u32 = sai_action;
+
+    sai_status_t status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        return handleFailure("Failed to set switch level PFC DLR packet action to " +
+                           serializeAction(action) + " on port " + port.m_alias +
+                           ": " + to_string(status));
+    }
+
+    SWSS_LOG_NOTICE("Set PFC DLR packet action to %s at switch level (SAI action: %d)",
+                   serializeAction(action).c_str(), sai_action);
+
+    this->setPfcDlrPacketAction(action);
+    this->updateDlrPacketActionInStateTable();
+
+    return true;
 }
 
 bool PfcWdHwOrch::configureTimerGranularity(const Port& port, uint32_t detectionTime,
@@ -292,8 +633,52 @@ bool PfcWdHwOrch::configureTimerGranularity(const Port& port, uint32_t detection
                                             const function<bool(const string&)>& handleFailure)
 {
     SWSS_LOG_ENTER();
-    // TODO: Implementation
-    return false;
+
+    // SAI_PORT_ATTR_PFC_TC_DLD_TIMER_INTERVAL only applies to detection timer
+    if (!m_portLevelGranularitySupported)
+    {
+        SWSS_LOG_INFO("Port-level granularity not supported on port %s, ASIC will configure best available granularity",
+                     port.m_alias.c_str());
+        timerGranularity = 0;
+        return true;
+    }
+
+    // Find granularity that supports the detection time
+    if (!determineTimerGranularity(detectionTime, m_detectionTimeMin, m_detectionTimeMax, timerGranularity))
+    {
+        return handleFailure("Failed to determine suitable timer granularity for detection time " +
+                           to_string(detectionTime) + " ms on port " + port.m_alias);
+    }
+
+    SWSS_LOG_INFO("Using timer granularity %u ms for detection time %u ms on port %s",
+                 timerGranularity, detectionTime, port.m_alias.c_str());
+
+    // Build map with granularity for all TCs (0-7)
+    std::vector<sai_map_t> granularity_map_list;
+    for (uint8_t tc = 0; tc < PFC_WD_TC_MAX; tc++)
+    {
+        sai_map_t gran_map;
+        gran_map.key = tc;
+        gran_map.value = timerGranularity;
+        granularity_map_list.push_back(gran_map);
+    }
+
+    sai_attribute_t attr_granularity;
+    attr_granularity.id = SAI_PORT_ATTR_PFC_TC_DLD_TIMER_INTERVAL;
+    attr_granularity.value.maplist.count = static_cast<uint32_t>(granularity_map_list.size());
+    attr_granularity.value.maplist.list = granularity_map_list.data();
+
+    sai_status_t status = sai_port_api->set_port_attribute(port.m_port_id, &attr_granularity);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        return handleFailure("Failed to set PFC DLR timer granularity to " + to_string(timerGranularity) +
+                           " ms on port " + port.m_alias + ": " + to_string(status));
+    }
+
+    SWSS_LOG_NOTICE("Set PFC DLD timer granularity to %u ms for detection timer on port %s",
+                   timerGranularity, port.m_alias.c_str());
+
+    return true;
 }
 
 bool PfcWdHwOrch::configureTimerIntervals(const Port& port, const set<uint8_t>& losslessTc,
@@ -301,8 +686,57 @@ bool PfcWdHwOrch::configureTimerIntervals(const Port& port, const set<uint8_t>& 
                                           const function<bool(const string&)>& handleFailure)
 {
     SWSS_LOG_ENTER();
-    // TODO: Implementation
-    return false;
+
+    // Build map lists for detection and restoration intervals
+    std::vector<sai_map_t> dld_map_list;
+    std::vector<sai_map_t> dlr_map_list;
+
+    for (auto tc : losslessTc)
+    {
+        sai_map_t dld_map;
+        dld_map.key = tc;
+        dld_map.value = detectionTime;
+        dld_map_list.push_back(dld_map);
+
+        sai_map_t dlr_map;
+        dlr_map.key = tc;
+        dlr_map.value = restorationTime;
+        dlr_map_list.push_back(dlr_map);
+    }
+
+    // Set detection interval on port
+    sai_attribute_t attr_dld;
+    attr_dld.id = SAI_PORT_ATTR_PFC_TC_DLD_INTERVAL;
+    attr_dld.value.maplist.count = static_cast<uint32_t>(dld_map_list.size());
+    attr_dld.value.maplist.list = dld_map_list.data();
+
+    sai_status_t status = sai_port_api->set_port_attribute(port.m_port_id, &attr_dld);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        return handleFailure("Failed to set PFC DLD interval on port " + port.m_alias +
+                           ": " + to_string(status));
+    }
+
+    SWSS_LOG_NOTICE("Set PFC DLD (detection) interval on port %s to %u ms for %zu TCs",
+                   port.m_alias.c_str(), detectionTime, losslessTc.size());
+
+    // Set restoration interval on port
+    sai_attribute_t attr_dlr;
+    attr_dlr.id = SAI_PORT_ATTR_PFC_TC_DLR_INTERVAL;
+    attr_dlr.value.maplist.count = static_cast<uint32_t>(dlr_map_list.size());
+    attr_dlr.value.maplist.list = dlr_map_list.data();
+
+    status = sai_port_api->set_port_attribute(port.m_port_id, &attr_dlr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        return handleFailure("Failed to set PFC DLR interval on port " + port.m_alias +
+                           ": " + to_string(status));
+    }
+
+    SWSS_LOG_NOTICE("Set PFC DLR (restoration) interval on port %s to %u ms for %zu TCs",
+                   port.m_alias.c_str(), restorationTime, losslessTc.size());
+
+    return true;
 }
 
 bool PfcWdHwOrch::enableDldrOnLosslessQueues(const Port& port, const set<uint8_t>& losslessTc,
@@ -310,14 +744,131 @@ bool PfcWdHwOrch::enableDldrOnLosslessQueues(const Port& port, const set<uint8_t
                                              const function<bool(const string&)>& handleFailure)
 {
     SWSS_LOG_ENTER();
-    // TODO: Implementation
-    return false;
+
+    // Enable PFC DLDR on each lossless queue
+    for (auto tc : losslessTc)
+    {
+        if (tc >= port.m_queue_ids.size())
+        {
+            SWSS_LOG_ERROR("TC %d exceeds queue count %zu on port %s",
+                          tc, port.m_queue_ids.size(), port.m_alias.c_str());
+            continue;
+        }
+
+        sai_object_id_t queueId = port.m_queue_ids[tc];
+
+        sai_attribute_t attr_enable;
+        attr_enable.id = SAI_QUEUE_ATTR_ENABLE_PFC_DLDR;
+        attr_enable.value.booldata = true;
+
+        sai_status_t status = sai_queue_api->set_queue_attribute(queueId, &attr_enable);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            return handleFailure("Failed to enable PFC DLDR on port " + port.m_alias +
+                               " queue " + to_string(tc) + " (0x" +
+                               sai_serialize_object_id(queueId) + "): " + to_string(status));
+        }
+
+        SWSS_LOG_NOTICE("Enabled PFC DLDR on port %s TC %d queue 0x%" PRIx64 " (detection: %u ms, restoration: %u ms)",
+                       port.m_alias.c_str(), tc, queueId, detectionTime, restorationTime);
+    }
+
+    return true;
 }
 
 void PfcWdHwOrch::initializeQueueStats(const Port& port, const set<uint8_t>& losslessTc)
 {
     SWSS_LOG_ENTER();
-    // TODO: Implementation
+
+    // For each lossless queue, register PFC_WD FlexCounters, initialize
+    // watchdog counters, and populate the queue→port mapping.
+    for (auto tc : losslessTc)
+    {
+        if (tc >= port.m_queue_ids.size())
+        {
+            continue;
+        }
+
+        sai_object_id_t queueId = port.m_queue_ids[tc];
+        string queueIdStr = sai_serialize_object_id(queueId);
+
+        // Register queue stats/attributes in the dedicated PFC_WD FlexCounter group.
+        if (m_pfcwdFlexCounterManager)
+        {
+            if (!c_queueStatIds.empty())
+            {
+                auto queueStatIdSet = PfcWdBaseOrch::counterIdsToStr(c_queueStatIds, sai_serialize_queue_stat);
+                if (queueStatIdSet.empty())
+                {
+                    SWSS_LOG_WARN("Failed to convert queue stat IDs for queue 0x%" PRIx64 " on port %s",
+                                  queueId, port.m_alias.c_str());
+                }
+                else
+                {
+                    m_pfcwdFlexCounterManager->setCounterIdList(queueId,
+                                                                 CounterType::QUEUE,
+                                                                 queueStatIdSet,
+                                                                 SAI_OBJECT_TYPE_QUEUE);
+                    SWSS_LOG_DEBUG("Registered %zu queue stats for queue 0x%" PRIx64 " on port %s",
+                                   queueStatIdSet.size(), queueId, port.m_alias.c_str());
+                }
+            }
+
+            if (!c_queueAttrIds.empty())
+            {
+                auto queueAttrIdSet = PfcWdBaseOrch::counterIdsToStr(c_queueAttrIds, sai_serialize_queue_attr);
+                if (queueAttrIdSet.empty())
+                {
+                    SWSS_LOG_WARN("Failed to convert queue attr IDs for queue 0x%" PRIx64 " on port %s",
+                                  queueId, port.m_alias.c_str());
+                }
+                else
+                {
+                    auto *fcMgr = dynamic_cast<FlexCounterManager*>(m_pfcwdFlexCounterManager.get());
+                    if (fcMgr)
+                    {
+                        fcMgr->setCounterIdList(queueId,
+                                                CounterType::QUEUE_ATTR,
+                                                queueAttrIdSet);
+                        SWSS_LOG_DEBUG("Registered %zu queue attrs for queue 0x%" PRIx64 " on port %s",
+                                       queueAttrIdSet.size(), queueId, port.m_alias.c_str());
+                    }
+                    else
+                    {
+                        SWSS_LOG_WARN("PFC WD FlexCounter manager is not FlexCounterManager for queue 0x%" PRIx64 " on port %s",
+                                      queueId, port.m_alias.c_str());
+                    }
+                }
+            }
+        }
+
+        // Add to queue→port mapping for fast lookup in the notification callback.
+        PortQueueInfo info;
+        info.port_id = port.m_port_id;
+        info.port_alias = port.m_alias;
+        info.queue_index = tc;
+        m_queueToPortMap[queueId] = info;
+
+        // Initialize PFC WD counters in COUNTERS_DB (status operational, packet counters cleared).
+        // Preserve existing detect/restore counts from warm-reboot if present.
+        auto stats = getQueueStats(queueIdStr);
+        stats.operational = true;
+        stats.txPkt = 0;
+        stats.txDropPkt = 0;
+        stats.rxPkt = 0;
+        stats.rxDropPkt = 0;
+        stats.txPktLast = 0;
+        stats.txDropPktLast = 0;
+        stats.rxPktLast = 0;
+        stats.rxDropPktLast = 0;
+        updateQueueStats(queueIdStr, stats);
+
+        SWSS_LOG_DEBUG("Initialized PFC watchdog stats for port %s queue TC%d (0x%" PRIx64 ")",
+                      port.m_alias.c_str(), tc, queueId);
+    }
+
+    SWSS_LOG_NOTICE("Initialized PFC watchdog flex counters and stats for %zu lossless queues on port %s",
+                   losslessTc.size(), port.m_alias.c_str());
 }
 
 bool PfcWdHwOrch::disableHwWatchdog(const Port& port)

--- a/orchagent/pfcwdhworch.cpp
+++ b/orchagent/pfcwdhworch.cpp
@@ -206,9 +206,32 @@ task_process_status PfcWdHwOrch::createEntry(const string& key, const vector<Fie
 
 task_process_status PfcWdHwOrch::deleteEntry(const string& key)
 {
-    SWSS_LOG_ENTER();
-    // TODO: Implementation
-    return task_process_status::task_success;
+	SWSS_LOG_ENTER();
+
+	Port port;
+	if (!gPortsOrch->getPort(key, port))
+	{
+		SWSS_LOG_ERROR("Invalid port interface %s", key.c_str());
+		return task_process_status::task_invalid_entry;
+	}
+
+	// If hardware watchdog is configured on this port, disallow deletion
+	// while any lossless queue is still in stormed state.
+	if (m_hwWdPorts.find(port.m_alias) != m_hwWdPorts.end())
+	{
+		if (isPortInStormedState(port))
+		{
+			SWSS_LOG_ERROR(
+				"Cannot delete PFC watchdog configuration on port %s: port is in stormed state. "
+				"Wait for storm to pass before making changes.",
+				port.m_alias.c_str());
+			return task_process_status::task_invalid_entry;
+		}
+	}
+
+	// Delegate to base implementation to stop watchdog on the port and
+	// update common bookkeeping.
+	return PfcWdBaseOrch::deleteEntry(key);
 }
 
 bool PfcWdHwOrch::startWdOnPort(const Port& port,
@@ -222,8 +245,8 @@ bool PfcWdHwOrch::startWdOnPort(const Port& port,
 bool PfcWdHwOrch::stopWdOnPort(const Port& port)
 {
     SWSS_LOG_ENTER();
-    // TODO: Implementation
-    return false;
+
+    return disableHwWatchdog(port);
 }
 
 void PfcWdHwOrch::doTask(SelectableTimer &timer)
@@ -300,20 +323,156 @@ void PfcWdHwOrch::initializeQueueStats(const Port& port, const set<uint8_t>& los
 bool PfcWdHwOrch::disableHwWatchdog(const Port& port)
 {
     SWSS_LOG_ENTER();
-    // TODO: Implementation
-    return false;
+
+    SWSS_LOG_NOTICE("Disabling hardware watchdog on port %s", port.m_alias.c_str());
+
+    // Get lossless TCs for this port
+    std::set<uint8_t> losslessTc;
+    if (!getLosslessTcsForPort(port, losslessTc))
+    {
+        SWSS_LOG_NOTICE("No lossless TC found on port %s", port.m_alias.c_str());
+        return true;  // Nothing to disable
+    }
+
+    // Disable PFC DLDR on each lossless queue and remove from queue→port mapping
+    for (auto tc : losslessTc)
+    {
+        if (tc >= port.m_queue_ids.size())
+        {
+            SWSS_LOG_ERROR("TC %d exceeds queue count %zu on port %s",
+                          tc, port.m_queue_ids.size(), port.m_alias.c_str());
+            continue;
+        }
+
+        sai_object_id_t queueId = port.m_queue_ids[tc];
+
+        sai_attribute_t attr_enable;
+        attr_enable.id = SAI_QUEUE_ATTR_ENABLE_PFC_DLDR;
+        attr_enable.value.booldata = false;
+
+        sai_status_t status = sai_queue_api->set_queue_attribute(queueId, &attr_enable);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to disable PFC DLDR on port %s queue %d (0x%" PRIx64 "): %d",
+                          port.m_alias.c_str(), tc, queueId, status);
+        }
+        else
+        {
+            SWSS_LOG_INFO("Disabled PFC DLDR on port %s TC %d queue 0x%" PRIx64,
+                         port.m_alias.c_str(), tc, queueId);
+        }
+
+        // Clear this queue's registration in the dedicated PFC_WD FlexCounter group.
+        if (m_pfcwdFlexCounterManager)
+        {
+            m_pfcwdFlexCounterManager->clearCounterIdList(queueId, SAI_OBJECT_TYPE_QUEUE);
+            SWSS_LOG_DEBUG("Cleared FlexCounter registration for queue 0x%" PRIx64 " on port %s",
+                           queueId, port.m_alias.c_str());
+        }
+
+        // Remove from queue→port mapping
+        m_queueToPortMap.erase(queueId);
+
+        // Remove baseline stats
+        m_queueBaselineStats.erase(queueId);
+        SWSS_LOG_DEBUG("Removed baseline stats for queue 0x%" PRIx64, queueId);
+    }
+
+    // Clear detection and restoration intervals on port level
+    std::vector<sai_map_t> empty_map_list;
+
+    // Clear detection interval
+    sai_attribute_t attr_dld;
+    attr_dld.id = SAI_PORT_ATTR_PFC_TC_DLD_INTERVAL;
+    attr_dld.value.maplist.count = 0;
+    attr_dld.value.maplist.list = nullptr;
+
+    sai_status_t status = sai_port_api->set_port_attribute(port.m_port_id, &attr_dld);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_WARN("Failed to clear PFC DLD interval on port %s: %d", port.m_alias.c_str(), status);
+    }
+
+    // Clear restoration interval
+    sai_attribute_t attr_dlr;
+    attr_dlr.id = SAI_PORT_ATTR_PFC_TC_DLR_INTERVAL;
+    attr_dlr.value.maplist.count = 0;
+    attr_dlr.value.maplist.list = nullptr;
+
+    status = sai_port_api->set_port_attribute(port.m_port_id, &attr_dlr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_WARN("Failed to clear PFC DLR interval on port %s: %d", port.m_alias.c_str(), status);
+    }
+
+    // Remove port from tracking set
+    m_hwWdPorts.erase(port.m_alias);
+
+    // Remove entry from STATE_DB
+    m_pfcWdHwStateTable->del(port.m_alias);
+
+    // If no ports have hardware watchdog configured, reset action to unknown
+    if (m_hwWdPorts.empty())
+    {
+        this->setPfcDlrPacketAction(PfcWdAction::PFC_WD_ACTION_UNKNOWN);
+        this->updateDlrPacketActionInStateTable();
+        SWSS_LOG_NOTICE("All hardware PFC watchdog ports disabled, reset action to UNKNOWN");
+    }
+
+    SWSS_LOG_NOTICE("Successfully disabled hardware PFC watchdog on port %s",
+                   port.m_alias.c_str());
+
+    return true;
 }
 
 void PfcWdHwOrch::writeFailureStatus(const Port& port)
 {
-    SWSS_LOG_ENTER();
-    // TODO: Implementation
+    vector<FieldValueTuple> fvs;
+    fvs.emplace_back("recovery_type", "hardware");
+    fvs.emplace_back("status", "failed");
+    m_pfcWdHwStateTable->set(port.m_alias, fvs);
 }
 
 bool PfcWdHwOrch::isPortInStormedState(const Port& port)
 {
     SWSS_LOG_ENTER();
-    // TODO: Implementation
+
+    // Get PFC mask to identify lossless queues
+    uint8_t pfcMask = 0;
+    if (!gPortsOrch->getPortPfcWatchdogStatus(port.m_port_id, &pfcMask))
+    {
+        SWSS_LOG_WARN("Failed to get PFC mask on port %s", port.m_alias.c_str());
+        return false;
+    }
+
+    // Check each lossless queue to see if any is in stormed state
+    for (uint8_t i = 0; i < PFC_WD_TC_MAX; i++)
+    {
+        if ((pfcMask & (1 << i)) == 0)
+        {
+            continue;  // Skip non-lossless queues
+        }
+
+        if (i >= port.m_queue_ids.size())
+        {
+            continue;
+        }
+
+        sai_object_id_t queueId = port.m_queue_ids[i];
+        string queueIdStr = sai_serialize_object_id(queueId);
+
+        // Get queue statistics
+        auto stats = getQueueStats(queueIdStr);
+
+        // If operational is false, the queue is in stormed state
+        if (!stats.operational)
+        {
+            SWSS_LOG_WARN("Port %s has queue %d (0x%" PRIx64 ") in stormed state",
+                         port.m_alias.c_str(), i, queueId);
+            return true;
+        }
+    }
+
     return false;
 }
 

--- a/orchagent/pfcwdhworch.cpp
+++ b/orchagent/pfcwdhworch.cpp
@@ -7,6 +7,9 @@
 #include <algorithm>
 #include <set>
 
+#define PFC_WD_COUNTER_POLL_TIMEOUT_SEC  1
+#define PFC_HW_WD_POLL_MSECS 50
+
 extern sai_object_id_t gSwitchId;
 extern sai_switch_api_t* sai_switch_api;
 extern sai_port_api_t* sai_port_api;
@@ -108,6 +111,26 @@ void PfcWdHwOrch::registerCallbacks()
 {
     SWSS_LOG_ENTER();
 
+    // FlexCounter manager for PFC_WD queue statistics
+    m_pfcwdFlexCounterManager = make_shared<FlexCounterTaggedCachedManager<sai_object_type_t>>(
+        PFC_WD_FLEX_COUNTER_GROUP,
+        StatsMode::READ,
+        PFC_HW_WD_POLL_MSECS,
+        true,
+        make_pair("", ""));
+
+    SWSS_LOG_NOTICE("Initialized FlexCounter for hardware PFC watchdog with %d ms poll interval",
+                   PFC_HW_WD_POLL_MSECS);
+
+    // Create timer for periodic counter updates
+    auto interv = timespec { .tv_sec = PFC_WD_COUNTER_POLL_TIMEOUT_SEC, .tv_nsec = 0 };
+    auto timer = new SelectableTimer(interv);
+    auto executor = new ExecutableTimer(timer, this, "PFC_WD_HW_COUNTERS_POLL");
+    Orch::addExecutor(executor);
+    timer->start();
+    SWSS_LOG_NOTICE("Started periodic counter update timer with %d second interval",
+                   PFC_WD_COUNTER_POLL_TIMEOUT_SEC);
+
     // Register PFC deadlock notification callback
     bool supported = gSwitchOrch->querySwitchCapability(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_QUEUE_PFC_DEADLOCK_NOTIFY);
     if (supported)
@@ -181,8 +204,10 @@ void PfcWdHwOrch::onQueuePfcDeadlock(uint32_t count, sai_queue_deadlock_notifica
             // Initialize counters on storm detection
             if (port_found)
             {
-                m_stormedQueues.insert(notification.queue_id);
-                SWSS_LOG_DEBUG("PfcWdHwOrch: Queue 0x%" PRIx64 " entered storm", notification.queue_id);
+                string queueIdStr = sai_serialize_object_id(notification.queue_id);
+                initQueueCounters(queueIdStr, notification.queue_id, queue_index);
+                SWSS_LOG_DEBUG("PfcWdHwOrch: Initialized counters for queue 0x%" PRIx64 " on storm detection",
+                              notification.queue_id);
 
                 this->report_pfc_storm(notification.queue_id, port_id,
                                       queue_index, port_alias, "");
@@ -200,8 +225,13 @@ void PfcWdHwOrch::onQueuePfcDeadlock(uint32_t count, sai_queue_deadlock_notifica
             // Update counters on recovery
             if (port_found)
             {
-                m_stormedQueues.erase(notification.queue_id);
-                SWSS_LOG_DEBUG("PfcWdHwOrch: Queue 0x%" PRIx64 " left storm", notification.queue_id);
+                string queueIdStr = sai_serialize_object_id(notification.queue_id);
+                updateQueueCounters(queueIdStr, notification.queue_id, queue_index, false);  // false = not periodic (recovery)
+                SWSS_LOG_DEBUG("PfcWdHwOrch: Updated counters for queue 0x%" PRIx64 " on storm restoration",
+                              notification.queue_id);
+
+                // Remove baseline stats
+                m_queueBaselineStats.erase(notification.queue_id);
 
                 this->report_pfc_restored(notification.queue_id, port_id,
                                          queue_index, port_alias);
@@ -217,6 +247,99 @@ void PfcWdHwOrch::onQueuePfcDeadlock(uint32_t count, sai_queue_deadlock_notifica
                           notification.event, notification.queue_id);
         }
     }
+}
+
+PfcWdHwOrch::PfcWdQueueStats PfcWdHwOrch::getQueueStats(const string &queueIdStr)
+{
+    SWSS_LOG_ENTER();
+
+    PfcWdQueueStats stats;
+    memset(&stats, 0, sizeof(PfcWdQueueStats));
+    stats.operational = true;
+    vector<FieldValueTuple> fieldValues;
+
+    if (!this->getCountersTable()->get(queueIdStr, fieldValues))
+    {
+        // Return zeros if entry doesn't exist
+        return stats;
+    }
+
+    for (const auto& fv : fieldValues)
+    {
+        const auto field = fvField(fv);
+        const auto value = fvValue(fv);
+
+        if (field == "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED")
+        {
+            stats.detectCount = stoul(value);
+        }
+        else if (field == "PFC_WD_QUEUE_STATS_DEADLOCK_RESTORED")
+        {
+            stats.restoreCount = stoul(value);
+        }
+        else if (field == "PFC_WD_STATUS")
+        {
+            stats.operational = (value == "operational");
+        }
+        else if (field == "PFC_WD_QUEUE_STATS_TX_PACKETS")
+        {
+            stats.txPkt = stoul(value);
+        }
+        else if (field == "PFC_WD_QUEUE_STATS_TX_DROPPED_PACKETS")
+        {
+            stats.txDropPkt = stoul(value);
+        }
+        else if (field == "PFC_WD_QUEUE_STATS_RX_PACKETS")
+        {
+            stats.rxPkt = stoul(value);
+        }
+        else if (field == "PFC_WD_QUEUE_STATS_RX_DROPPED_PACKETS")
+        {
+            stats.rxDropPkt = stoul(value);
+        }
+        else if (field == "PFC_WD_QUEUE_STATS_TX_PACKETS_LAST")
+        {
+            stats.txPktLast = stoul(value);
+        }
+        else if (field == "PFC_WD_QUEUE_STATS_TX_DROPPED_PACKETS_LAST")
+        {
+            stats.txDropPktLast = stoul(value);
+        }
+        else if (field == "PFC_WD_QUEUE_STATS_RX_PACKETS_LAST")
+        {
+            stats.rxPktLast = stoul(value);
+        }
+        else if (field == "PFC_WD_QUEUE_STATS_RX_DROPPED_PACKETS_LAST")
+        {
+            stats.rxDropPktLast = stoul(value);
+        }
+    }
+
+    return stats;
+}
+
+void PfcWdHwOrch::updateQueueStats(const string &queueIdStr, const PfcWdQueueStats &stats)
+{
+    SWSS_LOG_ENTER();
+
+    vector<FieldValueTuple> resultFvValues;
+
+    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED", to_string(stats.detectCount));
+    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_DEADLOCK_RESTORED", to_string(stats.restoreCount));
+
+    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_TX_PACKETS", to_string(stats.txPkt));
+    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_TX_DROPPED_PACKETS", to_string(stats.txDropPkt));
+    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_RX_PACKETS", to_string(stats.rxPkt));
+    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_RX_DROPPED_PACKETS", to_string(stats.rxDropPkt));
+
+    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_TX_PACKETS_LAST", to_string(stats.txPktLast));
+    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_TX_DROPPED_PACKETS_LAST", to_string(stats.txDropPktLast));
+    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_RX_PACKETS_LAST", to_string(stats.rxPktLast));
+    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_RX_DROPPED_PACKETS_LAST", to_string(stats.rxDropPktLast));
+
+    resultFvValues.emplace_back("PFC_WD_STATUS", stats.operational ? "operational" : "stormed");
+
+    this->getCountersTable()->set(queueIdStr, resultFvValues);
 }
 
 task_process_status PfcWdHwOrch::createEntry(const string& key, const vector<FieldValueTuple>& data)
@@ -445,7 +568,7 @@ bool PfcWdHwOrch::startWdOnPort(const Port& port,
 	SWSS_LOG_ENTER();
 
 	// For hardware-based watchdog, all hardware programming and flex counter
-	// registration are handled in configureHwWatchdog().
+	// registration are handled in configureHwWatchdog()/initializeQueueStats().
 	// Any existing configuration is cleaned up via stopWdOnPort() before this
 	// function is invoked from createEntry().
 	return configureHwWatchdog(port, detectionTime, restorationTime, action);
@@ -456,6 +579,28 @@ bool PfcWdHwOrch::stopWdOnPort(const Port& port)
     SWSS_LOG_ENTER();
 
     return disableHwWatchdog(port);
+}
+
+void PfcWdHwOrch::doTask(SelectableTimer &timer)
+{
+    SWSS_LOG_ENTER();
+
+    // Update counters for queues in storm
+    for (auto& entry : m_queueBaselineStats)
+    {
+        sai_object_id_t queueId = entry.first;
+        auto it = m_queueToPortMap.find(queueId);
+        if (it != m_queueToPortMap.end())
+        {
+            string queueIdStr = sai_serialize_object_id(queueId);
+            updateQueueCounters(queueIdStr, queueId, it->second.queue_index, true);  // true = periodic
+            SWSS_LOG_DEBUG("Periodic counter update for queue 0x%" PRIx64, queueId);
+        }
+        else
+        {
+            SWSS_LOG_WARN("Queue 0x%" PRIx64 " has baseline stats but no port mapping", queueId);
+        }
+    }
 }
 
 bool PfcWdHwOrch::startWdActionOnQueue(const string &event, sai_object_id_t queueId, const string &info)
@@ -470,6 +615,8 @@ bool PfcWdHwOrch::startWdActionOnQueue(const string &event, sai_object_id_t queu
 
     return false;
 }
+
+
 
 bool PfcWdHwOrch::readBackTimerValue(const Port& port, sai_port_attr_t attrId,
                                      const set<uint8_t>& losslessTc, uint32_t expected,
@@ -558,6 +705,7 @@ bool PfcWdHwOrch::configureHwWatchdog(const Port& port, uint32_t detectionTime,
     }
 
     // Initialize queue statistics in COUNTERS_DB
+    initializeQueueStats(port, losslessTc);
 
     // Track this port
     m_hwWdPorts.insert(port.m_alias);
@@ -730,6 +878,100 @@ bool PfcWdHwOrch::enableDldrOnLosslessQueues(const Port& port, const set<uint8_t
     return true;
 }
 
+void PfcWdHwOrch::initializeQueueStats(const Port& port, const set<uint8_t>& losslessTc)
+{
+    SWSS_LOG_ENTER();
+
+    // For each lossless queue, register PFC_WD FlexCounters, initialize
+    // watchdog counters, and populate the queue→port mapping.
+    for (auto tc : losslessTc)
+    {
+        if (tc >= port.m_queue_ids.size())
+        {
+            continue;
+        }
+
+        sai_object_id_t queueId = port.m_queue_ids[tc];
+        string queueIdStr = sai_serialize_object_id(queueId);
+
+        // Register queue stats/attributes in the dedicated PFC_WD FlexCounter group.
+        if (m_pfcwdFlexCounterManager)
+        {
+            if (!c_queueStatIds.empty())
+            {
+                auto queueStatIdSet = PfcWdBaseOrch::counterIdsToStr(c_queueStatIds, sai_serialize_queue_stat);
+                if (queueStatIdSet.empty())
+                {
+                    SWSS_LOG_WARN("Failed to convert queue stat IDs for queue 0x%" PRIx64 " on port %s",
+                                  queueId, port.m_alias.c_str());
+                }
+                else
+                {
+                    m_pfcwdFlexCounterManager->setCounterIdList(queueId,
+                                                                 CounterType::QUEUE,
+                                                                 queueStatIdSet,
+                                                                 SAI_OBJECT_TYPE_QUEUE);
+                    SWSS_LOG_DEBUG("Registered %zu queue stats for queue 0x%" PRIx64 " on port %s",
+                                   queueStatIdSet.size(), queueId, port.m_alias.c_str());
+                }
+            }
+
+            if (!c_queueAttrIds.empty())
+            {
+                auto queueAttrIdSet = PfcWdBaseOrch::counterIdsToStr(c_queueAttrIds, sai_serialize_queue_attr);
+                if (queueAttrIdSet.empty())
+                {
+                    SWSS_LOG_WARN("Failed to convert queue attr IDs for queue 0x%" PRIx64 " on port %s",
+                                  queueId, port.m_alias.c_str());
+                }
+                else
+                {
+                    auto *fcMgr = dynamic_cast<FlexCounterManager*>(m_pfcwdFlexCounterManager.get());
+                    if (fcMgr)
+                    {
+                        fcMgr->setCounterIdList(queueId,
+                                                CounterType::QUEUE_ATTR,
+                                                queueAttrIdSet);
+                        SWSS_LOG_DEBUG("Registered %zu queue attrs for queue 0x%" PRIx64 " on port %s",
+                                       queueAttrIdSet.size(), queueId, port.m_alias.c_str());
+                    }
+                    else
+                    {
+                        SWSS_LOG_WARN("PFC WD FlexCounter manager is not FlexCounterManager for queue 0x%" PRIx64 " on port %s",
+                                      queueId, port.m_alias.c_str());
+                    }
+                }
+            }
+        }
+
+        // Add to queue→port mapping for fast lookup in the notification callback.
+        PortQueueInfo info;
+        info.port_id = port.m_port_id;
+        info.port_alias = port.m_alias;
+        info.queue_index = tc;
+        m_queueToPortMap[queueId] = info;
+
+        // Initialize PFC WD counters in COUNTERS_DB (status operational, packet counters cleared).
+        // Preserve existing detect/restore counts from warm-reboot if present.
+        auto stats = getQueueStats(queueIdStr);
+        stats.operational = true;
+        stats.txPkt = 0;
+        stats.txDropPkt = 0;
+        stats.rxPkt = 0;
+        stats.rxDropPkt = 0;
+        stats.txPktLast = 0;
+        stats.txDropPktLast = 0;
+        stats.rxPktLast = 0;
+        stats.rxDropPktLast = 0;
+        updateQueueStats(queueIdStr, stats);
+
+        // Baseline stats will be created on-demand when storm is detected.
+
+        SWSS_LOG_NOTICE("Initialized PFC watchdog for queue 0x%" PRIx64 " on port %s TC %d",
+                       queueId, port.m_alias.c_str(), tc);
+    }
+}
+
 bool PfcWdHwOrch::disableHwWatchdog(const Port& port)
 {
     SWSS_LOG_ENTER();
@@ -771,10 +1013,20 @@ bool PfcWdHwOrch::disableHwWatchdog(const Port& port)
                          port.m_alias.c_str(), tc, queueId);
         }
 
+        // Clear this queue's registration in the dedicated PFC_WD FlexCounter group.
+        if (m_pfcwdFlexCounterManager)
+        {
+            m_pfcwdFlexCounterManager->clearCounterIdList(queueId, SAI_OBJECT_TYPE_QUEUE);
+            SWSS_LOG_DEBUG("Cleared FlexCounter registration for queue 0x%" PRIx64 " on port %s",
+                           queueId, port.m_alias.c_str());
+        }
+
         // Remove from queue→port mapping
         m_queueToPortMap.erase(queueId);
 
-        m_stormedQueues.erase(queueId);
+        // Remove baseline stats
+        m_queueBaselineStats.erase(queueId);
+        SWSS_LOG_DEBUG("Removed baseline stats for queue 0x%" PRIx64, queueId);
     }
 
     // Clear detection and restoration intervals on port level
@@ -858,8 +1110,13 @@ bool PfcWdHwOrch::isPortInStormedState(const Port& port)
         }
 
         sai_object_id_t queueId = port.m_queue_ids[i];
+        string queueIdStr = sai_serialize_object_id(queueId);
 
-        if (m_stormedQueues.count(queueId) != 0)
+        // Get queue statistics
+        auto stats = getQueueStats(queueIdStr);
+
+        // If operational is false, the queue is in stormed state
+        if (!stats.operational)
         {
             SWSS_LOG_WARN("Port %s has queue %d (0x%" PRIx64 ") in stormed state",
                          port.m_alias.c_str(), i, queueId);
@@ -870,3 +1127,208 @@ bool PfcWdHwOrch::isPortInStormedState(const Port& port)
     return false;
 }
 
+bool PfcWdHwOrch::readHwCounters(sai_object_id_t queueId, uint8_t queueIndex, PfcWdHwStats& counters)
+{
+    SWSS_LOG_ENTER();
+
+    // For HW PFC watchdog, read queue/PG counters from COUNTERS_DB (via FlexCounter)
+    // instead of querying SAI directly.
+
+    string queueIdStr = sai_serialize_object_id(queueId);
+    vector<FieldValueTuple> fieldValues;
+
+    auto countersTable = getCountersTable();
+    if (!countersTable || !countersTable->get(queueIdStr, fieldValues))
+    {
+        SWSS_LOG_DEBUG("No counter entry found for queue 0x%" PRIx64, queueId);
+        memset(&counters, 0, sizeof(PfcWdHwStats));
+        return true;
+    }
+
+    // Initialize to zero
+    counters.txPkt = 0;
+    counters.txDropPkt = 0;
+    counters.rxPkt = 0;
+    counters.rxDropPkt = 0;
+
+    // Read TX counters (queue stats)
+    for (const auto& fv : fieldValues)
+    {
+        const auto field = fvField(fv);
+        const auto value = fvValue(fv);
+
+        if (field == "SAI_QUEUE_STAT_PACKETS")
+        {
+            counters.txPkt = stoull(value);
+        }
+        else if (field == "SAI_QUEUE_STAT_DROPPED_PACKETS")
+        {
+            counters.txDropPkt = stoull(value);
+        }
+    }
+
+    // Read RX counters from the priority group mapped to this queue.
+    Port portInstance;
+    auto it = m_queueToPortMap.find(queueId);
+    if (it == m_queueToPortMap.end())
+    {
+        SWSS_LOG_ERROR("Queue 0x%" PRIx64 " not found in queue-to-port map", queueId);
+        return false;
+    }
+
+    if (!gPortsOrch->getPort(it->second.port_id, portInstance))
+    {
+        SWSS_LOG_ERROR("Cannot get port by ID 0x%" PRIx64, it->second.port_id);
+        return false;
+    }
+
+    if (queueIndex >= portInstance.m_priority_group_ids.size())
+    {
+        SWSS_LOG_ERROR("Invalid queue index %u for port 0x%" PRIx64, queueIndex, it->second.port_id);
+        return false;
+    }
+
+    sai_object_id_t pg = portInstance.m_priority_group_ids[static_cast<size_t>(queueIndex)];
+    string pgIdStr = sai_serialize_object_id(pg);
+
+    fieldValues.clear();
+    if (countersTable->get(pgIdStr, fieldValues))
+    {
+        for (const auto& fv : fieldValues)
+        {
+            const auto field = fvField(fv);
+            const auto value = fvValue(fv);
+
+            if (field == "SAI_INGRESS_PRIORITY_GROUP_STAT_PACKETS")
+            {
+                counters.rxPkt = stoull(value);
+            }
+            else if (field == "SAI_INGRESS_PRIORITY_GROUP_STAT_DROPPED_PACKETS")
+            {
+                counters.rxDropPkt = stoull(value);
+            }
+        }
+    }
+
+    SWSS_LOG_DEBUG("Read HW counters for queue 0x%" PRIx64 ": txPkt=%" PRIu64 ", txDropPkt=%" PRIu64 ", rxPkt=%" PRIu64 ", rxDropPkt=%" PRIu64,
+                   queueId, counters.txPkt, counters.txDropPkt, counters.rxPkt, counters.rxDropPkt);
+
+    return true;
+}
+
+void PfcWdHwOrch::initQueueCounters(const string& queueIdStr, sai_object_id_t queueId, uint8_t queueIndex)
+{
+    SWSS_LOG_ENTER();
+
+    PfcWdHwStats hwStats;
+    if (!readHwCounters(queueId, queueIndex, hwStats))
+    {
+        return;
+    }
+
+    // Read current stats from COUNTERS_DB
+    auto wdQueueStats = getQueueStats(queueIdStr);
+
+    // Only bump detectCount for a new storm; if storm persisted across
+    // warm-reboot (detectCount > restoreCount), keep counters as-is.
+    if (!(wdQueueStats.detectCount > wdQueueStats.restoreCount))
+    {
+        wdQueueStats.detectCount++;
+        wdQueueStats.txPktLast = 0;
+        wdQueueStats.txDropPktLast = 0;
+        wdQueueStats.rxPktLast = 0;
+        wdQueueStats.rxDropPktLast = 0;
+    }
+    wdQueueStats.operational = false;
+
+    // Store baseline for delta calculation
+    m_queueBaselineStats[queueId] = hwStats;
+
+    // Write to COUNTERS_DB
+    updateQueueStats(queueIdStr, wdQueueStats);
+}
+
+void PfcWdHwOrch::updateQueueCounters(const string& queueIdStr, sai_object_id_t queueId,
+                                      uint8_t queueIndex, bool periodic)
+{
+    SWSS_LOG_ENTER();
+
+    PfcWdHwStats hwStats;
+    if (!readHwCounters(queueId, queueIndex, hwStats))
+    {
+        return;
+    }
+
+    auto finalStats = getQueueStats(queueIdStr);
+
+    if (!periodic)
+    {
+        finalStats.restoreCount++;
+    }
+    finalStats.operational = !periodic;
+
+    // Get baseline (stored in initQueueCounters or previous update)
+    auto it = m_queueBaselineStats.find(queueId);
+    if (it == m_queueBaselineStats.end())
+    {
+        SWSS_LOG_WARN("No baseline stats found for queue 0x%" PRIx64 ", initializing", queueId);
+        m_queueBaselineStats[queueId] = hwStats;
+        updateQueueStats(queueIdStr, finalStats);
+        return;
+    }
+
+    auto& baseline = it->second;
+
+    // Calculate deltas with underflow protection
+    // If hardware counters are less than baseline, it means counters were reset
+    // In this case, skip the update to avoid huge negative values
+    if (hwStats.txPkt >= baseline.txPkt)
+    {
+        finalStats.txPktLast += hwStats.txPkt - baseline.txPkt;
+        finalStats.txPkt += hwStats.txPkt - baseline.txPkt;
+    }
+    else
+    {
+        SWSS_LOG_WARN("Counter reset detected for queue 0x%" PRIx64 ": txPkt went from %" PRIu64 " to %" PRIu64,
+                     queueId, baseline.txPkt, hwStats.txPkt);
+    }
+
+    if (hwStats.txDropPkt >= baseline.txDropPkt)
+    {
+        finalStats.txDropPktLast += hwStats.txDropPkt - baseline.txDropPkt;
+        finalStats.txDropPkt += hwStats.txDropPkt - baseline.txDropPkt;
+    }
+    else
+    {
+        SWSS_LOG_WARN("Counter reset detected for queue 0x%" PRIx64 ": txDropPkt went from %" PRIu64 " to %" PRIu64,
+                     queueId, baseline.txDropPkt, hwStats.txDropPkt);
+    }
+
+    if (hwStats.rxPkt >= baseline.rxPkt)
+    {
+        finalStats.rxPktLast += hwStats.rxPkt - baseline.rxPkt;
+        finalStats.rxPkt += hwStats.rxPkt - baseline.rxPkt;
+    }
+    else
+    {
+        SWSS_LOG_WARN("Counter reset detected for queue 0x%" PRIx64 ": rxPkt went from %" PRIu64 " to %" PRIu64,
+                     queueId, baseline.rxPkt, hwStats.rxPkt);
+    }
+
+    if (hwStats.rxDropPkt >= baseline.rxDropPkt)
+    {
+        finalStats.rxDropPktLast += hwStats.rxDropPkt - baseline.rxDropPkt;
+        finalStats.rxDropPkt += hwStats.rxDropPkt - baseline.rxDropPkt;
+    }
+    else
+    {
+        SWSS_LOG_WARN("Counter reset detected for queue 0x%" PRIx64 ": rxDropPkt went from %" PRIu64 " to %" PRIu64,
+                     queueId, baseline.rxDropPkt, hwStats.rxDropPkt);
+    }
+
+    // Update baseline
+    baseline = hwStats;
+
+    // Write to COUNTERS_DB
+    updateQueueStats(queueIdStr, finalStats);
+}

--- a/orchagent/pfcwdhworch.cpp
+++ b/orchagent/pfcwdhworch.cpp
@@ -523,10 +523,10 @@ task_process_status PfcWdHwOrch::createEntry(const string& key, const vector<Fie
 
     if (!startWdOnPort(port, detectionTime, restorationTime, action, pfcStatHistory))
     {
-        SWSS_LOG_ERROR("Failed to start PFC Watchdog on port %s", port.m_alias.c_str());
-        return task_process_status::task_need_retry;
+        return handleStartWdOnPortFailure(port);
     }
 
+    clearPfcWdPending(port);
     SWSS_LOG_NOTICE("Started PFC Watchdog on port %s", port.m_alias.c_str());
     // Port is tracked in m_hwWdPorts by configureHwWatchdog
     return task_process_status::task_success;
@@ -667,17 +667,16 @@ bool PfcWdHwOrch::configureHwWatchdog(const Port& port, uint32_t detectionTime,
 {
     SWSS_LOG_ENTER();
 
-    SWSS_LOG_NOTICE("Configuring hardware watchdog on port %s: detection=%ums, restoration=%ums, action=%s",
-                    port.m_alias.c_str(), detectionTime, restorationTime, serializeAction(action).c_str());
-
     // Validate port has lossless TCs before configuring hardware
     set<uint8_t> losslessTc;
     if (!getLosslessTcsForPort(port, losslessTc))
     {
-        SWSS_LOG_NOTICE("No lossless TC found on port %s", port.m_alias.c_str());
         writeFailureStatus(port);
         return false;
     }
+
+    SWSS_LOG_NOTICE("Configuring hardware watchdog on port %s: detection=%ums, restoration=%ums, action=%s",
+                    port.m_alias.c_str(), detectionTime, restorationTime, serializeAction(action).c_str());
 
     // Cleanup handler called on configuration failure
     auto handleFailure = [this, &port](const string& errorMsg) -> bool {
@@ -977,15 +976,14 @@ bool PfcWdHwOrch::disableHwWatchdog(const Port& port)
 {
     SWSS_LOG_ENTER();
 
-    SWSS_LOG_NOTICE("Disabling hardware watchdog on port %s", port.m_alias.c_str());
-
     // Get lossless TCs for this port
     std::set<uint8_t> losslessTc;
     if (!getLosslessTcsForPort(port, losslessTc))
     {
-        SWSS_LOG_NOTICE("No lossless TC found on port %s", port.m_alias.c_str());
         return true;  // Nothing to disable
     }
+
+    SWSS_LOG_NOTICE("Disabling hardware watchdog on port %s", port.m_alias.c_str());
 
     // Disable PFC DLDR on each lossless queue and remove from queue→port mapping
     for (auto tc : losslessTc)

--- a/orchagent/pfcwdhworch.cpp
+++ b/orchagent/pfcwdhworch.cpp
@@ -1,0 +1,345 @@
+#include "pfcwdhworch.h"
+#include "schema.h"
+#include "switchorch.h"
+#include "portsorch.h"
+#include "saiextensions.h"
+#include "sai_serialize.h"
+#include "converter.h"
+#include <algorithm>
+#include <set>
+
+extern sai_object_id_t gSwitchId;
+extern sai_switch_api_t* sai_switch_api;
+extern sai_port_api_t* sai_port_api;
+extern sai_queue_api_t* sai_queue_api;
+extern sai_buffer_api_t* sai_buffer_api;
+extern event_handle_t g_events_handle;
+extern SwitchOrch *gSwitchOrch;
+extern PortsOrch *gPortsOrch;
+
+// Global instance pointer for SAI callback
+static PfcWdHwOrch* g_pfcWdHwOrch = nullptr;
+
+// SAI callback wrapper
+__attribute__((unused))
+static void on_queue_pfc_deadlock(
+        _In_ uint32_t count,
+        _In_ sai_queue_deadlock_notification_data_t *data)
+{
+    if (g_pfcWdHwOrch != nullptr)
+    {
+        g_pfcWdHwOrch->onQueuePfcDeadlock(count, data);
+    }
+}
+
+PfcWdHwOrch::PfcWdHwOrch(DBConnector *db, vector<string> &tableNames,
+                         const vector<sai_port_stat_t> &portStatIds,
+                         const vector<sai_queue_stat_t> &queueStatIds,
+                         const vector<sai_queue_attr_t> &queueAttrIds):
+    PfcWdBaseOrch(db, tableNames),
+    c_portStatIds(portStatIds),
+    c_queueStatIds(queueStatIds),
+    c_queueAttrIds(queueAttrIds),
+    m_detectionTimeMin(0),
+    m_detectionTimeMax(0),
+    m_restorationTimeMin(0),
+    m_restorationTimeMax(0),
+    m_stateDb(make_shared<DBConnector>("STATE_DB", 0)),
+    m_pfcWdHwStateTable(make_shared<Table>(m_stateDb.get(), STATE_PFC_WD_HW_STATE_TABLE_NAME)),
+    m_portLevelGranularitySupported(false)
+{
+    SWSS_LOG_ENTER();
+
+    // Set global instance pointer
+    g_pfcWdHwOrch = this;
+
+    // Mark hardware watchdog recovery in STATE_DB
+    this->updateStateTable(PFC_WD_RECOVERY_MECHANISM, PFC_WD_RECOVERY_HARDWARE);
+
+    SWSS_LOG_NOTICE("Initializing hardware-based PFC watchdog");
+
+    initializeCapabilities();
+    initializeTimerRanges();
+    registerCallbacks();
+    recoverWarmReboot(db);
+
+    SWSS_LOG_NOTICE("Hardware-based PFC watchdog initialization complete");
+}
+
+PfcWdHwOrch::~PfcWdHwOrch(void)
+{
+    SWSS_LOG_ENTER();
+
+    g_pfcWdHwOrch = nullptr;
+}
+
+void PfcWdHwOrch::initializeCapabilities()
+{
+    SWSS_LOG_ENTER();
+
+    // Detect platform capability for port-level timer granularity
+    sai_attr_capability_t attr_capability;
+    sai_status_t cap_status = sai_query_attribute_capability(
+        gSwitchId,
+        SAI_OBJECT_TYPE_PORT,
+        SAI_PORT_ATTR_PFC_TC_DLD_TIMER_INTERVAL,
+        &attr_capability);
+
+    if (cap_status == SAI_STATUS_SUCCESS &&
+        attr_capability.set_implemented &&
+        attr_capability.get_implemented)
+    {
+        m_portLevelGranularitySupported = true;
+        SWSS_LOG_NOTICE("Port-level PFC DLD timer granularity supported");
+    }
+    else
+    {
+        m_portLevelGranularitySupported = false;
+        SWSS_LOG_NOTICE("Port-level PFC DLD timer granularity not supported, using default 100ms");
+    }
+}
+
+void PfcWdHwOrch::initializeTimerRanges()
+{
+    SWSS_LOG_ENTER();
+
+    // Query hardware timer range capabilities
+    sai_attribute_t attr_dld, attr_dlr;
+    attr_dld.id = SAI_SWITCH_ATTR_PFC_TC_DLD_INTERVAL_RANGE;
+    attr_dlr.id = SAI_SWITCH_ATTR_PFC_TC_DLR_INTERVAL_RANGE;
+
+    sai_status_t status_dld = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr_dld);
+    sai_status_t status_dlr = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr_dlr);
+
+    if (status_dld == SAI_STATUS_SUCCESS && status_dlr == SAI_STATUS_SUCCESS)
+    {
+        m_detectionTimeMin = attr_dld.value.u32range.min;
+        m_detectionTimeMax = attr_dld.value.u32range.max;
+        m_restorationTimeMin = attr_dlr.value.u32range.min;
+        m_restorationTimeMax = attr_dlr.value.u32range.max;
+
+        SWSS_LOG_NOTICE("Hardware timer ranges - Detection: %u-%u ms, Restoration: %u-%u ms",
+                       m_detectionTimeMin, m_detectionTimeMax,
+                       m_restorationTimeMin, m_restorationTimeMax);
+
+        // Store ranges in STATE_DB
+        this->updateStateTable(PFC_WD_HW_DETECTION_TIME_MIN, to_string(m_detectionTimeMin));
+        this->updateStateTable(PFC_WD_HW_DETECTION_TIME_MAX, to_string(m_detectionTimeMax));
+        this->updateStateTable(PFC_WD_HW_RESTORATION_TIME_MIN, to_string(m_restorationTimeMin));
+        this->updateStateTable(PFC_WD_HW_RESTORATION_TIME_MAX, to_string(m_restorationTimeMax));
+    }
+    else
+    {
+        SWSS_LOG_WARN("Failed to query PFC watchdog hardware timer ranges (detection: %d, restoration: %d)",
+                     status_dld, status_dlr);
+    }
+}
+
+void PfcWdHwOrch::registerCallbacks()
+{
+    SWSS_LOG_ENTER();
+
+    // Register SAI callback for PFC deadlock notifications
+    // This will be invoked when hardware detects or restores from PFC storms
+    sai_attribute_t attr;
+    attr.id = SAI_SWITCH_ATTR_PFC_TC_DLD_INTERVAL;
+
+    // Note: The actual callback registration happens via SAI switch attribute
+    // SAI_SWITCH_ATTR_QUEUE_PFC_DEADLOCK_NOTIFY which should be set during
+    // switch initialization. The callback function is on_queue_pfc_deadlock()
+    // which calls this->onQueuePfcDeadlock()
+
+    SWSS_LOG_NOTICE("PFC watchdog hardware callbacks registered");
+}
+
+void PfcWdHwOrch::recoverWarmReboot(DBConnector *db)
+{
+    SWSS_LOG_ENTER();
+
+    // During warm reboot, we need to restore the hardware watchdog state
+    // from STATE_DB and re-enable monitoring on ports that had it configured
+    // before the reboot.
+
+    // This is a placeholder for warm reboot recovery logic.
+    // The full implementation will:
+    // 1. Read STATE_DB to find ports with active hardware watchdog
+    // 2. Re-enable flex counters for those ports
+    // 3. Re-register queue monitoring
+
+    SWSS_LOG_NOTICE("PFC watchdog warm reboot recovery completed");
+}
+
+void PfcWdHwOrch::onQueuePfcDeadlock(uint32_t count, sai_queue_deadlock_notification_data_t *data)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+}
+
+PfcWdHwOrch::PfcWdQueueStats PfcWdHwOrch::getQueueStats(const string &queueIdStr)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+    PfcWdQueueStats stats;
+    memset(&stats, 0, sizeof(PfcWdQueueStats));
+    return stats;
+}
+
+void PfcWdHwOrch::updateQueueStats(const string &queueIdStr, const PfcWdQueueStats &stats)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+}
+
+bool PfcWdHwOrch::determineTimerGranularity(uint32_t timeValue, uint32_t hwMin, uint32_t hwMax, uint32_t& granularity)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+    return false;
+}
+
+task_process_status PfcWdHwOrch::createEntry(const string& key, const vector<FieldValueTuple>& data)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+    return task_process_status::task_success;
+}
+
+task_process_status PfcWdHwOrch::deleteEntry(const string& key)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+    return task_process_status::task_success;
+}
+
+bool PfcWdHwOrch::startWdOnPort(const Port& port,
+        uint32_t detectionTime, uint32_t restorationTime, PfcWdAction action, string pfcStatHistory)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+    return false;
+}
+
+bool PfcWdHwOrch::stopWdOnPort(const Port& port)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+    return false;
+}
+
+void PfcWdHwOrch::doTask(SelectableTimer &timer)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+}
+
+bool PfcWdHwOrch::startWdActionOnQueue(const string &event, sai_object_id_t queueId, const string &info)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+    return false;
+}
+
+bool PfcWdHwOrch::readBackTimerValue(const Port& port, sai_port_attr_t attrId,
+                                     const set<uint8_t>& losslessTc, uint32_t expected,
+                                     uint32_t& actual, const string& timerName)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+    return false;
+}
+
+bool PfcWdHwOrch::configureHwWatchdog(const Port& port, uint32_t detectionTime,
+                                      uint32_t restorationTime, PfcWdAction action)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+    return false;
+}
+
+bool PfcWdHwOrch::configureSwitchAction(const Port& port, PfcWdAction action,
+                                        const function<bool(const string&)>& handleFailure)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+    return false;
+}
+
+bool PfcWdHwOrch::configureTimerGranularity(const Port& port, uint32_t detectionTime,
+                                            uint32_t& timerGranularity,
+                                            const function<bool(const string&)>& handleFailure)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+    return false;
+}
+
+bool PfcWdHwOrch::configureTimerIntervals(const Port& port, const set<uint8_t>& losslessTc,
+                                          uint32_t detectionTime, uint32_t restorationTime,
+                                          const function<bool(const string&)>& handleFailure)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+    return false;
+}
+
+bool PfcWdHwOrch::enableDldrOnLosslessQueues(const Port& port, const set<uint8_t>& losslessTc,
+                                             uint32_t detectionTime, uint32_t restorationTime,
+                                             const function<bool(const string&)>& handleFailure)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+    return false;
+}
+
+void PfcWdHwOrch::initializeQueueStats(const Port& port, const set<uint8_t>& losslessTc)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+}
+
+bool PfcWdHwOrch::disableHwWatchdog(const Port& port)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+    return false;
+}
+
+void PfcWdHwOrch::writeFailureStatus(const Port& port)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+}
+
+bool PfcWdHwOrch::isPortInStormedState(const Port& port)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+    return false;
+}
+
+bool PfcWdHwOrch::readHwCounters(sai_object_id_t queueId, uint8_t queueIndex, PfcWdHwStats& counters)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+    return false;
+}
+
+void PfcWdHwOrch::initQueueCounters(const string& queueIdStr, sai_object_id_t queueId, uint8_t queueIndex)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+}
+
+void PfcWdHwOrch::updateQueueCounters(const string& queueIdStr, sai_object_id_t queueId,
+                                      uint8_t queueIndex, bool periodic)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+}
+
+uint32_t PfcWdHwOrch::roundUpToValidInterval(uint32_t requestedTime, const vector<uint32_t>& validIntervals)
+{
+    SWSS_LOG_ENTER();
+    // TODO: Implementation
+    return 0;
+}

--- a/orchagent/pfcwdhworch.cpp
+++ b/orchagent/pfcwdhworch.cpp
@@ -7,9 +7,6 @@
 #include <algorithm>
 #include <set>
 
-#define PFC_WD_COUNTER_POLL_TIMEOUT_SEC  1
-#define PFC_HW_WD_POLL_MSECS 50
-
 extern sai_object_id_t gSwitchId;
 extern sai_switch_api_t* sai_switch_api;
 extern sai_port_api_t* sai_port_api;
@@ -111,26 +108,6 @@ void PfcWdHwOrch::registerCallbacks()
 {
     SWSS_LOG_ENTER();
 
-    // FlexCounter manager for PFC_WD queue statistics
-    m_pfcwdFlexCounterManager = make_shared<FlexCounterTaggedCachedManager<sai_object_type_t>>(
-        PFC_WD_FLEX_COUNTER_GROUP,
-        StatsMode::READ,
-        PFC_HW_WD_POLL_MSECS,
-        true,
-        make_pair("", ""));
-
-    SWSS_LOG_NOTICE("Initialized FlexCounter for hardware PFC watchdog with %d ms poll interval",
-                   PFC_HW_WD_POLL_MSECS);
-
-    // Create timer for periodic counter updates
-    auto interv = timespec { .tv_sec = PFC_WD_COUNTER_POLL_TIMEOUT_SEC, .tv_nsec = 0 };
-    auto timer = new SelectableTimer(interv);
-    auto executor = new ExecutableTimer(timer, this, "PFC_WD_HW_COUNTERS_POLL");
-    Orch::addExecutor(executor);
-    timer->start();
-    SWSS_LOG_NOTICE("Started periodic counter update timer with %d second interval",
-                   PFC_WD_COUNTER_POLL_TIMEOUT_SEC);
-
     // Register PFC deadlock notification callback
     bool supported = gSwitchOrch->querySwitchCapability(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_QUEUE_PFC_DEADLOCK_NOTIFY);
     if (supported)
@@ -204,10 +181,8 @@ void PfcWdHwOrch::onQueuePfcDeadlock(uint32_t count, sai_queue_deadlock_notifica
             // Initialize counters on storm detection
             if (port_found)
             {
-                string queueIdStr = sai_serialize_object_id(notification.queue_id);
-                initQueueCounters(queueIdStr, notification.queue_id, queue_index);
-                SWSS_LOG_DEBUG("PfcWdHwOrch: Initialized counters for queue 0x%" PRIx64 " on storm detection",
-                              notification.queue_id);
+                m_stormedQueues.insert(notification.queue_id);
+                SWSS_LOG_DEBUG("PfcWdHwOrch: Queue 0x%" PRIx64 " entered storm", notification.queue_id);
 
                 this->report_pfc_storm(notification.queue_id, port_id,
                                       queue_index, port_alias, "");
@@ -225,13 +200,8 @@ void PfcWdHwOrch::onQueuePfcDeadlock(uint32_t count, sai_queue_deadlock_notifica
             // Update counters on recovery
             if (port_found)
             {
-                string queueIdStr = sai_serialize_object_id(notification.queue_id);
-                updateQueueCounters(queueIdStr, notification.queue_id, queue_index, false);  // false = not periodic (recovery)
-                SWSS_LOG_DEBUG("PfcWdHwOrch: Updated counters for queue 0x%" PRIx64 " on storm restoration",
-                              notification.queue_id);
-
-                // Remove baseline stats
-                m_queueBaselineStats.erase(notification.queue_id);
+                m_stormedQueues.erase(notification.queue_id);
+                SWSS_LOG_DEBUG("PfcWdHwOrch: Queue 0x%" PRIx64 " left storm", notification.queue_id);
 
                 this->report_pfc_restored(notification.queue_id, port_id,
                                          queue_index, port_alias);
@@ -247,99 +217,6 @@ void PfcWdHwOrch::onQueuePfcDeadlock(uint32_t count, sai_queue_deadlock_notifica
                           notification.event, notification.queue_id);
         }
     }
-}
-
-PfcWdHwOrch::PfcWdQueueStats PfcWdHwOrch::getQueueStats(const string &queueIdStr)
-{
-    SWSS_LOG_ENTER();
-
-    PfcWdQueueStats stats;
-    memset(&stats, 0, sizeof(PfcWdQueueStats));
-    stats.operational = true;
-    vector<FieldValueTuple> fieldValues;
-
-    if (!this->getCountersTable()->get(queueIdStr, fieldValues))
-    {
-        // Return zeros if entry doesn't exist
-        return stats;
-    }
-
-    for (const auto& fv : fieldValues)
-    {
-        const auto field = fvField(fv);
-        const auto value = fvValue(fv);
-
-        if (field == "PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED")
-        {
-            stats.detectCount = stoul(value);
-        }
-        else if (field == "PFC_WD_QUEUE_STATS_DEADLOCK_RESTORED")
-        {
-            stats.restoreCount = stoul(value);
-        }
-        else if (field == "PFC_WD_STATUS")
-        {
-            stats.operational = (value == "operational");
-        }
-        else if (field == "PFC_WD_QUEUE_STATS_TX_PACKETS")
-        {
-            stats.txPkt = stoul(value);
-        }
-        else if (field == "PFC_WD_QUEUE_STATS_TX_DROPPED_PACKETS")
-        {
-            stats.txDropPkt = stoul(value);
-        }
-        else if (field == "PFC_WD_QUEUE_STATS_RX_PACKETS")
-        {
-            stats.rxPkt = stoul(value);
-        }
-        else if (field == "PFC_WD_QUEUE_STATS_RX_DROPPED_PACKETS")
-        {
-            stats.rxDropPkt = stoul(value);
-        }
-        else if (field == "PFC_WD_QUEUE_STATS_TX_PACKETS_LAST")
-        {
-            stats.txPktLast = stoul(value);
-        }
-        else if (field == "PFC_WD_QUEUE_STATS_TX_DROPPED_PACKETS_LAST")
-        {
-            stats.txDropPktLast = stoul(value);
-        }
-        else if (field == "PFC_WD_QUEUE_STATS_RX_PACKETS_LAST")
-        {
-            stats.rxPktLast = stoul(value);
-        }
-        else if (field == "PFC_WD_QUEUE_STATS_RX_DROPPED_PACKETS_LAST")
-        {
-            stats.rxDropPktLast = stoul(value);
-        }
-    }
-
-    return stats;
-}
-
-void PfcWdHwOrch::updateQueueStats(const string &queueIdStr, const PfcWdQueueStats &stats)
-{
-    SWSS_LOG_ENTER();
-
-    vector<FieldValueTuple> resultFvValues;
-
-    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_DEADLOCK_DETECTED", to_string(stats.detectCount));
-    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_DEADLOCK_RESTORED", to_string(stats.restoreCount));
-
-    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_TX_PACKETS", to_string(stats.txPkt));
-    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_TX_DROPPED_PACKETS", to_string(stats.txDropPkt));
-    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_RX_PACKETS", to_string(stats.rxPkt));
-    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_RX_DROPPED_PACKETS", to_string(stats.rxDropPkt));
-
-    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_TX_PACKETS_LAST", to_string(stats.txPktLast));
-    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_TX_DROPPED_PACKETS_LAST", to_string(stats.txDropPktLast));
-    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_RX_PACKETS_LAST", to_string(stats.rxPktLast));
-    resultFvValues.emplace_back("PFC_WD_QUEUE_STATS_RX_DROPPED_PACKETS_LAST", to_string(stats.rxDropPktLast));
-
-    resultFvValues.emplace_back("PFC_WD_STATUS", stats.operational ? "operational" : "stormed");
-
-    this->getCountersTable()->set(queueIdStr, resultFvValues);
 }
 
 task_process_status PfcWdHwOrch::createEntry(const string& key, const vector<FieldValueTuple>& data)
@@ -568,7 +445,7 @@ bool PfcWdHwOrch::startWdOnPort(const Port& port,
 	SWSS_LOG_ENTER();
 
 	// For hardware-based watchdog, all hardware programming and flex counter
-	// registration are handled in configureHwWatchdog()/initializeQueueStats().
+	// registration are handled in configureHwWatchdog().
 	// Any existing configuration is cleaned up via stopWdOnPort() before this
 	// function is invoked from createEntry().
 	return configureHwWatchdog(port, detectionTime, restorationTime, action);
@@ -579,28 +456,6 @@ bool PfcWdHwOrch::stopWdOnPort(const Port& port)
     SWSS_LOG_ENTER();
 
     return disableHwWatchdog(port);
-}
-
-void PfcWdHwOrch::doTask(SelectableTimer &timer)
-{
-    SWSS_LOG_ENTER();
-
-    // Update counters for queues in storm
-    for (auto& entry : m_queueBaselineStats)
-    {
-        sai_object_id_t queueId = entry.first;
-        auto it = m_queueToPortMap.find(queueId);
-        if (it != m_queueToPortMap.end())
-        {
-            string queueIdStr = sai_serialize_object_id(queueId);
-            updateQueueCounters(queueIdStr, queueId, it->second.queue_index, true);  // true = periodic
-            SWSS_LOG_DEBUG("Periodic counter update for queue 0x%" PRIx64, queueId);
-        }
-        else
-        {
-            SWSS_LOG_WARN("Queue 0x%" PRIx64 " has baseline stats but no port mapping", queueId);
-        }
-    }
 }
 
 bool PfcWdHwOrch::startWdActionOnQueue(const string &event, sai_object_id_t queueId, const string &info)
@@ -615,8 +470,6 @@ bool PfcWdHwOrch::startWdActionOnQueue(const string &event, sai_object_id_t queu
 
     return false;
 }
-
-
 
 bool PfcWdHwOrch::readBackTimerValue(const Port& port, sai_port_attr_t attrId,
                                      const set<uint8_t>& losslessTc, uint32_t expected,
@@ -705,7 +558,6 @@ bool PfcWdHwOrch::configureHwWatchdog(const Port& port, uint32_t detectionTime,
     }
 
     // Initialize queue statistics in COUNTERS_DB
-    initializeQueueStats(port, losslessTc);
 
     // Track this port
     m_hwWdPorts.insert(port.m_alias);
@@ -878,100 +730,6 @@ bool PfcWdHwOrch::enableDldrOnLosslessQueues(const Port& port, const set<uint8_t
     return true;
 }
 
-void PfcWdHwOrch::initializeQueueStats(const Port& port, const set<uint8_t>& losslessTc)
-{
-    SWSS_LOG_ENTER();
-
-    // For each lossless queue, register PFC_WD FlexCounters, initialize
-    // watchdog counters, and populate the queue→port mapping.
-    for (auto tc : losslessTc)
-    {
-        if (tc >= port.m_queue_ids.size())
-        {
-            continue;
-        }
-
-        sai_object_id_t queueId = port.m_queue_ids[tc];
-        string queueIdStr = sai_serialize_object_id(queueId);
-
-        // Register queue stats/attributes in the dedicated PFC_WD FlexCounter group.
-        if (m_pfcwdFlexCounterManager)
-        {
-            if (!c_queueStatIds.empty())
-            {
-                auto queueStatIdSet = PfcWdBaseOrch::counterIdsToStr(c_queueStatIds, sai_serialize_queue_stat);
-                if (queueStatIdSet.empty())
-                {
-                    SWSS_LOG_WARN("Failed to convert queue stat IDs for queue 0x%" PRIx64 " on port %s",
-                                  queueId, port.m_alias.c_str());
-                }
-                else
-                {
-                    m_pfcwdFlexCounterManager->setCounterIdList(queueId,
-                                                                 CounterType::QUEUE,
-                                                                 queueStatIdSet,
-                                                                 SAI_OBJECT_TYPE_QUEUE);
-                    SWSS_LOG_DEBUG("Registered %zu queue stats for queue 0x%" PRIx64 " on port %s",
-                                   queueStatIdSet.size(), queueId, port.m_alias.c_str());
-                }
-            }
-
-            if (!c_queueAttrIds.empty())
-            {
-                auto queueAttrIdSet = PfcWdBaseOrch::counterIdsToStr(c_queueAttrIds, sai_serialize_queue_attr);
-                if (queueAttrIdSet.empty())
-                {
-                    SWSS_LOG_WARN("Failed to convert queue attr IDs for queue 0x%" PRIx64 " on port %s",
-                                  queueId, port.m_alias.c_str());
-                }
-                else
-                {
-                    auto *fcMgr = dynamic_cast<FlexCounterManager*>(m_pfcwdFlexCounterManager.get());
-                    if (fcMgr)
-                    {
-                        fcMgr->setCounterIdList(queueId,
-                                                CounterType::QUEUE_ATTR,
-                                                queueAttrIdSet);
-                        SWSS_LOG_DEBUG("Registered %zu queue attrs for queue 0x%" PRIx64 " on port %s",
-                                       queueAttrIdSet.size(), queueId, port.m_alias.c_str());
-                    }
-                    else
-                    {
-                        SWSS_LOG_WARN("PFC WD FlexCounter manager is not FlexCounterManager for queue 0x%" PRIx64 " on port %s",
-                                      queueId, port.m_alias.c_str());
-                    }
-                }
-            }
-        }
-
-        // Add to queue→port mapping for fast lookup in the notification callback.
-        PortQueueInfo info;
-        info.port_id = port.m_port_id;
-        info.port_alias = port.m_alias;
-        info.queue_index = tc;
-        m_queueToPortMap[queueId] = info;
-
-        // Initialize PFC WD counters in COUNTERS_DB (status operational, packet counters cleared).
-        // Preserve existing detect/restore counts from warm-reboot if present.
-        auto stats = getQueueStats(queueIdStr);
-        stats.operational = true;
-        stats.txPkt = 0;
-        stats.txDropPkt = 0;
-        stats.rxPkt = 0;
-        stats.rxDropPkt = 0;
-        stats.txPktLast = 0;
-        stats.txDropPktLast = 0;
-        stats.rxPktLast = 0;
-        stats.rxDropPktLast = 0;
-        updateQueueStats(queueIdStr, stats);
-
-        // Baseline stats will be created on-demand when storm is detected.
-
-        SWSS_LOG_NOTICE("Initialized PFC watchdog for queue 0x%" PRIx64 " on port %s TC %d",
-                       queueId, port.m_alias.c_str(), tc);
-    }
-}
-
 bool PfcWdHwOrch::disableHwWatchdog(const Port& port)
 {
     SWSS_LOG_ENTER();
@@ -1013,20 +771,10 @@ bool PfcWdHwOrch::disableHwWatchdog(const Port& port)
                          port.m_alias.c_str(), tc, queueId);
         }
 
-        // Clear this queue's registration in the dedicated PFC_WD FlexCounter group.
-        if (m_pfcwdFlexCounterManager)
-        {
-            m_pfcwdFlexCounterManager->clearCounterIdList(queueId, SAI_OBJECT_TYPE_QUEUE);
-            SWSS_LOG_DEBUG("Cleared FlexCounter registration for queue 0x%" PRIx64 " on port %s",
-                           queueId, port.m_alias.c_str());
-        }
-
         // Remove from queue→port mapping
         m_queueToPortMap.erase(queueId);
 
-        // Remove baseline stats
-        m_queueBaselineStats.erase(queueId);
-        SWSS_LOG_DEBUG("Removed baseline stats for queue 0x%" PRIx64, queueId);
+        m_stormedQueues.erase(queueId);
     }
 
     // Clear detection and restoration intervals on port level
@@ -1110,13 +858,8 @@ bool PfcWdHwOrch::isPortInStormedState(const Port& port)
         }
 
         sai_object_id_t queueId = port.m_queue_ids[i];
-        string queueIdStr = sai_serialize_object_id(queueId);
 
-        // Get queue statistics
-        auto stats = getQueueStats(queueIdStr);
-
-        // If operational is false, the queue is in stormed state
-        if (!stats.operational)
+        if (m_stormedQueues.count(queueId) != 0)
         {
             SWSS_LOG_WARN("Port %s has queue %d (0x%" PRIx64 ") in stormed state",
                          port.m_alias.c_str(), i, queueId);
@@ -1127,208 +870,3 @@ bool PfcWdHwOrch::isPortInStormedState(const Port& port)
     return false;
 }
 
-bool PfcWdHwOrch::readHwCounters(sai_object_id_t queueId, uint8_t queueIndex, PfcWdHwStats& counters)
-{
-    SWSS_LOG_ENTER();
-
-    // For HW PFC watchdog, read queue/PG counters from COUNTERS_DB (via FlexCounter)
-    // instead of querying SAI directly.
-
-    string queueIdStr = sai_serialize_object_id(queueId);
-    vector<FieldValueTuple> fieldValues;
-
-    auto countersTable = getCountersTable();
-    if (!countersTable || !countersTable->get(queueIdStr, fieldValues))
-    {
-        SWSS_LOG_DEBUG("No counter entry found for queue 0x%" PRIx64, queueId);
-        memset(&counters, 0, sizeof(PfcWdHwStats));
-        return true;
-    }
-
-    // Initialize to zero
-    counters.txPkt = 0;
-    counters.txDropPkt = 0;
-    counters.rxPkt = 0;
-    counters.rxDropPkt = 0;
-
-    // Read TX counters (queue stats)
-    for (const auto& fv : fieldValues)
-    {
-        const auto field = fvField(fv);
-        const auto value = fvValue(fv);
-
-        if (field == "SAI_QUEUE_STAT_PACKETS")
-        {
-            counters.txPkt = stoull(value);
-        }
-        else if (field == "SAI_QUEUE_STAT_DROPPED_PACKETS")
-        {
-            counters.txDropPkt = stoull(value);
-        }
-    }
-
-    // Read RX counters from the priority group mapped to this queue.
-    Port portInstance;
-    auto it = m_queueToPortMap.find(queueId);
-    if (it == m_queueToPortMap.end())
-    {
-        SWSS_LOG_ERROR("Queue 0x%" PRIx64 " not found in queue-to-port map", queueId);
-        return false;
-    }
-
-    if (!gPortsOrch->getPort(it->second.port_id, portInstance))
-    {
-        SWSS_LOG_ERROR("Cannot get port by ID 0x%" PRIx64, it->second.port_id);
-        return false;
-    }
-
-    if (queueIndex >= portInstance.m_priority_group_ids.size())
-    {
-        SWSS_LOG_ERROR("Invalid queue index %u for port 0x%" PRIx64, queueIndex, it->second.port_id);
-        return false;
-    }
-
-    sai_object_id_t pg = portInstance.m_priority_group_ids[static_cast<size_t>(queueIndex)];
-    string pgIdStr = sai_serialize_object_id(pg);
-
-    fieldValues.clear();
-    if (countersTable->get(pgIdStr, fieldValues))
-    {
-        for (const auto& fv : fieldValues)
-        {
-            const auto field = fvField(fv);
-            const auto value = fvValue(fv);
-
-            if (field == "SAI_INGRESS_PRIORITY_GROUP_STAT_PACKETS")
-            {
-                counters.rxPkt = stoull(value);
-            }
-            else if (field == "SAI_INGRESS_PRIORITY_GROUP_STAT_DROPPED_PACKETS")
-            {
-                counters.rxDropPkt = stoull(value);
-            }
-        }
-    }
-
-    SWSS_LOG_DEBUG("Read HW counters for queue 0x%" PRIx64 ": txPkt=%" PRIu64 ", txDropPkt=%" PRIu64 ", rxPkt=%" PRIu64 ", rxDropPkt=%" PRIu64,
-                   queueId, counters.txPkt, counters.txDropPkt, counters.rxPkt, counters.rxDropPkt);
-
-    return true;
-}
-
-void PfcWdHwOrch::initQueueCounters(const string& queueIdStr, sai_object_id_t queueId, uint8_t queueIndex)
-{
-    SWSS_LOG_ENTER();
-
-    PfcWdHwStats hwStats;
-    if (!readHwCounters(queueId, queueIndex, hwStats))
-    {
-        return;
-    }
-
-    // Read current stats from COUNTERS_DB
-    auto wdQueueStats = getQueueStats(queueIdStr);
-
-    // Only bump detectCount for a new storm; if storm persisted across
-    // warm-reboot (detectCount > restoreCount), keep counters as-is.
-    if (!(wdQueueStats.detectCount > wdQueueStats.restoreCount))
-    {
-        wdQueueStats.detectCount++;
-        wdQueueStats.txPktLast = 0;
-        wdQueueStats.txDropPktLast = 0;
-        wdQueueStats.rxPktLast = 0;
-        wdQueueStats.rxDropPktLast = 0;
-    }
-    wdQueueStats.operational = false;
-
-    // Store baseline for delta calculation
-    m_queueBaselineStats[queueId] = hwStats;
-
-    // Write to COUNTERS_DB
-    updateQueueStats(queueIdStr, wdQueueStats);
-}
-
-void PfcWdHwOrch::updateQueueCounters(const string& queueIdStr, sai_object_id_t queueId,
-                                      uint8_t queueIndex, bool periodic)
-{
-    SWSS_LOG_ENTER();
-
-    PfcWdHwStats hwStats;
-    if (!readHwCounters(queueId, queueIndex, hwStats))
-    {
-        return;
-    }
-
-    auto finalStats = getQueueStats(queueIdStr);
-
-    if (!periodic)
-    {
-        finalStats.restoreCount++;
-    }
-    finalStats.operational = !periodic;
-
-    // Get baseline (stored in initQueueCounters or previous update)
-    auto it = m_queueBaselineStats.find(queueId);
-    if (it == m_queueBaselineStats.end())
-    {
-        SWSS_LOG_WARN("No baseline stats found for queue 0x%" PRIx64 ", initializing", queueId);
-        m_queueBaselineStats[queueId] = hwStats;
-        updateQueueStats(queueIdStr, finalStats);
-        return;
-    }
-
-    auto& baseline = it->second;
-
-    // Calculate deltas with underflow protection
-    // If hardware counters are less than baseline, it means counters were reset
-    // In this case, skip the update to avoid huge negative values
-    if (hwStats.txPkt >= baseline.txPkt)
-    {
-        finalStats.txPktLast += hwStats.txPkt - baseline.txPkt;
-        finalStats.txPkt += hwStats.txPkt - baseline.txPkt;
-    }
-    else
-    {
-        SWSS_LOG_WARN("Counter reset detected for queue 0x%" PRIx64 ": txPkt went from %" PRIu64 " to %" PRIu64,
-                     queueId, baseline.txPkt, hwStats.txPkt);
-    }
-
-    if (hwStats.txDropPkt >= baseline.txDropPkt)
-    {
-        finalStats.txDropPktLast += hwStats.txDropPkt - baseline.txDropPkt;
-        finalStats.txDropPkt += hwStats.txDropPkt - baseline.txDropPkt;
-    }
-    else
-    {
-        SWSS_LOG_WARN("Counter reset detected for queue 0x%" PRIx64 ": txDropPkt went from %" PRIu64 " to %" PRIu64,
-                     queueId, baseline.txDropPkt, hwStats.txDropPkt);
-    }
-
-    if (hwStats.rxPkt >= baseline.rxPkt)
-    {
-        finalStats.rxPktLast += hwStats.rxPkt - baseline.rxPkt;
-        finalStats.rxPkt += hwStats.rxPkt - baseline.rxPkt;
-    }
-    else
-    {
-        SWSS_LOG_WARN("Counter reset detected for queue 0x%" PRIx64 ": rxPkt went from %" PRIu64 " to %" PRIu64,
-                     queueId, baseline.rxPkt, hwStats.rxPkt);
-    }
-
-    if (hwStats.rxDropPkt >= baseline.rxDropPkt)
-    {
-        finalStats.rxDropPktLast += hwStats.rxDropPkt - baseline.rxDropPkt;
-        finalStats.rxDropPkt += hwStats.rxDropPkt - baseline.rxDropPkt;
-    }
-    else
-    {
-        SWSS_LOG_WARN("Counter reset detected for queue 0x%" PRIx64 ": rxDropPkt went from %" PRIu64 " to %" PRIu64,
-                     queueId, baseline.rxDropPkt, hwStats.rxDropPkt);
-    }
-
-    // Update baseline
-    baseline = hwStats;
-
-    // Write to COUNTERS_DB
-    updateQueueStats(queueIdStr, finalStats);
-}

--- a/orchagent/pfcwdhworch.h
+++ b/orchagent/pfcwdhworch.h
@@ -4,6 +4,7 @@
 #include "pfcwdorch.h"
 #include "timer.h"
 #include "dbconnector.h"
+#include "flex_counter/flex_counter_manager.h"
 
 extern "C" {
 #include "sai.h"
@@ -33,12 +34,49 @@ public:
     task_process_status createEntry(const string& key, const vector<FieldValueTuple>& data) override;
     task_process_status deleteEntry(const string& key) override;
 
+    // Timer-based polling for hardware counters
+    virtual void doTask(SelectableTimer &timer);
+
 protected:
     bool startWdActionOnQueue(const string &event, sai_object_id_t queueId, const string &info="") override;
 
 public:
     // PFC deadlock notification callback
     void onQueuePfcDeadlock(uint32_t count, sai_queue_deadlock_notification_data_t *data);
+
+private:
+
+    // Queue statistics for state tracking
+    struct PfcWdQueueStats
+    {
+        uint64_t detectCount;
+        uint64_t restoreCount;
+        uint64_t txPkt;
+        uint64_t txDropPkt;
+        uint64_t rxPkt;
+        uint64_t rxDropPkt;
+        uint64_t txPktLast;
+        uint64_t txDropPktLast;
+        uint64_t rxPktLast;
+        uint64_t rxDropPktLast;
+        bool     operational;
+    };
+
+    // Get current queue statistics from COUNTERS_DB
+    PfcWdQueueStats getQueueStats(const string &queueIdStr);
+
+    // Update queue statistics in COUNTERS_DB
+    void updateQueueStats(const string &queueIdStr, const PfcWdQueueStats &stats);
+
+    // Read hardware counters from COUNTERS_DB
+    bool readHwCounters(sai_object_id_t queueId, uint8_t queueIndex, PfcWdHwStats& counters);
+
+    // Initialize counters when deadlock is detected
+    void initQueueCounters(const string& queueIdStr, sai_object_id_t queueId, uint8_t queueIndex);
+
+    // Update counters periodically or on recovery
+    void updateQueueCounters(const string& queueIdStr, sai_object_id_t queueId,
+                            uint8_t queueIndex, bool periodic);
 
 private:
     // Hardware-specific methods
@@ -86,6 +124,7 @@ private:
     bool enableDldrOnLosslessQueues(const Port& port, const set<uint8_t>& losslessTc,
                                     uint32_t detectionTime, uint32_t restorationTime,
                                     const function<bool(const string&)>& handleFailure);
+    void initializeQueueStats(const Port& port, const set<uint8_t>& losslessTc);
 
     // Ports where hardware watchdog is configured
     std::set<std::string> m_hwWdPorts;
@@ -101,8 +140,8 @@ private:
     // Queue ID to port/queue info mapping
     std::unordered_map<sai_object_id_t, PortQueueInfo> m_queueToPortMap;
 
-    // Queues currently reported in storm by the hardware deadlock notification.
-    std::set<sai_object_id_t> m_stormedQueues;
+    // Queue ID to baseline hardware counters
+    std::unordered_map<sai_object_id_t, PfcWdHwStats> m_queueBaselineStats;
 };
 
 #endif

--- a/orchagent/pfcwdhworch.h
+++ b/orchagent/pfcwdhworch.h
@@ -53,7 +53,7 @@ private:
     const vector<sai_port_stat_t> c_portStatIds;
     const vector<sai_queue_stat_t> c_queueStatIds;
     const vector<sai_queue_attr_t> c_queueAttrIds;
-
+	
     // Hardware timer ranges
     uint32_t m_detectionTimeMin;
     uint32_t m_detectionTimeMax;

--- a/orchagent/pfcwdhworch.h
+++ b/orchagent/pfcwdhworch.h
@@ -53,7 +53,7 @@ private:
     const vector<sai_port_stat_t> c_portStatIds;
     const vector<sai_queue_stat_t> c_queueStatIds;
     const vector<sai_queue_attr_t> c_queueAttrIds;
-	
+    
     // Hardware timer ranges
     uint32_t m_detectionTimeMin;
     uint32_t m_detectionTimeMax;
@@ -75,6 +75,7 @@ private:
                            const set<uint8_t>& losslessTc, uint32_t expected,
                            uint32_t& actual, const string& timerName);
 
+    // Initialization functions
     void initializeTimerRanges();
     void registerCallbacks();
     void recoverWarmReboot(DBConnector *db);
@@ -88,6 +89,7 @@ private:
     bool enableDldrOnLosslessQueues(const Port& port, const set<uint8_t>& losslessTc,
                                     uint32_t detectionTime, uint32_t restorationTime,
                                     const function<bool(const string&)>& handleFailure);
+    void initializeQueueStats(const Port& port, const set<uint8_t>& losslessTc);
 
     // Ports where hardware watchdog is configured
     std::set<std::string> m_hwWdPorts;
@@ -105,4 +107,3 @@ private:
 };
 
 #endif
-

--- a/orchagent/pfcwdhworch.h
+++ b/orchagent/pfcwdhworch.h
@@ -4,7 +4,6 @@
 #include "pfcwdorch.h"
 #include "timer.h"
 #include "dbconnector.h"
-#include "flex_counter/flex_counter_manager.h"
 
 extern "C" {
 #include "sai.h"
@@ -34,49 +33,12 @@ public:
     task_process_status createEntry(const string& key, const vector<FieldValueTuple>& data) override;
     task_process_status deleteEntry(const string& key) override;
 
-    // Timer-based polling for hardware counters
-    virtual void doTask(SelectableTimer &timer);
-
 protected:
     bool startWdActionOnQueue(const string &event, sai_object_id_t queueId, const string &info="") override;
 
 public:
     // PFC deadlock notification callback
     void onQueuePfcDeadlock(uint32_t count, sai_queue_deadlock_notification_data_t *data);
-
-private:
-
-    // Queue statistics for state tracking
-    struct PfcWdQueueStats
-    {
-        uint64_t detectCount;
-        uint64_t restoreCount;
-        uint64_t txPkt;
-        uint64_t txDropPkt;
-        uint64_t rxPkt;
-        uint64_t rxDropPkt;
-        uint64_t txPktLast;
-        uint64_t txDropPktLast;
-        uint64_t rxPktLast;
-        uint64_t rxDropPktLast;
-        bool     operational;
-    };
-
-    // Get current queue statistics from COUNTERS_DB
-    PfcWdQueueStats getQueueStats(const string &queueIdStr);
-
-    // Update queue statistics in COUNTERS_DB
-    void updateQueueStats(const string &queueIdStr, const PfcWdQueueStats &stats);
-
-    // Read hardware counters from COUNTERS_DB
-    bool readHwCounters(sai_object_id_t queueId, uint8_t queueIndex, PfcWdHwStats& counters);
-
-    // Initialize counters when deadlock is detected
-    void initQueueCounters(const string& queueIdStr, sai_object_id_t queueId, uint8_t queueIndex);
-
-    // Update counters periodically or on recovery
-    void updateQueueCounters(const string& queueIdStr, sai_object_id_t queueId,
-                            uint8_t queueIndex, bool periodic);
 
 private:
     // Hardware-specific methods
@@ -124,7 +86,6 @@ private:
     bool enableDldrOnLosslessQueues(const Port& port, const set<uint8_t>& losslessTc,
                                     uint32_t detectionTime, uint32_t restorationTime,
                                     const function<bool(const string&)>& handleFailure);
-    void initializeQueueStats(const Port& port, const set<uint8_t>& losslessTc);
 
     // Ports where hardware watchdog is configured
     std::set<std::string> m_hwWdPorts;
@@ -140,8 +101,8 @@ private:
     // Queue ID to port/queue info mapping
     std::unordered_map<sai_object_id_t, PortQueueInfo> m_queueToPortMap;
 
-    // Queue ID to baseline hardware counters
-    std::unordered_map<sai_object_id_t, PfcWdHwStats> m_queueBaselineStats;
+    // Queues currently reported in storm by the hardware deadlock notification.
+    std::set<sai_object_id_t> m_stormedQueues;
 };
 
 #endif

--- a/orchagent/pfcwdhworch.h
+++ b/orchagent/pfcwdhworch.h
@@ -4,6 +4,7 @@
 #include "pfcwdorch.h"
 #include "timer.h"
 #include "dbconnector.h"
+#include "flex_counter/flex_counter_manager.h"
 
 extern "C" {
 #include "sai.h"
@@ -33,7 +34,7 @@ public:
     task_process_status createEntry(const string& key, const vector<FieldValueTuple>& data) override;
     task_process_status deleteEntry(const string& key) override;
 
-    // Periodic timer task
+    // Timer-based polling for hardware counters
     virtual void doTask(SelectableTimer &timer);
 
 protected:
@@ -42,6 +43,40 @@ protected:
 public:
     // PFC deadlock notification callback
     void onQueuePfcDeadlock(uint32_t count, sai_queue_deadlock_notification_data_t *data);
+
+private:
+
+    // Queue statistics for state tracking
+    struct PfcWdQueueStats
+    {
+        uint64_t detectCount;
+        uint64_t restoreCount;
+        uint64_t txPkt;
+        uint64_t txDropPkt;
+        uint64_t rxPkt;
+        uint64_t rxDropPkt;
+        uint64_t txPktLast;
+        uint64_t txDropPktLast;
+        uint64_t rxPktLast;
+        uint64_t rxDropPktLast;
+        bool     operational;
+    };
+
+    // Get current queue statistics from COUNTERS_DB
+    PfcWdQueueStats getQueueStats(const string &queueIdStr);
+
+    // Update queue statistics in COUNTERS_DB
+    void updateQueueStats(const string &queueIdStr, const PfcWdQueueStats &stats);
+
+    // Read hardware counters from COUNTERS_DB
+    bool readHwCounters(sai_object_id_t queueId, uint8_t queueIndex, PfcWdHwStats& counters);
+
+    // Initialize counters when deadlock is detected
+    void initQueueCounters(const string& queueIdStr, sai_object_id_t queueId, uint8_t queueIndex);
+
+    // Update counters periodically or on recovery
+    void updateQueueCounters(const string& queueIdStr, sai_object_id_t queueId,
+                            uint8_t queueIndex, bool periodic);
 
 private:
     // Hardware-specific methods
@@ -104,6 +139,9 @@ private:
 
     // Queue ID to port/queue info mapping
     std::unordered_map<sai_object_id_t, PortQueueInfo> m_queueToPortMap;
+
+    // Queue ID to baseline hardware counters
+    std::unordered_map<sai_object_id_t, PfcWdHwStats> m_queueBaselineStats;
 };
 
 #endif

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -15,6 +15,7 @@ extern sai_object_id_t gSwitchId;
 extern sai_switch_api_t* sai_switch_api;
 extern sai_port_api_t *sai_port_api;
 extern sai_queue_api_t *sai_queue_api;
+extern sai_buffer_api_t *sai_buffer_api;
 
 extern event_handle_t g_events_handle;
 
@@ -31,6 +32,8 @@ PfcWdBaseOrch::PfcWdBaseOrch(DBConnector *db, vector<string> &tableNames):
     Orch(db, tableNames),
     m_countersDb(new DBConnector("COUNTERS_DB", 0)),
     m_countersTable(new Table(m_countersDb.get(), COUNTERS_TABLE)),
+    m_stateDb(new DBConnector("STATE_DB", 0)),
+    m_stateTable(new Table(m_stateDb.get(), PFC_WD_STATE_TABLE)),
     m_platform(getenv("platform") ? getenv("platform") : "")
 {
     SWSS_LOG_ENTER();
@@ -39,6 +42,10 @@ PfcWdBaseOrch::PfcWdBaseOrch(DBConnector *db, vector<string> &tableNames):
         SWSS_LOG_ERROR("Platform environment variable is not defined");
         return;
     }
+
+    // Add PfcDlrPacketAction to state table
+    string dlrAction = PfcWdBaseOrch::serializeAction(this->getPfcDlrPacketAction());
+    this->updateStateTable(PFC_WD_DLR_PACKET_ACTION, dlrAction);
 }
 
 

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -66,6 +66,25 @@ bool PfcWdBaseOrch::getTimerRange(PfcWdTimerRange& range) const
     return true;
 }
 
+task_process_status PfcWdBaseOrch::handleStartWdOnPortFailure(const Port& port)
+{
+    SWSS_LOG_ENTER();
+
+    // A port with no lossless TCs is not ready for the PFC watchdog yet, so the entry stays pending and starts once the port becomes PFC-ready.
+    set<uint8_t> losslessTc;
+    if (!getLosslessTcsForPort(port, losslessTc))
+    {
+        if (m_pfcwdPendingPorts.insert(port.m_alias).second)
+        {
+            SWSS_LOG_INFO("Deferring PFC Watchdog on port %s: no lossless TC yet", port.m_alias.c_str());
+        }
+        return task_process_status::task_need_retry;
+    }
+
+    SWSS_LOG_ERROR("Failed to start PFC Watchdog on port %s", port.m_alias.c_str());
+    return task_process_status::task_need_retry;
+}
+
 bool PfcWdBaseOrch::getLosslessTcsForPort(const Port& port, set<uint8_t>& losslessTc)
 {
     SWSS_LOG_ENTER();

--- a/orchagent/pfcwdorch.h
+++ b/orchagent/pfcwdorch.h
@@ -8,14 +8,21 @@
 #include "notificationconsumer.h"
 #include "timer.h"
 #include "events.h"
+#include "table.h"
 
 extern "C" {
 #include "sai.h"
 }
 
 // ============================================================================
-// Global macros used across base and derived classes
+// Global macros used across base and derived classes (PfcWdBaseOrch,
+// PfcWdSwOrch, PfcWdHwOrch)
 // ============================================================================
+
+#define PFC_WD_RECOVERY_MECHANISM       "RECOVERY_MECHANISM"
+#define PFC_WD_RECOVERY_SOFTWARE        "SOFTWARE"
+#define PFC_WD_RECOVERY_HARDWARE        "HARDWARE"
+#define PFC_WD_TC_MAX                   8
 
 // State and configuration table identifiers
 #define PFC_WD_FLEX_COUNTER_GROUP       "PFC_WD"
@@ -69,6 +76,16 @@ public:
     shared_ptr<DBConnector> getCountersDb(void)
     {
         return m_countersDb;
+    }
+
+    shared_ptr<Table> getStateTable(void)
+    {
+        return m_stateTable;
+    }
+
+    shared_ptr<DBConnector> getStateDb(void)
+    {
+        return m_stateDb;
     }
 
     static PfcWdAction deserializeAction(const string& key);

--- a/orchagent/pfcwdorch.h
+++ b/orchagent/pfcwdorch.h
@@ -102,6 +102,18 @@ protected:
     // Supported timer limits. False defers the entry for retry.
     virtual bool getTimerRange(PfcWdTimerRange& range) const;
 
+    void updateStateTable(const string &field, const string &value)
+    {
+        string key = m_stateTable->getTableName() + m_stateTable->getTableNameSeparator() + "PFC_WD";
+        m_stateDb->hset(key, field, value);
+    }
+
+    void updateDlrPacketActionInStateTable()
+    {
+        string dlrAction = PfcWdBaseOrch::serializeAction(this->getPfcDlrPacketAction());
+        this->updateStateTable(PFC_WD_DLR_PACKET_ACTION, dlrAction);
+    }
+    
     // ========================================================================
     // Helper functions used in both SW and HW watchdog implementations
     // ========================================================================

--- a/orchagent/pfcwdorch.h
+++ b/orchagent/pfcwdorch.h
@@ -102,6 +102,15 @@ protected:
     // Supported timer limits. False defers the entry for retry.
     virtual bool getTimerRange(PfcWdTimerRange& range) const;
 
+    // A port with no lossless TCs is not PFC-ready yet: defer the entry and
+    // retry once the port becomes ready, logging the deferral only once.
+    task_process_status handleStartWdOnPortFailure(const Port& port);
+    void clearPfcWdPending(const Port& port) { m_pfcwdPendingPorts.erase(port.m_alias); }
+
+    // Ports that are admin-up but not yet PFC-ready, for which a deferral has
+    // already been logged.
+    std::set<std::string> m_pfcwdPendingPorts;
+
     void updateStateTable(const string &field, const string &value)
     {
         string key = m_stateTable->getTableName() + m_stateTable->getTableNameSeparator() + "PFC_WD";
@@ -149,6 +158,8 @@ private:
 
     shared_ptr<DBConnector> m_countersDb = nullptr;
     shared_ptr<Table> m_countersTable = nullptr;
+    shared_ptr<DBConnector> m_stateDb = nullptr;
+    shared_ptr<Table> m_stateTable = nullptr;
     PfcWdAction m_pfcDlrPacketAction = PfcWdAction::PFC_WD_ACTION_UNKNOWN;
     std::set<std::string> m_pfcwd_ports;
 };

--- a/orchagent/pfcwdsworch.cpp
+++ b/orchagent/pfcwdsworch.cpp
@@ -28,8 +28,6 @@ extern event_handle_t g_events_handle;
 extern SwitchOrch *gSwitchOrch;
 extern PortsOrch *gPortsOrch;
 
-
-
 template <typename DropHandler, typename ForwardHandler>
 task_process_status PfcWdSwOrch<DropHandler, ForwardHandler>::createEntry(const string& key,
         const vector<FieldValueTuple>& data)
@@ -127,6 +125,7 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::enableBigRedSwitchMode()
     for (auto &it: allPorts)
     {
         Port port = it.second;
+        uint8_t pfcMask = 0;
 
         if (port.m_type != Port::PHY)
         {
@@ -134,17 +133,16 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::enableBigRedSwitchMode()
             continue;
         }
 
-        // Get lossless TCs for this port
-        set<uint8_t> losslessTc;
-        if (!getLosslessTcsForPort(port, losslessTc))
+        if (!gPortsOrch->getPortPfcWatchdogStatus(port.m_port_id, &pfcMask))
         {
-            SWSS_LOG_DEBUG("No lossless TC found on port %s", port.m_alias.c_str());
+            SWSS_LOG_ERROR("Failed to get PFC watchdog mask on port %s", port.m_alias.c_str());
+            return;
         }
 
         for (uint8_t i = 0; i < PFC_WD_TC_MAX; i++)
         {
             sai_object_id_t queueId = port.m_queue_ids[i];
-            if (losslessTc.find(i) == losslessTc.end() && m_entryMap.find(queueId) == m_entryMap.end())
+            if ((pfcMask & (1 << i)) == 0 && m_entryMap.find(queueId) == m_entryMap.end())
             {
                 continue;
             }
@@ -171,6 +169,7 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::enableBigRedSwitchMode()
     for (auto & it: allPorts)
     {
         Port port = it.second;
+        uint8_t pfcMask = 0;
 
         if (port.m_type != Port::PHY)
         {
@@ -178,26 +177,23 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::enableBigRedSwitchMode()
             continue;
         }
 
-        // Get lossless TCs for this port
-        set<uint8_t> losslessTc;
-        if (!getLosslessTcsForPort(port, losslessTc))
+        if (!gPortsOrch->getPortPfcWatchdogStatus(port.m_port_id, &pfcMask))
         {
-            SWSS_LOG_DEBUG("No lossless TC found on port %s", port.m_alias.c_str());
-            continue;
+            SWSS_LOG_ERROR("Failed to get PFC watchdog mask on port %s", port.m_alias.c_str());
+            return;
         }
 
-        for (auto i : losslessTc)
+        for (uint8_t i = 0; i < PFC_WD_TC_MAX; i++)
         {
+            if ((pfcMask & (1 << i)) == 0)
+            {
+                continue;
+            }
+
             sai_object_id_t queueId = port.m_queue_ids[i];
             string queueIdStr = sai_serialize_object_id(queueId);
 
-            auto ret = m_brsEntryMap.emplace(queueId, PfcWdQueueEntry(PfcWdAction::PFC_WD_ACTION_DROP, port.m_port_id, i, port.m_alias));
-            if (!ret.second)
-            {
-                // Entry already exists, update it
-                ret.first->second = PfcWdQueueEntry(PfcWdAction::PFC_WD_ACTION_DROP, port.m_port_id, i, port.m_alias);
-            }
-            auto entry = ret.first;
+            auto entry = m_brsEntryMap.emplace(queueId, PfcWdQueueEntry(PfcWdAction::PFC_WD_ACTION_DROP, port.m_port_id, i, port.m_alias)).first;
 
             if (entry->second.handler== nullptr)
             {
@@ -225,7 +221,6 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::registerInWdDb(const Port& port,
 {
     SWSS_LOG_ENTER();
 
-    // Get lossless TCs for this port
     set<uint8_t> losslessTc;
     if (!getLosslessTcsForPort(port, losslessTc))
     {
@@ -269,12 +264,8 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::registerInWdDb(const Port& port,
             (dynamic_cast<FlexCounterManager*>(this->m_pfcwdFlexCounterManager.get()))->setCounterIdList(queueId, CounterType::QUEUE_ATTR, queueAttrIdSet);
         }
 
-        auto ret = m_entryMap.emplace(queueId, PfcWdQueueEntry(action, port.m_port_id, i, port.m_alias));
-        if (!ret.second)
-        {
-            // Entry already exists, update it
-            ret.first->second = PfcWdQueueEntry(action, port.m_port_id, i, port.m_alias);
-        }
+        // Create internal entry
+        m_entryMap.emplace(queueId, PfcWdQueueEntry(action, port.m_port_id, i, port.m_alias));
 
         // Initialize PFC WD related counters
         PfcWdActionHandler::initWdCounters(
@@ -355,6 +346,7 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::unregisterFromWdDb(const Port& po
             + port.m_alias;
         m_applDb->hdel(instormKey, to_string(i));
     }
+
 }
 
 template <typename DropHandler, typename ForwardHandler>
@@ -422,11 +414,6 @@ PfcWdSwOrch<DropHandler, ForwardHandler>::PfcWdSwOrch(
             m_applDb.get(), APP_PFC_WD_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE, default_orch_pri);
     auto ssConsumer = new Consumer(ssTable, this, APP_PFC_WD_TABLE_NAME);
     Orch::addExecutor(ssConsumer);
-
-    // Write to STATE_DB to indicate software-based PFC watchdog recovery
-    this->updateStateTable(PFC_WD_RECOVERY_MECHANISM, PFC_WD_RECOVERY_SOFTWARE);
-
-    SWSS_LOG_NOTICE("PFC Watchdog software-based recovery mechanism registered in STATE_DB");
 }
 
 template <typename DropHandler, typename ForwardHandler>
@@ -643,8 +630,7 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::startWdActionOnQueue(const string
         {
             if (entry->second.handler == nullptr)
             {
-                this->report_pfc_storm(entry->first, entry->second.portId,
-                                      entry->second.index, entry->second.portAlias, info);
+                report_pfc_storm(entry->first, entry->second.portId, entry->second.index, entry->second.portAlias, info);
 
                 entry->second.handler = make_shared<PfcWdActionHandler>(
                         entry->second.portId,
@@ -661,8 +647,7 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::startWdActionOnQueue(const string
         {
             if (entry->second.handler == nullptr)
             {
-                this->report_pfc_storm(entry->first, entry->second.portId,
-                                      entry->second.index, entry->second.portAlias, info);
+                report_pfc_storm(entry->first, entry->second.portId, entry->second.index, entry->second.portAlias, info);
 
                 entry->second.handler = make_shared<DropHandler>(
                         entry->second.portId,
@@ -679,8 +664,7 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::startWdActionOnQueue(const string
         {
             if (entry->second.handler == nullptr)
             {
-                this->report_pfc_storm(entry->first, entry->second.portId,
-                                      entry->second.index, entry->second.portAlias, info);
+                report_pfc_storm(entry->first, entry->second.portId, entry->second.index, entry->second.portAlias, info);
 
                 entry->second.handler = make_shared<ForwardHandler>(
                         entry->second.portId,
@@ -703,8 +687,7 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::startWdActionOnQueue(const string
     {
         if (entry->second.handler != nullptr)
         {
-            this->report_pfc_restored(entry->first, entry->second.portId,
-                                     entry->second.index, entry->second.portAlias);
+            report_pfc_restored(entry->first, entry->second.portId, entry->second.index, entry->second.portAlias);
 
             entry->second.handler->commitCounters();
             entry->second.handler = nullptr;

--- a/orchagent/pfcwdsworch.cpp
+++ b/orchagent/pfcwdsworch.cpp
@@ -28,6 +28,8 @@ extern event_handle_t g_events_handle;
 extern SwitchOrch *gSwitchOrch;
 extern PortsOrch *gPortsOrch;
 
+
+
 template <typename DropHandler, typename ForwardHandler>
 task_process_status PfcWdSwOrch<DropHandler, ForwardHandler>::createEntry(const string& key,
         const vector<FieldValueTuple>& data)
@@ -125,7 +127,6 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::enableBigRedSwitchMode()
     for (auto &it: allPorts)
     {
         Port port = it.second;
-        uint8_t pfcMask = 0;
 
         if (port.m_type != Port::PHY)
         {
@@ -133,16 +134,17 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::enableBigRedSwitchMode()
             continue;
         }
 
-        if (!gPortsOrch->getPortPfcWatchdogStatus(port.m_port_id, &pfcMask))
+        // Get lossless TCs for this port
+        set<uint8_t> losslessTc;
+        if (!getLosslessTcsForPort(port, losslessTc))
         {
-            SWSS_LOG_ERROR("Failed to get PFC watchdog mask on port %s", port.m_alias.c_str());
-            return;
+            SWSS_LOG_DEBUG("No lossless TC found on port %s", port.m_alias.c_str());
         }
 
         for (uint8_t i = 0; i < PFC_WD_TC_MAX; i++)
         {
             sai_object_id_t queueId = port.m_queue_ids[i];
-            if ((pfcMask & (1 << i)) == 0 && m_entryMap.find(queueId) == m_entryMap.end())
+            if (losslessTc.find(i) == losslessTc.end() && m_entryMap.find(queueId) == m_entryMap.end())
             {
                 continue;
             }
@@ -169,7 +171,6 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::enableBigRedSwitchMode()
     for (auto & it: allPorts)
     {
         Port port = it.second;
-        uint8_t pfcMask = 0;
 
         if (port.m_type != Port::PHY)
         {
@@ -177,23 +178,26 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::enableBigRedSwitchMode()
             continue;
         }
 
-        if (!gPortsOrch->getPortPfcWatchdogStatus(port.m_port_id, &pfcMask))
+        // Get lossless TCs for this port
+        set<uint8_t> losslessTc;
+        if (!getLosslessTcsForPort(port, losslessTc))
         {
-            SWSS_LOG_ERROR("Failed to get PFC watchdog mask on port %s", port.m_alias.c_str());
-            return;
+            SWSS_LOG_DEBUG("No lossless TC found on port %s", port.m_alias.c_str());
+            continue;
         }
 
-        for (uint8_t i = 0; i < PFC_WD_TC_MAX; i++)
+        for (auto i : losslessTc)
         {
-            if ((pfcMask & (1 << i)) == 0)
-            {
-                continue;
-            }
-
             sai_object_id_t queueId = port.m_queue_ids[i];
             string queueIdStr = sai_serialize_object_id(queueId);
 
-            auto entry = m_brsEntryMap.emplace(queueId, PfcWdQueueEntry(PfcWdAction::PFC_WD_ACTION_DROP, port.m_port_id, i, port.m_alias)).first;
+            auto ret = m_brsEntryMap.emplace(queueId, PfcWdQueueEntry(PfcWdAction::PFC_WD_ACTION_DROP, port.m_port_id, i, port.m_alias));
+            if (!ret.second)
+            {
+                // Entry already exists, update it
+                ret.first->second = PfcWdQueueEntry(PfcWdAction::PFC_WD_ACTION_DROP, port.m_port_id, i, port.m_alias);
+            }
+            auto entry = ret.first;
 
             if (entry->second.handler== nullptr)
             {
@@ -221,6 +225,7 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::registerInWdDb(const Port& port,
 {
     SWSS_LOG_ENTER();
 
+    // Get lossless TCs for this port
     set<uint8_t> losslessTc;
     if (!getLosslessTcsForPort(port, losslessTc))
     {
@@ -264,8 +269,12 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::registerInWdDb(const Port& port,
             (dynamic_cast<FlexCounterManager*>(this->m_pfcwdFlexCounterManager.get()))->setCounterIdList(queueId, CounterType::QUEUE_ATTR, queueAttrIdSet);
         }
 
-        // Create internal entry
-        m_entryMap.emplace(queueId, PfcWdQueueEntry(action, port.m_port_id, i, port.m_alias));
+        auto ret = m_entryMap.emplace(queueId, PfcWdQueueEntry(action, port.m_port_id, i, port.m_alias));
+        if (!ret.second)
+        {
+            // Entry already exists, update it
+            ret.first->second = PfcWdQueueEntry(action, port.m_port_id, i, port.m_alias);
+        }
 
         // Initialize PFC WD related counters
         PfcWdActionHandler::initWdCounters(
@@ -346,7 +355,6 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::unregisterFromWdDb(const Port& po
             + port.m_alias;
         m_applDb->hdel(instormKey, to_string(i));
     }
-
 }
 
 template <typename DropHandler, typename ForwardHandler>
@@ -635,7 +643,8 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::startWdActionOnQueue(const string
         {
             if (entry->second.handler == nullptr)
             {
-                report_pfc_storm(entry->first, entry->second.portId, entry->second.index, entry->second.portAlias, info);
+                this->report_pfc_storm(entry->first, entry->second.portId,
+                                      entry->second.index, entry->second.portAlias, info);
 
                 entry->second.handler = make_shared<PfcWdActionHandler>(
                         entry->second.portId,
@@ -652,7 +661,8 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::startWdActionOnQueue(const string
         {
             if (entry->second.handler == nullptr)
             {
-                report_pfc_storm(entry->first, entry->second.portId, entry->second.index, entry->second.portAlias, info);
+                this->report_pfc_storm(entry->first, entry->second.portId,
+                                      entry->second.index, entry->second.portAlias, info);
 
                 entry->second.handler = make_shared<DropHandler>(
                         entry->second.portId,
@@ -669,7 +679,8 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::startWdActionOnQueue(const string
         {
             if (entry->second.handler == nullptr)
             {
-                report_pfc_storm(entry->first, entry->second.portId, entry->second.index, entry->second.portAlias, info);
+                this->report_pfc_storm(entry->first, entry->second.portId,
+                                      entry->second.index, entry->second.portAlias, info);
 
                 entry->second.handler = make_shared<ForwardHandler>(
                         entry->second.portId,
@@ -692,7 +703,8 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::startWdActionOnQueue(const string
     {
         if (entry->second.handler != nullptr)
         {
-            report_pfc_restored(entry->first, entry->second.portId, entry->second.index, entry->second.portAlias);
+            this->report_pfc_restored(entry->first, entry->second.portId,
+                                     entry->second.index, entry->second.portAlias);
 
             entry->second.handler->commitCounters();
             entry->second.handler = nullptr;

--- a/orchagent/pfcwdsworch.cpp
+++ b/orchagent/pfcwdsworch.cpp
@@ -414,6 +414,11 @@ PfcWdSwOrch<DropHandler, ForwardHandler>::PfcWdSwOrch(
             m_applDb.get(), APP_PFC_WD_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE, default_orch_pri);
     auto ssConsumer = new Consumer(ssTable, this, APP_PFC_WD_TABLE_NAME);
     Orch::addExecutor(ssConsumer);
+
+    // Write to STATE_DB to indicate software-based PFC watchdog recovery
+    this->updateStateTable(PFC_WD_RECOVERY_MECHANISM, PFC_WD_RECOVERY_SOFTWARE);
+
+    SWSS_LOG_NOTICE("PFC Watchdog software-based recovery mechanism registered in STATE_DB");
 }
 
 template <typename DropHandler, typename ForwardHandler>

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -418,6 +418,7 @@ static const vector<sai_ingress_priority_group_stat_t> ingressPriorityGroupWater
 
 static const vector<sai_ingress_priority_group_stat_t> ingressPriorityGroupDropStatIds =
 {
+    SAI_INGRESS_PRIORITY_GROUP_STAT_PACKETS,
     SAI_INGRESS_PRIORITY_GROUP_STAT_DROPPED_PACKETS
 };
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -418,7 +418,6 @@ static const vector<sai_ingress_priority_group_stat_t> ingressPriorityGroupWater
 
 static const vector<sai_ingress_priority_group_stat_t> ingressPriorityGroupDropStatIds =
 {
-    SAI_INGRESS_PRIORITY_GROUP_STAT_PACKETS,
     SAI_INGRESS_PRIORITY_GROUP_STAT_DROPPED_PACKETS
 };
 

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -158,6 +158,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 $(top_srcdir)/orchagent/switchorch.cpp \
                 $(top_srcdir)/orchagent/pfcwdorch.cpp \
                 $(top_srcdir)/orchagent/pfcwdsworch.cpp \
+                $(top_srcdir)/orchagent/pfcwdhworch.cpp \
                 $(top_srcdir)/orchagent/pfcactionhandler.cpp \
                 $(top_srcdir)/orchagent/policerorch.cpp \
                 $(top_srcdir)/orchagent/crmorch.cpp \

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -31,6 +31,7 @@ tests_INCLUDES = -I $(FLEX_CTR_DIR) -I $(DEBUG_CTR_DIR) -I $(top_srcdir)/lib -I$
 tests_SOURCES = aclorch_ut.cpp \
                 aclorch_rule_ut.cpp \
                 portsorch_ut.cpp \
+                pfcwdhw_counters_ut.cpp \
                 routeorch_ut.cpp \
                 qosorch_ut.cpp \
                 bufferorch_ut.cpp \

--- a/tests/mock_tests/flexcounter_ut.cpp
+++ b/tests/mock_tests/flexcounter_ut.cpp
@@ -726,6 +726,7 @@ namespace flexcounter_test
         ASSERT_TRUE(checkFlexCounter(PG_DROP_STAT_COUNTER_FLEX_COUNTER_GROUP, pgOid,
                                      {
                                          {PG_COUNTER_ID_LIST,
+                                          "SAI_INGRESS_PRIORITY_GROUP_STAT_PACKETS,"
                                           "SAI_INGRESS_PRIORITY_GROUP_STAT_DROPPED_PACKETS"
                                          }
                                      }));

--- a/tests/mock_tests/flexcounter_ut.cpp
+++ b/tests/mock_tests/flexcounter_ut.cpp
@@ -726,7 +726,6 @@ namespace flexcounter_test
         ASSERT_TRUE(checkFlexCounter(PG_DROP_STAT_COUNTER_FLEX_COUNTER_GROUP, pgOid,
                                      {
                                          {PG_COUNTER_ID_LIST,
-                                          "SAI_INGRESS_PRIORITY_GROUP_STAT_PACKETS,"
                                           "SAI_INGRESS_PRIORITY_GROUP_STAT_DROPPED_PACKETS"
                                          }
                                      }));

--- a/tests/mock_tests/mock_orchagent_main.cpp
+++ b/tests/mock_tests/mock_orchagent_main.cpp
@@ -25,6 +25,7 @@ bool gEnableFibSuppress = false;
 sai_redis_communication_mode_t gRedisCommunicationMode = SAI_REDIS_COMMUNICATION_MODE_REDIS_ASYNC;
 
 VRFOrch *gVrfOrch;
+PfcWdHwOrch *gPfcWdHwOrch = nullptr;
 
 void syncd_apply_view() {}
 

--- a/tests/mock_tests/mock_orchagent_main.h
+++ b/tests/mock_tests/mock_orchagent_main.h
@@ -22,6 +22,7 @@
 #include "qosorch.h"
 #define protected public
 #include "pfcwdorch.h"
+#include "pfcwdhworch.h"
 #include "pfcwdsworch.h"
 #undef protected
 #undef private
@@ -57,6 +58,7 @@ extern sai_object_id_t gVirtualRouterId;
 extern sai_object_id_t gUnderlayIfId;
 
 extern SwitchOrch *gSwitchOrch;
+extern PfcWdHwOrch *gPfcWdHwOrch;
 extern CrmOrch *gCrmOrch;
 extern PortsOrch *gPortsOrch;
 extern DebugCounterOrch *gDebugCounterOrch;

--- a/tests/mock_tests/mock_orchagent_main.h
+++ b/tests/mock_tests/mock_orchagent_main.h
@@ -24,6 +24,7 @@
 #include "pfcwdorch.h"
 #include "pfcwdhworch.h"
 #include "pfcwdsworch.h"
+#include "pfcwdhworch.h"
 #undef protected
 #undef private
 #include "vrforch.h"

--- a/tests/mock_tests/pfcwdhw_counters_ut.cpp
+++ b/tests/mock_tests/pfcwdhw_counters_ut.cpp
@@ -1,0 +1,761 @@
+#include "ut_helper.h"
+#include "mock_orchagent_main.h"
+#include "mock_orch_test.h"
+#include "mock_table.h"
+
+#define private public
+#include "pfcwdhworch.h"
+#undef private
+
+#include <gtest/gtest.h>
+
+namespace pfcwdhworch_test
+{
+    using namespace std;
+    using namespace mock_orch_test;
+
+	    class PfcWdHwCountersTest : public MockOrchTest
+	    {
+	    protected:
+	        shared_ptr<swss::DBConnector> m_counters_db;
+	        shared_ptr<swss::Table> m_counters_table;
+	        PfcWdHwOrch *m_pfcwd_hw_orch;
+	        
+	        void SetUp() override
+	        {
+	            MockOrchTest::SetUp();
+
+	            // Bring up ports so gPortsOrch can resolve Ethernet0 and its queues/PGs.
+	            bringUpPorts();
+	            
+	            // Initialize COUNTERS_DB and table
+	            m_counters_db = make_shared<swss::DBConnector>("COUNTERS_DB", 0);
+	            m_counters_table = make_shared<swss::Table>(m_counters_db.get(), COUNTERS_TABLE);
+	            
+	            vector<string> pfc_wd_tables = { CFG_PFC_WD_TABLE_NAME };
+	            
+	            static const vector<sai_port_stat_t> portStatIds = {};
+	            
+	            static const vector<sai_queue_stat_t> queueStatIds = {
+	                SAI_QUEUE_STAT_PACKETS,
+	                SAI_QUEUE_STAT_DROPPED_PACKETS
+	            };
+	            
+	            static const vector<sai_queue_attr_t> queueAttrIds = {};
+	            
+	            m_pfcwd_hw_orch = new PfcWdHwOrch(
+	                m_config_db.get(), 
+	                pfc_wd_tables, 
+	                portStatIds, 
+	                queueStatIds, 
+	                queueAttrIds);
+	        }
+	        
+	        void TearDown() override
+	        {
+	            delete m_pfcwd_hw_orch;
+	            MockOrchTest::TearDown();
+	        }
+	        
+	        // Populate APP_PORT_TABLE and run PortsOrch so ports are ready.
+	        void bringUpPorts()
+	        {
+	            swss::Table portTable(m_app_db.get(), APP_PORT_TABLE_NAME);
+	            auto ports = ut_helper::getInitialSaiPorts();
+
+	            for (const auto &it : ports)
+	            {
+	                portTable.set(it.first, it.second);
+	            }
+
+	            portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+	            portTable.set("PortInitDone",   { { "lanes", "0" } });
+
+	            gPortsOrch->addExistingData(&portTable);
+	            static_cast<Orch *>(gPortsOrch)->doTask();
+	            static_cast<Orch *>(gPortsOrch)->doTask();
+	            ASSERT_TRUE(gPortsOrch->allPortsReady());
+	        }
+	        
+	        // Helper: Set hardware counter values in COUNTERS_DB for a queue
+        void setQueueHwCounters(sai_object_id_t queueId, uint64_t txPkt, uint64_t txDropPkt)
+        {
+            string queueIdStr = sai_serialize_object_id(queueId);
+            vector<FieldValueTuple> fvs = {
+                {"SAI_QUEUE_STAT_PACKETS", to_string(txPkt)},
+                {"SAI_QUEUE_STAT_DROPPED_PACKETS", to_string(txDropPkt)}
+            };
+            m_counters_table->set(queueIdStr, fvs);
+        }
+        
+        // Helper: Set hardware counter values in COUNTERS_DB for a priority group
+        void setPgHwCounters(sai_object_id_t pgId, uint64_t rxPkt, uint64_t rxDropPkt)
+        {
+            string pgIdStr = sai_serialize_object_id(pgId);
+            vector<FieldValueTuple> fvs = {
+                {"SAI_INGRESS_PRIORITY_GROUP_STAT_PACKETS", to_string(rxPkt)},
+                {"SAI_INGRESS_PRIORITY_GROUP_STAT_DROPPED_PACKETS", to_string(rxDropPkt)}
+            };
+            m_counters_table->set(pgIdStr, fvs);
+        }
+        
+        // Helper: Get queue statistics from COUNTERS_DB via the orch method
+        PfcWdHwOrch::PfcWdQueueStats getQueueStats(sai_object_id_t queueId)
+        {
+            string queueIdStr = sai_serialize_object_id(queueId);
+            return m_pfcwd_hw_orch->getQueueStats(queueIdStr);
+        }
+        
+        // Helper: Verify counter values match expectations
+        void verifyQueueStats(sai_object_id_t queueId,
+                             uint64_t expectedDetect, 
+                             uint64_t expectedRestore,
+                             uint64_t expectedTxPkt,
+                             uint64_t expectedTxDropPkt,
+                             uint64_t expectedRxPkt,
+                             uint64_t expectedRxDropPkt,
+                             bool expectedOperational)
+        {
+            auto stats = getQueueStats(queueId);
+            EXPECT_EQ(stats.detectCount, expectedDetect) << "detectCount mismatch";
+            EXPECT_EQ(stats.restoreCount, expectedRestore) << "restoreCount mismatch";
+            EXPECT_EQ(stats.txPkt, expectedTxPkt) << "txPkt mismatch";
+            EXPECT_EQ(stats.txDropPkt, expectedTxDropPkt) << "txDropPkt mismatch";
+            EXPECT_EQ(stats.rxPkt, expectedRxPkt) << "rxPkt mismatch";
+            EXPECT_EQ(stats.rxDropPkt, expectedRxDropPkt) << "rxDropPkt mismatch";
+            EXPECT_EQ(stats.operational, expectedOperational) << "operational status mismatch";
+        }
+        
+        void resetQueueStats(sai_object_id_t queueId)
+        {
+            string queueIdStr = sai_serialize_object_id(queueId);
+
+            // Delete the stats entry from COUNTERS_DB
+            m_counters_table->del(queueIdStr);
+
+            // Clear baseline so next initQueueCounters starts fresh
+            m_pfcwd_hw_orch->m_queueBaselineStats.erase(queueId);
+        }
+
+        void setupQueuePortMapping(sai_object_id_t queueId, const Port& port, uint8_t queueIndex)
+        {
+            PfcWdHwOrch::PortQueueInfo info;
+            info.port_id = port.m_port_id;
+            info.port_alias = port.m_alias;
+            info.queue_index = queueIndex;
+            m_pfcwd_hw_orch->m_queueToPortMap[queueId] = info;
+        }
+        
+        // Helper: Verify baseline counters are stored correctly
+        void verifyBaseline(sai_object_id_t queueId, 
+                           uint64_t expectedTxPkt,
+                           uint64_t expectedTxDropPkt,
+                           uint64_t expectedRxPkt,
+                           uint64_t expectedRxDropPkt)
+        {
+            ASSERT_NE(m_pfcwd_hw_orch->m_queueBaselineStats.find(queueId),
+                     m_pfcwd_hw_orch->m_queueBaselineStats.end()) 
+                << "Baseline not found for queue";
+            
+            auto& baseline = m_pfcwd_hw_orch->m_queueBaselineStats[queueId];
+            EXPECT_EQ(baseline.txPkt, expectedTxPkt) << "Baseline txPkt mismatch";
+            EXPECT_EQ(baseline.txDropPkt, expectedTxDropPkt) << "Baseline txDropPkt mismatch";
+            EXPECT_EQ(baseline.rxPkt, expectedRxPkt) << "Baseline rxPkt mismatch";
+            EXPECT_EQ(baseline.rxDropPkt, expectedRxDropPkt) << "Baseline rxDropPkt mismatch";
+        }
+    };
+
+    // ========================================================================
+    // Test Cases: initQueueCounters()
+    // ========================================================================
+
+    TEST_F(PfcWdHwCountersTest, InitQueueCounters_NewStorm)
+    {
+        // Get port from existing PortsOrch setup
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+
+        uint8_t queueIndex = 3;
+        sai_object_id_t queueId = port.m_queue_ids[queueIndex];
+        string queueIdStr = sai_serialize_object_id(queueId);
+
+        // Setup: Populate HW counters in COUNTERS_DB
+        setQueueHwCounters(queueId, 1000, 50);
+        setPgHwCounters(port.m_priority_group_ids[queueIndex], 2000, 100);
+
+        // Setup: Add queue to port mapping
+        setupQueuePortMapping(queueId, port, queueIndex);
+
+        // Test: Call initQueueCounters (simulates storm detection)
+        m_pfcwd_hw_orch->initQueueCounters(queueIdStr, queueId, queueIndex);
+
+        // Verify: detectCount = 1, restoreCount = 0
+        // Verify: operational = false (storm state)
+        // Verify: *_LAST counters = 0 (reset on detection)
+        // Verify: cumulative counters = 0 (new storm)
+        verifyQueueStats(queueId,
+                        1,      // detectCount
+                        0,      // restoreCount
+                        0,      // txPkt
+                        0,      // txDropPkt
+                        0,      // rxPkt
+                        0,      // rxDropPkt
+                        false); // operational
+
+        // Verify: Baseline stored with current HW values
+        verifyBaseline(queueId, 1000, 50, 2000, 100);
+    }
+
+    TEST_F(PfcWdHwCountersTest, InitQueueCounters_SubsequentStorm)
+    {
+        // Setup: Simulate previous storm that was restored
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+
+        uint8_t queueIndex = 3;
+        sai_object_id_t queueId = port.m_queue_ids[queueIndex];
+        string queueIdStr = sai_serialize_object_id(queueId);
+
+        setupQueuePortMapping(queueId, port, queueIndex);
+
+        // Pre-populate COUNTERS_DB with previous storm history
+        PfcWdHwOrch::PfcWdQueueStats prevStats;
+        memset(&prevStats, 0, sizeof(prevStats));
+        prevStats.detectCount = 1;
+        prevStats.restoreCount = 1;
+        prevStats.txPkt = 500;
+        prevStats.txDropPkt = 25;
+        prevStats.rxPkt = 1000;
+        prevStats.rxDropPkt = 50;
+        prevStats.operational = true;
+        m_pfcwd_hw_orch->updateQueueStats(queueIdStr, prevStats);
+
+        // Setup: New HW counter values for second storm
+        setQueueHwCounters(queueId, 5000, 200);
+        setPgHwCounters(port.m_priority_group_ids[queueIndex], 8000, 300);
+
+        // Test: Call initQueueCounters for second storm
+        m_pfcwd_hw_orch->initQueueCounters(queueIdStr, queueId, queueIndex);
+
+        auto stats = getQueueStats(queueId);
+        EXPECT_EQ(stats.detectCount, 2);
+        EXPECT_EQ(stats.restoreCount, 1);
+        EXPECT_EQ(stats.operational, false);
+
+        // Verify: *_LAST counters reset to 0 for new storm
+        EXPECT_EQ(stats.txPktLast, 0);
+        EXPECT_EQ(stats.txDropPktLast, 0);
+        EXPECT_EQ(stats.rxPktLast, 0);
+        EXPECT_EQ(stats.rxDropPktLast, 0);
+
+        // Verify: Cumulative counters from previous storm preserved
+        EXPECT_EQ(stats.txPkt, 500);
+        EXPECT_EQ(stats.txDropPkt, 25);
+
+        // Verify: New baseline set
+        verifyBaseline(queueId, 5000, 200, 8000, 300);
+    }
+
+    TEST_F(PfcWdHwCountersTest, InitQueueCounters_WarmRebootOngoingStorm)
+    {
+        // Test scenario: Storm was ongoing during warm reboot
+        // detectCount > restoreCount, so we don't increment detectCount again
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+
+        uint8_t queueIndex = 3;
+        sai_object_id_t queueId = port.m_queue_ids[queueIndex];
+        string queueIdStr = sai_serialize_object_id(queueId);
+
+        setupQueuePortMapping(queueId, port, queueIndex);
+
+        // Pre-populate: Storm detected before warm reboot
+        PfcWdHwOrch::PfcWdQueueStats prevStats;
+        memset(&prevStats, 0, sizeof(prevStats));
+        prevStats.detectCount = 1;
+        prevStats.restoreCount = 0;  // Storm still ongoing
+        prevStats.operational = false;
+        m_pfcwd_hw_orch->updateQueueStats(queueIdStr, prevStats);
+
+        // Setup: HW counters
+        setQueueHwCounters(queueId, 3000, 100);
+        setPgHwCounters(port.m_priority_group_ids[queueIndex], 5000, 200);
+
+        // Test: Call initQueueCounters (warm reboot recovery)
+        m_pfcwd_hw_orch->initQueueCounters(queueIdStr, queueId, queueIndex);
+
+        // Verify: detectCount NOT incremented (still 1)
+        auto stats = getQueueStats(queueId);
+        EXPECT_EQ(stats.detectCount, 1) << "detectCount should not increment on warm reboot recovery";
+        EXPECT_EQ(stats.restoreCount, 0);
+        EXPECT_EQ(stats.operational, false);
+
+        // Verify: Baseline re-established for continued monitoring
+        verifyBaseline(queueId, 3000, 100, 5000, 200);
+    }
+
+    // ========================================================================
+    // Test Cases: updateQueueCounters() - Periodic Updates
+    // ========================================================================
+
+    TEST_F(PfcWdHwCountersTest, UpdateQueueCounters_PeriodicFirstUpdate)
+    {
+        // Test first periodic update during an ongoing storm
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+
+        uint8_t queueIndex = 3;
+        sai_object_id_t queueId = port.m_queue_ids[queueIndex];
+        string queueIdStr = sai_serialize_object_id(queueId);
+
+        resetQueueStats(queueId);
+        setupQueuePortMapping(queueId, port, queueIndex);
+
+        // Setup: Initialize counters (storm detected)
+        setQueueHwCounters(queueId, 1000, 50);
+        setPgHwCounters(port.m_priority_group_ids[queueIndex], 2000, 100);
+        m_pfcwd_hw_orch->initQueueCounters(queueIdStr, queueId, queueIndex);
+
+        // Setup: Update HW counters (traffic during storm)
+        setQueueHwCounters(queueId, 1500, 75);
+        setPgHwCounters(port.m_priority_group_ids[queueIndex], 2500, 150);
+
+        // Test: Call updateQueueCounters with periodic=true
+        m_pfcwd_hw_orch->updateQueueCounters(queueIdStr, queueId, queueIndex, true);
+
+        // Verify: Deltas accumulated
+        auto stats = getQueueStats(queueId);
+        EXPECT_EQ(stats.txPkt, 500) << "txPkt should be delta: 1500 - 1000";
+        EXPECT_EQ(stats.txDropPkt, 25) << "txDropPkt should be delta: 75 - 50";
+        EXPECT_EQ(stats.rxPkt, 500) << "rxPkt should be delta: 2500 - 2000";
+        EXPECT_EQ(stats.rxDropPkt, 50) << "rxDropPkt should be delta: 150 - 100";
+
+        // Verify: *_LAST counters also updated
+        EXPECT_EQ(stats.txPktLast, 500);
+        EXPECT_EQ(stats.txDropPktLast, 25);
+        EXPECT_EQ(stats.rxPktLast, 500);
+        EXPECT_EQ(stats.rxDropPktLast, 50);
+
+        // Verify: Still in storm state
+        EXPECT_EQ(stats.operational, false);
+        EXPECT_EQ(stats.detectCount, 1);
+        EXPECT_EQ(stats.restoreCount, 0) << "restoreCount should not change on periodic update";
+
+        // Verify: Baseline updated to current HW values
+        verifyBaseline(queueId, 1500, 75, 2500, 150);
+    }
+
+    TEST_F(PfcWdHwCountersTest, UpdateQueueCounters_PeriodicMultipleUpdates)
+    {
+        // Test multiple periodic updates accumulate correctly
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+
+        uint8_t queueIndex = 3;
+        sai_object_id_t queueId = port.m_queue_ids[queueIndex];
+        string queueIdStr = sai_serialize_object_id(queueId);
+
+        resetQueueStats(queueId);
+        setupQueuePortMapping(queueId, port, queueIndex);
+
+        // Setup: Initialize counters
+        setQueueHwCounters(queueId, 1000, 50);
+        setPgHwCounters(port.m_priority_group_ids[queueIndex], 2000, 100);
+        m_pfcwd_hw_orch->initQueueCounters(queueIdStr, queueId, queueIndex);
+
+        // First periodic update
+        setQueueHwCounters(queueId, 1500, 75);
+        setPgHwCounters(port.m_priority_group_ids[queueIndex], 2500, 150);
+        m_pfcwd_hw_orch->updateQueueCounters(queueIdStr, queueId, queueIndex, true);
+
+        // Second periodic update
+        setQueueHwCounters(queueId, 2200, 110);
+        setPgHwCounters(port.m_priority_group_ids[queueIndex], 3300, 220);
+        m_pfcwd_hw_orch->updateQueueCounters(queueIdStr, queueId, queueIndex, true);
+
+        // Third periodic update
+        setQueueHwCounters(queueId, 3000, 150);
+        setPgHwCounters(port.m_priority_group_ids[queueIndex], 4500, 300);
+        m_pfcwd_hw_orch->updateQueueCounters(queueIdStr, queueId, queueIndex, true);
+
+        // Verify: Cumulative counters = sum of all deltas
+        auto stats = getQueueStats(queueId);
+        EXPECT_EQ(stats.txPkt, 2000) << "Should be total: (1500-1000) + (2200-1500) + (3000-2200)";
+        EXPECT_EQ(stats.txDropPkt, 100) << "Should be total: (75-50) + (110-75) + (150-110)";
+        EXPECT_EQ(stats.rxPkt, 2500);
+        EXPECT_EQ(stats.rxDropPkt, 200);
+
+        // Verify: *_LAST counters also accumulate
+        EXPECT_EQ(stats.txPktLast, 2000);
+        EXPECT_EQ(stats.txDropPktLast, 100);
+
+        // Verify: Final baseline is latest HW value
+        verifyBaseline(queueId, 3000, 150, 4500, 300);
+    }
+
+    TEST_F(PfcWdHwCountersTest, UpdateQueueCounters_PeriodicNoTraffic)
+    {
+        // Test periodic update when no new traffic (HW counters unchanged)
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+
+        uint8_t queueIndex = 3;
+        sai_object_id_t queueId = port.m_queue_ids[queueIndex];
+        string queueIdStr = sai_serialize_object_id(queueId);
+
+        resetQueueStats(queueId);
+        setupQueuePortMapping(queueId, port, queueIndex);
+
+        // Setup: Initialize counters
+        setQueueHwCounters(queueId, 1000, 50);
+        setPgHwCounters(port.m_priority_group_ids[queueIndex], 2000, 100);
+        m_pfcwd_hw_orch->initQueueCounters(queueIdStr, queueId, queueIndex);
+        m_pfcwd_hw_orch->updateQueueCounters(queueIdStr, queueId, queueIndex, true);
+
+        // Verify: All delta counters remain 0
+        auto stats = getQueueStats(queueId);
+        EXPECT_EQ(stats.txPkt, 0);
+        EXPECT_EQ(stats.txDropPkt, 0);
+        EXPECT_EQ(stats.rxPkt, 0);
+        EXPECT_EQ(stats.rxDropPkt, 0);
+        EXPECT_EQ(stats.operational, false);
+    }
+
+    // ========================================================================
+    // Test Cases: updateQueueCounters() - Restoration
+    // ========================================================================
+
+    TEST_F(PfcWdHwCountersTest, UpdateQueueCounters_Restoration)
+    {
+        // Test storm restoration (periodic=false)
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+
+        uint8_t queueIndex = 3;
+        sai_object_id_t queueId = port.m_queue_ids[queueIndex];
+        string queueIdStr = sai_serialize_object_id(queueId);
+
+        resetQueueStats(queueId);
+        setupQueuePortMapping(queueId, port, queueIndex);
+
+        // Setup: Storm detected and some traffic during storm
+        setQueueHwCounters(queueId, 1000, 50);
+        setPgHwCounters(port.m_priority_group_ids[queueIndex], 2000, 100);
+        m_pfcwd_hw_orch->initQueueCounters(queueIdStr, queueId, queueIndex);
+
+        // Periodic update during storm
+        setQueueHwCounters(queueId, 2000, 100);
+        setPgHwCounters(port.m_priority_group_ids[queueIndex], 4000, 200);
+        m_pfcwd_hw_orch->updateQueueCounters(queueIdStr, queueId, queueIndex, true);
+
+        // Test: Restoration (periodic=false)
+        setQueueHwCounters(queueId, 3000, 150);
+        setPgHwCounters(port.m_priority_group_ids[queueIndex], 6000, 300);
+        m_pfcwd_hw_orch->updateQueueCounters(queueIdStr, queueId, queueIndex, false);
+
+        // Verify: restoreCount incremented
+        auto stats = getQueueStats(queueId);
+        EXPECT_EQ(stats.restoreCount, 1);
+        EXPECT_EQ(stats.detectCount, 1);
+
+        // Verify: operational = true (restored)
+        EXPECT_EQ(stats.operational, true);
+
+        // Verify: Deltas still calculated and accumulated
+        EXPECT_EQ(stats.txPkt, 2000) << "Total: (2000-1000) + (3000-2000)";
+        EXPECT_EQ(stats.txDropPkt, 100) << "Total: (100-50) + (150-100)";
+        EXPECT_EQ(stats.rxPkt, 4000);
+        EXPECT_EQ(stats.rxDropPkt, 200);
+    }
+
+    TEST_F(PfcWdHwCountersTest, UpdateQueueCounters_RestorationAfterMultiplePeriodic)
+    {
+        // Test restoration after multiple periodic updates
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+
+        uint8_t queueIndex = 3;
+        sai_object_id_t queueId = port.m_queue_ids[queueIndex];
+        string queueIdStr = sai_serialize_object_id(queueId);
+
+        resetQueueStats(queueId);
+        setupQueuePortMapping(queueId, port, queueIndex);
+
+        // Init
+        setQueueHwCounters(queueId, 1000, 50);
+        setPgHwCounters(port.m_priority_group_ids[queueIndex], 2000, 100);
+        m_pfcwd_hw_orch->initQueueCounters(queueIdStr, queueId, queueIndex);
+
+        // Multiple periodic updates
+        for (int i = 1; i <= 5; i++)
+        {
+            setQueueHwCounters(queueId, 1000 + (i * 500), 50 + (i * 25));
+            setPgHwCounters(port.m_priority_group_ids[queueIndex], 2000 + (i * 1000), 100 + (i * 50));
+            m_pfcwd_hw_orch->updateQueueCounters(queueIdStr, queueId, queueIndex, true);
+        }
+
+        // Final restoration
+        setQueueHwCounters(queueId, 5000, 250);
+        setPgHwCounters(port.m_priority_group_ids[queueIndex], 10000, 500);
+        m_pfcwd_hw_orch->updateQueueCounters(queueIdStr, queueId, queueIndex, false);
+
+        // Verify restoration
+        auto stats = getQueueStats(queueId);
+        EXPECT_EQ(stats.restoreCount, 1);
+        EXPECT_EQ(stats.operational, true);
+        EXPECT_EQ(stats.txPkt, 4000) << "Total accumulated: 5000 - 1000";
+        EXPECT_EQ(stats.txDropPkt, 200) << "Total accumulated: 250 - 50";
+    }
+
+    // ========================================================================
+    // Test Cases: Counter Underflow Protection
+    // ========================================================================
+
+    TEST_F(PfcWdHwCountersTest, UpdateQueueCounters_CounterResetTxPkt)
+    {
+        // Test underflow protection when txPkt counter resets/wraps
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+
+        uint8_t queueIndex = 3;
+        sai_object_id_t queueId = port.m_queue_ids[queueIndex];
+        string queueIdStr = sai_serialize_object_id(queueId);
+
+        resetQueueStats(queueId);
+        setupQueuePortMapping(queueId, port, queueIndex);
+
+        // Setup: Initialize with high counter values
+        setQueueHwCounters(queueId, 5000, 250);
+        setPgHwCounters(port.m_priority_group_ids[queueIndex], 10000, 500);
+        m_pfcwd_hw_orch->initQueueCounters(queueIdStr, queueId, queueIndex);
+
+        // Test: HW counter reset/wrapped (txPkt < baseline)
+        setQueueHwCounters(queueId, 100, 260);
+        setPgHwCounters(port.m_priority_group_ids[queueIndex], 10500, 550);
+        m_pfcwd_hw_orch->updateQueueCounters(queueIdStr, queueId, queueIndex, true);
+
+        // Verify: txPkt NOT updated (underflow protection)
+        auto stats = getQueueStats(queueId);
+        EXPECT_EQ(stats.txPkt, 0) << "txPkt should not update when HW < baseline";
+
+        // Verify: Other counters that didn't wrap still update
+        EXPECT_EQ(stats.txDropPkt, 10) << "txDropPkt should still update: 260 - 250";
+        EXPECT_EQ(stats.rxPkt, 500);
+        EXPECT_EQ(stats.rxDropPkt, 50);
+    }
+
+    TEST_F(PfcWdHwCountersTest, UpdateQueueCounters_AllCountersReset)
+    {
+        // Test when all HW counters reset (complete reset scenario)
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+
+        uint8_t queueIndex = 3;
+        sai_object_id_t queueId = port.m_queue_ids[queueIndex];
+        string queueIdStr = sai_serialize_object_id(queueId);
+
+        resetQueueStats(queueId);
+        setupQueuePortMapping(queueId, port, queueIndex);
+
+        // Setup: Initialize with high values
+        setQueueHwCounters(queueId, 5000, 250);
+        setPgHwCounters(port.m_priority_group_ids[queueIndex], 10000, 500);
+        m_pfcwd_hw_orch->initQueueCounters(queueIdStr, queueId, queueIndex);
+
+        // Test: All counters reset to 0
+        setQueueHwCounters(queueId, 0, 0);
+        setPgHwCounters(port.m_priority_group_ids[queueIndex], 0, 0);
+        m_pfcwd_hw_orch->updateQueueCounters(queueIdStr, queueId, queueIndex, true);
+
+        // Verify: No counters updated (all skipped due to underflow)
+        auto stats = getQueueStats(queueId);
+        EXPECT_EQ(stats.txPkt, 0);
+        EXPECT_EQ(stats.txDropPkt, 0);
+        EXPECT_EQ(stats.rxPkt, 0);
+        EXPECT_EQ(stats.rxDropPkt, 0);
+    }
+
+    // ========================================================================
+    // Test Cases: readHwCounters()
+    // ========================================================================
+
+    TEST_F(PfcWdHwCountersTest, ReadHwCounters_Success)
+    {
+        // Test successful read of HW counters for both queue and PG
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+
+        uint8_t queueIndex = 3;
+        sai_object_id_t queueId = port.m_queue_ids[queueIndex];
+
+        setupQueuePortMapping(queueId, port, queueIndex);
+
+        // Setup: Populate HW counters in COUNTERS_DB
+        setQueueHwCounters(queueId, 1000, 50);
+        setPgHwCounters(port.m_priority_group_ids[queueIndex], 2000, 100);
+
+        // Test: Read HW counters
+        PfcWdHwOrch::PfcWdHwStats hwStats;
+        bool result = m_pfcwd_hw_orch->readHwCounters(queueId, queueIndex, hwStats);
+
+        // Verify: Success
+        EXPECT_TRUE(result);
+        EXPECT_EQ(hwStats.txPkt, 1000);
+        EXPECT_EQ(hwStats.txDropPkt, 50);
+        EXPECT_EQ(hwStats.rxPkt, 2000);
+        EXPECT_EQ(hwStats.rxDropPkt, 100);
+    }
+
+    TEST_F(PfcWdHwCountersTest, ReadHwCounters_MissingQueueCounters)
+    {
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+
+        uint8_t queueIndex = 3;
+        sai_object_id_t queueId = port.m_queue_ids[queueIndex];
+        string queueIdStr = sai_serialize_object_id(queueId);
+
+        setupQueuePortMapping(queueId, port, queueIndex);
+
+        // Ensure queue entry is deleted from COUNTERS_DB
+        m_counters_table->del(queueIdStr);
+
+        // Test: Read HW counters
+        PfcWdHwOrch::PfcWdHwStats hwStats;
+        bool result = m_pfcwd_hw_orch->readHwCounters(queueId, queueIndex, hwStats);
+
+        // Verify: When queue entry is missing, implementation returns early with ALL counters zero
+        EXPECT_TRUE(result);
+        EXPECT_EQ(hwStats.txPkt, 0);
+        EXPECT_EQ(hwStats.txDropPkt, 0);
+        EXPECT_EQ(hwStats.rxPkt, 0);
+        EXPECT_EQ(hwStats.rxDropPkt, 0);
+    }
+
+    TEST_F(PfcWdHwCountersTest, ReadHwCounters_MissingPgCounters)
+    {
+        // Test when PG counters are missing from COUNTERS_DB
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+
+        uint8_t queueIndex = 3;
+        sai_object_id_t queueId = port.m_queue_ids[queueIndex];
+        sai_object_id_t pgId = port.m_priority_group_ids[queueIndex];
+        string pgIdStr = sai_serialize_object_id(pgId);
+
+        setupQueuePortMapping(queueId, port, queueIndex);
+
+        // Ensure PG entry is deleted from COUNTERS_DB (might exist from previous test)
+        m_counters_table->del(pgIdStr);
+
+        // Setup: Only populate queue counters (PG counters missing)
+        setQueueHwCounters(queueId, 1000, 50);
+
+        // Test: Read HW counters
+        PfcWdHwOrch::PfcWdHwStats hwStats;
+        bool result = m_pfcwd_hw_orch->readHwCounters(queueId, queueIndex, hwStats);
+
+        // Verify: Success with zero RX counters (implementation returns true when PG entry missing)
+        EXPECT_TRUE(result);
+        EXPECT_EQ(hwStats.txPkt, 1000);
+        EXPECT_EQ(hwStats.txDropPkt, 50);
+        EXPECT_EQ(hwStats.rxPkt, 0);
+        EXPECT_EQ(hwStats.rxDropPkt, 0);
+    }
+
+    TEST_F(PfcWdHwCountersTest, ReadHwCounters_MissingQueuePortMapping)
+    {
+        // Test when queue is not in m_queueToPortMap
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+
+        uint8_t queueIndex = 3;
+        sai_object_id_t queueId = port.m_queue_ids[queueIndex];
+
+        // NOTE: Not calling setupQueuePortMapping - mapping missing
+
+        // Setup: Populate HW counters
+        setQueueHwCounters(queueId, 1000, 50);
+        setPgHwCounters(port.m_priority_group_ids[queueIndex], 2000, 100);
+
+        // Test: Read HW counters
+        PfcWdHwOrch::PfcWdHwStats hwStats;
+        bool result = m_pfcwd_hw_orch->readHwCounters(queueId, queueIndex, hwStats);
+
+        // Verify: Failure expected (cannot find port info)
+        EXPECT_FALSE(result);
+    }
+
+    // ========================================================================
+    // Test Cases: getQueueStats() and updateQueueStats()
+    // ========================================================================
+
+    TEST_F(PfcWdHwCountersTest, GetQueueStats_NonExistent)
+    {
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+
+        sai_object_id_t queueId = port.m_queue_ids[7];
+
+        resetQueueStats(queueId);
+        auto stats = getQueueStats(queueId);
+
+        // Verify: All fields are zero, but operational defaults to true (implementation behavior)
+        EXPECT_EQ(stats.detectCount, 0);
+        EXPECT_EQ(stats.restoreCount, 0);
+        EXPECT_EQ(stats.txPkt, 0);
+        EXPECT_EQ(stats.txDropPkt, 0);
+        EXPECT_EQ(stats.rxPkt, 0);
+        EXPECT_EQ(stats.rxDropPkt, 0);
+        EXPECT_EQ(stats.txPktLast, 0);
+        EXPECT_EQ(stats.txDropPktLast, 0);
+        EXPECT_EQ(stats.rxPktLast, 0);
+        EXPECT_EQ(stats.rxDropPktLast, 0);
+        EXPECT_EQ(stats.operational, true);  // getQueueStats() defaults to true when entry missing
+    }
+
+    TEST_F(PfcWdHwCountersTest, UpdateAndGetQueueStats)
+    {
+        Port port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+
+        sai_object_id_t queueId = port.m_queue_ids[3];
+        string queueIdStr = sai_serialize_object_id(queueId);
+
+        // Create and populate stats
+        PfcWdHwOrch::PfcWdQueueStats expectedStats;
+        memset(&expectedStats, 0, sizeof(expectedStats));
+        expectedStats.detectCount = 5;
+        expectedStats.restoreCount = 3;
+        expectedStats.txPkt = 12345;
+        expectedStats.txDropPkt = 678;
+        expectedStats.rxPkt = 98765;
+        expectedStats.rxDropPkt = 432;
+        expectedStats.txPktLast = 1000;
+        expectedStats.txDropPktLast = 50;
+        expectedStats.rxPktLast = 2000;
+        expectedStats.rxDropPktLast = 100;
+        expectedStats.operational = true;
+
+        // Test: Update stats
+        m_pfcwd_hw_orch->updateQueueStats(queueIdStr, expectedStats);
+
+        // Test: Read stats back
+        auto actualStats = getQueueStats(queueId);
+
+        // Verify: All fields match
+        EXPECT_EQ(actualStats.detectCount, expectedStats.detectCount);
+        EXPECT_EQ(actualStats.restoreCount, expectedStats.restoreCount);
+        EXPECT_EQ(actualStats.txPkt, expectedStats.txPkt);
+        EXPECT_EQ(actualStats.txDropPkt, expectedStats.txDropPkt);
+        EXPECT_EQ(actualStats.rxPkt, expectedStats.rxPkt);
+        EXPECT_EQ(actualStats.rxDropPkt, expectedStats.rxDropPkt);
+        EXPECT_EQ(actualStats.txPktLast, expectedStats.txPktLast);
+        EXPECT_EQ(actualStats.txDropPktLast, expectedStats.txDropPktLast);
+        EXPECT_EQ(actualStats.rxPktLast, expectedStats.rxPktLast);
+        EXPECT_EQ(actualStats.rxDropPktLast, expectedStats.rxDropPktLast);
+        EXPECT_EQ(actualStats.operational, expectedStats.operational);
+    }
+
+}
+

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -75,6 +75,22 @@ namespace portsorch_test
     sai_object_id_t _sai_create_port_serdes_fail_for_port_id = SAI_NULL_OBJECT_ID;
     std::map<sai_object_id_t, sai_object_id_t> _port_to_serdes_map;
 
+    // HW PFCWD tracking - declare before functions that use them
+    uint32_t _sai_pfc_dld_range_min = 10;
+    uint32_t _sai_pfc_dld_range_max = 1500;
+    uint32_t _sai_pfc_dlr_range_min = 100;
+    uint32_t _sai_pfc_dlr_range_max = 1000;
+    sai_queue_pfc_deadlock_notification_fn _sai_captured_deadlock_callback = nullptr;
+    map<sai_object_id_t, uint32_t> _sai_port_dld_intervals;
+    map<sai_object_id_t, uint32_t> _sai_port_dlr_intervals;
+    map<sai_object_id_t, bool> _sai_queue_dldr_enabled;  // Track actual DLDR state per queue
+
+    // Failure injection flags for PFC watchdog SAI calls
+    bool _sai_fail_switch_dlr_packet_action = false;
+    bool _sai_fail_port_dld_interval = false;
+    bool _sai_fail_port_dlr_interval = false;
+    bool _sai_fail_queue_dldr_enable = false;
+
     sai_status_t _ut_stub_sai_get_port_attribute(
         _In_ sai_object_id_t port_id,
         _In_ uint32_t attr_count,
@@ -131,6 +147,34 @@ namespace portsorch_test
         else if (attr_count == 1 && attr_list[0].id == SAI_PORT_ATTR_SUPPORTED_AUTO_NEG_MODE)
         {
             attr_list[0].value.booldata = mock_autoneg_cap_supported;
+            status = SAI_STATUS_SUCCESS;
+        }
+        else if (attr_count == 1 && attr_list[0].id == SAI_PORT_ATTR_PFC_TC_DLD_INTERVAL)
+        {
+            auto it = _sai_port_dld_intervals.find(port_id);
+            if (it != _sai_port_dld_intervals.end() &&
+                attr_list[0].value.maplist.count > 0 &&
+                attr_list[0].value.maplist.list != nullptr)
+            {
+                for (uint32_t i = 0; i < attr_list[0].value.maplist.count; i++)
+                {
+                    attr_list[0].value.maplist.list[i].value = it->second;
+                }
+            }
+            status = SAI_STATUS_SUCCESS;
+        }
+        else if (attr_count == 1 && attr_list[0].id == SAI_PORT_ATTR_PFC_TC_DLR_INTERVAL)
+        {
+            auto it = _sai_port_dlr_intervals.find(port_id);
+            if (it != _sai_port_dlr_intervals.end() &&
+                attr_list[0].value.maplist.count > 0 &&
+                attr_list[0].value.maplist.list != nullptr)
+            {
+                for (uint32_t i = 0; i < attr_list[0].value.maplist.count; i++)
+                {
+                    attr_list[0].value.maplist.list[i].value = it->second;
+                }
+            }
             status = SAI_STATUS_SUCCESS;
         }
         else
@@ -257,6 +301,36 @@ namespace portsorch_test
             {
                 return SAI_STATUS_FAILURE;
             }
+        else if (attr[0].id == SAI_PORT_ATTR_PFC_TC_DLD_INTERVAL)
+        {
+            if (_sai_fail_port_dld_interval)
+            {
+                return SAI_STATUS_FAILURE;
+            }
+            if (attr[0].value.maplist.count == 0)
+            {
+                _sai_port_dld_intervals.erase(port_id);
+            }
+            else if (attr[0].value.maplist.list != nullptr)
+            {
+                _sai_port_dld_intervals[port_id] = attr[0].value.maplist.list[0].value;
+            }
+            return SAI_STATUS_SUCCESS;
+        }
+        else if (attr[0].id == SAI_PORT_ATTR_PFC_TC_DLR_INTERVAL)
+        {
+            if (_sai_fail_port_dlr_interval)
+            {
+                return SAI_STATUS_FAILURE;
+            }
+            if (attr[0].value.maplist.count == 0)
+            {
+                _sai_port_dlr_intervals.erase(port_id);
+            }
+            else if (attr[0].value.maplist.list != nullptr)
+            {
+                _sai_port_dlr_intervals[port_id] = attr[0].value.maplist.list[0].value;
+            }
             return SAI_STATUS_SUCCESS;
         }
         else if (attr[0].id == SAI_REDIS_PORT_ATTR_LINK_EVENT_DAMPING_ALGORITHM)
@@ -314,6 +388,18 @@ namespace portsorch_test
             attr_list[0].value.s32list.count = i;
             status = SAI_STATUS_SUCCESS;
         }
+        else if (attr_count == 1 && attr_list[0].id == SAI_SWITCH_ATTR_PFC_TC_DLD_INTERVAL_RANGE)
+        {
+            attr_list[0].value.u32range.min = _sai_pfc_dld_range_min;
+            attr_list[0].value.u32range.max = _sai_pfc_dld_range_max;
+            status = SAI_STATUS_SUCCESS;
+        }
+        else if (attr_count == 1 && attr_list[0].id == SAI_SWITCH_ATTR_PFC_TC_DLR_INTERVAL_RANGE)
+        {
+            attr_list[0].value.u32range.min = _sai_pfc_dlr_range_min;
+            attr_list[0].value.u32range.max = _sai_pfc_dlr_range_max;
+            status = SAI_STATUS_SUCCESS;
+        }
         else
         {
             status = pold_sai_switch_api->get_switch_attribute(switch_id, attr_count, attr_list);
@@ -325,6 +411,7 @@ namespace portsorch_test
     int32_t *_sai_syncd_notification_event;
     uint32_t _sai_switch_dlr_packet_action_count;
     uint32_t _sai_switch_dlr_packet_action;
+
     sai_status_t _ut_stub_sai_set_switch_attribute(
         _In_ sai_object_id_t switch_id,
         _In_ const sai_attribute_t *attr)
@@ -337,8 +424,18 @@ namespace portsorch_test
 	else if (attr[0].id == SAI_SWITCH_ATTR_PFC_DLR_PACKET_ACTION)
         {
 	    _sai_switch_dlr_packet_action_count++;
+	    if (_sai_fail_switch_dlr_packet_action)
+	    {
+	        return SAI_STATUS_FAILURE;
+	    }
 	    _sai_switch_dlr_packet_action = attr[0].value.s32;
 	}
+        else if (attr[0].id == SAI_SWITCH_ATTR_QUEUE_PFC_DEADLOCK_NOTIFY)
+        {
+            _sai_captured_deadlock_callback =
+                reinterpret_cast<sai_queue_pfc_deadlock_notification_fn>(attr[0].value.ptr);
+            return SAI_STATUS_SUCCESS;
+        }
         return pold_sai_switch_api->set_switch_attribute(switch_id, attr);
     }
 
@@ -471,6 +568,14 @@ namespace portsorch_test
                 _sai_set_queue_attr_count--;
             }
         }
+        else if (attr->id == SAI_QUEUE_ATTR_ENABLE_PFC_DLDR)
+        {
+            if (_sai_fail_queue_dldr_enable)
+            {
+                return SAI_STATUS_FAILURE;
+            }
+            _sai_queue_dldr_enabled[queue_id] = attr->value.booldata;
+        }
         return SAI_STATUS_SUCCESS;
     }
 
@@ -481,6 +586,17 @@ namespace portsorch_test
         _In_ uint32_t attr_count,
         _Inout_ sai_attribute_t *attr_list)
     {
+        for (auto i = 0u; i < attr_count; i++)
+        {
+            if (attr_list[i].id == SAI_QUEUE_ATTR_ENABLE_PFC_DLDR)
+            {
+                // Return the actual DLDR state for this queue
+                auto it = _sai_queue_dldr_enabled.find(queue_id);
+                attr_list[i].value.booldata = (it != _sai_queue_dldr_enabled.end()) ? it->second : false;
+                return SAI_STATUS_SUCCESS;
+            }
+        }
+
         if (_sai_mock_queue_attr)
         {
             _sai_get_queue_attr_count++;
@@ -1614,7 +1730,6 @@ namespace portsorch_test
 
         // Verify unreliablelos
         ASSERT_EQ(p.m_unreliable_los, false);
-
 
         // Dump pending tasks
         std::vector<std::string> taskList;
@@ -2855,7 +2970,6 @@ namespace portsorch_test
 
         set_pt_interface_id_fail = false;
 
-
         // Simulate failure when PortsOrch attempts to set the Path Tracing Timestamp Template
         set_pt_timestamp_template_fail = true;
 
@@ -2878,7 +2992,6 @@ namespace portsorch_test
         ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
 
         set_pt_timestamp_template_fail = false;
-
 
         // Simulate failure when PortsOrch attempts to set the port TAM object
         set_port_tam_fail = true;
@@ -3168,7 +3281,6 @@ namespace portsorch_test
         static_cast<Orch *>(gPortsOrch)->doTask();
 
         uint32_t current_sai_api_call_count = _sai_set_link_event_damping_algorithm_count;
-
 
         entries.push_back({"Ethernet0", "SET",
                            {
@@ -4197,7 +4309,6 @@ namespace portsorch_test
         ASSERT_EQ(port.m_priority_group_ids.size(), 0);
         ASSERT_EQ(port.m_queue_ids.size(), 0);
     }
-
 
     TEST_F(PortsOrchTest, PfcDlrHandlerCallingDlrInitAttribute)
     {
@@ -5784,4 +5895,771 @@ namespace portsorch_test
 
         ASSERT_FALSE(gPortsOrch->getPort("Vlan200", vlan));
     }
+// ============================================================================
+// PFC Hardware Watchdog Tests
+// ============================================================================
+
+struct PfcWdHwOrchTest : public PortsOrchTest
+{
+    static const vector<sai_port_stat_t>  s_portStatIds;
+    static const vector<sai_queue_stat_t> s_queueStatIds;
+    static const vector<sai_queue_attr_t> s_queueAttrIds;
+
+    void SetUp() override
+    {
+        // Initialize logger to output to stdout/stderr
+        swss::Logger::getInstance().setMinPrio(swss::Logger::SWSS_NOTICE);
+
+        PortsOrchTest::SetUp();
+
+        // Set platform environment variable required by PfcWdBaseOrch constructor
+        setenv("platform", "broadcom", 1);
+
+        // SAI hooks must be in place before PfcWdHwOrch constructor so that
+        // initializeTimerRanges() and registerCallbacks() see the stubs.
+        _hook_sai_switch_api();
+        _hook_sai_port_api();
+        _hook_sai_queue_api();
+
+        // Reset hw-specific counters for each test
+        _sai_switch_dlr_packet_action_count = 0;
+        _sai_captured_deadlock_callback = nullptr;
+        _sai_port_dld_intervals.clear();
+        _sai_port_dlr_intervals.clear();
+        _sai_queue_dldr_enabled.clear();
+
+        vector<string> pfc_wd_tables = { CFG_PFC_WD_TABLE_NAME };
+        gPfcWdHwOrch = new PfcWdHwOrch(
+            m_config_db.get(), pfc_wd_tables,
+            s_portStatIds, s_queueStatIds, s_queueAttrIds);
+    }
+
+    void TearDown() override
+    {
+        delete gPfcWdHwOrch;
+        gPfcWdHwOrch = nullptr;
+        _unhook_sai_queue_api();
+        _unhook_sai_port_api();
+        _unhook_sai_switch_api();
+        unsetenv("platform");
+        PortsOrchTest::TearDown();
+    }
+
+    // Reset all PFC watchdog failure injection flags
+    void resetPfcWdFailureFlags()
+    {
+        _sai_fail_switch_dlr_packet_action = false;
+        _sai_fail_port_dld_interval = false;
+        _sai_fail_port_dlr_interval = false;
+        _sai_fail_queue_dldr_enable = false;
+    }
+
+    // Populate APP_PORT_TABLE, run portsorch, assert allPortsReady.
+    void bringUpPorts()
+    {
+        Table portTable(m_app_db.get(), APP_PORT_TABLE_NAME);
+        auto ports = ut_helper::getInitialSaiPorts();
+        for (const auto &it : ports)
+            portTable.set(it.first, it.second);
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+        portTable.set("PortInitDone",   { { "lanes", "0" } });
+        gPortsOrch->addExistingData(&portTable);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+        static_cast<Orch *>(gPortsOrch)->doTask();
+        ASSERT_TRUE(gPortsOrch->allPortsReady());
+    }
+
+    // Enable PFC on given queues for the named port via PORT_QOS_MAP.
+    void enablePfcOnPort(const string &portName, const string &queues = "3,4")
+    {
+        deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({ portName, "SET",
+            { { "pfc_enable", queues }, { "pfcwd_sw_enable", queues } } });
+        auto consumer = dynamic_cast<Consumer *>(
+            gQosOrch->getExecutor(CFG_PORT_QOS_MAP_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gQosOrch)->doTask();
+    }
+
+    // Push a DEL entry to the hw orch consumer and run doTask().
+    void deleteHwWdEntry(const string &port)
+    {
+        deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({ port, "DEL", {} });
+        auto consumer = dynamic_cast<Consumer *>(
+            gPfcWdHwOrch->getExecutor(CFG_PFC_WD_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gPfcWdHwOrch)->doTask();
+    }
+};
+
+const vector<sai_port_stat_t> PfcWdHwOrchTest::s_portStatIds = {
+    SAI_PORT_STAT_PFC_0_ON2OFF_RX_PKTS,
+    SAI_PORT_STAT_PFC_1_ON2OFF_RX_PKTS,
+    SAI_PORT_STAT_PFC_2_ON2OFF_RX_PKTS,
+    SAI_PORT_STAT_PFC_3_ON2OFF_RX_PKTS,
+    SAI_PORT_STAT_PFC_4_ON2OFF_RX_PKTS,
+    SAI_PORT_STAT_PFC_5_ON2OFF_RX_PKTS,
+    SAI_PORT_STAT_PFC_6_ON2OFF_RX_PKTS,
+    SAI_PORT_STAT_PFC_7_ON2OFF_RX_PKTS,
+};
+const vector<sai_queue_stat_t> PfcWdHwOrchTest::s_queueStatIds = {
+    SAI_QUEUE_STAT_PACKETS,
+    SAI_QUEUE_STAT_CURR_OCCUPANCY_BYTES,
+};
+const vector<sai_queue_attr_t> PfcWdHwOrchTest::s_queueAttrIds = {
+    SAI_QUEUE_ATTR_PAUSE_STATUS,
+};
+
+TEST_F(PfcWdHwOrchTest, GlobalConfigRejected)
+{
+    // Capture the return status
+    auto status = gPfcWdHwOrch->createEntry("GLOBAL",
+        { { "poll_interval", "200" } });
+
+    // Verify GLOBAL config returns invalid_entry status
+    ASSERT_EQ(status, task_process_status::task_invalid_entry);
+
+    // GLOBAL configuration should be rejected for hardware-based PFC watchdog
+    ASSERT_EQ(gPfcWdHwOrch->m_hwWdPorts.count("GLOBAL"), 0u);
+}
+
+TEST_F(PfcWdHwOrchTest, NonPhysicalPortRejected)
+{
+    // Create a LAG port (non-physical)
+    auto consumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_LAG_TABLE_NAME));
+    deque<KeyOpFieldsValuesTuple> entries;
+    entries.push_back({"PortChannel01", "SET", {}});
+    consumer->addToSync(entries);
+    static_cast<Orch *>(gPortsOrch)->doTask();
+
+    // Try to configure PFC watchdog on LAG port
+    auto status = gPfcWdHwOrch->createEntry("PortChannel01",
+        { { "action", "drop" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+
+    // Non-physical port should be rejected
+    ASSERT_EQ(status, task_process_status::task_invalid_entry);
+    ASSERT_EQ(gPfcWdHwOrch->m_hwWdPorts.count("PortChannel01"), 0u);
+}
+
+TEST_F(PfcWdHwOrchTest, InvalidPortRejected)
+{
+    auto status = gPfcWdHwOrch->createEntry("EthernetNonExistent",
+        { { "action", "drop" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+
+    ASSERT_EQ(status, task_process_status::task_invalid_entry);
+    ASSERT_EQ(gPfcWdHwOrch->m_hwWdPorts.count("EthernetNonExistent"), 0u);
+}
+
+TEST_F(PfcWdHwOrchTest, DeleteEntryValidation)
+{
+    // Delete non-existent port
+    auto status = gPfcWdHwOrch->deleteEntry("EthernetNonExistent");
+    ASSERT_EQ(status, task_process_status::task_invalid_entry);
+}
+
+TEST_F(PfcWdHwOrchTest, TimeRangeValidation)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+
+    struct TimeRangeTestCase {
+        string name;
+        uint32_t detectionMin;
+        uint32_t detectionMax;
+        uint32_t restorationMin;
+        uint32_t restorationMax;
+        string requestedDetection;
+        string requestedRestoration;
+    };
+
+    vector<TimeRangeTestCase> testCases = {
+        {
+            "DetectionTimeBelowMin",
+            200,   // min
+            5000,  // max
+            100,   // restoration min
+            60000, // restoration max
+            "100", // requested (below min of 200)
+            "200"
+        },
+        {
+            "DetectionTimeAboveMax",
+            100,   // min
+            500,   // max
+            100,   // restoration min
+            60000, // restoration max
+            "1000", // requested (above max of 500)
+            "200"
+        },
+        {
+            "RestorationTimeBelowMin",
+            100,   // detection min
+            5000,  // detection max
+            500,   // min
+            60000, // max
+            "200",
+            "200"  // requested (below min of 500)
+        },
+        {
+            "RestorationTimeAboveMax",
+            100,   // detection min
+            5000,  // detection max
+            100,   // min
+            1000,  // max
+            "200",
+            "2000" // requested (above max of 1000)
+        }
+    };
+
+    for (const auto& tc : testCases) {
+        // Configure hardware time ranges
+        gPfcWdHwOrch->m_detectionTimeMin = tc.detectionMin;
+        gPfcWdHwOrch->m_detectionTimeMax = tc.detectionMax;
+        gPfcWdHwOrch->m_restorationTimeMin = tc.restorationMin;
+        gPfcWdHwOrch->m_restorationTimeMax = tc.restorationMax;
+
+        auto status = gPfcWdHwOrch->createEntry("Ethernet0",
+            { { "action", "drop" },
+              { "detection_time", tc.requestedDetection },
+              { "restoration_time", tc.requestedRestoration } });
+
+        ASSERT_EQ(status, task_process_status::task_invalid_entry)
+            << "Test case '" << tc.name << "' failed: should reject out-of-range time";
+        ASSERT_EQ(gPfcWdHwOrch->m_hwWdPorts.count("Ethernet0"), 0u)
+            << "Test case '" << tc.name << "' failed: port should not be configured";
+    }
+}
+
+TEST_F(PfcWdHwOrchTest, InvalidConfigRejected)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+
+    // Test 1: Unknown action
+    auto status = gPfcWdHwOrch->createEntry("Ethernet0",
+        { { "action", "invalid_action" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+    ASSERT_EQ(status, task_process_status::task_invalid_entry);
+    ASSERT_EQ(gPfcWdHwOrch->m_hwWdPorts.count("Ethernet0"), 0u);
+
+    // Test 2: Missing detection_time field
+    status = gPfcWdHwOrch->createEntry("Ethernet0",
+        { { "action", "drop" }, { "restoration_time", "200" } });
+    ASSERT_EQ(status, task_process_status::task_invalid_entry);
+    ASSERT_EQ(gPfcWdHwOrch->m_hwWdPorts.count("Ethernet0"), 0u);
+
+    // Test 3: Unknown field
+    status = gPfcWdHwOrch->createEntry("Ethernet0",
+        { { "action", "drop" },
+          { "detection_time", "200" },
+          { "restoration_time", "200" },
+          { "unknown_field", "some_value" } });
+    ASSERT_EQ(status, task_process_status::task_invalid_entry);
+    ASSERT_EQ(gPfcWdHwOrch->m_hwWdPorts.count("Ethernet0"), 0u);
+}
+
+TEST_F(PfcWdHwOrchTest, NoLosslessTcFailure)
+{
+    bringUpPorts();
+    // Deliberately skip enablePfcOnPort — no lossless TCs on Ethernet0
+
+    auto consumer = dynamic_cast<Consumer *>(
+        gPfcWdHwOrch->getExecutor(CFG_PFC_WD_TABLE_NAME));
+    deque<KeyOpFieldsValuesTuple> entries;
+    entries.push_back({ "Ethernet0", "SET",
+        { { "action", "drop" }, { "detection_time", "200" },
+          { "restoration_time", "200" } } });
+    consumer->addToSync(entries);
+    static_cast<Orch *>(gPfcWdHwOrch)->doTask();
+
+    // Verify STATE_DB reports failure status
+    vector<FieldValueTuple> fvs;
+    ASSERT_TRUE(gPfcWdHwOrch->m_pfcWdHwStateTable->get("Ethernet0", fvs));
+    map<string, string> fields(fvs.begin(), fvs.end());
+    ASSERT_EQ(fields["status"], "failed");
+
+    // Port must not be tracked
+    ASSERT_EQ(gPfcWdHwOrch->m_hwWdPorts.count("Ethernet0"), 0u);
+}
+
+TEST_F(PfcWdHwOrchTest, FirstPortAction)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+    enablePfcOnPort("Ethernet8");
+
+    auto before = _sai_switch_dlr_packet_action_count;
+    gPfcWdHwOrch->createEntry("Ethernet0", { { "action", "drop" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+
+    ASSERT_EQ(_sai_switch_dlr_packet_action_count, before + 1);
+    ASSERT_EQ(_sai_switch_dlr_packet_action, (uint32_t)SAI_PACKET_ACTION_DROP);
+    ASSERT_EQ(gPfcWdHwOrch->m_hwWdPorts.count("Ethernet0"), 1u);
+}
+
+TEST_F(PfcWdHwOrchTest, ActionMismatchRejected)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+    enablePfcOnPort("Ethernet8");
+
+    gPfcWdHwOrch->createEntry("Ethernet0", { { "action", "drop" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+
+    // Attempt forward on second port while first is drop — must be rejected
+    auto status = gPfcWdHwOrch->createEntry("Ethernet8", { { "action", "forward" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+
+    ASSERT_EQ(status, task_process_status::task_invalid_entry);
+    ASSERT_EQ(gPfcWdHwOrch->m_hwWdPorts.count("Ethernet8"), 0u);
+}
+
+TEST_F(PfcWdHwOrchTest, ActionResetOnLastDelete)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+
+    gPfcWdHwOrch->createEntry("Ethernet0", { { "action", "drop" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+    ASSERT_EQ(gPfcWdHwOrch->getPfcDlrPacketAction(), PfcWdAction::PFC_WD_ACTION_DROP);
+
+    deleteHwWdEntry("Ethernet0");
+    ASSERT_EQ(gPfcWdHwOrch->getPfcDlrPacketAction(), PfcWdAction::PFC_WD_ACTION_UNKNOWN);
+    ASSERT_TRUE(gPfcWdHwOrch->m_hwWdPorts.empty());
+}
+
+TEST_F(PfcWdHwOrchTest, ForwardActionConfig)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+
+    auto beforeCount = _sai_switch_dlr_packet_action_count;
+
+    auto status = gPfcWdHwOrch->createEntry("Ethernet0",
+        { { "action", "forward" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+
+    ASSERT_EQ(status, task_process_status::task_success);
+    ASSERT_EQ(gPfcWdHwOrch->m_hwWdPorts.count("Ethernet0"), 1u);
+
+    // Verify SAI_SWITCH_ATTR_PFC_DLR_PACKET_ACTION was set to FORWARD
+    ASSERT_GT(_sai_switch_dlr_packet_action_count, beforeCount);
+    ASSERT_EQ(_sai_switch_dlr_packet_action, SAI_PACKET_ACTION_FORWARD);
+
+    Port port;
+    gPortsOrch->getPort("Ethernet0", port);
+
+    // Verify DLDR is enabled on lossless queues even with forward action
+    sai_object_id_t queue_tc3 = port.m_queue_ids[3];
+    sai_object_id_t queue_tc4 = port.m_queue_ids[4];
+    ASSERT_TRUE(_sai_queue_dldr_enabled[queue_tc3]);
+    ASSERT_TRUE(_sai_queue_dldr_enabled[queue_tc4]);
+}
+
+TEST_F(PfcWdHwOrchTest, ReconfigurePort)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+
+    gPfcWdHwOrch->createEntry("Ethernet0", { { "action", "drop" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+    ASSERT_EQ(gPfcWdHwOrch->m_hwWdPorts.count("Ethernet0"), 1u);
+
+    Port port;
+    gPortsOrch->getPort("Ethernet0", port);
+
+    // Verify initial intervals
+    ASSERT_EQ(_sai_port_dld_intervals[port.m_port_id], 200u);
+    ASSERT_EQ(_sai_port_dlr_intervals[port.m_port_id], 200u);
+
+    // Same port reconfigures with forward action and new intervals
+    auto beforeAction = _sai_switch_dlr_packet_action_count;
+
+    gPfcWdHwOrch->createEntry("Ethernet0", { { "action", "forward" }, { "detection_time", "300" }, { "restoration_time", "400" } });
+
+    // Verify action was re-set
+    ASSERT_GT(_sai_switch_dlr_packet_action_count, beforeAction);
+    ASSERT_EQ(_sai_switch_dlr_packet_action, (uint32_t)SAI_PACKET_ACTION_FORWARD);
+
+    // Verify DLD interval was re-set with new value
+    ASSERT_EQ(_sai_port_dld_intervals[port.m_port_id], 300u);
+
+    // Verify DLR interval was re-set with new value
+    ASSERT_EQ(_sai_port_dlr_intervals[port.m_port_id], 400u);
+}
+
+TEST_F(PfcWdHwOrchTest, StateDbLifecycle)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+
+    // Configure PFC watchdog
+    gPfcWdHwOrch->createEntry("Ethernet0", { { "action", "drop" }, { "detection_time", "200" }, { "restoration_time", "300" } });
+
+    // Verify STATE_DB entry written on success
+    vector<FieldValueTuple> fvs;
+    ASSERT_TRUE(gPfcWdHwOrch->m_pfcWdHwStateTable->get("Ethernet0", fvs));
+    map<string, string> fields(fvs.begin(), fvs.end());
+    ASSERT_EQ(fields["recovery_type"], "hardware");
+    ASSERT_EQ(fields["status"], "configured");
+    ASSERT_EQ(fields["action"], "drop");
+    ASSERT_EQ(fields["configured_detection_time"], "200");
+    ASSERT_EQ(fields["configured_restoration_time"], "300");
+
+    // Delete PFC watchdog
+    deleteHwWdEntry("Ethernet0");
+
+    // Verify STATE_DB entry removed on stop
+    ASSERT_FALSE(gPfcWdHwOrch->m_pfcWdHwStateTable->get("Ethernet0", fvs));
+}
+
+TEST_F(PfcWdHwOrchTest, StateDbGlobalRecoveryMechanism)
+{
+    auto stateTable = gPfcWdHwOrch->getStateTable();
+    string fullKey = stateTable->getTableName() + stateTable->getTableNameSeparator() + "PFC_WD";
+    auto value = gPfcWdHwOrch->getStateDb()->hget(fullKey, PFC_WD_RECOVERY_MECHANISM);
+    ASSERT_NE(value, nullptr);
+    ASSERT_EQ(*value, PFC_WD_RECOVERY_HARDWARE);
+}
+
+TEST_F(PfcWdHwOrchTest, WarmRebootRecovery)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+
+    // Add configuration to CONFIG_DB before warm reboot
+    Table cfgPfcWdTable(m_config_db.get(), CFG_PFC_WD_TABLE_NAME);
+    cfgPfcWdTable.set("Ethernet0", {
+        { "action", "drop" },
+        { "detection_time", "200" },
+        { "restoration_time", "200" }
+    });
+
+    // Simulate warm reboot: destroy and recreate PfcWdHwOrch
+    delete gPfcWdHwOrch;
+
+    vector<string> pfc_wd_tables = { CFG_PFC_WD_TABLE_NAME };
+    static const vector<sai_port_stat_t> portStatIds = {
+        SAI_PORT_STAT_PFC_0_RX_PKTS,
+        SAI_PORT_STAT_PFC_1_RX_PKTS
+    };
+    static const vector<sai_queue_stat_t> queueStatIds = {
+        SAI_QUEUE_STAT_PACKETS
+    };
+    static const vector<sai_queue_attr_t> queueAttrIds = {
+        SAI_QUEUE_ATTR_PAUSE_STATUS
+    };
+
+    gPfcWdHwOrch = new PfcWdHwOrch(m_config_db.get(), pfc_wd_tables,
+                                    portStatIds, queueStatIds, queueAttrIds);
+
+    // Process warm reboot recovery
+    static_cast<Orch *>(gPfcWdHwOrch)->doTask();
+
+    // Verify configuration was restored
+    ASSERT_EQ(gPfcWdHwOrch->m_hwWdPorts.count("Ethernet0"), 1u);
+
+    Port port;
+    gPortsOrch->getPort("Ethernet0", port);
+    ASSERT_EQ(_sai_port_dld_intervals.count(port.m_port_id), 1u);
+    ASSERT_EQ(_sai_port_dlr_intervals.count(port.m_port_id), 1u);
+}
+
+TEST_F(PfcWdHwOrchTest, IntervalsSet)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+
+    gPfcWdHwOrch->createEntry("Ethernet0", { { "action", "drop" }, { "detection_time", "300" }, { "restoration_time", "400" } });
+
+    Port port;
+    gPortsOrch->getPort("Ethernet0", port);
+
+    // Verify DLD interval value (detection_time = 300ms)
+    ASSERT_EQ(_sai_port_dld_intervals.count(port.m_port_id), 1u);
+    ASSERT_EQ(_sai_port_dld_intervals[port.m_port_id], 300u);
+
+    // Verify DLR interval value (restoration_time = 400ms)
+    ASSERT_EQ(_sai_port_dlr_intervals.count(port.m_port_id), 1u);
+    ASSERT_EQ(_sai_port_dlr_intervals[port.m_port_id], 400u);
+}
+
+TEST_F(PfcWdHwOrchTest, IntervalsCleared)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+
+    gPfcWdHwOrch->createEntry("Ethernet0", { { "action", "drop" }, { "detection_time", "300" }, { "restoration_time", "400" } });
+    Port port;
+    gPortsOrch->getPort("Ethernet0", port);
+
+    // Verify both intervals are set
+    ASSERT_EQ(_sai_port_dld_intervals.count(port.m_port_id), 1u);
+    ASSERT_EQ(_sai_port_dlr_intervals.count(port.m_port_id), 1u);
+
+    deleteHwWdEntry("Ethernet0");
+
+    // Verify both interval maps are cleared for this port after disable
+    ASSERT_EQ(_sai_port_dld_intervals.count(port.m_port_id), 0u);
+    ASSERT_EQ(_sai_port_dlr_intervals.count(port.m_port_id), 0u);
+}
+
+TEST_F(PfcWdHwOrchTest, DldrLifecycle)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+
+    gPfcWdHwOrch->createEntry("Ethernet0", { { "action", "drop" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+
+    // Get port and queue IDs
+    Port port;
+    ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", port));
+    ASSERT_LT(3, port.m_queue_ids.size());
+    ASSERT_LT(4, port.m_queue_ids.size());
+    sai_object_id_t queue_tc3 = port.m_queue_ids[3];
+    sai_object_id_t queue_tc4 = port.m_queue_ids[4];
+
+    // Verify DLDR is enabled on lossless queues (TCs 3 and 4)
+    ASSERT_TRUE(_sai_queue_dldr_enabled.find(queue_tc3) != _sai_queue_dldr_enabled.end());
+    ASSERT_TRUE(_sai_queue_dldr_enabled[queue_tc3]);
+    ASSERT_TRUE(_sai_queue_dldr_enabled.find(queue_tc4) != _sai_queue_dldr_enabled.end());
+    ASSERT_TRUE(_sai_queue_dldr_enabled[queue_tc4]);
+
+    deleteHwWdEntry("Ethernet0");
+
+    // Verify DLDR is disabled after deletion
+    ASSERT_FALSE(_sai_queue_dldr_enabled[queue_tc3]);
+    ASSERT_FALSE(_sai_queue_dldr_enabled[queue_tc4]);
+}
+
+TEST_F(PfcWdHwOrchTest, StormedPortProtection)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+    gPfcWdHwOrch->createEntry("Ethernet0", { { "action", "drop" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+
+    // Simulate storm on TC 3
+    Port port;
+    gPortsOrch->getPort("Ethernet0", port);
+    sai_object_id_t queueId = port.m_queue_ids[3];
+    sai_queue_deadlock_notification_data_t data;
+    data.queue_id           = queueId;
+    data.event              = SAI_QUEUE_PFC_DEADLOCK_EVENT_TYPE_DETECTED;
+    data.app_managed_recovery = true;
+    gPfcWdHwOrch->onQueuePfcDeadlock(1, &data);
+
+    ASSERT_TRUE(gPfcWdHwOrch->isPortInStormedState(port));
+
+    // Test 1: Reject modify while stormed
+    auto consumer = dynamic_cast<Consumer *>(
+        gPfcWdHwOrch->getExecutor(CFG_PFC_WD_TABLE_NAME));
+    deque<KeyOpFieldsValuesTuple> entries;
+    entries.push_back({ "Ethernet0", "SET",
+        { { "action", "drop" }, { "detection_time", "400" },
+          { "restoration_time", "400" } } });
+    consumer->addToSync(entries);
+    static_cast<Orch *>(gPfcWdHwOrch)->doTask();
+
+    // Detection time must remain 200 ms (not 400) - modification rejected
+    ASSERT_EQ(_sai_port_dld_intervals.count(port.m_port_id), 1u);
+    ASSERT_EQ(_sai_port_dld_intervals[port.m_port_id], 200u);
+
+    // Test 2: Reject delete while stormed
+    deleteHwWdEntry("Ethernet0");
+
+    // Port must still be tracked - delete was rejected
+    ASSERT_EQ(gPfcWdHwOrch->m_hwWdPorts.count("Ethernet0"), 1u);
+}
+
+TEST_F(PfcWdHwOrchTest, QueueMapLifecycle)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+    gPfcWdHwOrch->createEntry("Ethernet0", { { "action", "drop" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+
+    Port port;
+    gPortsOrch->getPort("Ethernet0", port);
+    sai_object_id_t q3 = port.m_queue_ids[3];
+    sai_object_id_t q4 = port.m_queue_ids[4];
+
+    // Verify queue-to-port map is populated (TCs 3 and 4)
+    ASSERT_EQ(gPfcWdHwOrch->m_queueToPortMap.count(q3), 1u);
+    ASSERT_EQ(gPfcWdHwOrch->m_queueToPortMap.count(q4), 1u);
+    ASSERT_EQ(gPfcWdHwOrch->m_queueToPortMap[q3].port_alias, "Ethernet0");
+    ASSERT_EQ(gPfcWdHwOrch->m_queueToPortMap[q3].queue_index, 3u);
+
+    deleteHwWdEntry("Ethernet0");
+
+    // Verify queue-to-port map is cleared after deletion
+    ASSERT_EQ(gPfcWdHwOrch->m_queueToPortMap.count(q3), 0u);
+    ASSERT_EQ(gPfcWdHwOrch->m_queueToPortMap.count(q4), 0u);
+}
+
+TEST_F(PfcWdHwOrchTest, SAIFailureSwitchAction)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+
+    // Inject failure for SAI_SWITCH_ATTR_PFC_DLR_PACKET_ACTION
+    _sai_fail_switch_dlr_packet_action = true;
+
+    auto status = gPfcWdHwOrch->createEntry("Ethernet0",
+        { { "action", "drop" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+
+    // Verify entry creation failed
+    ASSERT_NE(status, task_process_status::task_success);
+
+    // Verify clean state: port not added to m_hwWdPorts
+    ASSERT_EQ(gPfcWdHwOrch->m_hwWdPorts.count("Ethernet0"), 0u);
+
+    Port port;
+    gPortsOrch->getPort("Ethernet0", port);
+
+    // Verify clean state: no intervals set on port
+    ASSERT_EQ(_sai_port_dld_intervals.count(port.m_port_id), 0u);
+    ASSERT_EQ(_sai_port_dlr_intervals.count(port.m_port_id), 0u);
+
+    // Verify clean state: DLDR not enabled on queues
+    for (auto queueId : port.m_queue_ids)
+    {
+        ASSERT_FALSE(_sai_queue_dldr_enabled[queueId]);
+    }
+
+    // Verify STATE_DB reports failure status
+    vector<FieldValueTuple> fvs;
+    ASSERT_TRUE(gPfcWdHwOrch->m_pfcWdHwStateTable->get("Ethernet0", fvs));
+    map<string, string> fields(fvs.begin(), fvs.end());
+    ASSERT_EQ(fields["status"], "failed");
+    ASSERT_EQ(fields["recovery_type"], "hardware");
+
+    resetPfcWdFailureFlags();
+}
+
+TEST_F(PfcWdHwOrchTest, SAIFailureDldInterval)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+
+    // Inject failure for SAI_PORT_ATTR_PFC_TC_DLD_INTERVAL
+    _sai_fail_port_dld_interval = true;
+
+    auto status = gPfcWdHwOrch->createEntry("Ethernet0",
+        { { "action", "drop" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+
+    // Verify entry creation failed
+    ASSERT_NE(status, task_process_status::task_success);
+
+    // Verify clean state: port not added to m_hwWdPorts
+    ASSERT_EQ(gPfcWdHwOrch->m_hwWdPorts.count("Ethernet0"), 0u);
+
+    Port port;
+    gPortsOrch->getPort("Ethernet0", port);
+
+    // Verify clean state: no DLD interval set
+    ASSERT_EQ(_sai_port_dld_intervals.count(port.m_port_id), 0u);
+
+    // Verify clean state: no DLR interval set (rollback)
+    ASSERT_EQ(_sai_port_dlr_intervals.count(port.m_port_id), 0u);
+
+    // Verify clean state: DLDR not enabled on queues (rollback)
+    for (auto queueId : port.m_queue_ids)
+    {
+        ASSERT_FALSE(_sai_queue_dldr_enabled[queueId]);
+    }
+
+    // Verify clean state: switch action not set (rollback)
+    ASSERT_EQ(_sai_switch_dlr_packet_action, 0u);
+
+    // Verify STATE_DB reports failure status
+    vector<FieldValueTuple> fvs;
+    ASSERT_TRUE(gPfcWdHwOrch->m_pfcWdHwStateTable->get("Ethernet0", fvs));
+    map<string, string> fields(fvs.begin(), fvs.end());
+    ASSERT_EQ(fields["status"], "failed");
+    ASSERT_EQ(fields["recovery_type"], "hardware");
+
+    resetPfcWdFailureFlags();
+}
+
+TEST_F(PfcWdHwOrchTest, SAIFailureDlrInterval)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+
+    // Inject failure for SAI_PORT_ATTR_PFC_TC_DLR_INTERVAL
+    _sai_fail_port_dlr_interval = true;
+
+    auto status = gPfcWdHwOrch->createEntry("Ethernet0",
+        { { "action", "drop" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+
+    // Verify entry creation failed
+    ASSERT_NE(status, task_process_status::task_success);
+
+    // Verify clean state: port not added to m_hwWdPorts
+    ASSERT_EQ(gPfcWdHwOrch->m_hwWdPorts.count("Ethernet0"), 0u);
+
+    Port port;
+    gPortsOrch->getPort("Ethernet0", port);
+
+    // Verify clean state: no DLR interval set
+    ASSERT_EQ(_sai_port_dlr_intervals.count(port.m_port_id), 0u);
+
+    // Verify clean state: DLD interval rolled back
+    ASSERT_EQ(_sai_port_dld_intervals.count(port.m_port_id), 0u);
+
+    // Verify clean state: DLDR not enabled on queues (rollback)
+    for (auto queueId : port.m_queue_ids)
+    {
+        ASSERT_FALSE(_sai_queue_dldr_enabled[queueId]);
+    }
+
+    // Verify clean state: switch action rolled back
+    ASSERT_EQ(_sai_switch_dlr_packet_action, 0u);
+
+    // Verify STATE_DB reports failure status
+    vector<FieldValueTuple> fvs;
+    ASSERT_TRUE(gPfcWdHwOrch->m_pfcWdHwStateTable->get("Ethernet0", fvs));
+    map<string, string> fields(fvs.begin(), fvs.end());
+    ASSERT_EQ(fields["status"], "failed");
+    ASSERT_EQ(fields["recovery_type"], "hardware");
+
+    resetPfcWdFailureFlags();
+}
+
+TEST_F(PfcWdHwOrchTest, SAIFailureQueueDldr)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+
+    // Inject failure for SAI_QUEUE_ATTR_ENABLE_PFC_DLDR
+    _sai_fail_queue_dldr_enable = true;
+
+    auto status = gPfcWdHwOrch->createEntry("Ethernet0",
+        { { "action", "drop" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+
+    // Verify entry creation failed
+    ASSERT_NE(status, task_process_status::task_success);
+
+    // Verify clean state: port not added to m_hwWdPorts
+    ASSERT_EQ(gPfcWdHwOrch->m_hwWdPorts.count("Ethernet0"), 0u);
+
+    Port port;
+    gPortsOrch->getPort("Ethernet0", port);
+
+    // Verify clean state: DLDR not enabled on any queue
+    for (auto queueId : port.m_queue_ids)
+    {
+        ASSERT_FALSE(_sai_queue_dldr_enabled[queueId]);
+    }
+
+    // Verify clean state: intervals rolled back
+    ASSERT_EQ(_sai_port_dld_intervals.count(port.m_port_id), 0u);
+    ASSERT_EQ(_sai_port_dlr_intervals.count(port.m_port_id), 0u);
+
+    // Verify clean state: switch action rolled back
+    ASSERT_EQ(_sai_switch_dlr_packet_action, 0u);
+
+    // Verify STATE_DB reports failure status
+    vector<FieldValueTuple> fvs;
+    ASSERT_TRUE(gPfcWdHwOrch->m_pfcWdHwStateTable->get("Ethernet0", fvs));
+    map<string, string> fields(fvs.begin(), fvs.end());
+    ASSERT_EQ(fields["status"], "failed");
+    ASSERT_EQ(fields["recovery_type"], "hardware");
+
+    resetPfcWdFailureFlags();
+}
+
 }

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -6662,4 +6662,177 @@ TEST_F(PfcWdHwOrchTest, SAIFailureQueueDldr)
     resetPfcWdFailureFlags();
 }
 
+TEST_F(PfcWdHwOrchTest, CallbackRegistered)
+{
+    // Verify callback was registered during PfcWdHwOrch construction
+    ASSERT_NE(_sai_captured_deadlock_callback, nullptr);
+
+    // Verify callback can be invoked
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+    gPfcWdHwOrch->createEntry("Ethernet0",
+        { { "action", "drop" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+
+    Port port;
+    gPortsOrch->getPort("Ethernet0", port);
+    sai_object_id_t queueId = port.m_queue_ids[3];
+
+    // Invoke the captured callback directly
+    sai_queue_deadlock_notification_data_t data;
+    data.queue_id = queueId;
+    data.event = SAI_QUEUE_PFC_DEADLOCK_EVENT_TYPE_DETECTED;
+    data.app_managed_recovery = true;
+
+    _sai_captured_deadlock_callback(1, &data);
+
+    // Verify callback executed successfully (stats updated)
+    string queueIdStr = sai_serialize_object_id(queueId);
+    auto stats = gPfcWdHwOrch->getQueueStats(queueIdStr);
+    ASSERT_EQ(stats.detectCount, 1u);
+}
+
+TEST_F(PfcWdHwOrchTest, DeadlockLifecycle)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+    gPfcWdHwOrch->createEntry("Ethernet0", { { "action", "drop" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+
+    Port port;
+    gPortsOrch->getPort("Ethernet0", port);
+    sai_object_id_t queueId = port.m_queue_ids[3];
+
+    string queueIdStr = sai_serialize_object_id(queueId);
+    sai_queue_deadlock_notification_data_t data;
+    data.queue_id           = queueId;
+    data.app_managed_recovery = true;
+
+    // Simulate DETECTED event from hardware
+    data.event = SAI_QUEUE_PFC_DEADLOCK_EVENT_TYPE_DETECTED;
+    gPfcWdHwOrch->onQueuePfcDeadlock(1, &data);
+
+    // Verify stats after detection
+    auto stats = gPfcWdHwOrch->getQueueStats(queueIdStr);
+    ASSERT_EQ(stats.detectCount, 1u);
+    ASSERT_FALSE(stats.operational);
+
+    // Simulate RECOVERED event from hardware
+    data.event = SAI_QUEUE_PFC_DEADLOCK_EVENT_TYPE_RECOVERED;
+    gPfcWdHwOrch->onQueuePfcDeadlock(1, &data);
+
+    // Verify stats after recovery
+    stats = gPfcWdHwOrch->getQueueStats(queueIdStr);
+    ASSERT_EQ(stats.detectCount, 1u);
+    ASSERT_EQ(stats.restoreCount, 1u);
+    ASSERT_TRUE(stats.operational);
+}
+
+TEST_F(PfcWdHwOrchTest, DeadlockCountsAccumulate)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+    gPfcWdHwOrch->createEntry("Ethernet0", { { "action", "drop" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+
+    Port port;
+    gPortsOrch->getPort("Ethernet0", port);
+    sai_object_id_t queueId = port.m_queue_ids[3];
+    string queueIdStr = sai_serialize_object_id(queueId);
+
+    // Storm DETECTED and RECOVERED three times each
+    sai_queue_deadlock_notification_data_t data;
+    data.queue_id = queueId;
+    data.app_managed_recovery = true;
+
+    for (int i = 0; i < 3; i++)
+    {
+        data.event = SAI_QUEUE_PFC_DEADLOCK_EVENT_TYPE_DETECTED;
+        gPfcWdHwOrch->onQueuePfcDeadlock(1, &data);
+        data.event = SAI_QUEUE_PFC_DEADLOCK_EVENT_TYPE_RECOVERED;
+        gPfcWdHwOrch->onQueuePfcDeadlock(1, &data);
+    }
+
+    auto stats = gPfcWdHwOrch->getQueueStats(queueIdStr);
+    ASSERT_EQ(stats.detectCount,  3u);
+    ASSERT_EQ(stats.restoreCount, 3u);
+}
+
+TEST_F(PfcWdHwOrchTest, UnknownQueueHandled)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+    gPfcWdHwOrch->createEntry("Ethernet0", { { "action", "drop" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+
+    // Use a queue ID that is not in m_queueToPortMap
+    sai_object_id_t unknownQueueId = 0xDEADBEEF;
+    ASSERT_EQ(gPfcWdHwOrch->m_queueToPortMap.count(unknownQueueId), 0u);
+
+    sai_queue_deadlock_notification_data_t data;
+    data.queue_id           = unknownQueueId;
+    data.event              = SAI_QUEUE_PFC_DEADLOCK_EVENT_TYPE_DETECTED;
+    data.app_managed_recovery = true;
+
+    // Must not crash, stats will not be created but no port info
+    ASSERT_NO_FATAL_FAILURE(gPfcWdHwOrch->onQueuePfcDeadlock(1, &data));
+
+    string queueIdStr = sai_serialize_object_id(unknownQueueId);
+    auto stats = gPfcWdHwOrch->getQueueStats(queueIdStr);
+    ASSERT_EQ(stats.detectCount, 0u);
+}
+
+TEST_F(PfcWdHwOrchTest, MultipleEventsHandled)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+    gPfcWdHwOrch->createEntry("Ethernet0", { { "action", "drop" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+
+    Port port;
+    gPortsOrch->getPort("Ethernet0", port);
+    sai_object_id_t queueId3 = port.m_queue_ids[3];
+    sai_object_id_t queueId4 = port.m_queue_ids[4];
+
+    // Single callback invocation with two events
+    sai_queue_deadlock_notification_data_t data[2];
+    data[0].queue_id           = queueId3;
+    data[0].event              = SAI_QUEUE_PFC_DEADLOCK_EVENT_TYPE_DETECTED;
+    data[0].app_managed_recovery = true;
+    data[1].queue_id           = queueId4;
+    data[1].event              = SAI_QUEUE_PFC_DEADLOCK_EVENT_TYPE_DETECTED;
+    data[1].app_managed_recovery = true;
+
+    gPfcWdHwOrch->onQueuePfcDeadlock(2, data);
+
+    auto stats3 = gPfcWdHwOrch->getQueueStats(sai_serialize_object_id(queueId3));
+    auto stats4 = gPfcWdHwOrch->getQueueStats(sai_serialize_object_id(queueId4));
+    ASSERT_EQ(stats3.detectCount, 1u);
+    ASSERT_EQ(stats4.detectCount, 1u);
+}
+
+TEST_F(PfcWdHwOrchTest, StatsPreservedOnReconfig)
+{
+    bringUpPorts();
+    enablePfcOnPort("Ethernet0");
+    gPfcWdHwOrch->createEntry("Ethernet0", { { "action", "drop" }, { "detection_time", "200" }, { "restoration_time", "200" } });
+
+    Port port;
+    gPortsOrch->getPort("Ethernet0", port);
+    sai_object_id_t queueId = port.m_queue_ids[3];
+
+    // Record a detection event
+    sai_queue_deadlock_notification_data_t data;
+    data.queue_id           = queueId;
+    data.event              = SAI_QUEUE_PFC_DEADLOCK_EVENT_TYPE_DETECTED;
+    data.app_managed_recovery = true;
+    gPfcWdHwOrch->onQueuePfcDeadlock(1, &data);
+    data.event              = SAI_QUEUE_PFC_DEADLOCK_EVENT_TYPE_RECOVERED;
+    gPfcWdHwOrch->onQueuePfcDeadlock(1, &data);
+
+    // Reconfigure
+    gPfcWdHwOrch->createEntry("Ethernet0", { { "action", "drop" }, { "detection_time", "300" }, { "restoration_time", "300" } });
+
+    // detectCount must survive the reconfigure
+    string queueIdStr = sai_serialize_object_id(queueId);
+    auto stats = gPfcWdHwOrch->getQueueStats(queueIdStr);
+    ASSERT_EQ(stats.detectCount, 1u);
+    ASSERT_EQ(stats.restoreCount, 1u);
+}
+
 }


### PR DESCRIPTION
#### Why I did it

Splits the counter handling for the hardware PFC watchdog out of #4412 so that
PR stays about orchestration only, and the counter work can be reviewed on its
own together with its tests.

Depends on #4412.

#### How I did it

Carries the counter side of `PfcWdHwOrch`:

- `readHwCounters()` reads the hardware counters for a queue
- `initQueueCounters()` takes the baseline when the hardware reports a storm
- `updateQueueCounters()` updates on recovery and on the periodic poll
- `getQueueStats()` / `updateQueueStats()` for the COUNTERS_DB round trip
- `initializeQueueStats()` registers a port's lossless queues
- the dedicated PFC_WD FlexCounter group and its per-queue registration
- the poll timer and `doTask()`
- `SAI_QUEUE_STAT_DROPPED_PACKETS` and `SAI_INGRESS_PRIORITY_GROUP_STAT_PACKETS`

and adds `tests/mock_tests/pfcwdhw_counters_ut.cpp` covering the baseline,
recovery and periodic paths and the COUNTERS_DB round trip.

The unification of the counter structures with `PfcWdActionHandler` is being
validated internally and will follow here, so the review has data behind it.

#### How to verify it

`make check` in `tests/mock_tests` runs `pfcwdhw_counters_ut`.

Hardware verification on NH-4010 (Golden Eagle) is in progress.

#### Which release branch to backport

None.