### PR TITLE
[fpmsyncd/fdbsyncd]: Add FDB synchronization over the FPM channel

### DIFF
--- a/fdbsyncd/fdbsync.cpp
+++ b/fdbsyncd/fdbsync.cpp
@@ -679,6 +679,14 @@ void FdbSync::updateMclagRemoteMacPort(int ifindex, int vlan, std::string mac, u
  */
 void FdbSync::macRefreshStateDB(int vlan, string kmac, uint8_t protocol)
 {
+    /* Reached from onMsgNbr() ahead of its own fpm check: in fpm mode the kernel
+     * bridge is not the transport, so refreshing it there is both useless and a
+     * process spawn per MAC. */
+    if (m_fpmMacSync)
+    {
+        return;
+    }
+
     string key = "Vlan" + to_string(vlan) + ":" + kmac;
     char *type;
     string port_name = "";

--- a/fdbsyncd/fdbsync.cpp
+++ b/fdbsyncd/fdbsync.cpp
@@ -1239,6 +1239,14 @@ void FdbSync::onMsg(int nlmsg_type, struct nl_object *obj)
 
 void FdbSync::onMsgNhg(struct nlmsghdr *msg)
 {
+    /* fpmsyncd publishes these straight from the FPM channel in this mode.
+     * Leaving both in place would have two writers racing on the cascade a
+     * withdrawn member triggers. */
+    if (m_fpmMacSync)
+    {
+        return;
+    }
+
     if (!m_isEvpnNvoExist)
     {
         SWSS_LOG_DEBUG("EVPN NVO is not configured, skipping L2 nexthop group message");

--- a/fdbsyncd/fdbsync.cpp
+++ b/fdbsyncd/fdbsync.cpp
@@ -35,15 +35,86 @@ FdbSync::FdbSync(RedisPipeline *pipelineAppDB, DBConnector *stateDb, DBConnector
     m_l2NhgTable(pipelineAppDB, APP_L2_NEXTHOP_GROUP_TABLE_NAME),
     m_fdbStateTable(stateDb, STATE_FDB_TABLE_NAME),
     m_mclagRemoteFdbStateTable(stateDb, STATE_MCLAG_REMOTE_FDB_TABLE_NAME),
-    m_cfgEvpnNvoTable(config_db, CFG_VXLAN_EVPN_NVO_TABLE_NAME)
+    m_cfgEvpnNvoTable(config_db, CFG_VXLAN_EVPN_NVO_TABLE_NAME),
+    m_cfgFdbSyncTable(config_db, CFG_FDB_SYNC_TABLE_NAME),
+    m_cfgFdbSyncTableRead(config_db, CFG_FDB_SYNC_TABLE_NAME)
 {
+    readCfgFdbSyncMode();
+
     m_AppRestartAssist = new AppRestartAssist(pipelineAppDB, "fdbsyncd", "swss", DEFAULT_FDBSYNC_WARMSTART_TIMER);
     if (m_AppRestartAssist)
     {
-        m_AppRestartAssist->registerAppTable(APP_VXLAN_FDB_TABLE_NAME, &m_fdbTable);
+        /*
+         * Only the producer of a table may drive its warm-restart
+         * reconciliation: reconcile() deletes every entry left STALE. In FPM
+         * mode fpmsyncd produces APP_VXLAN_FDB_TABLE, so registering it here
+         * would delete all remote MACs across a warm reboot.
+         */
+        if (!m_fpmMacSync)
+        {
+            m_AppRestartAssist->registerAppTable(APP_VXLAN_FDB_TABLE_NAME, &m_fdbTable);
+        }
         m_AppRestartAssist->registerAppTable(APP_VXLAN_REMOTE_VNI_TABLE_NAME, &m_imetTable);
     }
-    m_isFdbProtoSupported = checkFdbProtoSupport();
+    m_isFdbProtoSupported = m_fpmMacSync ? false : checkFdbProtoSupport();
+}
+
+void FdbSync::readCfgFdbSyncMode()
+{
+    string mode;
+
+    if (m_cfgFdbSyncTableRead.hget("global", "mac_sync_mode", mode))
+    {
+        setMacSyncMode(mode);
+    }
+}
+
+void FdbSync::setMacSyncMode(const string& mode)
+{
+    bool fpmMacSync = (mode == "fpm");
+
+    if (fpmMacSync == m_fpmMacSync)
+    {
+        return;
+    }
+
+    m_fpmMacSync = fpmMacSync;
+    SWSS_LOG_NOTICE("FdbSync: mac_sync_mode is now %s", m_fpmMacSync ? "fpm" : "kernel");
+
+    if (!m_fpmMacSync)
+    {
+        m_isFdbProtoSupported = checkFdbProtoSupport();
+        updateAllLocalMac();
+    }
+}
+
+void FdbSync::processCfgFdbSync()
+{
+    std::deque<KeyOpFieldsValuesTuple> entries;
+
+    m_cfgFdbSyncTable.pops(entries);
+
+    for (auto& entry : entries)
+    {
+        if (kfvKey(entry) != "global")
+        {
+            continue;
+        }
+
+        if (kfvOp(entry) != SET_COMMAND)
+        {
+            setMacSyncMode("");
+            continue;
+        }
+
+        for (auto& fv : kfvFieldsValues(entry))
+        {
+            if (fvField(fv) == "mac_sync_mode")
+            {
+                setMacSyncMode(fvValue(fv));
+            }
+        }
+    }
 }
 
 FdbSync::~FdbSync()
@@ -406,6 +477,13 @@ void FdbSync::updateLocalMac (struct m_fdb_info *info)
         return;
     }
 
+    if (m_fpmMacSync)
+    {
+        /* fpmsyncd carries local MACs to zebra over FPM in this mode. */
+        SWSS_LOG_INFO("Ignore kernel update, MAC sync runs over FPM, MAC %s", key.c_str());
+        return;
+    }
+
     if (fdb_type == FDB_TYPE_DYNAMIC)
     {
         type = "dynamic extern_learn";
@@ -453,6 +531,11 @@ void FdbSync::addLocalMac(string key, string op)
     string vlan = "";
     size_t str_loc = string::npos;
     std::string proto_string = "";
+
+    if (m_fpmMacSync)
+    {
+        return;
+    }
 
     str_loc = key.find(":");
     if (str_loc == string::npos)
@@ -1083,6 +1166,17 @@ void FdbSync::onMsgNbr(int nlmsg_type, struct nl_object *obj, struct nlmsghdr *h
     key += vlan_id;
     key += ":";
     key += macStr;
+
+    /*
+     * Only unicast MACs move to the FPM channel. IMET/remote-VNI handling
+     * above still comes from the kernel, so the gate cannot sit on the whole
+     * neighbour path.
+     */
+    if (m_fpmMacSync)
+    {
+        SWSS_LOG_INFO("Ignore kernel remote MAC, MAC sync runs over FPM, key %s", key.c_str());
+        return;
+    }
 
     if (!delete_key)
     {

--- a/fdbsyncd/fdbsync.cpp
+++ b/fdbsyncd/fdbsync.cpp
@@ -25,9 +25,6 @@ using namespace std;
 using namespace swss;
 
 #define VXLAN_BR_IF_NAME_PREFIX    "Brvxlan"
-#ifndef RTPROT_HW
-#define RTPROT_HW 193  /* Protocol ID for hardware learned routes */
-#endif
 
 FdbSync::FdbSync(RedisPipeline *pipelineAppDB, DBConnector *stateDb, DBConnector *config_db) :
     m_fdbTable(pipelineAppDB, APP_VXLAN_FDB_TABLE_NAME),
@@ -56,7 +53,6 @@ FdbSync::FdbSync(RedisPipeline *pipelineAppDB, DBConnector *stateDb, DBConnector
         }
         m_AppRestartAssist->registerAppTable(APP_VXLAN_REMOTE_VNI_TABLE_NAME, &m_imetTable);
     }
-    m_isFdbProtoSupported = m_fpmMacSync ? false : checkFdbProtoSupport();
 }
 
 void FdbSync::readCfgFdbSyncMode()
@@ -83,7 +79,6 @@ void FdbSync::setMacSyncMode(const string& mode)
 
     if (!m_fpmMacSync)
     {
-        m_isFdbProtoSupported = checkFdbProtoSupport();
         updateAllLocalMac();
     }
 }
@@ -123,31 +118,6 @@ FdbSync::~FdbSync()
     {
         delete m_AppRestartAssist;
     }
-}
-
-bool FdbSync::checkFdbProtoSupport()
-{
-    /* Test whether the local bridge command and kernel both support the
-     * exact proto syntax used below. Some iproute2 versions advertise a
-     * protocol field but still reject the "proto hw" spelling/name. */
-    std::string res;
-    int ret = swss::exec("bridge fdb help 2>&1 | grep -q proto", res);
-    if (ret != 0)
-    {
-        SWSS_LOG_NOTICE("bridge fdb proto support not detected");
-        return false;
-    }
-
-    ret = swss::exec("bridge fdb add 00:00:00:00:00:00 dev lo proto hw 2>/dev/null", res);
-    swss::exec("bridge fdb del 00:00:00:00:00:00 dev lo 2>/dev/null", res);
-    if (ret != 0)
-    {
-        SWSS_LOG_NOTICE("bridge fdb proto support not detected");
-        return false;
-    }
-
-    SWSS_LOG_NOTICE("bridge fdb proto support detected");
-    return true;
 }
 
 // Check if interface entries are restored in kernel
@@ -451,7 +421,6 @@ void FdbSync::updateLocalMac (struct m_fdb_info *info)
 {
     char *op;
     char *type;
-    std::string proto_string = "";
     string port_name = "";
     string key = info->vid + ":" + info->mac;
     short fdb_type;    /*dynamic or static*/
@@ -487,7 +456,6 @@ void FdbSync::updateLocalMac (struct m_fdb_info *info)
     if (fdb_type == FDB_TYPE_DYNAMIC)
     {
         type = "dynamic extern_learn";
-        proto_string = m_isFdbProtoSupported ? " proto hw" : "";
     }
     else
     {
@@ -496,7 +464,7 @@ void FdbSync::updateLocalMac (struct m_fdb_info *info)
 
     const std::string cmds = std::string("")
         + " bridge fdb " + op + " " + info->mac + " dev "
-        + port_name + " master " + type + " vlan " + info->vid.substr(4) + proto_string;
+        + port_name + " master " + type + " vlan " + info->vid.substr(4);
 
     std::string res;
     int ret = swss::exec(cmds, res);
@@ -530,7 +498,6 @@ void FdbSync::addLocalMac(string key, string op)
     string mac = "";
     string vlan = "";
     size_t str_loc = string::npos;
-    std::string proto_string = "";
 
     if (m_fpmMacSync)
     {
@@ -560,7 +527,6 @@ void FdbSync::addLocalMac(string key, string op)
         if (m_fdb_mac[key].type == FDB_TYPE_DYNAMIC)
         {
             type = "dynamic extern_learn";
-            proto_string = m_isFdbProtoSupported ? " proto hw" : "";
         }
         else
         {
@@ -569,8 +535,7 @@ void FdbSync::addLocalMac(string key, string op)
 
         const std::string cmds = std::string("")
                 + " bridge fdb " + op + " " + mac + " dev "
-                + port_name + " master " + type  + " vlan " + vlan
-                + proto_string;
+                + port_name + " master " + type  + " vlan " + vlan;
 
         std::string res;
         int ret = swss::exec(cmds, res);
@@ -591,7 +556,6 @@ void FdbSync::updateMclagRemoteMac (struct m_fdb_info *info)
     string port_name = "";
     string key = info->vid + ":" + info->mac;
     short fdb_type;    /*dynamic or static*/
-    std::string proto_string = "";
 
     if (info->op_type == FDB_OPER_ADD)
     {
@@ -611,7 +575,6 @@ void FdbSync::updateMclagRemoteMac (struct m_fdb_info *info)
     if (fdb_type == FDB_TYPE_DYNAMIC)
     {
         type = "dynamic extern_learn";
-        proto_string = m_isFdbProtoSupported ? " proto hw" : "";
     }
     else
     {
@@ -620,7 +583,7 @@ void FdbSync::updateMclagRemoteMac (struct m_fdb_info *info)
 
     const std::string cmds = std::string("")
         + " bridge fdb " + op + " " + info->mac + " dev "
-        + port_name + " master " + type + " vlan " + info->vid.substr(4) + proto_string;
+        + port_name + " master " + type + " vlan " + info->vid.substr(4);
 
     std::string res;
     int ret = swss::exec(cmds, res);
@@ -630,12 +593,11 @@ void FdbSync::updateMclagRemoteMac (struct m_fdb_info *info)
     return;
 }
 
-void FdbSync::updateMclagRemoteMacPort(int ifindex, int vlan, std::string mac, uint8_t protocol)
+void FdbSync::updateMclagRemoteMacPort(int ifindex, int vlan, std::string mac)
 {
     string key = "Vlan" + to_string(vlan) + ":" + mac;
     int type = 0;
     string port_name = "";
-    std::string proto_string = "";
 
     SWSS_LOG_INFO("Updating Intf %d, Vlan:%d MAC:%s Key %s", ifindex, vlan, mac.c_str(), key.c_str());
 
@@ -643,18 +605,13 @@ void FdbSync::updateMclagRemoteMacPort(int ifindex, int vlan, std::string mac, u
     {
         type = m_mclag_remote_fdb_mac[key].type;
         port_name = m_mclag_remote_fdb_mac[key].port_name;
-        if (protocol == RTPROT_ZEBRA)
-            proto_string = m_isFdbProtoSupported ? " proto zebra" : "";
-        else if (protocol == RTPROT_HW)
-            /* Unlikely this can happen, but keeping just in case */
-            proto_string = m_isFdbProtoSupported ? " proto hw" : "";
-        SWSS_LOG_INFO(" port %s, type %d %s\n", port_name.c_str(), type, proto_string.c_str());
+        SWSS_LOG_INFO(" port %s, type %d\n", port_name.c_str(), type);
 
         if (type == FDB_TYPE_STATIC)
         {
             const std::string cmds = std::string("")
                 + " bridge fdb replace" + " " + mac + " dev "
-                + port_name + " master static vlan " + to_string(vlan) + proto_string;
+                + port_name + " master static vlan " + to_string(vlan);
 
             std::string res;
             int ret = swss::exec(cmds, res);
@@ -677,7 +634,7 @@ void FdbSync::updateMclagRemoteMacPort(int ifindex, int vlan, std::string mac, u
  * If MAC is still present in the state DB cache then fdbsyncd will be 
  * re-programmed with MAC in the Kernel
  */
-void FdbSync::macRefreshStateDB(int vlan, string kmac, uint8_t protocol)
+void FdbSync::macRefreshStateDB(int vlan, string kmac)
 {
     /* Reached from onMsgNbr() ahead of its own fpm check: in fpm mode the kernel
      * bridge is not the transport, so refreshing it there is both useless and a
@@ -690,7 +647,6 @@ void FdbSync::macRefreshStateDB(int vlan, string kmac, uint8_t protocol)
     string key = "Vlan" + to_string(vlan) + ":" + kmac;
     char *type;
     string port_name = "";
-    std::string proto_string = "";
 
     SWSS_LOG_INFO("Refreshing Vlan:%d MAC route MAC:%s Key %s", vlan, kmac.c_str(), key.c_str());
 
@@ -712,14 +668,9 @@ void FdbSync::macRefreshStateDB(int vlan, string kmac, uint8_t protocol)
             type = "static";
         }
 
-        if (protocol == RTPROT_ZEBRA)
-            proto_string = m_isFdbProtoSupported ? " proto zebra" : "";
-        else if (protocol == RTPROT_HW)
-            proto_string = m_isFdbProtoSupported ? " proto hw" : "";
-
         const std::string cmds = std::string("")
             + " bridge fdb " + "replace" + " " + kmac + " dev "
-            + port_name + " master " + type  + " vlan " + to_string(vlan) + proto_string;
+            + port_name + " master " + type  + " vlan " + to_string(vlan);
 
         std::string res;
         int ret = swss::exec(cmds, res);
@@ -823,12 +774,10 @@ void FdbSync::macDelVxlanDB(string key)
     string type = m_mac[key].type;
     string vni = to_string(m_mac[key].vni);
     string ifname = m_mac[key].ifname;
-    string protocol = to_string(m_mac[key].protocol);
 
     FieldValueTuple t("type", type);
     FieldValueTuple v("vni", vni);
     FieldValueTuple f("ifname", ifname);
-    FieldValueTuple p("protocol", protocol);
 
     if (m_mac[key].nhtype == FdbDest::VTEP)
     {
@@ -836,8 +785,8 @@ void FdbSync::macDelVxlanDB(string key)
         string vtep = m_mac[key].nexthop_value;
         FieldValueTuple nh("remote_vtep", vtep);
         fvVector.push_back(nh);
-        SWSS_LOG_NOTICE("VXLAN_FDB_TABLE: DEL_KEY %s vtep:%s type:%s vni:%s protocol:%u",
-                        key.c_str(), vtep.c_str(), type.c_str(), vni.c_str(), m_mac[key].protocol);
+        SWSS_LOG_NOTICE("VXLAN_FDB_TABLE: DEL_KEY %s vtep:%s type:%s vni:%s",
+                        key.c_str(), vtep.c_str(), type.c_str(), vni.c_str());
     }
     else if (m_mac[key].nhtype == FdbDest::NEXTHOPGROUP)
     {
@@ -845,8 +794,8 @@ void FdbSync::macDelVxlanDB(string key)
         string nexthop_group = m_mac[key].nexthop_value;
         FieldValueTuple nh("nexthop_group", nexthop_group);
         fvVector.push_back(nh);
-        SWSS_LOG_NOTICE("VXLAN_FDB_TABLE: DEL_KEY %s nexthop_group:%s type:%s vni:%s protocol:%u",
-                        key.c_str(), nexthop_group.c_str(), type.c_str(), vni.c_str(), m_mac[key].protocol);
+        SWSS_LOG_NOTICE("VXLAN_FDB_TABLE: DEL_KEY %s nexthop_group:%s type:%s vni:%s",
+                        key.c_str(), nexthop_group.c_str(), type.c_str(), vni.c_str());
     }
     else if (m_mac[key].nhtype == FdbDest::IFNAME)
     {
@@ -854,14 +803,13 @@ void FdbSync::macDelVxlanDB(string key)
         string ifname = m_mac[key].nexthop_value;
         FieldValueTuple nh("ifname", ifname);
         fvVector.push_back(nh);
-        SWSS_LOG_INFO("VXLAN_FDB_TABLE: DEL_KEY %s ifname:%s type:%s vni:%s protocol:%u",
-                        key.c_str(), ifname.c_str(), type.c_str(), vni.c_str(), m_mac[key].protocol);
+        SWSS_LOG_INFO("VXLAN_FDB_TABLE: DEL_KEY %s ifname:%s type:%s vni:%s",
+                        key.c_str(), ifname.c_str(), type.c_str(), vni.c_str());
     }
 
     fvVector.push_back(t);
     fvVector.push_back(v);
     fvVector.push_back(f);
-    fvVector.push_back(p);
 
     // If warmstart is in progress, we take all netlink changes into the cache map
     if (m_AppRestartAssist && m_AppRestartAssist->isWarmStartInProgress())
@@ -876,7 +824,7 @@ void FdbSync::macDelVxlanDB(string key)
 }
 
 void FdbSync::macAddVxlan(string key, struct nl_addr *vtep, string type, uint32_t vni, string intf_name,
-     string nexthop_group, FdbDest dest_type, uint8_t protocol)
+     string nexthop_group, FdbDest dest_type)
 {
     std::vector<FieldValueTuple> fvVector;
     string svni = to_string(vni);
@@ -885,11 +833,9 @@ void FdbSync::macAddVxlan(string key, struct nl_addr *vtep, string type, uint32_
     m_mac[key].type = type;
     m_mac[key].vni = vni;
     m_mac[key].ifname = intf_name;
-    m_mac[key].protocol = protocol;
 
     FieldValueTuple fv_type("type", type);
     FieldValueTuple fv_vni("vni", svni);
-    FieldValueTuple fv_protocol("protocol", to_string(protocol));
 
     if (dest_type == FdbDest::NEXTHOPGROUP)
     {
@@ -899,8 +845,8 @@ void FdbSync::macAddVxlan(string key, struct nl_addr *vtep, string type, uint32_
         m_mac[key].nexthop_value = nexthop_group;
         FieldValueTuple nh("nexthop_group", nexthop_group);
         fvVector.push_back(nh);
-        SWSS_LOG_INFO("VXLAN_FDB_TABLE: ADD_KEY %s nexthop_group:%s type:%s vni:%s ifname:%s protocol:%u",
-                      key.c_str(), nexthop_group.c_str(), type.c_str(), svni.c_str(), intf_name.c_str(), protocol);
+        SWSS_LOG_INFO("VXLAN_FDB_TABLE: ADD_KEY %s nexthop_group:%s type:%s vni:%s ifname:%s",
+                      key.c_str(), nexthop_group.c_str(), type.c_str(), svni.c_str(), intf_name.c_str());
     }
     else if (dest_type == FdbDest::VTEP)
     {
@@ -912,8 +858,8 @@ void FdbSync::macAddVxlan(string key, struct nl_addr *vtep, string type, uint32_
         m_mac[key].nexthop_value = svtep;
         FieldValueTuple nh("remote_vtep", svtep);
         fvVector.push_back(nh);
-        SWSS_LOG_INFO("VXLAN_FDB_TABLE: ADD_KEY %s vtep:%s type:%s vni:%s ifname:%s protocol:%u",
-                      key.c_str(), svtep.c_str(), type.c_str(), svni.c_str(), intf_name.c_str(), protocol);
+        SWSS_LOG_INFO("VXLAN_FDB_TABLE: ADD_KEY %s vtep:%s type:%s vni:%s ifname:%s",
+                      key.c_str(), svtep.c_str(), type.c_str(), svni.c_str(), intf_name.c_str());
     }
     else if (dest_type == FdbDest::IFNAME)
     {
@@ -923,8 +869,8 @@ void FdbSync::macAddVxlan(string key, struct nl_addr *vtep, string type, uint32_
         m_mac[key].nexthop_value = intf_name;
         FieldValueTuple fv_ifname("ifname", intf_name);
         fvVector.push_back(fv_ifname);
-        SWSS_LOG_INFO("VXLAN_FDB_TABLE: ADD_KEY %s ifname:%s type:%s vni:%s ifname:%s protocol:%u",
-                      key.c_str(), intf_name.c_str(), type.c_str(), svni.c_str(), intf_name.c_str(), protocol);
+        SWSS_LOG_INFO("VXLAN_FDB_TABLE: ADD_KEY %s ifname:%s type:%s vni:%s ifname:%s",
+                      key.c_str(), intf_name.c_str(), type.c_str(), svni.c_str(), intf_name.c_str());
     } else {
         SWSS_LOG_ERROR("VXLAN_FDB_TABLE: dest_type:%d is invalid, ADD_KEY %s type:%s vni:%s ifname:%s",
                 static_cast<int>(dest_type), key.c_str(), type.c_str(), svni.c_str(), intf_name.c_str());
@@ -933,10 +879,6 @@ void FdbSync::macAddVxlan(string key, struct nl_addr *vtep, string type, uint32_
 
     fvVector.push_back(fv_type);
     fvVector.push_back(fv_vni);
-    if (protocol != RTPROT_UNSPEC)
-    {
-        fvVector.push_back(fv_protocol);
-    }
 
     // If warmstart is in progress, we take all netlink changes into the cache map
     if (m_AppRestartAssist && m_AppRestartAssist->isWarmStartInProgress())
@@ -956,25 +898,25 @@ void FdbSync::macDelVxlan(string key)
     {
         if (m_mac[key].nhtype == FdbDest::VTEP)
         {
-            SWSS_LOG_INFO("DEL_KEY %s vtep:%s type:%s vni:%s ifname:%s protocol:%u", key.c_str(),
+            SWSS_LOG_INFO("DEL_KEY %s vtep:%s type:%s vni:%s ifname:%s", key.c_str(),
                            m_mac[key].nexthop_value.c_str(), m_mac[key].type.c_str(),
-                           to_string(m_mac[key].vni).c_str(), m_mac[key].ifname.c_str(), m_mac[key].protocol);
+                           to_string(m_mac[key].vni).c_str(), m_mac[key].ifname.c_str());
         }
         else if (m_mac[key].nhtype == FdbDest::NEXTHOPGROUP)
         {
-            SWSS_LOG_INFO("DEL_KEY %s nexthop:%s type:%s vni:%s ifname:%s protocol:%u", key.c_str(),
+            SWSS_LOG_INFO("DEL_KEY %s nexthop:%s type:%s vni:%s ifname:%s", key.c_str(),
                            m_mac[key].nexthop_value.c_str(), m_mac[key].type.c_str(),
-                           to_string(m_mac[key].vni).c_str(), m_mac[key].ifname.c_str(), m_mac[key].protocol);
+                           to_string(m_mac[key].vni).c_str(), m_mac[key].ifname.c_str());
         }
         else if (m_mac[key].nhtype == FdbDest::IFNAME)
         {
-            SWSS_LOG_INFO("DEL_KEY %s ifname:%s type:%s vni:%s protocol:%u", key.c_str(),
+            SWSS_LOG_INFO("DEL_KEY %s ifname:%s type:%s vni:%s", key.c_str(),
                            m_mac[key].nexthop_value.c_str(), m_mac[key].type.c_str(),
-                           to_string(m_mac[key].vni).c_str(), m_mac[key].protocol);
+                           to_string(m_mac[key].vni).c_str());
         }
         else {
-            SWSS_LOG_ERROR("DEL_KEY %s type: %s vni:%s ifname:%s protocol:%u, entry nhtype is invalid, nhtype: %d", key.c_str(),
-                m_mac[key].type.c_str(), to_string(m_mac[key].vni).c_str(), m_mac[key].ifname.c_str(), m_mac[key].protocol, static_cast<int>(m_mac[key].nhtype));
+            SWSS_LOG_ERROR("DEL_KEY %s type: %s vni:%s ifname:%s, entry nhtype is invalid, nhtype: %d", key.c_str(),
+                m_mac[key].type.c_str(), to_string(m_mac[key].vni).c_str(), m_mac[key].ifname.c_str(), static_cast<int>(m_mac[key].nhtype));
 
         }
         macDelVxlanDB(key);
@@ -1069,7 +1011,7 @@ void FdbSync::onMsgNbr(int nlmsg_type, struct nl_object *obj, struct nlmsghdr *h
             int vid = rtnl_neigh_get_vlan(neigh);
             if (state & NUD_PERMANENT)
             {
-                updateMclagRemoteMacPort(ifindex, vid, macStr, RTPROT_UNSPEC);
+                updateMclagRemoteMacPort(ifindex, vid, macStr);
             }
         }
 
@@ -1103,7 +1045,7 @@ void FdbSync::onMsgNbr(int nlmsg_type, struct nl_object *obj, struct nlmsghdr *h
         vlan = rtnl_neigh_get_vlan(neigh);
         if (m_isEvpnNvoExist)
         {
-            macRefreshStateDB(vlan, macStr, RTPROT_UNSPEC);
+            macRefreshStateDB(vlan, macStr);
         }
         return;
     }
@@ -1188,7 +1130,7 @@ void FdbSync::onMsgNbr(int nlmsg_type, struct nl_object *obj, struct nlmsghdr *h
 
     if (!delete_key)
     {
-        macAddVxlan(key, vtep_addr, type, vni, ifname, nexthop_group, dest_type, RTPROT_UNSPEC);
+        macAddVxlan(key, vtep_addr, type, vni, ifname, nexthop_group, dest_type);
     }
     else
     {

--- a/fdbsyncd/fdbsync.h
+++ b/fdbsyncd/fdbsync.h
@@ -8,6 +8,7 @@
 #include "dbconnector.h"
 #include "producerstatetable.h"
 #include "subscriberstatetable.h"
+#include "table.h"
 #include "netmsg.h"
 #include "warmRestartAssist.h"
 #include "lib/fdb_defs.h"
@@ -78,11 +79,24 @@ public:
         return &m_cfgEvpnNvoTable;
     }
 
+    SubscriberStateTable *getCfgFdbSyncTable()
+    {
+        return &m_cfgFdbSyncTable;
+    }
+
     void processStateFdb();
 
     void processStateMclagRemoteFdb();
 
     void processCfgEvpnNvo();
+
+    void processCfgFdbSync();
+
+    /* True when fpmsyncd owns MAC synchronization over the FPM channel. */
+    bool isFpmMacSync() const
+    {
+        return m_fpmMacSync;
+    }
 
     bool m_reconcileDone = false;
 
@@ -91,6 +105,10 @@ public:
 private:
     bool m_isFdbProtoSupported = false;
     bool checkFdbProtoSupport();
+    void readCfgFdbSyncMode();
+    void setMacSyncMode(const std::string& mode);
+
+    bool m_fpmMacSync = false;
 
     ProducerStateTable m_fdbTable;
     ProducerStateTable m_imetTable;
@@ -99,6 +117,8 @@ private:
     SubscriberStateTable m_mclagRemoteFdbStateTable;
     AppRestartAssist  *m_AppRestartAssist;
     SubscriberStateTable m_cfgEvpnNvoTable;
+    SubscriberStateTable m_cfgFdbSyncTable;
+    Table m_cfgFdbSyncTableRead;
 
     struct m_local_fdb_info
     {

--- a/fdbsyncd/fdbsync.h
+++ b/fdbsyncd/fdbsync.h
@@ -103,8 +103,6 @@ public:
     bool m_isEvpnNvoExist = false;
 
 private:
-    bool m_isFdbProtoSupported = false;
-    bool checkFdbProtoSupport();
     void readCfgFdbSyncMode();
     void setMacSyncMode(const std::string& mode);
 
@@ -139,11 +137,11 @@ private:
 
     void updateAllLocalMac();
 
-    void macRefreshStateDB(int vlan, std::string kmac, uint8_t protocol);
+    void macRefreshStateDB(int vlan, std::string kmac);
 
     void updateMclagRemoteMac(struct m_fdb_info *info);
 
-    void updateMclagRemoteMacPort(int ifindex, int vlan, std::string mac, uint8_t protocol);
+    void updateMclagRemoteMacPort(int ifindex, int vlan, std::string mac);
 
     void macUpdateMclagRemoteCache(struct m_fdb_info *info);
 
@@ -157,7 +155,6 @@ private:
         std::string type;
         unsigned int vni;
         std::string ifname;
-        uint8_t protocol;
 
         // Nexthop destination value - interpretation depends on nhtype:
         // - nhtype == VTEP: contains remote VTEP IP address
@@ -181,7 +178,7 @@ private:
     std::unordered_map<int, intf> m_intf_info;
 
     void addLocalMac(std::string key, std::string op);
-    void macAddVxlan(std::string key, struct nl_addr *vtep, std::string type, uint32_t vni, std::string intf_name, std::string nexthop_group, FdbDest dest_type, uint8_t protocol);
+    void macAddVxlan(std::string key, struct nl_addr *vtep, std::string type, uint32_t vni, std::string intf_name, std::string nexthop_group, FdbDest dest_type);
     void macDelVxlan(std::string auxkey);
     void macDelVxlanDB(std::string key);
     void imetAddRoute(struct nl_addr *vtep, std::string ifname, uint32_t vni);

--- a/fdbsyncd/fdbsyncd.cpp
+++ b/fdbsyncd/fdbsyncd.cpp
@@ -98,6 +98,7 @@ int main(int argc, char **argv)
             s.addSelectable(sync.getFdbStateTable());
             s.addSelectable(sync.getMclagRemoteFdbStateTable());
             s.addSelectable(sync.getCfgEvpnNvoTable());
+            s.addSelectable(sync.getCfgFdbSyncTable());
             while (true)
             {
                 s.select(&temps);
@@ -113,6 +114,10 @@ int main(int argc, char **argv)
                 else if (temps == (Selectable *)sync.getCfgEvpnNvoTable())
                 {
                     sync.processCfgEvpnNvo();
+                }
+                else if (temps == (Selectable *)sync.getCfgFdbSyncTable())
+                {
+                    sync.processCfgFdbSync();
                 }
                 else if (temps == &replayCheckTimer)
                 {

--- a/fpmsyncd/Makefile.am
+++ b/fpmsyncd/Makefile.am
@@ -8,7 +8,7 @@ else
 DBGFLAGS = -g
 endif
 
-fpmsyncd_SOURCES = fpmsyncd.cpp fpmlink.cpp routesync.cpp $(top_srcdir)/warmrestart/warmRestartHelper.cpp \
+fpmsyncd_SOURCES = fpmsyncd.cpp fpmlink.cpp routesync.cpp macsync.cpp $(top_srcdir)/warmrestart/warmRestartHelper.cpp \
                     $(top_srcdir)/lib/orch_zmq_config.cpp
 
 fpmsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)

--- a/fpmsyncd/fpm/fpm.h
+++ b/fpmsyncd/fpm/fpm.h
@@ -169,7 +169,16 @@ typedef enum {
   RTM_FPM_ADD_EVPN_ES_BACKUP_NHG,
   /* Notify FPM about a delete of a backup NHG */
   RTM_FPM_DEL_EVPN_ES_BACKUP_NHG,
-  RTM_FPM_LAST = RTM_FPM_DEL_EVPN_ES_BACKUP_NHG,
+  /*
+   * End of a MAC replay generation. nlmsg_seq carries the generation.
+   *
+   * Pinned to an explicit value: this enum and the zebra copy in
+   * zebra/kernel_netlink.h have drifted (zebra lacks the two
+   * ES_BACKUP_NHG values), so a positional value would not match on
+   * the wire. 147 and 148 stay reserved for the ES_BACKUP_NHG pair.
+   */
+  RTM_FPM_MAC_REPLAY_END = 149,
+  RTM_FPM_LAST = RTM_FPM_MAC_REPLAY_END,
   RTM_FPM_MAX = RTM_FPM_LAST
 } rtm_fpm_msg_types_et;
 

--- a/fpmsyncd/fpm/fpm.h
+++ b/fpmsyncd/fpm/fpm.h
@@ -172,6 +172,11 @@ typedef enum {
   /*
    * End of a MAC replay generation. nlmsg_seq carries the generation.
    *
+   * Generation 0 is never handed out by a replay and means the sender no
+   * longer owns local MACs, which happens when mac_sync_mode leaves fpm.
+   * The receiver releases ownership and treats every MAC it was given as
+   * stale, since nothing will refresh them again.
+   *
    * Pinned to an explicit value: this enum and the zebra copy in
    * zebra/kernel_netlink.h have drifted (zebra lacks the two
    * ES_BACKUP_NHG values), so a positional value would not match on

--- a/fpmsyncd/fpmlink.cpp
+++ b/fpmsyncd/fpmlink.cpp
@@ -66,6 +66,21 @@ bool FpmLink::isRawProcessing(struct nlmsghdr *h)
             return true;
         }
 
+        /*
+         * Bridge FDB entries share RTM_NEWNEIGH/RTM_DELNEIGH with IP neighbours,
+         * so the address family is what selects the MAC path.
+         */
+        if (h->nlmsg_type == RTM_NEWNEIGH || h->nlmsg_type == RTM_DELNEIGH)
+        {
+            if (h->nlmsg_len < NLMSG_LENGTH(sizeof(struct ndmsg)))
+            {
+                return false;
+            }
+
+            struct ndmsg *ndm = (struct ndmsg *)NLMSG_DATA(h);
+            return ndm->ndm_family == AF_BRIDGE;
+        }
+
         return false;
     }
 

--- a/fpmsyncd/fpmsyncd.cpp
+++ b/fpmsyncd/fpmsyncd.cpp
@@ -151,7 +151,6 @@ int main(int argc, char **argv)
             s.addSelectable(&netlink);
             s.addSelectable(macsync.getStateFdbTable());
             s.addSelectable(macsync.getCfgFdbSyncTable());
-            s.addSelectable(macsync.getStaleTimer());
 
             if (sync.isSuppressionEnabled())
             {
@@ -210,12 +209,6 @@ int main(int argc, char **argv)
                 if (temps == (Selectable *)macsync.getCfgFdbSyncTable())
                 {
                     macsync.processCfgFdbSync();
-                    continue;
-                }
-
-                if (temps == (Selectable *)macsync.getStaleTimer())
-                {
-                    macsync.onStaleTimer();
                     continue;
                 }
 

--- a/fpmsyncd/fpmsyncd.cpp
+++ b/fpmsyncd/fpmsyncd.cpp
@@ -151,6 +151,7 @@ int main(int argc, char **argv)
             s.addSelectable(&netlink);
             s.addSelectable(macsync.getStateFdbTable());
             s.addSelectable(macsync.getCfgFdbSyncTable());
+            s.addSelectable(macsync.getAppPortTable());
 
             if (sync.isSuppressionEnabled())
             {
@@ -209,6 +210,12 @@ int main(int argc, char **argv)
                 if (temps == (Selectable *)macsync.getCfgFdbSyncTable())
                 {
                     macsync.processCfgFdbSync();
+                    continue;
+                }
+
+                if (temps == (Selectable *)macsync.getAppPortTable())
+                {
+                    macsync.processAppPort();
                     continue;
                 }
 

--- a/fpmsyncd/fpmsyncd.cpp
+++ b/fpmsyncd/fpmsyncd.cpp
@@ -12,6 +12,7 @@
 #include "fpmsyncd/fpmlink.h"
 #include "fpmsyncd/fpmsyncd.h"
 #include "fpmsyncd/routesync.h"
+#include "fpmsyncd/macsync.h"
 
 #include <netlink/route/route.h>
 
@@ -88,6 +89,9 @@ int main(int argc, char **argv)
     DBConnector stateDb("STATE_DB", 0);
     Table bgpStateTable(&stateDb, STATE_BGP_TABLE_NAME);
 
+    MacSync macsync(&pipeline, &stateDb, &cfgDb);
+    sync.setMacSync(&macsync);
+
     NetLink netlink;
 
     netlink.registerGroup(RTNLGRP_LINK);
@@ -141,8 +145,13 @@ int main(int argc, char **argv)
             fpm.accept();
             cout << "Connected!" << endl;
 
+            macsync.onFpmConnected(fpm);
+
             s.addSelectable(&fpm);
             s.addSelectable(&netlink);
+            s.addSelectable(macsync.getStateFdbTable());
+            s.addSelectable(macsync.getCfgFdbSyncTable());
+
             if (sync.isSuppressionEnabled())
             {
                 s.addSelectable(routeResponseChannel.get());
@@ -190,6 +199,18 @@ int main(int argc, char **argv)
 
                 /* Reading FPM messages forever (and calling "readMe" to read them) */
                 s.select(&temps, gSelectTimeout);
+
+                if (temps == (Selectable *)macsync.getStateFdbTable())
+                {
+                    macsync.processStateFdb();
+                    continue;
+                }
+
+                if (temps == (Selectable *)macsync.getCfgFdbSyncTable())
+                {
+                    macsync.processCfgFdbSync();
+                    continue;
+                }
 
                 /*
                  * Upon expiration of the warm-restart timer or eoiu Hold Timer, proceed to run the
@@ -269,6 +290,7 @@ int main(int argc, char **argv)
         }
         catch (FpmLink::FpmConnectionClosedException &e)
         {
+            macsync.onFpmDisconnected();
             cout << "Connection lost, reconnecting..." << endl;
         }
     }

--- a/fpmsyncd/fpmsyncd.cpp
+++ b/fpmsyncd/fpmsyncd.cpp
@@ -151,6 +151,7 @@ int main(int argc, char **argv)
             s.addSelectable(&netlink);
             s.addSelectable(macsync.getStateFdbTable());
             s.addSelectable(macsync.getCfgFdbSyncTable());
+            s.addSelectable(macsync.getStaleTimer());
 
             if (sync.isSuppressionEnabled())
             {
@@ -209,6 +210,12 @@ int main(int argc, char **argv)
                 if (temps == (Selectable *)macsync.getCfgFdbSyncTable())
                 {
                     macsync.processCfgFdbSync();
+                    continue;
+                }
+
+                if (temps == (Selectable *)macsync.getStaleTimer())
+                {
+                    macsync.onStaleTimer();
                     continue;
                 }
 

--- a/fpmsyncd/macsync.cpp
+++ b/fpmsyncd/macsync.cpp
@@ -100,6 +100,7 @@ MacSync::MacSync(RedisPipeline *pipeline, DBConnector *stateDb, DBConnector *cfg
     m_stateFdbTable(stateDb, STATE_FDB_TABLE_NAME),
     m_cfgFdbSyncTable(cfgDb, CFG_FDB_SYNC_TABLE_NAME),
     m_cfgFdbSyncTableRead(cfgDb, CFG_FDB_SYNC_TABLE_NAME),
+    m_cfgEvpnEsTable(cfgDb, "EVPN_ETHERNET_SEGMENT"),
     m_stateFdbTableRead(stateDb, STATE_FDB_TABLE_NAME),
     m_stateFdbSyncTable(stateDb, STATE_FDB_SYNC_TABLE_NAME),
     m_staleTimer(timespec{MAC_STALE_HOLD_SECONDS, 0})
@@ -115,6 +116,15 @@ void MacSync::readCfgFdbSyncMode()
     {
         setMacSyncMode(mode);
     }
+}
+
+/* The Ethernet Segment table is keyed by the interface the ESI is bound to, so
+ * an entry is the authority on whether this port carries one. */
+bool MacSync::isEthernetSegmentInterface(const string& ifname)
+{
+    std::vector<FieldValueTuple> values;
+
+    return m_cfgEvpnEsTable.get(ifname, values);
 }
 
 void MacSync::setMacSyncMode(const string& mode)
@@ -628,22 +638,33 @@ void MacSync::onMacMsg(struct nlmsghdr *h, int len)
     }
 
     char vtep[INET6_ADDRSTRLEN] = {0};
+    string esInterface;
 
     if (nexthopGroup.empty())
     {
-        if (!tb[NDA_DST])
+        if (tb[NDA_DST])
+        {
+            size_t dstLen = RTA_PAYLOAD(tb[NDA_DST]);
+            int family = (dstLen == sizeof(struct in6_addr)) ? AF_INET6 : AF_INET;
+
+            if (!inet_ntop(family, RTA_DATA(tb[NDA_DST]), vtep, sizeof(vtep)))
+            {
+                SWSS_LOG_ERROR("MacSync: cannot parse remote VTEP for %s", key.c_str());
+                return;
+            }
+        }
+        else if (ifname[0] && isEthernetSegmentInterface(ifname))
+        {
+            /* A MAC on an Ethernet Segment we also hold locally is reachable
+             * through our own access port, so zebra sends it against that port
+             * with neither a VTEP nor a group. FdbOrch programs it against the
+             * port with ageing disabled. */
+            esInterface = ifname;
+        }
+        else
         {
             /* The bridge-side copy of a remote MAC; the VxLAN-side copy carries the VTEP. */
             SWSS_LOG_INFO("MacSync: skipping inbound MAC %s without NDA_DST", key.c_str());
-            return;
-        }
-
-        size_t dstLen = RTA_PAYLOAD(tb[NDA_DST]);
-        int family = (dstLen == sizeof(struct in6_addr)) ? AF_INET6 : AF_INET;
-
-        if (!inet_ntop(family, RTA_DATA(tb[NDA_DST]), vtep, sizeof(vtep)))
-        {
-            SWSS_LOG_ERROR("MacSync: cannot parse remote VTEP for %s", key.c_str());
             return;
         }
     }
@@ -660,13 +681,17 @@ void MacSync::onMacMsg(struct nlmsghdr *h, int len)
     }
 
     std::vector<FieldValueTuple> fvVector;
-    if (nexthopGroup.empty())
+    if (!nexthopGroup.empty())
     {
-        fvVector.emplace_back("remote_vtep", vtep);
+        fvVector.emplace_back("nexthop_group", nexthopGroup);
+    }
+    else if (!esInterface.empty())
+    {
+        fvVector.emplace_back("ifname", esInterface);
     }
     else
     {
-        fvVector.emplace_back("nexthop_group", nexthopGroup);
+        fvVector.emplace_back("remote_vtep", vtep);
     }
     fvVector.emplace_back("type", (ndm->ndm_state & NUD_NOARP) ? "static" : "dynamic");
     fvVector.emplace_back("vni", to_string(vni));
@@ -679,7 +704,8 @@ void MacSync::onMacMsg(struct nlmsghdr *h, int len)
         m_remoteMacsSeen.insert(key);
     }
 
-    string dest = nexthopGroup.empty() ? ("vtep " + string(vtep))
-                                       : ("nexthop_group " + nexthopGroup);
+    string dest = !nexthopGroup.empty() ? ("nexthop_group " + nexthopGroup)
+                : !esInterface.empty()  ? ("ifname " + esInterface)
+                                        : ("vtep " + string(vtep));
     SWSS_LOG_INFO("MacSync: added remote MAC %s %s vni %u", key.c_str(), dest.c_str(), vni);
 }

--- a/fpmsyncd/macsync.cpp
+++ b/fpmsyncd/macsync.cpp
@@ -21,6 +21,18 @@ using namespace swss;
 #define NDA_SRC_VNI 11
 #endif
 
+#ifndef NDA_PROTOCOL
+#define NDA_PROTOCOL 12
+#endif
+
+/* Marks a MAC as data-plane (hardware) learnt, as opposed to a control-plane
+ * entry zebra originated. The kernel path carried this as "bridge fdb ...
+ * proto hw"; on the FPM channel it rides as NDA_PROTOCOL so zebra can still
+ * tell the two apart. */
+#ifndef RTPROT_HW
+#define RTPROT_HW 193
+#endif
+
 #define MAC_SYNC_MODE_FIELD "mac_sync_mode"
 #define MAC_SYNC_MODE_FPM   "fpm"
 #define FDB_SYNC_GLOBAL_KEY "global"
@@ -116,6 +128,9 @@ void MacSync::setMacSyncMode(const string& mode)
     if (m_fpmMode)
     {
         loadRemoteMacs();
+        /* processStateFdb() discards updates while fdbsyncd owns the kernel
+         * path, so the local cache is stale on the way into fpm mode. */
+        loadLocalMacs();
         replayLocalMacs();
     }
 }
@@ -477,11 +492,34 @@ void MacSync::sendLocalMac(const string& vlanName, const string& mac, const stri
     req.n.nlmsg_seq = m_generation;
     req.ndm.ndm_family = AF_BRIDGE;
     req.ndm.ndm_ifindex = (int)ifindex;
-    req.ndm.ndm_state = isStatic ? NUD_NOARP : NUD_REACHABLE;
     req.ndm.ndm_flags = NTF_MASTER | NTF_EXT_LEARNED;
+    /* Follow zebra's own encoding (netlink_macfdb_update_ctx): NTF_STICKY and
+     * NUD_NOARP are set together, and only for a sticky entry. NUD_NOARP on its
+     * own is not an encoding zebra produces or reads, so it must not be used to
+     * mean "static" on its own.
+     *
+     * Only administratively configured MACs are sticky. STATE_DB carries local
+     * entries only, so a static entry here is a provisioned MAC that is pinned
+     * to a port by configuration and must not move; RFC 7432 section 7.8 wants
+     * exactly that advertised with the sticky bit so remote PEs reject a move.
+     * Hardware-learnt MACs stay mobile. */
+    if (isStatic)
+    {
+        req.ndm.ndm_flags |= NTF_STICKY;
+        req.ndm.ndm_state = NUD_REACHABLE | NUD_NOARP;
+    }
+    else
+    {
+        req.ndm.ndm_state = NUD_REACHABLE;
+    }
+
+    /* Marks the entry as hardware learnt, the FPM equivalent of the "proto hw"
+     * the kernel path passed to "bridge fdb". */
+    uint8_t protocol = RTPROT_HW;
 
     if (!addAttr(&req.n, sizeof(req), NDA_LLADDR, macAddress.getMac(), ETHER_ADDR_LEN) ||
-        !addAttr(&req.n, sizeof(req), NDA_VLAN, &vlanId, sizeof(vlanId)))
+        !addAttr(&req.n, sizeof(req), NDA_VLAN, &vlanId, sizeof(vlanId)) ||
+        !addAttr(&req.n, sizeof(req), NDA_PROTOCOL, &protocol, sizeof(protocol)))
     {
         return;
     }
@@ -493,8 +531,9 @@ void MacSync::sendLocalMac(const string& vlanName, const string& mac, const stri
         return;
     }
 
-    SWSS_LOG_INFO("MacSync: sent local MAC %s %s:%s port %s",
-                  add ? "add" : "del", vlanName.c_str(), mac.c_str(), port.c_str());
+    SWSS_LOG_INFO("MacSync: sent local MAC %s %s:%s port %s%s",
+                  add ? "add" : "del", vlanName.c_str(), mac.c_str(), port.c_str(),
+                  isStatic ? " (static, sticky)" : "");
 }
 
 void MacSync::onMacMsg(struct nlmsghdr *h, int len)

--- a/fpmsyncd/macsync.cpp
+++ b/fpmsyncd/macsync.cpp
@@ -1,6 +1,7 @@
 #include <arpa/inet.h>
 #include <assert.h>
 #include <net/if.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "logger.h"
@@ -23,6 +24,7 @@ using namespace swss;
 #define MAC_SYNC_MODE_FIELD "mac_sync_mode"
 #define MAC_SYNC_MODE_FPM   "fpm"
 #define FDB_SYNC_GLOBAL_KEY "global"
+#define FDB_SYNC_GENERATION_FIELD "generation"
 
 /* Same buffer shape zebra uses for AF_BRIDGE FDB messages. */
 struct MacNlRequest
@@ -71,7 +73,9 @@ MacSync::MacSync(RedisPipeline *pipeline, DBConnector *stateDb, DBConnector *cfg
     m_vxlanFdbTable(pipeline, APP_VXLAN_FDB_TABLE_NAME, true),
     m_stateFdbTable(stateDb, STATE_FDB_TABLE_NAME),
     m_cfgFdbSyncTable(cfgDb, CFG_FDB_SYNC_TABLE_NAME),
-    m_cfgFdbSyncTableRead(cfgDb, CFG_FDB_SYNC_TABLE_NAME)
+    m_cfgFdbSyncTableRead(cfgDb, CFG_FDB_SYNC_TABLE_NAME),
+    m_stateFdbTableRead(stateDb, STATE_FDB_TABLE_NAME),
+    m_stateFdbSyncTable(stateDb, STATE_FDB_SYNC_TABLE_NAME)
 {
     readCfgFdbSyncMode();
 }
@@ -136,7 +140,9 @@ void MacSync::processCfgFdbSync()
 void MacSync::onFpmConnected(FpmInterface& fpm)
 {
     m_fpmInterface = &fpm;
-    ++m_generation;
+    m_generation = nextGeneration();
+
+    loadLocalMacs();
     replayLocalMacs();
     sendReplayEnd();
 }
@@ -144,6 +150,79 @@ void MacSync::onFpmConnected(FpmInterface& fpm)
 void MacSync::onFpmDisconnected()
 {
     m_fpmInterface = nullptr;
+}
+
+/*
+ * Rebuild the local MAC set straight from STATE_DB. The subscriber delivers the
+ * existing entries through the select loop, which has not necessarily run by the
+ * time zebra connects; replaying from an unpopulated map would tell zebra that
+ * no MAC is local and have it withdraw every one of them.
+ */
+/*
+ * Zebra keeps the MACs a previous fpmsyncd gave it, so reusing that process's
+ * generation would make them look current and survive the sweep. The counter is
+ * stored before it is sent, so a crash mid-replay cannot hand out the same value
+ * twice.
+ */
+uint32_t MacSync::nextGeneration()
+{
+    std::string value;
+    uint32_t generation = 0;
+
+    if (m_stateFdbSyncTable.hget(FDB_SYNC_GLOBAL_KEY, FDB_SYNC_GENERATION_FIELD, value))
+    {
+        generation = (uint32_t)strtoul(value.c_str(), nullptr, 10);
+    }
+
+    ++generation;
+    m_stateFdbSyncTable.hset(FDB_SYNC_GLOBAL_KEY, FDB_SYNC_GENERATION_FIELD,
+                             std::to_string(generation));
+
+    return generation;
+}
+
+void MacSync::loadLocalMacs()
+{
+    if (!m_fpmMode)
+    {
+        return;
+    }
+
+    std::vector<std::string> keys;
+    m_stateFdbTableRead.getKeys(keys);
+
+    m_localMacs.clear();
+
+    for (const auto& key : keys)
+    {
+        std::vector<FieldValueTuple> values;
+        if (!m_stateFdbTableRead.get(key, values))
+        {
+            continue;
+        }
+
+        string port;
+        bool isStatic = false;
+
+        for (const auto& fv : values)
+        {
+            if (fvField(fv) == "port")
+            {
+                port = fvValue(fv);
+            }
+            else if (fvField(fv) == "type")
+            {
+                isStatic = (fvValue(fv) == "static");
+            }
+        }
+
+        if (port.empty())
+        {
+            continue;
+        }
+
+        m_localMacs[key] = {port, isStatic};
+    }
 }
 
 void MacSync::replayLocalMacs()

--- a/fpmsyncd/macsync.cpp
+++ b/fpmsyncd/macsync.cpp
@@ -26,6 +26,15 @@ using namespace swss;
 #define FDB_SYNC_GLOBAL_KEY "global"
 #define FDB_SYNC_GENERATION_FIELD "generation"
 
+/* zebra replays what it knows at FPM connect, which on a restart of the whole
+ * bgp container is before BGP has re-learned anything. Deleting on that basis
+ * would drop live MACs, so the decision is held until the peer has had time to
+ * converge. Matches the interval fdbsyncd uses for the same reason.
+ *
+ * zebra holds the MACs it learns from here on a separate timer of its own. The
+ * two are deliberately not synchronised: this window waits on BGP converging,
+ * that one waits on STATE_DB becoming readable, so they need not agree. */
+#define MAC_STALE_HOLD_SECONDS 120
 /* Same buffer shape zebra uses for AF_BRIDGE FDB messages. */
 struct MacNlRequest
 {
@@ -76,7 +85,8 @@ MacSync::MacSync(RedisPipeline *pipeline, DBConnector *stateDb, DBConnector *cfg
     m_cfgFdbSyncTable(cfgDb, CFG_FDB_SYNC_TABLE_NAME),
     m_cfgFdbSyncTableRead(cfgDb, CFG_FDB_SYNC_TABLE_NAME),
     m_stateFdbTableRead(stateDb, STATE_FDB_TABLE_NAME),
-    m_stateFdbSyncTable(stateDb, STATE_FDB_SYNC_TABLE_NAME)
+    m_stateFdbSyncTable(stateDb, STATE_FDB_SYNC_TABLE_NAME),
+    m_staleTimer(timespec{MAC_STALE_HOLD_SECONDS, 0})
 {
     readCfgFdbSyncMode();
 }
@@ -144,6 +154,11 @@ void MacSync::onFpmConnected(FpmInterface& fpm)
     m_fpmInterface = &fpm;
     m_generation = nextGeneration();
 
+    /* zebra replays its remote MACs on connect; until the marker arrives we
+     * cannot tell "not replayed yet" from "withdrawn while we were down". */
+    m_remoteMacsSeen.clear();
+    m_remoteReplayPending = true;
+
     loadLocalMacs();
     replayLocalMacs();
     sendReplayEnd();
@@ -152,6 +167,63 @@ void MacSync::onFpmConnected(FpmInterface& fpm)
 void MacSync::onFpmDisconnected()
 {
     m_fpmInterface = nullptr;
+}
+
+/*
+ * Anything we hold that zebra did not replay no longer exists, and zebra will
+ * never mention it again. Without the marker this cannot be distinguished from
+ * a replay still in flight, so an unsolicited marker sweeps nothing.
+ */
+void MacSync::onRemoteReplayEnd()
+{
+    if (!m_fpmMode || !m_remoteReplayPending)
+    {
+        return;
+    }
+
+    m_staleCandidates.clear();
+    for (const auto& key : m_remoteMacs)
+    {
+        if (!m_remoteMacsSeen.count(key))
+        {
+            m_staleCandidates.insert(key);
+        }
+    }
+
+    m_remoteMacsSeen.clear();
+    m_remoteReplayPending = false;
+
+    if (m_staleCandidates.empty())
+    {
+        SWSS_LOG_NOTICE("MacSync: remote replay ended, all %zu remote MAC(s) accounted for",
+                        m_remoteMacs.size());
+        return;
+    }
+
+    m_staleTimer.start();
+    SWSS_LOG_NOTICE("MacSync: remote replay ended, %zu remote MAC(s) unaccounted for, "
+                    "deleting in %ds unless re-advertised",
+                    m_staleCandidates.size(), MAC_STALE_HOLD_SECONDS);
+}
+
+void MacSync::onStaleTimer()
+{
+    m_staleTimer.stop();
+
+    unsigned int removed = 0;
+
+    for (const auto& key : m_staleCandidates)
+    {
+        if (m_remoteMacs.erase(key))
+        {
+            m_vxlanFdbTable.del(key);
+            ++removed;
+        }
+    }
+
+    SWSS_LOG_NOTICE("MacSync: hold-down expired, removed %u stale remote MAC(s), retained %zu",
+                    removed, m_remoteMacs.size());
+    m_staleCandidates.clear();
 }
 
 /*
@@ -493,6 +565,7 @@ void MacSync::onMacMsg(struct nlmsghdr *h, int len)
             m_vxlanFdbTable.del(key);
             SWSS_LOG_INFO("MacSync: removed remote MAC %s", key.c_str());
         }
+        m_remoteMacsSeen.erase(key);
         return;
     }
 
@@ -531,6 +604,11 @@ void MacSync::onMacMsg(struct nlmsghdr *h, int len)
 
     m_vxlanFdbTable.set(key, fvVector);
     m_remoteMacs.insert(key);
+    m_staleCandidates.erase(key);
+    if (m_remoteReplayPending)
+    {
+        m_remoteMacsSeen.insert(key);
+    }
 
     SWSS_LOG_INFO("MacSync: added remote MAC %s vtep %s vni %u", key.c_str(), vtep, vni);
 }

--- a/fpmsyncd/macsync.cpp
+++ b/fpmsyncd/macsync.cpp
@@ -1,10 +1,12 @@
 #include <arpa/inet.h>
+#include <assert.h>
 #include <net/if.h>
 #include <string.h>
 
 #include "logger.h"
 #include "macaddress.h"
 #include "schema.h"
+#include "fpm/fpm.h"
 #include "fpmsyncd/macsync.h"
 
 using namespace std;
@@ -134,7 +136,9 @@ void MacSync::processCfgFdbSync()
 void MacSync::onFpmConnected(FpmInterface& fpm)
 {
     m_fpmInterface = &fpm;
+    ++m_generation;
     replayLocalMacs();
+    sendReplayEnd();
 }
 
 void MacSync::onFpmDisconnected()
@@ -159,6 +163,31 @@ void MacSync::replayLocalMacs()
         sendLocalMac(it.first.substr(0, delimiter), it.first.substr(delimiter + 1),
                      it.second.port, it.second.isStatic, true);
     }
+}
+
+void MacSync::sendReplayEnd()
+{
+    if (!m_fpmMode || !m_fpmInterface)
+    {
+        return;
+    }
+
+    struct nlmsghdr n{};
+
+    n.nlmsg_len = NLMSG_LENGTH(0);
+    n.nlmsg_flags = NLM_F_REQUEST;
+    n.nlmsg_type = RTM_FPM_MAC_REPLAY_END;
+    n.nlmsg_seq = m_generation;
+
+    if (!m_fpmInterface->send(&n))
+    {
+        SWSS_LOG_ERROR("MacSync: failed to send end-of-replay for generation %u",
+                       m_generation);
+        return;
+    }
+
+    SWSS_LOG_NOTICE("MacSync: replayed %zu local MACs, generation %u",
+                    m_localMacs.size(), m_generation);
 }
 
 void MacSync::processStateFdb()
@@ -275,6 +304,7 @@ void MacSync::sendLocalMac(const string& vlanName, const string& mac, const stri
     req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct ndmsg));
     req.n.nlmsg_flags = NLM_F_REQUEST | (add ? (NLM_F_CREATE | NLM_F_REPLACE) : 0);
     req.n.nlmsg_type = add ? RTM_NEWNEIGH : RTM_DELNEIGH;
+    req.n.nlmsg_seq = m_generation;
     req.ndm.ndm_family = AF_BRIDGE;
     req.ndm.ndm_ifindex = (int)ifindex;
     req.ndm.ndm_state = isStatic ? NUD_NOARP : NUD_REACHABLE;

--- a/fpmsyncd/macsync.cpp
+++ b/fpmsyncd/macsync.cpp
@@ -71,6 +71,7 @@ static void parseRtAttrs(struct rtattr **tb, int max, struct rtattr *rta, int le
 
 MacSync::MacSync(RedisPipeline *pipeline, DBConnector *stateDb, DBConnector *cfgDb) :
     m_vxlanFdbTable(pipeline, APP_VXLAN_FDB_TABLE_NAME, true),
+    m_vxlanFdbTableRead(pipeline, APP_VXLAN_FDB_TABLE_NAME, false),
     m_stateFdbTable(stateDb, STATE_FDB_TABLE_NAME),
     m_cfgFdbSyncTable(cfgDb, CFG_FDB_SYNC_TABLE_NAME),
     m_cfgFdbSyncTableRead(cfgDb, CFG_FDB_SYNC_TABLE_NAME),
@@ -104,6 +105,7 @@ void MacSync::setMacSyncMode(const string& mode)
 
     if (m_fpmMode)
     {
+        loadRemoteMacs();
         replayLocalMacs();
     }
 }
@@ -179,6 +181,23 @@ uint32_t MacSync::nextGeneration()
                              std::to_string(generation));
 
     return generation;
+}
+
+/*
+ * zebra replays router MACs on reconnect but never the remote EVPN MACs, so an
+ * entry inherited from fdbsyncd or from a previous fpmsyncd would otherwise
+ * find nothing to erase on withdrawal and stay programmed forever.
+ */
+void MacSync::loadRemoteMacs()
+{
+    std::vector<std::string> keys;
+
+    m_vxlanFdbTableRead.getKeys(keys);
+    m_remoteMacs.clear();
+    m_remoteMacs.insert(keys.begin(), keys.end());
+
+    SWSS_LOG_NOTICE("MacSync: adopted %zu remote MACs already in APPL_DB",
+                    m_remoteMacs.size());
 }
 
 void MacSync::loadLocalMacs()

--- a/fpmsyncd/macsync.cpp
+++ b/fpmsyncd/macsync.cpp
@@ -1,0 +1,408 @@
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <string.h>
+
+#include "logger.h"
+#include "macaddress.h"
+#include "schema.h"
+#include "fpmsyncd/macsync.h"
+
+using namespace std;
+using namespace swss;
+
+#ifndef NDA_VNI
+#define NDA_VNI 7
+#endif
+
+#ifndef NDA_SRC_VNI
+#define NDA_SRC_VNI 11
+#endif
+
+#define MAC_SYNC_MODE_FIELD "mac_sync_mode"
+#define MAC_SYNC_MODE_FPM   "fpm"
+#define FDB_SYNC_GLOBAL_KEY "global"
+
+/* Same buffer shape zebra uses for AF_BRIDGE FDB messages. */
+struct MacNlRequest
+{
+    struct nlmsghdr n;
+    struct ndmsg ndm;
+    char buf[256];
+};
+
+static bool addAttr(struct nlmsghdr *n, size_t maxLen, int type,
+                    const void *data, size_t alen)
+{
+    size_t len = RTA_LENGTH(alen);
+
+    if (NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len) > maxLen)
+    {
+        SWSS_LOG_ERROR("MacSync: netlink attribute %d does not fit in the message", type);
+        return false;
+    }
+
+    struct rtattr *rta = (struct rtattr *)(((char *)n) + NLMSG_ALIGN(n->nlmsg_len));
+    rta->rta_type = (unsigned short)type;
+    rta->rta_len = (unsigned short)len;
+    if (alen)
+    {
+        memcpy(RTA_DATA(rta), data, alen);
+    }
+    n->nlmsg_len = (uint32_t)(NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len));
+    return true;
+}
+
+static void parseRtAttrs(struct rtattr **tb, int max, struct rtattr *rta, int len)
+{
+    memset(tb, 0, sizeof(struct rtattr *) * (unsigned int)(max + 1));
+    while (RTA_OK(rta, len))
+    {
+        if (rta->rta_type <= max)
+        {
+            tb[rta->rta_type] = rta;
+        }
+        rta = RTA_NEXT(rta, len);
+    }
+}
+
+MacSync::MacSync(RedisPipeline *pipeline, DBConnector *stateDb, DBConnector *cfgDb) :
+    m_vxlanFdbTable(pipeline, APP_VXLAN_FDB_TABLE_NAME, true),
+    m_stateFdbTable(stateDb, STATE_FDB_TABLE_NAME),
+    m_cfgFdbSyncTable(cfgDb, CFG_FDB_SYNC_TABLE_NAME),
+    m_cfgFdbSyncTableRead(cfgDb, CFG_FDB_SYNC_TABLE_NAME)
+{
+    readCfgFdbSyncMode();
+}
+
+void MacSync::readCfgFdbSyncMode()
+{
+    string mode;
+
+    if (m_cfgFdbSyncTableRead.hget(FDB_SYNC_GLOBAL_KEY, MAC_SYNC_MODE_FIELD, mode))
+    {
+        setMacSyncMode(mode);
+    }
+}
+
+void MacSync::setMacSyncMode(const string& mode)
+{
+    bool fpmMode = (mode == MAC_SYNC_MODE_FPM);
+
+    if (fpmMode == m_fpmMode)
+    {
+        return;
+    }
+
+    m_fpmMode = fpmMode;
+    SWSS_LOG_NOTICE("MacSync: mac_sync_mode is now %s", m_fpmMode ? "fpm" : "kernel");
+
+    if (m_fpmMode)
+    {
+        replayLocalMacs();
+    }
+}
+
+void MacSync::processCfgFdbSync()
+{
+    std::deque<KeyOpFieldsValuesTuple> entries;
+
+    m_cfgFdbSyncTable.pops(entries);
+
+    for (auto& entry : entries)
+    {
+        if (kfvKey(entry) != FDB_SYNC_GLOBAL_KEY)
+        {
+            continue;
+        }
+
+        if (kfvOp(entry) != SET_COMMAND)
+        {
+            setMacSyncMode("");
+            continue;
+        }
+
+        for (auto& fv : kfvFieldsValues(entry))
+        {
+            if (fvField(fv) == MAC_SYNC_MODE_FIELD)
+            {
+                setMacSyncMode(fvValue(fv));
+            }
+        }
+    }
+}
+
+void MacSync::onFpmConnected(FpmInterface& fpm)
+{
+    m_fpmInterface = &fpm;
+    replayLocalMacs();
+}
+
+void MacSync::onFpmDisconnected()
+{
+    m_fpmInterface = nullptr;
+}
+
+void MacSync::replayLocalMacs()
+{
+    if (!m_fpmMode || !m_fpmInterface)
+    {
+        return;
+    }
+
+    for (const auto& it : m_localMacs)
+    {
+        auto delimiter = it.first.find_first_of(':');
+        if (delimiter == string::npos)
+        {
+            continue;
+        }
+        sendLocalMac(it.first.substr(0, delimiter), it.first.substr(delimiter + 1),
+                     it.second.port, it.second.isStatic, true);
+    }
+}
+
+void MacSync::processStateFdb()
+{
+    std::deque<KeyOpFieldsValuesTuple> entries;
+
+    m_stateFdbTable.pops(entries);
+
+    if (!m_fpmMode)
+    {
+        /* fdbsyncd owns the kernel path in this mode. */
+        return;
+    }
+
+    for (auto& entry : entries)
+    {
+        const string& key = kfvKey(entry);
+        bool add = (kfvOp(entry) == SET_COMMAND);
+
+        auto delimiter = key.find_first_of(':');
+        if (delimiter == string::npos)
+        {
+            SWSS_LOG_ERROR("MacSync: malformed STATE_DB FDB key %s", key.c_str());
+            continue;
+        }
+
+        string vlanName = key.substr(0, delimiter);
+        string mac = key.substr(delimiter + 1);
+        string port;
+        bool isStatic = false;
+
+        for (auto& fv : kfvFieldsValues(entry))
+        {
+            if (fvField(fv) == "port")
+            {
+                port = fvValue(fv);
+            }
+            else if (fvField(fv) == "type")
+            {
+                isStatic = (fvValue(fv) == "static");
+            }
+        }
+
+        if (add)
+        {
+            if (port.empty())
+            {
+                SWSS_LOG_ERROR("MacSync: STATE_DB FDB entry %s has no port", key.c_str());
+                continue;
+            }
+            m_localMacs[key] = {port, isStatic};
+        }
+        else
+        {
+            auto it = m_localMacs.find(key);
+            if (it == m_localMacs.end())
+            {
+                continue;
+            }
+            port = it->second.port;
+            isStatic = it->second.isStatic;
+            m_localMacs.erase(it);
+        }
+
+        sendLocalMac(vlanName, mac, port, isStatic, add);
+    }
+}
+
+void MacSync::sendLocalMac(const string& vlanName, const string& mac, const string& port,
+                           bool isStatic, bool add)
+{
+    if (!m_fpmMode || !m_fpmInterface)
+    {
+        return;
+    }
+
+    unsigned int ifindex = if_nametoindex(port.c_str());
+    if (ifindex == 0)
+    {
+        SWSS_LOG_ERROR("MacSync: cannot resolve ifindex for port %s", port.c_str());
+        return;
+    }
+
+    if (vlanName.compare(0, 4, "Vlan") != 0)
+    {
+        SWSS_LOG_ERROR("MacSync: unexpected VLAN name %s", vlanName.c_str());
+        return;
+    }
+
+    uint16_t vlanId;
+    try
+    {
+        vlanId = (uint16_t)stoul(vlanName.substr(4));
+    }
+    catch (const std::exception& e)
+    {
+        SWSS_LOG_ERROR("MacSync: cannot parse VLAN id from %s", vlanName.c_str());
+        return;
+    }
+
+    MacAddress macAddress;
+    try
+    {
+        macAddress = MacAddress(mac);
+    }
+    catch (const std::exception& e)
+    {
+        SWSS_LOG_ERROR("MacSync: cannot parse MAC %s", mac.c_str());
+        return;
+    }
+
+    MacNlRequest req{};
+
+    req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct ndmsg));
+    req.n.nlmsg_flags = NLM_F_REQUEST | (add ? (NLM_F_CREATE | NLM_F_REPLACE) : 0);
+    req.n.nlmsg_type = add ? RTM_NEWNEIGH : RTM_DELNEIGH;
+    req.ndm.ndm_family = AF_BRIDGE;
+    req.ndm.ndm_ifindex = (int)ifindex;
+    req.ndm.ndm_state = isStatic ? NUD_NOARP : NUD_REACHABLE;
+    req.ndm.ndm_flags = NTF_MASTER | NTF_EXT_LEARNED;
+
+    if (!addAttr(&req.n, sizeof(req), NDA_LLADDR, macAddress.getMac(), ETHER_ADDR_LEN) ||
+        !addAttr(&req.n, sizeof(req), NDA_VLAN, &vlanId, sizeof(vlanId)))
+    {
+        return;
+    }
+
+    if (!m_fpmInterface->send(&req.n))
+    {
+        SWSS_LOG_ERROR("MacSync: failed to send local MAC %s:%s to zebra",
+                       vlanName.c_str(), mac.c_str());
+        return;
+    }
+
+    SWSS_LOG_INFO("MacSync: sent local MAC %s %s:%s port %s",
+                  add ? "add" : "del", vlanName.c_str(), mac.c_str(), port.c_str());
+}
+
+void MacSync::onMacMsg(struct nlmsghdr *h, int len)
+{
+    if (!m_fpmMode)
+    {
+        return;
+    }
+
+    struct ndmsg *ndm = (struct ndmsg *)NLMSG_DATA(h);
+
+    if (ndm->ndm_family != AF_BRIDGE)
+    {
+        return;
+    }
+
+    struct rtattr *tb[NDA_MAX + 1];
+    parseRtAttrs(tb, NDA_MAX, (struct rtattr *)((char *)ndm + sizeof(struct ndmsg)), len);
+
+    if (!tb[NDA_LLADDR])
+    {
+        SWSS_LOG_ERROR("MacSync: inbound MAC message without NDA_LLADDR");
+        return;
+    }
+
+    MacAddress mac((uint8_t *)RTA_DATA(tb[NDA_LLADDR]));
+
+    /* zebra emits a remote MAC twice: a bridge-side copy carrying NDA_VLAN but no
+     * VTEP, and a VxLAN-side copy carrying NDA_DST but no VLAN. The netdev name
+     * is the only VLAN source present on both, so derive from it as fdbsyncd does
+     * (SONiC names the device <tunnel>-<vlanid>). */
+    string vlanName;
+    char ifname[IF_NAMESIZE] = {0};
+
+    if (if_indextoname((unsigned int)ndm->ndm_ifindex, ifname))
+    {
+        string intf(ifname);
+        auto dash = intf.rfind('-');
+        if (dash != string::npos)
+        {
+            vlanName = "Vlan" + intf.substr(dash + 1);
+        }
+    }
+
+    if (vlanName.empty() && tb[NDA_VLAN])
+    {
+        vlanName = "Vlan" + to_string(*(uint16_t *)RTA_DATA(tb[NDA_VLAN]));
+    }
+
+    if (vlanName.empty())
+    {
+        SWSS_LOG_ERROR("MacSync: cannot determine VLAN for inbound MAC %s on ifindex %d",
+                       mac.to_string().c_str(), ndm->ndm_ifindex);
+        return;
+    }
+
+    string key = vlanName + ":" + mac.to_string();
+    /* Same withdrawal semantics fdbsyncd applies on the kernel path: an
+     * add carrying NUD_INCOMPLETE or NUD_FAILED is a removal. */
+    bool remove = (h->nlmsg_type == RTM_DELNEIGH) ||
+                  (ndm->ndm_state == NUD_INCOMPLETE) ||
+                  (ndm->ndm_state == NUD_FAILED);
+
+    if (remove)
+    {
+        if (m_remoteMacs.erase(key))
+        {
+            m_vxlanFdbTable.del(key);
+            SWSS_LOG_INFO("MacSync: removed remote MAC %s", key.c_str());
+        }
+        return;
+    }
+
+    if (!tb[NDA_DST])
+    {
+        /* The bridge-side copy of a remote MAC; the VxLAN-side copy carries the VTEP. */
+        SWSS_LOG_INFO("MacSync: skipping inbound MAC %s without NDA_DST", key.c_str());
+        return;
+    }
+
+    char vtep[INET6_ADDRSTRLEN] = {0};
+    size_t dstLen = RTA_PAYLOAD(tb[NDA_DST]);
+    int family = (dstLen == sizeof(struct in6_addr)) ? AF_INET6 : AF_INET;
+
+    if (!inet_ntop(family, RTA_DATA(tb[NDA_DST]), vtep, sizeof(vtep)))
+    {
+        SWSS_LOG_ERROR("MacSync: cannot parse remote VTEP for %s", key.c_str());
+        return;
+    }
+
+    /* zebra encodes the VNI as NDA_SRC_VNI; NDA_VNI is accepted as a fallback. */
+    uint32_t vni = 0;
+    if (tb[NDA_SRC_VNI])
+    {
+        vni = *(uint32_t *)RTA_DATA(tb[NDA_SRC_VNI]);
+    }
+    else if (tb[NDA_VNI])
+    {
+        vni = *(uint32_t *)RTA_DATA(tb[NDA_VNI]);
+    }
+
+    std::vector<FieldValueTuple> fvVector;
+    fvVector.emplace_back("remote_vtep", vtep);
+    fvVector.emplace_back("type", (ndm->ndm_state & NUD_NOARP) ? "static" : "dynamic");
+    fvVector.emplace_back("vni", to_string(vni));
+
+    m_vxlanFdbTable.set(key, fvVector);
+    m_remoteMacs.insert(key);
+
+    SWSS_LOG_INFO("MacSync: added remote MAC %s vtep %s vni %u", key.c_str(), vtep, vni);
+}

--- a/fpmsyncd/macsync.cpp
+++ b/fpmsyncd/macsync.cpp
@@ -21,6 +21,10 @@ using namespace swss;
 #define NDA_SRC_VNI 11
 #endif
 
+#ifndef NDA_NH_ID
+#define NDA_NH_ID 13
+#endif
+
 #ifndef NDA_PROTOCOL
 #define NDA_PROTOCOL 12
 #endif
@@ -608,21 +612,40 @@ void MacSync::onMacMsg(struct nlmsghdr *h, int len)
         return;
     }
 
-    if (!tb[NDA_DST])
+    /* A MAC behind an Ethernet Segment reaches several VTEPs, so zebra resolves
+     * it to an L2 nexthop group and sends NDA_NH_ID with no NDA_DST. The group
+     * itself is published to L2_NEXTHOP_GROUP_TABLE by fdbsyncd, which keeps
+     * reading it from the kernel in either mac_sync_mode. */
+    string nexthopGroup;
+
+    if (tb[NDA_NH_ID])
     {
-        /* The bridge-side copy of a remote MAC; the VxLAN-side copy carries the VTEP. */
-        SWSS_LOG_INFO("MacSync: skipping inbound MAC %s without NDA_DST", key.c_str());
-        return;
+        uint32_t nhid = *(uint32_t *)RTA_DATA(tb[NDA_NH_ID]);
+        if (nhid)
+        {
+            nexthopGroup = to_string(nhid);
+        }
     }
 
     char vtep[INET6_ADDRSTRLEN] = {0};
-    size_t dstLen = RTA_PAYLOAD(tb[NDA_DST]);
-    int family = (dstLen == sizeof(struct in6_addr)) ? AF_INET6 : AF_INET;
 
-    if (!inet_ntop(family, RTA_DATA(tb[NDA_DST]), vtep, sizeof(vtep)))
+    if (nexthopGroup.empty())
     {
-        SWSS_LOG_ERROR("MacSync: cannot parse remote VTEP for %s", key.c_str());
-        return;
+        if (!tb[NDA_DST])
+        {
+            /* The bridge-side copy of a remote MAC; the VxLAN-side copy carries the VTEP. */
+            SWSS_LOG_INFO("MacSync: skipping inbound MAC %s without NDA_DST", key.c_str());
+            return;
+        }
+
+        size_t dstLen = RTA_PAYLOAD(tb[NDA_DST]);
+        int family = (dstLen == sizeof(struct in6_addr)) ? AF_INET6 : AF_INET;
+
+        if (!inet_ntop(family, RTA_DATA(tb[NDA_DST]), vtep, sizeof(vtep)))
+        {
+            SWSS_LOG_ERROR("MacSync: cannot parse remote VTEP for %s", key.c_str());
+            return;
+        }
     }
 
     /* zebra encodes the VNI as NDA_SRC_VNI; NDA_VNI is accepted as a fallback. */
@@ -637,7 +660,14 @@ void MacSync::onMacMsg(struct nlmsghdr *h, int len)
     }
 
     std::vector<FieldValueTuple> fvVector;
-    fvVector.emplace_back("remote_vtep", vtep);
+    if (nexthopGroup.empty())
+    {
+        fvVector.emplace_back("remote_vtep", vtep);
+    }
+    else
+    {
+        fvVector.emplace_back("nexthop_group", nexthopGroup);
+    }
     fvVector.emplace_back("type", (ndm->ndm_state & NUD_NOARP) ? "static" : "dynamic");
     fvVector.emplace_back("vni", to_string(vni));
 
@@ -649,5 +679,7 @@ void MacSync::onMacMsg(struct nlmsghdr *h, int len)
         m_remoteMacsSeen.insert(key);
     }
 
-    SWSS_LOG_INFO("MacSync: added remote MAC %s vtep %s vni %u", key.c_str(), vtep, vni);
+    string dest = nexthopGroup.empty() ? ("vtep " + string(vtep))
+                                       : ("nexthop_group " + nexthopGroup);
+    SWSS_LOG_INFO("MacSync: added remote MAC %s %s vni %u", key.c_str(), dest.c_str(), vni);
 }

--- a/fpmsyncd/macsync.cpp
+++ b/fpmsyncd/macsync.cpp
@@ -42,15 +42,6 @@ using namespace swss;
 #define FDB_SYNC_GLOBAL_KEY "global"
 #define FDB_SYNC_GENERATION_FIELD "generation"
 
-/* zebra replays what it knows at FPM connect, which on a restart of the whole
- * bgp container is before BGP has re-learned anything. Deleting on that basis
- * would drop live MACs, so the decision is held until the peer has had time to
- * converge. Matches the interval fdbsyncd uses for the same reason.
- *
- * zebra holds the MACs it learns from here on a separate timer of its own. The
- * two are deliberately not synchronised: this window waits on BGP converging,
- * that one waits on STATE_DB becoming readable, so they need not agree. */
-#define MAC_STALE_HOLD_SECONDS 120
 /* Same buffer shape zebra uses for AF_BRIDGE FDB messages. */
 struct MacNlRequest
 {
@@ -102,8 +93,7 @@ MacSync::MacSync(RedisPipeline *pipeline, DBConnector *stateDb, DBConnector *cfg
     m_cfgFdbSyncTableRead(cfgDb, CFG_FDB_SYNC_TABLE_NAME),
     m_cfgEvpnEsTable(cfgDb, "EVPN_ETHERNET_SEGMENT"),
     m_stateFdbTableRead(stateDb, STATE_FDB_TABLE_NAME),
-    m_stateFdbSyncTable(stateDb, STATE_FDB_SYNC_TABLE_NAME),
-    m_staleTimer(timespec{MAC_STALE_HOLD_SECONDS, 0})
+    m_stateFdbSyncTable(stateDb, STATE_FDB_SYNC_TABLE_NAME)
 {
     readCfgFdbSyncMode();
 }
@@ -210,49 +200,26 @@ void MacSync::onRemoteReplayEnd()
         return;
     }
 
-    m_staleCandidates.clear();
-    for (const auto& key : m_remoteMacs)
+    unsigned int removed = 0;
+
+    for (auto it = m_remoteMacs.begin(); it != m_remoteMacs.end(); )
     {
-        if (!m_remoteMacsSeen.count(key))
+        if (m_remoteMacsSeen.count(*it))
         {
-            m_staleCandidates.insert(key);
+            ++it;
+            continue;
         }
+
+        m_vxlanFdbTable.del(*it);
+        it = m_remoteMacs.erase(it);
+        ++removed;
     }
 
     m_remoteMacsSeen.clear();
     m_remoteReplayPending = false;
 
-    if (m_staleCandidates.empty())
-    {
-        SWSS_LOG_NOTICE("MacSync: remote replay ended, all %zu remote MAC(s) accounted for",
-                        m_remoteMacs.size());
-        return;
-    }
-
-    m_staleTimer.start();
-    SWSS_LOG_NOTICE("MacSync: remote replay ended, %zu remote MAC(s) unaccounted for, "
-                    "deleting in %ds unless re-advertised",
-                    m_staleCandidates.size(), MAC_STALE_HOLD_SECONDS);
-}
-
-void MacSync::onStaleTimer()
-{
-    m_staleTimer.stop();
-
-    unsigned int removed = 0;
-
-    for (const auto& key : m_staleCandidates)
-    {
-        if (m_remoteMacs.erase(key))
-        {
-            m_vxlanFdbTable.del(key);
-            ++removed;
-        }
-    }
-
-    SWSS_LOG_NOTICE("MacSync: hold-down expired, removed %u stale remote MAC(s), retained %zu",
+    SWSS_LOG_NOTICE("MacSync: remote replay ended, removed %u stale remote MAC(s), retained %zu",
                     removed, m_remoteMacs.size());
-    m_staleCandidates.clear();
 }
 
 /*
@@ -698,7 +665,6 @@ void MacSync::onMacMsg(struct nlmsghdr *h, int len)
 
     m_vxlanFdbTable.set(key, fvVector);
     m_remoteMacs.insert(key);
-    m_staleCandidates.erase(key);
     if (m_remoteReplayPending)
     {
         m_remoteMacsSeen.insert(key);

--- a/fpmsyncd/macsync.cpp
+++ b/fpmsyncd/macsync.cpp
@@ -1,8 +1,11 @@
 #include <arpa/inet.h>
 #include <assert.h>
+#include <linux/nexthop.h>
 #include <net/if.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include <algorithm>
 
 #include "logger.h"
 #include "macaddress.h"
@@ -88,6 +91,7 @@ static void parseRtAttrs(struct rtattr **tb, int max, struct rtattr *rta, int le
 MacSync::MacSync(RedisPipeline *pipeline, DBConnector *stateDb, DBConnector *cfgDb) :
     m_vxlanFdbTable(pipeline, APP_VXLAN_FDB_TABLE_NAME, true),
     m_vxlanFdbTableRead(pipeline, APP_VXLAN_FDB_TABLE_NAME, false),
+    m_l2NhgTable(pipeline, APP_L2_NEXTHOP_GROUP_TABLE_NAME, true),
     m_stateFdbTable(stateDb, STATE_FDB_TABLE_NAME),
     m_cfgFdbSyncTable(cfgDb, CFG_FDB_SYNC_TABLE_NAME),
     m_cfgFdbSyncTableRead(cfgDb, CFG_FDB_SYNC_TABLE_NAME),
@@ -186,6 +190,175 @@ void MacSync::onFpmConnected(FpmInterface& fpm)
 void MacSync::onFpmDisconnected()
 {
     m_fpmInterface = nullptr;
+}
+
+/*
+ * An FDB nexthop is an EVPN Ethernet Segment destination: either one remote
+ * VTEP, or a group of other FDB nexthops. zebra programs these straight to the
+ * kernel, so until now fdbsyncd read them back out of it; over FPM they arrive
+ * here instead. Returns true once NHA_FDB identifies the message as ours, even
+ * when nothing is published, because the route path must never see it.
+ */
+bool MacSync::onFdbNhgMsg(struct nlmsghdr *h, int len)
+{
+    struct nhmsg *nhm = (struct nhmsg *)NLMSG_DATA(h);
+    struct rtattr *tb[NHA_MAX + 1];
+
+    parseRtAttrs(tb, NHA_MAX, (struct rtattr *)((char *)nhm + NLMSG_ALIGN(sizeof(*nhm))), len);
+
+    if (!tb[NHA_FDB])
+    {
+        return false;
+    }
+
+    /* fdbsyncd still owns this table while the kernel is the transport. */
+    if (!m_fpmMode)
+    {
+        return true;
+    }
+
+    if (!tb[NHA_ID])
+    {
+        SWSS_LOG_ERROR("MacSync: FDB nexthop without an id");
+        return true;
+    }
+
+    uint32_t nhid = *(uint32_t *)RTA_DATA(tb[NHA_ID]);
+    string key = to_string(nhid);
+
+    if (h->nlmsg_type == RTM_DELNEXTHOP)
+    {
+        m_l2NhgTable.del(key);
+        m_l2Nhgs.erase(nhid);
+
+        /* A group naming this id is no longer what it claimed to be. */
+        for (auto it = m_l2Nhgs.begin(); it != m_l2Nhgs.end(); )
+        {
+            if (it->second.type != L2_NHG_TYPE_GROUP)
+            {
+                ++it;
+                continue;
+            }
+
+            auto& members = it->second.memberIds;
+            auto gone = std::find(members.begin(), members.end(), nhid);
+            if (gone == members.end())
+            {
+                ++it;
+                continue;
+            }
+
+            members.erase(gone);
+            if (members.empty())
+            {
+                m_l2NhgTable.del(to_string(it->first));
+                it = m_l2Nhgs.erase(it);
+                continue;
+            }
+
+            string remaining;
+            for (size_t i = 0; i < members.size(); i++)
+            {
+                remaining += (i ? "," : "") + to_string(members[i]);
+            }
+            m_l2NhgTable.set(to_string(it->first),
+                             vector<FieldValueTuple>{{"nexthop_group", remaining}});
+            ++it;
+        }
+
+        SWSS_LOG_INFO("MacSync: removed FDB nexthop %u", nhid);
+        return true;
+    }
+
+    /* An output interface makes it an ordinary nexthop, not an ES destination. */
+    if (tb[NHA_OIF])
+    {
+        SWSS_LOG_INFO("MacSync: FDB nexthop %u has an OIF, skipping", nhid);
+        return true;
+    }
+
+    if (tb[NHA_GATEWAY])
+    {
+        char vtep[INET6_ADDRSTRLEN] = {0};
+
+        if (nhm->nh_family == AF_INET)
+        {
+            struct in_addr addr;
+
+            memcpy(&addr, RTA_DATA(tb[NHA_GATEWAY]), sizeof(addr));
+            /* A link-local VTEP is the kernel's own plumbing, not a peer. */
+            if ((ntohl(addr.s_addr) & 0xFFFF0000) == 0xA9FE0000)
+            {
+                return true;
+            }
+            inet_ntop(AF_INET, &addr, vtep, sizeof(vtep));
+        }
+        else if (nhm->nh_family == AF_INET6)
+        {
+            struct in6_addr addr;
+
+            memcpy(&addr, RTA_DATA(tb[NHA_GATEWAY]), sizeof(addr));
+            if (addr.s6_addr[0] == 0xfe && (addr.s6_addr[1] & 0xc0) == 0x80)
+            {
+                return true;
+            }
+            inet_ntop(AF_INET6, &addr, vtep, sizeof(vtep));
+        }
+        else
+        {
+            SWSS_LOG_INFO("MacSync: FDB nexthop %u has family %d, skipping",
+                          nhid, nhm->nh_family);
+            return true;
+        }
+
+        m_l2NhgTable.set(key, vector<FieldValueTuple>{{"remote_vtep", vtep}});
+
+        L2NhgInfo info;
+        info.type = L2_NHG_TYPE_VTEP;
+        info.vtepIp = vtep;
+        m_l2Nhgs[nhid] = info;
+
+        SWSS_LOG_INFO("MacSync: FDB nexthop %u -> vtep %s", nhid, vtep);
+        return true;
+    }
+
+    if (tb[NHA_GROUP])
+    {
+        struct nexthop_grp *grp = (struct nexthop_grp *)RTA_DATA(tb[NHA_GROUP]);
+        size_t count = RTA_PAYLOAD(tb[NHA_GROUP]) / sizeof(struct nexthop_grp);
+        vector<uint32_t> members;
+        string joined;
+
+        for (size_t i = 0; i < count; i++)
+        {
+            /* A group is only meaningful once every member is known, otherwise
+             * fdbOrch would resolve it against a nexthop that does not exist. */
+            if (!m_l2Nhgs.count(grp[i].id))
+            {
+                SWSS_LOG_INFO("MacSync: FDB nexthop group %u names unknown member %u, skipping",
+                              nhid, grp[i].id);
+                return true;
+            }
+            members.push_back(grp[i].id);
+            joined += (i ? "," : "") + to_string(grp[i].id);
+        }
+
+        if (members.empty())
+        {
+            return true;
+        }
+
+        m_l2NhgTable.set(key, vector<FieldValueTuple>{{"nexthop_group", joined}});
+
+        L2NhgInfo info;
+        info.type = L2_NHG_TYPE_GROUP;
+        info.memberIds = members;
+        m_l2Nhgs[nhid] = info;
+
+        SWSS_LOG_INFO("MacSync: FDB nexthop group %u -> %s", nhid, joined.c_str());
+    }
+
+    return true;
 }
 
 /*
@@ -609,9 +782,20 @@ void MacSync::onMacMsg(struct nlmsghdr *h, int len)
 
     if (nexthopGroup.empty())
     {
-        if (tb[NDA_DST])
+        size_t dstLen = tb[NDA_DST] ? RTA_PAYLOAD(tb[NDA_DST]) : 0;
+        bool haveDst = false;
+
+        /* zebra emits NDA_DST even when there is no VTEP, sized from the address
+         * family it guessed rather than from what it holds, so an unusable or
+         * all-zero destination means "no VTEP" and not 0.0.0.0. */
+        if (dstLen == sizeof(struct in_addr) || dstLen == sizeof(struct in6_addr))
         {
-            size_t dstLen = RTA_PAYLOAD(tb[NDA_DST]);
+            const uint8_t *dst = (const uint8_t *)RTA_DATA(tb[NDA_DST]);
+            haveDst = std::any_of(dst, dst + dstLen, [](uint8_t b) { return b != 0; });
+        }
+
+        if (haveDst)
+        {
             int family = (dstLen == sizeof(struct in6_addr)) ? AF_INET6 : AF_INET;
 
             if (!inet_ntop(family, RTA_DATA(tb[NDA_DST]), vtep, sizeof(vtep)))

--- a/fpmsyncd/macsync.cpp
+++ b/fpmsyncd/macsync.cpp
@@ -10,6 +10,7 @@
 #include "logger.h"
 #include "macaddress.h"
 #include "schema.h"
+#include "warm_restart.h"
 #include "fpm/fpm.h"
 #include "fpmsyncd/macsync.h"
 
@@ -94,10 +95,12 @@ MacSync::MacSync(RedisPipeline *pipeline, DBConnector *stateDb, DBConnector *cfg
     m_l2NhgTable(pipeline, APP_L2_NEXTHOP_GROUP_TABLE_NAME, true),
     m_stateFdbTable(stateDb, STATE_FDB_TABLE_NAME),
     m_cfgFdbSyncTable(cfgDb, CFG_FDB_SYNC_TABLE_NAME),
+    m_appPortTable(pipeline->getDBConnector(), APP_PORT_TABLE_NAME),
     m_cfgFdbSyncTableRead(cfgDb, CFG_FDB_SYNC_TABLE_NAME),
     m_cfgEvpnEsTable(cfgDb, "EVPN_ETHERNET_SEGMENT"),
     m_stateFdbTableRead(stateDb, STATE_FDB_TABLE_NAME),
-    m_stateFdbSyncTable(stateDb, STATE_FDB_SYNC_TABLE_NAME)
+    m_stateFdbSyncTable(stateDb, STATE_FDB_SYNC_TABLE_NAME),
+    m_appPortTableRead(pipeline, APP_PORT_TABLE_NAME, false)
 {
     readCfgFdbSyncMode();
 }
@@ -140,6 +143,16 @@ void MacSync::setMacSyncMode(const string& mode)
          * path, so the local cache is stale on the way into fpm mode. */
         loadLocalMacs();
         replayLocalMacs();
+        /* Only a fresh connect sends the marker otherwise, so without this a
+         * mode change back to fpm would leave zebra writing local MACs too. */
+        trySendReplayEnd();
+    }
+    else
+    {
+        /* fdbsyncd owns the kernel path again, so zebra has to stop deferring
+         * local MACs to us. Nothing else tells it the mode changed. */
+        sendLocalMacRelease();
+        m_localMacs.clear();
     }
 }
 
@@ -184,12 +197,13 @@ void MacSync::onFpmConnected(FpmInterface& fpm)
 
     loadLocalMacs();
     replayLocalMacs();
-    sendReplayEnd();
+    trySendReplayEnd();
 }
 
 void MacSync::onFpmDisconnected()
 {
     m_fpmInterface = nullptr;
+    m_replayEndPending = false;
 }
 
 /*
@@ -418,6 +432,12 @@ uint32_t MacSync::nextGeneration()
     }
 
     ++generation;
+    /* 0 means "local MACs are not owned over the FPM", so it is never a
+     * replay generation. */
+    if (generation == 0)
+    {
+        generation = 1;
+    }
     m_stateFdbSyncTable.hset(FDB_SYNC_GLOBAL_KEY, FDB_SYNC_GENERATION_FIELD,
                              std::to_string(generation));
 
@@ -504,6 +524,73 @@ void MacSync::replayLocalMacs()
     }
 }
 
+/*
+ * The marker tells zebra to drop every local MAC it did not just receive, so
+ * sending it while STATE_DB is still filling would withdraw MACs that exist.
+ * orchagent owns STATE_DB FDB_TABLE, so the question is whether orchagent is
+ * far enough along for its silence to mean "no MACs" rather than "not yet".
+ *
+ * PortInitDone says orchagent finished creating ports, and a warm restart adds
+ * the ASIC's retained MACs afterwards during reconciliation.
+ */
+bool MacSync::isLocalMacViewComplete()
+{
+    std::vector<FieldValueTuple> values;
+    /* Retries are driven by port and FDB events, so without this only-once
+     * guard a boot logs one line per event: ~700 on a 500 port switch. */
+    bool firstCheckOfHold = !m_replayEndPending;
+
+    if (!m_appPortTableRead.get("PortInitDone", values))
+    {
+        if (firstCheckOfHold)
+        {
+            SWSS_LOG_NOTICE("MacSync: orchagent has not signalled PortInitDone, "
+                            "holding the end-of-replay marker");
+        }
+        return false;
+    }
+
+    if (WarmStart::isWarmStart())
+    {
+        WarmStart::WarmStartState state;
+
+        WarmStart::getWarmStartState("orchagent", state);
+        if (state != WarmStart::REPLAYED && state != WarmStart::RECONCILED)
+        {
+            if (firstCheckOfHold)
+            {
+                SWSS_LOG_NOTICE("MacSync: orchagent is still reconciling its warm "
+                                "restart, holding the end-of-replay marker");
+            }
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/*
+ * Deferring is the safe direction: zebra keeps MACs it might have swept, and
+ * the sweep still happens once STATE_DB is trustworthy. Local MAC adds are not
+ * held back, only the marker, so nothing is delayed except the withdrawal.
+ */
+void MacSync::trySendReplayEnd()
+{
+    if (!m_fpmMode || !m_fpmInterface)
+    {
+        return;
+    }
+
+    if (!isLocalMacViewComplete())
+    {
+        m_replayEndPending = true;
+        return;
+    }
+
+    m_replayEndPending = false;
+    sendReplayEnd();
+}
+
 void MacSync::sendReplayEnd()
 {
     if (!m_fpmMode || !m_fpmInterface)
@@ -527,6 +614,53 @@ void MacSync::sendReplayEnd()
 
     SWSS_LOG_NOTICE("MacSync: replayed %zu local MACs, generation %u",
                     m_localMacs.size(), m_generation);
+}
+
+/*
+ * Hand local MACs back to zebra. Generation 0 is not a replay, so it does not
+ * go through trySendReplayEnd(): there is no view of STATE_DB left to complete
+ * and holding the message would leave zebra suppressing writes nobody is making.
+ */
+void MacSync::sendLocalMacRelease()
+{
+    if (!m_fpmInterface)
+    {
+        return;
+    }
+
+    struct nlmsghdr n{};
+
+    n.nlmsg_len = NLMSG_LENGTH(0);
+    n.nlmsg_flags = NLM_F_REQUEST;
+    n.nlmsg_type = RTM_FPM_MAC_REPLAY_END;
+    n.nlmsg_seq = 0;
+
+    if (!m_fpmInterface->send(&n))
+    {
+        SWSS_LOG_ERROR("MacSync: failed to release local MACs to zebra");
+        return;
+    }
+
+    m_replayEndPending = false;
+    SWSS_LOG_NOTICE("MacSync: released local MACs, zebra owns them again");
+}
+
+/*
+ * orchagent signals PortInitDone here. A marker held because STATE_DB could not
+ * be trusted yet has no other wake-up: if orchagent comes up owning no MACs it
+ * publishes nothing to STATE_DB, so waiting on FDB traffic alone would hold the
+ * marker until the next FPM reconnect.
+ */
+void MacSync::processAppPort()
+{
+    std::deque<KeyOpFieldsValuesTuple> entries;
+
+    m_appPortTable.pops(entries);
+
+    if (m_replayEndPending)
+    {
+        trySendReplayEnd();
+    }
 }
 
 void MacSync::processStateFdb()
@@ -592,6 +726,13 @@ void MacSync::processStateFdb()
         }
 
         sendLocalMac(vlanName, mac, port, isStatic, add);
+    }
+
+    /* orchagent publishing again is the signal that its silence would now mean
+     * "no MACs", which is what a held marker was waiting for. */
+    if (m_replayEndPending)
+    {
+        trySendReplayEnd();
     }
 }
 

--- a/fpmsyncd/macsync.h
+++ b/fpmsyncd/macsync.h
@@ -60,11 +60,13 @@ private:
     void sendLocalMac(const std::string& vlanName, const std::string& mac,
                       const std::string& port, bool isStatic, bool add);
     void loadLocalMacs();
+    void loadRemoteMacs();
     uint32_t nextGeneration();
     void replayLocalMacs();
     void sendReplayEnd();
 
     ProducerStateTable m_vxlanFdbTable;
+    Table m_vxlanFdbTableRead;
     SubscriberStateTable m_stateFdbTable;
     SubscriberStateTable m_cfgFdbSyncTable;
     Table m_cfgFdbSyncTableRead;

--- a/fpmsyncd/macsync.h
+++ b/fpmsyncd/macsync.h
@@ -65,6 +65,7 @@ private:
 
     void readCfgFdbSyncMode();
     void setMacSyncMode(const std::string& mode);
+    bool isEthernetSegmentInterface(const std::string& ifname);
     void sendLocalMac(const std::string& vlanName, const std::string& mac,
                       const std::string& port, bool isStatic, bool add);
     void loadLocalMacs();
@@ -78,6 +79,7 @@ private:
     SubscriberStateTable m_stateFdbTable;
     SubscriberStateTable m_cfgFdbSyncTable;
     Table m_cfgFdbSyncTableRead;
+    Table m_cfgEvpnEsTable;
     Table m_stateFdbTableRead;
     Table m_stateFdbSyncTable;
 

--- a/fpmsyncd/macsync.h
+++ b/fpmsyncd/macsync.h
@@ -60,6 +60,7 @@ private:
     void sendLocalMac(const std::string& vlanName, const std::string& mac,
                       const std::string& port, bool isStatic, bool add);
     void replayLocalMacs();
+    void sendReplayEnd();
 
     ProducerStateTable m_vxlanFdbTable;
     SubscriberStateTable m_stateFdbTable;
@@ -68,6 +69,10 @@ private:
 
     FpmInterface *m_fpmInterface {nullptr};
     bool m_fpmMode {false};
+
+    /* Bumped on every FPM connect and carried in nlmsg_seq, so zebra can drop
+     * MACs left over from a previous session once the replay ends. */
+    uint32_t m_generation {0};
 
     std::map<std::string, LocalMac> m_localMacs;
     std::set<std::string> m_remoteMacs;

--- a/fpmsyncd/macsync.h
+++ b/fpmsyncd/macsync.h
@@ -33,7 +33,6 @@ public:
 
     SubscriberStateTable *getStateFdbTable() { return &m_stateFdbTable; }
     SubscriberStateTable *getCfgFdbSyncTable() { return &m_cfgFdbSyncTable; }
-    SelectableTimer *getStaleTimer() { return &m_staleTimer; }
 
     /* CONFIG_DB FDB_SYNC|global updates. */
     void processCfgFdbSync();
@@ -46,9 +45,6 @@ public:
 
     /* zebra finished replaying its remote MACs. */
     void onRemoteReplayEnd();
-
-    /* Hold-down expired: whatever zebra still has not mentioned is gone. */
-    void onStaleTimer();
 
     void onFpmConnected(FpmInterface& fpm);
     void onFpmDisconnected();
@@ -98,11 +94,6 @@ private:
      * missing from this set at end of replay no longer exist. */
     std::set<std::string> m_remoteMacsSeen;
     bool m_remoteReplayPending {false};
-
-    /* Not deleted at end of replay: zebra's own EVPN state may still be
-     * converging, so a re-advertisement clears the entry from this set. */
-    std::set<std::string> m_staleCandidates;
-    SelectableTimer m_staleTimer;
 };
 
 }

--- a/fpmsyncd/macsync.h
+++ b/fpmsyncd/macsync.h
@@ -9,6 +9,7 @@
 
 #include "dbconnector.h"
 #include "producerstatetable.h"
+#include "selectabletimer.h"
 #include "subscriberstatetable.h"
 #include "table.h"
 #include "fpmsyncd/fpminterface.h"
@@ -32,6 +33,7 @@ public:
 
     SubscriberStateTable *getStateFdbTable() { return &m_stateFdbTable; }
     SubscriberStateTable *getCfgFdbSyncTable() { return &m_cfgFdbSyncTable; }
+    SelectableTimer *getStaleTimer() { return &m_staleTimer; }
 
     /* CONFIG_DB FDB_SYNC|global updates. */
     void processCfgFdbSync();
@@ -41,6 +43,12 @@ public:
 
     /* Inbound AF_BRIDGE neighbour message from zebra: remote MACs toward APPL_DB. */
     void onMacMsg(struct nlmsghdr *h, int len);
+
+    /* zebra finished replaying its remote MACs. */
+    void onRemoteReplayEnd();
+
+    /* Hold-down expired: whatever zebra still has not mentioned is gone. */
+    void onStaleTimer();
 
     void onFpmConnected(FpmInterface& fpm);
     void onFpmDisconnected();
@@ -83,6 +91,16 @@ private:
 
     std::map<std::string, LocalMac> m_localMacs;
     std::set<std::string> m_remoteMacs;
+
+    /* Remote MACs zebra mentioned since it connected. Entries in m_remoteMacs
+     * missing from this set at end of replay no longer exist. */
+    std::set<std::string> m_remoteMacsSeen;
+    bool m_remoteReplayPending {false};
+
+    /* Not deleted at end of replay: zebra's own EVPN state may still be
+     * converging, so a re-advertisement clears the entry from this set. */
+    std::set<std::string> m_staleCandidates;
+    SelectableTimer m_staleTimer;
 };
 
 }

--- a/fpmsyncd/macsync.h
+++ b/fpmsyncd/macsync.h
@@ -3,9 +3,12 @@
 
 #include <linux/rtnetlink.h>
 #include <linux/neighbour.h>
+#include <linux/nexthop.h>
 
+#include <map>
 #include <set>
 #include <string>
+#include <vector>
 
 #include "dbconnector.h"
 #include "producerstatetable.h"
@@ -43,6 +46,11 @@ public:
     /* Inbound AF_BRIDGE neighbour message from zebra: remote MACs toward APPL_DB. */
     void onMacMsg(struct nlmsghdr *h, int len);
 
+    /* Inbound nexthop message from zebra. An FDB nexthop is an EVPN Ethernet
+     * Segment destination rather than an L3 one, so it is consumed here and
+     * must not reach the route path. Returns true when it was an FDB nexthop. */
+    bool onFdbNhgMsg(struct nlmsghdr *h, int len);
+
     /* zebra finished replaying its remote MACs. */
     void onRemoteReplayEnd();
 
@@ -59,6 +67,22 @@ private:
         bool isStatic;
     };
 
+    /* An FDB nexthop is either a single remote VTEP or a group of other FDB
+     * nexthop ids. Kept so a group can be validated against its members and
+     * re-derived when one of them is withdrawn. */
+    enum L2NhgType
+    {
+        L2_NHG_TYPE_VTEP,
+        L2_NHG_TYPE_GROUP,
+    };
+
+    struct L2NhgInfo
+    {
+        L2NhgType type;
+        std::string vtepIp;
+        std::vector<uint32_t> memberIds;
+    };
+
     void readCfgFdbSyncMode();
     void setMacSyncMode(const std::string& mode);
     bool isEthernetSegmentInterface(const std::string& ifname);
@@ -72,6 +96,7 @@ private:
 
     ProducerStateTable m_vxlanFdbTable;
     Table m_vxlanFdbTableRead;
+    ProducerStateTable m_l2NhgTable;
     SubscriberStateTable m_stateFdbTable;
     SubscriberStateTable m_cfgFdbSyncTable;
     Table m_cfgFdbSyncTableRead;
@@ -94,6 +119,8 @@ private:
      * missing from this set at end of replay no longer exist. */
     std::set<std::string> m_remoteMacsSeen;
     bool m_remoteReplayPending {false};
+
+    std::map<uint32_t, L2NhgInfo> m_l2Nhgs;
 };
 
 }

