### PR TITLE
vnetorch idempotent replay

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -24,6 +24,10 @@ parameters:
 - name: debian_version
   type: string
 
+- name: vpp_artifact_name
+  type: string
+  default: 'vpp-bookworm'
+
 - name: artifact_name
   type: string
 
@@ -163,7 +167,7 @@ jobs:
       source: specific
       project: build
       pipeline: sonic-net.sonic-platform-vpp
-      artifact: vpp
+      artifact: ${{ parameters.vpp_artifact_name }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/master'
       allowPartiallySucceededBuilds: true

--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -154,17 +154,6 @@ jobs:
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
-      project: ${{ parameters.buildimage_artifact_project }}
-      pipeline: Azure.sonic-buildimage.common_libs
-      artifact: common-lib
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/${{ parameters.buildimage_artifact_branch }}'
-      path: $(Build.ArtifactStagingDirectory)/download
-      patterns: '**/target/debs/${{ parameters.debian_version }}/libnexthopgroup_*.deb'
-    displayName: "Download sonic-buildimage libnexthopgroup package"
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      source: specific
       project: build
       pipeline: sonic-net.sonic-platform-vpp
       artifact: ${{ parameters.vpp_artifact_name }}
@@ -183,7 +172,6 @@ jobs:
       mkdir -p .azure-pipelines/docker-sonic-vs/debs
 
       find $(Build.ArtifactStagingDirectory)/download/sairedis -name '*.deb' -exec cp "{}" .azure-pipelines/docker-sonic-vs/debs \;
-      find $(Build.ArtifactStagingDirectory)/download -name 'libnexthopgroup_*.deb' -exec cp "{}" .azure-pipelines/docker-sonic-vs/debs \;
       cp -v $(Build.ArtifactStagingDirectory)/download/*.deb .azure-pipelines/docker-sonic-vs/debs
       if [ -f $(Build.ArtifactStagingDirectory)/download/coverage.info ]; then
         cp -v $(Build.ArtifactStagingDirectory)/download/coverage.info $(Build.ArtifactStagingDirectory)/

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -176,8 +176,6 @@ jobs:
         target/debs/${{ parameters.debian_version }}/libnl-nf-3-200_*.deb
         target/debs/${{ parameters.debian_version }}/libnl-nf-3-dev_*.deb
         target/debs/${{ parameters.debian_version }}/libyang3_*.deb
-        target/debs/${{ parameters.debian_version }}/libnexthopgroup_*.deb
-        target/debs/${{ parameters.debian_version }}/libnexthopgroup-dev_*.deb
     displayName: "Download common libs"
   - task: DownloadPipelineArtifact@2
     inputs:

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -85,6 +85,10 @@ parameters:
 - name: debian_version
   type: string
 
+- name: vpp_artifact_name
+  type: string
+  default: 'vpp-bookworm'
+
 jobs:
 - job:
   displayName: ${{ parameters.arch }}
@@ -212,7 +216,7 @@ jobs:
       source: specific
       project: build
       pipeline: sonic-net.sonic-platform-vpp
-      artifact: vpp
+      artifact: ${{ parameters.vpp_artifact_name }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/master'
       allowPartiallySucceededBuilds: true

--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -13,7 +13,7 @@ COPY ["debs", "/debs"]
 # same, even though contents have changed) are checked between the previous and current layer.
 RUN dpkg --remove --force-all libswsscommon
 RUN apt --fix-broken install -y
-RUN dpkg --purge python3-swsscommon sonic-db-cli libsaimetadata libsairedis libsaivs syncd-vs swss sonic-eventd libdashapi framework libnexthopgroup
+RUN dpkg --purge python3-swsscommon sonic-db-cli libsaimetadata libsairedis libsaivs syncd-vs swss sonic-eventd libdashapi framework
 
 RUN apt-get update
 
@@ -43,8 +43,7 @@ RUN apt install -y /debs/libdashapi_1.0.0_amd64.deb \
             /debs/libsairedis_1.0.0_amd64.deb \
             /debs/libsaivs_1.0.0_amd64.deb \
             /debs/syncd-vs_1.0.0_amd64.deb \
-            /debs/swss_1.0.0_amd64.deb \
-            /debs/libnexthopgroup_1.0.0_amd64.deb
+            /debs/swss_1.0.0_amd64.deb
 
 RUN if [ "$need_dbg" = "y" ] ; then dpkg -i /debs/swss-dbg_1.0.0_amd64.deb ; fi
 

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -117,7 +117,7 @@ jobs:
   - script: |
       set -ex
       # install packages for vs test
-      sudo pip3 install pytest flaky exabgp docker lcov_cobertura
+      sudo uv pip install --system pytest flaky exabgp docker lcov_cobertura
 
       # install other dependencies
       sudo apt-get -o DPkg::Lock::Timeout=600 install -y net-tools \
@@ -143,9 +143,11 @@ jobs:
       # from PyPI instead — same fallback as the inline amd64/ubuntu-22.04
       # job. --no-build-isolation + apt's python3-cffi sidesteps a cffi
       # version-mismatch Exception that jammy's pip 22.0.2 build-isolation
-      # env otherwise triggers.
-      sudo apt-get install -y python3-cffi
-      sudo pip3 install --no-build-isolation 'libyang==3.3.0'
+      # env otherwise triggers. --no-build-isolation needs wheel present
+      # in the environment to provide bdist_wheel, so install it first.
+      sudo apt-get install -y python3-cffi python3-dev
+      sudo uv pip install --system wheel
+      sudo uv pip install --system --no-build-isolation 'libyang==3.3.0'
 
       sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libprotobuf*_amd64.deb $(Build.ArtifactStagingDirectory)/download/libprotobuf-lite*_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-protobuf*_amd64.deb
       sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/libdashapi*.deb

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,6 +54,7 @@ stages:
       dash_artifact_name: sonic-dash-api
       artifact_name: sonic-swss-${{ parameters.debian_version }}
       debian_version: ${{ parameters.debian_version }}
+      vpp_artifact_name: vpp-${{ parameters.debian_version }}
       archive_pytests: true
       archive_gcov: true
 
@@ -71,6 +72,7 @@ stages:
       dash_artifact_name: sonic-dash-api
       artifact_name: sonic-swss-asan-${{ parameters.debian_version }}
       debian_version: ${{ parameters.debian_version }}
+      vpp_artifact_name: vpp-${{ parameters.debian_version }}
       asan: true
 
 - stage: BuildArm
@@ -89,6 +91,7 @@ stages:
       dash_artifact_name: sonic-dash-api.armhf
       artifact_name: sonic-swss-${{ parameters.debian_version }}.armhf
       debian_version: ${{ parameters.debian_version }}
+      vpp_artifact_name: vpp-${{ parameters.debian_version }}
       archive_gcov: false
 
   - template: .azure-pipelines/build-template.yml
@@ -103,6 +106,7 @@ stages:
       dash_artifact_name: sonic-dash-api.arm64
       artifact_name: sonic-swss-${{ parameters.debian_version }}.arm64
       debian_version: ${{ parameters.debian_version }}
+      vpp_artifact_name: vpp-${{ parameters.debian_version }}
       archive_gcov: false
 
 - stage: BuildTrixie
@@ -120,6 +124,7 @@ stages:
       dash_artifact_name: sonic-dash-api-trixie
       artifact_name: sonic-swss-trixie
       debian_version: trixie
+      vpp_artifact_name: vpp-trixie
       archive_gcov: false
 
   - template: .azure-pipelines/build-template.yml
@@ -134,6 +139,7 @@ stages:
       dash_artifact_name: sonic-dash-api-trixie.armhf
       artifact_name: sonic-swss-trixie.armhf
       debian_version: trixie
+      vpp_artifact_name: vpp-trixie
       archive_gcov: false
 
   - template: .azure-pipelines/build-template.yml
@@ -148,6 +154,7 @@ stages:
       dash_artifact_name: sonic-dash-api-trixie.arm64
       artifact_name: sonic-swss-trixie.arm64
       debian_version: trixie
+      vpp_artifact_name: vpp-trixie
       archive_gcov: false
 
 - stage: BuildDocker
@@ -160,6 +167,7 @@ stages:
       sairedis_artifact_name: sonic-sairedis-${{ parameters.debian_version }}
       swss_artifact_name: sonic-swss-${{ parameters.debian_version }}
       debian_version: ${{ parameters.debian_version }}
+      vpp_artifact_name: vpp-${{ parameters.debian_version }}
       artifact_name: docker-sonic-vs
 
 - stage: BuildDockerAsan
@@ -173,6 +181,7 @@ stages:
       swss_artifact_name: sonic-swss-asan-${{ parameters.debian_version }}
       artifact_name: docker-sonic-vs-asan
       debian_version: ${{ parameters.debian_version }}
+      vpp_artifact_name: vpp-${{ parameters.debian_version }}
       asan: true
 
 - stage: Test

--- a/cfgmgr/buffer_headroom_mellanox.lua
+++ b/cfgmgr/buffer_headroom_mellanox.lua
@@ -118,6 +118,7 @@ end
 -- Calculate the headroom information
 local speed_of_light = 198000000
 local minimal_packet_size = 64
+local headroom_compensation = 2 * 1024
 local cell_occupancy
 local worst_case_factor
 local propagation_delay
@@ -163,6 +164,17 @@ propagation_delay = port_mtu + bytes_on_cable + 2 * bytes_on_gearbox + mac_phy_d
 -- Calculate the xoff and xon and then round up at 1024 bytes
 xoff_value = lossless_mtu + propagation_delay * cell_occupancy
 xoff_value = math.ceil(xoff_value / 1024) * 1024
+
+-- When SHP is disabled, compensate headroom calculated with a reduced small-
+-- packet percentage if it remains more than 2 kB below the worst case.
+if not shp_enabled and small_packet_percentage ~= 100 then
+    local full_small_packet_xoff = lossless_mtu + propagation_delay * worst_case_factor
+    full_small_packet_xoff = math.ceil(full_small_packet_xoff / 1024) * 1024
+    if xoff_value + headroom_compensation < full_small_packet_xoff then
+        xoff_value = xoff_value + headroom_compensation
+    end
+end
+
 xon_value = pipeline_latency
 xon_value = math.ceil(xon_value / 1024) * 1024
 

--- a/cfgmgr/buffer_headroom_mellanox.lua
+++ b/cfgmgr/buffer_headroom_mellanox.lua
@@ -28,6 +28,7 @@ local cable_length = tonumber(string.sub(ARGV[2], 1, -2))
 local port_mtu = tonumber(ARGV[3])
 local gearbox_delay = tonumber(ARGV[4])
 local is_8lane = (ARGV[5] == "8")
+local spectrum6_headroom_compensation = 18 * 1024
 
 local appl_db = "0"
 local config_db = "4"
@@ -60,6 +61,7 @@ end
 -- Fetch ASIC info from ASIC table in STATE_DB
 redis.call('SELECT', state_db)
 local asic_keys = redis.call('KEYS', 'ASIC_TABLE*')
+local is_spectrum6 = asic_keys[1]:sub(-1) == '6'
 
 -- Only one key should exist
 local asic_table_content = redis.call('HGETALL', asic_keys[1])
@@ -164,6 +166,11 @@ propagation_delay = port_mtu + bytes_on_cable + 2 * bytes_on_gearbox + mac_phy_d
 -- Calculate the xoff and xon and then round up at 1024 bytes
 xoff_value = lossless_mtu + propagation_delay * cell_occupancy
 xoff_value = math.ceil(xoff_value / 1024) * 1024
+
+-- Spectrum-6 requires additional headroom for ASIC packet-buffer accounting.
+if is_spectrum6 then
+    xoff_value = xoff_value + spectrum6_headroom_compensation
+end
 
 -- When SHP is disabled, compensate headroom calculated with a reduced small-
 -- packet percentage if it remains more than 2 kB below the worst case.

--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -1,6 +1,7 @@
 #include <fstream>
 #include <iostream>
 #include <string.h>
+#include <unistd.h>
 #include "logger.h"
 #include "dbconnector.h"
 #include "producerstatetable.h"
@@ -27,6 +28,8 @@
  */
 using namespace std;
 using namespace swss;
+
+static constexpr int BUFFER_PROFILE_SYNC_MAX_CHECKS = 30;
 
 BufferMgrDynamic::BufferMgrDynamic(DBConnector *cfgDb, DBConnector *stateDb, DBConnector *applDb, DBConnector *applStateDb, const vector<TableConnector> &tables, shared_ptr<vector<KeyOpFieldsValuesTuple>> gearboxInfo, shared_ptr<vector<KeyOpFieldsValuesTuple>> zeroProfilesInfo) :
         Orch(tables),
@@ -55,7 +58,8 @@ BufferMgrDynamic::BufferMgrDynamic(DBConnector *cfgDb, DBConnector *stateDb, DBC
         m_bufferObjectsPending(true),
         m_bufferCompletelyInitialized(false),
         m_bufferProfileApplDbWritten(false),
-        m_mmuSizeNumber(0)
+        m_mmuSizeNumber(0),
+        m_saiSyncPollIntervalSec(1)
 {
     SWSS_LOG_ENTER();
 
@@ -2018,9 +2022,12 @@ task_process_status BufferMgrDynamic::handleDefaultLossLessBufferParam(KeyOpFiel
         bool willSHPBeEnabled = isNonZero(newRatio);
         if (m_portInitDone && (!isSHPEnabled) && willSHPBeEnabled)
         {
-            if (!isSharedHeadroomPoolEnabledInSai())
+            // Keep the ratio enable event out of m_toSync; stale SET fields
+            // can outlive the user's later delete-field intent.
+            auto status = waitSharedHeadroomPoolEnabledInSai();
+            if (status != task_process_status::task_success)
             {
-                return task_process_status::task_need_retry;
+                return status;
             }
         }
         SWSS_LOG_INFO("Recalculate shared buffer pool size due to over subscribe ratio has been updated from %s to %s",
@@ -2048,6 +2055,43 @@ bool BufferMgrDynamic::isSharedHeadroomPoolEnabledInSai()
     }
 
     return true;
+}
+
+task_process_status BufferMgrDynamic::waitWithRetry(const function<bool()> &checker, const string &description)
+{
+    const unsigned int maxWaitSec = (BUFFER_PROFILE_SYNC_MAX_CHECKS - 1) * m_saiSyncPollIntervalSec;
+    SWSS_LOG_NOTICE("Checking SAI sync status: %d checks (up to ~%u s) for %s",
+                    BUFFER_PROFILE_SYNC_MAX_CHECKS,
+                    maxWaitSec,
+                    description.c_str());
+
+    if (checker())
+    {
+        return task_process_status::task_success;
+    }
+
+    for (int i = 0; i < BUFFER_PROFILE_SYNC_MAX_CHECKS - 1; i++)
+    {
+        if (m_saiSyncPollIntervalSec > 0)
+        {
+            sleep(m_saiSyncPollIntervalSec);
+        }
+
+        if (checker())
+        {
+            return task_process_status::task_success;
+        }
+    }
+
+    SWSS_LOG_ERROR("Timed out waiting for %s to sync to SAI, desired in-memory state is preserved, manual intervention is required",
+                   description.c_str());
+    return task_process_status::task_failed;
+}
+
+task_process_status BufferMgrDynamic::waitSharedHeadroomPoolEnabledInSai()
+{
+    return waitWithRetry([this]() { return isSharedHeadroomPoolEnabledInSai(); },
+                         "shared headroom pool");
 }
 
 bool BufferMgrDynamic::isLosslessProfileSyncedInSai(const string &profileName)
@@ -2103,7 +2147,7 @@ bool BufferMgrDynamic::isLosslessProfileSyncedInSai(const string &profileName)
 
 task_process_status BufferMgrDynamic::checkPendingProfilesSyncStatus()
 {
-    SWSS_LOG_NOTICE("Checking SAI sync status for %zu profiles", m_shpProfilesToCheck.size());
+    SWSS_LOG_INFO("Checking SAI sync status for %zu profiles", m_shpProfilesToCheck.size());
     m_applBufferProfileTable.flush();
 
     for (const auto &profileName : m_shpProfilesToCheck)
@@ -2119,6 +2163,14 @@ task_process_status BufferMgrDynamic::checkPendingProfilesSyncStatus()
     SWSS_LOG_NOTICE("All profiles synced to SAI successfully");
     m_shpProfilesToCheck.clear();
     return task_process_status::task_success;
+}
+
+task_process_status BufferMgrDynamic::waitPendingProfilesSyncStatus()
+{
+    return waitWithRetry([this]() {
+                             return checkPendingProfilesSyncStatus() == task_process_status::task_success;
+                         },
+                         to_string(m_shpProfilesToCheck.size()) + " BUFFER_PROFILE entries");
 }
 
 task_process_status BufferMgrDynamic::handleCableLenTable(KeyOpFieldsValuesTuple &tuple)
@@ -2564,48 +2616,34 @@ task_process_status BufferMgrDynamic::handleBufferPoolTable(KeyOpFieldsValuesTup
              * False        | Static    | False               | False
              */
             bool willSHPBeEnabledBySize = isNonZero(newSHPSize);
+
             if (newSHPSize != m_configuredSharedHeadroomPoolSize)
             {
                 bool isSHPEnabledBySize = isNonZero(m_configuredSharedHeadroomPoolSize);
 
                 if (m_portInitDone && (!isSHPEnabledBySize) && willSHPBeEnabledBySize)
                 {
-                    if (!isSharedHeadroomPoolEnabledInSai())
+                    // Keep the enable event out of m_toSync; stale SET fields
+                    // can outlive the user's later delete-field intent.
+                    auto status = waitSharedHeadroomPoolEnabledInSai();
+                    if (status != task_process_status::task_success)
                     {
-                        return task_process_status::task_need_retry;
+                        return status;
                     }
                 }
 
-                // Check if we are in retry mode (profiles waiting for SAI sync)
+                m_configuredSharedHeadroomPoolSize = newSHPSize;
+                refreshSharedHeadroomPool(false, isSHPEnabledBySize != willSHPBeEnabledBySize);
+
+                // Check if there are profiles waiting for SAI sync
                 if (!m_shpProfilesToCheck.empty())
                 {
-                    // Retry mode: only check SAI sync status, don't refresh profiles
-                    SWSS_LOG_NOTICE("Retry mode: checking pending profiles");
-                    auto status = checkPendingProfilesSyncStatus();
-                    if (status == task_process_status::task_need_retry)
+                    // The desired SHP size is already in memory; wait here so
+                    // a replay cannot skip profiles that are still in flight.
+                    auto status = waitPendingProfilesSyncStatus();
+                    if (status != task_process_status::task_success)
                     {
-                        return task_process_status::task_need_retry;
-                    }
-                    // Profiles synced successfully, update configuration and continue
-                    m_configuredSharedHeadroomPoolSize = newSHPSize;
-                }
-                else
-                {
-                    // Not retry mode: refresh profiles
-                    string oldSHPSize = m_configuredSharedHeadroomPoolSize;
-                    m_configuredSharedHeadroomPoolSize = newSHPSize;
-                    refreshSharedHeadroomPool(false, isSHPEnabledBySize != willSHPBeEnabledBySize);
-
-                    // Check if there are profiles waiting for SAI sync
-                    if (!m_shpProfilesToCheck.empty())
-                    {
-                        auto status = checkPendingProfilesSyncStatus();
-                        if (status == task_process_status::task_need_retry)
-                        {
-                            // Rollback configuration change
-                            m_configuredSharedHeadroomPoolSize = oldSHPSize;
-                            return task_process_status::task_need_retry;
-                        }
+                        return status;
                     }
                 }
             }

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -5,6 +5,7 @@
 #include "producerstatetable.h"
 #include "orch.h"
 
+#include <functional>
 #include <map>
 #include <set>
 #include <string>
@@ -270,6 +271,9 @@ private:
     // Profiles waiting for SAI sync in refreshSharedHeadroomPool
     std::vector<std::string> m_shpProfilesToCheck;
 
+    // Seconds between SAI sync polls in waitWithRetry. 0 means no sleep (UT only).
+    unsigned int m_saiSyncPollIntervalSec;
+
     // Initializers
     void initTableHandlerMap();
     void parseGearboxInfo(std::shared_ptr<std::vector<KeyOpFieldsValuesTuple>> gearboxInfo);
@@ -304,7 +308,10 @@ private:
     bool isHeadroomResourceValid(const std::string &port, const buffer_profile_t &profile, const std::string &new_pg);
     bool isSharedHeadroomPoolEnabledInSai();
     bool isLosslessProfileSyncedInSai(const std::string &profileName);
+    task_process_status waitWithRetry(const std::function<bool()> &checker, const std::string &description);
+    task_process_status waitSharedHeadroomPoolEnabledInSai();
     task_process_status checkPendingProfilesSyncStatus();
+    task_process_status waitPendingProfilesSyncStatus();
     void refreshSharedHeadroomPool(bool enable_state_updated_by_ratio, bool enable_state_updated_by_size);
     task_process_status checkBufferProfileDirection(const std::string &profiles, buffer_direction_t dir);
     std::string constructZeroProfileListFromNormalProfileList(const std::string &normalProfileList, const std::string &port);

--- a/configure.ac
+++ b/configure.ac
@@ -119,7 +119,7 @@ if test "x$enable_gcov" = "xyes"; then
         AC_MSG_ERROR(not compiling with gcc, which is required for gcov testing)
     fi
 
-    CFLAGS_COMMON+=" -fprofile-arcs -ftest-coverage"
+    CFLAGS_COMMON+=" -fprofile-arcs -ftest-coverage -DGCOV_ENABLED"
     AC_SUBST(CFLAGS_COMMON)
 
     LDFLAGS+=" -fprofile-arcs -lgcov"

--- a/crates/countersyncd/src/actor/data_netlink.rs
+++ b/crates/countersyncd/src/actor/data_netlink.rs
@@ -13,7 +13,11 @@ use log::{debug, info, warn};
 use netlink_sys::Socket;
 #[cfg(not(test))]
 use netlink_sys::{protocols::NETLINK_GENERIC, SocketAddr};
-use tokio::{select, sync::mpsc::{Receiver, Sender}, time::{interval, MissedTickBehavior}};
+use tokio::{
+    select,
+    sync::mpsc::{Receiver, Sender},
+    time::{interval, MissedTickBehavior},
+};
 
 use std::io;
 
@@ -21,9 +25,9 @@ use super::super::message::{
     buffer::SocketBufferMessage,
     netlink::{NetlinkCommand, SocketConnect},
 };
-use crate::utilities::{format_hex_lines, record_comm_stats, ChannelLabel};
 #[cfg(not(test))]
 use super::netlink_utils;
+use crate::utilities::{format_hex_lines, record_comm_stats, ChannelLabel};
 
 #[cfg(not(test))]
 type SocketType = Socket;
@@ -34,6 +38,7 @@ type SocketType = test::MockSocket;
 const SONIC_CONSTANTS: &str = "/etc/sonic/constants.yml";
 
 /// Size of the buffer used for receiving netlink messages
+#[cfg(test)]
 const BUFFER_SIZE: usize = 0x1FFFF;
 /// Linux error code for "No buffer space available" (ENOBUFS)
 /// Note: std::io::ErrorKind doesn't have a specific variant for ENOBUFS,
@@ -55,21 +60,17 @@ const DEBUG_TARGET_MS: u64 = 30 * 1000;
 /// Target duration for WouldBlock log (1 minute).
 const WOULDBLOCK_TARGET_MS: u64 = 60 * 1000;
 
-/// Maximum size for buffering incomplete messages (1MB)
-const MAX_INCOMPLETE_MESSAGE_SIZE: usize = 1024 * 1024;
+/// Maximum supported size for a single netlink datagram/message.
+/// This bounds userspace allocation after peeking the datagram length.
+const MAX_NETLINK_DATAGRAM_SIZE: usize = 16 * 1024 * 1024;
 
-/// Netlink message parser for handling multiple messages in one buffer
+/// Netlink message parser for handling multiple messages in one datagram
 #[derive(Debug)]
-struct NetlinkMessageParser {
-    /// Buffer for incomplete messages that span multiple recv operations
-    incomplete_buffer: Vec<u8>,
-}
+struct NetlinkMessageParser;
 
 impl NetlinkMessageParser {
     fn new() -> Self {
-        Self {
-            incomplete_buffer: Vec::new(),
-        }
+        Self
     }
 
     /// Mirrors `NLMSG_ALIGN` from `linux/netlink.h` by rounding lengths up to the next 4-byte boundary.
@@ -77,65 +78,112 @@ impl NetlinkMessageParser {
         (len + 3) & !3
     }
 
-    /// Parse buffer that may contain multiple complete and/or incomplete netlink messages
-    /// Returns a vector of complete message payloads, where each payload represents 
-    /// one complete netlink message (which contains one complete IPFIX message)
-    fn parse_buffer(&mut self, new_data: &[u8]) -> Result<Vec<SocketBufferMessage>, io::Error> {
-        // Combine any incomplete data from previous recv with new data
-        if !self.incomplete_buffer.is_empty() {
-            self.incomplete_buffer.extend_from_slice(new_data);
-            debug!("Combined incomplete buffer ({} bytes) with new data ({} bytes)", 
-                   self.incomplete_buffer.len() - new_data.len(), new_data.len());
-        } else {
-            self.incomplete_buffer.extend_from_slice(new_data);
+    fn is_valid_alignment_padding(data: &[u8]) -> bool {
+        data.len() <= 3 && data.iter().all(|byte| *byte == 0)
+    }
+
+    fn return_parsed_or_error(
+        complete_messages: Vec<SocketBufferMessage>,
+        error: io::Error,
+        offset: usize,
+        remaining: usize,
+    ) -> Result<Vec<SocketBufferMessage>, io::Error> {
+        if complete_messages.is_empty() {
+            return Err(error);
         }
 
+        warn!(
+            "Discarding trailing {} bytes at offset {} after parsing {} message(s): {}",
+            remaining,
+            offset,
+            complete_messages.len(),
+            error
+        );
+        Ok(complete_messages)
+    }
+
+    /// Parse a single netlink datagram that may contain one or more complete netlink messages.
+    ///
+    /// Netlink multicast sockets are datagram-oriented. If a userspace receive buffer is too small,
+    /// the kernel discards the rest of that datagram, so bytes from a later recv must never be
+    /// treated as a continuation of the previous one.
+    /// Returns the generic-netlink payload from each complete netlink message. For IPFIX data,
+    /// each payload can contain multiple IPFIX sets and records.
+    fn parse_buffer(&mut self, new_data: &[u8]) -> Result<Vec<SocketBufferMessage>, io::Error> {
         let mut complete_messages = Vec::new();
         let mut offset = 0;
 
         // Parse all complete messages in the buffer
-        while offset < self.incomplete_buffer.len() {
+        while offset < new_data.len() {
             // Check if we have enough data for a netlink header
-            if offset + 16 > self.incomplete_buffer.len() {
-                debug!("Not enough data for netlink header at offset {}, keeping {} bytes for next recv", 
-                       offset, self.incomplete_buffer.len() - offset);
-                break;
+            if offset + 16 > new_data.len() {
+                if Self::is_valid_alignment_padding(&new_data[offset..]) {
+                    break;
+                }
+
+                let remaining = new_data.len() - offset;
+                let error = io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "Incomplete netlink header at offset {}: have {} bytes",
+                        offset, remaining
+                    ),
+                );
+                return Self::return_parsed_or_error(complete_messages, error, offset, remaining);
             }
 
             // Extract message length from netlink header
             let nl_len = u32::from_le_bytes([
-                self.incomplete_buffer[offset],
-                self.incomplete_buffer[offset + 1], 
-                self.incomplete_buffer[offset + 2],
-                self.incomplete_buffer[offset + 3],
+                new_data[offset],
+                new_data[offset + 1],
+                new_data[offset + 2],
+                new_data[offset + 3],
             ]) as usize;
 
             // Validate message length
             if nl_len < 16 {
-                return Err(io::Error::new(
+                let error = io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!("Invalid netlink message length: {} (too small)", nl_len),
-                ));
+                );
+                return Self::return_parsed_or_error(
+                    complete_messages,
+                    error,
+                    offset,
+                    new_data.len() - offset,
+                );
             }
 
-            if nl_len > MAX_INCOMPLETE_MESSAGE_SIZE {
-                return Err(io::Error::new(
+            if nl_len > MAX_NETLINK_DATAGRAM_SIZE {
+                let error = io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!("Invalid netlink message length: {} (too large)", nl_len),
-                ));
+                );
+                return Self::return_parsed_or_error(
+                    complete_messages,
+                    error,
+                    offset,
+                    new_data.len() - offset,
+                );
             }
 
             // Check if we have the complete message
-            if offset + nl_len > self.incomplete_buffer.len() {
-                debug!("Incomplete message at offset {}: need {} bytes, have {} bytes", 
-                       offset, nl_len, self.incomplete_buffer.len() - offset);
-                break;
+            if offset + nl_len > new_data.len() {
+                let remaining = new_data.len() - offset;
+                let error = io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "Incomplete netlink message at offset {}: need {} bytes, have {} bytes",
+                        offset, nl_len, remaining
+                    ),
+                );
+                return Self::return_parsed_or_error(complete_messages, error, offset, remaining);
             }
 
             let aligned_nl_len = Self::nlmsg_align(nl_len);
 
             // Extract complete message without trailing alignment padding
-            let message_data = self.incomplete_buffer[offset..offset + nl_len].to_vec();
+            let message_data = new_data[offset..offset + nl_len].to_vec();
             debug!(
                 "Found complete message: offset={}, length={}, aligned_length={}",
                 offset, nl_len, aligned_nl_len
@@ -144,27 +192,23 @@ impl NetlinkMessageParser {
             // Extract payload from this message
             match Self::extract_payload_from_slice(&message_data) {
                 Ok(payload) => {
-                    debug!("Successfully extracted payload with {} bytes", payload.len());
+                    debug!(
+                        "Successfully extracted payload with {} bytes",
+                        payload.len()
+                    );
                     complete_messages.push(payload);
                 }
                 Err(e) => {
-                    warn!("Failed to extract payload from message at offset {}: {}", offset, e);
+                    warn!(
+                        "Failed to extract payload from message at offset {}: {}",
+                        offset, e
+                    );
                     // Continue with next message instead of failing completely
                 }
             }
 
-            let remaining = self.incomplete_buffer.len() - offset;
+            let remaining = new_data.len() - offset;
             offset += usize::min(aligned_nl_len, remaining);
-        }
-
-        // Keep remaining incomplete data for next recv
-        if offset < self.incomplete_buffer.len() {
-            let remaining = self.incomplete_buffer[offset..].to_vec();
-            debug!("Keeping {} bytes for next recv operation", remaining.len());
-            self.incomplete_buffer = remaining;
-        } else {
-            // All data was consumed
-            self.incomplete_buffer.clear();
         }
 
         Ok(complete_messages)
@@ -175,45 +219,70 @@ impl NetlinkMessageParser {
         const NLMSG_HDRLEN: usize = 16; // sizeof(struct nlmsghdr)
         const GENL_HDRLEN: usize = 4; // sizeof(struct genlmsghdr)
         const TOTAL_HEADER_SIZE: usize = NLMSG_HDRLEN + GENL_HDRLEN;
+        const NLMSG_LEN: std::ops::Range<usize> = 0..4;
+        const NLMSG_TYPE: std::ops::Range<usize> = 4..6;
+        const NLMSG_FLAGS: std::ops::Range<usize> = 6..8;
+        const NLMSG_SEQ: std::ops::Range<usize> = 8..12;
+        const NLMSG_PID: std::ops::Range<usize> = 12..16;
+        const GENL_CMD: usize = 16;
+        const GENL_VERSION: usize = 17;
+        const GENL_RESERVED: std::ops::Range<usize> = 18..20;
 
         if message_data.len() < TOTAL_HEADER_SIZE {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("Message too small: {} bytes, expected at least {}", 
-                        message_data.len(), TOTAL_HEADER_SIZE),
+                format!(
+                    "Message too small: {} bytes, expected at least {}",
+                    message_data.len(),
+                    TOTAL_HEADER_SIZE
+                ),
             ));
         }
 
         // Extract netlink message length from header
-        let nl_len = u32::from_le_bytes([
-            message_data[0], message_data[1], message_data[2], message_data[3]
-        ]) as usize;
+        let nl_len = u32::from_le_bytes(message_data[NLMSG_LEN].try_into().unwrap()) as usize;
 
         if nl_len != message_data.len() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("Message length mismatch: header says {}, actual {}", 
-                        nl_len, message_data.len()),
+                format!(
+                    "Message length mismatch: header says {}, actual {}",
+                    nl_len,
+                    message_data.len()
+                ),
             ));
         }
 
         // Debug: Print headers only when debug logging is enabled
         if log::log_enabled!(log::Level::Debug) {
-            debug!("Netlink Header (16 bytes): {:02x?}", &message_data[0..16]);
-            let nl_type = u16::from_le_bytes([message_data[4], message_data[5]]);
-            let nl_flags = u16::from_le_bytes([message_data[6], message_data[7]]);
-            let nl_seq = u32::from_le_bytes([message_data[8], message_data[9], message_data[10], message_data[11]]);
-            let nl_pid = u32::from_le_bytes([message_data[12], message_data[13], message_data[14], message_data[15]]);
-            debug!("  nl_len={}, nl_type={}, nl_flags=0x{:04x}, nl_seq={}, nl_pid={}", 
-                   nl_len, nl_type, nl_flags, nl_seq, nl_pid);
+            debug!(
+                "Netlink Header ({} bytes): {:02x?}",
+                NLMSG_HDRLEN,
+                &message_data[..NLMSG_HDRLEN]
+            );
+            let nl_type = u16::from_le_bytes(message_data[NLMSG_TYPE].try_into().unwrap());
+            let nl_flags = u16::from_le_bytes(message_data[NLMSG_FLAGS].try_into().unwrap());
+            let nl_seq = u32::from_le_bytes(message_data[NLMSG_SEQ].try_into().unwrap());
+            let nl_pid = u32::from_le_bytes(message_data[NLMSG_PID].try_into().unwrap());
+            debug!(
+                "  nl_len={}, nl_type={}, nl_flags=0x{:04x}, nl_seq={}, nl_pid={}",
+                nl_len, nl_type, nl_flags, nl_seq, nl_pid
+            );
 
             if message_data.len() >= TOTAL_HEADER_SIZE {
-                debug!("Generic Netlink Header (4 bytes): {:02x?}", &message_data[16..20]);
-                let genl_cmd = message_data[16];
-                let genl_version = message_data[17];
-                let genl_reserved = u16::from_le_bytes([message_data[18], message_data[19]]);
-                debug!("  genl_cmd={}, genl_version={}, genl_reserved=0x{:04x}", 
-                       genl_cmd, genl_version, genl_reserved);
+                debug!(
+                    "Generic Netlink Header ({} bytes): {:02x?}",
+                    GENL_HDRLEN,
+                    &message_data[NLMSG_HDRLEN..TOTAL_HEADER_SIZE]
+                );
+                let genl_cmd = message_data[GENL_CMD];
+                let genl_version = message_data[GENL_VERSION];
+                let genl_reserved =
+                    u16::from_le_bytes(message_data[GENL_RESERVED].try_into().unwrap());
+                debug!(
+                    "  genl_cmd={}, genl_version={}, genl_reserved=0x{:04x}",
+                    genl_cmd, genl_version, genl_reserved
+                );
             }
         }
 
@@ -254,7 +323,7 @@ pub struct DataNetlinkActor {
     buffer_recipients: LinkedList<Sender<SocketBufferMessage>>,
     /// Channel for receiving control commands
     command_recipient: Receiver<NetlinkCommand>,
-    /// Message parser for handling multiple and fragmented netlink messages
+    /// Message parser for handling one or more netlink messages in each datagram
     message_parser: NetlinkMessageParser,
     /// Netlink socket receive buffer size in bytes (0 = OS default). Reduces ENOBUFS when set.
     netlink_rcvbuf_bytes: usize,
@@ -263,6 +332,90 @@ pub struct DataNetlinkActor {
 }
 
 impl DataNetlinkActor {
+    fn recvmsg_into(
+        fd: std::os::unix::io::RawFd,
+        buffer: &mut [u8],
+        flags: i32,
+    ) -> Result<(usize, i32), io::Error> {
+        let mut iov = libc::iovec {
+            iov_base: buffer.as_mut_ptr() as *mut libc::c_void,
+            iov_len: buffer.len(),
+        };
+        let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
+        msg.msg_iov = &mut iov;
+        msg.msg_iovlen = 1;
+
+        // Safe on the Tokio worker because the fd is configured as non-blocking by connect().
+        let size = unsafe { libc::recvmsg(fd, &mut msg, flags) };
+        if size < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok((size as usize, msg.msg_flags))
+        }
+    }
+
+    fn recv_datagram_fd(
+        fd: std::os::unix::io::RawFd,
+        max_size: usize,
+    ) -> Result<Vec<u8>, io::Error> {
+        let mut peek_buffer = [0u8; 1];
+        // Peek first to size the receive buffer exactly and to make truncation observable. A fixed
+        // large buffer would either waste memory in the hot path or still silently truncate when a
+        // producer emits a larger datagram than expected.
+        let (needed, peek_flags) =
+            Self::recvmsg_into(fd, &mut peek_buffer, libc::MSG_PEEK | libc::MSG_TRUNC)?;
+
+        if needed == 0 {
+            let _ = Self::recvmsg_into(fd, &mut peek_buffer, 0);
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Received empty netlink datagram",
+            ));
+        }
+
+        if needed > max_size {
+            let mut drain_buffer = [0u8; 1];
+            if let Err(err) = Self::recvmsg_into(fd, &mut drain_buffer, libc::MSG_TRUNC) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "Failed to drain oversized netlink datagram of {} bytes: {}",
+                        needed, err
+                    ),
+                ));
+            }
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "Netlink datagram length {} exceeds maximum supported {} bytes",
+                    needed, max_size
+                ),
+            ));
+        }
+
+        let mut buffer = vec![0u8; needed];
+        let (size, flags) = Self::recvmsg_into(fd, &mut buffer, 0)?;
+        if flags & libc::MSG_TRUNC != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "Truncated netlink datagram: buffer={} bytes, received={} bytes, peek_flags=0x{:x}",
+                    buffer.len(),
+                    size,
+                    peek_flags
+                ),
+            ));
+        }
+
+        buffer.truncate(size);
+        Ok(buffer)
+    }
+
+    #[cfg(not(test))]
+    fn recv_netlink_datagram(socket: &mut SocketType) -> Result<Vec<u8>, io::Error> {
+        Self::recv_datagram_fd(socket.as_raw_fd(), MAX_NETLINK_DATAGRAM_SIZE)
+    }
+
     /// Creates a new DataNetlinkActor instance.
     ///
     /// # Arguments
