### PR TITLE
[stpmgrd]: Fix STPd IPC socket descriptor validation and lifecycle

### DIFF
--- a/cfgmgr/stpmgr.cpp
+++ b/cfgmgr/stpmgr.cpp
@@ -38,6 +38,7 @@ StpMgr::StpMgr(DBConnector *confDb, DBConnector *applDb, DBConnector *statDb,
 {
     SWSS_LOG_ENTER();
     l2ProtoEnabled = L2_NONE;
+    stpd_fd = -1;
 
     stpGlobalTask = stpVlanTask = stpVlanPortTask = stpPortTask = stpMstInstTask = false;
 
@@ -868,7 +869,7 @@ void StpMgr::ipcInitStpd()
     unlink(STPMGRD_SOCK_NAME);
     // create socket
     stpd_fd = socket(AF_UNIX, SOCK_DGRAM, 0);
-    if (!stpd_fd) {
+    if (stpd_fd < 0) {
 		SWSS_LOG_ERROR("socket error %s", strerror(errno));
 		return;
     }
@@ -883,6 +884,7 @@ void StpMgr::ipcInitStpd()
     {
 		SWSS_LOG_ERROR("ipc bind error %s", strerror(errno));
         close(stpd_fd);
+        stpd_fd = -1;
         return;
     }
 }
@@ -1221,6 +1223,12 @@ void StpMgr::doStpMstInstPortTask(Consumer &consumer)
 // Send Message to STPd
 int StpMgr::sendMsgStpd(STP_MSG_TYPE msgType, uint32_t msgLen, void *data)
 {
+    if (stpd_fd < 0)
+    {
+        SWSS_LOG_ERROR("STPd IPC socket not initialized, dropping msg type %d", msgType);
+        return -1;
+    }
+
     STP_IPC_MSG *tx_msg;
     size_t len = 0;
     struct sockaddr_un addr;


### PR DESCRIPTION
**What I did**

Fixed descriptor validation and lifecycle for the STPd IPC socket in `cfgmgr/stpmgr.cpp`:

- Initialize `stpd_fd` to `-1` in the `StpMgr` constructor
- Test the `socket()` result with `< 0` instead of `!stpd_fd`
- Reset `stpd_fd` to `-1` after `close()` on the `bind()` failure path
- Reject messages in `sendMsgStpd()` when `stpd_fd` is invalid


**Why I did it**

The STPd socket descriptor had four related problems, one per change above:

- `if (!stpd_fd)` is only true for descriptor `0`, but `socket()` reports failure as `-1`. A real failure slipped through to `bind()` and was misreported as `"ipc bind error"`, while a valid descriptor `0` was wrongly rejected.
- On the `bind()` failure path the descriptor is closed but never reset. `stpmgrd` calls `ipcInitStpd()` once with no retry, so the stale number persists for the life of the process.
- `sendMsgStpd()` never validated `stpd_fd` before `sendto()`, so all nine call sites kept writing to that closed descriptor, which the kernel is free to reassign.
- `stpd_fd` was never initialized, so it held an indeterminate value until `ipcInitStpd()` ran.

`ipcInitStpd()` returns void, so `stpmgrd` is never informed that initialization failed. It enters the event loop, consumes CONFIG_DB and erases entries as processed, while STP silently receives nothing.

`FpmLink` and `MclagLink` already handle their descriptor members this way, so this follows existing convention rather than introducing a new one.

**How I verified it**

Checked the three assumptions behind the fix with a small standalone program:

- `socket()` returned `-1` on failure, and `!fd` evaluates false for `-1`, so the old check never fired on a real failure.
- After `close()`, the next unrelated socket was handed the same descriptor number, so a write through a stale `stpd_fd` can land on an unrelated object.
- With stdin closed, `socket()` returned descriptor `0`, which the old check rejected as invalid.

`stpd_fd` is assigned in exactly one place, `ipcInitStpd()`, which `stpmgrd` calls once with no retry, and it is read in nine places, all of them through `sendMsgStpd()`. The guard added there therefore covers every read.


**Details if related**

- Introduced in `5a8d403d` ("PVST feature support", #3425) and unchanged since.
- Comparable prior fix in this daemon: `5a739288`, "[agent][stpmgrd] Fix file descriptor leak in debug reload check".
- No functional overlap with open PR #4790: it does not touch `stpd_fd`, `socket()`, `ipcInitStpd()`, or `close()`. It does edit the constructor and the top of `sendMsgStpd()`, so a trivial textual conflict is possible — happy to rebase whichever lands second.