--- a/fpmsyncd/macsync.h
+++ b/fpmsyncd/macsync.h
@@ -59,6 +59,8 @@ private:
     void setMacSyncMode(const std::string& mode);
     void sendLocalMac(const std::string& vlanName, const std::string& mac,
                       const std::string& port, bool isStatic, bool add);
+    void loadLocalMacs();
+    uint32_t nextGeneration();
     void replayLocalMacs();
     void sendReplayEnd();
 
@@ -66,12 +68,15 @@ private:
     SubscriberStateTable m_stateFdbTable;
     SubscriberStateTable m_cfgFdbSyncTable;
     Table m_cfgFdbSyncTableRead;
+    Table m_stateFdbTableRead;
+    Table m_stateFdbSyncTable;
 
     FpmInterface *m_fpmInterface {nullptr};
     bool m_fpmMode {false};
 
-    /* Bumped on every FPM connect and carried in nlmsg_seq, so zebra can drop
-     * MACs left over from a previous session once the replay ends. */
+    /* Carried in nlmsg_seq so zebra can drop MACs left over from a previous
+     * session once the replay ends. Kept in STATE_DB because it has to differ
+     * from the one the previous fpmsyncd process sent. */
     uint32_t m_generation {0};
 
     std::map<std::string, LocalMac> m_localMacs;