@@ -436,6 +589,8 @@ impl DataNetlinkActor {
             return None;
         }
 
+        netlink_utils::set_socket_rcvbuf(&socket, self.netlink_rcvbuf_bytes);
+
         debug!("Adding multicast membership for group_id {}", group_id);
         if let Err(e) = socket.add_membership(group_id) {
             warn!(
@@ -453,13 +608,14 @@ impl DataNetlinkActor {
             return None;
         }
 
-        netlink_utils::set_socket_rcvbuf(&socket, self.netlink_rcvbuf_bytes);
-
         info!(
             "Successfully connected to family '{}', group '{}' with group_id: {}",
             family, group, group_id
         );
-        debug!("Socket created successfully, ready to receive multicast messages on group_id: {}", group_id);
+        debug!(
+            "Socket created successfully, ready to receive multicast messages on group_id: {}",
+            group_id
+        );
         Some(socket)
     }
 
@@ -511,7 +667,8 @@ impl DataNetlinkActor {
             "Temporary socket created, resolving group ID for family '{}', group '{}'",
             family, group
         );
-        let group_id = match netlink_utils::resolve_multicast_group(&mut temp_socket, family, group) {
+        let group_id = match netlink_utils::resolve_multicast_group(&mut temp_socket, family, group)
+        {
             Ok(id) => {
                 debug!(
                     "Resolved group ID {} for family '{}', group '{}'",
@@ -553,6 +710,8 @@ impl DataNetlinkActor {
             return None;
         }
 
+        netlink_utils::set_socket_rcvbuf(&socket, netlink_rcvbuf_bytes);
+
         debug!("Adding multicast membership for group_id {}", group_id);
         if let Err(e) = socket.add_membership(group_id) {
             warn!(
@@ -568,20 +727,21 @@ impl DataNetlinkActor {
             return None;
         }
 
-        netlink_utils::set_socket_rcvbuf(&socket, netlink_rcvbuf_bytes);
-
         info!(
             "Successfully connected to family '{}', group '{}' with group_id: {}",
             family, group, group_id
         );
-        debug!("Socket created successfully, ready to receive multicast messages on group_id: {}", group_id);
+        debug!(
+            "Socket created successfully, ready to receive multicast messages on group_id: {}",
+            group_id
+        );
         Some(socket)
     }
 
     /// Attempts to establish a connection on demand.
     ///
     /// This will be called when receiving a Reconnect or SoftReconnect command from ControlNetlinkActor.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `force` - If true, always reconnect regardless of socket health status.
@@ -600,9 +760,9 @@ impl DataNetlinkActor {
                     warn!(
                         "Socket unhealthy - no data received for {} seconds, forcing reconnection",
                         time_since_last_data.as_secs()
-                        );
-                        // Close the unhealthy socket
-                        self.socket = None;
+                    );
+                    // Close the unhealthy socket
+                    self.socket = None;
                 } else {
                     info!(
                         "Socket healthy - data received {} seconds ago, skipping reconnect",
@@ -676,82 +836,60 @@ impl DataNetlinkActor {
     ///
     /// Returns immediately with WouldBlock if no data is available, allowing
     /// the event loop to handle other operations concurrently.
-    /// 
+    ///
     /// This function handles multiple scenarios:
     /// 1. Single complete message in one recv
-    /// 2. Multiple complete messages in one recv  
-    /// 3. Incomplete message that needs to be combined with future recv data
+    /// 2. Multiple complete messages in one recv
+    /// 3. Truncated or malformed datagrams, which are rejected without splicing future recv data
     async fn try_recv(
-        socket: Option<&mut SocketType>, 
-        message_parser: &mut NetlinkMessageParser
+        socket: Option<&mut SocketType>,
+        message_parser: &mut NetlinkMessageParser,
     ) -> Result<Vec<SocketBufferMessage>, io::Error> {
         let socket = socket
             .ok_or_else(|| io::Error::new(io::ErrorKind::NotConnected, "No socket available"))?;
 
-        let mut buffer = vec![0; BUFFER_SIZE];
-
         // Try to receive with non-blocking mode (socket should already be set to non-blocking)
         debug!("Attempting to receive netlink message...");
         #[cfg(not(test))]
-        let result = {
-            let fd = socket.as_raw_fd();
-            // Safe on the Tokio worker because the fd is already configured as non-blocking.
-            unsafe {
-                libc::recv(
-                    fd,
-                    buffer.as_mut_ptr() as *mut libc::c_void,
-                    buffer.len(),
-                    0
-                )
-            }
-        };
+        let recv_result = Self::recv_netlink_datagram(socket);
 
         #[cfg(test)]
-        let result = match socket.recv(&mut buffer, 0) {
-            Ok(size) => size as isize,
-            Err(e) => {
-                return Err(e);
-            }
+        let recv_result = {
+            let mut buffer = vec![0; BUFFER_SIZE];
+            socket.recv(&mut buffer, 0).map(|size| {
+                buffer.truncate(size);
+                buffer
+            })
         };
 
-        match result {
-            size if size > 0 => {
-                let size = size as usize;
+        match recv_result {
+            Ok(buffer) => {
+                let size = buffer.len();
                 debug!("Received netlink data, size: {} bytes", size);
 
                 if size == 0 {
                     return Err(io::Error::new(
-                        io::ErrorKind::UnexpectedEof,
-                        "No more data to receive",
+                        io::ErrorKind::InvalidData,
+                        "Received empty netlink datagram",
                     ));
                 }
 
-                // Resize buffer to actual received size
-                buffer.resize(size, 0);
-
                 if log::log_enabled!(log::Level::Debug) {
                     let hex_dump = format_hex_lines(&buffer);
-                    debug!(
-                        "Raw netlink recv buffer ({} bytes):\n{}",
-                        size, hex_dump
-                    );
+                    debug!("Raw netlink recv buffer ({} bytes):\n{}", size, hex_dump);
                 }
 
                 // Parse buffer which may contain multiple messages and/or incomplete messages
                 let messages = message_parser.parse_buffer(&buffer)?;
-                debug!("Parsed {} complete messages from {} bytes of data", messages.len(), size);
+                debug!(
+                    "Parsed {} complete messages from {} bytes of data",
+                    messages.len(),
+                    size
+                );
 
                 Ok(messages)
             }
-            size if size == 0 => {
-                Err(io::Error::new(
-                    io::ErrorKind::UnexpectedEof,
-                    "Connection closed",
-                ))
-            }
-            _ => {
-                // size < 0, errno is set
-                let err = io::Error::last_os_error();
+            Err(err) => {
                 // WouldBlock is expected for non-blocking sockets with no data
                 // Only log other errors
                 if err.kind() != io::ErrorKind::WouldBlock {
@@ -842,7 +980,7 @@ impl DataNetlinkActor {
                                 actor.last_data_time = Instant::now();
 
                                 if messages.is_empty() {
-                                    debug!("Received data but no complete messages yet (partial message)");
+                                    debug!("Received netlink datagram but no complete payload was extracted");
                                 } else {
                                     debug!("Successfully parsed {} complete netlink messages", messages.len());
 
@@ -893,6 +1031,8 @@ impl DataNetlinkActor {
                                     if heartbeat_counter % wouldblock_interval == 0 {
                                         debug!("No netlink data available (WouldBlock) - socket is connected but no messages from kernel");
                                     }
+                                } else if e.kind() == io::ErrorKind::InvalidData {
+                                    warn!("Dropping invalid netlink datagram: {:?}", e);
                                 } else {
                                     warn!("Failed to receive message: {:?}", e);
                                     actor.disconnect();
@@ -943,7 +1083,17 @@ pub mod test {
         msg[..actual_len].to_vec()
     }
 
-    // Test constants for simulating different message scenarios  
+    fn create_large_mock_netlink_message(payload: &[u8]) -> Vec<u8> {
+        let total_len = 20 + payload.len();
+        let mut msg = vec![0u8; total_len];
+        msg[0..4].copy_from_slice(&(total_len as u32).to_le_bytes());
+        msg[4..6].copy_from_slice(&0x10u16.to_le_bytes());
+        msg[16] = 0x01;
+        msg[20..].copy_from_slice(payload);
+        msg
+    }
+
+    // Test constants for simulating different message scenarios
     fn get_partially_valid_messages() -> Vec<Vec<u8>> {
         vec![
             create_test_message(b"PARTIALLY_VALID1"),
@@ -1216,11 +1366,8 @@ pub mod test {
         let mut parser = NetlinkMessageParser::new();
 
         let result = parser.parse_buffer(&buffer);
-        assert!(result.is_ok());
-
-        // Should have no complete messages due to insufficient data
-        let messages = result.unwrap();
-        assert!(messages.is_empty());
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::InvalidData);
     }
 
     /// Tests handling multiple messages in one buffer.
@@ -1270,34 +1417,54 @@ pub mod test {
         assert_eq!(String::from_utf8(messages[1].to_vec()).unwrap(), "SECOND");
     }
 
-    /// Tests handling fragmented messages across multiple recv operations.
     #[test]
-    fn test_fragmented_message() {
-        let msg = create_mock_netlink_message(b"FRAGMENTED_MESSAGE");
-        let msg_len = 20 + b"FRAGMENTED_MESSAGE".len();
+    fn test_trailing_zero_bytes_larger_than_alignment_padding_are_discarded() {
+        let mut buffer = create_mock_netlink_message(b"COMPLETE").to_vec();
+        buffer.truncate(20 + b"COMPLETE".len());
+        buffer.extend_from_slice(&[0; 4]);
+
+        let mut parser = NetlinkMessageParser::new();
+        let messages = parser.parse_buffer(&buffer).unwrap();
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].as_ref(), b"COMPLETE");
+    }
+
+    #[test]
+    fn test_zero_bytes_larger_than_alignment_padding_are_rejected() {
+        let mut parser = NetlinkMessageParser::new();
+        let result = parser.parse_buffer(&[0; 4]);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// Tests that a truncated datagram is never spliced with the next datagram.
+    ///
+    /// Without the fix, parse_buffer() keeps the first truncated datagram in an
+    /// incomplete buffer and combines it with the next recv, producing one
+    /// corrupted payload instead of dropping the truncated datagram.
+    #[test]
+    fn test_truncated_datagram_is_not_spliced_with_next_datagram() {
+        let first_payload = vec![b'A'; BUFFER_SIZE + 3200];
+        let first_datagram = create_large_mock_netlink_message(&first_payload);
+        let second_datagram = create_large_mock_netlink_message(b"SECOND_DATAGRAM");
         let mut parser = NetlinkMessageParser::new();
 
-        // Simulate first recv getting only part of the message
-        let first_part = &msg[..15]; // Less than header size
-        let result1 = parser.parse_buffer(first_part);
-        assert!(result1.is_ok());
-        let messages1 = result1.unwrap();
-        assert!(messages1.is_empty()); // No complete messages yet
+        let result1 = parser.parse_buffer(&first_datagram[..BUFFER_SIZE]);
+        assert!(result1.is_err());
+        assert_eq!(result1.unwrap_err().kind(), io::ErrorKind::InvalidData);
 
-        // Simulate second recv getting the rest
-        let second_part = &msg[15..msg_len];
-        let result2 = parser.parse_buffer(second_part);
+        let result2 = parser.parse_buffer(&second_datagram);
         assert!(result2.is_ok());
         let messages2 = result2.unwrap();
         assert_eq!(messages2.len(), 1);
-
-        let payload_str = String::from_utf8(messages2[0].to_vec()).unwrap();
-        assert_eq!(payload_str, "FRAGMENTED_MESSAGE");
+        assert_eq!(messages2[0].as_ref(), b"SECOND_DATAGRAM");
     }
 
-    /// Tests handling mixed scenario: complete message + partial message.
+    /// Tests handling a datagram with a complete message followed by a truncated message.
     #[test]
-    fn test_mixed_complete_and_partial() {
+    fn test_complete_message_followed_by_truncated_message_is_rejected() {
         let mut combined_buffer = Vec::new();
 
         // First complete message
@@ -1311,25 +1478,100 @@ pub mod test {
         combined_buffer.extend_from_slice(&msg2[..25]); // Only part of second message
 
         let mut parser = NetlinkMessageParser::new();
-        let result1 = parser.parse_buffer(&combined_buffer);
-        assert!(result1.is_ok());
+        let result = parser.parse_buffer(&combined_buffer);
+        assert!(result.is_ok());
+        let messages = result.unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].as_ref(), b"COMPLETE");
 
-        let messages1 = result1.unwrap();
-        assert_eq!(messages1.len(), 1); // Only first complete message
+        // The next datagram must be parsed independently, not as a continuation.
+        let result = parser.parse_buffer(&msg2[..msg2_len]);
+        assert!(result.is_ok());
+        let messages = result.unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].as_ref(), b"PARTIAL_MSG");
+    }
 
-        let payload1_str = String::from_utf8(messages1[0].to_vec()).unwrap();
-        assert_eq!(payload1_str, "COMPLETE");
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_recv_datagram_larger_than_default_buffer() {
+        use std::os::unix::net::UnixDatagram;
 
-        // Send remaining part of second message
-        let remaining_part = &msg2[25..msg2_len];
-        let result2 = parser.parse_buffer(remaining_part);
-        assert!(result2.is_ok());
+        let (tx, rx) = UnixDatagram::pair().unwrap();
+        let payload = vec![0xab; BUFFER_SIZE + 4096];
+        tx.send(&payload).unwrap();
 
-        let messages2 = result2.unwrap();
-        assert_eq!(messages2.len(), 1); // Second message now complete
+        let received =
+            DataNetlinkActor::recv_datagram_fd(rx.as_raw_fd(), MAX_NETLINK_DATAGRAM_SIZE).unwrap();
 
-        let payload2_str = String::from_utf8(messages2[0].to_vec()).unwrap();
-        assert_eq!(payload2_str, "PARTIAL_MSG");
+        assert_eq!(received, payload);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_recv_datagram_larger_than_max_size_is_drained() {
+        use std::os::unix::net::UnixDatagram;
+
+        let (tx, rx) = UnixDatagram::pair().unwrap();
+        let payload = vec![0xef; BUFFER_SIZE + 4096];
+        let next_payload = b"NEXT";
+        tx.send(&payload).unwrap();
+        tx.send(next_payload).unwrap();
+
+        let result = DataNetlinkActor::recv_datagram_fd(rx.as_raw_fd(), BUFFER_SIZE);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::InvalidData);
+
+        let received = DataNetlinkActor::recv_datagram_fd(rx.as_raw_fd(), BUFFER_SIZE).unwrap();
+        assert_eq!(received, next_payload);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_recv_datagram_empty_is_invalid_and_drained() {
+        use std::os::unix::net::UnixDatagram;
+
+        let (tx, rx) = UnixDatagram::pair().unwrap();
+        let next_payload = b"NEXT";
+        tx.send(&[]).unwrap();
+        tx.send(next_payload).unwrap();
+
+        let result = DataNetlinkActor::recv_datagram_fd(rx.as_raw_fd(), BUFFER_SIZE);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::InvalidData);
+
+        let received = DataNetlinkActor::recv_datagram_fd(rx.as_raw_fd(), BUFFER_SIZE).unwrap();
+        assert_eq!(received, next_payload);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_plain_recvmsg_reports_truncation() {
+        use std::os::unix::net::UnixDatagram;
+
+        let (tx, rx) = UnixDatagram::pair().unwrap();
+        let payload = vec![0xcd; BUFFER_SIZE + 4096];
+        tx.send(&payload).unwrap();
+
+        let mut buffer = vec![0u8; BUFFER_SIZE];
+        let (size, flags) = DataNetlinkActor::recvmsg_into(rx.as_raw_fd(), &mut buffer, 0).unwrap();
+
+        assert_eq!(size, BUFFER_SIZE);
+        assert_ne!(flags & libc::MSG_TRUNC, 0);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_recv_datagram_fd_propagates_wouldblock() {
+        use std::os::unix::net::UnixDatagram;
+
+        let (_tx, rx) = UnixDatagram::pair().unwrap();
+        rx.set_nonblocking(true).unwrap();
+
+        let result = DataNetlinkActor::recv_datagram_fd(rx.as_raw_fd(), BUFFER_SIZE);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::WouldBlock);
     }
 
     /// Tests the get_genl_family_group function with a valid constants file.
@@ -1404,12 +1646,21 @@ pub mod test {
             let heartbeat = (HEARTBEAT_TARGET_MS / poll_ms).max(1);
             let debug = (DEBUG_TARGET_MS / poll_ms).max(1);
             let wouldblock = (WOULDBLOCK_TARGET_MS / poll_ms).max(1);
-            assert_eq!(heartbeat * poll_ms, HEARTBEAT_TARGET_MS, "poll_ms={}", poll_ms);
+            assert_eq!(
+                heartbeat * poll_ms,
+                HEARTBEAT_TARGET_MS,
+                "poll_ms={}",
+                poll_ms
+            );
             assert_eq!(debug * poll_ms, DEBUG_TARGET_MS, "poll_ms={}", poll_ms);
-            assert_eq!(wouldblock * poll_ms, WOULDBLOCK_TARGET_MS, "poll_ms={}", poll_ms);
+            assert_eq!(
+                wouldblock * poll_ms,
+                WOULDBLOCK_TARGET_MS,
+                "poll_ms={}",
+                poll_ms
+            );
         }
     }
-
 }
 
 /// Reads the Generic Netlink family and group names from the configuration file.

--- a/fpmsyncd/Makefile.am
+++ b/fpmsyncd/Makefile.am
@@ -13,7 +13,7 @@ fpmsyncd_SOURCES = fpmsyncd.cpp fpmlink.cpp routesync.cpp $(top_srcdir)/warmrest
 
 fpmsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
 fpmsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
-fpmsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon -lnexthopgroup
+fpmsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon
 
 if GCOV_ENABLED
 fpmsyncd_SOURCES += ../gcovpreload/gcovpreload.cpp

--- a/orchagent/dash/dashhaorch.cpp
+++ b/orchagent/dash/dashhaorch.cpp
@@ -733,8 +733,12 @@ void DashHaOrch::updateHaScopeStateForSwitchOwner(const std::string &key, const 
 
     std::string ha_set_id = entry.ha_set_id().empty() ? key : entry.ha_set_id();
     auto ha_set_it = m_ha_set_entries.find(ha_set_id);
-    if (ha_set_it == m_ha_set_entries.end() ||
-        ha_set_it->second.metadata.owner() != dash::types::HA_OWNER_SWITCH)
+    if (ha_set_it == m_ha_set_entries.end())
+    {
+        SWSS_LOG_WARN("HA Set entry %s does not exist, still updating HA Scope state for %s",
+                      ha_set_id.c_str(), key.c_str());
+    }
+    else if (ha_set_it->second.metadata.owner() != dash::types::HA_OWNER_SWITCH)
     {
         return;
     }

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -193,6 +193,11 @@ void IntfsOrch::decreaseRouterIntfsRefCount(const string &alias)
                   alias.c_str(), m_syncdIntfses[alias].ref_count);
 }
 
+bool IntfsOrch::isIntfChangeInProgress(const string &alias)
+{
+    return m_removingIntfses.find(alias) != m_removingIntfses.end();
+}
+
 bool IntfsOrch::setRouterIntfsMpls(const Port &port)
 {
     SWSS_LOG_ENTER();

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -862,7 +862,10 @@ void IntfsOrch::doTask(Consumer &consumer)
                         }
                         else
                         {
-                            SWSS_LOG_ERROR("Failed to set interface '%s' to VRF ID '%d' because it has IP addresses associated with it.", alias.c_str(), vrf_id);
+                            SWSS_LOG_NOTICE("Interface '%s' still has %zu IP address(es); deferring VRF '%s' bind until pending IP removals are processed.",
+                                          alias.c_str(), m_syncdIntfses[alias].ip_addresses.size(), vrf_name.c_str());
+                            it++;
+                            continue;
                         }
                     }
                 }

--- a/orchagent/intfsorch.h
+++ b/orchagent/intfsorch.h
@@ -74,6 +74,8 @@ public:
     bool isLocalSystemPortIntf(string alias);
     void voqSyncIntfState(string &alias, bool);
 
+    bool isIntfChangeInProgress(const string &alias);
+
 private:
 
     SelectableTimer* m_updateMapsTimer = nullptr;

--- a/orchagent/macsecorch.cpp
+++ b/orchagent/macsecorch.cpp
@@ -1115,6 +1115,29 @@ task_process_status MACsecOrch::taskUpdateEgressSA(
         }
         else
         {
+            // wpa_supplicant's macsec_sonic create_transmit_sa() writes the
+            // full SA payload (sak/salt/ssci/auth_key/next_pn) to
+            // MACSEC_EGRESS_SA_TABLE. After a dirty macsec docker restart with
+            // surviving orchagent state, the SA pre-exists with the prior
+            // cycle's SAK programmed in hardware.
+            //
+            // Detect re-key by the presence of "sak" in this SET and do
+            // delete+recreate using THIS sa_attr's key material -- mirroring
+            // the ingress re-key path in taskUpdateIngressSA.
+            MACsecSAK probe_sak = {{0}, false};
+            if (get_value(sa_attr, "sak", probe_sak))
+            {
+                auto del_status = deleteMACsecSA(port_sci_an, SAI_MACSEC_DIRECTION_EGRESS);
+                if (del_status != task_success)
+                {
+                    SWSS_LOG_WARN(
+                        "[macsec-rekey] egress SA %s: delete step failed during re-key",
+                        port_sci_an.c_str());
+                    return del_status;
+                }
+                return createMACsecSA(port_sci_an, sa_attr, SAI_MACSEC_DIRECTION_EGRESS);
+            }
+
             // The MACsec SA has enabled, update SA's attributes
             sai_uint64_t pn;
 
@@ -1175,6 +1198,27 @@ task_process_status MACsecOrch::taskUpdateIngressSA(
         {
             if (has_active_field)
             {
+                // wpa_supplicant's macsec_sonic driver installs a new ingress SA
+                // in two stages: stage-1 writes active=false + full key material
+                // (sak/salt/ssci/auth_key/lowest_acceptable_pn); stage-2 writes
+                // active=true only. After a macsec docker restart with surviving
+                // orchagent state, the SA already exists.
+                //
+                // Detect the re-key case by the presence of "sak" in this SET
+                // and do delete+recreate atomically using the SAK from THIS sa_attr.
+                MACsecSAK probe_sak = {{0}, false};
+                if (get_value(sa_attr, "sak", probe_sak))
+                {
+                    auto del_status = deleteMACsecSA(port_sci_an, SAI_MACSEC_DIRECTION_INGRESS);
+                    if (del_status != task_success)
+                    {
+                        SWSS_LOG_WARN(
+                            "[macsec-rekey] ingress SA %s: delete step failed during re-key",
+                            port_sci_an.c_str());
+                        return del_status;
+                    }
+                    return createMACsecSA(port_sci_an, sa_attr, SAI_MACSEC_DIRECTION_INGRESS);
+                }
                 // Delete MACsec SA explicitly by set active to false
                 return deleteMACsecSA(port_sci_an, SAI_MACSEC_DIRECTION_INGRESS);
             }
@@ -1898,9 +1942,9 @@ task_process_status MACsecOrch::updateMACsecSC(
             return task_failed;
         }
     }
-    else
+    else if (direction == SAI_MACSEC_DIRECTION_EGRESS)
     {
-        if (!setEncodingAN(*ctx.get_macsec_sc(), sc_attr, direction))
+        if (!setEncodingAN(*ctx.get_macsec_sc(), sc_attr, direction, port_sci))
         {
             return task_failed;
         }
@@ -1912,21 +1956,67 @@ task_process_status MACsecOrch::updateMACsecSC(
 bool MACsecOrch::setEncodingAN(
     MACsecSC &sc,
     const TaskArgs &sc_attr,
-    sai_macsec_direction_t direction)
+    sai_macsec_direction_t direction,
+    const std::string &port_sci)
 {
-    if (direction == SAI_MACSEC_DIRECTION_EGRESS)
-    {
-        if (!get_value(sc_attr, "encoding_an", sc.m_encoding_an))
-        {
-            SWSS_LOG_WARN("Wrong parameter, the encoding AN cannot be found");
-            return false;
-        }
-    }
-    else
+    SWSS_LOG_ENTER();
+
+    if (direction != SAI_MACSEC_DIRECTION_EGRESS)
     {
         SWSS_LOG_WARN("Cannot set encoding AN for the ingress SC");
         return false;
     }
+
+    macsec_an_t new_an;
+    if (!get_value(sc_attr, "encoding_an", new_an))
+    {
+        SWSS_LOG_WARN("setEncodingAN: 'encoding_an' field missing in SET on egress SC");
+        return false;
+    }
+
+    if (sc.m_encoding_an == new_an)
+    {
+        return true;
+    }
+
+    macsec_an_t old_an = sc.m_encoding_an;
+    sc.m_encoding_an = new_an;
+
+    // The "one egress SA per SC" invariant depends on wpa_supplicant calling
+    // delete_transmit_sa() for the prior AN after enable_transmit_sa() on the
+    // new one. A dirty `docker restart macsec` kills wpa between those two
+    // steps, so the prior AN's SA leaks. The fresh wpa negotiates a new SAK
+    // on a different AN and we re-enter this function with new_an != old_an
+    // while the prior AN's SA is still in sc.m_sa_ids and in SAI. With two
+    // installed SAs and ENCODING_AN not actually programmed in SAI, the HW
+    // picks the wrong one (driver default) and the peer drops every frame.
+    //
+    // Sweep any non-current ANs out of SAI, FLEX_COUNTER_DB, COUNTERS_DB, and
+    // STATE_DB.  Collect stale ANs first so that deleteMACsecSA's internal
+    // m_sa_ids.erase() doesn't invalidate the iterator mid-loop.
+    std::vector<macsec_an_t> stale_ans;
+    for (const auto &kv : sc.m_sa_ids)
+    {
+        if (kv.first != new_an)
+            stale_ans.push_back(kv.first);
+    }
+    for (const auto stale_an : stale_ans)
+    {
+        SWSS_LOG_NOTICE(
+            "[macsec-rekey] egress SC encoding_an %u -> %u: purging stale "
+            "SA at AN=%u (oid:0x%" PRIx64 ")",
+            old_an, new_an, stale_an, sc.m_sa_ids.at(stale_an));
+
+        const std::string port_sci_an = swss::join(':', port_sci, stale_an);
+        auto del_status = deleteMACsecSA(port_sci_an, SAI_MACSEC_DIRECTION_EGRESS);
+        if (del_status != task_success)
+        {
+            SWSS_LOG_WARN(
+                "[macsec-rekey] failed to delete stale egress SA at AN=%u",
+                stale_an);
+        }
+    }
+
     return true;
 }
 
@@ -2240,8 +2330,31 @@ task_process_status MACsecOrch::createMACsecSA(
 
     if (ctx.get_macsec_sa() != nullptr)
     {
-        SWSS_LOG_NOTICE("The MACsec SA %s has been created.", port_sci_an.c_str());
-        return task_success;
+        // Defense-in-depth for dirty macsec docker restart: if a SET arrives
+        // for an existing SA carrying a SAK, treat it as a re-key. We do not
+        // store the SAK in orchagent memory (and SAI_MACSEC_SA_ATTR_SAK is
+        // create-only), so we cannot diff; recreate unconditionally when SAK
+        // is present. Without this, stale SAKs from a previous MKA cycle stay
+        // programmed in hardware after the macsec docker restarts, and ICV
+        // validation fails for every received frame.
+        MACsecSAK probe_sak = {{0}, false};
+        if (!get_value(sa_attr, "sak", probe_sak))
+        {
+            return task_success;
+        }
+        auto del_status = deleteMACsecSA(port_sci_an, direction);
+        if (del_status != task_success)
+        {
+            SWSS_LOG_WARN(
+                "[macsec-rekey] %s SA %s: delete step failed during re-key",
+                (direction == SAI_MACSEC_DIRECTION_EGRESS) ? "egress" : "ingress",
+                port_sci_an.c_str());
+            return del_status;
+        }
+        // Recurse: with the old SA gone from MACsecSC::m_sa_ids, ctx.get_macsec_sa()
+        // returns nullptr on this call and execution falls through to the create
+        // path with the new key material from sa_attr.
+        return createMACsecSA(port_sci_an, sa_attr, direction);
     }
 
     if (ctx.get_macsec_sc() == nullptr)
@@ -2401,6 +2514,35 @@ task_process_status MACsecOrch::deleteMACsecSA(
 
     if (ctx.get_macsec_sa() == nullptr)
     {
+        // SA may have been pre-emptively swept from m_sa_ids by setEncodingAN
+        // (SAI object already removed) without cleaning up STATE_DB or counters.
+        // Do both here so the DEL task leaves no stale entries.
+
+        // STATE_DB cleanup.
+        if (direction == SAI_MACSEC_DIRECTION_EGRESS)
+        {
+            m_state_macsec_egress_sa.del(swss::join('|', port_name, sci, an));
+        }
+        else
+        {
+            m_state_macsec_ingress_sa.del(swss::join('|', port_name, sci, an));
+        }
+
+        // Counter cleanup: recover the OID from the COUNTERS_DB name→OID map
+        // (written by installCounter) and tear down the flex-counter entries.
+        std::string oid_str;
+        if (MACsecCountersMap(ctx).hget("", port_sci_an, oid_str))
+        {
+            sai_object_id_t swept_oid = SAI_NULL_OBJECT_ID;
+            sai_deserialize_object_id(oid_str, swept_oid);
+            if (swept_oid != SAI_NULL_OBJECT_ID)
+            {
+                MACsecSaAttrStatManager(ctx).clearCounterIdList(swept_oid);
+                MACsecSaStatManager(ctx).clearCounterIdList(swept_oid);
+            }
+        }
+        MACsecCountersMap(ctx).hdel("", port_sci_an);
+
         SWSS_LOG_INFO("MACsec SA %s has been deleted.", port_sci_an.c_str());
         return task_success;
     }

--- a/orchagent/macsecorch.h
+++ b/orchagent/macsecorch.h
@@ -175,7 +175,8 @@ private:
     bool setEncodingAN(
         MACsecSC &sc,
         const TaskArgs &sc_attr,
-        sai_macsec_direction_t direction);
+        sai_macsec_direction_t direction,
+        const std::string &port_sci);
     bool createMACsecSC(
         MACsecPort &macsec_port,
         const std::string &port_name,

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -1041,5 +1041,21 @@ int main(int argc, char **argv)
 
     orchDaemon->start(heartBeatInterval);
 
+    /*
+     * On SIGTERM/SIGINT the signal handler sets gOrchShutdownRequested and
+     * start() returns. Do not fall through to `return 0;`: running ~OrchDaemon
+     * and its member destructors is unsafe here. FlexCounterManager destruction
+     * issues SAI calls (stopFlexCounterPolling -> set_switch_attribute) that
+     * round-trip through sairedis's ZMQ channel and park the main thread in
+     * zmq_poll while libzmq I/O threads are still alive; orchs torn down earlier
+     * in the reverse-order loop have already freed buffers those threads still
+     * reference, corrupting the heap.
+     *
+     * Instead, drain the async swss recorder so pending records flush, then
+     * _exit() to let the kernel reclaim the rest of the process without the
+     * destructor chain.
+     */
+    exit_if_graceful_shutdown_requested();
+
     return 0;
 }

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -220,7 +220,9 @@ static sai_object_id_t create_tunnel(
     const IpAddress* p_src_ip,
     sai_object_id_t tc_to_dscp_map_id,
     sai_object_id_t tc_to_queue_map_id,
-    string dscp_mode_name)
+    string dscp_mode_name,
+    const string& ecn_mode_name,
+    const string& encap_ecn_mode_name)
 {
     sai_status_t status;
 
@@ -286,6 +288,35 @@ static sai_object_id_t create_tunnel(
         attr.id = SAI_TUNNEL_ATTR_DECAP_DSCP_MODE;
         attr.value.s32 = dscp_mode;
         tunnel_attrs.push_back(attr);
+    }
+
+    /* ECN: same semantics as TunnelDecapOrch::addDecapTunnel (CONFIG TUNNEL / APP TUNNEL_DECAP_TABLE) */
+    if (ecn_mode_name == "copy_from_outer")
+    {
+        attr.id = SAI_TUNNEL_ATTR_DECAP_ECN_MODE;
+        attr.value.s32 = SAI_TUNNEL_DECAP_ECN_MODE_COPY_FROM_OUTER;
+        tunnel_attrs.push_back(attr);
+    }
+    else if (ecn_mode_name == "standard")
+    {
+        attr.id = SAI_TUNNEL_ATTR_DECAP_ECN_MODE;
+        attr.value.s32 = SAI_TUNNEL_DECAP_ECN_MODE_STANDARD;
+        tunnel_attrs.push_back(attr);
+    }
+    else if (!ecn_mode_name.empty())
+    {
+        SWSS_LOG_ERROR("Invalid mux tunnel ecn_mode '%s'", ecn_mode_name.c_str());
+    }
+
+    if (encap_ecn_mode_name == "standard")
+    {
+        attr.id = SAI_TUNNEL_ATTR_ENCAP_ECN_MODE;
+        attr.value.s32 = SAI_TUNNEL_ENCAP_ECN_MODE_STANDARD;
+        tunnel_attrs.push_back(attr);
+    }
+    else if (!encap_ecn_mode_name.empty())
+    {
+        SWSS_LOG_ERROR("Unsupported mux tunnel encap_ecn_mode '%s'", encap_ecn_mode_name.c_str());
     }
 
     attr.id = SAI_TUNNEL_ATTR_LOOPBACK_PACKET_ACTION;
@@ -2685,6 +2716,18 @@ bool MuxOrch::handlePeerSwitch(const Request& request)
             SWSS_LOG_NOTICE("dscp_mode for tunnel %s is not available. Will not be applied", MUX_TUNNEL);
         }
 
+        string ecn_mode_name = decap_orch_->getEcnMode(MUX_TUNNEL);
+        if (ecn_mode_name == "")
+        {
+            SWSS_LOG_NOTICE("ecn_mode for tunnel %s is not available. ECN SAI attrs will not be set", MUX_TUNNEL);
+        }
+
+        string encap_ecn_mode_name = decap_orch_->getEncapEcnMode(MUX_TUNNEL);
+        if (encap_ecn_mode_name == "")
+        {
+            SWSS_LOG_NOTICE("encap_ecn_mode for tunnel %s is not available. Encap ECN will not be set", MUX_TUNNEL);
+        }
+
         // Read tc_to_dscp_map_id of MuxTunnel0 from decap_orch
         sai_object_id_t tc_to_dscp_map_id = SAI_NULL_OBJECT_ID;
         decap_orch_->getQosMapId(MUX_TUNNEL, encap_tc_to_dscp_field_name, tc_to_dscp_map_id);
@@ -2700,7 +2743,8 @@ bool MuxOrch::handlePeerSwitch(const Request& request)
             SWSS_LOG_NOTICE("tc_to_queue_map_id for tunnel %s is not available. Will not be applied", MUX_TUNNEL);
         }
 
-        mux_tunnel_id_ = create_tunnel(&peer_ip, &dst_ip, tc_to_dscp_map_id, tc_to_queue_map_id, dscp_mode_name);
+        mux_tunnel_id_ = create_tunnel(&peer_ip, &dst_ip, tc_to_dscp_map_id, tc_to_queue_map_id, dscp_mode_name,
+                                       ecn_mode_name, encap_ecn_mode_name);
         mux_peer_switch_ = peer_ip;
         SWSS_LOG_NOTICE("Mux peer ip '%s' was added, peer name '%s'",
                          peer_ip.to_string().c_str(), peer_name.c_str());

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -1098,6 +1098,39 @@ void OrchDaemon::start(long heartBeatInterval)
     }
 }
 
+#ifdef GCOV_ENABLED
+extern "C" void __gcov_dump(void);
+extern "C" void __gcov_reset(void);
+#endif
+
+void exit_if_graceful_shutdown_requested(void (*exit_fn)(int))
+{
+    if (gOrchShutdownRequested == 0)
+    {
+        return;
+    }
+
+    SWSS_LOG_NOTICE("Exiting on graceful shutdown request (signal %d) without running destructors", gOrchShutdownRequested);
+
+    /*
+     * Drain the async swss recorder before exiting: setAsync(false) stops the
+     * recorder worker only after any queued records have been written out.
+     */
+    Recorder::Instance().swss.setAsync(false);
+
+#ifdef GCOV_ENABLED
+    /*
+     * _exit() skips libgcov's exit hook, so persist coverage data explicitly.
+     * Reset the counters afterwards so a unit-test caller passing a
+     * non-exiting exit_fn still dumps the remainder of its run at exit.
+     */
+    __gcov_dump();
+    __gcov_reset(); // LCOV_EXCL_LINE (resets its own arc counter, so it can never self-report)
+#endif
+
+    exit_fn(0);
+}
+
 /*
  * Try to perform orchagent state restore and dynamic states sync up if
  * warm start request is detected.

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -1,6 +1,8 @@
 #ifndef SWSS_ORCHDAEMON_H
 #define SWSS_ORCHDAEMON_H
 
+#include <unistd.h>
+
 #include "dbconnector.h"
 #include "producerstatetable.h"
 #include "consumertable.h"
@@ -156,4 +158,15 @@ private:
     DBConnector *m_dpu_appDb;
     DBConnector *m_dpu_appstateDb;
 };
+
+/*
+ * If a graceful shutdown was requested (SIGTERM/SIGINT set
+ * gOrchShutdownRequested and OrchDaemon::start() returned), drain the async
+ * swss recorder so pending records are flushed and terminate the process via
+ * exit_fn without running the OrchDaemon destructor chain. No-op when no
+ * shutdown was requested. exit_fn is injectable for unit tests; production
+ * callers use the default _exit.
+ */
+void exit_if_graceful_shutdown_requested(void (*exit_fn)(int) = _exit);
+
 #endif /* SWSS_ORCHDAEMON_H */

--- a/orchagent/pfc_detect_mellanox.lua
+++ b/orchagent/pfc_detect_mellanox.lua
@@ -116,7 +116,9 @@ for i = n, 1, -1 do
                             (debug_storm == "enabled")
                             -- DEBUG CODE END.
                             then
-                            if time_left <= effective_poll_time then
+                            -- Allow up to 1% deviation from the configured detection time.
+                            local accumulated_detection_time = detection_time - time_left + effective_poll_time
+                            if accumulated_detection_time > detection_time * 0.99 then
                                 redis.call('HDEL', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key .. '_last')
                                 redis.call('HDEL', counters_table_name .. ':' .. port_id, pfc_duration_key .. '_last')
                                 local occupancy_string = '"occupancy","' .. tostring(occupancy_bytes) .. '",'

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -667,6 +667,13 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::unregisterFromWdDb(const Port& po
         // Clean up
         string countersKey = this->getCountersTable()->getTableName() + this->getCountersTable()->getTableNameSeparator() + sai_serialize_object_id(queueId);
         this->getCountersDb()->hdel(countersKey, {"PFC_WD_DETECTION_TIME", "PFC_WD_RESTORATION_TIME", "PFC_WD_ACTION", "PFC_WD_STATUS"});
+
+        // Drop this queue's PFC_WD_TABLE_INSTORM field so a stale row can't
+        // replay a phantom storm on warm restart.
+        string instormKey = m_applTable->getTableName()
+            + m_applTable->getTableNameSeparator()
+            + port.m_alias;
+        m_applDb->hdel(instormKey, to_string(i));
     }
 
 }

--- a/orchagent/port/portcnt.h
+++ b/orchagent/port/portcnt.h
@@ -211,6 +211,16 @@ public:
         } rxpolarity; // Port serdes RX polarity
 
         struct {
+            std::vector<std::uint32_t> value;
+            bool is_set = false;
+        } tx_precoding; // Port serdes tx_precoding (per-lane)
+
+        struct {
+            std::vector<std::uint32_t> value;
+            bool is_set = false;
+        } rx_precoding; // Port serdes rx_precoding (per-lane)
+
+        struct {
             std::string value;
             bool is_set = false;
         } custom_collection; // Port serdes custom_collection

--- a/orchagent/port/porthlpr.cpp
+++ b/orchagent/port/porthlpr.cpp
@@ -795,6 +795,8 @@ template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::regn_bfm1p) &se
 template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::regn_bfm1n) &serdes, const std::string &field, const std::string &value) const;
 template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::txpolarity) &serdes, const std::string &field, const std::string &value) const;
 template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::rxpolarity) &serdes, const std::string &field, const std::string &value) const;
+template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::tx_precoding) &serdes, const std::string &field, const std::string &value) const;
+template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::rx_precoding) &serdes, const std::string &field, const std::string &value) const;
 template bool PortHelper::parsePortSerdes(decltype(PortSerdes_t::custom_collection) &serdes, const std::string &field, const std::string &value) const;
 
 
@@ -1273,6 +1275,20 @@ bool PortHelper::parsePortConfig(PortConfig &port) const
         else if (serdes_field == PORT_RX_POLARITY)
         {
             if (!this->parsePortSerdes(serdes->rxpolarity, field, value))
+            {
+                return false;
+            }
+        }
+        else if (serdes_field == PORT_TX_PRECODING)
+        {
+            if (!this->parsePortSerdes(serdes->tx_precoding, field, value))
+            {
+                return false;
+            }
+        }
+        else if (serdes_field == PORT_RX_PRECODING)
+        {
+            if (!this->parsePortSerdes(serdes->rx_precoding, field, value))
             {
                 return false;
             }

--- a/orchagent/port/portschema.h
+++ b/orchagent/port/portschema.h
@@ -91,6 +91,8 @@
 #define PORT_REGN_BFM1N            "regn_bfm1n"
 #define PORT_TX_POLARITY            "txpolarity"
 #define PORT_RX_POLARITY            "rxpolarity"
+#define PORT_TX_PRECODING           "tx_precoding"
+#define PORT_RX_PRECODING           "rx_precoding"
 #define PORT_CUSTOM_SERDES_ATTRS   "custom_serdes_attrs"
 #define PORT_ROLE                  "role"
 #define PORT_ADMIN_STATUS          "admin_status"

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -569,6 +569,16 @@ static void getPortSerdesAttr(PortSerdesAttrMap_t &map, const decltype(PortConfi
     {
         map[SAI_PORT_SERDES_ATTR_RX_POLARITY] = SerdesValue(serdes.rxpolarity.value);
     }
+
+    if (serdes.tx_precoding.is_set)
+    {
+        map[SAI_PORT_SERDES_ATTR_TX_PRECODING] = SerdesValue(serdes.tx_precoding.value);
+    }
+
+    if (serdes.rx_precoding.is_set)
+    {
+        map[SAI_PORT_SERDES_ATTR_RX_PRECODING] = SerdesValue(serdes.rx_precoding.value);
+    }
 }
 
 static bool isPathTracingSupported()

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -5949,12 +5949,17 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
         vlan_alias = VLAN_PREFIX + to_string(vlan_id);
         string op = kfvOp(t);
 
-        assert(m_portList.find(vlan_alias) != m_portList.end());
         Port vlan, port;
 
         /* When VLAN member is to be created before VLAN is created */
         if (!getPort(vlan_alias, vlan))
         {
+            if (op == DEL_COMMAND)
+            {
+                it = consumer.m_toSync.erase(it);
+                continue;
+            }
+
             SWSS_LOG_INFO("Failed to locate VLAN %s", vlan_alias.c_str());
             it++;
             continue;
@@ -5990,6 +5995,15 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
             if (vlan.m_members.find(port_alias) != vlan.m_members.end())
             {
                 it = consumer.m_toSync.erase(it);
+                continue;
+            }
+
+            /* Defer vlan member add while port is still a LAG member in orchagent */
+            if (isValidPortTypeForLagMember(port) && port.m_lag_member_id != SAI_NULL_OBJECT_ID)
+            {
+                SWSS_LOG_INFO("Port %s is still a LAG member (lmid:%" PRIx64 "), delaying vlan member add",
+                               port.m_alias.c_str(), port.m_lag_member_id);
+                it++;
                 continue;
             }
 

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -71,21 +71,6 @@ RouteOrch::RouteOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames,
     else
     {
         m_maxNextHopGroupCount = attr.value.s32;
-
-        /*
-         * ASIC specific workaround to re-calculate maximum ECMP groups
-         * according to different ECMP mode used.
-         *
-         * On Mellanox platform, the maximum ECMP groups returned is the value
-         * under the condition that the ECMP group size is 1. Dividing this
-         * number by DEFAULT_MAX_ECMP_GROUP_SIZE gets the maximum number of
-         * ECMP groups when the maximum ECMP group size is 32.
-         */
-        char *platform = getenv("platform");
-        if (platform && strstr(platform, MLNX_PLATFORM_SUBSTRING))
-        {
-            m_maxNextHopGroupCount /= DEFAULT_MAX_ECMP_GROUP_SIZE;
-        }
     }
     vector<FieldValueTuple> fvTuple;
     fvTuple.emplace_back("MAX_NEXTHOP_GROUP_COUNT", to_string(m_maxNextHopGroupCount));

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -2099,6 +2099,17 @@ bool RouteOrch::addRoute(RouteBulkContext& ctx, const NextHopGroupKey &nextHops)
                         nextHops.to_string().c_str(), ipPrefix.to_string().c_str());
                 return false;
             }
+
+            /* Verify RIF is not mid-VRF-migration.
+             * During VRF bind, the old RIF may still exist in the previous VRF
+             * if neighbor references prevent its removal. Retry until the RIF is
+             * recreated in the correct VRF. */
+            if (m_intfsOrch->isIntfChangeInProgress(nexthop.alias))
+            {
+                SWSS_LOG_INFO("Interface %s is being removed, retry route %s later",
+                        nexthop.alias.c_str(), ipPrefix.to_string().c_str());
+                return false;
+            }
         }
         else
         {

--- a/orchagent/tunneldecaporch.cpp
+++ b/orchagent/tunneldecaporch.cpp
@@ -1447,6 +1447,28 @@ std::string TunnelDecapOrch::getDscpMode(const std::string &tunnelKey) const
     return iter->second.dscp_mode;
 }
 
+std::string TunnelDecapOrch::getEcnMode(const std::string &tunnelKey) const
+{
+    auto iter = tunnelTable.find(tunnelKey);
+    if (iter == tunnelTable.end())
+    {
+        SWSS_LOG_INFO("Tunnel not found %s", tunnelKey.c_str());
+        return "";
+    }
+    return iter->second.ecn_mode;
+}
+
+std::string TunnelDecapOrch::getEncapEcnMode(const std::string &tunnelKey) const
+{
+    auto iter = tunnelTable.find(tunnelKey);
+    if (iter == tunnelTable.end())
+    {
+        SWSS_LOG_INFO("Tunnel not found %s", tunnelKey.c_str());
+        return "";
+    }
+    return iter->second.encap_ecn_mode;
+}
+
 bool TunnelDecapOrch::getQosMapId(const std::string &tunnelKey, const std::string &qos_table_type, sai_object_id_t &oid) const
 {
     auto iter = tunnelTable.find(tunnelKey);

--- a/orchagent/tunneldecaporch.h
+++ b/orchagent/tunneldecaporch.h
@@ -82,6 +82,8 @@ public:
     bool removeNextHopTunnel(std::string tunnelKey, swss::IpAddress& ipAddr);
     swss::IpAddresses getDstIpAddresses(std::string tunnelKey);
     std::string getDscpMode(const std::string &tunnelKey) const;
+    std::string getEcnMode(const std::string &tunnelKey) const;
+    std::string getEncapEcnMode(const std::string &tunnelKey) const;
     bool getQosMapId(const std::string &tunnelKey, const std::string &qos_table_type, sai_object_id_t &oid) const;
     const SubnetDecapConfig &getSubnetDecapConfig() const
     {

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -777,15 +777,28 @@ bool VNetRouteOrch::addNextHopGroup(const string& vnet, const NextHopGroupKey &n
     vector<sai_object_id_t> next_hop_ids;
     set<NextHopKey> next_hop_set = nexthops.getNextHops();
     std::map<sai_object_id_t, NextHopKey> nhopgroup_members_set;
-    std::map<NextHopKey, uint32_t> nh_seq_id_in_nhgrp;
+    std::map<sai_object_id_t, uint32_t> nh_seq_id_in_nhgrp;
     uint32_t seq_id = 0;
 
     for (auto it : next_hop_set)
     {
-        nh_seq_id_in_nhgrp[it] = ++seq_id;
+        uint32_t nh_seq_id = ++seq_id;
         if (monitoring != VNET_MONITORING_TYPE_CUSTOM && monitoring != VNET_MONITORING_TYPE_CUSTOM_BFD && nexthop_info_[vnet].find(it.ip_address) != nexthop_info_[vnet].end() && nexthop_info_[vnet][it.ip_address].bfd_state != SAI_BFD_SESSION_STATE_UP)
         {
             continue;
+        }
+        // VNET_ROUTE_TUNNEL_TABLE endpoints can be processed before the neighbor
+        // is resolved. In that ordering, the cached NextHopKey is created with
+        // only IP and an empty alias. For directly-connected local endpoints,
+        // resolve the current RIF alias from NeighOrch before has/getNextHop().
+        if (isLocalEp && it.alias.empty())
+        {
+            NeighborEntry neigh_entry;
+            MacAddress mac;
+            if (gNeighOrch->getNeighborEntry(it.ip_address, neigh_entry, mac))
+            {
+                it = NextHopKey(it.ip_address, neigh_entry.alias);
+            }
         }
         if (isLocalEp && !gNeighOrch->hasNextHop(it))
         {
@@ -795,6 +808,7 @@ bool VNetRouteOrch::addNextHopGroup(const string& vnet, const NextHopGroupKey &n
         sai_object_id_t next_hop_id = isLocalEp? gNeighOrch->getNextHopId(it):vrf_obj->getTunnelNextHop(it);
         next_hop_ids.push_back(next_hop_id);
         nhopgroup_members_set[next_hop_id] = it;
+        nh_seq_id_in_nhgrp[next_hop_id] = nh_seq_id;
     }
 
     sai_attribute_t nhg_attr;
@@ -841,7 +855,7 @@ bool VNetRouteOrch::addNextHopGroup(const string& vnet, const NextHopGroupKey &n
         if (gSwitchOrch->checkOrderedEcmpEnable())
         {
             nhgm_attr.id = SAI_NEXT_HOP_GROUP_MEMBER_ATTR_SEQUENCE_ID;
-            nhgm_attr.value.u32 = nh_seq_id_in_nhgrp[nhopgroup_members_set.find(nhid)->second];
+            nhgm_attr.value.u32 = nh_seq_id_in_nhgrp.at(nhid);
             nhgm_attrs.push_back(nhgm_attr);
         }
 
@@ -947,6 +961,22 @@ bool VNetRouteOrch::createNextHopGroup(const string& vnet,
     {
         NextHopKey nexthop = *nexthops.getNextHops().begin();
         bool isLocalEp = isLocalEndpoint(vnet, nexthop.ip_address);
+        // VNET_ROUTE_TUNNEL_TABLE endpoints can be seen before neighbor
+        // resolution. In that case, the stored NextHopKey may still carry an
+        // empty alias. For local endpoints, refresh alias from NeighOrch so the
+        // key matches the resolved IP@ifname form used by NeighOrch caches.
+        if (isLocalEp && nexthop.alias.empty())
+        {
+            NeighborEntry neigh_entry;
+            MacAddress mac;
+            if (gNeighOrch->getNeighborEntry(nexthop.ip_address, neigh_entry, mac))
+            {
+                nexthop = NextHopKey(nexthop.ip_address, neigh_entry.alias);
+                SWSS_LOG_INFO("Resolved local endpoint %s to interface %s",
+                              nexthop.ip_address.to_string().c_str(),
+                              neigh_entry.alias.c_str());
+            }
+        }
         if (isLocalEp && !gNeighOrch->hasNextHop(nexthop))
         {
             SWSS_LOG_NOTICE("Next hop %s not found in neighorch, skipping.", nexthop.to_string().c_str());

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -94,6 +94,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 saihelper_ut.cpp \
                 mock_saihelper.cpp \
                 mirrororch_ut.cpp \
+                macsecorch_ut.cpp \
                 hftelorch_ut.cpp \
                 hftelorch_notify_ut.cpp \
                 hftelorch_is_supported_sai_wrap.cpp \

--- a/tests/mock_tests/buffermgrdyn_ut.cpp
+++ b/tests/mock_tests/buffermgrdyn_ut.cpp
@@ -7,12 +7,14 @@
 #include "ut_helper.h"
 #include "mock_orchagent_main.h"
 #include "mock_table.h"
+#include <hiredis/hiredis.h>
 #define private public
 #include "buffermgrdyn.h"
 #include "warm_restart.h"
 #undef private
 
 extern string gMySwitchType;
+extern redisReply *mockReply;
 
 
 namespace buffermgrdyn_test
@@ -48,6 +50,23 @@ namespace buffermgrdyn_test
 
     map<string, vector<FieldValueTuple>> zeroProfileMap;
     vector<KeyOpFieldsValuesTuple> zeroProfile;
+
+    void FreeRedisReply(redisReply *reply)
+    {
+        if (reply == nullptr)
+        {
+            return;
+        }
+
+        for (size_t i = 0; i < reply->elements; i++)
+        {
+            FreeRedisReply(reply->element[i]);
+        }
+
+        free(reply->element);
+        free(reply->str);
+        free(reply);
+    }
 
     struct BufferMgrDynTest : public ::testing::Test
     {
@@ -167,6 +186,8 @@ namespace buffermgrdyn_test
 
             WarmStart::initialize("buffermgrd", "swss");
             WarmStart::checkWarmStart("buffermgrd", "swss");
+
+            ClearMockRedisReply();
         }
 
         void StartBufferManager(shared_ptr<vector<KeyOpFieldsValuesTuple>> zero_profile=nullptr)
@@ -187,6 +208,55 @@ namespace buffermgrdyn_test
             };
 
             m_dynamicBuffer = new BufferMgrDynamic(m_config_db.get(), m_state_db.get(), m_app_db.get(), m_app_state_db.get(), buffer_table_connectors, nullptr, zero_profile);
+            m_dynamicBuffer->m_saiSyncPollIntervalSec = 0;
+        }
+
+        void ClearMockRedisReply()
+        {
+            FreeRedisReply(mockReply);
+            mockReply = nullptr;
+        }
+
+        // UT-only mock tree. mock_hiredis returns a copy per redisGetReply; release here.
+        void SetRedisScriptReply(const vector<string> &values)
+        {
+            ClearMockRedisReply();
+
+            mockReply = (redisReply *)calloc(1, sizeof(redisReply));
+            if (mockReply == nullptr)
+            {
+                return;
+            }
+
+            mockReply->type = REDIS_REPLY_ARRAY;
+            mockReply->element = (redisReply **)calloc(values.size(), sizeof(redisReply *));
+            if (mockReply->element == nullptr)
+            {
+                free(mockReply);
+                mockReply = nullptr;
+                return;
+            }
+
+            mockReply->elements = values.size();
+
+            for (size_t i = 0; i < values.size(); i++)
+            {
+                mockReply->element[i] = (redisReply *)calloc(1, sizeof(redisReply));
+                if (mockReply->element[i] == nullptr)
+                {
+                    continue;
+                }
+
+                mockReply->element[i]->type = REDIS_REPLY_STRING;
+                mockReply->element[i]->len = values[i].length();
+                mockReply->element[i]->str = (char *)calloc(values[i].length() + 1, sizeof(char));
+                if (mockReply->element[i]->str == nullptr)
+                {
+                    continue;
+                }
+
+                memcpy(mockReply->element[i]->str, values[i].c_str(), values[i].length());
+            }
         }
 
         void InitPort(const string &port="Ethernet0", const string &admin_status="up")
@@ -509,6 +579,8 @@ namespace buffermgrdyn_test
 
         void TearDown() override
         {
+            ClearMockRedisReply();
+
             delete m_dynamicBuffer;
             m_dynamicBuffer = nullptr;
 
@@ -2076,7 +2148,7 @@ namespace buffermgrdyn_test
         // TEST CASE 1: Manually test retry mode - profiles not synced
         // Directly populate m_shpProfilesToCheck to simulate being in retry mode
         m_dynamicBuffer->m_shpProfilesToCheck = {testProfile.name};
-        
+
         // Verify checkPendingProfilesSyncStatus returns retry when profile not in APPL_STATE_DB
         auto status = m_dynamicBuffer->checkPendingProfilesSyncStatus();
         EXPECT_EQ(status, task_process_status::task_need_retry)
@@ -2099,16 +2171,19 @@ namespace buffermgrdyn_test
         EXPECT_TRUE(m_dynamicBuffer->m_shpProfilesToCheck.empty())
             << "m_shpProfilesToCheck should be cleared after successful sync";
 
-        // TEST CASE 3: Test the actual handleBufferPoolTable retry flow
+        // TEST CASE 3: Test the actual handleBufferPoolTable flow once profiles are synced
         // Set up: current SHP size is "1048576", want to change to "2097152"
-        // Manually set retry state
+        // Manually set retry state and keep APPL_STATE_DB synced to avoid waiting for timeout
         m_dynamicBuffer->m_configuredSharedHeadroomPoolSize = "1048576";
         m_dynamicBuffer->m_shpProfilesToCheck = {testProfile.name};
-        
-        // Clear APPL_STATE_DB to simulate profiles not synced yet
-        m_dynamicBuffer->m_applStateBufferProfileTable.del(testProfile.name);
 
-        // Try to update SHP size while in retry mode
+        m_dynamicBuffer->m_applStateBufferProfileTable.set(testProfile.name, {
+            {"xoff", testProfile.xoff},
+            {"xon", testProfile.xon},
+            {"size", testProfile.size}
+        });
+
+        // Try to update SHP size after pending profiles have reached APPL_STATE_DB
         vector<FieldValueTuple> fvVector = {
             {"mode", "dynamic"},
             {"type", "ingress"},
@@ -2117,23 +2192,10 @@ namespace buffermgrdyn_test
         KeyOpFieldsValuesTuple tuple = {INGRESS_LOSSLESS_PG_POOL_NAME, "SET", fvVector};
 
         status = m_dynamicBuffer->handleBufferPoolTable(tuple);
-        EXPECT_EQ(status, task_process_status::task_need_retry)
-            << "handleBufferPoolTable should return task_need_retry in retry mode when profiles not synced";
-        EXPECT_EQ(m_dynamicBuffer->m_configuredSharedHeadroomPoolSize, "1048576")
-            << "SHP size should not be updated when in retry mode and profiles not synced";
-
-        // TEST CASE 4: Sync profiles and retry
-        m_dynamicBuffer->m_applStateBufferProfileTable.set(testProfile.name, {
-            {"xoff", testProfile.xoff},
-            {"xon", testProfile.xon},
-            {"size", testProfile.size}
-        });
-
-        status = m_dynamicBuffer->handleBufferPoolTable(tuple);
         EXPECT_EQ(status, task_process_status::task_success)
-            << "handleBufferPoolTable should succeed when profiles are synced in retry mode";
+            << "handleBufferPoolTable should succeed when pending profiles are already synced";
         EXPECT_EQ(m_dynamicBuffer->m_configuredSharedHeadroomPoolSize, "2097152")
-            << "SHP size should be updated after profiles are synced";
+            << "SHP size should be updated after pending profiles are synced";
         EXPECT_TRUE(m_dynamicBuffer->m_shpProfilesToCheck.empty())
             << "m_shpProfilesToCheck should be cleared after successful update";
     }
@@ -2399,4 +2461,267 @@ namespace buffermgrdyn_test
         EXPECT_EQ(m_dynamicBuffer->m_shpProfilesToCheck.size(), profileCheckListSizeBefore)
             << "Should not add profiles to check list when SHP size unchanged";
     }
+
+    /*
+     * waitWithRetry polling is covered here with a mock checker. Production
+     * callers use isSharedHeadroomPoolEnabledInSai and checkPendingProfilesSyncStatus.
+     */
+    TEST_F(BufferMgrDynTest, TestWaitWithRetry)
+    {
+        constexpr size_t bufferProfileSyncMaxChecks = 30;
+
+        StartBufferManager();
+        EXPECT_EQ(m_dynamicBuffer->m_saiSyncPollIntervalSec, 0u);
+
+        size_t checkerCalls = 0;
+        auto status = m_dynamicBuffer->waitWithRetry([&]() {
+            checkerCalls++;
+            return true;
+        }, "immediate success");
+        EXPECT_EQ(status, task_process_status::task_success);
+        EXPECT_EQ(checkerCalls, 1u);
+
+        checkerCalls = 0;
+        status = m_dynamicBuffer->waitWithRetry([&]() {
+            checkerCalls++;
+            return checkerCalls >= 3;
+        }, "success after retries");
+        EXPECT_EQ(status, task_process_status::task_success);
+        EXPECT_EQ(checkerCalls, 3u);
+
+        checkerCalls = 0;
+        status = m_dynamicBuffer->waitWithRetry([&]() {
+            checkerCalls++;
+            return false;
+        }, "timeout");
+        EXPECT_EQ(status, task_process_status::task_failed);
+        EXPECT_EQ(checkerCalls, bufferProfileSyncMaxChecks);
+    }
+
+    TEST_F(BufferMgrDynTest, TestHandleBufferPoolTableSHPEnableBySizeWaitsForSaiSync)
+    {
+        InitDefaultLosslessParameter();
+        InitMmuSize();
+        StartBufferManager();
+        m_dynamicBuffer->m_bufferpoolSha = "mock_buffer_pool";
+
+        InitPort();
+        SetPortInitDone();
+        m_dynamicBuffer->doTask(m_selectableTable);
+        InitBufferPool();
+
+        m_dynamicBuffer->m_configuredSharedHeadroomPoolSize = "0";
+        m_dynamicBuffer->m_bufferPoolLookup[INGRESS_LOSSLESS_PG_POOL_NAME].xoff = "0";
+        m_dynamicBuffer->m_applStateBufferPoolTable.set(INGRESS_LOSSLESS_PG_POOL_NAME,
+                                                        {{"xoff", "1024000"}});
+
+        vector<FieldValueTuple> fvVector = {
+            {"mode", "dynamic"},
+            {"type", "ingress"},
+            {"xoff", "1024000"}
+        };
+        KeyOpFieldsValuesTuple tuple = {INGRESS_LOSSLESS_PG_POOL_NAME, "SET", fvVector};
+
+        SetRedisScriptReply({"ingress_lossless_pool:1024000:1024000"});
+        auto status = m_dynamicBuffer->handleBufferPoolTable(tuple);
+        ClearMockRedisReply();
+
+        EXPECT_EQ(status, task_process_status::task_success)
+            << "SHP enable by size should succeed when pool xoff is already in APPL_STATE_DB";
+        EXPECT_EQ(m_dynamicBuffer->m_configuredSharedHeadroomPoolSize, "1024000")
+            << "The old enable task must not be left in m_toSync for a later retry";
+    }
+
+    TEST_F(BufferMgrDynTest, TestDefaultLosslessParamSHPEnableByRatioWaitsForSaiSync)
+    {
+        InitDefaultLosslessParameter();
+        InitMmuSize();
+        StartBufferManager();
+        m_dynamicBuffer->m_bufferpoolSha = "mock_buffer_pool";
+
+        InitPort();
+        SetPortInitDone();
+        m_dynamicBuffer->doTask(m_selectableTable);
+        InitBufferPool();
+
+        m_dynamicBuffer->m_overSubscribeRatio = "";
+        m_dynamicBuffer->m_configuredSharedHeadroomPoolSize = "0";
+        m_dynamicBuffer->m_bufferPoolLookup[INGRESS_LOSSLESS_PG_POOL_NAME].xoff = "0";
+        m_dynamicBuffer->m_applStateBufferPoolTable.set(INGRESS_LOSSLESS_PG_POOL_NAME,
+                                                        {{"xoff", "655360"}});
+
+        vector<FieldValueTuple> fvVector = {
+            {"default_dynamic_th", "0"},
+            {"over_subscribe_ratio", "2"}
+        };
+        KeyOpFieldsValuesTuple tuple = {"AZURE", "SET", fvVector};
+
+        SetRedisScriptReply({"ingress_lossless_pool:97001472:655360"});
+        auto status = m_dynamicBuffer->handleDefaultLossLessBufferParam(tuple);
+        ClearMockRedisReply();
+
+        EXPECT_EQ(status, task_process_status::task_success)
+            << "SHP enable by ratio should succeed when pool xoff is already in APPL_STATE_DB";
+        EXPECT_EQ(m_dynamicBuffer->m_overSubscribeRatio, "2")
+            << "The old ratio enable task must not be left in m_toSync for a later retry";
+    }
+
+    /*
+     * Test SHP disable keeps the new desired size while waiting for profile
+     * sync. Rolling it back lets unrelated refresh paths calculate profiles
+     * against the old SHP-enabled state.
+     */
+    TEST_F(BufferMgrDynTest, TestHandleBufferPoolTableSHPDisableRetryDoesNotRollback)
+    {
+        InitDefaultLosslessParameter();
+        InitMmuSize();
+        StartBufferManager();
+        m_dynamicBuffer->m_headroomSha = "mock_headroom";
+
+        InitPort();
+        SetPortInitDone();
+        m_dynamicBuffer->doTask(m_selectableTable);
+
+        InitBufferPool();
+        InitDefaultBufferProfile();
+
+        buffer_profile_t testProfile;
+        testProfile.name = "pg_lossless_100000_5m_profile";
+        testProfile.size = "43008";
+        testProfile.xon = "43008";
+        testProfile.xoff = "50176";
+        testProfile.static_configured = false;
+        testProfile.lossless = true;
+        testProfile.pool_name = INGRESS_LOSSLESS_PG_POOL_NAME;
+        testProfile.speed = "100000";
+        testProfile.cable_length = "5m";
+        testProfile.port_mtu = "9100";
+        testProfile.gearbox_model = "";
+        testProfile.threshold_mode = buffer_dynamic_th_field_name;
+        testProfile.threshold = "0";
+        m_dynamicBuffer->m_bufferProfileLookup[testProfile.name] = testProfile;
+
+        defaultLosslessParameterTable.del("AZURE");
+        defaultLosslessParameterTable.set("AZURE", {{"default_dynamic_th", "0"}});
+        bufferPoolTable.del(INGRESS_LOSSLESS_PG_POOL_NAME);
+        bufferPoolTable.set(INGRESS_LOSSLESS_PG_POOL_NAME,
+                            {
+                                {"mode", "dynamic"},
+                                {"type", "ingress"}
+                            });
+        m_dynamicBuffer->m_configuredSharedHeadroomPoolSize = "1024000";
+        m_dynamicBuffer->m_overSubscribeRatio = "";
+        m_dynamicBuffer->m_shpProfilesToCheck.clear();
+        m_dynamicBuffer->m_applStateBufferProfileTable.set(testProfile.name, {
+            {"xoff", "50176"},
+            {"xon", "43008"},
+            {"size", "93184"}
+        });
+
+        vector<FieldValueTuple> fvVector = {
+            {"mode", "dynamic"},
+            {"type", "ingress"}
+        };
+        KeyOpFieldsValuesTuple tuple = {INGRESS_LOSSLESS_PG_POOL_NAME, "SET", fvVector};
+
+        SetRedisScriptReply({"xon:43008", "xoff:50176", "size:93184"});
+        auto status = m_dynamicBuffer->handleBufferPoolTable(tuple);
+        ClearMockRedisReply();
+        EXPECT_EQ(status, task_process_status::task_success)
+            << "SHP disable should succeed when recalculated profiles are already synced";
+        EXPECT_EQ(m_dynamicBuffer->m_configuredSharedHeadroomPoolSize, "0")
+            << "Desired SHP size must not be rolled back during retry";
+
+        const auto disabledProfileSize = m_dynamicBuffer->m_bufferProfileLookup[testProfile.name].size;
+        const auto enabledProfileSize = m_dynamicBuffer->m_bufferProfileLookup[testProfile.name].xon;
+        EXPECT_EQ(disabledProfileSize, "93184")
+            << "SHP-disabled profile size should be xon + xoff";
+        EXPECT_EQ(enabledProfileSize, "43008")
+            << "SHP-enabled profile size is xon only";
+        EXPECT_NE(disabledProfileSize, enabledProfileSize)
+            << "The test must distinguish SHP-disabled size from SHP-enabled size";
+
+        /*
+         * The failure happened in the retry window: another refresh path
+         * recalculated lossless profiles while the desired SHP disable was still
+         * waiting for SAI sync. That refresh must keep the disabled size.
+         */
+        const bool shpEnabledBySize = !m_dynamicBuffer->m_configuredSharedHeadroomPoolSize.empty() &&
+                                      m_dynamicBuffer->m_configuredSharedHeadroomPoolSize != "0";
+        const string retryWindowProfileSize = shpEnabledBySize ? "43008" : "93184";
+        SetRedisScriptReply({"xon:43008", "xoff:50176", "size:" + retryWindowProfileSize});
+        m_dynamicBuffer->refreshSharedHeadroomPool(false, true);
+        ClearMockRedisReply();
+        EXPECT_EQ(m_dynamicBuffer->m_bufferProfileLookup[testProfile.name].size, disabledProfileSize)
+            << "Retry-window refresh must not rewrite the profile as SHP-enabled";
+
+        m_dynamicBuffer->m_applBufferProfileTable.flush();
+        vector<FieldValueTuple> profileFvVector;
+        ASSERT_TRUE(appBufferProfileTable.get(testProfile.name, profileFvVector));
+
+        auto getField = [](const vector<FieldValueTuple> &fieldValues, const string &field) -> string
+        {
+            for (const auto &fv : fieldValues)
+            {
+                if (fvField(fv) == field)
+                {
+                    return fvValue(fv);
+                }
+            }
+            return "";
+        };
+
+        const string applDbProfileSize = getField(profileFvVector, buffer_size_field_name);
+        ASSERT_FALSE(applDbProfileSize.empty());
+        EXPECT_EQ(applDbProfileSize, disabledProfileSize)
+            << "APPL_DB profile size must remain the SHP-disabled size";
+        EXPECT_NE(applDbProfileSize, enabledProfileSize)
+            << "The bad dump had APPL_DB profile size equal to xon, meaning SHP was enabled again";
+        EXPECT_EQ(getField(profileFvVector, buffer_xon_field_name), "43008");
+        EXPECT_EQ(getField(profileFvVector, buffer_xoff_field_name), "50176");
+        EXPECT_EQ(getField(profileFvVector, buffer_dynamic_th_field_name), "0");
+
+        vector<FieldValueTuple> configPoolFvVector;
+        ASSERT_TRUE(bufferPoolTable.get(INGRESS_LOSSLESS_PG_POOL_NAME, configPoolFvVector));
+        EXPECT_TRUE(getField(configPoolFvVector, buffer_pool_xoff_field_name).empty())
+            << "CONFIG_DB should represent SHP disabled by removing pool xoff";
+
+        m_dynamicBuffer->m_applStateBufferProfileTable.set(testProfile.name, profileFvVector);
+        vector<FieldValueTuple> stateProfileFvVector;
+        ASSERT_TRUE(m_dynamicBuffer->m_applStateBufferProfileTable.get(testProfile.name, stateProfileFvVector));
+        EXPECT_EQ(getField(stateProfileFvVector, buffer_size_field_name), disabledProfileSize)
+            << "If OA writes back the APPL_DB payload, APPL_STATE_DB should not contain the bad size=xon state";
+
+        status = m_dynamicBuffer->handleBufferPoolTable(tuple);
+        EXPECT_EQ(status, task_process_status::task_success)
+            << "Once profile sync is observed, the retry should finish and publish the disabled pool";
+        m_dynamicBuffer->m_applBufferPoolTable.flush();
+
+        vector<FieldValueTuple> applPoolFvVector;
+        ASSERT_TRUE(appBufferPoolTable.get(INGRESS_LOSSLESS_PG_POOL_NAME, applPoolFvVector));
+        EXPECT_TRUE(getField(applPoolFvVector, buffer_pool_xoff_field_name).empty())
+            << "APPL_DB pool should not keep a non-zero SHP xoff after the disable retry finishes";
+
+        const bool profileIndicatesShpEnabled = (m_dynamicBuffer->m_bufferProfileLookup[testProfile.name].size == enabledProfileSize);
+        m_dynamicBuffer->m_bufferpoolSha = "mock_buffer_pool";
+        m_dynamicBuffer->m_mmuSize = "200000000";
+        m_dynamicBuffer->m_mmuSizeNumber = 200000000;
+        if (profileIndicatesShpEnabled)
+        {
+            SetRedisScriptReply({"ingress_lossless_pool:100081664:655360"});
+        }
+        else
+        {
+            SetRedisScriptReply({"ingress_lossless_pool:100081664"});
+        }
+        m_dynamicBuffer->recalculateSharedBufferPool();
+        ClearMockRedisReply();
+        m_dynamicBuffer->m_applBufferPoolTable.flush();
+
+        applPoolFvVector.clear();
+        ASSERT_TRUE(appBufferPoolTable.get(INGRESS_LOSSLESS_PG_POOL_NAME, applPoolFvVector));
+        EXPECT_NE(getField(applPoolFvVector, buffer_pool_xoff_field_name), "655360")
+            << "The bad dump's pool xoff=655360 is produced only when the profile has already fallen back to size=xon";
+    }
+
 }

--- a/tests/mock_tests/dashhaorch_ut.cpp
+++ b/tests/mock_tests/dashhaorch_ut.cpp
@@ -1229,4 +1229,39 @@ namespace dashhaorch_ut
         RemoveHaScope();
         RemoveHaSet();
     }
+
+    TEST_F(DashHaOrchTestSwitchOwner, SwitchOwnerSetRoleUpdatesStateWhenHaSetMissing)
+    {
+        // Create switch-owner HA Set, then HA Scope.
+        EXPECT_CALL(*mock_sai_dash_ha_api, create_ha_set)
+            .Times(1).WillOnce(Return(SAI_STATUS_SUCCESS));
+        CreateSwitchOwnerDpuScopeHaSet();
+
+        EXPECT_CALL(*mock_sai_dash_ha_api, create_ha_scope)
+            .Times(1).WillOnce(Return(SAI_STATUS_SUCCESS));
+        CreateHaScope();
+
+        // Remove the HA Set while HA Scope still exists. This makes the HA Set
+        // lookup inside updateHaScopeStateForSwitchOwner fail.
+        EXPECT_CALL(*mock_sai_dash_ha_api, remove_ha_set)
+            .Times(1).WillOnce(Return(SAI_STATUS_SUCCESS));
+        RemoveHaSet();
+        ASSERT_TRUE(m_dashHaOrch->getHaSetEntries().find("HA_SET_1") == m_dashHaOrch->getHaSetEntries().end());
+
+        // Trigger a role change. The new code path should emit a warning that
+        // the HA Set is missing but still update the in-memory ha_state for the
+        // HA Scope entry (previously this path would silently early-return).
+        EXPECT_CALL(*mock_sai_dash_ha_api, set_ha_scope_attribute)
+            .WillRepeatedly(Return(SAI_STATUS_SUCCESS));
+        SetHaScopeHaRole("active");
+
+        auto scope_it = m_dashHaOrch->getHaScopeEntries().find("HA_SET_1");
+        ASSERT_NE(scope_it, m_dashHaOrch->getHaScopeEntries().end());
+        EXPECT_EQ(scope_it->second.ha_state, SAI_DASH_HA_STATE_ACTIVE);
+        EXPECT_EQ(to_sai(scope_it->second.metadata.ha_role()), SAI_DASH_HA_ROLE_ACTIVE);
+
+        EXPECT_CALL(*mock_sai_dash_ha_api, remove_ha_scope)
+            .Times(1).WillOnce(Return(SAI_STATUS_SUCCESS));
+        RemoveHaScope();
+    }
 }

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -395,4 +395,57 @@ namespace intfsorch_test
         m_syncdIntfses = gIntfsOrch->getSyncdIntfses();
         ASSERT_EQ(m_syncdIntfses["Loopback3"].vrf_id, gVirtualRouterId);    
     }
+
+    // Regression test for the batched IP-removal + VRF-bind race.
+    // m_toSync is an ordered multimap, so within a single drain the bare interface
+    // key ("Loopback6") is processed before the per-IP key ("Loopback6:6.6.6.6/32").
+    // When a config sequence removes the loopback IPs and rebinds the interface to a
+    // VRF back-to-back, both land in one batch and the VRF-change SET is evaluated
+    // while the IP is still present. The fix defers (retains) that SET instead of
+    // logging an error and dropping it, so the bind converges on a later drain.
+    TEST_F(IntfsOrchTest, IntfsOrchVrfBindDeferredUntilIpRemoved)
+    {
+        // create a new vrf
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({"Vrf-Blue", "SET", { {"NULL", "NULL"}}});
+        auto vrfConsumer = dynamic_cast<Consumer *>(gVrfOrch->getExecutor(APP_VRF_TABLE_NAME));
+        vrfConsumer->addToSync(entries);
+        static_cast<Orch *>(gVrfOrch)->doTask();
+        ASSERT_TRUE(gVrfOrch->isVRFexists("Vrf-Blue"));
+        auto base_vrf_ref = gVrfOrch->getVrfRefCount("Vrf-Blue");
+
+        auto intfConsumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
+
+        // create a loopback in the default vrf and give it an IP address
+        entries.clear();
+        entries.push_back({"Loopback6", "SET", {}});
+        entries.push_back({"Loopback6:6.6.6.6/32", "SET", {{"scope", "global"}, {"family", "IPv4"}}});
+        intfConsumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+        auto syncd = gIntfsOrch->getSyncdIntfses();
+        ASSERT_EQ(syncd["Loopback6"].vrf_id, gVirtualRouterId);
+        ASSERT_EQ(syncd["Loopback6"].ip_addresses.size(), static_cast<size_t>(1));
+
+        // Single batch: remove the IP AND rebind the interface to Vrf-Blue.
+        // The bare "Loopback6" SET sorts before "Loopback6:6.6.6.6/32" DEL, so the
+        // bind is evaluated first (IP still present) and must be deferred, not dropped.
+        entries.clear();
+        entries.push_back({"Loopback6", "SET", { {"vrf_name", "Vrf-Blue"}}});
+        entries.push_back({"Loopback6:6.6.6.6/32", "DEL", {}});
+        intfConsumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+
+        // After the first drain: IP removed, interface still present and still in the
+        // default vrf (the bind is pending, not lost).
+        syncd = gIntfsOrch->getSyncdIntfses();
+        ASSERT_NE(syncd.find("Loopback6"), syncd.end());
+        ASSERT_EQ(syncd["Loopback6"].ip_addresses.size(), static_cast<size_t>(0));
+        ASSERT_EQ(syncd["Loopback6"].vrf_id, gVirtualRouterId);
+
+        // The deferred bind is retried on the next drain and now succeeds.
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+        syncd = gIntfsOrch->getSyncdIntfses();
+        ASSERT_EQ(syncd["Loopback6"].vrf_id, gVrfOrch->getVRFid("Vrf-Blue"));
+        ASSERT_EQ(gVrfOrch->getVrfRefCount("Vrf-Blue"), base_vrf_ref + 1);
+    }
 }

--- a/tests/mock_tests/macsecorch_ut.cpp
+++ b/tests/mock_tests/macsecorch_ut.cpp
@@ -1,0 +1,682 @@
+#include "ut_helper.h"
+#include "mock_orchagent_main.h"
+
+#include <vector>
+#include <string>
+#include <cstring>
+#include <cstdlib>
+#include <new>
+
+#define private public
+#define protected public
+#include "macsecorch.h"
+#include "portsorch.h"
+#undef protected
+#undef private
+
+extern sai_object_id_t gSwitchId;
+extern sai_macsec_api_t *sai_macsec_api;
+extern sai_acl_api_t    *sai_acl_api;
+
+using namespace swss;
+
+namespace macsecorch_test
+{
+    // ------------------------------------------------------------------
+    // SAI call recorder
+    // ------------------------------------------------------------------
+    struct SaiSaCall
+    {
+        sai_object_id_t                 oid;          // assigned for create; ignored for remove
+        std::vector<sai_attribute_t>    attrs;        // recorded attribute list (create only)
+    };
+
+    static std::vector<SaiSaCall>       g_created_sas;
+    static std::vector<sai_object_id_t> g_removed_sas;
+    static sai_object_id_t              g_next_sa_oid;
+    static bool                         g_remove_should_fail;
+
+    static void reset_sai_recorder()
+    {
+        g_created_sas.clear();
+        g_removed_sas.clear();
+        g_next_sa_oid        = 0x5c00000000010000ULL;   // mimic real OID prefix range
+        g_remove_should_fail = false;
+    }
+
+    // Helper: pull the SAK bytes out of a recorded SAI attribute list.
+    // Returns true if found, fills `out`.
+    static bool extract_sai_sak(const std::vector<sai_attribute_t> &attrs,
+                                sai_macsec_sak_t                   &out)
+    {
+        for (const auto &a : attrs)
+        {
+            if (a.id == SAI_MACSEC_SA_ATTR_SAK)
+            {
+                memcpy(out, a.value.macsecsak, sizeof(sai_macsec_sak_t));
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static sai_status_t fake_create_macsec_sa(sai_object_id_t        *sa_id,
+                                              sai_object_id_t         switch_id,
+                                              uint32_t                attr_count,
+                                              const sai_attribute_t  *attr_list)
+    {
+        SaiSaCall call;
+        call.oid = ++g_next_sa_oid;
+        call.attrs.assign(attr_list, attr_list + attr_count);
+        *sa_id = call.oid;
+        g_created_sas.push_back(std::move(call));
+        return SAI_STATUS_SUCCESS;
+    }
+
+    static sai_status_t fake_remove_macsec_sa(sai_object_id_t sa_id)
+    {
+        if (g_remove_should_fail)
+            return SAI_STATUS_OBJECT_IN_USE;
+        g_removed_sas.push_back(sa_id);
+        return SAI_STATUS_SUCCESS;
+    }
+
+    // ------------------------------------------------------------------
+    // Fixture: stand up a minimal MACsecOrch with the SAI MACsec API
+    // pointed at our recorders, and pre-populate the per-port state so
+    // that a "surviving SA from the prior MKA cycle" is visible to the
+    // re-key paths under test.
+    // ------------------------------------------------------------------
+    class MacsecOrchStaleSakTest : public ::testing::Test
+    {
+    public:
+        static constexpr const char    *kPortName       = "Ethernet0";
+        // SCI hex strings as wpa_supplicant's macsec_sonic driver
+        // writes them to APPL_DB. Numeric m_sci values are derived
+        // via MACsecSCI::operator=(string) so the byte ordering
+        // matches whatever the orch actually parses.
+        static constexpr const char    *kIngressSciHex = "220eefebbc130001";
+        static constexpr const char    *kEgressSciHex  = "e8e49d1111320001";
+        static constexpr macsec_an_t    kAN            = 0;
+
+        // The simulated "stale" hardware OID populated into m_sa_ids
+        // before each test calls the re-key path.
+        static constexpr sai_object_id_t kStaleSaOid =
+            0x5c00000000005a5aULL;
+
+    protected:
+        void SetUp() override
+        {
+            // Set up SAI vslib so global gSwitchId resolves.
+            std::map<std::string, std::string> profile = {
+                { "SAI_VS_SWITCH_TYPE", "SAI_VS_SWITCH_TYPE_BCM56850" },
+                { "KV_DEVICE_MAC_ADDRESS", "e8:e4:9d:11:13:20"        },
+            };
+            ASSERT_EQ(ut_helper::initSaiApi(profile), SAI_STATUS_SUCCESS);
+
+            ASSERT_EQ(sai_api_query(SAI_API_MACSEC, (void **)&sai_macsec_api),
+                      SAI_STATUS_SUCCESS);
+
+            // Create the SAI switch so gSwitchId is valid.
+            sai_attribute_t init = {};
+            init.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+            init.value.booldata = true;
+            ASSERT_EQ(sai_switch_api->create_switch(&gSwitchId, 1, &init),
+                      SAI_STATUS_SUCCESS);
+
+            ASSERT_NE(sai_macsec_api, nullptr);
+            saved_create_macsec_sa = sai_macsec_api->create_macsec_sa;
+            saved_remove_macsec_sa = sai_macsec_api->remove_macsec_sa;
+            sai_macsec_api->create_macsec_sa = fake_create_macsec_sa;
+            sai_macsec_api->remove_macsec_sa = fake_remove_macsec_sa;
+            reset_sai_recorder();
+
+            app_db   = std::make_shared<DBConnector>("APPL_DB",  0);
+            state_db = std::make_shared<DBConnector>("STATE_DB", 0);
+
+            // PortsOrch with just one port, Ethernet0
+            fake_ports_orch_buf = std::malloc(sizeof(PortsOrch));
+            ASSERT_NE(fake_ports_orch_buf, nullptr);
+            std::memset(fake_ports_orch_buf, 0, sizeof(PortsOrch));
+            auto *fake_ports =
+                reinterpret_cast<PortsOrch *>(fake_ports_orch_buf);
+            ::new (&fake_ports->m_portList)
+                std::map<std::string, swss::Port>();
+            swss::Port p;
+            p.m_alias   = kPortName;
+            p.m_port_id = 0x1000000000000abcULL;
+            fake_ports->m_portList[kPortName] = p;
+            saved_ports_orch = gPortsOrch;
+            gPortsOrch = fake_ports;
+
+            std::vector<std::string> tables = {
+                APP_MACSEC_PORT_TABLE_NAME,
+                APP_MACSEC_EGRESS_SC_TABLE_NAME,
+                APP_MACSEC_INGRESS_SC_TABLE_NAME,
+                APP_MACSEC_EGRESS_SA_TABLE_NAME,
+                APP_MACSEC_INGRESS_SA_TABLE_NAME,
+            };
+            orch = std::make_shared<MACsecOrch>(app_db.get(),
+                                                state_db.get(),
+                                                tables,
+                                                gPortsOrch);
+        }
+
+        void TearDown() override
+        {
+            orch->m_macsec_ports.clear();
+            orch.reset();
+
+            sai_macsec_api->create_macsec_sa = saved_create_macsec_sa;
+            sai_macsec_api->remove_macsec_sa = saved_remove_macsec_sa;
+
+            if (fake_ports_orch_buf != nullptr)
+            {
+                auto *fake_ports =
+                    reinterpret_cast<PortsOrch *>(fake_ports_orch_buf);
+                fake_ports->m_portList.~map();
+                std::free(fake_ports_orch_buf);
+                fake_ports_orch_buf = nullptr;
+            }
+            gPortsOrch = saved_ports_orch;
+
+            ASSERT_EQ(sai_switch_api->remove_switch(gSwitchId),
+                      SAI_STATUS_SUCCESS);
+            gSwitchId = SAI_NULL_OBJECT_ID;
+
+            ASSERT_EQ(ut_helper::uninitSaiApi(), SAI_STATUS_SUCCESS);
+        }
+
+        // Construct a TaskArgs vector that looks like a full SA
+        // payload from wpa_supplicant's macsec_sonic driver:
+        //   sak / auth_key / lowest_acceptable_pn / ssci / salt
+        // (egress: next_pn instead of lowest_acceptable_pn)
+        // Caller picks the SAK bytes; the rest are arbitrary but
+        // self-consistent so the create path inside MACsecOrch
+        // succeeds.
+        std::vector<FieldValueTuple>
+        buildSaFvs(const std::string &sak_hex_32,
+                   bool               include_active,
+                   bool               active,
+                   bool               egress)
+        {
+            std::vector<FieldValueTuple> fvs;
+            if (include_active)
+            {
+                fvs.emplace_back("active", active ? "true" : "false");
+            }
+            fvs.emplace_back("sak", sak_hex_32);   // 16-byte AES-128 SAK
+            fvs.emplace_back("auth_key", "00112233445566778899AABBCCDDEEFF");
+            fvs.emplace_back("ssci", egress ? "2" : "1");
+            fvs.emplace_back("salt", "000000000000000000000000");
+            fvs.emplace_back(egress ? "next_pn" : "lowest_acceptable_pn", "1");
+            return fvs;
+        }
+
+        static sai_uint64_t parseSciHex(const std::string &hex)
+        {
+            sai_uint64_t v = 0;
+            uint8_t *bytes = reinterpret_cast<uint8_t *>(&v);
+            for (size_t i = 0; i < sizeof(v) && (2 * i + 1) < hex.size(); ++i)
+            {
+                char buf[3] = { hex[2 * i], hex[2 * i + 1], '\0' };
+                bytes[i] = static_cast<uint8_t>(std::strtoul(buf, nullptr, 16));
+            }
+            return v;
+        }
+
+        // Pre-populate m_macsec_ports so that the SC and AN under test
+        // already exist with a "stale" SA OID -- the same shape orchagent
+        // is in after macsec docker SIGKILL has surfaced the bug.
+        void seedSurvivingSa(sai_macsec_direction_t direction,
+                             sai_uint64_t           sci)
+        {
+            auto port = std::make_shared<MACsecOrch::MACsecPort>();
+            port->m_cipher_suite = SAI_MACSEC_CIPHER_SUITE_GCM_AES_128;
+            port->m_enable       = false;
+
+            auto &scs = (direction == SAI_MACSEC_DIRECTION_EGRESS)
+                        ? port->m_egress_scs
+                        : port->m_ingress_scs;
+            MACsecOrch::MACsecSC sc{};
+            sc.m_sc_id        = 0x5b00000000000001ULL;
+            sc.m_flow_id      = 0x5a00000000000001ULL;
+            sc.m_encoding_an  = kAN;
+            sc.m_sa_ids[kAN]  = kStaleSaOid;
+            scs[sci] = sc;
+
+            orch->m_macsec_ports[kPortName] = port;
+        }
+
+        std::shared_ptr<DBConnector>  app_db;
+        std::shared_ptr<DBConnector>  state_db;
+        std::shared_ptr<MACsecOrch>   orch;
+
+        sai_status_t (*saved_create_macsec_sa)(sai_object_id_t*,
+                                               sai_object_id_t,
+                                               uint32_t,
+                                               const sai_attribute_t*) = nullptr;
+        sai_status_t (*saved_remove_macsec_sa)(sai_object_id_t)        = nullptr;
+
+        // Raw buffer holding a placement-new'd m_portList (see SetUp).
+        void       *fake_ports_orch_buf = nullptr;
+        PortsOrch  *saved_ports_orch    = nullptr;
+    };
+
+    constexpr const char    *MacsecOrchStaleSakTest::kPortName;
+    constexpr const char    *MacsecOrchStaleSakTest::kIngressSciHex;
+    constexpr const char    *MacsecOrchStaleSakTest::kEgressSciHex;
+    constexpr macsec_an_t    MacsecOrchStaleSakTest::kAN;
+    constexpr sai_object_id_t MacsecOrchStaleSakTest::kStaleSaOid;
+
+    // Convenience: the macsec_sonic driver writes SAKs as upper-case
+    // hex strings; pick two distinguishable values for "old" vs "new".
+    static const std::string kOldSakHex =
+        "B9A68A8F3B02F02BC0DFEFD738BBECB1";   // pre-restart
+    static const std::string kNewSakHex =
+        "C7AF571AC1A17C79DCD8C2F6E5DB1C18";   // post-restart MKA re-key
+
+    // ------------------------------------------------------------------
+    // Test 1: taskUpdateIngressSA(active=false + SAK)
+    //
+    // A surviving ingress SA exists in orchagent state.
+    // The post-restart wpa_supplicant fires its stage-1 SET
+    // (active=false + full key material). The fix must delete the
+    // surviving SA AND recreate from THIS sa_attr, not wait for stage-2.
+    // ------------------------------------------------------------------
+    TEST_F(MacsecOrchStaleSakTest,
+           taskUpdateIngressSA_active_false_with_sak_deletes_stale_and_recreates)
+    {
+        seedSurvivingSa(SAI_MACSEC_DIRECTION_INGRESS, parseSciHex(kIngressSciHex));
+
+        auto fvs = buildSaFvs(kNewSakHex,
+                              /*include_active*/ true,
+                              /*active*/         false,
+                              /*egress*/         false);
+
+        const std::string key = std::string(kPortName) + ":" +
+                                kIngressSciHex + ":" + std::to_string(kAN);
+        auto status = orch->taskUpdateIngressSA(key, fvs);
+        EXPECT_EQ(status, task_success);
+
+        // Old SA must have been removed.
+        ASSERT_EQ(g_removed_sas.size(), 1u);
+        EXPECT_EQ(g_removed_sas[0], kStaleSaOid);
+
+        // New SA must have been created and carry the NEW SAK.
+        ASSERT_EQ(g_created_sas.size(), 1u);
+        sai_macsec_sak_t saw{};
+        ASSERT_TRUE(extract_sai_sak(g_created_sas[0].attrs, saw));
+        // AES-128 SAK occupies the lower 16 bytes; upper 16 should be 0.
+        // Re-stringify to compare against kNewSakHex.
+        char buf[33];
+        for (int i = 0; i < 16; ++i)
+            snprintf(buf + 2 * i, 3, "%02X", saw[16 + i]);
+        buf[32] = '\0';
+        EXPECT_STREQ(buf, kNewSakHex.c_str());
+    }
+
+    // ------------------------------------------------------------------
+    // Test 2: createMACsecSA early-exit re-key
+    //
+    // A SET arrives with active=true and a fresh SAK on an SA that
+    // already exists. The legacy code returned task_success without 
+    // touching SAI; the fix delete+recreates.
+    // ------------------------------------------------------------------
+    TEST_F(MacsecOrchStaleSakTest,
+           createMACsecSA_existing_with_sak_deletes_stale_and_recreates)
+    {
+        seedSurvivingSa(SAI_MACSEC_DIRECTION_INGRESS, parseSciHex(kIngressSciHex));
+
+        auto fvs = buildSaFvs(kNewSakHex,
+                              /*include_active*/ true,
+                              /*active*/         true,
+                              /*egress*/         false);
+
+        const std::string key = std::string(kPortName) + ":" +
+                                kIngressSciHex + ":" + std::to_string(kAN);
+        // taskUpdateIngressSA's active=true branch funnels through
+        // createMACsecSA; this exercises the createMACsecSA early-exit
+        // fix.
+        auto status = orch->taskUpdateIngressSA(key, fvs);
+        EXPECT_EQ(status, task_success);
+
+        ASSERT_EQ(g_removed_sas.size(), 1u);
+        EXPECT_EQ(g_removed_sas[0], kStaleSaOid);
+
+        ASSERT_EQ(g_created_sas.size(), 1u);
+        sai_macsec_sak_t saw{};
+        ASSERT_TRUE(extract_sai_sak(g_created_sas[0].attrs, saw));
+        char buf[33];
+        for (int i = 0; i < 16; ++i)
+            snprintf(buf + 2 * i, 3, "%02X", saw[16 + i]);
+        buf[32] = '\0';
+        EXPECT_STREQ(buf, kNewSakHex.c_str());
+    }
+
+    // ------------------------------------------------------------------
+    // Test 3: taskUpdateEgressSA SA exists + SAK in fvs
+    //
+    // Egress flow: wpa_supplicant calls create_transmit_sa which
+    // writes MACSEC_EGRESS_SA_TABLE with sak/salt/ssci/auth_key/next_pn
+    // (no `active` field). On a surviving SA the legacy code only
+    // updated next_pn and silently dropped the new SAK; the fix
+    // delete+recreates.
+    // ------------------------------------------------------------------
+    TEST_F(MacsecOrchStaleSakTest,
+           taskUpdateEgressSA_existing_with_sak_deletes_stale_and_recreates)
+    {
+        seedSurvivingSa(SAI_MACSEC_DIRECTION_EGRESS, parseSciHex(kEgressSciHex));
+
+        auto fvs = buildSaFvs(kNewSakHex,
+                              /*include_active*/ false,
+                              /*active*/         false,
+                              /*egress*/         true);
+
+        const std::string key = std::string(kPortName) + ":" +
+                                kEgressSciHex + ":" + std::to_string(kAN);
+        auto status = orch->taskUpdateEgressSA(key, fvs);
+        EXPECT_EQ(status, task_success);
+
+        ASSERT_EQ(g_removed_sas.size(), 1u);
+        EXPECT_EQ(g_removed_sas[0], kStaleSaOid);
+
+        ASSERT_EQ(g_created_sas.size(), 1u);
+        sai_macsec_sak_t saw{};
+        ASSERT_TRUE(extract_sai_sak(g_created_sas[0].attrs, saw));
+        char buf[33];
+        for (int i = 0; i < 16; ++i)
+            snprintf(buf + 2 * i, 3, "%02X", saw[16 + i]);
+        buf[32] = '\0';
+        EXPECT_STREQ(buf, kNewSakHex.c_str());
+    }
+
+    // ------------------------------------------------------------------
+    // Test 4: legacy fast-path -- SET on existing SA without SAK
+    //
+    // Counterpart to the three re-key tests: when wpa_supplicant
+    // sends stage-2 (active=true with no SAK) on an SA that already
+    // exists, the SA must be LEFT IN PLACE -- no remove, no create.
+    // This guards against the fix over-firing on the no-SAK path.
+    // ------------------------------------------------------------------
+    TEST_F(MacsecOrchStaleSakTest,
+           taskUpdateIngressSA_existing_active_true_no_sak_leaves_sa_in_place)
+    {
+        const sai_uint64_t sci_num = parseSciHex(kIngressSciHex);
+        seedSurvivingSa(SAI_MACSEC_DIRECTION_INGRESS, sci_num);
+
+        // active=true ONLY, no key material -- stage-2 from
+        // wpa_supplicant's enable_receive_sa().
+        std::vector<FieldValueTuple> fvs = {
+            { "active", "true" },
+        };
+
+        const std::string key = std::string(kPortName) + ":" +
+                                kIngressSciHex + ":" + std::to_string(kAN);
+        auto status = orch->taskUpdateIngressSA(key, fvs);
+        EXPECT_EQ(status, task_success);
+
+        // No SAI calls at all -- the surviving SA stays untouched.
+        EXPECT_EQ(g_removed_sas.size(), 0u);
+        EXPECT_EQ(g_created_sas.size(), 0u);
+
+        // And the orch's in-memory state still points at the stale OID.
+        auto &port = orch->m_macsec_ports[kPortName];
+        EXPECT_EQ(port->m_ingress_scs.at(sci_num).m_sa_ids.at(kAN),
+                  kStaleSaOid);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 5: taskUpdateIngressSA delete-failure propagation
+    //
+    // When SAI remove_macsec_sa fails during the ingress re-key path,
+    // the error must be returned to the caller (not silently swallowed)
+    // and no create must follow.  Covers the `del_status != task_success`
+    // branch added in taskUpdateIngressSA.
+    // ------------------------------------------------------------------
+    TEST_F(MacsecOrchStaleSakTest,
+           taskUpdateIngressSA_delete_failure_propagates_error)
+    {
+        seedSurvivingSa(SAI_MACSEC_DIRECTION_INGRESS, parseSciHex(kIngressSciHex));
+
+        g_remove_should_fail = true;
+
+        auto fvs = buildSaFvs(kNewSakHex,
+                              /*include_active*/ true,
+                              /*active*/         false,
+                              /*egress*/         false);
+
+        const std::string key = std::string(kPortName) + ":" +
+                                kIngressSciHex + ":" + std::to_string(kAN);
+        auto status = orch->taskUpdateIngressSA(key, fvs);
+        EXPECT_NE(status, task_success);
+
+        // No SA must have been created (the re-key aborted after the
+        // failed delete).
+        EXPECT_EQ(g_created_sas.size(), 0u);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 6: taskUpdateEgressSA delete-failure propagation
+    //
+    // Same invariant as Test 5 but for the egress re-key path.
+    // Covers the `del_status != task_success` branch in
+    // taskUpdateEgressSA.
+    // ------------------------------------------------------------------
+    TEST_F(MacsecOrchStaleSakTest,
+           taskUpdateEgressSA_delete_failure_propagates_error)
+    {
+        seedSurvivingSa(SAI_MACSEC_DIRECTION_EGRESS, parseSciHex(kEgressSciHex));
+
+        g_remove_should_fail = true;
+
+        auto fvs = buildSaFvs(kNewSakHex,
+                              /*include_active*/ false,
+                              /*active*/         false,
+                              /*egress*/         true);
+
+        const std::string key = std::string(kPortName) + ":" +
+                                kEgressSciHex + ":" + std::to_string(kAN);
+        auto status = orch->taskUpdateEgressSA(key, fvs);
+        EXPECT_NE(status, task_success);
+
+        EXPECT_EQ(g_created_sas.size(), 0u);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 7: createMACsecSA delete-failure propagation
+    //
+    // When the defense-in-depth path in createMACsecSA detects an
+    // existing SA with a new SAK but the preceding delete fails, the
+    // error must be returned and no recursive create must follow.
+    // Covers the `del_status != task_success` branch in createMACsecSA.
+    // ------------------------------------------------------------------
+    TEST_F(MacsecOrchStaleSakTest,
+           createMACsecSA_delete_failure_propagates_error)
+    {
+        seedSurvivingSa(SAI_MACSEC_DIRECTION_INGRESS, parseSciHex(kIngressSciHex));
+
+        g_remove_should_fail = true;
+
+        // active=true funnels through createMACsecSA, exercising the
+        // early-exit re-key block (ctx.get_macsec_sa() != nullptr &&
+        // SAK present).
+        auto fvs = buildSaFvs(kNewSakHex,
+                              /*include_active*/ true,
+                              /*active*/         true,
+                              /*egress*/         false);
+
+        const std::string key = std::string(kPortName) + ":" +
+                                kIngressSciHex + ":" + std::to_string(kAN);
+        auto status = orch->taskUpdateIngressSA(key, fvs);
+        EXPECT_NE(status, task_success);
+
+        EXPECT_EQ(g_created_sas.size(), 0u);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 8: setEncodingAN sweeps stale SA when encoding_an changes
+    //
+    // Covers the dirty-restart AN-boundary case (NOS-7806, SC side):
+    // an egress SC has two SAs installed (AN=0 from the prior MKA
+    // cycle that survived the SIGKILL, AN=1 just negotiated by the
+    // fresh wpa).  When taskUpdateEgressSC writes encoding_an=1,
+    // setEncodingAN must remove the AN=0 SA from SAI and leave AN=1
+    // intact.
+    //
+    // The SC is seeded into m_macsec_ports so that the full cleanup
+    // path (deleteMACsecSA(port_sci_an, direction)) can look it up.
+    // ------------------------------------------------------------------
+    TEST_F(MacsecOrchStaleSakTest,
+           setEncodingAN_sweeps_stale_sa_on_encoding_an_change)
+    {
+        static constexpr sai_object_id_t kCurrentOidAN1 = 0x5c00000000001001ULL;
+
+        // Seed the SC with AN=0 (kStaleSaOid) into m_macsec_ports.
+        seedSurvivingSa(SAI_MACSEC_DIRECTION_EGRESS, parseSciHex(kEgressSciHex));
+
+        // Add AN=1 directly to the seeded SC.
+        auto &sc = orch->m_macsec_ports[kPortName]
+                       ->m_egress_scs[parseSciHex(kEgressSciHex)];
+        sc.m_sa_ids[1] = kCurrentOidAN1;
+
+        const std::string port_sci =
+            std::string(kPortName) + ":" + kEgressSciHex;
+
+        // port_sci_an for AN=0 — used to pre-seed and verify cleanup of
+        // COUNTERS_DB (uses ':' separator) and STATE_DB (uses '|' separator).
+        const std::string port_sci_an_0 =
+            std::string(kPortName) + ":" + kEgressSciHex + ":" + std::to_string(kAN);
+        const std::string state_key_0 =
+            std::string(kPortName) + "|" + kEgressSciHex + "|" + std::to_string(kAN);
+
+        // Plant fake COUNTERS_DB and STATE_DB entries for AN=0, simulating
+        // what installCounter / createMACsecSA would have written.
+        orch->m_macsec_counters_map.hset("", port_sci_an_0,
+                                         sai_serialize_object_id(kStaleSaOid));
+        orch->m_state_macsec_egress_sa.hset(state_key_0, "state", "ok");
+
+        MACsecOrch::TaskArgs attrs = { { "encoding_an", "1" } };
+
+        bool result = orch->setEncodingAN(sc, attrs,
+                                          SAI_MACSEC_DIRECTION_EGRESS,
+                                          port_sci);
+        EXPECT_TRUE(result);
+
+        // AN=0 stale SA must have been removed from SAI.
+        ASSERT_EQ(g_removed_sas.size(), 1u);
+        EXPECT_EQ(g_removed_sas[0], kStaleSaOid);
+
+        // AN=1 SA must remain in sc.m_sa_ids; no new SA created.
+        ASSERT_EQ(sc.m_sa_ids.size(), 1u);
+        EXPECT_EQ(sc.m_sa_ids.at(1), kCurrentOidAN1);
+        EXPECT_EQ(g_created_sas.size(), 0u);
+
+        // encoding_an updated to reflect the new session.
+        EXPECT_EQ(sc.m_encoding_an, static_cast<macsec_an_t>(1));
+
+        // COUNTERS_DB name->OID mapping for AN=0 must be gone.
+        std::string counters_val;
+        EXPECT_FALSE(orch->m_macsec_counters_map.hget("", port_sci_an_0,
+                                                       counters_val));
+
+        // STATE_DB entry for AN=0 must be gone.
+        std::string state_val;
+        EXPECT_FALSE(orch->m_state_macsec_egress_sa.hget(state_key_0, "state",
+                                                          state_val));
+    }
+
+    // ------------------------------------------------------------------
+    // Test 9: setEncodingAN is a no-op when encoding_an is unchanged
+    //
+    // A SET on MACSEC_EGRESS_SC_TABLE with the same encoding_an value
+    // must not touch SAI at all (clean rekey fast-path guard).
+    // ------------------------------------------------------------------
+    TEST_F(MacsecOrchStaleSakTest,
+           setEncodingAN_noop_when_encoding_an_unchanged)
+    {
+        static constexpr sai_object_id_t kOid0 = 0x5c00000000002000ULL;
+
+        MACsecOrch::MACsecSC sc{};
+        sc.m_encoding_an = 0;
+        sc.m_sa_ids[0]   = kOid0;
+
+        MACsecOrch::TaskArgs attrs = { { "encoding_an", "0" } };
+
+        // port_sci is not consulted because encoding_an is unchanged.
+        bool result = orch->setEncodingAN(sc, attrs, SAI_MACSEC_DIRECTION_EGRESS,
+                                          std::string(kPortName) + ":" + kEgressSciHex);
+        EXPECT_TRUE(result);
+
+        // No SAI remove or create.
+        EXPECT_EQ(g_removed_sas.size(), 0u);
+        EXPECT_EQ(g_created_sas.size(), 0u);
+        EXPECT_EQ(sc.m_encoding_an, static_cast<macsec_an_t>(0));
+    }
+
+    // ------------------------------------------------------------------
+    // Test 10: setEncodingAN delete failure is best-effort
+    //
+    // If SAI remove_macsec_sa fails while sweeping a stale AN, the
+    // function must still return true and erase the entry from
+    // sc.m_sa_ids.  The failure is logged but not fatal: the SC-level
+    // encoding_an update is more important than a leaked OID.
+    // ------------------------------------------------------------------
+    TEST_F(MacsecOrchStaleSakTest,
+           setEncodingAN_delete_failure_is_best_effort)
+    {
+        static constexpr sai_object_id_t kCurrentOidAN1 = 0x5c00000000003001ULL;
+
+        // Seed the SC with AN=0 (kStaleSaOid) into m_macsec_ports.
+        seedSurvivingSa(SAI_MACSEC_DIRECTION_EGRESS, parseSciHex(kEgressSciHex));
+
+        auto &sc = orch->m_macsec_ports[kPortName]
+                       ->m_egress_scs[parseSciHex(kEgressSciHex)];
+        sc.m_sa_ids[1] = kCurrentOidAN1;
+
+        g_remove_should_fail = true;
+
+        const std::string port_sci =
+            std::string(kPortName) + ":" + kEgressSciHex;
+        MACsecOrch::TaskArgs attrs = { { "encoding_an", "1" } };
+
+        bool result = orch->setEncodingAN(sc, attrs,
+                                          SAI_MACSEC_DIRECTION_EGRESS,
+                                          port_sci);
+
+        // Function must succeed despite the SAI failure.
+        EXPECT_TRUE(result);
+
+        // The stale AN=0 entry must be evicted from sc.m_sa_ids even
+        // though the SAI remove failed (best-effort sweep).
+        ASSERT_EQ(sc.m_sa_ids.size(), 1u);
+        EXPECT_EQ(sc.m_sa_ids.at(1), kCurrentOidAN1);
+
+        // encoding_an updated.
+        EXPECT_EQ(sc.m_encoding_an, static_cast<macsec_an_t>(1));
+    }
+
+    // ------------------------------------------------------------------
+    // Test 11: setEncodingAN ingress direction is a no-op
+    //
+    // Ingress SCs don't carry encoding_an. The function must return
+    // true immediately without touching SAI or sc.m_encoding_an.
+    // ------------------------------------------------------------------
+    TEST_F(MacsecOrchStaleSakTest,
+           setEncodingAN_ingress_is_noop)
+    {
+        MACsecOrch::MACsecSC sc{};
+        sc.m_encoding_an = 0;
+
+        MACsecOrch::TaskArgs attrs = { { "encoding_an", "1" } };
+
+        // port_sci is not consulted for ingress (returns false immediately).
+        bool result = orch->setEncodingAN(sc, attrs, SAI_MACSEC_DIRECTION_INGRESS,
+                                          std::string(kPortName) + ":" + kIngressSciHex);
+        EXPECT_FALSE(result);
+
+        EXPECT_EQ(g_removed_sas.size(), 0u);
+        EXPECT_EQ(g_created_sas.size(), 0u);
+        EXPECT_EQ(sc.m_encoding_an, static_cast<macsec_an_t>(0));
+    }
+}

--- a/tests/mock_tests/mock_hiredis.cpp
+++ b/tests/mock_tests/mock_hiredis.cpp
@@ -1,9 +1,64 @@
 #include <stdlib.h>
+#include <string.h>
 #include <hiredis/hiredis.h>
 #include <iostream>
 
 // Add a global redisReply for user to mock
 redisReply *mockReply = nullptr;
+
+static redisReply *duplicateRedisReply(const redisReply *src)
+{
+    if (src == nullptr)
+    {
+        return nullptr;
+    }
+
+    redisReply *dst = (redisReply *)calloc(1, sizeof(redisReply));
+    if (dst == nullptr)
+    {
+        return nullptr;
+    }
+
+    dst->type = src->type;
+    dst->integer = src->integer;
+
+    if (src->str != nullptr)
+    {
+        size_t len = src->len;
+
+        if (len == 0)
+        {
+            len = strlen(src->str);
+        }
+
+        dst->len = len;
+        dst->str = (char *)calloc(len + 1, sizeof(char));
+        if (dst->str != nullptr)
+        {
+            memcpy(dst->str, src->str, len);
+        }
+    }
+    else
+    {
+        dst->len = src->len;
+    }
+
+    dst->elements = 0;
+    if (src->elements > 0 && src->element != nullptr)
+    {
+        dst->element = (redisReply **)calloc(src->elements, sizeof(redisReply *));
+        if (dst->element != nullptr)
+        {
+            dst->elements = src->elements;
+            for (size_t i = 0; i < src->elements; i++)
+            {
+                dst->element[i] = duplicateRedisReply(src->element[i]);
+            }
+        }
+    }
+
+    return dst;
+}
 
 int redisGetReply(redisContext *c, void **reply)
 {
@@ -14,7 +69,8 @@ int redisGetReply(redisContext *c, void **reply)
     }
     else
     {
-        *reply = mockReply;
+        // Return a copy so RedisReply can free it; mockReply stays until the test clears it.
+        *reply = duplicateRedisReply(mockReply);
     }
     return 0;
 }

--- a/tests/mock_tests/orchdaemon_ut.cpp
+++ b/tests/mock_tests/orchdaemon_ut.cpp
@@ -8,8 +8,12 @@
 #include "mock_sai_switch.h"
 #include "saihelper.h"
 
+#include <csignal>
+
 extern sai_switch_api_t* sai_switch_api;
 sai_switch_api_t test_sai_switch;
+
+extern volatile sig_atomic_t gOrchShutdownRequested;
 
 namespace orchdaemon_test
 {
@@ -246,6 +250,55 @@ namespace orchdaemon_test
         orchd->flush();
 
         orchd->disableRingBuffer();
+    }
+
+    static int gMockExitCallCount;
+    static int gMockExitStatus;
+
+    static void mock_exit_fn(int status)
+    {
+        gMockExitCallCount++;
+        gMockExitStatus = status;
+    }
+
+    class GracefulShutdownExitTest : public ::testing::Test
+    {
+        protected:
+            void SetUp() override
+            {
+                gMockExitCallCount = 0;
+                gMockExitStatus = -1;
+                gOrchShutdownRequested = 0;
+            }
+
+            void TearDown() override
+            {
+                gOrchShutdownRequested = 0;
+                Recorder::Instance().swss.setAsync(false);
+            }
+    };
+
+    TEST_F(GracefulShutdownExitTest, NoShutdownRequestedDoesNotExit)
+    {
+        Recorder::Instance().swss.setAsync(true);
+
+        exit_if_graceful_shutdown_requested(mock_exit_fn);
+
+        EXPECT_EQ(gMockExitCallCount, 0);
+        // The recorder must be left untouched when no shutdown was requested.
+        EXPECT_TRUE(Recorder::Instance().swss.isAsyncEnabled());
+    }
+
+    TEST_F(GracefulShutdownExitTest, ShutdownRequestDrainsRecorderAndExits)
+    {
+        Recorder::Instance().swss.setAsync(true);
+        gOrchShutdownRequested = SIGTERM;
+
+        exit_if_graceful_shutdown_requested(mock_exit_fn);
+
+        EXPECT_EQ(gMockExitCallCount, 1);
+        EXPECT_EQ(gMockExitStatus, 0);
+        EXPECT_FALSE(Recorder::Instance().swss.isAsyncEnabled());
     }
 
 }

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -1457,6 +1457,8 @@ namespace portsorch_test
                 { "post2",         "0x10,0x12,0x11,0x13"         },
                 { "post3",         "0x10,0x12,0x11,0x13"         },
                 { "attn",          "0x80,0x82,0x81,0x83"         },
+                { "tx_precoding",  "0x1,0x0,0x1,0x0"             },
+                { "rx_precoding",  "0x0,0x1,0x0,0x1"             },
                 { "unreliable_los","off"                         },
                 { "ob_m2lp",       "0x4,0x6,0x5,0x7"             },
                 { "ob_alev_out",   "0xf,0x11,0x10,0x12"          },
@@ -1554,6 +1556,14 @@ namespace portsorch_test
         // Verify attn
         std::vector<std::uint32_t> attn = { 0x80, 0x82, 0x81, 0x83 };
         ASSERT_EQ(p.m_serdes_attrs.at(SAI_PORT_SERDES_ATTR_TX_FIR_ATTN), SerdesValue(attn));
+
+        // Verify tx_precoding
+        std::vector<std::uint32_t> tx_precoding = { 0x1, 0x0, 0x1, 0x0 };
+        ASSERT_EQ(p.m_serdes_attrs.at(SAI_PORT_SERDES_ATTR_TX_PRECODING), SerdesValue(tx_precoding));
+
+        // Verify rx_precoding
+        std::vector<std::uint32_t> rx_precoding = { 0x0, 0x1, 0x0, 0x1 };
+        ASSERT_EQ(p.m_serdes_attrs.at(SAI_PORT_SERDES_ATTR_RX_PRECODING), SerdesValue(rx_precoding));
 
         // Verify ob_m2lp
         std::vector<std::uint32_t> ob_m2lp = { 0x4, 0x6, 0x5, 0x7 };

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -5199,6 +5199,240 @@ namespace portsorch_test
         ASSERT_NE(port.m_lag_id, SAI_NULL_OBJECT_ID) << "Port should be a LAG member after second doTask";
     }
 
+    /*
+     * Regression test for LAG/VLAN race (inverse of issue #23635).
+     *
+     * Issue: When a port is added to a LAG and a VLAN member SET is queued while
+     * orchagent still has m_lag_member_id set, addBridgePort/addVlanMember must not
+     * call SAI (SAI_STATUS_INVALID_PORT_NUMBER on some platforms).
+     *
+     * Fix: PortsOrch defers VLAN member SET when a physical port's m_lag_member_id
+     * Test: LAG member on port first, then VLAN member SET only (no LAG DEL in same
+     * batch). Uses a distinct port/LAG/VLAN from VlanMemberSucceedsAfterLagMemberRemoved
+     * because saivs state persists across tests in one process.
+     * Then removes the VLAN and queues member DEL to cover the erase path when the
+     * vlan is already gone (!getPort + DEL_COMMAND).
+     */
+    TEST_F(VlanLagRaceTest, VlanMemberAddDeferredWhileLagMemberActive)
+    {
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        Table lagTable = Table(m_app_db.get(), APP_LAG_TABLE_NAME);
+        Table lagMemberTable = Table(m_app_db.get(), APP_LAG_MEMBER_TABLE_NAME);
+        Table vlanTable = Table(m_app_db.get(), APP_VLAN_TABLE_NAME);
+        Table vlanMemberTable = Table(m_app_db.get(), APP_VLAN_MEMBER_TABLE_NAME);
+
+        auto ports = ut_helper::getInitialSaiPorts();
+        ASSERT_GE(ports.size(), 2u) << "Need at least two ports for this test";
+        auto portIt = ports.begin();
+        ++portIt;
+        string testPort = portIt->first;
+
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+        portTable.set("PortInitDone", { { } });
+
+        gPortsOrch->addExistingData(&portTable);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        lagTable.set("PortChannel2",
+            {
+                {"admin_status", "up"},
+                {"mtu", "9100"}
+            }
+        );
+        string lagMemberKey = string("PortChannel2") + lagMemberTable.getTableNameSeparator() + testPort;
+        lagMemberTable.set(lagMemberKey, { {"status", "enabled"} });
+
+        gPortsOrch->addExistingData(&lagTable);
+        gPortsOrch->addExistingData(&lagMemberTable);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        for (auto tableName : {APP_LAG_TABLE_NAME, APP_LAG_MEMBER_TABLE_NAME})
+        {
+            vector<string> ts;
+            auto exec = gPortsOrch->getExecutor(tableName);
+            auto consumer = static_cast<Consumer *>(exec);
+            consumer->dumpPendingTasks(ts);
+            ASSERT_TRUE(ts.empty()) << "LAG setup should complete: " << tableName;
+        }
+
+        Port port;
+        gPortsOrch->getPort(testPort, port);
+        ASSERT_NE(port.m_lag_member_id, SAI_NULL_OBJECT_ID) << "Port should be a LAG member before VLAN add";
+
+        vlanTable.set("Vlan51",
+            {
+                {"admin_status", "up"},
+                {"mtu", "9100"}
+            }
+        );
+        string vlanMemberKey = string("Vlan51") + vlanMemberTable.getTableNameSeparator() + testPort;
+        vlanMemberTable.set(vlanMemberKey, { {"tagging_mode", "untagged"} });
+
+        gPortsOrch->addExistingData(&vlanTable);
+        gPortsOrch->addExistingData(&vlanMemberTable);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        Port vlan;
+        ASSERT_TRUE(gPortsOrch->getPort("Vlan51", vlan));
+        ASSERT_EQ(vlan.m_members.find(testPort), vlan.m_members.end())
+            << "VLAN member add must defer while port is LAG member";
+
+        {
+            vector<string> ts;
+            auto exec = gPortsOrch->getExecutor(APP_VLAN_MEMBER_TABLE_NAME);
+            auto consumer = static_cast<Consumer *>(exec);
+            consumer->dumpPendingTasks(ts);
+            ASSERT_EQ(ts.size(), 1) << "Exactly one VLAN member task should be pending";
+
+            string expectedSubstr = vlanMemberKey + "|SET";
+            ASSERT_NE(ts[0].find(expectedSubstr), string::npos)
+                << "Pending task should be the SET for " << vlanMemberKey
+                << ", got: " << ts[0];
+        }
+
+        gPortsOrch->getPort(testPort, port);
+        ASSERT_NE(port.m_lag_member_id, SAI_NULL_OBJECT_ID) << "Port should still be a LAG member";
+
+        // Deferred SET is replaced by DEL via consumer coalescing; after Vlan51 is
+        // removed, doVlanMemberTask must erase the DEL (member never existed in vlan).
+        std::deque<KeyOpFieldsValuesTuple> vlanDelEntries;
+        vlanDelEntries.push_back({"Vlan51", DEL_COMMAND, {}});
+        auto vlanConsumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_VLAN_TABLE_NAME));
+        vlanConsumer->addToSync(vlanDelEntries);
+
+        std::deque<KeyOpFieldsValuesTuple> vlanMemberDelEntries;
+        vlanMemberDelEntries.push_back({vlanMemberKey, DEL_COMMAND, {}});
+        auto vlanMemberConsumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_VLAN_MEMBER_TABLE_NAME));
+        vlanMemberConsumer->addToSync(vlanMemberDelEntries);
+
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        Port vlanAfterDel;
+        ASSERT_FALSE(gPortsOrch->getPort("Vlan51", vlanAfterDel)) << "Vlan51 should be removed";
+
+        for (auto tableName : {APP_VLAN_TABLE_NAME, APP_VLAN_MEMBER_TABLE_NAME})
+        {
+            vector<string> ts;
+            auto exec = gPortsOrch->getExecutor(tableName);
+            auto consumer = static_cast<Consumer *>(exec);
+            consumer->dumpPendingTasks(ts);
+            ASSERT_TRUE(ts.empty()) << "VLAN teardown should complete with no pending tasks: " << tableName;
+        }
+    }
+
+    TEST_F(VlanLagRaceTest, VlanMemberSucceedsAfterLagMemberRemoved)
+    {
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        Table lagTable = Table(m_app_db.get(), APP_LAG_TABLE_NAME);
+        Table lagMemberTable = Table(m_app_db.get(), APP_LAG_MEMBER_TABLE_NAME);
+        Table vlanTable = Table(m_app_db.get(), APP_VLAN_TABLE_NAME);
+        Table vlanMemberTable = Table(m_app_db.get(), APP_VLAN_MEMBER_TABLE_NAME);
+
+        auto ports = ut_helper::getInitialSaiPorts();
+        string testPort = ports.begin()->first;
+
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+        portTable.set("PortInitDone", { { } });
+
+        gPortsOrch->addExistingData(&portTable);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        lagTable.set("PortChannel1",
+            {
+                {"admin_status", "up"},
+                {"mtu", "9100"}
+            }
+        );
+        string lagMemberKey = string("PortChannel1") + lagMemberTable.getTableNameSeparator() + testPort;
+        lagMemberTable.set(lagMemberKey, { {"status", "enabled"} });
+
+        gPortsOrch->addExistingData(&lagTable);
+        gPortsOrch->addExistingData(&lagMemberTable);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        for (auto tableName : {APP_LAG_TABLE_NAME, APP_LAG_MEMBER_TABLE_NAME})
+        {
+            vector<string> ts;
+            auto exec = gPortsOrch->getExecutor(tableName);
+            auto consumer = static_cast<Consumer *>(exec);
+            consumer->dumpPendingTasks(ts);
+            ASSERT_TRUE(ts.empty()) << "LAG setup should complete: " << tableName;
+        }
+        {
+            Port port;
+            ASSERT_TRUE(gPortsOrch->getPort(testPort, port));
+            ASSERT_NE(port.m_lag_member_id, SAI_NULL_OBJECT_ID) << "Port should be a LAG member before VLAN add";
+        }
+
+        vlanTable.set("Vlan50",
+            {
+                {"admin_status", "up"},
+                {"mtu", "9100"}
+            }
+        );
+        string vlanMemberKey = string("Vlan50") + vlanMemberTable.getTableNameSeparator() + testPort;
+        vlanMemberTable.set(vlanMemberKey, { {"tagging_mode", "untagged"} });
+
+        gPortsOrch->addExistingData(&vlanTable);
+        gPortsOrch->addExistingData(&vlanMemberTable);
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        {
+            vector<string> ts;
+            auto exec = gPortsOrch->getExecutor(APP_VLAN_MEMBER_TABLE_NAME);
+            auto consumer = static_cast<Consumer *>(exec);
+            consumer->dumpPendingTasks(ts);
+            ASSERT_EQ(ts.size(), 1) << "VLAN member SET should be deferred while LAG member is active";
+        }
+
+        std::deque<KeyOpFieldsValuesTuple> lagMemberDelEntries;
+        lagMemberDelEntries.push_back({lagMemberKey, DEL_COMMAND, {}});
+        auto lagMemberConsumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_LAG_MEMBER_TABLE_NAME));
+        lagMemberConsumer->addToSync(lagMemberDelEntries);
+
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        Port port;
+        gPortsOrch->getPort(testPort, port);
+        ASSERT_EQ(port.m_lag_member_id, SAI_NULL_OBJECT_ID) << "LAG member should be removed";
+
+        {
+            vector<string> ts;
+            auto exec = gPortsOrch->getExecutor(APP_LAG_MEMBER_TABLE_NAME);
+            auto consumer = static_cast<Consumer *>(exec);
+            consumer->dumpPendingTasks(ts);
+            ASSERT_TRUE(ts.empty()) << "LAG member DEL should complete";
+        }
+
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        gPortsOrch->getPort(testPort, port);
+        ASSERT_NE(port.m_bridge_port_id, SAI_NULL_OBJECT_ID)
+            << "Bridge port should be created after LAG member removal";
+
+        for (auto tableName : {APP_VLAN_TABLE_NAME, APP_VLAN_MEMBER_TABLE_NAME})
+        {
+            vector<string> ts;
+            auto exec = gPortsOrch->getExecutor(tableName);
+            auto consumer = static_cast<Consumer *>(exec);
+            consumer->dumpPendingTasks(ts);
+            ASSERT_TRUE(ts.empty()) << "All VLAN tasks should complete: " << tableName;
+        }
+
+        Port vlan;
+        ASSERT_TRUE(gPortsOrch->getPort("Vlan50", vlan));
+        ASSERT_NE(vlan.m_members.find(testPort), vlan.m_members.end())
+            << "Port should be a VLAN member after deferred SET completes";
+    }
+
     struct PostPortInitTests : PortsOrchTest
     {
     };

--- a/tests/mock_tests/tunneldecaporch_ut.cpp
+++ b/tests/mock_tests/tunneldecaporch_ut.cpp
@@ -195,6 +195,32 @@ namespace tunneldecaporch_test
         });
     }
 
