### PR TITLE
[vxlanmgrd]: Support configurable VXLAN UDP source and destination ports

### DIFF
--- a/cfgmgr/vxlanmgr.cpp
+++ b/cfgmgr/vxlanmgr.cpp
@@ -30,6 +30,10 @@ extern MacAddress gMacAddress;
 
 #define SWITCH "switch"
 #define VXLAN_ROUTER_MAC "vxlan_router_mac"
+#define VXLAN_PORT "vxlan_port"
+#define VXLAN_SPORT "vxlan_sport"
+#define VXLAN_MASK "vxlan_mask"
+#define VXLAN_DEFAULT_UDP_PORT "4789"
 
 #define VXLAN_NAME_PREFIX "Vxlan"
 #define VXLAN_IF_NAME_PREFIX "Brvxlan"
@@ -52,9 +56,13 @@ static std::string getVxlanIfName(const swss::VxlanMgr::VxlanInfo & info)
 
 #define RET_SUCCESS 0
 
-static int cmdCreateVxlan(const swss::VxlanMgr::VxlanInfo & info, std::string & res)
+static int cmdCreateVxlan(const swss::VxlanMgr::VxlanInfo & info,
+                          const std::string & dstPort,
+                          const std::string & srcPortMin,
+                          const std::string & srcPortMax,
+                          std::string & res)
 {
-    // ip link add {{VXLAN}} type vxlan id {{VNI}} [local {{SOURCE IP}}] dstport 4789
+    // ip link add {{VXLAN}} type vxlan id {{VNI}} [local {{SRC IP}}] dstport <port> [srcport <min> <max>]
     ostringstream cmd;
     cmd << IP_CMD " link add "
         << shellquote(info.m_vxlan)
@@ -65,10 +73,13 @@ static int cmdCreateVxlan(const swss::VxlanMgr::VxlanInfo & info, std::string & 
     {
         cmd << " local " << shellquote(info.m_sourceIp);
     }
-    cmd << " dstport 4789";
+    cmd << " dstport "  << shellquote(dstPort);
+    if (!srcPortMin.empty() && !srcPortMax.empty())
+    {
+        cmd << " srcport " << shellquote(srcPortMin) << " " << shellquote(srcPortMax);
+    }
     if (!info.m_sourceIp.empty())
     {
-        // Parse IP to determine IPv4 vs IPv6
         struct in6_addr addr6;
         if (inet_pton(AF_INET6, info.m_sourceIp.c_str(), &addr6) == 1)
         {
@@ -344,14 +355,14 @@ bool VxlanMgr::doVxlanCreateTask(const KeyOpFieldsValuesTuple & t)
     }
 
     // If the mac address has been set
-    auto macAddress = getVxlanRouterMacAddress();
-    if (!macAddress.first)
+    if (m_VxlanSwitchTableConfig.m_routerMac.empty() && !getSwitchTableVxlanConfig())
     {
-        SWSS_LOG_DEBUG("Mac address is not ready");
+        SWSS_LOG_DEBUG("Vxlan switch table config is not ready");
         // Suspend this message until the mac address is set
         return false;
     }
-    info.m_macAddress = macAddress.second;
+
+    info.m_macAddress = m_VxlanSwitchTableConfig.m_routerMac;
 
     auto sourceIp = std::find_if(
         it->second.fvt.begin(),
@@ -798,27 +809,70 @@ bool VxlanMgr::isVlanStateOk(const std::string &vlanName)
     return false;
 }
 
-std::pair<bool, std::string> VxlanMgr::getVxlanRouterMacAddress()
+bool VxlanMgr::getSwitchTableVxlanConfig()
 {
     std::vector<FieldValueTuple> temp;
+    std::string sport;
+    std::string mask;
+    bool returnValue = false;
+
 
     if (m_appSwitchTable.get(SWITCH, temp))
     {
-        auto itr = std::find_if(
-            temp.begin(),
-            temp.end(),
-            [](const FieldValueTuple &fvt) { return fvt.first == VXLAN_ROUTER_MAC; });
-        if (itr != temp.end() && !(itr->second.empty()))
+        for (const auto & fv : temp)
         {
-            SWSS_LOG_DEBUG("Mac address %s is ready", itr->second.c_str());
-            return std::make_pair(true, itr->second);
+            if (fv.first == VXLAN_ROUTER_MAC)
+            {
+                m_VxlanSwitchTableConfig.m_routerMac = fv.second;
+            }
+            else if (fv.first == VXLAN_PORT)
+            {
+                m_VxlanSwitchTableConfig.m_vxlanDstPort = fv.second;
+            }
+            else if (fv.first == VXLAN_SPORT)
+            {
+                sport = fv.second;
+            }
+            else if (fv.first == VXLAN_MASK)
+            {
+                mask = fv.second;
+            }
         }
-        SWSS_LOG_DEBUG("Mac address will be automatically set");
-        return std::make_pair(true, "");
+
+        returnValue = m_VxlanSwitchTableConfig.m_routerMac.empty() ? false : true;
+
+        if (m_VxlanSwitchTableConfig.m_vxlanDstPort.empty())
+        {
+            m_VxlanSwitchTableConfig.m_vxlanDstPort = VXLAN_DEFAULT_UDP_PORT;
+        }
+
+        if (!sport.empty() && !mask.empty())
+        {
+            unsigned long sportUL = std::strtoul(sport.c_str(), nullptr, 10);
+            unsigned long maskUL = std::strtoul(mask.c_str(), nullptr, 10);
+
+            if (sportUL > 0xFFFF) 
+            {
+                SWSS_LOG_WARN("Invalid VXLAN source port %s, must be in range 0-65535, all source ports will be used", sport.c_str());
+                return returnValue;
+            }
+
+            if (maskUL > 16 || maskUL == 0) 
+            {
+                SWSS_LOG_WARN("Invalid VXLAN source port mask %s, must be in range 1-16, all source ports will be used", mask.c_str());
+                return returnValue;
+            }
+
+            uint32_t span = (maskUL == 0) ? 0u : ((1u << maskUL) - 1u);
+            uint32_t portMin = static_cast<uint32_t>(sportUL) & ~span;
+            uint32_t portMax = portMin | span;
+
+            m_VxlanSwitchTableConfig.m_vxlanSrcPortRangeStart = std::to_string(portMin);
+            m_VxlanSwitchTableConfig.m_vxlanSrcPortRangeEnd = std::to_string(portMax);
+        }
     }
 
-    SWSS_LOG_DEBUG("Mac address is not ready");
-    return std::make_pair(false, "");
+    return returnValue;
 }
 
 bool VxlanMgr::createVxlan(const VxlanInfo & info)
@@ -829,7 +883,11 @@ bool VxlanMgr::createVxlan(const VxlanInfo & info)
     int ret = 0;
 
     // Create Vxlan
-    ret = cmdCreateVxlan(info, res);
+    ret = cmdCreateVxlan(info,
+                         m_VxlanSwitchTableConfig.m_vxlanDstPort,
+                         m_VxlanSwitchTableConfig.m_vxlanSrcPortRangeStart,
+                         m_VxlanSwitchTableConfig.m_vxlanSrcPortRangeEnd,
+                         res);
     if (ret != RET_SUCCESS)
     {
         SWSS_LOG_WARN(
@@ -1029,7 +1087,7 @@ int VxlanMgr::createVxlanNetdevice(std::string vxlanTunnelName, std::string vni_
                    " address " + gMacAddress.to_string() + " type vxlan id " +
                    std::string(vni_id) + " local " + src_ip +
                    ((dst_ip  == "")? "":(" remote " + dst_ip)) +
-                   " nolearning " + " dstport 4789";
+                   " nolearning " + " dstport " + m_VxlanSwitchTableConfig.m_vxlanDstPort;
 
     // Add udp6zerocsumrx only for IPv6
     struct in6_addr addr6;

--- a/cfgmgr/vxlanmgr.h
+++ b/cfgmgr/vxlanmgr.h
@@ -44,6 +44,14 @@ public:
         std::string vni_id;
     } MapCache;
 
+    typedef struct VxlanSwitchTableConfig
+    {
+        std::string m_routerMac;
+        std::string m_vxlanDstPort;
+        std::string m_vxlanSrcPortRangeStart;
+        std::string m_vxlanSrcPortRangeEnd;
+    } VxlanSwitchTableConfig;
+
     void waitTillReadyToReconcile();
     void beginReconcile(bool warm);
     void endReconcile(bool warm);
@@ -84,7 +92,7 @@ private:
     bool isVrfStateOk(const std::string & vrfName);
     bool isVxlanStateOk(const std::string & vxlanName);
     bool isVlanStateOk(const std::string &vlanName);
-    std::pair<bool, std::string> getVxlanRouterMacAddress();
+    bool getSwitchTableVxlanConfig();
 
     bool createVxlan(const VxlanInfo & info);
     bool deleteVxlan(const VxlanInfo & info);
@@ -106,6 +114,7 @@ private:
     std::map<std::string, std::string> m_vlanMapCache;
     std::map<std::string, std::string> m_vniMapCache;
     std::map<std::string, std::string> m_EvpnNvoCache;
+    VxlanSwitchTableConfig m_VxlanSwitchTableConfig;
 
     /*
     * Vnet Cache

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -9,9 +9,9 @@ CXXFLAGS = -g -O0
 
 CFLAGS_SAI = -I /usr/include/sai
 
-TESTS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_fdbsyncd tests_response_publisher tests_nbrmgrd tests_teamsyncd
+TESTS = tests tests_vxlanmgrd tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_fdbsyncd tests_response_publisher tests_nbrmgrd tests_teamsyncd
 
-noinst_PROGRAMS = tests tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_fdbsyncd tests_response_publisher tests_nbrmgrd tests_teamsyncd
+noinst_PROGRAMS = tests tests_vxlanmgrd tests_intfmgrd tests_teammgrd tests_portsyncd tests_fpmsyncd tests_fdbsyncd tests_response_publisher tests_nbrmgrd tests_teamsyncd
 
 LDADD_SAI = -lsaivs -lsairedis -lsaimeta -lsaimetadata
 
@@ -425,3 +425,19 @@ tests_teamsyncd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 \
         -lswsscommon -ldl -lhiredis -lgtest -lgtest_main -lpthread -lteam -lteamdctl -lnl-route-3
 
 LOG_DRIVER = $(top_srcdir)/run-gtest-suite.py
+
+## vxlanmgrd unit tests
+
+tests_vxlanmgrd_SOURCES = vxlanmgrd/vxlanmgr_ut.cpp \
+                         $(top_srcdir)/cfgmgr/vxlanmgr.cpp \
+                         $(top_srcdir)/lib/recorder.cpp \
+                         $(top_srcdir)/orchagent/orch.cpp \
+                         $(top_srcdir)/orchagent/request_parser.cpp \
+                         fake_response_publisher.cpp \
+                         common/mock_shell_command.cpp
+
+tests_vxlanmgrd_INCLUDES = $(tests_INCLUDES) -I$(top_srcdir)/cfgmgr -I$(top_srcdir)/lib
+tests_vxlanmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
+tests_vxlanmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) $(tests_vxlanmgrd_INCLUDES)
+tests_vxlanmgrd_LDADD = $(LDADD_GTEST) $(LDADD_SAI) -lnl-genl-3 -lhiredis -lhiredis \
+        -lswsscommon -lswsscommon -lgtest -lgtest_main -lzmq -lnl-3 -lnl-route-3 -lpthread -lgmock -lgmock_main

--- a/tests/mock_tests/vxlanmgrd/vxlanmgr_ut.cpp
+++ b/tests/mock_tests/vxlanmgrd/vxlanmgr_ut.cpp
@@ -1,0 +1,163 @@
+#include "gtest/gtest.h"
+#include <string>
+#include <vector>
+#include <sstream>
+#include <memory>
+#include "schema.h"
+#include "warm_restart.h"
+#include "table.h"
+#include "macaddress.h"
+
+#define private public
+#include "vxlanmgr.h"
+#undef private
+
+extern int (*callback)(const std::string &cmd, std::string &stdout);
+extern std::vector<std::string> mockCallArgs;
+
+swss::MacAddress gMacAddress;
+
+namespace vxlanmgr_ut
+{
+
+using namespace swss;
+
+static int vxlan_cb(const std::string &cmd, std::string &stdout)
+{
+    mockCallArgs.push_back(cmd);
+    stdout.clear();
+    return 0;
+}
+
+static bool cmdHasTokens(const std::string &tokens)
+{
+    std::istringstream iss(tokens);
+    std::vector<std::string> toks;
+    std::string t;
+    while (iss >> t) toks.push_back(t);
+    for (const auto &c : mockCallArgs)
+    {
+        bool ok = true;
+        for (const auto &tok : toks)
+        {
+            if (c.find(tok) == std::string::npos) { ok = false; break; }
+        }
+        if (ok) return true;
+    }
+    return false;
+}
+
+struct VxlanMgrTest : public ::testing::Test
+{
+    std::shared_ptr<swss::DBConnector> m_cfg_db;
+    std::shared_ptr<swss::DBConnector> m_app_db;
+    std::shared_ptr<swss::DBConnector> m_state_db;
+    std::vector<std::string> m_tables;
+
+    void SetUp() override
+    {
+        m_cfg_db = std::make_shared<swss::DBConnector>("CONFIG_DB", 0);
+        m_app_db = std::make_shared<swss::DBConnector>("APPL_DB", 0);
+        m_state_db = std::make_shared<swss::DBConnector>("STATE_DB", 0);
+        m_cfg_db->flushdb();
+        m_app_db->flushdb();
+        m_state_db->flushdb();
+        swss::WarmStart::initialize("vxlanmgrd", "swss");
+        m_tables = {};
+        mockCallArgs.clear();
+        callback = vxlan_cb;
+    }
+
+    void TearDown() override
+    {
+        callback = nullptr;
+    }
+
+    void setSwitch(const std::vector<FieldValueTuple> &fvs)
+    {
+        swss::Table(m_app_db.get(), APP_SWITCH_TABLE_NAME).set("switch", fvs);
+    }
+};
+
+TEST_F(VxlanMgrTest, SwitchTableConfigDefaultDstPortWhenOnlyMacSet)
+{
+    setSwitch({{"vxlan_router_mac", "aa:bb:cc:dd:ee:ff"}});
+    VxlanMgr mgr(m_cfg_db.get(), m_app_db.get(), m_state_db.get(), m_tables);
+    ASSERT_TRUE(mgr.getSwitchTableVxlanConfig());
+    ASSERT_EQ(mgr.m_VxlanSwitchTableConfig.m_routerMac, "aa:bb:cc:dd:ee:ff");
+    ASSERT_EQ(mgr.m_VxlanSwitchTableConfig.m_vxlanDstPort, "4789");
+    ASSERT_TRUE(mgr.m_VxlanSwitchTableConfig.m_vxlanSrcPortRangeStart.empty());
+    ASSERT_TRUE(mgr.m_VxlanSwitchTableConfig.m_vxlanSrcPortRangeEnd.empty());
+}
+
+TEST_F(VxlanMgrTest, SwitchTableConfigReadsCustomDstPort)
+{
+    setSwitch({{"vxlan_router_mac", "aa:bb:cc:dd:ee:ff"},
+               {"vxlan_port", "4788"}});
+    VxlanMgr mgr(m_cfg_db.get(), m_app_db.get(), m_state_db.get(), m_tables);
+    ASSERT_TRUE(mgr.getSwitchTableVxlanConfig());
+    ASSERT_EQ(mgr.m_VxlanSwitchTableConfig.m_vxlanDstPort, "4788");
+}
+
+TEST_F(VxlanMgrTest, SwitchTableConfigComputesSrcPortRange)
+{
+    setSwitch({{"vxlan_router_mac", "aa:bb:cc:dd:ee:ff"},
+               {"vxlan_sport", "32768"},
+               {"vxlan_mask", "4"}});
+    VxlanMgr mgr(m_cfg_db.get(), m_app_db.get(), m_state_db.get(), m_tables);
+    ASSERT_TRUE(mgr.getSwitchTableVxlanConfig());
+    ASSERT_EQ(mgr.m_VxlanSwitchTableConfig.m_vxlanSrcPortRangeStart, "32768");
+    ASSERT_EQ(mgr.m_VxlanSwitchTableConfig.m_vxlanSrcPortRangeEnd, "32783");
+}
+
+TEST_F(VxlanMgrTest, VxlanCreationProgramsCustomSrcAndDstPorts)
+{
+    setSwitch({{"vxlan_router_mac", "aa:bb:cc:dd:ee:ff"},
+               {"vxlan_port", "4788"},
+               {"vxlan_sport", "32775"},
+               {"vxlan_mask", "4"}});
+    swss::Table(m_state_db.get(), STATE_VRF_TABLE_NAME).set("Vnet1", {{"state", "ok"}});
+    VxlanMgr mgr(m_cfg_db.get(), m_app_db.get(), m_state_db.get(), m_tables);
+    KeyOpFieldsValuesTuple tunnel{"tunnel0", SET_COMMAND, {{"src_ip", "10.0.0.1"}}};
+    ASSERT_TRUE(mgr.doVxlanTunnelCreateTask(tunnel));
+
+    mockCallArgs.clear();
+    KeyOpFieldsValuesTuple vnet{"Vnet1", SET_COMMAND,
+                                {{"vxlan_tunnel", "tunnel0"}, {"vni", "1000"}}};
+    ASSERT_TRUE(mgr.doVxlanCreateTask(vnet));
+
+    ASSERT_TRUE(cmdHasTokens("link add Vxlan1000 type vxlan id 1000 local 10.0.0.1 "
+                            "dstport 4788 srcport 32768 32783"));
+    ASSERT_TRUE(mgr.isVxlanStateOk("Vxlan1000"));
+}
+
+TEST_F(VxlanMgrTest, SwitchTableConfigRejectsInvalidMask)
+{
+    setSwitch({{"vxlan_router_mac", "aa:bb:cc:dd:ee:ff"},
+               {"vxlan_sport", "32768"},
+               {"vxlan_mask", "17"}});
+    VxlanMgr mgr(m_cfg_db.get(), m_app_db.get(), m_state_db.get(), m_tables);
+    ASSERT_TRUE(mgr.getSwitchTableVxlanConfig());
+    ASSERT_TRUE(mgr.m_VxlanSwitchTableConfig.m_vxlanSrcPortRangeStart.empty());
+    ASSERT_TRUE(mgr.m_VxlanSwitchTableConfig.m_vxlanSrcPortRangeEnd.empty());
+}
+
+TEST_F(VxlanMgrTest, SwitchTableConfigRejectsOutOfRangeSport)
+{
+    setSwitch({{"vxlan_router_mac", "aa:bb:cc:dd:ee:ff"},
+               {"vxlan_sport", "70000"},
+               {"vxlan_mask", "4"}});
+    VxlanMgr mgr(m_cfg_db.get(), m_app_db.get(), m_state_db.get(), m_tables);
+    ASSERT_TRUE(mgr.getSwitchTableVxlanConfig());
+    ASSERT_TRUE(mgr.m_VxlanSwitchTableConfig.m_vxlanSrcPortRangeStart.empty());
+    ASSERT_TRUE(mgr.m_VxlanSwitchTableConfig.m_vxlanSrcPortRangeEnd.empty());
+}
+
+TEST_F(VxlanMgrTest, SwitchTableConfigDefersWhenRowMissing)
+{
+    VxlanMgr mgr(m_cfg_db.get(), m_app_db.get(), m_state_db.get(), m_tables);
+    ASSERT_FALSE(mgr.getSwitchTableVxlanConfig());
+    ASSERT_TRUE(mgr.m_VxlanSwitchTableConfig.m_routerMac.empty());
+}
+
+}  // namespace vxlanmgr_ut


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
 - Read VXLAN UDP port settings from APP_DB  ```SWITCH_TABLE:switch``` :  ```vxlan_port ```,  ```vxlan_sport```, and ```vxlan_mask```.
 - Use ```SWITCH_TABLE:switch's vxlan_port``` to configure the Vxlan netdev object in kernel, if a vxlan_port is not specified the default value of 4789 will be used
 - Derive a source-port range from  vxlan_sport  and  vxlan_mask , and pass it through the Linux  ip link add ... type vxlan  command.

**Why I did it**
Allow overriding the default vxlan src and dst ports for kernel configured netdev

**How I verified it**
Using UT, PTF test using KVM sonic, and physical DUT test

**Details if related**