--- a/fpmsyncd/macsync.h
+++ b/fpmsyncd/macsync.h
@@ -1,0 +1,78 @@
+#ifndef __MACSYNC__
+#define __MACSYNC__
+
+#include <linux/rtnetlink.h>
+#include <linux/neighbour.h>
+
+#include <set>
+#include <string>
+
+#include "dbconnector.h"
+#include "producerstatetable.h"
+#include "subscriberstatetable.h"
+#include "table.h"
+#include "fpmsyncd/fpminterface.h"
+
+namespace swss {
+
+/*
+ * MAC (bridge FDB) synchronization with zebra over the FPM channel.
+ *
+ * Local direction : STATE_DB FDB_TABLE -> AF_BRIDGE RTM_NEWNEIGH/RTM_DELNEIGH -> zebra.
+ * Remote direction: AF_BRIDGE RTM_NEWNEIGH/RTM_DELNEIGH from zebra -> APP_VXLAN_FDB_TABLE.
+ *
+ * Active only while CONFIG_DB FDB_SYNC|global mac_sync_mode is "fpm"; in "kernel"
+ * mode every entry point is a no-op so behaviour is identical to fdbsyncd's
+ * netlink path.
+ */
+class MacSync
+{
+public:
+    MacSync(RedisPipeline *pipeline, DBConnector *stateDb, DBConnector *cfgDb);
+
+    SubscriberStateTable *getStateFdbTable() { return &m_stateFdbTable; }
+    SubscriberStateTable *getCfgFdbSyncTable() { return &m_cfgFdbSyncTable; }
+
+    /* CONFIG_DB FDB_SYNC|global updates. */
+    void processCfgFdbSync();
+
+    /* STATE_DB FDB_TABLE updates: local MACs toward zebra. */
+    void processStateFdb();
+
+    /* Inbound AF_BRIDGE neighbour message from zebra: remote MACs toward APPL_DB. */
+    void onMacMsg(struct nlmsghdr *h, int len);
+
+    void onFpmConnected(FpmInterface& fpm);
+    void onFpmDisconnected();
+
+    bool isFpmMode() const { return m_fpmMode; }
+
+private:
+    /* Local MACs already advertised to zebra, keyed "Vlan<id>:<mac>". */
+    struct LocalMac
+    {
+        std::string port;
+        bool isStatic;
+    };
+
+    void readCfgFdbSyncMode();
+    void setMacSyncMode(const std::string& mode);
+    void sendLocalMac(const std::string& vlanName, const std::string& mac,
+                      const std::string& port, bool isStatic, bool add);
+    void replayLocalMacs();
+
+    ProducerStateTable m_vxlanFdbTable;
+    SubscriberStateTable m_stateFdbTable;
+    SubscriberStateTable m_cfgFdbSyncTable;
+    Table m_cfgFdbSyncTableRead;
+
+    FpmInterface *m_fpmInterface {nullptr};
+    bool m_fpmMode {false};
+
+    std::map<std::string, LocalMac> m_localMacs;
+    std::set<std::string> m_remoteMacs;
+};
+
+}
+
+#endif