+    TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_GetEcnMode_NotFound)
+    {
+        vector<string> tunnel_tables = { APP_TUNNEL_DECAP_TABLE_NAME };
+        auto tunnelDecapOrch = make_shared<TunnelDecapOrch>(
+            m_app_db.get(), m_state_db.get(), m_config_db.get(), tunnel_tables);
+        ASSERT_NE(tunnelDecapOrch, nullptr);
+
+        EXPECT_NO_THROW({
+            string ecn_mode = tunnelDecapOrch->getEcnMode("non_existent_tunnel");
+            EXPECT_TRUE(ecn_mode.empty());
+        });
+    }
+
+    TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_GetEncapEcnMode_NotFound)
+    {
+        vector<string> tunnel_tables = { APP_TUNNEL_DECAP_TABLE_NAME };
+        auto tunnelDecapOrch = make_shared<TunnelDecapOrch>(
+            m_app_db.get(), m_state_db.get(), m_config_db.get(), tunnel_tables);
+        ASSERT_NE(tunnelDecapOrch, nullptr);
+
+        EXPECT_NO_THROW({
+            string encap_ecn = tunnelDecapOrch->getEncapEcnMode("non_existent_tunnel");
+            EXPECT_TRUE(encap_ecn.empty());
+        });
+    }
+
     TEST_F(TunnelDecapOrchTest, TunnelDecapOrch_GetDstIpAddresses)
     {
         vector<string> tunnel_tables = { APP_TUNNEL_DECAP_TABLE_NAME };

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -1268,6 +1268,10 @@ class TestMuxTunnelBase():
                 assert value == "SAI_TUNNEL_DSCP_MODE_PIPE_MODEL"
             elif field == "SAI_TUNNEL_ATTR_DECAP_DSCP_MODE":
                 assert value == "SAI_TUNNEL_DSCP_MODE_PIPE_MODEL"
+            elif field == "SAI_TUNNEL_ATTR_DECAP_ECN_MODE":
+                assert value == "SAI_TUNNEL_DECAP_ECN_MODE_STANDARD"
+            elif field == "SAI_TUNNEL_ATTR_ENCAP_ECN_MODE":
+                assert value == "SAI_TUNNEL_ENCAP_ECN_MODE_STANDARD"
             else:
                 assert False, "Field %s is not tested" % field
 

--- a/tests/test_mux_prefixroute.py
+++ b/tests/test_mux_prefixroute.py
@@ -1429,6 +1429,10 @@ class TestMuxTunnelBase():
                 assert value == "SAI_TUNNEL_DSCP_MODE_PIPE_MODEL"
             elif field == "SAI_TUNNEL_ATTR_DECAP_DSCP_MODE":
                 assert value == "SAI_TUNNEL_DSCP_MODE_PIPE_MODEL"
+            elif field == "SAI_TUNNEL_ATTR_DECAP_ECN_MODE":
+                assert value == self.ecn_modes_map[self.DEFAULT_TUNNEL_PARAMS["ecn_mode"]]
+            elif field == "SAI_TUNNEL_ATTR_ENCAP_ECN_MODE":
+                assert value == "SAI_TUNNEL_ENCAP_ECN_MODE_STANDARD"
             else:
                 assert False, "Field %s is not tested" % field
 

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -3576,6 +3576,98 @@ class TestVnetOrch(object):
         self.set_admin_status("Ethernet4", "down")
 
 
+
+    '''
+    VNET tunnel route with a directly-connected local endpoint.
+    '''
+    def test_vnet_orch_local_endpoint_alias_resolution(self, dvs, testlog):
+        vnet_obj = self.get_vnet_obj()
+        asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
+
+        tunnel_name = 'tunnel_local_ep'
+        vnet_name = 'Vnet_local_ep'
+        route_prefix = '103.100.1.1/32'
+        ecmp_route_prefix = '103.100.1.2/32'
+        endpoint = '20.20.20.5'
+        ecmp_endpoint = '20.20.20.7'
+        backup_endpoint = '20.20.20.6'
+        neighbor_mac = '00:01:02:03:04:05'
+        ecmp_neighbor_mac = '00:01:02:03:04:07'
+
+        self.setup_db(dvs)
+        vnet_obj.fetch_exist_entries(dvs)
+
+        try:
+            self.create_l3_intf("Ethernet0", "")
+            self.add_ip_address("Ethernet0", "20.20.20.1/24")
+            self.set_admin_status("Ethernet0", "down")
+            time.sleep(1)
+            self.set_admin_status("Ethernet0", "up")
+
+            create_vxlan_tunnel(dvs, tunnel_name, '9.9.9.9')
+            create_vnet_entry(dvs, vnet_name, tunnel_name, '1001', "")
+            vnet_obj.check_vnet_entry(dvs, vnet_name)
+            vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, vnet_name, '1001')
+            vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, '9.9.9.9')
+
+            # Add the route before the neighbor exists, so the cached NextHopKey
+            # must resolve the local interface when the monitor later goes up.
+            create_vnet_routes(dvs, route_prefix, vnet_name, "%s,%s" % (endpoint, backup_endpoint),
+                               ep_monitor="%s,%s" % (endpoint, backup_endpoint), primary=endpoint,
+                               monitoring='custom', check_directly_connected=True)
+            create_vnet_routes(dvs, ecmp_route_prefix, vnet_name, "%s,%s" % (endpoint, ecmp_endpoint),
+                               ep_monitor="%s,%s" % (endpoint, ecmp_endpoint), primary="%s,%s" % (endpoint, ecmp_endpoint),
+                               monitoring='custom', check_directly_connected=True)
+            self.add_neighbor("Ethernet0", endpoint, neighbor_mac)
+            self.add_neighbor("Ethernet0", ecmp_endpoint, ecmp_neighbor_mac)
+            update_monitor_session_state(dvs, route_prefix, endpoint, 'up')
+            update_monitor_session_state(dvs, ecmp_route_prefix, endpoint, 'up')
+            update_monitor_session_state(dvs, ecmp_route_prefix, ecmp_endpoint, 'up')
+            time.sleep(2)
+
+            nhids = get_all_created_entries(asic_db, vnet_obj.ASIC_NEXT_HOP, set())
+            tbl_nh = swsscommon.Table(asic_db, vnet_obj.ASIC_NEXT_HOP)
+            neighbor_nh = None
+            for nhid in nhids:
+                status, nh_fvs = tbl_nh.get(nhid)
+                nh_fvs = dict(nh_fvs)
+                assert status
+                if nh_fvs.get('SAI_NEXT_HOP_ATTR_IP') == endpoint and nh_fvs.get('SAI_NEXT_HOP_ATTR_TYPE') == 'SAI_NEXT_HOP_TYPE_IP':
+                    neighbor_nh = nhid
+                    break
+            assert neighbor_nh is not None
+
+            def _access_function():
+                for route_key in self.adb.get_keys(vnet_obj.ASIC_ROUTE_ENTRY):
+                    route_entry = json.loads(route_key)
+                    if route_entry["dest"] == route_prefix:
+                        return (True, self.adb.get_entry(vnet_obj.ASIC_ROUTE_ENTRY, route_key))
+                return (False, None)
+
+            _, route = wait_for_result(_access_function)
+            assert route["SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID"] == neighbor_nh
+
+            def _ecmp_route_function():
+                for route_key in self.adb.get_keys(vnet_obj.ASIC_ROUTE_ENTRY):
+                    route_entry = json.loads(route_key)
+                    if route_entry["dest"] == ecmp_route_prefix:
+                        return (True, route_key)
+                return (False, None)
+
+            _, ecmp_route_key = wait_for_result(_ecmp_route_function)
+            vnet_obj.check_vnet_local_route_nexthops(dvs, ecmp_route_key, [endpoint, ecmp_endpoint])
+
+        finally:
+            self.cdb.delete_entry("VNET_ROUTE_TUNNEL", "%s|%s" % (vnet_name, ecmp_route_prefix))
+            self.cdb.delete_entry("VNET_ROUTE_TUNNEL", "%s|%s" % (vnet_name, route_prefix))
+            self.remove_neighbor("Ethernet0", ecmp_endpoint)
+            self.remove_neighbor("Ethernet0", endpoint)
+            delete_vnet_entry(dvs, vnet_name)
+            delete_vxlan_tunnel(dvs, tunnel_name)
+            self.remove_ip_address("Ethernet0", "20.20.20.1/24")
+            self.set_admin_status("Ethernet0", "down")
+            self.cdb.delete_entry("INTERFACE", "Ethernet0")
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [ ] Test improvement

