### PR TITLE
[portsorch]: Skip gearbox ports for PORT_PHY_ATTR

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4276,7 +4276,8 @@ void PortsOrch::registerPort(Port &p)
     if (flex_counters_orch->getPortPhyAttrCounterState())
     {
         if (!m_supported_phy_attrs.empty() && p.m_type == Port::Type::PHY &&
-            p.m_role != Port::Role::Rec && p.m_role != Port::Role::Inb)
+            p.m_role != Port::Role::Rec && p.m_role != Port::Role::Inb &&
+            getGearboxPhy(p) == nullptr)
         {
             auto supported_attrs = getPortPhySupportedAttrs(p.m_port_id, p.m_alias.c_str());
             if (!supported_attrs.empty())
@@ -9469,7 +9470,8 @@ void PortsOrch::generatePortPhyAttrCounterMap()
     {
         if (it.second.m_type == Port::Type::PHY &&
             it.second.m_role != Port::Role::Rec &&
-            it.second.m_role != Port::Role::Inb)
+            it.second.m_role != Port::Role::Inb &&
+            getGearboxPhy(it.second) == nullptr)
         {
             auto supported_attrs = getPortPhySupportedAttrs(it.second.m_port_id, it.second.m_alias.c_str());
             if (!supported_attrs.empty())

--- a/tests/mock_tests/portphyattr_ut.cpp
+++ b/tests/mock_tests/portphyattr_ut.cpp
@@ -170,6 +170,20 @@ namespace portphyattr_test
             sai_port_api = old_sai_port_api;
         }
 
+        // Registers a synthetic gearbox interface/phy pair so getGearboxPhy()
+        // resolves for a port carrying the given index.
+        void addGearboxInterface(int index, int phy_id)
+        {
+            gearbox_interface_t iface{};
+            iface.index = index;
+            iface.phy_id = phy_id;
+            gPortsOrch->m_gearboxInterfaceMap[index] = iface;
+
+            gearbox_phy_t phy{};
+            phy.phy_id = phy_id;
+            gPortsOrch->m_gearboxPhyMap[phy_id] = phy;
+        }
+
         static void SetUpTestCase()
         {
             // Initialize the SAI virtual switch environment for unit testing
@@ -446,5 +460,69 @@ namespace portphyattr_test
         EXPECT_GT(g_serdes_id_queried_port_ids.count(fp_oid), 0u)
             << "removePortSerdesAttribute did not issue SAI GET on FP port "
             << fp_port.m_alias;
+    }
+
+    // A gearbox-connected port's ASIC-side OID does not implement PHY-attr
+    // GETs (the external PHY does); PORT_PHY_ATTR must skip such ports via
+    // getGearboxPhy() while still polling ordinary PHY ports.
+    TEST_F(PortAttrTest, GearboxConnectedPortSkippedInGenerateCounterMap)
+    {
+        ASSERT_FALSE(gPortsOrch->m_supported_phy_attrs.empty());
+
+        Port fp_port;
+        ASSERT_TRUE(gPortsOrch->getPort("Ethernet0", fp_port));
+
+        addGearboxInterface(9001, 1);
+        Port gb_port("Ethernet-GB0", Port::Type::PHY);
+        gb_port.m_port_id = 0xFEED3001;
+        gb_port.m_role = Port::Role::Ext;
+        gb_port.m_index = 9001;
+        gPortsOrch->m_portList["Ethernet-GB0"] = gb_port;
+        ASSERT_NE(gPortsOrch->getGearboxPhy(gb_port), nullptr);
+
+        g_phy_attr_queried_port_ids.clear();
+        gPortsOrch->generatePortPhyAttrCounterMap();
+
+        EXPECT_EQ(g_phy_attr_queried_port_ids.count(gb_port.m_port_id), 0u)
+            << "Gearbox port's ASIC-side OID was probed for PHY attrs";
+        EXPECT_GT(g_phy_attr_queried_port_ids.count(fp_port.m_port_id), 0u)
+            << "Non-gearbox front-panel port was not probed";
+    }
+
+    // Mirror of the above for PortsOrch::registerPort(), used when a port is
+    // added after PORT_PHY_ATTR is already enabled.
+    TEST_F(PortAttrTest, GearboxConnectedPortSkippedInRegisterPort)
+    {
+        ASSERT_FALSE(gPortsOrch->m_supported_phy_attrs.empty());
+
+        auto consumer = dynamic_cast<Consumer *>(m_flexCounterOrch->getExecutor(CFG_FLEX_COUNTER_TABLE_NAME));
+        ASSERT_NE(consumer, nullptr);
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({"PORT_PHY_ATTR", "SET", {{"FLEX_COUNTER_STATUS", "enable"}, {"POLL_INTERVAL", "1000"}}});
+        consumer->addToSync(entries);
+        static_cast<Orch *>(m_flexCounterOrch)->doTask(*consumer);
+        ASSERT_TRUE(m_flexCounterOrch->getPortPhyAttrCounterState());
+
+        addGearboxInterface(9101, 2);
+        Port gb_port("Ethernet-GB1", Port::Type::PHY);
+        gb_port.m_port_id = 0xFEED3101;
+        gb_port.m_role = Port::Role::Ext;
+        gb_port.m_index = 9101;
+        ASSERT_NE(gPortsOrch->getGearboxPhy(gb_port), nullptr);
+
+        // Same role/type, no gearbox interface for this index.
+        Port plain_port("Ethernet-GB2", Port::Type::PHY);
+        plain_port.m_port_id = 0xFEED3102;
+        plain_port.m_role = Port::Role::Ext;
+        plain_port.m_index = 9102;
+
+        g_phy_attr_queried_port_ids.clear();
+        gPortsOrch->registerPort(gb_port);
+        gPortsOrch->registerPort(plain_port);
+
+        EXPECT_EQ(g_phy_attr_queried_port_ids.count(gb_port.m_port_id), 0u)
+            << "registerPort() probed PHY attrs on a gearbox port's ASIC-side OID";
+        EXPECT_GT(g_phy_attr_queried_port_ids.count(plain_port.m_port_id), 0u)
+            << "registerPort() did not probe PHY attrs on a non-gearbox port";
     }
 } // namespace portphyattr_test


