### PR TITLE
Set default port role to external

### DIFF
--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -294,7 +294,7 @@ public:
     uint32_t m_reuse_threshold = 0;
     uint32_t m_flap_penalty = 0;
 
-    Role m_role;
+    Role m_role = Role::Ext;
 };
 
 }

--- a/orchagent/port/portcnt.h
+++ b/orchagent/port/portcnt.h
@@ -228,7 +228,7 @@ public:
     } serdes, serdes_gb_line, serdes_gb_system; // Port serdes (ASIC port, gearbox line-side, gearbox system-side)
 
     struct {
-        swss::Port::Role value;
+        swss::Port::Role value = swss::Port::Role::Ext;
         bool is_set = false;
     } role; // Port role
 

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -1201,8 +1201,6 @@ namespace portsorch_test
         ASSERT_TRUE(!ports.empty());
 
         // default Ethernet0 has different lanes so create_ports() is triggered.
-        // Set role explicitly: PortConfig::role.value has no default initializer,
-        // so leaving it unset would propagate uninitialized memory into Port::m_role.
         std::vector<FieldValueTuple> fvList = {
             { "alias",               alias       },
             { "index",               "0"         },
@@ -1217,7 +1215,6 @@ namespace portsorch_test
             { "tpid",                "0x8101"    },
             { "pfc_asym",            "on"        },
             { "admin_status",        "up"        },
-            { "role",                "Ext"       },
             { "description",         "FP port"   }
         };
 
@@ -1248,6 +1245,7 @@ namespace portsorch_test
 
         Port p;
         EXPECT_TRUE(gPortsOrch->getPort(alias, p));
+        EXPECT_EQ(p.m_role, Port::Role::Ext);
 
         // Validate SAI port configuration
 

--- a/tests/mock_tests/ut_saihelper.cpp
+++ b/tests/mock_tests/ut_saihelper.cpp
@@ -207,13 +207,7 @@ namespace ut_helper
                 { "lanes", lanes_str },
                 { "speed", "1000" },
                 { "mtu", "6000" },
-                { "admin_status", "up" },
-                // PortConfig::role.value has no default initializer; without
-                // an explicit role here, p.m_role is read from uninitialized
-                // memory and intermittently matches Rec/Inb, which would make
-                // the recycle/inband gates in portsorch silently skip serdes
-                // and PHY-attr setup for these ports.
-                { "role", "Ext" }
+                { "admin_status", "up" }
             };
 
             auto key = FRONT_PANEL_PORT_PREFIX + to_string(i);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Default PortConfig::role and Port::m_role to Ext.
Update unit tests to cover ports without an explicit role.

**Why I did it**
Port roles were left uninitialized when the role field was absent from port_config.ini. This could misidentify front-panel ports as inband or recirculation ports, skipping SerDes programming and causing subsequent warm-reboot reconciliation failures.

**How I verified it**
Verified that the Arista-7050CX3-32S-C32 retrieves preemphasis configurations from ASIC_DB when a role is omitted in port_config.ini and values are required from media_settings.json:
202511 with internal review build:
```shell
admin@ld495:/tmp$ show version | grep "SONiC Software Version"
SONiC Software Version: SONiC.branch.202511-ars.bb776d89-buildimage.origin.202511-review.800778.3-2026.09.11.16.37
admin@ld495:/tmp$ sonic-db-cli ASIC_DB HGETALL ASIC_STATE:SAI_OBJECT_TYPE_PORT_SERDES:oid:0x57000000000651
{'SAI_PORT_SERDES_ATTR_PORT_ID': 'oid:0x1000000000012', 'SAI_PORT_SERDES_ATTR_PREEMPHASIS': '4:404995,404995,404995,404995'}
```
202605 with internal review build:
```shell
admin@ld481:/tmp$ show version | grep "SONiC Software Version"
SONiC Software Version: SONiC.branch.202605-ars.41a922a7-buildimage.4519ff2e1d167f878f9f29b1542174c3e04f411f-review.798485.3-2026.09.10.06.13
admin@ld481:/tmp$ sonic-db-cli ASIC_DB HGETALL ASIC_STATE:SAI_OBJECT_TYPE_PORT_SERDES:oid:0x5700000000448b
{'SAI_PORT_SERDES_ATTR_PREEMPHASIS': '4:404995,404995,404995,404995', 'SAI_PORT_SERDES_ATTR_PORT_ID': 'oid:0x1000000000012'}
```

**Details if related**
Fixes: https://github.com/sonic-net/sonic-buildimage/issues/28167
