### PR TITLE
swssrec: queue depth warning and narrower batch enqueue lock (#4532)

### DIFF
--- a/lib/recorder.cpp
+++ b/lib/recorder.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <inttypes.h>
 #include <unistd.h>
+#include <vector>
 
 using namespace swss;
 
@@ -89,8 +90,11 @@ void SwSSRec::recordTupleAsync(const std::string& prefix, const KeyOpFieldsValue
     {
         return;
     }
-    struct timeval received_time;
-    gettimeofday(&received_time, nullptr);
+
+    AsyncSwssRecordEntry staged;
+    gettimeofday(&staged.received_time, nullptr);
+    staged.prefix = prefix;
+    staged.tuple = tuple;
 
     {
         std::unique_lock<std::mutex> stateLock(m_stateMutex);
@@ -102,15 +106,14 @@ void SwSSRec::recordTupleAsync(const std::string& prefix, const KeyOpFieldsValue
         if (!m_asyncEnabled.load(std::memory_order_relaxed))
         {
             stateLock.unlock();
-            AsyncSwssRecordEntry entry = {{}, prefix, tuple};
-            record(serialize(entry));
+            record(serialize(staged));
             return;
         }
 
         ensureAsyncWorkerLocked();
 
         std::lock_guard<std::mutex> lock(m_mutex);
-        m_queue.push_back({received_time, prefix, tuple});
+        m_queue.push_back(std::move(staged));
         onEnqueue(1);
     }
 
@@ -151,13 +154,19 @@ void SwSSRec::recordTuplesAsync(const std::string& prefix, const std::deque<KeyO
 
         ensureAsyncWorkerLocked();
 
-        std::lock_guard<std::mutex> lock(m_mutex);
+        std::vector<AsyncSwssRecordEntry> staged;
+        staged.reserve(entries.size());
         for (const auto& entry : entries)
         {
             struct timeval received_time;
             gettimeofday(&received_time, nullptr);
-            m_queue.push_back({received_time, prefix, entry});
+            staged.push_back({received_time, prefix, entry});
         }
+
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_queue.insert(m_queue.end(),
+                       std::make_move_iterator(staged.begin()),
+                       std::make_move_iterator(staged.end()));
         onEnqueue(entries.size());
     }
 
@@ -240,6 +249,7 @@ void SwSSRec::stopAsyncWorker()
      * above), so platforms running with async disabled stay silent.
      */
     auto stats = getAsyncDebugStats();
+    m_pendingWarnActive.store(false, std::memory_order_relaxed);
     SWSS_LOG_NOTICE(
         "AsyncSwssRecorder graceful shutdown: pending_after_shutdown=%" PRIu64
         " drained_total=%" PRIu64 " high_watermark=%" PRIu64,
@@ -258,12 +268,31 @@ void SwSSRec::onEnqueue(size_t count)
            !m_highWatermark.compare_exchange_weak(current, depth, std::memory_order_relaxed))
     {
     }
+
+    if (!m_pendingWarnActive.load(std::memory_order_relaxed) &&
+        depth >= ASYNC_SWSS_RECORDER_PENDING_WARN_THRESHOLD)
+    {
+        m_pendingWarnActive.store(true, std::memory_order_relaxed);
+        SWSS_LOG_WARN(
+            "AsyncSwssRecorder queue depth exceeded threshold: pending=%" PRIu64
+            " threshold=%" PRIu64 " high_watermark=%" PRIu64 " enqueued_total=%" PRIu64,
+            depth,
+            static_cast<uint64_t>(ASYNC_SWSS_RECORDER_PENDING_WARN_THRESHOLD),
+            m_highWatermark.load(std::memory_order_relaxed),
+            m_enqueuedTotal.load(std::memory_order_relaxed));
+    }
 }
 
 void SwSSRec::onDrain()
 {
-    m_pendingCount.fetch_sub(1, std::memory_order_relaxed);
+    auto depth = m_pendingCount.fetch_sub(1, std::memory_order_relaxed) - 1;
     m_drainedTotal.fetch_add(1, std::memory_order_relaxed);
+
+    if (m_pendingWarnActive.load(std::memory_order_relaxed) &&
+        depth <= ASYNC_SWSS_RECORDER_PENDING_WARN_THRESHOLD / 2)
+    {
+        m_pendingWarnActive.store(false, std::memory_order_relaxed);
+    }
 }
 
 std::string SwSSRec::formatTimestamp(const struct timeval& tv) const

--- a/lib/recorder.h
+++ b/lib/recorder.h
@@ -63,6 +63,10 @@ public:
     RetryRec();
 };
 
