### PR TITLE
[portsorch] Skip `SAI_PORT_ATTR_PORT_SERDES_ID` calls on internal ports

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4238,7 +4238,8 @@ void PortsOrch::registerPort(Port &p)
 
     /* Get Port Serdes Id of this port*/
     sai_object_id_t port_serdes_id = SAI_NULL_OBJECT_ID;
-    if (p.m_type == Port::Type::PHY) {
+    if (p.m_type == Port::Type::PHY &&
+        p.m_role != Port::Role::Rec && p.m_role != Port::Role::Inb) {
         port_serdes_id = getPortSerdesIdFromPortId(p.m_port_id);
     }
 
@@ -9490,7 +9491,9 @@ void PortsOrch::clearPortPhyAttrCounterMap()
     for (const auto& it: m_portList)
     {
         // Clear counter stats only for PHY ports that were previously configured
-        if (it.second.m_type != Port::Type::PHY)
+        if (it.second.m_type != Port::Type::PHY ||
+            it.second.m_role == Port::Role::Rec ||
+            it.second.m_role == Port::Role::Inb)
         {
             continue;
         }
@@ -9616,7 +9619,9 @@ void PortsOrch::generatePortPhySerdesAttrCounterMap()
 
     for (const auto& it: m_portList)
     {
-        if (it.second.m_type == Port::Type::PHY)
+        if (it.second.m_type == Port::Type::PHY &&
+            it.second.m_role != Port::Role::Rec &&
+            it.second.m_role != Port::Role::Inb)
         {
             const char *port_name = it.second.m_alias.c_str();
             sai_object_id_t port_id = it.second.m_port_id;


### PR DESCRIPTION
Fixes: https://github.com/sonic-net/sonic-mgmt/issues/27730

**What I did**

Skips were already put in some places by this master PR https://github.com/sonic-net/sonic-swss/pull/4543
But further skips were added in the 202511 PR that was never put back in master https://github.com/sonic-net/sonic-swss/pull/4542

This change is intended to bring those necessary skips in 202511 back to master

**Why I did it**

Without this we see the following failures in LogAnalyzer:
```
E               Match Messages:
E               2026 Sep  2 22:12:02.902894 ctn107 ERR syncd#syncd: [none] SAI_API_PORT:_brcm_sai_get_recycle_port_attribute:22515 Unknown port attribute 108 passed
E
E               2026 Sep  2 22:12:02.902898 ctn107 ERR syncd#syncd: [none] SAI_API_PORT:_brcm_sai_get_recycle_port_attribute:22523 Error processing port attributes for attr_id:108
E
E               2026 Sep  2 22:12:06.946084 ctn107 ERR swss#orchagent: :- generatePortPhySerdesAttrCounterMap: PORT_PHY_SERDES_ATTR: Port Ethernet-Rec0 has no serdes object
```

**How I verified it**

Ran a number of tests that do reboot/config reload and never saw these log messages

**Details if related**

I believe this was a mistake during cherry-picking of https://github.com/sonic-net/sonic-swss/pull/4543 to 202511 https://github.com/sonic-net/sonic-swss/pull/4542 as 202511 contains this code already.

**Testing Done**

202605 - Latest internally build 202605 image - multiple full runs of sonic-mgmt without seeing these log messages
Kusto upload - b2d2f8be-b538-4e3d-9bff-0db0e6aad79b