--- a/fpmsyncd/macsync.h
+++ b/fpmsyncd/macsync.h
@@ -36,9 +36,13 @@ public:
 
     SubscriberStateTable *getStateFdbTable() { return &m_stateFdbTable; }
     SubscriberStateTable *getCfgFdbSyncTable() { return &m_cfgFdbSyncTable; }
+    SubscriberStateTable *getAppPortTable() { return &m_appPortTable; }
 
     /* CONFIG_DB FDB_SYNC|global updates. */
     void processCfgFdbSync();
+
+    /* APPL_DB PORT_TABLE updates: orchagent readiness for a held replay marker. */
+    void processAppPort();
 
     /* STATE_DB FDB_TABLE updates: local MACs toward zebra. */
     void processStateFdb();
@@ -92,17 +96,22 @@ private:
     void loadRemoteMacs();
     uint32_t nextGeneration();
     void replayLocalMacs();
+    bool isLocalMacViewComplete();
+    void trySendReplayEnd();
     void sendReplayEnd();
+    void sendLocalMacRelease();
 
     ProducerStateTable m_vxlanFdbTable;
     Table m_vxlanFdbTableRead;
     ProducerStateTable m_l2NhgTable;
     SubscriberStateTable m_stateFdbTable;
     SubscriberStateTable m_cfgFdbSyncTable;