+#ifndef ASYNC_SWSS_RECORDER_PENDING_WARN_THRESHOLD
+#define ASYNC_SWSS_RECORDER_PENDING_WARN_THRESHOLD 100000
+#endif
+
 struct AsyncSwssRecorderDebugStats
 {
     uint64_t pending_count;
@@ -109,6 +113,7 @@ private:
     mutable std::atomic<uint64_t> m_highWatermark{0};
     mutable std::atomic<uint64_t> m_enqueuedTotal{0};
     mutable std::atomic<uint64_t> m_drainedTotal{0};
+    std::atomic<bool> m_pendingWarnActive{false};
     std::mutex m_stateMutex; // Serializes async mode transitions and worker lifecycle.
     std::mutex m_mutex;
     std::condition_variable m_signal;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -23,7 +23,8 @@ tests_SOURCES = swssnet_ut.cpp request_parser_ut.cpp ../orchagent/request_parser
         quoted_ut.cpp ../lib/recorder.cpp
 
 tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
-tests_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) -I../orchagent
+tests_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI) -I../orchagent \
+        -DASYNC_SWSS_RECORDER_PENDING_WARN_THRESHOLD=10
 tests_LDADD = $(LDADD_GTEST) -lnl-genl-3 -lhiredis -lhiredis -lpthread \
         -lswsscommon -lswsscommon -lgtest -lgtest_main
 

