### PR TITLE
[orchagent] Add reach_mode (NR/ER) port serdes attribute support

### DIFF
--- a/orchagent/port/portcnt.h
+++ b/orchagent/port/portcnt.h
@@ -221,6 +221,11 @@ public:
         } rx_precoding; // Port serdes rx_precoding (per-lane)
 
         struct {
+            std::vector<std::uint32_t> value;
+            bool is_set = false;
+        } reach_mode; // Port serdes reach mode (per-lane)
+
+        struct {
             std::string value;
             bool is_set = false;
         } custom_collection; // Port serdes custom_collection

--- a/orchagent/port/porthlpr.cpp
+++ b/orchagent/port/porthlpr.cpp
@@ -776,6 +776,44 @@ PortHelper::parseSerdesValueImpl(T &serdes, const std::string &field, const std:
     return true;
 }
 
+// Reach mode uses symbolic per-lane values ("NR"/"ER") rather than the numeric
+// lists handled by parseSerdesValueImpl, so it gets a dedicated parser.
+template<typename T>
+bool PortHelper::parsePortReachMode(T &serdes, const std::string &field, const std::string &value) const
+{
+    SWSS_LOG_ENTER();
+
+    if (value.empty())
+    {
+        SWSS_LOG_ERROR("Failed to parse field(%s): empty string is prohibited", field.c_str());
+        return false;
+    }
+
+    for (const auto &cit : tokenize(value, ','))
+    {
+        const auto &mode = boost::algorithm::to_lower_copy(cit);
+
+        if (mode == "nr")
+        {
+            serdes.value.push_back(static_cast<std::uint32_t>(SAI_PORT_SERDES_REACH_MODE_NR));
+        }
+        else if (mode == "er")
+        {
+            serdes.value.push_back(static_cast<std::uint32_t>(SAI_PORT_SERDES_REACH_MODE_ER));
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Failed to parse field(%s): invalid value(%s), expected 'NR' or 'ER'",
+                           field.c_str(), value.c_str());
+            return false;
+        }
+    }
+
+    serdes.is_set = true;
+
+    return true;
+}
+
 template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::preemphasis) &serdes, const std::string &field, const std::string &value) const;
 template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::idriver) &serdes, const std::string &field, const std::string &value) const;
 template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::ipredriver) &serdes, const std::string &field, const std::string &value) const;
@@ -798,6 +836,7 @@ template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::rxpolarity) &se
 template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::tx_precoding) &serdes, const std::string &field, const std::string &value) const;
 template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::rx_precoding) &serdes, const std::string &field, const std::string &value) const;
 template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::custom_collection) &serdes, const std::string &field, const std::string &value) const;
+template bool PortHelper::parsePortReachMode(decltype(PortSerdes_t::reach_mode) &serdes, const std::string &field, const std::string &value) const;
 
 
 