+    SubscriberStateTable m_appPortTable;
     Table m_cfgFdbSyncTableRead;
     Table m_cfgEvpnEsTable;
     Table m_stateFdbTableRead;
     Table m_stateFdbSyncTable;
+    Table m_appPortTableRead;
 
     FpmInterface *m_fpmInterface {nullptr};
     bool m_fpmMode {false};
@@ -119,6 +128,11 @@ private:
      * missing from this set at end of replay no longer exist. */
     std::set<std::string> m_remoteMacsSeen;
     bool m_remoteReplayPending {false};
+
+    /* The end-of-replay marker makes zebra drop every local MAC we did not just
+     * replay, so it may only be sent once STATE_DB is known to hold the real
+     * set. Held here until then. */
+    bool m_replayEndPending {false};
 
     std::map<uint32_t, L2NhgInfo> m_l2Nhgs;
 };

--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -2472,6 +2472,13 @@ void RouteSync::onMsgRaw(struct nlmsghdr *h)
     {
     case RTM_NEWNEXTHOP:
     case RTM_DELNEXTHOP:
+        /* An FDB nexthop names an EVPN Ethernet Segment destination, not an L3
+         * nexthop. Letting it reach onNextHopMsg() would publish it as a real
+         * NEXTHOP_GROUP. */
+        if (m_macsync && m_macsync->onFdbNhgMsg(h, len))
+        {
+            return;
+        }
         onNextHopMsg(h, len);
         return;
     case RTM_NEWPICCONTEXT:

--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -2450,6 +2450,10 @@ void RouteSync::onMsgRaw(struct nlmsghdr *h)
     case RTM_FPM_DEL_EVPN_ES_BACKUP_NHG:
         hdr_len = sizeof(struct evpn_backup_nhg_msg);
         break;
+    case RTM_FPM_MAC_REPLAY_END:
+        /* Marker only; the generation travels in nlmsg_seq. */
+        hdr_len = 0;
+        break;
     default:
         hdr_len = sizeof(struct ndmsg);
         break;
@@ -2503,6 +2507,12 @@ void RouteSync::onMsgRaw(struct nlmsghdr *h)
         if (m_macsync)
         {
             m_macsync->onMacMsg(h, len);
+        }
+        return;
+    case RTM_FPM_MAC_REPLAY_END:
+        if (m_macsync)
+        {
+            m_macsync->onRemoteReplayEnd();
         }
         return;
     default:

--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -10,6 +10,7 @@
 #include "producerstatetable.h"
 #include "fpmsyncd/fpmlink.h"
 #include "fpmsyncd/routesync.h"
+#include "fpmsyncd/macsync.h"
 #include "fpmsyncd/fpm/fpm.h"
 #include "macaddress.h"
 #include "converter.h"
@@ -2417,6 +2418,8 @@ void RouteSync::onMsgRaw(struct nlmsghdr *h)
         && (h->nlmsg_type != RTM_DELSRV6LOCALSID)
         && (h->nlmsg_type != RTM_NEWTFILTER)
         && (h->nlmsg_type != RTM_DELTFILTER)
+        && (h->nlmsg_type != RTM_NEWNEIGH)
+        && (h->nlmsg_type != RTM_DELNEIGH)
         && !(h->nlmsg_type >= RTM_FPM_FIRST && h->nlmsg_type <= RTM_FPM_LAST))
     {
         return;
@@ -2494,6 +2497,13 @@ void RouteSync::onMsgRaw(struct nlmsghdr *h)
     case RTM_FPM_ADD_EVPN_ES_BACKUP_NHG:
     case RTM_FPM_DEL_EVPN_ES_BACKUP_NHG:
         onEvpnEsBackupNhgMsg(h, len);
+        return;
+    case RTM_NEWNEIGH:
+    case RTM_DELNEIGH:
+        if (m_macsync)
+        {
+            m_macsync->onMacMsg(h, len);
+        }
         return;
     default:
         break;

--- a/fpmsyncd/routesync.h
+++ b/fpmsyncd/routesync.h
@@ -208,6 +208,8 @@ class Srv6SidListTableFieldValueTupleWrapper : public FieldValueTupleWrapperBase
     string path = string();
 };
 
+class MacSync;
+
 class RouteSync : public NetMsg
 {
 public:
@@ -220,6 +222,11 @@ public:
     virtual void onMsg(int nlmsg_type, struct nl_object *obj);
 
     virtual void onMsgRaw(struct nlmsghdr *obj);
+
+    void setMacSync(MacSync *macsync)
+    {
+        m_macsync = macsync;
+    }
 
     void setSuppressionEnabled(bool enabled);
 
@@ -300,6 +307,8 @@ private:
 
     bool                m_isSuppressionEnabled{false};
     FpmInterface*       m_fpmInterface {nullptr};
+
+    MacSync*            m_macsync {nullptr};
 
     /* Handle regular route (include VRF route) */
     void onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf);

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -7430,14 +7430,6 @@ bool PortsOrch::addBridgePort(Port &port)
     attr.value.s32 = port.m_learn_mode;
     attrs.push_back(attr);
 
-    /* If the interface is associated with an ethernet segment, set the DF role */
-    if (gEvpnMhOrch && gEvpnMhOrch->isPortInterfaceAssociatedToEs(port.m_alias)) {
-        /* TODO FIXME: sridsant : Use proper attribute once its available in SAI */
-        attr.id = SAI_BRIDGE_PORT_ATTR_EGRESS_FILTERING;
-        attr.value.booldata = gEvpnMhOrch->isInterfaceDF(port.m_alias, DEFAULT_PORT_VLAN_ID);
-        attrs.push_back(attr);
-    }
-
     sai_status_t status = sai_bridge_api->create_bridge_port(&port.m_bridge_port_id, gSwitchId, (uint32_t)attrs.size(), attrs.data());
     if (status != SAI_STATUS_SUCCESS)
     {
@@ -7449,6 +7441,28 @@ bool PortsOrch::addBridgePort(Port &port)
             return parseHandleSaiStatusFailure(handle_status);
         }
         return false;
+    }
+
+    /* Set after create: the DF role is optional, and a platform that does not
+     * implement it must not lose the bridge port along with it. */
+    if (gEvpnMhOrch && gEvpnMhOrch->isPortInterfaceAssociatedToEs(port.m_alias)) {
+        /* TODO FIXME: sridsant : Use proper attribute once its available in SAI */
+        sai_attribute_t df_attr;
+        df_attr.id = SAI_BRIDGE_PORT_ATTR_EGRESS_FILTERING;
+        df_attr.value.booldata = gEvpnMhOrch->isInterfaceDF(port.m_alias, DEFAULT_PORT_VLAN_ID);
+
+        sai_status_t df_status = sai_bridge_api->set_bridge_port_attribute(port.m_bridge_port_id, &df_attr);
+        if (df_status == SAI_STATUS_NOT_SUPPORTED || df_status == SAI_STATUS_NOT_IMPLEMENTED ||
+            SAI_STATUS_IS_ATTR_NOT_SUPPORTED(df_status) || SAI_STATUS_IS_ATTR_NOT_IMPLEMENTED(df_status))
+        {
+            SWSS_LOG_WARN("Bridge port %s: DF role attribute unavailable on this platform, "
+                          "non-DF BUM suppression not applied", port.m_alias.c_str());
+        }
+        else if (df_status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Bridge port %s: failed to set DF role, rv:%d",
+                           port.m_alias.c_str(), df_status);
+        }
     }
 
     if (!setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_KEEP))
@@ -7733,14 +7747,6 @@ bool PortsOrch::addVlanMember(Port &vlan, Port &port, string &tagging_mode, stri
     attr.value.s32 = sai_tagging_mode;
     attrs.push_back(attr);
 
-    /* If the interface is associated with an ethernet segment, send the SAI vlan DF attribute */
-    if (gEvpnMhOrch && gEvpnMhOrch->isPortAndVlanAssociatedToEs(port.m_alias, vlan.m_vlan_info.vlan_id)) {
-        /* TODO: Use proper attribute once its available in SAI */
-        attr.id = SAI_VLAN_MEMBER_ATTR_TUNNEL_TERM_BUM_TX_DROP;
-        attr.value.booldata = gEvpnMhOrch->isInterfaceDF(port.m_alias, vlan.m_vlan_info.vlan_id);
-        attrs.push_back(attr);
-    }
-
     sai_object_id_t vlan_member_id;
     sai_status_t status = sai_vlan_api->create_vlan_member(&vlan_member_id, gSwitchId, (uint32_t)attrs.size(), attrs.data());
     if (status != SAI_STATUS_SUCCESS)
@@ -7751,6 +7757,27 @@ bool PortsOrch::addVlanMember(Port &vlan, Port &port, string &tagging_mode, stri
         if (handle_status != task_success)
         {
             return parseHandleSaiStatusFailure(handle_status);
+        }
+    }
+
+    /* Set after create, for the same reason as the bridge port DF role above. */
+    if (gEvpnMhOrch && gEvpnMhOrch->isPortAndVlanAssociatedToEs(port.m_alias, vlan.m_vlan_info.vlan_id)) {
+        /* TODO: Use proper attribute once its available in SAI */
+        sai_attribute_t df_attr;
+        df_attr.id = SAI_VLAN_MEMBER_ATTR_TUNNEL_TERM_BUM_TX_DROP;
+        df_attr.value.booldata = gEvpnMhOrch->isInterfaceDF(port.m_alias, vlan.m_vlan_info.vlan_id);
+
+        sai_status_t df_status = sai_vlan_api->set_vlan_member_attribute(vlan_member_id, &df_attr);
+        if (df_status == SAI_STATUS_NOT_SUPPORTED || df_status == SAI_STATUS_NOT_IMPLEMENTED ||
+            SAI_STATUS_IS_ATTR_NOT_SUPPORTED(df_status) || SAI_STATUS_IS_ATTR_NOT_IMPLEMENTED(df_status))
+        {
+            SWSS_LOG_WARN("VLAN member %s on %s: DF role attribute unavailable on this platform, "
+                          "non-DF BUM suppression not applied", port.m_alias.c_str(), vlan.m_alias.c_str());
+        }
+        else if (df_status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("VLAN member %s on %s: failed to set DF role, rv:%d",
+                           port.m_alias.c_str(), vlan.m_alias.c_str(), df_status);
         }
     }
     SWSS_LOG_NOTICE("Add member %s to VLAN %s vid:%hu pid%" PRIx64,

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -327,6 +327,8 @@ tests_fpmsyncd_SOURCES = fpmsyncd/test_fpmlink.cpp \
                          fpmsyncd/receive_srv6_mysids_ut.cpp \
                          fpmsyncd/ut_helpers_fpmsyncd.cpp \
                          fpmsyncd/fpmsyncd_evpn_mh_ut.cpp \
+                         fpmsyncd/macsync_ut.cpp \
+                         fdbsyncd/fake_subscriberstatetable.cpp \
                          fake_netlink.cpp \
                          fake_warmstarthelper.cpp \
                          fake_producerstatetable.cpp \
@@ -336,7 +338,8 @@ tests_fpmsyncd_SOURCES = fpmsyncd/test_fpmlink.cpp \
                          $(top_srcdir)/lib/orch_zmq_config.cpp \
                          $(top_srcdir)/warmrestart/ \
                          $(top_srcdir)/fpmsyncd/fpmlink.cpp \
-                         $(top_srcdir)/fpmsyncd/routesync.cpp
+                         $(top_srcdir)/fpmsyncd/routesync.cpp \
+                         $(top_srcdir)/fpmsyncd/macsync.cpp
 
 tests_fpmsyncd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/tests_fpmsyncd -I$(top_srcdir)/lib -I$(top_srcdir)/warmrestart -I$(top_srcdir)/fpmsyncd
 tests_fpmsyncd_CXXFLAGS = -Wl,-wrap,rtnl_link_i2name
@@ -356,6 +359,7 @@ tests_fdbsyncd_SOURCES = fdbsyncd/fdbsyncd_ut.cpp \
                          mock_table.cpp \
                          mock_hiredis.cpp \
                          mock_redisreply.cpp \
+                         common/mock_shell_command.cpp \
                          $(top_srcdir)/fdbsyncd/fdbsync.cpp
 
 tests_fdbsyncd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/tests_fdbsyncd -I$(top_srcdir)/lib -I$(top_srcdir)/warmrestart

--- a/tests/mock_tests/evpnmhorch_ut.cpp
+++ b/tests/mock_tests/evpnmhorch_ut.cpp
@@ -414,25 +414,38 @@ namespace evpnmhorch_test
         gEvpnMhOrch->addExistingData(&evpnEsIntfTable);
         static_cast<Orch *>(gEvpnMhOrch)->doTask();
 
-        bool df_attr_found;
-        bool df_attr_value;
+        bool df_attr_found = false;
+        bool df_attr_value = false;
+        bool df_attr_in_create = false;
 
         auto vlanSpy = SpyOn<SAI_API_VLAN, SAI_OBJECT_TYPE_VLAN_MEMBER>(&sai_vlan_api->create_vlan_member);
         vlanSpy->callFake([&](sai_object_id_t *oid, sai_object_id_t swoid, uint32_t count, const sai_attribute_t *attrs) -> sai_status_t {
             uint32_t i;
 
-            for (i = 0; i < count && !df_attr_found; i++)
+            for (i = 0; i < count && !df_attr_in_create; i++)
             {
                 // TODO: Use the correct attribute once its available in SAI
                 if (attrs[i].id == SAI_VLAN_MEMBER_ATTR_TUNNEL_TERM_BUM_TX_DROP)
                 {
-                    df_attr_found = true;
-                    // This is inverted from the currently proposed NON_DF SAI attribute
-                    df_attr_value = attrs[i].value.booldata;
+                    df_attr_in_create = true;
                 }
             }
 
             return org_sai_vlan_api->create_vlan_member(oid, swoid, count, attrs);
+        });
+
+        auto vlanMemberAttrSpy = SpyOn<SAI_API_VLAN, SAI_OBJECT_TYPE_VLAN>(&sai_vlan_api->set_vlan_member_attribute);
+        vlanMemberAttrSpy->callFake([&](sai_object_id_t oid, const sai_attribute_t *attr) -> sai_status_t {
+            // TODO: Use the correct attribute once its available in SAI
+            if (attr->id == SAI_VLAN_MEMBER_ATTR_TUNNEL_TERM_BUM_TX_DROP)
+            {
+                df_attr_found = true;
+                df_attr_received = attr->id;
+                // This is inverted from the currently proposed NON_DF SAI attribute
+                df_attr_value = attr->value.booldata;
+            }
+
+            return org_sai_vlan_api->set_vlan_member_attribute(oid, attr);
         });
 
         ApplyDualTorConfigsForSingleVlan();
@@ -440,16 +453,11 @@ namespace evpnmhorch_test
         ASSERT_TRUE(gEvpnMhOrch->isPortInterfaceAssociatedToEs("Ethernet1"));
         ASSERT_TRUE(gEvpnMhOrch->isPortAndVlanAssociatedToEs("Ethernet1", 10));
         ASSERT_FALSE(gEvpnMhOrch->isInterfaceDF("Ethernet1", 10));
+        /* The DF role is applied after create so an unimplemented attribute cannot
+         * fail the VLAN member itself. */
+        ASSERT_FALSE(df_attr_in_create);
         ASSERT_TRUE(df_attr_found);
         ASSERT_FALSE(df_attr_value);
-
-        auto vlanMemberAttrSpy = SpyOn<SAI_API_VLAN, SAI_OBJECT_TYPE_VLAN>(&sai_vlan_api->set_vlan_member_attribute);
-        vlanMemberAttrSpy->callFake([&](sai_object_id_t oid, const sai_attribute_t *attr) -> sai_status_t {
-            df_attr_received = attr->id;
-            df_attr_value = attr->value.booldata;
-
-            return org_sai_vlan_api->set_vlan_member_attribute(oid, attr);
-        });
 
         std::deque<KeyOpFieldsValuesTuple> entries;
         entries.clear();

--- a/tests/mock_tests/fdborch/fdborch_vxlan_ut.cpp
+++ b/tests/mock_tests/fdborch/fdborch_vxlan_ut.cpp
@@ -573,6 +573,189 @@ namespace fdborch_vxlan_ut
         ASSERT_EQ(m_portsOrch->m_portList[VXLAN_REMOTE].m_fdb_count, 0);
     }
 
+    /* The SAI attribute union has uninitialised padding, so render only the
+     * member that each attribute id actually uses. */
+    static std::string renderFdbAttrs(const sai_attribute_t *attrs, uint32_t count)
+    {
+        std::vector<std::string> rendered;
+
+        for (uint32_t i = 0; i < count; i++)
+        {
+            std::string line = to_string(attrs[i].id) + "=";
+
+            switch (attrs[i].id)
+            {
+                case SAI_FDB_ENTRY_ATTR_TYPE:
+                    line += to_string(attrs[i].value.s32);
+                    break;
+                case SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID:
+                    line += to_string(attrs[i].value.oid);
+                    break;
+                case SAI_FDB_ENTRY_ATTR_ENDPOINT_IP:
+                    line += to_string(attrs[i].value.ipaddr.addr_family) + "/" +
+                            to_string(attrs[i].value.ipaddr.addr.ip4);
+                    break;
+                case SAI_FDB_ENTRY_ATTR_ALLOW_MAC_MOVE:
+                    line += to_string(attrs[i].value.booldata);
+                    break;
+                default:
+                    line += "unrendered";
+                    break;
+            }
+
+            rendered.push_back(line);
+        }
+
+        std::sort(rendered.begin(), rendered.end());
+
+        std::string out;
+        for (const auto &line : rendered)
+        {
+            out += line + ";";
+        }
+        return out;
+    }
+
+    /*
+     * fdbsyncd and fpmsyncd's MacSync populate VXLAN_FDB_TABLE independently.
+     * MacSync omits "protocol", which FdbOrch never reads, so both producers
+     * must still program byte-identical FDB state.
+     */
+    TEST_F(VxlanFdbOrchTest, FpmAndKernelFieldSetsProgramIdenticalFdbEntry)
+    {
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        auto consumer = dynamic_cast<Consumer *>(gFdbOrch->getExecutor("VXLAN_FDB_TABLE"));
+
+        auto ports = ut_helper::getInitialSaiPorts();
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+        portTable.set("PortInitDone", { { "lanes", "0" } });
+
+        m_portsOrch.get()->addExistingData(&portTable);
+        static_cast<Orch *>(m_portsOrch.get())->doTask();
+
+        ASSERT_NE(m_portsOrch, nullptr);
+        setUpVlan(m_portsOrch.get());
+        setUpVxlanPort(m_portsOrch.get());
+        setUpVxlanMember(m_portsOrch.get());
+
+        const std::string key = "Vlan40:7c:fe:90:12:22:ec";
+
+        sai_fdb_entry_t kernelEntry = {};
+        sai_fdb_entry_t fpmEntry = {};
+        sai_attribute_t kernelAttrs[16] = {};
+        sai_attribute_t fpmAttrs[16] = {};
+        uint32_t kernelCount = 0;
+        uint32_t fpmCount = 0;
+
+        EXPECT_CALL(*mock_sai_fdb_api, create_fdb_entry(_, _, _))
+            .Times(2)
+            .WillOnce(::testing::DoAll(SaveArgPointee<0>(&kernelEntry),
+                                       SaveArg<1>(&kernelCount),
+                                       SaveSAIAttrs(kernelAttrs),
+                                       ::testing::Return(SAI_STATUS_SUCCESS)))
+            .WillOnce(::testing::DoAll(SaveArgPointee<0>(&fpmEntry),
+                                       SaveArg<1>(&fpmCount),
+                                       SaveSAIAttrs(fpmAttrs),
+                                       ::testing::Return(SAI_STATUS_SUCCESS)));
+
+        /* fdbsyncd's field set, as built by FdbSync::macAddVxlan for a VTEP */
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({key, "SET", {
+            {"remote_vtep", "1.1.1.1"},
+            {"type", "dynamic"},
+            {"vni", "40"},
+            {"protocol", "186"}
+        }});
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gFdbOrch)->doTask();
+        ASSERT_EQ(m_portsOrch->m_portList[VXLAN_REMOTE].m_fdb_count, 1);
+
+        entries.clear();
+        entries.push_back({key, "DEL", {}});
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gFdbOrch)->doTask();
+        ASSERT_EQ(m_portsOrch->m_portList[VXLAN_REMOTE].m_fdb_count, 0);
+
+        /* MacSync's field set, as built by MacSync::onMacMsg */
+        entries.clear();
+        entries.push_back({key, "SET", {
+            {"remote_vtep", "1.1.1.1"},
+            {"type", "dynamic"},
+            {"vni", "40"}
+        }});
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gFdbOrch)->doTask();
+        ASSERT_EQ(m_portsOrch->m_portList[VXLAN_REMOTE].m_fdb_count, 1);
+
+        ASSERT_EQ(kernelCount, fpmCount);
+        ASSERT_EQ(kernelEntry.bv_id, fpmEntry.bv_id);
+        ASSERT_EQ(memcmp(kernelEntry.mac_address, fpmEntry.mac_address, sizeof(sai_mac_t)), 0);
+        ASSERT_EQ(renderFdbAttrs(kernelAttrs, kernelCount), renderFdbAttrs(fpmAttrs, fpmCount));
+    }
+
+    /*
+     * FdbOrch applies no precedence between remote_vtep, nexthop_group and
+     * ifname: the last one parsed wins. No producer emits more than one today,
+     * so this pins current behaviour rather than endorsing it.
+     */
+    TEST_F(VxlanFdbOrchTest, DestinationFieldOrderDecidesDestType)
+    {
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        auto consumer = dynamic_cast<Consumer *>(gFdbOrch->getExecutor("VXLAN_FDB_TABLE"));
+
+        auto ports = ut_helper::getInitialSaiPorts();
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+        portTable.set("PortInitDone", { { "lanes", "0" } });
+
+        m_portsOrch.get()->addExistingData(&portTable);
+        static_cast<Orch *>(m_portsOrch.get())->doTask();
+
+        ASSERT_NE(m_portsOrch, nullptr);
+        setUpVlan(m_portsOrch.get());
+        setUpPort(m_portsOrch.get());
+        setUpVlanMember(m_portsOrch.get());
+        setUpVxlanPort(m_portsOrch.get());
+        setUpVxlanMember(m_portsOrch.get());
+
+        std::deque<KeyOpFieldsValuesTuple> entries;
+
+        /* ifname parsed last, so the entry lands on the physical port */
+        entries.push_back({"Vlan40:7c:fe:90:12:22:ec", "SET", {
+            {"vni", "40"},
+            {"type", "dynamic"},
+            {"remote_vtep", "1.1.1.1"},
+            {"ifname", ETH0}
+        }});
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gFdbOrch)->doTask();
+
+        ASSERT_EQ(m_portsOrch->m_portList[ETH0].m_fdb_count, 1);
+        ASSERT_EQ(m_portsOrch->m_portList[VXLAN_REMOTE].m_fdb_count, 0);
+
+        /* Same fields, reversed, so the entry lands on the VTEP instead */
+        entries.clear();
+        entries.push_back({"Vlan40:7c:fe:90:12:22:ed", "SET", {
+            {"vni", "40"},
+            {"type", "dynamic"},
+            {"ifname", ETH0},
+            {"remote_vtep", "1.1.1.1"}
+        }});
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gFdbOrch)->doTask();
+
+        ASSERT_EQ(m_portsOrch->m_portList[ETH0].m_fdb_count, 1);
+        ASSERT_EQ(m_portsOrch->m_portList[VXLAN_REMOTE].m_fdb_count, 1);
+        ASSERT_EQ(m_portsOrch->m_portList[VLAN40].m_fdb_count, 2);
+    }
+
     TEST_F(VxlanFdbOrchTest, RemoteMacAddAfterNeighborDoesNotDisableNeighbor)
     {
         Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);

--- a/tests/mock_tests/fdbsyncd/fdbsyncd_ut.cpp
+++ b/tests/mock_tests/fdbsyncd/fdbsyncd_ut.cpp
@@ -2367,3 +2367,26 @@ TEST_F(FdbSyncdEvpnMhTest, AddLocalMacNotProgrammedIntoKernelInFpmMode)
     m_mockFdbSync.addLocalMac(key, "replace");
     EXPECT_EQ(countBridgeFdbCmds(), 0u);
 }
+
+/* fpmsyncd carries ES-backed MACs as a nexthop group, so an Ethernet Segment
+ * does not stop fpm mode. fdbsyncd must therefore stand down in that case too,
+ * rather than both daemons driving the kernel. */
+TEST_F(FdbSyncdEvpnMhTest, FpmModeHonouredWhileEvpnMultihomingConfigured)
+{
+    const std::string key = "Vlan100:aa:bb:cc:dd:ee:22";
+    struct m_fdb_info info;
+    info.mac = "aa:bb:cc:dd:ee:22";
+    info.vid = "Vlan100";
+    info.port_name = "Ethernet8";
+    info.type = FDB_TYPE_DYNAMIC;
+    info.op_type = FDB_OPER_ADD;
+    m_mockFdbSync.macUpdateCache(&info);
+
+    swss::Table esTable(m_configDb.get(), "EVPN_ETHERNET_SEGMENT");
+    esTable.hset("PortChannel1", "esi", "00:11:22:33:44:55:66:77:88:99");
+
+    m_mockFdbSync.setMacSyncMode("fpm");
+    mockCallArgs.clear();
+    m_mockFdbSync.addLocalMac(key, "replace");
+    EXPECT_EQ(countBridgeFdbCmds(), 0u);
+}

--- a/tests/mock_tests/fdbsyncd/fdbsyncd_ut.cpp
+++ b/tests/mock_tests/fdbsyncd/fdbsyncd_ut.cpp
@@ -15,6 +15,23 @@
 #define RTPROT_HW 193  /* Protocol ID for hardware learned routes */
 #endif
 
+/* Recorded by common/mock_shell_command.cpp; the only way to observe whether
+ * fdbsyncd programmed the kernel. */
+extern std::vector<std::string> mockCallArgs;
+
+static size_t countBridgeFdbCmds()
+{
+    size_t n = 0;
+    for (const auto &cmd : mockCallArgs)
+    {
+        if (cmd.find("bridge fdb") != std::string::npos)
+        {
+            ++n;
+        }
+    }
+    return n;
+}
+
 #define MAX_PAYLOAD 1024
 #define ETH_ALEN 6
 
@@ -2255,4 +2272,98 @@ TEST_F(FdbSyncdEvpnMhTest, TestMixedNhgAndVtepMacs)
     free(nlmsg);
 
     ASSERT_TRUE(true);