--- a/tests/quoted_ut.cpp
+++ b/tests/quoted_ut.cpp
@@ -23,9 +23,13 @@ using namespace swss;
 namespace
 {
 
-vector<string> waitForRecordedLines(const string& path, const string& marker, size_t expected)
+vector<string> waitForRecordedLines(
+        const string& path,
+        const string& marker,
+        size_t expected,
+        size_t maxRetries = 50)
 {
-    for (size_t retry = 0; retry < 50; ++retry)
+    for (size_t retry = 0; retry < maxRetries; ++retry)
     {
         ifstream ifs(path);
         vector<string> matches;
@@ -53,9 +57,10 @@ vector<string> waitForRecordedLines(const string& path, const string& marker, si
 AsyncSwssRecorderDebugStats waitForRecorderStats(
         SwSSRec& recorder,
         uint64_t expectedEnqueued,
-        uint64_t expectedDrained)
+        uint64_t expectedDrained,
+        size_t maxRetries = 50)
 {
-    for (size_t retry = 0; retry < 50; ++retry)
+    for (size_t retry = 0; retry < maxRetries; ++retry)
     {
         auto stats = recorder.getAsyncDebugStats();
         if (stats.enqueued_total >= expectedEnqueued &&
@@ -286,6 +291,102 @@ TEST(swssrec, setAsyncDisableDrainsWorkerAndSingleTupleFallsBackToSync)
 
     ASSERT_EQ(remove(fullpath.c_str()), 0);
     ASSERT_EQ(rmdir(dirname.c_str()), 0);
+}
+
+TEST(swssrec, recordTuplesAsyncBulkEnqueue)
+{
+    char dir_template[] = "/tmp/swss-recorder-ut-XXXXXX";
+    auto dir = mkdtemp(dir_template);
+    ASSERT_NE(dir, nullptr);
+
+    const string dirname(dir);
+    const string filename = "swss-bulk-enqueue.rec";
+    const string fullpath = dirname + "/" + filename;
+    const string prefix = "TEST_TABLE:";
+    const string keyPrefix = "batch-enqueue-key-";
+    const size_t batchSize = 1024;
+
+    SwSSRec recorder;
+    recorder.setRecord(true);
+    recorder.setLocation(dirname);
+    recorder.setFileName(filename);
+    recorder.setAsync(true);
+    recorder.startRec(true);
+
+    deque<KeyOpFieldsValuesTuple> entries;
+    for (size_t i = 0; i < batchSize; ++i)
+    {
+        entries.push_back(KeyOpFieldsValuesTuple(
+            { keyPrefix + to_string(i),
+              SET_COMMAND,
+              { { "field1", "value1" } } }));
+    }
+
+    recorder.recordTuplesAsync(prefix, entries);
+
+    const auto stats = waitForRecorderStats(recorder, batchSize, batchSize, 200);
+    EXPECT_EQ(stats.enqueued_total, batchSize);
+    EXPECT_EQ(stats.drained_total, batchSize);
+    EXPECT_EQ(stats.pending_count, 0u);
+    EXPECT_GE(stats.high_watermark, batchSize);
+
+    const auto lines = waitForRecordedLines(fullpath, keyPrefix, batchSize, 200);
+    ASSERT_EQ(lines.size(), batchSize);
+
+    const string firstMarker = keyPrefix + "0|SET";
+    const string lastMarker = keyPrefix + to_string(batchSize - 1) + "|SET";
+    bool foundFirst = false;
+    bool foundLast = false;
+    for (const auto& line : lines)
+    {
+        if (line.find(firstMarker) != string::npos)
+        {
+            foundFirst = true;
+        }
+        if (line.find(lastMarker) != string::npos)
+        {
+            foundLast = true;
+        }
+    }
+    EXPECT_TRUE(foundFirst);
+    EXPECT_TRUE(foundLast);
+}
+
+TEST(swssrec, pendingThresholdWarningTracksHighWatermark)
+{
+    char dir_template[] = "/tmp/swss-recorder-ut-XXXXXX";
+    auto dir = mkdtemp(dir_template);
+    ASSERT_NE(dir, nullptr);
+
+    const string dirname(dir);
+    const string filename = "swss-pending-threshold.rec";
+    const string fullpath = dirname + "/" + filename;
+    const string prefix = "TEST_TABLE:";
+    const size_t enqueueCount = 30;
+
+    SwSSRec recorder;
+    recorder.setRecord(true);
+    recorder.setLocation(dirname);
+    recorder.setFileName(filename);
+    recorder.setAsync(true);
+    recorder.startRec(true);
+
+    deque<KeyOpFieldsValuesTuple> entries;
+    for (size_t i = 0; i < enqueueCount; ++i)
+    {
+        entries.push_back(KeyOpFieldsValuesTuple(
+            { "threshold-key-" + to_string(i),
+              SET_COMMAND,
+              { { "field1", "value1" } } }));
+    }
+
+    recorder.recordTuplesAsync(prefix, entries);
+
+    const auto stats = waitForRecorderStats(recorder, enqueueCount, enqueueCount);
+    EXPECT_EQ(stats.enqueued_total, enqueueCount);
+    EXPECT_EQ(stats.drained_total, enqueueCount);
+    EXPECT_EQ(stats.pending_count, 0u);
+    EXPECT_GE(stats.high_watermark, static_cast<uint64_t>(ASYNC_SWSS_RECORDER_PENDING_WARN_THRESHOLD));
 }
 
 TEST(swssrec, signalSafeStatsDumpFormatsOutput)


### PR DESCRIPTION
## Summary
- **Item 1:** WARN when async `swss.rec` pending queue exceeds 100k (hysteresis clear at <=50k); reset on async worker stop.
- **Item 2:** Stage batch enqueue entries outside `m_mutex`; insert and `onEnqueue()` under the lock.
- `quoted_ut` coverage (UT threshold via `Makefile.am`; 1024-entry batch).

Follow-up to async recorder (#4400). **Items 1-2** from #4532 only; items 3-5 deferred.

## Test plan
- [x] `quoted_ut`: `pendingThresholdWarningTracksHighWatermark`, `recordTuplesAsyncBulkEnqueue`
- [x] Nokia IXR DUT: async_rec load; ~baseline timing; WARN ~100k; `pending_after_shutdown=0`

Fixes #4532 (items 1-2).