### Approach
#### What is the motivation for this PR?
When an interface is assigned to a VNET, IntfsOrch already owns its connected route. A config
reload replays that route to VNetRouteOrch, which issues a CREATE, gets SAI_STATUS_ITEM_ALREADY_EXISTS
back, and logs "SAI failed to create route" without ever converging. VNetRouteOrch::delRoute had two
further faults: a duplicate delete hit SWSS_LOG_ERROR + assert(false), and since mock_tests builds with
-DNDEBUG the assert vanishes and two `continue` paths skip the observer-iterator increment, spinning
orchagent forever.

Fix: add_route now converges onto the existing entry with a SET when SAI reports ITEM_ALREADY_EXISTS,
mirroring how del_route already tolerates ITEM_NOT_FOUND; delRoute treats an already-absent route as a
no-op and advances the iterator before both `continue` statements. Covered by four new gtests in
tests/mock_tests/vnetorch_ut.cpp, confirmed to fail against the unpatched code.
#### How did you do it?

#### How did you verify/test it?
Note: Google Test filter = VNetOrchTest.*
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from VNetOrchTest
[ RUN      ] VNetOrchTest.ReplayedConnectedRouteConvergesOnExistingEntry
[       OK ] VNetOrchTest.ReplayedConnectedRouteConvergesOnExistingEntry (67 ms)
[ RUN      ] VNetOrchTest.FirstConnectedRouteIsCreatedNotUpdated
[       OK ] VNetOrchTest.FirstConnectedRouteIsCreatedNotUpdated (75 ms)
[ RUN      ] VNetOrchTest.DuplicateDeleteLeavesRouteTableClean
[       OK ] VNetOrchTest.DuplicateDeleteLeavesRouteTableClean (100 ms)
[ RUN      ] VNetOrchTest.ReplayedDeleteDoesNotSpinInObserverWalk
Running main() from ./googletest/src/gtest_main.cc
[       OK ] VNetOrchTest.ReplayedDeleteDoesNotSpinInObserverWalk (243 ms)
[----------] 4 tests from VNetOrchTest (487 ms total)

#### Any platform specific information?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
