### PR TITLE
[orchagent]: Reject malformed numeric fields in buffer, policer and pfcwd instead of stalling the table

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -4,6 +4,7 @@
 #include "logger.h"
 #include "sai_serialize.h"
 #include "warm_restart.h"
+#include "converter.h"
 
 #include <inttypes.h>
 #include <sstream>
@@ -425,7 +426,7 @@ task_process_status BufferOrch::processBufferPool(KeyOpFieldsValuesTuple &tuple)
             if (field == buffer_size_field_name)
             {
                 attr.id = SAI_BUFFER_POOL_ATTR_SIZE;
-                attr.value.u64 = (uint64_t)stoul(value);
+                attr.value.u64 = to_uint<uint64_t>(value);
                 attribs.push_back(attr);
             }
             else if (field == buffer_pool_type_field_name)
@@ -489,7 +490,7 @@ task_process_status BufferOrch::processBufferPool(KeyOpFieldsValuesTuple &tuple)
             }
             else if (field == buffer_pool_xoff_field_name)
             {
-                attr.value.u64 = (uint64_t)stoul(value);
+                attr.value.u64 = to_uint<uint64_t>(value);
                 attr.id = SAI_BUFFER_POOL_ATTR_XOFF_SIZE;
                 attribs.push_back(attr);
                 xoff = value;
@@ -664,19 +665,19 @@ task_process_status BufferOrch::processBufferProfile(KeyOpFieldsValuesTuple &tup
             }
             else if (field == buffer_xon_field_name)
             {
-                attr.value.u64 = (uint64_t)stoul(value);
+                attr.value.u64 = to_uint<uint64_t>(value);
                 attr.id = SAI_BUFFER_PROFILE_ATTR_XON_TH;
                 attribs.push_back(attr);
             }
             else if (field == buffer_xon_offset_field_name)
             {
-                attr.value.u64 = (uint64_t)stoul(value);
+                attr.value.u64 = to_uint<uint64_t>(value);
                 attr.id = SAI_BUFFER_PROFILE_ATTR_XON_OFFSET_TH;
                 attribs.push_back(attr);
             }
             else if (field == buffer_xoff_field_name)
             {
-                attr.value.u64 = (uint64_t)stoul(value);
+                attr.value.u64 = to_uint<uint64_t>(value);
                 attr.id = SAI_BUFFER_PROFILE_ATTR_XOFF_TH;
                 attribs.push_back(attr);
                 is_lossless = true;
@@ -684,7 +685,7 @@ task_process_status BufferOrch::processBufferProfile(KeyOpFieldsValuesTuple &tup
             else if (field == buffer_size_field_name)
             {
                 attr.id = SAI_BUFFER_PROFILE_ATTR_BUFFER_SIZE;
-                attr.value.u64 = (uint64_t)stoul(value);
+                attr.value.u64 = to_uint<uint64_t>(value);
                 attribs.push_back(attr);
             }
             else if (field == buffer_dynamic_th_field_name)
@@ -702,7 +703,7 @@ task_process_status BufferOrch::processBufferProfile(KeyOpFieldsValuesTuple &tup
                 }
 
                 attr.id = SAI_BUFFER_PROFILE_ATTR_SHARED_DYNAMIC_TH;
-                attr.value.s8 = (sai_int8_t)stol(value);
+                attr.value.s8 = to_int<sai_int8_t>(value);
                 attribs.push_back(attr);
             }
             else if (field == buffer_static_th_field_name)
@@ -720,7 +721,7 @@ task_process_status BufferOrch::processBufferProfile(KeyOpFieldsValuesTuple &tup
                 }
 
                 attr.id = SAI_BUFFER_PROFILE_ATTR_SHARED_STATIC_TH;
-                attr.value.u64 = (uint64_t)stoul(value);
+                attr.value.u64 = to_uint<uint64_t>(value);
                 attribs.push_back(attr);
             }
             else if (field == BUFFER_PROFILE_PACKET_DISCARD_ACTION)
@@ -2108,7 +2109,17 @@ void BufferOrch::doTask(Consumer &consumer)
             continue;
         }
 