### PR DESCRIPTION
**What I did**

* Skip gearbox-connected ports when registering `PORT_PHY_ATTR` flex counters.
* Apply the check in both:

  * `PortsOrch::generatePortPhyAttrCounterMap()`
  * `PortsOrch::registerPort()` for ports added after PHY polling is already enabled.
* Add mock regression tests covering both paths while confirming regular non-gearbox PHY ports continue to be queried.

**Why I did it**

On platforms with an external PHY/gearbox, the ASIC-side port object can return `SAI_STATUS_NOT_SUPPORTED` for PHY attributes such as:

* `SAI_PORT_ATTR_RX_SIGNAL_DETECT`
* `SAI_PORT_ATTR_FEC_ALIGNMENT_LOCK`
* `SAI_PORT_ATTR_RX_SNR`

The existing `PORT_PHY_ATTR` path registers the ASIC-side `m_port_id` in the main flex-counter group for all front-panel PHY ports except recirculation and inband ports. This results in repeated unsupported attribute polling for gearbox-connected ports.

This change prevents those gearbox-connected ASIC-side ports from being registered in the main-ASIC `PORT_PHY_ATTR` group.

Fixes #4664

**How I verified it**

* Added mock tests verifying that gearbox-connected ports are not queried for `PORT_PHY_ATTR` through their ASIC-side OID.
* Verified that normal non-gearbox PHY ports continue to be queried.
* Added coverage for both bulk counter-map generation and port registration after PHY polling is enabled.
* `git diff --check` passes.

The C++ mock tests could not be executed locally because the required SONiC development libraries/build environment are not available in the current WSL environment. `./autogen.sh` completed, but the local configure/build could not proceed due to missing SONiC dependencies. The regression tests are included for CI validation.

**Details if related**

This change intentionally does not add PHY-attribute polling through the gearbox flex-counter path. Supporting external-PHY telemetry would require separate gearbox counter-group handling and is outside the scope of this bug fix.
