### PR TITLE
IPv6 link local programming with no host route

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -1348,13 +1348,22 @@ bool NeighOrch::addNeighbor(NeighborContext& ctx)
     bool prefix_route = false;
     bool is_nbr_active = true;
 
-    if ((ip_address.getAddrScope() == IpAddress::LINK_SCOPE) && (ip_address.isV4()))
+    if (ip_address.getAddrScope() == IpAddress::LINK_SCOPE)
     {
-        /* Check if this prefix is a configured ip, if not allow */
-        IpPrefix ipll_prefix(ip_address.getV4Addr(), 16);
-        if (!m_intfsOrch->isPrefixSubnet (ipll_prefix, alias))
+        if (ip_address.isV4())
         {
+            /* Check if this prefix is a configured ip, if not allow */
+            IpPrefix ipll_prefix(ip_address.getV4Addr(), 16);
+            if (!m_intfsOrch->isPrefixSubnet (ipll_prefix, alias))
+            {
+                no_host_route = true;
+            }
+        }
+        else
+        {
+            /* IPv6 link-local: fe80:: */
             no_host_route = true;
+            
         }
     }
 

--- a/tests/test_neighbor.py
+++ b/tests/test_neighbor.py
@@ -515,6 +515,58 @@ class TestNeighbor(object):
         intf_entries = tbl.getKeys()
         assert len(intf_entries) == 0
 
+    def test_Ipv6LinkLocalNeighbor(self, dvs, testlog):
+        self.setup_db(dvs)
+
+        # bring up interface
+        self.set_admin_status("Ethernet8", "up")
+
+        # create interface
+        self.create_l3_intf("Ethernet8", "")
+
+        # assign IP to interface
+        self.add_ip_address("Ethernet8", "2000::1/64")
+
+        # add neighbor
+        self.add_neighbor("Ethernet8", "fe80::2", "00:01:02:03:04:05")
+
+        # check application database
+        tbl = swsscommon.Table(self.pdb, "NEIGH_TABLE:Ethernet8")
+        intf_entries = tbl.getKeys()
+        assert len(intf_entries) == 1
+
+        # check ASIC neighbor database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY")
+        intf_entries = tbl.getKeys()
+        assert len(intf_entries) == 1
+
+        # IPv6 link-local neighbor must be programmed without a host route
+        (status, fvs) = tbl.get(intf_entries[0])
+        assert status == True
+        assert ("SAI_NEIGHBOR_ENTRY_ATTR_NO_HOST_ROUTE", "true") in fvs
+
+        # remove neighbor
+        self.remove_neighbor("Ethernet8", "fe80::2")
+
+        # remove IP from interface
+        self.remove_ip_address("Ethernet8", "2000::1/64")
+
+        # remove interface
+        self.remove_l3_intf("Ethernet8")
+
+        # bring down interface
+        self.set_admin_status("Ethernet8", "down")
+
+        # check application database
+        tbl = swsscommon.Table(self.pdb, "NEIGH_TABLE:Ethernet8")
+        intf_entries = tbl.getKeys()
+        assert len(intf_entries) == 0
+
+        # check ASIC neighbor database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY")
+        intf_entries = tbl.getKeys()
+        assert len(intf_entries) == 0
+
     @pytest.fixture
     def setup_peer_switch(self, dvs):
         config_db = dvs.get_config_db()


### PR DESCRIPTION
**What I did**
1. Updated addNeighbor() so link-local handling is done for IPv6.
2. Kept existing IPv4 link-local behavior:
   1. For IPv4 link-local, still check whether the /16 prefix is configured on the interface.
   2. If not configured, set no_host_route = true as before.
3. Added IPv6 link-local behavior:
   1. For IPv6 link-local addresses (fe80::/10), directly set no_host_route = true.
   2. This ensures neighbor gets programmed without creating a host route for IPv6 link-local neighbors.

**Why I did it**
1. IPv6 link-local neighbors are control-plane reachability entries and should not require per-neighbor host routes.
2. Prior logic only applied no-host-route handling to IPv4 link-local, so IPv6 link-local could still follow host-route programming path.
3. This change aligns IPv6 link-local behavior similar to IPv4.

**How I verified it**
   1. Add an IPv6 link-local neighbor and verify neighbor entry is programmed.
   2. Verify no corresponding IPv6 host route is created for that neighbor.
   3. Re-check IPv4 link-local behavior remains unchanged.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