-        auto task_status = (this->*(m_bufferHandlerMap[map_type_name]))(it->second);
+        task_process_status task_status;
+        try
+        {
+            task_status = (this->*(m_bufferHandlerMap[map_type_name]))(it->second);
+        }
+        catch (const std::exception &e)
+        {
+            SWSS_LOG_ERROR("Exception caught: type=exception, table=%s, key=%s, error=%s",
+                           map_type_name.c_str(), kfvKey(it->second).c_str(), e.what());
+            task_status = task_process_status::task_invalid_entry;
+        }
         switch(task_status)
         {
             case task_process_status::task_success :

--- a/orchagent/pfcwdsworch.cpp
+++ b/orchagent/pfcwdsworch.cpp
@@ -43,7 +43,16 @@ task_process_status PfcWdSwOrch<DropHandler, ForwardHandler>::createEntry(const 
 
             if (field == POLL_INTERVAL_FIELD)
             {
-                this->m_pfcwdFlexCounterManager->updateGroupPollingInterval(stoi(value));
+                try
+                {
+                    this->m_pfcwdFlexCounterManager->updateGroupPollingInterval(to_uint<uint32_t>(value));
+                }
+                catch (const std::exception &e)
+                {
+                    SWSS_LOG_ERROR("Invalid %s value %s for %s: %s",
+                                   POLL_INTERVAL_FIELD, value.c_str(), key.c_str(), e.what());
+                    continue;
+                }
             }
             else if (field == BIG_RED_SWITCH_FIELD)
             {

--- a/orchagent/policerorch.cpp
+++ b/orchagent/policerorch.cpp
@@ -179,7 +179,7 @@ task_process_status PolicerOrch::handlePortStormControlTable(swss::KeyOpFieldsVa
             {
                 attr.id = SAI_POLICER_ATTR_CIR;
                 /*convert kbps to bps*/
-                attr.value.u64 = (stoul(value)*1000/8);
+                attr.value.u64 = to_uint<uint64_t>(value) * 1000 / 8;
                 cir = true;
                 attrs.push_back(attr);
                 SWSS_LOG_DEBUG("CIR %s",value.c_str());
@@ -393,7 +393,16 @@ void PolicerOrch::doTask(Consumer &consumer)
         // Special handling for storm-control configuration.
         if (table_name == CFG_PORT_STORM_CONTROL_TABLE_NAME)
         {
-            storm_status = handlePortStormControlTable(tuple);
+            try
+            {
+                storm_status = handlePortStormControlTable(tuple);
+            }
+            catch (const std::exception &e)
+            {
+                SWSS_LOG_ERROR("Exception caught: type=exception, table=%s, key=%s, error=%s",
+                               table_name.c_str(), key.c_str(), e.what());
+                storm_status = task_process_status::task_failed;
+            }
             if ((storm_status == task_process_status::task_success) ||
                     (storm_status == task_process_status::task_failed))
             {
@@ -413,76 +422,86 @@ void PolicerOrch::doTask(Consumer &consumer)
             vector<sai_attribute_t> attrs;
             bool meter_type = false, mode = false;
 
-            for (auto i = kfvFieldsValues(tuple).begin();
-                    i != kfvFieldsValues(tuple).end(); ++i)
+            try
             {
-                auto field = to_upper(fvField(*i));
-                auto value = to_upper(fvValue(*i));
+                for (auto i = kfvFieldsValues(tuple).begin();
+                        i != kfvFieldsValues(tuple).end(); ++i)
+                {
+                    auto field = to_upper(fvField(*i));
+                    auto value = to_upper(fvValue(*i));
 
-                SWSS_LOG_DEBUG("attribute: %s value: %s", field.c_str(), value.c_str());
+                    SWSS_LOG_DEBUG("attribute: %s value: %s", field.c_str(), value.c_str());
 
-                sai_attribute_t attr;
+                    sai_attribute_t attr;
 
-                if (field == meter_type_field)
-                {
-                    attr.id = SAI_POLICER_ATTR_METER_TYPE;
-                    attr.value.s32 = (sai_meter_type_t) meter_type_map.at(value);
-                    meter_type = true;
-                }
-                else if (field == mode_field)
-                {
-                    attr.id = SAI_POLICER_ATTR_MODE;
-                    attr.value.s32 = (sai_policer_mode_t) policer_mode_map.at(value);
-                    mode = true;
-                }
-                else if (field == color_source_field)
-                {
-                    attr.id = SAI_POLICER_ATTR_COLOR_SOURCE;
-                    attr.value.s32 = policer_color_source_map.at(value);
-                }
-                else if (field == cbs_field)
-                {
-                    attr.id = SAI_POLICER_ATTR_CBS;
-                    attr.value.u64 = stoul(value);
-                }
-                else if (field == cir_field)
-                {
-                    attr.id = SAI_POLICER_ATTR_CIR;
-                    attr.value.u64 = stoul(value);
-                }
-                else if (field == pbs_field)
-                {
-                    attr.id = SAI_POLICER_ATTR_PBS;
-                    attr.value.u64 = stoul(value);
-                }
-                else if (field == pir_field)
-                {
-                    attr.id = SAI_POLICER_ATTR_PIR;
-                    attr.value.u64 = stoul(value);
-                }
-                else if (field == red_packet_action_field)
-                {
-                    attr.id = SAI_POLICER_ATTR_RED_PACKET_ACTION;
-                    attr.value.s32 = packet_action_map.at(value);
-                }
-                else if (field == green_packet_action_field)
-                {
-                    attr.id = SAI_POLICER_ATTR_GREEN_PACKET_ACTION;
-                    attr.value.s32 = packet_action_map.at(value);
-                }
-                else if (field == yellow_packet_action_field)
-                {
-                    attr.id = SAI_POLICER_ATTR_YELLOW_PACKET_ACTION;
-                    attr.value.s32 = packet_action_map.at(value);
-                }
-                else
-                {
-                    SWSS_LOG_ERROR("Unknown policer attribute %s specified",
-                            field.c_str());
-                    continue;
-                }
+                    if (field == meter_type_field)
+                    {
+                        attr.id = SAI_POLICER_ATTR_METER_TYPE;
+                        attr.value.s32 = (sai_meter_type_t) meter_type_map.at(value);
+                        meter_type = true;
+                    }
+                    else if (field == mode_field)
+                    {
+                        attr.id = SAI_POLICER_ATTR_MODE;
+                        attr.value.s32 = (sai_policer_mode_t) policer_mode_map.at(value);
+                        mode = true;
+                    }
+                    else if (field == color_source_field)
+                    {
+                        attr.id = SAI_POLICER_ATTR_COLOR_SOURCE;
+                        attr.value.s32 = policer_color_source_map.at(value);
+                    }
+                    else if (field == cbs_field)
+                    {
+                        attr.id = SAI_POLICER_ATTR_CBS;
+                        attr.value.u64 = to_uint<uint64_t>(value);
+                    }
+                    else if (field == cir_field)
+                    {
+                        attr.id = SAI_POLICER_ATTR_CIR;
+                        attr.value.u64 = to_uint<uint64_t>(value);
+                    }
+                    else if (field == pbs_field)
+                    {
+                        attr.id = SAI_POLICER_ATTR_PBS;
+                        attr.value.u64 = to_uint<uint64_t>(value);
+                    }
+                    else if (field == pir_field)
+                    {
+                        attr.id = SAI_POLICER_ATTR_PIR;
+                        attr.value.u64 = to_uint<uint64_t>(value);
+                    }
+                    else if (field == red_packet_action_field)
+                    {
+                        attr.id = SAI_POLICER_ATTR_RED_PACKET_ACTION;
+                        attr.value.s32 = packet_action_map.at(value);
+                    }
+                    else if (field == green_packet_action_field)
+                    {
+                        attr.id = SAI_POLICER_ATTR_GREEN_PACKET_ACTION;
+                        attr.value.s32 = packet_action_map.at(value);
+                    }
+                    else if (field == yellow_packet_action_field)
+                    {
+                        attr.id = SAI_POLICER_ATTR_YELLOW_PACKET_ACTION;
+                        attr.value.s32 = packet_action_map.at(value);
+                    }
+                    else
+                    {
+                        SWSS_LOG_ERROR("Unknown policer attribute %s specified",
+                                field.c_str());
+                        continue;
+                    }
 
-                attrs.push_back(attr);
+                    attrs.push_back(attr);
+                }
+            }
+            catch (const std::exception &e)
+            {
+                SWSS_LOG_ERROR("Exception caught: type=exception, table=%s, key=%s, error=%s",
+                               table_name.c_str(), key.c_str(), e.what());
+                it = consumer.m_toSync.erase(it);
+                continue;
             }
 
             // Create a new policer

--- a/tests/mock_tests/bufferorch_ut.cpp
+++ b/tests/mock_tests/bufferorch_ut.cpp
@@ -911,6 +911,156 @@ namespace bufferorch_test
         _unhook_sai_apis();
     }
 
+    TEST_F(BufferOrchTest, BufferOrchTestMalformedNumericFieldsAreDropped)
+    {
+        vector<string> ts;
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        auto &poolMap = *BufferOrch::m_buffer_type_maps[APP_BUFFER_POOL_TABLE_NAME];
+        auto &profileMap = *BufferOrch::m_buffer_type_maps[APP_BUFFER_PROFILE_TABLE_NAME];
+
+        // m_toSync is ordered by key, so the malformed pools are processed
+        // ahead of the valid one. Every entry must be consumed: the bad ones
+        // are rejected and dropped, the good one is created. Previously the
+        // first bad entry threw out of doTask() and left all of them pending.
+        entries.push_back({"bad_pool_alpha", "SET",
+                           {
+                               {"size", "abc"},
+                               {"mode", "dynamic"},
+                               {"type", "ingress"}
+                           }});
+        entries.push_back({"bad_pool_trailing", "SET",
+                           {
+                               {"size", "1024000abc"},
+                               {"mode", "dynamic"},
+                               {"type", "ingress"}
+                           }});
+        entries.push_back({"bad_pool_xoff", "SET",
+                           {
+                               {"size", "1024000"},
+                               {"xoff", "10240x"},
+                               {"mode", "dynamic"},
+                               {"type", "ingress"}
+                           }});
+        entries.push_back({"bad_pool_empty", "SET",
+                           {
+                               {"size", ""},
+                               {"mode", "dynamic"},
+                               {"type", "ingress"}
+                           }});
+        entries.push_back({"bad_pool_overflow", "SET",
+                           {
+                               {"size", "99999999999999999999"},
+                               {"mode", "dynamic"},
+                               {"type", "ingress"}
+                           }});
+        entries.push_back({"good_pool", "SET",
+                           {
+                               {"size", "1024000"},
+                               {"mode", "dynamic"},
+                               {"type", "ingress"}
+                           }});
+        auto poolConsumer = dynamic_cast<Consumer *>(gBufferOrch->getExecutor(APP_BUFFER_POOL_TABLE_NAME));
+        poolConsumer->addToSync(entries);
+        entries.clear();
+        static_cast<Orch *>(gBufferOrch)->doTask();
+
+        static_cast<Orch *>(gBufferOrch)->dumpPendingTasks(ts);
+        ASSERT_TRUE(ts.empty());
+        ASSERT_EQ(poolMap.count("bad_pool_alpha"), 0);
+        ASSERT_EQ(poolMap.count("bad_pool_trailing"), 0);
+        ASSERT_EQ(poolMap.count("bad_pool_xoff"), 0);
+        ASSERT_EQ(poolMap.count("bad_pool_empty"), 0);
+        ASSERT_EQ(poolMap.count("bad_pool_overflow"), 0);
+        ASSERT_EQ(poolMap.count("good_pool"), 1);
+        auto goodPoolOid = poolMap["good_pool"].m_saiObjectId;
+        ASSERT_NE(goodPoolOid, SAI_NULL_OBJECT_ID);
+
+        // A malformed update of an existing object is dropped too, and the
+        // object it targets is left as it was.
+        entries.push_back({"good_pool", "SET",
+                           {
+                               {"size", "abc"}
+                           }});
+        poolConsumer->addToSync(entries);
+        entries.clear();
+        static_cast<Orch *>(gBufferOrch)->doTask();
+
+        static_cast<Orch *>(gBufferOrch)->dumpPendingTasks(ts);
+        ASSERT_TRUE(ts.empty());
+        ASSERT_EQ(poolMap.count("good_pool"), 1);
+        ASSERT_EQ(poolMap["good_pool"].m_saiObjectId, goodPoolOid);
+
+        // Same for profiles: every converted field is covered, and the value
+        // classes include non-numeric, trailing garbage, float and
+        // out-of-range (dynamic_th is an int8).
+        entries.push_back({"bad_profile_dynamic_th", "SET",
+                           {
+                               {"pool", "ingress_lossless_pool"},
+                               {"size", "0"},
+                               {"dynamic_th", "abc"}
+                           }});
+        entries.push_back({"bad_profile_dynamic_th_range", "SET",
+                           {
+                               {"pool", "ingress_lossless_pool"},
+                               {"size", "0"},
+                               {"dynamic_th", "300"}
+                           }});
+        entries.push_back({"bad_profile_xon", "SET",
+                           {
+                               {"pool", "ingress_lossless_pool"},
+                               {"dynamic_th", "0"},
+                               {"size", "39936"},
+                               {"xon", "19456x"},
+                               {"xoff", "20480"}
+                           }});
+        entries.push_back({"bad_profile_xoff", "SET",
+                           {
+                               {"pool", "ingress_lossless_pool"},
+                               {"dynamic_th", "0"},
+                               {"size", "39936"},
+                               {"xon", "19456"},
+                               {"xoff", "20480.5"}
+                           }});
+        entries.push_back({"bad_profile_xon_offset", "SET",
+                           {
+                               {"pool", "ingress_lossless_pool"},
+                               {"dynamic_th", "0"},
+                               {"size", "39936"},
+                               {"xon", "19456"},
+                               {"xon_offset", "abc"},
+                               {"xoff", "20480"}
+                           }});
+        entries.push_back({"bad_profile_static_th", "SET",
+                           {
+                               {"pool", "ingress_lossless_pool"},
+                               {"size", "0"},
+                               {"static_th", "1000x"}
+                           }});
+        entries.push_back({"good_profile", "SET",
+                           {
+                               {"pool", "ingress_lossless_pool"},
+                               {"dynamic_th", "0"},
+                               {"size", "39936"},
+                               {"xon", "19456"},
+                               {"xoff", "20480"}
+                           }});
+        auto profileConsumer = dynamic_cast<Consumer *>(gBufferOrch->getExecutor(APP_BUFFER_PROFILE_TABLE_NAME));
+        profileConsumer->addToSync(entries);
+        entries.clear();
+        static_cast<Orch *>(gBufferOrch)->doTask();
+
+        static_cast<Orch *>(gBufferOrch)->dumpPendingTasks(ts);
+        ASSERT_TRUE(ts.empty());
+        ASSERT_EQ(profileMap.count("bad_profile_dynamic_th"), 0);
+        ASSERT_EQ(profileMap.count("bad_profile_dynamic_th_range"), 0);
+        ASSERT_EQ(profileMap.count("bad_profile_xon"), 0);
+        ASSERT_EQ(profileMap.count("bad_profile_xoff"), 0);
+        ASSERT_EQ(profileMap.count("bad_profile_xon_offset"), 0);
+        ASSERT_EQ(profileMap.count("bad_profile_static_th"), 0);
+        ASSERT_EQ(profileMap.count("good_profile"), 1);
+        ASSERT_NE(profileMap["good_profile"].m_saiObjectId, SAI_NULL_OBJECT_ID);
+    }
+
     TEST_F(BufferOrchTest, BufferOrchTestCreateOnlyConfigDbBuffersDynamicUpdate)
     {
         // Get FlexCounterOrch from directory

--- a/tests/mock_tests/flexcounter_ut.cpp
+++ b/tests/mock_tests/flexcounter_ut.cpp
@@ -940,6 +940,33 @@ namespace flexcounter_test
                                          {QUEUE_ATTR_ID_LIST, "SAI_QUEUE_ATTR_PAUSE_STATUS"}
                                      }));
 
+        // A malformed GLOBAL POLL_INTERVAL must be rejected and dropped rather
+        // than left pending (where it would block every later PFC_WD update),
+        // and the group must keep its previous interval. A negative value is
+        // not covered: swss::to_uint<> is built on stoul(), which wraps "-1"
+        // to ULONG_MAX, and on 32-bit targets that is within uint32 range.
+        for (const auto &badInterval : {"abc", "200ms", ""})
+        {
+            entries.push_back({"GLOBAL", "SET",
+                              {
+                                {POLL_INTERVAL_FIELD, badInterval},
+                              }});
+            consumer->addToSync(entries);
+            entries.clear();
+            static_cast<Orch *>(gPfcwdOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>)->doTask();
+
+            std::vector<std::string> pfcwdPending;
+            static_cast<Orch *>(gPfcwdOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>)->dumpPendingTasks(pfcwdPending);
+            ASSERT_TRUE(pfcwdPending.empty()) << "POLL_INTERVAL=" << badInterval;
+            ASSERT_TRUE(checkFlexCounterGroup(PFC_WD_FLEX_COUNTER_GROUP,
+                                              {
+                                                  {POLL_INTERVAL_FIELD, "200"},
+                                                  {STATS_MODE_FIELD, STATS_MODE_READ},
+                                                  {FLEX_COUNTER_STATUS_FIELD, "enable"},
+                                                  {QUEUE_PLUGIN_FIELD, ""}
+                                              })) << "POLL_INTERVAL=" << badInterval;
+        }
+
         entries.push_back({firstPort.m_alias, "DEL", { {}}});
         consumer->addToSync(entries);
         entries.clear();

--- a/tests/mock_tests/policerorch_ut.cpp
+++ b/tests/mock_tests/policerorch_ut.cpp
@@ -177,4 +177,126 @@ namespace policerorch_test
         doPolicerConfig(policer, DEL_COMMAND, {});
         EXPECT_EQ(m_policerMock->removed_oid, kPolicerOid);
     }
+
+    TEST_F(PolicerOrchTest, PolicerMalformedFieldsAreDropped)
+    {
+        // Only the valid policer may reach SAI. The malformed entries sort
+        // ahead of it in m_toSync, so if any of them threw out of doTask() or
+        // were left pending, the valid one would never be created.
+        EXPECT_CALL(*mock_sai_policer_api, create_policer)
+            .Times(1)
+            .WillOnce(Invoke(m_policerMock.get(), &PolicerSaiMock::handleCreate));
+        EXPECT_CALL(*mock_sai_policer_api, set_policer_attribute).Times(0);
+        EXPECT_CALL(*mock_sai_policer_api, remove_policer).Times(0);
+
+        auto *policerConsumer = dynamic_cast<Consumer *>(
+            static_cast<Orch *>(gPolicerOrch)->getExecutor(CFG_POLICER_TABLE_NAME));
+        ASSERT_NE(policerConsumer, nullptr);
+
+        deque<KeyOpFieldsValuesTuple> entries;
+        // Non-numeric rate.
+        entries.push_back({"BAD_CIR", SET_COMMAND,
+                           {
+                               {"meter_type", "packets"},
+                               {"mode", "sr_tcm"},
+                               {"cir", "abc"},
+                               {"cbs", "600"},
+                           }});
+        // Trailing garbage: stoul() used to silently accept this as 600.
+        entries.push_back({"BAD_CIR_TRAILING", SET_COMMAND,
+                           {
+                               {"meter_type", "packets"},
+                               {"mode", "sr_tcm"},
+                               {"cir", "600kbps"},
+                               {"cbs", "600"},
+                           }});
+        // Float.
+        entries.push_back({"BAD_CBS", SET_COMMAND,
+                           {
+                               {"meter_type", "packets"},
+                               {"mode", "sr_tcm"},
+                               {"cir", "600"},
+                               {"cbs", "600.5"},
+                           }});
+        // Empty.
+        entries.push_back({"BAD_PIR", SET_COMMAND,
+                           {
+                               {"meter_type", "packets"},
+                               {"mode", "tr_tcm"},
+                               {"cir", "600"},
+                               {"cbs", "600"},
+                               {"pir", ""},
+                               {"pbs", "600"},
+                           }});
+        // Overflows uint64.
+        entries.push_back({"BAD_PBS", SET_COMMAND,
+                           {
+                               {"meter_type", "packets"},
+                               {"mode", "tr_tcm"},
+                               {"cir", "600"},
+                               {"cbs", "600"},
+                               {"pir", "600"},
+                               {"pbs", "99999999999999999999"},
+                           }});
+        // Unknown enum values: map::at() throws std::out_of_range.
+        entries.push_back({"BAD_METER_TYPE", SET_COMMAND,
+                           {
+                               {"meter_type", "furlongs"},
+                               {"mode", "sr_tcm"},
+                               {"cir", "600"},
+                               {"cbs", "600"},
+                           }});
+        entries.push_back({"BAD_MODE", SET_COMMAND,
+                           {
+                               {"meter_type", "packets"},
+                               {"mode", "hyperspace"},
+                               {"cir", "600"},
+                               {"cbs", "600"},
+                           }});
+        entries.push_back({"GOOD", SET_COMMAND,
+                           {
+                               {"meter_type", "packets"},
+                               {"mode", "sr_tcm"},
+                               {"cir", "600"},
+                               {"cbs", "600"},
+                               {"red_packet_action", "drop"},
+                           }});
+        policerConsumer->addToSync(entries);
+        entries.clear();
+
+        // Storm control is served by the same orch; a malformed kbps must be
+        // dropped as well (it fails before any SAI call is made).
+        auto *stormConsumer = dynamic_cast<Consumer *>(
+            static_cast<Orch *>(gPolicerOrch)->getExecutor(CFG_PORT_STORM_CONTROL_TABLE_NAME));
+        ASSERT_NE(stormConsumer, nullptr);
+        entries.push_back({"Ethernet0|broadcast", SET_COMMAND, {{"kbps", "abc"}}});
+        stormConsumer->addToSync(entries);
+        entries.clear();
+
+        // Drain through the production path (Orch::doTask -> Consumer::drain).
+        static_cast<Orch *>(gPolicerOrch)->doTask();
+
+        vector<string> pending;
+        static_cast<Orch *>(gPolicerOrch)->dumpPendingTasks(pending);
+        EXPECT_TRUE(pending.empty());
+
+        // The one create carries GOOD's five attributes.
+        ASSERT_EQ(m_policerMock->create_attrs.size(), 5U);
+        sai_attribute_value_t v;
+        ASSERT_TRUE(m_policerMock->findCreateAttr(SAI_POLICER_ATTR_METER_TYPE, v));
+        EXPECT_EQ(v.s32, SAI_METER_TYPE_PACKETS);
+        ASSERT_TRUE(m_policerMock->findCreateAttr(SAI_POLICER_ATTR_CIR, v));
+        EXPECT_EQ(v.u64, 600U);
+
+        // A malformed update of the existing policer is dropped without
+        // touching it: set_policer_attribute stays at Times(0).
+        entries.push_back({"GOOD", SET_COMMAND, {{"cir", "abc"}}});
+        policerConsumer->addToSync(entries);
+        entries.clear();
+        static_cast<Orch *>(gPolicerOrch)->doTask();
+
+        pending.clear();
+        static_cast<Orch *>(gPolicerOrch)->dumpPendingTasks(pending);
+        EXPECT_TRUE(pending.empty());
+    }
 }


### PR DESCRIPTION
**What I did**

Replaced bare `stoul`/`stol`/`stoi` in `BufferOrch`, `PolicerOrch` and `PfcWdSwOrch` with `swss::to_uint<>` / `swss::to_int<>`, and made each orch log and drop an entry that fails to parse instead of letting the exception escape `doTask()`.

Added mock tests covering every converted field. The error log uses the `Exception caught: type=..., table=..., key=..., error=...` signature introduced by #4469.

**Why I did it**

A single malformed numeric value in `BUFFER_POOL_TABLE`, `BUFFER_PROFILE_TABLE`, `POLICER`, `PORT_STORM_CONTROL` or `PFC_WD|GLOBAL` stalls processing of that entire table in orchagent.

When `stoul("abc")` throws inside `doTask()`, the exception unwinds out of the orch before it can erase the entry. Since #4469, `Consumer::drain()` catches the exception so orchagent survives, but `drain()` has no way of knowing which entry threw, so it leaves `m_toSync` exactly as it was. Because `m_toSync` is ordered by key, every entry that sorts after the malformed one is never reached, and on the next wake-up the same entry throws again. The result is that valid configuration behind it is never programmed, and warm restart is blocked by a task that will never leave the pending queue.

Before #4469 this input crashed orchagent, which made it visible. Now it is a silent stall with one `ERROR` line per drain.

`stoul` also accepted `"1024000abc"` as `1024000` and `"600kbps"` as `600`, and those values reached SAI. `to_uint`/`to_int` is already the convention elsewhere in orchagent (~160 sites); these calls predate it.

**How I verified it**

Mock tests, built in a `debian:bookworm` container against current `master` swss-common / sairedis. Each new test queues malformed entries that sort *ahead* of a valid one and drains through `Orch::doTask()` -> `Consumer::drain()`, so a stall shows up as the valid entry left pending.

With only the test commit on `master` (`ffb60db7`), the tests fail as expected:

```
[ RUN      ] BufferOrchTest.BufferOrchTestMalformedNumericFieldsAreDropped
bufferorch_ut.cpp:968: Failure
Value of: ts.empty()
  Actual: false
Expected: true
[  FAILED  ] BufferOrchTest.BufferOrchTestMalformedNumericFieldsAreDropped (32 ms)
[ RUN      ] PolicerOrchTest.PolicerMalformedFieldsAreDropped
policerorch_ut.cpp:281: Failure
Value of: pending.empty()
  Actual: false
Expected: true
policerorch_ut.cpp:284: Failure
Expected equality of these values:
  m_policerMock->create_attrs.size()
    Which is: 4
  5U
    Which is: 5
[  FAILED  ] PolicerOrchTest.PolicerMalformedFieldsAreDropped (37 ms)
```

The `4` is `BAD_CBS` (`cbs=600.5`, parsed by `stoul` as `600`) reaching SAI before `BAD_CIR` threw and stalled everything after it, including `GOOD`.

With the fix applied:

```
[----------] 8 tests from BufferOrchTest
[       OK ] BufferOrchTest.BufferOrchTestMalformedNumericFieldsAreDropped (21 ms)
...
[----------] 2 tests from PolicerOrchTest
[       OK ] PolicerOrchTest.PolicerBasic (62 ms)
[       OK ] PolicerOrchTest.PolicerMalformedFieldsAreDropped (58 ms)
[----------] 8 tests from FlexCounterTests/FlexCounterTest
[       OK ] FlexCounterTests/FlexCounterTest.CounterTest/0 (26 ms)
...
[       OK ] FlexCounterTests/FlexCounterTest.CounterTest/7 (87 ms)
[==========] 18 tests from 3 test suites ran. (852 ms total)
[  PASSED  ] 18 tests.
```

**Details if related**

Precedent, all merged:

- #4469: added the `Consumer::drain()` catch "similar to how it is done for `Orch2::doTask()`". `Orch2` catches and erases *per entry*; `Orch`-based orchs do not. This PR closes that gap for three tables and follows the log format agreed in that review.
- #4566 (dash): "per-item exception handling to prevent malformed entries from getting stuck in the consumer" — same failure mode, same fix shape.
- #4656 (portsorch), #3887 (hftorch), #3674 (muxorch), #2593 (neighsyncd): invalid-input handling fixes of the same kind.

Bad values reach orchagent because `swssconfig`, `redis-cli`, `config load` of an edited JSON and template errors all bypass CLI/YANG validation (sonic-net/sonic-buildimage#6424).

Known limitation: `to_uint<>` does not reject negative input. `stoul` wraps `"-1"` to `ULONG_MAX`, which is always in range for `uint64_t` and, on 32-bit targets (armhf), for `uint32_t` as well, so the result depends on the platform rather than the field. The tests therefore do not include negative values. A sign check belongs in `converter.h` in sonic-swss-common and will be a separate PR, after which negative cases can be added here unchanged.

The same pattern exists in `qosorch` (WRED/scheduler), `copporch`, `fabricportsorch`, `natorch`, `srv6orch`, `stporch`, `fgnhgorch`, `sfloworch`, `dtelorch` and `portsorch`; those are candidates for follow-up PRs.
