### PR TITLE
[teammgr] Check each command separately when adding a LAG member

### DIFF
--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -760,10 +760,26 @@ task_process_status TeamMgr::addLagMember(const string &lag, const string &membe
     // teamdctl <port_channel_name> port config update <member> { "lacp_key": <lacp_key>, "link_watch": { "name": "ethtool" } };
     // teamdctl <port_channel_name> port add <member>;
     cmd << IP_CMD << " link set dev " << shellquote(member) << " down; ";
+    if (exec(cmd.str(), res) != 0)
+    {
+        SWSS_LOG_WARN("Failed to set %s down", member.c_str());
+
+        return task_need_retry;
+    }
+
+    cmd.clear();
     cmd << TEAMDCTL_CMD << " " << shellquote(lag) << " port config update " << shellquote(member)
         << " '{\"lacp_key\":"
         << keyId
         << ",\"link_watch\": {\"name\": \"ethtool\"} }'; ";
+    if (exec(cmd.str(), res) != 0)
+    {
+        SWSS_LOG_WARN("Failed to execute %s, retry...",
+                cmd.str().c_str());
+        return task_need_retry;
+    }
+
+    cmd.clear();
     cmd << TEAMDCTL_CMD << " " << shellquote(lag) << " port add " << shellquote(member);
 
     if (exec(cmd.str(), res) != 0)


### PR DESCRIPTION
What I did
Execute the three commands required for adding a LAG member one by one and check the return value of each of them, instead of concatenating them into a single shell string and checking only the final result.

Why I did it
addLagMember() built one shell string that chained the following commands:
  - ip link set dev <member> down
  - teamdctl <lag> port config update <member> {"lacp_key": ..., "link_watch": ...}
  - teamdctl <lag> port add <member> Since only the exit code of the whole string was examined, the failure of an earlier command was silently ignored as long as the last one succeeded. In that case the member was enslaved with parameters that had never been applied, e.g. lacp_key=0, which breaks LACP negotiation on that member.

How I did it
- Run "ip link set dev <member> down" first and return task_need_retry if it fails, so the member is not enslaved before it is brought down.
- Run the "teamdctl port config update" command on its own and return task_need_retry if it fails, so the LACP key is never left unset.
- Keep the existing handling of "teamdctl port add" unchanged.
- Log the failing command so the retry can be traced.

Signed-off-by: InspurSDN <sdn@ieisystem.com>