+}
+
+/*
+ * The three cases below cover MAC sync ownership. When fpmsyncd carries local
+ * MACs to zebra over FPM, fdbsyncd must step back from both the kernel and
+ * APP_DB, otherwise the two write the same entries from different directions.
+ */
+
+TEST_F(FdbSyncdEvpnMhTest, MacSyncModeTogglesOwnership)
+{
+    m_mockFdbSync.setMacSyncMode("fpm");
+    EXPECT_TRUE(m_mockFdbSync.isFpmMacSync());
+
+    m_mockFdbSync.setMacSyncMode("kernel");
+    EXPECT_FALSE(m_mockFdbSync.isFpmMacSync());
+
+    m_mockFdbSync.setMacSyncMode("fpm");
+    EXPECT_TRUE(m_mockFdbSync.isFpmMacSync());
+
+    /* A removed CONFIG_DB row arrives as an empty mode and must hand ownership
+     * back to the kernel path rather than leaving it with fpmsyncd. */
+    m_mockFdbSync.setMacSyncMode("");
+    EXPECT_FALSE(m_mockFdbSync.isFpmMacSync());
+}
+
+TEST_F(FdbSyncdEvpnMhTest, LocalMacNotProgrammedIntoKernelInFpmMode)
+{
+    struct m_fdb_info info;
+    info.mac = "aa:bb:cc:dd:ee:20";
+    info.vid = "Vlan100";
+    info.port_name = "Ethernet4";
+    info.type = FDB_TYPE_DYNAMIC;
+    info.op_type = FDB_OPER_ADD;
+    m_mockFdbSync.macUpdateCache(&info);
+
+    /* Control: kernel ownership still programs the bridge. */
+    m_mockFdbSync.setMacSyncMode("kernel");
+    mockCallArgs.clear();
+    m_mockFdbSync.updateLocalMac(&info);
+    EXPECT_GT(countBridgeFdbCmds(), 0u);
+
+    m_mockFdbSync.setMacSyncMode("fpm");
+    mockCallArgs.clear();
+    m_mockFdbSync.updateLocalMac(&info);
+    EXPECT_EQ(countBridgeFdbCmds(), 0u);
+}
+
+TEST_F(FdbSyncdEvpnMhTest, RemoteMacNotWrittenToAppDbInFpmMode)
+{
+    swss::MacAddress mac("dd:ee:ff:00:11:44");
+    const std::string key = "Vlan100:dd:ee:ff:00:11:44";
+    std::vector<FieldValueTuple> values;
+
+    m_mockFdbSync.setMacSyncMode("fpm");
+    struct nlmsghdr *nlmsg = mac_route_msg(true, 0, "192.168.1.77", 100, 100, mac);
+    m_mockFdbSync.onMsgRaw(nlmsg);
+    free(nlmsg);
+    EXPECT_FALSE(getFdbTable().get(key, values));
+
+    /* Control: the same message is accepted under kernel ownership, so the
+     * absence above is the guard and not a malformed message. */
+    m_mockFdbSync.setMacSyncMode("kernel");
+    nlmsg = mac_route_msg(true, 0, "192.168.1.77", 100, 100, mac);
+    m_mockFdbSync.onMsgRaw(nlmsg);
+    free(nlmsg);
+    EXPECT_TRUE(getFdbTable().get(key, values));
+
+    nlmsg = mac_route_msg(false, 0, "192.168.1.77", 100, 100, mac);
+    m_mockFdbSync.onMsgRaw(nlmsg);
+    free(nlmsg);
+}
+
+/* addLocalMac() is a separate entry point with its own guard, reached from the
+ * STATE_DB path rather than from netlink. */
+TEST_F(FdbSyncdEvpnMhTest, AddLocalMacNotProgrammedIntoKernelInFpmMode)
+{
+    const std::string key = "Vlan100:aa:bb:cc:dd:ee:21";
+    struct m_fdb_info info;
+    info.mac = "aa:bb:cc:dd:ee:21";
+    info.vid = "Vlan100";
+    info.port_name = "Ethernet8";
+    info.type = FDB_TYPE_DYNAMIC;
+    info.op_type = FDB_OPER_ADD;
+    m_mockFdbSync.macUpdateCache(&info);
+
+    m_mockFdbSync.setMacSyncMode("kernel");
+    mockCallArgs.clear();
+    m_mockFdbSync.addLocalMac(key, "replace");
+    EXPECT_GT(countBridgeFdbCmds(), 0u);
+
+    m_mockFdbSync.setMacSyncMode("fpm");
+    mockCallArgs.clear();
+    m_mockFdbSync.addLocalMac(key, "replace");
+    EXPECT_EQ(countBridgeFdbCmds(), 0u);
 }

--- a/tests/mock_tests/fdbsyncd/fdbsyncd_ut.cpp
+++ b/tests/mock_tests/fdbsyncd/fdbsyncd_ut.cpp
@@ -2368,6 +2368,30 @@ TEST_F(FdbSyncdEvpnMhTest, AddLocalMacNotProgrammedIntoKernelInFpmMode)
     EXPECT_EQ(countBridgeFdbCmds(), 0u);
 }
 
+/* onMsgNbr() reaches macRefreshStateDB() well before its own fpm check, so the
+ * guard has to sit in the refresh itself. Without it, fpm mode still spawns a
+ * bridge process per local MAC to refresh a kernel FDB it no longer uses. */
+TEST_F(FdbSyncdEvpnMhTest, MacRefreshIssuesNoBridgeCommandInFpmMode)
+{
+    struct m_fdb_info info;
+    info.mac = "aa:bb:cc:dd:ee:23";
+    info.vid = "Vlan100";
+    info.port_name = "Ethernet8";
+    info.type = FDB_TYPE_DYNAMIC;
+    info.op_type = FDB_OPER_ADD;
+    m_mockFdbSync.macUpdateCache(&info);
+
+    m_mockFdbSync.setMacSyncMode("kernel");
+    mockCallArgs.clear();
+    m_mockFdbSync.macRefreshStateDB(100, "aa:bb:cc:dd:ee:23", RTPROT_UNSPEC);
+    EXPECT_GT(countBridgeFdbCmds(), 0u);
+
+    m_mockFdbSync.setMacSyncMode("fpm");
+    mockCallArgs.clear();
+    m_mockFdbSync.macRefreshStateDB(100, "aa:bb:cc:dd:ee:23", RTPROT_UNSPEC);
+    EXPECT_EQ(countBridgeFdbCmds(), 0u);
+}
+
 /* fpmsyncd carries ES-backed MACs as a nexthop group, so an Ethernet Segment
  * does not stop fpm mode. fdbsyncd must therefore stand down in that case too,
  * rather than both daemons driving the kernel. */

--- a/tests/mock_tests/fdbsyncd/fdbsyncd_ut.cpp
+++ b/tests/mock_tests/fdbsyncd/fdbsyncd_ut.cpp
@@ -2414,3 +2414,23 @@ TEST_F(FdbSyncdEvpnMhTest, FpmModeHonouredWhileEvpnMultihomingConfigured)
     m_mockFdbSync.addLocalMac(key, "replace");
     EXPECT_EQ(countBridgeFdbCmds(), 0u);
 }
+
+/* fpmsyncd publishes L2_NEXTHOP_GROUP_TABLE from the FPM channel in fpm mode.
+ * Both daemons writing it would race on the cascade a withdrawn member causes,
+ * so the same message must be acted on in kernel mode and ignored in fpm mode. */
+TEST_F(FdbSyncdEvpnMhTest, L2NhgNotPublishedInFpmMode)
+{
+    uint32_t vtep_nhid = 4242;
+    struct nlmsghdr *nhg = create_l2_nhg_member_msg(vtep_nhid, "10.0.0.9", 0);
+    std::vector<swss::FieldValueTuple> values;
+
+    m_mockFdbSync.setMacSyncMode("fpm");
+    m_mockFdbSync.onMsgRaw(nhg);
+    EXPECT_FALSE(getNhgTable().get(std::to_string(vtep_nhid), values));
+
+    m_mockFdbSync.setMacSyncMode("kernel");
+    m_mockFdbSync.onMsgRaw(nhg);
+    EXPECT_TRUE(getNhgTable().get(std::to_string(vtep_nhid), values));
+
+    free(nhg);
+}

--- a/tests/mock_tests/fdbsyncd/fdbsyncd_ut.cpp
+++ b/tests/mock_tests/fdbsyncd/fdbsyncd_ut.cpp
@@ -11,10 +11,6 @@
 #include "macaddress.h"
 #undef private
 
-#ifndef RTPROT_HW
-#define RTPROT_HW 193  /* Protocol ID for hardware learned routes */
-#endif
-
 /* Recorded by common/mock_shell_command.cpp; the only way to observe whether
  * fdbsyncd programmed the kernel. */
 extern std::vector<std::string> mockCallArgs;
@@ -1339,10 +1335,9 @@ TEST_F(FdbSyncdEvpnMhTest, TestMacRefreshStateDB)
     // Test MAC refresh in STATE_DB
     int vlan = 100;
     std::string kmac = "00:11:22:33:44:55";
-    uint8_t protocol = 0; // RTPROT_KERNEL
 
     // Call macRefreshStateDB
-    m_mockFdbSync.macRefreshStateDB(vlan, kmac, protocol);
+    m_mockFdbSync.macRefreshStateDB(vlan, kmac);
 
     // Verify STATE_DB was updated
     std::shared_ptr<swss::DBConnector> m_state_db;
@@ -1565,7 +1560,6 @@ TEST_F(FdbSyncdEvpnMhTest, TestMacDelVxlan)
     m_mockFdbSync.m_mac[key].type = "dynamic";
     m_mockFdbSync.m_mac[key].vni = 20200;
     m_mockFdbSync.m_mac[key].ifname = "Vxlan-200";
-    m_mockFdbSync.m_mac[key].protocol = RTPROT_UNSPEC;
     m_mockFdbSync.m_mac[key].nhtype = FdbDest::NEXTHOPGROUP;
     m_mockFdbSync.m_mac[key].nexthop_value = "536870912";
 
@@ -1588,7 +1582,6 @@ TEST_F(FdbSyncdEvpnMhTest, TestMacDelVxlanEntryNHG)
     m_mockFdbSync.m_mac[key].type = "static";
     m_mockFdbSync.m_mac[key].vni = 30300;
     m_mockFdbSync.m_mac[key].ifname = "Vxlan-300";
-    m_mockFdbSync.m_mac[key].protocol = RTPROT_UNSPEC;
     m_mockFdbSync.m_mac[key].nhtype = FdbDest::NEXTHOPGROUP;
     m_mockFdbSync.m_mac[key].nexthop_value = "536870913";
 
@@ -1855,7 +1848,6 @@ TEST_F(FdbSyncdEvpnMhTest, TestUpdateLocalMacWithVxlanEntry)
     m_mockFdbSync.m_mac[key].type = "dynamic";
     m_mockFdbSync.m_mac[key].vni = 20200;
     m_mockFdbSync.m_mac[key].ifname = "Vxlan-200";
-    m_mockFdbSync.m_mac[key].protocol = RTPROT_UNSPEC;
     m_mockFdbSync.m_mac[key].nhtype = FdbDest::NEXTHOPGROUP;
     m_mockFdbSync.m_mac[key].nexthop_value = "536870914";
 
@@ -1875,32 +1867,30 @@ TEST_F(FdbSyncdEvpnMhTest, TestUpdateMclagRemoteMacPort)
     int ifindex = 10;
     int vlan = 100;
     std::string mac = "aa:bb:cc:dd:ee:f5";
-    uint8_t protocol = RTPROT_ZEBRA;
 
     // Populate m_mclag_remote_fdb_mac to trigger the update path
     m_mockFdbSync.m_mclag_remote_fdb_mac[key].port_name = "PortChannel10";
     m_mockFdbSync.m_mclag_remote_fdb_mac[key].type = FDB_TYPE_STATIC;
 
     // Call updateMclagRemoteMacPort
-    m_mockFdbSync.updateMclagRemoteMacPort(ifindex, vlan, mac, protocol);
+    m_mockFdbSync.updateMclagRemoteMacPort(ifindex, vlan, mac);
 
     ASSERT_TRUE(true);
 }
 
 TEST_F(FdbSyncdEvpnMhTest, TestUpdateMclagRemoteMacPortHwProto)
 {
-    // Test updateMclagRemoteMacPort with RTPROT_HW protocol
+    // Second static MAC on a different key and port
     std::string key = "Vlan200:bb:cc:dd:ee:ff:f6";
     int ifindex = 20;
     int vlan = 200;
     std::string mac = "bb:cc:dd:ee:ff:f6";
-    uint8_t protocol = RTPROT_HW;
 
     // Populate m_mclag_remote_fdb_mac
     m_mockFdbSync.m_mclag_remote_fdb_mac[key].port_name = "PortChannel20";
     m_mockFdbSync.m_mclag_remote_fdb_mac[key].type = FDB_TYPE_STATIC;
 
-    m_mockFdbSync.updateMclagRemoteMacPort(ifindex, vlan, mac, protocol);
+    m_mockFdbSync.updateMclagRemoteMacPort(ifindex, vlan, mac);
 
     ASSERT_TRUE(true);
 }
@@ -1912,13 +1902,12 @@ TEST_F(FdbSyncdEvpnMhTest, TestUpdateMclagRemoteMacPortDynamic)
     int ifindex = 30;
     int vlan = 300;
     std::string mac = "cc:dd:ee:ff:00:f7";
-    uint8_t protocol = RTPROT_ZEBRA;
 
     // Populate with dynamic type - should skip bridge fdb command
     m_mockFdbSync.m_mclag_remote_fdb_mac[key].port_name = "PortChannel30";
     m_mockFdbSync.m_mclag_remote_fdb_mac[key].type = FDB_TYPE_DYNAMIC;
 
-    m_mockFdbSync.updateMclagRemoteMacPort(ifindex, vlan, mac, protocol);
+    m_mockFdbSync.updateMclagRemoteMacPort(ifindex, vlan, mac);
 
     ASSERT_TRUE(true);
 }
@@ -2383,12 +2372,12 @@ TEST_F(FdbSyncdEvpnMhTest, MacRefreshIssuesNoBridgeCommandInFpmMode)
 
     m_mockFdbSync.setMacSyncMode("kernel");
     mockCallArgs.clear();
-    m_mockFdbSync.macRefreshStateDB(100, "aa:bb:cc:dd:ee:23", RTPROT_UNSPEC);
+    m_mockFdbSync.macRefreshStateDB(100, "aa:bb:cc:dd:ee:23");
     EXPECT_GT(countBridgeFdbCmds(), 0u);
 
     m_mockFdbSync.setMacSyncMode("fpm");
     mockCallArgs.clear();
-    m_mockFdbSync.macRefreshStateDB(100, "aa:bb:cc:dd:ee:23", RTPROT_UNSPEC);
+    m_mockFdbSync.macRefreshStateDB(100, "aa:bb:cc:dd:ee:23");
     EXPECT_EQ(countBridgeFdbCmds(), 0u);
 }
 

--- a/tests/mock_tests/fpmsyncd/macsync_ut.cpp
+++ b/tests/mock_tests/fpmsyncd/macsync_ut.cpp
@@ -117,6 +117,7 @@ public:
 
     void addVlan(MacMsg& req, uint16_t vlan) { addAttr(req, NDA_VLAN, &vlan, sizeof(vlan)); }
     void addSrcVni(MacMsg& req, uint32_t vni) { addAttr(req, NDA_SRC_VNI, &vni, sizeof(vni)); }
+    void addNhgId(MacMsg& req, uint32_t nhid) { addAttr(req, NDA_NH_ID, &nhid, sizeof(nhid)); }
 
     void addVtep(MacMsg& req, const char *ip)
     {
@@ -624,6 +625,96 @@ TEST_F(MacSyncTest, LocalStaticMacIsSticky)
  * to have delivered: zebra can connect before the select loop has run, and a
  * replay of nothing tells zebra to withdraw every local MAC.
  */
+/*
+ * A MAC behind an Ethernet Segment reaches several VTEPs at once, so zebra
+ * resolves it to an L2 nexthop group and sends NDA_NH_ID with no NDA_DST. It
+ * has to be programmed against that group rather than discarded as though it
+ * were the harmless bridge-side duplicate. fdbsyncd publishes the group itself
+ * into L2_NEXTHOP_GROUP_TABLE from the kernel in either mac_sync_mode.
+ */
+TEST_F(MacSyncTest, EsBackedRemoteMacProgrammedAgainstNexthopGroup)
+{
+    MacMsg req;
+    buildMacMsg(req, RTM_NEWNEIGH, NUD_REACHABLE);
+    addVlan(req, TEST_VLAN);
+    addSrcVni(req, TEST_VNI);
+    addNhgId(req, 4242);
+    feed(req);
+
+    std::vector<FieldValueTuple> values;
+    ASSERT_TRUE(getEntry(TEST_KEY, values));
+    EXPECT_EQ(fieldValue(values, "nexthop_group"), "4242");
+    EXPECT_EQ(fieldValue(values, "remote_vtep"), "");
+    EXPECT_EQ(fieldValue(values, "vni"), std::to_string(TEST_VNI));
+}
+
+/* Zero is the "no group" sentinel, so such a MAC still needs a VTEP and is the
+ * bridge-side copy when it has none. */
+TEST_F(MacSyncTest, RemoteMacWithZeroNexthopGroupIsNotProgrammed)
+{
+    MacMsg req;
+    buildMacMsg(req, RTM_NEWNEIGH, NUD_REACHABLE);
+    addVlan(req, TEST_VLAN);
+    addSrcVni(req, TEST_VNI);
+    addNhgId(req, 0);
+    feed(req);
+
+    std::vector<FieldValueTuple> values;
+    EXPECT_FALSE(getEntry(TEST_KEY, values));
+}
+
+/* An ES-backed MAC is withdrawn the same way as a VTEP-backed one. */
+TEST_F(MacSyncTest, EsBackedRemoteMacWithdrawn)
+{
+    MacMsg add;
+    buildMacMsg(add, RTM_NEWNEIGH, NUD_REACHABLE);
+    addVlan(add, TEST_VLAN);
+    addSrcVni(add, TEST_VNI);
+    addNhgId(add, 4242);
+    feed(add);
+
+    std::vector<FieldValueTuple> values;
+    ASSERT_TRUE(getEntry(TEST_KEY, values));
+
+    MacMsg del;
+    buildMacMsg(del, RTM_DELNEIGH, NUD_REACHABLE);
+    addVlan(del, TEST_VLAN);
+    addNhgId(del, 4242);
+    feed(del);
+
+    EXPECT_FALSE(getEntry(TEST_KEY, values));
+}
+
+/*
+ * fpm mode used to be refused outright while Ethernet Segments existed, because
+ * an ES-backed MAC was dropped for want of a VTEP. Now that such a MAC is
+ * carried as a nexthop group the two features coexist, so the mode must be
+ * accepted and the MAC still programmed.
+ */
+TEST_F(MacSyncTest, FpmModeCoexistsWithEvpnMultihoming)
+{
+    Table cfgEs(m_cfgDb.get(), "EVPN_ETHERNET_SEGMENT");
+    cfgEs.set("PortChannel121", std::vector<FieldValueTuple>{{"esi", "AUTO"}});
+
+    m_macSync->setMacSyncMode("kernel");
+    m_macSync->setMacSyncMode("fpm");
+
+    EXPECT_TRUE(m_macSync->isFpmMode());
+
+    MacMsg req;
+    buildMacMsg(req, RTM_NEWNEIGH, NUD_REACHABLE);
+    addVlan(req, TEST_VLAN);
+    addSrcVni(req, TEST_VNI);
+    addNhgId(req, 4242);
+    feed(req);
+
+    std::vector<FieldValueTuple> values;
+    ASSERT_TRUE(getEntry(TEST_KEY, values));
+    EXPECT_EQ(fieldValue(values, "nexthop_group"), "4242");
+
+    cfgEs.del("PortChannel121");
+}
+
 TEST_F(MacSyncTest, ReplayLoadsLocalMacsFromStateDb)
 {
     /* Deliberately not touching m_localMacs - only STATE_DB. "lo" is used

--- a/tests/mock_tests/fpmsyncd/macsync_ut.cpp
+++ b/tests/mock_tests/fpmsyncd/macsync_ut.cpp
@@ -318,24 +318,17 @@ TEST_F(MacSyncTest, StaleRemoteMacSweptAtEndOfReplay)
     m_macSync->m_remoteReplayPending = true;
     m_macSync->onRemoteReplayEnd();
 
-    /* Held, not deleted: zebra may still be converging. */
     std::vector<FieldValueTuple> values;
-    EXPECT_TRUE(getEntry(TEST_KEY, values));
-    EXPECT_EQ(m_macSync->m_staleCandidates.count(TEST_KEY), 1u);
-
-    m_macSync->onStaleTimer();
-
-    values.clear();
     EXPECT_FALSE(getEntry(TEST_KEY, values));
     EXPECT_EQ(m_macSync->m_remoteMacs.count(TEST_KEY), 0u);
 }
 
 /*
- * The case the lab caught: on a restart of the whole bgp container zebra's
- * replay is empty because BGP has not converged yet. A MAC re-advertised during
- * the hold-down must survive, or a live entry is dropped.
+ * The marker is the whole answer, so a MAC zebra did not replay is gone the
+ * moment it arrives. If zebra advertises it afterwards the entry comes back,
+ * but it was absent in between: there is no hold-down to sit in.
  */
-TEST_F(MacSyncTest, LateReadvertisementCancelsTheDeletion)
+TEST_F(MacSyncTest, ReadvertisementAfterTheSweepRestoresTheMac)
 {
     Table appFdb(m_appDb.get(), APP_VXLAN_FDB_TABLE_NAME);
     appFdb.set(TEST_KEY, std::vector<FieldValueTuple>{{"remote_vtep", "10.1.1.1"}});
@@ -346,7 +339,9 @@ TEST_F(MacSyncTest, LateReadvertisementCancelsTheDeletion)
     m_macSync->m_remoteMacsSeen.clear();
     m_macSync->m_remoteReplayPending = true;
     m_macSync->onRemoteReplayEnd();
-    ASSERT_EQ(m_macSync->m_staleCandidates.count(TEST_KEY), 1u);
+
+    std::vector<FieldValueTuple> swept;
+    ASSERT_FALSE(getEntry(TEST_KEY, swept));
 
     /* zebra catches up after the marker. */
     MacMsg late;
@@ -355,10 +350,6 @@ TEST_F(MacSyncTest, LateReadvertisementCancelsTheDeletion)
     addVtep(late, "10.1.1.1");
     addSrcVni(late, TEST_VNI);
     feed(late);
-
-    EXPECT_EQ(m_macSync->m_staleCandidates.count(TEST_KEY), 0u);
-
-    m_macSync->onStaleTimer();
 
     std::vector<FieldValueTuple> values;
     EXPECT_TRUE(getEntry(TEST_KEY, values));
@@ -384,7 +375,6 @@ TEST_F(MacSyncTest, ReplayedRemoteMacSurvivesTheSweep)
     feed(replay);
 
     m_macSync->onRemoteReplayEnd();
-    m_macSync->onStaleTimer();
 
     std::vector<FieldValueTuple> values;
     EXPECT_TRUE(getEntry(TEST_KEY, values));
@@ -402,7 +392,6 @@ TEST_F(MacSyncTest, UnsolicitedReplayEndSweepsNothing)
 
     m_macSync->m_remoteReplayPending = false;
     m_macSync->onRemoteReplayEnd();
-    m_macSync->onStaleTimer();
 
     std::vector<FieldValueTuple> values;
     EXPECT_TRUE(getEntry(TEST_KEY, values));

--- a/tests/mock_tests/fpmsyncd/macsync_ut.cpp
+++ b/tests/mock_tests/fpmsyncd/macsync_ut.cpp
@@ -283,6 +283,115 @@ TEST_F(MacSyncTest, EnteringFpmModeAdoptsExistingRemoteMacs)
     EXPECT_EQ(m_macSync->m_remoteMacs.count(TEST_KEY), 1u);
 }
 
+/*
+ * An adopted entry that zebra does not replay was withdrawn while we were down.
+ * zebra will never mention it again, so end of replay is the only chance to
+ * remove it.
+ */
+TEST_F(MacSyncTest, StaleRemoteMacSweptAtEndOfReplay)
+{
+    Table appFdb(m_appDb.get(), APP_VXLAN_FDB_TABLE_NAME);
+    appFdb.set(TEST_KEY, std::vector<FieldValueTuple>{{"remote_vtep", "10.1.1.1"}});
+
+    m_macSync->setMacSyncMode("kernel");
+    m_macSync->setMacSyncMode("fpm");
+    ASSERT_EQ(m_macSync->m_remoteMacs.count(TEST_KEY), 1u);
+
+    m_macSync->m_remoteMacsSeen.clear();
+    m_macSync->m_remoteReplayPending = true;
+    m_macSync->onRemoteReplayEnd();
+
+    /* Held, not deleted: zebra may still be converging. */
+    std::vector<FieldValueTuple> values;
+    EXPECT_TRUE(getEntry(TEST_KEY, values));
+    EXPECT_EQ(m_macSync->m_staleCandidates.count(TEST_KEY), 1u);
+
+    m_macSync->onStaleTimer();
+
+    values.clear();
+    EXPECT_FALSE(getEntry(TEST_KEY, values));
+    EXPECT_EQ(m_macSync->m_remoteMacs.count(TEST_KEY), 0u);
+}
+
+/*
+ * The case the lab caught: on a restart of the whole bgp container zebra's
+ * replay is empty because BGP has not converged yet. A MAC re-advertised during
+ * the hold-down must survive, or a live entry is dropped.
+ */
+TEST_F(MacSyncTest, LateReadvertisementCancelsTheDeletion)
+{
+    Table appFdb(m_appDb.get(), APP_VXLAN_FDB_TABLE_NAME);
+    appFdb.set(TEST_KEY, std::vector<FieldValueTuple>{{"remote_vtep", "10.1.1.1"}});
+
+    m_macSync->setMacSyncMode("kernel");
+    m_macSync->setMacSyncMode("fpm");
+
+    m_macSync->m_remoteMacsSeen.clear();
+    m_macSync->m_remoteReplayPending = true;
+    m_macSync->onRemoteReplayEnd();
+    ASSERT_EQ(m_macSync->m_staleCandidates.count(TEST_KEY), 1u);
+
+    /* zebra catches up after the marker. */
+    MacMsg late;
+    buildMacMsg(late, RTM_NEWNEIGH, NUD_REACHABLE);
+    addVlan(late, TEST_VLAN);
+    addVtep(late, "10.1.1.1");
+    addSrcVni(late, TEST_VNI);
+    feed(late);
+
+    EXPECT_EQ(m_macSync->m_staleCandidates.count(TEST_KEY), 0u);
+
+    m_macSync->onStaleTimer();
+
+    std::vector<FieldValueTuple> values;
+    EXPECT_TRUE(getEntry(TEST_KEY, values));
+    EXPECT_EQ(m_macSync->m_remoteMacs.count(TEST_KEY), 1u);
+}
+
+TEST_F(MacSyncTest, ReplayedRemoteMacSurvivesTheSweep)
+{
+    Table appFdb(m_appDb.get(), APP_VXLAN_FDB_TABLE_NAME);
+    appFdb.set(TEST_KEY, std::vector<FieldValueTuple>{{"remote_vtep", "10.1.1.1"}});
+
+    m_macSync->setMacSyncMode("kernel");
+    m_macSync->setMacSyncMode("fpm");
+
+    m_macSync->m_remoteMacsSeen.clear();
+    m_macSync->m_remoteReplayPending = true;
+
+    MacMsg replay;
+    buildMacMsg(replay, RTM_NEWNEIGH, NUD_REACHABLE);
+    addVlan(replay, TEST_VLAN);
+    addVtep(replay, "10.1.1.1");
+    addSrcVni(replay, TEST_VNI);
+    feed(replay);
+
+    m_macSync->onRemoteReplayEnd();
+    m_macSync->onStaleTimer();
+
+    std::vector<FieldValueTuple> values;
+    EXPECT_TRUE(getEntry(TEST_KEY, values));
+    EXPECT_EQ(m_macSync->m_remoteMacs.count(TEST_KEY), 1u);
+}
+
+/* A marker outside a replay would otherwise delete every remote MAC. */
+TEST_F(MacSyncTest, UnsolicitedReplayEndSweepsNothing)
+{
+    Table appFdb(m_appDb.get(), APP_VXLAN_FDB_TABLE_NAME);
+    appFdb.set(TEST_KEY, std::vector<FieldValueTuple>{{"remote_vtep", "10.1.1.1"}});
+
+    m_macSync->setMacSyncMode("kernel");
+    m_macSync->setMacSyncMode("fpm");
+
+    m_macSync->m_remoteReplayPending = false;
+    m_macSync->onRemoteReplayEnd();
+    m_macSync->onStaleTimer();
+
+    std::vector<FieldValueTuple> values;
+    EXPECT_TRUE(getEntry(TEST_KEY, values));
+    EXPECT_EQ(m_macSync->m_remoteMacs.count(TEST_KEY), 1u);
+}
+
 /* NUD_NOARP marks a sticky MAC, which fdbOrch consumes as a static entry. */
 TEST_F(MacSyncTest, StickyRemoteMacIsStatic)
 {

--- a/tests/mock_tests/fpmsyncd/macsync_ut.cpp
+++ b/tests/mock_tests/fpmsyncd/macsync_ut.cpp
@@ -14,6 +14,8 @@
 
 #include <gtest/gtest.h>
 
+#include <net/if.h>
+
 #include <cstring>
 #include <vector>
 
@@ -625,6 +627,49 @@ TEST_F(MacSyncTest, LocalStaticMacIsSticky)
  * to have delivered: zebra can connect before the select loop has run, and a
  * replay of nothing tells zebra to withdraw every local MAC.
  */
+/*
+ * A MAC on an Ethernet Segment we also hold locally is reachable through our own
+ * access port, so zebra sends it against that port with neither a VTEP nor a
+ * nexthop group. It must be programmed against the port, not discarded as the
+ * bridge-side duplicate, and FdbOrch disables ageing on it.
+ */
+TEST_F(MacSyncTest, MacOnLocalEthernetSegmentProgrammedAgainstItsPort)
+{
+    Table cfgEs(m_cfgDb.get(), "EVPN_ETHERNET_SEGMENT");
+    cfgEs.set("lo", std::vector<FieldValueTuple>{{"esi", "AUTO"}});
+
+    MacMsg req;
+    buildMacMsg(req, RTM_NEWNEIGH, NUD_REACHABLE | NUD_NOARP);
+    req.ndm.ndm_ifindex = (int)if_nametoindex("lo");
+    addVlan(req, TEST_VLAN);
+    addSrcVni(req, TEST_VNI);
+    feed(req);
+
+    std::vector<FieldValueTuple> values;
+    ASSERT_TRUE(getEntry(TEST_KEY, values));
+    EXPECT_EQ(fieldValue(values, "ifname"), "lo");
+    EXPECT_EQ(fieldValue(values, "remote_vtep"), "");
+    EXPECT_EQ(fieldValue(values, "nexthop_group"), "");
+    EXPECT_EQ(fieldValue(values, "type"), "static");
+
+    cfgEs.del("lo");
+}
+
+/* The same message on a port with no Ethernet Segment is the bridge-side copy of
+ * a remote MAC, and is still discarded. */
+TEST_F(MacSyncTest, MacOnNonEsPortWithoutVtepIsSkipped)
+{
+    MacMsg req;
+    buildMacMsg(req, RTM_NEWNEIGH, NUD_REACHABLE);
+    req.ndm.ndm_ifindex = (int)if_nametoindex("lo");
+    addVlan(req, TEST_VLAN);
+    addSrcVni(req, TEST_VNI);
+    feed(req);
+
+    std::vector<FieldValueTuple> values;
+    EXPECT_FALSE(getEntry(TEST_KEY, values));
+}
+
 /*
  * A MAC behind an Ethernet Segment reaches several VTEPs at once, so zebra
  * resolves it to an L2 nexthop group and sends NDA_NH_ID with no NDA_DST. It

--- a/tests/mock_tests/fpmsyncd/macsync_ut.cpp
+++ b/tests/mock_tests/fpmsyncd/macsync_ut.cpp
@@ -129,6 +129,18 @@ public:
         return table.get(key, values);
     }
 
+    /* Writes where fdborch would, so the replay path is exercised as it runs in
+     * fpmsyncd rather than by priming the in-memory map. */
+    void seedStateFdb(const std::string& key, const std::string& port, bool isStatic)
+    {
+        Table table(m_stateDb.get(), STATE_FDB_TABLE_NAME);
+        std::vector<FieldValueTuple> values = {
+            {"port", port},
+            {"type", isStatic ? "static" : "dynamic"},
+        };
+        table.set(key, values);
+    }
+
     std::string fieldValue(const std::vector<FieldValueTuple>& values,
                            const std::string& field)
     {
@@ -383,42 +395,76 @@ private:
 };
 
 /*
- * Without the trailing marker zebra never learns the replay finished and keeps
- * MACs from the previous session, so assert on the whole sequence rather than
- * just that something was sent.
+ * The replay must come from STATE_DB, not from whatever the subscriber happens
+ * to have delivered: zebra can connect before the select loop has run, and a
+ * replay of nothing tells zebra to withdraw every local MAC.
  */
-TEST_F(MacSyncTest, ReplayStampsGenerationAndEndsWithMarker)
+TEST_F(MacSyncTest, ReplayLoadsLocalMacsFromStateDb)
 {
-    /* "lo" is used because sendLocalMac resolves the port via if_nametoindex. */
-    m_macSync->m_localMacs["Vlan100:00:11:22:33:44:55"] = {"lo", false};
+    /* Deliberately not touching m_localMacs - only STATE_DB. "lo" is used
+     * because sendLocalMac resolves the port via if_nametoindex. */
+    seedStateFdb("Vlan100:00:11:22:33:44:55", "lo", false);
 
     RecordingFpm fpm;
     m_macSync->onFpmConnected(fpm);
 
     ASSERT_EQ(fpm.count(), 2u);
     EXPECT_EQ(fpm.at(0)->nlmsg_type, RTM_NEWNEIGH);
-    EXPECT_EQ(fpm.at(0)->nlmsg_seq, 1u);
     EXPECT_EQ(fpm.at(1)->nlmsg_type, RTM_FPM_MAC_REPLAY_END);
-    EXPECT_EQ(fpm.at(1)->nlmsg_seq, 1u);
+
+    /* Both must carry the same generation or the marker sweeps what it replayed. */
+    EXPECT_EQ(fpm.at(0)->nlmsg_seq, fpm.at(1)->nlmsg_seq);
+    EXPECT_NE(fpm.at(0)->nlmsg_seq, 0u);
 }
 
-/* A generation that does not advance makes the sweep a no-op. */
+/*
+ * A generation that repeats across an fpmsyncd restart leaves previously
+ * stamped MACs looking current, so the sweep never removes anything.
+ */
 TEST_F(MacSyncTest, GenerationAdvancesOnEveryConnect)
 {
-    m_macSync->m_localMacs["Vlan100:00:11:22:33:44:55"] = {"lo", false};
+    seedStateFdb("Vlan100:00:11:22:33:44:55", "lo", false);
 
     RecordingFpm first;
     m_macSync->onFpmConnected(first);
     ASSERT_EQ(first.count(), 2u);
-    EXPECT_EQ(first.at(1)->nlmsg_seq, 1u);
+    uint32_t g1 = first.at(1)->nlmsg_seq;
 
     m_macSync->onFpmDisconnected();
 
     RecordingFpm second;
     m_macSync->onFpmConnected(second);
     ASSERT_EQ(second.count(), 2u);
-    EXPECT_EQ(second.at(0)->nlmsg_seq, 2u);
-    EXPECT_EQ(second.at(1)->nlmsg_seq, 2u);
+    uint32_t g2 = second.at(1)->nlmsg_seq;
+
+    EXPECT_GT(g2, g1);
+    EXPECT_EQ(second.at(0)->nlmsg_seq, g2);
+}
+
+/*
+ * A restarted fpmsyncd must not reissue a generation zebra has already seen,
+ * or the MACs stamped by the previous process look current and are never swept.
+ * A second instance stands in for the restarted process: its members start from
+ * their initializers, so only what reached STATE_DB carries over.
+ */
+TEST_F(MacSyncTest, GenerationDoesNotRepeatAcrossRestart)
+{
+    seedStateFdb("Vlan100:00:11:22:33:44:55", "lo", false);
+
+    RecordingFpm first;
+    m_macSync->onFpmConnected(first);
+    ASSERT_EQ(first.count(), 2u);
+    uint32_t before = first.at(1)->nlmsg_seq;
+
+    MacSync restarted(m_pipeline.get(), m_stateDb.get(), m_cfgDb.get());
+    restarted.m_fpmMode = true;
+
+    RecordingFpm second;
+    restarted.onFpmConnected(second);
+    ASSERT_EQ(second.count(), 2u);
+
+    EXPECT_NE(second.at(1)->nlmsg_seq, before);
+    EXPECT_EQ(second.at(0)->nlmsg_seq, second.at(1)->nlmsg_seq);
 }
 
 /* The marker must still close a replay that carried no MACs. */
@@ -429,5 +475,5 @@ TEST_F(MacSyncTest, ReplayWithNoLocalMacsStillSendsMarker)
 
     ASSERT_EQ(fpm.count(), 1u);
     EXPECT_EQ(fpm.at(0)->nlmsg_type, RTM_FPM_MAC_REPLAY_END);
-    EXPECT_EQ(fpm.at(0)->nlmsg_seq, 1u);
+    EXPECT_NE(fpm.at(0)->nlmsg_seq, 0u);
 }

--- a/tests/mock_tests/fpmsyncd/macsync_ut.cpp
+++ b/tests/mock_tests/fpmsyncd/macsync_ut.cpp
@@ -14,6 +14,9 @@
 
 #include <gtest/gtest.h>
 
+#include <cstring>
+#include <vector>
+
 #include <linux/if_ether.h>
 #include <linux/neighbour.h>
 #include <netinet/in.h>
@@ -350,4 +353,81 @@ TEST_F(MacSyncTest, RemoteMacWithdrawalReachesMacSyncThroughOnMsgRaw)
     feedRaw(del);
 
     EXPECT_FALSE(getEntry(TEST_KEY, values));
+}
+
+/* Captures what MacSync sends so the replay sequence can be inspected. */
+class RecordingFpm : public FpmInterface
+{
+public:
+    bool send(nlmsghdr *hdr) override
+    {
+        size_t len = hdr->nlmsg_len ? hdr->nlmsg_len : NLMSG_LENGTH(0);
+        std::vector<uint8_t> copy(len);
+        memcpy(copy.data(), hdr, len);
+        m_sent.push_back(std::move(copy));
+        return true;
+    }
+
+    int getFd() override { return -1; }
+    uint64_t readData() override { return 0; }
+
+    size_t count() const { return m_sent.size(); }
+
+    const nlmsghdr *at(size_t i) const
+    {
+        return reinterpret_cast<const nlmsghdr *>(m_sent.at(i).data());
+    }
+
+private:
+    std::vector<std::vector<uint8_t>> m_sent;
+};
+
+/*
+ * Without the trailing marker zebra never learns the replay finished and keeps
+ * MACs from the previous session, so assert on the whole sequence rather than
+ * just that something was sent.
+ */
+TEST_F(MacSyncTest, ReplayStampsGenerationAndEndsWithMarker)
+{
+    /* "lo" is used because sendLocalMac resolves the port via if_nametoindex. */
+    m_macSync->m_localMacs["Vlan100:00:11:22:33:44:55"] = {"lo", false};
+
+    RecordingFpm fpm;
+    m_macSync->onFpmConnected(fpm);
+
+    ASSERT_EQ(fpm.count(), 2u);
+    EXPECT_EQ(fpm.at(0)->nlmsg_type, RTM_NEWNEIGH);
+    EXPECT_EQ(fpm.at(0)->nlmsg_seq, 1u);
+    EXPECT_EQ(fpm.at(1)->nlmsg_type, RTM_FPM_MAC_REPLAY_END);
+    EXPECT_EQ(fpm.at(1)->nlmsg_seq, 1u);
+}
+
+/* A generation that does not advance makes the sweep a no-op. */
+TEST_F(MacSyncTest, GenerationAdvancesOnEveryConnect)
+{
+    m_macSync->m_localMacs["Vlan100:00:11:22:33:44:55"] = {"lo", false};
+
+    RecordingFpm first;
+    m_macSync->onFpmConnected(first);
+    ASSERT_EQ(first.count(), 2u);
+    EXPECT_EQ(first.at(1)->nlmsg_seq, 1u);
+
+    m_macSync->onFpmDisconnected();
+
+    RecordingFpm second;
+    m_macSync->onFpmConnected(second);
+    ASSERT_EQ(second.count(), 2u);
+    EXPECT_EQ(second.at(0)->nlmsg_seq, 2u);
+    EXPECT_EQ(second.at(1)->nlmsg_seq, 2u);
+}
+
+/* The marker must still close a replay that carried no MACs. */
+TEST_F(MacSyncTest, ReplayWithNoLocalMacsStillSendsMarker)
+{
+    RecordingFpm fpm;
+    m_macSync->onFpmConnected(fpm);
+
+    ASSERT_EQ(fpm.count(), 1u);
+    EXPECT_EQ(fpm.at(0)->nlmsg_type, RTM_FPM_MAC_REPLAY_END);
+    EXPECT_EQ(fpm.at(0)->nlmsg_seq, 1u);
 }

