### PR TITLE
[switchorch]: skip unsupported SAI vxlan_port set

### DIFF
--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -737,7 +737,18 @@ void SwitchOrch::doAppSwitchTableTask(Consumer &consumer)
                         break;
 
                     case SAI_SWITCH_ATTR_VXLAN_DEFAULT_PORT:
-                        attr.value.u16 = to_uint<uint16_t>(value);
+                        // Some SAI implementations do not support runtime set of
+                        // SAI_SWITCH_ATTR_VXLAN_DEFAULT_PORT. Query first so we skip
+                        // the set and avoid handleSaiFailure ERR on a working datapath.
+                        ret = querySwitchCapability(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_VXLAN_DEFAULT_PORT);
+                        if (ret == false)
+                        {
+                            unsupported_attr = true;
+                        }
+                        else
+                        {
+                            attr.value.u16 = to_uint<uint16_t>(value);
+                        }
                         break;
 
                     case SAI_SWITCH_ATTR_VXLAN_DEFAULT_ROUTER_MAC:
@@ -810,7 +821,16 @@ void SwitchOrch::doAppSwitchTableTask(Consumer &consumer)
                     break;
                 }
                 if (unsupported_attr){
-                    SWSS_LOG_ERROR("Unsupported Attribute %s", attribute.c_str());
+                    // vxlan_port is unimplemented on some platforms. NOTICE (not ERROR)
+                    // so loganalyzer does not fail a working VXLAN datapath.
+                    if (attr.id == SAI_SWITCH_ATTR_VXLAN_DEFAULT_PORT)
+                    {
+                        SWSS_LOG_NOTICE("Switch attribute vxlan_port is not supported, skipping");
+                    }
+                    else
+                    {
+                        SWSS_LOG_ERROR("Unsupported Attribute %s", attribute.c_str());
+                    }
                     // Continue to set the rest of the attributes, even if current attribute is unsupported
                     continue;
                 }
@@ -818,6 +838,15 @@ void SwitchOrch::doAppSwitchTableTask(Consumer &consumer)
                 sai_status_t status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);
                 if (status != SAI_STATUS_SUCCESS)
                 {
+                    // Capability can report set_implemented while set still returns
+                    // NOT_SUPPORTED / NOT_IMPLEMENTED. Skip without handleSaiFailure.
+                    if (attr.id == SAI_SWITCH_ATTR_VXLAN_DEFAULT_PORT &&
+                        (status == SAI_STATUS_NOT_SUPPORTED || status == SAI_STATUS_NOT_IMPLEMENTED))
+                    {
+                        SWSS_LOG_NOTICE("Switch attribute vxlan_port set is not supported (rv:%d), skipping",
+                                        status);
+                        continue;
+                    }
                     SWSS_LOG_ERROR("Failed to set switch attribute %s to %s, rv:%d",
                             attribute.c_str(), value.c_str(), status);
                     retry = (handleSaiSetStatus(SAI_API_SWITCH, status) == task_need_retry);


### PR DESCRIPTION
**What I did**

Query SAI attribute capability before applying VxLAN switch attributes in `SwitchOrch`:

1. `SAI_SWITCH_ATTR_VXLAN_DEFAULT_PORT` (`vxlan_port`): skip the attribute when `set_implemented` is false, using the same `querySwitchCapability` / `unsupported_attr` path as `ecmp_hash_offset` / `lag_hash_offset`.
2. `SAI_SWITCH_TUNNEL_ATTR_TUNNEL_VXLAN_UDP_SPORT_MODE` (`vxlan_sport`): skip switch-tunnel create when `create_implemented` is false, so later fields in the same `SWITCH` row (notably `vxlan_router_mac`) are still applied.

Added `SwitchOrch` mock tests that stub `sai_query_attribute_capability` for both cases.

**Why I did it**

These attributes are optional. orchagent currently sets them unconditionally. On platforms that do not implement them, SAI returns `SAI_STATUS_NOT_SUPPORTED`, `doAppSwitchTableTask` breaks out of the field loop, and later fields in the same row are silently dropped.

**How I verified it**

- Added `SwitchOrchTest.VxlanSportModeNotSupportedSkipsSwitchTunnel` and `SwitchOrchTest.VxlanDefaultPortNotSupportedSkipsAttribute`.
- Ran `git diff --check` successfully.
- Focused mock tests were not executed in this environment.

**Details if related**

Companion changes:

- SAI: report GR2 dest-port / sport capability as unimplemented (Leaba SDK `branches/lts-customer/sdk-26.5.4140`; push currently blocked because that repo is archived).
- sonic-mgmt: loganalyzer ignore for `Unsupported Attribute vxlan_port` (draft PR opened against `202605`).

Replaces closed draft https://github.com/sonic-net/sonic-swss/pull/4877 (was targeting `master` with a post-set skip). This PR targets `202605` and skips only after the capability query.
