### PR TITLE
[buffermgrd] Defer reclaiming buffer on admin-down port until oper st…

### DIFF
--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -1253,6 +1253,12 @@ bool BufferMgrDynamic::isReadyToReclaimBufferOnPort(const string &port)
         }
     }
 
+    if (portInfo.oper_status != "down")
+    {
+        SWSS_LOG_NOTICE("Port %s oper status is still %s, reclaiming reserved buffer deferred", port.c_str(), portInfo.oper_status.c_str());
+        return false;
+    }
+
     return true;
 }
 
@@ -2130,6 +2136,28 @@ task_process_status BufferMgrDynamic::handlePortStateTable(KeyOpFieldsValuesTupl
                         {
                             portInfo.state = PORT_READY;
                             refreshPgsForPort(port, portInfo.effective_speed, portInfo.cable_length, portInfo.mtu);
+                        }
+                    }
+                }
+            }
+            else if (fvField(i) == "netdev_oper_status")
+            {
+                auto &portInfo = m_portInfoLookup[port];
+                if (fvValue(i) != portInfo.oper_status)
+                {
+                    portInfo.oper_status = fvValue(i);
+                    SWSS_LOG_INFO("Port %s: oper status updated to %s", port.c_str(), portInfo.oper_status.c_str());
+                    if (portInfo.oper_status == "down" && m_pendingApplyZeroProfilePorts.find(port) != m_pendingApplyZeroProfilePorts.end())
+                    {
+                        if (!m_bufferPoolReady || m_defaultThreshold.empty())
+                        {
+                            SWSS_LOG_INFO("Buffer pool of default threshold not ready, keep port %s pending", port.c_str());
+                        }
+                        else if (isReadyToReclaimBufferOnPort(port))
+                        {
+                            SWSS_LOG_INFO("Admin-down port %s is handled after oper status have been down", port.c_str());
+                            reclaimReservedBufferForPort(port, m_portPgLookup, BUFFER_PG);
+                            reclaimReservedBufferForPort(port, m_portQueueLookup, BUFFER_QUEUE);
                         }
                     }
                 }

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -107,6 +107,7 @@ typedef struct {
     std::string cable_length;
     std::string mtu;
     std::string gearbox_model;
+    std::string oper_status = "down";
 
     bool auto_neg;
     std::string effective_speed;


### PR DESCRIPTION
What I did
Reclaim the reserved buffer of an admin-down port only after its netdev oper      
status has become down, instead of doing it as soon as the admin-status change    
is handled.

Why I did it
When a port is shut down, buffermgrd applies the zero profiles on its PGs and
queues immediately after handling the admin-status change. At that moment the
port's oper status is still up, so the hardware keeps receiving and enqueuing
packets on the port while the buffer reserved for those queues has already been
reclaimed. This causes packet loss in the port queues during the shutdown.

How I did it
- Add oper_status to the per-port information cached by buffermgrd and keep it
  in sync with the netdev_oper_status field of STATE_DB PORT_TABLE.
- Make isReadyToReclaimBufferOnPort require the port's oper status to be down
  in addition to the existing checks. Otherwise the reclamation is deferred and
  the port stays in m_pendingApplyZeroProfilePorts, which is already retried by
  handlePendingBufferObjects.
- Once netdev_oper_status turns down, drain the pending admin-down ports: if
  the buffer pools and the default threshold are ready, apply the zero profiles
  on the PGs and queues of the port right away.
- oper_status is initialized to "down", so a port whose oper status has never     
  been reported keeps the original behavior and is not deferred indefinitely.     
                                                                                  
Signed-off-by:InspurSDN <sdn@ieisystem.com> 