--- a/tests/mock_tests/fpmsyncd/macsync_ut.cpp
+++ b/tests/mock_tests/fpmsyncd/macsync_ut.cpp
@@ -1,0 +1,353 @@
+/**
+ * @file macsync_ut.cpp
+ * @brief Unit tests for MAC synchronization over the FPM channel.
+ *
+ * The cases here are deliberately shaped around defects that a build cannot
+ * catch: every one of them produces a plausible-looking but wrong
+ * APP_VXLAN_FDB_TABLE entry rather than a crash or a link error.
+ */
+
+#include "table.h"
+#include "schema.h"
+#include "redisutility.h"
+#include "mock_table.h"
+
+#include <gtest/gtest.h>
+
+#include <linux/if_ether.h>
+#include <linux/neighbour.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#define private public
+#include "fpmsyncd/macsync.h"
+#undef private
+
+#include "fpmsyncd/routesync.h"
+
+using namespace swss;
+
+#ifndef NDA_SRC_VNI
+#define NDA_SRC_VNI 11
+#endif
+
+namespace {
+
+constexpr uint16_t TEST_VLAN = 100;
+constexpr uint32_t TEST_VNI = 20100;
+const uint8_t TEST_MAC[ETH_ALEN] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55};
+const char *TEST_KEY = "Vlan100:00:11:22:33:44:55";
+
+}
+
+class MacSyncTest : public ::testing::Test
+{
+public:
+    void SetUp() override
+    {
+        testing_db::reset();
+        m_appDb = std::make_shared<DBConnector>("APPL_DB", 0);
+        m_stateDb = std::make_shared<DBConnector>("STATE_DB", 0);
+        m_cfgDb = std::make_shared<DBConnector>("CONFIG_DB", 0);
+        m_pipeline = std::make_shared<RedisPipeline>(m_appDb.get());
+        m_macSync = std::make_unique<MacSync>(m_pipeline.get(), m_stateDb.get(),
+                                              m_cfgDb.get());
+        /* CONFIG_DB is not populated under the mock, so drive the mode directly. */
+        m_macSync->m_fpmMode = true;
+
+        /* Needed to exercise the real dispatch path rather than calling the
+         * handler directly; onMsgRaw filters message types before MacSync. */
+        m_routeSync = std::make_unique<RouteSync>(m_pipeline.get());
+        m_routeSync->setMacSync(m_macSync.get());
+    }
+
+    void TearDown() override
+    {
+        m_routeSync.reset();
+        m_macSync.reset();
+        m_pipeline.reset();
+    }
+
+    /* Builds an AF_BRIDGE neighbour message of the shape zebra emits. */
+    struct MacMsg
+    {
+        struct nlmsghdr n;
+        struct ndmsg ndm;
+        char buf[256];
+    };
+
+    void buildMacMsg(MacMsg& req, uint16_t nlmsgType, uint16_t state)
+    {
+        memset(&req, 0, sizeof(req));
+        req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct ndmsg));
+        req.n.nlmsg_type = nlmsgType;
+        req.ndm.ndm_family = AF_BRIDGE;
+        req.ndm.ndm_state = state;
+        req.ndm.ndm_flags = NTF_MASTER | NTF_EXT_LEARNED;
+        addAttr(req, NDA_LLADDR, TEST_MAC, ETH_ALEN);
+    }
+
+    void addAttr(MacMsg& req, int type, const void *data, size_t alen)
+    {
+        size_t len = RTA_LENGTH(alen);
+        struct rtattr *rta =
+            (struct rtattr *)(((char *)&req.n) + NLMSG_ALIGN(req.n.nlmsg_len));
+        rta->rta_type = (unsigned short)type;
+        rta->rta_len = (unsigned short)len;
+        memcpy(RTA_DATA(rta), data, alen);
+        req.n.nlmsg_len = (uint32_t)(NLMSG_ALIGN(req.n.nlmsg_len) + RTA_ALIGN(len));
+    }
+
+    void addVlan(MacMsg& req, uint16_t vlan) { addAttr(req, NDA_VLAN, &vlan, sizeof(vlan)); }
+    void addSrcVni(MacMsg& req, uint32_t vni) { addAttr(req, NDA_SRC_VNI, &vni, sizeof(vni)); }
+
+    void addVtep(MacMsg& req, const char *ip)
+    {
+        struct in_addr addr;
+        inet_pton(AF_INET, ip, &addr);
+        addAttr(req, NDA_DST, &addr, sizeof(addr));
+    }
+
+    void feed(MacMsg& req)
+    {
+        int len = (int)(req.n.nlmsg_len - NLMSG_LENGTH(sizeof(struct ndmsg)));
+        m_macSync->onMacMsg(&req.n, len);
+    }
+
+    /* Delivers through RouteSync so the message-type filter is exercised. */
+    void feedRaw(MacMsg& req)
+    {
+        m_routeSync->onMsgRaw(&req.n);
+    }
+
+    bool getEntry(const std::string& key, std::vector<FieldValueTuple>& values)
+    {
+        Table table(m_appDb.get(), APP_VXLAN_FDB_TABLE_NAME);
+        return table.get(key, values);
+    }
+
+    std::string fieldValue(const std::vector<FieldValueTuple>& values,
+                           const std::string& field)
+    {
+        auto v = swss::fvsGetValue(values, field);
+        return v.has_value() ? *v : std::string();
+    }
+
+protected:
+    std::shared_ptr<DBConnector> m_appDb;
+    std::shared_ptr<DBConnector> m_stateDb;
+    std::shared_ptr<DBConnector> m_cfgDb;
+    std::shared_ptr<RedisPipeline> m_pipeline;
+    std::unique_ptr<MacSync> m_macSync;
+    std::unique_ptr<RouteSync> m_routeSync;
+};
+
+/*
+ * zebra encodes the VNI as NDA_SRC_VNI. Reading NDA_VNI instead yields a
+ * well-formed entry carrying vni 0.
+ */
+TEST_F(MacSyncTest, RemoteMacTakesVniFromSrcVni)
+{
+    MacMsg req;
+    buildMacMsg(req, RTM_NEWNEIGH, NUD_REACHABLE);
+    addVlan(req, TEST_VLAN);
+    addVtep(req, "10.1.1.1");
+    addSrcVni(req, TEST_VNI);
+    feed(req);
+
+    std::vector<FieldValueTuple> values;
+    ASSERT_TRUE(getEntry(TEST_KEY, values));
+    EXPECT_EQ(fieldValue(values, "vni"), std::to_string(TEST_VNI));
+    EXPECT_EQ(fieldValue(values, "remote_vtep"), "10.1.1.1");
+}
+
+/*
+ * A withdrawal can arrive as an add carrying NUD_INCOMPLETE or NUD_FAILED,
+ * which must remove the entry rather than install it.
+ */
+TEST_F(MacSyncTest, RemoteMacWithdrawnOnIncompleteState)
+{
+    MacMsg add;
+    buildMacMsg(add, RTM_NEWNEIGH, NUD_REACHABLE);
+    addVlan(add, TEST_VLAN);
+    addVtep(add, "10.1.1.1");
+    addSrcVni(add, TEST_VNI);
+    feed(add);
+
+    std::vector<FieldValueTuple> values;
+    ASSERT_TRUE(getEntry(TEST_KEY, values));
+
+    MacMsg withdraw;
+    buildMacMsg(withdraw, RTM_NEWNEIGH, NUD_INCOMPLETE);
+    addVlan(withdraw, TEST_VLAN);
+    addVtep(withdraw, "10.1.1.1");
+    feed(withdraw);
+
+    values.clear();
+    EXPECT_FALSE(getEntry(TEST_KEY, values));
+}
+
+TEST_F(MacSyncTest, RemoteMacWithdrawnOnFailedState)
+{
+    MacMsg add;
+    buildMacMsg(add, RTM_NEWNEIGH, NUD_REACHABLE);
+    addVlan(add, TEST_VLAN);
+    addVtep(add, "10.1.1.1");
+    addSrcVni(add, TEST_VNI);
+    feed(add);
+
+    std::vector<FieldValueTuple> values;
+    ASSERT_TRUE(getEntry(TEST_KEY, values));
+
+    MacMsg withdraw;
+    buildMacMsg(withdraw, RTM_NEWNEIGH, NUD_FAILED);
+    addVlan(withdraw, TEST_VLAN);
+    addVtep(withdraw, "10.1.1.1");
+    feed(withdraw);
+
+    values.clear();
+    EXPECT_FALSE(getEntry(TEST_KEY, values));
+}
+
+TEST_F(MacSyncTest, RemoteMacDeletedOnDelNeigh)
+{
+    MacMsg add;
+    buildMacMsg(add, RTM_NEWNEIGH, NUD_REACHABLE);
+    addVlan(add, TEST_VLAN);
+    addVtep(add, "10.1.1.1");
+    addSrcVni(add, TEST_VNI);
+    feed(add);
+
+    MacMsg del;
+    buildMacMsg(del, RTM_DELNEIGH, NUD_REACHABLE);
+    addVlan(del, TEST_VLAN);
+    addVtep(del, "10.1.1.1");
+    feed(del);
+
+    std::vector<FieldValueTuple> values;
+    EXPECT_FALSE(getEntry(TEST_KEY, values));
+}
+
+/* NUD_NOARP marks a sticky MAC, which fdbOrch consumes as a static entry. */
+TEST_F(MacSyncTest, StickyRemoteMacIsStatic)
+{
+    MacMsg req;
+    buildMacMsg(req, RTM_NEWNEIGH, NUD_REACHABLE | NUD_NOARP);
+    addVlan(req, TEST_VLAN);
+    addVtep(req, "10.1.1.1");
+    addSrcVni(req, TEST_VNI);
+    feed(req);
+
+    std::vector<FieldValueTuple> values;
+    ASSERT_TRUE(getEntry(TEST_KEY, values));
+    EXPECT_EQ(fieldValue(values, "type"), "static");
+}
+
+TEST_F(MacSyncTest, NonStickyRemoteMacIsDynamic)
+{
+    MacMsg req;
+    buildMacMsg(req, RTM_NEWNEIGH, NUD_REACHABLE);
+    addVlan(req, TEST_VLAN);
+    addVtep(req, "10.1.1.1");
+    addSrcVni(req, TEST_VNI);
+    feed(req);
+
+    std::vector<FieldValueTuple> values;
+    ASSERT_TRUE(getEntry(TEST_KEY, values));
+    EXPECT_EQ(fieldValue(values, "type"), "dynamic");
+}
+
+/* Without NDA_VLAN the table key cannot be built, so nothing may be written. */
+TEST_F(MacSyncTest, RemoteMacWithoutVlanIsRejected)
+{
+    MacMsg req;
+    buildMacMsg(req, RTM_NEWNEIGH, NUD_REACHABLE);
+    addVtep(req, "10.1.1.1");
+    addSrcVni(req, TEST_VNI);
+    feed(req);
+
+    std::vector<FieldValueTuple> values;
+    EXPECT_FALSE(getEntry(TEST_KEY, values));
+}
+
+TEST_F(MacSyncTest, RemoteMacWithoutVtepIsRejected)
+{
+    MacMsg req;
+    buildMacMsg(req, RTM_NEWNEIGH, NUD_REACHABLE);
+    addVlan(req, TEST_VLAN);
+    addSrcVni(req, TEST_VNI);
+    feed(req);
+
+    std::vector<FieldValueTuple> values;
+    EXPECT_FALSE(getEntry(TEST_KEY, values));
+}
+
+/* In kernel mode fdbsyncd owns the table and MacSync must not touch it. */
+TEST_F(MacSyncTest, KernelModeIgnoresRemoteMac)
+{
+    m_macSync->m_fpmMode = false;
+
+    MacMsg req;
+    buildMacMsg(req, RTM_NEWNEIGH, NUD_REACHABLE);
+    addVlan(req, TEST_VLAN);
+    addVtep(req, "10.1.1.1");
+    addSrcVni(req, TEST_VNI);
+    feed(req);
+
+    std::vector<FieldValueTuple> values;
+    EXPECT_FALSE(getEntry(TEST_KEY, values));
+}
+
+/* IP neighbours share the message type and must not reach the MAC path. */
+TEST_F(MacSyncTest, NonBridgeFamilyIsIgnored)
+{
+    MacMsg req;
+    buildMacMsg(req, RTM_NEWNEIGH, NUD_REACHABLE);
+    req.ndm.ndm_family = AF_INET;
+    addVlan(req, TEST_VLAN);
+    addVtep(req, "10.1.1.1");
+    feed(req);
+
+    std::vector<FieldValueTuple> values;
+    EXPECT_FALSE(getEntry(TEST_KEY, values));
+}
+
+/*
+ * onMsgRaw filters on an allow-list of message types before dispatching. A
+ * handler that works when called directly is still dead if its message type
+ * is missing from that list, so these two drive the real path end to end.
+ */
+TEST_F(MacSyncTest, RemoteMacReachesMacSyncThroughOnMsgRaw)
+{
+    MacMsg req;
+    buildMacMsg(req, RTM_NEWNEIGH, NUD_REACHABLE);
+    addVlan(req, TEST_VLAN);
+    addVtep(req, "10.1.1.1");
+    addSrcVni(req, TEST_VNI);
+    feedRaw(req);
+
+    std::vector<FieldValueTuple> values;
+    ASSERT_TRUE(getEntry(TEST_KEY, values));
+    EXPECT_EQ(fieldValue(values, "remote_vtep"), "10.1.1.1");
+    EXPECT_EQ(fieldValue(values, "vni"), std::to_string(TEST_VNI));
+}
+
+TEST_F(MacSyncTest, RemoteMacWithdrawalReachesMacSyncThroughOnMsgRaw)
+{
+    MacMsg add;
+    buildMacMsg(add, RTM_NEWNEIGH, NUD_REACHABLE);
+    addVlan(add, TEST_VLAN);
+    addVtep(add, "10.1.1.1");
+    addSrcVni(add, TEST_VNI);
+    feedRaw(add);
+
+    std::vector<FieldValueTuple> values;
+    ASSERT_TRUE(getEntry(TEST_KEY, values));
+
+    MacMsg del;
+    buildMacMsg(del, RTM_DELNEIGH, NUD_REACHABLE);
+    addVlan(del, TEST_VLAN);
+    feedRaw(del);
+
+    EXPECT_FALSE(getEntry(TEST_KEY, values));
+}

--- a/tests/mock_tests/fpmsyncd/macsync_ut.cpp
+++ b/tests/mock_tests/fpmsyncd/macsync_ut.cpp
@@ -34,6 +34,20 @@ using namespace swss;
 #define NDA_SRC_VNI 11
 #endif
 
+#ifndef NDA_PROTOCOL
+#define NDA_PROTOCOL 12
+#endif
+
+/* Hardware-learnt MAC marker, from the SONiC rtnetlink patch. */
+#ifndef RTPROT_HW
+#define RTPROT_HW 193
+#endif
+
+/* Present only on newer kernel headers. */
+#ifndef NTF_STICKY
+#define NTF_STICKY 0x40
+#endif
+
 namespace {
 
 constexpr uint16_t TEST_VLAN = 100;
@@ -544,6 +558,68 @@ private:
 };
 
 /*
+ * The outbound encoding zebra actually parses. Stickiness rides in ndm_flags as
+ * NTF_STICKY, and zebra sets NUD_NOARP only alongside it, so a hardware-learnt
+ * MAC must carry neither: were it sent sticky, BGP would advertise it as an
+ * EVPN static MAC and the address could never move. NDA_PROTOCOL is the FPM
+ * stand-in for the "proto hw" the kernel path passed to "bridge fdb".
+ */
+static const struct rtattr *findAttr(const nlmsghdr *hdr, int type)
+{
+    const struct ndmsg *ndm = (const struct ndmsg *)NLMSG_DATA(hdr);
+    int len = (int)(hdr->nlmsg_len - NLMSG_LENGTH(sizeof(struct ndmsg)));
+    const struct rtattr *rta =
+        (const struct rtattr *)((const char *)ndm + NLMSG_ALIGN(sizeof(struct ndmsg)));
+
+    for (; RTA_OK(rta, len); rta = RTA_NEXT(rta, len))
+    {
+        if (rta->rta_type == type)
+            return rta;
+    }
+    return nullptr;
+}
+
+TEST_F(MacSyncTest, LocalDynamicMacIsNotSticky)
+{
+    seedStateFdb("Vlan100:00:11:22:33:44:55", "lo", false);
+
+    RecordingFpm fpm;
+    m_macSync->onFpmConnected(fpm);
+    ASSERT_EQ(fpm.count(), 2u);
+
+    const nlmsghdr *hdr = fpm.at(0);
+    const struct ndmsg *ndm = (const struct ndmsg *)NLMSG_DATA(hdr);
+
+    EXPECT_TRUE(ndm->ndm_flags & NTF_MASTER);
+    EXPECT_TRUE(ndm->ndm_flags & NTF_EXT_LEARNED);
+    EXPECT_FALSE(ndm->ndm_flags & NTF_STICKY);
+    EXPECT_FALSE(ndm->ndm_state & NUD_NOARP);
+
+    const struct rtattr *proto = findAttr(hdr, NDA_PROTOCOL);
+    ASSERT_NE(proto, nullptr);
+    EXPECT_EQ(*(const uint8_t *)RTA_DATA(proto), RTPROT_HW);
+}
+
+/*
+ * A provisioned MAC is pinned to a port by configuration, so it is advertised
+ * sticky and remote PEs reject a move for it (RFC 7432 section 7.8). Only local
+ * entries reach STATE_DB, so this can never catch an EVPN-learnt address.
+ */
+TEST_F(MacSyncTest, LocalStaticMacIsSticky)
+{
+    seedStateFdb("Vlan100:00:11:22:33:44:66", "lo", true);
+
+    RecordingFpm fpm;
+    m_macSync->onFpmConnected(fpm);
+    ASSERT_EQ(fpm.count(), 2u);
+
+    const struct ndmsg *ndm = (const struct ndmsg *)NLMSG_DATA(fpm.at(0));
+
+    EXPECT_TRUE(ndm->ndm_flags & NTF_STICKY);
+    EXPECT_TRUE(ndm->ndm_state & NUD_NOARP);
+}
+
+/*
  * The replay must come from STATE_DB, not from whatever the subscriber happens
  * to have delivered: zebra can connect before the select loop has run, and a
  * replay of nothing tells zebra to withdraw every local MAC.
@@ -564,6 +640,27 @@ TEST_F(MacSyncTest, ReplayLoadsLocalMacsFromStateDb)
     /* Both must carry the same generation or the marker sweeps what it replayed. */
     EXPECT_EQ(fpm.at(0)->nlmsg_seq, fpm.at(1)->nlmsg_seq);
     EXPECT_NE(fpm.at(0)->nlmsg_seq, 0u);