@@ -1289,6 +1328,13 @@ bool PortHelper::parsePortConfig(PortConfig &port) const
         else if (serdes_field == PORT_RX_PRECODING)
         {
             if (!this->parsePortSerdes(serdes->rx_precoding, field, value))
+            {
+                return false;
+            }
+        }
+        else if (serdes_field == PORT_REACH_MODE)
+        {
+            if (!this->parsePortReachMode(serdes->reach_mode, field, value))
             {
                 return false;
             }

--- a/orchagent/port/porthlpr.h
+++ b/orchagent/port/porthlpr.h
@@ -47,6 +47,9 @@ private:
     typename std::enable_if<std::is_same<decltype(T::value), std::vector<std::uint32_t>>::value, bool>::type
     parseSerdesValueImpl(T &serdes, const std::string &field, const std::string &value) const;
 
+    template<typename T>
+    bool parsePortReachMode(T &serdes, const std::string &field, const std::string &value) const;
+
     bool parsePortLinkEventDampingAlgorithm(PortConfig &port, const std::string &field, const std::string &value) const;
     template<typename T>
     bool parsePortLinkEventDampingConfig(T &damping_config_attr, const std::string &field, const std::string &value) const;

--- a/orchagent/port/portschema.h
+++ b/orchagent/port/portschema.h
@@ -93,6 +93,7 @@
 #define PORT_RX_POLARITY            "rxpolarity"
 #define PORT_TX_PRECODING           "tx_precoding"
 #define PORT_RX_PRECODING           "rx_precoding"
+#define PORT_REACH_MODE             "reach_mode"
 #define PORT_CUSTOM_SERDES_ATTRS   "custom_serdes_attrs"
 #define PORT_ROLE                  "role"
 #define PORT_ADMIN_STATUS          "admin_status"

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -599,6 +599,11 @@ static void getPortSerdesAttr(PortSerdesAttrMap_t &map, const decltype(PortConfi
     {
         map[SAI_PORT_SERDES_ATTR_RX_PRECODING] = SerdesValue(serdes.rx_precoding.value);
     }
+
+    if (serdes.reach_mode.is_set)
+    {
+        map[SAI_PORT_SERDES_ATTR_REACH_MODE] = SerdesValue(serdes.reach_mode.value);
+    }
 }
 
 static bool isPathTracingSupported()

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -1477,6 +1477,7 @@ namespace portsorch_test
                 { "attn",          "0x80,0x82,0x81,0x83"         },
                 { "tx_precoding",  "0x1,0x0,0x1,0x0"             },
                 { "rx_precoding",  "0x0,0x1,0x0,0x1"             },
+                { "reach_mode",    "ER,NR,ER,NR"                 },
                 { "unreliable_los","off"                         },
                 { "ob_m2lp",       "0x4,0x6,0x5,0x7"             },
                 { "ob_alev_out",   "0xf,0x11,0x10,0x12"          },
@@ -1582,6 +1583,13 @@ namespace portsorch_test
         // Verify rx_precoding
         std::vector<std::uint32_t> rx_precoding = { 0x0, 0x1, 0x0, 0x1 };
         ASSERT_EQ(p.m_serdes_attrs.at(SAI_PORT_SERDES_ATTR_RX_PRECODING), SerdesValue(rx_precoding));
+
+        // Verify reach_mode
+        std::vector<std::uint32_t> reach_mode = {
+            SAI_PORT_SERDES_REACH_MODE_ER, SAI_PORT_SERDES_REACH_MODE_NR,
+            SAI_PORT_SERDES_REACH_MODE_ER, SAI_PORT_SERDES_REACH_MODE_NR
+        };
+        ASSERT_EQ(p.m_serdes_attrs.at(SAI_PORT_SERDES_ATTR_REACH_MODE), SerdesValue(reach_mode));
 
         // Verify ob_m2lp
         std::vector<std::uint32_t> ob_m2lp = { 0x4, 0x6, 0x5, 0x7 };


### PR DESCRIPTION
**⚠️ Draft — has a SAI dependency.** `SAI_PORT_SERDES_ATTR_REACH_MODE` and `sai_port_serdes_reach_mode_t` do not exist in OCP SAI yet, so this will not compile until a corresponding SAI change lands and sonic-sairedis picks it up. Opening as a draft to get early feedback on the swss side. Proposed SAI definition (in `inc/saiport.h`, alongside `SAI_PORT_SERDES_ATTR_TX_PRECODING`/`RX_PRECODING`):

```c
/**
 * @brief Serdes reach mode
 */
typedef enum _sai_port_serdes_reach_mode_t
{
    /** Normal Reach */
    SAI_PORT_SERDES_REACH_MODE_NR,
    /** Extended Reach */
    SAI_PORT_SERDES_REACH_MODE_ER
} sai_port_serdes_reach_mode_t;

/**
 * @brief Port serdes reach mode control
 *
 * List of port serdes reach mode values. The count is the number of
 * lanes in a port and the list specifies the value applied to each lane.
 *
 * @type sai_s32_list_t sai_port_serdes_reach_mode_t
 * @flags CREATE_AND_SET
 * @default empty
 */
SAI_PORT_SERDES_ATTR_REACH_MODE,
```

**What I did**

Added support for a `reach_mode` field in PORT_TABLE, parsed as a comma-separated per-lane list of `NR`/`ER` values (case-insensitive) and programmed via `SAI_PORT_SERDES_ATTR_REACH_MODE`, following the same pattern as the existing serdes attributes (most recently `tx_precoding`/`rx_precoding` in #4609):

- `portschema.h`: `PORT_REACH_MODE` field name
- `portcnt.h`: `reach_mode` member in the port serdes config
- `porthlpr.cpp/.h`: dedicated `parsePortReachMode` parser — the values are symbolic (`NR`/`ER`) rather than the numeric lists handled by `parseSerdesValueImpl`
- `portsorch.cpp`: map the parsed list into the serdes attribute map in `getPortSerdesAttr`
- `tests/mock_tests/portsorch_ut.cpp`: extended `PortsOrchTest.PortSerdes` coverage

**Why I did it**

Extended-reach (ER) serdes mode is required (together with precoding) to bring up some 200G-per-lane PAM4 optical links. xcvrd already passes through arbitrary per-lane entries from `media_settings.json` to APPL_DB PORT_TABLE, so with this change platforms can drive reach mode from `media_settings.json` exactly like the other per-lane SI settings — but today orchagent has no handler for the field.

**How I verified it**

Verified downstream on a Broadcom Tomahawk-based 800G (8x100G PAM4) platform using an equivalent vendor extension attribute: per-lane `"reach_mode": {"lane0": "ER", ...}` entries in `media_settings.json` flow xcvrd → APPL_DB (`ER,ER,...`) → orchagent → SAI as a full per-lane list with zero SAI errors; the PHY shows extended-reach mode active on all lanes, flipping the entry ER↔NR live updates the PHY accordingly, and links requiring ER + precoding come up. Also extended the `portsorch_ut` mock test in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)