+}
+
+/*
+ * Switching into fpm mode has to replay what STATE_DB already holds. The local
+ * cache cannot be trusted here: processStateFdb() drops updates while fdbsyncd
+ * owns the kernel path, so entering fpm mode with a stale cache would leave
+ * every already-learnt local MAC unknown to zebra until the next reconnect.
+ */
+TEST_F(MacSyncTest, EnteringFpmModeReplaysExistingLocalMacs)
+{
+    m_macSync->setMacSyncMode("kernel");
+    seedStateFdb("Vlan100:00:11:22:33:44:55", "lo", false);
+
+    RecordingFpm fpm;
+    m_macSync->onFpmConnected(fpm);
+    ASSERT_EQ(fpm.count(), 0u);
+
+    m_macSync->setMacSyncMode("fpm");
+
+    ASSERT_EQ(fpm.count(), 1u);
+    EXPECT_EQ(fpm.at(0)->nlmsg_type, RTM_NEWNEIGH);
 }
 
 /*

--- a/tests/mock_tests/fpmsyncd/macsync_ut.cpp
+++ b/tests/mock_tests/fpmsyncd/macsync_ut.cpp
@@ -243,6 +243,46 @@ TEST_F(MacSyncTest, RemoteMacDeletedOnDelNeigh)
     EXPECT_FALSE(getEntry(TEST_KEY, values));
 }
 
+/*
+ * zebra replays router MACs on reconnect but never remote EVPN MACs, so an entry
+ * left in APPL_DB by fdbsyncd across a mode change, or by a previous fpmsyncd,
+ * is only removable if fpmsyncd adopted it when it entered fpm mode.
+ */
+TEST_F(MacSyncTest, InheritedRemoteMacIsWithdrawn)
+{
+    Table appFdb(m_appDb.get(), APP_VXLAN_FDB_TABLE_NAME);
+    appFdb.set(TEST_KEY, std::vector<FieldValueTuple>{
+        {"remote_vtep", "10.1.1.1"},
+        {"type", "dynamic"},
+        {"vni", std::to_string(TEST_VNI)},
+    });
+
+    /* Enter fpm mode the way startup does, so the adoption runs. */
+    m_macSync->setMacSyncMode("kernel");
+    m_macSync->setMacSyncMode("fpm");
+
+    MacMsg del;
+    buildMacMsg(del, RTM_DELNEIGH, NUD_REACHABLE);
+    addVlan(del, TEST_VLAN);
+    addVtep(del, "10.1.1.1");
+    feed(del);
+
+    std::vector<FieldValueTuple> values;
+    EXPECT_FALSE(getEntry(TEST_KEY, values));
+}
+
+TEST_F(MacSyncTest, EnteringFpmModeAdoptsExistingRemoteMacs)
+{
+    Table appFdb(m_appDb.get(), APP_VXLAN_FDB_TABLE_NAME);
+    appFdb.set(TEST_KEY, std::vector<FieldValueTuple>{{"remote_vtep", "10.1.1.1"}});
+
+    m_macSync->setMacSyncMode("kernel");
+    EXPECT_EQ(m_macSync->m_remoteMacs.count(TEST_KEY), 0u);
+
+    m_macSync->setMacSyncMode("fpm");
+    EXPECT_EQ(m_macSync->m_remoteMacs.count(TEST_KEY), 1u);
+}
+
 /* NUD_NOARP marks a sticky MAC, which fdbOrch consumes as a static entry. */
 TEST_F(MacSyncTest, StickyRemoteMacIsStatic)
 {

--- a/tests/mock_tests/fpmsyncd/macsync_ut.cpp
+++ b/tests/mock_tests/fpmsyncd/macsync_ut.cpp
@@ -21,6 +21,7 @@
 
 #include <linux/if_ether.h>
 #include <linux/neighbour.h>
+#include <linux/nexthop.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
@@ -163,6 +164,72 @@ public:
     {
         auto v = swss::fvsGetValue(values, field);
         return v.has_value() ? *v : std::string();
+    }
+
+    /* Builds the nexthop message zebra emits for an Ethernet Segment. */
+    struct NhgMsg
+    {
+        struct nlmsghdr n;
+        struct nhmsg nhm;
+        char buf[256];
+    };
+
+    void buildNhgMsg(NhgMsg& req, uint16_t nlmsgType, uint32_t id, bool fdb = true)
+    {
+        memset(&req, 0, sizeof(req));
+        req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct nhmsg));
+        req.n.nlmsg_type = nlmsgType;
+        req.nhm.nh_family = AF_UNSPEC;
+        addNhgAttr(req, NHA_ID, &id, sizeof(id));
+        if (fdb)
+        {
+            addNhgAttr(req, NHA_FDB, nullptr, 0);
+        }
+    }
+
+    void addNhgAttr(NhgMsg& req, int type, const void *data, size_t alen)
+    {
+        size_t len = RTA_LENGTH(alen);
+        struct rtattr *rta =
+            (struct rtattr *)(((char *)&req.n) + NLMSG_ALIGN(req.n.nlmsg_len));
+        rta->rta_type = (unsigned short)type;
+        rta->rta_len = (unsigned short)len;
+        if (alen)
+        {
+            memcpy(RTA_DATA(rta), data, alen);
+        }
+        req.n.nlmsg_len = (uint32_t)(NLMSG_ALIGN(req.n.nlmsg_len) + RTA_ALIGN(len));
+    }
+
+    void addNhgGateway(NhgMsg& req, const char *ip)
+    {
+        struct in_addr addr;
+        inet_pton(AF_INET, ip, &addr);
+        req.nhm.nh_family = AF_INET;
+        addNhgAttr(req, NHA_GATEWAY, &addr, sizeof(addr));
+    }
+
+    void addNhgMembers(NhgMsg& req, const std::vector<uint32_t>& ids)
+    {
+        std::vector<struct nexthop_grp> grp(ids.size());
+        for (size_t i = 0; i < ids.size(); i++)
+        {
+            memset(&grp[i], 0, sizeof(grp[i]));
+            grp[i].id = ids[i];
+        }
+        addNhgAttr(req, NHA_GROUP, grp.data(), grp.size() * sizeof(struct nexthop_grp));
+    }
+
+    bool feedNhg(NhgMsg& req)
+    {
+        int len = (int)(req.n.nlmsg_len - NLMSG_LENGTH(sizeof(struct nhmsg)));
+        return m_macSync->onFdbNhgMsg(&req.n, len);
+    }
+
+    bool getL2Nhg(uint32_t id, std::vector<FieldValueTuple>& values)
+    {
+        Table table(m_appDb.get(), APP_L2_NEXTHOP_GROUP_TABLE_NAME);
+        return table.get(std::to_string(id), values);
     }
 
 protected:
@@ -660,6 +727,55 @@ TEST_F(MacSyncTest, MacOnNonEsPortWithoutVtepIsSkipped)
 }
 
 /*
+ * zebra sizes NDA_DST from the address family it guessed rather than from what
+ * it actually holds, so a MAC with no VTEP still arrives carrying a 16 byte
+ * all-zero destination. Treating that as a real address published `::` as the
+ * remote VTEP and hid the Ethernet Segment the MAC really sits on.
+ */
+TEST_F(MacSyncTest, UnspecifiedVtepIsNotAnAddress)
+{
+    Table cfgEs(m_cfgDb.get(), "EVPN_ETHERNET_SEGMENT");
+    cfgEs.set("lo", std::vector<FieldValueTuple>{{"esi", "AUTO"}});
+
+    struct in6_addr unspecified;
+    memset(&unspecified, 0, sizeof(unspecified));
+
+    MacMsg req;
+    buildMacMsg(req, RTM_NEWNEIGH, NUD_REACHABLE | NUD_NOARP);
+    req.ndm.ndm_ifindex = (int)if_nametoindex("lo");
+    addVlan(req, TEST_VLAN);
+    addSrcVni(req, TEST_VNI);
+    addAttr(req, NDA_DST, &unspecified, sizeof(unspecified));
+    feed(req);
+
+    std::vector<FieldValueTuple> values;
+    ASSERT_TRUE(getEntry(TEST_KEY, values));
+    EXPECT_EQ(fieldValue(values, "ifname"), "lo");
+    EXPECT_EQ(fieldValue(values, "remote_vtep"), "");
+
+    cfgEs.del("lo");
+}
+
+/* Same encoding on a port that is not an Ethernet Segment: there is nothing to
+ * program the MAC against, so it must be dropped rather than published. */
+TEST_F(MacSyncTest, UnspecifiedVtepOnNonEsPortIsSkipped)
+{
+    struct in6_addr unspecified;
+    memset(&unspecified, 0, sizeof(unspecified));
+
+    MacMsg req;
+    buildMacMsg(req, RTM_NEWNEIGH, NUD_REACHABLE);
+    req.ndm.ndm_ifindex = (int)if_nametoindex("lo");
+    addVlan(req, TEST_VLAN);
+    addSrcVni(req, TEST_VNI);
+    addAttr(req, NDA_DST, &unspecified, sizeof(unspecified));
+    feed(req);
+
+    std::vector<FieldValueTuple> values;
+    EXPECT_FALSE(getEntry(TEST_KEY, values));
+}
+
+/*
  * A MAC behind an Ethernet Segment reaches several VTEPs at once, so zebra
  * resolves it to an L2 nexthop group and sends NDA_NH_ID with no NDA_DST. It
  * has to be programmed against that group rather than discarded as though it
@@ -847,4 +963,125 @@ TEST_F(MacSyncTest, ReplayWithNoLocalMacsStillSendsMarker)
     ASSERT_EQ(fpm.count(), 1u);
     EXPECT_EQ(fpm.at(0)->nlmsg_type, RTM_FPM_MAC_REPLAY_END);
     EXPECT_NE(fpm.at(0)->nlmsg_seq, 0u);
+}
+
+/*
+ * The FDB nexthop cases below all share one hazard: RTM_NEWNEXTHOP is also how
+ * L3 nexthop groups arrive, and routesync will publish anything it is handed as
+ * a real NEXTHOP_GROUP. Misclassifying in either direction is silent.
+ */
+TEST_F(MacSyncTest, FdbNexthopWithGatewayPublishesRemoteVtep)
+{
+    NhgMsg req;
+    buildNhgMsg(req, RTM_NEWNEXTHOP, 4001);
+    addNhgGateway(req, "10.1.1.1");
+    ASSERT_TRUE(feedNhg(req));
+
+    std::vector<FieldValueTuple> values;
+    ASSERT_TRUE(getL2Nhg(4001, values));
+    EXPECT_EQ(fieldValue(values, "remote_vtep"), "10.1.1.1");
+}
+
+TEST_F(MacSyncTest, FdbNexthopGroupPublishesItsMembers)
+{
+    NhgMsg a, b, g;
+    buildNhgMsg(a, RTM_NEWNEXTHOP, 4001);
+    addNhgGateway(a, "10.1.1.1");
+    feedNhg(a);
+
+    buildNhgMsg(b, RTM_NEWNEXTHOP, 4002);
+    addNhgGateway(b, "10.1.1.2");
+    feedNhg(b);
+
+    buildNhgMsg(g, RTM_NEWNEXTHOP, 5000);
+    addNhgMembers(g, {4001, 4002});
+    ASSERT_TRUE(feedNhg(g));
+
+    std::vector<FieldValueTuple> values;
+    ASSERT_TRUE(getL2Nhg(5000, values));
+    EXPECT_EQ(fieldValue(values, "nexthop_group"), "4001,4002");
+}
+
+/* fdbOrch would resolve the group against a nexthop that does not exist. */
+TEST_F(MacSyncTest, FdbNexthopGroupWithUnknownMemberIsNotPublished)
+{
+    NhgMsg g;
+    buildNhgMsg(g, RTM_NEWNEXTHOP, 5000);
+    addNhgMembers(g, {4001, 9999});
+    EXPECT_TRUE(feedNhg(g));
+
+    std::vector<FieldValueTuple> values;
+    EXPECT_FALSE(getL2Nhg(5000, values));
+}
+
+/* Withdrawing a member must re-derive every group that named it. */
+TEST_F(MacSyncTest, FdbNexthopDeleteRederivesTheGroupsThatNamedIt)
+{
+    NhgMsg a, b, g, del;
+    buildNhgMsg(a, RTM_NEWNEXTHOP, 4001);
+    addNhgGateway(a, "10.1.1.1");
+    feedNhg(a);
+    buildNhgMsg(b, RTM_NEWNEXTHOP, 4002);
+    addNhgGateway(b, "10.1.1.2");
+    feedNhg(b);
+    buildNhgMsg(g, RTM_NEWNEXTHOP, 5000);
+    addNhgMembers(g, {4001, 4002});
+    feedNhg(g);
+
+    buildNhgMsg(del, RTM_DELNEXTHOP, 4001);
+    ASSERT_TRUE(feedNhg(del));
+
+    std::vector<FieldValueTuple> gone;
+    EXPECT_FALSE(getL2Nhg(4001, gone));
+
+    std::vector<FieldValueTuple> values;
+    ASSERT_TRUE(getL2Nhg(5000, values));
+    EXPECT_EQ(fieldValue(values, "nexthop_group"), "4002");
+}
+
+/* An output interface makes it an ordinary nexthop, not an ES destination. */
+TEST_F(MacSyncTest, FdbNexthopWithOifIsNotPublished)
+{
+    NhgMsg req;
+    uint32_t oif = 7;
+
+    buildNhgMsg(req, RTM_NEWNEXTHOP, 4001);
+    addNhgGateway(req, "10.1.1.1");
+    addNhgAttr(req, NHA_OIF, &oif, sizeof(oif));
+    EXPECT_TRUE(feedNhg(req));
+
+    std::vector<FieldValueTuple> values;
+    EXPECT_FALSE(getL2Nhg(4001, values));
+}
+
+/*
+ * The safety property: without NHA_FDB the message is an L3 nexthop and must be
+ * declined, or routesync never sees it and the route's group disappears.
+ */
+TEST_F(MacSyncTest, NonFdbNexthopIsDeclinedForTheRoutePath)
+{
+    NhgMsg req;
+    buildNhgMsg(req, RTM_NEWNEXTHOP, 4001, false /* no NHA_FDB */);
+    addNhgGateway(req, "10.1.1.1");
+
+    EXPECT_FALSE(feedNhg(req));
+
+    std::vector<FieldValueTuple> values;
+    EXPECT_FALSE(getL2Nhg(4001, values));
+}
+
+/* fdbsyncd still owns the table while the kernel is the transport. */
+TEST_F(MacSyncTest, FdbNexthopIsConsumedButNotPublishedInKernelMode)
+{
+    m_macSync->m_fpmMode = false;
+
+    NhgMsg req;
+    buildNhgMsg(req, RTM_NEWNEXTHOP, 4001);
+    addNhgGateway(req, "10.1.1.1");
+
+    /* Consumed, so it cannot reach the route path, but not published. */
+    EXPECT_TRUE(feedNhg(req));
+
+    std::vector<FieldValueTuple> values;
+    EXPECT_FALSE(getL2Nhg(4001, values));
 }

--- a/tests/mock_tests/fpmsyncd/macsync_ut.cpp
+++ b/tests/mock_tests/fpmsyncd/macsync_ut.cpp
@@ -75,6 +75,10 @@ public:
         /* CONFIG_DB is not populated under the mock, so drive the mode directly. */
         m_macSync->m_fpmMode = true;
 
+        /* A ready orchagent is the normal case, so the end-of-replay marker is
+         * not gated in most tests; the gate itself is covered separately. */
+        setPortInitDone();
+
         /* Needed to exercise the real dispatch path rather than calling the
          * handler directly; onMsgRaw filters message types before MacSync. */
         m_routeSync = std::make_unique<RouteSync>(m_pipeline.get());
@@ -86,6 +90,18 @@ public:
         m_routeSync.reset();
         m_macSync.reset();
         m_pipeline.reset();
+    }
+
+    void setPortInitDone()
+    {
+        Table portTable(m_appDb.get(), APP_PORT_TABLE_NAME);
+        portTable.set("PortInitDone", std::vector<FieldValueTuple>{{"lanes", "0"}});
+    }
+
+    void clearPortInitDone()
+    {
+        Table portTable(m_appDb.get(), APP_PORT_TABLE_NAME);
+        portTable.del("PortInitDone");
     }
 
     /* Builds an AF_BRIDGE neighbour message of the shape zebra emits. */
@@ -900,8 +916,11 @@ TEST_F(MacSyncTest, EnteringFpmModeReplaysExistingLocalMacs)
 
     m_macSync->setMacSyncMode("fpm");
 
-    ASSERT_EQ(fpm.count(), 1u);
+    /* The MAC, then the marker that claims ownership of local MACs. */
+    ASSERT_EQ(fpm.count(), 2u);
     EXPECT_EQ(fpm.at(0)->nlmsg_type, RTM_NEWNEIGH);
+    EXPECT_EQ(fpm.at(1)->nlmsg_type, RTM_FPM_MAC_REPLAY_END);
+    EXPECT_NE(fpm.at(1)->nlmsg_seq, 0u);
 }
 
 /*
@@ -963,6 +982,154 @@ TEST_F(MacSyncTest, ReplayWithNoLocalMacsStillSendsMarker)
     ASSERT_EQ(fpm.count(), 1u);
     EXPECT_EQ(fpm.at(0)->nlmsg_type, RTM_FPM_MAC_REPLAY_END);
     EXPECT_NE(fpm.at(0)->nlmsg_seq, 0u);
+}
+
+/*
+ * Leaving fpm mode hands local MACs back. Without this zebra keeps suppressing
+ * its own kernel writes while fdbsyncd owns the path, so nobody programs them.
+ */
+TEST_F(MacSyncTest, LeavingFpmModeReleasesLocalMacs)
+{
+    RecordingFpm fpm;
+    m_macSync->onFpmConnected(fpm);
+    ASSERT_EQ(fpm.count(), 1u);
+
+    m_macSync->setMacSyncMode("kernel");
+
+    ASSERT_EQ(fpm.count(), 2u);
+    EXPECT_EQ(fpm.at(1)->nlmsg_type, RTM_FPM_MAC_REPLAY_END);
+    EXPECT_EQ(fpm.at(1)->nlmsg_seq, 0u);
+}
+
+/* Re-entering fpm mode takes ownership back with a real generation. */
+TEST_F(MacSyncTest, ReEnteringFpmModeTakesLocalMacsBack)
+{
+    RecordingFpm fpm;
+    m_macSync->onFpmConnected(fpm);
+    m_macSync->setMacSyncMode("kernel");
+    ASSERT_EQ(fpm.count(), 2u);
+
+    m_macSync->setMacSyncMode("fpm");
+
+    ASSERT_EQ(fpm.count(), 3u);
+    EXPECT_EQ(fpm.at(2)->nlmsg_type, RTM_FPM_MAC_REPLAY_END);
+    EXPECT_NE(fpm.at(2)->nlmsg_seq, 0u);
+}
+
+/* A mode set that changes nothing must not disturb ownership. */
+TEST_F(MacSyncTest, RepeatedKernelModeReleasesOnlyOnce)
+{
+    RecordingFpm fpm;
+    m_macSync->onFpmConnected(fpm);
+    m_macSync->setMacSyncMode("kernel");
+    ASSERT_EQ(fpm.count(), 2u);
+
+    m_macSync->setMacSyncMode("kernel");
+
+    EXPECT_EQ(fpm.count(), 2u);
+}
+
+/*
+ * The marker makes zebra drop every local MAC it did not just receive, so it
+ * asserts that STATE_DB holds the real set. Sending it before orchagent has
+ * signalled PortInitDone turns "orchagent has not filled STATE_DB yet" into
+ * "SONiC has no MACs", withdrawing MACs that exist.
+ */
+TEST_F(MacSyncTest, MarkerIsHeldUntilOrchagentIsReady)
+{
+    clearPortInitDone();
+    seedStateFdb("Vlan100:00:11:22:33:44:55", "lo", false);
+
+    RecordingFpm fpm;
+    m_macSync->onFpmConnected(fpm);
+
+    /* The MAC still goes out; only the marker waits. */
+    ASSERT_EQ(fpm.count(), 1u);
+    EXPECT_EQ(fpm.at(0)->nlmsg_type, RTM_NEWNEIGH);
+    EXPECT_TRUE(m_macSync->m_replayEndPending);
+}
+
+/* Once orchagent publishes, its silence means "no MACs" and the marker is due. */
+TEST_F(MacSyncTest, HeldMarkerIsSentOnceOrchagentPublishes)
+{
+    clearPortInitDone();
+
+    RecordingFpm fpm;
+    m_macSync->onFpmConnected(fpm);
+    ASSERT_EQ(fpm.count(), 0u);
+    ASSERT_TRUE(m_macSync->m_replayEndPending);
+
+    setPortInitDone();
+    m_macSync->processStateFdb();
+
+    ASSERT_EQ(fpm.count(), 1u);
+    EXPECT_EQ(fpm.at(0)->nlmsg_type, RTM_FPM_MAC_REPLAY_END);
+    EXPECT_FALSE(m_macSync->m_replayEndPending);
+}
+
+/* A held marker must not go out while orchagent is still unready. */
+TEST_F(MacSyncTest, HeldMarkerSurvivesAnEarlyRetry)
+{
+    clearPortInitDone();
+
+    RecordingFpm fpm;
+    m_macSync->onFpmConnected(fpm);
+    ASSERT_TRUE(m_macSync->m_replayEndPending);
+
+    m_macSync->processStateFdb();
+
+    EXPECT_EQ(fpm.count(), 0u);
+    EXPECT_TRUE(m_macSync->m_replayEndPending);
+}
+
+/*
+ * PortInitDone is the only wake-up a held marker gets when orchagent comes up
+ * owning no MACs: it publishes nothing to STATE_DB, so waiting on FDB traffic
+ * alone would hold the marker until the next FPM reconnect.
+ */
+TEST_F(MacSyncTest, HeldMarkerIsSentWhenPortInitDoneArrives)
+{
+    clearPortInitDone();
+
+    RecordingFpm fpm;
+    m_macSync->onFpmConnected(fpm);
+    ASSERT_EQ(fpm.count(), 0u);
+    ASSERT_TRUE(m_macSync->m_replayEndPending);
+
+    setPortInitDone();
+    m_macSync->processAppPort();
+
+    ASSERT_EQ(fpm.count(), 1u);
+    EXPECT_EQ(fpm.at(0)->nlmsg_type, RTM_FPM_MAC_REPLAY_END);
+    EXPECT_FALSE(m_macSync->m_replayEndPending);
+}
+
+/* The same wake-up must not release the marker while orchagent is still absent. */
+TEST_F(MacSyncTest, PortTableActivityAloneDoesNotReleaseTheMarker)
+{
+    clearPortInitDone();
+
+    RecordingFpm fpm;
+    m_macSync->onFpmConnected(fpm);
+    ASSERT_TRUE(m_macSync->m_replayEndPending);
+
+    m_macSync->processAppPort();
+
+    EXPECT_EQ(fpm.count(), 0u);
+    EXPECT_TRUE(m_macSync->m_replayEndPending);
+}
+
+/* A marker owed to a session that has gone away must not follow the next one. */
+TEST_F(MacSyncTest, HeldMarkerIsDroppedOnDisconnect)
+{
+    clearPortInitDone();
+
+    RecordingFpm fpm;
+    m_macSync->onFpmConnected(fpm);
+    ASSERT_TRUE(m_macSync->m_replayEndPending);
+
+    m_macSync->onFpmDisconnected();
+    EXPECT_FALSE(m_macSync->m_replayEndPending);
 }
 
 /*


### PR DESCRIPTION
#### Why I did it

MAC (FDB) state currently reaches FRR through the Linux kernel bridge FDB. That
makes the kernel a required data store in the ASIC-to-FRR path, and it means the
kernel arbitrates coexistence between control-plane and data-plane entries.

This series moves MAC synchronization onto the FPM channel so fpmsyncd and zebra
exchange MAC state directly. The kernel bridge FDB is still programmed so ARP/ND
behaviour is unchanged, but it is no longer the transport.

The behaviour is selected by `FDB_SYNC|global mac_sync_mode`, which defaults to
`kernel`. Existing deployments are unaffected unless the mode is set to `fpm`.

#### How I did it

- Add FDB synchronization over the FPM channel in fpmsyncd/fdbsyncd.
- Stamp a generation on replayed local MACs and keep it across restarts, so a
  reconnect can distinguish a fresh view from a stale one.
- Adopt remote MACs already present in APPL_DB rather than re-learning them.
- Retire remote MACs zebra did not replay, after a hold-down.
- Load local MACs before replaying them, and sweep on the end-of-replay marker
  rather than on a timer.
- Hold the end-of-replay marker until orchagent signals PortInitDone, so a sweep
  cannot run against an incomplete local view at boot.
- Carry ES-backed remote MACs as an L2 nexthop group, and program a MAC on a
  local Ethernet Segment against its port.
- Stop fdbsyncd spawning `bridge` processes when in fpm mode.
- Drop the now-dead kernel FDB protocol plumbing.
- portsorch: move the optional EVPN-MH DF attribute to a post-create `set` that
  tolerates `NOT_IMPLEMENTED`/`NOT_SUPPORTED`, so an unimplemented optional
  attribute no longer fails bridge port and VLAN member creation.

#### How to verify it

Unit tests, run as part of the package build:

```
make target/debs/trixie/swss_1.0.0_amd64.deb
# mock_tests: 1388 total, 1387 passed, 1 skipped, 0 failed
# tests     :   70 total,   70 passed,          0 failed
```

On hardware, with `config fdb mac-sync-mode fpm` and `config save -y`:

```
redis-cli -n 4 hgetall "FDB_SYNC|global"
docker exec bgp vtysh -c "show zebra dplane providers"   # dplane_fpm_sonic_mac before Kernel
docker exec bgp vtysh -c "show evpn mac vni <vni>"
pgrep -cf 'bridge fdb'                                    # must be 0 in fpm mode
```

Verified on an Arista 7060X6-64PE-B pair: fpm mode engaged on both daemons, the
end-of-replay marker correctly held until PortInitDone, zero `bridge fdb`
processes in fpm mode, and the PRE_KERNEL dataplane provider ordered ahead of
Kernel. Data-plane MAC learning verification is still outstanding while the lab
servers are offline for unrelated maintenance; this PR is a draft until that
completes.

#### Dependency / merge order

- Requires `sonic-swss-common` FDB_SYNC schema PR to merge **first**.
- The `sonic-linux-kernel` PR that drops the bridge FDB protocol patch must
  merge **after** this one, because master still contains the protocol plumbing
  that patch supports.

#### Which release branch to backport

None requested at this time.

#### Description for the changelog

Add FDB synchronization over the FPM channel, selectable via
FDB_SYNC|global mac_sync_mode (default kernel).
